### PR TITLE
Add sap-system/databases linking from host overview

### DIFF
--- a/assets/js/components/HostsList.jsx
+++ b/assets/js/components/HostsList.jsx
@@ -24,14 +24,6 @@ const getHeartbeatIcon = ({ heartbeat }) => {
   }
 };
 
-const getSAPInstanceFromSID = (sid, sapSystems) => {
-  const instance = sapSystems.find(
-    (instance) => instance.instance?.sid === sid
-  );
-
-  return instance;
-};
-
 const getSapSystemsByHost = (sapSystems, hostId) => {
   const appInstances = sapSystems
     .flatMap((sapSystem) => sapSystem.application_instances)
@@ -119,15 +111,14 @@ const HostsList = () => {
         filter: (filter, key) => (element) =>
           element[key].some((sid) => filter.includes(sid)),
         render: (sids, { sap_systems }) => {
-          let sidsArray = sids.map((sid, index) => [
+          let sidsArray = sap_systems.map((instance, index) => [
             index > 0 && ', ',
             <SapSystemLink
-              systemType={getSAPInstanceFromSID(sid, sap_systems).type}
-              sapSystemId={
-                getSAPInstanceFromSID(sid, sap_systems).instance?.sap_system_id
-              }
+              key={index}
+              systemType={instance.type}
+              sapSystemId={instance.instance?.sap_system_id}
             >
-              {sid}
+              {instance.instance?.sid}
             </SapSystemLink>,
           ]);
 
@@ -172,15 +163,14 @@ const HostsList = () => {
   const data = hosts.map((host) => {
     const cluster = clusters.find((cluster) => cluster.id === host.cluster_id);
     const sapSystemList = getSapSystemsByHost(sapSystems, host.id);
-    const sids = sapSystemList.map((sapSystem) => {
-      return sapSystem.instance.sid;
-    });
     return {
       heartbeat: host.heartbeat,
       hostname: host.hostname,
       ip: host.ip_addresses,
       provider: host.provider,
-      sid: sids,
+      sid: sapSystemList.map((sapSystem) => {
+        return sapSystem.instance.sid;
+      }),
       cluster: cluster,
       agent_version: host.agent_version,
       id: host.id,

--- a/assets/js/components/SapSystemLink.jsx
+++ b/assets/js/components/SapSystemLink.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import { Link } from 'react-router-dom';
+
+const SapSystemLink = ({ systemType, sapSystemId, children }) => {
+  return (
+    <Link
+      key={sapSystemId}
+      className="text-jungle-green-500 hover:opacity-75"
+      to={`/${systemType}/${sapSystemId}`}
+    >
+      {children}
+    </Link>
+  );
+};
+
+export default SapSystemLink;


### PR DESCRIPTION
This PR adds linking to sap-systems and databases overview from the SID column. I've added it as draft as I'm not really sure there is a better way to do this. It gets a bit ugly when we need to apply some logic to find out if the SID should link to a DB or a sap-system.

Thanks to @arbulu89  for the help!

![Peek 18-04-2022 16-53](https://user-images.githubusercontent.com/2668401/163835308-f14a431f-16a5-43ed-ada8-226758b5a8e6.gif)
