### PR TITLE
Add obs disk constraints to avoid out of space issue

### DIFF
--- a/packaging/suse/_constraints
+++ b/packaging/suse/_constraints
@@ -1,0 +1,7 @@
+<constraints>
+  <hardware>
+    <disk>
+      <size unit="G">8</size>
+    </disk>
+  </hardware>
+</constraints>


### PR DESCRIPTION
Avoid recurrent `out of space` issue in OBS

https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.build_job_constraints.html#id-1.5.10.16.13