### PR TITLE
Add checks integration service and mock runner (part 1)

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -92,6 +92,7 @@ config :trento, Trento.Scheduler,
   ]
 
 config :trento, Trento.Integration.Telemetry, adapter: Trento.Integration.Telemetry.ToLogger
+config :trento, Trento.Integration.Checks, adapter: Trento.Integration.Checks.MockRunner
 
 # Do not include metadata nor timestamps in development logs
 config :logger, :console, format: "[$level] $message\n"

--- a/lib/trento/application/integration/checks/adapter/gen.ex
+++ b/lib/trento/application/integration/checks/adapter/gen.ex
@@ -1,0 +1,13 @@
+defmodule Trento.Integration.Checks.Gen do
+  @moduledoc """
+  Behaviour of a telemetry adapter.
+  """
+
+  @callback request_execution(
+              execution_id :: String.t(),
+              cluster_id :: [String.t()],
+              hosts :: String.t(),
+              selected_checks :: [String.t()]
+            ) ::
+              :ok | {:error, any}
+end

--- a/lib/trento/application/integration/checks/adapter/mock_runner.ex
+++ b/lib/trento/application/integration/checks/adapter/mock_runner.ex
@@ -1,0 +1,88 @@
+defmodule Trento.Integration.Checks.MockRunner do
+  @moduledoc """
+  Mocks a checks runner.
+  """
+
+  @behaviour Trento.Integration.Checks.Gen
+
+  use GenServer
+
+  require Logger
+
+  defstruct [:expected_results]
+
+  @type t :: %__MODULE__{
+          expected_results: :passing | :warning | :critical | :random
+        }
+
+  def start_link do
+    GenServer.start_link(
+      __MODULE__,
+      %__MODULE__{
+        expected_results: :random
+      },
+      name: __MODULE__
+    )
+  end
+
+  @impl true
+  def init(state), do: {:ok, state}
+
+  @impl true
+  def handle_cast(
+        {:request_execution, execution_id, cluster_id, hosts, selected_checks},
+        %__MODULE__{
+          expected_results: expected_results
+        }
+      ) do
+    :ok = send_execution_started_event(execution_id)
+    # simulate a real execution by sleeping for a while
+    2000..4000 |> Enum.random() |> Process.sleep()
+
+    :ok =
+      send_check_results_event(execution_id, cluster_id, hosts, selected_checks, expected_results)
+
+    {:noreply,
+     %__MODULE__{
+       expected_results: :random
+     }}
+  end
+
+  def handle_cast({:set_expected_results, expected_results}, state) do
+    {:noreply, %__MODULE__{state | expected_results: expected_results}}
+  end
+
+  @impl true
+  def request_execution(execution_id, cluster_id, hosts, selected_checks) do
+    GenServer.cast(
+      __MODULE__,
+      {:request_execution, execution_id, cluster_id, hosts, selected_checks}
+    )
+  end
+
+  @doc """
+  Set the expected results for the next execution.
+  """
+  @spec set_expected_results(:passing | :warning | :critical | :random) :: :ok
+  def set_expected_results(expected_results) do
+    GenServer.cast(__MODULE__, {:set_expected_results, expected_results})
+  end
+
+  defp send_execution_started_event(execution_id) do
+    # TODO: post event to callback
+    Logger.debug("started #{execution_id}")
+  end
+
+  defp send_check_results_event(
+         execution_id,
+         cluster_id,
+         hosts,
+         selected_checks,
+         expected_results
+       ) do
+    # TODO: post event to callback
+    Logger.debug(
+      "results #{execution_id} #{cluster_id} #{hosts} #{selected_checks} #{expected_results}"
+    )
+  end
+end

--- a/lib/trento/application/integration/checks/checks.ex
+++ b/lib/trento/application/integration/checks/checks.ex
@@ -1,0 +1,12 @@
+defmodule Trento.Integration.Checks do
+  @moduledoc """
+  Checks runner service integration
+  """
+  @spec request_execution(String.t(), String.t(), [String.t()], [String.t()]) ::
+          :ok | {:error, any}
+  def request_execution(execution_id, cluster_id, hosts, selected_checks),
+    do: adapter().request_execution(execution_id, cluster_id, hosts, selected_checks)
+
+  defp adapter,
+    do: Application.fetch_env!(:trento, __MODULE__)[:adapter]
+end

--- a/lib/trento/application/projectors/host_projector.ex
+++ b/lib/trento/application/projectors/host_projector.ex
@@ -20,8 +20,6 @@ defmodule Trento.HostProjector do
 
   alias Trento.HostReadModel
 
-  alias Trento.Repo
-
   project(
     %HostRegistered{
       host_id: id,


### PR DESCRIPTION
This PR adds an integration service to interact with a generic checks runner and a mock runner we can use in development to simulate a real runner.

TODO:
- add runner webhook endpoint
- consume the callbacks from the mock runner
- refactor/rewrite the checks domain logic in the cluster aggregate
- wire-up 