### PR TITLE
Generate admin user on init

### DIFF
--- a/lib/trento/application/usecases/accounts/user.ex
+++ b/lib/trento/application/usecases/accounts/user.ex
@@ -14,4 +14,10 @@ defmodule Trento.User do
 
     timestamps()
   end
+
+  def changeset(user, attrs) do
+    user
+    |> pow_changeset(attrs)
+    |> pow_extension_changeset(attrs)
+  end
 end

--- a/lib/trento/application/usecases/accounts/user.ex
+++ b/lib/trento/application/usecases/accounts/user.ex
@@ -2,7 +2,9 @@ defmodule Trento.User do
   @moduledoc false
 
   use Ecto.Schema
-  use Pow.Ecto.Schema
+
+  use Pow.Ecto.Schema,
+    user_id_field: :username
 
   use Pow.Extension.Ecto.Schema,
     extensions: [PowPersistentSession]

--- a/lib/trento_web/templates/pow/session/new.html.eex
+++ b/lib/trento_web/templates/pow/session/new.html.eex
@@ -11,11 +11,11 @@
       <form class="space-y-6" action="/session" method="POST">
         <input type="hidden" name="_csrf_token" value="<%= Plug.CSRFProtection.get_csrf_token() %>">
         <div>
-          <label for="email" class="block text-sm font-medium text-gray-700">
-            Email address
+          <label for="username" class="block text-sm font-medium text-gray-700">
+            Username
           </label>
           <div class="mt-1">
-            <input id="user_email" name="user[email]" type="email" autocomplete="email" required class="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-jungle-green-500 focus:border-jungle-green-500 sm:text-sm">
+            <input id="user_username" name="user[username]" autocomplete="username" required class="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-jungle-green-500 focus:border-jungle-green-500 sm:text-sm">
           </div>
         </div>
 

--- a/priv/repo/migrations/20211211133519_create_users.exs
+++ b/priv/repo/migrations/20211211133519_create_users.exs
@@ -3,12 +3,12 @@ defmodule Trento.Repo.Migrations.CreateUsers do
 
   def change do
     create table(:users) do
-      add :email, :string, null: false
+      add :username, :string, null: false
       add :password_hash, :string, redact: true
 
       timestamps()
     end
 
-    create unique_index(:users, [:email])
+    create unique_index(:users, [:username])
   end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -12,7 +12,6 @@
 
 %Trento.User{}
 |> Trento.User.changeset(%{
-  email: "admin@trento-project.io",
   username: "admin",
   password: "adminpassword",
   confirm_password: "adminpassword"

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -12,8 +12,9 @@
 
 %Trento.User{}
 |> Trento.User.changeset(%{
-  email: "chiecks@trento.io",
-  password: "secret1234",
-  confirm_password: "secret1234"
+  email: "admin@trento-project.io",
+  username: "admin",
+  password: "adminpassword",
+  confirm_password: "adminpassword"
 })
 |> Trento.Repo.insert!()

--- a/test/e2e/cypress.json
+++ b/test/e2e/cypress.json
@@ -10,7 +10,7 @@
     "db_port": 5432,
     "project_root": "../..",
     "photofinish_binary": "photofinish",
-    "login_user": "chiecks@trento.io",
-    "login_password": "secret1234"
+    "login_user": "admin",
+    "login_password": "adminpassword"
   }
 }

--- a/test/e2e/cypress/integration/login.js
+++ b/test/e2e/cypress/integration/login.js
@@ -7,7 +7,7 @@ context('Trento login page', () => {
     it('should show a login form', () => {
       cy.get('.mt-6').should('contain', 'Login to Trento');
       cy.get('.mx-auto').should('exist');
-      cy.get(':nth-child(2) > .text-sm').should('contain', 'Email address');
+      cy.get(':nth-child(2) > .text-sm').should('contain', 'Username');
     });
   });
   

--- a/test/e2e/cypress/support/commands.js
+++ b/test/e2e/cypress/support/commands.js
@@ -32,7 +32,7 @@ Cypress.Commands.add("login", () => {
     Cypress.env("login_password")
   ];
   cy.visit("/login");
-  cy.get("#user_email").type(username);
+  cy.get("#user_username").type(username);
   cy.get("#user_password").type(password);
   cy.get(":nth-child(5) > .w-full").click();
   cy.url().should("include", "/");


### PR DESCRIPTION
Adds release task to generate an admin user from env variables with defaults.
Uses "username" instead of "email" for the users.