### PR TITLE
Document SAP system aggregate

### DIFF
--- a/lib/trento/domain/sap_system/commands/register_application_instance.ex
+++ b/lib/trento/domain/sap_system/commands/register_application_instance.ex
@@ -1,6 +1,16 @@
 defmodule Trento.Domain.Commands.RegisterApplicationInstance do
   @moduledoc """
   Register an application instance to the monitoring system.
+
+  In order to register an application instance a database entry associated to this application
+  must be already registered.
+
+  The database/application association consists of having:
+  - the application instance `tenant` field matching with an already registered database instance `tenant`
+  - the application `db_host` field matching with one of the IP addresses of the host where this database is running
+
+  Find the association protocol code [here](https://github.com/trento-project/web/blob/main/lib/trento/application/integration/discovery/protocol/enrich_register_application_instance.ex)
+  as reference.
   """
 
   @required_fields [

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -6,7 +6,7 @@ defmodule Trento.Domain.SapSystem do
 
   In order to have a fully registered SAP system, both the database and application
   composing this system must be registered. And each of the two layers might be composed
-  by multiple instances altogether. This means that a SAP system aggregate stream can have
+  by multiple instances altogether. This means that a SAP system aggregate state can have
   multiple application/database instances.
 
   ## SAP instance
@@ -29,7 +29,7 @@ defmodule Trento.Domain.SapSystem do
   That being said, this is the logical order of events in order to register a full system:
 
   1. A SAP system discovery message with a new database instance is received. At this point, the
-     registration process starts and the database stream is registered.
+     registration process starts and the database is registered.
      Any application instance discovery message without an associated database is ignored.
   2. New database instances/updates coming from already registered database instances are registered/applied.
   3. A SAP system discovery with a new application instance is received, and the database associated to

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -2,7 +2,7 @@ defmodule Trento.Domain.SapSystem do
   @moduledoc """
   The SAP system aggregate manages all the domain logic related to
   deployed SAP systems, which are composed by a database and application layers.
-  **The HANA database is the unique supported database type.**
+  **The HANA database is the only supported database type.**
 
   In order to have a fully registered SAP system, both the database and application
   composing this system must be registered. And each of the two layers might be composed
@@ -11,16 +11,16 @@ defmodule Trento.Domain.SapSystem do
 
   ## SAP instance
 
-  A SAP instance can be understood as a single SAP workload installation running in a
-  particular host. So the instance runs entirely in one host, but in the other hand
+  A SAP instance can be seen as a single SAP workload installation running in a
+  particular host. So the instance runs entirely in one host, but on the other hand
   multiple different SAP instances might be running in the same host.
 
   For example, a HANA database might be composed by two database instances
-  that are working together in a System replication scenario.
+  that are working together in a System Replication scenario.
 
   ## SAP system registration process
 
-  The SAP system registration process have some caveats, so let's see them in more details.
+  The SAP system registration process has some caveats, so let's see them in more details.
 
   As a main concept, the SAP system is uniquely identified by the database ID. This means that
   there cannot exist any SAP system without a database, so Trento agents must be running

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -1,5 +1,44 @@
 defmodule Trento.Domain.SapSystem do
-  @moduledoc false
+  @moduledoc """
+  The SAP system aggregate manages all the domain logic related to
+  deployed SAP systems, which are composed by a database and application layers.
+  **The HANA database is the unique supported database type.**
+
+  In order to have a fully registered SAP system, both the database and application
+  composing this system must be registered. And each of the two layers might be composed
+  by multiple instances altogether. This means that a SAP system aggregate stream can have
+  multiple application/database instances.
+
+  ## SAP instance
+
+  A SAP instance can be understood as a single SAP workload installation running in a
+  particular host. So the instance runs entirely in one host, but in the other hand
+  multiple different SAP instances might be running in the same host.
+
+  For example, a HANA database might be composed by two database instances
+  that are working together in a System replication scenario.
+
+  ## SAP system registration process
+
+  The SAP system registration process have some caveats, so let's see them in more details.
+
+  As a main concept, the SAP system is uniquely identified by the database ID. This means that
+  there cannot exist any SAP system without a database, so Trento agents must be running
+  in those hosts in order to start the registration.
+
+  That being said, this is the logical order of events in order to register a full system:
+
+  1. A SAP system discovery message with a new database instance is received. At this point, the
+     registration process starts and the database stream is registered.
+     Any application instance discovery message without an associated database is ignored.
+  2. New database instances/updates coming from already registered database instances are registered/applied.
+  3. A SAP system discovery with a new application instance is received, and the database associated to
+     this application exists, the application instance is registered together with the complete
+     SAP system. The SAP system is fully registered now.
+  4. New application instances/updates coming from already registered application instances are registered/applied.
+
+  Find additional information about the application/database association in `Trento.Domain.Commands.RegisterApplicationInstance`.
+  """
 
   require Trento.Domain.Enums.Health, as: Health
 


### PR DESCRIPTION
Document SAP system aggregate code. I have included some additional documentation in the SAP application instance registering command, to explain how the application and database are associated.
This part of the code is a bit hidden, but I hope the new docs help a bit on that.

PD: We cannot put docs in the protocol code as it is a `defimpl`, that's why it goes in the register command, which at the end looks an appropriate place
