### PR TITLE
Completely skip alerting feature steps when alerting is disabled

### DIFF
--- a/lib/trento/application/usecases/alerting/alerting.ex
+++ b/lib/trento/application/usecases/alerting/alerting.ex
@@ -16,31 +16,53 @@ defmodule Trento.Application.UseCases.Alerting do
   require Logger
 
   @spec notify_heartbeat_failed(String.t()) :: :ok
-  def notify_heartbeat_failed(host_id) do
+  def notify_heartbeat_failed(host_id),
+    do: maybe_notify_heartbeat_failed(enabled?(), host_id)
+
+  @spec notify_critical_cluster_health(String.t()) :: :ok
+  def notify_critical_cluster_health(cluster_id),
+    do: maybe_notify_critical_cluster_health(enabled?(), cluster_id)
+
+  @spec notify_critical_database_health(String.t()) :: :ok
+  def notify_critical_database_health(id),
+    do: maybe_notify_critical_database_health(enabled?(), id)
+
+  @spec notify_critical_sap_system_health(String.t()) :: :ok
+  def notify_critical_sap_system_health(id),
+    do: maybe_notify_critical_sap_system_health(enabled?(), id)
+
+  defp enabled?, do: Application.fetch_env!(:trento, :alerting)[:enabled]
+
+  defp maybe_notify_heartbeat_failed(false, _), do: :ok
+
+  defp maybe_notify_heartbeat_failed(true, host_id) do
     %HostReadModel{hostname: hostname} = Trento.Repo.get!(HostReadModel, host_id)
 
     EmailAlert.alert("Host", "hostname", hostname, "heartbeat failed")
     |> deliver_notification()
   end
 
-  @spec notify_critical_cluster_health(String.t()) :: :ok
-  def notify_critical_cluster_health(cluster_id) do
+  defp maybe_notify_critical_cluster_health(false, _), do: :ok
+
+  defp maybe_notify_critical_cluster_health(true, cluster_id) do
     %ClusterReadModel{name: name} = Trento.Repo.get!(ClusterReadModel, cluster_id)
 
     EmailAlert.alert("Cluster", "name", name, "health is now in critical state")
     |> deliver_notification()
   end
 
-  @spec notify_critical_database_health(String.t()) :: :ok
-  def notify_critical_database_health(id) do
+  defp maybe_notify_critical_database_health(false, _), do: :ok
+
+  defp maybe_notify_critical_database_health(true, id) do
     %DatabaseReadModel{sid: sid} = Trento.Repo.get!(DatabaseReadModel, id)
 
     EmailAlert.alert("Database", "SID", sid, "health is now in critical state")
     |> deliver_notification()
   end
 
-  @spec notify_critical_sap_system_health(String.t()) :: :ok
-  def notify_critical_sap_system_health(id) do
+  defp maybe_notify_critical_sap_system_health(false, _), do: :ok
+
+  defp maybe_notify_critical_sap_system_health(true, id) do
     %SapSystemReadModel{sid: sid} = Trento.Repo.get!(SapSystemReadModel, id)
 
     EmailAlert.alert("Sap System", "SID", sid, "health is now in critical state")
@@ -48,15 +70,7 @@ defmodule Trento.Application.UseCases.Alerting do
   end
 
   @spec deliver_notification(Swoosh.Email.t()) :: :ok
-  defp deliver_notification(%Swoosh.Email{} = notification) do
-    maybe_deliver_notification(Application.fetch_env!(:trento, :alerting)[:enabled], notification)
-  end
-
-  @spec maybe_deliver_notification(false, Swoosh.Email.t()) :: :ok
-  defp maybe_deliver_notification(false, _), do: :ok
-
-  @spec maybe_deliver_notification(true, Swoosh.Email.t()) :: :ok
-  defp maybe_deliver_notification(true, %Swoosh.Email{subject: subject} = notification) do
+  defp deliver_notification(%Swoosh.Email{subject: subject} = notification) do
     notification
     |> Mailer.deliver()
     |> case do


### PR DESCRIPTION
When alerting was disabled, the notification (email) to be sent was build anyway.
No recipient is required unless alerting is enabled, yet building the email notification **does require** the recipient :sweat_smile: 

This was inconsistent ad rasied errors.

This fix completely skips the steps of alerting if disabled.
As an extra we get some less queries.