### PR TITLE
Fix nil provider broadcast

### DIFF
--- a/lib/trento/application/projectors/host_projector.ex
+++ b/lib/trento/application/projectors/host_projector.ex
@@ -184,7 +184,11 @@ defmodule Trento.HostProjector do
     TrentoWeb.Endpoint.broadcast(
       "monitoring:hosts",
       "host_details_updated",
-      host |> to_map() |> Map.delete("cluster_id") |> Map.delete("heartbeat")
+      host
+      |> to_map()
+      |> Map.delete("cluster_id")
+      |> Map.delete("heartbeat")
+      |> Map.delete("provider")
     )
   end
 


### PR DESCRIPTION
This PR fixes the `HostDetailsUpdated` broadcast that overrides the provider with a nil value