### PR TITLE
About openapi

### DIFF
--- a/lib/trento_web/controllers/about_controller.ex
+++ b/lib/trento_web/controllers/about_controller.ex
@@ -3,7 +3,19 @@ defmodule TrentoWeb.AboutController do
 
   alias Trento.Hosts
 
+  alias TrentoWeb.OpenApi.Schema
+
+  use OpenApiSpex.ControllerSpecs
+
   @version Mix.Project.config()[:version]
+
+  operation :info,
+    summary: "Platform General Information",
+    tags: ["Platform"],
+    description: "Provides general information about the current Platform installation.",
+    responses: [
+      ok: {"Platform Information", "application/json", Schema.Platform.GeneralInformation}
+    ]
 
   @spec info(Plug.Conn.t(), map) :: Plug.Conn.t()
   def info(conn, _) do

--- a/lib/trento_web/openapi/schema/platform.ex
+++ b/lib/trento_web/openapi/schema/platform.ex
@@ -23,4 +23,29 @@ defmodule TrentoWeb.OpenApi.Schema.Platform do
       }
     })
   end
+
+  defmodule GeneralInformation do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "GeneralInformation",
+      description: "General information about the current installation",
+      type: :object,
+      properties: %{
+        flavor: %Schema{
+          type: :string,
+          description: "Flavor of the current installation",
+          enum: ["Community", "Premium"]
+        },
+        version: %Schema{
+          type: :string,
+          description: "Version of the current server component installation"
+        },
+        sles_subscriptions: %Schema{
+          type: :integer,
+          description: "The number of SLES Subscription discovered on the target infrastructure"
+        }
+      }
+    })
+  end
 end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8167114/169978149-38f46908-baa1-4588-bc76-e01729c65f9d.png)

![image](https://user-images.githubusercontent.com/8167114/169978307-3a1ad4c8-0476-43bb-adb0-4ce077466acd.png)

- [x] GET     /api/hosts
- [x] GET     /api/clusters
- [x] GET     /api/sap_systems
- [x] GET     /api/databases
- [x] GET     /api/checks/catalog
- [x] POST    /api/clusters/:cluster_id/checks
- [x] POST    /api/clusters/:cluster_id/checks/request_execution
- [x] POST    /api/runner/callback
- [x] GET /api/installation/api-key
- [x] GET /api/sap_systems/health
- [x] POST /api/accept_eula
- [x] GET /api/settings
- [x] GET /api/about

Follows up https://github.com/trento-project/web/pull/512 https://github.com/trento-project/web/pull/522 https://github.com/trento-project/web/pull/528 https://github.com/trento-project/web/pull/536 https://github.com/trento-project/web/pull/546 https://github.com/trento-project/web/pull/558 https://github.com/trento-project/web/pull/569 https://github.com/trento-project/web/pull/570 https://github.com/trento-project/web/pull/579 https://github.com/trento-project/web/pull/581 https://github.com/trento-project/web/pull/584