### PR TITLE
Split back again the dockerfiles for gh and obs registries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -335,7 +335,7 @@ jobs:
       - name: Set version
         run: |
           VERSION=$(./hack/get_version_from_git.sh)
-          sed -i 's~%%VERSION%%~'"${VERSION}"'~' Dockerfile
+          sed -i 's~%%VERSION%%~'"${VERSION}"'~' packaging/suse/Dockerfile
 
       - name: Configure OSC
         # OSC credentials must be configured beforehand as the HOME variables cannot be changed from /github/home
@@ -350,7 +350,6 @@ jobs:
           OBS_PACKAGE=$OBS_PROJECT/$NAME
           osc checkout $OBS_PACKAGE -o $DEST_FOLDER
           cp -r packaging/suse/* $DEST_FOLDER
-          cp Dockerfile $DEST_FOLDER
           tar --transform 's,^./,/web/,' -zcvf $DEST_FOLDER/web.tar.gz --exclude=./.git ./*
           cd $DEST_FOLDER
           osc ar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,32 @@
-#!BuildTag: trento/trento-web:latest
-#!BuildTag: trento/trento-web:%%VERSION%%
-#!BuildTag: trento/trento-web:%%VERSION%%-build%RELEASE%
-#!UseOBSRepositories
-
-FROM bci/nodejs:16 AS assets-build
-ADD web.tar.gz /build/
-WORKDIR /build/web/assets
-RUN npm run tailwind:build
-RUN npm run build
-
-FROM suse/sle15:15.3 AS release
-# FLAVOR defined in prjconf, e.g.
-#  BuildFlags: dockerarg:FLAVOR=Community
-ARG FLAVOR=Community
-# # Workaround for https://github.com/openSUSE/obs-build/issues/487
-RUN zypper --non-interactive in sles-release
-RUN zypper -n in elixir elixir-hex erlang-rebar3
-COPY --from=assets-build /build /build
-WORKDIR /build/web/
+FROM opensuse/leap AS elixir-build
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
+RUN zypper -n addrepo https://download.opensuse.org/repositories/devel:/languages:/erlang/SLE_15_SP3/devel:languages:erlang.repo
+RUN zypper -n --gpg-auto-import-keys ref -s
+RUN zypper -n in elixir
+COPY . /build
+WORKDIR /build
 ENV MIX_ENV=prod
-ENV MIX_HOME=/usr/bin
-ENV FLAVOR="$FLAVOR"
+RUN mix local.rebar --force \
+    && mix local.hex --force \
+    && mix deps.get
+
+FROM registry.suse.com/bci/nodejs:16 AS assets-build
+COPY --from=elixir-build /build /build
+WORKDIR /build/assets
+RUN npm install
+RUN npm run tailwind:build
+RUN npm run build
+
+FROM elixir-build AS release
+COPY --from=assets-build /build /build
+WORKDIR /build
+ENV MIX_ENV=prod
 RUN mix phx.digest
 RUN mix release
 
-FROM suse/sle15:15.3 AS trento
-# Define labels according to https://en.opensuse.org/Building_derived_containers
-# labelprefix=com.suse.trento
+FROM registry.suse.com/bci/bci-base:15.3 AS trento
 LABEL org.opencontainers.image.source="https://github.com/trento-project/web"
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/packaging/suse/Dockerfile
+++ b/packaging/suse/Dockerfile
@@ -1,0 +1,39 @@
+#!BuildTag: trento/trento-web:latest
+#!BuildTag: trento/trento-web:%%VERSION%%
+#!BuildTag: trento/trento-web:%%VERSION%%-build%RELEASE%
+#!UseOBSRepositories
+
+FROM bci/nodejs:16 AS assets-build
+ADD web.tar.gz /build/
+WORKDIR /build/web/assets
+RUN npm run tailwind:build
+RUN npm run build
+
+FROM bci/bci-base:15.3 AS release
+# Workaround for https://github.com/openSUSE/obs-build/issues/487
+RUN zypper --non-interactive in sles-release
+RUN zypper -n in elixir elixir-hex erlang-rebar3
+COPY --from=assets-build /build /build
+WORKDIR /build/web/
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+ENV MIX_ENV=prod
+ENV MIX_HOME=/usr/bin
+ENV FLAVOR="Premium"
+RUN mix phx.digest
+RUN mix release
+
+FROM bci/bci-base:15.3 AS trento
+# Define labels according to https://en.opensuse.org/Building_derived_containers
+# labelprefix=com.suse.trento
+LABEL org.opencontainers.image.source="https://github.com/trento-project/web"
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+# tar is required by kubectl cp
+RUN zypper -n in tar
+WORKDIR /app
+COPY --from=release /build/web/_build/prod/rel/trento .
+EXPOSE 4000/tcp
+ENTRYPOINT ["/app/bin/trento"]


### PR DESCRIPTION
As agreed with the team, split back again the Dockerfiles to have a OBS based and "out of OBS" based versions.

This adds some duplication to the code, but hoping that the dockerfile changes won't happen often.

PD:
The OBS based dockerfile is based exclusively on `bci` images. In the other version, this is not possible, as there is not any bci image with elixir, so we need to use something else, openSUSE Leap in this case.