### PR TITLE
Make Pacemaker Clusters status icon interactive

### DIFF
--- a/assets/js/components/Health/HealthIcon.jsx
+++ b/assets/js/components/Health/HealthIcon.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { computedIconCssClass } from '@lib/icon';
+import { Link } from 'react-router-dom';
 
 import {
   EOS_CHECK_CIRCLE_OUTLINED,
@@ -10,33 +11,41 @@ import {
 
 import Spinner from '@components/Spinner';
 
-const HealthIcon = ({ health = undefined, centered = false }) => {
+const HealthIcon = ({ health = undefined, centered = false, link }) => {
   switch (health) {
     case 'passing':
       return (
-        <EOS_CHECK_CIRCLE_OUTLINED
-          className={computedIconCssClass('fill-jungle-green-500', centered)}
-        />
+        <Link to={link}>
+          <EOS_CHECK_CIRCLE_OUTLINED
+            className={computedIconCssClass('fill-jungle-green-500', centered)}
+          />
+        </Link>
       );
     case 'warning':
       return (
-        <EOS_WARNING_OUTLINED
-          className={computedIconCssClass('fill-yellow-500', centered)}
-        />
+        <Link to={link}>
+          <EOS_WARNING_OUTLINED
+            className={computedIconCssClass('fill-yellow-500', centered)}
+          />
+        </Link>
       );
     case 'critical':
       return (
-        <EOS_ERROR_OUTLINED
-          className={computedIconCssClass('fill-red-500', centered)}
-        />
+        <Link to={link}>
+          <EOS_ERROR_OUTLINED
+            className={computedIconCssClass('fill-red-500', centered)}
+          />
+        </Link>
       );
     case 'pending':
       return <Spinner />;
     default:
       return (
-        <EOS_LENS_FILLED
-          className={computedIconCssClass('fill-gray-500', centered)}
-        />
+        <Link to={link}>
+          <EOS_LENS_FILLED
+            className={computedIconCssClass('fill-gray-500', centered)}
+          />
+        </Link>
       );
   }
 };

--- a/assets/js/components/Health/HealthIcon.jsx
+++ b/assets/js/components/Health/HealthIcon.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { computedIconCssClass } from '@lib/icon';
-import { Link } from 'react-router-dom';
 
 import {
   EOS_CHECK_CIRCLE_OUTLINED,
@@ -11,41 +10,33 @@ import {
 
 import Spinner from '@components/Spinner';
 
-const HealthIcon = ({ health = undefined, centered = false, link }) => {
+const HealthIcon = ({ health = undefined, centered = false }) => {
   switch (health) {
     case 'passing':
       return (
-        <Link to={link}>
-          <EOS_CHECK_CIRCLE_OUTLINED
-            className={computedIconCssClass('fill-jungle-green-500', centered)}
-          />
-        </Link>
+        <EOS_CHECK_CIRCLE_OUTLINED
+          className={computedIconCssClass('fill-jungle-green-500', centered)}
+        />
       );
     case 'warning':
       return (
-        <Link to={link}>
-          <EOS_WARNING_OUTLINED
-            className={computedIconCssClass('fill-yellow-500', centered)}
-          />
-        </Link>
+        <EOS_WARNING_OUTLINED
+          className={computedIconCssClass('fill-yellow-500', centered)}
+        />
       );
     case 'critical':
       return (
-        <Link to={link}>
-          <EOS_ERROR_OUTLINED
-            className={computedIconCssClass('fill-red-500', centered)}
-          />
-        </Link>
+        <EOS_ERROR_OUTLINED
+          className={computedIconCssClass('fill-red-500', centered)}
+        />
       );
     case 'pending':
       return <Spinner />;
     default:
       return (
-        <Link to={link}>
-          <EOS_LENS_FILLED
-            className={computedIconCssClass('fill-gray-500', centered)}
-          />
-        </Link>
+        <EOS_LENS_FILLED
+          className={computedIconCssClass('fill-gray-500', centered)}
+        />
       );
   }
 };

--- a/assets/js/components/HealthSummary/HomeHealthSummary.jsx
+++ b/assets/js/components/HealthSummary/HomeHealthSummary.jsx
@@ -39,9 +39,11 @@ const healthSummaryTableConfig = {
       key: 'clustersHealth',
       className: 'text-center',
       render: (content, item) => {
-        const link_to_cluster = '/clusters/' + item.clusterId;
+        const linkToCluster = `/clusters/${item.clusterId}`;
         return (
-          <HealthIcon health={content} centered={true} link={link_to_cluster} />
+          <Link to={linkToCluster}>
+            <HealthIcon health={content} centered={true} />
+          </Link>
         );
       },
     },

--- a/assets/js/components/HealthSummary/HomeHealthSummary.jsx
+++ b/assets/js/components/HealthSummary/HomeHealthSummary.jsx
@@ -38,8 +38,11 @@ const healthSummaryTableConfig = {
       title: 'Pacemaker Clusters',
       key: 'clustersHealth',
       className: 'text-center',
-      render: (content) => {
-        return <HealthIcon health={content} centered={true} />;
+      render: (content, item) => {
+        const link_to_cluster = '/clusters/' + item.clusterId;
+        return (
+          <HealthIcon health={content} centered={true} link={link_to_cluster} />
+        );
       },
     },
     {


### PR DESCRIPTION
# Description
Makes the Pacemaker Status icon clickable in the Dashboard and takes the user to the details view of the corresponding database.

## How was this tested?
This was tested manually
A test will be added in a future implementation when the database and the sap instance icons are also clickable.