### PR TITLE
Added margin to the bottom of each result/host container.

### DIFF
--- a/assets/js/components/ClusterDetails/ChecksResults.jsx
+++ b/assets/js/components/ClusterDetails/ChecksResults.jsx
@@ -25,6 +25,7 @@ import { getClusterName } from '@components/ClusterLink';
 import ChecksResultFilters, {
   useFilteredChecks,
 } from '@components/ClusterDetails/ChecksResultFilters';
+import classNames from 'classnames';
 
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -126,7 +127,7 @@ export const ChecksResults = () => {
 
     pageContent = lastExecution.map(
       ({ _cluster_id, host_id, reachable, msg }, idx) => (
-        <div key={idx} className={`flex flex-col ${idx != (cluster.hosts_executions.length - 1) ? "mb-8" : ""}`}>
+        <div key={idx} className={classNames('flex', 'flex-col', {'mb-8': idx != (cluster.hosts_executions.length - 1)})}>
           <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
             <div className="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
               <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">

--- a/assets/js/components/ClusterDetails/ChecksResults.jsx
+++ b/assets/js/components/ClusterDetails/ChecksResults.jsx
@@ -126,7 +126,7 @@ export const ChecksResults = () => {
 
     pageContent = lastExecution.map(
       ({ _cluster_id, host_id, reachable, msg }, idx) => (
-        <div key={idx} className="flex flex-col">
+        <div key={idx} className={`flex flex-col ${idx != (cluster.hosts_executions.length - 1) ? "mb-8" : ""}`}>
           <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
             <div className="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
               <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">

--- a/assets/js/components/ClusterDetails/ChecksResults.jsx
+++ b/assets/js/components/ClusterDetails/ChecksResults.jsx
@@ -127,7 +127,12 @@ export const ChecksResults = () => {
 
     pageContent = lastExecution.map(
       ({ _cluster_id, host_id, reachable, msg }, idx) => (
-        <div key={idx} className={classNames('flex', 'flex-col', {'mb-8': idx != (cluster.hosts_executions.length - 1)})}>
+        <div
+          key={idx}
+          className={classNames('flex', 'flex-col', {
+            'mb-8': idx != cluster.hosts_executions.length - 1,
+          })}
+        >
           <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
             <div className="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
               <div className="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">


### PR DESCRIPTION
# Description

Added margin to the bottom of the each container/host in the results on the Check Results screen. This margin appears for every container except for the last one in the list.

<img width="1427" alt="Screenshot 2022-09-28 at 16 35 02" src="https://user-images.githubusercontent.com/40714533/192809655-a1f21797-51b5-4671-9a6d-f87d95b25a82.png">


## How was this tested?

Visually
