### PR TITLE
Reduce vertical padding in `ClusterInfoBox` component

### DIFF
--- a/assets/js/components/ClusterDetails/ClusterInfoBox.jsx
+++ b/assets/js/components/ClusterDetails/ClusterInfoBox.jsx
@@ -9,7 +9,7 @@ const haScenarioToString = {
 };
 
 export const ClusterInfoBox = ({ haScenario, provider }) => (
-  <div className="tn-cluster-details w-full my-4 mr-4 bg-white shadow rounded-lg px-8 py-8">
+  <div className="tn-cluster-details w-full my-4 mr-4 bg-white shadow rounded-lg px-8 py-4">
     <ListView
       className="grid-flow-row"
       titleClassName="text-lg"


### PR DESCRIPTION
# Description

Currently the `ClusterInfoBox` component has too much vertical padding. This PR reduces the padding as per design review.

Before:

![image](https://user-images.githubusercontent.com/113615552/203525501-407015b9-90f6-4054-89af-4a6386f5701d.png)

After:

![image](https://user-images.githubusercontent.com/113615552/203525620-62e0f76a-6584-4c77-ac09-3901b7ddde08.png)
