### PR TITLE
Display aws metadata frontend

### DIFF
--- a/.photofinish.toml
+++ b/.photofinish.toml
@@ -3,9 +3,11 @@
 directories = ["./test/fixtures/scenarios/healthy-27-node-SAP-cluster"]
 
 [aws-landscape]
+
 directories = ["./test/fixtures/scenarios/aws-landscape"]
 
 [gcp-landscape]
+
 directories = ["./test/fixtures/scenarios/gcp-landscape"]
 
 [sap-system-detail-GRAY]
@@ -95,3 +97,7 @@ files = ["./test/fixtures/scenarios/healthy-27-node-SAP-cluster/9cd46919-5f19-59
 [host-details-aws]
 
 files = ["./test/fixtures/scenarios/host-details/9cd46919-5f19-59aa-993e-cf3736c71053_cloud_discovery_aws.json"]
+
+[host-details-unknown]
+
+files = ["./test/fixtures/scenarios/host-details/9cd46919-5f19-59aa-993e-cf3736c71053_cloud_discovery_unknown.json"]

--- a/.photofinish.toml
+++ b/.photofinish.toml
@@ -87,3 +87,11 @@ files = ["./test/fixtures/scenarios/clusters-overview/13e8c25c-3180-5a9a-95c8-51
 [cluster-unnamed]
 
 files = ["./test/fixtures/scenarios/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_unnamed.json"]
+
+[host-details-azure]
+
+files = ["./test/fixtures/scenarios/healthy-27-node-SAP-cluster/9cd46919-5f19-59aa-993e-cf3736c71053_cloud_discovery.json"]
+
+[host-details-aws]
+
+files = ["./test/fixtures/scenarios/host-details/9cd46919-5f19-59aa-993e-cf3736c71053_cloud_discovery_aws.json"]

--- a/assets/js/components/HostDetails/AwsDetails.jsx
+++ b/assets/js/components/HostDetails/AwsDetails.jsx
@@ -25,12 +25,12 @@ const AwsDetails = ({ provider, provider_data }) => {
             title: 'Account ID',
             content: provider_data?.account_id,
           },
-          { title: 'Ami ID', content: provider_data?.ami_id },
+          { title: 'AMI ID', content: provider_data?.ami_id },
           {
             title: 'Region',
             content: `${provider_data?.region} (${provider_data?.availability_zone})`,
           },
-          { title: 'Vpc ID', content: provider_data?.vpc_id },
+          { title: 'VPC ID', content: provider_data?.vpc_id },
         ]}
       />
     </div>

--- a/assets/js/components/HostDetails/AwsDetails.jsx
+++ b/assets/js/components/HostDetails/AwsDetails.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import ListView from '@components/ListView';
+
+const AwsDetails = ({ provider, provider_data }) => {
+  return (
+    <div className="mt-4 bg-white shadow rounded-lg py-4 px-8">
+      <ListView
+        className="grid-rows-2"
+        orientation="vertical"
+        rows={2}
+        data={[
+          {
+            title: 'Provider',
+            content: provider,
+            render: (content) => <p className="uppercase">{content}</p>,
+          },
+          { title: 'Instance type', content: provider_data?.instance_type },
+          { title: 'Instance ID', content: provider_data?.instance_id },
+          {
+            title: 'Data disk number',
+            content: provider_data?.data_disk_number,
+          },
+          {
+            title: 'Account ID',
+            content: provider_data?.account_id,
+          },
+          { title: 'Ami ID', content: provider_data?.ami_id },
+          {
+            title: 'Region',
+            content: `${provider_data?.region} (${provider_data?.availability_zone})`,
+          },
+          { title: 'Vpc ID', content: provider_data?.vpc_id },
+        ]}
+      />
+    </div>
+  );
+};
+
+export default AwsDetails;

--- a/assets/js/components/HostDetails/AzureDetails.jsx
+++ b/assets/js/components/HostDetails/AzureDetails.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import ListView from '@components/ListView';
+
+const AzureDetails = ({ provider, provider_data }) => {
+  return (
+    <div className="mt-4 bg-white shadow rounded-lg py-4 px-8">
+      <ListView
+        className="grid-rows-2"
+        orientation="vertical"
+        rows={2}
+        data={[
+          {
+            title: 'Provider',
+            content: provider,
+            render: (content) => <p className="capitalize">{content}</p>,
+          },
+          { title: 'VM Size', content: provider_data?.vm_size },
+          { title: 'VM Name', content: provider_data?.vm_name },
+          {
+            title: 'Data disk number',
+            content: provider_data?.data_disk_number,
+          },
+          {
+            title: 'Resource group',
+            content: provider_data?.resource_group,
+          },
+          { title: 'Offer', content: provider_data?.offer },
+          { title: 'Location', content: provider_data?.location },
+          { title: 'SKU', content: provider_data?.sku },
+        ]}
+      />
+    </div>
+  );
+};
+
+export default AzureDetails;

--- a/assets/js/components/HostDetails/CloudDetails.jsx
+++ b/assets/js/components/HostDetails/CloudDetails.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import AzureDetails from './AzureDetails';
+import AwsDetails from './AwsDetails';
+
+const CloudDetails = ({ provider, provider_data }) => {
+  switch (provider) {
+    case 'azure':
+      return <AzureDetails provider={provider} provider_data={provider_data} />;
+    case 'aws':
+      return <AwsDetails provider={provider} provider_data={provider_data} />;
+  }
+};
+
+export default CloudDetails;

--- a/assets/js/components/HostDetails/HostDetails.jsx
+++ b/assets/js/components/HostDetails/HostDetails.jsx
@@ -8,7 +8,7 @@ import ListView from '@components/ListView';
 import Table from '@components/Table';
 
 import StatusPill from './StatusPill';
-import CloudDetails from './CloudDetails';
+import ProviderDetails from './ProviderDetails';
 
 import ClusterLink from '@components/ClusterLink';
 
@@ -104,9 +104,9 @@ const HostDetails = () => {
 
       <div className="mt-16">
         <div className="mb-4">
-          <h2 className="text-2xl font-bold">Cloud details</h2>
+          <h2 className="text-2xl font-bold">Provider details</h2>
         </div>
-        <CloudDetails
+        <ProviderDetails
           provider={host.provider}
           provider_data={host.provider_data}
         />

--- a/assets/js/components/HostDetails/HostDetails.jsx
+++ b/assets/js/components/HostDetails/HostDetails.jsx
@@ -8,6 +8,7 @@ import ListView from '@components/ListView';
 import Table from '@components/Table';
 
 import StatusPill from './StatusPill';
+import CloudDetails from './CloudDetails';
 
 import ClusterLink from '@components/ClusterLink';
 
@@ -105,33 +106,10 @@ const HostDetails = () => {
         <div className="mb-4">
           <h2 className="text-2xl font-bold">Cloud details</h2>
         </div>
-        <div className="mt-4 bg-white shadow rounded-lg py-4 px-8">
-          <ListView
-            className="grid-rows-2"
-            orientation="vertical"
-            rows={2}
-            data={[
-              {
-                title: 'Provider',
-                content: host.provider,
-                render: (content) => <p className="capitalize">{content}</p>,
-              },
-              { title: 'VM Size', content: host.provider_data?.vm_size },
-              { title: 'VM Name', content: host.provider_data?.vm_name },
-              {
-                title: 'Data disk number',
-                content: host.provider_data?.data_disk_number,
-              },
-              {
-                title: 'Resource group',
-                content: host.provider_data?.resource_group,
-              },
-              { title: 'Offer', content: host.provider_data?.offer },
-              { title: 'Location', content: host.provider_data?.location },
-              { title: 'SKU', content: host.provider_data?.sku },
-            ]}
-          />
-        </div>
+        <CloudDetails
+          provider={host.provider}
+          provider_data={host.provider_data}
+        />
       </div>
 
       <div className="mt-8">

--- a/assets/js/components/HostDetails/ProviderDetails.jsx
+++ b/assets/js/components/HostDetails/ProviderDetails.jsx
@@ -1,15 +1,22 @@
 import React from 'react';
+import Pill from '@components/Pill';
 
 import AzureDetails from './AzureDetails';
 import AwsDetails from './AwsDetails';
 
-const CloudDetails = ({ provider, provider_data }) => {
+const ProviderDetails = ({ provider, provider_data }) => {
   switch (provider) {
     case 'azure':
       return <AzureDetails provider={provider} provider_data={provider_data} />;
     case 'aws':
       return <AwsDetails provider={provider} provider_data={provider_data} />;
+    default:
+      return (
+        <Pill className="bg-gray-200 text-gray-800 shadow">
+          Provider not recognized
+        </Pill>
+      );
   }
 };
 
-export default CloudDetails;
+export default ProviderDetails;

--- a/test/e2e/cypress/fixtures/host-details/host_details.feature
+++ b/test/e2e/cypress/fixtures/host-details/host_details.feature
@@ -30,6 +30,11 @@ Feature: Host details view
         And the host is running on AWS
         Then the displayed details should include all the correct AWS cloud metadata information
 
+    Scenario: Provider details are not available
+        Given I am in the host details view ('/hosts/9cd46919-5f19-59aa-993e-cf3736c71053')
+        And the host is running on unknown provider platform
+        Then provider not recognized message is displayed
+
     Scenario: Agent health matches the information resulted from a successful heartbeat
         Given I am in the host details view ('/hosts/9cd46919-5f19-59aa-993e-cf3736c71053')
         Then the displayed details should include a Trento Agent status labeled as 'running'

--- a/test/e2e/cypress/fixtures/host-details/host_details.feature
+++ b/test/e2e/cypress/fixtures/host-details/host_details.feature
@@ -20,9 +20,15 @@ Feature: Host details view
         And a link to a cluster details view with name `hana_cluster_3` should be under the cluster label
         And one entry with ID '6c9208eb-a5bb-57ef-be5c-6422dedab602' should be present in the SAP instances list
 
-    Scenario: Cloud details are available in the view
+    Scenario: Azure cloud details are available in the view
         Given I am in the host details view ('/hosts/9cd46919-5f19-59aa-993e-cf3736c71053')
-        Then the displayed details should include all the correct cloud metadata information
+        And the host is running on Azure
+        Then the displayed details should include all the correct Azure cloud metadata information
+
+    Scenario: AWS cloud details are available in the view
+        Given I am in the host details view ('/hosts/9cd46919-5f19-59aa-993e-cf3736c71053')
+        And the host is running on AWS
+        Then the displayed details should include all the correct AWS cloud metadata information
 
     Scenario: Agent health matches the information resulted from a successful heartbeat
         Given I am in the host details view ('/hosts/9cd46919-5f19-59aa-993e-cf3736c71053')

--- a/test/e2e/cypress/fixtures/host-details/selected_host.js
+++ b/test/e2e/cypress/fixtures/host-details/selected_host.js
@@ -4,7 +4,7 @@ export const selectedHost = {
   hostName: 'vmhdbprd01',
   clusterName: 'hana_cluster_3',
   clusterId: '469e7be5-4e20-5007-b044-c6f540a87493',
-  cloudDetails: {
+  azureCloudDetails: {
     provider: 'azure',
     vmName: 'vmhdbprd01',
     resourceGroup: 'resourceGroupName',
@@ -13,6 +13,16 @@ export const selectedHost = {
     dataDiskNumber: '7',
     offer: 'sles-sap-15-sp3-byos',
     sku: 'gen2',
+  },
+  awsCloudDetails: {
+    provider: 'aws',
+    instanceId: 'i-12345',
+    accountId: '123456',
+    region: 'eu-west-1 (eu-west-1a)',
+    instanceType: 't3.micro',
+    dataDiskNumber: '1',
+    amiId: 'ami-12345',
+    vpcId: 'vpc-12345',
   },
   sapInstance: {
     id: '6c9208eb-a5bb-57ef-be5c-6422dedab602',

--- a/test/e2e/cypress/integration/host_details.js
+++ b/test/e2e/cypress/integration/host_details.js
@@ -120,11 +120,11 @@ context('Host Details', () => {
         .next()
         .should('contain', selectedHost.awsCloudDetails.dataDiskNumber);
       cy.get('div')
-        .contains('Ami ID')
+        .contains('AMI ID')
         .next()
         .should('contain', selectedHost.awsCloudDetails.amiId);
       cy.get('div')
-        .contains('Vpc ID')
+        .contains('VPC ID')
         .next()
         .should('contain', selectedHost.awsCloudDetails.vpcId);
     });

--- a/test/e2e/cypress/integration/host_details.js
+++ b/test/e2e/cypress/integration/host_details.js
@@ -57,7 +57,7 @@ context('Host Details', () => {
 
     it(`should show Azure cloud details correctly`, () => {
       cy.get('div')
-        .contains('Provider')
+        .contains(/^Provider$/)
         .next()
         .should('contain', selectedHost.azureCloudDetails.provider);
       cy.get('div')
@@ -93,11 +93,10 @@ context('Host Details', () => {
     it(`should show AWS cloud details correctly`, () => {
       cy.loadScenario('host-details-aws');
 
-      cy.get('div')
-      .should('contain', selectedHost.awsCloudDetails.provider);
+      cy.get('div').should('contain', selectedHost.awsCloudDetails.provider);
 
       cy.get('div')
-        .contains('Provider')
+        .contains(/^Provider$/)
         .next()
         .should('contain', selectedHost.awsCloudDetails.provider);
       cy.get('div')
@@ -128,6 +127,12 @@ context('Host Details', () => {
         .contains('Vpc ID')
         .next()
         .should('contain', selectedHost.awsCloudDetails.vpcId);
+    });
+
+    it(`should display provider not recognized message`, () => {
+      cy.loadScenario('host-details-unknown');
+
+      cy.get('div').should('contain', 'Provider not recognized');
     });
   });
 

--- a/test/e2e/cypress/integration/host_details.js
+++ b/test/e2e/cypress/integration/host_details.js
@@ -50,39 +50,84 @@ context('Host Details', () => {
   });
 
   describe('Cloud details for this host should be displayed', () => {
-    it(`should show the cloud details correctly`, () => {
+    // Restore host provider data
+    after(() => {
+      cy.loadScenario('host-details-azure');
+    });
+
+    it(`should show Azure cloud details correctly`, () => {
       cy.get('div')
         .contains('Provider')
         .next()
-        .should('contain', selectedHost.cloudDetails.provider);
+        .should('contain', selectedHost.azureCloudDetails.provider);
       cy.get('div')
         .contains('VM Name')
         .next()
-        .should('contain', selectedHost.cloudDetails.vmName);
+        .should('contain', selectedHost.azureCloudDetails.vmName);
       cy.get('div')
         .contains('Resource group')
         .next()
-        .should('contain', selectedHost.cloudDetails.resourceGroup);
+        .should('contain', selectedHost.azureCloudDetails.resourceGroup);
       cy.get('div')
         .contains('Location')
         .next()
-        .should('contain', selectedHost.cloudDetails.location);
+        .should('contain', selectedHost.azureCloudDetails.location);
       cy.get('div')
         .contains('VM Size')
         .next()
-        .should('contain', selectedHost.cloudDetails.vmSize);
+        .should('contain', selectedHost.azureCloudDetails.vmSize);
       cy.get('div')
         .contains('Data disk number')
         .next()
-        .should('contain', selectedHost.cloudDetails.dataDiskNumber);
+        .should('contain', selectedHost.azureCloudDetails.dataDiskNumber);
       cy.get('div')
         .contains('Offer')
         .next()
-        .should('contain', selectedHost.cloudDetails.offer);
+        .should('contain', selectedHost.azureCloudDetails.offer);
       cy.get('div')
         .contains('SKU')
         .next()
-        .should('contain', selectedHost.cloudDetails.sku);
+        .should('contain', selectedHost.azureCloudDetails.sku);
+    });
+
+    it(`should show AWS cloud details correctly`, () => {
+      cy.loadScenario('host-details-aws');
+
+      cy.get('div')
+      .should('contain', selectedHost.awsCloudDetails.provider);
+
+      cy.get('div')
+        .contains('Provider')
+        .next()
+        .should('contain', selectedHost.awsCloudDetails.provider);
+      cy.get('div')
+        .contains('Instance ID')
+        .next()
+        .should('contain', selectedHost.awsCloudDetails.instanceId);
+      cy.get('div')
+        .contains('Account ID')
+        .next()
+        .should('contain', selectedHost.awsCloudDetails.accountId);
+      cy.get('div')
+        .contains('Region')
+        .next()
+        .should('contain', selectedHost.awsCloudDetails.region);
+      cy.get('div')
+        .contains('Instance type')
+        .next()
+        .should('contain', selectedHost.awsCloudDetails.instanceType);
+      cy.get('div')
+        .contains('Data disk number')
+        .next()
+        .should('contain', selectedHost.awsCloudDetails.dataDiskNumber);
+      cy.get('div')
+        .contains('Ami ID')
+        .next()
+        .should('contain', selectedHost.awsCloudDetails.amiId);
+      cy.get('div')
+        .contains('Vpc ID')
+        .next()
+        .should('contain', selectedHost.awsCloudDetails.vpcId);
     });
   });
 

--- a/test/fixtures/scenarios/host-details/9cd46919-5f19-59aa-993e-cf3736c71053_cloud_discovery_aws.json
+++ b/test/fixtures/scenarios/host-details/9cd46919-5f19-59aa-993e-cf3736c71053_cloud_discovery_aws.json
@@ -1,0 +1,17 @@
+{
+  "discovery_type": "cloud_discovery",
+  "agent_id": "9cd46919-5f19-59aa-993e-cf3736c71053",
+  "payload": {
+    "Provider": "aws",
+    "Metadata": {
+      "account_id": "123456",
+      "ami_id": "ami-12345",
+      "availability_zone": "eu-west-1a",
+      "data_disk_number": 1,
+      "instance_id": "i-12345",
+      "instance_type": "t3.micro",
+      "region": "eu-west-1",
+      "vpc_id": "vpc-12345"
+    }
+  }
+}

--- a/test/fixtures/scenarios/host-details/9cd46919-5f19-59aa-993e-cf3736c71053_cloud_discovery_unknown.json
+++ b/test/fixtures/scenarios/host-details/9cd46919-5f19-59aa-993e-cf3736c71053_cloud_discovery_unknown.json
@@ -1,0 +1,8 @@
+{
+  "discovery_type": "cloud_discovery",
+  "agent_id": "9cd46919-5f19-59aa-993e-cf3736c71053",
+  "payload": {
+    "Provider": "unknown",
+    "Metadata": {}
+  }
+}


### PR DESCRIPTION
Display AWS cloud details. Besides this:
- Rename `Cloud details` to `Provider details`
- Handle the unknown scenario with a `Provider not recognized` message

@abravosuse Putting you as reviewer simply you can validation the images and the visualized data hehe

This is how it looks like:

AWS:
![image](https://user-images.githubusercontent.com/36370954/173069845-25b45e5e-9a1c-47a0-bc72-4afef9adcf6c.png)

Unknown:
![image](https://user-images.githubusercontent.com/36370954/173069868-ef4f97b9-0135-4976-ac74-92257cc56f10.png)

If the Pill option is not good, we could use a simpler one (or any other suggestion):
![image](https://user-images.githubusercontent.com/36370954/173069934-5fbf3303-5155-40e8-863a-33b9b7ae81a3.png)
