### PR TITLE
Expose Execution Request API documentation

### DIFF
--- a/lib/trento_web/controllers/cluster_controller.ex
+++ b/lib/trento_web/controllers/cluster_controller.ex
@@ -41,7 +41,7 @@ defmodule TrentoWeb.ClusterController do
     ],
     responses: [
       accepted:
-        {"The Command has been accepted and the Requested execution will start shortly",
+        {"The Command has been accepted and the Requested execution is scheduled",
          "application/json", %OpenApiSpex.Schema{example: %{}}},
       bad_request:
         {"Something went wrong while triggering an Execution Request", "application/json",

--- a/lib/trento_web/controllers/cluster_controller.ex
+++ b/lib/trento_web/controllers/cluster_controller.ex
@@ -9,6 +9,12 @@ defmodule TrentoWeb.ClusterController do
 
   use OpenApiSpex.ControllerSpecs
 
+  @cluster_id_schema [
+    in: :path,
+    required: true,
+    type: %OpenApiSpex.Schema{type: :string, format: :uuid}
+  ]
+
   operation :list,
     summary: "List Pacemaker Clusters",
     tags: ["Landscape"],
@@ -26,7 +32,22 @@ defmodule TrentoWeb.ClusterController do
     json(conn, clusters)
   end
 
-  operation :request_checks_execution, false
+  operation :request_checks_execution,
+    summary: "Request Checks Execution for a Cluster",
+    tags: ["Checks"],
+    description: "Trigger execution of the latest Checks Selection on the target infrastructure",
+    parameters: [
+      cluster_id: @cluster_id_schema
+    ],
+    responses: [
+      accepted:
+        {"The Command has been accepted and the Requested execution will start shortly",
+         "application/json", %OpenApiSpex.Schema{example: %{}}},
+      bad_request:
+        {"Something went wrong while triggering an Execution Request", "application/json",
+         Schema.Common.BadRequestResponse}
+    ]
+
   @spec request_checks_execution(Plug.Conn.t(), map) :: Plug.Conn.t()
   def request_checks_execution(conn, %{"cluster_id" => cluster_id}) do
     case Clusters.request_checks_execution(cluster_id) do
@@ -63,6 +84,7 @@ defmodule TrentoWeb.ClusterController do
     tags: ["Checks"],
     description: "Select the Checks eligible for execution on the target infrastructure",
     parameters: [
+      cluster_id: @cluster_id_schema,
       selected_checks: [
         in: :body,
         required: true,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8167114/169473111-15bbd9b1-62c7-4560-a1c8-7f6515977d41.png)

- [x] GET     /api/hosts
- [x] GET     /api/clusters
- [x] GET     /api/sap_systems
- [x] GET     /api/databases
- [x] GET     /api/checks/catalog
- [x] POST    /api/clusters/:cluster_id/checks
- [x] POST    /api/clusters/:cluster_id/checks/request_execution
- [ ] POST    /api/runner/callback
- [ ] GET /api/installation/api-key
- [ ] GET /api/sap_systems/health
- [ ] GET /api/about
- [ ] GET /api/settings
- [ ] POST /api/accept_eula

Follows up https://github.com/trento-project/web/pull/512 https://github.com/trento-project/web/pull/522 https://github.com/trento-project/web/pull/528 https://github.com/trento-project/web/pull/536 https://github.com/trento-project/web/pull/546