### PR TITLE
Add default value to os_version

### DIFF
--- a/lib/trento/application/integration/discovery/discovery.ex
+++ b/lib/trento/application/integration/discovery/discovery.ex
@@ -28,7 +28,7 @@ defmodule Trento.Integration.Discovery do
     else
       # TODO improve error handling, bubbling up validation / command dispatch errors
       {:error, reason} = error ->
-        Logger.error("Failed to handle discovery event", error: reason)
+        Logger.error("Failed to handle discovery event", error: inspect(reason))
 
         error
     end

--- a/lib/trento/domain/host/commands/register_host.ex
+++ b/lib/trento/domain/host/commands/register_host.ex
@@ -16,6 +16,6 @@ defmodule Trento.Domain.Commands.RegisterHost do
     field :cpu_count, :integer
     field :total_memory_mb, :integer
     field :socket_count, :integer
-    field :os_version, :string
+    field :os_version, :string, default: "Unknown"
   end
 end


### PR DESCRIPTION
In my development machine, the os_version detected by the agent is nil. (I use Arch, btw)
This PR adds a default value to the field, so the discovery does not fail.