### PR TITLE
Expose a valid OpenApi specification

### DIFF
--- a/lib/trento_web/controllers/cluster_controller.ex
+++ b/lib/trento_web/controllers/cluster_controller.ex
@@ -68,13 +68,7 @@ defmodule TrentoWeb.ClusterController do
     tags: ["Checks"],
     description:
       "The Runner executing the Checks Selection on the target infrastructure, publishes updates about the progress of the Execution.",
-    parameters: [
-      callback_event: [
-        in: :body,
-        required: true,
-        type: Schema.Runner.CallbackEvent
-      ]
-    ],
+    request_body: {"Callback Event", "application/json", Schema.Runner.CallbackEvent},
     responses: [
       accepted:
         {"The Operation has been accepted, and the proper followup processes will trigger",
@@ -104,13 +98,9 @@ defmodule TrentoWeb.ClusterController do
     tags: ["Checks"],
     description: "Select the Checks eligible for execution on the target infrastructure",
     parameters: [
-      cluster_id: @cluster_id_schema,
-      selected_checks: [
-        in: :body,
-        required: true,
-        type: Schema.Checks.ChecksSelectionRequest
-      ]
+      cluster_id: @cluster_id_schema
     ],
+    request_body: {"Checks Selection", "application/json", Schema.Checks.ChecksSelectionRequest},
     responses: [
       accepted:
         {"The Selection has been successfully collected", "application/json",

--- a/lib/trento_web/openapi/schema/host.ex
+++ b/lib/trento_web/openapi/schema/host.ex
@@ -40,7 +40,7 @@ defmodule TrentoWeb.OpenApi.Schema.Host do
           type: :array,
           description: "IP addresses",
           items: %Schema{
-            title: "IP address",
+            title: "IPAddress",
             oneOf: [
               IPv4,
               IPv6


### PR DESCRIPTION
I noticed our openapi spec is not valid (shame on me :smile: )

![image](https://user-images.githubusercontent.com/8167114/170996098-8d867ae1-5c43-498d-8081-73f937f7cffe.png)

here are the reasons https://validator.swagger.io/validator/debug?url=http%3A%2F%2Fdemo.trento-project.io%2Fapi%2Fopenapi

```json
{
  "messages": [
    "attribute paths.'/api/clusters/{cluster_id}/checks'(post).parameters.[selected_checks].in is not of type `string`",
    "attribute paths.'/api/runner/callback'(post).parameters.[callback_event].in is not of type `string`",
    "attribute components.schemas.Schema name IP address doesn't adhere to regular expression ^[a-zA-Z0-9\\.\\-_]+$"
  ],
  "schemaValidationMessages": [
    {
      "level": "error",
      "domain": "validation",
      "keyword": "oneOf",
      "message": "instance failed to match exactly one schema (matched 0 out of 2)",
      "schema": {
        "loadingURI": "#",
        "pointer": "/definitions/Operation/properties/parameters/items"
      },
      "instance": {
        "pointer": "/paths/~1api~1clusters~1{cluster_id}~1checks/post/parameters/1"
      }
    }
  ]
}
```

with these changes we it's green again
![image](https://user-images.githubusercontent.com/8167114/170996508-a30acd05-e93c-4cdd-8664-81eac0d690d2.png)

![image](https://user-images.githubusercontent.com/8167114/170996727-04b80a2b-9dea-4d00-a405-966ff8ee3dd8.png)

![image](https://user-images.githubusercontent.com/8167114/170996779-fc531d68-d40c-434a-91ea-3a784b020998.png)
