### PR TITLE
Handle DAA and unknown sap system payloads

### DIFF
--- a/lib/trento/application/integration/discovery/payloads/sap_system_discovery_payload.ex
+++ b/lib/trento/application/integration/discovery/payloads/sap_system_discovery_payload.ex
@@ -9,7 +9,13 @@ defmodule Trento.Integration.Discovery.SapSystemDiscoveryPayload do
     Profile
   }
 
+  @unknown_type 0
+  @database_type 1
+  @application_type 2
+  @diagnostics_type 3
+
   @required_fields [:Id, :SID, :Type, :Profile, :Databases, :Instances]
+  @system_types [@unknown_type, @database_type, @application_type, @diagnostics_type]
 
   use Trento.Type
 
@@ -35,6 +41,7 @@ defmodule Trento.Integration.Discovery.SapSystemDiscoveryPayload do
     |> cast_embed(:Databases)
     |> cast_embed(:Instances)
     |> validate_required_fields(@required_fields)
+    |> validate_inclusion(:Type, @system_types)
   end
 
   defp parse_system_type(%{"Type" => system_type}), do: system_type
@@ -221,7 +228,6 @@ defmodule Trento.Integration.Discovery.SapSystemDiscoveryPayload do
       :features,
       :hostname,
       :httpPort,
-      :httpsPort,
       :dispstatus,
       :instanceNr,
       :startPriority

--- a/lib/trento/application/integration/discovery/policies/sap_system_policy.ex
+++ b/lib/trento/application/integration/discovery/policies/sap_system_policy.ex
@@ -19,8 +19,10 @@ defmodule Trento.Integration.Discovery.SapSystemPolicy do
 
   @uuid_namespace Application.compile_env!(:trento, :uuid_namespace)
 
+  @unknown_type 0
   @database_type 1
   @application_type 2
+  @diagnostics_type 3
 
   @spec handle(map) ::
           {:ok, [RegisterApplicationInstance.t() | RegisterDatabaseInstance.t()]} | {:error, any}
@@ -105,6 +107,9 @@ defmodule Trento.Integration.Discovery.SapSystemPolicy do
       })
     end)
   end
+
+  defp build_commands(%SapSystemDiscoveryPayload{Type: @diagnostics_type}, _), do: []
+  defp build_commands(%SapSystemDiscoveryPayload{Type: @unknown_type}, _), do: []
 
   defp parse_instance_number(instance), do: parse_sap_control_property("SAPSYSTEM", instance)
 

--- a/test/fixtures/discovery/sap_system_discovery_application_diagnostics.json
+++ b/test/fixtures/discovery/sap_system_discovery_application_diagnostics.json
@@ -1,0 +1,354 @@
+{
+  "agent_id": "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
+  "discovery_type": "sap_system_discovery",
+  "payload": [
+    {
+      "Id": "7b65dc281f9fae2c8e68e6cab669993e",
+      "SID": "HA1",
+      "Type": 2,
+      "DBAddress": "10.74.1.12",
+      "Profile": {
+        "SAPDBHOST": "10.74.1.12",
+        "gw/acl_mode": "1",
+        "gw/sec_info": "$(DIR_GLOBAL)$(DIR_SEP)secinfo$(FT_DAT)",
+        "j2ee/dbhost": "10.74.1.12",
+        "j2ee/dbname": "PRD",
+        "j2ee/dbtype": "hdb",
+        "system/type": "ABAP",
+        "vmcj/enable": "off",
+        "rdisp/mshost": "sapha1as",
+        "rdisp/msserv": "sapmsHA1",
+        "SAPGLOBALHOST": "sapha1as",
+        "SAPSYSTEMNAME": "HA1",
+        "rdisp/btctime": "0",
+        "dbs/hdb/dbname": "PRD",
+        "dbs/hdb/schema": "SAPABAP1",
+        "enque/serverhost": "sapha1as",
+        "enque/serverinst": "00",
+        "icf/user_recheck": "1",
+        "rdisp/bufrefmode": "sendoff",
+        "rsdb/ssfs_connect": "0",
+        "rsec/ssfs_keypath": "$(DIR_GLOBAL)$(DIR_SEP)security$(DIR_SEP)rsecssfs$(DIR_SEP)key",
+        "rdisp/autoabaptime": "0",
+        "rsec/ssfs_datapath": "$(DIR_GLOBAL)$(DIR_SEP)security$(DIR_SEP)rsecssfs$(DIR_SEP)data",
+        "login/system_client": "001",
+        "rdisp/msserv_internal": "3900",
+        "enque/process_location": "REMOTESA",
+        "enque/deque_wait_answer": "TRUE",
+        "service/protectedwebmethods": "SDEFAULT",
+        "is/HTTP/show_detailed_errors": "FALSE",
+        "login/password_downwards_compatibility": "0",
+        "icm/HTTP/ASJava/disable_url_session_tracking": "TRUE"
+      },
+      "Databases": null,
+      "Instances": [
+        {
+          "Host": "vmnetweaver04",
+          "Name": "D02",
+          "Type": 2,
+          "SAPControl": {
+            "Instances": [
+              {
+                "features": "MESSAGESERVER|ENQUE",
+                "hostname": "sapha1as",
+                "httpPort": 50013,
+                "httpsPort": 50014,
+                "dispstatus": "SAPControl-GREEN",
+                "instanceNr": 0,
+                "startPriority": "1"
+              },
+              {
+                "features": "ENQREP",
+                "hostname": "sapha1er",
+                "httpPort": 51013,
+                "httpsPort": 51014,
+                "dispstatus": "SAPControl-GREEN",
+                "instanceNr": 10,
+                "startPriority": "0.5"
+              },
+              {
+                "features": "ABAP|GATEWAY|ICMAN|IGS",
+                "hostname": "sapha1pas",
+                "httpPort": 50113,
+                "httpsPort": 50114,
+                "dispstatus": "SAPControl-GREEN",
+                "instanceNr": 1,
+                "startPriority": "3"
+              },
+              {
+                "features": "ABAP|GATEWAY|ICMAN|IGS",
+                "hostname": "sapha1aas1",
+                "httpPort": 50213,
+                "httpsPort": 50214,
+                "dispstatus": "SAPControl-GREEN",
+                "instanceNr": 2,
+                "startPriority": "3"
+              }
+            ],
+            "Processes": [
+              {
+                "pid": 17444,
+                "name": "gwrd",
+                "starttime": "2021 09 28 16:58:24",
+                "dispstatus": "SAPControl-GREEN",
+                "textstatus": "Running",
+                "description": "Gateway",
+                "elapsedtime": "1557:46:59"
+              },
+              {
+                "pid": 17445,
+                "name": "icman",
+                "starttime": "2021 09 28 16:58:24",
+                "dispstatus": "SAPControl-GREEN",
+                "textstatus": "Running",
+                "description": "ICM",
+                "elapsedtime": "1557:46:59"
+              },
+              {
+                "pid": 17440,
+                "name": "igswd_mt",
+                "starttime": "2021 09 28 16:58:23",
+                "dispstatus": "SAPControl-GREEN",
+                "textstatus": "Running",
+                "description": "IGS Watchdog",
+                "elapsedtime": "1557:47:00"
+              },
+              {
+                "pid": 17439,
+                "name": "disp+work",
+                "starttime": "2021 09 28 16:58:23",
+                "dispstatus": "SAPControl-GREEN",
+                "textstatus": "Running",
+                "description": "Dispatcher",
+                "elapsedtime": "1557:47:00"
+              }
+            ],
+            "Properties": [
+              {
+                "value": "HTTP://sapha1aas1:0/sap/admin/public/index.html",
+                "property": "ICM",
+                "propertytype": "NodeURL"
+              },
+              {
+                "value": "http://sapha1aas1:40280",
+                "property": "IGS",
+                "propertytype": "NodeURL"
+              },
+              {
+                "value": "ABAPReadSyslog",
+                "property": "Syslog",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "ICMGetCacheEntries",
+                "property": "ICM Cache",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "02",
+                "property": "SAPSYSTEM",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "Start,InstanceStart,StartBypassHA,Bootstrap,Stop,InstanceStop,StopBypassHA,Shutdown,ParameterValue,GetProcessList,GetStartProfile,GetTraceFile,GetAlertTree,GetAlerts,RestartService,StopService,GetEnvironment,ListDeveloperTraces,ReadDeveloperTrace,RestartInstance,SendSignal,GetVersionInfo,GetQueueStatistic,GetInstanceProperties,OSExecute,ReadLogFile,AnalyseLogFiles,ListLogFiles,GetAccessPointList,GetSystemInstanceList,GetSystemUpdateList,StartSystem,StopSystem,RestartSystem,UpdateSystem,UpdateSCSInstance,CheckUpdateSystem,AccessCheck,GetProcessParameter,SetProcessParameter,SetProcessParameter2,ShmDetach,GetNetworkId,GetSecNetworkId,RequestLogonFile,CreateSnapshot,ReadSnapshot,ListSnapshots,DeleteSnapshots,GetCallstack,ABAPReadSyslog,ABAPReadRawSyslog,ABAPGetWPTable,ABAPAcknowledgeAlerts,ABAPGetComponentList,ABAPCheckRFCDestinations,ABAPGetSystemWPTable,J2EEGetProcessList,J2EEGetProcessList2,J2EEControlProcess,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadCallStack,J2EEGetThreadTaskStack,J2EEGetSessionList,J2EEGetWebSessionList,J2EEGetWebSessionList2,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetApplicationAliasList,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetEJBSessionList,J2EEGetRemoteObjectList,J2EEGetClusterMsgList,J2EEGetSharedTableInfo,J2EEGetComponentList,J2EEControlComponents,ICMGetThreadList,ICMGetConnectionList,ICMGetCacheEntries,ICMGetProxyConnectionList,WebDispGetServerList,EnqGetLockTable,EnqRemoveLocks,EnqGetStatistic,UpdateSystemPKI,UpdateInstancePSE,HACheckConfig,HACheckFailoverConfig,HAGetFailoverConfig,HAFailoverToNode",
+                "property": "Webmethods",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "ICMGetThreadList",
+                "property": "ICM Threads",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "GetAlertTree",
+                "property": "Open Alerts",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "GetProcessList",
+                "property": "Process List",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "sapha1aas1",
+                "property": "SAPLOCALHOST",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "ABAPGetWPTable",
+                "property": "ABAP WP Table",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "GetAccessPointList",
+                "property": "Access Points",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "D02",
+                "property": "INSTANCE_NAME",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "https://launchpad.support.sap.com/#/softwarecenter/template/products/_APP=00200682500000001943&_EVENT=DISPHIER&HEADER=Y&FUNCTIONBAR=N&EVENT=TREE&NE=NAVIGATE&ENR=73554900100200001710&V=MAINT",
+                "property": "Kernel Update",
+                "propertytype": "NodeURL"
+              },
+              {
+                "value": "HA1",
+                "property": "SAPSYSTEMNAME",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "3",
+                "property": "StartPriority",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "GetAlertTree",
+                "property": "Current Status",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "ICMGetConnectionList",
+                "property": "ICM Connections",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "GetQueueStatistic",
+                "property": "Queue Statistic",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "ABAPAcknowledgeAlerts,ABAPCheckRFCDestinations,ABAPGetComponentList,ABAPGetSystemWPTable,ABAPGetWPTable,ABAPReadRawSyslog,ABAPReadSyslog,AnalyseLogFiles,Bootstrap,CheckUpdateSystem,ConfigureLogFileList,CreateSnapshot,DeleteSnapshots,EnqGetLockTable,EnqGetStatistic,EnqRemoveLocks,GetAccessPointList,GetAlerts,GetAlertTree,GetCallstack,GetEnvironment,GetLogFileList,GetProcessParameter,GetQueueStatistic,GetStartProfile,GetSystemUpdateList,GetTraceFile,GetVersionInfo,HACheckConfig,HACheckFailoverConfig,HAFailoverToNode,HAGetFailoverConfig,ICMGetCacheEntries,ICMGetConnectionList,ICMGetProxyConnectionList,ICMGetThreadList,InstanceStart,InstanceStop,J2EEControlCluster,J2EEControlComponents,J2EEControlProcess,J2EEDisableDbgSession,J2EEEnableDbgSession,J2EEGetApplicationAliasList,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetClusterMsgList,J2EEGetComponentList,J2EEGetEJBSessionList,J2EEGetProcessList,J2EEGetProcessList2,J2EEGetRemoteObjectList,J2EEGetSessionList,J2EEGetSharedTableInfo,J2EEGetThreadCallStack,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadTaskStack,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetWebSessionList,J2EEGetWebSessionList2,ListDeveloperTraces,ListLogFiles,ListSnapshots,OSExecute,ParameterValue,ReadDeveloperTrace,ReadLogFile,ReadSnapshot,RestartInstance,RestartService,RestartSystem,SendSignal,SetProcessParameter,SetProcessParameter2,ShmDetach,Shutdown,Start,StartBypassHA,StartSystem,Stop,StopBypassHA,StopService,StopSystem,UpdateInstancePSE,UpdateSCSInstance,UpdateSystem,UpdateSystemPKI,WebDispGetServerList,GetAgentConfig,MtChangeStatus,MtCustomizeWrite,MtDbsetToWpsetByTid,MtDestroyMarkNTry,MtReset,PerfCustomizeWrite,ReadDirectory,ReadFile,ReadProfileParameters,Register,SnglmgsCustomizeWrite,SystemObjectSetValue,ToolSet,ToolSetRuntimeStatus,TriggerDataCollection,Unregister,UtilAlChangeStatus",
+                "property": "Protected Webmethods",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "ICMGetProxyConnectionList",
+                "property": "ICM Proxy Connections",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "http://sapha1aas1:50213/sapparamEN.html",
+                "property": "Parameter Documentation",
+                "propertytype": "NodeURL"
+              }
+            ]
+          },
+          "HdbnsutilSRstate": null,
+          "HostConfiguration": null,
+          "SystemReplication": null
+        }
+      ]
+    },
+    {
+      "Id": "e06e328f8d6b0f46c1e66ffcd44d0dd7",
+      "SID": "DAA",
+      "Type": 3,
+      "DBAddress": "",
+      "Profile": {},
+      "Databases": null,
+      "Instances": [
+        {
+          "Host": "vmhana01",
+          "Name": "SMDA98",
+          "Type": 3,
+          "SAPControl": {
+            "Instances": [
+              {
+                "features": "SMDAGENT",
+                "hostname": "vmhana01",
+                "httpPort": 59813,
+                "dispstatus": "SAPControl-GREEN",
+                "instanceNr": 98,
+                "startPriority": "3"
+              }
+            ],
+            "Processes": [
+              {
+                "pid": 5197,
+                "name": "jstart",
+                "starttime": "2022 03 01 15:39:27",
+                "dispstatus": "SAPControl-GREEN",
+                "textstatus": "All processes running",
+                "description": "J2EE Server",
+                "elapsedtime": "17:06:31"
+              }
+            ],
+            "Properties": [
+              {
+                "value": "98",
+                "property": "SAPSYSTEM",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "Start,InstanceStart,StartBypassHA,Bootstrap,Stop,InstanceStop,StopBypassHA,Shutdown,ParameterValue,GetProcessList,GetStartProfile,GetTraceFile,GetAlertTree,GetAlerts,RestartService,StopService,GetEnvironment,ListDeveloperTraces,ReadDeveloperTrace,RestartInstance,SendSignal,GetVersionInfo,GetQueueStatistic,GetInstanceProperties,OSExecute,ReadLogFile,AnalyseLogFiles,ListLogFiles,GetAccessPointList,GetSystemInstanceList,GetSystemUpdateList,StartSystem,StopSystem,RestartSystem,UpdateSystem,UpdateSCSInstance,CheckUpdateSystem,AccessCheck,GetProcessParameter,SetProcessParameter,SetProcessParameter2,CheckParameter,ShmDetach,GetNetworkId,GetSecNetworkId,RequestLogonFile,CreateSnapshot,ReadSnapshot,ListSnapshots,DeleteSnapshots,GetCallstack,ABAPReadSyslog,ABAPReadRawSyslog,ABAPGetWPTable,ABAPAcknowledgeAlerts,ABAPGetComponentList,ABAPCheckRFCDestinations,ABAPGetSystemWPTable,ABAPSetServerInactive,J2EEGetProcessList,J2EEGetProcessList2,J2EEControlProcess,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadCallStack,J2EEGetThreadTaskStack,J2EEGetSessionList,J2EEGetWebSessionList,J2EEGetWebSessionList2,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetApplicationAliasList,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetEJBSessionList,J2EEGetRemoteObjectList,J2EEGetClusterMsgList,J2EEGetSharedTableInfo,J2EEGetComponentList,J2EEControlComponents,ICMGetThreadList,ICMGetConnectionList,ICMGetCacheEntries,ICMGetProxyConnectionList,WebDispGetServerList,WebDispGetGroupList,WebDispGetVirtHostList,WebDispGetUrlPrefixList,EnqGetLockTable,EnqRemoveLocks,EnqRemoveUserLocks,EnqGetStatistic,GWCancelConnections,GWDeleteClients,GWDeleteConnections,GWGetConnectionList,GWGetClientList,UpdateSystemPKI,UpdateInstancePSE,StorePSE,DeletePSE,CheckPSE,HACheckConfig,HACheckFailoverConfig,HAGetFailoverConfig,HAFailoverToNode,HASetMaintenanceMode,HACheckMaintenanceMode,ListConfigFiles,ReadConfigFile",
+                "property": "Webmethods",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "GetProcessList",
+                "property": "Process List",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "vmhana01",
+                "property": "SAPLOCALHOST",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "GetAccessPointList",
+                "property": "Access Points",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "SMDA98",
+                "property": "INSTANCE_NAME",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "DAA",
+                "property": "SAPSYSTEMNAME",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "3",
+                "property": "StartPriority",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "J2EEGetVMGCHistory2,J2EEGetVMGCHistory",
+                "property": "J2EE GC History",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "J2EEGetVMHeapInfo",
+                "property": "J2EE Heap Memory",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "J2EEGetProcessList2,J2EEGetProcessList",
+                "property": "J2EE Process Table",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "ABAPAcknowledgeAlerts,ABAPCheckRFCDestinations,ABAPGetComponentList,ABAPGetSystemWPTable,ABAPGetWPTable,ABAPReadRawSyslog,ABAPReadSyslog,ABAPSetServerInactive,AnalyseLogFiles,Bootstrap,CheckParameter,CheckPSE,CheckUpdateSystem,ConfigureLogFileList,CreatePSECredential,CreateSnapshot,DeletePSE,DeleteSnapshots,EnqGetLockTable,EnqGetStatistic,EnqRemoveLocks,EnqRemoveUserLocks,GetAccessPointList,GetAlerts,GetAlertTree,GetCallstack,GetEnvironment,GetLogFileList,GetProcessParameter,GetQueueStatistic,GetStartProfile,GetSystemUpdateList,GetTraceFile,GetVersionInfo,GWCancelConnections,GWDeleteClients,GWDeleteConnections,GWGetConnectionList,GWGetClientList,HACheckConfig,HACheckFailoverConfig,HACheckMaintenanceMode,HAFailoverToNode,HAGetFailoverConfig,HASetMaintenanceMode,ICMGetCacheEntries,ICMGetConnectionList,ICMGetProxyConnectionList,ICMGetThreadList,InstanceStart,InstanceStop,J2EEControlCluster,J2EEControlComponents,J2EEControlProcess,J2EEDisableDbgSession,J2EEEnableDbgSession,J2EEGetApplicationAliasList,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetClusterMsgList,J2EEGetComponentList,J2EEGetEJBSessionList,J2EEGetProcessList,J2EEGetProcessList2,J2EEGetRemoteObjectList,J2EEGetSessionList,J2EEGetSharedTableInfo,J2EEGetThreadCallStack,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadTaskStack,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetWebSessionList,J2EEGetWebSessionList2,ListConfigFiles,ListDeveloperTraces,ListLogFiles,ListSnapshots,OSExecute,ParameterValue,ReadConfigFile,ReadDeveloperTrace,ReadLogFile,ReadSnapshot,RestartInstance,RestartService,RestartSystem,SendSignal,SetProcessParameter,SetProcessParameter2,ShmDetach,Shutdown,Start,StartBypassHA,StartSystem,Stop,StopBypassHA,StopService,StopSystem,StorePSE,UpdateInstancePSE,UpdateSCSInstance,UpdateSystem,UpdateSystemPKI,WebDispGetServerList,WebDispGetGroupList,WebDispGetVirtHostList,WebDispGetUrlPrefixList,GetAgentConfig,GetListOfMaByCusGrp,GetMcInLocalMs,GetMtesByRequestTable,GetMtListByMtclass,InfoGetTree,MscCustomizeWrite,MscDeleteLines,MscReadCache,MsGetLocalMsInfo,MsGetMteclsInLocalMs,MtChangeStatus,MtCustomizeWrite,MtDbsetToWpsetByTid,MtDestroyMarkNTry,MteGetByToolRunstatus,MtGetAllToCust,MtGetAllToolsToSet,MtGetMteinfo,MtGetTidByName,MtRead,MtReset,PerfCustomizeWrite,PerfRead,PerfReadSmoothData,ReadDirectory,ReadFile,ReadProfileParameters,ReferenceRead,Register,RequestLogonFile,SnglmgsCustomizeWrite,SystemObjectSetValue,TextAttrRead,ToolGetEffective,ToolSet,ToolSetRuntimeStatus,TriggerDataCollection,Unregister,UtilAlChangeStatus,UtilMtGetAidByTid,UtilMtGetTreeLocal,UtilMtReadAll,UtilReadRawalertByAid,UtilSnglmsgReadRawdata",
+                "property": "Protected Webmethods",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "http://vmhana01:59813/sapparamEN.html",
+                "property": "Parameter Documentation",
+                "propertytype": "NodeURL"
+              }
+            ]
+          },
+          "HdbnsutilSRstate": null,
+          "HostConfiguration": null,
+          "SystemReplication": null
+        }
+      ]
+    }
+  ]
+}

--- a/test/trento/application/integration/discovery/policies/sap_system_test.exs
+++ b/test/trento/application/integration/discovery/policies/sap_system_test.exs
@@ -69,4 +69,23 @@ defmodule Trento.Integration.Discovery.SapSystemPolicyTest do
              |> load_discovery_event_fixture()
              |> SapSystemPolicy.handle()
   end
+
+  test "should return the expected commands when a sap_system payload of type application and diagnostics is handled" do
+    assert {:ok,
+            [
+              %RegisterApplicationInstance{
+                db_host: "10.74.1.12",
+                features: "ABAP|GATEWAY|ICMAN|IGS",
+                host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
+                instance_number: "02",
+                sap_system_id: nil,
+                sid: "HA1",
+                tenant: "PRD",
+                health: :passing
+              }
+            ]} =
+             "sap_system_discovery_application_diagnostics"
+             |> load_discovery_event_fixture()
+             |> SapSystemPolicy.handle()
+  end
 end


### PR DESCRIPTION
Handle SAP system payloads with DAA and unknown types.
- The `httpsPort` is not required now as the `DAA` instance doesn't have it (and maybe other neither)
- Only known system types are accepted

It accommodates the code for new changes in the agent: https://github.com/trento-project/agent/pull/55