### PR TITLE
Add development docker-compose service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,7 @@
+/.github
+/.pgdata/
 /_build/
 /assets/node_modules/
 /deps/
-/doc/
 /priv/static/assets
-/test/
 /tmp/
-/.pgdata/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,7 +121,7 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_DB: trento_test
         ports:
           - 5433:5432
@@ -180,7 +180,7 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_DB: trento_dev
         ports:
           - 5433:5432

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,7 +124,7 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_DB: trento_test
         ports:
-          - 5433:5432
+          - 5432:5432
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
@@ -183,7 +183,7 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
           POSTGRES_DB: trento_dev
         ports:
-          - 5433:5432
+          - 5432:5432
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,25 +2,31 @@ FROM registry.opensuse.org/opensuse/leap:15.4 AS system
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
-ENV MIX_ENV=prod
 RUN zypper -n addrepo https://download.opensuse.org/repositories/devel:/languages:/erlang/15.4/devel:languages:erlang.repo &&\
     zypper -n --gpg-auto-import-keys ref -s &&\
-    zypper -n in elixir nodejs16 npm16
-WORKDIR /app
+    zypper -n in inotify-tools elixir nodejs16 npm16
+WORKDIR /source
 RUN mix local.rebar --force &&\
     mix local.hex --force
 
 FROM system AS deps
-COPY ./mix.* /app/
-COPY assets/package*.json /app/assets/
-RUN mix deps.all
+ENV MIX_ENV=prod
+COPY ./mix.* /source/
+COPY assets/package*.json /source/assets/
+RUN mix install
 
 FROM deps AS full
-COPY . /app
+LABEL org.opencontainers.image.version="rolling-full"
+LABEL org.opencontainers.image.source="https://github.com/trento-project/web"
+COPY . /source
 RUN mix assets.deploy &&\
-    mix release
+    mix release --path /app
+WORKDIR /app
+EXPOSE 4000/tcp
+ENTRYPOINT ["/app/bin/trento"]
 
 FROM registry.suse.com/bci/bci-base:15.4 AS minimal
+LABEL org.opencontainers.image.version="rolling"
 LABEL org.opencontainers.image.source="https://github.com/trento-project/web"
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
@@ -28,6 +34,6 @@ ENV LC_ALL en_US.UTF-8
 # tar is required by kubectl cp
 RUN zypper -n in tar
 WORKDIR /app
-COPY --from=full /app/_build/prod/rel/trento .
+COPY --from=full /app .
 EXPOSE 4000/tcp
 ENTRYPOINT ["/app/bin/trento"]

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,14 +7,18 @@
 # General application configuration
 import Config
 
-config :trento,
-  ecto_repos: [Trento.Repo]
-
 # Configures the endpoint
 config :trento, TrentoWeb.Endpoint,
+  http: [
+    # Enable IPv6 and bind on all interfaces.
+    # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.
+    # See the documentation on https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html
+    # for details about using IPv6 vs IPv4 and loopback vs public addresses.
+    ip: {0, 0, 0, 0, 0, 0, 0, 0},
+    port: 4000
+  ],
   render_errors: [view: TrentoWeb.ErrorView, accepts: ~w(html json), layout: false],
-  pubsub_server: Trento.PubSub,
-  live_view: [signing_salt: "4tNZ+tm7"]
+  pubsub_server: Trento.PubSub
 
 # Configures the mailer
 #
@@ -28,7 +32,8 @@ config :trento, Trento.Mailer, adapter: Swoosh.Adapters.Local
 # Swoosh API client is needed for adapters other than SMTP.
 config :swoosh, :api_client, false
 
-config :trento, :alerting, enabled: true
+config :trento, :alerting,
+  enabled: true
 
 # Configure esbuild (the version is required)
 config :esbuild,
@@ -56,10 +61,16 @@ config :trento, Trento.Commanded,
   pubsub: :local,
   registry: :local
 
+config :trento,
+  ecto_repos: [Trento.Repo]
+
+config :trento, Trento.Repo, pool_size: 10
+
 config :trento, Trento.EventStore,
   serializer: Trento.JsonbSerializer,
   column_data_type: "jsonb",
-  types: EventStore.PostgresTypes
+  types: EventStore.PostgresTypes,
+  pool_size: 10
 
 config :trento, event_stores: [Trento.EventStore]
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -12,7 +12,6 @@ config :trento,
 
 # Configures the endpoint
 config :trento, TrentoWeb.Endpoint,
-  url: [host: "localhost"],
   render_errors: [view: TrentoWeb.ErrorView, accepts: ~w(html json), layout: false],
   pubsub_server: Trento.PubSub,
   live_view: [signing_salt: "4tNZ+tm7"]
@@ -107,10 +106,6 @@ config :trento, Trento.Integration.Telemetry, adapter: Trento.Integration.Teleme
 config :trento, Trento.Integration.Checks, adapter: Trento.Integration.Checks.Runner
 
 config :trento, :grafana,
-  user: "admin",
-  password: "admin",
-  public_url: "http://localhost:3000",
-  api_url: "http://localhost:3000/api",
   dashboards: ["node_exporter"]
 
 config :trento,

--- a/config/config.exs
+++ b/config/config.exs
@@ -28,10 +28,7 @@ config :trento, Trento.Mailer, adapter: Swoosh.Adapters.Local
 # Swoosh API client is needed for adapters other than SMTP.
 config :swoosh, :api_client, false
 
-# configure the recipient for alert notifications
-config :trento, :alerting,
-  enabled: true,
-  recipient: "admin@trento.io"
+config :trento, :alerting, enabled: true
 
 # Configure esbuild (the version is required)
 config :esbuild,

--- a/config/config.exs
+++ b/config/config.exs
@@ -32,8 +32,7 @@ config :trento, Trento.Mailer, adapter: Swoosh.Adapters.Local
 # Swoosh API client is needed for adapters other than SMTP.
 config :swoosh, :api_client, false
 
-config :trento, :alerting,
-  enabled: true
+config :trento, :alerting, enabled: true
 
 # Configure esbuild (the version is required)
 config :esbuild,

--- a/config/config.exs
+++ b/config/config.exs
@@ -105,8 +105,7 @@ config :trento, Trento.Scheduler,
 config :trento, Trento.Integration.Telemetry, adapter: Trento.Integration.Telemetry.Suse
 config :trento, Trento.Integration.Checks, adapter: Trento.Integration.Checks.Runner
 
-config :trento, :grafana,
-  dashboards: ["node_exporter"]
+config :trento, :grafana, dashboards: ["node_exporter"]
 
 config :trento,
   uuid_namespace: "fb92284e-aa5e-47f6-a883-bf9469e7a0dc",

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -16,9 +16,6 @@ config :trento, Trento.EventStore,
 # watchers to your application. For example, we use it
 # with esbuild to bundle .js and .css sources.
 config :trento, TrentoWeb.Endpoint,
-  # Binding to loopback ipv4 address prevents access from other machines.
-  # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
-  http: [ip: {0, 0, 0, 0}, port: 4000],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -109,5 +109,4 @@ config :trento, :grafana,
 
 config :trento, Trento.Integration.Checks.Runner, runner_url: "http://localhost:8080"
 
-config :trento, :alerting,
-  recipient: "mail@domain.tld"
+config :trento, :alerting, recipient: "mail@domain.tld"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,10 +2,12 @@ import Config
 
 # Configure your database
 config :trento, Trento.Repo,
+  url: "postgres://postgres@localhost:5432/trento_dev",
   show_sensitive_data_on_connection_error: true,
   log: false
 
 config :trento, Trento.EventStore,
+  url: "postgres://postgres@localhost:5432/trento_eventstore_dev",
   show_sensitive_data_on_connection_error: true,
   log: false
 
@@ -20,6 +22,7 @@ config :trento, TrentoWeb.Endpoint,
   code_reloader: true,
   debug_errors: true,
   secret_key_base: "s2ZdE+3+ke1USHEJ5O45KT364KiXPYaB9cJPdH3p60t8yT0nkLexLBNw8TFSzC7k",
+  live_view: [signing_salt: "4tNZ+tm7"],
   watchers: [
     node: [
       "build.js",
@@ -97,3 +100,14 @@ config :phoenix, :stacktrace_depth, 20
 config :phoenix, :plug_init_mode, :runtime
 
 config :trento, :api_key_authentication, enabled: false
+
+config :trento, :grafana,
+  user: "admin",
+  password: "admin",
+  public_url: "http://localhost:3000",
+  api_url: "http://localhost:3000/api"
+
+config :trento, Trento.Integration.Checks.Runner, runner_url: "http://localhost:8080"
+
+config :trento, :alerting,
+  recipient: "mail@domain.tld"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,22 +2,12 @@ import Config
 
 # Configure your database
 config :trento, Trento.Repo,
-  username: "postgres",
-  password: "postgres",
-  database: "trento_dev",
-  hostname: "localhost",
-  port: 5433,
   show_sensitive_data_on_connection_error: true,
-  pool_size: 10,
   log: false
 
 config :trento, Trento.EventStore,
-  username: "postgres",
-  password: "postgres",
-  database: "trento_eventstore_dev",
-  hostname: "localhost",
-  port: 5433,
-  pool_size: 10
+  show_sensitive_data_on_connection_error: true,
+  log: false
 
 # For development, we disable any cache and enable
 # debugging and code reloading.

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -14,4 +14,7 @@ config :trento, Trento.Mailer,
 config :swoosh, local: false
 
 # Do not print debug messages in production
-# config :logger, level: :info
+config :logger, level: :info
+
+# alerting is usually enabled by default, but it's the opposite in prod
+config :trento, :alerting, enabled: false

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -5,6 +5,12 @@ config :trento, TrentoWeb.Endpoint,
   cache_static_manifest: "priv/static/cache_manifest.json",
   server: true
 
+config :trento, Trento.Mailer,
+  adapter: Swoosh.Adapters.SMTP,
+  auth: :always,
+  ssl: :if_available,
+  tls: :if_available
+
 config :swoosh, local: false
 
 # Do not print debug messages in production

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -9,13 +9,13 @@ import Trento.Config
 
 config :trento, Trento.Repo,
   url:
-    System.get_env("DATABASE_URL") || "postgres://postgres@localhost:5433/#{db_name("trento")}",
+    System.get_env("DATABASE_URL") || "postgres://postgres@localhost:5432/#{db_name("trento")}",
   pool_size: String.to_integer(System.get_env("DATABASE_POOL_SIZE") || "10")
 
 config :trento, Trento.EventStore,
   url:
     System.get_env("EVENTSTORE_URL") ||
-      "postgres://postgres@localhost:5433/#{db_name("trento_eventstore")}",
+      "postgres://postgres@localhost:5432/#{db_name("trento_eventstore")}",
   pool_size: String.to_integer(System.get_env("EVENTSTORE_POOL_SIZE") || "10")
 
 config :trento, TrentoWeb.Endpoint,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -8,11 +8,14 @@ import Trento.Config
 # any compile-time configuration in here, as it won't be applied.
 
 config :trento, Trento.Repo,
-  url: System.get_env("DATABASE_URL") || "postgres://postgres@localhost:5433/#{db_name("trento")}",
+  url:
+    System.get_env("DATABASE_URL") || "postgres://postgres@localhost:5433/#{db_name("trento")}",
   pool_size: String.to_integer(System.get_env("DATABASE_POOL_SIZE") || "10")
 
 config :trento, Trento.EventStore,
-  url: System.get_env("EVENTSTORE_URL") || "postgres://postgres@localhost:5433/#{db_name("trento_eventstore")}",
+  url:
+    System.get_env("EVENTSTORE_URL") ||
+      "postgres://postgres@localhost:5433/#{db_name("trento_eventstore")}",
   pool_size: String.to_integer(System.get_env("EVENTSTORE_POOL_SIZE") || "10")
 
 if config_env() == :prod do
@@ -27,8 +30,8 @@ if config_env() == :prod do
       environment variable SECRET_KEY_BASE is missing.
       You can generate one by calling: mix phx.gen.secret
       """
-  config :trento, TrentoWeb.Endpoint,
-    secret_key_base: secret_key_base
+
+  config :trento, TrentoWeb.Endpoint, secret_key_base: secret_key_base
 end
 
 config :trento, TrentoWeb.Endpoint,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -45,6 +45,7 @@ enable_alerting =
   end
 
 alert_recipient = System.get_env("ALERT_RECIPIENT") || fallback([:alerting, :recipient])
+
 if enable_alerting and is_nil(alert_recipient) do
   raise("Missing required environment variable: ALERT_RECIPIENT")
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -40,7 +40,7 @@ config :trento, :grafana,
 
 enable_alerting =
   case get_env_bool("ENABLE_ALERTING") do
-    value when is_bool(value) -> value
+    value when is_boolean(value) -> value
     nil -> fallback([:alerting, :enabled])
   end
 
@@ -81,7 +81,7 @@ config :trento, Trento.Mailer,
 # so we need to do some interpolation in the crontab format
 runner_schedule =
   case get_env_int("RUNNER_INTERVAL") do
-    value when is_int(value) -> "*/#{value} * * * *"
+    value when is_integer(value) -> "*/#{value} * * * *"
     nil -> fallback([Trento.Scheduler, :jobs, :clusters_checks_execution, :schedule])
   end
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,36 +1,21 @@
 import Config
+import Trento.Config
 
 # config/runtime.exs is executed for all environments, including
 # during releases. It is executed after compilation and before the
 # system starts, so it is typically used to load production configuration
 # and secrets from environment variables or elsewhere. Do not define
 # any compile-time configuration in here, as it won't be applied.
-# The block below contains prod specific runtime configuration.
+
+config :trento, Trento.Repo,
+  url: System.get_env("DATABASE_URL") || "postgres://postgres@localhost:5433/#{db_name("trento")}",
+  pool_size: String.to_integer(System.get_env("DATABASE_POOL_SIZE") || "10")
+
+config :trento, Trento.EventStore,
+  url: System.get_env("EVENTSTORE_URL") || "postgres://postgres@localhost:5433/#{db_name("trento_eventstore")}",
+  pool_size: String.to_integer(System.get_env("EVENTSTORE_POOL_SIZE") || "10")
+
 if config_env() == :prod do
-  database_url =
-    System.get_env("DATABASE_URL") ||
-      raise """
-      environment variable DATABASE_URL is missing.
-      For example: ecto://USER:PASS@HOST/DATABASE
-      """
-
-  config :trento, Trento.Repo,
-    # ssl: true,
-    # socket_options: [:inet6],
-    url: database_url,
-    pool_size: String.to_integer(System.get_env("DATABASE_POOL_SIZE") || "10")
-
-  evenstore_url =
-    System.get_env("EVENTSTORE_URL") ||
-      raise """
-      environment variable EVENTSTORE_URL is missing.
-      For example: ecto://USER:PASS@HOST/DATABASE
-      """
-
-  config :trento, Trento.EventStore,
-    url: evenstore_url,
-    pool_size: String.to_integer(System.get_env("EVENTSTORE_POOL_SIZE") || "10")
-
   # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you
   # want to use a different value for prod and you most likely don't want
@@ -42,80 +27,75 @@ if config_env() == :prod do
       environment variable SECRET_KEY_BASE is missing.
       You can generate one by calling: mix phx.gen.secret
       """
-
   config :trento, TrentoWeb.Endpoint,
-    http: [
-      # Enable IPv6 and bind on all interfaces.
-      # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.
-      # See the documentation on https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html
-      # for details about using IPv6 vs IPv4 and loopback vs public addresses.
-      ip: {0, 0, 0, 0, 0, 0, 0, 0},
-      port: String.to_integer(System.get_env("PORT") || "4000")
-    ],
     secret_key_base: secret_key_base
-
-  runner_url =
-    System.get_env("RUNNER_URL") ||
-      raise """
-      environment variable RUNNER_URL is missing.
-      For example: http://localhost:8080
-      """
-
-  config :trento, Trento.Integration.Checks.Runner, runner_url: runner_url
-
-  config :trento, :grafana,
-    user: System.get_env("GRAFANA_USER") || "admin",
-    password: System.get_env("GRAFANA_PASSWORD") || "admin",
-    public_url: System.get_env("GRAFANA_PUBLIC_URL") || "http://localhost:3000",
-    api_url: System.get_env("GRAFANA_API_URL") || "http://localhost:3000/api"
-
-  # ## Using releases
-  #
-  # If you are doing OTP releases, you need to instruct Phoenix
-  # to start each relevant endpoint:
-  #
-  #     config :trento, TrentoWeb.Endpoint, server: true
-  #
-  # Then you can assemble a release by calling `mix release`.
-  # See `mix help release` for more information.
-
-  # ## Configuring the mailer
-  #
-  # In production you need to configure the mailer to use a different adapter.
-  # Also, you may need to configure the Swoosh API client of your choice if you
-  # are not using SMTP. Here is an example of the configuration:
-  #
-  #     config :trento, Trento.Mailer,
-  #       adapter: Swoosh.Adapters.Mailgun,
-  #       api_key: System.get_env("MAILGUN_API_KEY"),
-  #       domain: System.get_env("MAILGUN_DOMAIN")
-  #
-  # For this example you need include a HTTP client required by Swoosh API client.
-  # Swoosh supports Hackney and Finch out of the box:
-  #
-  #     config :swoosh, :api_client, Swoosh.ApiClient.Hackney
-  #
-  # See https://hexdocs.pm/swoosh/Swoosh.html#module-installation for details.
-
-  config :trento, :alerting,
-    enabled: System.get_env("ENABLE_ALERTING", "false") == "true",
-    recipient: System.get_env("ALERT_RECIPIENT") || "admin@trento-project.io"
-
-  config :trento, Trento.Mailer,
-    adapter: Swoosh.Adapters.SMTP,
-    relay: System.get_env("SMTP_SERVER") || "",
-    port: System.get_env("SMTP_PORT") || "",
-    username: System.get_env("SMTP_USER") || "",
-    password: System.get_env("SMTP_PASSWORD") || "",
-    auth: :always,
-    ssl: :if_available,
-    tls: :if_available
-
-  config :trento, Trento.Scheduler,
-    jobs: [
-      clusters_checks_execution: [
-        # Runs every five minutes by default
-        schedule: "*/#{System.get_env("RUNNER_INTERVAL", "5")} * * * *"
-      ]
-    ]
 end
+
+config :trento, TrentoWeb.Endpoint,
+  http: [
+    # Enable IPv6 and bind on all interfaces.
+    # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.
+    # See the documentation on https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html
+    # for details about using IPv6 vs IPv4 and loopback vs public addresses.
+    ip: {0, 0, 0, 0, 0, 0, 0, 0},
+    port: String.to_integer(System.get_env("PORT") || "4000")
+  ]
+
+config :trento, Trento.Integration.Checks.Runner,
+  runner_url: System.get_env("RUNNER_URL") || "http://localhost:8080"
+
+config :trento, :grafana,
+  user: System.get_env("GRAFANA_USER") || "admin",
+  password: System.get_env("GRAFANA_PASSWORD") || "admin",
+  public_url: System.get_env("GRAFANA_PUBLIC_URL") || "http://localhost:3000",
+  api_url: System.get_env("GRAFANA_API_URL") || "http://localhost:3000/api"
+
+# ## Using releases
+#
+# If you are doing OTP releases, you need to instruct Phoenix
+# to start each relevant endpoint:
+#
+#     config :trento, TrentoWeb.Endpoint, server: true
+#
+# Then you can assemble a release by calling `mix release`.
+# See `mix help release` for more information.
+
+# ## Configuring the mailer
+#
+# In production you need to configure the mailer to use a different adapter.
+# Also, you may need to configure the Swoosh API client of your choice if you
+# are not using SMTP. Here is an example of the configuration:
+#
+#     config :trento, Trento.Mailer,
+#       adapter: Swoosh.Adapters.Mailgun,
+#       api_key: System.get_env("MAILGUN_API_KEY"),
+#       domain: System.get_env("MAILGUN_DOMAIN")
+#
+# For this example you need include a HTTP client required by Swoosh API client.
+# Swoosh supports Hackney and Finch out of the box:
+#
+#     config :swoosh, :api_client, Swoosh.ApiClient.Hackney
+#
+# See https://hexdocs.pm/swoosh/Swoosh.html#module-installation for details.
+
+config :trento, :alerting,
+  enabled: System.get_env("ENABLE_ALERTING") == "true",
+  recipient: System.get_env("ALERT_RECIPIENT") || "admin@trento-project.io"
+
+config :trento, Trento.Mailer,
+  adapter: Swoosh.Adapters.SMTP,
+  relay: System.get_env("SMTP_SERVER") || "",
+  port: System.get_env("SMTP_PORT") || "",
+  username: System.get_env("SMTP_USER") || "",
+  password: System.get_env("SMTP_PASSWORD") || "",
+  auth: :always,
+  ssl: :if_available,
+  tls: :if_available
+
+config :trento, Trento.Scheduler,
+  jobs: [
+    clusters_checks_execution: [
+      # Runs every five minutes by default
+      schedule: "*/#{System.get_env("RUNNER_INTERVAL", "5")} * * * *"
+    ]
+  ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -44,5 +44,4 @@ config :trento, :grafana,
 
 config :trento, Trento.Integration.Checks.Runner, runner_url: "http://localhost:8080"
 
-config :trento, :alerting,
-  recipient: "mail@domain.tld"
+config :trento, :alerting, recipient: "mail@domain.tld"

--- a/config/test.exs
+++ b/config/test.exs
@@ -16,11 +16,9 @@ config :trento, Trento.Commanded,
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :trento, TrentoWeb.Endpoint,
-  http: [ip: {127, 0, 0, 1}, port: 4002],
   secret_key_base: "dN6epjGF+jdAdq1+q4cuJSMVwrwDMWUcakjB6ISxfFmvNziaOpBsJcCPaBaydJIk",
   server: false
 
-# In test we don't send emails.
 config :trento, Trento.Mailer, adapter: Swoosh.Adapters.Test
 
 # Print only warnings and errors during test

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,7 +5,14 @@ import Config
 # The MIX_TEST_PARTITION environment variable can be used
 # to provide built-in test partitioning in CI environment.
 # Run `mix help test` for more information.
-config :trento, Trento.Repo, pool: Ecto.Adapters.SQL.Sandbox
+# Configure your database
+config :trento, Trento.Repo,
+  pool: Ecto.Adapters.SQL.Sandbox,
+  url: "postgres://postgres@localhost:5432/trento_test#{System.get_env("MIX_TEST_PARTITION")}"
+
+config :trento, Trento.EventStore,
+  url:
+    "postgres://postgres@localhost:5432/trento_eventstore_test#{System.get_env("MIX_TEST_PARTITION")}"
 
 config :trento, Trento.Commanded,
   event_store: [
@@ -28,3 +35,14 @@ config :logger, level: :warn
 config :phoenix, :plug_init_mode, :runtime
 
 config :trento, :api_key_authentication, enabled: false
+
+config :trento, :grafana,
+  user: "admin",
+  password: "admin",
+  public_url: "http://localhost:3000",
+  api_url: "http://localhost:3000/api"
+
+config :trento, Trento.Integration.Checks.Runner, runner_url: "http://localhost:8080"
+
+config :trento, :alerting,
+  recipient: "mail@domain.tld"

--- a/config/test.exs
+++ b/config/test.exs
@@ -6,13 +6,7 @@ import Config
 # to provide built-in test partitioning in CI environment.
 # Run `mix help test` for more information.
 config :trento, Trento.Repo,
-  username: "postgres",
-  password: "postgres",
-  database: "trento_test#{System.get_env("MIX_TEST_PARTITION")}",
-  hostname: "localhost",
-  port: 5433,
-  pool: Ecto.Adapters.SQL.Sandbox,
-  pool_size: 10
+  pool: Ecto.Adapters.SQL.Sandbox
 
 config :trento, Trento.Commanded,
   event_store: [

--- a/config/test.exs
+++ b/config/test.exs
@@ -5,8 +5,7 @@ import Config
 # The MIX_TEST_PARTITION environment variable can be used
 # to provide built-in test partitioning in CI environment.
 # Run `mix help test` for more information.
-config :trento, Trento.Repo,
-  pool: Ecto.Adapters.SQL.Sandbox
+config :trento, Trento.Repo, pool: Ecto.Adapters.SQL.Sandbox
 
 config :trento, Trento.Commanded,
   event_store: [

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,17 +1,45 @@
-version: "3"
+version: "3.9"
 
 services:
+  web:
+    depends_on:
+      - runner
+      - postgres
+      - grafana
+    build:
+      context: .
+      target: system
+    environment:
+      DATABASE_URL: postgres://postgres@postgres:5432/trento
+      EVENTSTORE_URL: postgres://postgres@postgres:5432/trento_eventstore
+      GRAFANA_PUBLIC_URL: http://grafana:3000
+      GRAFANA_API_URL: http://grafana:3000/api
+      RUNNER_URL: http://runner:8000
+    volumes:
+      - .:/app
+      - build_cache:/app/_build
+    ports:
+      - 4000:4000
+
+  runner:
+    image: ghcr.io/trento-project/trento-runner:1.0.0
+    command:
+      - --callbacks-url
+      - "http://web/api/runner/callback"
+      - start
+    ports:
+      - 8000:8000
+
   postgres:
     image: postgres:latest
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      PGDATA: /var/lib/postgresql/data/pgdata
+      POSTGRES_HOST_AUTH_METHOD: trust
     ports:
       - 5433:5432
     restart: always
     volumes:
-      - ./.pgdata:/var/lib/postgresql/data
+      - pg_data:/var/lib/postgresql/data
+
   grafana:
     image: grafana/grafana:latest
     environment:
@@ -19,3 +47,7 @@ services:
       GF_AUTH_ANONYMOUS_ENABLED: "true"
     ports:
       - 3000:3000
+
+volumes:
+  build_cache: {}
+  pg_data: {}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
-      - 5433:5432
+      - 5432:5432
     restart: always
     volumes:
       - pg_data:/var/lib/postgresql/data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,8 +16,8 @@ services:
       GRAFANA_API_URL: http://grafana:3000/api
       RUNNER_URL: http://runner:8000
     volumes:
-      - .:/app
-      - build_cache:/app/_build
+      - .:/source
+      - build_cache:/source/_build
     ports:
       - 4000:4000
 

--- a/lib/trento/support/config.ex
+++ b/lib/trento/support/config.ex
@@ -1,4 +1,5 @@
 import Config
+
 defmodule Trento.Config do
   def db_name(name, env \\ config_env()) do
     if env == :prod do

--- a/lib/trento/support/config.ex
+++ b/lib/trento/support/config.ex
@@ -1,0 +1,10 @@
+import Config
+defmodule Trento.Config do
+  def db_name(name, env \\ config_env()) do
+    if env == :prod do
+      name
+    end
+
+    "#{name}_#{env}#{System.get_env("MIX_TEST_PARTITION")}"
+  end
+end

--- a/lib/trento/support/config.ex
+++ b/lib/trento/support/config.ex
@@ -1,15 +1,34 @@
-import Config
-
 defmodule Trento.Config do
   @moduledoc """
   Configuration helper functions
   """
 
-  def db_name(name, env \\ config_env()) do
-    if env == :prod do
-      name
-    end
+  @doc """
+  retrieve an environment configuration setting from the system environment
+  using existing Application configuration as fallback
+  """
+  def fallback(config_path) do
+    :trento |> Application.get_all_env() |> get_in(config_path)
+  end
 
-    "#{name}_#{env}#{System.get_env("MIX_TEST_PARTITION")}"
+  def get_env_int(env_var, default \\ nil) do
+    value = System.get_env(env_var, default)
+
+    if is_nil(value) do
+      value
+    else
+      String.to_integer(value)
+    end
+  end
+
+  def get_env_bool(env_var, default \\ nil) do
+    value = System.get_env(env_var, default)
+
+    cond do
+      is_nil(value) -> nil
+      value in ["true", "1", "yes"] -> true
+      value in ["false", "0", "no"] -> false
+      true -> raise "Cannot parse #{env_var} boolean value from '#{value}'"
+    end
   end
 end

--- a/lib/trento/support/config.ex
+++ b/lib/trento/support/config.ex
@@ -1,6 +1,10 @@
 import Config
 
 defmodule Trento.Config do
+  @moduledoc """
+  Configuration helper functions
+  """
+
   def db_name(name, env \\ config_env()) do
     if env == :prod do
       name

--- a/mix.exs
+++ b/mix.exs
@@ -95,6 +95,7 @@ defmodule Trento.MixProject do
         "setup",
         "phx.server"
       ],
+      "start.full": [ "docker-compose up -d postgres grafana runner", "start"],
       install: ["deps.get", "cmd --cd assets npm install"],
       setup: ["event_store.setup", "ecto.setup", "init_grafana_dashboards"],
       reset: ["event_store.reset", "ecto.reset"],

--- a/mix.exs
+++ b/mix.exs
@@ -95,7 +95,7 @@ defmodule Trento.MixProject do
         "setup",
         "phx.server"
       ],
-      "start.full": [ "docker-compose up -d postgres grafana runner", "start"],
+      "start.full": ["docker-compose up -d postgres grafana runner", "start"],
       install: ["deps.get", "cmd --cd assets npm install"],
       setup: ["event_store.setup", "ecto.setup", "init_grafana_dashboards"],
       reset: ["event_store.reset", "ecto.reset"],

--- a/mix.exs
+++ b/mix.exs
@@ -95,7 +95,7 @@ defmodule Trento.MixProject do
         "setup",
         "phx.server"
       ],
-      "start.full": ["docker-compose up -d postgres grafana runner", "start"],
+      "start.full": ["docker-compose up -d postgres grafana", "start"],
       install: ["deps.get", "cmd --cd assets npm install"],
       setup: ["event_store.setup", "ecto.setup", "init_grafana_dashboards"],
       reset: ["event_store.reset", "ecto.reset"],


### PR DESCRIPTION
- reinstate mix task starting compose services
- add the 'web' service in docker-compose and further updates the Dockerfile, following up to #486
- tweak docker context
- move everything related to env vars to runtime.exs
- add helper config module to enable falling back to mix env-specific config settings.