### PR TITLE
Downgrade to previus k3s due to PodSecurityPolicy deprecation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -471,7 +471,7 @@ jobs:
       - name: Start a local k8s cluster
         uses: jupyterhub/action-k3s-helm@v3
         with:
-          k3s-channel: latest
+          k3s-channel: v1.24.4+k3s1
 
       - name: Add bitnami helm deps
         run: |


### PR DESCRIPTION
Due to the latest k3s release deprecating the beta PodSecurityPolicy, we need to freeze and stay with 1.24.x

See [k3s 1.25.0 release notes](https://github.com/k3s-io/k3s/releases/tag/v1.25.0%2Bk3s1) for more information