### PR TITLE
Add missing :kvm and :nutanix atoms to the provider field in events/commands/read models

### DIFF
--- a/lib/trento/application/integration/discovery/payloads/cluster/cluster_discovery_payload.ex
+++ b/lib/trento/application/integration/discovery/payloads/cluster/cluster_discovery_payload.ex
@@ -16,7 +16,11 @@ defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload do
 
   deftype do
     field :dc, :boolean
-    field :provider, Ecto.Enum, values: [:aws, :gcp, :azure, :unknown], default: :unknown
+
+    field :provider, Ecto.Enum,
+      values: [:aws, :gcp, :azure, :kvm, :nutanix, :unknown],
+      default: :unknown
+
     field :id, :string
     field :name, :string
     field :cluster_type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]

--- a/lib/trento/application/integration/discovery/policies/host_policy.ex
+++ b/lib/trento/application/integration/discovery/policies/host_policy.ex
@@ -129,7 +129,8 @@ defmodule Trento.Integration.Discovery.HostPolicy do
     end
   end
 
-  @spec parse_cloud_provider_metadata(:azure | :aws | :gcp | :unknown, map) :: map
+  @spec parse_cloud_provider_metadata(:azure | :aws | :gcp | :kvm | :nutanix | :unknown, map) ::
+          map
   defp parse_cloud_provider_metadata(
          :azure,
          %AzureMetadata{

--- a/lib/trento/application/read_models/cluster_read_model.ex
+++ b/lib/trento/application/read_models/cluster_read_model.ex
@@ -19,7 +19,7 @@ defmodule Trento.ClusterReadModel do
   schema "clusters" do
     field :name, :string, default: ""
     field :sid, :string
-    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :unknown]
+    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :kvm, :nutanix, :unknown]
     field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
     field :selected_checks, {:array, :string}, default: []
     field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]

--- a/lib/trento/application/read_models/host_read_model.ex
+++ b/lib/trento/application/read_models/host_read_model.ex
@@ -21,7 +21,7 @@ defmodule Trento.HostReadModel do
     field :cluster_id, Ecto.UUID
     field :heartbeat, Ecto.Enum, values: [:critical, :passing, :unknown]
 
-    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :unknown]
+    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :kvm, :nutanix, :unknown]
     field :provider_data, :map
 
     has_many :tags, Trento.Tag, foreign_key: :resource_id

--- a/lib/trento/application/read_models/host_telemetry_read_model.ex
+++ b/lib/trento/application/read_models/host_telemetry_read_model.ex
@@ -23,7 +23,7 @@ defmodule Trento.HostTelemetryReadModel do
       values: [:community, :suse, :unknown],
       default: :unknown
 
-    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :unknown]
+    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :kvm, :nutanix, :unknown]
 
     timestamps()
   end

--- a/lib/trento/domain/cluster/cluster.ex
+++ b/lib/trento/domain/cluster/cluster.ex
@@ -60,7 +60,7 @@ defmodule Trento.Domain.Cluster do
           cluster_id: String.t(),
           name: String.t(),
           type: :hana_scale_up | :hana_scale_out | :unknown,
-          provider: :azure | :aws | :gcp | :unknown,
+          provider: :azure | :aws | :gcp | :kvm | :nutanix | :unknown,
           discovered_health: nil | :passing | :warning | :critical | :unknown,
           checks_health: nil | :passing | :warning | :critical | :unknown,
           health: :passing | :warning | :critical | :unknown,

--- a/lib/trento/domain/cluster/commands/register_cluster_host.ex
+++ b/lib/trento/domain/cluster/commands/register_cluster_host.ex
@@ -22,7 +22,7 @@ defmodule Trento.Domain.Commands.RegisterClusterHost do
     field :name, :string
     field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
     field :sid, :string
-    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :unknown]
+    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :kvm, :nutanix, :unknown]
     field :designated_controller, :boolean
     field :resources_number, :integer
     field :hosts_number, :integer

--- a/lib/trento/domain/cluster/events/checks_execution_requested.ex
+++ b/lib/trento/domain/cluster/events/checks_execution_requested.ex
@@ -9,6 +9,6 @@ defmodule Trento.Domain.Events.ChecksExecutionRequested do
     field :cluster_id, Ecto.UUID
     field :hosts, {:array, Ecto.UUID}
     field :checks, {:array, :string}
-    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :unknown]
+    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :kvm, :nutanix, :unknown]
   end
 end

--- a/lib/trento/domain/cluster/events/cluster_details_updated.ex
+++ b/lib/trento/domain/cluster/events/cluster_details_updated.ex
@@ -12,7 +12,7 @@ defmodule Trento.Domain.Events.ClusterDetailsUpdated do
     field :name, :string
     field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
     field :sid, :string
-    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :unknown]
+    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :kvm, :nutanix, :unknown]
     field :resources_number, :integer
     field :hosts_number, :integer
 

--- a/lib/trento/domain/cluster/events/cluster_registered.ex
+++ b/lib/trento/domain/cluster/events/cluster_registered.ex
@@ -12,7 +12,7 @@ defmodule Trento.Domain.Events.ClusterRegistered do
     field :name, :string
     field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
     field :sid, :string
-    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :unknown]
+    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :kvm, :nutanix, :unknown]
     field :resources_number, :integer
     field :hosts_number, :integer
     field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]

--- a/lib/trento/domain/cluster/events/cluster_rolled_up.ex
+++ b/lib/trento/domain/cluster/events/cluster_rolled_up.ex
@@ -12,7 +12,7 @@ defmodule Trento.Domain.Events.ClusterRolledUp do
     field :name, :string
     field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
     field :sid, :string
-    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :unknown]
+    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :kvm, :nutanix, :unknown]
     field :resources_number, :integer
     field :hosts_number, :integer
     field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]

--- a/lib/trento/domain/host/host.ex
+++ b/lib/trento/domain/host/host.ex
@@ -49,7 +49,7 @@ defmodule Trento.Domain.Host do
           ip_addresses: [String.t()],
           ssh_address: String.t(),
           agent_version: String.t(),
-          provider: :azure | :aws | :gcp | :unknown,
+          provider: :azure | :aws | :gcp | :kvm | :nutanix | :unknown,
           cpu_count: non_neg_integer(),
           total_memory_mb: non_neg_integer(),
           socket_count: non_neg_integer(),

--- a/lib/trento_web/openapi/schema/provider.ex
+++ b/lib/trento_web/openapi/schema/provider.ex
@@ -11,7 +11,7 @@ defmodule TrentoWeb.OpenApi.Schema.Provider do
       title: "SupportedProviders",
       type: :string,
       description: "Detected Provider where the resource is running",
-      enum: [:azure, :aws, :gcp, :unknown]
+      enum: [:azure, :aws, :gcp, :kvm, :nutanix, :unknown]
     })
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -93,7 +93,7 @@ defmodule Trento.Factory do
       agent_version: Faker.StarWars.planet(),
       cluster_id: Faker.UUID.v4(),
       heartbeat: :unknown,
-      provider: :unknown,
+      provider: Enum.random([:aws, :gcp, :azure, :nutanix, :kvm, :unknown]),
       provider_data: nil
     }
   end
@@ -111,7 +111,7 @@ defmodule Trento.Factory do
       host_id: Faker.UUID.v4(),
       name: Faker.StarWars.character(),
       sid: Faker.StarWars.planet(),
-      provider: :azure,
+      provider: Enum.random([:aws, :gcp, :azure, :nutanix, :kvm, :unknown]),
       resources_number: 8,
       hosts_number: 2,
       details: hana_cluster_details_value_object(),
@@ -126,7 +126,7 @@ defmodule Trento.Factory do
       cluster_id: Faker.UUID.v4(),
       name: Faker.StarWars.character(),
       sid: Faker.StarWars.planet(),
-      provider: :azure,
+      provider: Enum.random([:aws, :gcp, :azure, :nutanix, :kvm, :unknown]),
       resources_number: 8,
       hosts_number: 2,
       details: hana_cluster_details_value_object(),
@@ -169,7 +169,7 @@ defmodule Trento.Factory do
       id: Faker.UUID.v4(),
       name: Faker.StarWars.character(),
       sid: Faker.StarWars.planet(),
-      provider: :azure,
+      provider: Enum.random([:aws, :gcp, :azure, :nutanix, :kvm, :unknown]),
       type: :hana_scale_up,
       health: :passing
     }

--- a/test/trento/domain/cluster/cluster_test.exs
+++ b/test/trento/domain/cluster/cluster_test.exs
@@ -205,7 +205,8 @@ defmodule Trento.ClusterTest do
           cluster_id: cluster_id,
           name: name,
           sid: sid,
-          details: nil
+          details: nil,
+          provider: :azure
         ),
         build(:host_added_to_cluster_event, cluster_id: cluster_id, host_id: host_id)
       ]
@@ -282,7 +283,8 @@ defmodule Trento.ClusterTest do
             cluster_id: cluster_id,
             name: name,
             sid: sid,
-            details: nil
+            details: nil,
+            provider: :azure
           )
         ],
         [
@@ -292,7 +294,8 @@ defmodule Trento.ClusterTest do
             name: name,
             sid: sid,
             details: nil,
-            discovered_health: :passing
+            discovered_health: :passing,
+            provider: :azure
           ),
           SelectChecks.new!(%{
             cluster_id: cluster_id,
@@ -322,7 +325,7 @@ defmodule Trento.ClusterTest do
 
       assert_events_and_state(
         [
-          build(:cluster_registered_event, cluster_id: cluster_id),
+          build(:cluster_registered_event, cluster_id: cluster_id, provider: :azure),
           build(:host_added_to_cluster_event, cluster_id: cluster_id, host_id: host_id),
           %ChecksSelected{
             cluster_id: cluster_id,
@@ -563,7 +566,7 @@ defmodule Trento.ClusterTest do
           host_id: host_added_to_cluster_event.host_id,
           name: cluster_registered_event.name,
           sid: cluster_registered_event.sid,
-          provider: :azure,
+          provider: cluster_registered_event.provider,
           type: cluster_registered_event.type,
           resources_number: cluster_registered_event.resources_number,
           hosts_number: cluster_registered_event.hosts_number,
@@ -592,7 +595,8 @@ defmodule Trento.ClusterTest do
     end
 
     test "should not change the discovered health" do
-      cluster_registered_event = build(:cluster_registered_event, health: :passing)
+      cluster_registered_event =
+        build(:cluster_registered_event, health: :passing, provider: :azure)
 
       host_added_to_cluster_event =
         build(:host_added_to_cluster_event, cluster_id: cluster_registered_event.cluster_id)
@@ -628,7 +632,8 @@ defmodule Trento.ClusterTest do
     end
 
     test "should not change the the cluster aggregated health if checks health is worst" do
-      cluster_registered_event = build(:cluster_registered_event, health: :passing)
+      cluster_registered_event =
+        build(:cluster_registered_event, health: :passing, provider: :azure)
 
       host_added_to_cluster_event =
         build(:host_added_to_cluster_event, cluster_id: cluster_registered_event.cluster_id)


### PR DESCRIPTION
Add missing `:kvm` and `:nutanix` atoms to the provider field in events/commands/read models, except for the catalog where we just have `:aws | :gcp | :azure | :default`.

Improve testing by adding random providers to the factory.