### PR TITLE
Fix active style matching inside navlink usage

### DIFF
--- a/assets/js/components/Layout/Layout.jsx
+++ b/assets/js/components/Layout/Layout.jsx
@@ -97,6 +97,7 @@ const Layout = () => {
                           }`
                         }
                         to={item.href}
+                        end={item.href == '/'}
                       >
                         <span className="text-left">
                           <item.icon />


### PR DESCRIPTION
# Description
The `NavLink` component inside react-router-dom has its own logic when it comes to determining wether or not the element is active that needs to be a little bit instructed. Basically the dashboard, which route is `/` always matches because of subroutes including `/` at the beginning, while we only need it to be matched in a special way.

Before:

![image](https://user-images.githubusercontent.com/20770/192756044-81157119-1ea7-486d-af80-85e70cf14857.png)

After:
![image](https://user-images.githubusercontent.com/20770/192756057-d6de3c20-8282-45d9-a9b1-d9717064eae3.png)


## Did you add the right label?
Aye

## How was this tested?
Manually :innocent: 
