### PR TITLE
Correct log replication and log operation mode names

### DIFF
--- a/assets/js/components/ClusterDetails/ClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetails.jsx
@@ -149,7 +149,7 @@ const ClusterDetails = () => {
               content: cluster.cib_last_written || '-',
             },
             {
-              title: 'HANA system replication mode',
+              title: 'HANA log replication mode',
               content:
                 cluster.details && cluster.details.system_replication_mode,
             },
@@ -158,7 +158,7 @@ const ClusterDetails = () => {
               content: cluster.details && cluster.details.secondary_sync_state,
             },
             {
-              title: 'HANA system replication mode',
+              title: 'HANA log operation mode',
               content:
                 cluster.details &&
                 cluster.details.system_replication_operation_mode,


### PR DESCRIPTION
Fix the `HANA log replication mode` and `HANA log operation mode` names:

![image](https://user-images.githubusercontent.com/36370954/167806114-2248bd93-9ee9-4adc-bb97-cb179cd009c0.png)
