### PR TITLE
Fix HealthSummaryDto's required fields

### DIFF
--- a/lib/trento/application/usecases/sap_systems/dto/health_summary_dto.ex
+++ b/lib/trento/application/usecases/sap_systems/dto/health_summary_dto.ex
@@ -3,7 +3,14 @@ defmodule Trento.Application.UseCases.SapSystems.HealthSummaryDto do
   HealthSummary for SAP Systems
   """
 
-  @required_fields :all
+  @required_fields [
+    :id,
+    :sid,
+    :sapsystem_health,
+    :database_health,
+    :clusters_health,
+    :hosts_health
+  ]
 
   use Trento.Type
 


### PR DESCRIPTION
# Description
```elixir
13:46:15.884 [error] #PID<0.1598.0> running TrentoWeb.Endpoint (connection #PID<0.1147.0>, stream id 14) terminated
Server: localhost:4000 (http)
Request: GET /api/sap_systems/health
** (exit) an exception was raised:
    ** (RuntimeError) %{cluster_id: ["can't be blank"]}
        (trento 1.1.0+git.dev166.1665401462.1d37b84) lib/trento/application/usecases/sap_systems/dto/health_summary_dto.ex:8: Trento.Application.UseCases.SapSystems.HealthSummaryDto.new!/1
```

ONOZ we don't wanna see that happening.

## How was this tested?

Existing tests passing, adding a unit test for a simple map validation seemed like an overkill.
