### PR TITLE
Make the premium EULA rely entirely on the flavor

### DIFF
--- a/lib/trento/application/usecases/installation/installation.ex
+++ b/lib/trento/application/usecases/installation/installation.ex
@@ -33,6 +33,10 @@ defmodule Trento.Installation do
     :ok
   end
 
+  def premium? do
+    flavor() == "Premium"
+  end
+
   @spec premium_active? :: boolean
   def premium_active? do
     flavor() == "Premium" && has_premium_subscription?()

--- a/lib/trento_web/controllers/settings_controller.ex
+++ b/lib/trento_web/controllers/settings_controller.ex
@@ -7,7 +7,7 @@ defmodule TrentoWeb.SettingsController do
     conn
     |> json(%{
       eula_accepted: Installation.eula_accepted?(),
-      premium_subscription: Installation.premium_active?()
+      premium_subscription: Installation.premium?()
     })
   end
 


### PR DESCRIPTION
This way we show the EULA if the user has premium enabled based exclusively on the build flavor. 