### PR TITLE
Revert "Use get-latest action to avoid issues with git after CVE-2022-24765"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -314,12 +314,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
-
-      - uses: actions-ecosystem/action-get-latest-tag@v1
-        id: latest-tag
         with:
-          semver_only: true
-          initial_version: 0.0.1
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -334,7 +330,7 @@ jobs:
 
       - name: Set version
         run: |
-          VERSION=${{ steps.latest-tag.outputs.tag }}
+          VERSION=$(./hack/get_version_from_git.sh)
           sed -i 's~%%VERSION%%~'"${VERSION}"'~' packaging/suse/Dockerfile
 
       - name: Configure OSC


### PR DESCRIPTION
Reverts trento-project/web#492