### PR TITLE
Enable telemetry community

### DIFF
--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -113,10 +113,10 @@ function* initialDataFetch() {
   yield loadSapSystemsHealthSummary();
 
   const {
-    data: { eula_accepted, premium_subscription },
+    data: { eula_accepted },
   } = yield call(get, '/api/settings');
 
-  if (!eula_accepted && premium_subscription) {
+  if (!eula_accepted) {
     yield put(setEulaVisible());
   }
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -32,6 +32,9 @@ config :trento, TrentoWeb.Endpoint,
 # In test we don't send emails.
 config :trento, Trento.Mailer, adapter: Swoosh.Adapters.Test
 
+# Disable telemetry publishing during test
+config :trento, Trento.Integration.Telemetry, adapter: Trento.Integration.Telemetry.ToLogger
+
 # Print only warnings and errors during test
 config :logger, level: :warn
 

--- a/lib/trento/application/integration/telemetry/adapter/gen.ex
+++ b/lib/trento/application/integration/telemetry/adapter/gen.ex
@@ -6,7 +6,12 @@ defmodule Trento.Integration.Telemetry.Gen do
   alias Trento.HostTelemetryReadModel
 
   @type installation_id :: String.t()
+  @type installation_flavor :: String.t()
 
-  @callback publish_hosts_telemetry([HostTelemetryReadModel.t()], installation_id) ::
+  @callback publish_hosts_telemetry(
+              [HostTelemetryReadModel.t()],
+              installation_id,
+              installation_flavor
+            ) ::
               :ok | {:error, any}
 end

--- a/lib/trento/application/integration/telemetry/adapter/suse.ex
+++ b/lib/trento/application/integration/telemetry/adapter/suse.ex
@@ -9,10 +9,10 @@ defmodule Trento.Integration.Telemetry.Suse do
 
   require Logger
 
-  def publish_hosts_telemetry(hosts_telemetry, installation_id) do
+  def publish_hosts_telemetry(hosts_telemetry, installation_id, installation_flavor) do
     case HTTPoison.post(
            "#{@telemetry_url}/api/collect/hosts",
-           build_payload(hosts_telemetry, installation_id),
+           build_payload(hosts_telemetry, installation_id, installation_flavor),
            [
              {"Content-Type", "application/json"}
            ]
@@ -41,11 +41,12 @@ defmodule Trento.Integration.Telemetry.Suse do
     end
   end
 
-  defp build_payload(hosts_telemetry, installation_id) do
+  defp build_payload(hosts_telemetry, installation_id, installation_flavor) do
     hosts_telemetry
     |> Enum.map(
       &%{
         installation_id: installation_id,
+        installation_flavor: installation_flavor,
         agent_id: &1.agent_id,
         sles_version: &1.sles_version,
         cpu_count: &1.cpu_count,

--- a/lib/trento/application/integration/telemetry/adapter/to_logger.ex
+++ b/lib/trento/application/integration/telemetry/adapter/to_logger.ex
@@ -8,6 +8,11 @@ defmodule Trento.Integration.Telemetry.ToLogger do
 
   require Logger
 
-  def publish_hosts_telemetry(hosts_telemetry, installation_id),
-    do: Logger.debug(hosts_telemetry: hosts_telemetry, installation_id: installation_id)
+  def publish_hosts_telemetry(hosts_telemetry, installation_id, installation_flavor),
+    do:
+      Logger.debug(
+        hosts_telemetry: hosts_telemetry,
+        installation_id: installation_id,
+        installation_flavor: installation_flavor
+      )
 end

--- a/lib/trento/application/integration/telemetry/telemetry.ex
+++ b/lib/trento/application/integration/telemetry/telemetry.ex
@@ -32,7 +32,7 @@ defmodule Trento.Integration.Telemetry do
 
   @spec telemetry_enabled? :: boolean
   defp telemetry_enabled?,
-    do: Installation.premium_active?() && Installation.eula_accepted?()
+    do: Installation.eula_accepted?()
 
   defp adapter,
     do: Application.fetch_env!(:trento, __MODULE__)[:adapter]

--- a/lib/trento/application/integration/telemetry/telemetry.ex
+++ b/lib/trento/application/integration/telemetry/telemetry.ex
@@ -13,20 +13,20 @@ defmodule Trento.Integration.Telemetry do
   @spec publish :: :ok | {:error, any}
   def publish do
     if telemetry_enabled?() do
-      publish_hosts_telemetry(Installation.get_installation_id())
+      publish_hosts_telemetry(Installation.get_installation_id(), Installation.flavor())
     else
       Logger.debug("Telemetry is not enabled... Skipping.")
     end
   end
 
-  @spec publish_hosts_telemetry(String.t()) :: :ok | {:error, any}
-  defp publish_hosts_telemetry(installation_id) do
+  @spec publish_hosts_telemetry(String.t(), String.t()) :: :ok | {:error, any}
+  defp publish_hosts_telemetry(installation_id, installation_flavor) do
     case Repo.all(HostTelemetryReadModel) do
       [] ->
         Logger.info("No telemetry data found... Skipping.")
 
       hosts_telemetry ->
-        adapter().publish_hosts_telemetry(hosts_telemetry, installation_id)
+        adapter().publish_hosts_telemetry(hosts_telemetry, installation_id, installation_flavor)
     end
   end
 

--- a/test/e2e/cypress/support/commands.js
+++ b/test/e2e/cypress/support/commands.js
@@ -38,6 +38,15 @@ Cypress.Commands.add('login', () => {
   cy.url().should('include', '/');
 });
 
+Cypress.Commands.add('acceptEula', () => {
+  cy.request('/api/settings').then((response) => {
+    if (!response.body.eula_accepted) {
+      cy.get('div').should('contain', 'License agreement');
+      cy.get('button').contains('Accept').click();
+    }
+  });
+});
+
 Cypress.Commands.add('loadScenario', (scenario) => {
   const [projectRoot, photofinishBinary, webAPIHost, webAPIPort] = [
     Cypress.env('project_root'),

--- a/test/e2e/cypress/support/index.js
+++ b/test/e2e/cypress/support/index.js
@@ -25,6 +25,7 @@ const sessionCookie = '_trento_key';
 before(() => {
   cy.loadScenario('healthy-27-node-SAP-cluster');
   cy.login();
+  cy.acceptEula();
 });
 
 after(() => {

--- a/test/trento/application/integration/telemetry/telemetry_test.exs
+++ b/test/trento/application/integration/telemetry/telemetry_test.exs
@@ -11,11 +11,7 @@ defmodule Trento.Integration.TelemetryTest do
   setup :verify_on_exit!
 
   setup do
-    Application.put_env(:trento, :flavor, "Premium")
-    insert(:sles_subscription, identifier: "SLES_SAP")
     Installation.accept_eula()
-
-    on_exit(fn -> Application.put_env(:trento, :flavor, "Community") end)
   end
 
   test "should publish hosts telemetry if telemetry is enabled" do

--- a/test/trento/application/integration/telemetry/telemetry_test.exs
+++ b/test/trento/application/integration/telemetry/telemetry_test.exs
@@ -12,13 +12,35 @@ defmodule Trento.Integration.TelemetryTest do
 
   setup do
     Installation.accept_eula()
+
+    on_exit(fn -> Application.put_env(:trento, :flavor, "Community") end)
   end
 
-  test "should publish hosts telemetry if telemetry is enabled" do
+  test "should publish hosts telemetry with community flavor" do
     host_telemetry = insert(:host_telemetry)
 
-    expect(Trento.Integration.Telemetry.Mock, :publish_hosts_telemetry, fn hosts_telemetry, _ ->
+    expect(Trento.Integration.Telemetry.Mock, :publish_hosts_telemetry, fn hosts_telemetry,
+                                                                           installation_id,
+                                                                           flavor ->
       assert [host_telemetry] == hosts_telemetry
+      assert Installation.get_installation_id() == installation_id
+      assert "Community" == flavor
+      :ok
+    end)
+
+    assert :ok = Telemetry.publish()
+  end
+
+  test "should publish hosts telemetry with premium flavor" do
+    Application.put_env(:trento, :flavor, "Premium")
+    host_telemetry = insert(:host_telemetry)
+
+    expect(Trento.Integration.Telemetry.Mock, :publish_hosts_telemetry, fn hosts_telemetry,
+                                                                           installation_id,
+                                                                           flavor ->
+      assert [host_telemetry] == hosts_telemetry
+      assert Installation.get_installation_id() == installation_id
+      assert "Premium" == flavor
       :ok
     end)
 


### PR DESCRIPTION
Enable telemetry publishing in the community flavor. Basically, the code removes the need of having the premium flavor to publish telemetry. This means that the EULA is shown in the 2 versions.

Besides that, a new field, `installation_flavor` is sent as other metric, so the option to filter by the options is available in the telemetry server side.

As a todo thing, the eula message is the same for the community flavor, and it relates to the premium version, something to change on the road.

Once this is accepted and merged, the next step would be to parse the new coming field in the telemetry server, and use it filter the grafana dashboards.