### PR TITLE
Handle gcp details

### DIFF
--- a/lib/trento/application/integration/discovery/payloads/cloud_discovery_payload.ex
+++ b/lib/trento/application/integration/discovery/payloads/cloud_discovery_payload.ex
@@ -12,7 +12,11 @@ defmodule Trento.Integration.Discovery.CloudDiscoveryPayload do
     field :provider, Ecto.Enum, values: [:aws, :gcp, :azure, :unknown], default: :unknown
 
     field :metadata, PolymorphicEmbed,
-      types: [azure: __MODULE__.AzureMetadata, aws: __MODULE__.AwsMetadata],
+      types: [
+        azure: __MODULE__.AzureMetadata,
+        aws: __MODULE__.AwsMetadata,
+        gcp: __MODULE__.GcpMetadata
+      ],
       on_type_not_found: :nilify,
       on_replace: :update
   end
@@ -96,6 +100,23 @@ defmodule Trento.Integration.Discovery.CloudDiscoveryPayload do
       field :instance_type, :string
       field :region, :string
       field :vpc_id, :string
+    end
+  end
+
+  defmodule GcpMetadata do
+    @moduledoc nil
+
+    @required_fields :all
+    use Trento.Type
+
+    deftype do
+      field :disk_number, :integer
+      field :image, :string
+      field :instance_name, :string
+      field :machine_type, :string
+      field :network, :string
+      field :project_id, :string
+      field :zone, :string
     end
   end
 end

--- a/lib/trento/application/integration/discovery/policies/host_policy.ex
+++ b/lib/trento/application/integration/discovery/policies/host_policy.ex
@@ -13,6 +13,7 @@ defmodule Trento.Integration.Discovery.HostPolicy do
     CloudDiscoveryPayload,
     CloudDiscoveryPayload.AwsMetadata,
     CloudDiscoveryPayload.AzureMetadata,
+    CloudDiscoveryPayload.GcpMetadata,
     HostDiscoveryPayload,
     SlesSubscriptionDiscoveryPayload
   }
@@ -175,6 +176,28 @@ defmodule Trento.Integration.Discovery.HostPolicy do
          instance_type: instance_type,
          region: region,
          vpc_id: vpc_id
+       }
+
+  defp parse_cloud_provider_metadata(
+         :gcp,
+         %GcpMetadata{
+           disk_number: disk_number,
+           image: image,
+           instance_name: instance_name,
+           machine_type: machine_type,
+           network: network,
+           project_id: project_id,
+           zone: zone
+         }
+       ),
+       do: %{
+         disk_number: disk_number,
+         image: image,
+         instance_name: instance_name,
+         machine_type: machine_type,
+         network: network,
+         project_id: project_id,
+         zone: zone
        }
 
   defp parse_cloud_provider_metadata(_, generic_metadata), do: generic_metadata

--- a/lib/trento/domain/host/commands/update_provider.ex
+++ b/lib/trento/domain/host/commands/update_provider.ex
@@ -9,7 +9,8 @@ defmodule Trento.Domain.Commands.UpdateProvider do
 
   alias Trento.Domain.{
     AwsProvider,
-    AzureProvider
+    AzureProvider,
+    GcpProvider
   }
 
   import PolymorphicEmbed, only: [cast_polymorphic_embed: 3]
@@ -21,7 +22,8 @@ defmodule Trento.Domain.Commands.UpdateProvider do
     field :provider_data, PolymorphicEmbed,
       types: [
         azure: [module: AzureProvider, identify_by_fields: [:resource_group]],
-        aws: [module: AwsProvider, identify_by_fields: [:ami_id]]
+        aws: [module: AwsProvider, identify_by_fields: [:ami_id]],
+        gcp: [module: GcpProvider, identify_by_fields: [:project_id]]
       ],
       on_replace: :update
   end

--- a/lib/trento/domain/host/events/provider_updated.ex
+++ b/lib/trento/domain/host/events/provider_updated.ex
@@ -7,7 +7,8 @@ defmodule Trento.Domain.Events.ProviderUpdated do
 
   alias Trento.Domain.{
     AwsProvider,
-    AzureProvider
+    AzureProvider,
+    GcpProvider
   }
 
   import PolymorphicEmbed, only: [cast_polymorphic_embed: 3]
@@ -19,7 +20,8 @@ defmodule Trento.Domain.Events.ProviderUpdated do
     field :provider_data, PolymorphicEmbed,
       types: [
         azure: [module: AzureProvider, identify_by_fields: [:resource_group]],
-        aws: [module: AwsProvider, identify_by_fields: [:ami_id]]
+        aws: [module: AwsProvider, identify_by_fields: [:ami_id]],
+        gcp: [module: GcpProvider, identify_by_fields: [:project_id]]
       ],
       on_replace: :update
   end

--- a/lib/trento/domain/host/host.ex
+++ b/lib/trento/domain/host/host.ex
@@ -4,7 +4,9 @@ defmodule Trento.Domain.Host do
   alias Trento.Domain.Host
 
   alias Trento.Domain.{
+    AwsProvider,
     AzureProvider,
+    GcpProvider,
     SlesSubscription
   }
 
@@ -52,7 +54,7 @@ defmodule Trento.Domain.Host do
           socket_count: non_neg_integer(),
           os_version: String.t(),
           subscriptions: [SlesSubscription.t()],
-          provider_data: AzureProvider.t() | nil,
+          provider_data: AwsProvider.t() | AzureProvider.t() | GcpProvider.t() | nil,
           heartbeat: :passing | :critical | :unknown
         }
 

--- a/lib/trento/domain/value_objects/gcp_provider.ex
+++ b/lib/trento/domain/value_objects/gcp_provider.ex
@@ -1,0 +1,19 @@
+defmodule Trento.Domain.GcpProvider do
+  @moduledoc """
+  Gcp provider value object
+  """
+
+  @required_fields nil
+
+  use Trento.Type
+
+  deftype do
+    field :disk_number, :integer
+    field :image, :string
+    field :instance_name, :string
+    field :machine_type, :string
+    field :network, :string
+    field :project_id, :string
+    field :zone, :string
+  end
+end

--- a/lib/trento_web/openapi/schema/provider.ex
+++ b/lib/trento_web/openapi/schema/provider.ex
@@ -65,6 +65,25 @@ defmodule TrentoWeb.OpenApi.Schema.Provider do
     })
   end
 
+  defmodule GcpProviderData do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "GcpProviderData",
+      description: "GCP detected metadata",
+      type: :object,
+      properties: %{
+        disk_number: %Schema{type: :integer},
+        image: %Schema{type: :string},
+        instance_name: %Schema{type: :string},
+        machine_type: %Schema{type: :string},
+        network: %Schema{type: :string},
+        project_id: %Schema{type: :string},
+        zone: %Schema{type: :string}
+      }
+    })
+  end
+
   defmodule ProviderData do
     @moduledoc false
 
@@ -73,7 +92,8 @@ defmodule TrentoWeb.OpenApi.Schema.Provider do
       description: "Detected metadata for any provider",
       oneOf: [
         AwsProviderData,
-        AzureProviderData
+        AzureProviderData,
+        GcpProviderData
       ]
     })
   end

--- a/test/fixtures/discovery/cloud_discovery_gcp.json
+++ b/test/fixtures/discovery/cloud_discovery_gcp.json
@@ -3,6 +3,14 @@
   "agent_id": "0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4",
   "payload": {
     "Provider": "gcp",
-    "Metadata": null
+    "Metadata": {
+      "disk_number": 4,
+      "image": "sles-15-sp1-sap-byos-v20220126",
+      "instance_name": "vmhana01",
+      "machine_type": "n1-highmem-8",
+      "network": "network",
+      "project_id": "123456",
+      "zone": "europe-west1-b"
+    }
   }
 }

--- a/test/trento/application/integration/discovery/policies/host_policy_test.exs
+++ b/test/trento/application/integration/discovery/policies/host_policy_test.exs
@@ -15,6 +15,7 @@ defmodule Trento.Integration.Discovery.HostPolicyTest do
   alias Trento.Domain.{
     AwsProvider,
     AzureProvider,
+    GcpProvider,
     SlesSubscription
   }
 
@@ -85,7 +86,15 @@ defmodule Trento.Integration.Discovery.HostPolicyTest do
              %UpdateProvider{
                host_id: "0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4",
                provider: :gcp,
-               provider_data: nil
+               provider_data: %GcpProvider{
+                 disk_number: 4,
+                 image: "sles-15-sp1-sap-byos-v20220126",
+                 instance_name: "vmhana01",
+                 machine_type: "n1-highmem-8",
+                 network: "network",
+                 project_id: "123456",
+                 zone: "europe-west1-b"
+               }
              }
            } ==
              "cloud_discovery_gcp"

--- a/test/trento/application/projectors/host_projector_test.exs
+++ b/test/trento/application/projectors/host_projector_test.exs
@@ -11,7 +11,8 @@ defmodule Trento.HostProjectorTest do
 
   alias Trento.Domain.{
     AwsProvider,
-    AzureProvider
+    AzureProvider,
+    GcpProvider
   }
 
   alias Trento.Domain.Events.{
@@ -215,13 +216,31 @@ defmodule Trento.HostProjectorTest do
     event = %ProviderUpdated{
       host_id: host_id,
       provider: :gcp,
-      provider_data: nil
+      provider_data: %GcpProvider{
+        disk_number: 4,
+        image: "sles-15-sp1-sap-byos-v20220126",
+        instance_name: "vmhana01",
+        machine_type: "n1-highmem-8",
+        network: "network",
+        project_id: "123456",
+        zone: "europe-west1-b"
+      }
     }
 
     ProjectorTestHelper.project(HostProjector, event, "host_projector")
     host_projection = Repo.get!(HostReadModel, event.host_id)
 
+    expected_gcp_model = %{
+      "disk_number" => 4,
+      "image" => "sles-15-sp1-sap-byos-v20220126",
+      "instance_name" => "vmhana01",
+      "machine_type" => "n1-highmem-8",
+      "network" => "network",
+      "project_id" => "123456",
+      "zone" => "europe-west1-b"
+    }
+
     assert :gcp == host_projection.provider
-    assert nil == host_projection.provider_data
+    assert expected_gcp_model == host_projection.provider_data
   end
 end

--- a/test/trento/domain/host/host_test.exs
+++ b/test/trento/domain/host/host_test.exs
@@ -21,7 +21,8 @@ defmodule Trento.HostTest do
 
   alias Trento.Domain.{
     AwsProvider,
-    AzureProvider
+    AzureProvider,
+    GcpProvider
   }
 
   alias Trento.Domain.Host
@@ -403,6 +404,57 @@ defmodule Trento.HostTest do
                      instance_type: "t3.micro",
                      region: "eu-west-1",
                      vpc_id: "vpc-12345"
+                   }
+                 } = state
+        end
+      )
+    end
+
+    test "should update gcp provider" do
+      host_id = Faker.UUID.v4()
+
+      initial_events = [
+        build(:host_registered_event, host_id: host_id)
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        UpdateProvider.new!(%{
+          host_id: host_id,
+          provider: :azure,
+          provider_data: %{
+            disk_number: 4,
+            image: "sles-15-sp1-sap-byos-v20220126",
+            instance_name: "vmhana01",
+            machine_type: "n1-highmem-8",
+            network: "network",
+            project_id: "123456",
+            zone: "europe-west1-b"
+          }
+        }),
+        %ProviderUpdated{
+          host_id: host_id,
+          provider: :azure,
+          provider_data: %GcpProvider{
+            disk_number: 4,
+            image: "sles-15-sp1-sap-byos-v20220126",
+            instance_name: "vmhana01",
+            machine_type: "n1-highmem-8",
+            network: "network",
+            project_id: "123456",
+            zone: "europe-west1-b"
+          }
+        },
+        fn state ->
+          assert %Host{
+                   provider_data: %GcpProvider{
+                     disk_number: 4,
+                     image: "sles-15-sp1-sap-byos-v20220126",
+                     instance_name: "vmhana01",
+                     machine_type: "n1-highmem-8",
+                     network: "network",
+                     project_id: "123456",
+                     zone: "europe-west1-b"
                    }
                  } = state
         end


### PR DESCRIPTION
Handle GCP provider discoveries in the server side. Pending to update the frontend, in a subsequent PR.
Depends on: https://github.com/trento-project/agent/pull/43

![image](https://user-images.githubusercontent.com/36370954/173379251-fa7664bf-e404-4f13-b213-a8b271bbf07d.png)


