### PR TITLE
Add database tag endpoint

### DIFF
--- a/lib/trento/application/read_models/database_read_model.ex
+++ b/lib/trento/application/read_models/database_read_model.ex
@@ -17,6 +17,8 @@ defmodule Trento.DatabaseReadModel do
     field :sid, :string
     field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
 
+    has_many :tags, Trento.Tag, foreign_key: :resource_id
+
     has_many :database_instances, DatabaseInstanceReadModel,
       references: :id,
       foreign_key: :sap_system_id,

--- a/lib/trento/application/usecases/sap_systems/sap_systems.ex
+++ b/lib/trento/application/usecases/sap_systems/sap_systems.ex
@@ -27,5 +27,6 @@ defmodule Trento.SapSystems do
     DatabaseReadModel
     |> Repo.all()
     |> Repo.preload(:database_instances)
+    |> Repo.preload(:tags)
   end
 end

--- a/lib/trento/application/usecases/sap_systems/sap_systems.ex
+++ b/lib/trento/application/usecases/sap_systems/sap_systems.ex
@@ -25,6 +25,7 @@ defmodule Trento.SapSystems do
   @spec get_all_databases :: [map]
   def get_all_databases do
     DatabaseReadModel
+    |> order_by(asc: :sid)
     |> Repo.all()
     |> Repo.preload(:database_instances)
     |> Repo.preload(:tags)

--- a/lib/trento_web/controllers/sap_system_controller.ex
+++ b/lib/trento_web/controllers/sap_system_controller.ex
@@ -59,7 +59,7 @@ defmodule TrentoWeb.SapSystemController do
   end
 
   # FIXME: refactor tags api, we just need a generic tag API
-  def create_db_tag(conn, %{
+  def create_database_tag(conn, %{
         "id" => resource_id,
         "value" => value
       }) do

--- a/lib/trento_web/controllers/sap_system_controller.ex
+++ b/lib/trento_web/controllers/sap_system_controller.ex
@@ -57,4 +57,22 @@ defmodule TrentoWeb.SapSystemController do
         send_resp(conn, :not_found, "")
     end
   end
+
+  # FIXME: refactor tags api, we just need a generic tag API
+  def create_db_tag(conn, %{
+        "id" => resource_id,
+        "value" => value
+      }) do
+    case Tags.create_tag(value, resource_id, "database") do
+      {:ok, _} ->
+        conn
+        |> put_status(:created)
+        |> json(%{value: value})
+
+      {:error, _} ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{error: "tag creation failed"})
+    end
+  end
 end

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -50,7 +50,10 @@ defmodule TrentoWeb.Router do
     get "/sap_systems", SapSystemController, :list
     post "/sap_systems/:id/tags", SapSystemController, :create_tag
     delete "/sap_systems/:id/tags/:value", SapSystemController, :delete_tag
+
     get "/databases", SapSystemController, :list_databases
+    post "/databases/:id/tags", SapSystemController, :create_db_tag
+    delete "/databases/:id/tags/:value", SapSystemController, :delete_tag
 
     post "/clusters/:cluster_id/checks", ClusterController, :select_checks
 

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -52,7 +52,7 @@ defmodule TrentoWeb.Router do
     delete "/sap_systems/:id/tags/:value", SapSystemController, :delete_tag
 
     get "/databases", SapSystemController, :list_databases
-    post "/databases/:id/tags", SapSystemController, :create_db_tag
+    post "/databases/:id/tags", SapSystemController, :create_database_tag
     delete "/databases/:id/tags/:value", SapSystemController, :delete_tag
 
     post "/clusters/:cluster_id/checks", ClusterController, :select_checks

--- a/test/trento_web/controllers/sap_system_controller_test.exs
+++ b/test/trento_web/controllers/sap_system_controller_test.exs
@@ -43,6 +43,28 @@ defmodule TrentoWeb.SapSystemControllerTest do
 
       assert 404 == conn.status
     end
+
+    test "should add a tag to a database", %{conn: conn} do
+      conn =
+        post(conn, Routes.sap_system_path(conn, :create_database_tag, Faker.UUID.v4()), %{
+          "value" => Faker.Beer.style()
+        })
+
+      assert 201 == conn.status
+    end
+
+    test "should remove a tag from a database", %{conn: conn} do
+      %Tag{
+        id: _id,
+        value: value,
+        resource_id: resource_id,
+        resource_type: _resource_type
+      } = tag()
+
+      conn = delete(conn, Routes.sap_system_path(conn, :delete_tag, resource_id, value))
+
+      assert 204 == conn.status
+    end
   end
 
   describe "list" do
@@ -79,6 +101,43 @@ defmodule TrentoWeb.SapSystemControllerTest do
                %{
                  "id" => ^sap_system_id_3,
                  "sid" => ^sap_system_sid_3
+               }
+             ] = json_response(conn, 200)
+    end
+
+    test "should list all databases", %{conn: conn} do
+      [
+        %{
+          id: database_id_1,
+          sid: database_sid_1
+        },
+        %{
+          id: database_id_2,
+          sid: database_sid_2
+        },
+        %{
+          id: database_id_3,
+          sid: database_sid_3
+        }
+      ] =
+        0..2
+        |> Enum.map(fn _ -> database_projection() end)
+        |> Enum.sort_by(& &1.sid)
+
+      conn = get(conn, Routes.sap_system_path(conn, :list_databases))
+
+      assert [
+               %{
+                 "id" => ^database_id_1,
+                 "sid" => ^database_sid_1
+               },
+               %{
+                 "id" => ^database_id_2,
+                 "sid" => ^database_sid_2
+               },
+               %{
+                 "id" => ^database_id_3,
+                 "sid" => ^database_sid_3
                }
              ] = json_response(conn, 200)
     end


### PR DESCRIPTION
This adds the missing bits and pieces to add endpoint(s) to handle database tags. There is soe further code duplication but we will refactor/improve later when we address #222 