### PR TITLE
Add HANA details page e2e tests

### DIFF
--- a/.photofinish.toml
+++ b/.photofinish.toml
@@ -46,7 +46,7 @@ files = ["./test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9
 
 [hana-database-detail-NEW]
 
-files = ["./test/fixtures/scenarios/hana-database-details/newagent_sap_system_discovery_new.json"]
+files = ["./test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_new.json"]
 
 [sap-systems-overview-GRAY]
 

--- a/assets/js/components/DatabaseDetails/DatabaseDetails.jsx
+++ b/assets/js/components/DatabaseDetails/DatabaseDetails.jsx
@@ -15,7 +15,7 @@ const DatabaseDetails = () => {
 
   return (
     <GenericSystemDetails
-      title={'HANA Database details'}
+      title={'HANA Database Details'}
       type={DATABASE_TYPE}
       system={database}
     />

--- a/test/e2e/cypress/fixtures/hana-database-details/hana_database_details.feature
+++ b/test/e2e/cypress/fixtures/hana-database-details/hana_database_details.feature
@@ -1,0 +1,45 @@
+Feature: HANA database details view
+    This is where the user has a detailed view of the status of one specific discovered HANA database
+
+    Background:
+        Given a discovered HANA database within a SAP deployment with the following properties
+        # Id: 'f534a4ad-cef7-5234-b196-e67082ffb50c',
+        # Sid: 'HDD',
+        # Hosts: ['vmhdbdev01', 'vmhdbdev02']
+        And 2 hosts associated to the HANA database
+
+    Scenario: Detailed view of one specific HANA database is available
+        When I navigate to a specific HANA database ('/databases/f534a4ad-cef7-5234-b196-e67082ffb50c')
+        Then the displayed HANA database SID is correct
+        And the displayed HANA database has "HANA Database" type
+
+    Scenario: Not found is given when the HANA database is not available
+        When I navigate to a specific HANA database ('/databases/other')
+        Then Not found message is displayed
+
+    Scenario: HANA database instances are properly shown
+        Given I navigate to a specific HANA database ('/databases/f534a4ad-cef7-5234-b196-e67082ffb50c')
+        Then 2 instances are displayed
+        And the data of each instance is correct
+        And the status of each instance is GREEN
+
+    Scenario: HANA database instances status change event is received
+        Given I navigate to a specific HANA database ('/databases/f534a4ad-cef7-5234-b196-e67082ffb50c')
+        When a new HANA database event for this database with the 1st instance with a GRAY status is received
+        Then the status of the 1st instance is GRAY
+        When a new HANA database event for this database with the 1st instance with a GREEN status is received
+        Then the status of the 1st instance is GREEN
+        When a new HANA database event for this database with the 1st instance with a YELLOW status is received
+        Then the status of the 1st instance is YELLOW
+        When a new HANA database event for this database with the 1st instance with a RED status is received
+        Then the status of the 1st instance is RED
+
+    Scenario: New instance is discovered in the HANA database
+        Given I navigate to a specific HANA database ('/databases/f534a4ad-cef7-5234-b196-e67082ffb50c')
+        When a new instance is discovered in a new agent
+        Then the new instance is added in the layout table
+
+    Scenario: The hosts table shows all associated hosts
+        Given I navigate to a specific HANA database ('/databases/f534a4ad-cef7-5234-b196-e67082ffb50c')
+        Then the hosts table shows all the associated hosts
+        And each host has correct data

--- a/test/e2e/cypress/fixtures/hana-database-details/selected_database.js
+++ b/test/e2e/cypress/fixtures/hana-database-details/selected_database.js
@@ -1,0 +1,48 @@
+export const selectedDatabase = {
+  Id: 'f534a4ad-cef7-5234-b196-e67082ffb50c',
+  Sid: 'HDD',
+  Type: 'HANA Database',
+  Hosts: [
+    {
+      Hostname: 'vmhdbdev02',
+      Instance: '10',
+      Features: 'HDB|HDB_WORKER',
+      HttpPort: '51013',
+      HttpsPort: '51014',
+      StartPriority: '0.3',
+      Status: 'SAPControl-GREEN',
+      StatusBadge: 'GREEN',
+    },
+    {
+      Hostname: 'vmhdbdev01',
+      Instance: '10',
+      Features: 'HDB|HDB_WORKER',
+      HttpPort: '51013',
+      HttpsPort: '51014',
+      StartPriority: '0.3',
+      Status: 'SAPControl-GREEN',
+      StatusBadge: 'GREEN',
+    },
+  ],
+};
+
+export const attachedHosts = [
+  {
+    Name: 'vmhdbdev02',
+    AgentId: '0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4',
+    Addresses: ['10.100.1.12'],
+    Provider: 'azure',
+    Cluster: 'hana_cluster',
+    ClusterId: '7965f822-0254-5858-abca-f6e8b4c27714',
+    Version: '0.7.1+git.dev42.1640084952.33229fc',
+  },
+  {
+    Name: 'vmhdbdev01',
+    AgentId: '13e8c25c-3180-5a9a-95c8-51ec38e50cfc',
+    Addresses: ['10.100.1.11', '10.100.1.13'],
+    Provider: 'azure',
+    Cluster: 'hana_cluster',
+    ClusterId: '7965f822-0254-5858-abca-f6e8b4c27714',
+    Version: '0.7.1+git.dev42.1640084952.33229fc',
+  },
+];

--- a/test/e2e/cypress/integration/hana_database_details.js
+++ b/test/e2e/cypress/integration/hana_database_details.js
@@ -1,0 +1,139 @@
+import { healthMap } from '../fixtures/sap-system-details/selected_system';
+
+import {
+  selectedDatabase,
+  attachedHosts,
+} from '../fixtures/hana-database-details/selected_database';
+
+context('HANA database details', () => {
+  const sessionCookie = '_trento_key';
+
+  before(() => {
+    cy.loadScenario('healthy-27-node-SAP-cluster');
+    cy.login();
+
+    cy.visit(`/databases/${selectedDatabase.Id}`);
+    cy.url().should('include', `/databases/${selectedDatabase.Id}`);
+  });
+
+  after(() => {
+    cy.clearCookie(sessionCookie);
+  });
+
+  beforeEach(() => {
+    cy.Cookies.preserveOnce(sessionCookie);
+  });
+
+  describe('HANA database details page is available', () => {
+    it(`should display the "${selectedDatabase.Sid}" database details page`, () => {
+      cy.get('h1').should('contain', 'HANA Database Details');
+      cy.get('div')
+        .contains('Name')
+        .next()
+        .should('contain', selectedDatabase.Sid);
+      cy.get('div')
+        .contains('Type')
+        .next()
+        .should('contain', selectedDatabase.Type);
+    });
+
+    it(`should display "Not found" page when HANA database doesn't exist`, () => {
+      cy.visit(`/databases/other`, { failOnStatusCode: false });
+      cy.url().should('include', `/databases/other`);
+      cy.get('div').should('contain', 'Not Found');
+    });
+  });
+
+  describe('The database layout shows all the running instances', () => {
+    before(() => {
+      cy.visit(`/databases/${selectedDatabase.Id}`);
+      cy.url().should('include', `/databases/${selectedDatabase.Id}`);
+    });
+
+    selectedDatabase.Hosts.forEach((instance, index) => {
+      it(`should show hostname "${instance.Hostname}" with the correct values`, () => {
+        cy.get('table.table-fixed')
+          .eq(0)
+          .find('tr')
+          .eq(index + 1)
+          .find('td')
+          .as('tableCell');
+        cy.get('@tableCell').eq(0).should('contain', instance.Hostname);
+        cy.get('@tableCell').eq(1).should('contain', instance.Instance);
+        instance.Features.split('|').forEach((feature) => {
+          cy.get('@tableCell').eq(2).should('contain', feature);
+        });
+        cy.get('@tableCell').eq(3).should('contain', instance.HttpPort);
+        cy.get('@tableCell').eq(4).should('contain', instance.HttpsPort);
+        cy.get('@tableCell').eq(5).should('contain', instance.StartPriority);
+        cy.get('@tableCell').eq(6).should('contain', instance.Status);
+        cy.get('@tableCell')
+          .eq(6)
+          .find('span')
+          .should('have.class', healthMap[instance.StatusBadge]);
+      });
+    });
+
+    Object.entries(healthMap).forEach(([state, health]) => {
+      it(`should show ${state} badge in instance when SAPControl-${state} state is received`, () => {
+        cy.loadScenario(`hana-database-detail-${state}`);
+        // using row 1 as the changed instance is the 3rd in order based on instance_number
+        cy.get('table.table-fixed')
+          .eq(0)
+          .find('tr')
+          .eq(1)
+          .find('td')
+          .as('tableCell');
+        cy.get('@tableCell').eq(6).should('contain', `SAPControl-${state}`);
+        cy.get('@tableCell').eq(6).find('span').should('have.class', health);
+      });
+    });
+    /* This test is commented because there is not any option to remove added database instances or
+    resetting the database afterwards, and it affects the rest of the test suite.
+    it(`should show a new instance when an event with a new SAP instance is received`, () => {
+      cy.loadScenario(`hana-database-detail-NEW`);
+      cy.get('table.table-fixed').eq(0).find('tr').should('have.length', 4);
+      cy.get('table.table-fixed')
+        .eq(0)
+        .find('tr')
+        .eq(-1)
+        .find('td')
+        .as('tableCell');
+      cy.get('@tableCell').eq(0).should('contain', 'vmhdbdev02');
+      cy.get('@tableCell').eq(1).should('contain', '11');
+    });
+    */
+  });
+
+  describe('The hosts table shows the attached hosts to this HANA database', () => {
+    attachedHosts.forEach((host, index) => {
+      it(`should show ${host.Name} with the data`, () => {
+        cy.get('table.table-fixed')
+          .eq(1)
+          .find('tr')
+          .eq(index + 1)
+          .find('td')
+          .as('tableCell');
+        cy.get('@tableCell').eq(0).should('contain', host.Name);
+        host.Addresses.forEach((address) => {
+          cy.get('@tableCell').eq(1).should('contain', address);
+        });
+        cy.get('@tableCell').eq(2).should('contain', host.Provider);
+        cy.get('@tableCell').eq(3).should('contain', host.Cluster);
+        cy.get('@tableCell').eq(4).should('contain', host.Version);
+      });
+
+      it(`should have a correct link to the ${host.Name} host`, () => {
+        cy.get('table.table-fixed')
+          .eq(1)
+          .find('tr')
+          .eq(index + 1)
+          .find('td')
+          .as('tableCell');
+        cy.get('@tableCell').eq(0).find('a').click();
+        cy.location('pathname').should('eq', `/hosts/${host.AgentId}`);
+        cy.go('back');
+      });
+    });
+  });
+});

--- a/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_new.json
+++ b/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_new.json
@@ -1,5 +1,5 @@
 {
-  "agent_id": "newagent",
+  "agent_id": "0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4",
   "discovery_type": "sap_system_discovery",
   "payload": [
     {
@@ -30,17 +30,17 @@
       "Instances": [
         {
           "Host": "vmhdbdev02",
-          "Name": "HDB10",
+          "Name": "HDB11",
           "Type": 1,
           "SAPControl": {
             "Instances": [
               {
                 "features": "HDB|HDB_WORKER",
-                "hostname": "newinstance",
+                "hostname": "vmhdbdev02",
                 "httpPort": 12345,
                 "httpsPort": 12345,
                 "dispstatus": "SAPControl-GRAY",
-                "instanceNr": 99,
+                "instanceNr": 11,
                 "startPriority": "0.3"
               }
             ],
@@ -111,7 +111,7 @@
             ],
             "Properties": [
               {
-                "value": "99",
+                "value": "11",
                 "property": "SAPSYSTEM",
                 "propertytype": "Attribute"
               },
@@ -146,7 +146,7 @@
                 "propertytype": "NodeWebmethod"
               },
               {
-                "value": "HDB10",
+                "value": "HDB11",
                 "property": "INSTANCE_NAME",
                 "propertytype": "Attribute"
               },


### PR DESCRIPTION
HANA details page E2E tests.

As it happened with the SAP details page, one of the tests goes commented for not being to remove this instance afterwards.