### PR TITLE
Use mocked redux store

### DIFF
--- a/assets/js/components/ClustersList.test.jsx
+++ b/assets/js/components/ClustersList.test.jsx
@@ -4,12 +4,12 @@ import 'intersection-observer';
 import '@testing-library/jest-dom';
 
 import ClustersList from './ClustersList';
-import { renderWithRouter, withState } from '../lib/test-utils';
+import { renderWithRouter, withDefaultState } from '../lib/test-utils';
 
 describe('ClustersList component', () => {
   describe('query string filtering behavior', () => {
     it('should put the filters values in the query string when filters are selected', () => {
-      const [StatefulClustersList] = withState(<ClustersList />);
+      const [StatefulClustersList] = withDefaultState(<ClustersList />);
       renderWithRouter(StatefulClustersList);
 
       ['Health', 'Name', 'SID', 'Type', 'Tags'].forEach((filter) => {

--- a/assets/js/components/Eula/Eula.test.jsx
+++ b/assets/js/components/Eula/Eula.test.jsx
@@ -3,31 +3,44 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import 'intersection-observer';
 import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
 
 import { withState } from '@lib/test-utils';
-import { setEulaVisible, setIsPremium } from '@state/settings';
 
 import Eula from '.';
 
 describe('Eula component', () => {
   it('should render community eula correctly', () => {
-    const [statefulEula, store] = withState(<Eula />);
-
-    store.dispatch(setEulaVisible());
+    const initialState = {
+      settings: { eulaVisible: true, setIsPremium: false },
+    };
+    const [statefulEula, store] = withState(<Eula />, initialState);
 
     render(statefulEula);
-    expect(screen.getByRole('button')).toHaveTextContent('Accept');
+    const acceptButton = screen.getByRole('button');
+    expect(acceptButton).toHaveTextContent('Accept');
     expect(screen.getByText(/Trento Community/)).toBeTruthy();
+
+    userEvent.click(acceptButton);
+
+    const actions = store.getActions();
+    const expectedPayload = { type: 'ACCEPT_EULA' };
+    expect(actions).toEqual([expectedPayload]);
   });
 
   it('should render premium eula correctly', () => {
-    const [statefulEula, store] = withState(<Eula />);
-
-    store.dispatch(setEulaVisible());
-    store.dispatch(setIsPremium());
+    const initialState = { settings: { eulaVisible: true, isPremium: true } };
+    const [statefulEula, store] = withState(<Eula />, initialState);
 
     render(statefulEula);
-    expect(screen.getByRole('button')).toHaveTextContent('Accept');
+    const acceptButton = screen.getByRole('button');
+    expect(acceptButton).toHaveTextContent('Accept');
     expect(screen.getByText(/Trento Premium/)).toBeTruthy();
+
+    userEvent.click(acceptButton);
+
+    const actions = store.getActions();
+    const expectedPayload = { type: 'ACCEPT_EULA' };
+    expect(actions).toEqual([expectedPayload]);
   });
 });

--- a/assets/js/components/HealthSummary/HomeHealthSummary.test.jsx
+++ b/assets/js/components/HealthSummary/HomeHealthSummary.test.jsx
@@ -2,15 +2,10 @@ import React from 'react';
 import { screen, fireEvent } from '@testing-library/react';
 import 'intersection-observer';
 import '@testing-library/jest-dom';
-import { keysToCamel } from '@lib/serialization';
 
 import { HomeHealthSummary } from './HomeHealthSummary';
 import { renderWithRouter, withState } from '@lib/test-utils';
-import {
-  setHealthSummary,
-  stopHealthSummaryLoading,
-} from '@state/healthSummary';
-import { act } from 'react-dom/test-utils';
+
 import { healthSummaryFactory } from '../../lib/test-utils/factories';
 
 const homeHealthSummaryActionPayload = [
@@ -35,18 +30,21 @@ const homeHealthSummaryActionPayload = [
   }),
 ];
 
+const initialState = {
+  sapSystemsHealthSummary: {
+    sapSystemsHealth: homeHealthSummaryActionPayload,
+    loading: false,
+  },
+};
+
 describe('HomeHealthSummary component', () => {
   it('should have a clickable SAP INSTANCE icon with link to the belonging instance', () => {
-    const [StatefulHomeHealthSummary, store] = withState(<HomeHealthSummary />);
+    const [StatefulHomeHealthSummary] = withState(
+      <HomeHealthSummary />,
+      initialState
+    );
     const { container } = renderWithRouter(StatefulHomeHealthSummary);
     const [{ id }] = homeHealthSummaryActionPayload;
-
-    act(() => {
-      store.dispatch(
-        setHealthSummary(keysToCamel(homeHealthSummaryActionPayload))
-      );
-      store.dispatch(stopHealthSummaryLoading());
-    });
 
     expect(
       container
@@ -58,15 +56,11 @@ describe('HomeHealthSummary component', () => {
 
 describe('HomeHealthSummary component', () => {
   it('should have a working link to the passing checks in the overview component', () => {
-    const [StatefulHomeHealthSummary, store] = withState(<HomeHealthSummary />);
+    const [StatefulHomeHealthSummary] = withState(
+      <HomeHealthSummary />,
+      initialState
+    );
     const { container } = renderWithRouter(StatefulHomeHealthSummary);
-
-    act(() => {
-      store.dispatch(
-        setHealthSummary(keysToCamel(homeHealthSummaryActionPayload))
-      );
-      store.dispatch(stopHealthSummaryLoading());
-    });
 
     expect(
       container
@@ -77,17 +71,11 @@ describe('HomeHealthSummary component', () => {
 
   describe('health box filter behaviour', () => {
     it('should put the filters values in the query string when health filters are selected', async () => {
-      const [StatefulHomeHealthSummary, store] = withState(
-        <HomeHealthSummary />
+      const [StatefulHomeHealthSummary] = withState(
+        <HomeHealthSummary />,
+        initialState
       );
       const { container } = renderWithRouter(StatefulHomeHealthSummary);
-
-      act(() => {
-        store.dispatch(
-          setHealthSummary(keysToCamel(homeHealthSummaryActionPayload))
-        );
-        store.dispatch(stopHealthSummaryLoading());
-      });
 
       expect(container.querySelector('tbody').childNodes.length).toEqual(3);
 

--- a/assets/js/components/HostsList.test.jsx
+++ b/assets/js/components/HostsList.test.jsx
@@ -4,12 +4,12 @@ import 'intersection-observer';
 import '@testing-library/jest-dom';
 
 import HostsList from './HostsList';
-import { renderWithRouter, withState } from '../lib/test-utils';
+import { renderWithRouter, withDefaultState } from '../lib/test-utils';
 
 describe('HostsLists component', () => {
   describe('query string filtering behavior', () => {
     it('should put the filters values in the query string when filters are selected', () => {
-      const [StatefulHostsList] = withState(<HostsList />);
+      const [StatefulHostsList] = withDefaultState(<HostsList />);
       renderWithRouter(StatefulHostsList);
 
       ['Health', 'Hostname', 'Tags', 'SID'].forEach((filter) => {

--- a/assets/js/components/SapSystemsOverview/SapSystemsOverview.test.jsx
+++ b/assets/js/components/SapSystemsOverview/SapSystemsOverview.test.jsx
@@ -4,12 +4,14 @@ import 'intersection-observer';
 import '@testing-library/jest-dom';
 
 import SapSystemsOverview from './SapSystemsOverview';
-import { renderWithRouter, withState } from '../../lib/test-utils';
+import { renderWithRouter, withDefaultState } from '../../lib/test-utils';
 
 describe('SapSystemsOverviews component', () => {
   describe('query string filtering behavior', () => {
     it('should put the filters values in the query string when filters are selected', () => {
-      const [StatefulSapSystemsOverview] = withState(<SapSystemsOverview />);
+      const [StatefulSapSystemsOverview] = withDefaultState(
+        <SapSystemsOverview />
+      );
       renderWithRouter(StatefulSapSystemsOverview);
 
       ['Health', 'SID', 'Tags'].forEach((filter) => {

--- a/assets/js/lib/test-utils/index.jsx
+++ b/assets/js/lib/test-utils/index.jsx
@@ -2,20 +2,13 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
+import configureStore from 'redux-mock-store';
 
-import { store } from '@state';
-import { setHosts } from '@state/hosts';
-import { setClusters } from '@state/clusters';
-import { setSapSystems } from '@state/sapSystems';
+const middlewares = [];
+const mockStore = configureStore(middlewares);
 
-import hosts from './data/hosts';
-import clusters from './data/clusters';
-import sapSystems from './data/sapSystems';
-
-export const withState = (component) => {
-  store.dispatch(setHosts(hosts));
-  store.dispatch(setClusters(clusters));
-  store.dispatch(setSapSystems(sapSystems));
+export const withState = (component, initialState = {}) => {
+  const store = mockStore(initialState);
 
   return [
     <Provider key="root" store={store}>

--- a/assets/js/lib/test-utils/index.jsx
+++ b/assets/js/lib/test-utils/index.jsx
@@ -4,8 +4,26 @@ import { render } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 
+import hosts from './data/hosts';
+import clusters from './data/clusters';
+import sapSystems from './data/sapSystems';
+
 const middlewares = [];
 const mockStore = configureStore(middlewares);
+
+const defaultInitialState = {
+  hostsList: { hosts: hosts },
+  clustersList: { clusters: clusters },
+  sapSystemsList: {
+    sapSystems: sapSystems,
+    applicationInstances: sapSystems.flatMap(
+      (sapSystem) => sapSystem.application_instances
+    ),
+    databaseInstances: sapSystems.flatMap(
+      (sapSystem) => sapSystem.database_instances
+    ),
+  },
+};
 
 export const withState = (component, initialState = {}) => {
   const store = mockStore(initialState);
@@ -16,6 +34,10 @@ export const withState = (component, initialState = {}) => {
     </Provider>,
     store,
   ];
+};
+
+export const withDefaultState = (component) => {
+  return withState(component, defaultInitialState);
 };
 
 export const renderWithRouter = (ui, { route = '/' } = {}) => {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -53,6 +53,7 @@
         "jest-environment-jsdom": "^29.2.2",
         "postcss": "^8.4.19",
         "prettier": "2.7.1",
+        "redux-mock-store": "^1.5.4",
         "tailwindcss": "^3.2.3"
       }
     },
@@ -20313,6 +20314,12 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -24316,6 +24323,15 @@
       "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-mock-store": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.4.tgz",
+      "integrity": "sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==",
+      "dev": true,
+      "dependencies": {
+        "lodash.isplainobject": "^4.0.6"
       }
     },
     "node_modules/redux-saga": {
@@ -44634,6 +44650,12 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -47558,6 +47580,15 @@
       "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
       "requires": {
         "@babel/runtime": "^7.9.2"
+      }
+    },
+    "redux-mock-store": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.4.tgz",
+      "integrity": "sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==",
+      "dev": true,
+      "requires": {
+        "lodash.isplainobject": "^4.0.6"
       }
     },
     "redux-saga": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -27,6 +27,7 @@
     "jest-environment-jsdom": "^29.2.2",
     "postcss": "^8.4.19",
     "prettier": "2.7.1",
+    "redux-mock-store": "^1.5.4",
     "tailwindcss": "^3.2.3"
   },
   "dependencies": {


### PR DESCRIPTION
# Description
Use the [https://github.com/reduxjs/redux-mock-store](https://github.com/reduxjs/redux-mock-store) package to mock the tests redux store. Until now, we were using the real state, which doesn't help much on the testing phase.

## Did you add the right label?

Remember to add the right labels to this PR.

## How was this tested?

New test utility added
