### PR TITLE
Enable query string filtering in existing views

### DIFF
--- a/assets/jest.config.js
+++ b/assets/jest.config.js
@@ -86,6 +86,7 @@ module.exports = {
   moduleNameMapper: {
     '^@lib(.*)$': '<rootDir>/js/lib$1',
     '^@components(.*)$': '<rootDir>/js/components$1',
+    '^@hooks(.*)$': '<rootDir>/js/hooks$1',
     '^@state(.*)$': '<rootDir>/js/state$1',
     phoenix: '<rootDir>/../deps/phoenix/priv/static/phoenix.cjs.js',
     'react-markdown':

--- a/assets/js/components/ClustersList.jsx
+++ b/assets/js/components/ClustersList.jsx
@@ -7,6 +7,7 @@ import ClusterLink from '@components/ClusterLink';
 import { ExecutionIcon } from '@components/ClusterDetails';
 import { ComponentHealthSummary } from '@components/HealthSummary';
 import { post, del } from '@lib/network';
+import { useSearchParams } from 'react-router-dom';
 
 const getClusterTypeLabel = (type) => {
   switch (type) {
@@ -32,6 +33,7 @@ const removeTag = (tag, clusterId) => {
 const ClustersList = () => {
   const clusters = useSelector((state) => state.clustersList.clusters);
   const dispatch = useDispatch();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const config = {
     pagination: true,
@@ -41,6 +43,7 @@ const ClustersList = () => {
         title: 'Health',
         key: 'health',
         filter: true,
+        filterFromParams: true,
         render: (health, { checks_execution: checksExecution }) => {
           return (
             <div className="ml-4">
@@ -53,6 +56,7 @@ const ClustersList = () => {
         title: 'Name',
         key: 'name',
         filter: true,
+        filterFromParams: true,
         render: (content, item) => (
           <span className="tn-clustername">
             <ClusterLink cluster={item} />
@@ -62,6 +66,7 @@ const ClustersList = () => {
       {
         title: 'SID',
         key: 'sid',
+        filterFromParams: true,
         filter: true,
       },
       {
@@ -76,6 +81,7 @@ const ClustersList = () => {
         title: 'Type',
         key: 'type',
         filter: true,
+        filterFromParams: true,
         render: (content, item) => (
           <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800 truncate">
             {getClusterTypeLabel(item.type)}
@@ -86,6 +92,7 @@ const ClustersList = () => {
         title: 'Tags',
         key: 'tags',
         className: 'w-80',
+        filterFromParams: true,
         filter: (filter, key) => (element) =>
           element[key].some((tag) => filter.includes(tag)),
         render: (content, item) => (
@@ -128,7 +135,12 @@ const ClustersList = () => {
   return (
     <Fragment>
       <ComponentHealthSummary data={data} />
-      <Table config={config} data={data} />
+      <Table
+        config={config}
+        data={data}
+        searchParams={searchParams}
+        setSearchParams={setSearchParams}
+      />
     </Fragment>
   );
 };

--- a/assets/js/components/ClustersList.test.jsx
+++ b/assets/js/components/ClustersList.test.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react';
+import 'intersection-observer';
+import '@testing-library/jest-dom';
+
+import ClustersList from './ClustersList';
+import { renderWithRouter, withState } from '../lib/test-utils';
+
+describe('ClustersList component', () => {
+  describe('query string filtering behavior', () => {
+    it('should put the filters values in the query string when filters are selected', () => {
+      const [StatefulClustersList] = withState(<ClustersList />);
+      renderWithRouter(StatefulClustersList);
+
+      ['Health', 'Name', 'SID', 'Type', 'Tags'].forEach((filter) => {
+        fireEvent.click(screen.getByTestId(`filter-${filter}`));
+
+        fireEvent.click(
+          screen
+            .getByTestId(`filter-${filter}-options`)
+            .querySelector('li > div > span').firstChild
+        );
+      });
+
+      expect(window.location.search).toEqual(
+        '?health=unknown&name=drbd_cluster&sid=HDD&type=unknown&tags=tag1'
+      );
+    });
+  });
+});

--- a/assets/js/components/DatabasesOverview/DatabasesOverview.jsx
+++ b/assets/js/components/DatabasesOverview/DatabasesOverview.jsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import HealthIcon from '@components/Health';
 import Table from '@components/Table';
 import DatabaseItemOverview from './DatabaseItemOverview';
@@ -27,6 +27,8 @@ const DatabasesOverview = () => {
     (state) => state.databasesList
   );
   const dispatch = useDispatch();
+  const [searchParams, setSearchParams] = useSearchParams();
+
   const config = {
     pagination: true,
     usePadding: false,
@@ -35,6 +37,7 @@ const DatabasesOverview = () => {
         title: 'Health',
         key: 'health',
         filter: true,
+        filterFromParams: true,
         render: (content) => (
           <div className="ml-4">
             <HealthIcon health={content} />
@@ -44,6 +47,7 @@ const DatabasesOverview = () => {
       {
         title: 'SID',
         key: 'sid',
+        filterFromParams: true,
         filter: true,
         render: (content, item) => {
           return (
@@ -96,6 +100,7 @@ const DatabasesOverview = () => {
         title: 'Tags',
         key: 'tags',
         className: 'w-80',
+        filterFromParams: true,
         filter: (filter, key) => (element) =>
           element[key].some((tag) => filter.includes(tag)),
         render: (content, item) => (
@@ -141,7 +146,12 @@ const DatabasesOverview = () => {
   ) : (
     <Fragment>
       <ComponentHealthSummary data={data} />
-      <Table config={config} data={data} />
+      <Table
+        config={config}
+        data={data}
+        searchParams={searchParams}
+        setSearchParams={setSearchParams}
+      />
     </Fragment>
   );
 };

--- a/assets/js/components/HostsList.jsx
+++ b/assets/js/components/HostsList.jsx
@@ -57,6 +57,7 @@ const HostsList = () => {
         title: 'Health',
         key: 'heartbeat',
         filter: true,
+        filterFromParams: true,
         render: (_content, item) => {
           return <HealthIcon health={item.heartbeat} centered={true} />;
         },
@@ -66,6 +67,7 @@ const HostsList = () => {
         key: 'hostname',
         className: 'w-40',
         filter: true,
+        filterFromParams: true,
         render: (content, { id }) => <HostLink hostId={id}>{content}</HostLink>,
       },
       {

--- a/assets/js/components/HostsList.test.jsx
+++ b/assets/js/components/HostsList.test.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react';
+import 'intersection-observer';
+import '@testing-library/jest-dom';
+
+import HostsList from './HostsList';
+import { renderWithRouter, withState } from '../lib/test-utils';
+
+describe('HostsLists component', () => {
+  describe('query string filtering behavior', () => {
+    it('should put the filters values in the query string when filters are selected', () => {
+      const [StatefulHostsList] = withState(<HostsList />);
+      renderWithRouter(StatefulHostsList);
+
+      ['Health', 'Hostname', 'Tags', 'SID'].forEach((filter) => {
+        fireEvent.click(screen.getByTestId(`filter-${filter}`));
+
+        fireEvent.click(
+          screen
+            .getByTestId(`filter-${filter}-options`)
+            .querySelector('li > div > span').firstChild
+        );
+      });
+
+      expect(window.location.search).toEqual(
+        '?heartbeat=unknown&hostname=vmdrbddev01&tags=tag1&sid=HDD'
+      );
+    });
+  });
+});

--- a/assets/js/components/SapSystemsOverview/SapSystemsOverview.jsx
+++ b/assets/js/components/SapSystemsOverview/SapSystemsOverview.jsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import HealthIcon from '@components/Health';
 import Table from '@components/Table';
 import SAPSystemItemOverview from '@components/SapSystemsOverview/SapSystemItemOverview';
@@ -27,6 +27,8 @@ const SapSystemsOverview = () => {
   const { sapSystems, applicationInstances, databaseInstances, loading } =
     useSelector((state) => state.sapSystemsList);
   const dispatch = useDispatch();
+  const [searchParams, setSearchParams] = useSearchParams();
+
   const config = {
     pagination: true,
     usePadding: false,
@@ -34,6 +36,7 @@ const SapSystemsOverview = () => {
       {
         title: 'Health',
         key: 'health',
+        filterFromParams: true,
         filter: true,
         render: (content) => (
           <div className="ml-4">
@@ -44,6 +47,7 @@ const SapSystemsOverview = () => {
       {
         title: 'SID',
         key: 'sid',
+        filterFromParams: true,
         filter: true,
         render: (content, item) => {
           return (
@@ -83,6 +87,7 @@ const SapSystemsOverview = () => {
         title: 'Tags',
         key: 'tags',
         className: 'w-80',
+        filterFromParams: true,
         filter: (filter, key) => (element) =>
           element[key].some((tag) => filter.includes(tag)),
         render: (content, item) => (
@@ -131,7 +136,12 @@ const SapSystemsOverview = () => {
   ) : (
     <Fragment>
       <ComponentHealthSummary data={data} />
-      <Table config={config} data={data} />
+      <Table
+        config={config}
+        data={data}
+        searchParams={searchParams}
+        setSearchParams={setSearchParams}
+      />
     </Fragment>
   );
 };

--- a/assets/js/components/SapSystemsOverview/SapSystemsOverview.test.jsx
+++ b/assets/js/components/SapSystemsOverview/SapSystemsOverview.test.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react';
+import 'intersection-observer';
+import '@testing-library/jest-dom';
+
+import SapSystemsOverview from './SapSystemsOverview';
+import { renderWithRouter, withState } from '../../lib/test-utils';
+
+describe('SapSystemsOverviews component', () => {
+  describe('query string filtering behavior', () => {
+    it('should put the filters values in the query string when filters are selected', () => {
+      const [StatefulSapSystemsOverview] = withState(<SapSystemsOverview />);
+      renderWithRouter(StatefulSapSystemsOverview);
+
+      ['Health', 'SID', 'Tags'].forEach((filter) => {
+        fireEvent.click(screen.getByTestId(`filter-${filter}`));
+
+        fireEvent.click(
+          screen
+            .getByTestId(`filter-${filter}-options`)
+            .querySelector('li > div > span').firstChild
+        );
+      });
+
+      expect(window.location.search).toEqual(
+        '?health=passing&sid=NWD&tags=tag1'
+      );
+    });
+  });
+});

--- a/assets/js/components/Table/Filter.jsx
+++ b/assets/js/components/Table/Filter.jsx
@@ -36,6 +36,7 @@ const Filter = ({ options, title, value, onChange }) => {
         )}
         <button
           type="button"
+          data-testid={`filter-${title}`}
           onClick={() => setOpen(!open)}
           className="relative w-full bg-white rounded-md shadow pl-3 pr-10 py-3 text-left cursor-default focus:outline-none focus:ring-1 focus:ring-jungle-green-500 focus:border-jungle-green-500 sm:text-sm"
         >
@@ -86,6 +87,7 @@ const Filter = ({ options, title, value, onChange }) => {
               <ul
                 tabIndex="-1"
                 role="listbox"
+                data-testid={`filter-${title}-options`}
                 aria-labelledby="listbox-label"
                 className="max-h-56 py-2 text-base overflow-auto focus:outline-none sm:text-sm"
               >

--- a/assets/js/lib/test-utils/data/clusters.js
+++ b/assets/js/lib/test-utils/data/clusters.js
@@ -12,7 +12,7 @@ export default [
     resources_number: 9,
     selected_checks: [],
     sid: null,
-    tags: [],
+    tags: [{ value: 'tag1' }],
     type: 'unknown',
   },
   {
@@ -28,7 +28,7 @@ export default [
     resources_number: 9,
     selected_checks: [],
     sid: null,
-    tags: [],
+    tags: [{ value: 'tag1' }],
     type: 'unknown',
   },
   {
@@ -44,7 +44,7 @@ export default [
     resources_number: 9,
     selected_checks: [],
     sid: null,
-    tags: [],
+    tags: [{ value: 'tag1' }],
     type: 'unknown',
   },
   {
@@ -168,7 +168,7 @@ export default [
     resources_number: 7,
     selected_checks: [],
     sid: 'HDD',
-    tags: [],
+    tags: [{ value: 'tag1' }],
     type: 'hana_scale_up',
   },
   {
@@ -290,7 +290,7 @@ export default [
     resources_number: 7,
     selected_checks: [],
     sid: 'HDQ',
-    tags: [],
+    tags: [{ value: 'tag1' }],
     type: 'hana_scale_up',
   },
   {
@@ -423,7 +423,7 @@ export default [
     resources_number: 7,
     selected_checks: [],
     sid: 'HDP',
-    tags: [],
+    tags: [{ value: 'tag1' }],
     type: 'hana_scale_up',
   },
   {
@@ -439,7 +439,7 @@ export default [
     resources_number: 9,
     selected_checks: [],
     sid: null,
-    tags: [],
+    tags: [{ value: 'tag1' }],
     type: 'unknown',
   },
   {
@@ -455,7 +455,7 @@ export default [
     resources_number: 9,
     selected_checks: [],
     sid: null,
-    tags: [],
+    tags: [{ value: 'tag1' }],
     type: 'unknown',
   },
   {
@@ -471,7 +471,7 @@ export default [
     resources_number: 9,
     selected_checks: [],
     sid: null,
-    tags: [],
+    tags: [{ value: 'tag1' }],
     type: 'unknown',
   },
 ];

--- a/assets/js/lib/test-utils/data/hosts.js
+++ b/assets/js/lib/test-utils/data/hosts.js
@@ -111,7 +111,7 @@ export default [
       },
     ],
     ssh_address: '10.100.1.31',
-    tags: [],
+    tags: ['tag1', 'tag2', 'tag3'],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -225,7 +225,7 @@ export default [
       },
     ],
     ssh_address: '10.100.1.32',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -339,7 +339,7 @@ export default [
       },
     ],
     ssh_address: '10.80.1.31',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -453,7 +453,7 @@ export default [
       },
     ],
     ssh_address: '10.80.1.32',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -567,7 +567,7 @@ export default [
       },
     ],
     ssh_address: '10.90.1.31',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -681,7 +681,7 @@ export default [
       },
     ],
     ssh_address: '10.90.1.32',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -795,7 +795,7 @@ export default [
       },
     ],
     ssh_address: '10.100.1.11',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -909,7 +909,7 @@ export default [
       },
     ],
     ssh_address: '10.100.1.12',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -1023,7 +1023,7 @@ export default [
       },
     ],
     ssh_address: '10.80.1.11',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -1137,7 +1137,7 @@ export default [
       },
     ],
     ssh_address: '10.80.1.12',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -1251,7 +1251,7 @@ export default [
       },
     ],
     ssh_address: '10.90.1.11',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -1365,7 +1365,7 @@ export default [
       },
     ],
     ssh_address: '10.90.1.12',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -1479,7 +1479,7 @@ export default [
       },
     ],
     ssh_address: '10.100.1.4',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -1593,7 +1593,7 @@ export default [
       },
     ],
     ssh_address: '10.80.1.4',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -1707,7 +1707,7 @@ export default [
       },
     ],
     ssh_address: '10.90.1.4',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -1821,7 +1821,7 @@ export default [
       },
     ],
     ssh_address: '10.100.1.21',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -1935,7 +1935,7 @@ export default [
       },
     ],
     ssh_address: '10.100.1.22',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -2049,7 +2049,7 @@ export default [
       },
     ],
     ssh_address: '10.100.1.23',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -2163,7 +2163,7 @@ export default [
       },
     ],
     ssh_address: '10.100.1.24',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -2277,7 +2277,7 @@ export default [
       },
     ],
     ssh_address: '10.80.1.21',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -2391,7 +2391,7 @@ export default [
       },
     ],
     ssh_address: '10.80.1.22',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -2505,7 +2505,7 @@ export default [
       },
     ],
     ssh_address: '10.80.1.23',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -2619,7 +2619,7 @@ export default [
       },
     ],
     ssh_address: '10.80.1.24',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -2733,7 +2733,7 @@ export default [
       },
     ],
     ssh_address: '10.90.1.21',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -2847,7 +2847,7 @@ export default [
       },
     ],
     ssh_address: '10.90.1.22',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -2952,7 +2952,7 @@ export default [
       },
     ],
     ssh_address: '10.90.1.23',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
   {
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
@@ -3057,6 +3057,6 @@ export default [
       },
     ],
     ssh_address: '10.90.1.24',
-    tags: [],
+    tags: [{ value: 'tag1' }],
   },
 ];

--- a/assets/js/lib/test-utils/data/sapSystems.js
+++ b/assets/js/lib/test-utils/data/sapSystems.js
@@ -86,7 +86,7 @@ export default [
     health: 'passing',
     id: 'f534a4ad-cef7-5234-b196-e67082ffb50c',
     sid: 'NWD',
-    tags: [],
+    tags: [{ value: 'tag1' }],
     tenant: 'HDD',
   },
   {
@@ -176,7 +176,7 @@ export default [
     health: 'passing',
     id: '6c9208eb-a5bb-57ef-be5c-6422dedab602',
     sid: 'NWP',
-    tags: [],
+    tags: [{ value: 'tag1' }],
     tenant: 'HDP',
   },
   {
@@ -266,7 +266,7 @@ export default [
     health: 'passing',
     id: 'cd52e571-c897-5bba-b0f9-e155ceca1fff',
     sid: 'NWQ',
-    tags: [],
+    tags: [{ value: 'tag1' }],
     tenant: 'HDQ',
   },
 ];

--- a/assets/js/lib/test-utils/index.jsx
+++ b/assets/js/lib/test-utils/index.jsx
@@ -10,7 +10,7 @@ import { setSapSystems } from '@state/sapSystems';
 
 import hosts from './data/hosts';
 import clusters from './data/clusters';
-import sapSystems from './data/hosts';
+import sapSystems from './data/sapSystems';
 
 export const withState = (component) => {
   store.dispatch(setHosts(hosts));


### PR DESCRIPTION
# Description

This PR enables the query string filter capability on every filtered table column in the application.

This enable the users to share their links with filters in order to have a more consistent UX across the tables.

Feature enabled in

- Hosts List
- Clusters List
- Sap Systems List
- Databases List

The gif will show the filtering feature in every screen.

![trento_filters_all_tables](https://user-images.githubusercontent.com/9409502/199477200-8d745cb6-9140-4a0b-8373-9afaa4911c9e.gif)


Tag @jagabomb for UX review.

## How was this tested?

The table filtering feature was already test with e2e test in another PR.
