### PR TITLE
Add the possibility to add environment configuration to the bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,6 @@ trento-*.tar
 # In case you use Node.js/npm, you want to ignore these.
 npm-debug.log
 /assets/node_modules/
+/assets/.env
 
 .pgdata/

--- a/assets/.env.example
+++ b/assets/.env.example
@@ -1,0 +1,1 @@
+WANDA_URL=http://localhost:4001

--- a/assets/build.js
+++ b/assets/build.js
@@ -5,8 +5,18 @@ const alias = require('esbuild-plugin-path-alias');
 
 const resolvePath = (p) => path.resolve(__dirname, p);
 
+const WANDA_URL =
+  process.env.NODE_ENV === 'production'
+    ? ''
+    : JSON.stringify('http://localhost:4001');
+
+const define = {
+  'process.env.WANDA_URL': WANDA_URL,
+};
+
 require('esbuild')
   .build({
+    define,
     entryPoints: ['js/app.js', 'js/trento.jsx'],
     outdir: resolvePath('../priv/static/assets'),
     bundle: true,

--- a/assets/build.js
+++ b/assets/build.js
@@ -2,13 +2,16 @@
 /* eslint-disable no-console */
 const path = require('path');
 const alias = require('esbuild-plugin-path-alias');
+const { config } = require('dotenv');
+
+config();
 
 const resolvePath = (p) => path.resolve(__dirname, p);
 
 const WANDA_URL =
   process.env.NODE_ENV === 'production'
     ? ''
-    : JSON.stringify('http://localhost:4001');
+    : JSON.stringify(process.env.WANDA_URL);
 
 const define = {
   'process.env.WANDA_URL': WANDA_URL,

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -12,6 +12,7 @@
         "classnames": "^2.3.2",
         "date-fns": "^2.29.3",
         "dayjs": "^1.11.6",
+        "dotenv": "^16.0.3",
         "eos-icons-react": "^2.4.0",
         "postcss-import": "^15.0.0",
         "react": "^18.2.0",
@@ -13733,12 +13734,11 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
-      "dev": true,
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/dotenv-expand": {
@@ -20165,6 +20165,15 @@
         "node": ">=6.0.0",
         "npm": ">=6.0.0",
         "yarn": ">=1.0.0"
+      }
+    },
+    "node_modules/lazy-universal-dotenv/node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/leven": {
@@ -39615,10 +39624,9 @@
       }
     },
     "dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
-      "dev": true
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "dotenv-expand": {
       "version": "5.1.0",
@@ -44514,6 +44522,14 @@
         "core-js": "^3.0.4",
         "dotenv": "^8.0.0",
         "dotenv-expand": "^5.1.0"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "8.6.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+          "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+          "dev": true
+        }
       }
     },
     "leven": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -37,6 +37,7 @@
     "classnames": "^2.3.2",
     "date-fns": "^2.29.3",
     "dayjs": "^1.11.6",
+    "dotenv": "^16.0.3",
     "eos-icons-react": "^2.4.0",
     "postcss-import": "^15.0.0",
     "react": "^18.2.0",


### PR DESCRIPTION
# Description

We need to be able to configure variables depending upon `NODE_ENV`, or to put it clearly, to switch between development and production values. In `esbuild` this can be done through the `define` field. Inside the app the value can be accessed through `process.env.WANDA_URL`.

## How was this tested?
Manually!
