### PR TITLE
Add provider enum

### DIFF
--- a/lib/trento/application/integration/checks/dto/flat_check_dto.ex
+++ b/lib/trento/application/integration/checks/dto/flat_check_dto.ex
@@ -18,7 +18,7 @@ defmodule Trento.Integration.Checks.FlatCheckDto do
 
   deftype do
     field :id, :string
-    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :default, :unknown]
+    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :default]
     field :group, :string
     field :name, :string
     field :description, :string

--- a/lib/trento/application/integration/checks/dto/provider_dto.ex
+++ b/lib/trento/application/integration/checks/dto/provider_dto.ex
@@ -13,7 +13,7 @@ defmodule Trento.Integration.Checks.ProviderDto do
   alias Trento.Integration.Checks.GroupDto
 
   deftype do
-    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :default, :unknown]
+    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :default]
 
     embeds_many :groups, GroupDto
   end

--- a/lib/trento/application/integration/discovery/payloads/cloud_discovery_payload.ex
+++ b/lib/trento/application/integration/discovery/payloads/cloud_discovery_payload.ex
@@ -6,11 +6,14 @@ defmodule Trento.Integration.Discovery.CloudDiscoveryPayload do
   @required_fields []
 
   use Trento.Type
+
   import PolymorphicEmbed, only: [cast_polymorphic_embed: 3]
+
+  require Trento.Domain.Enum.Provider, as: Provider
 
   deftype do
     field :provider, Ecto.Enum,
-      values: [:aws, :gcp, :azure, :kvm, :nutanix, :unknown],
+      values: Provider.values(),
       default: :unknown
 
     field :metadata, PolymorphicEmbed,

--- a/lib/trento/application/integration/discovery/payloads/cluster/cluster_discovery_payload.ex
+++ b/lib/trento/application/integration/discovery/payloads/cluster/cluster_discovery_payload.ex
@@ -3,23 +3,25 @@ defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload do
   Cluster discovery integration event payload
   """
 
+  @required_fields [:dc, :provider, :id, :cluster_type, :cib, :sbd, :crmmon]
+  @required_fields_hana [:sid]
+
+  use Trento.Type
+
+  require Trento.Domain.Enum.Provider, as: Provider
+
   alias Trento.Integration.Discovery.ClusterDiscoveryPayload.{
     Cib,
     Crmmon,
     Sbd
   }
 
-  @required_fields [:dc, :provider, :id, :cluster_type, :cib, :sbd, :crmmon]
-
-  @required_fields_hana [:sid]
-  use Trento.Type
-
   deftype do
     field :dc, :boolean
 
     field :provider, Ecto.Enum,
-      values: [:aws, :gcp, :azure, :kvm, :nutanix, :unknown],
-      default: :unknown
+      values: Provider.values(),
+      default: Provider.unknown()
 
     field :id, :string
     field :name, :string

--- a/lib/trento/application/integration/discovery/policies/cluster_policy.ex
+++ b/lib/trento/application/integration/discovery/policies/cluster_policy.ex
@@ -3,9 +3,12 @@ defmodule Trento.Integration.Discovery.ClusterPolicy do
   This module contains functions to transform cluster related integration events into commands.
   """
 
-  alias Trento.Domain.Commands.RegisterClusterHost
+  require Trento.Domain.Enum.Provider, as: Provider
 
-  alias Trento.Integration.Discovery.ClusterDiscoveryPayload
+  alias Trento.{
+    Domain.Commands.RegisterClusterHost,
+    Integration.Discovery.ClusterDiscoveryPayload
+  }
 
   @uuid_namespace Application.compile_env!(:trento, :uuid_namespace)
 
@@ -336,9 +339,9 @@ defmodule Trento.Integration.Discovery.ClusterPolicy do
     end)
   end
 
-  defp get_virtual_ip_type_suffix_by_provider(:azure), do: "IPaddr2"
-  defp get_virtual_ip_type_suffix_by_provider(:aws), do: "aws-vpc-move-ip"
-  defp get_virtual_ip_type_suffix_by_provider(:gcp), do: "IPaddr2"
+  defp get_virtual_ip_type_suffix_by_provider(Provider.azure()), do: "IPaddr2"
+  defp get_virtual_ip_type_suffix_by_provider(Provider.aws()), do: "aws-vpc-move-ip"
+  defp get_virtual_ip_type_suffix_by_provider(Provider.gcp()), do: "IPaddr2"
   defp get_virtual_ip_type_suffix_by_provider(_), do: "IPaddr2"
 
   defp do_parse_hana_status(nil, _), do: "Unknown"

--- a/lib/trento/application/integration/discovery/policies/host_policy.ex
+++ b/lib/trento/application/integration/discovery/policies/host_policy.ex
@@ -3,6 +3,8 @@ defmodule Trento.Integration.Discovery.HostPolicy do
   This module contains functions to transform host related integration events into commands.
   """
 
+  require Trento.Domain.Enum.Provider, as: Provider
+
   alias Trento.Domain.Commands.{
     RegisterHost,
     UpdateProvider,
@@ -129,10 +131,10 @@ defmodule Trento.Integration.Discovery.HostPolicy do
     end
   end
 
-  @spec parse_cloud_provider_metadata(:azure | :aws | :gcp | :kvm | :nutanix | :unknown, map) ::
+  @spec parse_cloud_provider_metadata(Provider.t(), map) ::
           map
   defp parse_cloud_provider_metadata(
-         :azure,
+         Provider.azure(),
          %AzureMetadata{
            compute: %{
              name: name,
@@ -158,7 +160,7 @@ defmodule Trento.Integration.Discovery.HostPolicy do
        }
 
   defp parse_cloud_provider_metadata(
-         :aws,
+         Provider.aws(),
          %AwsMetadata{
            account_id: account_id,
            ami_id: ami_id,
@@ -182,7 +184,7 @@ defmodule Trento.Integration.Discovery.HostPolicy do
        }
 
   defp parse_cloud_provider_metadata(
-         :gcp,
+         Provider.gcp(),
          %GcpMetadata{
            disk_number: disk_number,
            image: image,

--- a/lib/trento/application/read_models/cluster_read_model.ex
+++ b/lib/trento/application/read_models/cluster_read_model.ex
@@ -7,6 +7,8 @@ defmodule Trento.ClusterReadModel do
 
   import Ecto.Changeset
 
+  require Trento.Domain.Enum.Provider, as: Provider
+
   alias Trento.{
     CheckResultReadModel,
     HostChecksExecutionsReadModel
@@ -19,7 +21,7 @@ defmodule Trento.ClusterReadModel do
   schema "clusters" do
     field :name, :string, default: ""
     field :sid, :string
-    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :kvm, :nutanix, :unknown]
+    field :provider, Ecto.Enum, values: Provider.values()
     field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
     field :selected_checks, {:array, :string}, default: []
     field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]

--- a/lib/trento/application/read_models/host_read_model.ex
+++ b/lib/trento/application/read_models/host_read_model.ex
@@ -7,6 +7,8 @@ defmodule Trento.HostReadModel do
 
   import Ecto.Changeset
 
+  require Trento.Domain.Enum.Provider, as: Provider
+
   alias Trento.SlesSubscriptionReadModel
 
   @type t :: %__MODULE__{}
@@ -21,7 +23,7 @@ defmodule Trento.HostReadModel do
     field :cluster_id, Ecto.UUID
     field :heartbeat, Ecto.Enum, values: [:critical, :passing, :unknown]
 
-    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :kvm, :nutanix, :unknown]
+    field :provider, Ecto.Enum, values: Provider.values()
     field :provider_data, :map
 
     has_many :tags, Trento.Tag, foreign_key: :resource_id

--- a/lib/trento/application/read_models/host_telemetry_read_model.ex
+++ b/lib/trento/application/read_models/host_telemetry_read_model.ex
@@ -7,6 +7,8 @@ defmodule Trento.HostTelemetryReadModel do
 
   import Ecto.Changeset
 
+  require Trento.Domain.Enum.Provider, as: Provider
+
   @type t :: %__MODULE__{}
 
   @derive {Jason.Encoder, except: [:__meta__, :__struct__]}
@@ -23,7 +25,7 @@ defmodule Trento.HostTelemetryReadModel do
       values: [:community, :suse, :unknown],
       default: :unknown
 
-    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :kvm, :nutanix, :unknown]
+    field :provider, Ecto.Enum, values: Provider.values()
 
     timestamps()
   end

--- a/lib/trento/domain/cluster/cluster.ex
+++ b/lib/trento/domain/cluster/cluster.ex
@@ -1,6 +1,8 @@
 defmodule Trento.Domain.Cluster do
   @moduledoc false
 
+  require Trento.Domain.Enum.Provider, as: Provider
+
   alias Commanded.Aggregate.Multi
 
   alias Trento.Domain.{
@@ -60,7 +62,7 @@ defmodule Trento.Domain.Cluster do
           cluster_id: String.t(),
           name: String.t(),
           type: :hana_scale_up | :hana_scale_out | :unknown,
-          provider: :azure | :aws | :gcp | :kvm | :nutanix | :unknown,
+          provider: Provider.t(),
           discovered_health: nil | :passing | :warning | :critical | :unknown,
           checks_health: nil | :passing | :warning | :critical | :unknown,
           health: :passing | :warning | :critical | :unknown,

--- a/lib/trento/domain/cluster/commands/register_cluster_host.ex
+++ b/lib/trento/domain/cluster/commands/register_cluster_host.ex
@@ -14,6 +14,8 @@ defmodule Trento.Domain.Commands.RegisterClusterHost do
 
   use Trento.Command
 
+  require Trento.Domain.Enum.Provider, as: Provider
+
   alias Trento.Domain.HanaClusterDetails
 
   defcommand do
@@ -22,7 +24,7 @@ defmodule Trento.Domain.Commands.RegisterClusterHost do
     field :name, :string
     field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
     field :sid, :string
-    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :kvm, :nutanix, :unknown]
+    field :provider, Ecto.Enum, values: Provider.values()
     field :designated_controller, :boolean
     field :resources_number, :integer
     field :hosts_number, :integer

--- a/lib/trento/domain/cluster/events/checks_execution_requested.ex
+++ b/lib/trento/domain/cluster/events/checks_execution_requested.ex
@@ -5,10 +5,12 @@ defmodule Trento.Domain.Events.ChecksExecutionRequested do
 
   use Trento.Event
 
+  require Trento.Domain.Enum.Provider, as: Provider
+
   defevent do
     field :cluster_id, Ecto.UUID
     field :hosts, {:array, Ecto.UUID}
     field :checks, {:array, :string}
-    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :kvm, :nutanix, :unknown]
+    field :provider, Ecto.Enum, values: Provider.values()
   end
 end

--- a/lib/trento/domain/cluster/events/cluster_details_updated.ex
+++ b/lib/trento/domain/cluster/events/cluster_details_updated.ex
@@ -5,6 +5,8 @@ defmodule Trento.Domain.Events.ClusterDetailsUpdated do
 
   use Trento.Event
 
+  require Trento.Domain.Enum.Provider, as: Provider
+
   alias Trento.Domain.HanaClusterDetails
 
   defevent do
@@ -12,7 +14,7 @@ defmodule Trento.Domain.Events.ClusterDetailsUpdated do
     field :name, :string
     field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
     field :sid, :string
-    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :kvm, :nutanix, :unknown]
+    field :provider, Ecto.Enum, values: Provider.values()
     field :resources_number, :integer
     field :hosts_number, :integer
 

--- a/lib/trento/domain/cluster/events/cluster_registered.ex
+++ b/lib/trento/domain/cluster/events/cluster_registered.ex
@@ -5,6 +5,8 @@ defmodule Trento.Domain.Events.ClusterRegistered do
 
   use Trento.Event
 
+  require Trento.Domain.Enum.Provider, as: Provider
+
   alias Trento.Domain.HanaClusterDetails
 
   defevent do
@@ -12,7 +14,7 @@ defmodule Trento.Domain.Events.ClusterRegistered do
     field :name, :string
     field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
     field :sid, :string
-    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :kvm, :nutanix, :unknown]
+    field :provider, Ecto.Enum, values: Provider.values()
     field :resources_number, :integer
     field :hosts_number, :integer
     field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]

--- a/lib/trento/domain/cluster/events/cluster_rolled_up.ex
+++ b/lib/trento/domain/cluster/events/cluster_rolled_up.ex
@@ -5,14 +5,19 @@ defmodule Trento.Domain.Events.ClusterRolledUp do
 
   use Trento.Event
 
-  alias Trento.Domain.{HanaClusterDetails, HostExecution}
+  require Trento.Domain.Enum.Provider, as: Provider
+
+  alias Trento.Domain.{
+    HanaClusterDetails,
+    HostExecution
+  }
 
   defevent do
     field :cluster_id, :string
     field :name, :string
     field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
     field :sid, :string
-    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :kvm, :nutanix, :unknown]
+    field :provider, Ecto.Enum, values: Provider.values()
     field :resources_number, :integer
     field :hosts_number, :integer
     field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]

--- a/lib/trento/domain/enums/enum.ex
+++ b/lib/trento/domain/enums/enum.ex
@@ -1,0 +1,24 @@
+defmodule Trento.Domain.Enum do
+  @moduledoc """
+  Enum  module with added macros to define a type,
+  check supported values and validate possible values
+  """
+
+  defmacro __using__(opts) do
+    values = Keyword.fetch!(opts, :values)
+
+    quote do
+      @type t :: unquote(Enum.reduce(values, &{:|, [], [&1, &2]}))
+
+      defmacro values, do: unquote(values)
+
+      unquote(
+        Enum.map(values, fn value ->
+          quote do
+            defmacro unquote(value)(), do: unquote(value)
+          end
+        end)
+      )
+    end
+  end
+end

--- a/lib/trento/domain/enums/provider.ex
+++ b/lib/trento/domain/enums/provider.ex
@@ -3,5 +3,5 @@ defmodule Trento.Domain.Enum.Provider do
   Type that represents the supported provider values by our agent.
   """
 
-  use Trento.Domain.Enum, values: [:azure, :aws, :gcp, :kvm, :nutanix, :default, :unknown]
+  use Trento.Domain.Enum, values: [:azure, :aws, :gcp, :kvm, :nutanix, :unknown]
 end

--- a/lib/trento/domain/enums/provider.ex
+++ b/lib/trento/domain/enums/provider.ex
@@ -1,0 +1,7 @@
+defmodule Trento.Domain.Enum.Provider do
+  @moduledoc """
+  Type that represents the supported provider values by our agent.
+  """
+
+  use Trento.Domain.Enum, values: [:azure, :aws, :gcp, :kvm, :nutanix, :default, :unknown]
+end

--- a/lib/trento/domain/host/commands/update_provider.ex
+++ b/lib/trento/domain/host/commands/update_provider.ex
@@ -7,17 +7,19 @@ defmodule Trento.Domain.Commands.UpdateProvider do
 
   use Trento.Command
 
+  import PolymorphicEmbed, only: [cast_polymorphic_embed: 3]
+
+  require Trento.Domain.Enum.Provider, as: Provider
+
   alias Trento.Domain.{
     AwsProvider,
     AzureProvider,
     GcpProvider
   }
 
-  import PolymorphicEmbed, only: [cast_polymorphic_embed: 3]
-
   defcommand do
     field :host_id, Ecto.UUID
-    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :kvm, :nutanix, :unknown]
+    field :provider, Ecto.Enum, values: Provider.values()
 
     field :provider_data, PolymorphicEmbed,
       types: [

--- a/lib/trento/domain/host/events/provider_updated.ex
+++ b/lib/trento/domain/host/events/provider_updated.ex
@@ -5,17 +5,19 @@ defmodule Trento.Domain.Events.ProviderUpdated do
 
   use Trento.Event
 
+  import PolymorphicEmbed, only: [cast_polymorphic_embed: 3]
+
+  require Trento.Domain.Enum.Provider, as: Provider
+
   alias Trento.Domain.{
     AwsProvider,
     AzureProvider,
     GcpProvider
   }
 
-  import PolymorphicEmbed, only: [cast_polymorphic_embed: 3]
-
   defevent do
     field :host_id, Ecto.UUID
-    field :provider, Ecto.Enum, values: [:azure, :aws, :gcp, :kvm, :nutanix, :unknown]
+    field :provider, Ecto.Enum, values: Provider.values()
 
     field :provider_data, PolymorphicEmbed,
       types: [

--- a/lib/trento/domain/host/host.ex
+++ b/lib/trento/domain/host/host.ex
@@ -1,6 +1,8 @@
 defmodule Trento.Domain.Host do
   @moduledoc false
 
+  require Trento.Domain.Enum.Provider, as: Provider
+
   alias Trento.Domain.Host
 
   alias Trento.Domain.{
@@ -49,7 +51,7 @@ defmodule Trento.Domain.Host do
           ip_addresses: [String.t()],
           ssh_address: String.t(),
           agent_version: String.t(),
-          provider: :azure | :aws | :gcp | :kvm | :nutanix | :unknown,
+          provider: Provider.t(),
           cpu_count: non_neg_integer(),
           total_memory_mb: non_neg_integer(),
           socket_count: non_neg_integer(),

--- a/lib/trento_web/openapi/schema/checks_catalog.ex
+++ b/lib/trento_web/openapi/schema/checks_catalog.ex
@@ -2,8 +2,8 @@ defmodule TrentoWeb.OpenApi.Schema.ChecksCatalog do
   @moduledoc false
 
   require OpenApiSpex
-  alias OpenApiSpex.Schema
 
+  alias OpenApiSpex.Schema
   alias TrentoWeb.OpenApi.Schema.Provider
 
   defmodule Check do

--- a/lib/trento_web/openapi/schema/provider.ex
+++ b/lib/trento_web/openapi/schema/provider.ex
@@ -2,6 +2,8 @@ defmodule TrentoWeb.OpenApi.Schema.Provider do
   @moduledoc false
 
   require OpenApiSpex
+  require Trento.Domain.Enum.Provider, as: Provider
+
   alias OpenApiSpex.Schema
 
   defmodule SupportedProviders do
@@ -11,7 +13,7 @@ defmodule TrentoWeb.OpenApi.Schema.Provider do
       title: "SupportedProviders",
       type: :string,
       description: "Detected Provider where the resource is running",
-      enum: [:azure, :aws, :gcp, :kvm, :nutanix, :unknown]
+      enum: Provider.values()
     })
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -3,6 +3,8 @@ defmodule Trento.Factory do
   A simple Factory helper module to be used within tests to generate test data
   """
 
+  require Trento.Domain.Enum.Provider, as: Provider
+
   alias Trento.Domain.{
     ClusterNode,
     ClusterResource,
@@ -93,7 +95,7 @@ defmodule Trento.Factory do
       agent_version: Faker.StarWars.planet(),
       cluster_id: Faker.UUID.v4(),
       heartbeat: :unknown,
-      provider: Enum.random([:aws, :gcp, :azure, :nutanix, :kvm, :unknown]),
+      provider: Enum.random(Provider.values()),
       provider_data: nil
     }
   end
@@ -111,7 +113,7 @@ defmodule Trento.Factory do
       host_id: Faker.UUID.v4(),
       name: Faker.StarWars.character(),
       sid: Faker.StarWars.planet(),
-      provider: Enum.random([:aws, :gcp, :azure, :nutanix, :kvm, :unknown]),
+      provider: Enum.random(Provider.values()),
       resources_number: 8,
       hosts_number: 2,
       details: hana_cluster_details_value_object(),
@@ -126,7 +128,7 @@ defmodule Trento.Factory do
       cluster_id: Faker.UUID.v4(),
       name: Faker.StarWars.character(),
       sid: Faker.StarWars.planet(),
-      provider: Enum.random([:aws, :gcp, :azure, :nutanix, :kvm, :unknown]),
+      provider: Enum.random(Provider.values()),
       resources_number: 8,
       hosts_number: 2,
       details: hana_cluster_details_value_object(),
@@ -169,7 +171,7 @@ defmodule Trento.Factory do
       id: Faker.UUID.v4(),
       name: Faker.StarWars.character(),
       sid: Faker.StarWars.planet(),
-      provider: Enum.random([:aws, :gcp, :azure, :nutanix, :kvm, :unknown]),
+      provider: Enum.random(Provider.values()),
       type: :hana_scale_up,
       health: :passing
     }

--- a/test/trento/application/integration/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/application/integration/discovery/policies/cluster_policy_test.exs
@@ -4,6 +4,8 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
 
   import Trento.Integration.DiscoveryFixturesHelper
 
+  require Trento.Domain.Enum.Provider, as: Provider
+
   alias Trento.Integration.Discovery.ClusterPolicy
 
   alias Trento.Domain.Commands.RegisterClusterHost
@@ -217,7 +219,7 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
               hosts_number: 2,
               resources_number: 8,
               discovered_health: :passing,
-              provider: :azure
+              provider: Provider.azure()
             }} ==
              "ha_cluster_discovery_hana_scale_up"
              |> load_discovery_event_fixture()
@@ -337,7 +339,7 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
                host_id: "a3279fd0-0443-1234-9354-2d7909fd6bc6",
                hosts_number: 2,
                name: "hana_cluster",
-               provider: :aws,
+               provider: Provider.aws(),
                resources_number: 7,
                sid: "PRD",
                type: :hana_scale_up
@@ -474,7 +476,7 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
                host_id: "1dc79771-0a96-1234-b5b6-cd4d0aef6acc",
                hosts_number: 2,
                name: "hana_cluster",
-               provider: :gcp,
+               provider: Provider.gcp(),
                resources_number: 9,
                sid: "PRD",
                type: :hana_scale_up
@@ -687,7 +689,7 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
               hosts_number: 2,
               resources_number: 8,
               discovered_health: :passing,
-              provider: :azure
+              provider: Provider.azure()
             }} ==
              "ha_cluster_discovery_unnamed"
              |> load_discovery_event_fixture()

--- a/test/trento/application/integration/discovery/policies/host_policy_test.exs
+++ b/test/trento/application/integration/discovery/policies/host_policy_test.exs
@@ -4,6 +4,8 @@ defmodule Trento.Integration.Discovery.HostPolicyTest do
 
   import Trento.Integration.DiscoveryFixturesHelper
 
+  require Trento.Domain.Enum.Provider, as: Provider
+
   alias Trento.Integration.Discovery.HostPolicy
 
   alias Trento.Domain.Commands.{
@@ -56,7 +58,7 @@ defmodule Trento.Integration.Discovery.HostPolicyTest do
              :ok,
              %UpdateProvider{
                host_id: "0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4",
-               provider: :azure,
+               provider: Provider.azure(),
                provider_data: %AzureProvider{
                  vm_name: "vmhdbdev01",
                  data_disk_number: 7,
@@ -79,7 +81,7 @@ defmodule Trento.Integration.Discovery.HostPolicyTest do
              :ok,
              %UpdateProvider{
                host_id: "0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4",
-               provider: :aws,
+               provider: Provider.aws(),
                provider_data: %AwsProvider{
                  account_id: "12345",
                  ami_id: "ami-12345",
@@ -102,7 +104,7 @@ defmodule Trento.Integration.Discovery.HostPolicyTest do
              :ok,
              %UpdateProvider{
                host_id: "0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4",
-               provider: :gcp,
+               provider: Provider.gcp(),
                provider_data: %GcpProvider{
                  disk_number: 4,
                  image: "sles-15-sp1-sap-byos-v20220126",
@@ -124,7 +126,7 @@ defmodule Trento.Integration.Discovery.HostPolicyTest do
              :ok,
              %UpdateProvider{
                host_id: "0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4",
-               provider: :kvm
+               provider: Provider.kvm()
              }
            } ==
              "cloud_discovery_kvm"
@@ -150,7 +152,7 @@ defmodule Trento.Integration.Discovery.HostPolicyTest do
              :ok,
              %UpdateProvider{
                host_id: "0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4",
-               provider: :unknown,
+               provider: Provider.unknown(),
                provider_data: nil
              }
            } =

--- a/test/trento/application/projectors/host_projector_test.exs
+++ b/test/trento/application/projectors/host_projector_test.exs
@@ -4,6 +4,8 @@ defmodule Trento.HostProjectorTest do
 
   import Trento.Factory
 
+  require Trento.Domain.Enum.Provider, as: Provider
+
   alias Trento.{
     HostProjector,
     HostReadModel
@@ -141,7 +143,7 @@ defmodule Trento.HostProjectorTest do
        } do
     event = %ProviderUpdated{
       host_id: host_id,
-      provider: :azure,
+      provider: Provider.azure(),
       provider_data: %AzureProvider{
         vm_name: "vmhdbdev01",
         data_disk_number: 7,
@@ -178,7 +180,7 @@ defmodule Trento.HostProjectorTest do
        } do
     event = %ProviderUpdated{
       host_id: host_id,
-      provider: :aws,
+      provider: Provider.aws(),
       provider_data: %AwsProvider{
         account_id: "12345",
         ami_id: "ami-12345",
@@ -205,7 +207,7 @@ defmodule Trento.HostProjectorTest do
       "vpc_id" => "vpc-12345"
     }
 
-    assert :aws == host_projection.provider
+    assert Provider.aws() == host_projection.provider
     assert expected_aws_model == host_projection.provider_data
   end
 
@@ -215,7 +217,7 @@ defmodule Trento.HostProjectorTest do
        } do
     event = %ProviderUpdated{
       host_id: host_id,
-      provider: :gcp,
+      provider: Provider.gcp(),
       provider_data: %GcpProvider{
         disk_number: 4,
         image: "sles-15-sp1-sap-byos-v20220126",


### PR DESCRIPTION
# Description

This PR adds:
  - A new `Trento.Support.Enum` module with:
    - A `.values()` macro: Get the possible enum values
    - Dynamically created macros based on the enum values: Can be used to validate a enum value; instead of using the `:something` directly, you can use `Trento.Domain.SomeEnum.something()` that will fail in `:something` is not a valid value for the enum.
    
  - A new `Trento.Domain.Provider` module that uses the above.

## How was this tested?

No new tests added, existing tests are passing.
