### PR TITLE
Use ExMachina as test data generation factory for host telemetry

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -54,6 +54,7 @@ defmodule Trento.MixProject do
       {:eventstore, "~> 1.1",
        [env: :prod, git: "https://github.com/commanded/eventstore.git", override: true]},
       {:eventstore_dashboard, github: "commanded/eventstore-dashboard"},
+      {:ex_machina, "~> 2.7.0", only: :test},
       {:faker, "~> 0.17", only: [:dev, :test]},
       {:floki, ">= 0.30.0", only: :test},
       {:fun_with_flags, "~> 1.8.1"},

--- a/mix.lock
+++ b/mix.lock
@@ -23,6 +23,7 @@
   "esbuild": {:hex, :esbuild, "0.4.0", "9f17db148aead4cf1e6e6a584214357287a93407b5fb51a031f122b61385d4c2", [:mix], [{:castore, ">= 0.0.0", [hex: :castore, repo: "hexpm", optional: false]}], "hexpm", "b61e4e6b92ffe45e4ee4755a22de6211a67c67987dc02afb35a425a0add1d447"},
   "eventstore": {:git, "https://github.com/commanded/eventstore.git", "9883f4ae9cb8bbde3e8c905e1dc6f66fac746a56", []},
   "eventstore_dashboard": {:git, "https://github.com/commanded/eventstore-dashboard.git", "434b17104b57791e191384e13e2c9cab964456f9", []},
+  "ex_machina": {:hex, :ex_machina, "2.7.0", "b792cc3127fd0680fecdb6299235b4727a4944a09ff0fa904cc639272cd92dc7", [:mix], [{:ecto, "~> 2.2 or ~> 3.0", [hex: :ecto, repo: "hexpm", optional: true]}, {:ecto_sql, "~> 3.0", [hex: :ecto_sql, repo: "hexpm", optional: true]}], "hexpm", "419aa7a39bde11894c87a615c4ecaa52d8f107bbdd81d810465186f783245bf8"},
   "exconstructor": {:hex, :exconstructor, "1.2.6", "246473024fad510329ea569d02eead44ca35c413f582a94752e503929b97afe7", [:mix], [], "hexpm", "52142eaf77d3783f4b88003e33d41eed83605d4b32116bfb6e8198e981d10c8c"},
   "faker": {:hex, :faker, "0.17.0", "671019d0652f63aefd8723b72167ecdb284baf7d47ad3a82a15e9b8a6df5d1fa", [:mix], [], "hexpm", "a7d4ad84a93fd25c5f5303510753789fc2433ff241bf3b4144d3f6f291658a6a"},
   "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -48,6 +48,8 @@ defmodule Trento.Factory do
 
   alias Trento.Integration.Discovery.DiscoveryEvent
 
+  use ExMachina.Ecto, repo: Trento.Repo
+
   def host_registered_event(attrs \\ []) do
     %HostRegistered{
       host_id: Keyword.get(attrs, :host_id, Faker.UUID.v4()),
@@ -129,15 +131,15 @@ defmodule Trento.Factory do
     })
   end
 
-  def host_telemetry_projection(attrs \\ []) do
-    Repo.insert!(%HostTelemetryReadModel{
-      agent_id: Keyword.get(attrs, :agent_id, Faker.UUID.v4()),
-      hostname: Keyword.get(attrs, :hostname, Faker.StarWars.character()),
-      cpu_count: Keyword.get(attrs, :cpu_usage, Enum.random(0..100)),
-      socket_count: Keyword.get(attrs, :memory_usage, Enum.random(0..100)),
-      total_memory_mb: Keyword.get(attrs, :total_memory_mb, Enum.random(0..100)),
-      sles_version: Keyword.get(attrs, :total_memory_mb, Faker.App.version())
-    })
+  def host_telemetry_factory do
+    %HostTelemetryReadModel{
+      agent_id: Faker.UUID.v4(),
+      hostname: Faker.StarWars.character(),
+      cpu_count: Enum.random(0..100),
+      socket_count: Enum.random(0..100),
+      total_memory_mb: Enum.random(0..100),
+      sles_version: Faker.App.version()
+    }
   end
 
   def cluster_projection(attrs \\ []) do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -13,7 +13,7 @@ Application.put_env(:trento, Trento.Integration.Prometheus,
   adapter: Trento.Integration.Prometheus.Mock
 )
 
+Application.ensure_all_started(:ex_machina, :faker)
+
 ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(Trento.Repo, :manual)
-
-Faker.start()

--- a/test/trento/application/integration/telemetry/telemetry_test.exs
+++ b/test/trento/application/integration/telemetry/telemetry_test.exs
@@ -19,7 +19,7 @@ defmodule Trento.Integration.TelemetryTest do
   end
 
   test "should publish hosts telemetry if telemetry is enabled" do
-    host_telemetry = host_telemetry_projection()
+    host_telemetry = insert(:host_telemetry)
 
     expect(Trento.Integration.Telemetry.Mock, :publish_hosts_telemetry, fn hosts_telemetry, _ ->
       assert [host_telemetry] == hosts_telemetry


### PR DESCRIPTION
Here a nitpick example of how [ExMachina](https://github.com/thoughtbot/ex_machina) usage looks like.

I just wanted to show a small change, so we all agree that this is the way to go. If we like it, I can continue modifying the rest of the factories. 

The work seems pretty straightforward.

PD: For people not familiar with ExMachina, I would recommend to have a look in the project README, as I find that it has important "hidden magic" functionalities, like attributes merging