### PR TITLE
Reset pagination when a filter is selected

### DIFF
--- a/assets/js/components/Table/Table.jsx
+++ b/assets/js/components/Table/Table.jsx
@@ -72,6 +72,7 @@ const Table = ({ config, data = [] }) => {
           filters={filters}
           onChange={(newFilters) => {
             setFilters(newFilters);
+            setCurrentPage(1);
           }}
         />
       </div>

--- a/test/e2e/cypress/fixtures/hosts-overview/hosts_overview.feature
+++ b/test/e2e/cypress/fixtures/hosts-overview/hosts_overview.feature
@@ -101,3 +101,11 @@ Scenario: Filtering the Host Overview by Tags
 
     When I filter by tag 'env3'
     Then 8 items should be shown
+
+Scenario: Filtering when a non 1st page is selected
+    Given all the hosts containing 'prd' in their name are tagged with 'env1'
+    And the selected page is the last one
+
+    When I filter by tag 'env1'
+    Then 8 items should be shown 
+    And the selected page is the 1st one

--- a/test/e2e/cypress/integration/hosts_overview.js
+++ b/test/e2e/cypress/integration/hosts_overview.js
@@ -251,6 +251,16 @@ context('Hosts Overview', () => {
             cy.get('li > div > span.ml-3.block').contains(tag).click();
           });
         });
+
+        it('should reset the pagination and go the 1st page when a filter is selected', () => {
+          const tag = 'env1';
+
+          cy.get('.tn-page-item').eq(2).click();
+          cy.get('span').contains('Filter Tags').parent().parent().click();
+          cy.get('li > div > span.ml-3.block').contains(tag).click();
+          cy.get('.tn-hostname').its('length').should('eq', 4);
+          cy.get('li > div > span.ml-3.block').contains(tag).click();
+        });
       });
     });
   });


### PR DESCRIPTION
Fix filtering when a non 1st page is selected.

Before the fix, this was the behaviour:
![Peek 2022-07-12 09-39](https://user-images.githubusercontent.com/36370954/178679453-13ce9133-f837-47cb-963d-1a5b779d7e61.gif)

Now:
![Peek 2022-07-13 09-46](https://user-images.githubusercontent.com/36370954/178679736-4cc5c971-4580-4e82-8854-84b79acd0e85.gif)

PD: I know, the number of hosts in the feature file and the test don't match... but it comes from before, and I don't want to start changing that in this PR

