### PR TITLE
Add support script

### DIFF
--- a/hack/trento-support.sh
+++ b/hack/trento-support.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+set -e
+
+readonly ARGS=("$@")
+readonly NOW="$(date +%x_%H%M%S)"
+
+indent() { sed 's/^/  /'; }
+
+trento_configuration() {
+    echo "===== TRENTO CONFIGURATION FILES ====="
+    
+    echo "/etc/trento/installer.conf content"
+    echo "$(</etc/trento/installer.conf)" | indent
+
+    echo "===== END TRENTO CONFIGURATION FILES ====="
+}
+
+base_system() {
+    echo "===== BASE SYSTEM DETAILS ====="
+
+    echo "k3s --version"
+    k3s --version | indent
+    echo "helm version"
+    helm version | indent
+    echo "helm get all trento-server"
+    helm get all trento-server | indent
+
+    echo "===== END BASE SYSTEM DETAILS ====="
+}
+
+kubernetes_state() {
+    echo "===== KUBERNETES CLUSTER STATE ====="
+
+    echo "kubectl get nodes -o wide"
+    kubectl get nodes -o wide | indent
+    echo "kubectl get pods"
+    kubectl get pods | indent
+    echo "kubectl logs deploy/trento-server-runner"
+    kubectl logs deploy/trento-server-runner | indent
+    echo "kubectl logs deploy/trento-server-web -c init"
+    kubectl logs deploy/trento-server-web -c init | indent
+    echo "kubectl logs deploy/trento-server-web"
+    kubectl logs deploy/trento-server-web | indent
+    echo "kubectl describe deployments"
+    kubectl describe deployments | indent
+    echo "crictl images"
+    crictl images | indent
+    
+    echo "===== END KUBERNETES CLUSTER STATE ====="
+}
+
+######
+# main
+######
+
+collect_all() {
+    trento_configuration
+    base_system
+    kubernetes_state    
+}
+
+usage() {
+    echo "Usage: $0 [base_system|kubernetes_state|collect_all]"
+}
+
+cmdline() {
+    local arg=
+
+    for arg; do
+        local delim=""
+        case "$arg" in
+        --help) args="${args}-h " ;;
+        --configuration) args="${args}-c " ;;
+        --base) args="${args}-b " ;;
+        --kubernetes) args="${args}-k " ;;
+        --all) args="${args}-a " ;;
+
+        # pass through anything else
+        *)
+            [[ "${arg:0:1}" == "-" ]] || delim="\""
+            args="${args}${delim}${arg}${delim} "
+            ;;
+        esac
+    done
+
+    eval set -- "$args"
+
+    while getopts "hcbka" OPTION; do
+        case $OPTION in
+        h)
+            usage
+            exit 0
+            ;;
+
+        c)
+            trento_configuration > "$(date +%Y-%m-%d_%H:%M)_trento_config_support.txt"
+            ;;
+
+        b)
+            base_system > "$(date +%Y-%m-%d_%H:%M)_trento_base_support.txt"
+            ;;
+
+        k)
+            kubernetes_state > "$(date +%Y-%m-%d_%H:%M)_trento_kubernetes_support.txt"
+            ;;
+
+        a)
+            collect_all > "$(date +%Y-%m-%d_%H:%M)_trento_all_support.txt"
+            ;;
+
+        *)
+            usage
+            exit 0
+            ;;
+        esac
+    done
+
+    return 0
+}
+
+cmdline "${ARGS[@]}"


### PR DESCRIPTION
This PR is a (draft) proposal to have a support script that customers or our L3 team can call to collect data about the installation.

The base idea is to collect everything that might help us determine what could be going wrong on the trento-server installation.

Some random thoughts:
 - Do we need something on the agent side too for agent related issues? Not sure if it would make sense to have something that needs to be executed on each agent or if instead we can rely on trento-server to collect such information from here
 - It would be nice if we can integrate this with `supportconfig` used in SLES. This script should still remain here (for non-SLES users), but could write a very simple wrapper plugin for supportconfig that call this script to collect all that it needs. The only change we would need is that we'd have to output to STDOUT instead of a file (as IIRC, supportconfig plugins are expect to output to STDOUT)

Suggestions welcome!