### PR TITLE
Encapsulated About content with a white container

### DIFF
--- a/assets/js/components/AboutPage/AboutPage.jsx
+++ b/assets/js/components/AboutPage/AboutPage.jsx
@@ -30,46 +30,48 @@ const AboutPage = () => {
   }, []);
 
   return (
-    <div className="grid grid-cols-2 gap-16">
-      <div className="divide-y divide-dashed">
-        <div className="pb-5">
-          <h2 className="text-5xl font-bold">About Trento Console</h2>
-          <h3 className="text-xl mt-5">
-            An open cloud-native web console improving the life of SAP
-            Applications administrators
-          </h3>
+    <div className="container max-w-7xl mx-auto p-4 sm:p-6 lg:p-8 bg-white dark:bg-gray-800 rounded-lg">
+      <div className="grid gap-16 lg:grid-cols-3">
+        <div className="divide-y divide-dashed col-span-3 lg:col-span-2 lg:pr-10">
+          <div className="pb-5">
+            <h2 className="text-5xl font-bold">About Trento Console</h2>
+            <h3 className="text-xl mt-5">
+              An open cloud-native web console improving the life of SAP
+              Applications administrators
+            </h3>
+          </div>
+          <div className="pt-5">
+            <ListView
+              className="text-sm"
+              orientation="horizontal"
+              data={[
+                {
+                  title: 'Trento flavor',
+                  content: loading ? 'Loading...' : flavor,
+                },
+                {
+                  title: 'Server version',
+                  content: loading ? 'Loading...' : version,
+                },
+                {
+                  title: 'GitHub repository',
+                  content: 'https://github.com/trento-project/web',
+                  render: (content) => <a href={content}>{content}</a>,
+                },
+                {
+                  title: 'SLES for SAP subscriptions',
+                  content: `${subscriptions} found`,
+                  render: (content) =>
+                    loading ? <span>Loading...</span> : <Pill>{content}</Pill>,
+                },
+              ]}
+            />
+          </div>
         </div>
-        <div className="pt-5">
-          <ListView
-            className="text-sm"
-            orientation="horizontal"
-            data={[
-              {
-                title: 'Trento flavor',
-                content: loading ? 'Loading...' : flavor,
-              },
-              {
-                title: 'Server version',
-                content: loading ? 'Loading...' : version,
-              },
-              {
-                title: 'GitHub repository',
-                content: 'https://github.com/trento-project/web',
-                render: (content) => <a href={content}>{content}</a>,
-              },
-              {
-                title: 'SLES for SAP subscriptions',
-                content: `${subscriptions} found`,
-                render: (content) =>
-                  loading ? <span>Loading...</span> : <Pill>{content}</Pill>,
-              },
-            ]}
-          />
-        </div>
-      </div>
-      <div className="max-w-xs">
-        <div className="">
-          <img src={TrentoLogo} />
+        <div className="max-w-xs m-auto col-span-3 lg:col-span-1">
+          <div className="">
+            <img src={TrentoLogo} />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Description

Added a white div container around the main content for the About page so that it is consistent with the other screens (e.g: Settings, Checks Catalog, etc) in Trento. 

## How was this tested?

Visually

![Trento About](https://user-images.githubusercontent.com/40714533/197495467-dde48c59-29e0-4776-9ec1-28c27b25382c.png)

