### PR TITLE
Add missing env vars required for photofinish

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -501,6 +501,9 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch'
     needs: deploy-demo-env
+    env:
+      TRENTO_DEMO_IP: ${{ secrets.TRENTO_DEMO_IP }}
+      TRENTO_API_KEY: ${{ secrets.TRENTO_API_KEY }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Sorry, missed this in PR https://github.com/trento-project/web/pull/723

This allows photofinish to use the secrets in GH to push the data to the right server with the right auth