### PR TITLE
Fix connection settings switch for when the input is empty

### DIFF
--- a/assets/js/components/ClusterDetails/ConnectionSettings.jsx
+++ b/assets/js/components/ClusterDetails/ConnectionSettings.jsx
@@ -69,7 +69,7 @@ export const ConnectionSettings = ({ clusterId, cluster }) => {
           return {
             ...hostSettings,
             user,
-            isDefaultUser: user === hostSettings.default_user,
+            isDefaultUser: user === hostSettings.default_user || !user,
           };
         }
         return hostSettings;


### PR DESCRIPTION
Now the default user switch is enabled if the user input is empty.
![empty_input](https://user-images.githubusercontent.com/36370954/165517169-727b3d71-7f56-4260-9ef1-c7fce651108f.gif)

