### PR TITLE
Increase the z-index for modals and modal backdrops

### DIFF
--- a/assets/js/components/Modal/Modal.jsx
+++ b/assets/js/components/Modal/Modal.jsx
@@ -6,7 +6,7 @@ const Modal = ({ children, open, onClose, title }) => {
     <Transition appear show={open} as={Fragment}>
       <Dialog
         as="div"
-        className="fixed inset-0 z-30 overflow-y-auto"
+        className="fixed inset-0 z-50 overflow-y-auto"
         onClose={onClose}
       >
         <div className="min-h-screen px-4 text-center">


### PR DESCRIPTION
Just increasing the z-index for modals and modal backdrops since with open modals we could see the sidebar handle.

Before:

![image](https://user-images.githubusercontent.com/20770/182176066-cc533651-ac48-40e7-8393-e1741bd2b304.png)


After:

![image](https://user-images.githubusercontent.com/20770/182175779-8175d34c-d978-474f-9af5-0cebf037e6d9.png)
