### PR TITLE
Ecto decode clusters discovery

### DIFF
--- a/lib/trento/application/integration/discovery/payloads/cluster/cib_discovery_payload.ex
+++ b/lib/trento/application/integration/discovery/payloads/cluster/cib_discovery_payload.ex
@@ -1,0 +1,145 @@
+defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload.Cib do
+  @moduledoc """
+  Cib field payload
+  """
+  alias Trento.Support.ListHelper
+
+  defmodule Primitive do
+    @moduledoc """
+    Primitive field payload
+    """
+
+    @required_fields [:id, :type, :class, :operations, :instance_attributes]
+    use Trento.Type
+
+    deftype do
+      field :id, :string
+      field :type, :string
+      field :class, :string
+      field :provider, :string
+
+      embeds_many :operations, Operation, primary_key: false do
+        field :id, :string
+        field :name, :string
+        field :role, :string
+        field :timeout, :string
+        field :interval, :string
+      end
+
+      embeds_many :instance_attributes, InstanceAttribute, primary_key: false do
+        field :id, :string
+        field :name, :string
+        field :value, :string
+      end
+    end
+
+    defp transform_nil_lists(
+           %{"operations" => operations, "instance_attributes" => instance_attributes} = attrs
+         ) do
+      attrs
+      |> Map.put("operations", ListHelper.to_list(operations))
+      |> Map.put("instance_attributes", ListHelper.to_list(instance_attributes))
+    end
+
+    def changeset(primitive, attrs) do
+      filtered_attrs = transform_nil_lists(attrs)
+
+      primitive
+      |> cast(filtered_attrs, [:id, :type, :class, :provider])
+      |> cast_embed(:operations, with: &operations_changeset/2)
+      |> cast_embed(:instance_attributes, with: &instance_attributes_changeset/2)
+      |> validate_required_fields(@required_fields)
+    end
+
+    defp operations_changeset(operations, attrs) do
+      operations
+      |> cast(attrs, [:id, :name, :role, :timeout, :interval])
+      |> validate_required_fields([:id, :name, :role])
+    end
+
+    defp instance_attributes_changeset(instance_attributes, attrs) do
+      instance_attributes
+      |> cast(attrs, [:id, :name, :value])
+      |> validate_required_fields([:id, :name, :value])
+    end
+  end
+
+  defmodule CibResources do
+    @moduledoc """
+    Resources field payload
+    """
+
+    @required_fields [:primitives, :clones, :groups]
+    use Trento.Type
+
+    deftype do
+      embeds_many :primitives, Primitive
+
+      embeds_many :clones, Clone, primary_key: false do
+        field :id, :string
+
+        embeds_one :primitive, Primitive
+      end
+
+      embeds_many :groups, Group, primary_key: false do
+        field :id, :string
+
+        embeds_many :primitives, Primitive
+      end
+    end
+
+    def changeset(cib_resources, attrs) do
+      filtered_attrs = transform_nil_lists(attrs)
+
+      cib_resources
+      |> cast(filtered_attrs, [])
+      |> cast_embed(:primitives)
+      |> cast_embed(:clones, with: &clones_changeset/2)
+      |> cast_embed(:groups, with: &groups_changeset/2)
+      |> validate_required_fields(@required_fields)
+    end
+
+    defp clones_changeset(clones, attrs) do
+      clones
+      |> cast(attrs, [:id])
+      |> cast_embed(:primitive)
+      |> validate_required_fields([:id])
+    end
+
+    defp groups_changeset(groups, attrs) do
+      groups
+      |> cast(attrs, [:id])
+      |> cast_embed(:primitives)
+      |> validate_required_fields([:id])
+    end
+
+    defp transform_nil_lists(%{"groups" => groups} = attrs) do
+      attrs
+      |> Map.put("groups", ListHelper.to_list(groups))
+    end
+  end
+
+  @required_fields [:configuration]
+
+  use Trento.Type
+
+  deftype do
+    embeds_one :configuration, Configuration do
+      embeds_one :resources, CibResources
+    end
+  end
+
+  def changeset(cib, attrs) do
+    cib
+    |> cast(attrs, [])
+    |> cast_embed(:configuration, with: &configuration_changeset/2)
+    |> validate_required_fields(@required_fields)
+  end
+
+  def configuration_changeset(configuration, attrs) do
+    configuration
+    |> cast(attrs, [])
+    |> cast_embed(:resources)
+    |> validate_required_fields([:resources])
+  end
+end

--- a/lib/trento/application/integration/discovery/payloads/cluster/cluster_discovery_payload.ex
+++ b/lib/trento/application/integration/discovery/payloads/cluster/cluster_discovery_payload.ex
@@ -9,7 +9,7 @@ defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload do
     Sbd
   }
 
-  @required_fields [:dc, :provider, :id, :cluster_type, :sid, :cib, :sbd, :crmmon]
+  @required_fields [:dc, :provider, :id, :cluster_type, :cib, :sbd, :crmmon]
 
   @required_fields_hana [:sid]
   use Trento.Type
@@ -29,7 +29,8 @@ defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload do
 
   def changeset(cluster, attrs) do
     enriched_attributes =
-      enrich_cluster_type(attrs)
+      attrs
+      |> enrich_cluster_type
       |> enrich_cluster_sid
 
     cluster

--- a/lib/trento/application/integration/discovery/payloads/cluster/cluster_discovery_payload.ex
+++ b/lib/trento/application/integration/discovery/payloads/cluster/cluster_discovery_payload.ex
@@ -1,0 +1,109 @@
+defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload do
+  @moduledoc """
+  Cluster discovery integration event payload
+  """
+
+  alias Trento.Integration.Discovery.ClusterDiscoveryPayload.{
+    Cib,
+    Crmmon,
+    Sbd
+  }
+
+  @required_fields [:dc, :provider, :id, :cluster_type, :sid, :cib, :sbd, :crmmon]
+
+  @required_fields_hana [:sid]
+  use Trento.Type
+
+  deftype do
+    field :dc, :boolean
+    field :provider, Ecto.Enum, values: [:aws, :gcp, :azure, :unknown], default: :unknown
+    field :id, :string
+    field :name, :string
+    field :cluster_type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
+    field :sid, :string
+
+    embeds_one :cib, Cib
+    embeds_one :sbd, Sbd
+    embeds_one :crmmon, Crmmon
+  end
+
+  def changeset(cluster, attrs) do
+    enriched_attributes =
+      enrich_cluster_type(attrs)
+      |> enrich_cluster_sid
+
+    cluster
+    |> cast(enriched_attributes, fields())
+    |> cast_embed(:cib)
+    |> cast_embed(:sbd)
+    |> cast_embed(:crmmon)
+    |> validate_required_fields(@required_fields)
+    |> maybe_validate_required_fields(enriched_attributes)
+  end
+
+  defp enrich_cluster_type(attrs),
+    do: attrs |> Map.put("cluster_type", parse_cluster_type(attrs))
+
+  defp enrich_cluster_sid(attrs), do: attrs |> Map.put("sid", parse_cluster_sid(attrs))
+
+  defp parse_cluster_type(%{"crmmon" => %{"clones" => nil}}), do: :unknown
+
+  defp parse_cluster_type(%{"crmmon" => %{"clones" => clones}}) do
+    has_sap_hana_topology =
+      Enum.any?(clones, fn %{"resources" => resources} ->
+        Enum.any?(resources, fn %{"agent" => agent} -> agent == "ocf::suse:SAPHanaTopology" end)
+      end)
+
+    has_sap_hana =
+      Enum.any?(clones, fn %{"resources" => resources} ->
+        Enum.any?(resources, fn %{"agent" => agent} -> agent == "ocf::suse:SAPHana" end)
+      end)
+
+    has_sap_hana_controller =
+      Enum.any?(clones, fn %{"resources" => resources} ->
+        Enum.any?(resources, fn %{"agent" => agent} ->
+          agent == "ocf::suse:SAPHanaController"
+        end)
+      end)
+
+    do_detect_cluster_type(has_sap_hana_topology, has_sap_hana, has_sap_hana_controller)
+  end
+
+  defp do_detect_cluster_type(true, true, _), do: :hana_scale_up
+  defp do_detect_cluster_type(true, _, true), do: :hana_scale_out
+  defp do_detect_cluster_type(_, _, _), do: :unknown
+
+  defp parse_cluster_sid(%{
+         "cib" => %{"configuration" => %{"resources" => %{"clones" => nil}}}
+       }),
+       do: nil
+
+  defp parse_cluster_sid(%{
+         "cib" => %{"configuration" => %{"resources" => %{"clones" => clones}}}
+       }) do
+    clones
+    |> Enum.find_value([], fn
+      %{"primitive" => %{"type" => "SAPHanaTopology", "instance_attributes" => attributes}} ->
+        attributes
+
+      _ ->
+        nil
+    end)
+    |> Enum.find_value(nil, fn
+      %{"name" => "SID", "value" => value} when value != "" ->
+        value
+
+      _ ->
+        nil
+    end)
+  end
+
+  defp maybe_validate_required_fields(cluster, %{"cluster_type" => :hana_scale_up}),
+    do: cluster |> validate_required(@required_fields_hana)
+
+  defp maybe_validate_required_fields(cluster, %{"cluster_type" => :hana_scale_out}),
+    do: cluster |> validate_required(@required_fields_hana)
+
+  defp maybe_validate_required_fields(cluster, _),
+    do: cluster
+end

--- a/lib/trento/application/integration/discovery/payloads/cluster/crmmon_discovery_payload.ex
+++ b/lib/trento/application/integration/discovery/payloads/cluster/crmmon_discovery_payload.ex
@@ -1,0 +1,274 @@
+defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload.Crmmon do
+  @moduledoc """
+  Crmmon field payload
+  """
+  alias Trento.Support.ListHelper
+
+  defmodule NodeHistory do
+    @moduledoc """
+    NodeHistory field payload
+    """
+
+    @required_fields [:nodes]
+    use Trento.Type
+
+    deftype do
+      embeds_many :nodes, Node do
+        field :name, :string
+
+        embeds_many :resource_history, HistoryDetail do
+          field :name, :string
+          field :fail_count, :integer
+          field :migration_threshold, :integer
+        end
+      end
+    end
+
+    def changeset(node_history, attrs) do
+      node_history
+      |> cast(attrs, [])
+      |> cast_embed(:nodes, with: &nodes_changeset/2)
+      |> validate_required_fields(@required_fields)
+    end
+
+    def nodes_changeset(nodes, attrs) do
+      nodes
+      |> cast(attrs, [:name])
+      |> cast_embed(:resource_history, with: &resource_history_changeset/2)
+      |> validate_required_fields([:name, :resource_history])
+    end
+
+    def resource_history_changeset(resource_history, attrs) do
+      resource_history
+      |> cast(attrs, [:name, :fail_count, :migration_threshold])
+      |> validate_required_fields([:name, :fail_count, :migration_threshold])
+    end
+  end
+
+  defmodule CrmmonResource do
+    @moduledoc """
+    CrmmonResource field payload
+    """
+
+    @required_fields [
+      :id,
+      :role,
+      :agent,
+      :active,
+      :failed,
+      :blocked,
+      :managed,
+      :orphaned,
+      :failure_ignored,
+      :nodes_running_on,
+      :node
+    ]
+    use Trento.Type
+
+    deftype do
+      field :id, :string
+      field :role, :string
+      field :agent, :string
+      field :active, :boolean
+      field :failed, :boolean
+      field :blocked, :boolean
+      field :managed, :boolean
+      field :orphaned, :boolean
+      field :failure_ignored, :boolean
+      field :nodes_running_on, :integer
+
+      embeds_one :node, ResourceNode, primary_key: false do
+        field :id, :string
+        field :name, :string
+        field :cached, :boolean
+      end
+    end
+
+    def changeset(crmmon_resource, attrs) do
+      crmmon_resource
+      |> cast(attrs, [
+        :id,
+        :role,
+        :agent,
+        :active,
+        :failed,
+        :blocked,
+        :managed,
+        :orphaned,
+        :failure_ignored,
+        :nodes_running_on
+      ])
+      |> cast_embed(:node, with: &resource_node_changeset/2)
+      |> validate_required_fields(@required_fields)
+    end
+
+    defp resource_node_changeset(resource_node, attrs) do
+      resource_node
+      |> cast(attrs, [:id, :name, :cached])
+      |> validate_required_fields([])
+    end
+  end
+
+  defmodule Summary do
+    @moduledoc """
+    Summary field payload
+    """
+
+    @required_fields [:nodes, :resources, :last_change]
+    use Trento.Type
+
+    deftype do
+      embeds_one :nodes, NodesSummary do
+        field :number, :integer
+      end
+
+      embeds_one :resources, ResourceSummary do
+        field :number, :integer
+        field :blocked, :integer
+        field :disabled, :integer
+      end
+
+      embeds_one :last_change, LastChangeSummary do
+        field :time, :string
+      end
+    end
+
+    def changeset(summary, attrs) do
+      summary
+      |> cast(attrs, [])
+      |> cast_embed(:nodes, with: &nodes_changeset/2)
+      |> cast_embed(:resources, with: &resources_changeset/2)
+      |> cast_embed(:last_change, with: &last_change_changeset/2)
+      |> validate_required_fields(@required_fields)
+    end
+
+    def nodes_changeset(nodes, attrs) do
+      nodes
+      |> cast(attrs, [:number])
+      |> validate_required_fields([:number])
+    end
+
+    def resources_changeset(resources, attrs) do
+      resources
+      |> cast(attrs, [:number, :blocked, :disabled])
+      |> validate_required_fields([:number, :blocked, :disabled])
+    end
+
+    def last_change_changeset(last_change, attrs) do
+      last_change
+      |> cast(attrs, [:time])
+      |> validate_required_fields([:time])
+    end
+  end
+
+  @required_fields [
+    :version,
+    :summary,
+    :resources,
+    :clones,
+    :node_history,
+    :node_attributes
+  ]
+  use Trento.Type
+
+  deftype do
+    field :version, :string
+
+    embeds_one :summary, Summary
+
+    embeds_many :resources, CrmmonResource
+
+    embeds_many :groups, CrmmonGroup, primary_key: false do
+      field :id, :string
+
+      embeds_many :primitives, Primitive
+      embeds_many :resources, CrmmonResource
+    end
+
+    embeds_many :clones, CrmmonClone, primary_key: false do
+      field :id, :string
+      field :failed, :boolean
+      field :unique, :boolean
+      field :managed, :boolean
+      field :multi_state, :boolean
+      field :failure_ignored, :boolean
+
+      embeds_many :resources, CrmmonResource
+    end
+
+    embeds_one :node_history, NodeHistory
+
+    embeds_one :node_attributes, NodeAttributes do
+      embeds_many :nodes, Node do
+        field :name, :string
+
+        embeds_many :attributes, Attribute do
+          field :name, :string
+          field :value, :string
+        end
+      end
+    end
+  end
+
+  def changeset(crmmon, attrs) do
+    filtered_attrs = transform_nil_lists(attrs)
+
+    crmmon
+    |> cast(filtered_attrs, [:version])
+    |> cast_embed(:summary)
+    |> cast_embed(:resources)
+    |> cast_embed(:groups, with: &groups_changeset/2)
+    |> cast_embed(:clones, with: &clones_changeset/2)
+    |> cast_embed(:node_history)
+    |> cast_embed(:node_attributes, with: &node_attributes_changeset/2)
+    |> validate_required_fields(@required_fields)
+  end
+
+  defp groups_changeset(groups, attrs) do
+    groups
+    |> cast(attrs, [:id])
+    |> cast_embed(:resources)
+    |> cast_embed(:primitives)
+    |> validate_required_fields([:id, :resources, :primitives])
+  end
+
+  defp clones_changeset(clones, attrs) do
+    clones
+    |> cast(attrs, [:id, :failed, :unique, :managed, :multi_state, :failure_ignored])
+    |> cast_embed(:resources)
+    |> validate_required_fields([
+      :id,
+      :failed,
+      :unique,
+      :managed,
+      :multi_state,
+      :failure_ignored,
+      :resources
+    ])
+  end
+
+  defp node_attributes_changeset(node_attributes, attrs) do
+    node_attributes
+    |> cast(attrs, [])
+    |> cast_embed(:nodes, with: &nodes_changeset/2)
+    |> validate_required_fields([:nodes])
+  end
+
+  defp nodes_changeset(nodes, attrs) do
+    nodes
+    |> cast(attrs, [:name])
+    |> cast_embed(:attributes, with: &attributes_changeset/2)
+    |> validate_required_fields([:name, :attributes])
+  end
+
+  defp attributes_changeset(attributes, attrs) do
+    attributes
+    |> cast(attrs, [:name, :value])
+    |> validate_required_fields([:name, :value])
+  end
+
+  defp transform_nil_lists(%{"groups" => groups} = attrs) do
+    attrs
+    |> Map.put("groups", ListHelper.to_list(groups))
+  end
+end

--- a/lib/trento/application/integration/discovery/payloads/cluster/crmmon_discovery_payload.ex
+++ b/lib/trento/application/integration/discovery/payloads/cluster/crmmon_discovery_payload.ex
@@ -86,18 +86,7 @@ defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload.Crmmon do
 
     def changeset(crmmon_resource, attrs) do
       crmmon_resource
-      |> cast(attrs, [
-        :id,
-        :role,
-        :agent,
-        :active,
-        :failed,
-        :blocked,
-        :managed,
-        :orphaned,
-        :failure_ignored,
-        :nodes_running_on
-      ])
+      |> cast(attrs, fields())
       |> cast_embed(:node, with: &resource_node_changeset/2)
       |> validate_required_fields(@required_fields)
     end
@@ -211,10 +200,10 @@ defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload.Crmmon do
   end
 
   def changeset(crmmon, attrs) do
-    filtered_attrs = transform_nil_lists(attrs)
+    transformed_attrs = transform_nil_lists(attrs)
 
     crmmon
-    |> cast(filtered_attrs, [:version])
+    |> cast(transformed_attrs, [:version])
     |> cast_embed(:summary)
     |> cast_embed(:resources)
     |> cast_embed(:groups, with: &groups_changeset/2)
@@ -267,8 +256,14 @@ defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload.Crmmon do
     |> validate_required_fields([:name, :value])
   end
 
-  defp transform_nil_lists(%{"groups" => groups} = attrs) do
+  defp transform_nil_lists(
+         %{"groups" => groups, "clones" => clones, "resources" => resources} = attrs
+       ) do
     attrs
     |> Map.put("groups", ListHelper.to_list(groups))
+    |> Map.put("clones", ListHelper.to_list(clones))
+    |> Map.put("resources", ListHelper.to_list(resources))
   end
+
+  defp transform_nil_lists(attrs), do: attrs
 end

--- a/lib/trento/application/integration/discovery/payloads/cluster/sbd_discovery_payload.ex
+++ b/lib/trento/application/integration/discovery/payloads/cluster/sbd_discovery_payload.ex
@@ -8,16 +8,7 @@ defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload.Sbd do
   use Trento.Type
 
   deftype do
-    embeds_one :config, SBDConfig do
-      field :sbd_delay_start, :string
-      field :sbd_device, :string
-      field :sbd_move_to_root_cgroup, :string
-      field :sbd_pacemaker, :string
-      field :sbd_startmode, :string
-      field :sbd_timeout_action, :string
-      field :sbd_watchdog_dev, :string
-      field :sbd_watchdog_timeout, :string
-    end
+    field :config, :map
 
     embeds_many :devices, Device do
       field :device, :string
@@ -26,37 +17,12 @@ defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload.Sbd do
   end
 
   def changeset(sbd, attrs) do
-    filtered_attrs = transform_nil_lists(attrs)
+    transformed_attrs = transform_nil_lists(attrs)
 
     sbd
-    |> cast(filtered_attrs, [])
-    |> cast_embed(:config, with: &config_changeset/2)
+    |> cast(transformed_attrs, [:config])
     |> cast_embed(:devices, with: &devices_changeset/2)
     |> validate_required_fields(@required_fields)
-  end
-
-  defp config_changeset(config, attrs) do
-    config
-    |> cast(attrs, [
-      :sbd_delay_start,
-      :sbd_device,
-      :sbd_move_to_root_cgroup,
-      :sbd_pacemaker,
-      :sbd_startmode,
-      :sbd_timeout_action,
-      :sbd_watchdog_dev,
-      :sbd_watchdog_timeout
-    ])
-    |> validate_required_fields([
-      :sbd_delay_start,
-      :sbd_device,
-      :sbd_move_to_root_cgroup,
-      :sbd_pacemaker,
-      :sbd_startmode,
-      :sbd_timeout_action,
-      :sbd_watchdog_dev,
-      :sbd_watchdog_timeout
-    ])
   end
 
   defp devices_changeset(devices, attrs) do

--- a/lib/trento/application/integration/discovery/payloads/cluster/sbd_discovery_payload.ex
+++ b/lib/trento/application/integration/discovery/payloads/cluster/sbd_discovery_payload.ex
@@ -1,0 +1,72 @@
+defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload.Sbd do
+  @moduledoc """
+  SBD field payload
+  """
+  alias Trento.Support.ListHelper
+
+  @required_fields []
+  use Trento.Type
+
+  deftype do
+    embeds_one :config, SBDConfig do
+      field :sbd_delay_start, :string
+      field :sbd_device, :string
+      field :sbd_move_to_root_cgroup, :string
+      field :sbd_pacemaker, :string
+      field :sbd_startmode, :string
+      field :sbd_timeout_action, :string
+      field :sbd_watchdog_dev, :string
+      field :sbd_watchdog_timeout, :string
+    end
+
+    embeds_many :devices, Device do
+      field :device, :string
+      field :status, :string
+    end
+  end
+
+  def changeset(sbd, attrs) do
+    filtered_attrs = transform_nil_lists(attrs)
+
+    sbd
+    |> cast(filtered_attrs, [])
+    |> cast_embed(:config, with: &config_changeset/2)
+    |> cast_embed(:devices, with: &devices_changeset/2)
+    |> validate_required_fields(@required_fields)
+  end
+
+  defp config_changeset(config, attrs) do
+    config
+    |> cast(attrs, [
+      :sbd_delay_start,
+      :sbd_device,
+      :sbd_move_to_root_cgroup,
+      :sbd_pacemaker,
+      :sbd_startmode,
+      :sbd_timeout_action,
+      :sbd_watchdog_dev,
+      :sbd_watchdog_timeout
+    ])
+    |> validate_required_fields([
+      :sbd_delay_start,
+      :sbd_device,
+      :sbd_move_to_root_cgroup,
+      :sbd_pacemaker,
+      :sbd_startmode,
+      :sbd_timeout_action,
+      :sbd_watchdog_dev,
+      :sbd_watchdog_timeout
+    ])
+  end
+
+  defp devices_changeset(devices, attrs) do
+    devices
+    |> cast(attrs, [:device, :status])
+    |> validate_required_fields([:device, :status])
+  end
+
+  defp transform_nil_lists(%{"devices" => devices} = attrs) do
+    attrs
+    |> Map.put("devices", ListHelper.to_list(devices))
+  end
+end

--- a/lib/trento/support/list_helper.ex
+++ b/lib/trento/support/list_helper.ex
@@ -1,0 +1,13 @@
+defmodule Trento.Support.ListHelper do
+  @moduledoc """
+  This module provides list utility functions
+  """
+  @doc """
+  Converts a nil value to an empty list.
+  This is useful for changeset, where the field is an EmbedsMany but
+  the received value is nil instead of an empty list
+  """
+
+  def to_list(list) when is_list(list), do: list
+  def to_list(nil), do: []
+end


### PR DESCRIPTION
This big PR basically continues the effort to use Ecto to define and validate the payloads for the different discovery policies, already started by PRs #602, #595, #582.

This time it's the turn for the **cluster** discovery. Some notes/clarifications:

 - Sometimes I use nested / inline deftype's such as:
 ```
   deftype do
    embeds_one :configuration, Configuration do
      embeds_one :resources, CibResources
    end
  end
  ```
  Because it feels "wrong" to have all the boilerplate to create a new deftype just for one or few fields. The line on when to do this vs using a deftype is a bit blurry to me, so suggestions accepted on that.
  
 - Sometimes I had to use `cast(attrs, [])` (cast with nothing to cast) to be able to define deftypes that are pure nested structs (with no fields). Thanks to @fabriziosestito for poiting this out, looked weird initially but it makes sense now:
 ```
   def changeset(cib, attrs) do
    cib
    |> cast(attrs, [])
    ...
 ```
 
 - Sometimes, the agent sends `null` on a field that should have a list. This causes the payload validation to fail, and for such cases, the "workaround" that @arbulu89 came up with was to convert these fields to lists before the `changeset` get's called, passing a `filtered_attrs` to it.
 
 ```
    defp transform_nil_lists(%{"groups" => groups} = attrs) do
      attrs
      |> Map.put("groups", ListHelper.to_list(groups))
    end
    
    def to_list(list) when is_list(list), do: list
    def to_list(nil), do: []
```

Comments appreciated!
 