### PR TITLE
Refactor cluster hosts executions state

### DIFF
--- a/test/trento/domain/cluster/cluster_test.exs
+++ b/test/trento/domain/cluster/cluster_test.exs
@@ -293,13 +293,13 @@ defmodule Trento.ClusterTest do
           assert %Cluster{
                    health: :unknown,
                    checks_execution: :requested,
-                   hosts_executions: %{
-                     ^host_id => %HostExecution{
+                   hosts_executions: [
+                     %HostExecution{
                        host_id: ^host_id,
                        reachable: true,
                        checks_results: ^checks_results
                      }
-                   }
+                   ]
                  } = cluster
         end
       )
@@ -340,7 +340,7 @@ defmodule Trento.ClusterTest do
       host_id = Faker.UUID.v4()
       selected_checks = Enum.map(0..4, fn _ -> Faker.Cat.name() end)
       checks_results = Enum.map(selected_checks, &%{check_id: &1, result: :critical})
-      expected_results = Enum.map(checks_results, &CheckResult.new!(&1))
+      expected_results = Enum.map(checks_results, &CheckResult.new!/1)
       msg = Faker.StarWars.planet()
 
       assert_events_and_state(
@@ -350,6 +350,15 @@ defmodule Trento.ClusterTest do
           %ChecksSelected{
             cluster_id: cluster_id,
             checks: selected_checks
+          },
+          %ChecksExecutionRequested{
+            cluster_id: cluster_id,
+            hosts: [host_id],
+            checks: selected_checks,
+            provider: :azure
+          },
+          %ChecksExecutionStarted{
+            cluster_id: cluster_id
           }
         ],
         CompleteChecksExecution.new!(%{
@@ -383,13 +392,13 @@ defmodule Trento.ClusterTest do
         fn cluster ->
           assert %Cluster{
                    checks_execution: :not_running,
-                   hosts_executions: %{
-                     ^host_id => %HostExecution{
+                   hosts_executions: [
+                     %HostExecution{
                        host_id: ^host_id,
                        reachable: true,
                        checks_results: ^expected_results
                      }
-                   }
+                   ]
                  } = cluster
         end
       )
@@ -445,11 +454,11 @@ defmodule Trento.ClusterTest do
         fn cluster ->
           assert %Cluster{
                    checks_execution: :not_running,
-                   hosts_executions: %{
-                     ^host_id => %HostExecution{
+                   hosts_executions: [
+                     %HostExecution{
                        checks_results: ^expected_results
                      }
-                   }
+                   ]
                  } = cluster
         end
       )


### PR DESCRIPTION
Refactors the hosts executions field in the cluster aggregate state.
This simplifies the apply/execute functions and it will allow to easily serialize the state for future snapshotting/rollup.