### PR TITLE
Add licensing metadata to SUSE Dockerfile

### DIFF
--- a/packaging/suse/Dockerfile
+++ b/packaging/suse/Dockerfile
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #!BuildTag: trento/trento-web:latest
 #!BuildTag: trento/trento-web:%%VERSION%%
 #!BuildTag: trento/trento-web:%%VERSION%%-build%RELEASE%


### PR DESCRIPTION
# Description

This PR just adds missing licensing metadata required by the IBS submissions