### PR TITLE
Checks catalog openapi

### DIFF
--- a/lib/trento_web/controllers/catalog_controller.ex
+++ b/lib/trento_web/controllers/catalog_controller.ex
@@ -3,6 +3,35 @@ defmodule TrentoWeb.CatalogController do
 
   alias Trento.Integration.Checks
 
+  alias TrentoWeb.OpenApi.Schema.{ChecksCatalog, Provider}
+
+  use OpenApiSpex.ControllerSpecs
+
+  tags(["Checks"])
+
+  operation(:checks_catalog,
+    summary: "Checks Catalog",
+    description:
+      "The list of the available checks that can be configured to run on the target SAP infrastructure",
+    parameters: [
+      flat: [
+        in: :query,
+        type: :string,
+        description:
+          "Whether to output a flat catalog or not. Just provide the flag, not the value. eg /api/checks/catalog?flat"
+      ],
+      provider: [
+        in: :query,
+        type: Provider.FilterableProviders,
+        description: "Whether to filter by a specific provider"
+      ]
+    ],
+    responses: [
+      ok: {"A Collection of the available Checks", "application/json", ChecksCatalog.Catalog},
+      not_found: {"Not found", "application/json", ChecksCatalog.CatalogNotfound}
+    ]
+  )
+
   @spec checks_catalog(Plug.Conn.t(), map) :: Plug.Conn.t()
   def checks_catalog(conn, params) do
     with {:ok, content} <- get_catalog(params),

--- a/lib/trento_web/controllers/catalog_controller.ex
+++ b/lib/trento_web/controllers/catalog_controller.ex
@@ -28,7 +28,8 @@ defmodule TrentoWeb.CatalogController do
     ],
     responses: [
       ok: {"A Collection of the available Checks", "application/json", ChecksCatalog.Catalog},
-      not_found: {"Not found", "application/json", ChecksCatalog.CatalogNotfound}
+      not_found: {"Not found", "application/json", ChecksCatalog.CatalogNotfound},
+      bad_request: {"Bad Request", "application/json", ChecksCatalog.UnableToLoadCatalog}
     ]
   )
 

--- a/lib/trento_web/openapi/api_spec.ex
+++ b/lib/trento_web/openapi/api_spec.ex
@@ -25,6 +25,10 @@ defmodule TrentoWeb.OpenApi.ApiSpec do
         %Tag{
           name: "Landscape",
           description: "Providing access to the discovered target infrastructure"
+        },
+        %Tag{
+          name: "Checks",
+          description: "Providing Checks related feature"
         }
       ]
     }

--- a/lib/trento_web/openapi/schema/checks_catalog.ex
+++ b/lib/trento_web/openapi/schema/checks_catalog.ex
@@ -1,0 +1,178 @@
+defmodule TrentoWeb.OpenApi.Schema.ChecksCatalog do
+  @moduledoc false
+
+  require OpenApiSpex
+  alias OpenApiSpex.Schema
+
+  alias TrentoWeb.OpenApi.Schema.Provider
+
+  defmodule Check do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "Check",
+      description: "An available check to be executed on the target infrastructure",
+      type: :object,
+      properties: %{
+        sap_system_id: %Schema{type: :string, description: "Check ID", format: :uuid},
+        name: %Schema{type: :string, description: "Check Name"},
+        description: %Schema{type: :string, description: "Check Description"},
+        remediation: %Schema{type: :string, description: "Check Remediation"},
+        implementation: %Schema{type: :string, description: "Check Implementation"},
+        labels: %Schema{type: :string, description: "Check Labels"},
+        premium: %Schema{
+          type: :boolean,
+          description: "Indicates whether the current check is a Premium check"
+        },
+        group: %Schema{
+          type: :string,
+          description: "Check Group, available when requiring a Flat Catalog"
+        },
+        provider: Provider.SupportedProviders
+      }
+    })
+  end
+
+  defmodule FlatCatalog do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "FlatCatalog",
+      description: "A flat list of the available Checks",
+      type: :array,
+      items: Check
+    })
+  end
+
+  defmodule ChecksGroup do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "ChecksGroup",
+      description: "A Group of related Checks (Corosync, Pacemaker ...)",
+      type: :object,
+      properties: %{
+        group: %Schema{type: :string, description: "Group Name"},
+        checks: FlatCatalog
+      }
+    })
+  end
+
+  defmodule ProviderCatalog do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "ProviderCatalog",
+      description: "A Provider specific Catalog, and respective values",
+      type: :object,
+      properties: %{
+        provider: %Schema{
+          title: "ChecksProvider",
+          type: :string,
+          description:
+            "The provider determining the values for the attached checks (azure, aws ...)",
+          # ??
+          enum: [:azure, :aws, :gcp, :unknown]
+        },
+        groups: %Schema{
+          title: "ChecksGroups",
+          description: "A list of ChecksGroup for the respective provider",
+          type: :array,
+          items: ChecksGroup
+        }
+      }
+    })
+  end
+
+  defmodule GroupedCatalog do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "GroupedCatalog",
+      description:
+        "A list of available Checks: grouped by provider (azure, aws ...) and checks groups (Corosync, Pacemaker ...)",
+      type: :array,
+      items: ProviderCatalog
+    })
+  end
+
+  defmodule Catalog do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "ChecksCatalog",
+      description: "A representation of the Checks Catalog",
+      oneOf: [
+        GroupedCatalog,
+        FlatCatalog
+      ],
+      example: [
+        %{
+          groups: [
+            %{
+              checks: [
+                %{
+                  description: "Corosync `token` timeout is set to `5000`\n",
+                  id: "156F64",
+                  implementation:
+                    "---\n\n- name: \"{{ name }}.check\"\n  lineinfile:\n    path: /etc/corosync/corosync.conf\n    regexp: '^(\\s+){{ key_name }}:'\n    line: \"\\t{{ key_name }}: {{ expected[name] }}\"\n    insertafter: 'totem {'\n  register: config_updated\n  when:\n    - ansible_check_mode\n\n- block:\n    - name: Post results\n      import_role:\n        name: post-results\n  when:\n    - ansible_check_mode\n  vars:\n    status: \"{{ config_updated is not changed }}\"",
+                  labels: "generic",
+                  name: "1.1.1",
+                  premium: false,
+                  remediation:
+                    "## Abstract\nThe value of the Corosync `token` timeout is not set as recommended.\n\n## Remediation\n\nAdjust the corosync `token` timeout as recommended on the best practices, and reload the corosync configuration\n\n1. Set the correct `token` timeout in the totem session in the corosync config file `/etc/corosync/corosync.conf`. This action must be repeated in all nodes of the cluster.\n   ```\n   [...]\n   totem { \n          token: <timeout value> \n         }\n   [...]\n   ```   \n2. Reload the corosync configuration:\n   `crm corosync reload`\n\n## References\n- https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker\n"
+                },
+                %{
+                  description: "Corosync is running with `token` timeout set to `5000`\n",
+                  id: "53D035",
+                  implementation:
+                    "---\n\n- name: \"{{ name }}.check\"\n  shell: 'corosync-cmapctl | grep \"runtime.config.totem.token (u32) = \" | sed \"s/^.*= //\"'\n  check_mode: false\n  register: config_updated\n  changed_when: config_updated.stdout != expected['1.1.1']\n\n- block:\n    - name: Post results\n      import_role:\n        name: post-results\n  when:\n    - ansible_check_mode\n  vars:\n    status: \"{{ config_updated is not changed }}\"",
+                  labels: "generic",
+                  name: "1.1.1.runtime",
+                  premium: false,
+                  remediation:
+                    "## Abstract\nThe runtime value of the Corosync `token` timeout is not set as recommended.\n\n## Remediation\n\nAdjust the corosync `token` timeout as recommended on the best practices, and reload the corosync configuration\n\n\n1. Set the correct `token` timeout in the totem session in the corosync config file `/etc/corosync/corosync.conf`. This action must be repeated in all nodes of the cluster.\n   ```\n   [...]\n   totem { \n          token: <timeout value> \n         }\n   [...]\n   ```   \n2. Reload the corosync configuration:\n   `crm corosync reload`\n\n## References\n- https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker\n"
+                }
+              ],
+              group: "Corosync"
+            },
+            %{
+              checks: [
+                %{
+                  description: "Fencing is enabled in the cluster attributes\n",
+                  id: "205AF7",
+                  implementation:
+                    "---\n\n- name: \"{{ name }}.check\"\n  command: 'crm_attribute -t crm_config -G -n stonith-enabled --quiet'\n  check_mode: false\n  register: config_updated\n  changed_when: config_updated.stdout != expected[name]\n\n- block:\n    - name: Post results\n      import_role:\n        name: post-results\n  when:\n    - ansible_check_mode\n  vars:\n    status: \"{{ config_updated is not changed }}\"",
+                  labels: "generic",
+                  name: "1.2.1",
+                  premium: false,
+                  remediation:
+                    "## Abstract\nFencing is mandatory to guarantee data integrity for your SAP Applications.\nRunning a HA Cluster without fencing is not supported and might cause data loss.\n\n## Remediation\nExecute the following command to enable it:\n```\ncrm configure property stonith-enabled=true\n```\n\n## References\n- https://documentation.suse.com/sle-ha/15-SP3/html/SLE-HA-all/cha-ha-fencing.html#sec-ha-fencing-recommend\n"
+                }
+              ],
+              group: "Pacemaker"
+            }
+          ],
+          provider: "aws"
+        }
+      ]
+    })
+  end
+
+  defmodule CatalogNotfound do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "CatalogNotfound",
+      description: "No Catalog was found for the provided query",
+      type: :object,
+      properties: %{
+        error: %Schema{
+          type: :string,
+          enum: [:not_found]
+        }
+      },
+      example: %{error: "not_found"}
+    })
+  end
+end

--- a/lib/trento_web/openapi/schema/checks_catalog.ex
+++ b/lib/trento_web/openapi/schema/checks_catalog.ex
@@ -175,4 +175,18 @@ defmodule TrentoWeb.OpenApi.Schema.ChecksCatalog do
       example: %{error: "not_found"}
     })
   end
+
+  defmodule UnableToLoadCatalog do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "UnableToLoadCatalog",
+      description: "Something wrong happened while loading the catalog. ie: it is not ready yet",
+      type: :object,
+      properties: %{
+        error: %Schema{type: :string, description: "The error message"}
+      },
+      example: %{error: "(not_ready|some other error message)"}
+    })
+  end
 end

--- a/lib/trento_web/openapi/schema/checks_catalog.ex
+++ b/lib/trento_web/openapi/schema/checks_catalog.ex
@@ -14,7 +14,7 @@ defmodule TrentoWeb.OpenApi.Schema.ChecksCatalog do
       description: "An available check to be executed on the target infrastructure",
       type: :object,
       properties: %{
-        sap_system_id: %Schema{type: :string, description: "Check ID", format: :uuid},
+        id: %Schema{type: :string, description: "Check ID", format: :uuid},
         name: %Schema{type: :string, description: "Check Name"},
         description: %Schema{type: :string, description: "Check Description"},
         remediation: %Schema{type: :string, description: "Check Remediation"},
@@ -71,8 +71,7 @@ defmodule TrentoWeb.OpenApi.Schema.ChecksCatalog do
           type: :string,
           description:
             "The provider determining the values for the attached checks (azure, aws ...)",
-          # ??
-          enum: [:azure, :aws, :gcp, :unknown]
+          enum: [:azure, :aws, :gcp, :default]
         },
         groups: %Schema{
           title: "ChecksGroups",

--- a/lib/trento_web/openapi/schema/provider.ex
+++ b/lib/trento_web/openapi/schema/provider.ex
@@ -22,8 +22,7 @@ defmodule TrentoWeb.OpenApi.Schema.Provider do
       title: "FilterableProvider",
       type: :string,
       description: "A provider that can be used to filter the Catalog",
-      # default?
-      enum: [:azure, :aws, :gcp]
+      enum: [:azure, :aws, :gcp, :default]
     })
   end
 

--- a/lib/trento_web/openapi/schema/provider.ex
+++ b/lib/trento_web/openapi/schema/provider.ex
@@ -15,6 +15,18 @@ defmodule TrentoWeb.OpenApi.Schema.Provider do
     })
   end
 
+  defmodule FilterableProviders do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "FilterableProvider",
+      type: :string,
+      description: "A provider that can be used to filter the Catalog",
+      # default?
+      enum: [:azure, :aws, :gcp]
+    })
+  end
+
   defmodule AzureProviderData do
     @moduledoc false
 


### PR DESCRIPTION
Added Checks Catalog OpenApi documentation.

https://user-images.githubusercontent.com/8167114/168640015-d136e520-1962-4b56-bbc8-d1b4c024db11.mp4

The `flat` option fits a bit strangely in the open api spec.
It might be worth considering making that more standard and actually making it a boolean.

- [x] GET     /api/hosts
- [x] GET     /api/clusters
- [x] GET     /api/sap_systems
- [x] GET     /api/databases
- [x] GET     /api/checks/catalog
- [ ] POST    /api/clusters/:cluster_id/checks
- [ ] POST    /api/clusters/:cluster_id/checks/request_execution
- [ ] POST    /api/runner/callback

Follows up https://github.com/trento-project/web/pull/512 https://github.com/trento-project/web/pull/522 https://github.com/trento-project/web/pull/528