### PR TITLE
Add cluster discovered health 

### DIFF
--- a/lib/trento/application/projectors/cluster_projector.ex
+++ b/lib/trento/application/projectors/cluster_projector.ex
@@ -30,7 +30,8 @@ defmodule Trento.ClusterProjector do
       name: name,
       sid: sid,
       type: type,
-      details: details
+      details: details,
+      health: health
     },
     fn multi ->
       changeset =
@@ -41,7 +42,7 @@ defmodule Trento.ClusterProjector do
           sid: sid,
           type: type,
           details: details,
-          health: :unknown,
+          health: health,
           checks_execution: :not_running
         })
 

--- a/lib/trento/domain/cluster/commands/register_cluster_host.ex
+++ b/lib/trento/domain/cluster/commands/register_cluster_host.ex
@@ -8,7 +8,8 @@ defmodule Trento.Domain.Commands.RegisterClusterHost do
     :host_id,
     :name,
     :type,
-    :designated_controller
+    :designated_controller,
+    :discovered_health
   ]
 
   use Trento.Command
@@ -22,6 +23,7 @@ defmodule Trento.Domain.Commands.RegisterClusterHost do
     field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
     field :sid, :string
     field :designated_controller, :boolean
+    field :discovered_health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
     field :cib_last_written, :string
 
     embeds_one :details, HanaClusterDetails

--- a/lib/trento/domain/cluster/events/cluster_discovered_health_changed.ex
+++ b/lib/trento/domain/cluster/events/cluster_discovered_health_changed.ex
@@ -1,0 +1,12 @@
+defmodule Trento.Domain.Events.ClusterDiscoveredHealthChanged do
+  @moduledoc """
+  This event is emitted when the discovered health of a cluster changes.
+  """
+
+  use Trento.Event
+
+  defevent do
+    field :cluster_id, :string
+    field :discovered_health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+  end
+end

--- a/lib/trento/domain/cluster/events/cluster_registered.ex
+++ b/lib/trento/domain/cluster/events/cluster_registered.ex
@@ -12,6 +12,7 @@ defmodule Trento.Domain.Events.ClusterRegistered do
     field :name, :string
     field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
     field :sid, :string
+    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
 
     embeds_one :details, HanaClusterDetails
   end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -101,6 +101,7 @@ defmodule Trento.Factory do
       name: Keyword.get(attrs, :name, Faker.StarWars.character()),
       sid: Keyword.get(attrs, :sid, Faker.StarWars.planet()),
       details: Keyword.get(attrs, :details, hana_cluster_details_value_object()),
+      health: Keyword.get(attrs, :health, :passing),
       type: Keyword.get(attrs, :type, :hana_scale_up)
     }
   end

--- a/test/trento/application/integration/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/application/integration/discovery/policies/cluster_policy_test.exs
@@ -211,7 +211,8 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
               host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
               name: "hana_cluster",
               sid: "PRD",
-              type: :hana_scale_up
+              type: :hana_scale_up,
+              discovered_health: :passing
             }} ==
              "ha_cluster_discovery_hana_scale_up"
              |> load_discovery_event_fixture()

--- a/test/trento/application/projectors/cluster_projector_test.exs
+++ b/test/trento/application/projectors/cluster_projector_test.exs
@@ -34,6 +34,7 @@ defmodule Trento.ClusterProjectorTest do
     assert event.sid == cluster_projection.sid
     assert StructHelper.to_map(event.details) == cluster_projection.details
     assert event.type == cluster_projection.type
+    assert event.health == cluster_projection.health
   end
 
   test "should update the cluster details when ClusterDetailsUpdated is received" do


### PR DESCRIPTION
This PR adds the discovered health to the cluster health aggregation business logic.
The health is discovered for the HANA cluster in the discovery policy and a new event is emitted if the discovered health has changed. Consequentially a cluster health changed event will be emitted.

TODO:
Since now we are aggregating health from two sources, we should add the checks result health to the execution completed event and to the state of the aggregate, so we can distinguish between the two.