### PR TITLE
Debounce Homepage health overview refresh

### DIFF
--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -4,8 +4,8 @@ import {
   all,
   call,
   takeEvery,
-  takeLatest,
   select,
+  debounce,
 } from 'redux-saga/effects';
 import { urlEncode, keysToCamel } from '@lib/serialization';
 
@@ -518,15 +518,53 @@ function* watchCatalogUpdate() {
 }
 
 function* refreshHealthSummaryOnComnponentsHealthChange() {
-  yield takeLatest('HOST_REGISTERED', loadSapSystemsHealthSummary);
-  yield takeLatest('CLUSTER_REGISTERED', loadSapSystemsHealthSummary);
-  yield takeLatest('DATABASE_REGISTERED', loadSapSystemsHealthSummary);
-  yield takeLatest('SAP_SYSTEM_REGISTERED', loadSapSystemsHealthSummary);
-  yield takeLatest('HEARTBEAT_FAILED', loadSapSystemsHealthSummary);
-  yield takeLatest('HEARTBEAT_SUCCEDED', loadSapSystemsHealthSummary);
-  yield takeLatest('DATABASE_HEALTH_CHANGED', loadSapSystemsHealthSummary);
-  yield takeLatest('SAP_SYSTEM_HEALTH_CHANGED', loadSapSystemsHealthSummary);
-  yield takeLatest('CLUSTER_HEALTH_CHANGED', loadSapSystemsHealthSummary);
+  const debounceDuration = 5000;
+
+  yield debounce(
+    debounceDuration,
+    'HOST_REGISTERED',
+    loadSapSystemsHealthSummary
+  );
+  yield debounce(
+    debounceDuration,
+    'CLUSTER_REGISTERED',
+    loadSapSystemsHealthSummary
+  );
+  yield debounce(
+    debounceDuration,
+    'DATABASE_REGISTERED',
+    loadSapSystemsHealthSummary
+  );
+  yield debounce(
+    debounceDuration,
+    'SAP_SYSTEM_REGISTERED',
+    loadSapSystemsHealthSummary
+  );
+  yield debounce(
+    debounceDuration,
+    'HEARTBEAT_FAILED',
+    loadSapSystemsHealthSummary
+  );
+  yield debounce(
+    debounceDuration,
+    'HEARTBEAT_SUCCEDED',
+    loadSapSystemsHealthSummary
+  );
+  yield debounce(
+    debounceDuration,
+    'DATABASE_HEALTH_CHANGED',
+    loadSapSystemsHealthSummary
+  );
+  yield debounce(
+    debounceDuration,
+    'SAP_SYSTEM_HEALTH_CHANGED',
+    loadSapSystemsHealthSummary
+  );
+  yield debounce(
+    debounceDuration,
+    'CLUSTER_HEALTH_CHANGED',
+    loadSapSystemsHealthSummary
+  );
 }
 
 function* loadClusterConnectionSettings({ payload: { cluster } }) {


### PR DESCRIPTION
e2e tests in our pipeline are failing on the `dashboard.js` test. Seems to be flaky.

A possible cause might be the fact that the dashboard gets refreshed whenever any of the following things happen
```
HOST_REGISTERED
CLUSTER_REGISTERED
DATABASE_REGISTERED
SAP_SYSTEM_REGISTERED
HEARTBEAT_FAILED
HEARTBEAT_SUCCEDED
DATABASE_HEALTH_CHANGED
SAP_SYSTEM_HEALTH_CHANGED
CLUSTER_HEALTH_CHANGED
```
In addition, when we run photofinish loading the `healthy-27-node-SAP-cluster` a lot of those thing happen, triggering something like ~40 refreshes, hence ~40 api calls that stack one after another.

By adding debouncing in that scenario we reduced the API calls to ~5.

Not sure it fixes, yet might be anyway helpful :smile: 