### PR TITLE
remove Phoenix Framework suffix from root html title

### DIFF
--- a/lib/trento_web/templates/layout/root.html.heex
+++ b/lib/trento_web/templates/layout/root.html.heex
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <%= csrf_meta_tag() %>
-    <%= live_title_tag assigns[:page_title] || "Trento", suffix: " · Phoenix Framework" %>
+    <%= live_title_tag assigns[:page_title] || "Trento" %>
     <link phx-track-static rel="stylesheet" href={Routes.static_path(@conn, "/assets/app.css")}/>
     <script defer phx-track-static type="text/javascript" src={Routes.static_path(@conn, "/assets/app.js")}></script>
     <link href="https://fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet">


### PR DESCRIPTION
Probably a leftover of the initial boilerplate, I guess?
