### PR TITLE
Add codespell job to the ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,9 +57,35 @@ jobs:
           mix deps.compile --warnings-as-errors
           mix dialyzer --plt
 
+  codespell:
+    name: Check common misspellings
+    runs-on: ubuntu-20.04
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install codespell
+        run: |
+          sudo apt-get install -y git python3 python3-pip
+          python3 -m pip install codespell
+      - name: codespell
+        run: codespell -S priv*,*package*json,deps*,*node_modules*,*svg,*.git,*.app -L enque,daa
+
   static-code-analysis:
     name: Static Code Analysis
-    needs: deps
+    needs: [deps, codespell]
     runs-on: ubuntu-20.04
 
     steps:
@@ -114,7 +140,7 @@ jobs:
 
   test:
     name: Test
-    needs: deps
+    needs: static-code-analysis
     runs-on: ubuntu-20.04
 
     services:
@@ -172,7 +198,7 @@ jobs:
 
   test-e2e:
     name: End to end tests
-    needs: deps
+    needs: test
     runs-on: ubuntu-20.04
     env:
       MIX_ENV: dev

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,7 +85,7 @@ jobs:
 
   static-code-analysis:
     name: Static Code Analysis
-    needs: [deps, codespell]
+    needs: deps
     runs-on: ubuntu-20.04
 
     steps:
@@ -140,7 +140,7 @@ jobs:
 
   test:
     name: Test
-    needs: static-code-analysis
+    needs: deps
     runs-on: ubuntu-20.04
 
     services:
@@ -198,7 +198,7 @@ jobs:
 
   test-e2e:
     name: End to end tests
-    needs: test
+    needs: deps
     runs-on: ubuntu-20.04
     env:
       MIX_ENV: dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - EULA is only showed after a page refresh [\#397](https://github.com/trento-project/web/issues/397)
 - Add mailer for important alerts [\#58](https://github.com/trento-project/web/issues/58)
 - Suse delivery [\#408](https://github.com/trento-project/web/pull/408) ([arbulu89](https://github.com/arbulu89))
-- Implement the collapsable sidebar [\#344](https://github.com/trento-project/web/pull/344) ([arbulu89](https://github.com/arbulu89))
+- Implement the collapsible sidebar [\#344](https://github.com/trento-project/web/pull/344) ([arbulu89](https://github.com/arbulu89))
 - Update execution request payload to use one cluster [\#336](https://github.com/trento-project/web/pull/336) ([arbulu89](https://github.com/arbulu89))
 - Handle unreachable checks execution scenario [\#304](https://github.com/trento-project/web/pull/304) ([arbulu89](https://github.com/arbulu89))
 - Integrate real runner execution usage [\#300](https://github.com/trento-project/web/pull/300) ([arbulu89](https://github.com/arbulu89))

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ It's made by three main components:
 [Trento Runner](https://github.com/trento-project/runner) responsible of **running the Trento configuration health checks** among the installed Trento Agents.
 
 _Trento Web_ is the **control plane of the Trento Platform**.
-In cooperation withe the Agents and the Runner dicovers, observes, monitors and checks the target SAP infrastructure.
+In cooperation with the Agents and the Runner discovers, observes, monitors and checks the target SAP infrastructure.
 
 See the [architecture document](./docs/architecture/trento-architecture.md) for additional details.
 

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -425,7 +425,7 @@ function* databaseRegistered({ payload }) {
   yield put(
     appendEntryToLiveFeed({
       source: payload.sid,
-      message: 'New Databse registered.',
+      message: 'New Database registered.',
     })
   );
   yield put(

--- a/docs/architecture/trento-architecture.md
+++ b/docs/architecture/trento-architecture.md
@@ -21,7 +21,7 @@ The control plane Discovery integration securely accepts published discoveries, 
 ## Scenario Detection
 The control plane discovery integration leverages specific policies to determine the scenario to be triggered based on the discovered information.
 
-That means we need to be able to determine wich command to dispath in the application.
+That means we need to be able to determine which command to dispatch in the application.
 _(RegisterHost, RegisterDatabaseInstance and so forth...)_
 
 ---

--- a/lib/trento/application/event_handlers/checks_event_handler.ex
+++ b/lib/trento/application/event_handlers/checks_event_handler.ex
@@ -1,6 +1,6 @@
 defmodule Trento.ChecksEventHandler do
   @moduledoc """
-  This event hanlder is responsible to forward checks execution request to the agent.
+  This event handler is responsible to forward checks execution request to the agent.
   """
 
   use Commanded.Event.Handler,

--- a/lib/trento/application/integration/discovery/policies/cluster_policy.ex
+++ b/lib/trento/application/integration/discovery/policies/cluster_policy.ex
@@ -253,7 +253,7 @@ defmodule Trento.Integration.Discovery.ClusterPolicy do
 
   defp do_parse_hana_status(nil, _), do: "Unknown"
   defp do_parse_hana_status(_, nil), do: "Unknown"
-  # Noraml primary state
+  # Normal primary state
   defp do_parse_hana_status("P", "PRIM"), do: "Primary"
   # This happens when there is an initial failover
   defp do_parse_hana_status("P", _), do: "Failed"

--- a/lib/trento/application/usecases/hosts/hosts.ex
+++ b/lib/trento/application/usecases/hosts/hosts.ex
@@ -40,7 +40,7 @@ defmodule Trento.Hosts do
 
   @spec get_connection_settings(String.t()) :: map | {:error, any}
   def get_connection_settings(host_id) do
-    # TODO: refactor to a comon query
+    # TODO: refactor to a common query
     query =
       from h in HostReadModel,
         left_join: s in HostConnectionSettings,

--- a/lib/trento/domain/host/events/heartbeat_succeded.ex
+++ b/lib/trento/domain/host/events/heartbeat_succeded.ex
@@ -1,6 +1,6 @@
 defmodule Trento.Domain.Events.HeartbeatSucceded do
   @moduledoc """
-  Heartbeat succeded event
+  Heartbeat succeeded event
   """
 
   use Trento.Event

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -47,7 +47,7 @@ defmodule Trento.Domain.SapSystem do
           health: Health.t()
         }
 
-  # First time that a Datbase instance is registered, the SAP System starts its registration process.
+  # First time that a Database instance is registered, the SAP System starts its registration process.
   # When an Application is discovered, the SAP System completes the registration process.
   def execute(
         %SapSystem{sap_system_id: nil},

--- a/test/e2e/cypress/fixtures/sap-system-details/sap_system_details.feature
+++ b/test/e2e/cypress/fixtures/sap-system-details/sap_system_details.feature
@@ -37,7 +37,7 @@ Feature: SAP system details view
     Scenario: New instance is discovered in the SAP system
         Given I navigate to a specific SAP system ('/sap_systems/f534a4ad-cef7-5234-b196-e67082ffb50c')
         When a new instance is discovered in a new agent
-        Then the new instace is added in the layout table
+        Then the new instance is added in the layout table
 
     Scenario: The hosts table shows all associated hosts
         Given I navigate to a specific SAP system ('/sap_systems/f534a4ad-cef7-5234-b196-e67082ffb50c')

--- a/test/e2e/cypress/integration/sap_system_details.js
+++ b/test/e2e/cypress/integration/sap_system_details.js
@@ -74,7 +74,7 @@ context('SAP system details', () => {
     });
 
     Object.entries(healthMap).forEach(([state, health]) => {
-      it(`should show ${state} badge in instace when SAPControl-${state} state is received`, () => {
+      it(`should show ${state} badge in instance when SAPControl-${state} state is received`, () => {
         cy.loadScenario(`sap-system-detail-${state}`);
         // using row 3 as the changed instance is the 3rd in order based on instance_number
         cy.get('table.table-fixed')

--- a/test/e2e/cypress/integration/sap_systems_overview.js
+++ b/test/e2e/cypress/integration/sap_systems_overview.js
@@ -143,7 +143,7 @@ context('SAP Systems Overview', () => {
                   .should('contain', instances[instanceIndex].hostname);
               });
             });
-          // close the collapsable
+          // close the collapsible
           cy.get('table.table-fixed > tbody > tr')
             .filter(':visible')
             .eq(index)

--- a/test/fixtures/scenarios/clusters-overview/clusters_overview.feature
+++ b/test/fixtures/scenarios/clusters-overview/clusters_overview.feature
@@ -20,12 +20,12 @@ Feature: Pacemaker Clusters Overview
     Scenario: Clusters health state matches the cluster health and checks results outcome
         Given I am in the Pacemaker Clusters Overview
         When the SR state is 4 and sync state is SOK and checks are passing
-        Then the cluster with id '04b8f8c21f9fd8991224478e8c4362f8' is in Pasing status
+        Then the cluster with id '04b8f8c21f9fd8991224478e8c4362f8' is in Passing status
         When the SR state is 1 and sync state is SFAIL and checks are passing
         Then the cluster with id '04b8f8c21f9fd8991224478e8c4362f8' is in Critical status
-        When the SR state is 4 and sycn state is SOK and checs are in Warning
+        When the SR state is 4 and sync state is SOK and checs are in Warning
         Then the cluster with id '04b8f8c21f9fd8991224478e8c4362f8' is in Warning status
-        When the SR state is 4 and sycn state is SOK and checs are in Critical
+        When the SR state is 4 and sync state is SOK and checs are in Critical
         Then the cluster with id '04b8f8c21f9fd8991224478e8c4362f8' is in Critical status
 
     Scenario: Clusters that are not HANA type have unknown health state

--- a/test/fixtures/scenarios/hana-database-details/hana_database_details.feature
+++ b/test/fixtures/scenarios/hana-database-details/hana_database_details.feature
@@ -41,7 +41,7 @@ Feature: HANA database details view
     Scenario: New instance is discovered in the HANA database
         Given I navigate to a specific HANA database ('/databases/fd44c254ccb14331e54015c720c7a1f2')
         When a new instance is discovered in a new agent
-        Then the new instace is added in the layout table
+        Then the new instance is added in the layout table
 
     Scenario: The hosts table shows all associated hosts
         Given I navigate to a specific HANA database ('/databases/fd44c254ccb14331e54015c720c7a1f2')

--- a/test/fixtures/scenarios/sap-system-details/sap_system_details.feature
+++ b/test/fixtures/scenarios/sap-system-details/sap_system_details.feature
@@ -41,7 +41,7 @@ Feature: SAP system details view
     Scenario: New instance is discovered in the SAP system
         Given I navigate to a specific SAP system ('/sapsystems/a1e80e3e152a903662f7882fb3f8a851')
         When a new instance is discovered in a new agent
-        Then the new instace is added in the layout table
+        Then the new instance is added in the layout table
 
     Scenario: The hosts table shows all associated hosts
         Given I navigate to a specific SAP system ('/sapsystems/a1e80e3e152a903662f7882fb3f8a851')

--- a/test/trento/application/projectors/check_result_projector_test.exs
+++ b/test/trento/application/projectors/check_result_projector_test.exs
@@ -36,7 +36,7 @@ defmodule Trento.CheckResultProjectorTest do
            end)
   end
 
-  test "should project hosts executions with emtpy data when a ChecksExecutionRequested event is received" do
+  test "should project hosts executions with empty data when a ChecksExecutionRequested event is received" do
     insert(
       :host_checks_result,
       cluster_id: cluster_id = Faker.UUID.v4(),

--- a/test/trento/support/type_test.exs
+++ b/test/trento/support/type_test.exs
@@ -1,7 +1,7 @@
 defmodule Trento.TypeTest do
   use ExUnit.Case
 
-  test "should return errors if the paramaters of an embedded field could not be validated" do
+  test "should return errors if the parameters of an embedded field could not be validated" do
     assert {:error, %{embedded: %{id: ["is invalid"]}}} =
              TestData.new(%{
                id: Faker.UUID.v4(),
@@ -13,7 +13,7 @@ defmodule Trento.TypeTest do
              })
   end
 
-  test "should raise a RuntimeError  if the paramaters of an embedded field could not be validated" do
+  test "should raise a RuntimeError  if the parameters of an embedded field could not be validated" do
     assert_raise RuntimeError, "%{embedded: %{id: [\"is invalid\"]}}", fn ->
       TestData.new!(%{
         id: Faker.UUID.v4(),


### PR DESCRIPTION
A small goodie to check spelling issues in the CI.
I thought of including it in `mix`, and it can be done. This was the easiest way. 
If you know how we could make this option more generally available, rather than only the CI, idea are welcomed