### PR TITLE
Add tag validation

### DIFF
--- a/assets/js/components/Tags/Tags.jsx
+++ b/assets/js/components/Tags/Tags.jsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useRef } from 'react';
 import classNames from 'classnames';
-
 import { EOS_NEW_LABEL, EOS_CLOSE } from 'eos-icons-react';
-
 import Pill from '@components/Pill';
 import useOnClickOutside from '@hooks/useOnClickOutside';
+
+const tagRegexValidation = /^[\+\-=.,_:@\p{L}\w]*$/u;
+const tagValidation = (char) => tagRegexValidation.test(char)
 
 const Tags = ({ className, tags, onChange, onAdd, onRemove }) => {
   const [renderedTags, setTags] = useState(tags);
@@ -61,7 +62,6 @@ const Tags = ({ className, tags, onChange, onAdd, onRemove }) => {
                 (acc, current) => (current === tag ? acc : [...acc, current]),
                 []
               );
-
               setTags(newTagsList);
               onChange(newTagsList);
               onRemove(tag);
@@ -77,7 +77,9 @@ const Tags = ({ className, tags, onChange, onAdd, onRemove }) => {
             ref={inputRef}
             className="bg-green-100"
             onChange={({ target: { value } }) => {
-              setNewTagValue(value);
+              if (tagValidation(value)) {
+                setNewTagValue(value);
+              }
             }}
             onKeyDown={({ key }) => {
               if (key === 'Enter') {

--- a/assets/js/components/Tags/Tags.jsx
+++ b/assets/js/components/Tags/Tags.jsx
@@ -3,9 +3,9 @@ import classNames from 'classnames';
 import { EOS_NEW_LABEL, EOS_CLOSE } from 'eos-icons-react';
 import Pill from '@components/Pill';
 import useOnClickOutside from '@hooks/useOnClickOutside';
-
+//eslint-disable-next-line
 const tagRegexValidation = /^[\+\-=.,_:@\p{L}\w]*$/u;
-const tagValidation = (char) => tagRegexValidation.test(char)
+const tagValidation = (char) => tagRegexValidation.test(char);
 
 const Tags = ({ className, tags, onChange, onAdd, onRemove }) => {
   const [renderedTags, setTags] = useState(tags);

--- a/lib/trento/application/usecases/tags/tag.ex
+++ b/lib/trento/application/usecases/tags/tag.ex
@@ -5,6 +5,7 @@ defmodule Trento.Tag do
 
   import Ecto.Changeset
 
+  @forbidden_tag_chars_regex ~r/^[\+\-=.,_:@\p{L}\w]*$/u
   @type t :: %__MODULE__{}
 
   @derive {Jason.Encoder, except: [:__meta__, :__struct__]}
@@ -20,6 +21,7 @@ defmodule Trento.Tag do
     tag
     |> cast(attrs, [:value, :resource_id, :resource_type])
     |> validate_required([:value, :resource_id, :resource_type])
+    |> validate_format(:value, @forbidden_tag_chars_regex)
     |> unique_constraint([:resource_id, :value])
   end
 end

--- a/test/trento_web/controllers/tags_controller_test.exs
+++ b/test/trento_web/controllers/tags_controller_test.exs
@@ -6,7 +6,7 @@ defmodule TrentoWeb.TagsControllerTest do
   alias Trento.Tag
 
   describe "Tag Validation" do
-    test "should validate incoming tags", %{conn: conn} do
+    test "should decline tag with whitespace", %{conn: conn} do
       conn =
         post(conn, Routes.hosts_tagging_path(conn, :add_tag, Faker.UUID.v4()), %{
           "value" => "     "
@@ -15,6 +15,19 @@ defmodule TrentoWeb.TagsControllerTest do
       assert %{
                "errors" => %{
                  "value" => ["can't be blank"]
+               }
+             } = json_response(conn, 400)
+    end
+
+    test "should decline tag with forbidden characters", %{conn: conn} do
+      conn =
+        post(conn, Routes.hosts_tagging_path(conn, :add_tag, Faker.UUID.v4()), %{
+          "value" => "This / is a \ wrong #tag"
+        })
+
+      assert %{
+               "errors" => %{
+                 "value" => ["has invalid format"]
                }
              } = json_response(conn, 400)
     end

--- a/test/trento_web/controllers/tags_controller_test.exs
+++ b/test/trento_web/controllers/tags_controller_test.exs
@@ -2,7 +2,7 @@ defmodule TrentoWeb.TagsControllerTest do
   use TrentoWeb.ConnCase, async: true
 
   import Trento.Factory
-
+  alias Faker.Color
   alias Trento.Tag
 
   describe "Tag Validation" do
@@ -37,7 +37,7 @@ defmodule TrentoWeb.TagsControllerTest do
     test "should add a tag to a sap system", %{conn: conn} do
       conn =
         post(conn, Routes.sap_systems_tagging_path(conn, :add_tag, Faker.UUID.v4()), %{
-          "value" => String.replace(Faker.Beer.style(), " ", "")
+          "value" => Color.En.name()
         })
 
       assert 201 == conn.status
@@ -78,7 +78,7 @@ defmodule TrentoWeb.TagsControllerTest do
     test "should add a tag to a database", %{conn: conn} do
       conn =
         post(conn, Routes.databases_tagging_path(conn, :add_tag, Faker.UUID.v4()), %{
-          "value" => String.replace(Faker.Beer.style(), " ", "")
+          "value" => Color.En.name()
         })
 
       assert 201 == conn.status
@@ -102,7 +102,7 @@ defmodule TrentoWeb.TagsControllerTest do
     test "should add a tag to a cluster", %{conn: conn} do
       conn =
         post(conn, Routes.clusters_tagging_path(conn, :add_tag, Faker.UUID.v4()), %{
-          "value" => tag_value = String.replace(Faker.Beer.style(), " ", "")
+          "value" => tag_value = Color.En.name()
         })
 
       assert json_response(conn, 201)["value"] == tag_value
@@ -143,7 +143,7 @@ defmodule TrentoWeb.TagsControllerTest do
     test "should add a tag to a host", %{conn: conn} do
       conn =
         post(conn, Routes.hosts_tagging_path(conn, :add_tag, Faker.UUID.v4()), %{
-          "value" => String.replace(Faker.Beer.style(), " ", "")
+          "value" => Color.En.name()
         })
 
       assert 201 == conn.status

--- a/test/trento_web/controllers/tags_controller_test.exs
+++ b/test/trento_web/controllers/tags_controller_test.exs
@@ -40,7 +40,6 @@ defmodule TrentoWeb.TagsControllerTest do
           "value" => String.replace(Faker.Beer.style(), " ", "")
         })
 
-      IO.inspect(conn)
       assert 201 == conn.status
     end
 

--- a/test/trento_web/controllers/tags_controller_test.exs
+++ b/test/trento_web/controllers/tags_controller_test.exs
@@ -24,9 +24,10 @@ defmodule TrentoWeb.TagsControllerTest do
     test "should add a tag to a sap system", %{conn: conn} do
       conn =
         post(conn, Routes.sap_systems_tagging_path(conn, :add_tag, Faker.UUID.v4()), %{
-          "value" => Faker.Beer.style()
+          "value" => String.replace(Faker.Beer.style(), " ", "")
         })
 
+      IO.inspect(conn)
       assert 201 == conn.status
     end
 
@@ -65,7 +66,7 @@ defmodule TrentoWeb.TagsControllerTest do
     test "should add a tag to a database", %{conn: conn} do
       conn =
         post(conn, Routes.databases_tagging_path(conn, :add_tag, Faker.UUID.v4()), %{
-          "value" => Faker.Beer.style()
+          "value" => String.replace(Faker.Beer.style(), " ", "")
         })
 
       assert 201 == conn.status
@@ -89,7 +90,7 @@ defmodule TrentoWeb.TagsControllerTest do
     test "should add a tag to a cluster", %{conn: conn} do
       conn =
         post(conn, Routes.clusters_tagging_path(conn, :add_tag, Faker.UUID.v4()), %{
-          "value" => tag_value = Faker.Beer.style()
+          "value" => tag_value = String.replace(Faker.Beer.style(), " ", "")
         })
 
       assert json_response(conn, 201)["value"] == tag_value
@@ -130,7 +131,7 @@ defmodule TrentoWeb.TagsControllerTest do
     test "should add a tag to a host", %{conn: conn} do
       conn =
         post(conn, Routes.hosts_tagging_path(conn, :add_tag, Faker.UUID.v4()), %{
-          "value" => Faker.Beer.style()
+          "value" => String.replace(Faker.Beer.style(), " ", "")
         })
 
       assert 201 == conn.status


### PR DESCRIPTION
# Description

This pr adds: 
- frontend tag validation
- backend tag validation
- new test for wrong tags

When a user wants to create a tag in the frontend, every character of the input is validated.
In the case a forbidden character was used, the frontend will reject the input and don't add the character.
Additionally, a backend validation was added to ensure that the backend is protected when a user tries directly to interact with the backend.

Allowed characters are letters, numbers representable in UTF-8, and the following characters: + - = . , _ : @
This is leaned to the aws tag guidelines, for **instance tags** 
See here: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html

Fixes  #464

## How was this tested?
Existing tests were adjusted to the new requirements. 
A new test was added to check if the wrong tags are handled.
