### PR TITLE
Add HA scenario & provider to `Cluster Checks Results` & `Cluster Settings` views

### DIFF
--- a/assets/js/components/ChecksResults/ChecksResults.jsx
+++ b/assets/js/components/ChecksResults/ChecksResults.jsx
@@ -29,6 +29,7 @@ import {
   sortHosts,
   sortChecks,
 } from './checksUtils';
+import { ClusterInfoBox } from '@components/ClusterDetails';
 
 const truncatedClusterNameClasses =
   'font-bold truncate w-60 inline-block align-top';
@@ -112,6 +113,7 @@ const ChecksResults = () => {
           use results with caution
         </WarningBanner>
       )}
+      <ClusterInfoBox haScenario={cluster.type} provider={cluster.provider} />
       <ResultsContainer
         catalogError={catalogError}
         clusterID={clusterID}

--- a/assets/js/components/ClusterDetails/ClusterInfoBox.jsx
+++ b/assets/js/components/ClusterDetails/ClusterInfoBox.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import ListView from '@components/ListView';
+import ProviderLabel from './ProviderLabel';
+
+const haScenarioToString = {
+  hana_scale_up: 'HANA scale-up',
+  hana_scale_out: 'HANA scale-out',
+};
+
+export const ClusterInfoBox = ({ haScenario, provider }) => (
+  <div className="tn-cluster-details w-full my-4 mr-4 bg-white shadow rounded-lg px-8 py-8">
+    <ListView
+      className="grid-flow-row"
+      titleClassName="text-lg"
+      orientation="vertical"
+      data={[
+        {
+          title: 'HA Scenario',
+          content: haScenarioToString[haScenario] ?? 'Unknown',
+        },
+        {
+          title: 'Provider',
+          content: provider,
+          render: (content) => <ProviderLabel provider={content} />,
+        },
+      ]}
+    />
+  </div>
+);

--- a/assets/js/components/ClusterDetails/ClusterInfoBox.test.jsx
+++ b/assets/js/components/ClusterDetails/ClusterInfoBox.test.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ClusterInfoBox } from './ClusterInfoBox';
+
+describe('Cluster Info Box', () => {
+  [
+    {
+      haScenario: 'hana_scale_up',
+      haScenarioText: 'HANA scale-up',
+      provider: 'aws',
+      providerText: 'AWS',
+    },
+    {
+      haScenario: 'hana_scale_out',
+      haScenarioText: 'HANA scale-out',
+      provider: 'aws',
+      providerText: 'AWS',
+    },
+    {
+      haScenario: 'hana_scale_up',
+      haScenarioText: 'HANA scale-up',
+      provider: 'azure',
+      providerText: 'Azure',
+    },
+    {
+      haScenario: '',
+      haScenarioText: 'Unknown',
+      provider: 'gcp',
+      providerText: 'GCP',
+    },
+    {
+      haScenario: 'unknown',
+      haScenarioText: 'Unknown',
+      provider: 'kvm',
+      providerText: 'KVM',
+    },
+    {
+      haScenario: 'hana_scale_up',
+      haScenarioText: 'HANA scale-up',
+      provider: 'nutanix',
+      providerText: 'Nutanix',
+    },
+  ].forEach(({ haScenario, haScenarioText, provider, providerText }) => {
+    it(`should display ${providerText} as the provider and HA Scenario: ${haScenarioText}`, () => {
+      const { getByText } = render(
+        <ClusterInfoBox haScenario={haScenario} provider={provider} />
+      );
+      expect(getByText(providerText)).toBeTruthy();
+      expect(getByText(haScenarioText)).toBeTruthy();
+    });
+  });
+});

--- a/assets/js/components/ClusterDetails/ClusterSettings.jsx
+++ b/assets/js/components/ClusterDetails/ClusterSettings.jsx
@@ -8,12 +8,12 @@ import classNames from 'classnames';
 import BackButton from '@components/BackButton';
 import { Tab } from '@headlessui/react';
 import { ChecksSelection } from '@components/ClusterDetails/ChecksSelection';
-import { ConnectionSettings } from '@components/ClusterDetails/ConnectionSettings';
 import { getCluster } from '@state/selectors';
 import TriggerChecksExecutionRequest from '@components/TriggerChecksExecutionRequest';
 import { truncatedClusterNameClasses } from './ClusterDetails';
 import { getClusterName } from '@components/ClusterLink';
 import WarningBanner from '@components/Banners/WarningBanner';
+import { ConnectionSettings, ClusterInfoBox } from '@components/ClusterDetails';
 
 export const UNKNOWN_PROVIDER = 'unknown';
 
@@ -63,6 +63,7 @@ export const ClusterSettings = () => {
             </Tab>
           ))}
         </Tab.List>
+        <ClusterInfoBox haScenario={cluster.type} provider={cluster.provider} />
         {cluster.provider == UNKNOWN_PROVIDER && (
           <WarningBanner>
             The following catalog is valid for on-premise bare metal platforms.

--- a/assets/js/components/ClusterDetails/ProviderLabel.jsx
+++ b/assets/js/components/ClusterDetails/ProviderLabel.jsx
@@ -36,11 +36,11 @@ const ProviderLabel = ({ provider }) => (
     {providerData[provider] ? (
       <img
         src={providerData[provider].logo}
-        className="inline h-4 pr-2"
+        className="inline mr-2 h-4"
         alt={provider}
       />
     ) : (
-      <EOS_HELP />
+      <EOS_HELP className="inline mr-2" />
     )}
     {providerData[provider]
       ? providerData[provider].label

--- a/assets/js/components/ClusterDetails/index.js
+++ b/assets/js/components/ClusterDetails/index.js
@@ -3,5 +3,6 @@ import ClusterDetails from './ClusterDetails';
 export { ClusterSettings } from './ClusterSettings';
 export { ConnectionSettings } from './ConnectionSettings';
 export { ExecutionIcon } from './ExecutionIcon';
+export { ClusterInfoBox } from './ClusterInfoBox';
 
 export default ClusterDetails;


### PR DESCRIPTION
# Description

Adds the HA scenario and provider to the _Cluster Checks Results_ & _Cluster Settings_ views.

![image](https://user-images.githubusercontent.com/113615552/203067690-715441c2-0322-482a-811f-8665bbc714ea.png)

![image](https://user-images.githubusercontent.com/113615552/203280223-7b604c65-11c8-4122-bdf0-f9dec6cb1b10.png)


## How was this tested?

Tests have been added that validate the HA scenario and provider for a cluster in the _Cluster Checks Results_ view.
