### PR TITLE
Add notification message for non supported providers for checks

### DIFF
--- a/assets/js/components/ClusterDetails/ChecksResults.jsx
+++ b/assets/js/components/ClusterDetails/ChecksResults.jsx
@@ -74,11 +74,14 @@ export const ChecksResults = () => {
   const cluster = useSelector(getCluster(clusterID));
   const [hasAlreadyChecksResults, setHasAlreadyChecksResults] = useState(false);
 
-  const [catalogData, catalogError, loading] = useSelector((state) => [
-    state.catalog.data,
-    state.catalog.error,
-    state.catalog.loading,
-  ]);
+  const [catalogData, catalogErrorCode, catalogError, loading] = useSelector(
+    (state) => [
+      state.catalog.data,
+      state.catalog.errorCode,
+      state.catalog.error,
+      state.catalog.loading,
+    ]
+  );
 
   const dispatchUpdateCatalog = () => {
     dispatch({
@@ -101,23 +104,36 @@ export const ChecksResults = () => {
     return <LoadingBox text="Loading checks catalog..." />;
   }
 
-  if (catalogError) {
-    return (
-      <NotificationBox
-        icon={<EOS_ERROR className="m-auto" color="red" size="xl" />}
-        text={catalogError}
-        buttonText="Try again"
-        buttonOnClick={dispatchUpdateCatalog}
-      />
-    );
-  }
+  let pageContent;
 
   const description = (checkId) => {
     return catalogData.find(({ id }) => id === checkId)?.description;
   };
 
-  let pageContent;
-  if (!hasAlreadyChecksResults) {
+  if (catalogError) {
+    if (catalogErrorCode == 'not_found') {
+      pageContent = (
+        <NotificationBox
+          icon={<EOS_ERROR className="m-auto" color="red" size="xl" />}
+          text={
+            <ReactMarkdown
+              className="markdown"
+              remarkPlugins={[remarkGfm]}
+            >{`Provider \`${cluster?.provider}\` does not support checks execution`}</ReactMarkdown>
+          }
+        />
+      );
+    } else {
+      pageContent = (
+        <NotificationBox
+          icon={<EOS_ERROR className="m-auto" color="red" size="xl" />}
+          text={catalogError}
+          buttonText="Try again"
+          buttonOnClick={dispatchUpdateCatalog}
+        />
+      );
+    }
+  } else if (!hasAlreadyChecksResults) {
     pageContent = (
       <HintForChecksSelection
         clusterId={clusterID}

--- a/assets/js/components/ClusterDetails/ChecksSelection.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelection.jsx
@@ -36,11 +36,14 @@ export const ChecksSelection = ({ clusterId, cluster }) => {
   const isSelected = (check_id) =>
     selectedChecks ? selectedChecks.includes(check_id) : false;
 
-  const [[catalogData], catalogError, loading] = useSelector((state) => [
-    state.catalog.data,
-    state.catalog.error,
-    state.catalog.loading,
-  ]);
+  const [[catalogData], catalogErrorCode, catalogError, loading] = useSelector(
+    (state) => [
+      state.catalog.data,
+      state.catalog.errorCode,
+      state.catalog.error,
+      state.catalog.loading,
+    ]
+  );
 
   const { saving, savingError, savingSuccess } = useSelector(
     (state) => state.clusterChecksSelection
@@ -101,6 +104,20 @@ export const ChecksSelection = ({ clusterId, cluster }) => {
     }
     setLocalSavingSuccess(null);
   }, [loading, selectedChecks]);
+
+  if (catalogErrorCode == 'not_found') {
+    return (
+      <NotificationBox
+        icon={<EOS_ERROR className="m-auto" color="red" size="xl" />}
+        text={
+          <ReactMarkdown
+            className="markdown"
+            remarkPlugins={[remarkGfm]}
+          >{`Provider \`${cluster?.provider}\` does not support checks execution`}</ReactMarkdown>
+        }
+      />
+    );
+  }
 
   if (catalogError) {
     return (

--- a/assets/js/state/catalog.js
+++ b/assets/js/state/catalog.js
@@ -8,6 +8,7 @@ const errorMessages = {
 const initialState = {
   loading: false,
   data: [],
+  errorCode: '',
   error: '',
 };
 
@@ -24,12 +25,13 @@ export const catalogSlice = createSlice({
       state.loading = false;
 
       if (Object.prototype.hasOwnProperty.call(action.payload, 'error')) {
+        state.errorCode = action.payload.error;
         state.error =
           errorMessages[action.payload.error] || errorMessages['default'];
         state.data = [];
         return;
       }
-
+      state.errorCode = '';
       state.error = '';
       state.data = action.payload;
     },


### PR DESCRIPTION
When we don't have checks for the deployed provider (out of gcp, aws and azure), a notification error is given to the user.

(in this example, gcp is used on purpose, as in the mocked runner, we don't have a catalog for gcp, but in production it would return the catalog for azure,gcp and aws). The 2nd selection is for azure, to show that the catalog is there for known providers (maybe we could put the provider somewhere there anyway)
![demo](https://user-images.githubusercontent.com/36370954/165346655-d1b71b1c-968d-4d51-8595-de77d33a81ee.gif)

