### PR TITLE
Set expectations for the about.js from cypress.env

### DIFF
--- a/test/e2e/cypress/integration/about.js
+++ b/test/e2e/cypress/integration/about.js
@@ -17,17 +17,22 @@ describe('User account page', () => {
   });
 
   it('should show the correct server version', () => {
-    let version;
-    if (Cypress.env('version')) {
-      version = Cypress.env('version');
-    } else {
-      cy.exec(`cd ${Cypress.env('project_root')} && mix version`).then(
-        ({ stdout: out_version }) => {
-          version = out_version;
+    cy.get('div')
+      .contains('Server version')
+      .next()
+      .then(($sv) => {
+        if (Cypress.env('version')) {
+          expect($sv).to.contain(Cypress.env('version'));
+        } else {
+          cy.exec(`cd ${Cypress.env('project_root')} && mix version`)
+            .then(({ stdout: out_version }) => {
+              return out_version;
+            })
+            .then((version) => {
+              expect($sv.text()).to.contain(version);
+            });
         }
-      );
-    }
-    cy.get('div').contains('Server version').next().should('contain', version);
+      });
   });
 
   it('should show the github project link', () => {

--- a/test/e2e/cypress/integration/about.js
+++ b/test/e2e/cypress/integration/about.js
@@ -9,21 +9,25 @@ describe('User account page', () => {
   });
 
   it('should show the correct flavor', () => {
-    cy.get('div')
-      .contains('Trento flavor')
-      .next()
-      .should('contain', 'Community');
+    let flavour = 'Community';
+    if (Cypress.env('flavour')) {
+      flavour = Cypress.env('flavour');
+    }
+    cy.get('div').contains('Trento flavor').next().should('contain', flavour);
   });
 
   it('should show the correct server version', () => {
-    cy.exec(`cd ${Cypress.env('project_root')} && mix version`).then(
-      ({ stdout: version }) => {
-        cy.get('div')
-          .contains('Server version')
-          .next()
-          .should('contain', version);
-      }
-    );
+    let version;
+    if (Cypress.env('version')) {
+      version = Cypress.env('version');
+    } else {
+      cy.exec(`cd ${Cypress.env('project_root')} && mix version`).then(
+        ({ stdout: out_version }) => {
+          version = out_version;
+        }
+      );
+    }
+    cy.get('div').contains('Server version').next().should('contain', version);
   });
 
   it('should show the github project link', () => {
@@ -33,10 +37,14 @@ describe('User account page', () => {
       .should('contain', 'https://github.com/trento-project/web');
   });
 
-  it('should display 27 SLES subscriptions found', () => {
+  it('should display number of SLES subscriptions found', () => {
+    let subscriptions = 27;
+    if (typeof Cypress.env('subscriptions') !== 'undefined') {
+      subscriptions = Cypress.env('subscriptions');
+    }
     cy.get('div')
       .contains('SLES for SAP subscriptions')
       .next()
-      .should('contain', '27 found');
+      .should('contain', subscriptions + ' found');
   });
 });

--- a/test/e2e/cypress/support/commands.js
+++ b/test/e2e/cypress/support/commands.js
@@ -55,9 +55,11 @@ Cypress.Commands.add('loadScenario', (scenario) => {
     Cypress.env('web_api_port'),
   ];
   cy.log(`Loading scenario "${scenario}"...`);
-  cy.exec(
-    `cd ${projectRoot} && ${photofinishBinary} run --url "http://${webAPIHost}:${webAPIPort}/api/collect" ${scenario}`
-  );
+  if (photofinishBinary) {
+    cy.exec(
+      `cd ${projectRoot} && ${photofinishBinary} run --url "http://${webAPIHost}:${webAPIPort}/api/collect" ${scenario}`
+    );
+  }
 });
 
 Cypress.Commands.add('navigateToItem', (item) => {

--- a/test/e2e/cypress/support/commands.js
+++ b/test/e2e/cypress/support/commands.js
@@ -54,11 +54,13 @@ Cypress.Commands.add('loadScenario', (scenario) => {
     Cypress.env('web_api_host'),
     Cypress.env('web_api_port'),
   ];
-  cy.log(`Loading scenario "${scenario}"...`);
   if (photofinishBinary) {
+    cy.log(`Loading scenario "${scenario}"...`);
     cy.exec(
       `cd ${projectRoot} && ${photofinishBinary} run --url "http://${webAPIHost}:${webAPIPort}/api/collect" ${scenario}`
     );
+  } else {
+    cy.log(`Photofinish is not used.`);
   }
 });
 


### PR DESCRIPTION
It has only been tested against a Trento deployed in Azure. Not tested in the local simulated environment.
Tested with cypress.json like
```
{
  "baseUrl": "http://<IP_OF_MY_DEPLOYMENT>",
  "viewportWidth": 1366,
  "viewportHeight": 768,
  "defaultCommandTimeout": 10000,
  "env": {
    "web_api_host": "127.0.0.1",
    "web_api_port": 4000,
    "heartbeat_interval": 5000,
    "db_host": "127.0.0.1",
    "db_port": 5432,
    "project_root": "../..",
    "login_user": "admin",
    "login_password": "******",
    "flavour": "Premium",
    "version": "1.1.0",
    "subscriptions": 0
  }
}
``` 

Note that the env about photofinish has been removed, to disable its execution.