### PR TITLE
Set version with git

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -484,7 +484,10 @@ jobs:
 
       - name: Set version
         run: |
-          VERSION=${{ steps.latest-tag.outputs.tag }}
+          git config --global --add safe.directory /__w/web/web
+          VERSION=$(./hack/get_version_from_git.sh)
+          # "+" character is not allowed in OBS dockerfile version strings
+          VERSION=${VERSION//[+]/-}
           sed -i 's~%%VERSION%%~'"${VERSION}"'~' packaging/suse/Dockerfile
 
       - name: Commit on OBS

--- a/hack/get_version_from_git.sh
+++ b/hack/get_version_from_git.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+set -e
+set -o pipefail
+
 TAG=$( git tag | grep -E "[0-9]\.[0-9]\.[0-9]" | sort -rn | head -n1 )
 
 if [ -n "${TAG}" ]; then

--- a/mix.exs
+++ b/mix.exs
@@ -1,11 +1,26 @@
 defmodule Trento.MixProject do
   use Mix.Project
 
+  @version "1.1.0"
+  defp get_version do
+    case System.get_env("VERSION") do
+      nil -> get_version_from_git()
+      version -> version
+    end
+  end
+
+  defp get_version_from_git do
+    case File.cwd!() |> Path.join("hack/get_version_from_git.sh") |> System.cmd([]) do
+      {version, 0} -> version |> String.trim("\n")
+      _ -> @version
+    end
+  end
+
   def project do
     [
       app: :trento,
       description: "Easing your life in administering SAP applications",
-      version: "1.1.0",
+      version: get_version(),
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:gettext] ++ Mix.compilers(),

--- a/mix.exs
+++ b/mix.exs
@@ -2,19 +2,6 @@ defmodule Trento.MixProject do
   use Mix.Project
 
   @version "1.1.0"
-  defp get_version do
-    case System.get_env("VERSION") do
-      nil -> get_version_from_git()
-      version -> version
-    end
-  end
-
-  defp get_version_from_git do
-    case File.cwd!() |> Path.join("hack/get_version_from_git.sh") |> System.cmd([]) do
-      {version, 0} -> version |> String.trim("\n")
-      _ -> @version
-    end
-  end
 
   def project do
     [
@@ -135,5 +122,14 @@ defmodule Trento.MixProject do
         "phx.digest"
       ]
     ]
+  end
+
+  defp get_version, do: System.get_env("VERSION", get_version_from_git())
+
+  defp get_version_from_git do
+    case File.cwd!() |> Path.join("hack/get_version_from_git.sh") |> System.cmd([]) do
+      {version, 0} -> version |> String.trim("\n")
+      _ -> @version
+    end
   end
 end

--- a/packaging/suse/Dockerfile
+++ b/packaging/suse/Dockerfile
@@ -22,7 +22,7 @@ ENV MIX_ENV=prod
 ENV MIX_HOME=/usr/bin
 ENV FLAVOR="Premium"
 RUN mix phx.digest
-RUN mix release
+RUN VERSION=%%VERSION%% mix release
 
 FROM bci/bci-base:15.3 AS trento
 # Define labels according to https://en.opensuse.org/Building_derived_containers


### PR DESCRIPTION
In order to get the version of the rolling container, this PR includes a new way of getting the application version. It uses the next order:
1. `VERSION` env variable during the release creation
2. `hack/get_version_from_git.sh` script output
3. Default version

![image](https://user-images.githubusercontent.com/36370954/182158643-b91f5364-37a6-4360-af01-8c62c4e96793.png)


PD: I have already checked solutions like [edeliver](https://github.com/edeliver/edeliver), but they look more complicated than the thing we really need. Anyway, if there is any better way of doing so, I'm all open to apply it!