### PR TITLE
Add photofinish to the cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -364,19 +364,21 @@ jobs:
         run: mix setup
       - name: Run trento detached
         run: mix phx.server &
-      - name: Download Photofinish for e2e testing
-        if: steps.photofinish-cache.outputs.cache-hit != 'true'
-        run: |
-          set -x
-          wget -P /tmp https://github.com/trento-project/photofinish/releases/download/v1.1.0/photofinish
-          chmod +x /tmp/photofinish
+      - name: Install photofinish
+        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        with:
+          repo: trento-project/photofinish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Give executable permissions to photofinish
+        run: chmod +x $(whereis photofinish | cut -d" " -f2)
       - name: Cypress run
         uses: cypress-io/github-action@v4
         env:
           cypress_video: false
           cypress_db_host: postgres
           cypress_db_port: 5432
-          cypress_photofinish_binary: /tmp/photofinish
+          cypress_photofinish_binary: $(whereis photofinish | cut -d" " -f2)
         with:
           working-directory: test/e2e
           headless: true
@@ -511,13 +513,16 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Get Photofinish for e2e testing
-        run: |
-          set -x
-          wget -P /tmp https://github.com/trento-project/photofinish/releases/download/v1.1.2/photofinish
-          chmod +x /tmp/photofinish
+      - name: Install photofinish
+        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        with:
+          repo: trento-project/photofinish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Give executable permissions to photofinish
+        run: chmod +x $(whereis photofinish | cut -d" " -f2)
       - name: Push data
-        run: /tmp/photofinish run healthy-27-node-SAP-cluster -u "http://$TRENTO_DEMO_IP/api/collect" "$TRENTO_API_KEY"
+        run: photofinish run healthy-27-node-SAP-cluster -u "http://$TRENTO_DEMO_IP/api/collect" "$TRENTO_API_KEY"
 
   obs-commit:
     name: Commit the project on OBS

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -352,12 +352,6 @@ jobs:
           path: |
             test/e2e/node_modules
           key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('test/e2e/package-lock.json') }}
-      - name: Retrieve cached photofinish binary
-        uses: actions/cache@v3
-        id: photofinish-cache
-        with:
-          path: /tmp/photofinish
-          key: ${{ runner.os }}-photofinish
       - name: Check Eslint and JS Code Format
         run: cd test/e2e && npm run lint && npm run format:check
       - name: Mix setup
@@ -368,6 +362,8 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.5.0
         with:
           repo: trento-project/photofinish
+          tag: v1.1.2
+          cache: enable
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Give executable permissions to photofinish
@@ -517,6 +513,8 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.5.0
         with:
           repo: trento-project/photofinish
+          tag: v1.1.2
+          cache: enable
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Give executable permissions to photofinish

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -352,13 +352,20 @@ jobs:
           path: |
             test/e2e/node_modules
           key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('test/e2e/package-lock.json') }}
+      - name: Retrieve cached photofinish binary
+        uses: actions/cache@v3
+        id: photofinish-cache
+        with:
+          path: /tmp/photofinish
+          key: ${{ runner.os }}-photofinish
       - name: Check Eslint and JS Code Format
         run: cd test/e2e && npm run lint && npm run format:check
       - name: Mix setup
         run: mix setup
       - name: Run trento detached
         run: mix phx.server &
-      - name: Get Photofinish for e2e testing
+      - name: Download Photofinish for e2e testing
+        if: steps.photofinish-cache.outputs.cache-hit != 'true'
         run: |
           set -x
           wget -P /tmp https://github.com/trento-project/photofinish/releases/download/v1.1.0/photofinish


### PR DESCRIPTION
# Description

This PR enables the use of GH actions cache to store the photofinish binary used in the e2e testing.

In terms of speed there isn't a huge gain (though it seems to download faster from the cache than from the regular http endpoint) but it should prevent errors caused sometimes by download limits. See:
```
+ wget -P /tmp https://github.com/trento-project/photofinish/releases/download/v1.1.0/photofinish
--2022-11-23 13:54:35--  https://github.com/trento-project/photofinish/releases/download/v1.1.0/photofinish
...
Warning: Resolving objects.githubusercontent.com (objects.githubusercontent.com)... 185.199.111.133, 185.199.108.133, 185.199.109.133, ...
Connecting to objects.githubusercontent.com (objects.githubusercontent.com)|185.199.111.133|:443... connected.
HTTP request sent, awaiting response... 503 Egress is over the account limit.
2022-11-23 13:54:36 ERROR 503: Egress is over the account limit..
```

## How was this tested?

I runned it manually on my fork a few times to check if the cache asset was generated properly and used properly when available
