### PR TITLE
Change container tag to trento-web

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -174,7 +174,7 @@ jobs:
       packages: write
     env:
       REGISTRY: ghcr.io
-      IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/trento-web-dev
+      IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/trento-web
       IMAGE_TAG: "${{ (github.event_name == 'release' && github.event.release.tag_name) || (github.event_name == 'push' && github.ref_name == 'main' && 'rolling') || github.sha }}"
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This PR changes the container tag from `trento-web-dev` to `trento-web` overwriting the legacy package