### PR TITLE
Make check executions factory more dynamic

### DIFF
--- a/assets/js/components/ChecksResults/checksUtils.test.js
+++ b/assets/js/components/ChecksResults/checksUtils.test.js
@@ -2,7 +2,8 @@ import { faker } from '@faker-js/faker';
 import {
   agentCheckResultFactory,
   catalogCheckFactory,
-  checksExecutionFactory,
+  checksExecutionCompletedFactory,
+  checksExecutionRunningFactory,
   checkResultFactory,
 } from '@lib/test-utils/factories';
 
@@ -17,10 +18,9 @@ import {
 describe('checksUtils', () => {
   describe('getChecksResults', () => {
     it('getChecksResults returns a list of checks results', () => {
-      const checksExecution = checksExecutionFactory.build();
-      const checkResults = getCheckResults(checksExecution);
-
-      expect(checkResults).toBe(checksExecution.check_results);
+      const execution = checksExecutionCompletedFactory.build();
+      const checkResults = getCheckResults(execution);
+      expect(checkResults).toBe(execution.check_results);
     });
 
     it('getChecksResults returns an empty list when the execution is empty', () => {
@@ -28,10 +28,8 @@ describe('checksUtils', () => {
     });
 
     it('getChecksResults returns an empty list when there are no checks results', () => {
-      const checksExecution = checksExecutionFactory.build({
-        check_results: [],
-      });
-      expect(getCheckResults(checksExecution)).toStrictEqual([]);
+      const execution = checksExecutionRunningFactory.build();
+      expect(getCheckResults(execution)).toStrictEqual([]);
     });
   });
 
@@ -70,12 +68,12 @@ describe('checksUtils', () => {
 
   describe('getHealth', () => {
     it('getHealth should return health', () => {
-      const checkResults = checkResultFactory.build();
+      const checkResult = checkResultFactory.build();
       const { check_id: checkID, agents_check_results: agentChecks } =
-        checkResults;
+        checkResult;
 
       const { health, expectations, failedExpectations } = getHealth(
-        [checkResults],
+        [checkResult],
         checkID,
         agentChecks[0].agent_id
       );
@@ -86,11 +84,13 @@ describe('checksUtils', () => {
     });
 
     it('getHealth should return undefined when check is not found', () => {
-      const agentID = faker.datatype.uuid();
-      const { check_results: checkResults } = checksExecutionFactory.build({
-        agentID,
-      });
-      const healthInfo = getHealth(checkResults, 'carbonara', agentID);
+      const checkResult = checkResultFactory.build();
+      const { agents_check_results: agentChecks } = checkResult;
+      const healthInfo = getHealth(
+        [checkResult],
+        'carbonara',
+        agentChecks[0].agent_id
+      );
 
       expect(healthInfo).toBe(undefined);
     });

--- a/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
@@ -5,7 +5,8 @@ import { renderWithRouter } from '@lib/test-utils';
 import {
   hostnameFactory,
   agentCheckResultFactory,
-  checksExecutionFactory,
+  checksExecutionCompletedFactory,
+  checksExecutionRunningFactory,
   checkResultFactory,
   catalogCheckFactory,
 } from '@lib/test-utils/factories';
@@ -26,9 +27,8 @@ describe('ExecutionResults', () => {
       agents_check_results: [agent1, agent2],
     });
 
-    const executionResult = checksExecutionFactory.build({
+    const executionResult = checksExecutionCompletedFactory.build({
       check_results: checkResults,
-      status: 'completed',
       result: 'passing',
     });
     const {
@@ -57,17 +57,8 @@ describe('ExecutionResults', () => {
 
   it('should render ExecutionResults with running state', async () => {
     const hostnames = hostnameFactory.buildList(2);
-    const [{ id: agentID }] = hostnames;
-    const executionResult = checksExecutionFactory.build({
-      agentID,
-      status: 'running',
-    });
-    const {
-      groupID: clusterID,
-      execution_id: executionID,
-      check_results: [{ check_id: checkID }],
-    } = executionResult;
-    const catalog = [catalogCheckFactory.build({ id: checkID })];
+    const executionResult = checksExecutionRunningFactory.build();
+    const { group_id: clusterID, execution_id: executionID } = executionResult;
 
     await act(async () => {
       renderWithRouter(
@@ -75,7 +66,7 @@ describe('ExecutionResults', () => {
           clusterID={clusterID}
           executionID={executionID}
           onExecutionFetch={() => Promise.resolve({ data: executionResult })}
-          onCatalogFetch={() => Promise.resolve({ data: { items: catalog } })}
+          onCatalogFetch={() => Promise.resolve({ data: { items: [] } })}
           hostnames={hostnames}
         />
       );

--- a/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
@@ -4,7 +4,9 @@ import { act, screen } from '@testing-library/react';
 import { renderWithRouter } from '@lib/test-utils';
 import {
   hostnameFactory,
+  agentCheckResultFactory,
   checksExecutionFactory,
+  checkResultFactory,
   catalogCheckFactory,
 } from '@lib/test-utils/factories';
 
@@ -13,9 +15,19 @@ import ExecutionResults from './ExecutionResults';
 describe('ExecutionResults', () => {
   it('should render ExecutionResults with successfully fetched results', async () => {
     const hostnames = hostnameFactory.buildList(2);
-    const [{ id: agentID, hostname }] = hostnames;
+    const [
+      { id: agentID1, hostname: hostname1 },
+      { id: agentID2, hostname: hostname2 },
+    ] = hostnames;
+
+    const agent1 = agentCheckResultFactory.build({ agent_id: agentID1 });
+    const agent2 = agentCheckResultFactory.build({ agent_id: agentID2 });
+    const checkResults = checkResultFactory.buildList(1, {
+      agents_check_results: [agent1, agent2],
+    });
+
     const executionResult = checksExecutionFactory.build({
-      agentID,
+      check_results: checkResults,
       status: 'completed',
       result: 'passing',
     });
@@ -38,8 +50,9 @@ describe('ExecutionResults', () => {
       );
     });
 
-    expect(screen.getByText(hostname)).toBeTruthy();
-    expect(screen.getByText(checkID)).toBeTruthy();
+    expect(screen.getByText(hostname1)).toBeTruthy();
+    expect(screen.getByText(hostname2)).toBeTruthy();
+    expect(screen.getAllByText(checkID)).toHaveLength(2);
   });
 
   it('should render ExecutionResults with running state', async () => {

--- a/assets/js/lib/test-utils/factories/executions.js
+++ b/assets/js/lib/test-utils/factories/executions.js
@@ -8,18 +8,41 @@ export const checksExecutionStatusEnum = () =>
 const expectationReturnTypeEnum = () =>
   faker.helpers.arrayElement(['expect', 'expect_same']);
 
-export const checksExecutionFactory = Factory.define(() => {
-  return {
-    completed_at: faker.date.soon(),
-    execution_id: faker.datatype.uuid(),
-    group_id: faker.datatype.uuid(),
-    result: resultEnum(),
-    started_at: faker.date.soon(),
-    status: checksExecutionStatusEnum(),
-    timeout: [],
-    check_results: checkResultFactory.buildList(2),
-  };
+export const checksExecutionRunningFactory = Factory.define(() => ({
+  completed_at: null,
+  execution_id: faker.datatype.uuid(),
+  group_id: faker.datatype.uuid(),
+  result: null,
+  started_at: faker.date.soon(),
+  status: 'running',
+  timeout: [],
+  check_results: null,
+  targets: targetFactory.buildList(2),
+  passing_count: null,
+  warning_count: null,
+  critical_count: null,
+}));
+
+export const checksExecutionCompletedFactory = Factory.define(({ params }) => {
+  return withCompletedResults(checksExecutionRunningFactory.build(params));
 });
+
+export const withCompletedResults = (execution, result, checkResults) => {
+  return {
+    ...execution,
+    status: 'completed',
+    result: result ? result : checksExecutionStatusEnum(),
+    check_results: checkResults
+      ? checkResults
+      : checkResultFactory.buildList(2),
+    completed_at: faker.date.soon(),
+  };
+};
+
+export const targetFactory = Factory.define(() => ({
+  agent_id: faker.datatype.uuid(),
+  checks: Array.from({ length: 5 }).map((_) => faker.datatype.uuid()),
+}));
 
 export const checkResultFactory = Factory.define(() => ({
   check_id: faker.datatype.uuid(),

--- a/assets/js/lib/test-utils/factories/executions.js
+++ b/assets/js/lib/test-utils/factories/executions.js
@@ -1,0 +1,65 @@
+import { faker } from '@faker-js/faker';
+import { Factory } from 'fishery';
+import { resultEnum } from '.';
+
+export const checksExecutionStatusEnum = () =>
+  faker.helpers.arrayElement(['running', 'completed']);
+
+const expectationReturnTypeEnum = () =>
+  faker.helpers.arrayElement(['expect', 'expect_same']);
+
+export const checksExecutionFactory = Factory.define(() => {
+  return {
+    completed_at: faker.date.soon(),
+    execution_id: faker.datatype.uuid(),
+    group_id: faker.datatype.uuid(),
+    result: resultEnum(),
+    started_at: faker.date.soon(),
+    status: checksExecutionStatusEnum(),
+    timeout: [],
+    check_results: checkResultFactory.buildList(2),
+  };
+});
+
+export const checkResultFactory = Factory.define(() => ({
+  check_id: faker.datatype.uuid(),
+  result: resultEnum(),
+  agents_check_results: agentCheckResultFactory.buildList(2),
+  expectation_results: expectationResultFactory.buildList(2),
+}));
+
+export const agentCheckResultFactory = Factory.define(() => {
+  executionExpectationEvaluationFactory.rewindSequence();
+
+  return {
+    agent_id: faker.datatype.uuid(),
+    expectation_evaluations: executionExpectationEvaluationFactory.buildList(2),
+    facts: executionFactFactory.buildList(2),
+    values: executionValueFactory.buildList(2),
+  };
+});
+
+export const expectationResultFactory = Factory.define(({ sequence }) => ({
+  name: `execution_${sequence}`,
+  result: faker.datatype.boolean(),
+  type: expectationReturnTypeEnum(),
+}));
+
+export const executionExpectationEvaluationFactory = Factory.define(
+  ({ sequence }) => ({
+    name: `execution_${sequence}`,
+    return_value: faker.datatype.number(),
+    type: expectationReturnTypeEnum(),
+  })
+);
+
+export const executionFactFactory = Factory.define(() => ({
+  check_id: faker.datatype.uuid(),
+  name: faker.animal.cat(),
+  value: faker.datatype.number(),
+}));
+
+export const executionValueFactory = Factory.define(() => ({
+  name: faker.animal.cat(),
+  value: faker.datatype.number(),
+}));

--- a/assets/js/lib/test-utils/factories/index.js
+++ b/assets/js/lib/test-utils/factories/index.js
@@ -1,10 +1,12 @@
 import { faker } from '@faker-js/faker';
 import { Factory } from 'fishery';
 
+export * from './executions';
+
 const healthEnum = () =>
   faker.helpers.arrayElement(['requested', 'running', 'not_running']);
 
-const resultEnum = () =>
+export const resultEnum = () =>
   faker.helpers.arrayElement(['passing', 'critical', 'warning']);
 
 export const checkFactory = Factory.define(() => ({
@@ -35,53 +37,6 @@ export const catalogCheckFactory = Factory.define(() => ({
   description: faker.lorem.paragraph(),
   remediation: faker.lorem.paragraph(),
 }));
-
-export const checksExecutionStatusEnum = () =>
-  faker.helpers.arrayElement(['running', 'completed']);
-
-export const checksExecutionFactory = Factory.define(({ params }) => {
-  const {
-    agentID = faker.datatype.uuid(),
-    groupID = faker.datatype.uuid(),
-    executionID = faker.datatype.uuid(),
-    checkID = faker.datatype.uuid(),
-  } = params;
-
-  return {
-    completed_at: '2022-11-09T17:02:20.629366Z',
-    execution_id: executionID,
-    group_id: groupID,
-    result: resultEnum(),
-    started_at: '2022-11-09T15:11:31.436586Z',
-    status: checksExecutionStatusEnum(),
-    timeout: [],
-    check_results: [
-      {
-        agents_check_results: [
-          {
-            agent_id: agentID,
-            expectation_evaluations: [
-              {
-                name: 'expectation_example',
-                return_value: 123,
-                type: 'expect',
-              },
-            ],
-            facts: [
-              { check_id: checkID, name: 'lol_this_is_a_fact', value: 123 },
-            ],
-            values: [],
-          },
-        ],
-        check_id: checkID,
-        expectation_results: [
-          { name: 'expectation_example', result: true, type: 'expect' },
-        ],
-        result: resultEnum(),
-      },
-    ],
-  };
-});
 
 export const hostnameFactory = Factory.define(() => ({
   id: faker.datatype.uuid(),


### PR DESCRIPTION
Make execution results factory dynamic, without hardcoded values. To make it easier to follow, I have splitted the factories module in a folder and subfiles. By now, the old factories are in the index file, but we should move them to logical component files.

The execution factory still misses some improvements and functions like `withPassingResult`, `withAgentError`, etc, but I will add them in a next PR

PD: please don't look that much on the `checksUtils` file tests, I'm working in a sustantial change there. I just made the checks compliant by now
