### PR TITLE
Update fixtures to reflect a recent agent version

### DIFF
--- a/assets/js/lib/test-utils/data/hosts.js
+++ b/assets/js/lib/test-utils/data/hosts.js
@@ -1,6 +1,6 @@
 export default [
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: '6bd7ec60-8cb1-5c6b-a892-29e1fd2f8380',
     heartbeat: 'unknown',
     hostname: 'vmdrbddev01',
@@ -114,7 +114,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: '6bd7ec60-8cb1-5c6b-a892-29e1fd2f8380',
     heartbeat: 'unknown',
     hostname: 'vmdrbddev02',
@@ -228,7 +228,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: 'c7a1e943-bf46-590b-bd26-bfc7c78def97',
     heartbeat: 'unknown',
     hostname: 'vmdrbdprd01',
@@ -342,7 +342,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: 'c7a1e943-bf46-590b-bd26-bfc7c78def97',
     heartbeat: 'unknown',
     hostname: 'vmdrbdprd02',
@@ -456,7 +456,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: '8a66f8fb-5fe9-51b3-a34c-24321271a4e3',
     heartbeat: 'unknown',
     hostname: 'vmdrbdqas01',
@@ -570,7 +570,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: '8a66f8fb-5fe9-51b3-a34c-24321271a4e3',
     heartbeat: 'unknown',
     hostname: 'vmdrbdqas02',
@@ -684,7 +684,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: '7965f822-0254-5858-abca-f6e8b4c27714',
     heartbeat: 'unknown',
     hostname: 'vmhdbdev01',
@@ -798,7 +798,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: '7965f822-0254-5858-abca-f6e8b4c27714',
     heartbeat: 'unknown',
     hostname: 'vmhdbdev02',
@@ -912,7 +912,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: '469e7be5-4e20-5007-b044-c6f540a87493',
     heartbeat: 'unknown',
     hostname: 'vmhdbprd01',
@@ -1026,7 +1026,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: '469e7be5-4e20-5007-b044-c6f540a87493',
     heartbeat: 'unknown',
     hostname: 'vmhdbprd02',
@@ -1140,7 +1140,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: 'fa0d74a3-9240-5d9e-99fa-61c4137acf81',
     heartbeat: 'unknown',
     hostname: 'vmhdbqas01',
@@ -1254,7 +1254,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: 'fa0d74a3-9240-5d9e-99fa-61c4137acf81',
     heartbeat: 'unknown',
     hostname: 'vmhdbqas02',
@@ -1368,7 +1368,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: null,
     heartbeat: 'unknown',
     hostname: 'vmiscsi01',
@@ -1482,7 +1482,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: null,
     heartbeat: 'unknown',
     hostname: 'vmiscsi01',
@@ -1596,7 +1596,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: null,
     heartbeat: 'unknown',
     hostname: 'vmiscsi01',
@@ -1710,7 +1710,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: '5284f376-c1f4-5178-8966-d490df3dab4f',
     heartbeat: 'unknown',
     hostname: 'vmnwdev01',
@@ -1824,7 +1824,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: '5284f376-c1f4-5178-8966-d490df3dab4f',
     heartbeat: 'unknown',
     hostname: 'vmnwdev02',
@@ -1938,7 +1938,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: null,
     heartbeat: 'unknown',
     hostname: 'vmnwdev03',
@@ -2052,7 +2052,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: null,
     heartbeat: 'unknown',
     hostname: 'vmnwdev04',
@@ -2166,7 +2166,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: '0eac831a-aa66-5f45-89a4-007fbd2c5714',
     heartbeat: 'unknown',
     hostname: 'vmnwprd01',
@@ -2280,7 +2280,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: '0eac831a-aa66-5f45-89a4-007fbd2c5714',
     heartbeat: 'unknown',
     hostname: 'vmnwprd02',
@@ -2394,7 +2394,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: null,
     heartbeat: 'unknown',
     hostname: 'vmnwprd03',
@@ -2508,7 +2508,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: null,
     heartbeat: 'unknown',
     hostname: 'vmnwprd04',
@@ -2622,7 +2622,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: 'fb861bce-d212-56b5-8786-74afd6eb58cb',
     heartbeat: 'unknown',
     hostname: 'vmnwqas01',
@@ -2736,7 +2736,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: 'fb861bce-d212-56b5-8786-74afd6eb58cb',
     heartbeat: 'unknown',
     hostname: 'vmnwqas02',
@@ -2850,7 +2850,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: null,
     heartbeat: 'unknown',
     hostname: 'vmnwqas03',
@@ -2955,7 +2955,7 @@ export default [
     tags: [],
   },
   {
-    agent_version: '0.7.1+git.dev42.1640084952.33229fc',
+    agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
     cluster_id: null,
     heartbeat: 'unknown',
     hostname: 'vmnwqas04',

--- a/test/e2e/cypress/fixtures/hana-database-details/selected_database.js
+++ b/test/e2e/cypress/fixtures/hana-database-details/selected_database.js
@@ -34,7 +34,7 @@ export const attachedHosts = [
     Provider: 'azure',
     Cluster: 'hana_cluster',
     ClusterId: '7965f822-0254-5858-abca-f6e8b4c27714',
-    Version: '0.7.1+git.dev42.1640084952.33229fc',
+    Version: '1.1.0+git.dev17.1660137228.fe5ba8a',
   },
   {
     Name: 'vmhdbdev01',
@@ -43,6 +43,6 @@ export const attachedHosts = [
     Provider: 'azure',
     Cluster: 'hana_cluster',
     ClusterId: '7965f822-0254-5858-abca-f6e8b4c27714',
-    Version: '0.7.1+git.dev42.1640084952.33229fc',
+    Version: '1.1.0+git.dev17.1660137228.fe5ba8a',
   },
 ];

--- a/test/e2e/cypress/fixtures/host-details/selected_host.js
+++ b/test/e2e/cypress/fixtures/host-details/selected_host.js
@@ -1,6 +1,6 @@
 export const selectedHost = {
   agentId: '9cd46919-5f19-59aa-993e-cf3736c71053',
-  agentVersion: '0.7.1+git.dev42.1640084952.33229fc',
+  agentVersion: '1.1.0+git.dev17.1660137228.fe5ba8a',
   hostName: 'vmhdbprd01',
   clusterName: 'hana_cluster_3',
   clusterId: '469e7be5-4e20-5007-b044-c6f540a87493',

--- a/test/e2e/cypress/fixtures/hosts-overview/available_hosts.js
+++ b/test/e2e/cypress/fixtures/hosts-overview/available_hosts.js
@@ -8,7 +8,7 @@ export const availableHosts = [
     clusterId: '',
     sapSystemSid: '',
     sapSystemId: '',
-    agentVersion: '0.7.1+git.dev42.1640084952.33229fc',
+    agentVersion: '1.1.0+git.dev17.1660137228.fe5ba8a',
     tag: 'env1',
   },
   {
@@ -20,7 +20,7 @@ export const availableHosts = [
     clusterId: '',
     sapSystemSid: '',
     sapSystemId: '',
-    agentVersion: '0.7.1+git.dev42.1640084952.33229fc',
+    agentVersion: '1.1.0+git.dev17.1660137228.fe5ba8a',
     tag: 'env1',
   },
   {
@@ -32,7 +32,7 @@ export const availableHosts = [
     clusterId: '',
     sapSystemSid: '',
     sapSystemId: '',
-    agentVersion: '0.7.1+git.dev42.1640084952.33229fc',
+    agentVersion: '1.1.0+git.dev17.1660137228.fe5ba8a',
     tag: 'env2',
   },
   {
@@ -44,7 +44,7 @@ export const availableHosts = [
     clusterId: '',
     sapSystemSid: '',
     sapSystemId: '',
-    agentVersion: '0.7.1+git.dev42.1640084952.33229fc',
+    agentVersion: '1.1.0+git.dev17.1660137228.fe5ba8a',
     tag: 'env2',
   },
   {
@@ -56,7 +56,7 @@ export const availableHosts = [
     clusterId: '',
     sapSystemSid: '',
     sapSystemId: '',
-    agentVersion: '0.7.1+git.dev42.1640084952.33229fc',
+    agentVersion: '1.1.0+git.dev17.1660137228.fe5ba8a',
     tag: 'env3',
   },
   {
@@ -68,7 +68,7 @@ export const availableHosts = [
     clusterId: '',
     sapSystemSid: '',
     sapSystemId: '',
-    agentVersion: '0.7.1+git.dev42.1640084952.33229fc',
+    agentVersion: '1.1.0+git.dev17.1660137228.fe5ba8a',
     tag: 'env3',
   },
   {
@@ -80,7 +80,7 @@ export const availableHosts = [
     clusterId: '7965f822-0254-5858-abca-f6e8b4c27714',
     sapSystemSid: 'HDD',
     sapSystemId: 'f534a4ad-cef7-5234-b196-e67082ffb50c',
-    agentVersion: '0.7.1+git.dev42.1640084952.33229fc',
+    agentVersion: '1.1.0+git.dev17.1660137228.fe5ba8a',
     tag: 'env1',
   },
   {
@@ -92,7 +92,7 @@ export const availableHosts = [
     clusterId: '7965f822-0254-5858-abca-f6e8b4c27714',
     sapSystemSid: 'HDD',
     sapSystemId: 'f534a4ad-cef7-5234-b196-e67082ffb50c',
-    agentVersion: '0.7.1+git.dev42.1640084952.33229fc',
+    agentVersion: '1.1.0+git.dev17.1660137228.fe5ba8a',
     tag: 'env1',
   },
   {
@@ -104,7 +104,7 @@ export const availableHosts = [
     clusterId: '469e7be5-4e20-5007-b044-c6f540a87493',
     sapSystemSid: 'HDP',
     sapSystemId: '6c9208eb-a5bb-57ef-be5c-6422dedab602',
-    agentVersion: '0.7.1+git.dev42.1640084952.33229fc',
+    agentVersion: '1.1.0+git.dev17.1660137228.fe5ba8a',
     tag: 'env2',
   },
   {
@@ -116,7 +116,7 @@ export const availableHosts = [
     clusterId: '469e7be5-4e20-5007-b044-c6f540a87493',
     sapSystemSid: 'HDP',
     sapSystemId: '6c9208eb-a5bb-57ef-be5c-6422dedab602',
-    agentVersion: '0.7.1+git.dev42.1640084952.33229fc',
+    agentVersion: '1.1.0+git.dev17.1660137228.fe5ba8a',
     tag: 'env2',
   },
   {

--- a/test/e2e/cypress/fixtures/sap-system-details/selected_system.js
+++ b/test/e2e/cypress/fixtures/sap-system-details/selected_system.js
@@ -60,7 +60,7 @@ export const attachedHosts = [
     Addresses: ['10.100.1.21', '10.100.1.25'],
     Provider: 'azure',
     Cluster: 'netweaver_cluster',
-    Version: '0.7.1+git.dev42.1640084952.33229fc',
+    Version: '1.1.0+git.dev17.1660137228.fe5ba8a',
   },
   {
     Name: 'vmnwdev03',
@@ -68,7 +68,7 @@ export const attachedHosts = [
     Addresses: ['10.100.1.23', '10.100.1.27'],
     Provider: 'azure',
     Cluster: '',
-    Version: '0.7.1+git.dev42.1640084952.33229fc',
+    Version: '1.1.0+git.dev17.1660137228.fe5ba8a',
   },
   {
     Name: 'vmnwdev04',
@@ -76,7 +76,7 @@ export const attachedHosts = [
     Addresses: ['10.100.1.24', '10.100.1.28'],
     Provider: 'azure',
     Cluster: '',
-    Version: '0.7.1+git.dev42.1640084952.33229fc',
+    Version: '1.1.0+git.dev17.1660137228.fe5ba8a',
   },
   {
     Name: 'vmnwdev02',
@@ -84,6 +84,6 @@ export const attachedHosts = [
     Addresses: ['10.100.1.22', '10.100.1.26'],
     Provider: 'azure',
     Cluster: 'netweaver_cluster',
-    Version: '0.7.1+git.dev42.1640084952.33229fc',
+    Version: '1.1.0+git.dev17.1660137228.fe5ba8a',
   },
 ];

--- a/test/fixtures/scenarios/aws-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_host_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_host_discovery.json
@@ -13,7 +13,7 @@
       "fe80::6245:bdff:fe8a:5f6b"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 32107
   }
 }

--- a/test/fixtures/scenarios/aws-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_host_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8d:9b69"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 32107
   }
 }

--- a/test/fixtures/scenarios/aws-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_host_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8d:9a74"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/aws-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_host_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8a:5ce7"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/aws-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_host_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8d:9ef4"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/aws-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_host_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8d:9c7d"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/gcp-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_host_discovery.json
@@ -13,7 +13,7 @@
       "fe80::6245:bdff:fe8a:5f6b"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 32107
   }
 }

--- a/test/fixtures/scenarios/gcp-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8d:9b69"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 32107
   }
 }

--- a/test/fixtures/scenarios/gcp-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8d:9a74"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/gcp-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8a:5ce7"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/gcp-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8d:9ef4"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/gcp-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8d:9c7d"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/098fc159-3ed6-58e7-91be-38fda8a833ea_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/098fc159-3ed6-58e7-91be-38fda8a833ea_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8d:5d9"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_host_discovery.json
@@ -13,7 +13,7 @@
       "fe80::6245:bdff:fe8a:5f6b"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 32107
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0fc07435-7ee2-54ca-b0de-fb27ffdc5deb_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0fc07435-7ee2-54ca-b0de-fb27ffdc5deb_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::20d:3aff:fe2e:8fad"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/116d49bd-85e1-5e59-b820-83f66db8800c_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/116d49bd-85e1-5e59-b820-83f66db8800c_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::20d:3aff:fe2e:8f04"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8d:9b69"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 32107
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/1b0e9297-97dd-55d6-9874-8efde4d84c90_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/1b0e9297-97dd-55d6-9874-8efde4d84c90_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8d:9a74"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/21de186a-e38f-5804-b643-7f4ef22fecfd_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/21de186a-e38f-5804-b643-7f4ef22fecfd_host_discovery.json
@@ -13,7 +13,7 @@
       "fe80::6245:bdff:fe8d:95f1"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8a:5969"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/25677e37-fd33-5005-896c-9275b1284534_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/25677e37-fd33-5005-896c-9275b1284534_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8d:a30"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/3711ea88-9ccc-5b07-8f9d-042be449d72b_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/3711ea88-9ccc-5b07-8f9d-042be449d72b_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8d:6ef"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/422686d6-b2d1-5092-93e8-a744854f5085_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/422686d6-b2d1-5092-93e8-a744854f5085_host_discovery.json
@@ -13,7 +13,7 @@
       "fe80::6245:bdff:fe8d:523"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/4b30a6af-4b52-5bda-bccb-f2248a12c992_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/4b30a6af-4b52-5bda-bccb-f2248a12c992_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::20d:3aff:fe2e:8038"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/69f4dcbb-efa2-5a16-8bc8-01df7dbb7384_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/69f4dcbb-efa2-5a16-8bc8-01df7dbb7384_host_discovery.json
@@ -13,7 +13,7 @@
       "fe80::20d:3aff:fe2a:aabe"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 3421
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8a:5ce7"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/81e9b629-c1e7-538f-bff1-47d3a6580522_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/81e9b629-c1e7-538f-bff1-47d3a6580522_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8d:dca"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/927901fa-2c87-524e-b18c-3ef5187f504f_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/927901fa-2c87-524e-b18c-3ef5187f504f_host_discovery.json
@@ -13,7 +13,7 @@
       "fe80::20d:3aff:fe2e:8b91"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/99cf8a3a-48d6-57a4-b302-6e4482227ab6_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/99cf8a3a-48d6-57a4-b302-6e4482227ab6_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8d:1d5"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 32107
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a26b6d0-6e72-597c-9fe5-152a6875f214_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a26b6d0-6e72-597c-9fe5-152a6875f214_host_discovery.json
@@ -13,7 +13,7 @@
       "fe80::20d:3aff:fe2e:835a"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 3421
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8d:9ef4"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9cd46919-5f19-59aa-993e-cf3736c71053_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9cd46919-5f19-59aa-993e-cf3736c71053_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::20d:3aff:fe23:2c6b"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 32107
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a09d9cf3-46c1-505c-8fb8-4b0a71a9114e_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a09d9cf3-46c1-505c-8fb8-4b0a71a9114e_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::20d:3aff:fe25:7df0"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a3297d85-5e8b-5ac5-b8a3-55eebc2b8d12_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a3297d85-5e8b-5ac5-b8a3-55eebc2b8d12_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::20d:3aff:fe25:7f83"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_host_discovery.json
@@ -13,7 +13,7 @@
       "fe80::20d:3aff:fe21:f108"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 32107
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/ddcb7992-2ffb-5c10-8b39-80685f6eaaba_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/ddcb7992-2ffb-5c10-8b39-80685f6eaaba_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8d:c2"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/e0c182db-32ff-55c6-a9eb-2b82dd21bc8b_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/e0c182db-32ff-55c6-a9eb-2b82dd21bc8b_host_discovery.json
@@ -13,7 +13,7 @@
       "fe80::6245:bdff:fe8d:8b3"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 32107
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/f0c808b3-d869-5192-a944-20f66a6a8449_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/f0c808b3-d869-5192-a944-20f66a6a8449_host_discovery.json
@@ -13,7 +13,7 @@
       "fe80::222:48ff:fe7f:d2f9"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 3422
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_host_discovery.json
@@ -14,7 +14,7 @@
       "fe80::6245:bdff:fe8d:9c7d"
     ],
     "socket_count": 1,
-    "agent_version": "0.7.1+git.dev42.1640084952.33229fc",
+    "agent_version": "1.1.0+git.dev17.1660137228.fe5ba8a",
     "total_memory_mb": 7951
   }
 }


### PR DESCRIPTION
This PR updates any reference to the old agent version to a current version. This will be useful to show a more updated agent on the demo environment.