### PR TITLE
Remove heartbeat command deduplication

### DIFF
--- a/test/trento/application/usecases/heartbeats_test.exs
+++ b/test/trento/application/usecases/heartbeats_test.exs
@@ -56,7 +56,7 @@ defmodule Trento.HeartbeatsTest do
 
       assert heartbeat.timestamp == now
 
-      assert_not_called Trento.Commanded.dispatch(:_)
+      assert_called Trento.Commanded.dispatch(:_)
     end
   end
 
@@ -79,8 +79,6 @@ defmodule Trento.HeartbeatsTest do
       {Trento.Commanded, [:passthrough], dispatch: fn _ -> :ok end}
     ] do
       Heartbeats.dispatch_heartbeat_failed_commands()
-
-      assert [] == Repo.all(Heartbeat)
 
       assert_called Trento.Commanded.dispatch(%UpdateHeartbeat{
                       host_id: agent_id,


### PR DESCRIPTION
Remove premature optimization which was actually causing race conditions in the heartbeat logic (my bad, part of the first POC).
Erlang processes are super-lightweight so there is no need to prevent hitting the host aggregate with the heartbeat. The event is still emitted when the state changes.
