### PR TITLE
Adds openapi doc for ApiKey retriveal

### DIFF
--- a/lib/trento_web/controllers/installation_controller.ex
+++ b/lib/trento_web/controllers/installation_controller.ex
@@ -1,6 +1,29 @@
 defmodule TrentoWeb.InstallationController do
   use TrentoWeb, :controller
 
+  alias OpenApiSpex.Schema
+
+  use OpenApiSpex.ControllerSpecs
+
+  operation :get_api_key,
+    summary: "Retrieve API Key",
+    tags: ["Platform"],
+    description: "Retrieve the generated API Key. Needed for Agents installation",
+    responses: [
+      ok:
+        {"The generated API Key", "application/json",
+         %Schema{
+           title: "ApiKey",
+           type: :object,
+           properties: %{
+             api_key: %Schema{
+               type: :string
+             }
+           }
+         }}
+    ]
+
+  @spec get_api_key(Plug.Conn.t(), any) :: Plug.Conn.t()
   def get_api_key(conn, _) do
     key = Trento.Installation.get_api_key()
 

--- a/lib/trento_web/openapi/api_spec.ex
+++ b/lib/trento_web/openapi/api_spec.ex
@@ -29,6 +29,10 @@ defmodule TrentoWeb.OpenApi.ApiSpec do
         %Tag{
           name: "Checks",
           description: "Providing Checks related feature"
+        },
+        %Tag{
+          name: "Platform",
+          description: "Providing access to Trento Platform features"
         }
       ]
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8167114/169551730-7abfbcd1-e316-4284-b9ef-5d46b51da678.png)

- [x] GET     /api/hosts
- [x] GET     /api/clusters
- [x] GET     /api/sap_systems
- [x] GET     /api/databases
- [x] GET     /api/checks/catalog
- [x] POST    /api/clusters/:cluster_id/checks
- [x] POST    /api/clusters/:cluster_id/checks/request_execution
- [x] POST    /api/runner/callback
- [x] GET /api/installation/api-key
- [ ] GET /api/sap_systems/health
- [ ] GET /api/about
- [ ] GET /api/settings
- [ ] POST /api/accept_eula

Follows up https://github.com/trento-project/web/pull/512 https://github.com/trento-project/web/pull/522 https://github.com/trento-project/web/pull/528 https://github.com/trento-project/web/pull/536 https://github.com/trento-project/web/pull/546 https://github.com/trento-project/web/pull/558 https://github.com/trento-project/web/pull/569

-----
I am also here to ask if the proposed categorization makes sense:
- Landscape
- Checks
- Platform

![image](https://user-images.githubusercontent.com/8167114/169552497-a8c4ad2c-63e8-47bd-bb20-04761f796697.png)

Feel free to provide suggestions.
Consider that, the remaining apis will go under the `Platform` (or a better naming that we prefer), except for the **SAP Systems Health Overview** (aka at a glance API) which I'd keep under `Lamdscape` (or other alternatives)