### PR TITLE
Replace mock usage for dispatch

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -53,6 +53,8 @@ config :logger, :console,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
+config :trento, Trento.Commanded, adapter: Trento.Commanded
+
 config :trento, Trento.Commanded,
   event_store: [
     adapter: Commanded.EventStore.Adapters.EventStore,

--- a/config/test.exs
+++ b/config/test.exs
@@ -70,6 +70,13 @@ config :trento, Trento.Integration.Checks.Wanda.Messaging.AMQP,
     ]
   ]
 
+config :trento, Trento.Scheduler,
+  jobs: [
+    heartbeat_check: [
+      state: :inactive
+    ]
+  ]
+
 config :trento,
   extra_children: [
     Trento.Messaging.Adapters.AMQP.Publisher,

--- a/lib/trento/application/event_handlers/rollup_event_handler.ex
+++ b/lib/trento/application/event_handlers/rollup_event_handler.ex
@@ -26,6 +26,9 @@ defmodule Trento.RollupEventHandler do
   defp after_max_retries_reached(%ClusterRolledUp{cluster_id: cluster_id}, _, _) do
     %{cluster_id: cluster_id}
     |> AbortClusterRollup.new!()
-    |> Trento.Commanded.dispatch()
+    |> commanded().dispatch()
   end
+
+  defp commanded,
+    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
 end

--- a/lib/trento/application/integration/checks/checks.ex
+++ b/lib/trento/application/integration/checks/checks.ex
@@ -59,7 +59,7 @@ defmodule Trento.Integration.Checks do
       }) do
     case StartChecksExecution.new(%{cluster_id: cluster_id}) do
       {:ok, command} ->
-        Trento.Commanded.dispatch(command, correlation_id: execution_id)
+        commanded().dispatch(command, correlation_id: execution_id)
 
       error ->
         error
@@ -74,11 +74,14 @@ defmodule Trento.Integration.Checks do
     with {:ok, execution_completed_event} <- ExecutionCompletedEventDto.new(payload),
          {:ok, command} <-
            build_complete_checks_execution_command(execution_completed_event) do
-      Trento.Commanded.dispatch(command, correlation_id: execution_id)
+      commanded().dispatch(command, correlation_id: execution_id)
     end
   end
 
   def handle_callback(_), do: {:error, :invalid_payload}
+
+  defp commanded,
+    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
 
   defp adapter,
     do: Application.fetch_env!(:trento, __MODULE__)[:adapter]

--- a/lib/trento/application/integration/discovery/discovery.ex
+++ b/lib/trento/application/integration/discovery/discovery.ex
@@ -127,7 +127,7 @@ defmodule Trento.Integration.Discovery do
   @spec dispatch(command | [command]) :: :ok | {:error, any}
   defp dispatch(commands) when is_list(commands) do
     Enum.reduce(commands, :ok, fn command, acc ->
-      case {Trento.Commanded.dispatch(command), acc} do
+      case {commanded().dispatch(command), acc} do
         {:ok, :ok} ->
           :ok
 
@@ -140,5 +140,8 @@ defmodule Trento.Integration.Discovery do
     end)
   end
 
-  defp dispatch(command), do: Trento.Commanded.dispatch(command)
+  defp dispatch(command), do: commanded().dispatch(command)
+
+  defp commanded,
+    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
 end

--- a/lib/trento/application/usecases/clusters/clusters.ex
+++ b/lib/trento/application/usecases/clusters/clusters.ex
@@ -29,21 +29,21 @@ defmodule Trento.Clusters do
              host_id: host_id,
              checks_results: build_check_results(checks_results)
            }) do
-      Trento.Commanded.dispatch(command)
+      commanded().dispatch(command)
     end
   end
 
   @spec select_checks(String.t(), [String.t()]) :: :ok | {:error, any}
   def select_checks(cluster_id, checks) do
     with {:ok, command} <- SelectChecks.new(%{cluster_id: cluster_id, checks: checks}) do
-      Trento.Commanded.dispatch(command)
+      commanded().dispatch(command)
     end
   end
 
   @spec request_checks_execution(String.t()) :: :ok | {:error, any}
   def request_checks_execution(cluster_id) do
     with {:ok, command} <- RequestChecksExecution.new(%{cluster_id: cluster_id}) do
-      Trento.Commanded.dispatch(command)
+      commanded().dispatch(command)
     end
   end
 
@@ -95,6 +95,9 @@ defmodule Trento.Clusters do
       end
     end)
   end
+
+  defp commanded,
+    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
 
   @spec build_check_results([String.t()]) :: {:ok, [CheckResult.t()]} | {:error, any}
   defp build_check_results(checks_results) do

--- a/lib/trento/application/usecases/hosts/heartbeats.ex
+++ b/lib/trento/application/usecases/hosts/heartbeats.ex
@@ -56,7 +56,7 @@ defmodule Trento.Heartbeats do
   defp dispatch_command(agent_id, heartbeat) do
     case %{host_id: agent_id, heartbeat: heartbeat}
          |> UpdateHeartbeat.new!()
-         |> Trento.Commanded.dispatch() do
+         |> commanded().dispatch() do
       :ok ->
         {:ok, :done}
 
@@ -64,4 +64,7 @@ defmodule Trento.Heartbeats do
         error
     end
   end
+
+  defp commanded,
+    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
 end

--- a/lib/trento/infrastructure/router.ex
+++ b/lib/trento/infrastructure/router.ex
@@ -25,6 +25,9 @@ defmodule Trento.Router do
     UpdateSlesSubscriptions
   }
 
+  alias Commanded.Helpers.CommandAuditMiddleware
+
+  middleware CommandAuditMiddleware
   middleware Enrich
 
   identify Host, by: :host_id

--- a/lib/trento/infrastructure/router.ex
+++ b/lib/trento/infrastructure/router.ex
@@ -25,9 +25,6 @@ defmodule Trento.Router do
     UpdateSlesSubscriptions
   }
 
-  alias Commanded.Helpers.CommandAuditMiddleware
-
-  middleware CommandAuditMiddleware
   middleware Enrich
 
   identify Host, by: :host_id

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -41,6 +41,7 @@ defmodule Trento.Factory do
     ClusterReadModel,
     DatabaseInstanceReadModel,
     DatabaseReadModel,
+    Heartbeat,
     HostChecksExecutionsReadModel,
     HostConnectionSettings,
     HostReadModel,
@@ -99,6 +100,13 @@ defmodule Trento.Factory do
       heartbeat: :unknown,
       provider: Enum.random(Provider.values()),
       provider_data: nil
+    }
+  end
+
+  def heartbeat_factory do
+    %Heartbeat{
+      agent_id: Faker.UUID.v4(),
+      timestamp: DateTime.utc_now()
     }
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,7 @@
+Mox.defmock(Trento.Commanded.Mock, for: Commanded.Application)
+
+Application.put_env(:trento, Trento.Commanded, adapter: Trento.Commanded.Mock)
+
 Mox.defmock(Trento.Integration.Telemetry.Mock, for: Trento.Integration.Telemetry.Gen)
 
 Application.put_env(:trento, Trento.Integration.Telemetry,

--- a/test/trento/application/integration/checks/checks_test.exs
+++ b/test/trento/application/integration/checks/checks_test.exs
@@ -4,8 +4,6 @@ defmodule Trento.Integration.ChecksTest do
 
   import Mox
 
-  alias Commanded.Helpers.CommandAuditMiddleware
-
   alias Trento.Integration.Checks
 
   alias Trento.Integration.Checks.{
@@ -29,11 +27,7 @@ defmodule Trento.Integration.ChecksTest do
 
   @runner_fixtures_path File.cwd!() <> "/test/fixtures/runner"
 
-  setup do
-    start_supervised!(CommandAuditMiddleware)
-
-    :ok
-  end
+  setup [:set_mox_from_context, :verify_on_exit!]
 
   def load_runner_fixture(name) do
     @runner_fixtures_path
@@ -364,6 +358,20 @@ defmodule Trento.Integration.ChecksTest do
     execution_id = Faker.UUID.v4()
     cluster_id = Faker.UUID.v4()
 
+    expect(
+      Trento.Commanded.Mock,
+      :dispatch,
+      fn command, opts ->
+        assert %StartChecksExecution{
+                 cluster_id: ^cluster_id
+               } = command
+
+        assert [correlation_id: ^execution_id] = opts
+
+        :ok
+      end
+    )
+
     Checks.handle_callback(%{
       "event" => "execution_started",
       "execution_id" => execution_id,
@@ -371,15 +379,6 @@ defmodule Trento.Integration.ChecksTest do
         "cluster_id" => cluster_id
       }
     })
-
-    assert [
-             %{
-               command: %StartChecksExecution{
-                 cluster_id: ^cluster_id
-               },
-               correlation_id: ^execution_id
-             }
-           ] = CommandAuditMiddleware.dispatched_commands(& &1)
   end
 
   test "should handle execution completed event properly" do
@@ -387,6 +386,52 @@ defmodule Trento.Integration.ChecksTest do
     cluster_id = Faker.UUID.v4()
     host_id_1 = Faker.UUID.v4()
     host_id_2 = Faker.UUID.v4()
+
+    expect(
+      Trento.Commanded.Mock,
+      :dispatch,
+      fn command, opts ->
+        assert %CompleteChecksExecution{
+                 cluster_id: ^cluster_id,
+                 hosts_executions: [
+                   %HostExecution{
+                     checks_results: [
+                       %CheckResult{
+                         check_id: "check1",
+                         result: :passing
+                       },
+                       %CheckResult{
+                         check_id: "check2",
+                         result: :warning
+                       }
+                     ],
+                     host_id: ^host_id_1,
+                     msg: nil,
+                     reachable: true
+                   },
+                   %HostExecution{
+                     checks_results: [
+                       %CheckResult{
+                         check_id: "check1",
+                         result: :critical
+                       },
+                       %CheckResult{
+                         check_id: "check2",
+                         result: :warning
+                       }
+                     ],
+                     host_id: ^host_id_2,
+                     msg: nil,
+                     reachable: true
+                   }
+                 ]
+               } = command
+
+        assert [correlation_id: ^execution_id] = opts
+
+        :ok
+      end
+    )
 
     Checks.handle_callback(%{
       "event" => "execution_completed",
@@ -427,46 +472,5 @@ defmodule Trento.Integration.ChecksTest do
         ]
       }
     })
-
-    assert [
-             %{
-               command: %CompleteChecksExecution{
-                 cluster_id: ^cluster_id,
-                 hosts_executions: [
-                   %HostExecution{
-                     checks_results: [
-                       %CheckResult{
-                         check_id: "check1",
-                         result: :passing
-                       },
-                       %CheckResult{
-                         check_id: "check2",
-                         result: :warning
-                       }
-                     ],
-                     host_id: ^host_id_1,
-                     msg: nil,
-                     reachable: true
-                   },
-                   %HostExecution{
-                     checks_results: [
-                       %CheckResult{
-                         check_id: "check1",
-                         result: :critical
-                       },
-                       %CheckResult{
-                         check_id: "check2",
-                         result: :warning
-                       }
-                     ],
-                     host_id: ^host_id_2,
-                     msg: nil,
-                     reachable: true
-                   }
-                 ]
-               },
-               correlation_id: ^execution_id
-             }
-           ] = CommandAuditMiddleware.dispatched_commands(& &1)
   end
 end


### PR DESCRIPTION
# Description
Remove `mock` usage on commanded dispatched usages. I will send the removal of the DateTime mock in a next PR

## How was this tested?
Using Mox instead of Mock
