### PR TITLE
Ensure better key presence check in the catalog reducer

### DIFF
--- a/assets/js/components/NotificationBox.jsx
+++ b/assets/js/components/NotificationBox.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import Button from '@components/Button';
+
 const NotificationBox = ({ icon, text, buttonText, buttonOnClick }) => {
   return (
     <div className="shadow-lg rounded-2xl p-4 bg-white dark:bg-gray-800 w-1/2 m-auto">
@@ -10,14 +12,10 @@ const NotificationBox = ({ icon, text, buttonText, buttonOnClick }) => {
             {text}
           </p>
           {buttonText ? (
-            <div className="flex items-center justify-between gap-4 mt-8">
-              <button
-                type="button"
-                onClick={buttonOnClick}
-                className="py-2 px-4 bg-sky-400 text-white w-32 text-center text-base font-semibold shadow-md rounded-lg m-auto"
-              >
+            <div className="flex items-center justify-center gap-4 mt-8">
+              <Button type="primary" className="w-32" onClick={buttonOnClick}>
                 {buttonText}
-              </button>
+              </Button>
             </div>
           ) : null}
         </div>

--- a/assets/js/state/catalog.js
+++ b/assets/js/state/catalog.js
@@ -23,7 +23,7 @@ export const catalogSlice = createSlice({
 
       state.loading = false;
 
-      if (action.payload.error) {
+      if (Object.prototype.hasOwnProperty.call(action.payload, 'error')) {
         state.error =
           errorMessages[action.payload.error] || errorMessages['default'];
         state.data = [];


### PR DESCRIPTION
![2022-04-08-165511_622x232_scrot](https://user-images.githubusercontent.com/20770/162467080-f08dd0e1-6eb6-4a30-acdb-410ba5f074f9.png)

Using the `Button` component inside the notification box about important errors.

Also, ensuring better key presence check for `error` inside the catalog slice.