### PR TITLE
Premium EULA page content update

### DIFF
--- a/assets/js/components/Eula/Premium.jsx
+++ b/assets/js/components/Eula/Premium.jsx
@@ -64,6 +64,12 @@ const Premium = ({ visible, dispatch }) => {
               </p>
 
               <p className="mt-2">
+                The SUSE team uses the collected KPIs to have a better
+                understanding of how Trento is being used and to guide future
+                development.
+              </p>
+
+              <p className="mt-2">
                 By using Trento Premium and its updates available through SUSE
                 channels you agree to these terms. In case you disagree, please
                 switch to the Community version of Trento.


### PR DESCRIPTION
# Description

Adding paragraph to premium EULA page explaining the purpose of the collected KPIs.

Fixes # (issue)

N/A (this is a follow up to the discussion about the EULA page for the community version, where it was suggested by Legal to add such paragraph to both versions)

## Did you add the right label?

?

## How was this tested?

I don't know how to test before merging stuff. I just edited the content of the page using the community EULA page as reference.
