### PR TITLE
Databases overview reactiveness

### DIFF
--- a/assets/js/state/databases.js
+++ b/assets/js/state/databases.js
@@ -23,10 +23,21 @@ export const databasesListSlice = createSlice({
     stopDatabasesLoading: (state) => {
       state.loading = false;
     },
+    appendDatabase: (state, action) => {
+      state.databases = [...state.databases, action.payload];
+    },
+    appendDatabaseInstance: (state, action) => {
+      state.databaseInstances = [...state.databaseInstances, action.payload];
+    },
   },
 });
 
-export const { startDatabasesLoading, stopDatabasesLoading, setDatabases } =
-  databasesListSlice.actions;
+export const {
+  startDatabasesLoading,
+  stopDatabasesLoading,
+  setDatabases,
+  appendDatabase,
+  appendDatabaseInstance,
+} = databasesListSlice.actions;
 
 export default databasesListSlice.reducer;

--- a/assets/js/state/index.js
+++ b/assets/js/state/index.js
@@ -94,6 +94,10 @@ const processChannelEvents = (store) => {
     store.dispatch({ type: 'APPLICATION_INSTANCE_REGISTERED', payload })
   );
 
+  databasesChannel.on('database_registered', (payload) =>
+    store.dispatch({ type: 'DATABASE_REGISTERED', payload })
+  );
+
   databasesChannel.on('database_instance_registered', (payload) =>
     store.dispatch({ type: 'DATABASE_INSTANCE_REGISTERED', payload })
   );

--- a/assets/js/state/sapSystems.js
+++ b/assets/js/state/sapSystems.js
@@ -44,7 +44,7 @@ export const sapSystemsListSlice = createSlice({
     },
     // When a new DatabaseInstanceRegistered comes in,
     // it need to be appended to the list of the database instances of the relative sap system
-    appendDatabaseInstance: (state, action) => {
+    appendDatabaseInstanceToSapSystem: (state, action) => {
       state.databaseInstances = [...state.databaseInstances, action.payload];
     },
   },
@@ -56,7 +56,7 @@ export const {
   setSapSystems,
   appendSapsystem,
   appendApplicationInstance,
-  appendDatabaseInstance,
+  appendDatabaseInstanceToSapSystem,
 } = sapSystemsListSlice.actions;
 
 export default sapSystemsListSlice.reducer;


### PR DESCRIPTION
Follows up https://github.com/trento-project/web/pull/218 by adding reactiveness and tagging.

![reactive-databases-overview](https://user-images.githubusercontent.com/8167114/159328833-47ef43ff-b634-4979-ad43-8a0de4b0f7ff.gif)

