### PR TITLE
Cluster Aggregate rollup part 1

### DIFF
--- a/lib/trento/application/event_handlers/rollup_event_handler.ex
+++ b/lib/trento/application/event_handlers/rollup_event_handler.ex
@@ -1,0 +1,43 @@
+defmodule Trento.RollupEventHandler do
+  @moduledoc """
+    This event handler is responsible for rolling up aggregates.
+  """
+
+  use Commanded.Event.Handler,
+    application: Trento.Commanded,
+    name: "roll_up_event_handler",
+    consistency: :strong
+
+  alias Trento.Domain.Events.ClusterRolledUp
+
+  def handle(
+        %ClusterRolledUp{cluster_id: cluster_id, applied: false} = event,
+        _
+      ) do
+    rollup_aggregate(cluster_id, event)
+  end
+
+  defp rollup_aggregate(aggregate_id, event) do
+    {:ok, pid} = Postgrex.start_link(Trento.EventStore.config())
+
+    Postgrex.transaction(pid, fn conn ->
+      with :ok <- Trento.EventStore.delete_snapshot(aggregate_id, conn: conn),
+           :ok <- Trento.EventStore.delete_stream(aggregate_id, :any_version, :hard, conn: conn) do
+        Trento.EventStore.append_to_stream(
+          aggregate_id,
+          :any_version,
+          [
+            %EventStore.EventData{
+              causation_id: UUID.uuid4(),
+              correlation_id: UUID.uuid4(),
+              event_type: Commanded.EventStore.TypeProvider.to_string(event),
+              data: %{event | applied: true},
+              metadata: %{}
+            }
+          ],
+          conn: conn
+        )
+      end
+    end)
+  end
+end

--- a/lib/trento/domain/cluster/commands/rollup_cluster.ex
+++ b/lib/trento/domain/cluster/commands/rollup_cluster.ex
@@ -1,0 +1,13 @@
+defmodule Trento.Domain.Commands.RollupCluster do
+  @moduledoc """
+  Start a cluster aggregate rollup.
+  """
+
+  @required_fields nil
+
+  use Trento.Command
+
+  defcommand do
+    field :cluster_id, Ecto.UUID
+  end
+end

--- a/lib/trento/domain/cluster/events/cluster_rolled_up.ex
+++ b/lib/trento/domain/cluster/events/cluster_rolled_up.ex
@@ -1,0 +1,29 @@
+defmodule Trento.Domain.Events.ClusterRolledUp do
+  @moduledoc """
+  This event is emitted when a cluster is rolled up and its stream is reset.
+  """
+
+  use Trento.Event
+
+  alias Trento.Domain.{HanaClusterDetails, HostExecution}
+
+  defevent do
+    field :cluster_id, :string
+    field :name, :string
+    field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
+    field :sid, :string
+    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :unknown]
+    field :resources_number, :integer
+    field :hosts_number, :integer
+    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :hosts, {:array, :string}
+    field :selected_checks, {:array, :string}
+    field :discovered_health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :checks_health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+
+    embeds_one :details, HanaClusterDetails
+    embeds_many :hosts_executions, HostExecution
+
+    field :applied, :boolean, default: false
+  end
+end

--- a/lib/trento/domain/cluster/lifespan.ex
+++ b/lib/trento/domain/cluster/lifespan.ex
@@ -1,0 +1,14 @@
+defmodule Trento.Domain.Cluster.Lifespan do
+  @moduledoc false
+
+  @behaviour Commanded.Aggregates.AggregateLifespan
+
+  alias Trento.Domain.Events.ClusterRolledUp
+
+  def after_event(%ClusterRolledUp{applied: false}), do: :stop
+  def after_event(_), do: :infinity
+
+  def after_command(_), do: :infinity
+
+  def after_error(_), do: :stop
+end

--- a/lib/trento/infrastructure/event_handlers_supervisor.ex
+++ b/lib/trento/infrastructure/event_handlers_supervisor.ex
@@ -11,7 +11,8 @@ defmodule Trento.EventHandlersSupervisor do
   def init(_init_arg) do
     children = [
       Trento.AlertsEventHandler,
-      Trento.ChecksEventHandler
+      Trento.ChecksEventHandler,
+      Trento.RollupEventHandler
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/trento/infrastructure/event_store.ex
+++ b/lib/trento/infrastructure/event_store.ex
@@ -1,5 +1,5 @@
 defmodule Trento.EventStore do
   @moduledoc false
 
-  use EventStore, otp_app: :trento
+  use EventStore, otp_app: :trento, enable_hard_deletes: true
 end

--- a/lib/trento/infrastructure/router.ex
+++ b/lib/trento/infrastructure/router.ex
@@ -16,6 +16,7 @@ defmodule Trento.Router do
     RegisterDatabaseInstance,
     RegisterHost,
     RequestChecksExecution,
+    RollupCluster,
     SelectChecks,
     StartChecksExecution,
     UpdateHeartbeat,
@@ -31,13 +32,15 @@ defmodule Trento.Router do
   identify Cluster, by: :cluster_id
 
   dispatch [
+             RollupCluster,
              RegisterClusterHost,
              SelectChecks,
              RequestChecksExecution,
              StartChecksExecution,
              CompleteChecksExecution
            ],
-           to: Cluster
+           to: Cluster,
+           lifespan: Cluster.Lifespan
 
   identify SapSystem, by: :sap_system_id
 


### PR DESCRIPTION
Adds a rollup event for the cluster aggregate.
This allows deleting/cold storing past events that we don't want to keep "alive" in the system.
After a rollup is requested by an actor dispatching a command, the aggregate GenServer stops, and an event handler deletes the aggregate cluster, deletes the aggregate event stream, and appends a rollup event to a new stream with the same id (in a transaction).
The rollup event contains the summarized aggregate state that we want to keep after the stream is deleted.
While rolling up the aggregate, commands are not accepted and the aggregate will return an `{:error, :cluster_rolling_up}`  tuple.
This is needed to prevent concurrent commands to modify the state prior to appending the rollup event to the stream since this could cause data loss.

Still in TODO: 
transaction test
unlock the aggregate in case the rollup event handler fails (see #568 )