### PR TITLE
Fix AboutPage test console error output

### DIFF
--- a/assets/js/components/AboutPage/AboutPage.test.jsx
+++ b/assets/js/components/AboutPage/AboutPage.test.jsx
@@ -24,6 +24,8 @@ describe('AboutPage component', () => {
   it('should render the about page with default values if api get request fails', async () => {
     const stateValues = { flavor: 'N/A', subscriptions: 0, version: 'v0.0.0' };
     const errorMessage = { messages: "Get request '/api/about' failed" };
+    jest.spyOn(console, 'error').mockImplementation(() => null);
+
     await act(async () => {
       renderWithRouter(
         <AboutPage onFetch={() => Promise.reject(errorMessage)} />


### PR DESCRIPTION
# Description

Every time we run the AboutPage test, there is an annoying console log error message, even when the test runs perfect.

```
 console.error
    { messages: "Get request '/api/about' failed" }
```

The pr will remove the message, so the console log of the CI is not misleading.
