### PR TITLE
Add the possibility to decode lists of items with deftype

### DIFF
--- a/lib/trento/support/type.ex
+++ b/lib/trento/support/type.ex
@@ -100,6 +100,19 @@ defmodule Trento.Type do
       def cast_and_validate_required_embed(changeset, field, required_fields),
         do: cast_embed(changeset, field, required: field in required_fields)
 
+      def from_list(list_of_structs) do
+        list_of_structs
+        |> Enum.map(fn item -> __MODULE__.new(item) end)
+        |> Enum.group_by(
+          fn {is_valid, _} -> is_valid end,
+          fn {_, decoding_value} -> decoding_value end
+        )
+        |> decoding_results()
+      end
+
+      defp decoding_results(%{error: decoding_errors}), do: {:error, decoding_errors}
+      defp decoding_results(%{ok: decoding_results}), do: {:ok, decoding_results}
+
       defp fields, do: __MODULE__.__schema__(:fields) -- __MODULE__.__schema__(:embeds)
 
       defp embedded_fields, do: __MODULE__.__schema__(:embeds)

--- a/test/trento/support/type_test.exs
+++ b/test/trento/support/type_test.exs
@@ -33,4 +33,56 @@ defmodule Trento.TypeTest do
                name: "a"
              })
   end
+
+  test "should validate a list of maps" do
+    assert {:error, [%{embedded: ["can't be blank"]}, %{embedded: ["can't be blank"]}]} ==
+             TestData.from_list([
+               %{id: Faker.UUID.v4(), name: "carbonara"},
+               %{id: Faker.UUID.v4(), name: "amatriciana"}
+             ])
+
+    assert {:error, [%{embedded: ["can't be blank"]}, %{embedded: ["can't be blank"]}]} ==
+             TestData.from_list([
+               %{id: Faker.UUID.v4(), name: "carbonara"},
+               %{id: Faker.UUID.v4(), name: "amatriciana"},
+               %{
+                 id: Faker.UUID.v4(),
+                 name: "cacio_pepe",
+                 embedded: %{id: Faker.UUID.v4(), name: "yay"}
+               }
+             ])
+
+    {
+      :ok,
+      [
+        %TestData{
+          embedded: %EmbeddedTestData{id: _id1, name: "yay"},
+          id: _id2,
+          name: "cacio_pepe"
+        },
+        %TestData{
+          embedded: %EmbeddedTestData{
+            id: _id3,
+            name: "wow"
+          },
+          id: _id4,
+          name: "lasagne"
+        }
+      ] = decoded_list
+    } =
+      TestData.from_list([
+        %{
+          id: Faker.UUID.v4(),
+          name: "cacio_pepe",
+          embedded: %{id: Faker.UUID.v4(), name: "yay"}
+        },
+        %{
+          id: Faker.UUID.v4(),
+          name: "lasagne",
+          embedded: %{id: Faker.UUID.v4(), name: "wow"}
+        }
+      ])
+
+    assert 2 == length(decoded_list)
+  end
 end


### PR DESCRIPTION
Adding a new `from_list` function to `deftype` macro. This will allow us to decode payloads incoming as lists without too much boilerplate, returning meaningful errors in case of them, or just plain results. Of course the default behavior uses tagged tuples for flow control, if we want we can add banged functions to raise. At the moment I didn't feel the need for that.

Tests are pretty self-explaining.