### PR TITLE
Add hover style to health icon

### DIFF
--- a/assets/js/components/Health/HealthIcon.jsx
+++ b/assets/js/components/Health/HealthIcon.jsx
@@ -9,25 +9,35 @@ import {
 } from 'eos-icons-react';
 
 import Spinner from '@components/Spinner';
+import classNames from 'classnames';
 
 const HealthIcon = ({ health = undefined, centered = false }) => {
   switch (health) {
     case 'passing':
       return (
         <EOS_CHECK_CIRCLE_OUTLINED
-          className={computedIconCssClass('fill-jungle-green-500', centered)}
+          className={classNames(
+            'hover:opacity-75',
+            computedIconCssClass('fill-jungle-green-500', centered)
+          )}
         />
       );
     case 'warning':
       return (
         <EOS_WARNING_OUTLINED
-          className={computedIconCssClass('fill-yellow-500', centered)}
+          className={classNames(
+            'hover:opacity-75',
+            computedIconCssClass('fill-yellow-500', centered)
+          )}
         />
       );
     case 'critical':
       return (
         <EOS_ERROR_OUTLINED
-          className={computedIconCssClass('fill-red-500', centered)}
+          className={classNames(
+            'hover:opacity-75',
+            computedIconCssClass('fill-red-500', centered)
+          )}
         />
       );
     case 'pending':
@@ -35,7 +45,10 @@ const HealthIcon = ({ health = undefined, centered = false }) => {
     default:
       return (
         <EOS_LENS_FILLED
-          className={computedIconCssClass('fill-gray-500', centered)}
+          className={classNames(
+            'hover:opacity-75',
+            computedIconCssClass('fill-gray-500', centered)
+          )}
         />
       );
   }


### PR DESCRIPTION
# Description

As the title suggest.

The hover style is consistent with the health boxes.

![hover_icons_Dashboard](https://user-images.githubusercontent.com/9409502/200274268-4f5cab4c-2dbe-470d-bcd0-7861ab004862.gif)


## How was this tested?

Manually
