### PR TITLE
Frontend table filters from query string

### DIFF
--- a/assets/js/components/HostsList.jsx
+++ b/assets/js/components/HostsList.jsx
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import Table from './Table';
 import HealthIcon from '@components/Health/HealthIcon';
+import { useSearchParams } from 'react-router-dom';
 import Tags from './Tags';
 import { addTagToHost, removeTagFromHost } from '@state/hosts';
 import HostLink from '@components/HostLink';
@@ -43,6 +44,8 @@ const HostsList = () => {
   const { applicationInstances, databaseInstances } = useSelector(
     (state) => state.sapSystemsList
   );
+
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const dispatch = useDispatch();
 
@@ -171,7 +174,12 @@ const HostsList = () => {
   return (
     <Fragment>
       <ComponentHealthSummary data={data} />
-      <Table config={config} data={data} />
+      <Table
+        config={config}
+        data={data}
+        searchParams={searchParams}
+        setSearchParams={setSearchParams}
+      />
     </Fragment>
   );
 };

--- a/assets/js/components/HostsList.jsx
+++ b/assets/js/components/HostsList.jsx
@@ -90,6 +90,7 @@ const HostsList = () => {
       {
         title: 'SID',
         key: 'sid',
+        filterFromParams: true,
         filter: (filter, key) => (element) =>
           element[key].some((sid) => filter.includes(sid)),
         render: (sids, { sap_systems }) => {
@@ -120,6 +121,7 @@ const HostsList = () => {
         title: 'Tags',
         key: 'tags',
         className: 'w-80',
+        filterFromParams: true,
         filter: (filter, key) => (element) =>
           element[key].some((tag) => filter.includes(tag)),
         render: (content, item) => (

--- a/assets/js/components/Table/Table.jsx
+++ b/assets/js/components/Table/Table.jsx
@@ -1,6 +1,6 @@
 import React, { Fragment, useState } from 'react';
 import classNames from 'classnames';
-import { getDefaultFilterFunction, setFilter as createFilter } from './filters';
+import { getDefaultFilterFunction, createFilter } from './filters';
 import { page, pages } from '@lib/lists';
 
 import CollapsibleTableRow from './CollapsibleTableRow';

--- a/assets/js/components/Table/Table.jsx
+++ b/assets/js/components/Table/Table.jsx
@@ -56,7 +56,7 @@ const Table = ({ config, data = [], searchParams, setSearchParams }) => {
   const [filters, setFilters] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
 
-  const searchParamsEnabled = searchParams && setSearchParams;
+  const searchParamsEnabled = Boolean(searchParams && setSearchParams);
 
   const columnFiltersBoundToParams = columns.filter(
     (c) => c.filter && c.filterFromParams

--- a/assets/js/components/Table/Table.jsx
+++ b/assets/js/components/Table/Table.jsx
@@ -33,6 +33,18 @@ const renderCells = (columns, item) => {
   );
 };
 
+const updateSearchParams = (searchParams, values) => {
+  values.forEach((f) => {
+    searchParams.delete(f.key);
+
+    f.value.forEach((v) => {
+      searchParams.append(f.key, v);
+    });
+  });
+
+  return searchParams;
+};
+
 const Table = ({ config, data = [], searchParams, setSearchParams }) => {
   const {
     columns,
@@ -46,37 +58,28 @@ const Table = ({ config, data = [], searchParams, setSearchParams }) => {
 
   const searchParamsEnabled = searchParams && setSearchParams;
 
-  const columnFiltersBindToParams = columns.filter(
+  const columnFiltersBoundToParams = columns.filter(
     (c) => c.filter && c.filterFromParams
   );
 
   useEffect(() => {
     if (!searchParamsEnabled) return;
-    const currentParams = searchParams;
-    const filtersBindedToQs = filters.reduce((acc, curr) => {
-      const filterBoundToQs = columnFiltersBindToParams.find(
+    const filtersBoundToQs = filters.reduce((acc, curr) => {
+      const isFilterBoundToQs = columnFiltersBoundToParams.find(
         (col) => col.key === curr.key
       );
 
-      if (!filterBoundToQs) return [...acc];
+      if (!isFilterBoundToQs) return [...acc];
 
       return [...acc, { key: curr.key, value: curr.value }];
     }, []);
 
-    filtersBindedToQs.forEach((f) => {
-      currentParams.delete(f.key);
-
-      f.value.forEach((v) => {
-        currentParams.append(f.key, v);
-      });
-    });
-
-    setSearchParams(currentParams);
+    setSearchParams(updateSearchParams(searchParams, filtersBoundToQs));
   }, [filters, searchParams]);
 
   useEffect(() => {
     if (!searchParamsEnabled) return;
-    const filterFromQs = columnFiltersBindToParams.reduce((acc, curr) => {
+    const filterFromQs = columnFiltersBoundToParams.reduce((acc, curr) => {
       const paramsFilterValue = searchParams.getAll(curr.key);
 
       if (paramsFilterValue.length === 0) return [...acc];

--- a/assets/js/components/Table/filters.jsx
+++ b/assets/js/components/Table/filters.jsx
@@ -4,11 +4,11 @@ import { uniq } from '@lib/lists';
 
 import Filter from './Filter';
 
-const getDefaultFilterFunction = (filter, key) => (element) => {
+export const getDefaultFilterFunction = (filter, key) => (element) => {
   return filter.includes(element[key]);
 };
 
-const setFilter = (filters, filterKey, filterValue, filterFunction) => {
+export const setFilter = (filters, filterKey, filterValue, filterFunction) => {
   const { found, filtersList } = filters.reduce(
     ({ found, filtersList }, current) => {
       const { key } = current;

--- a/assets/js/components/Table/filters.jsx
+++ b/assets/js/components/Table/filters.jsx
@@ -8,7 +8,12 @@ export const getDefaultFilterFunction = (filter, key) => (element) => {
   return filter.includes(element[key]);
 };
 
-export const setFilter = (filters, filterKey, filterValue, filterFunction) => {
+export const createFilter = (
+  filters,
+  filterKey,
+  filterValue,
+  filterFunction
+) => {
   const { found, filtersList } = filters.reduce(
     ({ found, filtersList }, current) => {
       const { key } = current;
@@ -63,7 +68,7 @@ export const TableFilters = ({ config, data, filters, onChange }) => {
                 ? column.filter(list, column.key)
                 : getDefaultFilterFunction(list, column.key);
 
-            onChange(setFilter(filters, column.key, list, filterFunction));
+            onChange(createFilter(filters, column.key, list, filterFunction));
           }}
         />
       );

--- a/test/e2e/cypress/integration/hosts_overview.js
+++ b/test/e2e/cypress/integration/hosts_overview.js
@@ -221,7 +221,7 @@ context('Hosts Overview', () => {
         });
       });
 
-      it('should exctract HDD and HWD from query string and put in sid filter', () => {
+      it('should extract HDD and HWD from query string and put in sid filter', () => {
         cy.visit('/hosts?sid=HDD&sid=NWD');
         cy.get(
           ':nth-child(3) > .mt-1 > .relative > :nth-child(1) > .ml-3'
@@ -279,7 +279,7 @@ context('Hosts Overview', () => {
           cy.get('li > div > span.ml-3.block').contains(tag).click();
         });
 
-        it('should exctract tag1 and tag2 from query string and put in tag filter', () => {
+        it('should extract tag1 and tag2 from query string and put in tag filter', () => {
           cy.visit('/hosts?tags=tag1&tags=tag2');
           cy.get(
             ':nth-child(4) > .mt-1 > .relative > :nth-child(1) > .ml-3'

--- a/test/e2e/cypress/integration/hosts_overview.js
+++ b/test/e2e/cypress/integration/hosts_overview.js
@@ -135,6 +135,7 @@ context('Hosts Overview', () => {
   describe('Health Detection', () => {
     describe('Health Container shows the health overview of the deployed landscape', () => {
       before(() => {
+        cy.visit('/hosts');
         cy.task('startAgentHeartbeat', agents());
       });
 
@@ -152,6 +153,7 @@ context('Hosts Overview', () => {
     });
     describe('Health is changed to critical when the heartbeat is not sent', () => {
       before(() => {
+        cy.visit('/hosts');
         cy.task('stopAgentsHeartbeat');
       });
       it('should show health status of the entire cluster of 27 hosts with critical health', () => {
@@ -171,6 +173,7 @@ context('Hosts Overview', () => {
       const firstHost = availableHosts[0];
 
       before(() => {
+        cy.visit('/hosts');
         cy.task('startAgentHeartbeat', [firstHost.id]);
         cy.get('span').contains('Filter Health').parent().parent().click();
       });
@@ -217,10 +220,23 @@ context('Hosts Overview', () => {
           cy.get('li > div > span.ml-3.block').contains(sid).click();
         });
       });
+
+      it('should exctract HDD and HWD from query string and put in sid filter', () => {
+        cy.visit('/hosts?sid=HDD&sid=NWD');
+        cy.get(
+          ':nth-child(3) > .mt-1 > .relative > :nth-child(1) > .ml-3'
+        ).contains('HDD, NWD');
+
+        // clear
+        cy.get('.z-20 > [data-testid="eos-svg-component"]').click();
+
+        cy.url('eq', '/hosts');
+      });
     });
 
     describe('Tags', () => {
       before(() => {
+        cy.visit('/hosts');
         cy.removeTagsFromView();
       });
 
@@ -232,6 +248,7 @@ context('Hosts Overview', () => {
 
       describe('Filter by tags', () => {
         before(() => {
+          cy.visit('/hosts');
           cy.get('span').contains('Filter Tags').parent().parent().click();
         });
 
@@ -260,6 +277,16 @@ context('Hosts Overview', () => {
           cy.get('li > div > span.ml-3.block').contains(tag).click();
           cy.get('.tn-hostname').its('length').should('eq', 4);
           cy.get('li > div > span.ml-3.block').contains(tag).click();
+        });
+
+        it('should exctract tag1 and tag2 from query string and put in tag filter', () => {
+          cy.visit('/hosts?tags=tag1&tags=tag2');
+          cy.get(
+            ':nth-child(4) > .mt-1 > .relative > :nth-child(1) > .ml-3'
+          ).contains('tag1, tag2');
+
+          // clear
+          cy.get('.z-20 > [data-testid="eos-svg-component"]').click();
         });
       });
     });


### PR DESCRIPTION
# Description

This pr derives from the pr #908, following @rtorrero proposal on query string filters feature.

This pr enables all the tables in trento webapp application to be filtered with query string parameters.
The configuration is declarative and enables these capabilities with  option fields on columns.

### Demo
![trento_table_filters](https://user-images.githubusercontent.com/9409502/197186777-5eeb0e36-2cc9-469b-9369-d42b71df6ce7.gif)



Configuration examples:

```js
{
        title: 'SID',
        key: 'sid',
        filterFromParams: true,
        filter: true
}
```

`filter` field and `filterFromParams` field should be present.

You can enable the filters an all columns and filters type.

For demo/feature purpose the sid and tags filters are enabled with query string on HostOverview screen.

## How was this tested?

E2E testing with cypress, the component is compliant to unit testing with jest, but for pure testing purposes the filtering capabilities are tested with an e2e tests on the HostOverview screen with SID and Tags filters.


