### PR TITLE
Include premium field handling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -306,6 +306,8 @@ jobs:
         OBS_USER: ${{ secrets.OBS_USER }}
         OBS_PASS: ${{ secrets.OBS_PASS }}
         OBS_PROJECT: ${{ secrets.OBS_PROJECT }}
+        FOLDER: packaging/suse
+        REPOSITORY: ${{ github.repository }}
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1
@@ -332,11 +334,6 @@ jobs:
       - name: Get mix deps
         run: mix local.hex --force && mix deps.clean --all && mix deps.get
 
-      - name: Set version
-        run: |
-          VERSION=${{ steps.latest-tag.outputs.tag }}
-          sed -i 's~%%VERSION%%~'"${VERSION}"'~' packaging/suse/Dockerfile
-
       - name: Configure OSC
         # OSC credentials must be configured beforehand as the HOME variables cannot be changed from /github/home
         # that is used to run osc commands
@@ -344,6 +341,22 @@ jobs:
           /scripts/init_osc_creds.sh
           mkdir -p $HOME/.config/osc
           cp /root/.config/osc/oscrc $HOME/.config/osc
+
+      - name: Prepare .changes file
+        # The .changes file is updated only in release creation. This current task should be improved
+        # in order to add the current rolling release notes
+        if: github.event_name == 'release'
+        run: |
+          CHANGES_FILE=$NAME.changes
+          osc checkout $OBS_PROJECT $NAME $CHANGES_FILE
+          mv $CHANGES_FILE $FOLDER
+          VERSION=${{ steps.latest-tag.outputs.tag }}
+          hack/gh_release_to_obs_changeset.py $REPOSITORY -a shap-staff@suse.de -t $VERSION -f $FOLDER/$CHANGES_FILE
+
+      - name: Set version
+        run: |
+          VERSION=${{ steps.latest-tag.outputs.tag }}
+          sed -i 's~%%VERSION%%~'"${VERSION}"'~' packaging/suse/Dockerfile
 
       - name: Commit on OBS
         run: |

--- a/lib/trento/application/integration/checks/dto/check_dto.ex
+++ b/lib/trento/application/integration/checks/dto/check_dto.ex
@@ -21,6 +21,6 @@ defmodule Trento.Integration.Checks.CheckDto do
     field :remediation, :string
     field :implementation, :string
     field :labels, :string
-    field :premium, :boolean
+    field :premium, :boolean, default: false
   end
 end

--- a/lib/trento/application/integration/checks/dto/check_dto.ex
+++ b/lib/trento/application/integration/checks/dto/check_dto.ex
@@ -21,5 +21,6 @@ defmodule Trento.Integration.Checks.CheckDto do
     field :remediation, :string
     field :implementation, :string
     field :labels, :string
+    field :premium, :boolean
   end
 end

--- a/lib/trento/application/integration/checks/dto/flat_check_dto.ex
+++ b/lib/trento/application/integration/checks/dto/flat_check_dto.ex
@@ -25,5 +25,6 @@ defmodule Trento.Integration.Checks.FlatCheckDto do
     field :remediation, :string
     field :implementation, :string
     field :labels, :string
+    field :premium, :boolean
   end
 end

--- a/lib/trento/application/integration/checks/dto/flat_check_dto.ex
+++ b/lib/trento/application/integration/checks/dto/flat_check_dto.ex
@@ -25,6 +25,6 @@ defmodule Trento.Integration.Checks.FlatCheckDto do
     field :remediation, :string
     field :implementation, :string
     field :labels, :string
-    field :premium, :boolean
+    field :premium, :boolean, default: false
   end
 end

--- a/test/fixtures/runner/catalog.json
+++ b/test/fixtures/runner/catalog.json
@@ -7,7 +7,8 @@
     "description": "description 1",
     "remediation": "remediation 1",
     "implementation": "implementation 1",
-    "labels": "labels"
+    "labels": "labels",
+    "premium": true
   },
   {
     "id": "2",
@@ -57,7 +58,8 @@
     "description": "description 1",
     "remediation": "remediation 1",
     "implementation": "implementation 1",
-    "labels": "labels"
+    "labels": "labels",
+    "premium": true
   },
   {
     "id": "2",

--- a/test/trento/application/integration/checks/checks_test.exs
+++ b/test/trento/application/integration/checks/checks_test.exs
@@ -70,7 +70,8 @@ defmodule Trento.Integration.ChecksTest do
           labels: "labels",
           name: "test 1",
           provider: :azure,
-          remediation: "remediation 1"
+          remediation: "remediation 1",
+          premium: true
         },
         %FlatCheckDto{
           description: "description 2",
@@ -80,7 +81,8 @@ defmodule Trento.Integration.ChecksTest do
           labels: "labels",
           name: "test 2",
           provider: :azure,
-          remediation: "remediation 2"
+          remediation: "remediation 2",
+          premium: nil
         },
         %FlatCheckDto{
           description: "description 3",
@@ -90,7 +92,8 @@ defmodule Trento.Integration.ChecksTest do
           labels: "labels",
           name: "test 3",
           provider: :azure,
-          remediation: "remediation 3"
+          remediation: "remediation 3",
+          premium: nil
         },
         %FlatCheckDto{
           description: "description 4",
@@ -100,7 +103,8 @@ defmodule Trento.Integration.ChecksTest do
           labels: "labels",
           name: "test 4",
           provider: :azure,
-          remediation: "remediation 4"
+          remediation: "remediation 4",
+          premium: nil
         },
         %FlatCheckDto{
           description: "description 5",
@@ -110,7 +114,8 @@ defmodule Trento.Integration.ChecksTest do
           labels: "labels",
           name: "test 5",
           provider: :azure,
-          remediation: "remediation 5"
+          remediation: "remediation 5",
+          premium: nil
         },
         %FlatCheckDto{
           description: "description 1",
@@ -120,7 +125,8 @@ defmodule Trento.Integration.ChecksTest do
           labels: "labels",
           name: "test 1",
           provider: :aws,
-          remediation: "remediation 1"
+          remediation: "remediation 1",
+          premium: true
         },
         %FlatCheckDto{
           description: "description 2",
@@ -130,7 +136,8 @@ defmodule Trento.Integration.ChecksTest do
           labels: "labels",
           name: "test 2",
           provider: :aws,
-          remediation: "remediation 2"
+          remediation: "remediation 2",
+          premium: nil
         },
         %FlatCheckDto{
           description: "description 3",
@@ -140,7 +147,8 @@ defmodule Trento.Integration.ChecksTest do
           labels: "labels",
           name: "test 3",
           provider: :aws,
-          remediation: "remediation 3"
+          remediation: "remediation 3",
+          premium: nil
         },
         %FlatCheckDto{
           description: "description 4",
@@ -150,7 +158,8 @@ defmodule Trento.Integration.ChecksTest do
           labels: "labels",
           name: "test 4",
           provider: :aws,
-          remediation: "remediation 4"
+          remediation: "remediation 4",
+          premium: nil
         },
         %FlatCheckDto{
           description: "description 5",
@@ -160,7 +169,8 @@ defmodule Trento.Integration.ChecksTest do
           labels: "labels",
           name: "test 5",
           provider: :aws,
-          remediation: "remediation 5"
+          remediation: "remediation 5",
+          premium: nil
         }
       ]
     }
@@ -186,7 +196,8 @@ defmodule Trento.Integration.ChecksTest do
                   implementation: "implementation 1",
                   labels: "labels",
                   name: "test 1",
-                  remediation: "remediation 1"
+                  remediation: "remediation 1",
+                  premium: true
                 },
                 %CheckDto{
                   description: "description 2",
@@ -194,7 +205,8 @@ defmodule Trento.Integration.ChecksTest do
                   implementation: "implementation 2",
                   labels: "labels",
                   name: "test 2",
-                  remediation: "remediation 2"
+                  remediation: "remediation 2",
+                  premium: nil
                 }
               ],
               group: "Group 1"
@@ -207,7 +219,8 @@ defmodule Trento.Integration.ChecksTest do
                   implementation: "implementation 3",
                   labels: "labels",
                   name: "test 3",
-                  remediation: "remediation 3"
+                  remediation: "remediation 3",
+                  premium: nil
                 },
                 %CheckDto{
                   description: "description 4",
@@ -215,7 +228,8 @@ defmodule Trento.Integration.ChecksTest do
                   implementation: "implementation 4",
                   labels: "labels",
                   name: "test 4",
-                  remediation: "remediation 4"
+                  remediation: "remediation 4",
+                  premium: nil
                 }
               ],
               group: "Group 2"
@@ -228,7 +242,8 @@ defmodule Trento.Integration.ChecksTest do
                   implementation: "implementation 5",
                   labels: "labels",
                   name: "test 5",
-                  remediation: "remediation 5"
+                  remediation: "remediation 5",
+                  premium: nil
                 }
               ],
               group: "Group 3"
@@ -246,7 +261,8 @@ defmodule Trento.Integration.ChecksTest do
                   implementation: "implementation 1",
                   labels: "labels",
                   name: "test 1",
-                  remediation: "remediation 1"
+                  remediation: "remediation 1",
+                  premium: true
                 },
                 %CheckDto{
                   description: "description 2",
@@ -254,7 +270,8 @@ defmodule Trento.Integration.ChecksTest do
                   implementation: "implementation 2",
                   labels: "labels",
                   name: "test 2",
-                  remediation: "remediation 2"
+                  remediation: "remediation 2",
+                  premium: nil
                 }
               ],
               group: "Group 1"
@@ -267,7 +284,8 @@ defmodule Trento.Integration.ChecksTest do
                   implementation: "implementation 3",
                   labels: "labels",
                   name: "test 3",
-                  remediation: "remediation 3"
+                  remediation: "remediation 3",
+                  premium: nil
                 },
                 %CheckDto{
                   description: "description 4",
@@ -275,7 +293,8 @@ defmodule Trento.Integration.ChecksTest do
                   implementation: "implementation 4",
                   labels: "labels",
                   name: "test 4",
-                  remediation: "remediation 4"
+                  remediation: "remediation 4",
+                  premium: nil
                 }
               ],
               group: "Group 2"
@@ -288,7 +307,8 @@ defmodule Trento.Integration.ChecksTest do
                   implementation: "implementation 5",
                   labels: "labels",
                   name: "test 5",
-                  remediation: "remediation 5"
+                  remediation: "remediation 5",
+                  premium: nil
                 }
               ],
               group: "Group 3"

--- a/test/trento/application/integration/checks/checks_test.exs
+++ b/test/trento/application/integration/checks/checks_test.exs
@@ -82,7 +82,7 @@ defmodule Trento.Integration.ChecksTest do
           name: "test 2",
           provider: :azure,
           remediation: "remediation 2",
-          premium: nil
+          premium: false
         },
         %FlatCheckDto{
           description: "description 3",
@@ -93,7 +93,7 @@ defmodule Trento.Integration.ChecksTest do
           name: "test 3",
           provider: :azure,
           remediation: "remediation 3",
-          premium: nil
+          premium: false
         },
         %FlatCheckDto{
           description: "description 4",
@@ -104,7 +104,7 @@ defmodule Trento.Integration.ChecksTest do
           name: "test 4",
           provider: :azure,
           remediation: "remediation 4",
-          premium: nil
+          premium: false
         },
         %FlatCheckDto{
           description: "description 5",
@@ -115,7 +115,7 @@ defmodule Trento.Integration.ChecksTest do
           name: "test 5",
           provider: :azure,
           remediation: "remediation 5",
-          premium: nil
+          premium: false
         },
         %FlatCheckDto{
           description: "description 1",
@@ -137,7 +137,7 @@ defmodule Trento.Integration.ChecksTest do
           name: "test 2",
           provider: :aws,
           remediation: "remediation 2",
-          premium: nil
+          premium: false
         },
         %FlatCheckDto{
           description: "description 3",
@@ -148,7 +148,7 @@ defmodule Trento.Integration.ChecksTest do
           name: "test 3",
           provider: :aws,
           remediation: "remediation 3",
-          premium: nil
+          premium: false
         },
         %FlatCheckDto{
           description: "description 4",
@@ -159,7 +159,7 @@ defmodule Trento.Integration.ChecksTest do
           name: "test 4",
           provider: :aws,
           remediation: "remediation 4",
-          premium: nil
+          premium: false
         },
         %FlatCheckDto{
           description: "description 5",
@@ -170,7 +170,7 @@ defmodule Trento.Integration.ChecksTest do
           name: "test 5",
           provider: :aws,
           remediation: "remediation 5",
-          premium: nil
+          premium: false
         }
       ]
     }
@@ -206,7 +206,7 @@ defmodule Trento.Integration.ChecksTest do
                   labels: "labels",
                   name: "test 2",
                   remediation: "remediation 2",
-                  premium: nil
+                  premium: false
                 }
               ],
               group: "Group 1"
@@ -220,7 +220,7 @@ defmodule Trento.Integration.ChecksTest do
                   labels: "labels",
                   name: "test 3",
                   remediation: "remediation 3",
-                  premium: nil
+                  premium: false
                 },
                 %CheckDto{
                   description: "description 4",
@@ -229,7 +229,7 @@ defmodule Trento.Integration.ChecksTest do
                   labels: "labels",
                   name: "test 4",
                   remediation: "remediation 4",
-                  premium: nil
+                  premium: false
                 }
               ],
               group: "Group 2"
@@ -243,7 +243,7 @@ defmodule Trento.Integration.ChecksTest do
                   labels: "labels",
                   name: "test 5",
                   remediation: "remediation 5",
-                  premium: nil
+                  premium: false
                 }
               ],
               group: "Group 3"
@@ -271,7 +271,7 @@ defmodule Trento.Integration.ChecksTest do
                   labels: "labels",
                   name: "test 2",
                   remediation: "remediation 2",
-                  premium: nil
+                  premium: false
                 }
               ],
               group: "Group 1"
@@ -285,7 +285,7 @@ defmodule Trento.Integration.ChecksTest do
                   labels: "labels",
                   name: "test 3",
                   remediation: "remediation 3",
-                  premium: nil
+                  premium: false
                 },
                 %CheckDto{
                   description: "description 4",
@@ -294,7 +294,7 @@ defmodule Trento.Integration.ChecksTest do
                   labels: "labels",
                   name: "test 4",
                   remediation: "remediation 4",
-                  premium: nil
+                  premium: false
                 }
               ],
               group: "Group 2"
@@ -308,7 +308,7 @@ defmodule Trento.Integration.ChecksTest do
                   labels: "labels",
                   name: "test 5",
                   remediation: "remediation 5",
-                  premium: nil
+                  premium: false
                 }
               ],
               group: "Group 3"

--- a/test/trento_web/controllers/catalog_controller_test.exs
+++ b/test/trento_web/controllers/catalog_controller_test.exs
@@ -33,7 +33,8 @@ defmodule TrentoWeb.CatalogControllerTest do
                 "implementation" => "implementation 1",
                 "labels" => "labels",
                 "name" => "test 1",
-                "remediation" => "remediation 1"
+                "remediation" => "remediation 1",
+                "premium" => true
               },
               %{
                 "description" => "description 2",
@@ -41,7 +42,8 @@ defmodule TrentoWeb.CatalogControllerTest do
                 "implementation" => "implementation 2",
                 "labels" => "labels",
                 "name" => "test 2",
-                "remediation" => "remediation 2"
+                "remediation" => "remediation 2",
+                "premium" => nil
               }
             ],
             "group" => "Group 1"
@@ -54,7 +56,8 @@ defmodule TrentoWeb.CatalogControllerTest do
                 "implementation" => "implementation 3",
                 "labels" => "labels",
                 "name" => "test 3",
-                "remediation" => "remediation 3"
+                "remediation" => "remediation 3",
+                "premium" => nil
               },
               %{
                 "description" => "description 4",
@@ -62,7 +65,8 @@ defmodule TrentoWeb.CatalogControllerTest do
                 "implementation" => "implementation 4",
                 "labels" => "labels",
                 "name" => "test 4",
-                "remediation" => "remediation 4"
+                "remediation" => "remediation 4",
+                "premium" => nil
               }
             ],
             "group" => "Group 2"
@@ -75,7 +79,8 @@ defmodule TrentoWeb.CatalogControllerTest do
                 "implementation" => "implementation 5",
                 "labels" => "labels",
                 "name" => "test 5",
-                "remediation" => "remediation 5"
+                "remediation" => "remediation 5",
+                "premium" => nil
               }
             ],
             "group" => "Group 3"
@@ -93,7 +98,8 @@ defmodule TrentoWeb.CatalogControllerTest do
                 "implementation" => "implementation 1",
                 "labels" => "labels",
                 "name" => "test 1",
-                "remediation" => "remediation 1"
+                "remediation" => "remediation 1",
+                "premium" => true
               },
               %{
                 "description" => "description 2",
@@ -101,7 +107,8 @@ defmodule TrentoWeb.CatalogControllerTest do
                 "implementation" => "implementation 2",
                 "labels" => "labels",
                 "name" => "test 2",
-                "remediation" => "remediation 2"
+                "remediation" => "remediation 2",
+                "premium" => nil
               }
             ],
             "group" => "Group 1"
@@ -114,7 +121,8 @@ defmodule TrentoWeb.CatalogControllerTest do
                 "implementation" => "implementation 3",
                 "labels" => "labels",
                 "name" => "test 3",
-                "remediation" => "remediation 3"
+                "remediation" => "remediation 3",
+                "premium" => nil
               },
               %{
                 "description" => "description 4",
@@ -122,7 +130,8 @@ defmodule TrentoWeb.CatalogControllerTest do
                 "implementation" => "implementation 4",
                 "labels" => "labels",
                 "name" => "test 4",
-                "remediation" => "remediation 4"
+                "remediation" => "remediation 4",
+                "premium" => nil
               }
             ],
             "group" => "Group 2"
@@ -135,7 +144,8 @@ defmodule TrentoWeb.CatalogControllerTest do
                 "implementation" => "implementation 5",
                 "labels" => "labels",
                 "name" => "test 5",
-                "remediation" => "remediation 5"
+                "remediation" => "remediation 5",
+                "premium" => nil
               }
             ],
             "group" => "Group 3"
@@ -169,7 +179,8 @@ defmodule TrentoWeb.CatalogControllerTest do
         "implementation" => "implementation 1",
         "labels" => "labels",
         "name" => "test 1",
-        "remediation" => "remediation 1"
+        "remediation" => "remediation 1",
+        "premium" => true
       },
       %{
         "provider" => "azure",
@@ -179,7 +190,8 @@ defmodule TrentoWeb.CatalogControllerTest do
         "implementation" => "implementation 2",
         "labels" => "labels",
         "name" => "test 2",
-        "remediation" => "remediation 2"
+        "remediation" => "remediation 2",
+        "premium" => nil
       },
       %{
         "description" => "description 3",
@@ -189,7 +201,8 @@ defmodule TrentoWeb.CatalogControllerTest do
         "labels" => "labels",
         "name" => "test 3",
         "provider" => "azure",
-        "remediation" => "remediation 3"
+        "remediation" => "remediation 3",
+        "premium" => nil
       },
       %{
         "description" => "description 4",
@@ -199,7 +212,8 @@ defmodule TrentoWeb.CatalogControllerTest do
         "labels" => "labels",
         "name" => "test 4",
         "provider" => "azure",
-        "remediation" => "remediation 4"
+        "remediation" => "remediation 4",
+        "premium" => nil
       },
       %{
         "description" => "description 5",
@@ -209,7 +223,8 @@ defmodule TrentoWeb.CatalogControllerTest do
         "labels" => "labels",
         "name" => "test 5",
         "provider" => "azure",
-        "remediation" => "remediation 5"
+        "remediation" => "remediation 5",
+        "premium" => nil
       }
     ]
 
@@ -236,7 +251,8 @@ defmodule TrentoWeb.CatalogControllerTest do
         "implementation" => "implementation 1",
         "labels" => "labels",
         "name" => "test 1",
-        "remediation" => "remediation 1"
+        "remediation" => "remediation 1",
+        "premium" => true
       },
       %{
         "provider" => "azure",
@@ -246,7 +262,8 @@ defmodule TrentoWeb.CatalogControllerTest do
         "implementation" => "implementation 2",
         "labels" => "labels",
         "name" => "test 2",
-        "remediation" => "remediation 2"
+        "remediation" => "remediation 2",
+        "premium" => nil
       },
       %{
         "description" => "description 3",
@@ -256,7 +273,8 @@ defmodule TrentoWeb.CatalogControllerTest do
         "labels" => "labels",
         "name" => "test 3",
         "provider" => "azure",
-        "remediation" => "remediation 3"
+        "remediation" => "remediation 3",
+        "premium" => nil
       },
       %{
         "description" => "description 4",
@@ -266,7 +284,8 @@ defmodule TrentoWeb.CatalogControllerTest do
         "labels" => "labels",
         "name" => "test 4",
         "provider" => "azure",
-        "remediation" => "remediation 4"
+        "remediation" => "remediation 4",
+        "premium" => nil
       },
       %{
         "description" => "description 5",
@@ -276,7 +295,8 @@ defmodule TrentoWeb.CatalogControllerTest do
         "labels" => "labels",
         "name" => "test 5",
         "provider" => "azure",
-        "remediation" => "remediation 5"
+        "remediation" => "remediation 5",
+        "premium" => nil
       },
       %{
         "description" => "description 1",
@@ -286,7 +306,8 @@ defmodule TrentoWeb.CatalogControllerTest do
         "labels" => "labels",
         "name" => "test 1",
         "provider" => "aws",
-        "remediation" => "remediation 1"
+        "remediation" => "remediation 1",
+        "premium" => true
       },
       %{
         "description" => "description 2",
@@ -296,7 +317,8 @@ defmodule TrentoWeb.CatalogControllerTest do
         "labels" => "labels",
         "name" => "test 2",
         "provider" => "aws",
-        "remediation" => "remediation 2"
+        "remediation" => "remediation 2",
+        "premium" => nil
       },
       %{
         "description" => "description 3",
@@ -306,7 +328,8 @@ defmodule TrentoWeb.CatalogControllerTest do
         "labels" => "labels",
         "name" => "test 3",
         "provider" => "aws",
-        "remediation" => "remediation 3"
+        "remediation" => "remediation 3",
+        "premium" => nil
       },
       %{
         "description" => "description 4",
@@ -316,7 +339,8 @@ defmodule TrentoWeb.CatalogControllerTest do
         "labels" => "labels",
         "name" => "test 4",
         "provider" => "aws",
-        "remediation" => "remediation 4"
+        "remediation" => "remediation 4",
+        "premium" => nil
       },
       %{
         "description" => "description 5",
@@ -326,7 +350,8 @@ defmodule TrentoWeb.CatalogControllerTest do
         "labels" => "labels",
         "name" => "test 5",
         "provider" => "aws",
-        "remediation" => "remediation 5"
+        "remediation" => "remediation 5",
+        "premium" => nil
       }
     ]
 

--- a/test/trento_web/controllers/catalog_controller_test.exs
+++ b/test/trento_web/controllers/catalog_controller_test.exs
@@ -43,7 +43,7 @@ defmodule TrentoWeb.CatalogControllerTest do
                 "labels" => "labels",
                 "name" => "test 2",
                 "remediation" => "remediation 2",
-                "premium" => nil
+                "premium" => false
               }
             ],
             "group" => "Group 1"
@@ -57,7 +57,7 @@ defmodule TrentoWeb.CatalogControllerTest do
                 "labels" => "labels",
                 "name" => "test 3",
                 "remediation" => "remediation 3",
-                "premium" => nil
+                "premium" => false
               },
               %{
                 "description" => "description 4",
@@ -66,7 +66,7 @@ defmodule TrentoWeb.CatalogControllerTest do
                 "labels" => "labels",
                 "name" => "test 4",
                 "remediation" => "remediation 4",
-                "premium" => nil
+                "premium" => false
               }
             ],
             "group" => "Group 2"
@@ -80,7 +80,7 @@ defmodule TrentoWeb.CatalogControllerTest do
                 "labels" => "labels",
                 "name" => "test 5",
                 "remediation" => "remediation 5",
-                "premium" => nil
+                "premium" => false
               }
             ],
             "group" => "Group 3"
@@ -108,7 +108,7 @@ defmodule TrentoWeb.CatalogControllerTest do
                 "labels" => "labels",
                 "name" => "test 2",
                 "remediation" => "remediation 2",
-                "premium" => nil
+                "premium" => false
               }
             ],
             "group" => "Group 1"
@@ -122,7 +122,7 @@ defmodule TrentoWeb.CatalogControllerTest do
                 "labels" => "labels",
                 "name" => "test 3",
                 "remediation" => "remediation 3",
-                "premium" => nil
+                "premium" => false
               },
               %{
                 "description" => "description 4",
@@ -131,7 +131,7 @@ defmodule TrentoWeb.CatalogControllerTest do
                 "labels" => "labels",
                 "name" => "test 4",
                 "remediation" => "remediation 4",
-                "premium" => nil
+                "premium" => false
               }
             ],
             "group" => "Group 2"
@@ -145,7 +145,7 @@ defmodule TrentoWeb.CatalogControllerTest do
                 "labels" => "labels",
                 "name" => "test 5",
                 "remediation" => "remediation 5",
-                "premium" => nil
+                "premium" => false
               }
             ],
             "group" => "Group 3"
@@ -191,7 +191,7 @@ defmodule TrentoWeb.CatalogControllerTest do
         "labels" => "labels",
         "name" => "test 2",
         "remediation" => "remediation 2",
-        "premium" => nil
+        "premium" => false
       },
       %{
         "description" => "description 3",
@@ -202,7 +202,7 @@ defmodule TrentoWeb.CatalogControllerTest do
         "name" => "test 3",
         "provider" => "azure",
         "remediation" => "remediation 3",
-        "premium" => nil
+        "premium" => false
       },
       %{
         "description" => "description 4",
@@ -213,7 +213,7 @@ defmodule TrentoWeb.CatalogControllerTest do
         "name" => "test 4",
         "provider" => "azure",
         "remediation" => "remediation 4",
-        "premium" => nil
+        "premium" => false
       },
       %{
         "description" => "description 5",
@@ -224,7 +224,7 @@ defmodule TrentoWeb.CatalogControllerTest do
         "name" => "test 5",
         "provider" => "azure",
         "remediation" => "remediation 5",
-        "premium" => nil
+        "premium" => false
       }
     ]
 
@@ -263,7 +263,7 @@ defmodule TrentoWeb.CatalogControllerTest do
         "labels" => "labels",
         "name" => "test 2",
         "remediation" => "remediation 2",
-        "premium" => nil
+        "premium" => false
       },
       %{
         "description" => "description 3",
@@ -274,7 +274,7 @@ defmodule TrentoWeb.CatalogControllerTest do
         "name" => "test 3",
         "provider" => "azure",
         "remediation" => "remediation 3",
-        "premium" => nil
+        "premium" => false
       },
       %{
         "description" => "description 4",
@@ -285,7 +285,7 @@ defmodule TrentoWeb.CatalogControllerTest do
         "name" => "test 4",
         "provider" => "azure",
         "remediation" => "remediation 4",
-        "premium" => nil
+        "premium" => false
       },
       %{
         "description" => "description 5",
@@ -296,7 +296,7 @@ defmodule TrentoWeb.CatalogControllerTest do
         "name" => "test 5",
         "provider" => "azure",
         "remediation" => "remediation 5",
-        "premium" => nil
+        "premium" => false
       },
       %{
         "description" => "description 1",
@@ -318,7 +318,7 @@ defmodule TrentoWeb.CatalogControllerTest do
         "name" => "test 2",
         "provider" => "aws",
         "remediation" => "remediation 2",
-        "premium" => nil
+        "premium" => false
       },
       %{
         "description" => "description 3",
@@ -329,7 +329,7 @@ defmodule TrentoWeb.CatalogControllerTest do
         "name" => "test 3",
         "provider" => "aws",
         "remediation" => "remediation 3",
-        "premium" => nil
+        "premium" => false
       },
       %{
         "description" => "description 4",
@@ -340,7 +340,7 @@ defmodule TrentoWeb.CatalogControllerTest do
         "name" => "test 4",
         "provider" => "aws",
         "remediation" => "remediation 4",
-        "premium" => nil
+        "premium" => false
       },
       %{
         "description" => "description 5",
@@ -351,7 +351,7 @@ defmodule TrentoWeb.CatalogControllerTest do
         "name" => "test 5",
         "provider" => "aws",
         "remediation" => "remediation 5",
-        "premium" => nil
+        "premium" => false
       }
     ]
 


### PR DESCRIPTION
Include the premium field from the runner catalog in the DTOs, so we can store and visualize this field in the frontend.
This way, we show if a check is premium or not in the checks catalog view.

Besides that, I have included a small improvement in the CI, in the OBS commit task, to update the changes file in a new release. This very well could go in a different PR, but as initially I thought we would need a release yes or yes after this change, I added it, but finally this issue was not a roadblocker.