### PR TITLE
Update and add additional information to hack_on_the_trento documentation

### DIFF
--- a/docs/development/hack_on_the_trento.md
+++ b/docs/development/hack_on_the_trento.md
@@ -22,44 +22,65 @@ In order to run the trento web, you need
 A `docker-compose` development environment is provided.
 
 ```
-$> docker-compose up -d
+docker-compose up -d
 ```
 
 It will start a **postgres** database and a **grafana** instance, for storage and monitoring.
 ## Install dependencies
 
 ```
-$> mix deps.get
+mix deps.get
 ```
 
 ## Setup trento
 
 ```
-$> mix setup
+mix setup
+```
+
+## Install the JavaScript frontend packages
+
+```
+npm --prefix ./assets/ install ./assets
 ```
 
 ## Start trento in the repl
 
 ```
-$> iex -S mix phx.server
+iex -S mix phx.server
+```
+
+## Access the trento web 
+
+Login page: [localhost:4000](http://localhost:4000)
+
+**Hint**: Altering the default port requires changes in [config/dev.exs](./../../config/dev.exs)
+
+## Login 
+Username:
+```
+admin
+```
+Password:
+```
+adminpassword
 ```
 
 ## Environment Variables
 
 See [environment_variables](./environment_variables.md)
 
-
 ## Scenario loading with photofinish
 
 By leveraging [photofinish](https://github.com/trento-project/photofinish) it is possible to load different scenarios for development and debugging purposes.
 
 ```
-$> photofinish run --url "http://localhost:4000/api/collect" healthy-27-node-SAP-cluster
+photofinish run --url "http://localhost:4000/api/collect" healthy-27-node-SAP-cluster
 ```
 It's possible to use Photofinish' docker image too:
 
 ```
-$> docker run -v "$PWD":/data --network host ghcr.io/trento-project/photofinish run healthy-27-node-SAP-cluster -u http://localhost:4000/api/collect
+docker run -v "$PWD":/data --network host ghcr.io/trento-project/photofinish run healthy-27-node-SAP-cluster -u http://localhost:4000/api/collect
 ```
 
 Several useful scenario fixtures are available in [./test/fixtures/scenarios](../../test/fixtures/scenarios/), the same ones used in e2e tests.


### PR DESCRIPTION
This PR will  update, format and add content to the hack_on_the_trento documentation.

Changes:
-  Add a step for installation of required Node.js packages for the frontend.
-  Add description how to access the trento web ui.
-  Add information about a test user.
-  Format the docs, so the reader can directly copy and paste the commands.