### PR TITLE
Broadcast execution completed

### DIFF
--- a/assets/js/state/index.js
+++ b/assets/js/state/index.js
@@ -14,7 +14,9 @@ import catalogNewReducer from './catalogNew';
 import lastExecutionsReducer from './lastExecutions';
 import liveFeedReducer from './liveFeed';
 import settingsReducer from './settings';
-import registerEvents from './registerSocketEvents';
+import registerEvents, { joinChannel } from './registerSocketEvents';
+
+import { updateLastExecution } from '@state/actions/lastExecutions';
 
 import rootSaga from './sagas';
 
@@ -72,6 +74,16 @@ const processChannelEvents = (store) => {
     'database_instance_health_changed',
     'database_instance_system_replication_changed',
   ]);
+
+  // FIXME: This is to overcome the fact that we are generating names with registerEvents
+  // in the future we want to remove this and use the constants directly,
+  // since events and actions may have different names and parameters.
+  const channel = socket.channel('monitoring:executions', {});
+  channel.on('execution_completed', ({ group_id: groupID }) => {
+    store.dispatch(updateLastExecution(groupID));
+  });
+
+  joinChannel(channel);
 };
 
 processChannelEvents(store);

--- a/assets/js/state/registerSocketEvents.js
+++ b/assets/js/state/registerSocketEvents.js
@@ -1,6 +1,6 @@
 import { logMessage, logError } from '@lib/log';
 
-const joinChannel = (channel) => {
+export const joinChannel = (channel) => {
   channel
     .join()
     .receive('ok', ({ messages }) => logMessage('catching up', messages))


### PR DESCRIPTION
Adds the updated execution completed action dispatch when the BE receives an execution completed event from wanda.

NOTE:
I had to add the channel and the callback manually and couldn't rely on the `registerEvents` utility function since the name of the action and the message sent to the phoenix channel differs.
Also, I'd like to use action constants instead of generating the name of the action so I will track a debt to track an improvement on this side.