### PR TITLE
Event handlers failure context 

### DIFF
--- a/lib/trento/support/event_handler_failure_context.ex
+++ b/lib/trento/support/event_handler_failure_context.ex
@@ -1,0 +1,72 @@
+defmodule Trento.Support.EventHandlerFailureContext do
+  @moduledoc """
+  Event handler failure context
+
+  max_retries: max retries before the event handler is shut down (defauklt: 3)
+  retry_after: time between retries in ms (default: 0)
+  callback: callback to be called when the max retries are reached
+  skip: if skip is true, the event will be skipped, otherwise the process will stop (default: false)
+  """
+
+  defmacro __using__(opts \\ []) do
+    quote do
+      alias Commanded.Event.FailureContext
+
+      require Logger
+
+      def error(
+            error,
+            event,
+            %FailureContext{context: context, metadata: metadata} = failure_context
+          ) do
+        max_retries = Keyword.get(unquote(opts), :max_retries, 3)
+        retry_after = Keyword.get(unquote(opts), :retry_after, 500)
+        skip = Keyword.get(unquote(opts), :skip, false)
+
+        after_max_retries_reached =
+          Keyword.get(unquote(opts), :after_max_retries_reached, fn _event, _metadata, _context ->
+            :ok
+          end)
+
+        after_retry =
+          Keyword.get(unquote(opts), :after_retry, fn _event, _metadata, _context ->
+            :ok
+          end)
+
+        Logger.metadata(error: error, event: event, failure_context: failure_context)
+
+        case record_failure(context) do
+          %{failures: failures} when failures >= max_retries ->
+            :ok = after_max_retries_reached.(event, metadata, context)
+
+            if skip do
+              Logger.error(
+                "#{__MODULE__} failed to handle event, skipping after #{max_retries} retries"
+              )
+
+              :skip
+            else
+              Logger.error(
+                "#{__MODULE__} failed to handle event, stopping after #{max_retries} retries"
+              )
+
+              {:error, :max_retries_reached}
+            end
+
+          %{failures: failures} = context ->
+            :ok = after_retry.(event, metadata, context)
+
+            Logger.error(
+              "#{__MODULE__}  failed to handle event, retrying (#{failures}/#{max_retries})..."
+            )
+
+            {:retry, retry_after, context}
+        end
+      end
+
+      defp record_failure(context) do
+        Map.update(context, :failures, 1, fn failures -> failures + 1 end)
+      end
+    end
+  end
+end

--- a/lib/trento/support/event_handler_failure_context.ex
+++ b/lib/trento/support/event_handler_failure_context.ex
@@ -2,8 +2,8 @@ defmodule Trento.Support.EventHandlerFailureContext do
   @moduledoc """
   Event handler failure context
 
-  max_retries: max retries before the event handler is shut down (defauklt: 3)
-  retry_after: time between retries in ms (default: 0)
+  max_retries: max retries before the event handler is shut down (default: 3)
+  retry_after: time between retries in ms (default: 500)
   after_retry: callback to be called after reach retry
   after_max_retries_reached: callback to be called when the max retries are reached
   skip: if skip is true, the event will be skipped, otherwise the process will stop (default: false)

--- a/lib/trento/support/event_handler_failure_context.ex
+++ b/lib/trento/support/event_handler_failure_context.ex
@@ -4,7 +4,8 @@ defmodule Trento.Support.EventHandlerFailureContext do
 
   max_retries: max retries before the event handler is shut down (defauklt: 3)
   retry_after: time between retries in ms (default: 0)
-  callback: callback to be called when the max retries are reached
+  after_retry: callback to be called after reach retry
+  after_max_retries_reached: callback to be called when the max retries are reached
   skip: if skip is true, the event will be skipped, otherwise the process will stop (default: false)
   """
 

--- a/test/support/commanded/test_commanded_app.ex
+++ b/test/support/commanded/test_commanded_app.ex
@@ -1,0 +1,17 @@
+defmodule TestCommandedApp do
+  @moduledoc """
+  InMemory commanded app used in tests.
+  """
+
+  alias Commanded.EventStore.Adapters.InMemory
+  alias Commanded.Serialization.JsonSerializer
+
+  use Commanded.Application,
+    otp_app: :commanded,
+    event_store: [
+      adapter: InMemory,
+      serializer: JsonSerializer
+    ],
+    pubsub: :local,
+    registry: :local
+end

--- a/test/support/commanded/test_event_handler_with_failure_context.ex
+++ b/test/support/commanded/test_event_handler_with_failure_context.ex
@@ -1,0 +1,28 @@
+defmodule TestEventHandlerWithFailureContext do
+  @moduledoc """
+  This module defines an event handler that fails.
+  """
+
+  use Commanded.Event.Handler,
+    application: TestCommandedApp,
+    name: __MODULE__
+
+  use Trento.Support.EventHandlerFailureContext,
+    max_retry: 1,
+    retry_after: 1,
+    skip: true,
+    after_retry: fn _, %{reply_to: reply_to}, %{failures: failures} ->
+      send(reply_to, {:retry, failures})
+
+      :ok
+    end,
+    after_max_retries_reached: fn _, %{reply_to: reply_to}, _ ->
+      send(reply_to, :max_retries_reached)
+
+      :ok
+    end
+
+  def handle(%TestEvent{data: "error"}, _) do
+    {:error, :reason}
+  end
+end

--- a/test/support/structs/test_event.ex
+++ b/test/support/structs/test_event.ex
@@ -1,0 +1,9 @@
+defmodule TestEvent do
+  @moduledoc false
+
+  use Trento.Event
+
+  defevent do
+    field :data, :string
+  end
+end

--- a/test/trento/support/event_handler_failure_context_test.exs
+++ b/test/trento/support/event_handler_failure_context_test.exs
@@ -1,0 +1,56 @@
+defmodule Trento.Support.EventHandlerFailureContextTest do
+  use ExUnit.Case
+
+  alias Commanded.EventStore.TypeProvider
+
+  setup do
+    start_supervised!(TestCommandedApp)
+    handler = start_supervised!(TestEventHandlerWithFailureContext)
+
+    {:ok, %{handler: handler}}
+  end
+
+  @tag :capture_log
+  test "should retry 3 times before shutting down and call the callback functions", %{
+    handler: handler
+  } do
+    event = %TestEvent{data: "error"}
+
+    send_event(event, handler)
+
+    assert_receive {:retry, 1}
+    assert_receive {:retry, 2}
+    assert_receive :max_retries_reached
+
+    assert Process.alive?(handler)
+  end
+
+  defp send_event(event, handler) do
+    event_data = %EventStore.EventData{
+      causation_id: UUID.uuid4(),
+      correlation_id: UUID.uuid4(),
+      event_type: TypeProvider.to_string(event),
+      data: event,
+      metadata: %{reply_to: self()}
+    }
+
+    send(
+      handler,
+      {:events,
+       [
+         %Commanded.EventStore.RecordedEvent{
+           event_id: UUID.uuid4(),
+           event_number: 1,
+           stream_id: UUID.uuid4(),
+           stream_version: 0,
+           causation_id: event_data.causation_id,
+           correlation_id: event_data.correlation_id,
+           event_type: event_data.event_type,
+           data: event_data.data,
+           metadata: event_data.metadata,
+           created_at: DateTime.utc_now()
+         }
+       ]}
+    )
+  end
+end


### PR DESCRIPTION
This PR adds a failure context for event handlers (and projectors) that can be used to retry/skip an event that couldn't be handled. The failure context accepts two callbacks (`after_retry` and `after_max_retries_reached`),