### PR TITLE
Remove events from checks execution

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -122,6 +122,7 @@ config :trento, Trento.Scheduler,
 
 config :trento, Trento.Integration.Telemetry, adapter: Trento.Integration.Telemetry.Suse
 config :trento, Trento.Integration.Checks, adapter: Trento.Integration.Checks.Runner
+config :trento, Trento.Clusters, adapter: Trento.Clusters.Runner
 
 config :trento, Trento.Integration.Prometheus,
   adapter: Trento.Integration.Prometheus.PrometheusApi

--- a/config/config.exs
+++ b/config/config.exs
@@ -122,7 +122,7 @@ config :trento, Trento.Scheduler,
 
 config :trento, Trento.Integration.Telemetry, adapter: Trento.Integration.Telemetry.Suse
 config :trento, Trento.Integration.Checks, adapter: Trento.Integration.Checks.Runner
-config :trento, Trento.Clusters, adapter: Trento.Clusters.Runner
+config :trento, Trento.Clusters, checks_adapter: Trento.Clusters.Runner
 
 config :trento, Trento.Integration.Prometheus,
   adapter: Trento.Integration.Prometheus.PrometheusApi

--- a/config/wanda.exs
+++ b/config/wanda.exs
@@ -9,7 +9,7 @@ config :trento, Trento.Integration.Checks, adapter: Trento.Integration.Checks.Wa
 
 config :trento, Trento.Messaging.Publisher, adapter: Trento.Messaging.Adapters.AMQP
 
-config :trento, Trento.Clusters, adapter: Trento.Clusters.Wanda
+config :trento, Trento.Clusters, checks_adapter: Trento.Clusters.Wanda
 
 config :trento, Trento.Messaging.Adapters.AMQP,
   publisher: [

--- a/config/wanda.exs
+++ b/config/wanda.exs
@@ -9,6 +9,8 @@ config :trento, Trento.Integration.Checks, adapter: Trento.Integration.Checks.Wa
 
 config :trento, Trento.Messaging.Publisher, adapter: Trento.Messaging.Adapters.AMQP
 
+config :trento, Trento.Clusters, adapter: Trento.Clusters.Wanda
+
 config :trento, Trento.Messaging.Adapters.AMQP,
   publisher: [
     exchange: "trento.checks",

--- a/lib/trento/application/usecases/clusters/adapters/gen.ex
+++ b/lib/trento/application/usecases/clusters/adapters/gen.ex
@@ -1,0 +1,7 @@
+defmodule Trento.Clusters.Gen do
+  @moduledoc """
+  Request checks execution adapter
+  """
+
+  @callback request_checks_execution(cluster_id :: String.t()) :: :ok | {:error, any}
+end

--- a/lib/trento/application/usecases/clusters/adapters/runner.ex
+++ b/lib/trento/application/usecases/clusters/adapters/runner.ex
@@ -1,0 +1,19 @@
+defmodule Trento.Clusters.Runner do
+  @moduledoc """
+  Trento runner integration adapter
+  """
+
+  @behaviour Trento.Clusters.Gen
+
+  alias Trento.Domain.Commands.RequestChecksExecution
+
+  @impl true
+  def request_checks_execution(cluster_id) do
+    with {:ok, command} <- RequestChecksExecution.new(%{cluster_id: cluster_id}) do
+      commanded().dispatch(command)
+    end
+  end
+
+  defp commanded,
+    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
+end

--- a/lib/trento/application/usecases/clusters/adapters/wanda.ex
+++ b/lib/trento/application/usecases/clusters/adapters/wanda.ex
@@ -1,0 +1,51 @@
+defmodule Trento.Clusters.Wanda do
+  @moduledoc """
+  Wanda integration adapter
+  """
+
+  @behaviour Trento.Clusters.Gen
+
+  import Ecto.Query
+
+  require Logger
+
+  alias Trento.{
+    ClusterReadModel,
+    HostReadModel
+  }
+
+  alias Trento.Integration.Checks
+
+  alias Trento.Repo
+
+  @impl true
+  def request_checks_execution(cluster_id) do
+    hosts_query =
+      from h in HostReadModel,
+        select: %{host_id: h.id},
+        where: h.cluster_id == ^cluster_id
+
+    with %{provider: provider, selected_checks: selected_checks} <-
+           Repo.get(ClusterReadModel, cluster_id),
+         hosts_data <- Repo.all(hosts_query) do
+      Checks.request_execution(
+        UUID.uuid4(),
+        cluster_id,
+        provider,
+        hosts_data,
+        selected_checks
+      )
+    else
+      nil ->
+        Logger.error("Cluster with ID #{cluster_id} not found")
+        {:error, :cluster_not_found}
+
+      {:error, reason} ->
+        Logger.error("Failed to request checks execution for cluster #{cluster_id}: #{reason}",
+          error: reason
+        )
+
+        {:error, reason}
+    end
+  end
+end

--- a/lib/trento/application/usecases/clusters/adapters/wanda.ex
+++ b/lib/trento/application/usecases/clusters/adapters/wanda.ex
@@ -20,32 +20,34 @@ defmodule Trento.Clusters.Wanda do
 
   @impl true
   def request_checks_execution(cluster_id) do
-    hosts_query =
-      from h in HostReadModel,
-        select: %{host_id: h.id},
-        where: h.cluster_id == ^cluster_id
-
-    with %{provider: provider, selected_checks: selected_checks} <-
-           Repo.get(ClusterReadModel, cluster_id),
-         hosts_data <- Repo.all(hosts_query) do
-      Checks.request_execution(
-        UUID.uuid4(),
-        cluster_id,
-        provider,
-        hosts_data,
-        selected_checks
-      )
-    else
-      nil ->
-        Logger.error("Cluster with ID #{cluster_id} not found")
-        {:error, :cluster_not_found}
-
-      {:error, reason} ->
-        Logger.error("Failed to request checks execution for cluster #{cluster_id}: #{reason}",
-          error: reason
-        )
-
-        {:error, reason}
-    end
+    ClusterReadModel
+    |> Repo.get(cluster_id)
+    |> maybe_request_checks_execution()
   end
+
+  defp maybe_request_checks_execution(nil), do: {:error, :cluster_not_found}
+  defp maybe_request_checks_execution(%{selected_checks: []}), do: :ok
+
+  defp maybe_request_checks_execution(%{
+         id: cluster_id,
+         provider: provider,
+         selected_checks: selected_checks
+       }) do
+    hosts_data =
+      Repo.all(
+        from h in HostReadModel,
+          select: %{host_id: h.id},
+          where: h.cluster_id == ^cluster_id
+      )
+
+    Checks.request_execution(
+      UUID.uuid4(),
+      cluster_id,
+      provider,
+      hosts_data,
+      selected_checks
+    )
+  end
+
+  defp maybe_request_checks_execution(error), do: error
 end

--- a/lib/trento/application/usecases/clusters/clusters.ex
+++ b/lib/trento/application/usecases/clusters/clusters.ex
@@ -15,7 +15,6 @@ defmodule Trento.Clusters do
 
   alias Trento.Domain.Commands.{
     CompleteChecksExecution,
-    RequestChecksExecution,
     SelectChecks
   }
 
@@ -42,9 +41,7 @@ defmodule Trento.Clusters do
 
   @spec request_checks_execution(String.t()) :: :ok | {:error, any}
   def request_checks_execution(cluster_id) do
-    with {:ok, command} <- RequestChecksExecution.new(%{cluster_id: cluster_id}) do
-      commanded().dispatch(command)
-    end
+    adapter().request_checks_execution(cluster_id)
   end
 
   @spec get_all_clusters :: [ClusterReadModel.t()]
@@ -125,5 +122,9 @@ defmodule Trento.Clusters do
     end
     |> ClusterEnrichmentData.changeset(%{cib_last_written: cib_last_written})
     |> Repo.insert_or_update()
+  end
+
+  defp adapter do
+    Application.fetch_env!(:trento, __MODULE__)[:adapter]
   end
 end

--- a/lib/trento/application/usecases/clusters/clusters.ex
+++ b/lib/trento/application/usecases/clusters/clusters.ex
@@ -41,7 +41,7 @@ defmodule Trento.Clusters do
 
   @spec request_checks_execution(String.t()) :: :ok | {:error, any}
   def request_checks_execution(cluster_id) do
-    adapter().request_checks_execution(cluster_id)
+    checks_adapter().request_checks_execution(cluster_id)
   end
 
   @spec get_all_clusters :: [ClusterReadModel.t()]
@@ -124,7 +124,7 @@ defmodule Trento.Clusters do
     |> Repo.insert_or_update()
   end
 
-  defp adapter do
-    Application.fetch_env!(:trento, __MODULE__)[:adapter]
+  defp checks_adapter do
+    Application.fetch_env!(:trento, __MODULE__)[:checks_adapter]
   end
 end

--- a/lib/trento/application/usecases/clusters/clusters.ex
+++ b/lib/trento/application/usecases/clusters/clusters.ex
@@ -41,6 +41,9 @@ defmodule Trento.Clusters do
 
   @spec request_checks_execution(String.t()) :: :ok | {:error, any}
   def request_checks_execution(cluster_id) do
+    # FIXME: The checks_adapter is a temporary adapter used while old runner and wanda coexist
+    # Once the legacy option is removed, the adapter can be removed and wanda adapter code
+    # be used directly here
     checks_adapter().request_checks_execution(cluster_id)
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -183,7 +183,8 @@ defmodule Trento.Factory do
       sid: Faker.StarWars.planet(),
       provider: Enum.random(Provider.values()),
       type: ClusterType.hana_scale_up(),
-      health: Health.passing()
+      health: Health.passing(),
+      selected_checks: Enum.map(0..4, fn _ -> Faker.StarWars.planet() end)
     }
   end
 

--- a/test/trento/application/integration/checks/wanda/messaging/amqp/consumer_test.exs
+++ b/test/trento/application/integration/checks/wanda/messaging/amqp/consumer_test.exs
@@ -27,6 +27,7 @@ defmodule Trento.Integration.Checks.Wanda.Messaging.AMQP.ConsumerTest do
   end
 
   describe "handle_error/1" do
+    @tag capture_log: true
     test "should reject unknown events and move them to the dead letter queue" do
       pid = self()
 

--- a/test/trento/application/usecases/clusters_test.exs
+++ b/test/trento/application/usecases/clusters_test.exs
@@ -58,12 +58,16 @@ defmodule Trento.ClustersTest do
       assert :ok = Clusters.Wanda.request_checks_execution(cluster_id)
     end
 
-    @tag capture_log: true
     test "should not start checks execution if the cluster is not registered" do
       assert {:error, :cluster_not_found} = Clusters.Wanda.request_checks_execution(UUID.uuid4())
     end
 
-    @tag capture_log: true
+    test "should not start checks execution if no checks are selected" do
+      %{id: cluster_id} = insert(:cluster, selected_checks: [])
+
+      assert :ok = Clusters.Wanda.request_checks_execution(cluster_id)
+    end
+
     test "should return an error if the checks execution start fails" do
       %{id: cluster_id} = insert(:cluster)
 

--- a/test/trento/application/usecases/clusters_test.exs
+++ b/test/trento/application/usecases/clusters_test.exs
@@ -38,6 +38,43 @@ defmodule Trento.ClustersTest do
     end
   end
 
+  describe "checks execution with wanda adapter" do
+    test "should start a checks execution on demand" do
+      %{id: cluster_id, provider: provider, selected_checks: selected_checks} = insert(:cluster)
+      [%{id: host_id_1}, %{id: host_id_2}] = insert_list(2, :host, cluster_id: cluster_id)
+
+      expect(Trento.Integration.Checks.Mock, :request_execution, fn _,
+                                                                    expected_cluster_id,
+                                                                    expected_provider,
+                                                                    expected_hosts,
+                                                                    expected_checks ->
+        assert ^cluster_id = expected_cluster_id
+        assert ^provider = expected_provider
+        assert [%{host_id: host_id_1}, %{host_id: host_id_2}] == expected_hosts
+        assert ^selected_checks = expected_checks
+        :ok
+      end)
+
+      assert :ok = Clusters.Wanda.request_checks_execution(cluster_id)
+    end
+
+    @tag capture_log: true
+    test "should not start checks execution if the cluster is not registered" do
+      assert {:error, :cluster_not_found} = Clusters.Wanda.request_checks_execution(UUID.uuid4())
+    end
+
+    @tag capture_log: true
+    test "should return an error if the checks execution start fails" do
+      %{id: cluster_id} = insert(:cluster)
+
+      expect(Trento.Integration.Checks.Mock, :request_execution, fn _, _, _, _, _ ->
+        {:error, :some_error}
+      end)
+
+      assert {:error, :some_error} = Clusters.Wanda.request_checks_execution(cluster_id)
+    end
+  end
+
   describe "get clusters" do
     test "should return enriched clusters" do
       cib_last_written = Date.to_string(Faker.Date.forward(0))

--- a/test/trento/application/usecases/clusters_test.exs
+++ b/test/trento/application/usecases/clusters_test.exs
@@ -59,11 +59,15 @@ defmodule Trento.ClustersTest do
     end
 
     test "should not start checks execution if the cluster is not registered" do
+      expect(Trento.Integration.Checks.Mock, :request_execution, 0, fn _, _, _, _, _ -> :ok end)
+
       assert {:error, :cluster_not_found} = Clusters.Wanda.request_checks_execution(UUID.uuid4())
     end
 
     test "should not start checks execution if no checks are selected" do
       %{id: cluster_id} = insert(:cluster, selected_checks: [])
+
+      expect(Trento.Integration.Checks.Mock, :request_execution, 0, fn _, _, _, _, _ -> :ok end)
 
       assert :ok = Clusters.Wanda.request_checks_execution(cluster_id)
     end


### PR DESCRIPTION
# Description

Not use commanded commands/events to start checks execution. I have created an adapter to only use the new feature on `wanda` env.

As we don't use events anymore, using commands or using aggregate data/metadata is not possible. If we want to store information such as `issuer` and other things, we will need to send this info to wanda to store it there.

## Did you add the right label?

Remember to add the right labels to this PR.

## How was this tested?

Tests added
