### PR TITLE
Highlight check result row on hover and id in green

### DIFF
--- a/assets/js/components/ClusterDetails/ChecksResults.jsx
+++ b/assets/js/components/ClusterDetails/ChecksResults.jsx
@@ -183,13 +183,13 @@ export const ChecksResults = () => {
                       (checkId) => (
                         <tr
                           key={checkId}
-                          className="animate-fade tn-check-result-row cursor-pointer"
+                          className="animate-fade tn-check-result-row cursor-pointer hover:bg-emerald-50 ease-in-out duration-300"
                           onClick={() => {
                             setModalOpen(true);
                             setSelectedCheck(checkId);
                           }}
                         >
-                          <td className="px-6 py-4 whitespace-nowrap">
+                          <td className="px-6 py-4 whitespace-nowrap text-jungle-green-500">
                             {checkId}
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap">


### PR DESCRIPTION
The colors are coming from https://tailwindcss.com/docs/background-color
@jagabomb Feel free to recommend other color set.

![check-result-highlight](https://user-images.githubusercontent.com/36370954/181186224-7cec5c9a-078d-4755-9ab4-a2b8f267ca69.gif)

Edit: @dottorblaster @jagabomb I was actually thinking if all "clickable" rows in our app (check results, catalog, sap system/hana database expandable rows, etc) should follow the same styling

