### PR TITLE
Use new enum type for cluster types

### DIFF
--- a/lib/trento/application/integration/discovery/payloads/cluster/cluster_discovery_payload.ex
+++ b/lib/trento/application/integration/discovery/payloads/cluster/cluster_discovery_payload.ex
@@ -9,6 +9,7 @@ defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload do
   use Trento.Type
 
   require Trento.Domain.Enum.Provider, as: Provider
+  require Trento.Domain.Enum.ClusterType, as: ClusterType
 
   alias Trento.Integration.Discovery.ClusterDiscoveryPayload.{
     Cib,
@@ -25,7 +26,7 @@ defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload do
 
     field :id, :string
     field :name, :string
-    field :cluster_type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
+    field :cluster_type, Ecto.Enum, values: ClusterType.values()
     field :sid, :string
 
     embeds_one :cib, Cib
@@ -76,9 +77,9 @@ defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload do
     do_detect_cluster_type(has_sap_hana_topology, has_sap_hana, has_sap_hana_controller)
   end
 
-  defp do_detect_cluster_type(true, true, _), do: :hana_scale_up
-  defp do_detect_cluster_type(true, _, true), do: :hana_scale_out
-  defp do_detect_cluster_type(_, _, _), do: :unknown
+  defp do_detect_cluster_type(true, true, _), do: ClusterType.hana_scale_up()
+  defp do_detect_cluster_type(true, _, true), do: ClusterType.hana_scale_out()
+  defp do_detect_cluster_type(_, _, _), do: ClusterType.unknown()
 
   defp parse_cluster_sid(%{
          "cib" => %{"configuration" => %{"resources" => %{"clones" => nil}}}
@@ -105,10 +106,10 @@ defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload do
     end)
   end
 
-  defp maybe_validate_required_fields(cluster, %{"cluster_type" => :hana_scale_up}),
+  defp maybe_validate_required_fields(cluster, %{"cluster_type" => ClusterType.hana_scale_up()}),
     do: cluster |> validate_required(@required_fields_hana)
 
-  defp maybe_validate_required_fields(cluster, %{"cluster_type" => :hana_scale_out}),
+  defp maybe_validate_required_fields(cluster, %{"cluster_type" => ClusterType.hana_scale_out()}),
     do: cluster |> validate_required(@required_fields_hana)
 
   defp maybe_validate_required_fields(cluster, _),

--- a/lib/trento/application/integration/discovery/policies/cluster_policy.ex
+++ b/lib/trento/application/integration/discovery/policies/cluster_policy.ex
@@ -4,6 +4,7 @@ defmodule Trento.Integration.Discovery.ClusterPolicy do
   """
 
   require Trento.Domain.Enum.Provider, as: Provider
+  require Trento.Domain.Enum.ClusterType, as: ClusterType
 
   alias Trento.{
     Domain.Commands.RegisterClusterHost,
@@ -68,7 +69,7 @@ defmodule Trento.Integration.Discovery.ClusterPolicy do
   defp parse_cluster_details(
          %{crmmon: crmmon, sbd: sbd, cluster_type: cluster_type, sid: sid} = payload
        )
-       when cluster_type in [:hana_scale_up, :hana_scale_out] do
+       when cluster_type in [ClusterType.hana_scale_up(), ClusterType.hana_scale_out()] do
     nodes = parse_cluster_nodes(payload, sid)
 
     %{
@@ -364,7 +365,7 @@ defmodule Trento.Integration.Discovery.ClusterPolicy do
   defp generate_cluster_id(id), do: UUID.uuid5(@uuid_namespace, id)
 
   defp parse_cluster_health(details, cluster_type)
-       when cluster_type in [:hana_scale_up, :hana_scale_out],
+       when cluster_type in [ClusterType.hana_scale_up(), ClusterType.hana_scale_out()],
        do: parse_hana_cluster_health(details)
 
   defp parse_cluster_health(_, _), do: :unknown

--- a/lib/trento/application/read_models/cluster_read_model.ex
+++ b/lib/trento/application/read_models/cluster_read_model.ex
@@ -8,6 +8,7 @@ defmodule Trento.ClusterReadModel do
   import Ecto.Changeset
 
   require Trento.Domain.Enum.Provider, as: Provider
+  require Trento.Domain.Enum.ClusterType, as: ClusterType
 
   alias Trento.{
     CheckResultReadModel,
@@ -22,7 +23,7 @@ defmodule Trento.ClusterReadModel do
     field :name, :string, default: ""
     field :sid, :string
     field :provider, Ecto.Enum, values: Provider.values()
-    field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
+    field :type, Ecto.Enum, values: ClusterType.values()
     field :selected_checks, {:array, :string}, default: []
     field :health, Ecto.Enum, values: [:passing, :warning, :critical, :unknown]
     field :resources_number, :integer

--- a/lib/trento/application/usecases/clusters/clusters.ex
+++ b/lib/trento/application/usecases/clusters/clusters.ex
@@ -5,6 +5,9 @@ defmodule Trento.Clusters do
 
   import Ecto.Query
 
+  require Logger
+  require Trento.Domain.Enum.ClusterType, as: ClusterType
+
   alias Trento.ClusterEnrichmentData
   alias Trento.ClusterReadModel
 
@@ -17,8 +20,6 @@ defmodule Trento.Clusters do
   }
 
   alias Trento.Repo
-
-  require Logger
 
   def store_checks_results(cluster_id, host_id, checks_results) do
     with {:ok, checks_results} <- build_check_results(checks_results),
@@ -79,7 +80,7 @@ defmodule Trento.Clusters do
     query =
       from(c in ClusterReadModel,
         select: c.id,
-        where: c.type == :hana_scale_up or c.type == :hana_scale_out
+        where: c.type == ^ClusterType.hana_scale_up() or c.type == ^ClusterType.hana_scale_out()
       )
 
     query

--- a/lib/trento/application/usecases/sap_systems/health_summary_service.ex
+++ b/lib/trento/application/usecases/sap_systems/health_summary_service.ex
@@ -3,6 +3,10 @@ defmodule Trento.SapSystems.HealthSummaryService do
   Provides a set of functions to interact with SAP systems Health Summary
   """
 
+  import Ecto.Query
+
+  require Trento.Domain.Enum.ClusterType, as: ClusterType
+
   alias Trento.{
     ApplicationInstanceReadModel,
     ClusterReadModel,
@@ -15,8 +19,6 @@ defmodule Trento.SapSystems.HealthSummaryService do
 
   alias Trento.Application.UseCases.SapSystems.HealthSummaryDto
   alias Trento.Repo
-
-  import Ecto.Query
 
   @type instance_list :: [DatabaseInstanceReadModel.t() | ApplicationInstanceReadModel.t()]
 
@@ -94,7 +96,7 @@ defmodule Trento.SapSystems.HealthSummaryService do
   @spec keep_only_hana_scale_up_clusters([ClusterReadModel.t()]) :: [ClusterReadModel.t()]
   defp keep_only_hana_scale_up_clusters(clusters) do
     Enum.filter(clusters, fn
-      %ClusterReadModel{type: :hana_scale_up} -> true
+      %ClusterReadModel{type: ClusterType.hana_scale_up()} -> true
       _ -> false
     end)
   end

--- a/lib/trento/domain/cluster/cluster.ex
+++ b/lib/trento/domain/cluster/cluster.ex
@@ -2,6 +2,7 @@ defmodule Trento.Domain.Cluster do
   @moduledoc false
 
   require Trento.Domain.Enum.Provider, as: Provider
+  require Trento.Domain.Enum.ClusterType, as: ClusterType
 
   alias Commanded.Aggregate.Multi
 
@@ -61,7 +62,7 @@ defmodule Trento.Domain.Cluster do
   @type t :: %__MODULE__{
           cluster_id: String.t(),
           name: String.t(),
-          type: :hana_scale_up | :hana_scale_out | :unknown,
+          type: ClusterType.t(),
           provider: Provider.t(),
           discovered_health: nil | :passing | :warning | :critical | :unknown,
           checks_health: nil | :passing | :warning | :critical | :unknown,

--- a/lib/trento/domain/cluster/commands/register_cluster_host.ex
+++ b/lib/trento/domain/cluster/commands/register_cluster_host.ex
@@ -15,6 +15,7 @@ defmodule Trento.Domain.Commands.RegisterClusterHost do
   use Trento.Command
 
   require Trento.Domain.Enum.Provider, as: Provider
+  require Trento.Domain.Enum.ClusterType, as: ClusterType
 
   alias Trento.Domain.HanaClusterDetails
 
@@ -22,7 +23,7 @@ defmodule Trento.Domain.Commands.RegisterClusterHost do
     field :cluster_id, Ecto.UUID
     field :host_id, Ecto.UUID
     field :name, :string
-    field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
+    field :type, Ecto.Enum, values: ClusterType.values()
     field :sid, :string
     field :provider, Ecto.Enum, values: Provider.values()
     field :designated_controller, :boolean

--- a/lib/trento/domain/cluster/events/cluster_details_updated.ex
+++ b/lib/trento/domain/cluster/events/cluster_details_updated.ex
@@ -6,13 +6,14 @@ defmodule Trento.Domain.Events.ClusterDetailsUpdated do
   use Trento.Event
 
   require Trento.Domain.Enum.Provider, as: Provider
+  require Trento.Domain.Enum.ClusterType, as: ClusterType
 
   alias Trento.Domain.HanaClusterDetails
 
   defevent do
     field :cluster_id, :string
     field :name, :string
-    field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
+    field :type, Ecto.Enum, values: ClusterType.values()
     field :sid, :string
     field :provider, Ecto.Enum, values: Provider.values()
     field :resources_number, :integer

--- a/lib/trento/domain/cluster/events/cluster_registered.ex
+++ b/lib/trento/domain/cluster/events/cluster_registered.ex
@@ -6,13 +6,14 @@ defmodule Trento.Domain.Events.ClusterRegistered do
   use Trento.Event
 
   require Trento.Domain.Enum.Provider, as: Provider
+  require Trento.Domain.Enum.ClusterType, as: ClusterType
 
   alias Trento.Domain.HanaClusterDetails
 
   defevent do
     field :cluster_id, :string
     field :name, :string
-    field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
+    field :type, Ecto.Enum, values: ClusterType.values()
     field :sid, :string
     field :provider, Ecto.Enum, values: Provider.values()
     field :resources_number, :integer

--- a/lib/trento/domain/cluster/events/cluster_rolled_up.ex
+++ b/lib/trento/domain/cluster/events/cluster_rolled_up.ex
@@ -6,6 +6,7 @@ defmodule Trento.Domain.Events.ClusterRolledUp do
   use Trento.Event
 
   require Trento.Domain.Enum.Provider, as: Provider
+  require Trento.Domain.Enum.ClusterType, as: ClusterType
 
   alias Trento.Domain.{
     HanaClusterDetails,
@@ -15,7 +16,7 @@ defmodule Trento.Domain.Events.ClusterRolledUp do
   defevent do
     field :cluster_id, :string
     field :name, :string
-    field :type, Ecto.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
+    field :type, Ecto.Enum, values: ClusterType.values()
     field :sid, :string
     field :provider, Ecto.Enum, values: Provider.values()
     field :resources_number, :integer

--- a/lib/trento/domain/enums/cluster_type.ex
+++ b/lib/trento/domain/enums/cluster_type.ex
@@ -1,0 +1,7 @@
+defmodule Trento.Domain.Enum.ClusterType do
+  @moduledoc """
+  Type that represents the supported cluster types.
+  """
+
+  use Trento.Domain.Enum, values: [:hana_scale_up, :hana_scale_out, :unknown]
+end

--- a/lib/trento_web/openapi/schema/cluster.ex
+++ b/lib/trento_web/openapi/schema/cluster.ex
@@ -2,6 +2,8 @@ defmodule TrentoWeb.OpenApi.Schema.Cluster do
   @moduledoc false
 
   require OpenApiSpex
+  require Trento.Domain.Enum.ClusterType, as: ClusterType
+
   alias OpenApiSpex.Schema
 
   alias TrentoWeb.OpenApi.Schema.{Checks, Provider, ResourceHealth, Tags}
@@ -127,7 +129,7 @@ defmodule TrentoWeb.OpenApi.Schema.Cluster do
         type: %Schema{
           type: :string,
           description: "Detected type of the cluster",
-          enum: [:hana_scale_up, :hana_scale_out, :unknown]
+          enum: ClusterType.values()
         },
         selected_checks: %Schema{
           title: "SelectedChecks",

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -4,6 +4,7 @@ defmodule Trento.Factory do
   """
 
   require Trento.Domain.Enum.Provider, as: Provider
+  require Trento.Domain.Enum.ClusterType, as: ClusterType
 
   alias Trento.Domain.{
     ClusterNode,
@@ -117,7 +118,7 @@ defmodule Trento.Factory do
       resources_number: 8,
       hosts_number: 2,
       details: hana_cluster_details_value_object(),
-      type: :hana_scale_up,
+      type: ClusterType.hana_scale_up(),
       discovered_health: :passing,
       designated_controller: true
     }
@@ -133,7 +134,7 @@ defmodule Trento.Factory do
       hosts_number: 2,
       details: hana_cluster_details_value_object(),
       health: :passing,
-      type: :hana_scale_up
+      type: ClusterType.hana_scale_up()
     }
   end
 
@@ -172,7 +173,7 @@ defmodule Trento.Factory do
       name: Faker.StarWars.character(),
       sid: Faker.StarWars.planet(),
       provider: Enum.random(Provider.values()),
-      type: :hana_scale_up,
+      type: ClusterType.hana_scale_up(),
       health: :passing
     }
   end
@@ -433,10 +434,11 @@ defmodule Trento.Factory do
   end
 
   def sap_system_with_cluster_and_hosts do
-    %ClusterReadModel{id: cluster_id} = insert(:cluster, type: :hana_scale_up, health: :passing)
+    %ClusterReadModel{id: cluster_id} =
+      insert(:cluster, type: ClusterType.hana_scale_up(), health: :passing)
 
     %ClusterReadModel{id: another_cluster_id} =
-      insert(:cluster, type: :hana_scale_up, health: :warning)
+      insert(:cluster, type: ClusterType.hana_scale_up(), health: :warning)
 
     %HostReadModel{id: host_1_id} = insert(:host, cluster_id: cluster_id, heartbeat: :unknown)
 


### PR DESCRIPTION
# Description

Following up on the work started in PR https://github.com/trento-project/web/pull/849, this also uses the new Enum type macros and substitutes all the literal references to the possible cluster type values with the macros.

## How was this tested?

No new tests added, existing tests are passing.
