### PR TITLE
Allow custom email sender

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -32,6 +32,7 @@ config :swoosh, :api_client, false
 # configure the recipient for alert notifications
 config :trento, :alerting,
   enabled: true,
+  sender: "alerts@trento-project.io",
   recipient: "admin@trento.io"
 
 # Configure esbuild (the version is required)

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -102,7 +102,8 @@ if config_env() == :prod do
 
   config :trento, :alerting,
     enabled: System.get_env("ENABLE_ALERTING", "false") == "true",
-    recipient: System.get_env("ALERT_RECIPIENT") || "admin@trento-project.io"
+    sender: System.get_env("ALERT_SENDER", "alerts@trento-project.io"),
+    recipient: System.get_env("ALERT_RECIPIENT", "admin@trento-project.io")
 
   config :trento, Trento.Mailer,
     adapter: Swoosh.Adapters.SMTP,

--- a/docs/alerting/alerting.md
+++ b/docs/alerting/alerting.md
@@ -23,6 +23,7 @@ Currently **SMTP** is the **only supported delivery mechanism** for notification
 
 ```
 ENABLE_ALERTING=true
+ALERT_SENDER=sender@yourmail.com
 ALERT_RECIPIENT=recipient@yourmail.com
 
 SMTP_SERVER=your.smtp-server.com
@@ -32,4 +33,18 @@ SMTP_PASSWORD=password
 ```
 
 ## Enabling Alerting at a later stage
-If your current Trento installation has Alerting disabled, you can enable it by... (TBD)
+If your current Trento installation has Alerting disabled, you can enable it by upgrading the helm deployment.
+
+```
+helm upgrade
+   --install <THE_DEPLOYMENT> 
+   --set trento-web.adminUser.password=<ADMIN_PASSWORD>
+   --set-file trento-runner.privateKey=<PRIVATE_SSH_KEY>
+   --set trento-web.alerting.enabled=true
+   --set trento-web.alerting.smtpServer=<SMTP_SERVER> 
+   --set trento-web.alerting.smtpPort=<SMTP_PORT>
+   --set trento-web.alerting.smtpUser=<SMTP_USER>
+   --set trento-web.alerting.smtpPassword=<SMTP_PASSWORD>
+   --set trento-web.alerting.sender=<ALERT_SENDER> 
+   --set trento-web.alerting.recipient=<ALERT_RECIPIENT>
+```

--- a/lib/trento/application/usecases/alerting/email/email_alert.ex
+++ b/lib/trento/application/usecases/alerting/email/email_alert.ex
@@ -7,7 +7,7 @@ defmodule Trento.Application.UseCases.Alerting.EmailAlert do
 
   def alert(component, identified_by, identifier, reason) do
     new()
-    |> from({"Trento Alerts", "alerts@trento-project.io"})
+    |> from({"Trento Alerts", Application.fetch_env!(:trento, :alerting)[:sender]})
     |> to({"Trento Admin", Application.fetch_env!(:trento, :alerting)[:recipient]})
     |> subject("Trento Alert: #{component} #{identifier} needs attention.")
     |> render_body("critical.html", %{


### PR DESCRIPTION
Allow the user to provide a custom email sender for alerting.
Relates to https://github.com/trento-project/helm-charts/pull/31