### PR TITLE
Optional alerting config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,54 @@
-# trento
+# Trento
 
 An open cloud-native web console improving on the work day of SAP Applications administrators.
 
 # Table of contents
 
+- [Trento](#trento)
+- [Table of contents](#table-of-contents)
+- [Features](#features)
+  - [Alerting](#alerting)
+    - [Enabling Alerting](#enabling-alerting)
+    - [Delivery and Recipient](#delivery-and-recipient)
 - [Hack on the trento](#hack-on-the-trento)
   - [Install dependencies](#install-dependencies)
   - [Development environment](#development-environment)
   - [Setup trento](#setup-trento)
   - [Start trento in the repl](#start-trento-in-the-repl)
   - [Scenario loading with photofinish](#scenario-loading-with-photofinish)
+
+# Features
+
+## Alerting
+Alerting feature notifies the SAP Administrator about important updated in the Landscape being monitored/observed by Trento.
+
+Some of the notified events:
+- **Host heartbeat failed**
+- **Cluster Health detected critical**
+- **Database Health detected critical**
+- **SAP System Health detected critical**
+- ...
+
+The feature is **disabled by default**.
+### Enabling Alerting
+Provide `ENABLE_ALERTING=true` as an environment variable when starting Trento.
+### Delivery and Recipient
+A notification needs to be _delivered to someone_ in _some way_.
+
+With alerting enabled some extra configuration is needed to define the recipient and the delivery mechanism.
+
+Currently **SMTP** is the **only supported delivery mechanism** for notification.
+
+```
+ALERT_RECIPIENT=recipient@yourmail.com
+SMTP_SERVER=your.smtp-server.com
+SMTP_PORT=2525
+SMTP_USER=user
+SMTP_PASSWORD=password
+```
+
+### Enabling Alerting at a later stage
+If your current Trento installation has Alerting disabled, you can enable it by... (TBD)
 
 # Hack on the trento
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -30,7 +30,9 @@ config :trento, Trento.Mailer, adapter: Swoosh.Adapters.Local
 config :swoosh, :api_client, false
 
 # configure the recipient for alert notifications
-config :trento, :alerting, recipient: "admin@trento.io"
+config :trento, :alerting,
+  enabled: true,
+  recipient: "admin@trento.io"
 
 # Configure esbuild (the version is required)
 config :esbuild,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -96,38 +96,17 @@ if config_env() == :prod do
   #
   # See https://hexdocs.pm/swoosh/Swoosh.html#module-installation for details.
 
-  smtp_server =
-    System.get_env("SMTP_SERVER") ||
-      raise """
-      environment variable SMTP_SERVER is missing.
-      For example: smtp.yourserver.com
-      """
-
-  smtp_user =
-    System.get_env("SMTP_USER") ||
-      raise "environment variable SMTP_USER is missing."
-
-  smtp_password =
-    System.get_env("SMTP_PASSWORD") ||
-      raise "environment variable SMTP_PASSWORD is missing."
-
-  smtp_port =
-    System.get_env("SMTP_PORT") ||
-      raise "environment variable SMTP_PORT is missing."
+  config :trento, :alerting,
+    enabled: System.get_env("ENABLE_ALERTING", "false") == "true",
+    recipient: System.get_env("ALERT_RECIPIENT") || ""
 
   config :trento, Trento.Mailer,
     adapter: Swoosh.Adapters.SMTP,
-    relay: smtp_server,
-    username: smtp_user,
-    password: smtp_password,
-    port: smtp_port,
+    relay: System.get_env("SMTP_SERVER") || "",
+    port: System.get_env("SMTP_PORT") || "",
+    username: System.get_env("SMTP_USER") || "",
+    password: System.get_env("SMTP_PASSWORD") || "",
     auth: :always,
     ssl: :if_available,
     tls: :if_available
-
-  alert_recipient =
-    System.get_env("ALERT_RECIPIENT") ||
-      raise "environment variable ALERT_RECIPIENT is missing."
-
-  config :trento, :alerting, recipient: alert_recipient
 end

--- a/lib/trento/application/event_handlers/alerts_event_handler.ex
+++ b/lib/trento/application/event_handlers/alerts_event_handler.ex
@@ -20,7 +20,7 @@ defmodule Trento.AlertsEventHandler do
         %HeartbeatFailed{host_id: host_id},
         _metadata
       ) do
-    Alerting.notify_host_heartbeating_failure(host_id)
+    Alerting.notify_heartbeat_failed(host_id)
   end
 
   def handle(

--- a/test/trento/application/usecases/alerting_test.exs
+++ b/test/trento/application/usecases/alerting_test.exs
@@ -15,7 +15,7 @@ defmodule Trento.Application.UseCases.AlertingTest do
       host_id = Faker.UUID.v4()
       host = host_projection(id: host_id)
 
-      Alerting.notify_host_heartbeating_failure(host_id)
+      Alerting.notify_heartbeat_failed(host_id)
       assert_email_sent(subject: "Trento Alert: Host #{host.hostname} needs attention.")
     end
 


### PR DESCRIPTION
Allows optional alerting config.

By default Alerting is disabled (`ENABLE_ALERTING=false`)

When `ENABLE_ALERTING=true` then smtp settings and recipient are required.

See related helm chart PR https://github.com/trento-project/helm-charts/pull/4