### PR TITLE
Cluster health when no checks are selected

### DIFF
--- a/test/e2e/cypress/integration/dashboard.js
+++ b/test/e2e/cypress/integration/dashboard.js
@@ -1,8 +1,13 @@
 import { agents } from '../fixtures/hosts-overview/available_hosts';
+import { allClusterIds } from '../fixtures/clusters-overview/available_clusters';
+
 describe('Dashboard page', () => {
   before(() => {
     cy.loadScenario('healthy-27-node-SAP-cluster');
     cy.task('startAgentHeartbeat', agents());
+    allClusterIds().forEach((clusterId) => {
+      cy.selectChecks(clusterId, []);
+    });
     cy.login();
     cy.navigateToItem('Dashboard');
     cy.url().should('include', '/');

--- a/test/e2e/cypress/support/commands.js
+++ b/test/e2e/cypress/support/commands.js
@@ -60,3 +60,20 @@ Cypress.Commands.add('navigateToItem', (item) => {
 Cypress.Commands.add('clickOutside', () => {
   return cy.get('body').click(0, 0); //0,0 here are the x and y coordinates
 });
+
+Cypress.Commands.add('selectChecks', (clusterId, checks) => {
+  const [webAPIHost, webAPIPort] = [
+    Cypress.env('web_api_host'),
+    Cypress.env('web_api_port'),
+  ];
+  const checksBody = JSON.stringify({
+    checks: checks,
+  });
+
+  const headers = {
+    'Content-Type': 'application/json;charset=UTF-8',
+  };
+
+  const url = `http://${webAPIHost}:${webAPIPort}/api/clusters/${clusterId}/checks`;
+  cy.request({ method: 'POST', url: url, body: checksBody, headers: headers });
+});

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -26,6 +26,7 @@ defmodule Trento.Factory do
 
   alias Trento.Domain.Commands.{
     RegisterApplicationInstance,
+    RegisterClusterHost,
     RegisterDatabaseInstance
   }
 
@@ -95,6 +96,22 @@ defmodule Trento.Factory do
     %HostConnectionSettings{
       id: Faker.UUID.v4(),
       user: Faker.StarWars.character()
+    }
+  end
+
+  def register_cluster_host_factory do
+    %RegisterClusterHost{
+      cluster_id: Faker.UUID.v4(),
+      host_id: Faker.UUID.v4(),
+      name: Faker.StarWars.character(),
+      sid: Faker.StarWars.planet(),
+      provider: :azure,
+      resources_number: 8,
+      hosts_number: 2,
+      details: hana_cluster_details_value_object(),
+      type: :hana_scale_up,
+      discovered_health: :passing,
+      designated_controller: true
     }
   end
 

--- a/test/trento/domain/cluster/cluster_test.exs
+++ b/test/trento/domain/cluster/cluster_test.exs
@@ -259,6 +259,50 @@ defmodule Trento.ClusterTest do
       )
     end
 
+    test "should use discovered cluster health when no checks are selected" do
+      cluster_id = Faker.UUID.v4()
+      name = Faker.StarWars.character()
+      sid = Faker.StarWars.planet()
+
+      assert_events_and_state(
+        [
+          build(
+            :cluster_registered_event,
+            cluster_id: cluster_id,
+            name: name,
+            sid: sid,
+            details: nil
+          )
+        ],
+        [
+          build(
+            :register_cluster_host,
+            cluster_id: cluster_id,
+            name: name,
+            sid: sid,
+            details: nil,
+            discovered_health: :passing
+          ),
+          SelectChecks.new!(%{
+            cluster_id: cluster_id,
+            checks: []
+          })
+        ],
+        [
+          %ChecksSelected{
+            cluster_id: cluster_id,
+            checks: []
+          }
+        ],
+        fn cluster ->
+          assert %Cluster{
+                   selected_checks: [],
+                   health: :passing
+                 } = cluster
+        end
+      )
+    end
+
     test "should request a checks execution with the selected checks" do
       cluster_id = Faker.UUID.v4()
       host_id = Faker.UUID.v4()
@@ -302,6 +346,24 @@ defmodule Trento.ClusterTest do
                    }
                  } = cluster
         end
+      )
+    end
+
+    test "should not start a checks execution if no checks are selected" do
+      cluster_id = Faker.UUID.v4()
+
+      assert_events(
+        [
+          build(:cluster_registered_event, cluster_id: cluster_id),
+          %ChecksSelected{
+            cluster_id: cluster_id,
+            checks: []
+          }
+        ],
+        RequestChecksExecution.new!(%{
+          cluster_id: cluster_id
+        }),
+        []
       )
     end
 
@@ -466,9 +528,14 @@ defmodule Trento.ClusterTest do
       assert_events_and_state(
         [
           cluster_registered_event,
-          %HostAddedToCluster{
+          host_added_to_cluster_event,
+          %ChecksExecutionCompleted{
             cluster_id: cluster_registered_event.cluster_id,
-            host_id: host_added_to_cluster_event.host_id
+            health: :unknown
+          },
+          %ChecksSelected{
+            cluster_id: cluster_registered_event.cluster_id,
+            checks: []
           }
         ],
         RegisterClusterHost.new!(%{
@@ -482,21 +549,23 @@ defmodule Trento.ClusterTest do
           hosts_number: cluster_registered_event.hosts_number,
           details: StructHelper.to_map(cluster_registered_event.details),
           designated_controller: true,
-          discovered_health: :critical
+          discovered_health: :warning
         }),
         [
           %ClusterDiscoveredHealthChanged{
             cluster_id: cluster_registered_event.cluster_id,
-            discovered_health: :critical
+            discovered_health: :warning
           },
           %ClusterHealthChanged{
             cluster_id: cluster_registered_event.cluster_id,
-            health: :critical
+            health: :warning
           }
         ],
         fn cluster ->
           %Cluster{
-            discovered_health: :critical
+            discovered_health: :warning,
+            checks_health: :unknown,
+            health: :warning
           } = cluster
         end
       )
@@ -533,6 +602,58 @@ defmodule Trento.ClusterTest do
         fn cluster ->
           %Cluster{
             discovered_health: :passing
+          } = cluster
+        end
+      )
+    end
+
+    test "should not change the the cluster aggregated health if checks health is worst" do
+      cluster_registered_event = build(:cluster_registered_event, health: :passing)
+
+      host_added_to_cluster_event =
+        build(:host_added_to_cluster_event, cluster_id: cluster_registered_event.cluster_id)
+
+      assert_events_and_state(
+        [
+          cluster_registered_event,
+          host_added_to_cluster_event,
+          %ChecksSelected{
+            cluster_id: cluster_registered_event.cluster_id,
+            checks: [Faker.Cat.name()]
+          },
+          %ChecksExecutionCompleted{
+            cluster_id: cluster_registered_event.cluster_id,
+            health: :critical
+          },
+          %ClusterHealthChanged{
+            cluster_id: cluster_registered_event.cluster_id,
+            health: :critical
+          }
+        ],
+        RegisterClusterHost.new!(%{
+          cluster_id: cluster_registered_event.cluster_id,
+          host_id: host_added_to_cluster_event.host_id,
+          name: cluster_registered_event.name,
+          sid: cluster_registered_event.sid,
+          provider: :azure,
+          type: cluster_registered_event.type,
+          resources_number: cluster_registered_event.resources_number,
+          hosts_number: cluster_registered_event.hosts_number,
+          details: StructHelper.to_map(cluster_registered_event.details),
+          designated_controller: true,
+          discovered_health: :warning
+        }),
+        [
+          %ClusterDiscoveredHealthChanged{
+            cluster_id: cluster_registered_event.cluster_id,
+            discovered_health: :warning
+          }
+        ],
+        fn cluster ->
+          %Cluster{
+            discovered_health: :warning,
+            checks_health: :critical,
+            health: :critical
           } = cluster
         end
       )


### PR DESCRIPTION
When there is not any check selected, the cluster health is being still built aggregating the discovered health and the checks health, which is `uknown` in this case. This creates an unexpected cluster health, as it would be unknown.

With this change, when no checks are selected, the checks health is not used in the cluster health computation.

Besides that, I have improved the dashboards E2E tests to disable all checks in order to make the test more robuts