### PR TITLE
Add Accept Eula openapi spec

### DIFF
--- a/lib/trento_web/controllers/settings_controller.ex
+++ b/lib/trento_web/controllers/settings_controller.ex
@@ -3,6 +3,13 @@ defmodule TrentoWeb.SettingsController do
 
   alias Trento.Installation
 
+  alias TrentoWeb.OpenApi.Schema
+
+  use OpenApiSpex.ControllerSpecs
+
+  operation :settings, false
+
+  @spec settings(Plug.Conn.t(), any) :: Plug.Conn.t()
   def settings(conn, _) do
     conn
     |> json(%{
@@ -11,6 +18,17 @@ defmodule TrentoWeb.SettingsController do
     })
   end
 
+  operation :accept_eula,
+    summary: "Accept Eula",
+    tags: ["Platform"],
+    description: "Accepting EULA allows the end user to use the platform",
+    responses: [
+      ok:
+        {"EULA acceptance has been correctly registered and the user may continue using the platform",
+         "application/json", Schema.Common.EmptyResponse}
+    ]
+
+  @spec accept_eula(Plug.Conn.t(), any) :: Plug.Conn.t()
   def accept_eula(conn, _) do
     :ok = Installation.accept_eula()
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8167114/169839884-aa5981f2-5fcd-41f9-bada-7d2d01b0aa66.png)

- [x] GET     /api/hosts
- [x] GET     /api/clusters
- [x] GET     /api/sap_systems
- [x] GET     /api/databases
- [x] GET     /api/checks/catalog
- [x] POST    /api/clusters/:cluster_id/checks
- [x] POST    /api/clusters/:cluster_id/checks/request_execution
- [x] POST    /api/runner/callback
- [x] GET /api/installation/api-key
- [x] GET /api/sap_systems/health
- [x] POST /api/accept_eula
- [ ] GET /api/about
- [ ] GET /api/settings

Follows up https://github.com/trento-project/web/pull/512 https://github.com/trento-project/web/pull/522 https://github.com/trento-project/web/pull/528 https://github.com/trento-project/web/pull/536 https://github.com/trento-project/web/pull/546 https://github.com/trento-project/web/pull/558 https://github.com/trento-project/web/pull/569 https://github.com/trento-project/web/pull/570 https://github.com/trento-project/web/pull/579