### PR TITLE
Add hosts_execution to cluster_registered broadcast

### DIFF
--- a/lib/trento/application/projectors/cluster_projector.ex
+++ b/lib/trento/application/projectors/cluster_projector.ex
@@ -169,7 +169,7 @@ defmodule Trento.ClusterProjector do
       "monitoring:clusters",
       "cluster_registered",
       cluster
-      |> Repo.preload(:checks_results)
+      |> Repo.preload([:checks_results, :hosts_executions])
       |> enrich_cluster_model
       |> to_map()
     )


### PR DESCRIPTION
This PR is a fix for an issue currently present in `main` that causes the checks result not being displayed after a check execution is triggered:

![broken](https://user-images.githubusercontent.com/2668401/175016664-bf24febd-05c6-4be1-a242-84b75ea4ed4e.png)

We now preload the :hosts_executions before the `cluster_registered` broadcast to avoid `undefined` errors.