### PR TITLE
Add missing field to cluster projection

### DIFF
--- a/assets/js/components/ClustersList.jsx
+++ b/assets/js/components/ClustersList.jsx
@@ -86,11 +86,11 @@ const ClustersList = () => {
       },
       {
         title: 'Hosts',
-        key: 'hosts_number'
+        key: 'hosts_number',
       },
       {
         title: 'Resources',
-        key: 'resources_number'
+        key: 'resources_number',
       },
       {
         title: 'Type',

--- a/assets/js/components/ClustersList.jsx
+++ b/assets/js/components/ClustersList.jsx
@@ -85,6 +85,14 @@ const ClustersList = () => {
         filter: true,
       },
       {
+        title: 'Hosts',
+        key: 'hosts_number'
+      },
+      {
+        title: 'Resources',
+        key: 'resources_number'
+      },
+      {
         title: 'Type',
         key: 'type',
         filter: true,
@@ -216,7 +224,8 @@ const ClustersList = () => {
       id: cluster.id,
       sid: cluster.sid,
       type: cluster.type,
-      hasDetails: cluster.details != null,
+      hosts_number: cluster.hosts_number,
+      resources_number: cluster.resources_number,
       checks_execution: cluster.checks_execution,
       selected_checks: cluster.selected_checks,
       tags: (cluster.tags && cluster.tags.map((tag) => tag.value)) || [],

--- a/lib/trento/application/integration/discovery/policies/cluster_policy.ex
+++ b/lib/trento/application/integration/discovery/policies/cluster_policy.ex
@@ -18,8 +18,8 @@ defmodule Trento.Integration.Discovery.ClusterPolicy do
             "Crmmon" => %{
               "Summary" => %{
                 "LastChange" => %{"Time" => cib_last_written},
-                "Resources" => %{"Number" => _resources_number},
-                "Nodes" => %{"Number" => _hosts_number}
+                "Resources" => %{"Number" => resources_number},
+                "Nodes" => %{"Number" => hosts_number}
               }
             }
           } = payload
@@ -35,6 +35,8 @@ defmodule Trento.Integration.Discovery.ClusterPolicy do
       sid: sid,
       type: cluster_type,
       designated_controller: designated_controller,
+      resources_number: resources_number,
+      hosts_number: hosts_number,
       details: details,
       discovered_health: parse_cluster_health(details, cluster_type),
       cib_last_written: cib_last_written

--- a/lib/trento/application/projectors/cluster_projector.ex
+++ b/lib/trento/application/projectors/cluster_projector.ex
@@ -30,6 +30,8 @@ defmodule Trento.ClusterProjector do
       name: name,
       sid: sid,
       type: type,
+      resources_number: resources_number,
+      hosts_number: hosts_number,
       details: details,
       health: health
     },
@@ -41,6 +43,8 @@ defmodule Trento.ClusterProjector do
           name: name,
           sid: sid,
           type: type,
+          resources_number: resources_number,
+          hosts_number: hosts_number,
           details: details,
           health: health,
           checks_execution: :not_running
@@ -101,6 +105,8 @@ defmodule Trento.ClusterProjector do
       name: name,
       sid: sid,
       type: type,
+      resources_number: resources_number,
+      hosts_number: hosts_number,
       details: details
     },
     fn multi ->
@@ -110,6 +116,8 @@ defmodule Trento.ClusterProjector do
           name: name,
           sid: sid,
           type: type,
+          resources_number: resources_number,
+          hosts_number: hosts_number,
           details: details
         })
 

--- a/lib/trento/application/read_models/cluster_read_model.ex
+++ b/lib/trento/application/read_models/cluster_read_model.ex
@@ -19,6 +19,8 @@ defmodule Trento.ClusterReadModel do
     field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_down, :unknown]
     field :selected_checks, {:array, :string}, default: []
     field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :resources_number, :integer
+    field :hosts_number, :integer
     field :details, :map
     field :checks_execution, Ecto.Enum, values: [:not_running, :requested, :running]
 

--- a/lib/trento/domain/cluster/cluster.ex
+++ b/lib/trento/domain/cluster/cluster.ex
@@ -37,6 +37,8 @@ defmodule Trento.Domain.Cluster do
     :type,
     :sid,
     :details,
+    :resources_number,
+    :hosts_number,
     discovered_health: :unknown,
     health: :unknown,
     hosts: [],
@@ -69,6 +71,8 @@ defmodule Trento.Domain.Cluster do
           name: name,
           type: type,
           sid: sid,
+          resources_number: resources_number,
+          hosts_number: hosts_number,
           details: details,
           discovered_health: health,
           designated_controller: true
@@ -80,8 +84,10 @@ defmodule Trento.Domain.Cluster do
         name: name,
         type: type,
         sid: sid,
-        health: health,
-        details: details
+        resources_number: resources_number,
+        hosts_number: hosts_number,
+        details: details,
+        health: health
       },
       %HostAddedToCluster{
         cluster_id: cluster_id,
@@ -207,6 +213,8 @@ defmodule Trento.Domain.Cluster do
           name: name,
           type: type,
           sid: sid,
+          resources_number: resources_number,
+          hosts_number: hosts_number,
           details: details,
           health: health
         }
@@ -217,6 +225,8 @@ defmodule Trento.Domain.Cluster do
         name: name,
         type: type,
         sid: sid,
+        resources_number: resources_number,
+        hosts_number: hosts_number,
         details: details,
         discovered_health: health,
         health: health
@@ -238,6 +248,8 @@ defmodule Trento.Domain.Cluster do
           name: name,
           type: type,
           sid: sid,
+          resources_number: resources_number,
+          hosts_number: hosts_number,
           details: details
         }
       ) do
@@ -246,6 +258,8 @@ defmodule Trento.Domain.Cluster do
       | name: name,
         type: type,
         sid: sid,
+        resources_number: resources_number,
+        hosts_number: hosts_number,
         details: details
     }
   end
@@ -351,12 +365,16 @@ defmodule Trento.Domain.Cluster do
            name: name,
            type: type,
            sid: sid,
+           resources_number: resources_number,
+           hosts_number: hosts_number,
            details: details
          },
          %RegisterClusterHost{
            name: name,
            type: type,
            sid: sid,
+           resources_number: resources_number,
+           hosts_number: hosts_number,
            details: details
          }
        ) do
@@ -370,6 +388,8 @@ defmodule Trento.Domain.Cluster do
            name: name,
            type: type,
            sid: sid,
+           resources_number: resources_number,
+           hosts_number: hosts_number,
            details: details
          }
        ) do
@@ -378,6 +398,8 @@ defmodule Trento.Domain.Cluster do
       name: name,
       type: type,
       sid: sid,
+      resources_number: resources_number,
+      hosts_number: hosts_number,
       details: details
     }
   end

--- a/lib/trento/domain/cluster/commands/register_cluster_host.ex
+++ b/lib/trento/domain/cluster/commands/register_cluster_host.ex
@@ -23,6 +23,8 @@ defmodule Trento.Domain.Commands.RegisterClusterHost do
     field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
     field :sid, :string
     field :designated_controller, :boolean
+    field :resources_number, :integer
+    field :hosts_number, :integer
     field :discovered_health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
     field :cib_last_written, :string
 

--- a/lib/trento/domain/cluster/events/cluster_details_updated.ex
+++ b/lib/trento/domain/cluster/events/cluster_details_updated.ex
@@ -12,6 +12,8 @@ defmodule Trento.Domain.Events.ClusterDetailsUpdated do
     field :name, :string
     field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
     field :sid, :string
+    field :resources_number, :integer
+    field :hosts_number, :integer
 
     embeds_one :details, HanaClusterDetails
   end

--- a/lib/trento/domain/cluster/events/cluster_registered.ex
+++ b/lib/trento/domain/cluster/events/cluster_registered.ex
@@ -12,6 +12,8 @@ defmodule Trento.Domain.Events.ClusterRegistered do
     field :name, :string
     field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
     field :sid, :string
+    field :resources_number, :integer
+    field :hosts_number, :integer
     field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
 
     embeds_one :details, HanaClusterDetails

--- a/priv/repo/migrations/20220411084543_add_resources_number_hosts_number_to_cluster_read_model.exs
+++ b/priv/repo/migrations/20220411084543_add_resources_number_hosts_number_to_cluster_read_model.exs
@@ -1,0 +1,10 @@
+defmodule Trento.Repo.Migrations.AddResourcesNumberHostsNumberToClusterReadModel do
+  use Ecto.Migration
+
+  def change do
+    alter table(:clusters) do
+      add :resources_number, :integer
+      add :hosts_number, :integer
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -100,6 +100,8 @@ defmodule Trento.Factory do
       cluster_id: Keyword.get(attrs, :cluster_id, Faker.UUID.v4()),
       name: Keyword.get(attrs, :name, Faker.StarWars.character()),
       sid: Keyword.get(attrs, :sid, Faker.StarWars.planet()),
+      resources_number: Keyword.get(attrs, :resources_number, 8),
+      hosts_number: Keyword.get(attrs, :hosts_number, 2),
       details: Keyword.get(attrs, :details, hana_cluster_details_value_object()),
       health: Keyword.get(attrs, :health, :passing),
       type: Keyword.get(attrs, :type, :hana_scale_up)

--- a/test/trento/application/integration/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/application/integration/discovery/policies/cluster_policy_test.exs
@@ -212,6 +212,8 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
               name: "hana_cluster",
               sid: "PRD",
               type: :hana_scale_up,
+              hosts_number: 2,
+              resources_number: 8,
               discovered_health: :passing
             }} ==
              "ha_cluster_discovery_hana_scale_up"

--- a/test/trento/application/projectors/cluster_projector_test.exs
+++ b/test/trento/application/projectors/cluster_projector_test.exs
@@ -32,8 +32,10 @@ defmodule Trento.ClusterProjectorTest do
     assert event.cluster_id == cluster_projection.id
     assert event.name == cluster_projection.name
     assert event.sid == cluster_projection.sid
-    assert StructHelper.to_map(event.details) == cluster_projection.details
     assert event.type == cluster_projection.type
+    assert event.resources_number == cluster_projection.resources_number
+    assert event.hosts_number == cluster_projection.hosts_number
+    assert StructHelper.to_map(event.details) == cluster_projection.details
     assert event.health == cluster_projection.health
   end
 
@@ -45,6 +47,8 @@ defmodule Trento.ClusterProjectorTest do
       name: Faker.StarWars.character(),
       sid: Faker.StarWars.planet(),
       type: :hana_scale_up,
+      resources_number: 8,
+      hosts_number: 2,
       details: hana_cluster_details_value_object()
     }
 
@@ -60,6 +64,8 @@ defmodule Trento.ClusterProjectorTest do
     assert event.name == cluster_projection.name
     assert event.sid == cluster_projection.sid
     assert event.type == cluster_projection.type
+    assert event.resources_number == cluster_projection.resources_number
+    assert event.hosts_number == cluster_projection.hosts_number
     assert StructHelper.to_map(event.details) == cluster_projection.details
   end
 

--- a/test/trento/domain/cluster/cluster_test.exs
+++ b/test/trento/domain/cluster/cluster_test.exs
@@ -151,6 +151,8 @@ defmodule Trento.ClusterTest do
           name: new_name,
           sid: new_sid,
           type: :hana_scale_up,
+          resources_number: 2,
+          hosts_number: 1,
           discovered_health: :passing,
           details: StructHelper.to_map(details),
           designated_controller: true
@@ -160,6 +162,8 @@ defmodule Trento.ClusterTest do
           name: new_name,
           sid: new_sid,
           type: :hana_scale_up,
+          resources_number: 2,
+          hosts_number: 1,
           details: details
         },
         fn cluster ->
@@ -167,6 +171,8 @@ defmodule Trento.ClusterTest do
             cluster_id: ^cluster_id,
             name: ^new_name,
             sid: ^new_sid,
+            resources_number: 2,
+            hosts_number: 1,
             details: ^details
           } = cluster
         end
@@ -191,6 +197,8 @@ defmodule Trento.ClusterTest do
           host_id: host_id,
           name: name,
           sid: sid,
+          resources_number: 8,
+          hosts_number: 2,
           details: nil,
           type: :hana_scale_up,
           discovered_health: :passing,
@@ -344,9 +352,11 @@ defmodule Trento.ClusterTest do
           name: cluster_registered_event.name,
           sid: cluster_registered_event.sid,
           type: cluster_registered_event.type,
-          discovered_health: :critical,
+          resources_number: cluster_registered_event.resources_number,
+          hosts_number: cluster_registered_event.hosts_number,
           details: StructHelper.to_map(cluster_registered_event.details),
-          designated_controller: true
+          designated_controller: true,
+          discovered_health: :critical
         }),
         [
           %ClusterDiscoveredHealthChanged{
@@ -386,6 +396,8 @@ defmodule Trento.ClusterTest do
           name: cluster_registered_event.name,
           sid: cluster_registered_event.sid,
           type: cluster_registered_event.type,
+          resources_number: cluster_registered_event.resources_number,
+          hosts_number: cluster_registered_event.hosts_number,
           discovered_health: :passing,
           details: StructHelper.to_map(cluster_registered_event.details),
           designated_controller: true


### PR DESCRIPTION
Adds back hosts and resources columns

![image](https://user-images.githubusercontent.com/828651/162705960-3cafa5da-20ca-418b-8f13-3a786acd0d1a.png)
