### PR TITLE
Unified Api Response for errors

### DIFF
--- a/lib/trento_web/controllers/cluster_controller.ex
+++ b/lib/trento_web/controllers/cluster_controller.ex
@@ -15,6 +15,8 @@ defmodule TrentoWeb.ClusterController do
     type: %OpenApiSpex.Schema{type: :string, format: :uuid}
   ]
 
+  action_fallback TrentoWeb.FallbackController
+
   operation :list,
     summary: "List Pacemaker Clusters",
     tags: ["Target Infrastructure"],
@@ -57,9 +59,7 @@ defmodule TrentoWeb.ClusterController do
         |> json(%{})
 
       {:error, reason} ->
-        conn
-        |> put_status(:bad_request)
-        |> json(%{error: reason})
+        {:error, {:bad_request, reason}}
     end
   end
 
@@ -119,9 +119,7 @@ defmodule TrentoWeb.ClusterController do
         |> json(%{})
 
       {:error, reason} ->
-        conn
-        |> put_status(:bad_request)
-        |> json(%{error: reason})
+        {:error, {:bad_request, reason}}
     end
   end
 

--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -1,0 +1,17 @@
+defmodule TrentoWeb.FallbackController do
+  use TrentoWeb, :controller
+
+  alias TrentoWeb.ErrorView
+
+  def call(conn, {:error, {:bad_request, reason}}) do
+    conn
+    |> put_status(:bad_request)
+    |> render_error(reason)
+  end
+
+  defp render_error(conn, reason) do
+    conn
+    |> put_view(ErrorView)
+    |> render("error.json", reason: reason)
+  end
+end

--- a/lib/trento_web/views/error_view.ex
+++ b/lib/trento_web/views/error_view.ex
@@ -13,4 +13,8 @@ defmodule TrentoWeb.ErrorView do
   def template_not_found(template, _assigns) do
     Phoenix.Controller.status_message_from_template(template)
   end
+
+  def render("error.json", %{reason: reason}) do
+    %{error: reason}
+  end
 end

--- a/test/trento_web/controllers/cluster_controller_test.exs
+++ b/test/trento_web/controllers/cluster_controller_test.exs
@@ -7,6 +7,10 @@ defmodule TrentoWeb.ClusterControllerTest do
 
   import Trento.Factory
 
+  import Mox
+
+  setup [:set_mox_from_context, :verify_on_exit!]
+
   describe "list" do
     test "should list all clusters", %{conn: conn} do
       insert_list(2, :cluster)
@@ -17,6 +21,30 @@ defmodule TrentoWeb.ClusterControllerTest do
       |> get("/api/clusters")
       |> json_response(200)
       |> assert_schema("PacemakerClustersCollection", api_spec)
+    end
+  end
+
+  describe "select_checks" do
+    test "should return bad request when the request is malformed", %{conn: conn} do
+      cluster_id = UUID.uuid4()
+
+      expect(
+        Trento.Commanded.Mock,
+        :dispatch,
+        fn _ ->
+          {:error, "the reason is you"}
+        end
+      )
+
+      resp =
+        conn
+        |> post("/api/clusters/#{cluster_id}/checks", %{
+          "cluster_id" => cluster_id,
+          "checks" => []
+        })
+        |> json_response(400)
+
+      assert %{"error" => "the reason is you"} = resp
     end
   end
 


### PR DESCRIPTION
# Description

As the title suggest, this pr adds a unified way to deal with api errors, using ErrorView and phoenix fallback controller

## How was this tested?

Automated tests
