### PR TITLE
Add scheduled clusters checks execution

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -92,6 +92,13 @@ config :trento, Trento.Scheduler,
       task: {Trento.Integration.Telemetry, :publish, []},
       run_strategy: {Quantum.RunStrategy.Random, :cluster},
       overlap: false
+    ],
+    clusters_checks_execution: [
+      # Runs every five minutes
+      schedule: "*/5 * * * *",
+      task: {Trento.Clusters, :request_clusters_checks_execution, []},
+      run_strategy: {Quantum.RunStrategy.Random, :cluster},
+      overlap: false
     ]
   ],
   debug_logging: false

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -88,6 +88,9 @@ config :trento, Trento.Scheduler,
   jobs: [
     publish_telemetry: [
       schedule: {:extended, "@hourly"}
+    ],
+    clusters_checks_execution: [
+      schedule: {:extended, "@hourly"}
     ]
   ]
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -110,4 +110,12 @@ if config_env() == :prod do
     auth: :always,
     ssl: :if_available,
     tls: :if_available
+
+  config :trento, Trento.Scheduler,
+    jobs: [
+      clusters_checks_execution: [
+        # Runs every five minutes by default
+        schedule: "*/#{System.get_env("RUNNER_INTERVAL", "5")} * * * *"
+      ]
+    ]
 end

--- a/lib/trento/application/read_models/cluster_read_model.ex
+++ b/lib/trento/application/read_models/cluster_read_model.ex
@@ -20,7 +20,7 @@ defmodule Trento.ClusterReadModel do
     field :name, :string
     field :sid, :string
     field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :unknown]
-    field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_down, :unknown]
+    field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
     field :selected_checks, {:array, :string}, default: []
     field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
     field :resources_number, :integer


### PR DESCRIPTION
This PR adds the scheduled checks execution for each cluster. Defaults to 5 min and overridable by `RUNNER_INTERVAL` env variable (in minutes).

NOTE: little debt taken by using Mock instead of Mox in tests, tracking it.