### PR TITLE
Add virtual ip parsing

### DIFF
--- a/assets/js/components/ClusterDetails/ClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetails.jsx
@@ -25,9 +25,8 @@ const siteDetailsConfig = {
     },
     {
       title: 'Virtual IP',
-      key: '',
+      key: 'virtual_ip',
       className: 'table-col-m',
-      render: (_, _item) => 'Where to get this?',
     },
     {
       title: '',

--- a/lib/trento/domain/value_objects/cluster_node.ex
+++ b/lib/trento/domain/value_objects/cluster_node.ex
@@ -19,6 +19,7 @@ defmodule Trento.Domain.ClusterNode do
     field :site, :string
     field :hana_status, :string
     field :attributes, {:map, :string}
+    field :virtual_ip, :string
 
     embeds_many :resources, ClusterResource
   end

--- a/test/trento/application/integration/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/application/integration/discovery/policies/cluster_policy_test.exs
@@ -98,7 +98,8 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
                         type: "ocf::heartbeat:SAPInstance"
                       }
                     ],
-                    site: "PRIMARY_SITE_NAME"
+                    site: "PRIMARY_SITE_NAME",
+                    virtual_ip: "192.168.123.200"
                   },
                   %ClusterNode{
                     attributes: %{
@@ -167,7 +168,8 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
                         type: "ocf::heartbeat:SAPInstance"
                       }
                     ],
-                    site: "SECONDARY_SITE_NAME"
+                    site: "SECONDARY_SITE_NAME",
+                    virtual_ip: nil
                   }
                 ],
                 sbd_devices: [


### PR DESCRIPTION
This PR adds the missing virtual-ip field in the cluster details:

- We now parse this in cluster_policy
- Adjusted the tests to include the virtual IP
- Included the frontend change to show the field

Cluster details screenshot now:
![updated](https://user-images.githubusercontent.com/2668401/165074082-aa1d66a1-c4a5-4285-be17-6d942ed21f57.png)

