### PR TITLE
Prevent flaky tests by using UUIDs on the tags values

### DIFF
--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -382,7 +382,7 @@ defmodule Trento.Factory do
 
   def tag_factory do
     %Tag{
-      value: Faker.Beer.hop(),
+      value: Faker.UUID.v4(),
       resource_id: Faker.UUID.v4(),
       resource_type: :host
     }

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -382,7 +382,7 @@ defmodule Trento.Factory do
 
   def tag_factory do
     %Tag{
-      value: Faker.UUID.v4(),
+      value: sequence(:value, &"#{Faker.Beer.hop()}0#{&1}"),
       resource_id: Faker.UUID.v4(),
       resource_type: :host
     }


### PR DESCRIPTION
# Description
This PR changes the tag_factory to use UUIDs for the tag value.

Why?

 - We have a constraint that prevents the same tag/resource combination:
 ```|> unique_constraint([:resource_id, :value])```
 
 - The tests attempt to insert two tags generated in the factory `using Faker.Beer.hop()` which, given the sample size, causes collisions.
 
With this PR we shouldn't have any collision in the near future :sweat_smile: 

## How was this tested?

I tested the tests by manually running the tests :smile: 
