### PR TITLE
New checks overview in cluster details

### DIFF
--- a/assets/js/components/ClusterDetails/CheckResultCount.jsx
+++ b/assets/js/components/ClusterDetails/CheckResultCount.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+import {
+  EOS_CHECK_CIRCLE_OUTLINED,
+  EOS_ERROR_OUTLINED,
+  EOS_WARNING_OUTLINED,
+} from 'eos-icons-react';
+
+const uiForResult = {
+  passing: {
+    iconColorClassName: 'fill-green-600',
+    backgroundColorClassName: 'bg-green-200',
+    component: EOS_CHECK_CIRCLE_OUTLINED,
+    text: 'Passing',
+  },
+  warning: {
+    iconColorClassName: 'fill-yellow-600',
+    backgroundColorClassName: 'bg-yellow-200',
+    component: EOS_WARNING_OUTLINED,
+    text: 'Warning',
+  },
+  critical: {
+    iconColorClassName: 'fill-red-600',
+    backgroundColorClassName: 'bg-red-200',
+    component: EOS_ERROR_OUTLINED,
+    text: 'Critical',
+  },
+};
+
+const CheckResultCount = ({ value, result, onClick }) => {
+  const {
+    iconColorClassName,
+    backgroundColorClassName,
+    component: Component,
+    text,
+  } = uiForResult[result];
+
+  return (
+    <div
+      role="button"
+      onClick={onClick}
+      className="hover:text-jungle-green-500 flex items-center rounded p-3 text-lg font-bold"
+    >
+      <span className={`rounded-lg p-2 ${backgroundColorClassName} mr-2`}>
+        <Component size={25} className={`${iconColorClassName}`} />
+      </span>
+      <div className="flex w-full ml-2 items-center w-[65%]">
+        <p>{text}</p>
+      </div>
+      <div className="flex text-2xl">{value}</div>
+    </div>
+  );
+};
+
+export default CheckResultCount;

--- a/assets/js/components/ClusterDetails/ChecksResultOverview.jsx
+++ b/assets/js/components/ClusterDetails/ChecksResultOverview.jsx
@@ -1,56 +1,7 @@
-import { format } from 'date-fns';
-import {
-  EOS_CHECK_CIRCLE_OUTLINED,
-  EOS_ERROR_OUTLINED,
-  EOS_WARNING_OUTLINED,
-} from 'eos-icons-react';
 import React from 'react';
+import { format } from 'date-fns';
 
-const uiForResult = {
-  passing: {
-    iconColorClassName: 'fill-green-600',
-    backgroundColorClassName: 'bg-green-200',
-    component: EOS_CHECK_CIRCLE_OUTLINED,
-    text: 'Passing',
-  },
-  warning: {
-    iconColorClassName: 'fill-yellow-600',
-    backgroundColorClassName: 'bg-yellow-200',
-    component: EOS_WARNING_OUTLINED,
-    text: 'Warning',
-  },
-  critical: {
-    iconColorClassName: 'fill-red-600',
-    backgroundColorClassName: 'bg-red-200',
-    component: EOS_ERROR_OUTLINED,
-    text: 'Critical',
-  },
-};
-
-const CheckResult = ({ value, result, onClick }) => {
-  const {
-    iconColorClassName,
-    backgroundColorClassName,
-    component: Component,
-    text,
-  } = uiForResult[result];
-
-  return (
-    <div
-      role="button"
-      onClick={onClick}
-      className="hover:text-jungle-green-500 flex items-center rounded p-3 text-lg font-bold"
-    >
-      <span className={`rounded-lg p-2 ${backgroundColorClassName} mr-2`}>
-        <Component size={25} className={`${iconColorClassName}`} />
-      </span>
-      <div className="flex w-full ml-2 items-center w-[65%]">
-        <p>{text}</p>
-      </div>
-      <div className="flex text-2xl">{value}</div>
-    </div>
-  );
-};
+import CheckResultCount from './CheckResultCount';
 
 const ChecksResultOverview = ({
   passing = 0,
@@ -67,17 +18,17 @@ const ChecksResultOverview = ({
       </h6>
 
       <div className="flex flex-col self-start w-full px-4 mt-2">
-        <CheckResult
+        <CheckResultCount
           onClick={() => onCheckClick('passing')}
           value={passing}
           result="passing"
         />
-        <CheckResult
+        <CheckResultCount
           onClick={() => onCheckClick('warning')}
           value={warning}
           result="warning"
         />
-        <CheckResult
+        <CheckResultCount
           onClick={() => onCheckClick('critical')}
           value={critical}
           result="critical"

--- a/assets/js/components/ClusterDetails/ChecksResultOverviewNew.jsx
+++ b/assets/js/components/ClusterDetails/ChecksResultOverviewNew.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { format } from 'date-fns';
+
+import CheckResultCount from './CheckResultCount';
+import Spinner from '@components/Spinner';
+
+const ChecksResultOverviewNew = ({
+  data,
+  error = null,
+  loading = false,
+  onCheckClick,
+}) => {
+  if (loading || data?.status === 'running') {
+    return (
+      <div className="flex flex-col items-center mt-2 px-4">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center mt-2 px-4">
+        <div className="text-center text-xs">{error}</div>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="flex flex-col items-center mt-2 px-4">
+        <div className="text-center text-xs">No check results available.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center">
+      <h1 className="text-center text-2xl font-bold">Check Results</h1>
+      <h6 className="opacity-60 text-xs">
+        {format(new Date(data.completed_at), 'iii MMM dd, HH:MM:SS y')}
+      </h6>
+
+      <div className="flex flex-col self-start w-full px-4 mt-2">
+        <CheckResultCount
+          onClick={() => onCheckClick('passing')}
+          value={data.passing_count}
+          result="passing"
+        />
+        <CheckResultCount
+          onClick={() => onCheckClick('warning')}
+          value={data.warning_count}
+          result="warning"
+        />
+        <CheckResultCount
+          onClick={() => onCheckClick('critical')}
+          value={data.critical_count}
+          result="critical"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ChecksResultOverviewNew;

--- a/assets/js/components/ClusterDetails/ChecksResultOverviewNew.test.jsx
+++ b/assets/js/components/ClusterDetails/ChecksResultOverviewNew.test.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { faker } from '@faker-js/faker';
+
+import ChecksResultOverviewNew from './ChecksResultOverviewNew';
+
+describe('ChecksResultOverviewNew component', () => {
+  it('should render a spinner when in loading state', () => {
+    render(<ChecksResultOverviewNew loading={true} />);
+
+    expect(screen.getByRole('alert')).toBeVisible();
+    expect(screen.queryByText('Passing')).not.toBeInTheDocument();
+    expect(screen.queryByText('Warning')).not.toBeInTheDocument();
+    expect(screen.queryByText('Critical')).not.toBeInTheDocument();
+  });
+
+  it('should render an error message', () => {
+    const error = faker.hacker.noun();
+    render(<ChecksResultOverviewNew error={error} />);
+
+    expect(screen.getByText(error)).toBeVisible();
+    expect(screen.queryByText('Passing')).not.toBeInTheDocument();
+    expect(screen.queryByText('Warning')).not.toBeInTheDocument();
+    expect(screen.queryByText('Critical')).not.toBeInTheDocument();
+  });
+
+  it('should display a message if no last execution was found', () => {
+    render(<ChecksResultOverviewNew />);
+
+    expect(screen.getByText('No check results available.')).toBeVisible();
+    expect(screen.queryByText('Passing')).not.toBeInTheDocument();
+    expect(screen.queryByText('Warning')).not.toBeInTheDocument();
+    expect(screen.queryByText('Critical')).not.toBeInTheDocument();
+  });
+
+  it('should display the check results overview', () => {
+    const passing_count = faker.datatype.number();
+    const warning_count = faker.datatype.number();
+    const critical_count = faker.datatype.number();
+
+    const data = {
+      completed_at: faker.date.past().toISOString(),
+      passing_count: passing_count,
+      warning_count: warning_count,
+      critical_count: critical_count,
+      status: 'completed',
+    };
+
+    render(<ChecksResultOverviewNew data={data} />);
+
+    expect(screen.getByText('Passing')).toBeVisible();
+    expect(screen.getByText(passing_count)).toBeVisible();
+    expect(screen.getByText('Warning')).toBeVisible();
+    expect(screen.getByText(warning_count)).toBeVisible();
+    expect(screen.getByText('Critical')).toBeVisible();
+    expect(screen.getByText(critical_count)).toBeVisible();
+  });
+});

--- a/assets/js/components/ClusterDetails/ClusterDetailsNew.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetailsNew.jsx
@@ -1,0 +1,272 @@
+import React, { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useSelector, useDispatch } from 'react-redux';
+
+import { groupBy } from '@lib/lists';
+import classNames from 'classnames';
+
+import Button from '@components/Button';
+import ListView from '@components/ListView';
+import Pill from '@components/Pill';
+import Table from '@components/Table';
+import Tooltip from '@components/Tooltip';
+import TriggerChecksExecutionRequest from '@components/TriggerChecksExecutionRequest';
+import HostLink from '@components/HostLink';
+import SiteDetails from './SiteDetails';
+import ChecksResultOverviewNew from '@components/ClusterDetails/ChecksResultOverviewNew';
+import ProviderLabel from './ProviderLabel';
+import { getClusterName } from '@components/ClusterLink';
+import { EOS_SETTINGS, EOS_CLEAR_ALL, EOS_PLAY_CIRCLE } from 'eos-icons-react';
+
+import { getCluster } from '@state/selectors';
+import { updateLastExecution } from '@state/actions/lastExecutions';
+import { getLastExecution } from '@state/selectors/lastExecutions';
+
+export const truncatedClusterNameClasses = classNames(
+  'font-bold truncate w-60 inline-block align-top'
+);
+
+const siteDetailsConfig = {
+  usePadding: false,
+  columns: [
+    {
+      title: 'Hostname',
+      key: '',
+      render: (_, hostData) => (
+        <HostLink hostId={hostData.hostId}>{hostData.name}</HostLink>
+      ),
+    },
+    { title: 'Role', key: 'hana_status' },
+    {
+      title: 'IP',
+      key: 'ips',
+      className: 'table-col-m',
+      render: (content) => content?.join(', '),
+    },
+    {
+      title: 'Virtual IP',
+      key: 'virtual_ip',
+      className: 'table-col-m',
+    },
+    {
+      title: '',
+      key: '',
+      className: 'table-col-xs',
+      render: (_, item) => {
+        const { attributes, resources } = item;
+        return <SiteDetails attributes={attributes} resources={resources} />;
+      },
+    },
+  ],
+};
+
+const getStatusPill = (status) =>
+  status === 'healthy' ? (
+    <Pill className="bg-green-200 text-green-800 mr-2">Healthy</Pill>
+  ) : (
+    <Pill className="bg-red-200 text-red-800 mr-2">Unhealthy</Pill>
+  );
+
+export const ClusterDetailsNew = () => {
+  const { clusterID } = useParams();
+  const navigate = useNavigate();
+
+  const cluster = useSelector(getCluster(clusterID));
+
+  const dispatch = useDispatch();
+
+  const lastExecution = useSelector(getLastExecution(clusterID));
+
+  useEffect(() => {
+    dispatch(updateLastExecution(clusterID));
+  }, [dispatch]);
+
+  // FIXME: move this to a specific selector in the selectors folder
+  const hostsData = useSelector((state) =>
+    state.hostsList.hosts.reduce((accumulator, current) => {
+      if (current.cluster_id === clusterID) {
+        return {
+          ...accumulator,
+          [current.hostname]: { hostId: current.id, ips: current.ip_addresses },
+        };
+      }
+      return accumulator;
+    }, {})
+  );
+
+  if (!cluster) {
+    return <div>Loading...</div>;
+  }
+
+  const renderedNodes = cluster.details?.nodes?.map((node) =>
+    hostsData[node.name]
+      ? {
+          ...node,
+          ips: hostsData[node.name].ips,
+          hostId: hostsData[node.name].hostId,
+        }
+      : node
+  );
+
+  const hasSelectedChecks = cluster.selected_checks.length > 0;
+
+  return (
+    <div>
+      <div className="flex mb-4">
+        <h1 className="text-3xl font-bold w-1/2">
+          Pacemaker cluster details:{' '}
+          <span className={truncatedClusterNameClasses}>
+            {getClusterName(cluster)}
+          </span>
+        </h1>
+        <div className="flex w-1/2 justify-end">
+          <Button
+            type="primary-white"
+            className="w-1/4 mx-0.5 border-green-500 border"
+            size="small"
+            onClick={() => navigate(`/clusters/${clusterID}/settings_new`)}
+          >
+            <EOS_SETTINGS className="inline-block fill-jungle-green-500" />{' '}
+            Settings
+          </Button>
+          <Button
+            type="primary-white"
+            className="w-1/4 mx-0.5 border-green-500 border"
+            size="small"
+            onClick={() => navigate(`/clusters/${clusterID}/checks/results`)}
+          >
+            <EOS_CLEAR_ALL className="inline-block fill-jungle-green-500" />{' '}
+            Show Results
+          </Button>
+          <TriggerChecksExecutionRequest
+            cssClasses="rounded relative w-1/4 ml-0.5 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-gray-400"
+            clusterId={clusterID}
+            disabled={!hasSelectedChecks}
+          >
+            <EOS_PLAY_CIRCLE
+              className={classNames('inline-block fill-jungle-green-500', {
+                'fill-slate-500': !hasSelectedChecks,
+              })}
+            />{' '}
+            Start Execution
+            {!hasSelectedChecks && (
+              <Tooltip tooltipText="Select some Checks first!" />
+            )}
+          </TriggerChecksExecutionRequest>
+        </div>
+      </div>
+
+      <div className="flex xl:flex-row flex-col">
+        <div className="tn-cluster-details mt-4 bg-white shadow rounded-lg py-8 px-8 xl:w-3/4 w-full mr-4">
+          <ListView
+            className="grid-rows-3"
+            titleClassName="text-lg"
+            orientation="vertical"
+            data={[
+              {
+                title: 'Provider',
+                content: cluster.provider || 'Not defined',
+                render: (content) => <ProviderLabel provider={content} />,
+              },
+              { title: 'SID', content: cluster.sid },
+              {
+                title: 'Fencing type',
+                content: cluster.details && cluster.details.fencing_type,
+              },
+              {
+                title: 'Cluster type',
+                content:
+                  cluster.type === 'hana_scale_up'
+                    ? 'HANA scale-up'
+                    : 'Unknown',
+              },
+              {
+                title: 'SAPHanaSR health state',
+                content: cluster.details && cluster.details.sr_health_state,
+              },
+              {
+                title: 'CIB last written',
+                content: cluster.cib_last_written || '-',
+              },
+              {
+                title: 'HANA log replication mode',
+                content:
+                  cluster.details && cluster.details.system_replication_mode,
+              },
+              {
+                title: 'HANA secondary sync state',
+                content:
+                  cluster.details && cluster.details.secondary_sync_state,
+              },
+              {
+                title: 'HANA log operation mode',
+                content:
+                  cluster.details &&
+                  cluster.details.system_replication_operation_mode,
+              },
+            ]}
+          />
+        </div>
+        <div className="tn-cluster-checks-overview mt-4 bg-white shadow rounded-lg py-4 xl:w-1/4 w-full">
+          <ChecksResultOverviewNew
+            {...lastExecution}
+            onCheckClick={(health) =>
+              navigate(`/clusters/${clusterID}/checks/results?health=${health}`)
+            }
+          />
+        </div>
+      </div>
+
+      {cluster.details && cluster.details.stopped_resources.length > 0 && (
+        <div className="mt-16">
+          <div className="flex flex-direction-row">
+            <h2 className="text-2xl font-bold self-center">
+              Stopped resources
+            </h2>
+          </div>
+          <div className="mt-2">
+            {cluster.details.stopped_resources.map(({ id }) => (
+              <Pill className="bg-gray-200 text-gray-800" key={id}>
+                {id}
+              </Pill>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="mt-8">
+        <div>
+          <h2 className="text-2xl font-bold">Pacemaker Site details</h2>
+        </div>
+      </div>
+
+      <div className="mt-2 tn-site-details">
+        {Object.entries(groupBy(cluster.details.nodes, 'site')).map(
+          ([siteName]) => (
+            <div key={siteName} className={`tn-site-details-${siteName}`}>
+              <h3 className="text-l font-bold tn-site-name">{siteName}</h3>
+              <Table
+                className="tn-site-table"
+                config={siteDetailsConfig}
+                data={renderedNodes.filter(({ site }) => site === siteName)}
+              />
+            </div>
+          )
+        )}
+      </div>
+
+      <div className="mt-8">
+        <div>
+          <h2 className="text-2xl font-bold">SBD/Fencing</h2>
+        </div>
+      </div>
+      <div className="mt-2 bg-white shadow rounded-lg py-4 px-8 tn-sbd-details">
+        {cluster.details.sbd_devices.map(({ device, status }) => (
+          <div key={device}>
+            {getStatusPill(status)} {device}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/assets/js/components/ClusterDetails/index.js
+++ b/assets/js/components/ClusterDetails/index.js
@@ -6,3 +6,4 @@ export { ExecutionIcon } from './ExecutionIcon';
 export { ClusterInfoBox } from './ClusterInfoBox';
 
 export default ClusterDetails;
+export { ClusterDetailsNew } from './ClusterDetailsNew';

--- a/assets/js/components/Spinner.jsx
+++ b/assets/js/components/Spinner.jsx
@@ -5,9 +5,11 @@ import { EOS_LOADING_ANIMATED } from 'eos-icons-react';
 
 const Spinner = ({ centered = false }) => {
   return (
-    <EOS_LOADING_ANIMATED
-      className={computedIconCssClass('fill-jungle-green-500', centered)}
-    />
+    <div role="alert" aria-label="Loading">
+      <EOS_LOADING_ANIMATED
+        className={computedIconCssClass('fill-jungle-green-500', centered)}
+      />
+    </div>
   );
 };
 

--- a/assets/js/lib/api/wanda.js
+++ b/assets/js/lib/api/wanda.js
@@ -9,4 +9,7 @@ export const wandaClient = axios.create({
 export const getExecutionResult = (executionID) =>
   wandaClient.get(`/api/checks/executions/${executionID}`);
 
+export const getLastExecutionByGroupID = (groupID) =>
+  wandaClient.get(`/api/checks/groups/${groupID}/executions/last`);
+
 export const getCatalog = () => wandaClient.get('/api/checks/catalog');

--- a/assets/js/state/actions/catalog.js
+++ b/assets/js/state/actions/catalog.js
@@ -1,8 +1,8 @@
-export const updateCatalogAction = 'UPDATE_CATALOG_NEW';
+export const UPDATE_CATALOG = 'UPDATE_CATALOG_NEW';
 
 export const updateCatalog = () => {
   return {
-    type: updateCatalogAction,
+    type: UPDATE_CATALOG,
     payload: {},
   };
 };

--- a/assets/js/state/actions/lastExecutions.js
+++ b/assets/js/state/actions/lastExecutions.js
@@ -1,8 +1,8 @@
-export const updateLastExecutionAction = 'UPDATE_LAST_EXECUTION';
+export const UPDATE_LAST_EXECUTION = 'UPDATE_LAST_EXECUTION';
 
 export const updateLastExecution = (groupID) => {
   return {
-    type: updateLastExecutionAction,
+    type: UPDATE_LAST_EXECUTION,
     payload: { groupID: groupID },
   };
 };

--- a/assets/js/state/actions/lastExecutions.js
+++ b/assets/js/state/actions/lastExecutions.js
@@ -1,0 +1,8 @@
+export const updateLastExecutionAction = 'UPDATE_LAST_EXECUTION';
+
+export const updateLastExecution = (groupID) => {
+  return {
+    type: updateLastExecutionAction,
+    payload: { groupID: groupID },
+  };
+};

--- a/assets/js/state/index.js
+++ b/assets/js/state/index.js
@@ -11,6 +11,7 @@ import sapSystemListReducer from './sapSystems';
 import databasesListReducer from './databases';
 import catalogReducer from './catalog';
 import catalogNewReducer from './catalogNew';
+import lastExecutionsReducer from './lastExecutions';
 import liveFeedReducer from './liveFeed';
 import settingsReducer from './settings';
 import registerEvents from './registerSocketEvents';
@@ -30,6 +31,7 @@ export const store = configureStore({
     databasesList: databasesListReducer,
     catalog: catalogReducer,
     catalogNew: catalogNewReducer,
+    lastExecutions: lastExecutionsReducer,
     liveFeed: liveFeedReducer,
     settings: settingsReducer,
   },

--- a/assets/js/state/lastExecutions.js
+++ b/assets/js/state/lastExecutions.js
@@ -1,0 +1,60 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {};
+
+const initialExecutionState = {
+  data: null,
+  loading: false,
+  error: null,
+};
+
+export const lastExecutionsSlice = createSlice({
+  name: 'lastExecutions',
+  initialState,
+  reducers: {
+    setLastExecutionLoading: (state, { payload: groupID }) => {
+      const lastExecutionState = {
+        ...initialExecutionState,
+        loading: true,
+      };
+
+      state[groupID] = lastExecutionState;
+    },
+    setLastExecutionEmpty: (state, { payload: groupID }) => {
+      const lastExecutionState = {
+        ...initialExecutionState,
+      };
+
+      state[groupID] = lastExecutionState;
+    },
+    setLastExecution: (state, { payload }) => {
+      const { group_id: groupID } = payload;
+
+      const lastExecutionState = {
+        ...initialExecutionState,
+        data: payload,
+      };
+
+      state[groupID] = lastExecutionState;
+    },
+    setLastExecutionError: (state, { payload }) => {
+      const { groupID, error } = payload;
+
+      const lastExecutionState = {
+        ...initialExecutionState,
+        error: error,
+      };
+
+      state[groupID] = lastExecutionState;
+    },
+  },
+});
+
+export const {
+  setLastExecutionLoading,
+  setLastExecution,
+  setLastExecutionEmpty,
+  setLastExecutionError,
+} = lastExecutionsSlice.actions;
+
+export default lastExecutionsSlice.reducer;

--- a/assets/js/state/lastExecutions.test.js
+++ b/assets/js/state/lastExecutions.test.js
@@ -1,0 +1,101 @@
+import { faker } from '@faker-js/faker';
+
+import lastExecutionsReducer, {
+  setLastExecutionLoading,
+  setLastExecutionEmpty,
+  setLastExecutionError,
+  setLastExecution,
+} from './lastExecutions';
+
+describe('lastExecutions reducer', () => {
+  it('should set the last execution of a given groupID to the loading state', () => {
+    const initialState = {
+      someID: {
+        data: null,
+        loading: false,
+        error: null,
+      },
+    };
+
+    const action = setLastExecutionLoading('someID');
+
+    const expectedState = {
+      someID: {
+        data: null,
+        loading: true,
+        error: null,
+      },
+    };
+
+    expect(lastExecutionsReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should set the last execution of a given groupID to empty', () => {
+    const initialState = {
+      someID: {
+        data: JSON.parse(faker.datatype.json()),
+        loading: false,
+        error: null,
+      },
+    };
+
+    const action = setLastExecutionEmpty('someID');
+
+    const expectedState = {
+      someID: {
+        data: null,
+        loading: false,
+        error: null,
+      },
+    };
+
+    expect(lastExecutionsReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should set the last execution of a given groupID to the error state', () => {
+    const initialState = {
+      someID: {
+        data: JSON.parse(faker.datatype.json()),
+        loading: true,
+        error: null,
+      },
+    };
+
+    const error = faker.hacker.phrase();
+    const action = setLastExecutionError({ groupID: 'someID', error: error });
+
+    const expectedState = {
+      someID: {
+        data: null,
+        loading: false,
+        error: error,
+      },
+    };
+
+    expect(lastExecutionsReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should set the last execution of a given groupID', () => {
+    const initialState = {};
+
+    const data = {
+      group_id: 'someID',
+      critical_count: faker.datatype.number(),
+      warning_count: faker.datatype.number(),
+      passing_count: faker.datatype.number(),
+      status: 'completed',
+    };
+
+    const action = setLastExecution(data);
+
+    const expectedState = {
+      someID: {
+        data: data,
+        loading: false,
+        error: null,
+      },
+    };
+
+    expect(lastExecutionsReducer(initialState, action)).toEqual(expectedState);
+  });
+});

--- a/assets/js/state/sagas/catalog.js
+++ b/assets/js/state/sagas/catalog.js
@@ -1,6 +1,6 @@
 import { put, call, takeEvery } from 'redux-saga/effects';
 import { getCatalog } from '@lib/api/wanda';
-import { updateCatalogAction } from '@state/actions/catalog';
+import { UPDATE_CATALOG } from '@state/actions/catalog';
 
 import {
   setCatalogLoading,
@@ -19,5 +19,5 @@ export function* updateCatalog() {
 }
 
 export function* watchCatalogUpdateNew() {
-  yield takeEvery(updateCatalogAction, updateCatalog);
+  yield takeEvery(UPDATE_CATALOG, updateCatalog);
 }

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -69,6 +69,7 @@ import { setEulaVisible, setIsPremium } from '@state/settings';
 import { watchNotifications } from '@state/sagas/notifications';
 import { watchAcceptEula } from '@state/sagas/eula';
 import { watchCatalogUpdateNew } from '@state/sagas/catalog';
+import { watchUpdateLastExecution } from '@state/sagas/lastExecutions';
 
 import { getDatabase, getSapSystem } from '@state/selectors';
 import {
@@ -647,6 +648,7 @@ export default function* rootSaga() {
     watchDatabase(),
     watchCatalogUpdate(),
     watchCatalogUpdateNew(),
+    watchUpdateLastExecution(),
     watchAcceptEula(),
     refreshHealthSummaryOnComnponentsHealthChange(),
     watchClustrConnectionSettings(),

--- a/assets/js/state/sagas/lastExecutions.js
+++ b/assets/js/state/sagas/lastExecutions.js
@@ -1,6 +1,6 @@
 import { put, call, takeEvery } from 'redux-saga/effects';
 
-import { updateLastExecutionAction } from '@state/actions/lastExecutions';
+import { UPDATE_LAST_EXECUTION } from '@state/actions/lastExecutions';
 import { getLastExecutionByGroupID } from '@lib/api/wanda';
 import {
   setLastExecutionLoading,
@@ -32,5 +32,5 @@ export function* updateLastExecution({ payload }) {
 }
 
 export function* watchUpdateLastExecution() {
-  yield takeEvery(updateLastExecutionAction, updateLastExecution);
+  yield takeEvery(UPDATE_LAST_EXECUTION, updateLastExecution);
 }

--- a/assets/js/state/sagas/lastExecutions.js
+++ b/assets/js/state/sagas/lastExecutions.js
@@ -1,0 +1,36 @@
+import { put, call, takeEvery } from 'redux-saga/effects';
+
+import { updateLastExecutionAction } from '@state/actions/lastExecutions';
+import { getLastExecutionByGroupID } from '@lib/api/wanda';
+import {
+  setLastExecutionLoading,
+  setLastExecution,
+  setLastExecutionEmpty,
+  setLastExecutionError,
+} from '@state/lastExecutions';
+
+export function* updateLastExecution({ payload }) {
+  const { groupID } = payload;
+
+  yield put(setLastExecutionLoading(groupID));
+
+  try {
+    const { data } = yield call(getLastExecutionByGroupID, groupID);
+
+    yield put(setLastExecution(data));
+  } catch (error) {
+    if (error.response && error.response.status == 404) {
+      yield put(setLastExecutionEmpty(groupID));
+
+      return;
+    }
+
+    yield put(
+      setLastExecutionError({ groupID: groupID, error: error.message })
+    );
+  }
+}
+
+export function* watchUpdateLastExecution() {
+  yield takeEvery(updateLastExecutionAction, updateLastExecution);
+}

--- a/assets/js/state/sagas/lastExecutions.test.js
+++ b/assets/js/state/sagas/lastExecutions.test.js
@@ -1,0 +1,79 @@
+import MockAdapter from 'axios-mock-adapter';
+import { faker } from '@faker-js/faker';
+
+import { recordSaga } from '@lib/test-utils';
+
+import { wandaClient } from '@lib/api/wanda';
+import { updateLastExecution } from './lastExecutions';
+
+import {
+  setLastExecutionLoading,
+  setLastExecution,
+  setLastExecutionEmpty,
+  setLastExecutionError,
+} from '@state/lastExecutions';
+
+const axiosMock = new MockAdapter(wandaClient);
+const lastExecutionURL = (groupID) =>
+  `/api/checks/groups/${groupID}/executions/last`;
+
+describe('lastExecutions saga', () => {
+  beforeEach(() => {
+    axiosMock.reset();
+    jest.spyOn(console, 'error').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    /* eslint-disable-next-line */
+    console.error.mockRestore();
+  });
+
+  it('should update the last execution for a given groupID', async () => {
+    const groupID = faker.datatype.uuid();
+
+    const lastExecution = {
+      group_id: groupID,
+      critical_count: faker.datatype.number(),
+      warning_count: faker.datatype.number(),
+      passing_count: faker.datatype.number(),
+      status: 'completed',
+    };
+
+    axiosMock.onGet(lastExecutionURL(groupID)).reply(200, lastExecution);
+
+    const dispatched = await recordSaga(updateLastExecution, {
+      payload: { groupID: groupID },
+    });
+
+    expect(dispatched).toContainEqual(setLastExecutionLoading(groupID));
+    expect(dispatched).toContainEqual(setLastExecution(lastExecution));
+  });
+
+  it('should update the last execution for a given groupID to an empty state', async () => {
+    const groupID = faker.datatype.uuid();
+
+    axiosMock.onGet(lastExecutionURL(groupID)).reply(404, {});
+
+    const dispatched = await recordSaga(updateLastExecution, {
+      payload: { groupID: groupID },
+    });
+
+    expect(dispatched).toContainEqual(setLastExecutionLoading(groupID));
+    expect(dispatched).toContainEqual(setLastExecutionEmpty(groupID));
+  });
+
+  it('should the last execution for a given groupID with an error', async () => {
+    const groupID = faker.datatype.uuid();
+
+    axiosMock.onGet(lastExecutionURL(groupID)).networkError();
+
+    const dispatched = await recordSaga(updateLastExecution, {
+      payload: { groupID: groupID },
+    });
+
+    expect(dispatched).toContainEqual(setLastExecutionLoading(groupID));
+    expect(dispatched).toContainEqual(
+      setLastExecutionError({ groupID: groupID, error: 'Network Error' })
+    );
+  });
+});

--- a/assets/js/state/selectors/lastExecutions.js
+++ b/assets/js/state/selectors/lastExecutions.js
@@ -1,0 +1,5 @@
+export const getLastExecution =
+  (groupID) =>
+  ({ lastExecutions }) => {
+    return lastExecutions[groupID];
+  };

--- a/assets/js/state/selectors/lastExecutions.test.js
+++ b/assets/js/state/selectors/lastExecutions.test.js
@@ -1,0 +1,23 @@
+import { getLastExecution } from './lastExecutions';
+
+describe('lastExecutions selector', () => {
+  it('should return the expected last execution by group ID', () => {
+    const state = {
+      lastExecutions: {
+        someID: {
+          loading: false,
+          data: {},
+          error: null,
+        },
+      },
+    };
+
+    const expectedState = {
+      loading: false,
+      data: {},
+      error: null,
+    };
+
+    expect(getLastExecution('someID')(state)).toEqual(expectedState);
+  });
+});

--- a/assets/js/trento.jsx
+++ b/assets/js/trento.jsx
@@ -20,7 +20,7 @@ import ChecksResults from '@components/ChecksResults';
 import { ExecutionResultsPage } from '@components/ExecutionResults';
 import SapSystemsOverview from '@components/SapSystemsOverview';
 import HostDetails from '@components/HostDetails';
-import ClusterDetails from '@components/ClusterDetails';
+import ClusterDetails, { ClusterDetailsNew } from '@components/ClusterDetails';
 import DatabasesOverview from '@components/DatabasesOverview';
 import SapSystemDetails from './components/SapSystemDetails/SapSystemDetails';
 import DatabaseDetails from './components/DatabaseDetails';
@@ -73,6 +73,10 @@ const App = () => {
               <Route path="sap_systems/:id" element={<SapSystemDetails />} />
               <Route path="databases/:id" element={<DatabaseDetails />} />
               <Route path="clusters/:clusterID" element={<ClusterDetails />} />
+              <Route
+                path="clusters_new/:clusterID"
+                element={<ClusterDetailsNew />}
+              />
             </Route>
             <Route path="*" element={<NotFound />} />
           </Routes>


### PR DESCRIPTION
Adds the new checks overview (passing, warning, critical) count to the FE.
The component is reachable at the `clusters_new/<id>` route.

A follow up PR will include the broadcast of the execution completed event to the FE.