### PR TITLE
Fix boolean usage in docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,6 @@ services:
   grafana:
     image: grafana/grafana:latest
     environment:
-      GF_SECURITY_ALLOW_EMBEDDING: true
+      GF_SECURITY_ALLOW_EMBEDDING: "true"
     ports:
       - 3000:3000


### PR DESCRIPTION
I was experiencing this issue:

```
ERROR: The Compose file './docker-compose.yaml' is invalid because:
services.grafana.environment.GF_SECURITY_ALLOW_EMBEDDING contains true, which is an invalid type, it should be a string, number, or a null
```