### PR TITLE
Set the version properly in the suse container dockerfile

### DIFF
--- a/packaging/suse/Dockerfile
+++ b/packaging/suse/Dockerfile
@@ -21,8 +21,9 @@ ENV LC_ALL en_US.UTF-8
 ENV MIX_ENV=prod
 ENV MIX_HOME=/usr/bin
 ENV FLAVOR="Premium"
+ENV VERSION=%%VERSION%%
 RUN mix phx.digest
-RUN VERSION=%%VERSION%% mix release
+RUN mix release
 
 FROM bci/bci-base:15.3 AS trento
 # Define labels according to https://en.opensuse.org/Building_derived_containers


### PR DESCRIPTION
The `VERSION` variable was being used incorrectly, as the digest command was not getting it. Even thought the release command was okay, the about page was showing the default version