### PR TITLE
Update catalog frontend

### DIFF
--- a/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
@@ -18,9 +18,9 @@ const ChecksCatalog = () => {
   const catalog = useSelector((state) => state.catalog);
   const catalogData = catalog.data;
   const catalogError = catalog.error;
+  const loading = catalog.loading;
   const providers = catalogData.map((provider) => provider.provider);
   const [selected, setSelected] = useState(providers[0]);
-  const [loading, setLoading] = useState(true);
 
   const dispatchUpdateCatalog = () => {
     dispatch({
@@ -29,7 +29,6 @@ const ChecksCatalog = () => {
   }
 
   useEffect(() => {
-    setLoading(false);
     setSelected(providers[0]);
   }, [providers[0]]);
 

--- a/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
@@ -7,6 +7,10 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
 import ProviderSelection from './ProviderSelection';
+import NotificationBox from '../NotificationBox';
+import LoadingBox from '../LoadingBox';
+
+import { EOS_ERROR } from 'eos-icons-react';
 
 const ChecksCatalog = () => {
   const dispatch = useDispatch();
@@ -16,16 +20,37 @@ const ChecksCatalog = () => {
   const catalogError = catalog.error;
   const providers = catalogData.map((provider) => provider.provider);
   const [selected, setSelected] = useState(providers[0]);
+  const [loading, setLoading] = useState(true);
+
+  const dispatchUpdateCatalog = () => {
+    dispatch({
+      type: 'UPDATE_CATALOG',
+    });
+  }
 
   useEffect(() => {
+    setLoading(false);
     setSelected(providers[0]);
   }, [providers[0]]);
 
   useEffect(() => {
-    dispatch({
-      type: 'UPDATE_CATALOG',
-    });;
+    dispatchUpdateCatalog();
   }, [dispatch]);
+
+  if (loading) {
+    return <LoadingBox text="Loading checks catalog..." />;
+  }
+
+  if (catalogError) {
+    return (
+      <NotificationBox
+        icon={<EOS_ERROR className="m-auto" color="red" size="xl" />}
+        text={catalogError}
+        buttonText="Try again"
+        buttonOnClick={dispatchUpdateCatalog}
+      />
+    );
+  }
 
   return (
     <div>

--- a/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
@@ -15,10 +15,9 @@ import { EOS_ERROR } from 'eos-icons-react';
 const ChecksCatalog = () => {
   const dispatch = useDispatch();
 
-  const catalog = useSelector((state) => state.catalog);
-  const catalogData = catalog.data;
-  const catalogError = catalog.error;
-  const loading = catalog.loading;
+  const [catalogData, catalogError, loading] = useSelector(
+    (state) => ([state.catalog.data, state.catalog.error, state.catalog.loading]))
+
   const providers = catalogData.map((provider) => provider.provider);
   const [selected, setSelected] = useState(providers[0]);
 

--- a/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 
 import { Disclosure, Transition } from '@headlessui/react';
 
@@ -9,13 +9,23 @@ import remarkGfm from 'remark-gfm';
 import ProviderSelection from './ProviderSelection';
 
 const ChecksCatalog = () => {
-  const catalog = useSelector((state) => state.catalog.catalog);
-  const providers = catalog.map((provider) => provider.provider);
+  const dispatch = useDispatch();
+
+  const catalog = useSelector((state) => state.catalog);
+  const catalogData = catalog.data;
+  const catalogError = catalog.error;
+  const providers = catalogData.map((provider) => provider.provider);
   const [selected, setSelected] = useState(providers[0]);
 
   useEffect(() => {
     setSelected(providers[0]);
   }, [providers[0]]);
+
+  useEffect(() => {
+    dispatch({
+      type: 'UPDATE_CATALOG',
+    });;
+  }, [dispatch]);
 
   return (
     <div>
@@ -24,7 +34,7 @@ const ChecksCatalog = () => {
         selected={selected}
         onChange={setSelected}
       />
-      {catalog
+      {catalogData
         .filter((provider) => provider.provider == selected)
         .map(({ _, groups }) =>
           groups.map(({ group, checks }) => (

--- a/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
@@ -15,8 +15,11 @@ import { EOS_ERROR } from 'eos-icons-react';
 const ChecksCatalog = () => {
   const dispatch = useDispatch();
 
-  const [catalogData, catalogError, loading] = useSelector(
-    (state) => ([state.catalog.data, state.catalog.error, state.catalog.loading]))
+  const [catalogData, catalogError, loading] = useSelector((state) => [
+    state.catalog.data,
+    state.catalog.error,
+    state.catalog.loading,
+  ]);
 
   const providers = catalogData.map((provider) => provider.provider);
   const [selected, setSelected] = useState(providers[0]);
@@ -25,7 +28,7 @@ const ChecksCatalog = () => {
     dispatch({
       type: 'UPDATE_CATALOG',
     });
-  }
+  };
 
   useEffect(() => {
     setSelected(providers[0]);

--- a/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
@@ -7,8 +7,8 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
 import ProviderSelection from './ProviderSelection';
-import NotificationBox from '../NotificationBox';
-import LoadingBox from '../LoadingBox';
+import NotificationBox from '@components/NotificationBox';
+import LoadingBox from '@components/LoadingBox';
 
 import { EOS_ERROR } from 'eos-icons-react';
 

--- a/assets/js/components/ChecksResults.jsx
+++ b/assets/js/components/ChecksResults.jsx
@@ -2,8 +2,11 @@ import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useSelector, useDispatch  } from 'react-redux';
 
-import { EOS_LENS_FILLED } from 'eos-icons-react';
+import { EOS_LENS_FILLED, EOS_ERROR } from 'eos-icons-react';
 import Spinner from './Spinner';
+
+import NotificationBox from './NotificationBox';
+import LoadingBox from './LoadingBox';
 
 const getChecksResults = (cluster) => {
   if (cluster) {
@@ -69,6 +72,13 @@ const ChecksResults = () => {
   const catalog = useSelector((state) => state.catalog);
   const catalogData = catalog.data;
   const catalogError = catalog.error;
+  const loading = catalog.loading;
+
+  const dispatchUpdateCatalog = () => {
+    dispatch({
+      type: 'UPDATE_CATALOG',
+    });
+  }
 
   const checksResults = getChecksResults(cluster);
 
@@ -78,10 +88,23 @@ const ChecksResults = () => {
   const catalogByProvider = getCatalogByProvider(catalogData, 'azure');
 
   useEffect(() => {
-    dispatch({
-      type: 'UPDATE_CATALOG',
-    });
+    dispatchUpdateCatalog();
   }, [dispatch]);
+
+  if (loading) {
+    return <LoadingBox text="Loading checks catalog..." />;
+  }
+
+  if (catalogError) {
+    return (
+      <NotificationBox
+        icon={<EOS_ERROR className="m-auto" color="red" size="xl" />}
+        text={catalogError}
+        buttonText="Try again"
+        buttonOnClick={dispatchUpdateCatalog}
+      />
+    );
+  }
 
   const description = (checkId) => {
     return catalogByProvider?.groups

--- a/assets/js/components/ChecksResults.jsx
+++ b/assets/js/components/ChecksResults.jsx
@@ -69,10 +69,8 @@ const ChecksResults = () => {
     state.clustersList.clusters.find((cluster) => cluster.id === clusterID)
   );
 
-  const catalog = useSelector((state) => state.catalog);
-  const catalogData = catalog.data;
-  const catalogError = catalog.error;
-  const loading = catalog.loading;
+  const [catalogData, catalogError, loading] = useSelector(
+    (state) => ([state.catalog.data, state.catalog.error, state.catalog.loading]))
 
   const dispatchUpdateCatalog = () => {
     dispatch({

--- a/assets/js/components/ChecksResults.jsx
+++ b/assets/js/components/ChecksResults.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch  } from 'react-redux';
 
 import { EOS_LENS_FILLED } from 'eos-icons-react';
 import Spinner from './Spinner';
@@ -31,8 +31,8 @@ const getHostname =
     }, '');
   };
 
-const getCatalogByProvider = (catalogProvider) => (state) => {
-  return state.catalog.catalog.find(
+const getCatalogByProvider = (catalog, catalogProvider) => {
+  return catalog.find(
     ({ provider }) => provider === catalogProvider
   );
 };
@@ -60,20 +60,31 @@ const getResultIcon = (result) => {
 };
 
 const ChecksResults = () => {
+  const dispatch = useDispatch();
   const { clusterID } = useParams();
   const cluster = useSelector((state) =>
     state.clustersList.clusters.find((cluster) => cluster.id === clusterID)
   );
+
+  const catalog = useSelector((state) => state.catalog);
+  const catalogData = catalog.data;
+  const catalogError = catalog.error;
 
   const checksResults = getChecksResults(cluster);
 
   const hostname = getHostname(useSelector((state) => state.hostsList.hosts));
 
   // FIXME: Check the provider by cluster
-  const catalog = useSelector(getCatalogByProvider('azure'));
+  const catalogByProvider = getCatalogByProvider(catalogData, 'azure');
+
+  useEffect(() => {
+    dispatch({
+      type: 'UPDATE_CATALOG',
+    });
+  }, [dispatch]);
 
   const description = (checkId) => {
-    return catalog?.groups
+    return catalogByProvider?.groups
       ?.flatMap(({ checks }) => checks)
       .find(({ id }) => id === checkId).description;
   };

--- a/assets/js/components/ChecksResults.jsx
+++ b/assets/js/components/ChecksResults.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { useSelector, useDispatch  } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 
 import { EOS_LENS_FILLED, EOS_ERROR } from 'eos-icons-react';
 import Spinner from './Spinner';
@@ -35,9 +35,7 @@ const getHostname =
   };
 
 const getCatalogByProvider = (catalog, catalogProvider) => {
-  return catalog.find(
-    ({ provider }) => provider === catalogProvider
-  );
+  return catalog.find(({ provider }) => provider === catalogProvider);
 };
 
 const sortChecksResults = (checksResults = [], group) => {
@@ -69,14 +67,17 @@ const ChecksResults = () => {
     state.clustersList.clusters.find((cluster) => cluster.id === clusterID)
   );
 
-  const [catalogData, catalogError, loading] = useSelector(
-    (state) => ([state.catalog.data, state.catalog.error, state.catalog.loading]))
+  const [catalogData, catalogError, loading] = useSelector((state) => [
+    state.catalog.data,
+    state.catalog.error,
+    state.catalog.loading,
+  ]);
 
   const dispatchUpdateCatalog = () => {
     dispatch({
       type: 'UPDATE_CATALOG',
     });
-  }
+  };
 
   const checksResults = getChecksResults(cluster);
 

--- a/assets/js/components/ChecksSelection.jsx
+++ b/assets/js/components/ChecksSelection.jsx
@@ -33,14 +33,17 @@ const ChecksSelection = () => {
   const isSelected = (check_id) =>
     selectedChecks ? selectedChecks.includes(check_id) : false;
 
-  const [catalogData, catalogError, loading] = useSelector(
-    (state) => ([state.catalog.data, state.catalog.error, state.catalog.loading]))
+  const [catalogData, catalogError, loading] = useSelector((state) => [
+    state.catalog.data,
+    state.catalog.error,
+    state.catalog.loading,
+  ]);
 
   const dispatchUpdateCatalog = () => {
     dispatch({
       type: 'UPDATE_CATALOG',
     });
-  }
+  };
 
   useEffect(() => {
     if (cluster) {

--- a/assets/js/components/ChecksSelection.jsx
+++ b/assets/js/components/ChecksSelection.jsx
@@ -4,6 +4,11 @@ import { useParams, useNavigate } from 'react-router-dom';
 
 import { Switch } from '@headlessui/react';
 
+import NotificationBox from './NotificationBox';
+import LoadingBox from './LoadingBox';
+
+import { EOS_ERROR } from 'eos-icons-react';
+
 function classNames(...classes) {
   return classes.filter(Boolean).join(' ');
 }
@@ -21,6 +26,7 @@ const ChecksSelection = () => {
   const catalog = useSelector((state) => state.catalog);
   const catalogData = catalog.data;
   const catalogError = catalog.error;
+  const loading = catalog.loading;
 
   const clusters = useSelector((state) => state.clustersList.clusters);
   const cluster = clusters.find((cluster) => cluster.id === clusterID);
@@ -32,6 +38,12 @@ const ChecksSelection = () => {
   const isSelected = (check_id) =>
     selectedChecks ? selectedChecks.includes(check_id) : false;
 
+  const dispatchUpdateCatalog = () => {
+    dispatch({
+      type: 'UPDATE_CATALOG',
+    });
+  }
+
   useEffect(() => {
     if (cluster) {
       setSelectedChecks(cluster.selected_checks ? cluster.selected_checks : []);
@@ -39,10 +51,23 @@ const ChecksSelection = () => {
   }, [cluster]);
 
   useEffect(() => {
-    dispatch({
-      type: 'UPDATE_CATALOG',
-    });
+    dispatchUpdateCatalog();
   }, [dispatch]);
+
+  if (loading) {
+    return <LoadingBox text="Loading checks catalog..." />;
+  }
+
+  if (catalogError) {
+    return (
+      <NotificationBox
+        icon={<EOS_ERROR className="m-auto" color="red" size="xl" />}
+        text={catalogError}
+        buttonText="Try again"
+        buttonOnClick={dispatchUpdateCatalog}
+      />
+    );
+  }
 
   return (
     <div>

--- a/assets/js/components/ChecksSelection.jsx
+++ b/assets/js/components/ChecksSelection.jsx
@@ -18,7 +18,10 @@ const ChecksSelection = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
 
-  const catalog = useSelector((state) => state.catalog.catalog);
+  const catalog = useSelector((state) => state.catalog);
+  const catalogData = catalog.data;
+  const catalogError = catalog.error;
+
   const clusters = useSelector((state) => state.clustersList.clusters);
   const cluster = clusters.find((cluster) => cluster.id === clusterID);
 
@@ -35,9 +38,15 @@ const ChecksSelection = () => {
     }
   }, [cluster]);
 
+  useEffect(() => {
+    dispatch({
+      type: 'UPDATE_CATALOG',
+    });
+  }, [dispatch]);
+
   return (
     <div>
-      {catalog
+      {catalogData
         .flatMap(({ _provider, groups }) => groups)
         .map(({ group, checks }) => (
           <div

--- a/assets/js/components/ChecksSelection.jsx
+++ b/assets/js/components/ChecksSelection.jsx
@@ -23,11 +23,6 @@ const ChecksSelection = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
 
-  const catalog = useSelector((state) => state.catalog);
-  const catalogData = catalog.data;
-  const catalogError = catalog.error;
-  const loading = catalog.loading;
-
   const clusters = useSelector((state) => state.clustersList.clusters);
   const cluster = clusters.find((cluster) => cluster.id === clusterID);
 
@@ -37,6 +32,9 @@ const ChecksSelection = () => {
 
   const isSelected = (check_id) =>
     selectedChecks ? selectedChecks.includes(check_id) : false;
+
+  const [catalogData, catalogError, loading] = useSelector(
+    (state) => ([state.catalog.data, state.catalog.error, state.catalog.loading]))
 
   const dispatchUpdateCatalog = () => {
     dispatch({
@@ -71,7 +69,7 @@ const ChecksSelection = () => {
 
   return (
     <div>
-      {catalogData
+      {catalogData //FIXME: Catalog must be filtered by this cluster provider
         .flatMap(({ _provider, groups }) => groups)
         .map(({ group, checks }) => (
           <div

--- a/assets/js/components/LoadingBox.jsx
+++ b/assets/js/components/LoadingBox.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { EOS_LOADING_ANIMATED } from 'eos-icons-react';
+
+const LoadingBox = ({ text }) => {
+  return (
+    <div className="shadow-lg rounded-2xl p-4 bg-white dark:bg-gray-800 w-1/2 m-auto">
+      <div className="w-full h-full text-center">
+        <div className="flex h-full flex-col justify-between">
+          <EOS_LOADING_ANIMATED className="m-auto" color="green" size="xl" />
+          <p className="text-gray-600 dark:text-gray-100 text-md py-2 px-6">
+            {text}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LoadingBox;

--- a/assets/js/components/NotificationBox.jsx
+++ b/assets/js/components/NotificationBox.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+const NotificationBox = ({ icon, text, buttonText, buttonOnClick }) => {
+  return (
+    <div className="shadow-lg rounded-2xl p-4 bg-white dark:bg-gray-800 w-1/2 m-auto">
+      <div className="w-full h-full text-center">
+        <div className="flex h-full flex-col justify-between">
+          {icon}
+          <p className="text-gray-600 dark:text-gray-100 text-md py-2 px-6">
+            {text}
+          </p>
+          {buttonText ? (
+            <div className="flex items-center justify-between gap-4 mt-8">
+              <button
+                type="button"
+                onClick={buttonOnClick}
+                className="py-2 px-4 bg-sky-400 text-white w-32 text-center text-base font-semibold shadow-md rounded-lg m-auto"
+              >
+                {buttonText}
+              </button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NotificationBox;

--- a/assets/js/state/catalog.js
+++ b/assets/js/state/catalog.js
@@ -2,7 +2,8 @@ import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
   loading: false,
-  catalog: [],
+  data: [],
+  error: "",
 };
 
 export const catalogSlice = createSlice({
@@ -10,7 +11,13 @@ export const catalogSlice = createSlice({
   initialState,
   reducers: {
     setCatalog: (state, action) => {
-      state.catalog = action.payload;
+      if (action.payload.error) {
+        state.error = action.payload.error;
+        state.data = [];
+      } else {
+        state.error = "";
+        state.data = action.payload;
+      }
     },
   },
 });

--- a/assets/js/state/catalog.js
+++ b/assets/js/state/catalog.js
@@ -8,7 +8,7 @@ const errorMessages = {
 const initialState = {
   loading: false,
   data: [],
-  error: "",
+  error: '',
 };
 
 export const catalogSlice = createSlice({
@@ -18,18 +18,19 @@ export const catalogSlice = createSlice({
     setCatalog: (state, action) => {
       if (action.payload.loading) {
         state.loading = true;
-        return
+        return;
       }
 
       state.loading = false;
 
       if (action.payload.error) {
-        state.error = errorMessages[action.payload.error] || errorMessages["default"];
+        state.error =
+          errorMessages[action.payload.error] || errorMessages['default'];
         state.data = [];
-        return
+        return;
       }
 
-      state.error = "";
+      state.error = '';
       state.data = action.payload;
     },
   },

--- a/assets/js/state/catalog.js
+++ b/assets/js/state/catalog.js
@@ -16,13 +16,21 @@ export const catalogSlice = createSlice({
   initialState,
   reducers: {
     setCatalog: (state, action) => {
+      if (action.payload.loading) {
+        state.loading = true;
+        return
+      }
+
+      state.loading = false;
+
       if (action.payload.error) {
         state.error = errorMessages[action.payload.error] || errorMessages["default"];
         state.data = [];
-      } else {
-        state.error = "";
-        state.data = action.payload;
+        return
       }
+
+      state.error = "";
+      state.data = action.payload;
     },
   },
 });

--- a/assets/js/state/catalog.js
+++ b/assets/js/state/catalog.js
@@ -1,5 +1,10 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+const errorMessages = {
+  not_ready: 'The catalog is being built. Try again in some few moments',
+  default: 'Unexpected error happened trying to get the checks catalog',
+};
+
 const initialState = {
   loading: false,
   data: [],
@@ -12,7 +17,7 @@ export const catalogSlice = createSlice({
   reducers: {
     setCatalog: (state, action) => {
       if (action.payload.error) {
-        state.error = action.payload.error;
+        state.error = errorMessages[action.payload.error] || errorMessages["default"];
         state.data = [];
       } else {
         state.error = "";

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -426,6 +426,7 @@ function* watchDatabase() {
 }
 
 function* updateCatalog() {
+  yield put(setCatalog({loading: true}))
   try {
     const { data: catalog } = yield call(get, '/api/checks/catalog');
     yield put(setCatalog(catalog));

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -85,9 +85,6 @@ function* initialDataFetch() {
   const { data: databases } = yield call(get, '/api/databases');
   yield put(setDatabases(databases));
   yield put(stopDatabasesLoading());
-
-  const { data: catalog } = yield call(get, '/api/checks/catalog');
-  yield put(setCatalog(catalog));
 }
 
 function* hostRegistered({ payload }) {
@@ -428,6 +425,24 @@ function* watchDatabase() {
   );
 }
 
+function* updateCatalog() {
+  try {
+    const { data: catalog } = yield call(get, '/api/checks/catalog');
+    yield put(setCatalog(catalog));
+  }
+  catch(error) {
+    yield put(
+      setCatalog({
+        error: error.response.data.error,
+      }),
+    );
+  }
+}
+
+function* watchCatalogUpdate() {
+  yield takeEvery('UPDATE_CATALOG', updateCatalog);
+}
+
 export default function* rootSaga() {
   yield all([
     initialDataFetch(),
@@ -447,5 +462,6 @@ export default function* rootSaga() {
     watchClusterHealthChanged(),
     watchSapSystem(),
     watchDatabase(),
+    watchCatalogUpdate(),
   ]);
 }

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -426,16 +426,15 @@ function* watchDatabase() {
 }
 
 function* updateCatalog() {
-  yield put(setCatalog({loading: true}))
+  yield put(setCatalog({ loading: true }));
   try {
     const { data: catalog } = yield call(get, '/api/checks/catalog');
     yield put(setCatalog(catalog));
-  }
-  catch(error) {
+  } catch (error) {
     yield put(
       setCatalog({
         error: error.response.data.error,
-      }),
+      })
     );
   }
 }


### PR DESCRIPTION
Update how the catalog data is obtained to add some error handling. This way, we can show some error messages if something related to the checks catalog failed. **This views are not visiualized in the dev environment, we need a real runner. The mocked runner always answers with positive response**

Here some picks:
![image](https://user-images.githubusercontent.com/36370954/161275155-8a3c5c53-c9bb-4506-9a3e-5d2484a96ef6.png)
![image](https://user-images.githubusercontent.com/36370954/161275312-078270d5-3858-40cd-b02f-9a84a5dc43e5.png)

(The loading page doesn't show up a lot of time, but well, better than nothing I guess).

Things to consider:
- We can improve or change the error notification boxes. In this case, as we don't have any data, I didn't want to put an empty placeholder, or a toast, as time to time, the runner needs some time to build the catalog, so I thought having a retry button was a good idea. **We can change back to simple toasts in any case**
- A lot of duplicated code in the Components side... We can iterate on how to make the code more reusable
- In the future, we can try to unify the Catalog and checks selection views, as they are almost identical but have some differences. I didn't want to embark on creating more generic components, as it makes the thing more complex. Maybe it can come in next PRs
- We will need to add some `Back` buttons in the check selection and check results views, otherwise there is not direct path back to the checked cluster