### PR TITLE
Add SBD_OPTS to cluster discovery events

### DIFF
--- a/test/fixtures/discovery/ha_cluster_discovery_hana_scale_up.json
+++ b/test/fixtures/discovery/ha_cluster_discovery_hana_scale_up.json
@@ -1018,6 +1018,7 @@
         }
       ],
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DELAY_START": "no",
         "SBD_DEVICE": "/dev/vdc;/dev/vdb",
         "SBD_MOVE_TO_ROOT_CGROUP": "auto",

--- a/test/fixtures/discovery/ha_cluster_discovery_unnamed.json
+++ b/test/fixtures/discovery/ha_cluster_discovery_unnamed.json
@@ -1018,6 +1018,7 @@
         }
       ],
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DELAY_START": "no",
         "SBD_DEVICE": "/dev/vdc;/dev/vdb",
         "SBD_MOVE_TO_ROOT_CGROUP": "auto",

--- a/test/fixtures/scenarios/aws-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_ha_cluster_discovery.json
@@ -388,6 +388,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:182cb1b1-a815-4b82-b538-7a166b9bbb4a",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/aws-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery.json
@@ -388,6 +388,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:182cb1b1-a815-4b82-b538-7a166b9bbb4a",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/aws-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_ha_cluster_discovery.json
@@ -390,6 +390,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-36001405f01eb5f4c5c941e499beb055d",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/aws-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_ha_cluster_discovery.json
@@ -390,6 +390,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-36001405f01eb5f4c5c941e499beb055d",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_1_SFAIL.json
+++ b/test/fixtures/scenarios/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_1_SFAIL.json
@@ -388,6 +388,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:182cb1b1-a815-4b82-b538-7a166b9bbb4a",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_1_SOK.json
+++ b/test/fixtures/scenarios/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_1_SOK.json
@@ -388,6 +388,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:182cb1b1-a815-4b82-b538-7a166b9bbb4a",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_4_SFAIL.json
+++ b/test/fixtures/scenarios/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_4_SFAIL.json
@@ -388,6 +388,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:182cb1b1-a815-4b82-b538-7a166b9bbb4a",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_4_SOK.json
+++ b/test/fixtures/scenarios/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_4_SOK.json
@@ -388,6 +388,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:182cb1b1-a815-4b82-b538-7a166b9bbb4a",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_unnamed.json
+++ b/test/fixtures/scenarios/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_unnamed.json
@@ -388,6 +388,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:182cb1b1-a815-4b82-b538-7a166b9bbb4a",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/gcp-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_ha_cluster_discovery.json
@@ -388,6 +388,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:182cb1b1-a815-4b82-b538-7a166b9bbb4a",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/gcp-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery.json
@@ -388,6 +388,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:182cb1b1-a815-4b82-b538-7a166b9bbb4a",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/gcp-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_ha_cluster_discovery.json
@@ -390,6 +390,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-36001405f01eb5f4c5c941e499beb055d",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/gcp-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_ha_cluster_discovery.json
@@ -390,6 +390,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-36001405f01eb5f4c5c941e499beb055d",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/hana-cluster-details/b767b3e9-e802-587e-a442-541d093b86b9_ha_cluster_discovery_kvm_provider.json
+++ b/test/fixtures/scenarios/hana-cluster-details/b767b3e9-e802-587e-a442-541d093b86b9_ha_cluster_discovery_kvm_provider.json
@@ -388,6 +388,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_8d286026-c3a6-4404-90ac-f2549b924e77",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/hana-cluster-details/b767b3e9-e802-587e-a442-541d093b86b9_ha_cluster_discovery_nutanix_provider.json
+++ b/test/fixtures/scenarios/hana-cluster-details/b767b3e9-e802-587e-a442-541d093b86b9_ha_cluster_discovery_nutanix_provider.json
@@ -388,6 +388,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_8d286026-c3a6-4404-90ac-f2549b924e77",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/hana-cluster-details/b767b3e9-e802-587e-a442-541d093b86b9_ha_cluster_discovery_unknown_provider.json
+++ b/test/fixtures/scenarios/hana-cluster-details/b767b3e9-e802-587e-a442-541d093b86b9_ha_cluster_discovery_unknown_provider.json
@@ -388,6 +388,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_8d286026-c3a6-4404-90ac-f2549b924e77",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_ha_cluster_discovery.json
@@ -388,6 +388,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:182cb1b1-a815-4b82-b538-7a166b9bbb4a",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/116d49bd-85e1-5e59-b820-83f66db8800c_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/116d49bd-85e1-5e59-b820-83f66db8800c_ha_cluster_discovery.json
@@ -390,6 +390,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_e34218cd-0d9a-4b21-b6d5-a313980baa82",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery.json
@@ -388,6 +388,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:182cb1b1-a815-4b82-b538-7a166b9bbb4a",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/21de186a-e38f-5804-b643-7f4ef22fecfd_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/21de186a-e38f-5804-b643-7f4ef22fecfd_ha_cluster_discovery.json
@@ -324,6 +324,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:3947fa28-25e0-46d4-bbed-89ce88f977f1",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_ha_cluster_discovery.json
@@ -324,6 +324,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:3947fa28-25e0-46d4-bbed-89ce88f977f1",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/25677e37-fd33-5005-896c-9275b1284534_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/25677e37-fd33-5005-896c-9275b1284534_ha_cluster_discovery.json
@@ -390,6 +390,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_813ace38-2d4f-48f6-8aa2-5360252ca492",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/3711ea88-9ccc-5b07-8f9d-042be449d72b_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/3711ea88-9ccc-5b07-8f9d-042be449d72b_ha_cluster_discovery.json
@@ -390,6 +390,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_813ace38-2d4f-48f6-8aa2-5360252ca492",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/422686d6-b2d1-5092-93e8-a744854f5085_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/422686d6-b2d1-5092-93e8-a744854f5085_ha_cluster_discovery.json
@@ -324,6 +324,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:c1c003f5-4e45-4d6f-8d81-e338f666365c",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/4b30a6af-4b52-5bda-bccb-f2248a12c992_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/4b30a6af-4b52-5bda-bccb-f2248a12c992_ha_cluster_discovery.json
@@ -390,6 +390,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_e34218cd-0d9a-4b21-b6d5-a313980baa82",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_ha_cluster_discovery.json
@@ -390,6 +390,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-36001405f01eb5f4c5c941e499beb055d",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/927901fa-2c87-524e-b18c-3ef5187f504f_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/927901fa-2c87-524e-b18c-3ef5187f504f_ha_cluster_discovery.json
@@ -324,6 +324,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_b7b1cd3d-776e-4432-a9e5-6fe56e4b4e17",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/99cf8a3a-48d6-57a4-b302-6e4482227ab6_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/99cf8a3a-48d6-57a4-b302-6e4482227ab6_ha_cluster_discovery.json
@@ -388,6 +388,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-360014058d88c7795c6a4b66bc024f4bd",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9cd46919-5f19-59aa-993e-cf3736c71053_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9cd46919-5f19-59aa-993e-cf3736c71053_ha_cluster_discovery.json
@@ -388,6 +388,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_8d286026-c3a6-4404-90ac-f2549b924e77",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a09d9cf3-46c1-505c-8fb8-4b0a71a9114e_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a09d9cf3-46c1-505c-8fb8-4b0a71a9114e_ha_cluster_discovery.json
@@ -324,6 +324,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_b7b1cd3d-776e-4432-a9e5-6fe56e4b4e17",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_ha_cluster_discovery.json
@@ -388,6 +388,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_8d286026-c3a6-4404-90ac-f2549b924e77",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/ddcb7992-2ffb-5c10-8b39-80685f6eaaba_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/ddcb7992-2ffb-5c10-8b39-80685f6eaaba_ha_cluster_discovery.json
@@ -324,6 +324,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:c1c003f5-4e45-4d6f-8d81-e338f666365c",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/e0c182db-32ff-55c6-a9eb-2b82dd21bc8b_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/e0c182db-32ff-55c6-a9eb-2b82dd21bc8b_ha_cluster_discovery.json
@@ -388,6 +388,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-360014058d88c7795c6a4b66bc024f4bd",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_ha_cluster_discovery.json
@@ -390,6 +390,7 @@
     },
     "SBD": {
       "Config": {
+        "SBD_OPTS": "",
         "SBD_DEVICE": "/dev/disk/by-id/scsi-36001405f01eb5f4c5c941e499beb055d",
         "SBD_PACEMAKER": "yes",
         "SBD_STARTMODE": "always",


### PR DESCRIPTION
# Description

This change in the agent https://github.com/trento-project/agent/pull/145 exposes to discoveries also empty SBD configuration entries like `SBD_OPTS=` (becoming in the json `"SBD_OPTS": ""`)

With this PR we test that the change is supported by trento web as well.

## How was this tested?

Changed fixtures and let e2e tests run.