### PR TITLE
Use get-latest action to avoid issues with git after CVE-2022-24765

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -314,8 +314,12 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
+
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+        id: latest-tag
         with:
-          fetch-depth: 0
+          semver_only: true
+          initial_version: 0.0.1
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -330,7 +334,7 @@ jobs:
 
       - name: Set version
         run: |
-          VERSION=$(./hack/get_version_from_git.sh)
+          VERSION=${{ steps.latest-tag.outputs.tag }}
           sed -i 's~%%VERSION%%~'"${VERSION}"'~' packaging/suse/Dockerfile
 
       - name: Configure OSC


### PR DESCRIPTION
The version of the container is incorrectly found. Fix for that.

Fix for the git CVE-2022-24765. More info in:
https://github.blog/2022-04-12-git-security-vulnerability-announced/
https://github.com/actions/checkout/issues/760