### PR TITLE
Improve checks selection

### DIFF
--- a/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
@@ -64,9 +64,9 @@ const ChecksCatalog = () => {
       {catalogData
         .filter((provider) => provider.provider == selected)
         .map(({ _, groups }) =>
-          groups?.map(({ group, checks }) => (
+          groups?.map(({ group, checks }, idx) => (
             <div
-              key={group.id}
+              key={idx}
               className="bg-white shadow overflow-hidden sm:rounded-md mb-8"
             >
               <div className="bg-white px-4 py-5 border-b border-gray-200 sm:px-6">

--- a/assets/js/components/ClusterDetails/ChecksResults.jsx
+++ b/assets/js/components/ClusterDetails/ChecksResults.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 
@@ -7,6 +7,8 @@ import {
   EOS_ERROR,
   EOS_SCHEDULE,
   EOS_ARROW_BACK,
+  EOS_SETTINGS,
+  EOS_PLAY_CIRCLE,
 } from 'eos-icons-react';
 import Spinner from '../Spinner';
 
@@ -14,6 +16,9 @@ import NotificationBox from '../NotificationBox';
 import LoadingBox from '../LoadingBox';
 
 import Button from '@components/Button';
+import { getCluster } from '@state/selectors';
+import TrentoLogo from '../../../static/trento-icon.png';
+import { TriggerChecksExecutionRequest } from './ClusterDetails';
 
 const getHostname =
   (hosts = []) =>
@@ -63,9 +68,8 @@ export const ChecksResults = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const { clusterID } = useParams();
-  const cluster = useSelector((state) =>
-    state.clustersList.clusters.find((cluster) => cluster.id === clusterID)
-  );
+  const cluster = useSelector(getCluster(clusterID));
+  const [hasAlreadyChecksResults, setHasAlreadyChecksResults] = useState(false);
 
   const [catalogData, catalogError, loading] = useSelector((state) => [
     state.catalog.data,
@@ -76,17 +80,21 @@ export const ChecksResults = () => {
   const dispatchUpdateCatalog = () => {
     dispatch({
       type: 'UPDATE_CATALOG',
-      payload: { flat: '', provider: 'azure' }, //FIXME: Get provider properly
+      payload: { flat: '', provider: cluster.provider },
     });
   };
 
   const hostname = getHostname(useSelector((state) => state.hostsList.hosts));
 
   useEffect(() => {
-    dispatchUpdateCatalog();
-  }, [dispatch]);
+    cluster?.provider && dispatchUpdateCatalog();
+  }, [cluster?.provider]);
 
-  if (loading) {
+  useEffect(() => {
+    setHasAlreadyChecksResults(cluster?.checks_results.length > 0);
+  }, [cluster?.checks_results]);
+
+  if (loading || !cluster) {
     return <LoadingBox text="Loading checks catalog..." />;
   }
 
@@ -105,92 +113,159 @@ export const ChecksResults = () => {
     return catalogData.find(({ id }) => id === checkId)?.description;
   };
 
-  return (
-    <div>
-      <Button
-        type="secondary"
-        size="small"
-        onClick={() => navigate(`/clusters/${clusterID}`)}
-      >
-        <EOS_ARROW_BACK className="inline-block" /> Back to Cluster
-      </Button>
-      {sortHosts(cluster?.hosts_executions.slice()).map(
-        ({ _cluster_id, host_id, reachable, msg }, idx) => (
-          <div key={idx} className="flex flex-col">
-            <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
-              <div className="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
-                <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
-                  <div className="bg-white px-4 py-5 border-b border-gray-200 sm:px-6">
-                    <h3 className="text-lg leading-6 font-medium text-gray-900">
-                      {hostname(host_id)}
-                    </h3>
-                    {reachable == false && (
-                      <div
-                        className="bg-yellow-200 border-yellow-600 text-yellow-600 border-l-4 p-4"
-                        role="alert"
-                      >
-                        <p>{msg}</p>
-                      </div>
-                    )}
-                  </div>
-                  <table className="min-w-full divide-y divide-gray-200">
-                    <thead className="bg-gray-50">
-                      <tr>
-                        <th
-                          scope="col"
-                          className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                        >
-                          ID
-                        </th>
-                        <th
-                          scope="col"
-                          className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                        >
-                          Description
-                        </th>
-                        <th
-                          scope="col"
-                          className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-                        >
-                          Result
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody className="bg-white divide-y divide-gray-200">
-                      {sortChecksResults(cluster?.checks_results.slice())
-                        .filter(
-                          (check_result) => check_result.host_id == host_id
-                        )
-                        .filter(
-                          (check_result) => check_result.result != 'skipped'
-                        ) // Filter "skipped" results by now
-                        .map((checkResult) => (
-                          <tr
-                            key={checkResult.check_id}
-                            className="animate-fade"
-                          >
-                            <td className="px-6 py-4 whitespace-nowrap">
-                              {checkResult.check_id}
-                            </td>
-                            <td className="px-6 py-4 whitespace-nowrap">
-                              {description(checkResult.check_id)}
-                            </td>
-                            <td className="px-6 py-4 whitespace-nowrap content-center">
-                              {getResultIcon(
-                                cluster.checks_execution,
-                                checkResult.result
-                              )}
-                            </td>
-                          </tr>
-                        ))}
-                    </tbody>
-                  </table>
+  let pageContent;
+  if (!hasAlreadyChecksResults) {
+    pageContent = (
+      <HintForChecksSelection
+        clusterId={clusterID}
+        selectedChecks={cluster?.selected_checks}
+      />
+    );
+  } else {
+    const lastExecution = sortHosts(cluster?.hosts_executions.slice());
+    pageContent = lastExecution.map(
+      ({ _cluster_id, host_id, reachable, msg }, idx) => (
+        <div key={idx} className="flex flex-col">
+          <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+            <div className="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
+              <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+                <div className="bg-white px-4 py-5 border-b border-gray-200 sm:px-6">
+                  <h3 className="text-lg leading-6 font-medium text-gray-900">
+                    {hostname(host_id)}
+                  </h3>
+                  {reachable == false && (
+                    <div
+                      className="bg-yellow-200 border-yellow-600 text-yellow-600 border-l-4 p-4"
+                      role="alert"
+                    >
+                      <p>{msg}</p>
+                    </div>
+                  )}
                 </div>
+                <table className="min-w-full divide-y divide-gray-200">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th
+                        scope="col"
+                        className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                      >
+                        ID
+                      </th>
+                      <th
+                        scope="col"
+                        className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                      >
+                        Description
+                      </th>
+                      <th
+                        scope="col"
+                        className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                      >
+                        Result
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white divide-y divide-gray-200">
+                    {sortChecksResults(cluster?.checks_results.slice())
+                      .filter((check_result) => check_result.host_id == host_id)
+                      .filter(
+                        (check_result) => check_result.result != 'skipped'
+                      ) // Filter "skipped" results by now
+                      .map((checkResult) => (
+                        <tr key={checkResult.check_id} className="animate-fade">
+                          <td className="px-6 py-4 whitespace-nowrap">
+                            {checkResult.check_id}
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap">
+                            {description(checkResult.check_id)}
+                          </td>
+                          <td className="px-6 py-4 whitespace-nowrap content-center">
+                            {getResultIcon(
+                              cluster.checks_execution,
+                              checkResult.result
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                  </tbody>
+                </table>
               </div>
             </div>
           </div>
-        )
-      )}
+        </div>
+      )
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex mb-4">
+        <h1 className="text-3xl w-3/5">
+          <span className="font-medium">Checks Results for cluster</span>{' '}
+          <span className="font-bold">{cluster && cluster.name}</span>
+        </h1>
+        <div className="flex w-2/5 justify-end text-white">
+          <Button
+            className="w-1/3 bg-waterhole-blue text-white"
+            size="small"
+            onClick={() => navigate(`/clusters/${cluster.id}`)}
+          >
+            <EOS_ARROW_BACK className="inline-block fill-white" /> Back to
+            Cluster
+          </Button>
+        </div>
+      </div>
+      {pageContent}
+    </div>
+  );
+};
+
+const HintForChecksSelection = ({ clusterId, selectedChecks }) => {
+  const navigate = useNavigate();
+
+  const hasSelectedChecks = selectedChecks.length > 0;
+
+  return (
+    <div className="flex items-center justify-center py-5">
+      <div className="w-full rounded-lg bg-white dark:bg-gray-800 shadow-lg px-5 pt-5 pb-10 text-gray-800 dark:text-gray-50">
+        <div className="w-full pt-8 text-center pb-5 -mt-16 mx-auto">
+          <img
+            alt="profil"
+            src={TrentoLogo}
+            className="mx-auto object-cover h-20 w-20 "
+          />
+        </div>
+        <div className="w-full mb-10">
+          <p className="ttext-gray-600 dark:text-gray-100 text-center px-5">
+            {!hasSelectedChecks &&
+              'It looks like you have not configured any checks for the current cluster. Select your desired checks to be executed.'}
+            {hasSelectedChecks &&
+              'It looks like there is no recent execution for current cluster. Run your Check selection now!'}
+          </p>
+        </div>
+        <div className="w-full text-center">
+          {!hasSelectedChecks && (
+            <Button
+              className="bg-waterhole-blue mx-auto px-2 py-2 w-1/4 xs:w-full"
+              onClick={() => {
+                navigate(`/clusters/${clusterId}/settings`);
+              }}
+            >
+              <EOS_SETTINGS className="inline-block fill-white mr-1" />
+              Select Checks now!
+            </Button>
+          )}
+          {hasSelectedChecks && (
+            <TriggerChecksExecutionRequest
+              cssClasses="rounded relative w-1/4 ml-0.5 bg-waterhole-blue mx-auto px-2 py-2 w-1/4 xs:w-full text-base"
+              clusterId={clusterId}
+            >
+              <EOS_PLAY_CIRCLE className="inline-block fill-white" /> Start
+              Execution now
+            </TriggerChecksExecutionRequest>
+          )}
+        </div>
+      </div>
     </div>
   );
 };

--- a/assets/js/components/ClusterDetails/ChecksSelection.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelection.jsx
@@ -1,25 +1,29 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
 
-import { Switch } from '@headlessui/react';
+import { Disclosure, Switch, Transition } from '@headlessui/react';
 
 import NotificationBox from '../NotificationBox';
 import LoadingBox from '../LoadingBox';
 
-import { EOS_ERROR } from 'eos-icons-react';
-
-function classNames(...classes) {
-  return classes.filter(Boolean).join(' ');
-}
+import {
+  EOS_ERROR,
+  EOS_KEYBOARD_ARROW_RIGHT,
+  EOS_LOADING_ANIMATED,
+} from 'eos-icons-react';
+import classNames from 'classnames';
+import { remove, uniq } from '@lib/lists';
+import {
+  SavingFailedAlert,
+  SuggestTriggeringChecksExecutionAfterSettingsUpdated,
+} from './ClusterSettings';
 
 const toggle = (list, element) =>
   list.includes(element)
     ? list.filter((string) => string !== element)
     : [...list, element];
 
-export const ChecksSelection = ({ cluster }) => {
-  const navigate = useNavigate();
+export const ChecksSelection = ({ clusterId, cluster }) => {
   const dispatch = useDispatch();
 
   const [selectedChecks, setSelectedChecks] = useState(
@@ -29,16 +33,24 @@ export const ChecksSelection = ({ cluster }) => {
   const isSelected = (check_id) =>
     selectedChecks ? selectedChecks.includes(check_id) : false;
 
-  const [catalogData, catalogError, loading] = useSelector((state) => [
+  const [[catalogData], catalogError, loading] = useSelector((state) => [
     state.catalog.data,
     state.catalog.error,
     state.catalog.loading,
   ]);
 
+  const { saving, savingError, savingSuccess } = useSelector(
+    (state) => state.clusterChecksSelection
+  );
+
+  const [localSavingError, setLocalSavingError] = useState(null);
+  const [localSavingSuccess, setLocalSavingSuccess] = useState(null);
+  const [groupSelection, setGroupSelection] = useState([]);
+
   const dispatchUpdateCatalog = () => {
     dispatch({
       type: 'UPDATE_CATALOG',
-      payload: { provider: 'azure' }, //FIXME: Get provider properly
+      payload: { provider: cluster?.provider },
     });
   };
 
@@ -49,12 +61,43 @@ export const ChecksSelection = ({ cluster }) => {
   }, [cluster?.selected_checks]);
 
   useEffect(() => {
-    dispatchUpdateCatalog();
-  }, [dispatch]);
+    cluster?.provider && dispatchUpdateCatalog();
+  }, [cluster?.provider]);
 
-  if (loading) {
-    return <LoadingBox text="Loading checks catalog..." />;
-  }
+  useEffect(() => {
+    const groups = catalogData?.groups;
+    const groupedCheckSelection = groups?.map(({ group, checks }) => {
+      const groupChecks = checks.map((check) => ({
+        ...check,
+        selected: isSelected(check.id),
+      }));
+      const allSelected = checks.every((check) => isSelected(check.id));
+      const someSelected =
+        !allSelected && checks.some((check) => isSelected(check.id));
+      return {
+        group,
+        checks: groupChecks,
+        allSelected,
+        someSelected,
+        noneSelected: !allSelected && !someSelected,
+      };
+    });
+    setGroupSelection(groupedCheckSelection);
+  }, [catalogData?.groups, selectedChecks]);
+
+  useEffect(() => {
+    setLocalSavingError(savingError);
+    if (selectedChecks.length > 0) {
+      setLocalSavingSuccess(savingSuccess);
+    }
+  }, [savingError, savingSuccess, selectedChecks]);
+
+  useEffect(() => {
+    if (loading === true) {
+      setLocalSavingError(null);
+    }
+    setLocalSavingSuccess(null);
+  }, [loading, selectedChecks]);
 
   if (catalogError) {
     return (
@@ -67,83 +110,185 @@ export const ChecksSelection = ({ cluster }) => {
     );
   }
 
+  if (loading || !catalogData?.groups) {
+    return <LoadingBox text="Loading checks catalog..." />;
+  }
+
   return (
     <div>
-      {catalogData[0]?.groups &&
-        catalogData[0].groups.map(({ group, checks }, idx) => (
-          <div
-            key={idx}
-            className="bg-white shadow overflow-hidden sm:rounded-md mb-8"
-          >
-            <div className="bg-white px-4 py-5 border-b border-gray-200 sm:px-6">
-              <h3 className="text-lg leading-6 font-medium text-gray-900">
-                {group}
-              </h3>
-            </div>
-            <ul role="list" className="divide-y divide-gray-200">
-              {checks.map((check) => (
-                <li key={check.id}>
-                  <a href="#" className="block hover:bg-gray-50">
-                    <div className="px-4 py-4 sm:px-6">
-                      <div className="flex items-center">
-                        <p className="text-sm font-medium">{check.name}</p>
-                        <p className="ml-2 px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
-                          {check.id}
-                        </p>
-                      </div>
-                      <div className="mt-2 sm:flex sm:justify-between">
-                        <div className="sm:flex">
-                          <p className="flex items-center text-sm text-gray-500">
-                            {check.description}
-                          </p>
-                        </div>
-                        <Switch.Group as="div" className="flex items-center">
-                          <Switch
-                            checked={isSelected(check.id)}
-                            className={classNames(
-                              isSelected(check.id)
-                                ? 'bg-jungle-green-500'
-                                : 'bg-gray-200',
-                              'relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer focus:outline-none transition-colors ease-in-out duration-200'
-                            )}
-                            onChange={() => {
+      <div className="pb-4">
+        {groupSelection?.map(
+          ({ group, checks, allSelected, someSelected, noneSelected }, idx) => (
+            <div
+              key={idx}
+              className="bg-white shadow overflow-hidden sm:rounded-md mb-1"
+            >
+              <Disclosure>
+                {({ open }) => (
+                  <>
+                    <div className="flex hover:bg-gray-100 border-b border-gray-200">
+                      <Switch.Group
+                        as="div"
+                        className="flex items-center hover:bg-white pl-2"
+                      >
+                        <Switch
+                          className={classNames(
+                            {
+                              'bg-jungle-green-500': allSelected,
+                              'bg-green-300': someSelected,
+                              'bg-gray-200': noneSelected,
+                            },
+                            'relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer focus:outline-none transition-colors ease-in-out duration-200'
+                          )}
+                          onChange={() => {
+                            const groupChecks = checks.map((check) => check.id);
+                            if (noneSelected || someSelected) {
                               setSelectedChecks(
-                                toggle(selectedChecks, check.id)
+                                uniq([...selectedChecks, ...groupChecks])
                               );
-                            }}
-                          >
-                            <span
-                              aria-hidden="true"
-                              className={classNames(
-                                isSelected(check.id)
-                                  ? 'translate-x-5'
-                                  : 'translate-x-0',
-                                'inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200'
-                              )}
-                            />
-                          </Switch>
-                        </Switch.Group>
-                      </div>
+                            }
+                            if (allSelected) {
+                              setSelectedChecks(
+                                remove(groupChecks, selectedChecks)
+                              );
+                            }
+                          }}
+                        >
+                          <span
+                            aria-hidden="true"
+                            className={classNames(
+                              {
+                                'translate-x-5': allSelected,
+                                'translate-x-2.5': someSelected,
+                                'translate-x-0': noneSelected,
+                              },
+                              'inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200'
+                            )}
+                          />
+                        </Switch>
+                      </Switch.Group>
+                      <Disclosure.Button
+                        as="div"
+                        className="flex justify-between w-full cursor-pointer bg-white px-4 py-5 sm:px-6 hover:bg-gray-100"
+                      >
+                        <h3 className="text-lg leading-6 font-medium text-gray-900">
+                          {group}
+                        </h3>
+
+                        <EOS_KEYBOARD_ARROW_RIGHT
+                          className={`${open ? 'transform rotate-90' : ''}`}
+                        />
+                      </Disclosure.Button>
                     </div>
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </div>
-        ))}
-      <div className="place-items-end">
+
+                    {open && (
+                      <div>
+                        <Transition
+                          enter="transition duration-100 ease-out"
+                          enterFrom="transform opacity-0"
+                          enterTo="transform opacity-100"
+                          leave="transition duration-100 ease-out"
+                          leaveFrom="transform opacity-100"
+                          leaveTo="transform opacity-0"
+                        >
+                          <Disclosure.Panel className="border-none">
+                            <ul
+                              role="list"
+                              className="divide-y divide-gray-200"
+                            >
+                              {checks.map((check) => (
+                                <li key={check.id}>
+                                  <a className="block hover:bg-gray-50">
+                                    <div className="px-4 py-4 sm:px-6">
+                                      <div className="flex items-center">
+                                        <p className="text-sm font-medium">
+                                          {check.name}
+                                        </p>
+                                        <p className="ml-2 px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                                          {check.id}
+                                        </p>
+                                      </div>
+                                      <div className="mt-2 sm:flex sm:justify-between">
+                                        <div className="sm:flex">
+                                          <p className="flex items-center text-sm text-gray-500">
+                                            {check.description}
+                                          </p>
+                                        </div>
+                                        <Switch.Group
+                                          as="div"
+                                          className="flex items-center"
+                                        >
+                                          <Switch
+                                            checked={check.selected}
+                                            className={classNames(
+                                              isSelected(check.id)
+                                                ? 'bg-jungle-green-500'
+                                                : 'bg-gray-200',
+                                              'relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer focus:outline-none transition-colors ease-in-out duration-200'
+                                            )}
+                                            onChange={() => {
+                                              setSelectedChecks(
+                                                toggle(selectedChecks, check.id)
+                                              );
+                                            }}
+                                          >
+                                            <span
+                                              aria-hidden="true"
+                                              className={classNames(
+                                                isSelected(check.id)
+                                                  ? 'translate-x-5'
+                                                  : 'translate-x-0',
+                                                'inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200'
+                                              )}
+                                            />
+                                          </Switch>
+                                        </Switch.Group>
+                                      </div>
+                                    </div>
+                                  </a>
+                                </li>
+                              ))}
+                            </ul>
+                          </Disclosure.Panel>
+                        </Transition>
+                      </div>
+                    )}
+                  </>
+                )}
+              </Disclosure>
+            </div>
+          )
+        )}
+      </div>
+      <div className="place-items-end flex">
         <button
-          className="bg-jungle-green-500 hover:opacity-75 text-white font-bold py-2 px-4 rounded"
+          className="flex justify-center items-center bg-jungle-green-500 hover:opacity-75 text-white font-bold py-2 px-4 rounded"
           onClick={() => {
             dispatch({
               type: 'CHECKS_SELECTED',
-              payload: { checks: selectedChecks, clusterID: cluster.id },
+              payload: { checks: selectedChecks, clusterID: clusterId },
             });
-            navigate(`/clusters/${cluster.id}/checks/results`);
           }}
         >
-          Save Selected Checks
+          {saving ? (
+            <span className="px-20">
+              <EOS_LOADING_ANIMATED color="green" size={25} />
+            </span>
+          ) : (
+            'Select Checks for Execution'
+          )}
         </button>
+        {localSavingError && (
+          <SavingFailedAlert onClose={() => setLocalSavingError(null)}>
+            <p>{savingError}</p>
+          </SavingFailedAlert>
+        )}
+        {localSavingSuccess && selectedChecks.length > 0 && (
+          <SuggestTriggeringChecksExecutionAfterSettingsUpdated
+            clusterId={clusterId}
+            onClose={() => setLocalSavingSuccess(null)}
+          />
+        )}
       </div>
     </div>
   );

--- a/assets/js/components/ClusterDetails/ClusterSettings.jsx
+++ b/assets/js/components/ClusterDetails/ClusterSettings.jsx
@@ -2,20 +2,21 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import { useParams, useNavigate } from 'react-router-dom';
 
-import { EOS_ARROW_BACK } from 'eos-icons-react';
+import { EOS_ARROW_BACK, EOS_CANCEL, EOS_PLAY_CIRCLE } from 'eos-icons-react';
 import Button from '@components/Button';
 import classNames from 'classnames';
 
 import { Tab } from '@headlessui/react';
 import { ChecksSelection } from './ChecksSelection';
 import { ConnectionSettings } from './ConnectionSettings';
+import { getCluster } from '@state/selectors';
+import { TriggerChecksExecutionRequest } from './ClusterDetails';
 
 export const ClusterSettings = () => {
   const { clusterID } = useParams();
   const navigate = useNavigate();
 
-  const clusters = useSelector((state) => state.clustersList.clusters);
-  const cluster = clusters.find((cluster) => cluster.id === clusterID);
+  const cluster = useSelector(getCluster(clusterID));
 
   const tabsSettings = {
     'Checks Selection': (
@@ -77,6 +78,50 @@ export const ClusterSettings = () => {
           ))}
         </Tab.Panels>
       </Tab.Group>
+    </div>
+  );
+};
+
+export const SavingFailedAlert = ({ onClose = () => {}, children }) => {
+  return (
+    <div
+      className="rounded relative bg-red-200 border-red-600 text-red-600 border-l-4 p-2 ml-2 pr-10"
+      role="alert"
+    >
+      {children}
+      <button
+        className="absolute top-0 bottom-0 right-0 pr-2"
+        onClick={() => onClose()}
+      >
+        <EOS_CANCEL size={14} className="fill-red-600" />
+      </button>
+    </div>
+  );
+};
+
+export const SuggestTriggeringChecksExecutionAfterSettingsUpdated = ({
+  clusterId,
+  onClose = () => {},
+}) => {
+  return (
+    <div>
+      <div
+        className="flex first-letter:rounded relative bg-green-200 border-green-600 text-green-600 border-l-4 p-2 ml-2"
+        role="alert"
+      >
+        <p className="mr-1">
+          Well done! To start execution now, click here 👉{' '}
+        </p>
+        <TriggerChecksExecutionRequest
+          cssClasses="rounded-full group flex rounded-full items-center text-sm px-2 bg-jungle-green-500 text-white"
+          clusterId={clusterId}
+        >
+          <EOS_PLAY_CIRCLE color="green" />
+        </TriggerChecksExecutionRequest>
+        <button className="ml-1" onClick={() => onClose()}>
+          <EOS_CANCEL size={14} className="fill-green-600" />
+        </button>
+      </div>
     </div>
   );
 };

--- a/assets/js/state/clusterChecksSelection.js
+++ b/assets/js/state/clusterChecksSelection.js
@@ -1,0 +1,38 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  saving: false,
+  savingError: null,
+  savingSuccess: null,
+};
+
+export const clusterChecksSelectionSlice = createSlice({
+  name: 'clusterChecksSelection',
+  initialState,
+  reducers: {
+    startSavingClusterChecksSelection: (state) => {
+      state.saving = true;
+      state.savingError = null;
+      state.savingSuccess = null;
+    },
+    stopSavingClusterChecksSelection: (state) => {
+      state.saving = false;
+    },
+    setClusterChecksSelectionSavingError: (state) => {
+      state.savingError =
+        'An unexpected error happened while selecting your desired checks';
+    },
+    setClusterChecksSelectionSavingSuccess: (state) => {
+      state.savingSuccess = true;
+    },
+  },
+});
+
+export const {
+  startSavingClusterChecksSelection,
+  stopSavingClusterChecksSelection,
+  setClusterChecksSelectionSavingError,
+  setClusterChecksSelectionSavingSuccess,
+} = clusterChecksSelectionSlice.actions;
+
+export default clusterChecksSelectionSlice.reducer;

--- a/assets/js/state/clusterConnectionSettings.js
+++ b/assets/js/state/clusterConnectionSettings.js
@@ -6,6 +6,7 @@ const initialState = {
   settings: [],
   error: null,
   savingError: null,
+  savingSuccess: null,
 };
 
 export const clusterConnectionsSettingsSlice = createSlice({
@@ -16,6 +17,7 @@ export const clusterConnectionsSettingsSlice = createSlice({
       state.loading = true;
       state.error = null;
       state.savingError = null;
+      state.savingSuccess = null;
     },
     stopLoadingClusterConnectionSettings: (state) => {
       state.loading = false;
@@ -30,6 +32,7 @@ export const clusterConnectionsSettingsSlice = createSlice({
     startSavingClusterConnectionSettings: (state) => {
       state.saving = true;
       state.savingError = null;
+      state.savingSuccess = null;
     },
     stopSavingClusterConnectionSettings: (state) => {
       state.saving = false;
@@ -37,6 +40,9 @@ export const clusterConnectionsSettingsSlice = createSlice({
     setClusterConnectionSettingsSavingError: (state) => {
       state.savingError =
         'An unexpected error happened while saving your connection settings';
+    },
+    setClusterConnectionSettingsSavingSuccess: (state) => {
+      state.savingSuccess = true;
     },
   },
 });
@@ -49,6 +55,7 @@ export const {
   startSavingClusterConnectionSettings,
   stopSavingClusterConnectionSettings,
   setClusterConnectionSettingsSavingError,
+  setClusterConnectionSettingsSavingSuccess,
 } = clusterConnectionsSettingsSlice.actions;
 
 export default clusterConnectionsSettingsSlice.reducer;

--- a/assets/js/state/index.js
+++ b/assets/js/state/index.js
@@ -8,6 +8,7 @@ import sapSystemsHealthSummaryReducer from './healthSummary';
 import hostsListReducer from './hosts';
 import clustersListReducer from './clusters';
 import clusterConnectionsSettingsReducer from './clusterConnectionSettings';
+import clusterChecksSelectionReducer from './clusterChecksSelection';
 import sapSystemListReducer from './sapSystems';
 import databasesListReducer from './databases';
 import catalogReducer from './catalog';
@@ -24,6 +25,7 @@ export const store = configureStore({
     hostsList: hostsListReducer,
     clustersList: clustersListReducer,
     clusterConnectionSettings: clusterConnectionsSettingsReducer,
+    clusterChecksSelection: clusterChecksSelectionReducer,
     sapSystemsList: sapSystemListReducer,
     databasesList: databasesListReducer,
     catalog: catalogReducer,

--- a/lib/trento/application/projectors/cluster_projector.ex
+++ b/lib/trento/application/projectors/cluster_projector.ex
@@ -136,7 +136,11 @@ defmodule Trento.ClusterProjector do
     },
     fn multi ->
       changeset =
-        %ClusterReadModel{id: id}
+        ClusterReadModel
+        |> Repo.get(id)
+        # TODO: couldn't make it work with Ecto.Multi
+        # With following line when we receive an empty list of selected checks, the readmodel does not get updated
+        # %ClusterReadModel{id: id}
         |> ClusterReadModel.changeset(%{
           selected_checks: checks
         })


### PR DESCRIPTION
This PR adds:
- Start checks execution in cluster details, disabled with an empty check selection
- Grouped selectable catalog
- Suggestion to run checks _now_ when the cluster settings are correctly applied (check selection or connection settings)
- (in checks result page) suggestion to run checks _now_, if any, or select checks, if none selected.

https://user-images.githubusercontent.com/8167114/165242262-75e57670-0550-4441-9738-ee8392fe16a6.mp4