### PR TITLE
Add api auth

### DIFF
--- a/lib/trento/application/auth/api_key.ex
+++ b/lib/trento/application/auth/api_key.ex
@@ -13,8 +13,8 @@ defmodule Trento.Application.Auth.ApiKey do
   end
 
   @spec verify(String.t()) :: {:ok, any()} | {:error, :unauthenticated}
-  def verify(token) do
-    case Phoenix.Token.verify(TrentoWeb.Endpoint, @signing_salt, token) do
+  def verify(api_key) do
+    case Phoenix.Token.verify(TrentoWeb.Endpoint, @signing_salt, api_key) do
       {:ok, data} -> {:ok, data}
       _error -> {:error, :unauthenticated}
     end

--- a/lib/trento/application/auth/api_key.ex
+++ b/lib/trento/application/auth/api_key.ex
@@ -1,0 +1,22 @@
+defmodule Trento.Application.Auth.ApiKey do
+  @moduledoc """
+  This Module creates and verifies API Keys.
+  """
+
+  @signing_salt "trento-api-key"
+
+  @spec sign(map()) :: String.t()
+  def sign(data) do
+    # TODO: signed_at: 0 is a ugly hack to get a fixed api key.
+    # Use a proper authentication
+    Phoenix.Token.sign(TrentoWeb.Endpoint, @signing_salt, data, signed_at: 0, max_age: :infinity)
+  end
+
+  @spec verify(String.t()) :: {:ok, any()} | {:error, :unauthenticated}
+  def verify(token) do
+    case Phoenix.Token.verify(TrentoWeb.Endpoint, @signing_salt, token) do
+      {:ok, data} -> {:ok, data}
+      _error -> {:error, :unauthenticated}
+    end
+  end
+end

--- a/lib/trento/application/usecases/installation/installation.ex
+++ b/lib/trento/application/usecases/installation/installation.ex
@@ -50,4 +50,9 @@ defmodule Trento.Installation do
 
   @spec flavor :: String.t()
   def flavor, do: Application.get_env(:trento, :flavor)
+
+  @spec get_api_key :: String.t()
+  def get_api_key do
+    Trento.Application.Auth.ApiKey.sign(%{installation_id: get_installation_id()})
+  end
 end

--- a/lib/trento/infrastructure/auth/api_auth_error_handler.ex
+++ b/lib/trento/infrastructure/auth/api_auth_error_handler.ex
@@ -1,0 +1,18 @@
+defmodule Trento.Infrastructure.Auth.AuthenticatedAPIErrorHandler do
+  @moduledoc """
+  Used to handle authentication error in APIs
+
+  Can be attached to
+  `Pow.Plug.RequireAuthenticated`, `Trento.Infrastructure.Auth.AuthenticateAPIKeyPlug`
+  and any other auth plug supporting an :error_handler
+  """
+  use TrentoWeb, :controller
+  alias Plug.Conn
+
+  @spec call(Conn.t(), :not_authenticated) :: Conn.t()
+  def call(conn, :not_authenticated) do
+    conn
+    |> put_status(:unauthorized)
+    |> json(%{error: "Unauthorized"})
+  end
+end

--- a/lib/trento/infrastructure/auth/authenticate_apikey_plug.ex
+++ b/lib/trento/infrastructure/auth/authenticate_apikey_plug.ex
@@ -1,0 +1,27 @@
+defmodule Trento.Infrastructure.Auth.AuthenticateAPIKeyPlug do
+  @moduledoc """
+  A Plug that authenticates API calls via an API Key provided in `X-Trento-apiKey` HTTP header
+  """
+  import Plug.Conn
+  require Logger
+
+  def init(opts) do
+    Keyword.get(opts, :error_handler) ||
+      raise "No :error_handler configuration option provided. It's required to set this when using #{inspect(__MODULE__)}."
+  end
+
+  @spec call(Plug.Conn.t(), any) :: Plug.Conn.t()
+  def call(conn, handler) do
+    with [api_key] <- get_req_header(conn, "x-trento-apikey"),
+         {:ok, _data} <- Trento.Application.Auth.ApiKey.verify(api_key) do
+      assign(conn, :api_key_authenticated, true)
+    else
+      error ->
+        Logger.debug("Unable to authenticate apikey", error: error)
+
+        conn
+        |> handler.call(:not_authenticated)
+        |> halt()
+    end
+  end
+end

--- a/lib/trento_web/controllers/installation_controller.ex
+++ b/lib/trento_web/controllers/installation_controller.ex
@@ -1,0 +1,11 @@
+defmodule TrentoWeb.InstallationController do
+  use TrentoWeb, :controller
+
+  def get_api_key(conn, _) do
+    key = Trento.Installation.get_api_key()
+
+    conn
+    |> put_status(:ok)
+    |> json(%{"api_key" => key})
+  end
+end

--- a/lib/trento_web/templates/layout/root.html.heex
+++ b/lib/trento_web/templates/layout/root.html.heex
@@ -8,7 +8,6 @@
     <%= live_title_tag assigns[:page_title] || "Trento", suffix: " · Phoenix Framework" %>
     <link phx-track-static rel="stylesheet" href={Routes.static_path(@conn, "/assets/app.css")}/>
     <script defer phx-track-static type="text/javascript" src={Routes.static_path(@conn, "/assets/app.js")}></script>
-    <script defer phx-track-static type="text/javascript" src={Routes.static_path(@conn, "/assets/trento.js")}></script>
     <link href="https://fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet">
   </head>
   <body>

--- a/lib/trento_web/templates/page/index.html.heex
+++ b/lib/trento_web/templates/page/index.html.heex
@@ -5,3 +5,5 @@ const config = {
     grafanaPublicUrl: '<%= @grafana_public_url %>',
 };
 </script>
+
+<script defer phx-track-static type="text/javascript" src={Routes.static_path(@conn, "/assets/trento.js")}></script>

--- a/test/e2e/.gitignore
+++ b/test/e2e/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+cypress/videos
+cypress/screenshots/

--- a/test/e2e/cypress/integration/dashboard.js
+++ b/test/e2e/cypress/integration/dashboard.js
@@ -13,6 +13,7 @@ describe("Dashboard page", () => {
   describe("The current state should be available in a summary", () => {
     it("should display 2 Passing clusters and 1 critical", () => {
       cy.get(".bg-green-200 > .rounded > .flex > .font-semibold").should("contain", "2");
+      cy.get(".bg-yellow-200 > .rounded > .flex > .font-semibold").should("contain", "0");
       cy.get(".bg-red-200 > .rounded > .flex > .font-semibold").should("contain", "1");
     });
   });

--- a/test/trento/application/auth/api_key_test.exs
+++ b/test/trento/application/auth/api_key_test.exs
@@ -1,0 +1,52 @@
+defmodule Trento.ApiKeyTest do
+  use ExUnit.Case
+
+  alias Trento.Application.Auth.ApiKey
+
+  setup_all do
+    %{
+      scenarios: [
+        %{
+          installation_id: "some-installation-id",
+          api_key:
+            "SFMyNTY.g2gDdAAAAAFkAA9pbnN0YWxsYXRpb25faWRtAAAAFHNvbWUtaW5zdGFsbGF0aW9uLWlkYQBkAAhpbmZpbml0eQ.1BK6v9h8jw3JVavFvYWjp90PZpOGtLcnys6mSgqcLQM"
+        },
+        %{
+          installation_id: "another-installation-id",
+          api_key:
+            "SFMyNTY.g2gDdAAAAAFkAA9pbnN0YWxsYXRpb25faWRtAAAAF2Fub3RoZXItaW5zdGFsbGF0aW9uLWlkYQBkAAhpbmZpbml0eQ.acX8VYHlDyG3lDBiDKgl02nfw-hHnY4gk3040Lxna4c"
+        }
+      ]
+    }
+  end
+
+  describe "Signing data and generating an API key" do
+    test "should always generate expected api_key for current installation", %{
+      scenarios: scenarios
+    } do
+      Enum.each(scenarios, fn %{installation_id: installation_id, api_key: expected_api_key} ->
+        Enum.each(1..3, fn _ ->
+          assert expected_api_key ==
+                   ApiKey.sign(%{
+                     installation_id: installation_id
+                   })
+        end)
+      end)
+    end
+  end
+
+  describe "Verifying an API key" do
+    test "should reject an unauthenticated API key" do
+      assert {:error, :unauthenticated} = ApiKey.verify("definitely-a-fake-api-key")
+    end
+
+    test "should verify an authenticated API key", %{scenarios: scenarios} do
+      Enum.each(scenarios, fn %{installation_id: installation_id, api_key: api_key} ->
+        assert {:ok,
+                %{
+                  installation_id: ^installation_id
+                }} = ApiKey.verify(api_key)
+      end)
+    end
+  end
+end

--- a/test/trento/application/usecases/installation_test.exs
+++ b/test/trento/application/usecases/installation_test.exs
@@ -24,4 +24,12 @@ defmodule Trento.InstallationTest do
     Application.put_env(:trento, :flavor, "Community")
     assert Installation.flavor() === "Community"
   end
+
+  test "should provide the API key of the current installation" do
+    installation_id = Installation.get_installation_id()
+    api_key = Installation.get_api_key()
+
+    assert {:ok, decoded_data} = Trento.Application.Auth.ApiKey.verify(api_key)
+    assert %{installation_id: ^installation_id} = decoded_data
+  end
 end

--- a/test/trento/infrastructure/auth/authenticate_apikey_plug_test.exs
+++ b/test/trento/infrastructure/auth/authenticate_apikey_plug_test.exs
@@ -1,0 +1,25 @@
+defmodule Trento.AuthenticateAPIKeyPlugTest do
+  use TrentoWeb.ConnCase, async: true
+  use Plug.Test
+
+  alias Trento.Infrastructure.Auth.AuthenticateAPIKeyPlug
+  alias Trento.Infrastructure.Auth.AuthenticatedAPIErrorHandler
+
+  test "Reject an Unauthorized request" do
+    conn = conn(:get, "/foo", "bar=10")
+
+    conn = AuthenticateAPIKeyPlug.call(conn, AuthenticatedAPIErrorHandler)
+
+    assert {401, _headers, response_body} = sent_resp(conn)
+    assert %{"error" => "Unauthorized"} = Jason.decode!(response_body)
+  end
+
+  test "Accept an Authenticated request" do
+    conn =
+      conn(:get, "/foo")
+      |> put_req_header("x-trento-apikey", Trento.Installation.get_api_key())
+      |> AuthenticateAPIKeyPlug.call(AuthenticatedAPIErrorHandler)
+
+    assert %{assigns: %{api_key_authenticated: true}} = conn
+  end
+end


### PR DESCRIPTION
This PR
- Loads react app only if logged in, avoiding unnecessary requests on the login page itself
- Adds the ability to generate a deterministic API key for a Trento installation
- The installation usecase exposes the possibility to retrieve that API key
- Added an api controller to expose the api key to the frontend
- added authentication middlewares (plugs) supporting api keys
- secured APIs to make them accessible only when logged in

the api key will be copied and used during trento agents installation.

After logging in and having copied the cookie

```
curl --request GET 'http://localhost:4000/api/installation/api-key' \ 
--header 'Cookie: <TRENTO_COOKIES> | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   172  100   172    0     0   2606      0 --:--:-- --:--:-- --:--:--  2646
{
  "apiKey": "The API key"
}
```

The you can execute 
```
curl --location --request GET 'http://localhost:4000/api/test' \
--header 'X-Trento-apiKey: <the generated api key>' \
--header 'Content-Type: application/json'
```
(try it also without auth)

Next: 
- Provide a UI to grab the api key
- extend the agent to accept the api key during startup and send it along with the discoveries
- put the routes in the proper pipeline
- make internal routes not accessible at ingress level
- Trento web https 