### PR TITLE
Adds Platform Settings OpenApi spec

### DIFF
--- a/lib/trento_web/controllers/settings_controller.ex
+++ b/lib/trento_web/controllers/settings_controller.ex
@@ -7,7 +7,13 @@ defmodule TrentoWeb.SettingsController do
 
   use OpenApiSpex.ControllerSpecs
 
-  operation :settings, false
+  operation :settings,
+    summary: "Platform Settings",
+    tags: ["Platform"],
+    description: "Provides the Platform Settings for the current installation.",
+    responses: [
+      ok: {"Platform Settings", "application/json", Schema.Platform.Settings}
+    ]
 
   @spec settings(Plug.Conn.t(), any) :: Plug.Conn.t()
   def settings(conn, _) do

--- a/lib/trento_web/openapi/schema/platform.ex
+++ b/lib/trento_web/openapi/schema/platform.ex
@@ -1,0 +1,26 @@
+defmodule TrentoWeb.OpenApi.Schema.Platform do
+  @moduledoc false
+
+  require OpenApiSpex
+  alias OpenApiSpex.Schema
+
+  defmodule Settings do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "PlatformSettings",
+      description: "Settings values for the current installation",
+      type: :object,
+      properties: %{
+        eula_accepted: %Schema{
+          type: :boolean,
+          description: "Whether the user has accepted EULA (on a Premium installation)"
+        },
+        premium_subscription: %Schema{
+          type: :boolean,
+          description: "Whether current installation is a Premium one"
+        }
+      }
+    })
+  end
+end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8167114/169973871-d13b212f-3552-4af6-8007-9f4da1c84bba.png)

![image](https://user-images.githubusercontent.com/8167114/169973803-0875f28a-026d-432b-b114-dc631c0dd0b5.png)

- [x] GET     /api/hosts
- [x] GET     /api/clusters
- [x] GET     /api/sap_systems
- [x] GET     /api/databases
- [x] GET     /api/checks/catalog
- [x] POST    /api/clusters/:cluster_id/checks
- [x] POST    /api/clusters/:cluster_id/checks/request_execution
- [x] POST    /api/runner/callback
- [x] GET /api/installation/api-key
- [x] GET /api/sap_systems/health
- [x] POST /api/accept_eula
- [x] GET /api/settings
- [ ] GET /api/about

Follows up https://github.com/trento-project/web/pull/512 https://github.com/trento-project/web/pull/522 https://github.com/trento-project/web/pull/528 https://github.com/trento-project/web/pull/536 https://github.com/trento-project/web/pull/546 https://github.com/trento-project/web/pull/558 https://github.com/trento-project/web/pull/569 https://github.com/trento-project/web/pull/570 https://github.com/trento-project/web/pull/579 https://github.com/trento-project/web/pull/581