### PR TITLE
Add query parameters for catalog controller

### DIFF
--- a/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
@@ -27,6 +27,7 @@ const ChecksCatalog = () => {
   const dispatchUpdateCatalog = () => {
     dispatch({
       type: 'UPDATE_CATALOG',
+      payload: {},
     });
   };
 
@@ -63,7 +64,7 @@ const ChecksCatalog = () => {
       {catalogData
         .filter((provider) => provider.provider == selected)
         .map(({ _, groups }) =>
-          groups.map(({ group, checks }) => (
+          groups?.map(({ group, checks }) => (
             <div
               key={group.id}
               className="bg-white shadow overflow-hidden sm:rounded-md mb-8"

--- a/assets/js/components/ChecksResults.jsx
+++ b/assets/js/components/ChecksResults.jsx
@@ -34,10 +34,6 @@ const getHostname =
     }, '');
   };
 
-const getCatalogByProvider = (catalog, catalogProvider) => {
-  return catalog.find(({ provider }) => provider === catalogProvider);
-};
-
 const sortChecksResults = (checksResults = [], group) => {
   return checksResults.sort((a, b) => {
     if (a.check_id === b.check_id) {
@@ -76,15 +72,13 @@ const ChecksResults = () => {
   const dispatchUpdateCatalog = () => {
     dispatch({
       type: 'UPDATE_CATALOG',
+      payload: { flat: '', provider: 'azure' }, //FIXME: Get provider properly
     });
   };
 
   const checksResults = getChecksResults(cluster);
 
   const hostname = getHostname(useSelector((state) => state.hostsList.hosts));
-
-  // FIXME: Check the provider by cluster
-  const catalogByProvider = getCatalogByProvider(catalogData, 'azure');
 
   useEffect(() => {
     dispatchUpdateCatalog();
@@ -106,9 +100,7 @@ const ChecksResults = () => {
   }
 
   const description = (checkId) => {
-    return catalogByProvider?.groups
-      ?.flatMap(({ checks }) => checks)
-      .find(({ id }) => id === checkId).description;
+    return catalogData.find(({ id }) => id === checkId)?.description;
   };
 
   return (

--- a/assets/js/components/ChecksSelection.jsx
+++ b/assets/js/components/ChecksSelection.jsx
@@ -73,8 +73,8 @@ const ChecksSelection = () => {
 
   return (
     <div>
-      {catalogData[0]?.groups
-        .map(({ group, checks }) => (
+      {catalogData[0]?.groups &&
+        catalogData[0].groups.map(({ group, checks }) => (
           <div
             key={group.id}
             className="bg-white shadow overflow-hidden sm:rounded-md mb-8"

--- a/assets/js/components/ChecksSelection.jsx
+++ b/assets/js/components/ChecksSelection.jsx
@@ -42,6 +42,7 @@ const ChecksSelection = () => {
   const dispatchUpdateCatalog = () => {
     dispatch({
       type: 'UPDATE_CATALOG',
+      payload: { provider: 'azure' }, //FIXME: Get provider properly
     });
   };
 
@@ -72,8 +73,7 @@ const ChecksSelection = () => {
 
   return (
     <div>
-      {catalogData //FIXME: Catalog must be filtered by this cluster provider
-        .flatMap(({ _provider, groups }) => groups)
+      {catalogData[0]?.groups
         .map(({ group, checks }) => (
           <div
             key={group.id}

--- a/assets/js/lib/serialization/index.js
+++ b/assets/js/lib/serialization/index.js
@@ -29,3 +29,10 @@ export const keysToCamel = function (o) {
 
   return o;
 };
+
+export const urlEncode = function (params) {
+  var str = [];
+  for (var p in params)
+    str.push(encodeURIComponent(p) + '=' + encodeURIComponent(params[p]));
+  return str.join('&');
+};

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -1,5 +1,6 @@
 import { get, post } from 'axios';
 import { put, all, call, takeEvery, select } from 'redux-saga/effects';
+import { urlEncode } from '@lib/serialization';
 
 import {
   setHosts,
@@ -425,10 +426,13 @@ function* watchDatabase() {
   );
 }
 
-function* updateCatalog() {
+function* updateCatalog({ payload }) {
   yield put(setCatalog({ loading: true }));
   try {
-    const { data: catalog } = yield call(get, '/api/checks/catalog');
+    const { data: catalog } = yield call(
+      get,
+      `/api/checks/catalog?${urlEncode(payload)}`
+    );
     yield put(setCatalog(catalog));
   } catch (error) {
     yield put(

--- a/lib/trento/application/integration/checks/checks.ex
+++ b/lib/trento/application/integration/checks/checks.ex
@@ -31,9 +31,9 @@ defmodule Trento.Integration.Checks do
     end
   end
 
-  @spec get_catalog_by_provider ::
+  @spec get_catalog_grouped_by_provider ::
           {:ok, CatalogDto.t()} | {:error, any}
-  def get_catalog_by_provider do
+  def get_catalog_grouped_by_provider do
     case get_catalog() do
       {:ok, content} ->
         group_by_provider_by_group(content.checks)

--- a/lib/trento_web/controllers/catalog_controller.ex
+++ b/lib/trento_web/controllers/catalog_controller.ex
@@ -4,10 +4,15 @@ defmodule TrentoWeb.CatalogController do
   alias Trento.Integration.Checks
 
   @spec checks_catalog(Plug.Conn.t(), map) :: Plug.Conn.t()
-  def checks_catalog(conn, %{"flat" => ""}) do
-    case Checks.get_catalog() do
-      {:ok, catalog} ->
-        json(conn, catalog.checks)
+  def checks_catalog(conn, params) do
+    with {:ok, content} <- get_catalog(params),
+         {:ok, filtered_content} <- filter_by_provider(content, params) do
+      json(conn, filtered_content)
+    else
+      {:error, :not_found} ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{error: :not_found})
 
       {:error, reason} ->
         conn
@@ -16,15 +21,38 @@ defmodule TrentoWeb.CatalogController do
     end
   end
 
-  def checks_catalog(conn, _) do
-    case Checks.get_catalog_by_provider() do
+  defp get_catalog(%{"flat" => ""}) do
+    case Checks.get_catalog() do
       {:ok, catalog} ->
-        json(conn, catalog.providers)
+        {:ok, catalog.checks}
 
       {:error, reason} ->
-        conn
-        |> put_status(:bad_request)
-        |> json(%{error: reason})
+        {:error, reason}
     end
+  end
+
+  defp get_catalog(_) do
+    case Checks.get_catalog_by_provider() do
+      {:ok, catalog} ->
+        {:ok, catalog.providers}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp filter_by_provider(catalog, %{"provider" => provider}) do
+    filtered_catalog =
+      catalog
+      |> Enum.filter(fn x -> Atom.to_string(x.provider) == provider end)
+
+    case length(filtered_catalog) > 0 do
+      true -> {:ok, filtered_catalog}
+      false -> {:error, :not_found}
+    end
+  end
+
+  defp filter_by_provider(catalog, _) do
+    {:ok, catalog}
   end
 end

--- a/lib/trento_web/controllers/catalog_controller.ex
+++ b/lib/trento_web/controllers/catalog_controller.ex
@@ -32,7 +32,7 @@ defmodule TrentoWeb.CatalogController do
   end
 
   defp get_catalog(_) do
-    case Checks.get_catalog_by_provider() do
+    case Checks.get_catalog_grouped_by_provider() do
       {:ok, catalog} ->
         {:ok, catalog.providers}
 

--- a/test/trento/application/integration/checks/checks_test.exs
+++ b/test/trento/application/integration/checks/checks_test.exs
@@ -285,6 +285,6 @@ defmodule Trento.Integration.ChecksTest do
       ]
     }
 
-    assert {:ok, catalog_by_provider} == Checks.get_catalog_by_provider()
+    assert {:ok, catalog_by_provider} == Checks.get_catalog_grouped_by_provider()
   end
 end

--- a/test/trento_web/controllers/catalog_controller_test.exs
+++ b/test/trento_web/controllers/catalog_controller_test.exs
@@ -148,6 +148,74 @@ defmodule TrentoWeb.CatalogControllerTest do
     assert expected_json == json_response(conn, 200)
   end
 
+  test "should return a filtered flat catalog", %{conn: conn} do
+    raw_catalog = load_runner_fixture("catalog")
+
+    Trento.Integration.Checks.Mock
+    |> expect(:get_catalog, fn -> FlatCatalogDto.new(%{checks: raw_catalog}) end)
+
+    conn =
+      get(conn, Routes.catalog_path(conn, :checks_catalog), %{
+        "flat" => "",
+        "provider" => "azure"
+      })
+
+    expected_json = [
+      %{
+        "provider" => "azure",
+        "description" => "description 1",
+        "group" => "Group 1",
+        "id" => "1",
+        "implementation" => "implementation 1",
+        "labels" => "labels",
+        "name" => "test 1",
+        "remediation" => "remediation 1"
+      },
+      %{
+        "provider" => "azure",
+        "description" => "description 2",
+        "group" => "Group 1",
+        "id" => "2",
+        "implementation" => "implementation 2",
+        "labels" => "labels",
+        "name" => "test 2",
+        "remediation" => "remediation 2"
+      },
+      %{
+        "description" => "description 3",
+        "group" => "Group 2",
+        "id" => "3",
+        "implementation" => "implementation 3",
+        "labels" => "labels",
+        "name" => "test 3",
+        "provider" => "azure",
+        "remediation" => "remediation 3"
+      },
+      %{
+        "description" => "description 4",
+        "group" => "Group 2",
+        "id" => "4",
+        "implementation" => "implementation 4",
+        "labels" => "labels",
+        "name" => "test 4",
+        "provider" => "azure",
+        "remediation" => "remediation 4"
+      },
+      %{
+        "description" => "description 5",
+        "group" => "Group 3",
+        "id" => "5",
+        "implementation" => "implementation 5",
+        "labels" => "labels",
+        "name" => "test 5",
+        "provider" => "azure",
+        "remediation" => "remediation 5"
+      }
+    ]
+
+    assert expected_json == json_response(conn, 200)
+  end
+
   test "should return a flat catalog", %{conn: conn} do
     raw_catalog = load_runner_fixture("catalog")
 


### PR DESCRIPTION
Some small improvements on the catalog controller usage:
- Error handling in the frontend
- Provide the option to filter by provider from the backed (`api/cluster/checks?provider=azure`)
- Use the flatten version of the data in the frontend
- Rename `get_catalog_by_provider` to `get_catalog_grouped_by_provider` to be more meaningful