### PR TITLE
Redirect to login on 401 status responses

### DIFF
--- a/assets/js/components/AboutPage/AboutPage.jsx
+++ b/assets/js/components/AboutPage/AboutPage.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { get } from 'axios';
 
 import TrentoLogo from '../../../static/trento-icon.png';
 
+import { axiosGet } from '@lib/network';
 import { logError } from '@lib/log';
 
 import ListView from '@components/ListView';
@@ -16,7 +16,7 @@ const AboutPage = () => {
 
   useEffect(() => {
     setLoading(true);
-    get('/api/about')
+    axiosGet('/api/about')
       .then(({ data: { flavor, version, sles_subscriptions } }) => {
         setLoading(false);
         undefined !== flavor && setFlavor(flavor);

--- a/assets/js/components/ClustersList.jsx
+++ b/assets/js/components/ClustersList.jsx
@@ -1,15 +1,12 @@
 import React, { Fragment } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import axios from 'axios';
 import Table from './Table';
 import Tags from './Tags';
 import { addTagToCluster, removeTagFromCluster } from '@state/clusters';
 import ClusterLink from '@components/ClusterLink';
-
-import { logError } from '@lib/log';
-
 import { ExecutionIcon } from '@components/ClusterDetails';
 import { ComponentHealthSummary } from '@components/HealthSummary';
+import { axiosPost, axiosDelete } from '@lib/network';
 
 const getClusterTypeLabel = (type) => {
   switch (type) {
@@ -23,19 +20,13 @@ const getClusterTypeLabel = (type) => {
 };
 
 const addTag = (tag, clusterId) => {
-  axios
-    .post(`/api/clusters/${clusterId}/tags`, {
-      value: tag,
-    })
-    .catch((error) => {
-      logError('Error posting tag: ', error);
-    });
+  axiosPost(`/api/clusters/${clusterId}/tags`, {
+    value: tag,
+  });
 };
 
 const removeTag = (tag, clusterId) => {
-  axios.delete(`/api/clusters/${clusterId}/tags/${tag}`).catch((error) => {
-    logError('Error deleting tag: ', error);
-  });
+  axiosDelete(`/api/clusters/${clusterId}/tags/${tag}`);
 };
 
 const ClustersList = () => {

--- a/assets/js/components/DatabasesOverview/DatabasesOverview.jsx
+++ b/assets/js/components/DatabasesOverview/DatabasesOverview.jsx
@@ -1,32 +1,25 @@
 import React, { Fragment } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
-import axios from 'axios';
 import HealthIcon from '@components/Health';
 import Table from '@components/Table';
 import DatabaseItemOverview from './DatabaseItemOverview';
 import Tags from '@components/Tags';
 import { addTagToDatabase, removeTagFromDatabase } from '@state/databases';
 
-import { logError } from '@lib/log';
+import { axiosPost, axiosDelete } from '@lib/network';
 import { ComponentHealthSummary } from '@components/HealthSummary';
 
 const byDatabase = (id) => (instance) => instance.sap_system_id === id;
 
 const addTag = (tag, sapSystemId) => {
-  axios
-    .post(`/api/databases/${sapSystemId}/tags`, {
-      value: tag,
-    })
-    .catch((error) => {
-      logError('Error posting tag: ', error);
-    });
+  axiosPost(`/api/databases/${sapSystemId}/tags`, {
+    value: tag,
+  });
 };
 
 const removeTag = (tag, sapSystemId) => {
-  axios.delete(`/api/databases/${sapSystemId}/tags/${tag}`).catch((error) => {
-    logError('Error deleting tag: ', error);
-  });
+  axiosDelete(`/api/databases/${sapSystemId}/tags/${tag}`);
 };
 
 const DatabasesOverview = () => {

--- a/assets/js/components/HostsList.jsx
+++ b/assets/js/components/HostsList.jsx
@@ -1,6 +1,5 @@
 import React, { Fragment } from 'react';
 import { Link } from 'react-router-dom';
-import axios from 'axios';
 import Table from './Table';
 import Tags from './Tags';
 import { addTagToHost, removeTagFromHost } from '@state/hosts';
@@ -10,7 +9,7 @@ import { useSelector, useDispatch } from 'react-redux';
 
 import { EOS_LENS_FILLED } from 'eos-icons-react';
 
-import { logError } from '@lib/log';
+import { axiosPost, axiosDelete } from '@lib/network';
 import { ComponentHealthSummary } from '@components/HealthSummary';
 
 const getHeartbeatIcon = ({ heartbeat }) => {
@@ -41,19 +40,13 @@ const getInstancesByHost = (
 };
 
 const addTag = (tag, hostId) => {
-  axios
-    .post(`/api/hosts/${hostId}/tags`, {
-      value: tag,
-    })
-    .catch((error) => {
-      logError('Error posting tag: ', error);
-    });
+  axiosPost(`/api/hosts/${hostId}/tags`, {
+    value: tag,
+  });
 };
 
 const removeTag = (tag, hostId) => {
-  axios.delete(`/api/hosts/${hostId}/tags/${tag}`).catch((error) => {
-    logError('Error deleting tag: ', error);
-  });
+  axiosDelete(`/api/hosts/${hostId}/tags/${tag}`);
 };
 
 const HostsList = () => {

--- a/assets/js/components/SapSystemsOverview/SapSystemsOverview.jsx
+++ b/assets/js/components/SapSystemsOverview/SapSystemsOverview.jsx
@@ -1,7 +1,6 @@
 import React, { Fragment } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
-import axios from 'axios';
 import HealthIcon from '@components/Health';
 import Table from '@components/Table';
 import SAPSystemItemOverview from '@components/SapSystemsOverview/SapSystemItemOverview';
@@ -9,25 +8,19 @@ import Tags from '@components/Tags';
 
 import { addTagToSAPSystem, removeTagFromSAPSystem } from '@state/sapSystems';
 
-import { logError } from '@lib/log';
+import { axiosPost, axiosDelete } from '@lib/network';
 import { ComponentHealthSummary } from '@components/HealthSummary';
 
 const bySapSystem = (id) => (instance) => instance.sap_system_id === id;
 
 const addTag = (tag, sapSystemId) => {
-  axios
-    .post(`/api/sap_systems/${sapSystemId}/tags`, {
-      value: tag,
-    })
-    .catch((error) => {
-      logError('Error posting tag: ', error);
-    });
+  axiosPost(`/api/sap_systems/${sapSystemId}/tags`, {
+    value: tag,
+  });
 };
 
 const removeTag = (tag, sapSystemId) => {
-  axios.delete(`/api/sap_systems/${sapSystemId}/tags/${tag}`).catch((error) => {
-    logError('Error deleting tag: ', error);
-  });
+  axiosDelete(`/api/sap_systems/${sapSystemId}/tags/${tag}`);
 };
 
 const SapSystemsOverview = () => {

--- a/assets/js/components/Settings/Settings.jsx
+++ b/assets/js/components/Settings/Settings.jsx
@@ -2,9 +2,9 @@ import React, { useState, useEffect } from 'react';
 import { Transition } from '@headlessui/react';
 import classNames from 'classnames';
 
-import { get } from 'axios';
 import Button from '@components/Button';
 import { logError } from '@lib/log';
+import { axiosGet } from '@lib/network';
 
 const Settings = () => {
   const [loading, setLoading] = useState(false);
@@ -13,7 +13,7 @@ const Settings = () => {
 
   useEffect(() => {
     setLoading(true);
-    get('/api/installation/api-key')
+    axiosGet('/api/installation/api-key')
       .then(({ data: { api_key: apiKey } }) => {
         apiKey !== undefined && setApiKey(apiKey);
         setLoading(false);

--- a/assets/js/lib/log/index.js
+++ b/assets/js/lib/log/index.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-console */
 export const logError = (err) => console.error(err);
 
+export const logWarn = (...messages) => console.warn(...messages);
+
 export const logMessage = (...messages) => console.log(...messages);

--- a/assets/js/lib/network/index.js
+++ b/assets/js/lib/network/index.js
@@ -1,0 +1,62 @@
+import axios from 'axios';
+import { logError, logWarn } from '@lib/log';
+
+const conf = {
+  validateStatus: (status) => {
+    return status < 500;
+  },
+};
+
+export const axiosPost = function (url, data) {
+  return axios
+    .post(url, data, conf)
+    .then(handleResponseStatus)
+    .catch((error) => {
+      logError(error);
+    });
+};
+
+export const axiosDelete = function (url) {
+  return axios
+    .delete(url, conf)
+    .then(handleResponseStatus)
+    .catch((error) => {
+      logError(error);
+    });
+};
+
+export const axiosPut = function (url, data) {
+  return axios
+    .put(url, data, conf)
+    .then(handleResponseStatus)
+    .catch((error) => {
+      logError(error);
+    });
+};
+
+export const axiosGet = function (url) {
+  return axios
+    .get(url, conf)
+    .then(handleResponseStatus)
+    .catch((error) => {
+      logError(error);
+    });
+};
+
+function handleResponseStatus(response) {
+  if (response.status < 400) {
+    return response;
+  }
+  switch (response.status) {
+    case 401:
+    case 403:
+      logWarn('Redirecting to login after status', response.status);
+      window.location.href = '/session/new';
+      break;
+
+    default:
+      logError(response.statusText);
+  }
+
+  return response;
+}

--- a/assets/js/state/sagas/eula.js
+++ b/assets/js/state/sagas/eula.js
@@ -1,12 +1,13 @@
 import { put, call, takeEvery } from 'redux-saga/effects';
-import { post } from 'axios';
+import { axiosPost } from '@lib/network';
 
 import { acceptEula } from '@state/settings';
 import { logError } from '@lib/log';
 
 export function* acceptEulaSaga() {
   try {
-    yield call(post, '/api/accept_eula');
+    yield call(axiosPost, '/api/accept_eula', {});
+
     yield put(acceptEula());
   } catch (error) {
     logError(error);

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -1,4 +1,4 @@
-import { get, post, put as PUT } from 'axios';
+import { axiosGet, axiosPost, axiosPut } from '@lib/network';
 import {
   put,
   all,
@@ -103,7 +103,10 @@ const getClusterName = (clusterID) => (state) => {
 
 function* loadSapSystemsHealthSummary() {
   yield put(startHealthSummaryLoading());
-  const { data: healthSummary } = yield call(get, '/api/sap_systems/health');
+  const { data: healthSummary } = yield call(
+    axiosGet,
+    '/api/sap_systems/health'
+  );
 
   yield put(setHealthSummary(keysToCamel(healthSummary)));
   yield put(stopHealthSummaryLoading());
@@ -114,29 +117,29 @@ function* initialDataFetch() {
 
   const {
     data: { eula_accepted, premium_subscription },
-  } = yield call(get, '/api/settings');
+  } = yield call(axiosGet, '/api/settings');
 
   if (!eula_accepted && premium_subscription) {
     yield put(setEulaVisible());
   }
 
   yield put(startHostsLoading());
-  const { data: hosts } = yield call(get, '/api/hosts');
+  const { data: hosts } = yield call(axiosGet, '/api/hosts');
   yield put(setHosts(hosts));
   yield put(stopHostsLoading());
 
   yield put(startClustersLoading());
-  const { data: clusters } = yield call(get, '/api/clusters');
+  const { data: clusters } = yield call(axiosGet, '/api/clusters');
   yield put(setClusters(clusters));
   yield put(stopClustersLoading());
 
   yield put(startSapSystemsLoading());
-  const { data: sapSystems } = yield call(get, '/api/sap_systems');
+  const { data: sapSystems } = yield call(axiosGet, '/api/sap_systems');
   yield put(setSapSystems(sapSystems));
   yield put(stopSapSystemsLoading());
 
   yield put(startDatabasesLoading());
-  const { data: databases } = yield call(get, '/api/databases');
+  const { data: databases } = yield call(axiosGet, '/api/databases');
   yield put(setDatabases(databases));
   yield put(stopDatabasesLoading());
 }
@@ -241,7 +244,7 @@ function* checksSelected({ payload }) {
   yield put(startSavingClusterChecksSelection());
 
   try {
-    yield call(post, `/api/clusters/${payload.clusterID}/checks`, {
+    yield call(axiosPost, `/api/clusters/${payload.clusterID}/checks`, {
       checks: payload.checks,
     });
     yield put(updateSelectedChecks(payload));
@@ -274,7 +277,7 @@ function* watchChecksSelected() {
 function* requestChecksExecution({ payload }) {
   const clusterName = yield select(getClusterName(payload.clusterID));
   yield call(
-    post,
+    axiosPost,
     `/api/clusters/${payload.clusterID}/checks/request_execution`,
     {}
   );
@@ -500,7 +503,7 @@ function* updateCatalog({ payload }) {
   yield put(setCatalog({ loading: true }));
   try {
     const { data: catalog } = yield call(
-      get,
+      axiosGet,
       `/api/checks/catalog?${urlEncode(payload)}`
     );
     yield put(setCatalog(catalog));
@@ -533,7 +536,7 @@ function* loadClusterConnectionSettings({ payload: { cluster } }) {
   yield put(startLoadingClusterConnectionSettings());
   try {
     const { data: settings } = yield call(
-      get,
+      axiosGet,
       `/api/clusters/${cluster}/connection-settings`
     );
     yield put(setClusterConnectionSettings({ settings }));
@@ -547,7 +550,7 @@ function* saveClusterConnectionSettings({ payload: { cluster, settings } }) {
   yield put(startSavingClusterConnectionSettings());
   try {
     const { data: newSettings } = yield call(
-      PUT,
+      axiosPut,
       `/api/clusters/${cluster}/connection-settings`,
       {
         settings: settings.map((hostSettings) => ({
@@ -556,6 +559,7 @@ function* saveClusterConnectionSettings({ payload: { cluster, settings } }) {
         })),
       }
     );
+
     yield put(
       setClusterConnectionSettings({
         settings: newSettings,


### PR DESCRIPTION
This PR takes care of redirecting the user to the login page when any of the API calls to the trento web server returns a 401 response state.

This is particularly useful in the event of a server restart (e.g. for an update) while a user is connected as it prevents the user from interacting with trento and changing it's state just to lose it after he realizes he needs to login again.

To test this, `config :trento, :api_key_authentication, enabled: true` is needed
![redirect](https://user-images.githubusercontent.com/2668401/165769289-267839c3-1d63-4f5a-93a5-a2f7fd0a1bcc.gif)

