### PR TITLE
Speed up CI process

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -364,6 +364,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v2
         env:
+          cypress_video: false
           cypress_db_host: postgres
           cypress_db_port: 5432
           cypress_photofinish_binary: /tmp/photofinish
@@ -373,12 +374,12 @@ jobs:
           wait-on-timeout: 30
           config: baseUrl=http://localhost:4000
 
-      - name: Upload cypress test videos
+      - name: Upload cypress test screenshots
         uses: actions/upload-artifact@v3
         if: failure()
         with:
-          name: e2e-videos
-          path: test/e2e/cypress/videos/
+          name: e2e-screenshots
+          path: test/e2e/cypress/screenshots/
 
   build-and-push-container-images:
     name: Build and push container images

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,8 @@ env:
   NODE_VERSION: "16"
 
 jobs:
-  deps:
-    name: Dependencies
+  elixir-deps:
+    name: Elixir dependencies
     runs-on: ubuntu-20.04
     steps:
       - name: Cancel Previous Runs
@@ -57,6 +57,37 @@ jobs:
           mix deps.compile --warnings-as-errors
           mix dialyzer --plt
 
+  npm-deps:
+    name: Npm dependencies
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Retrieve Cached Dependencies
+        uses: actions/cache@v3
+        id: npm-cache
+        with:
+          path: |
+            assets/node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('assets/package-lock.json') }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}        
+
+      - name: Install NPM dependencies
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: cd assets && npm install
+
   codespell:
     name: Check common misspellings
     runs-on: ubuntu-20.04
@@ -85,7 +116,7 @@ jobs:
 
   static-code-analysis:
     name: Static Code Analysis
-    needs: deps
+    needs: [elixir-deps, npm-deps]
     runs-on: ubuntu-20.04
 
     steps:
@@ -111,9 +142,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - run: cd assets && npm install
 
-      - name: Retrieve Cached Dependencies
+      - name: Retrieve Elixir Cached Dependencies
         uses: actions/cache@v3
         id: mix-cache
         with:
@@ -122,6 +152,14 @@ jobs:
             _build/test
             priv/plts
           key: ${{ runner.os }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('mix.lock') }}
+
+      - name: Retrieve NPM Cached Dependencies
+        uses: actions/cache@v3
+        id: npm-cache
+        with:
+          path: |
+            assets/node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('assets/package-lock.json') }}
 
       - name: Check Code Format
         run: mix format --check-formatted
@@ -140,7 +178,7 @@ jobs:
 
   test:
     name: Test
-    needs: deps
+    needs: [elixir-deps, npm-deps]
     runs-on: ubuntu-20.04
 
     services:
@@ -174,6 +212,11 @@ jobs:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
 
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
       - name: Retrieve Cached Dependencies
         uses: actions/cache@v3
         id: mix-cache
@@ -184,21 +227,54 @@ jobs:
             priv/plts
           key: ${{ runner.os }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('mix.lock') }}
 
-      - name: Setup Node
-        uses: actions/setup-node@v3
+      - name: Retrieve NPM Cached Dependencies
+        uses: actions/cache@v3
+        id: npm-cache
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          path: |
+            assets/node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('assets/package-lock.json') }}
 
-      - run: cd assets && npm install
       - name: Run test
         run: mix test --color --trace --slowest 10
 
       - name: Run JS tests
         run: cd assets && npm test
 
+  npm-e2e-deps:
+    name: Npm E2E dependencies
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Retrieve Cached Dependencies
+        uses: actions/cache@v3
+        id: npm-e2e-cache
+        with:
+          path: |
+            test/e2e/node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('test/e2e/package-lock.json') }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install E2E NPM dependencies
+        if: steps.npm-e2e-cache.outputs.cache-hit != 'true'
+        run: cd test/e2e && npm install
+
   test-e2e:
     name: End to end tests
-    needs: deps
+    needs: [elixir-deps, npm-deps, npm-e2e-deps]
     runs-on: ubuntu-20.04
     env:
       MIX_ENV: dev
@@ -239,21 +315,42 @@ jobs:
         env:
           ImageOS: ubuntu20
 
-      - name: Check Eslint and JS Code Format
-        run: cd test/e2e && npm install && npm run lint && npm run format:check
-
-      - name: Get mix deps
-        run: mix deps.clean --all && mix deps.get
-
-      - name: Mix setup
-        run: mix do ecto.drop, event_store.drop, ecto.create, ecto.migrate, setup
-
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Install assets
-        run: cd assets && npm install
+
+      - name: Retrieve Cached Dependencies
+        uses: actions/cache@v3
+        id: mix-cache
+        with:
+          path: |
+            deps
+            _build/dev
+            priv/plts
+          key: ${{ runner.os }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('mix.lock') }}
+
+      - name: Retrieve NPM Cached Dependencies
+        uses: actions/cache@v3
+        id: npm-cache
+        with:
+          path: |
+            assets/node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('assets/package-lock.json') }}
+
+      - name: Retrieve E2E NPM Cached Dependencies
+        uses: actions/cache@v3
+        id: npm-e2e-cache
+        with:
+          path: |
+            test/e2e/node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('test/e2e/package-lock.json') }}
+
+      - name: Check Eslint and JS Code Format
+        run: cd test/e2e && npm run lint && npm run format:check
+
+      - name: Mix setup
+        run: mix setup
 
       - name: Run trento detached
         run: mix phx.server &
@@ -287,7 +384,7 @@ jobs:
     name: Build and push container images
     runs-on: ubuntu-latest
     if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch'
-    needs: [deps, static-code-analysis, test, test-e2e]
+    needs: [static-code-analysis, test, test-e2e]
     permissions:
       contents: read
       packages: write
@@ -325,7 +422,7 @@ jobs:
     name: Commit the project on OBS
     runs-on: ubuntu-20.04
     if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch'
-    needs: [deps, static-code-analysis, test, test-e2e]
+    needs: [static-code-analysis, test, test-e2e]
     container:
       image: ghcr.io/trento-project/continuous-delivery:master
       env:

--- a/test/e2e/cypress/integration/about.js
+++ b/test/e2e/cypress/integration/about.js
@@ -1,6 +1,5 @@
 describe('User account page', () => {
   before(() => {
-    cy.login();
     cy.navigateToItem('About');
     cy.url().should('include', '/about');
   });

--- a/test/e2e/cypress/integration/about.js
+++ b/test/e2e/cypress/integration/about.js
@@ -1,6 +1,5 @@
 describe('User account page', () => {
   before(() => {
-    cy.loadScenario('healthy-27-node-SAP-cluster');
     cy.login();
     cy.navigateToItem('About');
     cy.url().should('include', '/about');

--- a/test/e2e/cypress/integration/checks_catalog.js
+++ b/test/e2e/cypress/integration/checks_catalog.js
@@ -5,8 +5,7 @@ import {
 
 context('Checks catalog', () => {
   before(() => {
-    cy.login();
-    cy.visit('/catalog');
+    cy.navigateToItem('Checks catalog');
     cy.url().should('include', '/catalog');
   });
 

--- a/test/e2e/cypress/integration/clusters_overview.js
+++ b/test/e2e/cypress/integration/clusters_overview.js
@@ -6,7 +6,6 @@ import {
 context('Clusters Overview', () => {
   const availableClusters = allClusterNames();
   before(() => {
-    cy.loadScenario('healthy-27-node-SAP-cluster');
     cy.login();
     cy.navigateToItem('Clusters');
     cy.url().should('include', '/clusters');
@@ -34,6 +33,11 @@ context('Clusters Overview', () => {
     describe('Unnamed cluster', () => {
       before(() => {
         cy.loadScenario('cluster-unnamed');
+      });
+
+      // Restore cluster name
+      after(() => {
+        cy.loadScenario('cluster-4-SOK');
       });
 
       it('Unnamed clusters should use the ID as details page link', () => {

--- a/test/e2e/cypress/integration/clusters_overview.js
+++ b/test/e2e/cypress/integration/clusters_overview.js
@@ -6,7 +6,6 @@ import {
 context('Clusters Overview', () => {
   const availableClusters = allClusterNames();
   before(() => {
-    cy.login();
     cy.navigateToItem('Clusters');
     cy.url().should('include', '/clusters');
   });

--- a/test/e2e/cypress/integration/dashboard.js
+++ b/test/e2e/cypress/integration/dashboard.js
@@ -1,7 +1,6 @@
 import { agents } from '../fixtures/hosts-overview/available_hosts';
 describe('Dashboard page', () => {
   before(() => {
-    cy.loadScenario('healthy-27-node-SAP-cluster');
     cy.task('startAgentHeartbeat', agents());
     cy.login();
     cy.navigateToItem('Dashboard');

--- a/test/e2e/cypress/integration/dashboard.js
+++ b/test/e2e/cypress/integration/dashboard.js
@@ -2,7 +2,6 @@ import { agents } from '../fixtures/hosts-overview/available_hosts';
 describe('Dashboard page', () => {
   before(() => {
     cy.task('startAgentHeartbeat', agents());
-    cy.login();
     cy.navigateToItem('Dashboard');
     cy.url().should('include', '/');
   });

--- a/test/e2e/cypress/integration/hana_cluster_details.js
+++ b/test/e2e/cypress/integration/hana_cluster_details.js
@@ -2,7 +2,6 @@ import { availableHanaCluster } from '../fixtures/hana-cluster-details/available
 
 context('HANA database details', () => {
   before(() => {
-    cy.loadScenario('healthy-27-node-SAP-cluster');
     cy.login();
     cy.visit(`/clusters/${availableHanaCluster.id}`);
     cy.url().should('include', `/clusters/${availableHanaCluster.id}`);

--- a/test/e2e/cypress/integration/hana_cluster_details.js
+++ b/test/e2e/cypress/integration/hana_cluster_details.js
@@ -2,7 +2,6 @@ import { availableHanaCluster } from '../fixtures/hana-cluster-details/available
 
 context('HANA database details', () => {
   before(() => {
-    cy.login();
     cy.visit(`/clusters/${availableHanaCluster.id}`);
     cy.url().should('include', `/clusters/${availableHanaCluster.id}`);
   });

--- a/test/e2e/cypress/integration/hana_database_details.js
+++ b/test/e2e/cypress/integration/hana_database_details.js
@@ -9,7 +9,6 @@ context('HANA database details', () => {
   const sessionCookie = '_trento_key';
 
   before(() => {
-    cy.loadScenario('healthy-27-node-SAP-cluster');
     cy.login();
 
     cy.visit(`/databases/${selectedDatabase.Id}`);
@@ -48,6 +47,11 @@ context('HANA database details', () => {
     before(() => {
       cy.visit(`/databases/${selectedDatabase.Id}`);
       cy.url().should('include', `/databases/${selectedDatabase.Id}`);
+    });
+    
+    after(() => {
+      // Restore instance health
+      cy.loadScenario('hana-database-detail-GREEN');
     });
 
     selectedDatabase.Hosts.forEach((instance, index) => {

--- a/test/e2e/cypress/integration/hana_database_details.js
+++ b/test/e2e/cypress/integration/hana_database_details.js
@@ -6,21 +6,9 @@ import {
 } from '../fixtures/hana-database-details/selected_database';
 
 context('HANA database details', () => {
-  const sessionCookie = '_trento_key';
-
   before(() => {
-    cy.login();
-
     cy.visit(`/databases/${selectedDatabase.Id}`);
     cy.url().should('include', `/databases/${selectedDatabase.Id}`);
-  });
-
-  after(() => {
-    cy.clearCookie(sessionCookie);
-  });
-
-  beforeEach(() => {
-    cy.Cookies.preserveOnce(sessionCookie);
   });
 
   describe('HANA database details page is available', () => {
@@ -48,7 +36,7 @@ context('HANA database details', () => {
       cy.visit(`/databases/${selectedDatabase.Id}`);
       cy.url().should('include', `/databases/${selectedDatabase.Id}`);
     });
-    
+
     after(() => {
       // Restore instance health
       cy.loadScenario('hana-database-detail-GREEN');

--- a/test/e2e/cypress/integration/host_details.js
+++ b/test/e2e/cypress/integration/host_details.js
@@ -3,9 +3,7 @@ import { selectedHost } from '../fixtures/host-details/selected_host';
 context('Host Details', () => {
   before(() => {
     cy.task('startAgentHeartbeat', [selectedHost.agentId]);
-    cy.login();
 
-    cy.visit('/');
     cy.navigateToItem('Hosts');
     cy.get(`#host-${selectedHost.agentId} > a`).click();
     cy.url().should('include', `/hosts/${selectedHost.agentId}`);

--- a/test/e2e/cypress/integration/host_details.js
+++ b/test/e2e/cypress/integration/host_details.js
@@ -2,8 +2,6 @@ import { selectedHost } from '../fixtures/host-details/selected_host';
 
 context('Host Details', () => {
   before(() => {
-    cy.loadScenario('healthy-27-node-SAP-cluster');
-
     cy.task('startAgentHeartbeat', [selectedHost.agentId]);
     cy.login();
 

--- a/test/e2e/cypress/integration/hosts_overview.js
+++ b/test/e2e/cypress/integration/hosts_overview.js
@@ -6,7 +6,6 @@ import {
 context('Hosts Overview', () => {
   const availableHosts = allHostNames();
   before(() => {
-    cy.loadScenario('healthy-27-node-SAP-cluster');
     cy.task('startAgentHeartbeat', agents());
     cy.login();
 

--- a/test/e2e/cypress/integration/hosts_overview.js
+++ b/test/e2e/cypress/integration/hosts_overview.js
@@ -7,7 +7,6 @@ context('Hosts Overview', () => {
   const availableHosts = allHostNames();
   before(() => {
     cy.task('startAgentHeartbeat', agents());
-    cy.login();
 
     cy.navigateToItem('Hosts');
     cy.url().should('include', '/hosts');

--- a/test/e2e/cypress/integration/login.js
+++ b/test/e2e/cypress/integration/login.js
@@ -1,5 +1,6 @@
 context('Trento login page', () => {
   before(() => {
+    cy.clearCookies();
     cy.visit('/');
   });
 
@@ -8,5 +9,6 @@ context('Trento login page', () => {
     cy.get('.mt-6').should('contain', 'Login to Trento');
     cy.get('.mx-auto').should('exist');
     cy.get(':nth-child(2) > .text-sm').should('contain', 'Username');
+    cy.login();
   });
 });

--- a/test/e2e/cypress/integration/sap_system_details.js
+++ b/test/e2e/cypress/integration/sap_system_details.js
@@ -5,21 +5,9 @@ import {
 } from '../fixtures/sap-system-details/selected_system';
 
 context('SAP system details', () => {
-  const sessionCookie = '_trento_key';
-
   before(() => {
-    cy.login();
-
     cy.visit(`/sap_systems/${selectedSystem.Id}`);
     cy.url().should('include', `/sap_systems/${selectedSystem.Id}`);
-  });
-
-  after(() => {
-    cy.clearCookie(sessionCookie);
-  });
-
-  beforeEach(() => {
-    cy.Cookies.preserveOnce(sessionCookie);
   });
 
   describe('SAP system details page is available', () => {

--- a/test/e2e/cypress/integration/sap_system_details.js
+++ b/test/e2e/cypress/integration/sap_system_details.js
@@ -8,7 +8,6 @@ context('SAP system details', () => {
   const sessionCookie = '_trento_key';
 
   before(() => {
-    cy.loadScenario('healthy-27-node-SAP-cluster');
     cy.login();
 
     cy.visit(`/sap_systems/${selectedSystem.Id}`);
@@ -47,6 +46,11 @@ context('SAP system details', () => {
     before(() => {
       cy.visit(`/sap_systems/${selectedSystem.Id}`);
       cy.url().should('include', `/sap_systems/${selectedSystem.Id}`);
+    });
+
+    after(() => {
+      // Restore instance health
+      cy.loadScenario('sap-system-detail-GREEN');
     });
 
     selectedSystem.Hosts.forEach((instance, index) => {

--- a/test/e2e/cypress/integration/sap_systems_overview.js
+++ b/test/e2e/cypress/integration/sap_systems_overview.js
@@ -8,9 +8,6 @@ import {
 
 context('SAP Systems Overview', () => {
   before(() => {
-    cy.login();
-
-    cy.visit('/');
     cy.navigateToItem('SAP Systems');
     cy.url().should('include', '/sap_systems');
   });

--- a/test/e2e/cypress/integration/sap_systems_overview.js
+++ b/test/e2e/cypress/integration/sap_systems_overview.js
@@ -8,7 +8,6 @@ import {
 
 context('SAP Systems Overview', () => {
   before(() => {
-    cy.loadScenario('healthy-27-node-SAP-cluster');
     cy.login();
 
     cy.visit('/');

--- a/test/e2e/cypress/support/index.js
+++ b/test/e2e/cypress/support/index.js
@@ -19,3 +19,7 @@ import './commands';
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 //
+
+before(() => {
+    cy.loadScenario('healthy-27-node-SAP-cluster');
+});

--- a/test/e2e/cypress/support/index.js
+++ b/test/e2e/cypress/support/index.js
@@ -20,6 +20,17 @@ import './commands';
 // require('./commands')
 //
 
+const sessionCookie = '_trento_key';
+
 before(() => {
-    cy.loadScenario('healthy-27-node-SAP-cluster');
+  cy.loadScenario('healthy-27-node-SAP-cluster');
+  cy.login();
+});
+
+after(() => {
+  cy.clearCookie(sessionCookie);
+});
+
+beforeEach(() => {
+  cy.Cookies.preserveOnce(sessionCookie);
 });


### PR DESCRIPTION
Speed up the CI execution. 3 major changes:
- Cache as much as possible. At least the re-runs will be faster
- Disable the video recording on Cypress. This boosts a lot the speed, and we don't use almost the videos. The screenshots are still there
- Disable photofinish usage and the login process in all contexts. They are done just at the beginning of the suite