### PR TITLE
About page e2e

### DIFF
--- a/lib/trento/support/mix/tasks/print_version.ex
+++ b/lib/trento/support/mix/tasks/print_version.ex
@@ -1,0 +1,10 @@
+defmodule Mix.Tasks.PrintVersion do
+  @moduledoc "The hello mix task: `mix help hello`"
+
+  use Mix.Task
+
+  @shortdoc "Print application version"
+  def run(_args) do
+    IO.puts(Mix.Project.config()[:version])
+  end
+end

--- a/lib/trento/support/mix/tasks/version.ex
+++ b/lib/trento/support/mix/tasks/version.ex
@@ -1,4 +1,4 @@
-defmodule Mix.Tasks.PrintVersion do
+defmodule Mix.Tasks.Version do
   @moduledoc "The hello mix task: `mix help hello`"
 
   use Mix.Task

--- a/test/e2e/cypress/fixtures/about/about.feature
+++ b/test/e2e/cypress/fixtures/about/about.feature
@@ -1,0 +1,22 @@
+Feature: About
+    Show Trento info in the about page
+
+    Background:
+        Given an healthy SAP deployment of 27 hosts running SLES4SAP with an active subscription
+        And a Trento installation on this Cluster
+
+    Scenario: Trento flavor is shown in the about page
+        When I open the about page
+        Then I should see that the Trento installation is a "Community" one
+
+    Scenario: Trento version is shown in the about page
+        When I open the about page
+        Then I should see the current version of the Trento installation
+
+    Scenario: Trento GitHub repository is shown in the about page
+        When I open the about page
+        Then I should a link to the Trento GH repository
+
+    Scenario: SLES for SAP subscription shows 27 hosts found in the about page
+        When I open the about page
+        Then I should see that the SLES for SAP subscription has 27 hosts

--- a/test/e2e/cypress/integration/about.js
+++ b/test/e2e/cypress/integration/about.js
@@ -7,17 +7,27 @@ describe('User account page', () => {
   });
 
   it('should have the correct page title', () => {
-    cy.get('.text-5xl').should('contain', 'About Trento Console');
-  });
-
-  it('should display 27 SLES subscriptions found', () => {
-    cy.get('.px-2').should('contain', '27 found');
+    cy.get('h2.text-5xl').should('contain', 'About Trento Console');
   });
 
   it('should show the correct flavor', () => {
-    cy.get('.grid-flow-row > :nth-child(1) > :nth-child(2) > span').should(
-      'contain',
-      'Community'
-    );
+    cy.get('div')
+      .contains('Trento flavor')
+      .next()
+      .should('contain', 'Community');
+  });
+
+  it('should show the github project link', () => {
+    cy.get('div')
+      .contains('GitHub repository')
+      .next()
+      .should('contain', 'https://github.com/trento-project/web');
+  });
+
+  it('should display 27 SLES subscriptions found', () => {
+    cy.get('div')
+      .contains('SLES for SAP subscriptions')
+      .next()
+      .should('contain', '27 found');
   });
 });

--- a/test/e2e/cypress/integration/about.js
+++ b/test/e2e/cypress/integration/about.js
@@ -17,6 +17,17 @@ describe('User account page', () => {
       .should('contain', 'Community');
   });
 
+  it('should show the correct server version', () => {
+    cy.exec(`cd ${Cypress.env('project_root')} && mix print_version`).then(
+      ({ stdout: version }) => {
+        cy.get('div')
+          .contains('Server version')
+          .next()
+          .should('contain', version);
+      }
+    );
+  });
+
   it('should show the github project link', () => {
     cy.get('div')
       .contains('GitHub repository')

--- a/test/e2e/cypress/integration/about.js
+++ b/test/e2e/cypress/integration/about.js
@@ -18,7 +18,7 @@ describe('User account page', () => {
   });
 
   it('should show the correct server version', () => {
-    cy.exec(`cd ${Cypress.env('project_root')} && mix print_version`).then(
+    cy.exec(`cd ${Cypress.env('project_root')} && mix version`).then(
       ({ stdout: version }) => {
         cy.get('div')
           .contains('Server version')


### PR DESCRIPTION
Improve the e2e tests for the about page.
I have included the version test. The version identifier is coming from a `mix` task. I'm not sure if this is a good approach. What do you think @fabriziosestito ?

Otherwise, we will need to have other option to get the version or simply remove this test.