### PR TITLE
Add option to unselect the removed tag fix #416

### DIFF
--- a/assets/js/components/Table/filters.jsx
+++ b/assets/js/components/Table/filters.jsx
@@ -45,7 +45,10 @@ export const TableFilters = ({ config, data, filters, onChange }) => {
     .map((column) => {
       const filterValue = getFilter(column.key, filters);
       const filterOptions = uniq(
-        data.map(({ [column.key]: option }) => option).flat(Infinity)
+        data
+          .map(({ [column.key]: option }) => option)
+          .flat(Infinity)
+          .concat(filterValue)
       );
 
       return (


### PR DESCRIPTION
When the user removes the last tag of its type, the user can still unselect the remaining tag in the table. This is a small workaround until the problem can be resolved fully.