### PR TITLE
Rollup integration test

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -14,11 +14,13 @@ config :trento, Trento.Repo,
   pool: Ecto.Adapters.SQL.Sandbox,
   pool_size: 10
 
-config :trento, Trento.Commanded,
-  event_store: [
-    adapter: Commanded.EventStore.Adapters.InMemory,
-    serializer: Commanded.Serialization.JsonSerializer
-  ]
+config :trento, Trento.EventStore,
+  username: "postgres",
+  password: "postgres",
+  database: "trento_eventstore_test#{System.get_env("MIX_TEST_PARTITION")}",
+  hostname: "localhost",
+  port: 5433,
+  pool: Ecto.Adapters.SQL.Sandbox
 
 # We don't run a server during test. If one is required,
 # you can enable the server option below.

--- a/lib/trento/application/event_handlers/rollup_event_handler.ex
+++ b/lib/trento/application/event_handlers/rollup_event_handler.ex
@@ -1,6 +1,6 @@
 defmodule Trento.RollupEventHandler do
   @moduledoc """
-    This event handler is responsible for rolling up aggregates.
+  This event handler is responsible for rolling up aggregates.
   """
 
   use Commanded.Event.Handler,
@@ -8,36 +8,14 @@ defmodule Trento.RollupEventHandler do
     name: "roll_up_event_handler",
     consistency: :strong
 
+  alias Trento.Rollup
+
   alias Trento.Domain.Events.ClusterRolledUp
 
   def handle(
         %ClusterRolledUp{cluster_id: cluster_id, applied: false} = event,
         _
       ) do
-    rollup_aggregate(cluster_id, event)
-  end
-
-  defp rollup_aggregate(aggregate_id, event) do
-    {:ok, pid} = Postgrex.start_link(Trento.EventStore.config())
-
-    Postgrex.transaction(pid, fn conn ->
-      with :ok <- Trento.EventStore.delete_snapshot(aggregate_id, conn: conn),
-           :ok <- Trento.EventStore.delete_stream(aggregate_id, :any_version, :hard, conn: conn) do
-        Trento.EventStore.append_to_stream(
-          aggregate_id,
-          :any_version,
-          [
-            %EventStore.EventData{
-              causation_id: UUID.uuid4(),
-              correlation_id: UUID.uuid4(),
-              event_type: Commanded.EventStore.TypeProvider.to_string(event),
-              data: %{event | applied: true},
-              metadata: %{}
-            }
-          ],
-          conn: conn
-        )
-      end
-    end)
+    Rollup.rollup_aggregate(cluster_id, event)
   end
 end

--- a/lib/trento/application/usecases/rollup/rollup.ex
+++ b/lib/trento/application/usecases/rollup/rollup.ex
@@ -1,0 +1,29 @@
+defmodule Trento.Rollup do
+  @moduledoc """
+  Probides the rollup functionality
+  """
+
+  def rollup_aggregate(aggregate_id, event) do
+    {:ok, pid} = Postgrex.start_link(Trento.EventStore.config())
+
+    Postgrex.transaction(pid, fn conn ->
+      with :ok <- Trento.EventStore.delete_snapshot(aggregate_id, conn: conn),
+           :ok <- Trento.EventStore.delete_stream(aggregate_id, :any_version, :hard, conn: conn) do
+        Trento.EventStore.append_to_stream(
+          aggregate_id,
+          :any_version,
+          [
+            %EventStore.EventData{
+              causation_id: UUID.uuid4(),
+              correlation_id: UUID.uuid4(),
+              event_type: Commanded.EventStore.TypeProvider.to_string(event),
+              data: %{event | applied: true},
+              metadata: %{}
+            }
+          ],
+          conn: conn
+        )
+      end
+    end)
+  end
+end

--- a/lib/trento/application/usecases/rollup/rollup.ex
+++ b/lib/trento/application/usecases/rollup/rollup.ex
@@ -1,6 +1,6 @@
 defmodule Trento.Rollup do
   @moduledoc """
-  Probides the rollup functionality
+  Provides the rollup functionality
   """
 
   def rollup_aggregate(aggregate_id, event) do

--- a/mix.exs
+++ b/mix.exs
@@ -105,7 +105,13 @@ defmodule Trento.MixProject do
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       "event_store.setup": ["event_store.create", "event_store.init"],
       "event_store.reset": ["event_store.drop", "event_store.setup"],
-      test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
+      test: [
+        "ecto.create --quiet",
+        "ecto.migrate --quiet",
+        "event_store.create --quiet",
+        "event_store.init --quiet",
+        "test"
+      ],
       "assets.deploy": [
         "cmd --cd assets npm run tailwind:build",
         "cmd --cd assets npm run build",

--- a/test/support/event_store_case.ex
+++ b/test/support/event_store_case.ex
@@ -3,6 +3,7 @@ defmodule Trento.EventStoreCase do
   This module defines the test case to be used by
   tests that require setting an event store.
   """
+
   use ExUnit.CaseTemplate
 
   setup do
@@ -11,15 +12,12 @@ defmodule Trento.EventStoreCase do
     :ok = Application.stop(:eventstore)
 
     config = Trento.EventStore.config()
+
     {:ok, conn} = Postgrex.start_link(config)
-    reset_event_store(conn, config)
+    EventStore.Storage.Initializer.reset!(conn, config)
 
     {:ok, _} = Application.ensure_all_started(:trento)
 
     {:ok, %{conn: conn}}
-  end
-
-  defp reset_event_store(conn, config) do
-    EventStore.Storage.Initializer.reset!(conn, config)
   end
 end

--- a/test/support/event_store_case.ex
+++ b/test/support/event_store_case.ex
@@ -1,0 +1,25 @@
+defmodule Trento.EventStoreCase do
+  @moduledoc """
+  This module defines the test case to be used by
+  tests that require setting an event store.
+  """
+  use ExUnit.CaseTemplate
+
+  setup do
+    :ok = Application.stop(:trento)
+    :ok = Application.stop(:commanded)
+    :ok = Application.stop(:eventstore)
+
+    config = Trento.EventStore.config()
+    {:ok, conn} = Postgrex.start_link(config)
+    reset_event_store(conn, config)
+
+    {:ok, _} = Application.ensure_all_started(:trento)
+
+    {:ok, %{conn: conn}}
+  end
+
+  defp reset_event_store(conn, config) do
+    EventStore.Storage.Initializer.reset!(conn, config)
+  end
+end

--- a/test/support/structs/test_rollup_event.ex
+++ b/test/support/structs/test_rollup_event.ex
@@ -1,0 +1,10 @@
+defmodule TestRollupEvent do
+  @moduledoc false
+
+  use Trento.Event
+
+  defevent do
+    field :data, :string
+    field :applied, :boolean, default: false
+  end
+end

--- a/test/trento/application/usecases/rollup_test.exs
+++ b/test/trento/application/usecases/rollup_test.exs
@@ -3,10 +3,6 @@ defmodule Trento.RollupTest do
 
   alias Trento.Rollup
 
-  test "should rollback if no stream was found" do
-    {:error, :rollback} = Rollup.rollup_aggregate(Faker.UUID.v4(), %TestRollupEvent{})
-  end
-
   test "should rollup and append an applied rollup event", %{conn: conn} do
     stream_id = Faker.UUID.v4()
     event = %TestRollupEvent{data: "data"}
@@ -35,5 +31,10 @@ defmodule Trento.RollupTest do
                 data: %TestRollupEvent{data: "data", applied: true}
               }
             ]} = Trento.EventStore.read_stream_forward(stream_id)
+  end
+
+  @tag capture_log: true
+  test "should rollback if no stream was found" do
+    {:error, :rollback} = Rollup.rollup_aggregate(Faker.UUID.v4(), %TestRollupEvent{})
   end
 end

--- a/test/trento/application/usecases/rollup_test.exs
+++ b/test/trento/application/usecases/rollup_test.exs
@@ -1,0 +1,39 @@
+defmodule Trento.RollupTest do
+  use Trento.EventStoreCase, async: false
+
+  alias Trento.Rollup
+
+  test "should rollback if no stream was found" do
+    {:error, :rollback} = Rollup.rollup_aggregate(Faker.UUID.v4(), %TestRollupEvent{})
+  end
+
+  test "should rollup and append an applied rollup event", %{conn: conn} do
+    stream_id = Faker.UUID.v4()
+    event = %TestRollupEvent{data: "data"}
+
+    :ok =
+      Trento.EventStore.append_to_stream(
+        stream_id,
+        0,
+        [
+          %EventStore.EventData{
+            causation_id: UUID.uuid4(),
+            correlation_id: UUID.uuid4(),
+            event_type: Commanded.EventStore.TypeProvider.to_string(event),
+            data: event,
+            metadata: %{}
+          }
+        ],
+        conn: conn
+      )
+
+    assert {:ok, :ok} = Rollup.rollup_aggregate(stream_id, event)
+
+    assert {:ok,
+            [
+              %EventStore.RecordedEvent{
+                data: %TestRollupEvent{data: "data", applied: true}
+              }
+            ]} = Trento.EventStore.read_stream_forward(stream_id)
+  end
+end


### PR DESCRIPTION
This PR adds the rollup integration test.
Adds an event store case helper that resets the test eventstore every time a test runs against the ES.
