### PR TITLE
Remove PR type choice

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -6,15 +6,6 @@ dependencies that are required for this change.
 
 Fixes # (issue)
 
-## Type of change
-
-Please delete options that are not relevant.
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
-
 ## How to test this?
 
 Describe how to test the functionality or the tests that have been added.


### PR DESCRIPTION
# Description
Just getting rid of the `type of change` section in the PR template since we've got labels for that.