### PR TITLE
Help tailwind's JIT figure which classes we need

### DIFF
--- a/assets/js/components/ClusterDetails/ChecksResultOverview.jsx
+++ b/assets/js/components/ClusterDetails/ChecksResultOverview.jsx
@@ -8,20 +8,32 @@ import React from 'react';
 
 const uiForResult = {
   passing: {
-    color: 'green',
+    iconColorClassName: 'fill-green-600',
+    backgroundColorClassName: 'bg-green-200',
     component: EOS_CHECK_CIRCLE_OUTLINED,
     text: 'Passing',
   },
   warning: {
-    color: 'yellow',
+    iconColorClassName: 'fill-yellow-600',
+    backgroundColorClassName: 'bg-yellow-200',
     component: EOS_WARNING_OUTLINED,
     text: 'Warning',
   },
-  critical: { color: 'red', component: EOS_ERROR_OUTLINED, text: 'Critical' },
+  critical: {
+    iconColorClassName: 'fill-red-600',
+    backgroundColorClassName: 'bg-red-200',
+    component: EOS_ERROR_OUTLINED,
+    text: 'Critical',
+  },
 };
 
 const CheckResult = ({ value, result, onClick }) => {
-  const { color, component: Component, text } = uiForResult[result];
+  const {
+    iconColorClassName,
+    backgroundColorClassName,
+    component: Component,
+    text,
+  } = uiForResult[result];
 
   return (
     <div
@@ -29,8 +41,8 @@ const CheckResult = ({ value, result, onClick }) => {
       onClick={onClick}
       className="hover:text-jungle-green-500 flex items-center rounded p-3 text-lg font-bold"
     >
-      <span className={`rounded-lg p-2 bg-${color}-200 mr-2`}>
-        <Component size={25} className={`fill-${color}-600`} />
+      <span className={`rounded-lg p-2 ${backgroundColorClassName} mr-2`}>
+        <Component size={25} className={`${iconColorClassName}`} />
       </span>
       <div className="flex w-full ml-2 items-center w-[65%]">
         <p>{text}</p>


### PR DESCRIPTION
# Description

Since tailwind 3, [JIT mode](https://v2.tailwindcss.com/docs/just-in-time-mode) is enabled by default. This causes that classes are only added if needed. When we use variables to construct the name of a class, we prevent tailwind from being able to understand what class it needs to add.

This caused that we missed the `fill-yellow-600` class needed for the warning summary and rendering as black text instead.

By specifying the classname completely without string formatting or concatenation, it works again. Result:

![Captura desde 2022-11-23 13-32-37](https://user-images.githubusercontent.com/2668401/203559297-fe5f86e5-9ab5-4c00-a35c-d722efdeda4d.png)

## How was this tested?

It was tested manually. Unfortunately, I'm not sure we are able to add a test that checks the presence or absence of a CSS class.
