### PR TITLE
Checks selection from wanda

### DIFF
--- a/assets/js/components/ChecksCatalog/ChecksCatalogNew.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalogNew.jsx
@@ -4,6 +4,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { groupBy } from '@lib/lists';
 
 import { getCatalog } from '@state/selectors/catalog';
+import { dispatchUpdateCatalog } from '@state/actions/catalog';
 import CatalogContainer from './CatalogContainer';
 import CheckItem from './CheckItem';
 
@@ -17,19 +18,12 @@ export const ChecksCatalogNew = () => {
   } = useSelector(getCatalog());
 
   useEffect(() => {
-    dispatchUpdateCatalog();
+    dispatchUpdateCatalog()(dispatch);
   }, [dispatch]);
-
-  const dispatchUpdateCatalog = () => {
-    dispatch({
-      type: 'UPDATE_CATALOG_NEW',
-      payload: {},
-    });
-  };
 
   return (
     <CatalogContainer
-      onRefresh={() => dispatchUpdateCatalog()}
+      onRefresh={() => dispatchUpdateCatalog()(dispatch)}
       isCatalogEmpty={catalogData.length === 0}
       catalogError={catalogError}
       loading={loading}

--- a/assets/js/components/ChecksCatalog/ChecksCatalogNew.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalogNew.jsx
@@ -4,7 +4,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { groupBy } from '@lib/lists';
 
 import { getCatalog } from '@state/selectors/catalog';
-import { dispatchUpdateCatalog } from '@state/actions/catalog';
+import { updateCatalog } from '@state/actions/catalog';
 import CatalogContainer from './CatalogContainer';
 import CheckItem from './CheckItem';
 
@@ -18,12 +18,12 @@ export const ChecksCatalogNew = () => {
   } = useSelector(getCatalog());
 
   useEffect(() => {
-    dispatchUpdateCatalog()(dispatch);
+    dispatch(updateCatalog());
   }, [dispatch]);
 
   return (
     <CatalogContainer
-      onRefresh={() => dispatchUpdateCatalog()(dispatch)}
+      onRefresh={() => dispatch(updateCatalog())}
       isCatalogEmpty={catalogData.length === 0}
       catalogError={catalogError}
       loading={loading}

--- a/assets/js/components/ChecksCatalog/ChecksCatalogNew.test.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalogNew.test.jsx
@@ -20,7 +20,10 @@ describe('ChecksCatalog ChecksCatalogNew component', () => {
     const initialState = {
       catalogNew: { loading: false, data: catalog, error: null },
     };
-    const [statefulCatalog] = withState(<ChecksCatalogNew />, initialState);
+    const [statefulCatalog, store] = withState(
+      <ChecksCatalogNew />,
+      initialState
+    );
 
     await act(async () => renderWithRouter(statefulCatalog));
 
@@ -32,5 +35,14 @@ describe('ChecksCatalog ChecksCatalogNew component', () => {
       let checks = getAllByRole('listitem');
       expect(checks.length).toBe(5);
     }
+
+    const actions = store.getActions();
+    const expectedActions = [
+      {
+        type: 'UPDATE_CATALOG_NEW',
+        payload: {},
+      },
+    ];
+    expect(actions).toEqual(expectedActions);
   });
 });

--- a/assets/js/components/ClusterDetails/ChecksSelectionGroup.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionGroup.jsx
@@ -1,0 +1,91 @@
+import React from 'react';
+
+import classNames from 'classnames';
+
+import { Disclosure, Switch, Transition } from '@headlessui/react';
+
+import { EOS_KEYBOARD_ARROW_RIGHT } from 'eos-icons-react';
+
+const ChecksSelectionGroup = ({
+  children,
+  group,
+  allSelected,
+  someSelected,
+  noneSelected,
+  onChange = () => {},
+}) => {
+  return (
+    <div className="bg-white shadow overflow-hidden sm:rounded-md mb-1">
+      <Disclosure>
+        {({ open }) => (
+          <>
+            <div className="flex hover:bg-gray-100 border-b border-gray-200">
+              <Switch.Group
+                as="div"
+                className="flex items-center hover:bg-white pl-2"
+              >
+                <Switch
+                  checked={allSelected}
+                  className={classNames(
+                    {
+                      'bg-jungle-green-500': allSelected,
+                      'bg-green-300': someSelected,
+                      'bg-gray-200': noneSelected,
+                    },
+                    'tn-check-switch relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer focus:outline-none transition-colors ease-in-out duration-200'
+                  )}
+                  onChange={onChange}
+                >
+                  <span
+                    aria-hidden="true"
+                    className={classNames(
+                      {
+                        'translate-x-5': allSelected,
+                        'translate-x-2.5': someSelected,
+                        'translate-x-0': noneSelected,
+                      },
+                      'inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200'
+                    )}
+                  />
+                </Switch>
+              </Switch.Group>
+              <Disclosure.Button
+                as="div"
+                className="flex justify-between w-full cursor-pointer bg-white px-4 py-5 sm:px-6 hover:bg-gray-100"
+              >
+                <h3 className="tn-check-switch text-lg leading-6 font-medium text-gray-900">
+                  {group}
+                </h3>
+
+                <EOS_KEYBOARD_ARROW_RIGHT
+                  className={`${open ? 'transform rotate-90' : ''}`}
+                />
+              </Disclosure.Button>
+            </div>
+
+            {open && (
+              <div>
+                <Transition
+                  enter="transition duration-100 ease-out"
+                  enterFrom="transform opacity-0"
+                  enterTo="transform opacity-100"
+                  leave="transition duration-100 ease-out"
+                  leaveFrom="transform opacity-100"
+                  leaveTo="transform opacity-0"
+                >
+                  <Disclosure.Panel className="border-none">
+                    <ul role="list" className="divide-y divide-gray-200">
+                      {children}
+                    </ul>
+                  </Disclosure.Panel>
+                </Transition>
+              </div>
+            )}
+          </>
+        )}
+      </Disclosure>
+    </div>
+  );
+};
+
+export default ChecksSelectionGroup;

--- a/assets/js/components/ClusterDetails/ChecksSelectionGroup.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionGroup.jsx
@@ -6,30 +6,28 @@ import { Disclosure, Switch, Transition } from '@headlessui/react';
 
 import { EOS_KEYBOARD_ARROW_RIGHT } from 'eos-icons-react';
 
-export const groupState = {
-  None: 0,
-  Some: 1,
-  All: 2,
-};
+export const NONE_CHECKED = 'none';
+export const SOME_CHECKED = 'some';
+export const ALL_CHECKED = 'all';
 
 const switchClasses = {
-  [groupState.None]: 'bg-gray-200',
-  [groupState.Some]: 'bg-green-300',
-  [groupState.All]: 'bg-jungle-green-500',
+  [NONE_CHECKED]: 'bg-gray-200',
+  [SOME_CHECKED]: 'bg-green-300',
+  [ALL_CHECKED]: 'bg-jungle-green-500',
 };
 
 const translateClasses = {
-  [groupState.None]: 'translate-x-0',
-  [groupState.Some]: 'translate-x-2.5',
-  [groupState.All]: 'translate-x-5',
+  [NONE_CHECKED]: 'translate-x-0',
+  [SOME_CHECKED]: 'translate-x-2.5',
+  [ALL_CHECKED]: 'translate-x-5',
 };
 
-export const allSelected = (selectedState) => selectedState == groupState.All;
+export const allSelected = (selectedState) => selectedState == ALL_CHECKED;
 
 const ChecksSelectionGroup = ({
   children,
   group,
-  selected = groupState.None,
+  selected = NONE_CHECKED,
   onChange = () => {},
 }) => {
   return (

--- a/assets/js/components/ClusterDetails/ChecksSelectionGroup.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionGroup.jsx
@@ -6,12 +6,30 @@ import { Disclosure, Switch, Transition } from '@headlessui/react';
 
 import { EOS_KEYBOARD_ARROW_RIGHT } from 'eos-icons-react';
 
+export const groupState = {
+  None: 0,
+  Some: 1,
+  All: 2,
+};
+
+const switchClasses = {
+  [groupState.None]: 'bg-gray-200',
+  [groupState.Some]: 'bg-green-300',
+  [groupState.All]: 'bg-jungle-green-500',
+};
+
+const translateClasses = {
+  [groupState.None]: 'translate-x-0',
+  [groupState.Some]: 'translate-x-2.5',
+  [groupState.All]: 'translate-x-5',
+};
+
+export const allSelected = (selectedState) => selectedState == groupState.All;
+
 const ChecksSelectionGroup = ({
   children,
   group,
-  allSelected,
-  someSelected,
-  noneSelected,
+  selected = groupState.None,
   onChange = () => {},
 }) => {
   return (
@@ -25,13 +43,9 @@ const ChecksSelectionGroup = ({
                 className="flex items-center hover:bg-white pl-2"
               >
                 <Switch
-                  checked={allSelected}
+                  checked={allSelected(selected)}
                   className={classNames(
-                    {
-                      'bg-jungle-green-500': allSelected,
-                      'bg-green-300': someSelected,
-                      'bg-gray-200': noneSelected,
-                    },
+                    switchClasses[selected],
                     'tn-check-switch relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer focus:outline-none transition-colors ease-in-out duration-200'
                   )}
                   onChange={onChange}
@@ -39,11 +53,7 @@ const ChecksSelectionGroup = ({
                   <span
                     aria-hidden="true"
                     className={classNames(
-                      {
-                        'translate-x-5': allSelected,
-                        'translate-x-2.5': someSelected,
-                        'translate-x-0': noneSelected,
-                      },
+                      translateClasses[selected],
                       'inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200'
                     )}
                   />

--- a/assets/js/components/ClusterDetails/ChecksSelectionGroup.test.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionGroup.test.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+import { screen, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+
+import { renderWithRouter } from '@lib/test-utils';
+
+import ChecksSelectionGroup from './ChecksSelectionGroup';
+
+describe('ClusterDetails ChecksSelectionGroup component', () => {
+  it('should show group with selected state', () => {
+    const group = 'some-group';
+
+    renderWithRouter(<ChecksSelectionGroup group={group} allSelected={true} />);
+
+    expect(screen.getByText(group)).toBeVisible();
+    expect(screen.getByRole('switch')).toBeChecked();
+    expect(
+      screen.getByRole('switch').classList.contains('bg-jungle-green-500')
+    ).toBe(true);
+  });
+
+  it('should show group with some selected state', () => {
+    const group = 'some-group';
+
+    renderWithRouter(
+      <ChecksSelectionGroup
+        group={group}
+        allSelected={false}
+        someSelected={true}
+        noneSelected={false}
+      />
+    );
+
+    expect(screen.getByText(group)).toBeVisible();
+    expect(screen.getByRole('switch')).not.toBeChecked();
+    expect(screen.getByRole('switch').classList.contains('bg-green-300')).toBe(
+      true
+    );
+  });
+
+  it('should show group with none selected state', () => {
+    const group = 'some-group';
+
+    renderWithRouter(
+      <ChecksSelectionGroup
+        group={group}
+        allSelected={false}
+        someSelected={false}
+        noneSelected={true}
+      />
+    );
+
+    expect(screen.getByText(group)).toBeVisible();
+    expect(screen.getByRole('switch')).not.toBeChecked();
+    expect(screen.getByRole('switch').classList.contains('bg-gray-200')).toBe(
+      true
+    );
+  });
+
+  it('should show children checks when the group row is clicked', () => {
+    const group = 'some-group';
+
+    renderWithRouter(
+      <ChecksSelectionGroup group={group}>{[0,1,2].map(({value}, idx) =>
+        <li key={idx}>{value}</li>)}</ChecksSelectionGroup>
+    );
+
+    userEvent.click(screen.getByRole('heading').parentNode);
+    const groupItem = screen.getAllByRole('list');
+    expect(groupItem.length).toBe(1);
+
+    const { getAllByRole } = within(groupItem[0]);
+    const checkItems = getAllByRole('listitem');
+    expect(checkItems.length).toBe(3);
+  });
+});

--- a/assets/js/components/ClusterDetails/ChecksSelectionGroup.test.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionGroup.test.jsx
@@ -6,14 +6,18 @@ import userEvent from '@testing-library/user-event';
 
 import { renderWithRouter } from '@lib/test-utils';
 
-import ChecksSelectionGroup, { groupState } from './ChecksSelectionGroup';
+import ChecksSelectionGroup, {
+  NONE_CHECKED,
+  SOME_CHECKED,
+  ALL_CHECKED,
+} from './ChecksSelectionGroup';
 
 describe('ClusterDetails ChecksSelectionGroup component', () => {
   it('should show group with selected state', () => {
     const group = 'some-group';
 
     renderWithRouter(
-      <ChecksSelectionGroup group={group} selected={groupState.All} />
+      <ChecksSelectionGroup group={group} selected={ALL_CHECKED} />
     );
 
     expect(screen.getByText(group)).toBeVisible();
@@ -27,7 +31,7 @@ describe('ClusterDetails ChecksSelectionGroup component', () => {
     const group = 'some-group';
 
     renderWithRouter(
-      <ChecksSelectionGroup group={group} selected={groupState.Some} />
+      <ChecksSelectionGroup group={group} selected={SOME_CHECKED} />
     );
 
     expect(screen.getByText(group)).toBeVisible();
@@ -41,7 +45,7 @@ describe('ClusterDetails ChecksSelectionGroup component', () => {
     const group = 'some-group';
 
     renderWithRouter(
-      <ChecksSelectionGroup group={group} selected={groupState.None} />
+      <ChecksSelectionGroup group={group} selected={NONE_CHECKED} />
     );
 
     expect(screen.getByText(group)).toBeVisible();

--- a/assets/js/components/ClusterDetails/ChecksSelectionGroup.test.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionGroup.test.jsx
@@ -6,13 +6,15 @@ import userEvent from '@testing-library/user-event';
 
 import { renderWithRouter } from '@lib/test-utils';
 
-import ChecksSelectionGroup from './ChecksSelectionGroup';
+import ChecksSelectionGroup, { groupState } from './ChecksSelectionGroup';
 
 describe('ClusterDetails ChecksSelectionGroup component', () => {
   it('should show group with selected state', () => {
     const group = 'some-group';
 
-    renderWithRouter(<ChecksSelectionGroup group={group} allSelected={true} />);
+    renderWithRouter(
+      <ChecksSelectionGroup group={group} selected={groupState.All} />
+    );
 
     expect(screen.getByText(group)).toBeVisible();
     expect(screen.getByRole('switch')).toBeChecked();
@@ -25,12 +27,7 @@ describe('ClusterDetails ChecksSelectionGroup component', () => {
     const group = 'some-group';
 
     renderWithRouter(
-      <ChecksSelectionGroup
-        group={group}
-        allSelected={false}
-        someSelected={true}
-        noneSelected={false}
-      />
+      <ChecksSelectionGroup group={group} selected={groupState.Some} />
     );
 
     expect(screen.getByText(group)).toBeVisible();
@@ -44,12 +41,7 @@ describe('ClusterDetails ChecksSelectionGroup component', () => {
     const group = 'some-group';
 
     renderWithRouter(
-      <ChecksSelectionGroup
-        group={group}
-        allSelected={false}
-        someSelected={false}
-        noneSelected={true}
-      />
+      <ChecksSelectionGroup group={group} selected={groupState.None} />
     );
 
     expect(screen.getByText(group)).toBeVisible();

--- a/assets/js/components/ClusterDetails/ChecksSelectionGroup.test.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionGroup.test.jsx
@@ -78,4 +78,16 @@ describe('ClusterDetails ChecksSelectionGroup component', () => {
     const checkItems = getAllByRole('listitem');
     expect(checkItems.length).toBe(3);
   });
+
+  it('should run the onChange function when the switch button is clicked', () => {
+    const group = 'some-group';
+    const onChangeMock = jest.fn();
+
+    renderWithRouter(
+      <ChecksSelectionGroup group={group} onChange={onChangeMock} />
+    );
+
+    userEvent.click(screen.getByRole('switch'));
+    expect(onChangeMock).toBeCalled();
+  });
 });

--- a/assets/js/components/ClusterDetails/ChecksSelectionGroup.test.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionGroup.test.jsx
@@ -63,8 +63,11 @@ describe('ClusterDetails ChecksSelectionGroup component', () => {
     const group = 'some-group';
 
     renderWithRouter(
-      <ChecksSelectionGroup group={group}>{[0,1,2].map(({value}, idx) =>
-        <li key={idx}>{value}</li>)}</ChecksSelectionGroup>
+      <ChecksSelectionGroup group={group}>
+        {[0, 1, 2].map(({ value }, idx) => (
+          <li key={idx}>{value}</li>
+        ))}
+      </ChecksSelectionGroup>
     );
 
     userEvent.click(screen.getByRole('heading').parentNode);

--- a/assets/js/components/ClusterDetails/ChecksSelectionItem.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionItem.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+import { Switch } from '@headlessui/react';
+
+import classNames from 'classnames';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+export const ChecksSelectionItem = ({
+  checkID,
+  name,
+  description,
+  isSelected,
+  onChange = () => {},
+}) => {
+  return (
+    <li>
+      <a className="block hover:bg-gray-50">
+        <div className="px-4 py-4 sm:px-6">
+          <div className="flex items-center">
+            <p className="text-sm font-medium">{name}</p>
+            <p className="ml-2 px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+              {checkID}
+            </p>
+          </div>
+          <div className="mt-2 sm:flex sm:justify-between">
+            <div className="sm:flex">
+              <ReactMarkdown className="markdown" remarkPlugins={[remarkGfm]}>
+                {description}
+              </ReactMarkdown>
+            </div>
+            <Switch.Group as="div" className="flex items-center">
+              <Switch
+                checked={isSelected}
+                className={classNames(
+                  isSelected ? 'bg-jungle-green-500' : 'bg-gray-200',
+                  'relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer focus:outline-none transition-colors ease-in-out duration-200'
+                )}
+                onChange={onChange}
+              >
+                <span
+                  aria-hidden="true"
+                  className={classNames(
+                    isSelected ? 'translate-x-5' : 'translate-x-0',
+                    'inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200'
+                  )}
+                />
+              </Switch>
+            </Switch.Group>
+          </div>
+        </div>
+      </a>
+    </li>
+  );
+};

--- a/assets/js/components/ClusterDetails/ChecksSelectionItem.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionItem.jsx
@@ -33,7 +33,7 @@ const ChecksSelectionItem = ({
               <Switch
                 checked={selected}
                 className={classNames(
-                  selected ? 'bg-jungle-green-500' : 'bg-gray-200',
+                  { 'bg-jungle-green-500': selected, 'bg-gray-200': !selected },
                   'relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer focus:outline-none transition-colors ease-in-out duration-200'
                 )}
                 onChange={onChange}
@@ -41,7 +41,7 @@ const ChecksSelectionItem = ({
                 <span
                   aria-hidden="true"
                   className={classNames(
-                    selected ? 'translate-x-5' : 'translate-x-0',
+                    { 'translate-x-5': selected, 'translate-x-0': !selected },
                     'inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200'
                   )}
                 />

--- a/assets/js/components/ClusterDetails/ChecksSelectionItem.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionItem.jsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
-export const ChecksSelectionItem = ({
+const ChecksSelectionItem = ({
   checkID,
   name,
   description,
@@ -53,3 +53,5 @@ export const ChecksSelectionItem = ({
     </li>
   );
 };
+
+export default ChecksSelectionItem;

--- a/assets/js/components/ClusterDetails/ChecksSelectionItem.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionItem.jsx
@@ -10,7 +10,7 @@ const ChecksSelectionItem = ({
   checkID,
   name,
   description,
-  isSelected,
+  selected,
   onChange = () => {},
 }) => {
   return (
@@ -31,9 +31,9 @@ const ChecksSelectionItem = ({
             </div>
             <Switch.Group as="div" className="flex items-center">
               <Switch
-                checked={isSelected}
+                checked={selected}
                 className={classNames(
-                  isSelected ? 'bg-jungle-green-500' : 'bg-gray-200',
+                  selected ? 'bg-jungle-green-500' : 'bg-gray-200',
                   'relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer focus:outline-none transition-colors ease-in-out duration-200'
                 )}
                 onChange={onChange}
@@ -41,7 +41,7 @@ const ChecksSelectionItem = ({
                 <span
                   aria-hidden="true"
                   className={classNames(
-                    isSelected ? 'translate-x-5' : 'translate-x-0',
+                    selected ? 'translate-x-5' : 'translate-x-0',
                     'inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200'
                   )}
                 />

--- a/assets/js/components/ClusterDetails/ChecksSelectionItem.test.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionItem.test.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+
+import { renderWithRouter } from '@lib/test-utils';
+import { catalogCheckFactory } from '@lib/test-utils/factories';
+
+import { ChecksSelectionItem } from './ChecksSelectionItem';
+
+describe('ClusterDetails ChecksSelectionItem component', () => {
+  it('should show check with selected state', () => {
+    const check = catalogCheckFactory.build();
+
+    renderWithRouter(
+      <ChecksSelectionItem
+        key={check.id}
+        checkID={check.id}
+        name={check.name}
+        description={check.description}
+        isSelected={true}
+      />
+    );
+
+    expect(screen.getByText(check.id)).toBeVisible();
+    expect(screen.getByText(check.name)).toBeVisible();
+    expect(screen.getByText(check.description)).toBeVisible();
+    expect(screen.getByRole('switch')).toBeChecked();
+  });
+
+  it('should show check with unselected state', () => {
+    const check = catalogCheckFactory.build();
+
+    renderWithRouter(
+      <ChecksSelectionItem
+        key={check.id}
+        checkID={check.id}
+        name={check.name}
+        description={check.description}
+        isSelected={false}
+      />
+    );
+
+    expect(screen.getByRole('switch')).not.toBeChecked();
+  });
+
+  it('should run the onChange function when the switch button is clicked', () => {
+    const check = catalogCheckFactory.build();
+    const onChangeMock = jest.fn();
+
+    renderWithRouter(
+      <ChecksSelectionItem
+        key={check.id}
+        checkID={check.id}
+        name={check.name}
+        description={check.description}
+        isSelected={true}
+        onChange={onChangeMock}
+      />
+    );
+
+    userEvent.click(screen.getByRole('switch'));
+    expect(onChangeMock).toBeCalled();
+  });
+});

--- a/assets/js/components/ClusterDetails/ChecksSelectionItem.test.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionItem.test.jsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { renderWithRouter } from '@lib/test-utils';
 import { catalogCheckFactory } from '@lib/test-utils/factories';
 
-import { ChecksSelectionItem } from './ChecksSelectionItem';
+import ChecksSelectionItem from './ChecksSelectionItem';
 
 describe('ClusterDetails ChecksSelectionItem component', () => {
   it('should show check with selected state', () => {

--- a/assets/js/components/ClusterDetails/ChecksSelectionItem.test.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionItem.test.jsx
@@ -19,7 +19,7 @@ describe('ClusterDetails ChecksSelectionItem component', () => {
         checkID={check.id}
         name={check.name}
         description={check.description}
-        isSelected={true}
+        selected
       />
     );
 
@@ -38,7 +38,7 @@ describe('ClusterDetails ChecksSelectionItem component', () => {
         checkID={check.id}
         name={check.name}
         description={check.description}
-        isSelected={false}
+        selected={false}
       />
     );
 
@@ -55,7 +55,7 @@ describe('ClusterDetails ChecksSelectionItem component', () => {
         checkID={check.id}
         name={check.name}
         description={check.description}
-        isSelected={true}
+        selected
         onChange={onChangeMock}
       />
     );

--- a/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
@@ -1,22 +1,20 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
-import NotificationBox from '../NotificationBox';
-import LoadingBox from '../LoadingBox';
+import axios from 'axios';
 
 import { EOS_ERROR, EOS_LOADING_ANIMATED } from 'eos-icons-react';
-import { remove, uniq } from '@lib/lists';
+
+import { remove, uniq, toggle, groupBy } from '@lib/lists';
+
+import NotificationBox from '../NotificationBox';
+import LoadingBox from '../LoadingBox';
 import {
   SavingFailedAlert,
   SuggestTriggeringChecksExecutionAfterSettingsUpdated,
 } from './ClusterSettings';
-
 import ChecksSelectionGroup from './ChecksSelectionGroup';
 import ChecksSelectionItem from './ChecksSelectionItem';
-
-import axios from 'axios';
-
-import { toggle, groupBy } from '@lib/lists';
 
 const wandaURL = process.env.WANDA_URL;
 
@@ -68,6 +66,19 @@ export const ChecksSelectionNew = ({ clusterId, cluster }) => {
     setLocalSavingSuccess(savingSuccess);
   }, [savingError, savingSuccess]);
 
+  useEffect(() => {
+    if (cluster) {
+      setSelectedChecks(cluster.selected_checks ? cluster.selected_checks : []);
+    }
+  }, [cluster?.selected_checks]);
+
+  useEffect(() => {
+    if (loading === true) {
+      setLocalSavingError(null);
+      setLocalSavingSuccess(null);
+    }
+  }, [loading]);
+
   const getCatalog = () => {
     setLoaded(true);
     axios
@@ -85,6 +96,13 @@ export const ChecksSelectionNew = ({ clusterId, cluster }) => {
 
   const isSelected = (checkId) =>
     selectedChecks ? selectedChecks.includes(checkId) : false;
+
+  const dispatchChecksSelected = () => {
+    dispatch({
+      type: 'CHECKS_SELECTED',
+      payload: { checks: selectedChecks, clusterID: clusterId },
+    });
+  };
 
   if (loading) {
     return <LoadingBox text="Loading checks catalog..." />;
@@ -154,12 +172,7 @@ export const ChecksSelectionNew = ({ clusterId, cluster }) => {
       <div className="place-items-end flex">
         <button
           className="flex justify-center items-center bg-jungle-green-500 hover:opacity-75 text-white font-bold py-2 px-4 rounded"
-          onClick={() => {
-            dispatch({
-              type: 'CHECKS_SELECTED',
-              payload: { checks: selectedChecks, clusterID: clusterId },
-            });
-          }}
+          onClick={dispatchChecksSelected}
         >
           {saving ? (
             <span className="px-20">

--- a/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
@@ -122,7 +122,7 @@ const ChecksSelectionNew = ({ clusterId, cluster }) => {
                     checkID={check.id}
                     name={check.name}
                     description={check.description}
-                    isSelected={check.selected}
+                    selected={check.selected}
                     onChange={() => {
                       setSelectedChecks(toggle(check.id, selectedChecks));
                       setLocalSavingSuccess(null);
@@ -136,9 +136,7 @@ const ChecksSelectionNew = ({ clusterId, cluster }) => {
         <div className="place-items-end flex">
           <button
             className="flex justify-center items-center bg-jungle-green-500 hover:opacity-75 text-white font-bold py-2 px-4 rounded"
-            onClick={() =>
-              dispatch(checksSelected(selectedChecks, clusterId))
-            }
+            onClick={() => dispatch(checksSelected(selectedChecks, clusterId))}
           >
             {saving ? (
               <span className="px-20">

--- a/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
@@ -1,24 +1,18 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
-import { Disclosure, Switch, Transition } from '@headlessui/react';
-
 import NotificationBox from '../NotificationBox';
 import LoadingBox from '../LoadingBox';
 
-import {
-  EOS_ERROR,
-  EOS_KEYBOARD_ARROW_RIGHT,
-  EOS_LOADING_ANIMATED,
-} from 'eos-icons-react';
-import classNames from 'classnames';
+import { EOS_ERROR, EOS_LOADING_ANIMATED } from 'eos-icons-react';
 import { remove, uniq } from '@lib/lists';
 import {
   SavingFailedAlert,
   SuggestTriggeringChecksExecutionAfterSettingsUpdated,
 } from './ClusterSettings';
 
-import { ChecksSelectionItem } from './ChecksSelectionItem';
+import ChecksSelectionGroup from './ChecksSelectionGroup';
+import ChecksSelectionItem from './ChecksSelectionItem';
 
 import axios from 'axios';
 
@@ -123,109 +117,37 @@ export const ChecksSelectionNew = ({ clusterId, cluster }) => {
       <div className="pb-4">
         {groupSelection?.map(
           ({ group, checks, allSelected, someSelected, noneSelected }, idx) => (
-            <div
+            <ChecksSelectionGroup
               key={idx}
-              className="bg-white shadow overflow-hidden sm:rounded-md mb-1"
+              group={group}
+              allSelected={allSelected}
+              someSelected={someSelected}
+              noneSelected={noneSelected}
+              onChange={() => {
+                const groupChecks = checks.map((check) => check.id);
+                if (noneSelected || someSelected) {
+                  setSelectedChecks(uniq([...selectedChecks, ...groupChecks]));
+                }
+                if (allSelected) {
+                  setSelectedChecks(remove(groupChecks, selectedChecks));
+                }
+                setLocalSavingSuccess(null);
+              }}
             >
-              <Disclosure>
-                {({ open }) => (
-                  <>
-                    <div className="flex hover:bg-gray-100 border-b border-gray-200">
-                      <Switch.Group
-                        as="div"
-                        className="flex items-center hover:bg-white pl-2"
-                      >
-                        <Switch
-                          checked={allSelected}
-                          className={classNames(
-                            {
-                              'bg-jungle-green-500': allSelected,
-                              'bg-green-300': someSelected,
-                              'bg-gray-200': noneSelected,
-                            },
-                            'tn-check-switch relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer focus:outline-none transition-colors ease-in-out duration-200'
-                          )}
-                          onChange={() => {
-                            const groupChecks = checks.map((check) => check.id);
-                            if (noneSelected || someSelected) {
-                              setSelectedChecks(
-                                uniq([...selectedChecks, ...groupChecks])
-                              );
-                            }
-                            if (allSelected) {
-                              setSelectedChecks(
-                                remove(groupChecks, selectedChecks)
-                              );
-                            }
-                            setLocalSavingSuccess(null);
-                          }}
-                        >
-                          <span
-                            aria-hidden="true"
-                            className={classNames(
-                              {
-                                'translate-x-5': allSelected,
-                                'translate-x-2.5': someSelected,
-                                'translate-x-0': noneSelected,
-                              },
-                              'inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200'
-                            )}
-                          />
-                        </Switch>
-                      </Switch.Group>
-                      <Disclosure.Button
-                        as="div"
-                        className="flex justify-between w-full cursor-pointer bg-white px-4 py-5 sm:px-6 hover:bg-gray-100"
-                      >
-                        <h3 className="tn-check-switch text-lg leading-6 font-medium text-gray-900">
-                          {group}
-                        </h3>
-
-                        <EOS_KEYBOARD_ARROW_RIGHT
-                          className={`${open ? 'transform rotate-90' : ''}`}
-                        />
-                      </Disclosure.Button>
-                    </div>
-
-                    {open && (
-                      <div>
-                        <Transition
-                          enter="transition duration-100 ease-out"
-                          enterFrom="transform opacity-0"
-                          enterTo="transform opacity-100"
-                          leave="transition duration-100 ease-out"
-                          leaveFrom="transform opacity-100"
-                          leaveTo="transform opacity-0"
-                        >
-                          <Disclosure.Panel className="border-none">
-                            <ul
-                              role="list"
-                              className="divide-y divide-gray-200"
-                            >
-                              {checks.map((check) => (
-                                <ChecksSelectionItem
-                                  key={check.id}
-                                  checkID={check.id}
-                                  name={check.name}
-                                  description={check.description}
-                                  isSelected={check.selected}
-                                  onChange={() => {
-                                    setSelectedChecks(
-                                      toggle(check.id, selectedChecks)
-                                    );
-                                    setLocalSavingSuccess(null);
-                                  }}
-                                />
-                              ))}
-                            </ul>
-                          </Disclosure.Panel>
-                        </Transition>
-                      </div>
-                    )}
-                  </>
-                )}
-              </Disclosure>
-            </div>
+              {checks.map((check) => (
+                <ChecksSelectionItem
+                  key={check.id}
+                  checkID={check.id}
+                  name={check.name}
+                  description={check.description}
+                  isSelected={check.selected}
+                  onChange={() => {
+                    setSelectedChecks(toggle(check.id, selectedChecks));
+                    setLocalSavingSuccess(null);
+                  }}
+                />
+              ))}
+            </ChecksSelectionGroup>
           )
         )}
       </div>

--- a/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
@@ -3,18 +3,17 @@ import { useSelector, useDispatch } from 'react-redux';
 
 import axios from 'axios';
 
-import { EOS_ERROR, EOS_LOADING_ANIMATED } from 'eos-icons-react';
+import { EOS_LOADING_ANIMATED } from 'eos-icons-react';
 
 import { remove, uniq, toggle, groupBy } from '@lib/lists';
 
-import NotificationBox from '../NotificationBox';
-import LoadingBox from '../LoadingBox';
 import {
   SavingFailedAlert,
   SuggestTriggeringChecksExecutionAfterSettingsUpdated,
 } from './ClusterSettings';
 import ChecksSelectionGroup from './ChecksSelectionGroup';
 import ChecksSelectionItem from './ChecksSelectionItem';
+import CatalogContainer from '@components/ChecksCatalog/CatalogContainer';
 
 const wandaURL = process.env.WANDA_URL;
 
@@ -104,96 +103,82 @@ export const ChecksSelectionNew = ({ clusterId, cluster }) => {
     });
   };
 
-  if (loading) {
-    return <LoadingBox text="Loading checks catalog..." />;
-  }
-
-  if (catalogError) {
-    return (
-      <NotificationBox
-        icon={<EOS_ERROR className="m-auto" color="red" size="xl" />}
-        text={catalogError}
-        buttonText="Try again"
-        buttonOnClick={getCatalog()}
-      />
-    );
-  }
-
-  if (catalogData.size === 0) {
-    return (
-      <NotificationBox
-        icon={<EOS_ERROR className="m-auto" color="red" size="xl" />}
-        text="Checks catalog is empty."
-        buttonText="Try again"
-        buttonOnClick={getCatalog()}
-      />
-    );
-  }
-
   return (
-    <div>
-      <div className="pb-4">
-        {groupSelection?.map(
-          ({ group, checks, allSelected, someSelected, noneSelected }, idx) => (
-            <ChecksSelectionGroup
-              key={idx}
-              group={group}
-              allSelected={allSelected}
-              someSelected={someSelected}
-              noneSelected={noneSelected}
-              onChange={() => {
-                const groupChecks = checks.map((check) => check.id);
-                if (noneSelected || someSelected) {
-                  setSelectedChecks(uniq([...selectedChecks, ...groupChecks]));
-                }
-                if (allSelected) {
-                  setSelectedChecks(remove(groupChecks, selectedChecks));
-                }
-                setLocalSavingSuccess(null);
-              }}
-            >
-              {checks.map((check) => (
-                <ChecksSelectionItem
-                  key={check.id}
-                  checkID={check.id}
-                  name={check.name}
-                  description={check.description}
-                  isSelected={check.selected}
-                  onChange={() => {
-                    setSelectedChecks(toggle(check.id, selectedChecks));
-                    setLocalSavingSuccess(null);
-                  }}
-                />
-              ))}
-            </ChecksSelectionGroup>
-          )
-        )}
-      </div>
-      <div className="place-items-end flex">
-        <button
-          className="flex justify-center items-center bg-jungle-green-500 hover:opacity-75 text-white font-bold py-2 px-4 rounded"
-          onClick={dispatchChecksSelected}
-        >
-          {saving ? (
-            <span className="px-20">
-              <EOS_LOADING_ANIMATED color="green" size={25} />
-            </span>
-          ) : (
-            'Select Checks for Execution'
+    <CatalogContainer
+      onRefresh={() => getCatalog()}
+      isCatalogEmpty={catalogData.size === 0}
+      catalogError={catalogError}
+      loading={loading}
+    >
+      <div>
+        <div className="pb-4">
+          {groupSelection?.map(
+            (
+              { group, checks, allSelected, someSelected, noneSelected },
+              idx
+            ) => (
+              <ChecksSelectionGroup
+                key={idx}
+                group={group}
+                allSelected={allSelected}
+                someSelected={someSelected}
+                noneSelected={noneSelected}
+                onChange={() => {
+                  const groupChecks = checks.map((check) => check.id);
+                  if (noneSelected || someSelected) {
+                    setSelectedChecks(
+                      uniq([...selectedChecks, ...groupChecks])
+                    );
+                  }
+                  if (allSelected) {
+                    setSelectedChecks(remove(groupChecks, selectedChecks));
+                  }
+                  setLocalSavingSuccess(null);
+                }}
+              >
+                {checks.map((check) => (
+                  <ChecksSelectionItem
+                    key={check.id}
+                    checkID={check.id}
+                    name={check.name}
+                    description={check.description}
+                    isSelected={check.selected}
+                    onChange={() => {
+                      setSelectedChecks(toggle(check.id, selectedChecks));
+                      setLocalSavingSuccess(null);
+                    }}
+                  />
+                ))}
+              </ChecksSelectionGroup>
+            )
           )}
-        </button>
-        {localSavingError && (
-          <SavingFailedAlert onClose={() => setLocalSavingError(null)}>
-            <p>{savingError}</p>
-          </SavingFailedAlert>
-        )}
-        {localSavingSuccess && selectedChecks.length > 0 && (
-          <SuggestTriggeringChecksExecutionAfterSettingsUpdated
-            clusterId={clusterId}
-            onClose={() => setLocalSavingSuccess(null)}
-          />
-        )}
+        </div>
+        <div className="place-items-end flex">
+          <button
+            className="flex justify-center items-center bg-jungle-green-500 hover:opacity-75 text-white font-bold py-2 px-4 rounded"
+            onClick={dispatchChecksSelected}
+          >
+            {saving ? (
+              <span className="px-20">
+                <EOS_LOADING_ANIMATED color="green" size={25} />
+              </span>
+            ) : (
+              'Select Checks for Execution'
+            )}
+          </button>
+          {localSavingError && (
+            <SavingFailedAlert onClose={() => setLocalSavingError(null)}>
+              <p>{savingError}</p>
+            </SavingFailedAlert>
+          )}
+          {localSavingSuccess && selectedChecks.length > 0 && (
+            <SuggestTriggeringChecksExecutionAfterSettingsUpdated
+              clusterId={clusterId}
+              onClose={() => setLocalSavingSuccess(null)}
+            />
+          )}
+        </div>
       </div>
-    </div>
+    </CatalogContainer>
   );
 };

--- a/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
@@ -5,8 +5,8 @@ import { EOS_LOADING_ANIMATED } from 'eos-icons-react';
 
 import { remove, uniq, toggle, groupBy } from '@lib/lists';
 import { getCatalog } from '@state/selectors/catalog';
-import { dispatchUpdateCatalog } from '@state/actions/catalog';
-import { dispatchChecksSelected } from '@state/actions/cluster';
+import { updateCatalog } from '@state/actions/catalog';
+import { checksSelected } from '@state/actions/cluster';
 
 import CatalogContainer from '@components/ChecksCatalog/CatalogContainer';
 import {
@@ -37,7 +37,7 @@ const ChecksSelectionNew = ({ clusterId, cluster }) => {
   const [groupSelection, setGroupSelection] = useState([]);
 
   useEffect(() => {
-    dispatchUpdateCatalog()(dispatch);
+    dispatch(updateCatalog());
   }, [dispatch]);
 
   useEffect(() => {
@@ -85,7 +85,7 @@ const ChecksSelectionNew = ({ clusterId, cluster }) => {
 
   return (
     <CatalogContainer
-      onRefresh={() => dispatchUpdateCatalog()(dispatch)}
+      onRefresh={() => dispatch(updateCatalog())}
       isCatalogEmpty={catalogData.size === 0}
       catalogError={catalogError}
       loading={loading}
@@ -136,10 +136,9 @@ const ChecksSelectionNew = ({ clusterId, cluster }) => {
         <div className="place-items-end flex">
           <button
             className="flex justify-center items-center bg-jungle-green-500 hover:opacity-75 text-white font-bold py-2 px-4 rounded"
-            onClick={() => dispatchChecksSelected(
-              selectedChecks,
-              clusterId
-            )(dispatch)}
+            onClick={() =>
+              dispatch(checksSelected(selectedChecks, clusterId))
+            }
           >
             {saving ? (
               <span className="px-20">

--- a/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
@@ -1,0 +1,308 @@
+import React, { useState, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+import { Disclosure, Switch, Transition } from '@headlessui/react';
+
+import NotificationBox from '../NotificationBox';
+import LoadingBox from '../LoadingBox';
+
+import {
+  EOS_ERROR,
+  EOS_KEYBOARD_ARROW_RIGHT,
+  EOS_LOADING_ANIMATED,
+} from 'eos-icons-react';
+import classNames from 'classnames';
+import { remove, uniq } from '@lib/lists';
+import {
+  SavingFailedAlert,
+  SuggestTriggeringChecksExecutionAfterSettingsUpdated,
+} from './ClusterSettings';
+
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+import axios from 'axios';
+
+import { toggle, groupBy } from '@lib/lists';
+
+const wandaURL = process.env.WANDA_URL;
+
+export const ChecksSelectionNew = ({ clusterId, cluster }) => {
+  const dispatch = useDispatch();
+
+  const [selectedChecks, setSelectedChecks] = useState(
+    cluster ? cluster.selected_checks : []
+  );
+
+  const isSelected = (checkId) =>
+    selectedChecks ? selectedChecks.includes(checkId) : false;
+
+  const [catalogError, setError] = useState(null);
+  const [loading, setLoaded] = useState(true);
+  const [catalogData, setCatalog] = useState({});
+
+  useEffect(() => {
+    getCatalog();
+  }, []);
+
+  const getCatalog = () => {
+    setLoaded(true);
+    axios
+      .get(`${wandaURL}/api/checks/catalog`)
+      .then((catalog) => {
+        setCatalog(groupBy(catalog.data.items, 'group'));
+      })
+      .catch((error) => {
+        setError(error.message);
+      })
+      .finally(() => {
+        setLoaded(false);
+      });
+  };
+
+  const { saving, savingError, savingSuccess } = useSelector(
+    (state) => state.clusterChecksSelection
+  );
+
+  const [localSavingError, setLocalSavingError] = useState(null);
+  const [localSavingSuccess, setLocalSavingSuccess] = useState(null);
+  const [groupSelection, setGroupSelection] = useState([]);
+
+  useEffect(() => {
+    const groupedCheckSelection = Object.entries(catalogData).map(
+      ([group, checks]) => {
+        const groupChecks = checks.map((check) => ({
+          ...check,
+          selected: isSelected(check.id),
+        }));
+        const allSelected = checks.every((check) => isSelected(check.id));
+        const someSelected =
+          !allSelected && checks.some((check) => isSelected(check.id));
+        return {
+          group,
+          checks: groupChecks,
+          allSelected,
+          someSelected,
+          noneSelected: !allSelected && !someSelected,
+        };
+      }
+    );
+    setGroupSelection(groupedCheckSelection);
+  }, [catalogData, selectedChecks]);
+
+  useEffect(() => {
+    setLocalSavingError(savingError);
+    setLocalSavingSuccess(savingSuccess);
+  }, [savingError, savingSuccess]);
+
+  if (loading) {
+    return <LoadingBox text="Loading checks catalog..." />;
+  }
+
+  if (catalogError) {
+    return (
+      <NotificationBox
+        icon={<EOS_ERROR className="m-auto" color="red" size="xl" />}
+        text={catalogError}
+        buttonText="Try again"
+        buttonOnClick={getCatalog()}
+      />
+    );
+  }
+
+  if (catalogData.size === 0) {
+    return (
+      <NotificationBox
+        icon={<EOS_ERROR className="m-auto" color="red" size="xl" />}
+        text="Checks catalog is empty."
+        buttonText="Try again"
+        buttonOnClick={getCatalog()}
+      />
+    );
+  }
+
+  return (
+    <div>
+      <div className="pb-4">
+        {groupSelection?.map(
+          ({ group, checks, allSelected, someSelected, noneSelected }, idx) => (
+            <div
+              key={idx}
+              className="bg-white shadow overflow-hidden sm:rounded-md mb-1"
+            >
+              <Disclosure>
+                {({ open }) => (
+                  <>
+                    <div className="flex hover:bg-gray-100 border-b border-gray-200">
+                      <Switch.Group
+                        as="div"
+                        className="flex items-center hover:bg-white pl-2"
+                      >
+                        <Switch
+                          checked={allSelected}
+                          className={classNames(
+                            {
+                              'bg-jungle-green-500': allSelected,
+                              'bg-green-300': someSelected,
+                              'bg-gray-200': noneSelected,
+                            },
+                            'tn-check-switch relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer focus:outline-none transition-colors ease-in-out duration-200'
+                          )}
+                          onChange={() => {
+                            const groupChecks = checks.map((check) => check.id);
+                            if (noneSelected || someSelected) {
+                              setSelectedChecks(
+                                uniq([...selectedChecks, ...groupChecks])
+                              );
+                            }
+                            if (allSelected) {
+                              setSelectedChecks(
+                                remove(groupChecks, selectedChecks)
+                              );
+                            }
+                            setLocalSavingSuccess(null);
+                          }}
+                        >
+                          <span
+                            aria-hidden="true"
+                            className={classNames(
+                              {
+                                'translate-x-5': allSelected,
+                                'translate-x-2.5': someSelected,
+                                'translate-x-0': noneSelected,
+                              },
+                              'inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200'
+                            )}
+                          />
+                        </Switch>
+                      </Switch.Group>
+                      <Disclosure.Button
+                        as="div"
+                        className="flex justify-between w-full cursor-pointer bg-white px-4 py-5 sm:px-6 hover:bg-gray-100"
+                      >
+                        <h3 className="tn-check-switch text-lg leading-6 font-medium text-gray-900">
+                          {group}
+                        </h3>
+
+                        <EOS_KEYBOARD_ARROW_RIGHT
+                          className={`${open ? 'transform rotate-90' : ''}`}
+                        />
+                      </Disclosure.Button>
+                    </div>
+
+                    {open && (
+                      <div>
+                        <Transition
+                          enter="transition duration-100 ease-out"
+                          enterFrom="transform opacity-0"
+                          enterTo="transform opacity-100"
+                          leave="transition duration-100 ease-out"
+                          leaveFrom="transform opacity-100"
+                          leaveTo="transform opacity-0"
+                        >
+                          <Disclosure.Panel className="border-none">
+                            <ul
+                              role="list"
+                              className="divide-y divide-gray-200"
+                            >
+                              {checks.map((check) => (
+                                <li key={check.id}>
+                                  <a className="block hover:bg-gray-50">
+                                    <div className="px-4 py-4 sm:px-6">
+                                      <div className="flex items-center">
+                                        <p className="text-sm font-medium">
+                                          {check.name}
+                                        </p>
+                                        <p className="ml-2 px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                                          {check.id}
+                                        </p>
+                                      </div>
+                                      <div className="mt-2 sm:flex sm:justify-between">
+                                        <div className="sm:flex">
+                                          <ReactMarkdown
+                                            className="markdown"
+                                            remarkPlugins={[remarkGfm]}
+                                          >
+                                            {check.description}
+                                          </ReactMarkdown>
+                                        </div>
+                                        <Switch.Group
+                                          as="div"
+                                          className="flex items-center"
+                                        >
+                                          <Switch
+                                            checked={check.selected}
+                                            className={classNames(
+                                              isSelected(check.id)
+                                                ? 'bg-jungle-green-500'
+                                                : 'bg-gray-200',
+                                              'relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer focus:outline-none transition-colors ease-in-out duration-200'
+                                            )}
+                                            onChange={() => {
+                                              setSelectedChecks(
+                                                toggle(check.id, selectedChecks)
+                                              );
+                                              setLocalSavingSuccess(null);
+                                            }}
+                                          >
+                                            <span
+                                              aria-hidden="true"
+                                              className={classNames(
+                                                isSelected(check.id)
+                                                  ? 'translate-x-5'
+                                                  : 'translate-x-0',
+                                                'inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200'
+                                              )}
+                                            />
+                                          </Switch>
+                                        </Switch.Group>
+                                      </div>
+                                    </div>
+                                  </a>
+                                </li>
+                              ))}
+                            </ul>
+                          </Disclosure.Panel>
+                        </Transition>
+                      </div>
+                    )}
+                  </>
+                )}
+              </Disclosure>
+            </div>
+          )
+        )}
+      </div>
+      <div className="place-items-end flex">
+        <button
+          className="flex justify-center items-center bg-jungle-green-500 hover:opacity-75 text-white font-bold py-2 px-4 rounded"
+          onClick={() => {
+            dispatch({
+              type: 'CHECKS_SELECTED',
+              payload: { checks: selectedChecks, clusterID: clusterId },
+            });
+          }}
+        >
+          {saving ? (
+            <span className="px-20">
+              <EOS_LOADING_ANIMATED color="green" size={25} />
+            </span>
+          ) : (
+            'Select Checks for Execution'
+          )}
+        </button>
+        {localSavingError && (
+          <SavingFailedAlert onClose={() => setLocalSavingError(null)}>
+            <p>{savingError}</p>
+          </SavingFailedAlert>
+        )}
+        {localSavingSuccess && selectedChecks.length > 0 && (
+          <SuggestTriggeringChecksExecutionAfterSettingsUpdated
+            clusterId={clusterId}
+            onClose={() => setLocalSavingSuccess(null)}
+          />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
@@ -18,8 +18,7 @@ import {
   SuggestTriggeringChecksExecutionAfterSettingsUpdated,
 } from './ClusterSettings';
 
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
+import { ChecksSelectionItem } from './ChecksSelectionItem';
 
 import axios from 'axios';
 
@@ -30,43 +29,23 @@ const wandaURL = process.env.WANDA_URL;
 export const ChecksSelectionNew = ({ clusterId, cluster }) => {
   const dispatch = useDispatch();
 
-  const [selectedChecks, setSelectedChecks] = useState(
-    cluster ? cluster.selected_checks : []
-  );
-
-  const isSelected = (checkId) =>
-    selectedChecks ? selectedChecks.includes(checkId) : false;
-
-  const [catalogError, setError] = useState(null);
-  const [loading, setLoaded] = useState(true);
-  const [catalogData, setCatalog] = useState({});
-
-  useEffect(() => {
-    getCatalog();
-  }, []);
-
-  const getCatalog = () => {
-    setLoaded(true);
-    axios
-      .get(`${wandaURL}/api/checks/catalog`)
-      .then((catalog) => {
-        setCatalog(groupBy(catalog.data.items, 'group'));
-      })
-      .catch((error) => {
-        setError(error.message);
-      })
-      .finally(() => {
-        setLoaded(false);
-      });
-  };
-
   const { saving, savingError, savingSuccess } = useSelector(
     (state) => state.clusterChecksSelection
   );
 
+  const [catalogError, setError] = useState(null);
+  const [loading, setLoaded] = useState(true);
+  const [catalogData, setCatalog] = useState({});
+  const [selectedChecks, setSelectedChecks] = useState(
+    cluster ? cluster.selected_checks : []
+  );
   const [localSavingError, setLocalSavingError] = useState(null);
   const [localSavingSuccess, setLocalSavingSuccess] = useState(null);
   const [groupSelection, setGroupSelection] = useState([]);
+
+  useEffect(() => {
+    getCatalog();
+  }, []);
 
   useEffect(() => {
     const groupedCheckSelection = Object.entries(catalogData).map(
@@ -94,6 +73,24 @@ export const ChecksSelectionNew = ({ clusterId, cluster }) => {
     setLocalSavingError(savingError);
     setLocalSavingSuccess(savingSuccess);
   }, [savingError, savingSuccess]);
+
+  const getCatalog = () => {
+    setLoaded(true);
+    axios
+      .get(`${wandaURL}/api/checks/catalog`)
+      .then((catalog) => {
+        setCatalog(groupBy(catalog.data.items, 'group'));
+      })
+      .catch((error) => {
+        setError(error.message);
+      })
+      .finally(() => {
+        setLoaded(false);
+      });
+  };
+
+  const isSelected = (checkId) =>
+    selectedChecks ? selectedChecks.includes(checkId) : false;
 
   if (loading) {
     return <LoadingBox text="Loading checks catalog..." />;
@@ -206,60 +203,19 @@ export const ChecksSelectionNew = ({ clusterId, cluster }) => {
                               className="divide-y divide-gray-200"
                             >
                               {checks.map((check) => (
-                                <li key={check.id}>
-                                  <a className="block hover:bg-gray-50">
-                                    <div className="px-4 py-4 sm:px-6">
-                                      <div className="flex items-center">
-                                        <p className="text-sm font-medium">
-                                          {check.name}
-                                        </p>
-                                        <p className="ml-2 px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
-                                          {check.id}
-                                        </p>
-                                      </div>
-                                      <div className="mt-2 sm:flex sm:justify-between">
-                                        <div className="sm:flex">
-                                          <ReactMarkdown
-                                            className="markdown"
-                                            remarkPlugins={[remarkGfm]}
-                                          >
-                                            {check.description}
-                                          </ReactMarkdown>
-                                        </div>
-                                        <Switch.Group
-                                          as="div"
-                                          className="flex items-center"
-                                        >
-                                          <Switch
-                                            checked={check.selected}
-                                            className={classNames(
-                                              isSelected(check.id)
-                                                ? 'bg-jungle-green-500'
-                                                : 'bg-gray-200',
-                                              'relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer focus:outline-none transition-colors ease-in-out duration-200'
-                                            )}
-                                            onChange={() => {
-                                              setSelectedChecks(
-                                                toggle(check.id, selectedChecks)
-                                              );
-                                              setLocalSavingSuccess(null);
-                                            }}
-                                          >
-                                            <span
-                                              aria-hidden="true"
-                                              className={classNames(
-                                                isSelected(check.id)
-                                                  ? 'translate-x-5'
-                                                  : 'translate-x-0',
-                                                'inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200'
-                                              )}
-                                            />
-                                          </Switch>
-                                        </Switch.Group>
-                                      </div>
-                                    </div>
-                                  </a>
-                                </li>
+                                <ChecksSelectionItem
+                                  key={check.id}
+                                  checkID={check.id}
+                                  name={check.name}
+                                  description={check.description}
+                                  isSelected={check.selected}
+                                  onChange={() => {
+                                    setSelectedChecks(
+                                      toggle(check.id, selectedChecks)
+                                    );
+                                    setLocalSavingSuccess(null);
+                                  }}
+                                />
                               ))}
                             </ul>
                           </Disclosure.Panel>

--- a/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
@@ -7,17 +7,17 @@ import { EOS_LOADING_ANIMATED } from 'eos-icons-react';
 
 import { remove, uniq, toggle, groupBy } from '@lib/lists';
 
+import CatalogContainer from '@components/ChecksCatalog/CatalogContainer';
 import {
   SavingFailedAlert,
   SuggestTriggeringChecksExecutionAfterSettingsUpdated,
 } from './ClusterSettings';
 import ChecksSelectionGroup from './ChecksSelectionGroup';
 import ChecksSelectionItem from './ChecksSelectionItem';
-import CatalogContainer from '@components/ChecksCatalog/CatalogContainer';
 
 const wandaURL = process.env.WANDA_URL;
 
-export const ChecksSelectionNew = ({ clusterId, cluster }) => {
+const ChecksSelectionNew = ({ clusterId, cluster }) => {
   const dispatch = useDispatch();
 
   const { saving, savingError, savingSuccess } = useSelector(
@@ -182,3 +182,5 @@ export const ChecksSelectionNew = ({ clusterId, cluster }) => {
     </CatalogContainer>
   );
 };
+
+export default ChecksSelectionNew;

--- a/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
@@ -5,6 +5,8 @@ import { EOS_LOADING_ANIMATED } from 'eos-icons-react';
 
 import { remove, uniq, toggle, groupBy } from '@lib/lists';
 import { getCatalog } from '@state/selectors/catalog';
+import { dispatchUpdateCatalog } from '@state/actions/catalog';
+import { dispatchChecksSelected } from '@state/actions/cluster';
 
 import CatalogContainer from '@components/ChecksCatalog/CatalogContainer';
 import {
@@ -35,7 +37,7 @@ const ChecksSelectionNew = ({ clusterId, cluster }) => {
   const [groupSelection, setGroupSelection] = useState([]);
 
   useEffect(() => {
-    dispatchUpdateCatalog();
+    dispatchUpdateCatalog()(dispatch);
   }, [dispatch]);
 
   useEffect(() => {
@@ -81,23 +83,9 @@ const ChecksSelectionNew = ({ clusterId, cluster }) => {
   const isSelected = (checkId) =>
     selectedChecks ? selectedChecks.includes(checkId) : false;
 
-  const dispatchChecksSelected = () => {
-    dispatch({
-      type: 'CHECKS_SELECTED',
-      payload: { checks: selectedChecks, clusterID: clusterId },
-    });
-  };
-
-  const dispatchUpdateCatalog = () => {
-    dispatch({
-      type: 'UPDATE_CATALOG_NEW',
-      payload: {},
-    });
-  };
-
   return (
     <CatalogContainer
-      onRefresh={() => dispatchUpdateCatalog()}
+      onRefresh={() => dispatchUpdateCatalog()(dispatch)}
       isCatalogEmpty={catalogData.size === 0}
       catalogError={catalogError}
       loading={loading}
@@ -148,7 +136,10 @@ const ChecksSelectionNew = ({ clusterId, cluster }) => {
         <div className="place-items-end flex">
           <button
             className="flex justify-center items-center bg-jungle-green-500 hover:opacity-75 text-white font-bold py-2 px-4 rounded"
-            onClick={dispatchChecksSelected}
+            onClick={() => dispatchChecksSelected(
+              selectedChecks,
+              clusterId
+            )(dispatch)}
           >
             {saving ? (
               <span className="px-20">

--- a/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
@@ -14,7 +14,9 @@ import {
   SuggestTriggeringChecksExecutionAfterSettingsUpdated,
 } from './ClusterSettings';
 import ChecksSelectionGroup, {
-  groupState,
+  NONE_CHECKED,
+  SOME_CHECKED,
+  ALL_CHECKED,
   allSelected,
 } from './ChecksSelectionGroup';
 import ChecksSelectionItem from './ChecksSelectionItem';
@@ -24,11 +26,11 @@ const isSelected = (selectedChecks, checkID) =>
 
 const getGroupSelectedState = function (checks, selectedChecks) {
   if (checks.every(({ id }) => isSelected(selectedChecks, id))) {
-    return groupState.All;
+    return ALL_CHECKED;
   } else if (checks.some((check) => isSelected(selectedChecks, check.id))) {
-    return groupState.Some;
+    return SOME_CHECKED;
   } else {
-    return groupState.None;
+    return NONE_CHECKED;
   }
 };
 

--- a/assets/js/components/ClusterDetails/ChecksSelectionNew.test.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionNew.test.jsx
@@ -31,10 +31,14 @@ describe('ClusterDetails ChecksSelectionNew component', () => {
     });
 
     await act(async () => {
-      const [StatefulCheckSelection] = withState(
-        <ChecksSelectionNew clusterId={cluster.id} cluster={cluster} />
+      const initialState = {
+        clusterChecksSelection: {},
+      };
+      const [StatefulChecksSelection] = withState(
+        <ChecksSelectionNew clusterId={cluster.id} cluster={cluster} />,
+        initialState
       );
-      renderWithRouter(StatefulCheckSelection);
+      renderWithRouter(StatefulChecksSelection);
     });
 
     const groupItem = await waitFor(() => screen.getByRole('heading'));
@@ -69,10 +73,14 @@ describe('ClusterDetails ChecksSelectionNew component', () => {
     });
 
     await act(async () => {
-      const [StatefulCheckSelection] = withState(
-        <ChecksSelectionNew clusterId={cluster.id} cluster={cluster} />
+      const initialState = {
+        clusterChecksSelection: {},
+      };
+      const [StatefulChecksSelection] = withState(
+        <ChecksSelectionNew clusterId={cluster.id} cluster={cluster} />,
+        initialState
       );
-      renderWithRouter(StatefulCheckSelection);
+      renderWithRouter(StatefulChecksSelection);
     });
 
     const groupItem = await waitFor(() => screen.getByRole('heading'));
@@ -92,5 +100,45 @@ describe('ClusterDetails ChecksSelectionNew component', () => {
     userEvent.click(switches[2]);
 
     expect(switches[0]).not.toBeChecked();
+  });
+
+  it('should dispatch selected checks message when the save button is clicked', async () => {
+    const catalog = catalogCheckFactory.buildList(2);
+    const selectedChecks = [catalog[0].id, catalog[1].id];
+    const cluster = clusterFactory.build({
+      selected_checks: selectedChecks,
+    });
+
+    axiosMock.onGet(`${wandaURL}/api/checks/catalog`).reply(200, {
+      items: catalog,
+    });
+
+    const store = await act(async () => {
+      const initialState = {
+        clusterChecksSelection: {},
+      };
+      const [StatefulChecksSelection, store] = withState(
+        <ChecksSelectionNew clusterId={cluster.id} cluster={cluster} />,
+        initialState
+      );
+      renderWithRouter(StatefulChecksSelection);
+
+      return store;
+    });
+
+    await waitFor(() => screen.getAllByRole('heading'));
+
+    const saveButton = screen.getByRole('button');
+    userEvent.click(saveButton);
+
+    const actions = store.getActions();
+    const expectedPayload = {
+      type: 'CHECKS_SELECTED',
+      payload: {
+        checks: selectedChecks,
+        clusterID: cluster.id,
+      },
+    };
+    expect(actions).toEqual([expectedPayload]);
   });
 });

--- a/assets/js/components/ClusterDetails/ChecksSelectionNew.test.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionNew.test.jsx
@@ -1,0 +1,96 @@
+import React from 'react';
+
+import { screen, act, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { faker } from '@faker-js/faker';
+import { withState, renderWithRouter } from '@lib/test-utils';
+import { catalogCheckFactory, clusterFactory } from '@lib/test-utils/factories';
+
+import ChecksSelectionNew from './ChecksSelectionNew';
+
+const wandaURL = process.env.WANDA_URL;
+
+describe('ClusterDetails ChecksSelectionNew component', () => {
+  const axiosMock = new MockAdapter(axios);
+
+  beforeEach(() => {
+    axiosMock.reset();
+  });
+
+  it('should change individual check switches accordingly if the group switch is clicked', async () => {
+    const group = faker.animal.cat();
+    const catalog = catalogCheckFactory.buildList(2, { group: group });
+    const cluster = clusterFactory.build();
+
+    axiosMock.onGet(`${wandaURL}/api/checks/catalog`).reply(200, {
+      items: catalog,
+    });
+
+    await act(async () => {
+      const [StatefulCheckSelection] = withState(
+        <ChecksSelectionNew clusterId={cluster.id} cluster={cluster} />
+      );
+      renderWithRouter(StatefulCheckSelection);
+    });
+
+    const groupItem = await waitFor(() => screen.getByRole('heading'));
+
+    userEvent.click(groupItem.parentNode);
+    const switches = screen.getAllByRole('switch');
+
+    expect(switches[0]).not.toBeChecked();
+    expect(switches[1]).not.toBeChecked();
+    expect(switches[2]).not.toBeChecked();
+
+    userEvent.click(switches[0]);
+
+    expect(switches[1]).toBeChecked();
+    expect(switches[2]).toBeChecked();
+
+    userEvent.click(switches[0]);
+
+    expect(switches[1]).not.toBeChecked();
+    expect(switches[2]).not.toBeChecked();
+  });
+
+  it('should change group check switch accordingly if the children check switches are clicked', async () => {
+    const group = faker.animal.cat();
+    const catalog = catalogCheckFactory.buildList(2, { group: group });
+    const cluster = clusterFactory.build({
+      selected_checks: [catalog[0].id, catalog[1].id],
+    });
+
+    axiosMock.onGet(`${wandaURL}/api/checks/catalog`).reply(200, {
+      items: catalog,
+    });
+
+    await act(async () => {
+      const [StatefulCheckSelection] = withState(
+        <ChecksSelectionNew clusterId={cluster.id} cluster={cluster} />
+      );
+      renderWithRouter(StatefulCheckSelection);
+    });
+
+    const groupItem = await waitFor(() => screen.getByRole('heading'));
+
+    userEvent.click(groupItem.parentNode);
+    const switches = screen.getAllByRole('switch');
+
+    expect(switches[0]).toBeChecked();
+    expect(switches[1]).toBeChecked();
+    expect(switches[2]).toBeChecked();
+
+    userEvent.click(switches[1]);
+
+    expect(switches[0]).not.toBeChecked();
+    expect(switches[0].classList.contains('bg-green-300')).toBe(true);
+
+    userEvent.click(switches[2]);
+
+    expect(switches[0]).not.toBeChecked();
+  });
+});

--- a/assets/js/components/ClusterDetails/ChecksSelectionNew.test.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionNew.test.jsx
@@ -4,42 +4,28 @@ import { screen, act, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
 import { faker } from '@faker-js/faker';
 import { withState, renderWithRouter } from '@lib/test-utils';
 import { catalogCheckFactory, clusterFactory } from '@lib/test-utils/factories';
 
 import ChecksSelectionNew from './ChecksSelectionNew';
 
-const wandaURL = process.env.WANDA_URL;
-
 describe('ClusterDetails ChecksSelectionNew component', () => {
-  const axiosMock = new MockAdapter(axios);
-
-  beforeEach(() => {
-    axiosMock.reset();
-  });
-
   it('should change individual check switches accordingly if the group switch is clicked', async () => {
     const group = faker.animal.cat();
     const catalog = catalogCheckFactory.buildList(2, { group: group });
     const cluster = clusterFactory.build();
 
-    axiosMock.onGet(`${wandaURL}/api/checks/catalog`).reply(200, {
-      items: catalog,
-    });
+    const initialState = {
+      catalogNew: { loading: false, data: catalog, error: null },
+      clusterChecksSelection: {},
+    };
+    const [statefulChecksSelection] = withState(
+      <ChecksSelectionNew clusterId={cluster.id} cluster={cluster} />,
+      initialState
+    );
 
-    await act(async () => {
-      const initialState = {
-        clusterChecksSelection: {},
-      };
-      const [StatefulChecksSelection] = withState(
-        <ChecksSelectionNew clusterId={cluster.id} cluster={cluster} />,
-        initialState
-      );
-      renderWithRouter(StatefulChecksSelection);
-    });
+    await act(async () => renderWithRouter(statefulChecksSelection));
 
     const groupItem = await waitFor(() => screen.getByRole('heading'));
 
@@ -68,20 +54,16 @@ describe('ClusterDetails ChecksSelectionNew component', () => {
       selected_checks: [catalog[0].id, catalog[1].id],
     });
 
-    axiosMock.onGet(`${wandaURL}/api/checks/catalog`).reply(200, {
-      items: catalog,
-    });
+    const initialState = {
+      catalogNew: { loading: false, data: catalog, error: null },
+      clusterChecksSelection: {},
+    };
+    const [statefulChecksSelection] = withState(
+      <ChecksSelectionNew clusterId={cluster.id} cluster={cluster} />,
+      initialState
+    );
 
-    await act(async () => {
-      const initialState = {
-        clusterChecksSelection: {},
-      };
-      const [StatefulChecksSelection] = withState(
-        <ChecksSelectionNew clusterId={cluster.id} cluster={cluster} />,
-        initialState
-      );
-      renderWithRouter(StatefulChecksSelection);
-    });
+    await act(async () => renderWithRouter(statefulChecksSelection));
 
     const groupItem = await waitFor(() => screen.getByRole('heading'));
 
@@ -109,22 +91,16 @@ describe('ClusterDetails ChecksSelectionNew component', () => {
       selected_checks: selectedChecks,
     });
 
-    axiosMock.onGet(`${wandaURL}/api/checks/catalog`).reply(200, {
-      items: catalog,
-    });
+    const initialState = {
+      catalogNew: { loading: false, data: catalog, error: null },
+      clusterChecksSelection: {},
+    };
+    const [statefulChecksSelection, store] = withState(
+      <ChecksSelectionNew clusterId={cluster.id} cluster={cluster} />,
+      initialState
+    );
 
-    const store = await act(async () => {
-      const initialState = {
-        clusterChecksSelection: {},
-      };
-      const [StatefulChecksSelection, store] = withState(
-        <ChecksSelectionNew clusterId={cluster.id} cluster={cluster} />,
-        initialState
-      );
-      renderWithRouter(StatefulChecksSelection);
-
-      return store;
-    });
+    await act(async () => renderWithRouter(statefulChecksSelection));
 
     await waitFor(() => screen.getAllByRole('heading'));
 
@@ -132,13 +108,19 @@ describe('ClusterDetails ChecksSelectionNew component', () => {
     userEvent.click(saveButton);
 
     const actions = store.getActions();
-    const expectedPayload = {
-      type: 'CHECKS_SELECTED',
-      payload: {
-        checks: selectedChecks,
-        clusterID: cluster.id,
+    const expectedActions = [
+      {
+        type: 'UPDATE_CATALOG_NEW',
+        payload: {},
       },
-    };
-    expect(actions).toEqual([expectedPayload]);
+      {
+        type: 'CHECKS_SELECTED',
+        payload: {
+          checks: selectedChecks,
+          clusterID: cluster.id,
+        },
+      },
+    ];
+    expect(actions).toEqual(expectedActions);
   });
 });

--- a/assets/js/components/ClusterDetails/ChecksSelectionNew.test.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionNew.test.jsx
@@ -121,6 +121,6 @@ describe('ClusterDetails ChecksSelectionNew component', () => {
         },
       },
     ];
-    expect(actions).toEqual(expectedActions);
+    expect(actions).toEqual(expect.arrayContaining(expectedActions));
   });
 });

--- a/assets/js/components/ClusterDetails/ClusterSettings.jsx
+++ b/assets/js/components/ClusterDetails/ClusterSettings.jsx
@@ -31,6 +31,10 @@ export const ClusterSettings = () => {
     ),
   };
 
+  if (!cluster) {
+    return <div>Loading...</div>;
+  }
+
   return (
     <div className="w-full px-2 sm:px-0">
       <BackButton url={`/clusters/${clusterID}`}>

--- a/assets/js/components/ClusterDetails/ClusterSettings.jsx
+++ b/assets/js/components/ClusterDetails/ClusterSettings.jsx
@@ -8,6 +8,7 @@ import classNames from 'classnames';
 import BackButton from '@components/BackButton';
 import { Tab } from '@headlessui/react';
 import { ChecksSelection } from '@components/ClusterDetails/ChecksSelection';
+import ChecksSelectionNew from '@components/ClusterDetails/ChecksSelectionNew';
 import { getCluster } from '@state/selectors';
 import TriggerChecksExecutionRequest from '@components/TriggerChecksExecutionRequest';
 import { truncatedClusterNameClasses } from './ClusterDetails';
@@ -17,13 +18,15 @@ import { ConnectionSettings, ClusterInfoBox } from '@components/ClusterDetails';
 
 export const UNKNOWN_PROVIDER = 'unknown';
 
-export const ClusterSettings = () => {
+export const ClusterSettings = ({ newChecksSelectionView = false }) => {
   const { clusterID } = useParams();
 
   const cluster = useSelector(getCluster(clusterID));
 
   const tabsSettings = {
-    'Checks Selection': (
+    'Checks Selection': newChecksSelectionView ? (
+      <ChecksSelectionNew clusterId={clusterID} cluster={cluster} />
+    ) : (
       <ChecksSelection clusterId={clusterID} cluster={cluster} />
     ),
     'Connection Settings': (

--- a/assets/js/lib/test-utils/factories.js
+++ b/assets/js/lib/test-utils/factories.js
@@ -97,4 +97,4 @@ export const aboutFactory = Factory.define(() => ({
 export const clusterFactory = Factory.define(() => ({
   id: faker.datatype.uuid(),
   selected_checks: [],
-})); 
+}));

--- a/assets/js/lib/test-utils/factories.js
+++ b/assets/js/lib/test-utils/factories.js
@@ -93,3 +93,8 @@ export const aboutFactory = Factory.define(() => ({
   sles_subscriptions: faker.datatype.number(),
   version: faker.system.networkInterface(),
 }));
+
+export const clusterFactory = Factory.define(() => ({
+  id: faker.datatype.uuid(),
+  selected_checks: [],
+})); 

--- a/assets/js/state/actions/catalog.js
+++ b/assets/js/state/actions/catalog.js
@@ -1,0 +1,8 @@
+export const updateCatalogAction = 'UPDATE_CATALOG_NEW';
+
+export const dispatchUpdateCatalog = () => (dispatch) => {
+  dispatch({
+    type: updateCatalogAction,
+    payload: {},
+  });
+};

--- a/assets/js/state/actions/catalog.js
+++ b/assets/js/state/actions/catalog.js
@@ -1,8 +1,8 @@
 export const updateCatalogAction = 'UPDATE_CATALOG_NEW';
 
-export const dispatchUpdateCatalog = () => (dispatch) => {
-  dispatch({
+export const updateCatalog = () => {
+  return {
     type: updateCatalogAction,
     payload: {},
-  });
+  };
 };

--- a/assets/js/state/actions/cluster.js
+++ b/assets/js/state/actions/cluster.js
@@ -1,0 +1,9 @@
+export const checksSelectedAction = 'CHECKS_SELECTED';
+
+export const dispatchChecksSelected =
+  (selectedChecks, clusterID) => (dispatch) => {
+    dispatch({
+      type: checksSelectedAction,
+      payload: { checks: selectedChecks, clusterID: clusterID },
+    });
+  };

--- a/assets/js/state/actions/cluster.js
+++ b/assets/js/state/actions/cluster.js
@@ -1,9 +1,8 @@
 export const checksSelectedAction = 'CHECKS_SELECTED';
 
-export const dispatchChecksSelected =
-  (selectedChecks, clusterID) => (dispatch) => {
-    dispatch({
-      type: checksSelectedAction,
-      payload: { checks: selectedChecks, clusterID: clusterID },
-    });
+export const checksSelected = (selectedChecks, clusterID) => {
+  return {
+    type: checksSelectedAction,
+    payload: { checks: selectedChecks, clusterID: clusterID },
   };
+};

--- a/assets/js/state/sagas/catalog.js
+++ b/assets/js/state/sagas/catalog.js
@@ -1,5 +1,6 @@
 import { put, call, takeEvery } from 'redux-saga/effects';
 import { getCatalog } from '@lib/api/wanda';
+import { updateCatalogAction } from '@state/actions/catalog';
 
 import {
   setCatalogLoading,
@@ -18,5 +19,5 @@ export function* updateCatalog() {
 }
 
 export function* watchCatalogUpdateNew() {
-  yield takeEvery('UPDATE_CATALOG_NEW', updateCatalog);
+  yield takeEvery(updateCatalogAction, updateCatalog);
 }

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -88,6 +88,8 @@ import {
 } from '@state/clusterChecksSelection';
 import { setClusterConnectionSettingsSavingSuccess } from '@state/clusterConnectionSettings';
 
+import { checksSelectedAction } from '@state/actions/cluster';
+
 const notify = ({ text, icon }) => ({
   type: 'NOTIFICATION',
   payload: { text, icon },
@@ -273,7 +275,7 @@ function* checksSelected({ payload }) {
 }
 
 function* watchChecksSelected() {
-  yield takeEvery('CHECKS_SELECTED', checksSelected);
+  yield takeEvery(checksSelectedAction, checksSelected);
 }
 
 function* requestChecksExecution({ payload }) {

--- a/assets/js/trento.jsx
+++ b/assets/js/trento.jsx
@@ -58,6 +58,10 @@ const App = () => {
                 element={<ClusterSettings />}
               />
               <Route
+                path="clusters/:clusterID/settings_new"
+                element={<ClusterSettings newChecksSelectionView={true} />}
+              />
+              <Route
                 path="clusters/:clusterID/checks/results"
                 element={<ChecksResults />}
               />


### PR DESCRIPTION
# Description
Replace current checks selection view to use data coming from wanda.
Almost the complete work consists on having the checks selection view components in smaller pieces, beforehand everything was a unique view.
Besides that, I have introduced in the last commit the concept of  `actions` in a new folder. There, we can have the actions and their constants defined and reuse the dispatched actions. I think we should do this for all the logical components at some point, at the moment where we do the folder/file restructure

## How was this tested?
Tests added
