### PR TITLE
Use new enum type for Health

### DIFF
--- a/lib/trento/application/read_models/application_instance_read_model.ex
+++ b/lib/trento/application/read_models/application_instance_read_model.ex
@@ -7,6 +7,8 @@ defmodule Trento.ApplicationInstanceReadModel do
 
   import Ecto.Changeset
 
+  require Trento.Domain.Enum.Health, as: Health
+
   @type t :: %__MODULE__{}
 
   alias Trento.HostReadModel
@@ -23,7 +25,7 @@ defmodule Trento.ApplicationInstanceReadModel do
     field :https_port, :integer
     field :start_priority, :string
     field :host_id, Ecto.UUID, primary_key: true
-    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :health, Ecto.Enum, values: Health.values()
 
     has_one :host, HostReadModel, references: :host_id, foreign_key: :id
   end

--- a/lib/trento/application/read_models/cluster_read_model.ex
+++ b/lib/trento/application/read_models/cluster_read_model.ex
@@ -9,6 +9,7 @@ defmodule Trento.ClusterReadModel do
 
   require Trento.Domain.Enum.Provider, as: Provider
   require Trento.Domain.Enum.ClusterType, as: ClusterType
+  require Trento.Domain.Enum.Health, as: Health
 
   alias Trento.{
     CheckResultReadModel,
@@ -25,7 +26,7 @@ defmodule Trento.ClusterReadModel do
     field :provider, Ecto.Enum, values: Provider.values()
     field :type, Ecto.Enum, values: ClusterType.values()
     field :selected_checks, {:array, :string}, default: []
-    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :health, Ecto.Enum, values: Health.values()
     field :resources_number, :integer
     field :hosts_number, :integer
     field :details, :map

--- a/lib/trento/application/read_models/database_instance_read_model.ex
+++ b/lib/trento/application/read_models/database_instance_read_model.ex
@@ -7,6 +7,8 @@ defmodule Trento.DatabaseInstanceReadModel do
 
   import Ecto.Changeset
 
+  require Trento.Domain.Enum.Health, as: Health
+
   @type t :: %__MODULE__{}
 
   alias Trento.HostReadModel
@@ -26,7 +28,7 @@ defmodule Trento.DatabaseInstanceReadModel do
     field :host_id, Ecto.UUID, primary_key: true
     field :system_replication, :string, default: ""
     field :system_replication_status, :string, default: ""
-    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :health, Ecto.Enum, values: Health.values()
 
     has_one :host, HostReadModel, references: :host_id, foreign_key: :id
   end

--- a/lib/trento/application/read_models/database_read_model.ex
+++ b/lib/trento/application/read_models/database_read_model.ex
@@ -7,6 +7,8 @@ defmodule Trento.DatabaseReadModel do
 
   import Ecto.Changeset
 
+  require Trento.Domain.Enum.Health, as: Health
+
   alias Trento.DatabaseInstanceReadModel
 
   @type t :: %__MODULE__{}
@@ -15,7 +17,7 @@ defmodule Trento.DatabaseReadModel do
   @primary_key {:id, :binary_id, autogenerate: false}
   schema "databases" do
     field :sid, :string
-    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :health, Ecto.Enum, values: Health.values()
 
     has_many :tags, Trento.Tag, foreign_key: :resource_id
 

--- a/lib/trento/application/read_models/sap_system_read_model.ex
+++ b/lib/trento/application/read_models/sap_system_read_model.ex
@@ -7,6 +7,8 @@ defmodule Trento.SapSystemReadModel do
 
   import Ecto.Changeset
 
+  require Trento.Domain.Enum.Health, as: Health
+
   alias Trento.{
     ApplicationInstanceReadModel,
     DatabaseInstanceReadModel
@@ -20,7 +22,7 @@ defmodule Trento.SapSystemReadModel do
     field :sid, :string
     field :tenant, :string
     field :db_host, :string
-    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :health, Ecto.Enum, values: Health.values()
 
     has_many :database_instances, DatabaseInstanceReadModel,
       references: :id,

--- a/lib/trento/application/usecases/sap_systems/dto/health_summary_dto.ex
+++ b/lib/trento/application/usecases/sap_systems/dto/health_summary_dto.ex
@@ -7,12 +7,14 @@ defmodule Trento.Application.UseCases.SapSystems.HealthSummaryDto do
 
   use Trento.Type
 
+  require Trento.Domain.Enum.Health, as: Health
+
   deftype do
     field :id, :string
     field :sid, :string
-    field :sapsystem_health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
-    field :database_health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
-    field :clusters_health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :sapsystem_health, Ecto.Enum, values: Health.values()
+    field :database_health, Ecto.Enum, values: Health.values()
+    field :clusters_health, Ecto.Enum, values: Health.values()
     field :hosts_health, Ecto.Enum, values: [:passing, :critical, :unknown]
   end
 end

--- a/lib/trento/application/usecases/sap_systems/health_summary_service.ex
+++ b/lib/trento/application/usecases/sap_systems/health_summary_service.ex
@@ -14,7 +14,7 @@ defmodule Trento.SapSystems.HealthSummaryService do
     SapSystemReadModel
   }
 
-  alias Trento.Domain.Health
+  alias Trento.Domain.Enum.Health
   alias Trento.Domain.HealthService
 
   alias Trento.Application.UseCases.SapSystems.HealthSummaryDto

--- a/lib/trento/domain/cluster/cluster.ex
+++ b/lib/trento/domain/cluster/cluster.ex
@@ -3,6 +3,7 @@ defmodule Trento.Domain.Cluster do
 
   require Trento.Domain.Enum.Provider, as: Provider
   require Trento.Domain.Enum.ClusterType, as: ClusterType
+  require Trento.Domain.Enum.Health, as: Health
 
   alias Commanded.Aggregate.Multi
 
@@ -64,9 +65,9 @@ defmodule Trento.Domain.Cluster do
           name: String.t(),
           type: ClusterType.t(),
           provider: Provider.t(),
-          discovered_health: nil | :passing | :warning | :critical | :unknown,
-          checks_health: nil | :passing | :warning | :critical | :unknown,
-          health: :passing | :warning | :critical | :unknown,
+          discovered_health: nil | Health.t(),
+          checks_health: nil | Health.t(),
+          health: Health.t(),
           sid: String.t(),
           details: HanaClusterDetails.t() | nil,
           hosts: [String.t()],

--- a/lib/trento/domain/cluster/commands/register_cluster_host.ex
+++ b/lib/trento/domain/cluster/commands/register_cluster_host.ex
@@ -16,6 +16,7 @@ defmodule Trento.Domain.Commands.RegisterClusterHost do
 
   require Trento.Domain.Enum.Provider, as: Provider
   require Trento.Domain.Enum.ClusterType, as: ClusterType
+  require Trento.Domain.Enum.Health, as: Health
 
   alias Trento.Domain.HanaClusterDetails
 
@@ -29,7 +30,7 @@ defmodule Trento.Domain.Commands.RegisterClusterHost do
     field :designated_controller, :boolean
     field :resources_number, :integer
     field :hosts_number, :integer
-    field :discovered_health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :discovered_health, Ecto.Enum, values: Health.values()
     field :cib_last_written, :string
 
     embeds_one :details, HanaClusterDetails

--- a/lib/trento/domain/cluster/events/checks_execution_completed.ex
+++ b/lib/trento/domain/cluster/events/checks_execution_completed.ex
@@ -5,8 +5,10 @@ defmodule Trento.Domain.Events.ChecksExecutionCompleted do
 
   use Trento.Event
 
+  require Trento.Domain.Enum.Health, as: Health
+
   defevent do
     field :cluster_id, Ecto.UUID
-    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :health, Ecto.Enum, values: Health.values()
   end
 end

--- a/lib/trento/domain/cluster/events/cluster_discovered_health_changed.ex
+++ b/lib/trento/domain/cluster/events/cluster_discovered_health_changed.ex
@@ -5,8 +5,10 @@ defmodule Trento.Domain.Events.ClusterDiscoveredHealthChanged do
 
   use Trento.Event
 
+  require Trento.Domain.Enum.Health, as: Health
+
   defevent do
     field :cluster_id, :string
-    field :discovered_health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :discovered_health, Ecto.Enum, values: Health.values()
   end
 end

--- a/lib/trento/domain/cluster/events/cluster_health_changed.ex
+++ b/lib/trento/domain/cluster/events/cluster_health_changed.ex
@@ -5,8 +5,10 @@ defmodule Trento.Domain.Events.ClusterHealthChanged do
 
   use Trento.Event
 
+  require Trento.Domain.Enum.Health, as: Health
+
   defevent do
     field :cluster_id, :string
-    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :health, Ecto.Enum, values: Health.values()
   end
 end

--- a/lib/trento/domain/cluster/events/cluster_registered.ex
+++ b/lib/trento/domain/cluster/events/cluster_registered.ex
@@ -7,6 +7,7 @@ defmodule Trento.Domain.Events.ClusterRegistered do
 
   require Trento.Domain.Enum.Provider, as: Provider
   require Trento.Domain.Enum.ClusterType, as: ClusterType
+  require Trento.Domain.Enum.Health, as: Health
 
   alias Trento.Domain.HanaClusterDetails
 
@@ -18,7 +19,7 @@ defmodule Trento.Domain.Events.ClusterRegistered do
     field :provider, Ecto.Enum, values: Provider.values()
     field :resources_number, :integer
     field :hosts_number, :integer
-    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :health, Ecto.Enum, values: Health.values()
 
     embeds_one :details, HanaClusterDetails
   end

--- a/lib/trento/domain/cluster/events/cluster_rolled_up.ex
+++ b/lib/trento/domain/cluster/events/cluster_rolled_up.ex
@@ -7,6 +7,7 @@ defmodule Trento.Domain.Events.ClusterRolledUp do
 
   require Trento.Domain.Enum.Provider, as: Provider
   require Trento.Domain.Enum.ClusterType, as: ClusterType
+  require Trento.Domain.Enum.Health, as: Health
 
   alias Trento.Domain.{
     HanaClusterDetails,
@@ -21,11 +22,11 @@ defmodule Trento.Domain.Events.ClusterRolledUp do
     field :provider, Ecto.Enum, values: Provider.values()
     field :resources_number, :integer
     field :hosts_number, :integer
-    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :health, Ecto.Enum, values: Health.values()
     field :hosts, {:array, :string}
     field :selected_checks, {:array, :string}
-    field :discovered_health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
-    field :checks_health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :discovered_health, Ecto.Enum, values: Health.values()
+    field :checks_health, Ecto.Enum, values: Health.values()
 
     embeds_one :details, HanaClusterDetails
     embeds_many :hosts_executions, HostExecution

--- a/lib/trento/domain/enums/health.ex
+++ b/lib/trento/domain/enums/health.ex
@@ -1,7 +1,7 @@
-defmodule Trento.Domain.Health do
+defmodule Trento.Domain.Enum.Health do
   @moduledoc """
   Type that represents the possible health values in the system.
   """
 
-  @type t :: :passing | :warning | :critical | :unknown
+  use Trento.Domain.Enum, values: [:passing, :warning, :critical, :unknown]
 end

--- a/lib/trento/domain/sap_system/commands/register_application_instance.ex
+++ b/lib/trento/domain/sap_system/commands/register_application_instance.ex
@@ -22,6 +22,8 @@ defmodule Trento.Domain.Commands.RegisterApplicationInstance do
 
   use Trento.Command
 
+  require Trento.Domain.Enum.Health, as: Health
+
   defcommand do
     field :sap_system_id, Ecto.UUID
     field :sid, :string
@@ -34,6 +36,6 @@ defmodule Trento.Domain.Commands.RegisterApplicationInstance do
     field :http_port, :integer
     field :https_port, :integer
     field :start_priority, :string
-    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :health, Ecto.Enum, values: Health.values()
   end
 end

--- a/lib/trento/domain/sap_system/commands/register_database_instance.ex
+++ b/lib/trento/domain/sap_system/commands/register_database_instance.ex
@@ -17,6 +17,8 @@ defmodule Trento.Domain.Commands.RegisterDatabaseInstance do
 
   use Trento.Command
 
+  require Trento.Domain.Enum.Health, as: Health
+
   defcommand do
     field :sap_system_id, Ecto.UUID
     field :sid, :string
@@ -30,6 +32,6 @@ defmodule Trento.Domain.Commands.RegisterDatabaseInstance do
     field :start_priority, :string
     field :system_replication, :string
     field :system_replication_status, :string
-    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :health, Ecto.Enum, values: Health.values()
   end
 end

--- a/lib/trento/domain/sap_system/database.ex
+++ b/lib/trento/domain/sap_system/database.ex
@@ -3,7 +3,7 @@ defmodule Trento.Domain.SapSystem.Database do
   This module represents a SAP System database.
   """
 
-  alias Trento.Domain.Health
+  alias Trento.Domain.Enum.Health
 
   defstruct [
     :sid,

--- a/lib/trento/domain/sap_system/events/application_instance_health_changed.ex
+++ b/lib/trento/domain/sap_system/events/application_instance_health_changed.ex
@@ -5,10 +5,12 @@ defmodule Trento.Domain.Events.ApplicationInstanceHealthChanged do
 
   use Trento.Event
 
+  require Trento.Domain.Enum.Health, as: Health
+
   defevent do
     field :sap_system_id, Ecto.UUID
     field :host_id, Ecto.UUID
     field :instance_number, :string
-    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :health, Ecto.Enum, values: Health.values()
   end
 end

--- a/lib/trento/domain/sap_system/events/application_instance_registered.ex
+++ b/lib/trento/domain/sap_system/events/application_instance_registered.ex
@@ -5,6 +5,8 @@ defmodule Trento.Domain.Events.ApplicationInstanceRegistered do
 
   use Trento.Event
 
+  require Trento.Domain.Enum.Health, as: Health
+
   defevent do
     field :sap_system_id, Ecto.UUID
     field :sid, :string
@@ -15,6 +17,6 @@ defmodule Trento.Domain.Events.ApplicationInstanceRegistered do
     field :http_port, :integer
     field :https_port, :integer
     field :start_priority, :string
-    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :health, Ecto.Enum, values: Health.values()
   end
 end

--- a/lib/trento/domain/sap_system/events/database_health_changed.ex
+++ b/lib/trento/domain/sap_system/events/database_health_changed.ex
@@ -5,8 +5,10 @@ defmodule Trento.Domain.Events.DatabaseHealthChanged do
 
   use Trento.Event
 
+  require Trento.Domain.Enum.Health, as: Health
+
   defevent do
     field :sap_system_id, Ecto.UUID
-    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :health, Ecto.Enum, values: Health.values()
   end
 end

--- a/lib/trento/domain/sap_system/events/database_instance_health_changed.ex
+++ b/lib/trento/domain/sap_system/events/database_instance_health_changed.ex
@@ -5,10 +5,12 @@ defmodule Trento.Domain.Events.DatabaseInstanceHealthChanged do
 
   use Trento.Event
 
+  require Trento.Domain.Enum.Health, as: Health
+
   defevent do
     field :sap_system_id, Ecto.UUID
     field :host_id, Ecto.UUID
     field :instance_number, :string
-    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :health, Ecto.Enum, values: Health.values()
   end
 end

--- a/lib/trento/domain/sap_system/events/database_instance_registered.ex
+++ b/lib/trento/domain/sap_system/events/database_instance_registered.ex
@@ -5,6 +5,8 @@ defmodule Trento.Domain.Events.DatabaseInstanceRegistered do
 
   use Trento.Event
 
+  require Trento.Domain.Enum.Health, as: Health
+
   defevent do
     field :sap_system_id, Ecto.UUID
     field :sid, :string
@@ -18,6 +20,6 @@ defmodule Trento.Domain.Events.DatabaseInstanceRegistered do
     field :start_priority, :string
     field :system_replication, :string
     field :system_replication_status, :string
-    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :health, Ecto.Enum, values: Health.values()
   end
 end

--- a/lib/trento/domain/sap_system/events/database_registered.ex
+++ b/lib/trento/domain/sap_system/events/database_registered.ex
@@ -5,9 +5,11 @@ defmodule Trento.Domain.Events.DatabaseRegistered do
 
   use Trento.Event
 
+  require Trento.Domain.Enum.Health, as: Health
+
   defevent do
     field :sap_system_id, Ecto.UUID
     field :sid, :string
-    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :health, Ecto.Enum, values: Health.values()
   end
 end

--- a/lib/trento/domain/sap_system/events/sap_system_health_changed.ex
+++ b/lib/trento/domain/sap_system/events/sap_system_health_changed.ex
@@ -5,8 +5,10 @@ defmodule Trento.Domain.Events.SapSystemHealthChanged do
 
   use Trento.Event
 
+  require Trento.Domain.Enum.Health, as: Health
+
   defevent do
     field :sap_system_id, Ecto.UUID
-    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :health, Ecto.Enum, values: Health.values()
   end
 end

--- a/lib/trento/domain/sap_system/events/sap_system_registered.ex
+++ b/lib/trento/domain/sap_system/events/sap_system_registered.ex
@@ -5,11 +5,13 @@ defmodule Trento.Domain.Events.SapSystemRegistered do
 
   use Trento.Event
 
+  require Trento.Domain.Enum.Health, as: Health
+
   defevent do
     field :sap_system_id, Ecto.UUID
     field :sid, :string
     field :tenant, :string
     field :db_host, :string
-    field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
+    field :health, Ecto.Enum, values: Health.values()
   end
 end

--- a/lib/trento/domain/sap_system/instance.ex
+++ b/lib/trento/domain/sap_system/instance.ex
@@ -3,7 +3,7 @@ defmodule Trento.Domain.SapSystem.Instance do
   This module represents a SAP System instance.
   """
 
-  alias Trento.Domain.Health
+  alias Trento.Domain.Enum.Health
 
   defstruct [
     :sid,

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -28,7 +28,7 @@ defmodule Trento.Domain.SapSystem do
     SapSystemRegistered
   }
 
-  alias Trento.Domain.Health
+  alias Trento.Domain.Enum.Health
   alias Trento.Domain.HealthService
 
   defstruct [

--- a/lib/trento/domain/services/health_service.ex
+++ b/lib/trento/domain/services/health_service.ex
@@ -3,7 +3,7 @@ defmodule Trento.Domain.HealthService do
   This module contains the domain logic for everything health related.
   """
 
-  alias Trento.Domain.Health
+  alias Trento.Domain.Enum.Health
 
   @spec compute_aggregated_health([Health.t()]) :: Health.t()
   def compute_aggregated_health([]), do: :unknown

--- a/lib/trento_web/openapi/schema/health.ex
+++ b/lib/trento_web/openapi/schema/health.ex
@@ -2,11 +2,12 @@ defmodule TrentoWeb.OpenApi.Schema.ResourceHealth do
   @moduledoc false
 
   require OpenApiSpex
+  require Trento.Domain.Enum.Health, as: Health
 
   OpenApiSpex.schema(%{
     title: "ResourceHealth",
     type: :string,
     description: "Detected health of a Resource",
-    enum: [:passing, :warning, :critical, :unknown]
+    enum: Health.values()
   })
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -5,6 +5,7 @@ defmodule Trento.Factory do
 
   require Trento.Domain.Enum.Provider, as: Provider
   require Trento.Domain.Enum.ClusterType, as: ClusterType
+  require Trento.Domain.Enum.Health, as: Health
 
   alias Trento.Domain.{
     ClusterNode,
@@ -119,7 +120,7 @@ defmodule Trento.Factory do
       hosts_number: 2,
       details: hana_cluster_details_value_object(),
       type: ClusterType.hana_scale_up(),
-      discovered_health: :passing,
+      discovered_health: Health.passing(),
       designated_controller: true
     }
   end
@@ -133,7 +134,7 @@ defmodule Trento.Factory do
       resources_number: 8,
       hosts_number: 2,
       details: hana_cluster_details_value_object(),
-      health: :passing,
+      health: Health.passing(),
       type: ClusterType.hana_scale_up()
     }
   end
@@ -174,7 +175,7 @@ defmodule Trento.Factory do
       sid: Faker.StarWars.planet(),
       provider: Enum.random(Provider.values()),
       type: ClusterType.hana_scale_up(),
-      health: :passing
+      health: Health.passing()
     }
   end
 
@@ -216,7 +217,7 @@ defmodule Trento.Factory do
       host_id: Faker.UUID.v4(),
       system_replication: "Primary",
       system_replication_status: "ACTIVE",
-      health: :passing
+      health: Health.passing()
     }
   end
 
@@ -231,7 +232,7 @@ defmodule Trento.Factory do
       https_port: 8443,
       start_priority: "0.3",
       host_id: Faker.UUID.v4(),
-      health: :passing
+      health: Health.passing()
     }
   end
 
@@ -239,7 +240,7 @@ defmodule Trento.Factory do
     %DatabaseRegistered{
       sap_system_id: Faker.UUID.v4(),
       sid: Faker.UUID.v4(),
-      health: :passing
+      health: Health.passing()
     }
   end
 
@@ -249,7 +250,7 @@ defmodule Trento.Factory do
       sid: Faker.UUID.v4(),
       db_host: Faker.Internet.ip_v4_address(),
       tenant: Faker.Beer.hop(),
-      health: :passing
+      health: Health.passing()
     }
   end
 
@@ -308,7 +309,7 @@ defmodule Trento.Factory do
       sid: Faker.StarWars.planet(),
       tenant: Faker.Beer.hop(),
       db_host: Faker.Internet.ip_v4_address(),
-      health: :unknown
+      health: Health.unknown()
     }
   end
 
@@ -322,7 +323,7 @@ defmodule Trento.Factory do
       host_id: Faker.UUID.v4(),
       system_replication: "",
       system_replication_status: "",
-      health: :unknown
+      health: Health.unknown()
     }
   end
 
@@ -338,7 +339,7 @@ defmodule Trento.Factory do
       instance_number: "00",
       features: Faker.Pokemon.name(),
       host_id: Faker.UUID.v4(),
-      health: :unknown
+      health: Health.unknown()
     }
   end
 
@@ -385,7 +386,7 @@ defmodule Trento.Factory do
       https_port: 8443,
       start_priority: "0.3",
       host_id: Faker.UUID.v4(),
-      health: :passing
+      health: Health.passing()
     })
   end
 
@@ -403,7 +404,7 @@ defmodule Trento.Factory do
       host_id: Faker.UUID.v4(),
       system_replication: "Primary",
       system_replication_status: "ACTIVE",
-      health: :passing
+      health: Health.passing()
     })
   end
 
@@ -435,10 +436,10 @@ defmodule Trento.Factory do
 
   def sap_system_with_cluster_and_hosts do
     %ClusterReadModel{id: cluster_id} =
-      insert(:cluster, type: ClusterType.hana_scale_up(), health: :passing)
+      insert(:cluster, type: ClusterType.hana_scale_up(), health: Health.passing())
 
     %ClusterReadModel{id: another_cluster_id} =
-      insert(:cluster, type: ClusterType.hana_scale_up(), health: :warning)
+      insert(:cluster, type: ClusterType.hana_scale_up(), health: Health.warning())
 
     %HostReadModel{id: host_1_id} = insert(:host, cluster_id: cluster_id, heartbeat: :unknown)
 
@@ -450,14 +451,14 @@ defmodule Trento.Factory do
     %SapSystemReadModel{
       id: sap_system_id,
       sid: sid
-    } = insert(:sap_system, health: :passing)
+    } = insert(:sap_system, health: Health.passing())
 
     insert(
       :database_instance_without_host,
       sap_system_id: sap_system_id,
       sid: database_sid,
       host_id: host_1_id,
-      health: :warning
+      health: Health.warning()
     )
 
     insert(
@@ -465,7 +466,7 @@ defmodule Trento.Factory do
       sap_system_id: sap_system_id,
       sid: database_sid,
       host_id: host_2_id,
-      health: :critical
+      health: Health.critical()
     )
 
     insert(
@@ -473,7 +474,7 @@ defmodule Trento.Factory do
       sap_system_id: sap_system_id,
       sid: sid,
       host_id: host_1_id,
-      health: :passing
+      health: Health.passing()
     )
 
     insert(
@@ -481,7 +482,7 @@ defmodule Trento.Factory do
       sap_system_id: sap_system_id,
       sid: sid,
       host_id: host_2_id,
-      health: :warning
+      health: Health.warning()
     )
 
     %{


### PR DESCRIPTION
# Description
Following up on the work started in PR #849, this also uses the new Enum type macros and substitutes all the literal references to the possible health values with the macros.

## How was this tested?
No new tests added, existing tests are passing.