### PR TITLE
Remove container name from rabbitmq container in docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,7 +20,6 @@ services:
     ports:
       - 3000:3000
   rabbitmq:
-    container_name: rabbitmq
     image: rabbitmq:3.10.5-management-alpine
     ports:
       - 5672:5672


### PR DESCRIPTION
# Description
As the title suggest 

## How was this tested?

Manually
