### PR TITLE
Handle empty list in from_list function

### DIFF
--- a/lib/trento/support/type.ex
+++ b/lib/trento/support/type.ex
@@ -112,6 +112,7 @@ defmodule Trento.Type do
 
       defp decoding_results(%{error: decoding_errors}), do: {:error, decoding_errors}
       defp decoding_results(%{ok: decoding_results}), do: {:ok, decoding_results}
+      defp decoding_results(_), do: {:ok, []}
 
       defp fields, do: __MODULE__.__schema__(:fields) -- __MODULE__.__schema__(:embeds)
 

--- a/test/trento/support/type_test.exs
+++ b/test/trento/support/type_test.exs
@@ -52,6 +52,8 @@ defmodule Trento.TypeTest do
                }
              ])
 
+    assert {:ok, []} == TestData.from_list([])
+
     {
       :ok,
       [


### PR DESCRIPTION
Handle empty lists in the payload, in the `from_list` function. This scenario happens in the SAP system payload, when no sap system is found.

```
** (exit) an exception was raised:
    ** (FunctionClauseError) no function clause matching in Trento.Integration.Discovery.SapSystemDiscoveryPayload.decoding_results/1
        (trento 1.0.0) lib/trento/application/integration/discovery/payloads/sap_system_discovery_payload.ex:14: Trento.Integration.Discovery.SapSystemDiscoveryPayload.decoding_results(%{})
        (trento 1.0.0) lib/trento/application/integration/discovery/policies/sap_system_policy.ex:32: Trento.Integration.Discovery.SapSystemPolicy.handle/1
```