### PR TITLE
Add end-to-end tests for KVM & Nutanix cloud providers

### DIFF
--- a/test/e2e/cypress/fixtures/host-details/selected_host.js
+++ b/test/e2e/cypress/fixtures/host-details/selected_host.js
@@ -34,6 +34,12 @@ export const selectedHost = {
     zone: 'europe-west1-b',
     network: 'network',
   },
+  kvmCloudDetails: {
+    provider: 'kvm',
+  },
+  nutanixCloudDetails: {
+    provider: 'nutanix',
+  },
   sapInstance: {
     id: '6c9208eb-a5bb-57ef-be5c-6422dedab602',
     sid: 'HDP',

--- a/test/e2e/cypress/integration/host_details.js
+++ b/test/e2e/cypress/integration/host_details.js
@@ -171,13 +171,19 @@ context('Host Details', () => {
     it(`should show KVM cloud details correctly`, () => {
       cy.loadScenario('host-details-kvm');
 
-      cy.get('div').should('contain', selectedHost.kvmCloudDetails.provider);
+      cy.get('div')
+        .contains(/^Provider$/)
+        .next()
+        .should('contain', selectedHost.kvmCloudDetails.provider);
     });
 
     it(`should show Nutanix cloud details correctly`, () => {
       cy.loadScenario('host-details-nutanix');
 
-      cy.get('div').should('contain', selectedHost.nutanixCloudDetails.provider);
+      cy.get('div')
+        .contains(/^Provider$/)
+        .next()
+        .should('contain', selectedHost.nutanixCloudDetails.provider);
     });
 
     it(`should display provider not recognized message`, () => {

--- a/test/e2e/cypress/integration/host_details.js
+++ b/test/e2e/cypress/integration/host_details.js
@@ -168,6 +168,18 @@ context('Host Details', () => {
         .should('contain', selectedHost.gcpCloudDetails.network);
     });
 
+    it(`should show KVM cloud details correctly`, () => {
+      cy.loadScenario('host-details-kvm');
+
+      cy.get('div').should('contain', selectedHost.kvmCloudDetails.provider);
+    });
+
+    it(`should show Nutanix cloud details correctly`, () => {
+      cy.loadScenario('host-details-nutanix');
+
+      cy.get('div').should('contain', selectedHost.nutanixCloudDetails.provider);
+    });
+
     it(`should display provider not recognized message`, () => {
       cy.loadScenario('host-details-unknown');
 


### PR DESCRIPTION
# Description

Adds end-to-end tests to check that using the cloud providers KVM or Nutanix displays them correctly in the Host Detail view.

Original change: https://github.com/trento-project/web/pull/885

## How was this tested?

Added Cypress tests to check that using the cloud providers KVM or Nutanix displays them correctly in the Host Detail view.
