### PR TITLE
Refactor docker compose to add named volume for postgres persistence

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,6 @@
 version: "3"
-
+volumes:
+  pg_data:
 services:
   postgres:
     image: postgres:latest
@@ -11,7 +12,7 @@ services:
       - 5433:5432
     restart: always
     volumes:
-      - ./.pgdata:/var/lib/postgresql/data
+      - pg_data:/var/lib/postgresql/data
   grafana:
     image: grafana/grafana:latest
     environment:


### PR DESCRIPTION
We remove the local binding of docker compose in the project root.

We add a named docker-compose volume in order to maintain the persistence of postgres but avoid binding in the local directory with polluted data.