### PR TITLE
Sap system details e2e

### DIFF
--- a/.photofinish.toml
+++ b/.photofinish.toml
@@ -26,7 +26,7 @@ files = ["./test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8
 
 [sap-system-detail-NEW]
 
-files = ["./test/fixtures/scenarios/sap-system-details/newagent_sap_system_discovery_new.json"]
+files = ["./test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_new.json"]
 
 [hana-database-detail-GRAY]
 

--- a/assets/js/components/ClusterDetails/ClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetails.jsx
@@ -13,6 +13,7 @@ import { groupBy } from '@lib/lists';
 import SiteDetails from './SiteDetails';
 
 import { getClusterName } from '@components/ClusterLink';
+import HostLink from '@components/HostLink';
 
 import { EOS_SETTINGS, EOS_CLEAR_ALL, EOS_PLAY_CIRCLE } from 'eos-icons-react';
 import { getCluster } from '@state/selectors';
@@ -25,7 +26,13 @@ export const truncatedClusterNameClasses = classNames(
 const siteDetailsConfig = {
   usePadding: false,
   columns: [
-    { title: 'Hostname', key: 'name' },
+    {
+      title: 'Hostname',
+      key: '',
+      render: (_, hostData) => (
+        <HostLink hostId={hostData.hostId}>{hostData.name}</HostLink>
+      ),
+    },
     { title: 'Role', key: 'hana_status' },
     {
       title: 'IP',
@@ -63,10 +70,13 @@ const ClusterDetails = () => {
 
   const cluster = useSelector(getCluster(clusterID));
 
-  const ips = useSelector((state) =>
+  const hostsData = useSelector((state) =>
     state.hostsList.hosts.reduce((accumulator, current) => {
       if (current.cluster_id === clusterID) {
-        return { ...accumulator, [current.hostname]: current.ip_addresses };
+        return {
+          ...accumulator,
+          [current.hostname]: { hostId: current.id, ips: current.ip_addresses },
+        };
       }
       return accumulator;
     }, {})
@@ -77,7 +87,13 @@ const ClusterDetails = () => {
   }
 
   const renderedNodes = cluster.details?.nodes?.map((node) =>
-    ips[node.name] ? { ...node, ips: ips[node.name] } : node
+    hostsData[node.name]
+      ? {
+          ...node,
+          ips: hostsData[node.name].ips,
+          hostId: hostsData[node.name].hostId,
+        }
+      : node
   );
 
   const hasSelectedChecks = cluster.selected_checks.length > 0;

--- a/assets/js/components/HostLink.jsx
+++ b/assets/js/components/HostLink.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { Link } from 'react-router-dom';
+
+const HostLink = ({ hostId, children }) => {
+  return (
+    <span
+      id={`host-${hostId}`}
+      className="tn-hostname text-jungle-green-500 hover:opacity-75"
+    >
+      <Link to={`/hosts/${hostId}`}>{children}</Link>
+    </span>
+  );
+};
+
+export default HostLink;

--- a/assets/js/components/HostsList.jsx
+++ b/assets/js/components/HostsList.jsx
@@ -1,8 +1,8 @@
 import React, { Fragment } from 'react';
-import { Link } from 'react-router-dom';
 import Table from './Table';
 import Tags from './Tags';
 import { addTagToHost, removeTagFromHost } from '@state/hosts';
+import HostLink from '@components/HostLink';
 import ClusterLink from '@components/ClusterLink';
 import SapSystemLink from '@components/SapSystemLink';
 import { useSelector, useDispatch } from 'react-redux';
@@ -75,14 +75,7 @@ const HostsList = () => {
         key: 'hostname',
         className: 'w-40',
         filter: true,
-        render: (content, { id }) => (
-          <span
-            id={`host-${id}`}
-            className="tn-hostname text-jungle-green-500 hover:opacity-75"
-          >
-            <Link to={`/hosts/${id}`}>{content}</Link>
-          </span>
-        ),
+        render: (content, { id }) => <HostLink hostId={id}>{content}</HostLink>,
       },
       {
         title: 'IP',

--- a/assets/js/components/InstanceOverview/InstanceOverview.jsx
+++ b/assets/js/components/InstanceOverview/InstanceOverview.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { Link } from 'react-router-dom';
 import { getCluster, getHost } from '@state/selectors';
 import HealthIcon from '@components/Health';
 import { Features } from '@components/SapSystemDetails';
 import { DATABASE_TYPE } from '@lib/model';
+import HostLink from '@components/HostLink';
 import ClusterLink from '@components/ClusterLink';
 import Pill from '@components/Pill';
 const InstanceOverview = ({
@@ -50,12 +50,7 @@ const InstanceOverview = ({
         )}
       </div>
       <div className="table-cell p-2">
-        <Link
-          className="text-jungle-green-500 hover:opacity-75"
-          to={`/hosts/${hostId}`}
-        >
-          {host && host.hostname}
-        </Link>
+        <HostLink hostId={hostId}>{host && host.hostname}</HostLink>
       </div>
     </div>
   );

--- a/assets/js/components/SapSystemDetails/tableConfigs.jsx
+++ b/assets/js/components/SapSystemDetails/tableConfigs.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import HostLink from '@components/HostLink';
 import { Features, InstanceStatus } from './GenericSystemDetails';
 
 export const systemInstancesTableConfiguration = {
@@ -33,11 +33,7 @@ export const systemHostsTableConfiguration = {
     {
       title: 'Hostname',
       key: 'hostname',
-      render: (content, { id }) => (
-        <span className="transition hover:text-green-600">
-          <Link to={`/hosts/${id}`}>{content}</Link>
-        </span>
-      ),
+      render: (content, { id }) => <HostLink hostId={id}>{content}</HostLink>,
     },
     {
       title: 'IP',

--- a/test/e2e/cypress/fixtures/sap-system-details/sap_system_details.feature
+++ b/test/e2e/cypress/fixtures/sap-system-details/sap_system_details.feature
@@ -1,0 +1,49 @@
+Feature: SAP system details view
+    This is where the user has a detailed view of the status of one specific discovered SAP system
+
+    Background:
+        Given a discovered SAP system within a SAP deployment with the following properties
+        # Id: 'f534a4ad-cef7-5234-b196-e67082ffb50c',
+        # Sid: 'NWD',
+        # Hosts: ['vmnwdev01', 'vmnwdev02', 'vmnwdev03', 'vmnwdev04']
+        And 4 hosts associated to the SAP system
+
+    Scenario: Detailed view of one specific SAP system is available
+        When I navigate to a specific SAP system ('/sap_systems/f534a4ad-cef7-5234-b196-e67082ffb50c')
+        Then the displayed SAP system SID is correct
+        And the displayed SAP system has "Application server" type
+
+    Scenario: Not found is given when the SAP system is not available
+        When I navigate to a specific SAP system ('/sapsystems/other')
+        Then Not found message is displayed
+
+    Scenario: SAP system instances are properly shown
+        Given I navigate to a specific SAP system ('/sap_systems/f534a4ad-cef7-5234-b196-e67082ffb50c')
+        Then 4 instances are displayed
+        And the data of each instance is correct
+        And the status of each instance is GREEN
+
+    Scenario: SAP system instances status change event is received
+        Given I navigate to a specific SAP system ('/sap_systems/f534a4ad-cef7-5234-b196-e67082ffb50c')
+        When a new SAP system event for this system with the 1st instance with a GRAY status is received
+        And the page is refreshed
+        Then the status of the 1st instance is GRAY
+        When a new SAP system event for this system with the 1st instance with a GREEN status is received
+        And the page is refreshed
+        Then the status of the 1st instance is GREEN
+        When a new SAP system event for this system with the 1st instance with a YELLOW status is received
+        And the page is refreshed
+        Then the status of the 1st instance is YELLOW
+        When a new SAP system event for this system with the 1st instance with a RED status is received
+        And the page is refreshed
+        Then the status of the 1st instance is RED
+
+    Scenario: New instance is discovered in the SAP system
+        Given I navigate to a specific SAP system ('/sap_systems/f534a4ad-cef7-5234-b196-e67082ffb50c')
+        When a new instance is discovered in a new agent
+        Then the new instace is added in the layout table
+
+    Scenario: The hosts table shows all associated hosts
+        Given I navigate to a specific SAP system ('/sap_systems/f534a4ad-cef7-5234-b196-e67082ffb50c')
+        Then the hosts table shows all the associated hosts
+        And each host has correct data

--- a/test/e2e/cypress/fixtures/sap-system-details/sap_system_details.feature
+++ b/test/e2e/cypress/fixtures/sap-system-details/sap_system_details.feature
@@ -26,16 +26,12 @@ Feature: SAP system details view
     Scenario: SAP system instances status change event is received
         Given I navigate to a specific SAP system ('/sap_systems/f534a4ad-cef7-5234-b196-e67082ffb50c')
         When a new SAP system event for this system with the 1st instance with a GRAY status is received
-        And the page is refreshed
         Then the status of the 1st instance is GRAY
         When a new SAP system event for this system with the 1st instance with a GREEN status is received
-        And the page is refreshed
         Then the status of the 1st instance is GREEN
         When a new SAP system event for this system with the 1st instance with a YELLOW status is received
-        And the page is refreshed
         Then the status of the 1st instance is YELLOW
         When a new SAP system event for this system with the 1st instance with a RED status is received
-        And the page is refreshed
         Then the status of the 1st instance is RED
 
     Scenario: New instance is discovered in the SAP system

--- a/test/e2e/cypress/fixtures/sap-system-details/selected_system.js
+++ b/test/e2e/cypress/fixtures/sap-system-details/selected_system.js
@@ -1,0 +1,89 @@
+export const healthMap = {
+  GREEN: 'bg-jungle-green-500',
+  YELLOW: 'bg-yellow-500',
+  RED: 'bg-red-500',
+  GRAY: 'bg-gray-500',
+};
+
+export const selectedSystem = {
+  Id: 'f534a4ad-cef7-5234-b196-e67082ffb50c',
+  Sid: 'NWD',
+  Type: 'Application server',
+  Hosts: [
+    {
+      Hostname: 'sapnwdas',
+      Instance: '00',
+      Features: 'MESSAGESERVER|ENQUE',
+      HttpPort: '50013',
+      HttpsPort: '50014',
+      StartPriority: '1',
+      Status: 'SAPControl-GREEN',
+      StatusBadge: 'GREEN',
+    },
+    {
+      Hostname: 'sapnwdpas',
+      Instance: '01',
+      Features: 'ABAP|GATEWAY|ICMAN|IGS',
+      HttpPort: '50113',
+      HttpsPort: '50114',
+      StartPriority: '3',
+      Status: 'SAPControl-GREEN',
+      StatusBadge: 'GREEN',
+    },
+    {
+      Hostname: 'sapnwdaas1',
+      Instance: '02',
+      Features: 'ABAP|GATEWAY|ICMAN|IGS',
+      HttpPort: '50213',
+      HttpsPort: '50214',
+      StartPriority: '3',
+      Status: 'SAPControl-GREEN',
+      StatusBadge: 'GREEN',
+    },
+    {
+      Hostname: 'sapnwder',
+      Instance: '10',
+      Features: 'ENQREP',
+      HttpPort: '51013',
+      HttpsPort: '51014',
+      StartPriority: '0.5',
+      Status: 'SAPControl-GREEN',
+      StatusBadge: 'GREEN',
+    },
+  ],
+};
+
+export const attachedHosts = [
+  {
+    Name: 'vmnwdev01',
+    AgentId: '7269ee51-5007-5849-aaa7-7c4a98b0c9ce',
+    Addresses: ['10.100.1.21', '10.100.1.25'],
+    Provider: 'azure',
+    Cluster: 'netweaver_cluster',
+    Version: '0.7.1+git.dev42.1640084952.33229fc',
+  },
+  {
+    Name: 'vmnwdev03',
+    AgentId: '9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f',
+    Addresses: ['10.100.1.23', '10.100.1.27'],
+    Provider: 'azure',
+    Cluster: '',
+    Version: '0.7.1+git.dev42.1640084952.33229fc',
+  },
+  {
+    Name: 'vmnwdev04',
+    AgentId: '1b0e9297-97dd-55d6-9874-8efde4d84c90',
+    Addresses: ['10.100.1.24', '10.100.1.28'],
+    Provider: 'azure',
+    Cluster: '',
+    Version: '0.7.1+git.dev42.1640084952.33229fc',
+  },
+  {
+    Name: 'vmnwdev02',
+    AgentId: 'fb2c6b8a-9915-5969-a6b7-8b5a42de1971',
+    Addresses: ['10.100.1.22', '10.100.1.26'],
+    Provider: 'azure',
+    Cluster: 'netweaver_cluster',
+    Version: '0.7.1+git.dev42.1640084952.33229fc',
+  },
+];

--- a/test/e2e/cypress/fixtures/sap-systems-overview/sap_systems_overview.feature
+++ b/test/e2e/cypress/fixtures/sap-systems-overview/sap_systems_overview.feature
@@ -9,7 +9,7 @@ Feature: SAP Systems Overview
 
     Scenario: Registered SAP Systems should be available in the overview
         When I navigate to the SAP Systems overview page
-        Then the discovered SID ar the expected ones
+        Then the discovered SID are the expected ones
         And the health of each of the systems is healthy
         And the links to the to the details page are working
 
@@ -42,27 +42,22 @@ Feature: SAP Systems Overview
     Scenario: System health state is changed upon new SAP system events
         Given I navigate to the SAP Systems overview page
         When a new SAP system event for the first SAP system with the 1st instance with a GRAY status is received
-        And the page is refreshed
         Then the status of the 1st instance in this SAP system is GRAY
         And the SAP system state is GRAY
         When a new SAP system event for the first SAP system with the 2nd instance with a YELLOW status is received
-        And the page is refreshed
         Then the status of the 2nd instance in this SAP system is YELLOW
         And the SAP system state is YELLOW
         When a new SAP system event for the first SAP system with the 3rd instance with a RED status is received
-        And the page is refreshed
         Then the status of the 3rd instance in this SAP system is RED
         And the SAP system state is RED
 
     Scenario: System health state is changed upon new HANA database events attached
         Given I navigate to the SAP Systems overview page
         When a new HANA database event for the first SAP system with the 1st HANA instance with a RED status is received
-        And the page is refreshed
         Then the status of the 1st HANA instance in this SAP system is RED
         And the SAP system state is RED
 
     Scenario: SAP diagnostic agent discoveries are not displayed
         Given I navigate to the SAP Systems overview page
         When a new SAP discovery with a SAP diagnostics agent is received
-        And the page is refreshed
         Then the discovery with the SAP diagnostics agent is not displayed

--- a/test/e2e/cypress/integration/sap_system_details.js
+++ b/test/e2e/cypress/integration/sap_system_details.js
@@ -1,0 +1,136 @@
+import {
+  selectedSystem,
+  attachedHosts,
+  healthMap,
+} from '../fixtures/sap-system-details/selected_system';
+
+context('SAP system details', () => {
+  const sessionCookie = '_trento_key';
+
+  before(() => {
+    cy.loadScenario('healthy-27-node-SAP-cluster');
+    cy.login();
+
+    cy.visit(`/sap_systems/${selectedSystem.Id}`);
+    cy.url().should('include', `/sap_systems/${selectedSystem.Id}`);
+  });
+
+  after(() => {
+    cy.clearCookie(sessionCookie);
+  });
+
+  beforeEach(() => {
+    cy.Cookies.preserveOnce(sessionCookie);
+  });
+
+  describe('SAP system details page is available', () => {
+    it(`should display the "${selectedSystem.Sid}" system details page`, () => {
+      cy.get('h1').should('contain', 'SAP System Details');
+      cy.get('div')
+        .contains('Name')
+        .next()
+        .should('contain', selectedSystem.Sid);
+      cy.get('div')
+        .contains('Type')
+        .next()
+        .should('contain', selectedSystem.Type);
+    });
+
+    it(`should display "Not found" page when SAP system doesn't exist`, () => {
+      cy.visit(`/sap_systems/other`, { failOnStatusCode: false });
+      cy.url().should('include', `/sap_systems/other`);
+      cy.get('div').should('contain', 'Not Found');
+    });
+  });
+
+  describe('The system layout shows all the running instances', () => {
+    before(() => {
+      cy.visit(`/sap_systems/${selectedSystem.Id}`);
+      cy.url().should('include', `/sap_systems/${selectedSystem.Id}`);
+    });
+
+    selectedSystem.Hosts.forEach((instance, index) => {
+      it(`should show hostname "${instance.Hostname}" with the correct values`, () => {
+        cy.get('table.table-fixed')
+          .eq(0)
+          .find('tr')
+          .eq(index + 1)
+          .find('td')
+          .as('tableCell');
+        cy.get('@tableCell').eq(0).should('contain', instance.Hostname);
+        cy.get('@tableCell').eq(1).should('contain', instance.Instance);
+        instance.Features.split('|').forEach((feature) => {
+          cy.get('@tableCell').eq(2).should('contain', feature);
+        });
+        cy.get('@tableCell').eq(3).should('contain', instance.HttpPort);
+        cy.get('@tableCell').eq(4).should('contain', instance.HttpsPort);
+        cy.get('@tableCell').eq(5).should('contain', instance.StartPriority);
+        cy.get('@tableCell').eq(6).should('contain', instance.Status);
+        cy.get('@tableCell')
+          .eq(6)
+          .find('span')
+          .should('have.class', healthMap[instance.StatusBadge]);
+      });
+    });
+
+    Object.entries(healthMap).forEach(([state, health]) => {
+      it(`should show ${state} badge in instace when SAPControl-${state} state is received`, () => {
+        cy.loadScenario(`sap-system-detail-${state}`);
+        // using row 3 as the changed instance is the 3rd in order based on instance_number
+        cy.get('table.table-fixed')
+          .eq(0)
+          .find('tr')
+          .eq(3)
+          .find('td')
+          .as('tableCell');
+        cy.get('@tableCell').eq(6).should('contain', `SAPControl-${state}`);
+        cy.get('@tableCell').eq(6).find('span').should('have.class', health);
+      });
+    });
+
+    it(`should show a new instance when an event with a new SAP instance is received`, () => {
+      cy.loadScenario(`sap-system-detail-NEW`);
+      cy.get('table.table-fixed').eq(0).find('tr').should('have.length', 6);
+      cy.get('table.table-fixed')
+        .eq(0)
+        .find('tr')
+        .eq(-1)
+        .find('td')
+        .as('tableCell');
+      cy.get('@tableCell').eq(0).should('contain', 'sapnwdaas1');
+      cy.get('@tableCell').eq(1).should('contain', '99');
+    });
+  });
+
+  describe('The hosts table shows the attached hosts to this SAP system', () => {
+    attachedHosts.forEach((host, index) => {
+      it(`should show ${host.Name} with the data`, () => {
+        cy.get('table.table-fixed')
+          .eq(1)
+          .find('tr')
+          .eq(index + 1)
+          .find('td')
+          .as('tableCell');
+        cy.get('@tableCell').eq(0).should('contain', host.Name);
+        host.Addresses.forEach((address) => {
+          cy.get('@tableCell').eq(1).should('contain', address);
+        });
+        cy.get('@tableCell').eq(2).should('contain', host.Provider);
+        cy.get('@tableCell').eq(3).should('contain', host.Cluster);
+        cy.get('@tableCell').eq(4).should('contain', host.Version);
+      });
+
+      it(`should have a correct link to the ${host.Name} host`, () => {
+        cy.get('table.table-fixed')
+          .eq(1)
+          .find('tr')
+          .eq(index + 1)
+          .find('td')
+          .as('tableCell');
+        cy.get('@tableCell').eq(0).find('a').click();
+        cy.location('pathname').should('eq', `/hosts/${host.AgentId}`);
+        cy.go('back');
+      });
+    });
+  });
+});

--- a/test/e2e/cypress/integration/sap_system_details.js
+++ b/test/e2e/cypress/integration/sap_system_details.js
@@ -87,7 +87,8 @@ context('SAP system details', () => {
         cy.get('@tableCell').eq(6).find('span').should('have.class', health);
       });
     });
-
+    /* This test is commented because there is not any option to remove added SAP instances or
+    resetting the database afterwards, and it affects the rest of the test suite.
     it(`should show a new instance when an event with a new SAP instance is received`, () => {
       cy.loadScenario(`sap-system-detail-NEW`);
       cy.get('table.table-fixed').eq(0).find('tr').should('have.length', 6);
@@ -100,6 +101,7 @@ context('SAP system details', () => {
       cy.get('@tableCell').eq(0).should('contain', 'sapnwdaas1');
       cy.get('@tableCell').eq(1).should('contain', '99');
     });
+    */
   });
 
   describe('The hosts table shows the attached hosts to this SAP system', () => {

--- a/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_new.json
+++ b/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_new.json
@@ -1,5 +1,5 @@
 {
-  "agent_id": "newagent",
+  "agent_id": "1b0e9297-97dd-55d6-9874-8efde4d84c90",
   "discovery_type": "sap_system_discovery",
   "payload": [
     {
@@ -43,8 +43,8 @@
       "Databases": null,
       "Instances": [
         {
-          "Host": "vmnwdev04",
-          "Name": "D02",
+          "Host": "sapnwdaas1",
+          "Name": "D99",
           "Type": 2,
           "SAPControl": {
             "Instances": [
@@ -86,7 +86,7 @@
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
-                "hostname": "newinstance",
+                "hostname": "sapnwdaas1",
                 "httpPort": 12345,
                 "httpsPort": 12345,
                 "dispstatus": "SAPControl-GRAY",
@@ -194,7 +194,7 @@
                 "propertytype": "NodeWebmethod"
               },
               {
-                "value": "D02",
+                "value": "D99",
                 "property": "INSTANCE_NAME",
                 "propertytype": "Attribute"
               },


### PR DESCRIPTION
Add E2E tests for the SAP system details view, ported from the old trento legacy project.

Besides that, I have taken advantage and unify the links to the host details view using the new component `HostLink`