### PR TITLE
Add filtering through search params

### DIFF
--- a/assets/js/components/HealthSummary/HomeHealthSummary.jsx
+++ b/assets/js/components/HealthSummary/HomeHealthSummary.jsx
@@ -56,8 +56,13 @@ const healthSummaryTableConfig = {
       title: 'Hosts',
       key: 'hostsHealth',
       className: 'text-center',
-      render: (content) => {
-        return <HealthIcon health={content} centered={true} />;
+      render: (content, item) => {
+        const linkToHosts = `/hosts?sid=${item.sid}`;
+        return (
+          <Link to={linkToHosts}>
+            <HealthIcon health={content} centered={true} />
+          </Link>
+        );
       },
     },
   ],

--- a/test/e2e/cypress/integration/dashboard.js
+++ b/test/e2e/cypress/integration/dashboard.js
@@ -30,5 +30,11 @@ describe('Dashboard page', () => {
         '1'
       );
     });
+
+    it('should have a working link to the passing checks in the overview component', () => {
+      cy.get(':nth-child(1) > :nth-child(5) > a').click();
+      cy.url().should('include', `/hosts?sid=NWD`);
+      cy.go('back');
+    });
   });
 });


### PR DESCRIPTION
# Description

![Peek 18-10-2022 16-02](https://user-images.githubusercontent.com/2668401/196640127-5ce36618-ebec-4f3f-ad58-203762535e1f.gif)

This PR was initially supposed to just add linking from the dashboard to the hosts view with filters set in the search params, but after starting, it was clear that by allowing the filter component to handle the search params we could enable it in every view.

@CDimonaco actually has another approach on the works, if that works/looks better we can just close this, I just didn't want so many hours of bashing my head against the keyboard to end in nothing :smile: 

## How was this tested?

A new e2e test was added to check that the link from the dashboard includes the filter preset.
