### PR TITLE
Fix tagging test in hosts overview e2e suite

### DIFF
--- a/test/e2e/cypress/integration/clusters_overview.js
+++ b/test/e2e/cypress/integration/clusters_overview.js
@@ -135,7 +135,7 @@ context('Clusters Overview', () => {
         ];
         tagsScenarios.forEach(([tag, expectedTaggedClusters]) => {
           it(`should have ${expectedTaggedClusters} clusters tagged with tag '${tag}'`, () => {
-            cy.get(':nth-child(5) > .mt-1 > .relative').click();
+            cy.get('[data-testid="filter-Tags"]').click();
             cy.get('.max-h-56').contains(tag).click();
             cy.clickOutside();
 
@@ -143,7 +143,7 @@ context('Clusters Overview', () => {
               .its('length')
               .should('eq', expectedTaggedClusters);
 
-            cy.get(':nth-child(5) > .mt-1 > .relative').click();
+            cy.get('[data-testid="filter-Tags"]').click();
             cy.get('.max-h-56').contains(tag).click();
             cy.clickOutside();
           });
@@ -157,7 +157,7 @@ context('Clusters Overview', () => {
         ];
         healthScenarios.forEach(([health, expectedClustersWithThisHealth]) => {
           it(`should show ${expectedClustersWithThisHealth} clusters when filtering by health '${health}'`, () => {
-            cy.get(':nth-child(1) > .mt-1 > .relative').click();
+            cy.get('[data-testid="filter-Health"]').click();
             cy.get('.max-h-56').contains(health).click();
             cy.clickOutside();
 
@@ -165,7 +165,7 @@ context('Clusters Overview', () => {
               .its('length')
               .should('eq', expectedClustersWithThisHealth);
 
-            cy.get(':nth-child(1) > .mt-1 > .relative').click();
+            cy.get('[data-testid="filter-Health"]').click();
             cy.get('.max-h-56').contains(health).click();
             cy.clickOutside();
           });
@@ -180,7 +180,7 @@ context('Clusters Overview', () => {
         ];
         SAPSystemsScenarios.forEach(([sapsystem, expectedRelatedClusters]) => {
           it(`should have ${expectedRelatedClusters} clusters related to SAP system '${sapsystem}'`, () => {
-            cy.get(':nth-child(3) > .mt-1 > .relative').click();
+            cy.get('[data-testid="filter-SID"]').click();
             cy.get('.max-h-56').contains(sapsystem).click();
             cy.clickOutside();
 
@@ -188,7 +188,7 @@ context('Clusters Overview', () => {
               .its('length')
               .should('eq', expectedRelatedClusters);
 
-            cy.get(':nth-child(3) > .mt-1 > .relative').click();
+            cy.get('[data-testid="filter-SID"]').click();
             cy.get('.max-h-56').contains(sapsystem).click();
             cy.clickOutside();
           });
@@ -206,7 +206,7 @@ context('Clusters Overview', () => {
         clusterNameScenarios.forEach(
           ([clusterName, expectedRelatedClusters]) => {
             it(`should have ${expectedRelatedClusters} clusters related to name '${clusterName}'`, () => {
-              cy.get(':nth-child(2) > .mt-1 > .relative').click();
+              cy.get('[data-testid="filter-Name"]').click();
               cy.get('.max-h-56').contains(clusterName).click();
               cy.clickOutside();
 
@@ -214,7 +214,7 @@ context('Clusters Overview', () => {
                 .its('length')
                 .should('eq', expectedRelatedClusters);
 
-              cy.get(':nth-child(2) > .mt-1 > .relative').click();
+              cy.get('[data-testid="filter-Name"]').click();
               cy.get('.max-h-56').contains(clusterName).click();
               cy.clickOutside();
             });

--- a/test/e2e/cypress/integration/hosts_overview.js
+++ b/test/e2e/cypress/integration/hosts_overview.js
@@ -227,8 +227,7 @@ context('Hosts Overview', () => {
           ':nth-child(3) > .mt-1 > .relative > :nth-child(1) > .ml-3'
         ).contains('HDD, NWD');
 
-        // clear
-        cy.get('.z-20 > [data-testid="eos-svg-component"]').click();
+        cy.resetFilterSelection('SID');
 
         cy.url('eq', '/hosts');
       });
@@ -237,6 +236,7 @@ context('Hosts Overview', () => {
     describe('Tags', () => {
       before(() => {
         cy.visit('/hosts');
+        cy.get('.tn-hostname').its('length').should('be.gt', 0);
         cy.removeTagsFromView();
       });
 
@@ -248,12 +248,11 @@ context('Hosts Overview', () => {
 
       describe('Filter by tags', () => {
         before(() => {
-          cy.visit('/hosts');
-          cy.get('span').contains('Filter Tags').parent().parent().click();
+          cy.get('[data-testid="filter-Tags"]').click();
         });
 
-        after(() => {
-          cy.get('span').contains('Filter Tags').parent().parent().click();
+        afterEach(() => {
+          cy.resetFilterSelection('Tags');
         });
 
         ['env1', 'env2', 'env3'].forEach((tag) => {
@@ -273,7 +272,7 @@ context('Hosts Overview', () => {
           const tag = 'env1';
 
           cy.get('.tn-page-item').eq(2).click();
-          cy.get('span').contains('Filter Tags').parent().parent().click();
+          cy.get('[data-testid="filter-Tags"]').click();
           cy.get('li > div > span.ml-3.block').contains(tag).click();
           cy.get('.tn-hostname').its('length').should('eq', 4);
           cy.get('li > div > span.ml-3.block').contains(tag).click();
@@ -281,12 +280,7 @@ context('Hosts Overview', () => {
 
         it('should extract tag1 and tag2 from query string and put in tag filter', () => {
           cy.visit('/hosts?tags=tag1&tags=tag2');
-          cy.get(
-            ':nth-child(4) > .mt-1 > .relative > :nth-child(1) > .ml-3'
-          ).contains('tag1, tag2');
-
-          // clear
-          cy.get('.z-20 > [data-testid="eos-svg-component"]').click();
+          cy.get('[data-testid="filter-Tags"]').contains('tag1, tag2');
         });
       });
     });

--- a/test/e2e/cypress/integration/hosts_overview.js
+++ b/test/e2e/cypress/integration/hosts_overview.js
@@ -175,12 +175,12 @@ context('Hosts Overview', () => {
       before(() => {
         cy.visit('/hosts');
         cy.task('startAgentHeartbeat', [firstHost.id]);
-        cy.get('span').contains('Filter Health').parent().parent().click();
+        cy.get('[data-testid="filter-Health"]').click();
       });
 
       after(() => {
         cy.task('stopAgentsHeartbeat');
-        cy.get('span').contains('Filter Health').parent().parent().click();
+        cy.get('[data-testid="filter-Health"]').click();
       });
 
       it('should only show the passing host when hosts are filtered by only passing entries', () => {
@@ -200,11 +200,11 @@ context('Hosts Overview', () => {
 
     describe('SID', () => {
       before(() => {
-        cy.get('span').contains('Filter SID').parent().parent().click();
+        cy.get('[data-testid="filter-SID"]').click();
       });
 
       after(() => {
-        cy.get('span').contains('Filter SID').parent().parent().click();
+        cy.get('[data-testid="filter-SID"]').click();
       });
 
       ['HDD', 'NWD'].forEach((sid) => {

--- a/test/e2e/cypress/integration/sap_systems_overview.js
+++ b/test/e2e/cypress/integration/sap_systems_overview.js
@@ -213,10 +213,10 @@ context('SAP Systems Overview', () => {
   describe('Filtering the SAP Systems overview', () => {
     describe('Filtering by SIDs', () => {
       before(() => {
-        cy.get('span').contains('Filter SID').parent().parent().click();
+        cy.get('[data-testid="filter-SID"]').click();
       });
       after(() => {
-        cy.get('span').contains('Filter SID').parent().parent().click();
+        cy.get('[data-testid="filter-SID"]').click();
       });
       availableSAPSystems.forEach(({ sid }) => {
         it(`should have SAP Systems ${sid}'`, () => {
@@ -236,10 +236,10 @@ context('SAP Systems Overview', () => {
 
     describe('Filtering by tags', () => {
       before(() => {
-        cy.get('span').contains('Filter Tags').parent().parent().click();
+        cy.get('[data-testid="filter-Tags"]').click();
       });
       after(() => {
-        cy.get('span').contains('Filter Tags').parent().parent().click();
+        cy.get('[data-testid="filter-Tags"]').click();
       });
       availableSAPSystems.forEach(({ sid, tag }) => {
         it(`should have SAP Systems ${sid} tagged with tag '${tag}'`, () => {

--- a/test/e2e/cypress/support/commands.js
+++ b/test/e2e/cypress/support/commands.js
@@ -108,6 +108,19 @@ Cypress.Commands.add('addTagByColumnValue', (columnValue, tagValue) => {
     .parents('tr')
     .within(() => {
       cy.get('span').contains('Add Tag').type(`${tagValue}{enter}`);
+      cy.intercept('POST', '/api/*/*/tags');
+      cy.get('span').contains(tagValue);
+    });
+});
+
+Cypress.Commands.add('resetFilterSelection', (filterName) => {
+  cy.get(`[data-testid="filter-${filterName}"]`)
+    .parent()
+    .within(($filter) => {
+      const resetButton = '[data-testid="eos-svg-component"]';
+      if ($filter.find(resetButton).length > 0) {
+        cy.get(resetButton).click();
+      }
     });
 });
 


### PR DESCRIPTION
# Description
Fix hosts overview tagging test in the e2e  hosts overview suite.
As far as I could debug, the test was not giving enough time to type the last tag and store the data in the backend.

`cy.intercept('POST', '/api/hosts/*/tags');` fixes this (hopefully)

PD: tagging tests continue being inconsistent on the different views where filters are used, but "fixing" those would take much more time
