### PR TITLE
Handle unnamed cluster event

### DIFF
--- a/.photofinish.toml
+++ b/.photofinish.toml
@@ -83,3 +83,7 @@ files = ["./test/fixtures/scenarios/clusters-overview/13e8c25c-3180-5a9a-95c8-51
 [cluster-1-SFAIL]
 
 files = ["./test/fixtures/scenarios/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_1_SFAIL.json"]
+
+[cluster-unnamed]
+
+files = ["./test/fixtures/scenarios/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_unnamed.json"]

--- a/assets/js/components/ClusterDetails/ChecksResults.jsx
+++ b/assets/js/components/ClusterDetails/ChecksResults.jsx
@@ -15,7 +15,10 @@ import LoadingBox from '../LoadingBox';
 import Button from '@components/Button';
 import { getCluster } from '@state/selectors';
 import TrentoLogo from '../../../static/trento-icon.png';
-import { TriggerChecksExecutionRequest } from './ClusterDetails';
+import {
+  TriggerChecksExecutionRequest,
+  truncatedClusterNameClasses,
+} from './ClusterDetails';
 import { ExecutionIcon } from './ExecutionIcon';
 import { getClusterName } from '@components/ClusterLink';
 
@@ -210,7 +213,9 @@ export const ChecksResults = () => {
       <div className="flex mb-4">
         <h1 className="text-3xl w-3/5">
           <span className="font-medium">Checks Results for cluster</span>{' '}
-          <span className="font-bold">{getClusterName(cluster)}</span>
+          <span className={`font-bold ${truncatedClusterNameClasses}`}>
+            {getClusterName(cluster)}
+          </span>
         </h1>
         <div className="flex w-2/5 justify-end text-white">
           <Button

--- a/assets/js/components/ClusterDetails/ChecksResults.jsx
+++ b/assets/js/components/ClusterDetails/ChecksResults.jsx
@@ -17,6 +17,7 @@ import { getCluster } from '@state/selectors';
 import TrentoLogo from '../../../static/trento-icon.png';
 import { TriggerChecksExecutionRequest } from './ClusterDetails';
 import { ExecutionIcon } from './ExecutionIcon';
+import { getClusterName } from '@components/ClusterLink';
 
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -209,7 +210,7 @@ export const ChecksResults = () => {
       <div className="flex mb-4">
         <h1 className="text-3xl w-3/5">
           <span className="font-medium">Checks Results for cluster</span>{' '}
-          <span className="font-bold">{cluster && cluster.name}</span>
+          <span className="font-bold">{getClusterName(cluster)}</span>
         </h1>
         <div className="flex w-2/5 justify-end text-white">
           <Button

--- a/assets/js/components/ClusterDetails/ClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetails.jsx
@@ -12,6 +12,8 @@ import { groupBy } from '@lib/lists';
 
 import SiteDetails from './SiteDetails';
 
+import { getClusterName } from '@components/ClusterLink';
+
 import { EOS_SETTINGS, EOS_CLEAR_ALL, EOS_PLAY_CIRCLE } from 'eos-icons-react';
 import { getCluster } from '@state/selectors';
 import classNames from 'classnames';
@@ -80,7 +82,7 @@ const ClusterDetails = () => {
     <div>
       <div className="flex">
         <h1 className="text-3xl font-bold w-1/2">
-          Pacemaker cluster details: {cluster.name}
+          Pacemaker cluster details: {getClusterName(cluster)}
         </h1>
         <div className="flex w-1/2 justify-end">
           <Button

--- a/assets/js/components/ClusterDetails/ClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetails.jsx
@@ -18,6 +18,10 @@ import { EOS_SETTINGS, EOS_CLEAR_ALL, EOS_PLAY_CIRCLE } from 'eos-icons-react';
 import { getCluster } from '@state/selectors';
 import classNames from 'classnames';
 
+export const truncatedClusterNameClasses = classNames(
+  'font-bold truncate w-60 inline-block align-top'
+);
+
 const siteDetailsConfig = {
   usePadding: false,
   columns: [
@@ -82,7 +86,10 @@ const ClusterDetails = () => {
     <div>
       <div className="flex">
         <h1 className="text-3xl font-bold w-1/2">
-          Pacemaker cluster details: {getClusterName(cluster)}
+          Pacemaker cluster details:{' '}
+          <span className={truncatedClusterNameClasses}>
+            {getClusterName(cluster)}
+          </span>
         </h1>
         <div className="flex w-1/2 justify-end">
           <Button

--- a/assets/js/components/ClusterDetails/ClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetails.jsx
@@ -129,7 +129,7 @@ const ClusterDetails = () => {
           className="grid-rows-3"
           orientation="vertical"
           data={[
-            { title: 'Cluster name', content: cluster.name },
+            { title: 'Cluster name', content: cluster.name || 'Not defined' },
             { title: 'SID', content: cluster.sid },
             {
               title: 'Fencing type',

--- a/assets/js/components/ClusterDetails/ClusterSettings.jsx
+++ b/assets/js/components/ClusterDetails/ClusterSettings.jsx
@@ -11,6 +11,7 @@ import { ChecksSelection } from './ChecksSelection';
 import { ConnectionSettings } from './ConnectionSettings';
 import { getCluster } from '@state/selectors';
 import { TriggerChecksExecutionRequest } from './ClusterDetails';
+import { getClusterName } from '@components/ClusterLink';
 
 export const ClusterSettings = () => {
   const { clusterID } = useParams();
@@ -32,7 +33,7 @@ export const ClusterSettings = () => {
       <div className="flex mb-2">
         <h1 className="text-3xl w-1/2">
           <span className="font-medium">Cluster Settings for</span>{' '}
-          <span className="font-bold">{cluster && cluster.name}</span>
+          <span className="font-bold">{getClusterName(cluster)}</span>
         </h1>
         <div className="flex w-1/2 justify-end text-white">
           <Button

--- a/assets/js/components/ClusterDetails/ClusterSettings.jsx
+++ b/assets/js/components/ClusterDetails/ClusterSettings.jsx
@@ -10,7 +10,10 @@ import { Tab } from '@headlessui/react';
 import { ChecksSelection } from './ChecksSelection';
 import { ConnectionSettings } from './ConnectionSettings';
 import { getCluster } from '@state/selectors';
-import { TriggerChecksExecutionRequest } from './ClusterDetails';
+import {
+  TriggerChecksExecutionRequest,
+  truncatedClusterNameClasses,
+} from './ClusterDetails';
 import { getClusterName } from '@components/ClusterLink';
 
 export const ClusterSettings = () => {
@@ -33,7 +36,9 @@ export const ClusterSettings = () => {
       <div className="flex mb-2">
         <h1 className="text-3xl w-1/2">
           <span className="font-medium">Cluster Settings for</span>{' '}
-          <span className="font-bold">{getClusterName(cluster)}</span>
+          <span className={`font-bold ${truncatedClusterNameClasses}`}>
+            {getClusterName(cluster)}
+          </span>
         </h1>
         <div className="flex w-1/2 justify-end text-white">
           <Button

--- a/assets/js/components/ClusterLink.jsx
+++ b/assets/js/components/ClusterLink.jsx
@@ -1,14 +1,17 @@
 import React from 'react';
 
 import { Link } from 'react-router-dom';
+import classNames from 'classnames';
 
-const truncatedLength = 14; // Using 14 as it cuts the uuid format after the 2nd -
 export const getClusterName = (cluster) => {
-  return cluster?.name || cluster?.id.slice(0, truncatedLength) + '...';
+  return cluster?.name || cluster?.id;
 };
 
 const ClusterLink = ({ cluster }) => {
   const clusterName = getClusterName(cluster);
+  const truncatedClasses = classNames(
+    'truncate w-32 inline-block align-middle'
+  );
 
   if (cluster?.type == 'hana_scale_up' || cluster?.type == 'hana_scale_out') {
     return (
@@ -16,12 +19,12 @@ const ClusterLink = ({ cluster }) => {
         className="text-jungle-green-500 hover:opacity-75"
         to={`/clusters/${cluster.id}`}
       >
-        {clusterName}
+        <span className={truncatedClasses}>{clusterName}</span>
       </Link>
     );
   }
 
-  return <span>{clusterName}</span>;
+  return <span className={truncatedClasses}>{clusterName}</span>;
 };
 
 export default ClusterLink;

--- a/assets/js/components/ClusterLink.jsx
+++ b/assets/js/components/ClusterLink.jsx
@@ -2,19 +2,26 @@ import React from 'react';
 
 import { Link } from 'react-router-dom';
 
-const ClusterLink = ({ cluster, children }) => {
+const truncatedLength = 14; // Using 14 as it cuts the uuid format after the 2nd -
+export const getClusterName = (cluster) => {
+  return cluster?.name || cluster?.id.slice(0, truncatedLength) + '...';
+};
+
+const ClusterLink = ({ cluster }) => {
+  const clusterName = getClusterName(cluster);
+
   if (cluster?.type == 'hana_scale_up' || cluster?.type == 'hana_scale_out') {
     return (
       <Link
         className="text-jungle-green-500 hover:opacity-75"
         to={`/clusters/${cluster.id}`}
       >
-        {children}
+        {clusterName}
       </Link>
     );
   }
 
-  return <span>{children}</span>;
+  return <span>{clusterName}</span>;
 };
 
 export default ClusterLink;

--- a/assets/js/components/ClustersList.jsx
+++ b/assets/js/components/ClustersList.jsx
@@ -54,9 +54,9 @@ const ClustersList = () => {
         key: 'name',
         filter: true,
         render: (content, item) => (
-          <ClusterLink cluster={item}>
-            <span className="tn-clustername">{content}</span>
-          </ClusterLink>
+          <span className="tn-clustername">
+            <ClusterLink cluster={item} />
+          </span>
         ),
       },
       {

--- a/assets/js/components/HostDetails/HostDetails.jsx
+++ b/assets/js/components/HostDetails/HostDetails.jsx
@@ -50,9 +50,7 @@ const HostDetails = () => {
             { title: 'Name', content: host.hostname },
             {
               title: 'Cluster',
-              content: (
-                <ClusterLink cluster={cluster}>{cluster?.name}</ClusterLink>
-              ),
+              content: <ClusterLink cluster={cluster} />,
             },
             { title: 'Agent version', content: host.agent_version },
           ]}

--- a/assets/js/components/HostsList.jsx
+++ b/assets/js/components/HostsList.jsx
@@ -100,7 +100,7 @@ const HostsList = () => {
         key: 'cluster',
         className: 'w-40',
         render: (cluster) => {
-          return <ClusterLink cluster={cluster}>{cluster?.name}</ClusterLink>;
+          return <ClusterLink cluster={cluster} />;
         },
       },
       {

--- a/assets/js/components/InstanceOverview/InstanceOverview.jsx
+++ b/assets/js/components/InstanceOverview/InstanceOverview.jsx
@@ -42,7 +42,7 @@ const InstanceOverview = ({
       )}
       <div className="table-cell p-2">
         {cluster ? (
-          <ClusterLink cluster={cluster}>{cluster.name}</ClusterLink>
+          <ClusterLink cluster={cluster} />
         ) : (
           <p className="text-gray-500 dark:text-gray-300 text-sm">
             not available

--- a/lib/trento/application/read_models/cluster_read_model.ex
+++ b/lib/trento/application/read_models/cluster_read_model.ex
@@ -17,7 +17,7 @@ defmodule Trento.ClusterReadModel do
   @derive {Jason.Encoder, except: [:__meta__, :__struct__]}
   @primary_key {:id, :binary_id, autogenerate: false}
   schema "clusters" do
-    field :name, :string
+    field :name, :string, default: ""
     field :sid, :string
     field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :unknown]
     field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]

--- a/lib/trento/domain/cluster/cluster.ex
+++ b/lib/trento/domain/cluster/cluster.ex
@@ -52,7 +52,7 @@ defmodule Trento.Domain.Cluster do
 
   @type t :: %__MODULE__{
           cluster_id: String.t(),
-          name: [String.t()],
+          name: String.t(),
           type: :hana_scale_up | :hana_scale_out | :unknown,
           provider: :azure | :aws | :gcp | :unknown,
           discovered_health: nil | :passing | :warning | :critical | :unknown,

--- a/lib/trento/domain/cluster/commands/register_cluster_host.ex
+++ b/lib/trento/domain/cluster/commands/register_cluster_host.ex
@@ -6,7 +6,6 @@ defmodule Trento.Domain.Commands.RegisterClusterHost do
   @required_fields [
     :cluster_id,
     :host_id,
-    :name,
     :type,
     :designated_controller,
     :discovered_health,

--- a/test/e2e/cypress/fixtures/clusters-overview/available_clusters.js
+++ b/test/e2e/cypress/fixtures/clusters-overview/available_clusters.js
@@ -1,15 +1,15 @@
 const availableClusters = [
-    ['04a81f89c847e82390e35bece2e25c9b', 'drbd_cluster'],
-    ['238a4de1239aae2aa87433eed788b3ad', ' drbd_cluster'],
-    ['a034a158905404befe08775682910ee1', ' drbd_cluster'],
-    ['04b8f8c21f9fd8991224478e8c4362f8', 'hana_cluster_1'],
-    ['4e905d706da85f5be14f85fa947c1e39', 'hana_cluster_2'],
-    ['9c832998801e28cd70ad77380e82a5c0', 'hana_cluster_3'],
-    ['057f083c3be591f4398eed816d4c8cd7', 'netweaver_cluster'],
-    ['8bca366a6cb7816555538092a1ddd5aa', 'netweaver_cluster'],
-    ['acf59e7a5338f76f55d5055af3273480', 'netweaver_cluster'],
+    ['8a66f8fb-5fe9-51b3-a34c-24321271a4e3', 'drbd_cluster'],
+    ['6bd7ec60-8cb1-5c6b-a892-29e1fd2f8380', 'drbd_cluster'],
+    ['c7a1e943-bf46-590b-bd26-bfc7c78def97', 'drbd_cluster'],
+    ['7965f822-0254-5858-abca-f6e8b4c27714', 'hana_cluster_1'],
+    ['fa0d74a3-9240-5d9e-99fa-61c4137acf81', 'hana_cluster_2'],
+    ['469e7be5-4e20-5007-b044-c6f540a87493', 'hana_cluster_3'],
+    ['5284f376-c1f4-5178-8966-d490df3dab4f', 'netweaver_cluster'],
+    ['fb861bce-d212-56b5-8786-74afd6eb58cb', 'netweaver_cluster'],
+    ['0eac831a-aa66-5f45-89a4-007fbd2c5714', 'netweaver_cluster'],
   ];
-  
+
   export const allClusterNames = () =>
     availableClusters.map(([_, clusterName]) => clusterName);
   export const allClusterIds = () =>
@@ -18,4 +18,3 @@ const availableClusters = [
     availableClusters.find(([, name]) => name === clusterName)[0];
   export const clusterNameById = (clusterId) =>
     availableClusters.find(([id]) => id === clusterId)[1];
-  

--- a/test/e2e/cypress/integration/clusters_overview.js
+++ b/test/e2e/cypress/integration/clusters_overview.js
@@ -33,5 +33,16 @@ import {
           });
         });
       });
+      describe('Unnamed cluster', () => {
+        before(() => {
+          cy.loadScenario('cluster-unnamed');
+        });
+
+        it('Unnamed clusters should use the ID as details page link', () => {
+          const clusterID = clusterIdByName('hana_cluster_1')
+          const truncatedLength = 14;
+          cy.get(`a:contains(${clusterID.slice(0, truncatedLength)})`).should('be.visible')
+        });
+      });
     });
   });

--- a/test/e2e/cypress/integration/clusters_overview.js
+++ b/test/e2e/cypress/integration/clusters_overview.js
@@ -40,8 +40,7 @@ import {
 
         it('Unnamed clusters should use the ID as details page link', () => {
           const clusterID = clusterIdByName('hana_cluster_1')
-          const truncatedLength = 14;
-          cy.get(`a:contains(${clusterID.slice(0, truncatedLength)})`).should('be.visible')
+          cy.get(`a:contains(${clusterID})`).should('be.visible')
         });
       });
     });

--- a/test/fixtures/discovery/ha_cluster_discovery_unnamed.json
+++ b/test/fixtures/discovery/ha_cluster_discovery_unnamed.json
@@ -1,0 +1,1038 @@
+{
+  "agent_id": "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
+  "discovery_type": "ha_cluster_discovery",
+  "payload": {
+    "Cib": {
+      "Configuration": {
+        "CrmConfig": {
+          "ClusterProperties": [
+            {
+              "Id": "cib-bootstrap-options-have-watchdog",
+              "Name": "have-watchdog",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-dc-version",
+              "Name": "dc-version",
+              "Value": "1.1.18+20180430.b12c320f5-3.15.1-b12c320f5"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-infrastructure",
+              "Name": "cluster-infrastructure",
+              "Value": "corosync"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-name",
+              "Name": "cluster-name",
+              "Value": "hana_cluster"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-enabled",
+              "Name": "stonith-enabled",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-placement-strategy",
+              "Name": "placement-strategy",
+              "Value": "balanced"
+            }
+          ]
+        },
+        "Nodes": [
+          {
+            "Id": "1084783375",
+            "Uname": "node01",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-1084783375-lpa_prd_lpt",
+                "Name": "lpa_prd_lpt",
+                "Value": "1574095701"
+              },
+              {
+                "Id": "nodes-1084783375-hana_prd_vhost",
+                "Name": "hana_prd_vhost",
+                "Value": "node01"
+              },
+              {
+                "Id": "nodes-1084783375-hana_prd_site",
+                "Name": "hana_prd_site",
+                "Value": "PRIMARY_SITE_NAME"
+              },
+              {
+                "Id": "nodes-1084783375-hana_prd_op_mode",
+                "Name": "hana_prd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Id": "nodes-1084783375-hana_prd_srmode",
+                "Name": "hana_prd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Id": "nodes-1084783375-hana_prd_remoteHost",
+                "Name": "hana_prd_remoteHost",
+                "Value": "node02"
+              }
+            ]
+          },
+          {
+            "Id": "1084783376",
+            "Uname": "node02",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-1084783376-lpa_prd_lpt",
+                "Name": "lpa_prd_lpt",
+                "Value": "30"
+              },
+              {
+                "Id": "nodes-1084783376-hana_prd_op_mode",
+                "Name": "hana_prd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Id": "nodes-1084783376-hana_prd_vhost",
+                "Name": "hana_prd_vhost",
+                "Value": "node02"
+              },
+              {
+                "Id": "nodes-1084783376-hana_prd_remoteHost",
+                "Name": "hana_prd_remoteHost",
+                "Value": "node01"
+              },
+              {
+                "Id": "nodes-1084783376-hana_prd_site",
+                "Name": "hana_prd_site",
+                "Value": "SECONDARY_SITE_NAME"
+              },
+              {
+                "Id": "nodes-1084783376-hana_prd_srmode",
+                "Name": "hana_prd_srmode",
+                "Value": "sync"
+              }
+            ]
+          }
+        ],
+        "Resources": {
+          "Primitives": [
+            {
+              "Id": "stonith-sbd",
+              "Class": "stonith",
+              "Type": "external/sbd",
+              "Provider": "",
+              "InstanceAttributes": [
+                {
+                  "Id": "stonith-sbd-instance_attributes-pcmk_delay_max",
+                  "Name": "pcmk_delay_max",
+                  "Value": "30s"
+                }
+              ],
+              "MetaAttributes": null,
+              "Operations": null
+            },
+            {
+              "Id": "rsc_ip_PRD_HDB00",
+              "Class": "ocf",
+              "Type": "IPaddr2",
+              "Provider": "heartbeat",
+              "InstanceAttributes": [
+                {
+                  "Id": "rsc_ip_PRD_HDB00-instance_attributes-ip",
+                  "Name": "ip",
+                  "Value": "192.168.123.200"
+                },
+                {
+                  "Id": "rsc_ip_PRD_HDB00-instance_attributes-cidr_netmask",
+                  "Name": "cidr_netmask",
+                  "Value": "24"
+                },
+                {
+                  "Id": "rsc_ip_PRD_HDB00-instance_attributes-nic",
+                  "Name": "nic",
+                  "Value": "eth1"
+                }
+              ],
+              "MetaAttributes": null,
+              "Operations": [
+                {
+                  "Id": "rsc_ip_PRD_HDB00-start-0",
+                  "Name": "start",
+                  "Role": "",
+                  "Interval": "0",
+                  "Timeout": "20"
+                },
+                {
+                  "Id": "rsc_ip_PRD_HDB00-stop-0",
+                  "Name": "stop",
+                  "Role": "",
+                  "Interval": "0",
+                  "Timeout": "20"
+                },
+                {
+                  "Id": "rsc_ip_PRD_HDB00-monitor-10",
+                  "Name": "monitor",
+                  "Role": "",
+                  "Interval": "10",
+                  "Timeout": "20"
+                }
+              ]
+            },
+            {
+              "Id": "test",
+              "Class": "ocf",
+              "Type": "Dummy",
+              "Provider": "heartbeat",
+              "InstanceAttributes": null,
+              "MetaAttributes": null,
+              "Operations": null
+            },
+            {
+              "Id": "test-stop",
+              "Class": "ocf",
+              "Type": "Dummy",
+              "Provider": "heartbeat",
+              "InstanceAttributes": null,
+              "MetaAttributes": [
+                {
+                  "Id": "test-stop-meta_attributes-target-role",
+                  "Name": "target-role",
+                  "Value": "Stopped"
+                }
+              ],
+              "Operations": null
+            }
+          ],
+          "Masters": [
+            {
+              "Id": "msl_SAPHana_PRD_HDB00",
+              "MetaAttributes": [
+                {
+                  "Id": "msl_SAPHana_PRD_HDB00-meta_attributes-clone-max",
+                  "Name": "clone-max",
+                  "Value": "2"
+                },
+                {
+                  "Id": "msl_SAPHana_PRD_HDB00-meta_attributes-clone-node-max",
+                  "Name": "clone-node-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "msl_SAPHana_PRD_HDB00-meta_attributes-interleave",
+                  "Name": "interleave",
+                  "Value": "true"
+                }
+              ],
+              "Primitive": {
+                "Id": "rsc_SAPHana_PRD_HDB00",
+                "Class": "ocf",
+                "Type": "SAPHana",
+                "Provider": "suse",
+                "InstanceAttributes": [
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-instance_attributes-SID",
+                    "Name": "SID",
+                    "Value": "PRD"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-instance_attributes-InstanceNumber",
+                    "Name": "InstanceNumber",
+                    "Value": "00"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-instance_attributes-PREFER_SITE_TAKEOVER",
+                    "Name": "PREFER_SITE_TAKEOVER",
+                    "Value": "True"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-instance_attributes-AUTOMATED_REGISTER",
+                    "Name": "AUTOMATED_REGISTER",
+                    "Value": "False"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-instance_attributes-DUPLICATE_PRIMARY_TIMEOUT",
+                    "Name": "DUPLICATE_PRIMARY_TIMEOUT",
+                    "Value": "7200"
+                  }
+                ],
+                "MetaAttributes": null,
+                "Operations": [
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-start-0",
+                    "Name": "start",
+                    "Role": "",
+                    "Interval": "0",
+                    "Timeout": "3600"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-stop-0",
+                    "Name": "stop",
+                    "Role": "",
+                    "Interval": "0",
+                    "Timeout": "3600"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-promote-0",
+                    "Name": "promote",
+                    "Role": "",
+                    "Interval": "0",
+                    "Timeout": "3600"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-monitor-60",
+                    "Name": "monitor",
+                    "Role": "Master",
+                    "Interval": "60",
+                    "Timeout": "700"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_PRD_HDB00-monitor-61",
+                    "Name": "monitor",
+                    "Role": "Slave",
+                    "Interval": "61",
+                    "Timeout": "700"
+                  }
+                ]
+              }
+            }
+          ],
+          "Clones": [
+            {
+              "Id": "cln_SAPHanaTopology_PRD_HDB00",
+              "MetaAttributes": [
+                {
+                  "Id": "cln_SAPHanaTopology_PRD_HDB00-meta_attributes-is-managed",
+                  "Name": "is-managed",
+                  "Value": "true"
+                },
+                {
+                  "Id": "cln_SAPHanaTopology_PRD_HDB00-meta_attributes-clone-node-max",
+                  "Name": "clone-node-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "cln_SAPHanaTopology_PRD_HDB00-meta_attributes-interleave",
+                  "Name": "interleave",
+                  "Value": "true"
+                }
+              ],
+              "Primitive": {
+                "Id": "rsc_SAPHanaTopology_PRD_HDB00",
+                "Class": "ocf",
+                "Type": "SAPHanaTopology",
+                "Provider": "suse",
+                "InstanceAttributes": [
+                  {
+                    "Id": "rsc_SAPHanaTopology_PRD_HDB00-instance_attributes-SID",
+                    "Name": "SID",
+                    "Value": "PRD"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_PRD_HDB00-instance_attributes-InstanceNumber",
+                    "Name": "InstanceNumber",
+                    "Value": "00"
+                  }
+                ],
+                "MetaAttributes": null,
+                "Operations": [
+                  {
+                    "Id": "rsc_SAPHanaTopology_PRD_HDB00-monitor-10",
+                    "Name": "monitor",
+                    "Role": "",
+                    "Interval": "10",
+                    "Timeout": "600"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_PRD_HDB00-start-0",
+                    "Name": "start",
+                    "Role": "",
+                    "Interval": "0",
+                    "Timeout": "600"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_PRD_HDB00-stop-0",
+                    "Name": "stop",
+                    "Role": "",
+                    "Interval": "0",
+                    "Timeout": "300"
+                  }
+                ]
+              }
+            }
+          ],
+          "Groups": [
+            {
+              "Id": "g_ip_PRD_HDB00",
+              "Primitives": [
+                {
+                  "Id": "rsc_ip_PRD_HDB00",
+                  "Class": "ocf",
+                  "Type": "IPaddr2",
+                  "Provider": "heartbeat",
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_ip_PRD_HDB00-instance_attributes-ip",
+                      "Name": "ip",
+                      "Value": "10.74.1.12"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "Operations": null
+                }
+              ]
+            }
+          ]
+        },
+        "Constraints": {
+          "RscLocations": [
+            {
+              "Id": "cli-prefer-msl_SAPHana_PRD_HDB00",
+              "Node": "node01",
+              "Resource": "msl_SAPHana_PRD_HDB00",
+              "Role": "Started",
+              "Score": "INFINITY"
+            },
+            {
+              "Id": "cli-prefer-cln_SAPHanaTopology_PRD_HDB00",
+              "Node": "node01",
+              "Resource": "cln_SAPHanaTopology_PRD_HDB00",
+              "Role": "Started",
+              "Score": "INFINITY"
+            },
+            {
+              "Id": "cli-ban-msl_SAPHana_PRD_HDB00-on-node01",
+              "Node": "node01",
+              "Resource": "msl_SAPHana_PRD_HDB00",
+              "Role": "Started",
+              "Score": "-INFINITY"
+            },
+            {
+              "Id": "test",
+              "Node": "node02",
+              "Resource": "test",
+              "Role": "Started",
+              "Score": "666"
+            }
+          ]
+        }
+      }
+    },
+    "Crmmon": {
+      "Version": "2.0.0",
+      "Summary": {
+        "Nodes": {
+          "Number": 2
+        },
+        "LastChange": {
+          "Time": "Fri Oct 18 11:48:22 2019"
+        },
+        "Resources": {
+          "Number": 8,
+          "Disabled": 1,
+          "Blocked": 0
+        },
+        "ClusterOptions": {
+          "StonithEnabled": true
+        }
+      },
+      "Nodes": [
+        {
+          "Name": "node01",
+          "Id": "1084783375",
+          "Online": true,
+          "Standby": false,
+          "StandbyOnFail": false,
+          "Maintenance": false,
+          "Pending": false,
+          "Unclean": false,
+          "Shutdown": false,
+          "ExpectedUp": true,
+          "DC": true,
+          "ResourcesRunning": 7,
+          "Type": "member"
+        },
+        {
+          "Name": "node02",
+          "Id": "1084783376",
+          "Online": true,
+          "Standby": false,
+          "StandbyOnFail": false,
+          "Maintenance": false,
+          "Pending": false,
+          "Unclean": false,
+          "Shutdown": false,
+          "ExpectedUp": true,
+          "DC": false,
+          "ResourcesRunning": 5,
+          "Type": "member"
+        }
+      ],
+      "NodeAttributes": {
+        "Nodes": [
+          {
+            "Name": "node01",
+            "Attributes": [
+              {
+                "Name": "hana_prd_clone_state",
+                "Value": "PROMOTED"
+              },
+              {
+                "Name": "hana_prd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Name": "hana_prd_remoteHost",
+                "Value": "node02"
+              },
+              {
+                "Name": "hana_prd_roles",
+                "Value": "4:P:master1:master:worker:master"
+              },
+              {
+                "Name": "hana_prd_site",
+                "Value": "PRIMARY_SITE_NAME"
+              },
+              {
+                "Name": "hana_prd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Name": "hana_prd_sync_state",
+                "Value": "PRIM"
+              },
+              {
+                "Name": "hana_prd_version",
+                "Value": "2.00.040.00.1553674765"
+              },
+              {
+                "Name": "hana_prd_vhost",
+                "Value": "node01"
+              },
+              {
+                "Name": "lpa_prd_lpt",
+                "Value": "1571392102"
+              },
+              {
+                "Name": "master-rsc_SAPHana_PRD_HDB00",
+                "Value": "150"
+              }
+            ]
+          },
+          {
+            "Name": "node02",
+            "Attributes": [
+              {
+                "Name": "hana_prd_clone_state",
+                "Value": "DEMOTED"
+              },
+              {
+                "Name": "hana_prd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Name": "hana_prd_remoteHost",
+                "Value": "node01"
+              },
+              {
+                "Name": "hana_prd_roles",
+                "Value": "4:S:master1:master:worker:master"
+              },
+              {
+                "Name": "hana_prd_site",
+                "Value": "SECONDARY_SITE_NAME"
+              },
+              {
+                "Name": "hana_prd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Name": "hana_prd_sync_state",
+                "Value": "SOK"
+              },
+              {
+                "Name": "hana_prd_version",
+                "Value": "2.00.040.00.1553674765"
+              },
+              {
+                "Name": "hana_prd_vhost",
+                "Value": "node02"
+              },
+              {
+                "Name": "lpa_prd_lpt",
+                "Value": "30"
+              },
+              {
+                "Name": "master-rsc_SAPHana_PRD_HDB00",
+                "Value": "100"
+              }
+            ]
+          }
+        ]
+      },
+      "NodeHistory": {
+        "Nodes": [
+          {
+            "Name": "node01",
+            "ResourceHistory": [
+              {
+                "Name": "rsc_SAPHana_PRD_HDB00",
+                "MigrationThreshold": 5000,
+                "FailCount": 1000000
+              },
+              {
+                "Name": "rsc_ip_PRD_HDB00",
+                "MigrationThreshold": 5000,
+                "FailCount": 2
+              },
+              {
+                "Name": "stonith-sbd",
+                "MigrationThreshold": 5000,
+                "FailCount": 0
+              },
+              {
+                "Name": "rsc_SAPHanaTopology_PRD_HDB00",
+                "MigrationThreshold": 1,
+                "FailCount": 0
+              }
+            ]
+          },
+          {
+            "Name": "node02",
+            "ResourceHistory": [
+              {
+                "Name": "rsc_SAPHana_PRD_HDB00",
+                "MigrationThreshold": 50,
+                "FailCount": 300
+              },
+              {
+                "Name": "rsc_SAPHanaTopology_PRD_HDB00",
+                "MigrationThreshold": 3,
+                "FailCount": 0
+              },
+              {
+                "Name": "test",
+                "MigrationThreshold": 5000,
+                "FailCount": 0
+              },
+              {
+                "Name": "test-stop",
+                "MigrationThreshold": 5000,
+                "FailCount": 0
+              }
+            ]
+          }
+        ]
+      },
+      "Resources": [
+        {
+          "Id": "test-stop",
+          "Agent": "ocf::heartbeat:Dummy",
+          "Role": "Stopped",
+          "Active": false,
+          "Orphaned": false,
+          "Blocked": false,
+          "Managed": true,
+          "Failed": false,
+          "FailureIgnored": false,
+          "NodesRunningOn": 0,
+          "Node": null
+        },
+        {
+          "Id": "test",
+          "Agent": "ocf::heartbeat:Dummy",
+          "Role": "Started",
+          "Active": true,
+          "Orphaned": false,
+          "Blocked": false,
+          "Managed": true,
+          "Failed": false,
+          "FailureIgnored": false,
+          "NodesRunningOn": 1,
+          "Node": {
+            "Name": "node02",
+            "Id": "1084783376",
+            "Cached": false
+          }
+        },
+        {
+          "Id": "stonith-sbd",
+          "Agent": "stonith:external/sbd",
+          "Role": "Started",
+          "Active": true,
+          "Orphaned": false,
+          "Blocked": false,
+          "Managed": true,
+          "Failed": false,
+          "FailureIgnored": false,
+          "NodesRunningOn": 1,
+          "Node": {
+            "Name": "node01",
+            "Id": "1084783375",
+            "Cached": false
+          }
+        },
+        {
+          "Id": "rsc_ip_PRD_HDB00",
+          "Agent": "ocf::heartbeat:IPaddr2",
+          "Role": "Started",
+          "Active": true,
+          "Orphaned": false,
+          "Blocked": false,
+          "Managed": true,
+          "Failed": false,
+          "FailureIgnored": false,
+          "NodesRunningOn": 1,
+          "Node": {
+            "Name": "node01",
+            "Id": "1084783375",
+            "Cached": false
+          }
+        }
+      ],
+      "Clones": [
+        {
+          "Id": "msl_SAPHana_PRD_HDB00",
+          "MultiState": true,
+          "Managed": true,
+          "Failed": false,
+          "FailureIgnored": false,
+          "Unique": false,
+          "Resources": [
+            {
+              "Id": "rsc_SAPHana_PRD_HDB00",
+              "Agent": "ocf::suse:SAPHana",
+              "Role": "Master",
+              "Active": true,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1,
+              "Node": {
+                "Name": "node01",
+                "Id": "1084783375",
+                "Cached": false
+              }
+            },
+            {
+              "Id": "rsc_SAPHana_PRD_HDB00",
+              "Agent": "ocf::suse:SAPHana",
+              "Role": "Slave",
+              "Active": true,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1,
+              "Node": {
+                "Name": "node02",
+                "Id": "1084783376",
+                "Cached": false
+              }
+            }
+          ]
+        },
+        {
+          "Id": "cln_SAPHanaTopology_PRD_HDB00",
+          "MultiState": false,
+          "Managed": true,
+          "Failed": false,
+          "FailureIgnored": false,
+          "Unique": false,
+          "Resources": [
+            {
+              "Id": "rsc_SAPHanaTopology_PRD_HDB00",
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Role": "Started",
+              "Active": true,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1,
+              "Node": {
+                "Name": "node01",
+                "Id": "1084783375",
+                "Cached": false
+              }
+            },
+            {
+              "Id": "rsc_SAPHanaTopology_PRD_HDB00",
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Role": "Started",
+              "Active": true,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1,
+              "Node": {
+                "Name": "node02",
+                "Id": "1084783376",
+                "Cached": false
+              }
+            }
+          ]
+        },
+        {
+          "Id": "c-clusterfs",
+          "MultiState": false,
+          "Managed": true,
+          "Failed": false,
+          "FailureIgnored": false,
+          "Unique": false,
+          "Resources": [
+            {
+              "Id": "clusterfs",
+              "Agent": "ocf::heartbeat:Filesystem",
+              "Role": "Started",
+              "Active": true,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1,
+              "Node": {
+                "Name": "node01",
+                "Id": "1084783225",
+                "Cached": true
+              }
+            },
+            {
+              "Id": "clusterfs",
+              "Agent": "ocf::heartbeat:Filesystem",
+              "Role": "Started",
+              "Active": true,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1,
+              "Node": {
+                "Name": "node02",
+                "Id": "1084783226",
+                "Cached": true
+              }
+            },
+            {
+              "Id": "clusterfs",
+              "Agent": "ocf::heartbeat:Filesystem",
+              "Role": "Stopped",
+              "Active": false,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 0,
+              "Node": null
+            },
+            {
+              "Id": "clusterfs",
+              "Agent": "ocf::heartbeat:Filesystem",
+              "Role": "Stopped",
+              "Active": false,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 0,
+              "Node": null
+            }
+          ]
+        }
+      ],
+      "Groups": [
+        {
+          "Id": "grp_HA1_ASCS00",
+          "Resources": [
+            {
+              "Id": "rsc_ip_HA1_ASCS00",
+              "Agent": "ocf::heartbeat:IPaddr2",
+              "Role": "Started",
+              "Active": true,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1,
+              "Node": {
+                "Name": "node01",
+                "Id": "1084783375",
+                "Cached": false
+              }
+            },
+            {
+              "Id": "rsc_fs_HA1_ASCS00",
+              "Agent": "ocf::heartbeat:Filesystem",
+              "Role": "Started",
+              "Active": true,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1,
+              "Node": {
+                "Name": "node01",
+                "Id": "1084783375",
+                "Cached": false
+              }
+            },
+            {
+              "Id": "rsc_sap_HA1_ASCS00",
+              "Agent": "ocf::heartbeat:SAPInstance",
+              "Role": "Started",
+              "Active": true,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1,
+              "Node": {
+                "Name": "node01",
+                "Id": "1084783375",
+                "Cached": false
+              }
+            }
+          ]
+        },
+        {
+          "Id": "grp_HA1_ERS10",
+          "Resources": [
+            {
+              "Id": "rsc_ip_HA1_ERS10",
+              "Agent": "ocf::heartbeat:IPaddr2",
+              "Role": "Started",
+              "Active": true,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1,
+              "Node": {
+                "Name": "node02",
+                "Id": "1084783376",
+                "Cached": false
+              }
+            },
+            {
+              "Id": "rsc_fs_HA1_ERS10",
+              "Agent": "ocf::heartbeat:Filesystem",
+              "Role": "Started",
+              "Active": true,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1,
+              "Node": {
+                "Name": "node02",
+                "Id": "1084783376",
+                "Cached": false
+              }
+            },
+            {
+              "Id": "rsc_sap_HA1_ERS10",
+              "Agent": "ocf::heartbeat:SAPInstance",
+              "Role": "Started",
+              "Active": true,
+              "Orphaned": false,
+              "Blocked": false,
+              "Managed": true,
+              "Failed": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1,
+              "Node": {
+                "Name": "node02",
+                "Id": "1084783376",
+                "Cached": false
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "SBD": {
+      "Devices": [
+        {
+          "Device": "/dev/vdc",
+          "Status": "healthy",
+          "Dump": {
+            "Header": "2.1",
+            "Uuid": "f9ba490e-0f14-4908-859a-ace97aafaf34",
+            "Slots": 255,
+            "SectorSize": 512,
+            "TimeoutWatchdog": 5,
+            "TimeoutAllocate": 2,
+            "TimeoutLoop": 1,
+            "TimeoutMsgwait": 10
+          },
+          "List": [
+            {
+              "Id": 0,
+              "Name": "vmhana01",
+              "Status": "clear"
+            },
+            {
+              "Id": 1,
+              "Name": "vmhana02",
+              "Status": "clear"
+            }
+          ]
+        },
+        {
+          "Device": "/dev/vdb",
+          "Status": "healthy",
+          "Dump": {
+            "Header": "2.1",
+            "Uuid": "f9ba490e-0f14-4908-859a-ace97aafaf34",
+            "Slots": 255,
+            "SectorSize": 512,
+            "TimeoutWatchdog": 5,
+            "TimeoutAllocate": 2,
+            "TimeoutLoop": 1,
+            "TimeoutMsgwait": 10
+          },
+          "List": [
+            {
+              "Id": 0,
+              "Name": "vmhana01",
+              "Status": "clear"
+            },
+            {
+              "Id": 1,
+              "Name": "vmhana02",
+              "Status": "clear"
+            }
+          ]
+        }
+      ],
+      "Config": {
+        "SBD_DELAY_START": "no",
+        "SBD_DEVICE": "/dev/vdc;/dev/vdb",
+        "SBD_MOVE_TO_ROOT_CGROUP": "auto",
+        "SBD_PACEMAKER": "yes",
+        "SBD_STARTMODE": "always",
+        "SBD_TIMEOUT_ACTION": "flush,reboot",
+        "SBD_WATCHDOG_DEV": "/dev/watchdog",
+        "SBD_WATCHDOG_TIMEOUT": "5",
+        "TEST": "Value",
+        "TEST2": "Value2"
+      }
+    },
+    "Id": "47d1190ffb4f781974c8356d7f863b03",
+    "Name": "",
+    "DC": true,
+    "Provider": "azure"
+  }
+}

--- a/test/fixtures/scenarios/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_unnamed.json
+++ b/test/fixtures/scenarios/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_unnamed.json
@@ -1,0 +1,790 @@
+{
+  "agent_id": "13e8c25c-3180-5a9a-95c8-51ec38e50cfc",
+  "discovery_type": "ha_cluster_discovery",
+  "payload": {
+    "DC": true,
+    "Provider": "azure",
+    "Id": "04b8f8c21f9fd8991224478e8c4362f8",
+    "Cib": {
+      "Configuration": {
+        "Nodes": [
+          {
+            "Id": "1",
+            "Uname": "vmhdbdev01",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-1-lpa_hdd_lpt",
+                "Name": "lpa_hdd_lpt",
+                "Value": "10"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_vhost",
+                "Name": "hana_hdd_vhost",
+                "Value": "vmhdbdev01"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_site",
+                "Name": "hana_hdd_site",
+                "Value": "NBG"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_op_mode",
+                "Name": "hana_hdd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_srmode",
+                "Name": "hana_hdd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_remoteHost",
+                "Name": "hana_hdd_remoteHost",
+                "Value": "vmhdbdev02"
+              }
+            ]
+          },
+          {
+            "Id": "2",
+            "Uname": "vmhdbdev02",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-2-lpa_hdd_lpt",
+                "Name": "lpa_hdd_lpt",
+                "Value": "1643125026"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_op_mode",
+                "Name": "hana_hdd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_vhost",
+                "Name": "hana_hdd_vhost",
+                "Value": "vmhdbdev02"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_remoteHost",
+                "Name": "hana_hdd_remoteHost",
+                "Value": "vmhdbdev01"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_site",
+                "Name": "hana_hdd_site",
+                "Value": "WDF"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_srmode",
+                "Name": "hana_hdd_srmode",
+                "Value": "sync"
+              }
+            ]
+          }
+        ],
+        "CrmConfig": {
+          "ClusterProperties": [
+            {
+              "Id": "cib-bootstrap-options-have-watchdog",
+              "Name": "have-watchdog",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-dc-version",
+              "Name": "dc-version",
+              "Value": "2.0.5+20201202.ba59be712-4.13.1-2.0.5+20201202.ba59be712"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-infrastructure",
+              "Name": "cluster-infrastructure",
+              "Value": "corosync"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-name",
+              "Name": "cluster-name",
+              "Value": "hana_cluster_1"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-enabled",
+              "Name": "stonith-enabled",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-timeout",
+              "Name": "stonith-timeout",
+              "Value": "144s"
+            },
+            {
+              "Id": "cib-bootstrap-options-maintenance-mode",
+              "Name": "maintenance-mode",
+              "Value": "false"
+            },
+            {
+              "Id": "SAPHanaSR-hana_hdd_site_srHook_WDF",
+              "Name": "hana_hdd_site_srHook_WDF",
+              "Value": "PRIM"
+            }
+          ]
+        },
+        "Resources": {
+          "Clones": [
+            {
+              "Id": "cln_SAPHanaTopology_HDD_HDB10",
+              "Primitive": {
+                "Id": "rsc_SAPHanaTopology_HDD_HDB10",
+                "Type": "SAPHanaTopology",
+                "Class": "ocf",
+                "Provider": "suse",
+                "Operations": [
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-monitor-10",
+                    "Name": "monitor",
+                    "Role": "",
+                    "Timeout": "600",
+                    "Interval": "10"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-start-0",
+                    "Name": "start",
+                    "Role": "",
+                    "Timeout": "600",
+                    "Interval": "0"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-stop-0",
+                    "Name": "stop",
+                    "Role": "",
+                    "Timeout": "300",
+                    "Interval": "0"
+                  }
+                ],
+                "MetaAttributes": null,
+                "InstanceAttributes": [
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-instance_attributes-SID",
+                    "Name": "SID",
+                    "Value": "HDD"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-instance_attributes-InstanceNumber",
+                    "Name": "InstanceNumber",
+                    "Value": "10"
+                  }
+                ]
+              },
+              "MetaAttributes": [
+                {
+                  "Id": "cln_SAPHanaTopology_HDD_HDB10-meta_attributes-clone-node-max",
+                  "Name": "clone-node-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "cln_SAPHanaTopology_HDD_HDB10-meta_attributes-interleave",
+                  "Name": "interleave",
+                  "Value": "true"
+                }
+              ]
+            }
+          ],
+          "Groups": [
+            {
+              "Id": "g_ip_HDD_HDB10",
+              "Primitives": [
+                {
+                  "Id": "rsc_ip_HDD_HDB10",
+                  "Type": "IPaddr2",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-start-0",
+                      "Name": "start",
+                      "Role": "",
+                      "Timeout": "20",
+                      "Interval": "0"
+                    },
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-stop-0",
+                      "Name": "stop",
+                      "Role": "",
+                      "Timeout": "20",
+                      "Interval": "0"
+                    },
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-monitor-10",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "20",
+                      "Interval": "10"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-instance_attributes-ip",
+                      "Name": "ip",
+                      "Value": "10.100.1.13"
+                    },
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-instance_attributes-cidr_netmask",
+                      "Name": "cidr_netmask",
+                      "Value": "24"
+                    },
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-instance_attributes-nic",
+                      "Name": "nic",
+                      "Value": "eth0"
+                    }
+                  ]
+                },
+                {
+                  "Id": "rsc_socat_HDD_HDB10",
+                  "Type": "azure-lb",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_socat_HDD_HDB10-monitor-10",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "20",
+                      "Interval": "10"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_socat_HDD_HDB10-instance_attributes-port",
+                      "Name": "port",
+                      "Value": "62510"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "Masters": [
+            {
+              "Id": "msl_SAPHana_HDD_HDB10",
+              "Primitive": {
+                "Id": "rsc_SAPHana_HDD_HDB10",
+                "Type": "SAPHana",
+                "Class": "ocf",
+                "Provider": "suse",
+                "Operations": [
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-start-0",
+                    "Name": "start",
+                    "Role": "",
+                    "Timeout": "3600",
+                    "Interval": "0"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-stop-0",
+                    "Name": "stop",
+                    "Role": "",
+                    "Timeout": "3600",
+                    "Interval": "0"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-promote-0",
+                    "Name": "promote",
+                    "Role": "",
+                    "Timeout": "3600",
+                    "Interval": "0"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-monitor-60",
+                    "Name": "monitor",
+                    "Role": "Master",
+                    "Timeout": "700",
+                    "Interval": "60"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-monitor-61",
+                    "Name": "monitor",
+                    "Role": "Slave",
+                    "Timeout": "700",
+                    "Interval": "61"
+                  }
+                ],
+                "MetaAttributes": null,
+                "InstanceAttributes": [
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-SID",
+                    "Name": "SID",
+                    "Value": "HDD"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-InstanceNumber",
+                    "Name": "InstanceNumber",
+                    "Value": "10"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-PREFER_SITE_TAKEOVER",
+                    "Name": "PREFER_SITE_TAKEOVER",
+                    "Value": "True"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-AUTOMATED_REGISTER",
+                    "Name": "AUTOMATED_REGISTER",
+                    "Value": "False"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-DUPLICATE_PRIMARY_TIMEOUT",
+                    "Name": "DUPLICATE_PRIMARY_TIMEOUT",
+                    "Value": "7200"
+                  }
+                ]
+              },
+              "MetaAttributes": [
+                {
+                  "Id": "msl_SAPHana_HDD_HDB10-meta_attributes-clone-max",
+                  "Name": "clone-max",
+                  "Value": "2"
+                },
+                {
+                  "Id": "msl_SAPHana_HDD_HDB10-meta_attributes-clone-node-max",
+                  "Name": "clone-node-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "msl_SAPHana_HDD_HDB10-meta_attributes-interleave",
+                  "Name": "interleave",
+                  "Value": "true"
+                }
+              ]
+            }
+          ],
+          "Primitives": [
+            {
+              "Id": "stonith-sbd",
+              "Type": "external/sbd",
+              "Class": "stonith",
+              "Provider": "",
+              "Operations": [
+                {
+                  "Id": "stonith-sbd-monitor-15",
+                  "Name": "monitor",
+                  "Role": "",
+                  "Timeout": "15",
+                  "Interval": "15"
+                }
+              ],
+              "MetaAttributes": null,
+              "InstanceAttributes": [
+                {
+                  "Id": "stonith-sbd-instance_attributes-pcmk_delay_max",
+                  "Name": "pcmk_delay_max",
+                  "Value": "15"
+                }
+              ]
+            }
+          ]
+        },
+        "Constraints": {
+          "RscLocations": null
+        }
+      }
+    },
+    "SBD": {
+      "Config": {
+        "SBD_DEVICE": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:182cb1b1-a815-4b82-b538-7a166b9bbb4a",
+        "SBD_PACEMAKER": "yes",
+        "SBD_STARTMODE": "always",
+        "SBD_DELAY_START": "yes",
+        "SBD_WATCHDOG_DEV": "/dev/watchdog",
+        "SBD_TIMEOUT_ACTION": "flush,reboot",
+        "SBD_WATCHDOG_TIMEOUT": "5",
+        "SBD_MOVE_TO_ROOT_CGROUP": "auto",
+        "SBD_SYNC_RESOURCE_STARTUP": "no"
+      },
+      "Devices": [
+        {
+          "Dump": {
+            "Uuid": "cc39771e-ea2f-4fb1-8968-a6176aee3d0a",
+            "Slots": 255,
+            "Header": "2.1",
+            "SectorSize": 512,
+            "TimeoutLoop": 1,
+            "TimeoutMsgwait": 10,
+            "TimeoutAllocate": 2,
+            "TimeoutWatchdog": 5
+          },
+          "List": [
+            {
+              "Id": 0,
+              "Name": "vmhdbdev01",
+              "Status": "clear"
+            },
+            {
+              "Id": 1,
+              "Name": "vmhdbdev02",
+              "Status": "clear"
+            }
+          ],
+          "Device": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:182cb1b1-a815-4b82-b538-7a166b9bbb4a",
+          "Status": "healthy"
+        }
+      ]
+    },
+    "Name": "",
+    "Crmmon": {
+      "Nodes": [
+        {
+          "DC": true,
+          "Id": "1",
+          "Name": "vmhdbdev01",
+          "Type": "member",
+          "Online": true,
+          "Pending": false,
+          "Standby": false,
+          "Unclean": false,
+          "Shutdown": false,
+          "ExpectedUp": true,
+          "Maintenance": false,
+          "StandbyOnFail": false,
+          "ResourcesRunning": 2
+        },
+        {
+          "DC": false,
+          "Id": "2",
+          "Name": "vmhdbdev02",
+          "Type": "member",
+          "Online": true,
+          "Pending": false,
+          "Standby": false,
+          "Unclean": false,
+          "Shutdown": false,
+          "ExpectedUp": true,
+          "Maintenance": false,
+          "StandbyOnFail": false,
+          "ResourcesRunning": 4
+        }
+      ],
+      "Clones": [
+        {
+          "Id": "msl_SAPHana_HDD_HDB10",
+          "Failed": false,
+          "Unique": false,
+          "Managed": true,
+          "Resources": [
+            {
+              "Id": "rsc_SAPHana_HDD_HDB10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmhdbdev02",
+                "Cached": true
+              },
+              "Role": "Master",
+              "Agent": "ocf::suse:SAPHana",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_SAPHana_HDD_HDB10",
+              "Node": null,
+              "Role": "Stopped",
+              "Agent": "ocf::suse:SAPHana",
+              "Active": false,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 0
+            }
+          ],
+          "MultiState": true,
+          "FailureIgnored": false
+        },
+        {
+          "Id": "cln_SAPHanaTopology_HDD_HDB10",
+          "Failed": false,
+          "Unique": false,
+          "Managed": true,
+          "Resources": [
+            {
+              "Id": "rsc_SAPHanaTopology_HDD_HDB10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmhdbdev02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_SAPHanaTopology_HDD_HDB10",
+              "Node": {
+                "Id": "1",
+                "Name": "vmhdbdev01",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            }
+          ],
+          "MultiState": false,
+          "FailureIgnored": false
+        }
+      ],
+      "Groups": [
+        {
+          "Id": "g_ip_HDD_HDB10",
+          "Resources": [
+            {
+              "Id": "rsc_ip_HDD_HDB10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmhdbdev02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:IPaddr2",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_socat_HDD_HDB10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmhdbdev02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:azure-lb",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            }
+          ]
+        }
+      ],
+      "Summary": {
+        "Nodes": {
+          "Number": 2
+        },
+        "Resources": {
+          "Number": 7,
+          "Blocked": 0,
+          "Disabled": 0
+        },
+        "LastChange": {
+          "Time": "Tue Jan 25 15:37:06 2022"
+        },
+        "ClusterOptions": {
+          "StonithEnabled": true
+        }
+      },
+      "Version": "2.0.5",
+      "Resources": [
+        {
+          "Id": "stonith-sbd",
+          "Node": {
+            "Id": "1",
+            "Name": "vmhdbdev01",
+            "Cached": true
+          },
+          "Role": "Started",
+          "Agent": "stonith:external/sbd",
+          "Active": true,
+          "Failed": false,
+          "Blocked": false,
+          "Managed": true,
+          "Orphaned": false,
+          "FailureIgnored": false,
+          "NodesRunningOn": 1
+        }
+      ],
+      "NodeHistory": {
+        "Nodes": [
+          {
+            "Name": "vmhdbdev02",
+            "ResourceHistory": [
+              {
+                "Name": "rsc_ip_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_socat_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_SAPHana_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_SAPHanaTopology_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              }
+            ]
+          },
+          {
+            "Name": "vmhdbdev01",
+            "ResourceHistory": [
+              {
+                "Name": "stonith-sbd",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_ip_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_socat_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_SAPHana_HDD_HDB10",
+                "FailCount": 1000000,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_SAPHanaTopology_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              }
+            ]
+          }
+        ]
+      },
+      "NodeAttributes": {
+        "Nodes": [
+          {
+            "Name": "vmhdbdev01",
+            "Attributes": [
+              {
+                "Name": "hana_hdd_clone_state",
+                "Value": "UNDEFINED"
+              },
+              {
+                "Name": "hana_hdd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Name": "hana_hdd_remoteHost",
+                "Value": "vmhdbdev02"
+              },
+              {
+                "Name": "hana_hdd_roles",
+                "Value": "4:P:master1::worker:"
+              },
+              {
+                "Name": "hana_hdd_site",
+                "Value": "NBG"
+              },
+              {
+                "Name": "hana_hdd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Name": "hana_hdd_sync_state",
+                "Value": "SOK"
+              },
+              {
+                "Name": "hana_hdd_version",
+                "Value": "2.00.057.00.1629894416"
+              },
+              {
+                "Name": "hana_hdd_vhost",
+                "Value": "vmhdbdev01"
+              },
+              {
+                "Name": "lpa_hdd_lpt",
+                "Value": "10"
+              },
+              {
+                "Name": "master-rsc_SAPHana_HDD_HDB10",
+                "Value": "-9000"
+              }
+            ]
+          },
+          {
+            "Name": "vmhdbdev02",
+            "Attributes": [
+              {
+                "Name": "hana_hdd_clone_state",
+                "Value": "PROMOTED"
+              },
+              {
+                "Name": "hana_hdd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Name": "hana_hdd_remoteHost",
+                "Value": "vmhdbdev01"
+              },
+              {
+                "Name": "hana_hdd_roles",
+                "Value": "4:P:master1:master:worker:master"
+              },
+              {
+                "Name": "hana_hdd_site",
+                "Value": "WDF"
+              },
+              {
+                "Name": "hana_hdd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Name": "hana_hdd_sync_state",
+                "Value": "PRIM"
+              },
+              {
+                "Name": "hana_hdd_version",
+                "Value": "2.00.057.00.1629894416"
+              },
+              {
+                "Name": "hana_hdd_vhost",
+                "Value": "vmhdbdev02"
+              },
+              {
+                "Name": "lpa_hdd_lpt",
+                "Value": "1643125026"
+              },
+              {
+                "Name": "master-rsc_SAPHana_HDD_HDB10",
+                "Value": "150"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/trento/application/integration/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/application/integration/discovery/policies/cluster_policy_test.exs
@@ -484,4 +484,213 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
              |> load_discovery_event_fixture()
              |> ClusterPolicy.handle()
   end
+
+  test "should return the expected commands when a ha_cluster_discovery payload does not have a Name field" do
+    assert {:ok,
+            %RegisterClusterHost{
+              cib_last_written: "Fri Oct 18 11:48:22 2019",
+              cluster_id: "34a94290-2236-5e4d-8def-05beb32d14d4",
+              designated_controller: true,
+              details: %HanaClusterDetails{
+                fencing_type: "external/sbd",
+                nodes: [
+                  %ClusterNode{
+                    attributes: %{
+                      "hana_prd_clone_state" => "PROMOTED",
+                      "hana_prd_op_mode" => "logreplay",
+                      "hana_prd_remoteHost" => "node02",
+                      "hana_prd_roles" => "4:P:master1:master:worker:master",
+                      "hana_prd_site" => "PRIMARY_SITE_NAME",
+                      "hana_prd_srmode" => "sync",
+                      "hana_prd_sync_state" => "PRIM",
+                      "hana_prd_version" => "2.00.040.00.1553674765",
+                      "hana_prd_vhost" => "node01",
+                      "lpa_prd_lpt" => "1571392102",
+                      "master-rsc_SAPHana_PRD_HDB00" => "150"
+                    },
+                    hana_status: "Primary",
+                    name: "node01",
+                    resources: [
+                      %ClusterResource{
+                        fail_count: 0,
+                        id: "stonith-sbd",
+                        role: "Started",
+                        status: "Active",
+                        type: "stonith:external/sbd"
+                      },
+                      %ClusterResource{
+                        fail_count: 2,
+                        id: "rsc_ip_PRD_HDB00",
+                        role: "Started",
+                        status: "Active",
+                        type: "ocf::heartbeat:IPaddr2"
+                      },
+                      %ClusterResource{
+                        fail_count: 1_000_000,
+                        id: "rsc_SAPHana_PRD_HDB00",
+                        role: "Master",
+                        status: "Active",
+                        type: "ocf::suse:SAPHana"
+                      },
+                      %ClusterResource{
+                        fail_count: 0,
+                        id: "rsc_SAPHanaTopology_PRD_HDB00",
+                        role: "Started",
+                        status: "Active",
+                        type: "ocf::suse:SAPHanaTopology"
+                      },
+                      %ClusterResource{
+                        fail_count: nil,
+                        id: "clusterfs",
+                        role: "Started",
+                        status: "Active",
+                        type: "ocf::heartbeat:Filesystem"
+                      },
+                      %ClusterResource{
+                        fail_count: nil,
+                        id: "rsc_ip_HA1_ASCS00",
+                        role: "Started",
+                        status: "Active",
+                        type: "ocf::heartbeat:IPaddr2"
+                      },
+                      %ClusterResource{
+                        fail_count: nil,
+                        id: "rsc_fs_HA1_ASCS00",
+                        role: "Started",
+                        status: "Active",
+                        type: "ocf::heartbeat:Filesystem"
+                      },
+                      %ClusterResource{
+                        fail_count: nil,
+                        id: "rsc_sap_HA1_ASCS00",
+                        role: "Started",
+                        status: "Active",
+                        type: "ocf::heartbeat:SAPInstance"
+                      }
+                    ],
+                    site: "PRIMARY_SITE_NAME",
+                    virtual_ip: "192.168.123.200"
+                  },
+                  %ClusterNode{
+                    attributes: %{
+                      "hana_prd_clone_state" => "DEMOTED",
+                      "hana_prd_op_mode" => "logreplay",
+                      "hana_prd_remoteHost" => "node01",
+                      "hana_prd_roles" => "4:S:master1:master:worker:master",
+                      "hana_prd_site" => "SECONDARY_SITE_NAME",
+                      "hana_prd_srmode" => "sync",
+                      "hana_prd_sync_state" => "SOK",
+                      "hana_prd_version" => "2.00.040.00.1553674765",
+                      "hana_prd_vhost" => "node02",
+                      "lpa_prd_lpt" => "30",
+                      "master-rsc_SAPHana_PRD_HDB00" => "100"
+                    },
+                    hana_status: "Secondary",
+                    name: "node02",
+                    resources: [
+                      %ClusterResource{
+                        fail_count: 0,
+                        id: "test",
+                        role: "Started",
+                        status: "Active",
+                        type: "ocf::heartbeat:Dummy"
+                      },
+                      %ClusterResource{
+                        fail_count: 300,
+                        id: "rsc_SAPHana_PRD_HDB00",
+                        role: "Slave",
+                        status: "Active",
+                        type: "ocf::suse:SAPHana"
+                      },
+                      %ClusterResource{
+                        fail_count: 0,
+                        id: "rsc_SAPHanaTopology_PRD_HDB00",
+                        role: "Started",
+                        status: "Active",
+                        type: "ocf::suse:SAPHanaTopology"
+                      },
+                      %ClusterResource{
+                        fail_count: nil,
+                        id: "clusterfs",
+                        role: "Started",
+                        status: "Active",
+                        type: "ocf::heartbeat:Filesystem"
+                      },
+                      %ClusterResource{
+                        fail_count: nil,
+                        id: "rsc_ip_HA1_ERS10",
+                        role: "Started",
+                        status: "Active",
+                        type: "ocf::heartbeat:IPaddr2"
+                      },
+                      %ClusterResource{
+                        fail_count: nil,
+                        id: "rsc_fs_HA1_ERS10",
+                        role: "Started",
+                        status: "Active",
+                        type: "ocf::heartbeat:Filesystem"
+                      },
+                      %ClusterResource{
+                        fail_count: nil,
+                        id: "rsc_sap_HA1_ERS10",
+                        role: "Started",
+                        status: "Active",
+                        type: "ocf::heartbeat:SAPInstance"
+                      }
+                    ],
+                    site: "SECONDARY_SITE_NAME",
+                    virtual_ip: nil
+                  }
+                ],
+                sbd_devices: [
+                  %SbdDevice{
+                    device: "/dev/vdc",
+                    status: "healthy"
+                  },
+                  %SbdDevice{
+                    device: "/dev/vdb",
+                    status: "healthy"
+                  }
+                ],
+                secondary_sync_state: "SOK",
+                sr_health_state: "4",
+                stopped_resources: [
+                  %ClusterResource{
+                    fail_count: nil,
+                    id: "test-stop",
+                    role: "Stopped",
+                    status: nil,
+                    type: "ocf::heartbeat:Dummy"
+                  },
+                  %ClusterResource{
+                    fail_count: nil,
+                    id: "clusterfs",
+                    role: "Stopped",
+                    status: nil,
+                    type: "ocf::heartbeat:Filesystem"
+                  },
+                  %ClusterResource{
+                    fail_count: nil,
+                    id: "clusterfs",
+                    role: "Stopped",
+                    status: nil,
+                    type: "ocf::heartbeat:Filesystem"
+                  }
+                ],
+                system_replication_mode: "sync",
+                system_replication_operation_mode: "logreplay"
+              },
+              host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
+              name: nil,
+              sid: "PRD",
+              type: :hana_scale_up,
+              hosts_number: 2,
+              resources_number: 8,
+              discovered_health: :passing,
+              provider: :azure
+            }} ==
+             "ha_cluster_discovery_unnamed"
+             |> load_discovery_event_fixture()
+             |> ClusterPolicy.handle()
+  end
 end


### PR DESCRIPTION
Handle unnamed cluster (field `Name` coming empty in the cluster discovery event).
In the frontend, it shows a truncated version of the cluster id. I have chosen 14 chars length mostly for cosmetic reasons, as it is the length that better fits in the current views.

Here some pics:
Clusters view:
![image](https://user-images.githubusercontent.com/36370954/166949485-e9f771cd-bd01-42f0-827f-067e467a47dc.png)

Cluster details view:
![image](https://user-images.githubusercontent.com/36370954/166949558-5c161e63-b25c-40ff-b6f0-08a69462e03f.png)
![image](https://user-images.githubusercontent.com/36370954/166949602-8476b58e-08a0-4107-9c35-6943cdfc5c56.png)

Hosts view:
![image](https://user-images.githubusercontent.com/36370954/166949653-24a3bf2a-5fb7-4b53-be1d-7f59a607053a.png)
![image](https://user-images.githubusercontent.com/36370954/166949734-d1d13fa9-e7c8-4b06-9244-551b78d5233e.png)


