### PR TITLE
Add automated deployments to the demo environment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VERSION }}        
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install NPM dependencies
         if: steps.npm-cache.outputs.cache-hit != 'true'
@@ -420,6 +420,98 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  build-demo-img:
+    name: Build the docker image for the demo environment
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch'
+    needs: [static-code-analysis, test, test-e2e]
+    permissions:
+      contents: read
+      packages: write
+    env:
+      MIX_ENV: demo
+      REGISTRY: ghcr.io
+      IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/trento-web
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: docker/setup-buildx-action@v2
+      - name: Log in to the Container registry
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a
+        with:
+          images: ${{ env.IMAGE_REPOSITORY }}
+      - name: Build and push container image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ env.IMAGE_REPOSITORY }}:demo
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: MIX_ENV=demo
+
+  deploy-demo-env:
+    name: Deploy updated images to the demo environment
+    runs-on: self-hosted
+    if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch'
+    env:
+      IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/trento-web
+    needs: build-demo-img
+    steps:
+      - name: Start a local k8s cluster
+        uses: jupyterhub/action-k3s-helm@v3
+        with:
+          k3s-channel: latest
+
+      - name: Add bitnami helm deps
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo update
+
+      - name: Download and unzip helm chart
+        run: |
+          rm rolling.zip | true
+          rm -rf helm-charts-rolling | true
+          wget https://github.com/trento-project/helm-charts/archive/refs/tags/rolling.zip
+          unzip rolling.zip
+
+      - name: Install trento-server helm chart
+        run: |
+          cd helm-charts-rolling/charts/trento-server
+          helm dependency update          
+          helm upgrade -i trento --wait . \
+            --set-file trento-runner.privateKey=/home/azureuser/.ssh/id_rsa \
+            --set trento-web.adminUser.password="${{ secrets.DEMO_PASSWORD }}" \
+            --set trento-web.image.pullPolicy=Always \
+            --set trento-web.image.repository="${IMAGE_REPOSITORY}" \
+            --set trento-web.image.tag="demo"
+
+  run-photofinish-demo-env:
+    name: Use photofinish to push mock data to the demo environment
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch'
+    needs: deploy-demo-env
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Get Photofinish for e2e testing
+        run: |
+          set -x
+          wget -P /tmp https://github.com/trento-project/photofinish/releases/download/v1.1.2/photofinish
+          chmod +x /tmp/photofinish
+      - name: Push data
+        run: /tmp/photofinish run healthy-27-node-SAP-cluster -u "http://$TRENTO_DEMO_IP/api/collect" "$TRENTO_API_KEY"
 
   obs-commit:
     name: Commit the project on OBS

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN zypper -n --gpg-auto-import-keys ref -s
 RUN zypper -n in elixir
 COPY . /build
 WORKDIR /build
-ENV MIX_ENV=prod
+ARG MIX_ENV=prod
+ENV MIX_ENV=$MIX_ENV
 RUN mix local.rebar --force \
     && mix local.hex --force \
     && mix deps.get
@@ -22,18 +23,20 @@ RUN npm run build
 FROM elixir-build AS release
 COPY --from=assets-build /build /build
 WORKDIR /build
-ENV MIX_ENV=prod
+ARG MIX_ENV=prod
+ENV MIX_ENV=$MIX_ENV
 RUN mix phx.digest
 RUN mix release
 
 FROM registry.suse.com/bci/bci-base:15.3 AS trento
 LABEL org.opencontainers.image.source="https://github.com/trento-project/web"
+ARG MIX_ENV=prod
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 # tar is required by kubectl cp
 RUN zypper -n in tar
 WORKDIR /app
-COPY --from=release /build/_build/prod/rel/trento .
+COPY --from=release /build/_build/$MIX_ENV/rel/trento .
 EXPOSE 4000/tcp
 ENTRYPOINT ["/app/bin/trento"]

--- a/config/demo.exs
+++ b/config/demo.exs
@@ -1,0 +1,31 @@
+import Config
+
+config :trento, TrentoWeb.Endpoint,
+  check_origin: :conn,
+  cache_static_manifest: "priv/static/cache_manifest.json",
+  server: true
+
+config :swoosh, local: false
+
+# Do not print debug messages in production
+# config :logger, level: :info
+
+config :trento, Trento.Scheduler,
+  jobs: [
+    clusters_checks_execution: [
+      schedule: {:extended, "@hourly"}
+    ],
+    heartbeat_fake: [
+      schedule: {:extended, "*/5"},
+      task: {Trento.Heartbeats.Faker, :send_heartbeats, []},
+      run_strategy: {Quantum.RunStrategy.Random, :cluster},
+      overlap: false
+    ]
+  ]
+
+config :trento, Trento.Integration.Checks, adapter: Trento.Integration.Checks.MockRunner
+
+config :trento, Trento.Integration.Prometheus,
+  adapter: Trento.Integration.Prometheus.MockPrometheusApi
+
+config :trento, :extra_children, [Trento.Integration.Checks.MockRunner]

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -6,7 +6,7 @@ import Config
 # and secrets from environment variables or elsewhere. Do not define
 # any compile-time configuration in here, as it won't be applied.
 # The block below contains prod specific runtime configuration.
-if config_env() == :prod do
+if config_env() in [:prod, :demo] do
   database_url =
     System.get_env("DATABASE_URL") ||
       raise """

--- a/lib/trento/application/usecases/hosts/heartbeats_fake.ex
+++ b/lib/trento/application/usecases/hosts/heartbeats_fake.ex
@@ -1,0 +1,17 @@
+defmodule Trento.Heartbeats.Faker do
+  @moduledoc """
+  Heartbeat faker for demo environment
+  """
+  require Logger
+
+  alias Trento.Hosts
+
+  def send_heartbeats do
+    hosts = Hosts.get_all_hosts()
+
+    Enum.each(hosts, fn host ->
+      Logger.info("Sending fake heartbeat for host #{host.id}")
+      Trento.Heartbeats.heartbeat(host.id)
+    end)
+  end
+end


### PR DESCRIPTION
This PR makes use of self hosted GitHub actions runner to enable the automatic deployment of our demo environment. As of now, it's just the trento-server being deployed (no agents) and no mocked data. That will follow on a separate PR.