### PR TITLE
Pin erlang version in .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 elixir 1.13.1-otp-24
+erlang 24.3.3


### PR DESCRIPTION
I was using system installed elixir and erlang.

Now I am using the ones installed with [asdf](https://asdf-vm.com/) and while installing the the tools it suggested me to pin erlang version.