### PR TITLE
Move the check for unused deps to static code analysis step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,6 @@ jobs:
           mix local.rebar --force
           mix local.hex --force
           mix deps.get
-          mix deps.unlock --check-unused
           mix deps.compile --warnings-as-errors
           mix dialyzer --plt
 
@@ -163,6 +162,9 @@ jobs:
           path: |
             assets/node_modules
           key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('assets/package-lock.json') }}
+
+      - name: Check for unused dependencies
+        run: mix deps.unlock --check-unused
 
       - name: Check Code Format
         run: mix format --check-formatted


### PR DESCRIPTION
# Description
As we noticed that the step about deps is cached, we are moving the unused deps check to the static code analysis step.

## Did you add the right label?

Aye

## How was this tested?

Happy when the CI is
