### PR TITLE
Handle aws clusters empty lists

### DIFF
--- a/test/fixtures/discovery/ha_cluster_discovery_aws.json
+++ b/test/fixtures/discovery/ha_cluster_discovery_aws.json
@@ -1,0 +1,816 @@
+{
+  "agent_id": "a3279fd0-0443-1234-9354-2d7909fd6bc6",
+  "discovery_type": "ha_cluster_discovery",
+  "payload": {
+    "Cib": {
+      "Configuration": {
+        "CrmConfig": {
+          "ClusterProperties": [
+            {
+              "Id": "cib-bootstrap-options-have-watchdog",
+              "Name": "have-watchdog",
+              "Value": "false"
+            },
+            {
+              "Id": "cib-bootstrap-options-dc-version",
+              "Name": "dc-version",
+              "Value": "2.0.5+20201202.ba59be712-150300.4.16.1-2.0.5+20201202.ba59be712"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-infrastructure",
+              "Name": "cluster-infrastructure",
+              "Value": "corosync"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-name",
+              "Name": "cluster-name",
+              "Value": "hana_cluster"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-enabled",
+              "Name": "stonith-enabled",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-action",
+              "Name": "stonith-action",
+              "Value": "off"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-timeout",
+              "Name": "stonith-timeout",
+              "Value": "150s"
+            },
+            {
+              "Id": "cib-bootstrap-options-last-lrm-refresh",
+              "Name": "last-lrm-refresh",
+              "Value": "1650871060"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_site_srHook_Site2",
+              "Name": "hana_prd_site_srHook_Site2",
+              "Value": "SOK"
+            }
+          ]
+        },
+        "Nodes": [
+          {
+            "Id": "1",
+            "Uname": "vmhana01",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-1-lpa_prd_lpt",
+                "Name": "lpa_prd_lpt",
+                "Value": "1651045343"
+              },
+              {
+                "Id": "nodes-1-hana_prd_vhost",
+                "Name": "hana_prd_vhost",
+                "Value": "vmhana01"
+              },
+              {
+                "Id": "nodes-1-hana_prd_site",
+                "Name": "hana_prd_site",
+                "Value": "Site1"
+              },
+              {
+                "Id": "nodes-1-hana_prd_op_mode",
+                "Name": "hana_prd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Id": "nodes-1-hana_prd_srmode",
+                "Name": "hana_prd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Id": "nodes-1-hana_prd_remoteHost",
+                "Name": "hana_prd_remoteHost",
+                "Value": "vmhana02"
+              }
+            ]
+          },
+          {
+            "Id": "2",
+            "Uname": "vmhana02",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-2-lpa_prd_lpt",
+                "Name": "lpa_prd_lpt",
+                "Value": "30"
+              },
+              {
+                "Id": "nodes-2-hana_prd_op_mode",
+                "Name": "hana_prd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Id": "nodes-2-hana_prd_vhost",
+                "Name": "hana_prd_vhost",
+                "Value": "vmhana02"
+              },
+              {
+                "Id": "nodes-2-hana_prd_remoteHost",
+                "Name": "hana_prd_remoteHost",
+                "Value": "vmhana01"
+              },
+              {
+                "Id": "nodes-2-hana_prd_site",
+                "Name": "hana_prd_site",
+                "Value": "Site2"
+              },
+              {
+                "Id": "nodes-2-hana_prd_srmode",
+                "Name": "hana_prd_srmode",
+                "Value": "sync"
+              }
+            ]
+          }
+        ],
+        "Resources": {
+          "Primitives": [
+            {
+              "Id": "rsc_aws_stonith_PRD_HDB00",
+              "Class": "stonith",
+              "Type": "external/ec2",
+              "Provider": "",
+              "InstanceAttributes": [
+                {
+                  "Id": "rsc_aws_stonith_PRD_HDB00-instance_attributes-tag",
+                  "Name": "tag",
+                  "Value": "cluster"
+                },
+                {
+                  "Id": "rsc_aws_stonith_PRD_HDB00-instance_attributes-profile",
+                  "Name": "profile",
+                  "Value": "Cluster"
+                }
+              ],
+              "MetaAttributes": [
+                {
+                  "Id": "rsc_aws_stonith_PRD_HDB00-meta_attributes-target-role",
+                  "Name": "target-role",
+                  "Value": "Started"
+                }
+              ],
+              "Operations": [
+                {
+                  "Id": "rsc_aws_stonith_PRD_HDB00-start-0",
+                  "Name": "start",
+                  "Role": "",
+                  "Interval": "0",
+                  "Timeout": "180"
+                },
+                {
+                  "Id": "rsc_aws_stonith_PRD_HDB00-stop-0",
+                  "Name": "stop",
+                  "Role": "",
+                  "Interval": "0",
+                  "Timeout": "180"
+                },
+                {
+                  "Id": "rsc_aws_stonith_PRD_HDB00-monitor-120",
+                  "Name": "monitor",
+                  "Role": "",
+                  "Interval": "120",
+                  "Timeout": "60"
+                }
+              ]
+            },
+            {
+              "Id": "rsc_ip_PRD_HDB00",
+              "Class": "ocf",
+              "Type": "aws-vpc-move-ip",
+              "Provider": "suse",
+              "InstanceAttributes": [
+                {
+                  "Id": "rsc_ip_PRD_HDB00-instance_attributes-ip",
+                  "Name": "ip",
+                  "Value": "192.168.1.10"
+                },
+                {
+                  "Id": "rsc_ip_PRD_HDB00-instance_attributes-routing_table",
+                  "Name": "routing_table",
+                  "Value": "rtb-1234"
+                },
+                {
+                  "Id": "rsc_ip_PRD_HDB00-instance_attributes-interface",
+                  "Name": "interface",
+                  "Value": "eth0"
+                },
+                {
+                  "Id": "rsc_ip_PRD_HDB00-instance_attributes-profile",
+                  "Name": "profile",
+                  "Value": "Cluster"
+                }
+              ],
+              "MetaAttributes": null,
+              "Operations": [
+                {
+                  "Id": "rsc_ip_PRD_HDB00-start-0",
+                  "Name": "start",
+                  "Role": "",
+                  "Interval": "0",
+                  "Timeout": "180"
+                },
+                {
+                  "Id": "rsc_ip_PRD_HDB00-stop-0",
+                  "Name": "stop",
+                  "Role": "",
+                  "Interval": "0",
+                  "Timeout": "180"
+                },
+                {
+                  "Id": "rsc_ip_PRD_HDB00-monitor-60",
+                  "Name": "monitor",
+                  "Role": "",
+                  "Interval": "60",
+                  "Timeout": "60"
+                }
+              ]
+            },
+            {
+              "Id": "rsc_exporter_PRD_HDB00",
+              "Class": "systemd",
+              "Type": "prometheus-hanadb_exporter@PRD_HDB00",
+              "Provider": "",
+              "InstanceAttributes": null,
+              "MetaAttributes": [
+                {
+                  "Id": "rsc_exporter_PRD_HDB00-meta_attributes-resource-stickiness",
+                  "Name": "resource-stickiness",
+                  "Value": "0"
+                },
+                {
+                  "Id": "rsc_exporter_PRD_HDB00-meta_attributes-0-target-role",
+                  "Name": "target-role",
+                  "Value": "Started"
+                }
+              ],
+              "Operations": [
+                {
+                  "Id": "rsc_exporter_PRD_HDB00-start-0",
+                  "Name": "start",
+                  "Role": "",
+                  "Interval": "0",
+                  "Timeout": "100"
+                },
+                {
+                  "Id": "rsc_exporter_PRD_HDB00-stop-0",
+                  "Name": "stop",
+                  "Role": "",
+                  "Interval": "0",
+                  "Timeout": "100"
+                },
+                {
+                  "Id": "rsc_exporter_PRD_HDB00-monitor-10",
+                  "Name": "monitor",
+                  "Role": "",
+                  "Interval": "10",
+                  "Timeout": ""
+                }
+              ]
+            }
+          ],
+          "Masters": [
+            {
+              "Id": "msl_SAPHana_PRD_HDB00",
+              "MetaAttributes": [
+                {
+                  "Id": "msl_SAPHana_PRD_HDB00-meta_attributes-clone-max",
+                  "Name": "clone-max",
+                  "Value": "2"
+                },
+                {
+                  "Id": "msl_SAPHana_PRD_HDB00-meta_attributes-clone-node-max",
+                  "Name": "clone-node-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "msl_SAPHana_PRD_HDB00-meta_attributes-interleave",
+                  "Name": "interleave",
+                  "Value": "true"
+                }
+              ],
+              "Primitive": {
+                "Id": "rsc_SAPHana_PRD_HDB00",
+                "Class": "ocf",
+                "Type": "SAPHana",
+                "Provider": "suse",
+                "InstanceAttributes": [
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-instance_attributes-SID",
+                    "Name": "SID",
+                    "Value": "PRD"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-instance_attributes-InstanceNumber",
+                    "Name": "InstanceNumber",
+                    "Value": "00"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-instance_attributes-PREFER_SITE_TAKEOVER",
+                    "Name": "PREFER_SITE_TAKEOVER",
+                    "Value": "True"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-instance_attributes-AUTOMATED_REGISTER",
+                    "Name": "AUTOMATED_REGISTER",
+                    "Value": "False"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-instance_attributes-DUPLICATE_PRIMARY_TIMEOUT",
+                    "Name": "DUPLICATE_PRIMARY_TIMEOUT",
+                    "Value": "7200"
+                  }
+                ],
+                "MetaAttributes": null,
+                "Operations": [
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-start-0",
+                    "Name": "start",
+                    "Role": "",
+                    "Interval": "0",
+                    "Timeout": "3600"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-stop-0",
+                    "Name": "stop",
+                    "Role": "",
+                    "Interval": "0",
+                    "Timeout": "3600"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-promote-0",
+                    "Name": "promote",
+                    "Role": "",
+                    "Interval": "0",
+                    "Timeout": "3600"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-monitor-60",
+                    "Name": "monitor",
+                    "Role": "Master",
+                    "Interval": "60",
+                    "Timeout": "700"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-monitor-61",
+                    "Name": "monitor",
+                    "Role": "Slave",
+                    "Interval": "61",
+                    "Timeout": "700"
+                  }
+                ]
+              }
+            }
+          ],
+          "Clones": [
+            {
+              "Id": "cln_SAPHanaTopology_PRD_HDB00",
+              "MetaAttributes": [
+                {
+                  "Id": "cln_SAPHanaTopology_PRD_HDB00-meta_attributes-is-managed",
+                  "Name": "is-managed",
+                  "Value": "true"
+                },
+                {
+                  "Id": "cln_SAPHanaTopology_PRD_HDB00-meta_attributes-clone-node-max",
+                  "Name": "clone-node-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "cln_SAPHanaTopology_PRD_HDB00-meta_attributes-interleave",
+                  "Name": "interleave",
+                  "Value": "true"
+                }
+              ],
+              "Primitive": {
+                "Id": "rsc_SAPHanaTopology_PRD_HDB00",
+                "Class": "ocf",
+                "Type": "SAPHanaTopology",
+                "Provider": "suse",
+                "InstanceAttributes": [
+                  {
+                    "Id": "rsc_SAPHanaTopology_PRD_HDB00-instance_attributes-SID",
+                    "Name": "SID",
+                    "Value": "PRD"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_PRD_HDB00-instance_attributes-InstanceNumber",
+                    "Name": "InstanceNumber",
+                    "Value": "00"
+                  }
+                ],
+                "MetaAttributes": null,
+                "Operations": [
+                  {
+                    "Id": "rsc_SAPHanaTopology_PRD_HDB00-monitor-10",
+                    "Name": "monitor",
+                    "Role": "",
+                    "Interval": "10",
+                    "Timeout": "600"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_PRD_HDB00-start-0",
+                    "Name": "start",
+                    "Role": "",
+                    "Interval": "0",
+                    "Timeout": "600"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_PRD_HDB00-stop-0",
+                    "Name": "stop",
+                    "Role": "",
+                    "Interval": "0",
+                    "Timeout": "300"
+                  }
+                ]
+              }
+            }
+          ],
+          "Groups": null
+        },
+        "Constraints": {
+          "RscLocations": [
+            {
+              "Id": "SAPHana_PRD_HDB00_not_on_majority_maker",
+              "Node": "None",
+              "Resource": "msl_SAPHana_PRD_HDB00",
+              "Role": "",
+              "Score": "-INFINITY"
+            },
+            {
+              "Id": "SAPHanaTopology_PRD_HDB00_not_on_majority_maker",
+              "Node": "None",
+              "Resource": "cln_SAPHanaTopology_PRD_HDB00",
+              "Role": "",
+              "Score": "-INFINITY"
+            },
+            {
+              "Id": "exporter_PRD_HDB00_not_on_majority_maker",
+              "Node": "None",
+              "Resource": "rsc_exporter_PRD_HDB00",
+              "Role": "",
+              "Score": "-INFINITY"
+            }
+          ]
+        }
+      }
+    },
+    "Crmmon": {
+      "Version": "2.0.5",
+      "Summary": {
+        "Nodes": {
+          "Number": 2
+        },
+        "LastChange": {
+          "Time": "Wed Apr 27 07:42:23 2022"
+        },
+        "Resources": {
+          "Number": 7,
+          "Disabled": 0,
+          "Blocked": 0
+        },
+        "ClusterOptions": {
+          "StonithEnabled": true
+        }
+      },
+      "Nodes": [
+        {
+          "Name": "vmhana01",
+          "Id": "1",
+          "Online": true,
+          "Standby": false,
+          "StandbyOnFail": false,
+          "Maintenance": false,
+          "Pending": false,
+          "Unclean": false,
+          "Shutdown": false,
+          "ExpectedUp": true,
+          "DC": true,
+          "ResourcesRunning": 5,
+          "Type": "member"
+        },
+        {
+          "Name": "vmhana02",
+          "Id": "2",
+          "Online": true,
+          "Standby": false,
+          "StandbyOnFail": false,
+          "Maintenance": false,
+          "Pending": false,
+          "Unclean": false,
+          "Shutdown": false,
+          "ExpectedUp": true,
+          "DC": false,
+          "ResourcesRunning": 2,
+          "Type": "member"
+        }
+      ],
+      "NodeAttributes": {
+        "Nodes": [
+          {
+            "Name": "vmhana01",
+            "Attributes": [
+              {
+                "Name": "hana_prd_clone_state",
+                "Value": "PROMOTED"
+              },
+              {
+                "Name": "hana_prd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Name": "hana_prd_remoteHost",
+                "Value": "vmhana02"
+              },
+              {
+                "Name": "hana_prd_roles",
+                "Value": "4:P:master1:master:worker:master"
+              },
+              {
+                "Name": "hana_prd_site",
+                "Value": "Site1"
+              },
+              {
+                "Name": "hana_prd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Name": "hana_prd_sync_state",
+                "Value": "PRIM"
+              },
+              {
+                "Name": "hana_prd_version",
+                "Value": "2.00.052.00.1599235305"
+              },
+              {
+                "Name": "hana_prd_vhost",
+                "Value": "vmhana01"
+              },
+              {
+                "Name": "lpa_prd_lpt",
+                "Value": "1651045343"
+              },
+              {
+                "Name": "master-rsc_SAPHana_PRD_HDB00",
+                "Value": "150"
+              }
+            ]
+          },
+          {
+            "Name": "vmhana02",
+            "Attributes": [
+              {
+                "Name": "hana_prd_clone_state",
+                "Value": "DEMOTED"
+              },
+              {
+                "Name": "hana_prd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Name": "hana_prd_remoteHost",
+                "Value": "vmhana01"
+              },
+              {
+                "Name": "hana_prd_roles",
+                "Value": "4:S:master1:master:worker:master"
+              },
+              {
+                "Name": "hana_prd_site",
+                "Value": "Site2"
+              },
+              {
+                "Name": "hana_prd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Name": "hana_prd_sync_state",
+                "Value": "SOK"
+              },
+              {
+                "Name": "hana_prd_version",
+                "Value": "2.00.052.00.1599235305"
+              },
+              {
+                "Name": "hana_prd_vhost",
+                "Value": "vmhana02"
+              },
+              {
+                "Name": "lpa_prd_lpt",
+                "Value": "30"
+              },
+              {
+                "Name": "master-rsc_SAPHana_PRD_HDB00",
+                "Value": "100"
+              }
+            ]
+          }
+        ]
+      },
+      "NodeHistory": {
+        "Nodes": [
+          {
+            "Name": "vmhana01",
+            "ResourceHistory": [
+              {
+                "Name": "rsc_SAPHanaTopology_PRD_HDB00",
+                "MigrationThreshold": 5000,
+                "FailCount": 0
+              },
+              {
+                "Name": "rsc_ip_PRD_HDB00",
+                "MigrationThreshold": 5000,
+                "FailCount": 0
+              },
+              {
+                "Name": "rsc_aws_stonith_PRD_HDB00",
+                "MigrationThreshold": 5000,
+                "FailCount": 0
+              },
+              {
+                "Name": "rsc_exporter_PRD_HDB00",
+                "MigrationThreshold": 5000,
+                "FailCount": 0
+              },
+              {
+                "Name": "rsc_SAPHana_PRD_HDB00",
+                "MigrationThreshold": 5000,
+                "FailCount": 0
+              }
+            ]
+          },
+          {
+            "Name": "vmhana02",
+            "ResourceHistory": [
+              {
+                "Name": "rsc_SAPHana_PRD_HDB00",
+                "MigrationThreshold": 5000,
+                "FailCount": 0
+              },
+              {
+                "Name": "rsc_SAPHanaTopology_PRD_HDB00",
+                "MigrationThreshold": 5000,
+                "FailCount": 0
+              }
+            ]
+          }
+        ]
+      },
+      "Resources": [
+        {
+          "Id": "rsc_aws_stonith_PRD_HDB00",
+          "Agent": "stonith:external/ec2",
+          "Role": "Started",
+          "Active": true,
+          "Orphaned": false,
+          "Blocked": false,
+          "Managed": true,
+          "Failed": false,
+          "FailureIgnored": false,
+          "NodesRunningOn": 1,
+          "Node": {
+            "Name": "vmhana01",
+            "Id": "1",
+            "Cached": true
+          }
+        },
+        {
+          "Id": "rsc_ip_PRD_HDB00",
+          "Agent": "ocf::suse:aws-vpc-move-ip",
+          "Role": "Started",
+          "Active": true,
+          "Orphaned": false,
+          "Blocked": false,
+          "Managed": true,
+          "Failed": false,
+          "FailureIgnored": false,
+          "NodesRunningOn": 1,
+          "Node": {
+            "Name": "vmhana01",
+            "Id": "1",
+            "Cached": true
+          }
+        },
+        {
+          "Id": "rsc_exporter_PRD_HDB00",
+          "Agent": "systemd:prometheus-hanadb_exporter@PRD_HDB00",
+          "Role": "Started",
+          "Active": true,
+          "Orphaned": false,
+          "Blocked": false,
+          "Managed": true,
+          "Failed": false,
+          "FailureIgnored": false,
+          "NodesRunningOn": 1,
+          "Node": {
+            "Name": "vmhana01",
+            "Id": "1",
+            "Cached": true
+          }
+        }
+      ],
+      "Clones": [
+        {
+          "Id": "msl_SAPHana_PRD_HDB00",
+          "MultiState": true,
+          "Managed": true,
+          "Failed": false,
+          "FailureIgnored": false,
+          "Unique": false,
+          "Resources": [
+            {
+              "Id": "rsc_SAPHana_PRD_HDB00",
+              "Agent": "ocf::suse:SAPHana",
+              "Role": "Master",
+              "Active": true,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1,
+              "Node": {
+                "Name": "vmhana01",
+                "Id": "1",
+                "Cached": true
+              }
+            },
+            {
+              "Id": "rsc_SAPHana_PRD_HDB00",
+              "Agent": "ocf::suse:SAPHana",
+              "Role": "Slave",
+              "Active": true,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1,
+              "Node": {
+                "Name": "vmhana02",
+                "Id": "2",
+                "Cached": true
+              }
+            }
+          ]
+        },
+        {
+          "Id": "cln_SAPHanaTopology_PRD_HDB00",
+          "MultiState": false,
+          "Managed": true,
+          "Failed": false,
+          "FailureIgnored": false,
+          "Unique": false,
+          "Resources": [
+            {
+              "Id": "rsc_SAPHanaTopology_PRD_HDB00",
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Role": "Started",
+              "Active": true,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1,
+              "Node": {
+                "Name": "vmhana01",
+                "Id": "1",
+                "Cached": true
+              }
+            },
+            {
+              "Id": "rsc_SAPHanaTopology_PRD_HDB00",
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Role": "Started",
+              "Active": true,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1,
+              "Node": {
+                "Name": "vmhana02",
+                "Id": "2",
+                "Cached": true
+              }
+            }
+          ]
+        }
+      ],
+      "Groups": null
+    },
+    "SBD": {
+      "Devices": null,
+      "Config": null
+    },
+    "Id": "60461ddbd879923a43e8a6aa5d6bd0a2",
+    "Name": "hana_cluster",
+    "DC": true,
+    "Provider": "aws"
+  }
+}

--- a/test/fixtures/discovery/ha_cluster_discovery_gcp.json
+++ b/test/fixtures/discovery/ha_cluster_discovery_gcp.json
@@ -1,0 +1,861 @@
+{
+  "agent_id": "1dc79771-0a96-1234-b5b6-cd4d0aef6acc",
+  "discovery_type": "ha_cluster_discovery",
+  "payload": {
+    "Cib": {
+      "Configuration": {
+        "CrmConfig": {
+          "ClusterProperties": [
+            {
+              "Id": "cib-bootstrap-options-have-watchdog",
+              "Name": "have-watchdog",
+              "Value": "false"
+            },
+            {
+              "Id": "cib-bootstrap-options-dc-version",
+              "Name": "dc-version",
+              "Value": "2.0.5+20201202.ba59be712-150300.4.16.1-2.0.5+20201202.ba59be712"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-infrastructure",
+              "Name": "cluster-infrastructure",
+              "Value": "corosync"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-name",
+              "Name": "cluster-name",
+              "Value": "hana_cluster"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-enabled",
+              "Name": "stonith-enabled",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-timeout",
+              "Name": "stonith-timeout",
+              "Value": "150s"
+            }
+          ]
+        },
+        "Nodes": [
+          {
+            "Id": "1",
+            "Uname": "vmhana01",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-1-lpa_prd_lpt",
+                "Name": "lpa_prd_lpt",
+                "Value": "1650871168"
+              },
+              {
+                "Id": "nodes-1-hana_prd_vhost",
+                "Name": "hana_prd_vhost",
+                "Value": "vmhana01"
+              },
+              {
+                "Id": "nodes-1-hana_prd_site",
+                "Name": "hana_prd_site",
+                "Value": "Site1"
+              },
+              {
+                "Id": "nodes-1-hana_prd_op_mode",
+                "Name": "hana_prd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Id": "nodes-1-hana_prd_srmode",
+                "Name": "hana_prd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Id": "nodes-1-hana_prd_remoteHost",
+                "Name": "hana_prd_remoteHost",
+                "Value": "vmhana02"
+              }
+            ]
+          },
+          {
+            "Id": "2",
+            "Uname": "vmhana02",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-2-lpa_prd_lpt",
+                "Name": "lpa_prd_lpt",
+                "Value": "30"
+              },
+              {
+                "Id": "nodes-2-hana_prd_op_mode",
+                "Name": "hana_prd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Id": "nodes-2-hana_prd_vhost",
+                "Name": "hana_prd_vhost",
+                "Value": "vmhana02"
+              },
+              {
+                "Id": "nodes-2-hana_prd_remoteHost",
+                "Name": "hana_prd_remoteHost",
+                "Value": "vmhana01"
+              },
+              {
+                "Id": "nodes-2-hana_prd_site",
+                "Name": "hana_prd_site",
+                "Value": "Site2"
+              },
+              {
+                "Id": "nodes-2-hana_prd_srmode",
+                "Name": "hana_prd_srmode",
+                "Value": "sync"
+              }
+            ]
+          }
+        ],
+        "Resources": {
+          "Primitives": [
+            {
+              "Id": "rsc_gcp_stonith_PRD_HDB00_vmhana01",
+              "Class": "stonith",
+              "Type": "fence_gce",
+              "Provider": "",
+              "InstanceAttributes": [
+                {
+                  "Id": "rsc_gcp_stonith_PRD_HDB00_vmhana01-instance_attributes-plug",
+                  "Name": "plug",
+                  "Value": "vmhana01"
+                },
+                {
+                  "Id": "rsc_gcp_stonith_PRD_HDB00_vmhana01-instance_attributes-pcmk_host_map",
+                  "Name": "pcmk_host_map",
+                  "Value": "vmhana01:vmhana01"
+                }
+              ],
+              "MetaAttributes": [
+                {
+                  "Id": "rsc_gcp_stonith_PRD_HDB00_vmhana01-meta_attributes-target-role",
+                  "Name": "target-role",
+                  "Value": "Started"
+                }
+              ],
+              "Operations": null
+            },
+            {
+              "Id": "rsc_exporter_PRD_HDB00",
+              "Class": "systemd",
+              "Type": "prometheus-hanadb_exporter@PRD_HDB00",
+              "Provider": "",
+              "InstanceAttributes": null,
+              "MetaAttributes": [
+                {
+                  "Id": "rsc_exporter_PRD_HDB00-meta_attributes-resource-stickiness",
+                  "Name": "resource-stickiness",
+                  "Value": "0"
+                },
+                {
+                  "Id": "rsc_exporter_PRD_HDB00-meta_attributes-0-target-role",
+                  "Name": "target-role",
+                  "Value": "Started"
+                }
+              ],
+              "Operations": [
+                {
+                  "Id": "rsc_exporter_PRD_HDB00-start-0",
+                  "Name": "start",
+                  "Role": "",
+                  "Interval": "0",
+                  "Timeout": "100"
+                },
+                {
+                  "Id": "rsc_exporter_PRD_HDB00-stop-0",
+                  "Name": "stop",
+                  "Role": "",
+                  "Interval": "0",
+                  "Timeout": "100"
+                },
+                {
+                  "Id": "rsc_exporter_PRD_HDB00-monitor-10",
+                  "Name": "monitor",
+                  "Role": "",
+                  "Interval": "10",
+                  "Timeout": ""
+                }
+              ]
+            },
+            {
+              "Id": "rsc_gcp_stonith_PRD_HDB00_vmhana02",
+              "Class": "stonith",
+              "Type": "fence_gce",
+              "Provider": "",
+              "InstanceAttributes": [
+                {
+                  "Id": "rsc_gcp_stonith_PRD_HDB00_vmhana02-instance_attributes-plug",
+                  "Name": "plug",
+                  "Value": "vmhana02"
+                },
+                {
+                  "Id": "rsc_gcp_stonith_PRD_HDB00_vmhana02-instance_attributes-pcmk_host_map",
+                  "Name": "pcmk_host_map",
+                  "Value": "vmhana02:vmhana02"
+                }
+              ],
+              "MetaAttributes": [
+                {
+                  "Id": "rsc_gcp_stonith_PRD_HDB00_vmhana02-meta_attributes-target-role",
+                  "Name": "target-role",
+                  "Value": "Started"
+                }
+              ],
+              "Operations": null
+            }
+          ],
+          "Masters": [
+            {
+              "Id": "msl_SAPHana_PRD_HDB00",
+              "MetaAttributes": [
+                {
+                  "Id": "msl_SAPHana_PRD_HDB00-meta_attributes-clone-max",
+                  "Name": "clone-max",
+                  "Value": "2"
+                },
+                {
+                  "Id": "msl_SAPHana_PRD_HDB00-meta_attributes-clone-node-max",
+                  "Name": "clone-node-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "msl_SAPHana_PRD_HDB00-meta_attributes-interleave",
+                  "Name": "interleave",
+                  "Value": "true"
+                },
+                {
+                  "Id": "msl_SAPHana_PRD_HDB00-meta_attributes-maintenance",
+                  "Name": "maintenance",
+                  "Value": "false"
+                }
+              ],
+              "Primitive": {
+                "Id": "rsc_SAPHana_PRD_HDB00",
+                "Class": "ocf",
+                "Type": "SAPHana",
+                "Provider": "suse",
+                "InstanceAttributes": [
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-instance_attributes-SID",
+                    "Name": "SID",
+                    "Value": "PRD"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-instance_attributes-InstanceNumber",
+                    "Name": "InstanceNumber",
+                    "Value": "00"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-instance_attributes-PREFER_SITE_TAKEOVER",
+                    "Name": "PREFER_SITE_TAKEOVER",
+                    "Value": "True"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-instance_attributes-AUTOMATED_REGISTER",
+                    "Name": "AUTOMATED_REGISTER",
+                    "Value": "False"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-instance_attributes-DUPLICATE_PRIMARY_TIMEOUT",
+                    "Name": "DUPLICATE_PRIMARY_TIMEOUT",
+                    "Value": "7200"
+                  }
+                ],
+                "MetaAttributes": null,
+                "Operations": [
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-start-0",
+                    "Name": "start",
+                    "Role": "",
+                    "Interval": "0",
+                    "Timeout": "3600"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-stop-0",
+                    "Name": "stop",
+                    "Role": "",
+                    "Interval": "0",
+                    "Timeout": "3600"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-promote-0",
+                    "Name": "promote",
+                    "Role": "",
+                    "Interval": "0",
+                    "Timeout": "3600"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-monitor-60",
+                    "Name": "monitor",
+                    "Role": "Master",
+                    "Interval": "60",
+                    "Timeout": "700"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-monitor-61",
+                    "Name": "monitor",
+                    "Role": "Slave",
+                    "Interval": "61",
+                    "Timeout": "700"
+                  }
+                ]
+              }
+            }
+          ],
+          "Clones": [
+            {
+              "Id": "cln_SAPHanaTopology_PRD_HDB00",
+              "MetaAttributes": [
+                {
+                  "Id": "cln_SAPHanaTopology_PRD_HDB00-meta_attributes-is-managed",
+                  "Name": "is-managed",
+                  "Value": "true"
+                },
+                {
+                  "Id": "cln_SAPHanaTopology_PRD_HDB00-meta_attributes-clone-node-max",
+                  "Name": "clone-node-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "cln_SAPHanaTopology_PRD_HDB00-meta_attributes-interleave",
+                  "Name": "interleave",
+                  "Value": "true"
+                }
+              ],
+              "Primitive": {
+                "Id": "rsc_SAPHanaTopology_PRD_HDB00",
+                "Class": "ocf",
+                "Type": "SAPHanaTopology",
+                "Provider": "suse",
+                "InstanceAttributes": [
+                  {
+                    "Id": "rsc_SAPHanaTopology_PRD_HDB00-instance_attributes-SID",
+                    "Name": "SID",
+                    "Value": "PRD"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_PRD_HDB00-instance_attributes-InstanceNumber",
+                    "Name": "InstanceNumber",
+                    "Value": "00"
+                  }
+                ],
+                "MetaAttributes": null,
+                "Operations": [
+                  {
+                    "Id": "rsc_SAPHanaTopology_PRD_HDB00-monitor-10",
+                    "Name": "monitor",
+                    "Role": "",
+                    "Interval": "10",
+                    "Timeout": "600"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_PRD_HDB00-start-0",
+                    "Name": "start",
+                    "Role": "",
+                    "Interval": "0",
+                    "Timeout": "600"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_PRD_HDB00-stop-0",
+                    "Name": "stop",
+                    "Role": "",
+                    "Interval": "0",
+                    "Timeout": "300"
+                  }
+                ]
+              }
+            }
+          ],
+          "Groups": [
+            {
+              "Id": "g_ip_PRD_HDB00",
+              "Primitives": [
+                {
+                  "Id": "rsc_ip_PRD_HDB00",
+                  "Class": "ocf",
+                  "Type": "IPaddr2",
+                  "Provider": "heartbeat",
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_ip_PRD_HDB00-instance_attributes-ip",
+                      "Name": "ip",
+                      "Value": "10.0.0.12"
+                    },
+                    {
+                      "Id": "rsc_ip_PRD_HDB00-instance_attributes-cidr_netmask",
+                      "Name": "cidr_netmask",
+                      "Value": "32"
+                    },
+                    {
+                      "Id": "rsc_ip_PRD_HDB00-instance_attributes-nic",
+                      "Name": "nic",
+                      "Value": "eth0"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "Operations": [
+                    {
+                      "Id": "rsc_ip_PRD_HDB00-monitor-10s",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Interval": "10s",
+                      "Timeout": "20s"
+                    }
+                  ]
+                },
+                {
+                  "Id": "rsc_socat_PRD_HDB00",
+                  "Class": "ocf",
+                  "Type": "anything",
+                  "Provider": "heartbeat",
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_socat_PRD_HDB00-instance_attributes-binfile",
+                      "Name": "binfile",
+                      "Value": "/usr/bin/socat"
+                    },
+                    {
+                      "Id": "rsc_socat_PRD_HDB00-instance_attributes-cmdline_options",
+                      "Name": "cmdline_options",
+                      "Value": "-U TCP-LISTEN:62500,backlog=10,fork,reuseaddr /dev/null"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "Operations": [
+                    {
+                      "Id": "rsc_socat_PRD_HDB00-monitor-10",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Interval": "10",
+                      "Timeout": "20s"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "Constraints": {
+          "RscLocations": [
+            {
+              "Id": "SAPHana_PRD_HDB00_not_on_majority_maker",
+              "Node": "None",
+              "Resource": "msl_SAPHana_PRD_HDB00",
+              "Role": "",
+              "Score": "-INFINITY"
+            },
+            {
+              "Id": "SAPHanaTopology_PRD_HDB00_not_on_majority_maker",
+              "Node": "None",
+              "Resource": "cln_SAPHanaTopology_PRD_HDB00",
+              "Role": "",
+              "Score": "-INFINITY"
+            },
+            {
+              "Id": "exporter_PRD_HDB00_not_on_majority_maker",
+              "Node": "None",
+              "Resource": "rsc_exporter_PRD_HDB00",
+              "Role": "",
+              "Score": "-INFINITY"
+            }
+          ]
+        }
+      }
+    },
+    "Crmmon": {
+      "Version": "2.0.5",
+      "Summary": {
+        "Nodes": {
+          "Number": 2
+        },
+        "LastChange": {
+          "Time": "Wed Apr 27 07:02:35 2022"
+        },
+        "Resources": {
+          "Number": 9,
+          "Disabled": 0,
+          "Blocked": 0
+        },
+        "ClusterOptions": {
+          "StonithEnabled": true
+        }
+      },
+      "Nodes": [
+        {
+          "Name": "vmhana01",
+          "Id": "1",
+          "Online": true,
+          "Standby": false,
+          "StandbyOnFail": false,
+          "Maintenance": false,
+          "Pending": false,
+          "Unclean": false,
+          "Shutdown": false,
+          "ExpectedUp": true,
+          "DC": true,
+          "ResourcesRunning": 3,
+          "Type": "member"
+        },
+        {
+          "Name": "vmhana02",
+          "Id": "2",
+          "Online": true,
+          "Standby": false,
+          "StandbyOnFail": false,
+          "Maintenance": false,
+          "Pending": false,
+          "Unclean": false,
+          "Shutdown": false,
+          "ExpectedUp": true,
+          "DC": false,
+          "ResourcesRunning": 2,
+          "Type": "member"
+        }
+      ],
+      "NodeAttributes": {
+        "Nodes": [
+          {
+            "Name": "vmhana01",
+            "Attributes": [
+              {
+                "Name": "hana_prd_clone_state",
+                "Value": "UNDEFINED"
+              },
+              {
+                "Name": "hana_prd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Name": "hana_prd_remoteHost",
+                "Value": "vmhana02"
+              },
+              {
+                "Name": "hana_prd_roles",
+                "Value": "1:P:master1::worker:"
+              },
+              {
+                "Name": "hana_prd_site",
+                "Value": "Site1"
+              },
+              {
+                "Name": "hana_prd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Name": "hana_prd_version",
+                "Value": "2.00.057.00.1629894416"
+              },
+              {
+                "Name": "hana_prd_vhost",
+                "Value": "vmhana01"
+              },
+              {
+                "Name": "lpa_prd_lpt",
+                "Value": "1650871168"
+              },
+              {
+                "Name": "master-rsc_SAPHana_PRD_HDB00",
+                "Value": "-9000"
+              }
+            ]
+          },
+          {
+            "Name": "vmhana02",
+            "Attributes": [
+              {
+                "Name": "hana_prd_clone_state",
+                "Value": "DEMOTED"
+              },
+              {
+                "Name": "hana_prd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Name": "hana_prd_remoteHost",
+                "Value": "vmhana01"
+              },
+              {
+                "Name": "hana_prd_roles",
+                "Value": "4:S:master1:master:worker:master"
+              },
+              {
+                "Name": "hana_prd_site",
+                "Value": "Site2"
+              },
+              {
+                "Name": "hana_prd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Name": "hana_prd_version",
+                "Value": "2.00.057.00.1629894416"
+              },
+              {
+                "Name": "hana_prd_vhost",
+                "Value": "vmhana02"
+              },
+              {
+                "Name": "lpa_prd_lpt",
+                "Value": "30"
+              },
+              {
+                "Name": "master-rsc_SAPHana_PRD_HDB00",
+                "Value": "-INFINITY"
+              }
+            ]
+          }
+        ]
+      },
+      "NodeHistory": {
+        "Nodes": [
+          {
+            "Name": "vmhana01",
+            "ResourceHistory": [
+              {
+                "Name": "rsc_exporter_PRD_HDB00",
+                "MigrationThreshold": 5000,
+                "FailCount": 1000000
+              },
+              {
+                "Name": "rsc_SAPHana_PRD_HDB00",
+                "MigrationThreshold": 5000,
+                "FailCount": 1000000
+              },
+              {
+                "Name": "rsc_SAPHanaTopology_PRD_HDB00",
+                "MigrationThreshold": 5000,
+                "FailCount": 0
+              },
+              {
+                "Name": "rsc_socat_PRD_HDB00",
+                "MigrationThreshold": 5000,
+                "FailCount": 0
+              },
+              {
+                "Name": "rsc_ip_PRD_HDB00",
+                "MigrationThreshold": 5000,
+                "FailCount": 0
+              },
+              {
+                "Name": "rsc_gcp_stonith_PRD_HDB00_vmhana01",
+                "MigrationThreshold": 5000,
+                "FailCount": 1000000
+              },
+              {
+                "Name": "rsc_gcp_stonith_PRD_HDB00_vmhana02",
+                "MigrationThreshold": 5000,
+                "FailCount": 1000000
+              }
+            ]
+          },
+          {
+            "Name": "vmhana02",
+            "ResourceHistory": [
+              {
+                "Name": "rsc_gcp_stonith_PRD_HDB00_vmhana01",
+                "MigrationThreshold": 5000,
+                "FailCount": 1000000
+              },
+              {
+                "Name": "rsc_SAPHana_PRD_HDB00",
+                "MigrationThreshold": 5000,
+                "FailCount": 0
+              },
+              {
+                "Name": "rsc_SAPHanaTopology_PRD_HDB00",
+                "MigrationThreshold": 5000,
+                "FailCount": 0
+              },
+              {
+                "Name": "rsc_gcp_stonith_PRD_HDB00_vmhana02",
+                "MigrationThreshold": 5000,
+                "FailCount": 1000000
+              }
+            ]
+          }
+        ]
+      },
+      "Resources": [
+        {
+          "Id": "rsc_gcp_stonith_PRD_HDB00_vmhana01",
+          "Agent": "stonith:fence_gce",
+          "Role": "Stopped",
+          "Active": false,
+          "Orphaned": false,
+          "Blocked": false,
+          "Managed": true,
+          "Failed": false,
+          "FailureIgnored": false,
+          "NodesRunningOn": 0,
+          "Node": null
+        },
+        {
+          "Id": "rsc_exporter_PRD_HDB00",
+          "Agent": "systemd:prometheus-hanadb_exporter@PRD_HDB00",
+          "Role": "Stopped",
+          "Active": false,
+          "Orphaned": false,
+          "Blocked": false,
+          "Managed": true,
+          "Failed": false,
+          "FailureIgnored": false,
+          "NodesRunningOn": 0,
+          "Node": null
+        },
+        {
+          "Id": "rsc_gcp_stonith_PRD_HDB00_vmhana02",
+          "Agent": "stonith:fence_gce",
+          "Role": "Stopped",
+          "Active": false,
+          "Orphaned": false,
+          "Blocked": false,
+          "Managed": true,
+          "Failed": false,
+          "FailureIgnored": false,
+          "NodesRunningOn": 0,
+          "Node": null
+        }
+      ],
+      "Clones": [
+        {
+          "Id": "msl_SAPHana_PRD_HDB00",
+          "MultiState": true,
+          "Managed": true,
+          "Failed": false,
+          "FailureIgnored": false,
+          "Unique": false,
+          "Resources": [
+            {
+              "Id": "rsc_SAPHana_PRD_HDB00",
+              "Agent": "ocf::suse:SAPHana",
+              "Role": "Slave",
+              "Active": true,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1,
+              "Node": {
+                "Name": "vmhana02",
+                "Id": "2",
+                "Cached": true
+              }
+            },
+            {
+              "Id": "rsc_SAPHana_PRD_HDB00",
+              "Agent": "ocf::suse:SAPHana",
+              "Role": "Stopped",
+              "Active": false,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 0,
+              "Node": null
+            }
+          ]
+        },
+        {
+          "Id": "cln_SAPHanaTopology_PRD_HDB00",
+          "MultiState": false,
+          "Managed": true,
+          "Failed": false,
+          "FailureIgnored": false,
+          "Unique": false,
+          "Resources": [
+            {
+              "Id": "rsc_SAPHanaTopology_PRD_HDB00",
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Role": "Started",
+              "Active": true,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1,
+              "Node": {
+                "Name": "vmhana01",
+                "Id": "1",
+                "Cached": true
+              }
+            },
+            {
+              "Id": "rsc_SAPHanaTopology_PRD_HDB00",
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Role": "Started",
+              "Active": true,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1,
+              "Node": {
+                "Name": "vmhana02",
+                "Id": "2",
+                "Cached": true
+              }
+            }
+          ]
+        }
+      ],
+      "Groups": [
+        {
+          "Id": "g_ip_PRD_HDB00",
+          "Resources": [
+            {
+              "Id": "rsc_ip_PRD_HDB00",
+              "Agent": "ocf::heartbeat:IPaddr2",
+              "Role": "Started",
+              "Active": true,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1,
+              "Node": {
+                "Name": "vmhana01",
+                "Id": "1",
+                "Cached": true
+              }
+            },
+            {
+              "Id": "rsc_socat_PRD_HDB00",
+              "Agent": "ocf::heartbeat:anything",
+              "Role": "Started",
+              "Active": true,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1,
+              "Node": {
+                "Name": "vmhana01",
+                "Id": "1",
+                "Cached": true
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "SBD": {
+      "Devices": null,
+      "Config": null
+    },
+    "Id": "986ded1c87d1b24ec731b009adf679f4",
+    "Name": "hana_cluster",
+    "DC": true,
+    "Provider": "gcp"
+  }
+}

--- a/test/trento/application/integration/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/application/integration/discovery/policies/cluster_policy_test.exs
@@ -15,7 +15,7 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
     SbdDevice
   }
 
-  test "should return the expected commands when a ha_cluster_discovery payload of type hana_scale_up is handled" do
+  test "should return the expected commands when a ha_cluster_discovery payload with aws provider" do
     assert {:ok,
             %RegisterClusterHost{
               cib_last_written: "Fri Oct 18 11:48:22 2019",
@@ -220,6 +220,130 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
               provider: :azure
             }} ==
              "ha_cluster_discovery_hana_scale_up"
+             |> load_discovery_event_fixture()
+             |> ClusterPolicy.handle()
+  end
+
+  test "should return the expected commands when a ha_cluster_discovery payload of type hana_scale_up is handled" do
+    assert {
+             :ok,
+             %Trento.Domain.Commands.RegisterClusterHost{
+               cib_last_written: "Wed Apr 27 07:42:23 2022",
+               cluster_id: "3e83b9d1-00e8-544d-9e29-7a66d9ed7c1e",
+               designated_controller: true,
+               details: %Trento.Domain.HanaClusterDetails{
+                 fencing_type: "external/ec2",
+                 nodes: [
+                   %Trento.Domain.ClusterNode{
+                     attributes: %{
+                       "hana_prd_clone_state" => "PROMOTED",
+                       "hana_prd_op_mode" => "logreplay",
+                       "hana_prd_remoteHost" => "vmhana02",
+                       "hana_prd_roles" => "4:P:master1:master:worker:master",
+                       "hana_prd_site" => "Site1",
+                       "hana_prd_srmode" => "sync",
+                       "hana_prd_sync_state" => "PRIM",
+                       "hana_prd_version" => "2.00.052.00.1599235305",
+                       "hana_prd_vhost" => "vmhana01",
+                       "lpa_prd_lpt" => "1651045343",
+                       "master-rsc_SAPHana_PRD_HDB00" => "150"
+                     },
+                     hana_status: "Primary",
+                     name: "vmhana01",
+                     resources: [
+                       %Trento.Domain.ClusterResource{
+                         fail_count: 0,
+                         id: "rsc_aws_stonith_PRD_HDB00",
+                         role: "Started",
+                         status: "Active",
+                         type: "stonith:external/ec2"
+                       },
+                       %Trento.Domain.ClusterResource{
+                         fail_count: 0,
+                         id: "rsc_ip_PRD_HDB00",
+                         role: "Started",
+                         status: "Active",
+                         type: "ocf::suse:aws-vpc-move-ip"
+                       },
+                       %Trento.Domain.ClusterResource{
+                         fail_count: 0,
+                         id: "rsc_exporter_PRD_HDB00",
+                         role: "Started",
+                         status: "Active",
+                         type: "systemd:prometheus-hanadb_exporter@PRD_HDB00"
+                       },
+                       %Trento.Domain.ClusterResource{
+                         fail_count: 0,
+                         id: "rsc_SAPHana_PRD_HDB00",
+                         role: "Master",
+                         status: "Active",
+                         type: "ocf::suse:SAPHana"
+                       },
+                       %Trento.Domain.ClusterResource{
+                         fail_count: 0,
+                         id: "rsc_SAPHanaTopology_PRD_HDB00",
+                         role: "Started",
+                         status: "Active",
+                         type: "ocf::suse:SAPHanaTopology"
+                       }
+                     ],
+                     site: "Site1",
+                     virtual_ip: "192.168.1.10"
+                   },
+                   %Trento.Domain.ClusterNode{
+                     attributes: %{
+                       "hana_prd_clone_state" => "DEMOTED",
+                       "hana_prd_op_mode" => "logreplay",
+                       "hana_prd_remoteHost" => "vmhana01",
+                       "hana_prd_roles" => "4:S:master1:master:worker:master",
+                       "hana_prd_site" => "Site2",
+                       "hana_prd_srmode" => "sync",
+                       "hana_prd_sync_state" => "SOK",
+                       "hana_prd_version" => "2.00.052.00.1599235305",
+                       "hana_prd_vhost" => "vmhana02",
+                       "lpa_prd_lpt" => "30",
+                       "master-rsc_SAPHana_PRD_HDB00" => "100"
+                     },
+                     hana_status: "Secondary",
+                     name: "vmhana02",
+                     resources: [
+                       %Trento.Domain.ClusterResource{
+                         fail_count: 0,
+                         id: "rsc_SAPHana_PRD_HDB00",
+                         role: "Slave",
+                         status: "Active",
+                         type: "ocf::suse:SAPHana"
+                       },
+                       %Trento.Domain.ClusterResource{
+                         fail_count: 0,
+                         id: "rsc_SAPHanaTopology_PRD_HDB00",
+                         role: "Started",
+                         status: "Active",
+                         type: "ocf::suse:SAPHanaTopology"
+                       }
+                     ],
+                     site: "Site2",
+                     virtual_ip: nil
+                   }
+                 ],
+                 sbd_devices: [],
+                 secondary_sync_state: "SOK",
+                 sr_health_state: "4",
+                 stopped_resources: [],
+                 system_replication_mode: "sync",
+                 system_replication_operation_mode: "logreplay"
+               },
+               discovered_health: :passing,
+               host_id: "a3279fd0-0443-5f27-9354-2d7909fd6bc6",
+               hosts_number: 2,
+               name: "hana_cluster",
+               provider: :aws,
+               resources_number: 7,
+               sid: "PRD",
+               type: :hana_scale_up
+             }
+           } ==
+             "ha_cluster_discovery_aws"
              |> load_discovery_event_fixture()
              |> ClusterPolicy.handle()
   end

--- a/test/trento/application/integration/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/application/integration/discovery/policies/cluster_policy_test.exs
@@ -15,7 +15,7 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
     SbdDevice
   }
 
-  test "should return the expected commands when a ha_cluster_discovery payload with aws provider" do
+  test "should return the expected commands when a ha_cluster_discovery payload of type hana_scale_up is handled" do
     assert {:ok,
             %RegisterClusterHost{
               cib_last_written: "Fri Oct 18 11:48:22 2019",
@@ -224,7 +224,7 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
              |> ClusterPolicy.handle()
   end
 
-  test "should return the expected commands when a ha_cluster_discovery payload of type hana_scale_up is handled" do
+  test "should return the expected commands when a ha_cluster_discovery payload with aws provider" do
     assert {
              :ok,
              %Trento.Domain.Commands.RegisterClusterHost{
@@ -334,7 +334,7 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
                  system_replication_operation_mode: "logreplay"
                },
                discovered_health: :passing,
-               host_id: "a3279fd0-0443-5f27-9354-2d7909fd6bc6",
+               host_id: "a3279fd0-0443-1234-9354-2d7909fd6bc6",
                hosts_number: 2,
                name: "hana_cluster",
                provider: :aws,
@@ -344,6 +344,143 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
              }
            } ==
              "ha_cluster_discovery_aws"
+             |> load_discovery_event_fixture()
+             |> ClusterPolicy.handle()
+  end
+
+  test "should return the expected commands when a ha_cluster_discovery payload with gcp provider" do
+    assert {
+             :ok,
+             %Trento.Domain.Commands.RegisterClusterHost{
+               cib_last_written: "Wed Apr 27 07:02:35 2022",
+               cluster_id: "61b4f40d-5e1e-5b58-bdc1-7b855dd7ede2",
+               designated_controller: true,
+               details: %Trento.Domain.HanaClusterDetails{
+                 fencing_type: "fence_gce",
+                 nodes: [
+                   %Trento.Domain.ClusterNode{
+                     attributes: %{
+                       "hana_prd_clone_state" => "UNDEFINED",
+                       "hana_prd_op_mode" => "logreplay",
+                       "hana_prd_remoteHost" => "vmhana02",
+                       "hana_prd_roles" => "1:P:master1::worker:",
+                       "hana_prd_site" => "Site1",
+                       "hana_prd_srmode" => "sync",
+                       "hana_prd_version" => "2.00.057.00.1629894416",
+                       "hana_prd_vhost" => "vmhana01",
+                       "lpa_prd_lpt" => "1650871168",
+                       "master-rsc_SAPHana_PRD_HDB00" => "-9000"
+                     },
+                     hana_status: "Unknown",
+                     name: "vmhana01",
+                     resources: [
+                       %Trento.Domain.ClusterResource{
+                         fail_count: 0,
+                         id: "rsc_SAPHanaTopology_PRD_HDB00",
+                         role: "Started",
+                         status: "Active",
+                         type: "ocf::suse:SAPHanaTopology"
+                       },
+                       %Trento.Domain.ClusterResource{
+                         fail_count: 0,
+                         id: "rsc_ip_PRD_HDB00",
+                         role: "Started",
+                         status: "Active",
+                         type: "ocf::heartbeat:IPaddr2"
+                       },
+                       %Trento.Domain.ClusterResource{
+                         fail_count: 0,
+                         id: "rsc_socat_PRD_HDB00",
+                         role: "Started",
+                         status: "Active",
+                         type: "ocf::heartbeat:anything"
+                       }
+                     ],
+                     site: "Site1",
+                     virtual_ip: "10.0.0.12"
+                   },
+                   %Trento.Domain.ClusterNode{
+                     attributes: %{
+                       "hana_prd_clone_state" => "DEMOTED",
+                       "hana_prd_op_mode" => "logreplay",
+                       "hana_prd_remoteHost" => "vmhana01",
+                       "hana_prd_roles" => "4:S:master1:master:worker:master",
+                       "hana_prd_site" => "Site2",
+                       "hana_prd_srmode" => "sync",
+                       "hana_prd_version" => "2.00.057.00.1629894416",
+                       "hana_prd_vhost" => "vmhana02",
+                       "lpa_prd_lpt" => "30",
+                       "master-rsc_SAPHana_PRD_HDB00" => "-INFINITY"
+                     },
+                     hana_status: "Unknown",
+                     name: "vmhana02",
+                     resources: [
+                       %Trento.Domain.ClusterResource{
+                         fail_count: 0,
+                         id: "rsc_SAPHana_PRD_HDB00",
+                         role: "Slave",
+                         status: "Active",
+                         type: "ocf::suse:SAPHana"
+                       },
+                       %Trento.Domain.ClusterResource{
+                         fail_count: 0,
+                         id: "rsc_SAPHanaTopology_PRD_HDB00",
+                         role: "Started",
+                         status: "Active",
+                         type: "ocf::suse:SAPHanaTopology"
+                       }
+                     ],
+                     site: "Site2",
+                     virtual_ip: nil
+                   }
+                 ],
+                 sbd_devices: [],
+                 secondary_sync_state: "Unknown",
+                 sr_health_state: "Unknown",
+                 stopped_resources: [
+                   %Trento.Domain.ClusterResource{
+                     fail_count: nil,
+                     id: "rsc_gcp_stonith_PRD_HDB00_vmhana01",
+                     role: "Stopped",
+                     status: nil,
+                     type: "stonith:fence_gce"
+                   },
+                   %Trento.Domain.ClusterResource{
+                     fail_count: nil,
+                     id: "rsc_exporter_PRD_HDB00",
+                     role: "Stopped",
+                     status: nil,
+                     type: "systemd:prometheus-hanadb_exporter@PRD_HDB00"
+                   },
+                   %Trento.Domain.ClusterResource{
+                     fail_count: nil,
+                     id: "rsc_gcp_stonith_PRD_HDB00_vmhana02",
+                     role: "Stopped",
+                     status: nil,
+                     type: "stonith:fence_gce"
+                   },
+                   %Trento.Domain.ClusterResource{
+                     fail_count: nil,
+                     id: "rsc_SAPHana_PRD_HDB00",
+                     role: "Stopped",
+                     status: nil,
+                     type: "ocf::suse:SAPHana"
+                   }
+                 ],
+                 system_replication_mode: "sync",
+                 system_replication_operation_mode: "logreplay"
+               },
+               discovered_health: :critical,
+               host_id: "1dc79771-0a96-1234-b5b6-cd4d0aef6acc",
+               hosts_number: 2,
+               name: "hana_cluster",
+               provider: :gcp,
+               resources_number: 9,
+               sid: "PRD",
+               type: :hana_scale_up
+             }
+           } ==
+             "ha_cluster_discovery_gcp"
              |> load_discovery_event_fixture()
              |> ClusterPolicy.handle()
   end


### PR DESCRIPTION
Handle properly ha cluster messages coming from hosts running on AWS and GCP.

Basically, some fields are coming with `null`, but we expect to have empty list. Generally, these fields are transformed using the "workaround" `to_list` function (which should be removed once we do proper validation).

Besides that, some new handling for the virtual ip parsing and new test scenarios

PD: The gcp test payload is a bit strange, as the cluster was broken when it was obtained, but it should still work