### PR TITLE
Add installation_source field to the host telemetry

### DIFF
--- a/lib/trento/application/integration/discovery/payloads/host_discovery_payload.ex
+++ b/lib/trento/application/integration/discovery/payloads/host_discovery_payload.ex
@@ -3,16 +3,7 @@ defmodule Trento.Integration.Discovery.HostDiscoveryPayload do
   Host discovery integration event payload
   """
 
-  @required_fields [
-    :hostname,
-    :ip_addresses,
-    :ssh_address,
-    :agent_version,
-    :cpu_count,
-    :total_memory_mb,
-    :socket_count,
-    :os_version
-  ]
+  @required_fields :all
 
   use Trento.Type
 
@@ -32,9 +23,7 @@ defmodule Trento.Integration.Discovery.HostDiscoveryPayload do
   end
 
   def changeset(host, attrs) do
-    modified_attrs =
-      attrs
-      |> installation_source_to_downcase
+    modified_attrs = installation_source_to_downcase(attrs)
 
     host
     |> cast(modified_attrs, fields())

--- a/lib/trento/application/integration/discovery/payloads/host_discovery_payload.ex
+++ b/lib/trento/application/integration/discovery/payloads/host_discovery_payload.ex
@@ -25,6 +25,24 @@ defmodule Trento.Integration.Discovery.HostDiscoveryPayload do
     field :total_memory_mb, :integer
     field :socket_count, :integer
     field :os_version, :string
-    field :installation_source, :string, default: "Unknown"
+
+    field :installation_source, Ecto.Enum,
+      values: [:community, :suse, :unknown],
+      default: :unknown
   end
+
+  def changeset(host, attrs) do
+    modified_attrs =
+      attrs
+      |> installation_source_to_downcase
+
+    host
+    |> cast(modified_attrs, fields())
+    |> validate_required_fields(@required_fields)
+  end
+
+  defp installation_source_to_downcase(%{"installation_source" => installation_source} = attrs),
+    do: %{attrs | "installation_source" => String.downcase(installation_source)}
+
+  defp installation_source_to_downcase(attrs), do: attrs
 end

--- a/lib/trento/application/integration/discovery/payloads/host_discovery_payload.ex
+++ b/lib/trento/application/integration/discovery/payloads/host_discovery_payload.ex
@@ -3,7 +3,16 @@ defmodule Trento.Integration.Discovery.HostDiscoveryPayload do
   Host discovery integration event payload
   """
 
-  @required_fields :all
+  @required_fields [
+    :hostname,
+    :ip_addresses,
+    :ssh_address,
+    :agent_version,
+    :cpu_count,
+    :total_memory_mb,
+    :socket_count,
+    :os_version
+  ]
 
   use Trento.Type
 
@@ -16,5 +25,6 @@ defmodule Trento.Integration.Discovery.HostDiscoveryPayload do
     field :total_memory_mb, :integer
     field :socket_count, :integer
     field :os_version, :string
+    field :installation_source, :string, default: "Unknown"
   end
 end

--- a/lib/trento/application/integration/discovery/policies/host_policy.ex
+++ b/lib/trento/application/integration/discovery/policies/host_policy.ex
@@ -78,7 +78,8 @@ defmodule Trento.Integration.Discovery.HostPolicy do
          cpu_count: cpu_count,
          total_memory_mb: total_memory_mb,
          socket_count: socket_count,
-         os_version: os_version
+         os_version: os_version,
+         installation_source: installation_source
        }),
        do:
          RegisterHost.new(%{
@@ -90,7 +91,8 @@ defmodule Trento.Integration.Discovery.HostPolicy do
            cpu_count: cpu_count,
            total_memory_mb: total_memory_mb,
            socket_count: socket_count,
-           os_version: os_version
+           os_version: os_version,
+           installation_source: installation_source
          })
 
   defp build_update_provider_command(agent_id, %CloudDiscoveryPayload{

--- a/lib/trento/application/integration/telemetry/adapter/suse.ex
+++ b/lib/trento/application/integration/telemetry/adapter/suse.ex
@@ -53,6 +53,7 @@ defmodule Trento.Integration.Telemetry.Suse do
         socket_count: &1.socket_count,
         total_memory_mb: &1.total_memory_mb,
         cloud_provider: &1.provider,
+        agent_installation_source: &1.installation_source,
         time: &1.updated_at
       }
     )

--- a/lib/trento/application/projectors/telemetry_projector.ex
+++ b/lib/trento/application/projectors/telemetry_projector.ex
@@ -23,7 +23,8 @@ defmodule Trento.TelemetryProjector do
       cpu_count: cpu_count,
       total_memory_mb: total_memory_mb,
       socket_count: socket_count,
-      os_version: sles_version
+      os_version: sles_version,
+      installation_source: installation_source
     },
     fn multi ->
       changeset =
@@ -34,7 +35,8 @@ defmodule Trento.TelemetryProjector do
           cpu_count: cpu_count,
           socket_count: socket_count,
           total_memory_mb: total_memory_mb,
-          sles_version: sles_version
+          sles_version: sles_version,
+          installation_source: installation_source
         })
 
       Ecto.Multi.insert(multi, :host_telemetry, changeset,
@@ -51,7 +53,8 @@ defmodule Trento.TelemetryProjector do
       cpu_count: cpu_count,
       socket_count: socket_count,
       total_memory_mb: total_memory_mb,
-      os_version: sles_version
+      os_version: sles_version,
+      installation_source: installation_source
     },
     fn multi ->
       changeset =
@@ -62,7 +65,8 @@ defmodule Trento.TelemetryProjector do
           cpu_count: cpu_count,
           socket_count: socket_count,
           total_memory_mb: total_memory_mb,
-          sles_version: sles_version
+          sles_version: sles_version,
+          installation_source: installation_source
         })
 
       Ecto.Multi.insert(multi, :host_telemetry, changeset,

--- a/lib/trento/application/read_models/host_telemetry_read_model.ex
+++ b/lib/trento/application/read_models/host_telemetry_read_model.ex
@@ -18,6 +18,7 @@ defmodule Trento.HostTelemetryReadModel do
     field :socket_count, :integer
     field :total_memory_mb, :integer
     field :sles_version, :string
+    field :installation_source, :string
     field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :unknown]
 
     timestamps()

--- a/lib/trento/application/read_models/host_telemetry_read_model.ex
+++ b/lib/trento/application/read_models/host_telemetry_read_model.ex
@@ -18,7 +18,11 @@ defmodule Trento.HostTelemetryReadModel do
     field :socket_count, :integer
     field :total_memory_mb, :integer
     field :sles_version, :string
-    field :installation_source, :string
+
+    field :installation_source, Ecto.Enum,
+      values: [:community, :suse, :unknown],
+      default: :unknown
+
     field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :unknown]
 
     timestamps()

--- a/lib/trento/domain/host/commands/register_host.ex
+++ b/lib/trento/domain/host/commands/register_host.ex
@@ -17,5 +17,6 @@ defmodule Trento.Domain.Commands.RegisterHost do
     field :total_memory_mb, :integer
     field :socket_count, :integer
     field :os_version, :string, default: "Unknown"
+    field :installation_source, :string, default: "Unknown"
   end
 end

--- a/lib/trento/domain/host/commands/register_host.ex
+++ b/lib/trento/domain/host/commands/register_host.ex
@@ -17,6 +17,9 @@ defmodule Trento.Domain.Commands.RegisterHost do
     field :total_memory_mb, :integer
     field :socket_count, :integer
     field :os_version, :string, default: "Unknown"
-    field :installation_source, :string, default: "Unknown"
+
+    field :installation_source, Ecto.Enum,
+      values: [:community, :suse, :unknown],
+      default: :unknown
   end
 end

--- a/lib/trento/domain/host/commands/register_host.ex
+++ b/lib/trento/domain/host/commands/register_host.ex
@@ -18,8 +18,6 @@ defmodule Trento.Domain.Commands.RegisterHost do
     field :socket_count, :integer
     field :os_version, :string, default: "Unknown"
 
-    field :installation_source, Ecto.Enum,
-      values: [:community, :suse, :unknown],
-      default: :unknown
+    field :installation_source, Ecto.Enum, values: [:community, :suse, :unknown]
   end
 end

--- a/lib/trento/domain/host/events/host_details_updated.ex
+++ b/lib/trento/domain/host/events/host_details_updated.ex
@@ -5,7 +5,7 @@ defmodule Trento.Domain.Events.HostDetailsUpdated do
 
   use Trento.Event
 
-  defevent do
+  defevent version: 2 do
     field :host_id, Ecto.UUID
     field :hostname, :string
     field :ip_addresses, {:array, :string}
@@ -20,4 +20,6 @@ defmodule Trento.Domain.Events.HostDetailsUpdated do
       values: [:community, :suse, :unknown],
       default: :unknown
   end
+
+  def upcast(params, _, 2), do: Map.put(params, "installation_source", :unknown)
 end

--- a/lib/trento/domain/host/events/host_details_updated.ex
+++ b/lib/trento/domain/host/events/host_details_updated.ex
@@ -15,6 +15,9 @@ defmodule Trento.Domain.Events.HostDetailsUpdated do
     field :total_memory_mb, :integer
     field :socket_count, :integer
     field :os_version, :string
-    field :installation_source, :string
+
+    field :installation_source, Ecto.Enum,
+      values: [:community, :suse, :unknown],
+      default: :unknown
   end
 end

--- a/lib/trento/domain/host/events/host_details_updated.ex
+++ b/lib/trento/domain/host/events/host_details_updated.ex
@@ -16,9 +16,7 @@ defmodule Trento.Domain.Events.HostDetailsUpdated do
     field :socket_count, :integer
     field :os_version, :string
 
-    field :installation_source, Ecto.Enum,
-      values: [:community, :suse, :unknown],
-      default: :unknown
+    field :installation_source, Ecto.Enum, values: [:community, :suse, :unknown]
   end
 
   def upcast(params, _, 2), do: Map.put(params, "installation_source", :unknown)

--- a/lib/trento/domain/host/events/host_details_updated.ex
+++ b/lib/trento/domain/host/events/host_details_updated.ex
@@ -15,5 +15,6 @@ defmodule Trento.Domain.Events.HostDetailsUpdated do
     field :total_memory_mb, :integer
     field :socket_count, :integer
     field :os_version, :string
+    field :installation_source, :string
   end
 end

--- a/lib/trento/domain/host/events/host_registered.ex
+++ b/lib/trento/domain/host/events/host_registered.ex
@@ -16,9 +16,7 @@ defmodule Trento.Domain.Events.HostRegistered do
     field :socket_count, :integer
     field :os_version, :string
 
-    field :installation_source, Ecto.Enum,
-      values: [:community, :suse, :unknown],
-      default: :unknown
+    field :installation_source, Ecto.Enum, values: [:community, :suse, :unknown]
 
     field :heartbeat, Ecto.Enum, values: [:unknown]
   end

--- a/lib/trento/domain/host/events/host_registered.ex
+++ b/lib/trento/domain/host/events/host_registered.ex
@@ -15,6 +15,7 @@ defmodule Trento.Domain.Events.HostRegistered do
     field :total_memory_mb, :integer
     field :socket_count, :integer
     field :os_version, :string
+    field :installation_source, :string
     field :heartbeat, Ecto.Enum, values: [:unknown]
   end
 end

--- a/lib/trento/domain/host/events/host_registered.ex
+++ b/lib/trento/domain/host/events/host_registered.ex
@@ -15,7 +15,11 @@ defmodule Trento.Domain.Events.HostRegistered do
     field :total_memory_mb, :integer
     field :socket_count, :integer
     field :os_version, :string
-    field :installation_source, :string
+
+    field :installation_source, Ecto.Enum,
+      values: [:community, :suse, :unknown],
+      default: :unknown
+
     field :heartbeat, Ecto.Enum, values: [:unknown]
   end
 end

--- a/lib/trento/domain/host/events/host_registered.ex
+++ b/lib/trento/domain/host/events/host_registered.ex
@@ -5,7 +5,7 @@ defmodule Trento.Domain.Events.HostRegistered do
 
   use Trento.Event
 
-  defevent do
+  defevent version: 2 do
     field :host_id, Ecto.UUID
     field :hostname, :string
     field :ip_addresses, {:array, :string}
@@ -22,4 +22,6 @@ defmodule Trento.Domain.Events.HostRegistered do
 
     field :heartbeat, Ecto.Enum, values: [:unknown]
   end
+
+  def upcast(params, _, 2), do: Map.put(params, "installation_source", :unknown)
 end

--- a/lib/trento/domain/host/host.ex
+++ b/lib/trento/domain/host/host.ex
@@ -37,6 +37,7 @@ defmodule Trento.Domain.Host do
     :total_memory_mb,
     :socket_count,
     :os_version,
+    :installation_source,
     :heartbeat,
     :subscriptions,
     :provider_data
@@ -53,6 +54,7 @@ defmodule Trento.Domain.Host do
           total_memory_mb: non_neg_integer(),
           socket_count: non_neg_integer(),
           os_version: String.t(),
+          installation_source: String.t(),
           subscriptions: [SlesSubscription.t()],
           provider_data: AwsProvider.t() | AzureProvider.t() | GcpProvider.t() | nil,
           heartbeat: :passing | :critical | :unknown
@@ -70,7 +72,8 @@ defmodule Trento.Domain.Host do
           cpu_count: cpu_count,
           total_memory_mb: total_memory_mb,
           socket_count: socket_count,
-          os_version: os_version
+          os_version: os_version,
+          installation_source: installation_source
         }
       ) do
     %HostRegistered{
@@ -83,6 +86,7 @@ defmodule Trento.Domain.Host do
       total_memory_mb: total_memory_mb,
       socket_count: socket_count,
       os_version: os_version,
+      installation_source: installation_source,
       heartbeat: :unknown
     }
   end
@@ -97,7 +101,8 @@ defmodule Trento.Domain.Host do
           cpu_count: cpu_count,
           total_memory_mb: total_memory_mb,
           socket_count: socket_count,
-          os_version: os_version
+          os_version: os_version,
+          installation_source: installation_source
         },
         %RegisterHost{
           hostname: hostname,
@@ -107,7 +112,8 @@ defmodule Trento.Domain.Host do
           cpu_count: cpu_count,
           total_memory_mb: total_memory_mb,
           socket_count: socket_count,
-          os_version: os_version
+          os_version: os_version,
+          installation_source: installation_source
         }
       ) do
     []
@@ -124,7 +130,8 @@ defmodule Trento.Domain.Host do
           cpu_count: cpu_count,
           total_memory_mb: total_memory_mb,
           socket_count: socket_count,
-          os_version: os_version
+          os_version: os_version,
+          installation_source: installation_source
         }
       ) do
     %HostDetailsUpdated{
@@ -136,7 +143,8 @@ defmodule Trento.Domain.Host do
       cpu_count: cpu_count,
       total_memory_mb: total_memory_mb,
       socket_count: socket_count,
-      os_version: os_version
+      os_version: os_version,
+      installation_source: installation_source
     }
   end
 
@@ -232,6 +240,7 @@ defmodule Trento.Domain.Host do
           total_memory_mb: total_memory_mb,
           socket_count: socket_count,
           os_version: os_version,
+          installation_source: installation_source,
           heartbeat: heartbeat
         }
       ) do
@@ -246,6 +255,7 @@ defmodule Trento.Domain.Host do
         total_memory_mb: total_memory_mb,
         socket_count: socket_count,
         os_version: os_version,
+        installation_source: installation_source,
         heartbeat: heartbeat
     }
   end
@@ -260,7 +270,8 @@ defmodule Trento.Domain.Host do
           cpu_count: cpu_count,
           total_memory_mb: total_memory_mb,
           socket_count: socket_count,
-          os_version: os_version
+          os_version: os_version,
+          installation_source: installation_source
         }
       ) do
     %Host{
@@ -272,7 +283,8 @@ defmodule Trento.Domain.Host do
         cpu_count: cpu_count,
         total_memory_mb: total_memory_mb,
         socket_count: socket_count,
-        os_version: os_version
+        os_version: os_version,
+        installation_source: installation_source
     }
   end
 

--- a/lib/trento/domain/host/host.ex
+++ b/lib/trento/domain/host/host.ex
@@ -54,7 +54,7 @@ defmodule Trento.Domain.Host do
           total_memory_mb: non_neg_integer(),
           socket_count: non_neg_integer(),
           os_version: String.t(),
-          installation_source: String.t(),
+          installation_source: :community | :suse | :unknown,
           subscriptions: [SlesSubscription.t()],
           provider_data: AwsProvider.t() | AzureProvider.t() | GcpProvider.t() | nil,
           heartbeat: :passing | :critical | :unknown

--- a/priv/repo/migrations/20220729073320_add_installation_source_host_telemetry_read_model.exs
+++ b/priv/repo/migrations/20220729073320_add_installation_source_host_telemetry_read_model.exs
@@ -1,0 +1,9 @@
+defmodule Trento.Repo.Migrations.AddInstallationSourceHostTelemetryReadModel do
+  use Ecto.Migration
+
+  def change do
+    alter table(:hosts_telemetry) do
+      add :installation_source, :string
+    end
+  end
+end

--- a/test/fixtures/discovery/host_discovery_with_installation_source.json
+++ b/test/fixtures/discovery/host_discovery_with_installation_source.json
@@ -1,0 +1,15 @@
+{
+  "agent_id": "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
+  "discovery_type": "host_discovery",
+  "payload": {
+    "ssh_address": "10.2.2.22",
+    "os_version": "15-SP2",
+    "ip_addresses": ["10.1.1.4", "10.1.1.5", "10.1.1.6"],
+    "hostname": "suse",
+    "cpu_count": 2,
+    "socket_count": 1,
+    "total_memory_mb": 4096,
+    "agent_version": "0.1.0",
+    "installation_source": "Community"
+  }
+}

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -64,7 +64,7 @@ defmodule Trento.Factory do
       total_memory_mb: Enum.random(1..128),
       socket_count: Enum.random(1..16),
       os_version: Faker.App.semver(),
-      installation_source: Faker.StarWars.character(),
+      installation_source: Enum.random([:community, :suse, :unknown]),
       heartbeat: :unknown
     }
   end
@@ -80,7 +80,7 @@ defmodule Trento.Factory do
       total_memory_mb: Enum.random(1..128),
       socket_count: Enum.random(1..16),
       os_version: Faker.App.semver(),
-      installation_source: Faker.StarWars.character()
+      installation_source: Enum.random([:community, :suse, :unknown])
     }
   end
 
@@ -160,7 +160,7 @@ defmodule Trento.Factory do
       socket_count: Enum.random(0..100),
       total_memory_mb: Enum.random(0..100),
       sles_version: Faker.App.version(),
-      installation_source: Faker.StarWars.character()
+      installation_source: Enum.random([:community, :suse, :unknown])
     }
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -64,6 +64,7 @@ defmodule Trento.Factory do
       total_memory_mb: Enum.random(1..128),
       socket_count: Enum.random(1..16),
       os_version: Faker.App.semver(),
+      installation_source: Faker.StarWars.character(),
       heartbeat: :unknown
     }
   end
@@ -78,7 +79,8 @@ defmodule Trento.Factory do
       cpu_count: Enum.random(1..16),
       total_memory_mb: Enum.random(1..128),
       socket_count: Enum.random(1..16),
-      os_version: Faker.App.semver()
+      os_version: Faker.App.semver(),
+      installation_source: Faker.StarWars.character()
     }
   end
 
@@ -157,7 +159,8 @@ defmodule Trento.Factory do
       cpu_count: Enum.random(0..100),
       socket_count: Enum.random(0..100),
       total_memory_mb: Enum.random(0..100),
-      sles_version: Faker.App.version()
+      sles_version: Faker.App.version(),
+      installation_source: Faker.StarWars.character()
     }
   end
 

--- a/test/trento/application/integration/discovery/policies/host_policy_test.exs
+++ b/test/trento/application/integration/discovery/policies/host_policy_test.exs
@@ -27,7 +27,7 @@ defmodule Trento.Integration.Discovery.HostPolicyTest do
                host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
                hostname: "suse",
                ip_addresses: ["10.1.1.4", "10.1.1.5", "10.1.1.6"],
-               installation_source: "Unknown"
+               installation_source: :unknown
              }
            } =
              "host_discovery"
@@ -43,7 +43,7 @@ defmodule Trento.Integration.Discovery.HostPolicyTest do
                host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
                hostname: "suse",
                ip_addresses: ["10.1.1.4", "10.1.1.5", "10.1.1.6"],
-               installation_source: "Community"
+               installation_source: :community
              }
            } =
              "host_discovery_with_installation_source"

--- a/test/trento/application/integration/discovery/policies/host_policy_test.exs
+++ b/test/trento/application/integration/discovery/policies/host_policy_test.exs
@@ -26,10 +26,27 @@ defmodule Trento.Integration.Discovery.HostPolicyTest do
                agent_version: "0.1.0",
                host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
                hostname: "suse",
-               ip_addresses: ["10.1.1.4", "10.1.1.5", "10.1.1.6"]
+               ip_addresses: ["10.1.1.4", "10.1.1.5", "10.1.1.6"],
+               installation_source: "Unknown"
              }
            } =
              "host_discovery"
+             |> load_discovery_event_fixture()
+             |> HostPolicy.handle()
+  end
+
+  test "should return the expected commands when a host_discovery_with_installation_source payload is handled" do
+    assert {
+             :ok,
+             %RegisterHost{
+               agent_version: "0.1.0",
+               host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
+               hostname: "suse",
+               ip_addresses: ["10.1.1.4", "10.1.1.5", "10.1.1.6"],
+               installation_source: "Community"
+             }
+           } =
+             "host_discovery_with_installation_source"
              |> load_discovery_event_fixture()
              |> HostPolicy.handle()
   end

--- a/test/trento/domain/host/events/host_details_updated_test.exs
+++ b/test/trento/domain/host/events/host_details_updated_test.exs
@@ -1,0 +1,46 @@
+defmodule Trento.Domain.Events.HostDetailsUpdatedTest do
+  use Trento.AggregateCase, aggregate: Trento.Domain.Host, async: true
+
+  alias Trento.Domain.Events.HostDetailsUpdated
+
+  describe "HostDetailsUpdated event upcasting" do
+    test "should upcast HostDetailsUpdated event properly from version 1" do
+      host_id = Faker.UUID.v4()
+      hostname = Faker.StarWars.character()
+      ip_addresses = [Faker.Internet.ip_v4_address()]
+      ssh_address = Faker.Internet.ip_v4_address()
+      agent_version = Faker.Internet.slug()
+      cpu_count = Enum.random(1..16)
+      total_memory_mb = Enum.random(1..128)
+      socket_count = Enum.random(1..16)
+      os_version = Faker.App.version()
+
+      assert %HostDetailsUpdated{
+               version: 2,
+               host_id: host_id,
+               hostname: hostname,
+               ip_addresses: ip_addresses,
+               ssh_address: ssh_address,
+               agent_version: agent_version,
+               cpu_count: cpu_count,
+               total_memory_mb: total_memory_mb,
+               socket_count: socket_count,
+               os_version: os_version,
+               installation_source: :unknown
+             } ==
+               %{
+                 "host_id" => host_id,
+                 "hostname" => hostname,
+                 "ip_addresses" => ip_addresses,
+                 "ssh_address" => ssh_address,
+                 "agent_version" => agent_version,
+                 "cpu_count" => cpu_count,
+                 "total_memory_mb" => total_memory_mb,
+                 "socket_count" => socket_count,
+                 "os_version" => os_version
+               }
+               |> HostDetailsUpdated.upcast(%{})
+               |> HostDetailsUpdated.new!()
+    end
+  end
+end

--- a/test/trento/domain/host/events/host_registered_test.exs
+++ b/test/trento/domain/host/events/host_registered_test.exs
@@ -1,0 +1,46 @@
+defmodule Trento.Domain.Events.HostRegisteredTest do
+  use Trento.AggregateCase, aggregate: Trento.Domain.Host, async: true
+
+  alias Trento.Domain.Events.HostRegistered
+
+  describe "HostRegistered event upcasting" do
+    test "should upcast HostRegistered event properly from version 1" do
+      host_id = Faker.UUID.v4()
+      hostname = Faker.StarWars.character()
+      ip_addresses = [Faker.Internet.ip_v4_address()]
+      ssh_address = Faker.Internet.ip_v4_address()
+      agent_version = Faker.Internet.slug()
+      cpu_count = Enum.random(1..16)
+      total_memory_mb = Enum.random(1..128)
+      socket_count = Enum.random(1..16)
+      os_version = Faker.App.version()
+
+      assert %HostRegistered{
+               version: 2,
+               host_id: host_id,
+               hostname: hostname,
+               ip_addresses: ip_addresses,
+               ssh_address: ssh_address,
+               agent_version: agent_version,
+               cpu_count: cpu_count,
+               total_memory_mb: total_memory_mb,
+               socket_count: socket_count,
+               os_version: os_version,
+               installation_source: :unknown
+             } ==
+               %{
+                 "host_id" => host_id,
+                 "hostname" => hostname,
+                 "ip_addresses" => ip_addresses,
+                 "ssh_address" => ssh_address,
+                 "agent_version" => agent_version,
+                 "cpu_count" => cpu_count,
+                 "total_memory_mb" => total_memory_mb,
+                 "socket_count" => socket_count,
+                 "os_version" => os_version
+               }
+               |> HostRegistered.upcast(%{})
+               |> HostRegistered.new!()
+    end
+  end
+end

--- a/test/trento/domain/host/host_test.exs
+++ b/test/trento/domain/host/host_test.exs
@@ -531,4 +531,26 @@ defmodule Trento.HostTest do
       )
     end
   end
+
+  describe "event upcasting" do
+    test "should upcast HostRegistered event properly" do
+      assert %HostRegistered{
+               version: 2,
+               installation_source: :unknown
+             } ==
+               %{}
+               |> HostRegistered.upcast(%{})
+               |> HostRegistered.new!()
+    end
+
+    test "should upcast HostDetailsUpdated event properly" do
+      assert %HostDetailsUpdated{
+               version: 2,
+               installation_source: :unknown
+             } ==
+               %{}
+               |> HostDetailsUpdated.upcast(%{})
+               |> HostDetailsUpdated.new!()
+    end
+  end
 end

--- a/test/trento/domain/host/host_test.exs
+++ b/test/trento/domain/host/host_test.exs
@@ -39,7 +39,7 @@ defmodule Trento.HostTest do
       total_memory_mb = Enum.random(1..128)
       socket_count = Enum.random(1..16)
       os_version = Faker.App.version()
-      installation_source = Faker.StarWars.character()
+      installation_source = Enum.random([:community, :suse, :unknown])
 
       assert_events_and_state(
         [],
@@ -94,7 +94,7 @@ defmodule Trento.HostTest do
       new_total_memory_mb = Enum.random(1..128)
       new_socket_count = Enum.random(1..16)
       new_os_version = Faker.App.version()
-      new_installation_source = Faker.StarWars.character()
+      new_installation_source = Enum.random([:community, :suse, :unknown])
 
       assert_events_and_state(
         build(:host_registered_event, host_id: host_id),

--- a/test/trento/domain/host/host_test.exs
+++ b/test/trento/domain/host/host_test.exs
@@ -39,6 +39,7 @@ defmodule Trento.HostTest do
       total_memory_mb = Enum.random(1..128)
       socket_count = Enum.random(1..16)
       os_version = Faker.App.version()
+      installation_source = Faker.StarWars.character()
 
       assert_events_and_state(
         [],
@@ -51,7 +52,8 @@ defmodule Trento.HostTest do
           cpu_count: cpu_count,
           total_memory_mb: total_memory_mb,
           socket_count: socket_count,
-          os_version: os_version
+          os_version: os_version,
+          installation_source: installation_source
         }),
         %HostRegistered{
           host_id: host_id,
@@ -63,6 +65,7 @@ defmodule Trento.HostTest do
           total_memory_mb: total_memory_mb,
           socket_count: socket_count,
           os_version: os_version,
+          installation_source: installation_source,
           heartbeat: :unknown
         },
         %Host{
@@ -75,6 +78,7 @@ defmodule Trento.HostTest do
           total_memory_mb: total_memory_mb,
           socket_count: socket_count,
           os_version: os_version,
+          installation_source: installation_source,
           heartbeat: :unknown
         }
       )
@@ -90,6 +94,7 @@ defmodule Trento.HostTest do
       new_total_memory_mb = Enum.random(1..128)
       new_socket_count = Enum.random(1..16)
       new_os_version = Faker.App.version()
+      new_installation_source = Faker.StarWars.character()
 
       assert_events_and_state(
         build(:host_registered_event, host_id: host_id),
@@ -102,7 +107,8 @@ defmodule Trento.HostTest do
           cpu_count: new_cpu_count,
           total_memory_mb: new_total_memory_mb,
           socket_count: new_socket_count,
-          os_version: new_os_version
+          os_version: new_os_version,
+          installation_source: new_installation_source
         }),
         %HostDetailsUpdated{
           host_id: host_id,
@@ -113,7 +119,8 @@ defmodule Trento.HostTest do
           cpu_count: new_cpu_count,
           total_memory_mb: new_total_memory_mb,
           socket_count: new_socket_count,
-          os_version: new_os_version
+          os_version: new_os_version,
+          installation_source: new_installation_source
         },
         %Host{
           host_id: host_id,
@@ -125,6 +132,7 @@ defmodule Trento.HostTest do
           total_memory_mb: new_total_memory_mb,
           socket_count: new_socket_count,
           os_version: new_os_version,
+          installation_source: new_installation_source,
           heartbeat: :unknown
         }
       )
@@ -144,7 +152,8 @@ defmodule Trento.HostTest do
           cpu_count: host_registered_event.cpu_count,
           total_memory_mb: host_registered_event.total_memory_mb,
           socket_count: host_registered_event.socket_count,
-          os_version: host_registered_event.os_version
+          os_version: host_registered_event.os_version,
+          installation_source: host_registered_event.installation_source
         }),
         []
       )

--- a/test/trento/domain/host/host_test.exs
+++ b/test/trento/domain/host/host_test.exs
@@ -531,26 +531,4 @@ defmodule Trento.HostTest do
       )
     end
   end
-
-  describe "event upcasting" do
-    test "should upcast HostRegistered event properly" do
-      assert %HostRegistered{
-               version: 2,
-               installation_source: :unknown
-             } ==
-               %{}
-               |> HostRegistered.upcast(%{})
-               |> HostRegistered.new!()
-    end
-
-    test "should upcast HostDetailsUpdated event properly" do
-      assert %HostDetailsUpdated{
-               version: 2,
-               installation_source: :unknown
-             } ==
-               %{}
-               |> HostDetailsUpdated.upcast(%{})
-               |> HostDetailsUpdated.new!()
-    end
-  end
 end


### PR DESCRIPTION
Add the installation_source field to the host telemetry model.

This field is not required in the agent side, we so it is still backwards compatible with older agent version. In this cases, it is populated with `Unknown` string.

Depends on: https://github.com/trento-project/agent/pull/64