### PR TITLE
Add value files support inside the Cypress testing suite

### DIFF
--- a/test/e2e/cypress.json
+++ b/test/e2e/cypress.json
@@ -12,6 +12,7 @@
     "project_root": "../..",
     "photofinish_binary": "photofinish",
     "login_user": "admin",
-    "login_password": "adminpassword"
+    "login_password": "adminpassword",
+    "destination_environment": "dev"
   }
 }

--- a/test/e2e/cypress/integration/about.js
+++ b/test/e2e/cypress/integration/about.js
@@ -1,3 +1,5 @@
+import { getValue } from '../support/common';
+
 describe('User account page', () => {
   before(() => {
     cy.navigateToItem('About');
@@ -9,11 +11,10 @@ describe('User account page', () => {
   });
 
   it('should show the correct flavor', () => {
-    let flavour = 'Community';
-    if (Cypress.env('flavour')) {
-      flavour = Cypress.env('flavour');
-    }
-    cy.get('div').contains('Trento flavor').next().should('contain', flavour);
+    cy.get('div')
+      .contains('Trento flavor')
+      .next()
+      .should('contain', getValue('flavor'));
   });
 
   it('should show the correct server version', () => {
@@ -43,10 +44,7 @@ describe('User account page', () => {
   });
 
   it('should display number of SLES subscriptions found', () => {
-    let subscriptions = 27;
-    if (typeof Cypress.env('subscriptions') !== 'undefined') {
-      subscriptions = Cypress.env('subscriptions');
-    }
+    const subscriptions = getValue('subscriptions');
     cy.get('div')
       .contains('SLES for SAP subscriptions')
       .next()

--- a/test/e2e/cypress/support/common.js
+++ b/test/e2e/cypress/support/common.js
@@ -1,5 +1,5 @@
 import devValues from './values.dev.json';
-import prodValues from './values.dev.json';
+import prodValues from './values.prod.json';
 
 export const getValue = (key, defaultValue) => {
   const environment = Cypress.env('destination_environment');

--- a/test/e2e/cypress/support/common.js
+++ b/test/e2e/cypress/support/common.js
@@ -1,0 +1,15 @@
+import devValues from './values.dev.json';
+import prodValues from './values.dev.json';
+
+export const getValue = (key, defaultValue) => {
+  const environment = Cypress.env('destination_environment');
+
+  switch (environment) {
+    case 'dev':
+      return devValues[key];
+    case 'prod':
+      return prodValues[key];
+    default:
+      return defaultValue;
+  }
+};

--- a/test/e2e/cypress/support/values.dev.json
+++ b/test/e2e/cypress/support/values.dev.json
@@ -1,0 +1,4 @@
+{
+  "flavor": "Community",
+  "subscriptions": 27
+}

--- a/test/e2e/cypress/support/values.prod.json
+++ b/test/e2e/cypress/support/values.prod.json
@@ -1,0 +1,4 @@
+{
+  "flavor": "Premium",
+  "subscriptions": 27
+}


### PR DESCRIPTION
Since we aim to reuse the same e2e tests against the CI environment and a "real world" one, this PR introduces support for different value files depending on which environment do we run the test against.

To switch the environment the cypress env variable `destination_environment` can be used.