### PR TITLE
Fix docker-compose ports and config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -216,7 +216,7 @@ jobs:
           RABBITMQ_DEFAULT_USER: trento
           RABBITMQ_DEFAULT_PASS: trento
         ports:
-          - 5672:5672
+          - 5673:5672
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0

--- a/config/test.exs
+++ b/config/test.exs
@@ -48,7 +48,7 @@ config :trento, :messaging, adapter: Trento.Messaging.Adapters.AMQP
 config :trento, Trento.Messaging.Adapters.AMQP,
   publisher: [
     exchange: "trento.test.checks",
-    connection: "amqp://trento:trento@localhost:5672"
+    connection: "amqp://trento:trento@localhost:5673"
   ]
 
 config :trento, Trento.Integration.Checks.Wanda.Messaging.AMQP,
@@ -58,7 +58,7 @@ config :trento, Trento.Integration.Checks.Wanda.Messaging.AMQP,
     exchange: "trento.test.checks",
     routing_key: "results",
     prefetch_count: "10",
-    connection: "amqp://trento:trento@localhost:5672",
+    connection: "amqp://trento:trento@localhost:5673",
     retry_delay_function: fn attempt -> :timer.sleep(2000 * attempt) end,
     queue_options: [
       durable: false,

--- a/config/wanda.exs
+++ b/config/wanda.exs
@@ -14,7 +14,7 @@ config :trento, Trento.Clusters, checks_adapter: Trento.Clusters.Wanda
 config :trento, Trento.Messaging.Adapters.AMQP,
   publisher: [
     exchange: "trento.checks",
-    connection: "amqp://trento:trento@localhost:5672"
+    connection: "amqp://wanda:wanda@localhost:5674"
   ]
 
 config :trento, Trento.Integration.Checks.Wanda.Messaging.AMQP,
@@ -24,7 +24,7 @@ config :trento, Trento.Integration.Checks.Wanda.Messaging.AMQP,
     exchange: "trento.checks",
     routing_key: "results",
     prefetch_count: "10",
-    connection: "amqp://trento:trento@localhost:5672",
+    connection: "amqp://wanda:wanda@localhost:5674",
     retry_delay_function: fn attempt -> :timer.sleep(2000 * attempt) end
   ]
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,8 +22,8 @@ services:
   rabbitmq:
     image: rabbitmq:3.10.5-management-alpine
     ports:
-      - 5672:5672
-      - 15672:15672
+      - 5673:5672
+      - 15673:15672
     environment:
       RABBITMQ_DEFAULT_USER: trento
       RABBITMQ_DEFAULT_PASS: trento


### PR DESCRIPTION
Related to: https://github.com/trento-project/wanda/pull/105

Changes docker-compose forwarded ports and related config to avoid clashes with wanda.

The `wanda` environment is configured using the `wanda` compose port for rabbitmq.