### PR TITLE
Refactor from_list in new

### DIFF
--- a/lib/trento/application/integration/discovery/policies/host_policy.ex
+++ b/lib/trento/application/integration/discovery/policies/host_policy.ex
@@ -60,7 +60,7 @@ defmodule Trento.Integration.Discovery.HostPolicy do
         "payload" => payload
       }) do
     payload
-    |> SlesSubscriptionDiscoveryPayload.from_list()
+    |> SlesSubscriptionDiscoveryPayload.new()
     |> case do
       {:ok, decoded_payload} -> build_update_sles_subscriptions_command(agent_id, decoded_payload)
       error -> error

--- a/lib/trento/application/integration/discovery/policies/sap_system_policy.ex
+++ b/lib/trento/application/integration/discovery/policies/sap_system_policy.ex
@@ -29,7 +29,7 @@ defmodule Trento.Integration.Discovery.SapSystemPolicy do
         "agent_id" => agent_id,
         "payload" => payload
       }) do
-    case SapSystemDiscoveryPayload.from_list(payload) do
+    case SapSystemDiscoveryPayload.new(payload) do
       {:ok, sap_systems} ->
         sap_systems
         |> Enum.flat_map(fn sap_system -> build_commands(sap_system, agent_id) end)

--- a/test/trento/support/type_test.exs
+++ b/test/trento/support/type_test.exs
@@ -1,90 +1,113 @@
 defmodule Trento.TypeTest do
   use ExUnit.Case
 
-  test "should return errors if the parameters of an embedded field could not be validated" do
-    assert {:error, %{embedded: %{id: ["is invalid"]}}} =
-             TestData.new(%{
-               id: Faker.UUID.v4(),
-               name: "a",
-               embedded: %{
-                 id: 1,
-                 name: Faker.StarWars.planet()
-               }
-             })
-  end
+  describe "build a struct" do
+    test "should return errors if the parameters of an embedded field could not be validated" do
+      assert {:error, %{embedded: %{id: ["is invalid"]}}} =
+               TestData.new(%{
+                 id: Faker.UUID.v4(),
+                 name: "a",
+                 embedded: %{
+                   id: 1,
+                   name: Faker.StarWars.planet()
+                 }
+               })
+    end
 
-  test "should raise a RuntimeError  if the parameters of an embedded field could not be validated" do
-    assert_raise RuntimeError, "%{embedded: %{id: [\"is invalid\"]}}", fn ->
-      TestData.new!(%{
-        id: Faker.UUID.v4(),
-        name: "a",
-        embedded: %{
-          id: 2,
-          name: Faker.StarWars.planet()
-        }
-      })
+    test "should raise a RuntimeError  if the parameters of an embedded field could not be validated" do
+      assert_raise RuntimeError, "%{embedded: %{id: [\"is invalid\"]}}", fn ->
+        TestData.new!(%{
+          id: Faker.UUID.v4(),
+          name: "a",
+          embedded: %{
+            id: 2,
+            name: Faker.StarWars.planet()
+          }
+        })
+      end
+    end
+
+    test "should validate the presence of a required embedded field" do
+      assert {:error, %{embedded: ["can't be blank"]}} ==
+               TestData.new(%{
+                 id: Faker.UUID.v4(),
+                 name: "a"
+               })
     end
   end
 
-  test "should validate the presence of a required embedded field" do
-    assert {:error, %{embedded: ["can't be blank"]}} ==
-             TestData.new(%{
-               id: Faker.UUID.v4(),
-               name: "a"
-             })
-  end
+  describe "build a list of structs" do
+    test "should validate the presence of a required embedded field" do
+      assert {:error, [%{embedded: ["can't be blank"]}, %{embedded: ["can't be blank"]}]} ==
+               TestData.new([
+                 %{id: Faker.UUID.v4(), name: "carbonara"},
+                 %{id: Faker.UUID.v4(), name: "amatriciana"}
+               ])
 
-  test "should validate a list of maps" do
-    assert {:error, [%{embedded: ["can't be blank"]}, %{embedded: ["can't be blank"]}]} ==
-             TestData.from_list([
-               %{id: Faker.UUID.v4(), name: "carbonara"},
-               %{id: Faker.UUID.v4(), name: "amatriciana"}
-             ])
+      assert {:error, [%{embedded: ["can't be blank"]}, %{embedded: ["can't be blank"]}]} ==
+               TestData.new([
+                 %{id: Faker.UUID.v4(), name: "carbonara"},
+                 %{id: Faker.UUID.v4(), name: "amatriciana"},
+                 %{
+                   id: Faker.UUID.v4(),
+                   name: "cacio_pepe",
+                   embedded: %{id: Faker.UUID.v4(), name: "yay"}
+                 }
+               ])
+    end
 
-    assert {:error, [%{embedded: ["can't be blank"]}, %{embedded: ["can't be blank"]}]} ==
-             TestData.from_list([
-               %{id: Faker.UUID.v4(), name: "carbonara"},
-               %{id: Faker.UUID.v4(), name: "amatriciana"},
-               %{
-                 id: Faker.UUID.v4(),
-                 name: "cacio_pepe",
-                 embedded: %{id: Faker.UUID.v4(), name: "yay"}
-               }
-             ])
+    test "should return an empty list" do
+      assert {:ok, []} == TestData.new([])
 
-    assert {:ok, []} == TestData.from_list([])
+      assert [] == TestData.new!([])
+    end
 
-    {
-      :ok,
-      [
-        %TestData{
-          embedded: %EmbeddedTestData{id: _id1, name: "yay"},
-          id: _id2,
-          name: "cacio_pepe"
-        },
-        %TestData{
-          embedded: %EmbeddedTestData{
-            id: _id3,
-            name: "wow"
+    test "should return a list of structs" do
+      {
+        :ok,
+        [
+          %TestData{
+            embedded: %EmbeddedTestData{id: _id1, name: "yay"},
+            id: _id2,
+            name: "cacio_pepe"
           },
-          id: _id4,
-          name: "lasagne"
-        }
-      ] = decoded_list
-    } =
-      TestData.from_list([
-        %{
-          id: Faker.UUID.v4(),
-          name: "cacio_pepe",
-          embedded: %{id: Faker.UUID.v4(), name: "yay"}
-        },
-        %{
-          id: Faker.UUID.v4(),
-          name: "lasagne",
-          embedded: %{id: Faker.UUID.v4(), name: "wow"}
-        }
-      ])
+          %TestData{
+            embedded: %EmbeddedTestData{
+              id: _id3,
+              name: "wow"
+            },
+            id: _id4,
+            name: "lasagne"
+          }
+        ]
+      } =
+        TestData.new([
+          %{
+            id: Faker.UUID.v4(),
+            name: "cacio_pepe",
+            embedded: %{id: Faker.UUID.v4(), name: "yay"}
+          },
+          %{
+            id: Faker.UUID.v4(),
+            name: "lasagne",
+            embedded: %{id: Faker.UUID.v4(), name: "wow"}
+          }
+        ])
+    end
 
-    assert 2 == length(decoded_list)
+    test "should raise a RuntimeError if the parameters of an embedded field could not be validated" do
+      assert_raise RuntimeError, "[%{embedded: %{id: [\"is invalid\"]}}]", fn ->
+        TestData.new!([
+          %{
+            id: Faker.UUID.v4(),
+            name: "a",
+            embedded: %{
+              id: 2,
+              name: Faker.StarWars.planet()
+            }
+          }
+        ])
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR refactors `deftype` `from_list` in `new`.
As a happy accident,  the banged version `new!` now works for lists of structs too.

Cleaned up and improved tests as well.