### PR TITLE
Add checks health to checks execution completed

### DIFF
--- a/lib/trento/domain/cluster/events/checks_execution_completed.ex
+++ b/lib/trento/domain/cluster/events/checks_execution_completed.ex
@@ -7,5 +7,6 @@ defmodule Trento.Domain.Events.ChecksExecutionCompleted do
 
   defevent do
     field :cluster_id, Ecto.UUID
+    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
   end
 end

--- a/test/trento/domain/cluster/cluster_test.exs
+++ b/test/trento/domain/cluster/cluster_test.exs
@@ -331,7 +331,8 @@ defmodule Trento.ClusterTest do
             checks_results: checks_results
           }),
           %ChecksExecutionCompleted{
-            cluster_id: cluster_id
+            cluster_id: cluster_id,
+            health: :critical
           },
           %ClusterHealthChanged{
             cluster_id: cluster_id,
@@ -394,7 +395,8 @@ defmodule Trento.ClusterTest do
             checks_results: checks_results
           }),
           %ChecksExecutionCompleted{
-            cluster_id: cluster_id
+            cluster_id: cluster_id,
+            health: :unknown
           },
           %ClusterHealthChanged{cluster_id: cluster_id, health: :unknown}
         ],


### PR DESCRIPTION
This PR splits the checks execution health in a new field in the cluster aggregate state, and adds the health field to t he checks execution completed event so we can consume it separately from the aggregated health.