### PR TITLE
Read `ExecutionResults` state from Redux store

### DIFF
--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -13,7 +13,6 @@ import {
   ResultsContainer,
   HostResultsWrapper,
   CheckResult,
-  getChecks,
   getHealth,
   getCheckResults,
   getCheckDescription,
@@ -123,15 +122,13 @@ function ExecutionResults({
         catalogError={false}
         clusterID={clusterID}
         hasAlreadyChecksResults
-        selectedChecks={getChecks(checkResults)}
+        selectedChecks={checkResults}
         onCatalogRefresh={onCatalogRefresh}
       >
         {executionData?.targets.map(({ agent_id: hostID, checks }) => (
           <HostResultsWrapper
             key={hostID}
             hostname={hostnames.find(({ id }) => hostID === id)?.hostname}
-            reachable
-            unreachableMessage=""
           >
             {checks.map((checkID) => {
               const { health, error, expectations, failedExpectations } =

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -75,7 +75,14 @@ function ExecutionResults({
             : catalogError || executionError
         }
         buttonText="Try again"
-        buttonOnClick={onCatalogRefresh}
+        buttonOnClick={() => {
+          if (catalogError) {
+            onCatalogRefresh();
+          }
+          if (executionError) {
+            onLastExecutionUpdate();
+          }
+        }}
       />
     );
   }

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -87,10 +87,6 @@ function ExecutionResults({
     );
   }
 
-  if (executionData?.status === 'running') {
-    return <LoadingBox text="Check execution currently running..." />;
-  }
-
   const checkResults = getCheckResults(executionData);
 
   return (

--- a/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
@@ -1,78 +1,167 @@
 import React from 'react';
-import { act, screen } from '@testing-library/react';
-
-import { renderWithRouter } from '@lib/test-utils';
+import { screen } from '@testing-library/react';
+import { renderWithRouter, withState } from '@lib/test-utils';
 import {
   agentCheckResultFactory,
   checksExecutionCompletedFactory,
-  checksExecutionRunningFactory,
   checkResultFactory,
+  expectationResultFactory,
 } from '@lib/test-utils/factories/executions';
-import {
-  catalogCheckFactory,
-  hostnameFactory,
-} from '@lib/test-utils/factories';
+import { catalogFactory, hostnameFactory } from '@lib/test-utils/factories';
 
 import ExecutionResults from './ExecutionResults';
 
+const prepareStateData = (checkExecutionStatus) => {
+  const hostnames = hostnameFactory.buildList(2);
+  const [{ id: agentID1 }, { id: agentID2 }] = hostnames;
+  const agent1 = agentCheckResultFactory.build({ agent_id: agentID1 });
+  const agent2 = agentCheckResultFactory.build({ agent_id: agentID2 });
+  const agents = [agent1, agent2];
+  const checkResults = checkResultFactory.buildList(1, {
+    agents_check_results: [agent1, agent2],
+  });
+  const executionResult = checksExecutionCompletedFactory.build({
+    check_results: checkResults,
+    result: 'completed',
+  });
+
+  const {
+    group_id: clusterID,
+    check_results: [{ check_id: checkID }],
+  } = executionResult;
+
+  const { loading, catalog, error } = catalogFactory.build({
+    loading: false,
+    catalog: [catalogFactory.build({ id: checkID })],
+    error: null,
+  });
+
+  const targets = [
+    { agent_id: agentID1, checks: [catalog[0].id] },
+    { agent_id: agentID2, checks: [catalog[0].id] },
+  ];
+
+  const checkResult = checkResultFactory.build({
+    check_id: checkID,
+    result: 'passing',
+    agents_check_results: [agent1, agent2],
+    expectation_results: expectationResultFactory.buildList(2, {
+      result: true,
+    }),
+  });
+
+  const lastExecution = {
+    executionLoading: false,
+    executionData: {
+      status: checkExecutionStatus,
+      targets,
+      check_results: [checkResult],
+    },
+    error: '',
+  };
+
+  const {
+    executionLoading,
+    executionData,
+    error: executionError,
+  } = lastExecution;
+
+  const initialState = {
+    catalogNew: { loading, data: catalog, error },
+    lastExecutions: {
+      [clusterID]: {
+        loading: executionLoading,
+        error: executionError,
+        data: executionData,
+      },
+    },
+  };
+
+  return {
+    initialState,
+    clusterID,
+    executionResult,
+    loading,
+    catalog,
+    error,
+    targets,
+    hostnames,
+    checkID,
+    agents,
+    checkResult,
+    executionLoading,
+    executionData,
+    executionError,
+  };
+};
+
 describe('ExecutionResults', () => {
   it('should render ExecutionResults with successfully fetched results', async () => {
-    const hostnames = hostnameFactory.buildList(2);
-    const [
-      { id: agentID1, hostname: hostname1 },
-      { id: agentID2, hostname: hostname2 },
-    ] = hostnames;
-
-    const agent1 = agentCheckResultFactory.build({ agent_id: agentID1 });
-    const agent2 = agentCheckResultFactory.build({ agent_id: agentID2 });
-    const checkResults = checkResultFactory.buildList(1, {
-      agents_check_results: [agent1, agent2],
-    });
-
-    const executionResult = checksExecutionCompletedFactory.build({
-      check_results: checkResults,
-      result: 'passing',
-    });
     const {
-      groupID: clusterID,
-      execution_id: executionID,
-      check_results: [{ check_id: checkID }],
-    } = executionResult;
-    const catalog = [catalogCheckFactory.build({ id: checkID })];
+      initialState,
+      clusterID,
+      hostnames,
+      checkID,
+      loading,
+      catalog,
+      error,
+      executionLoading,
+      executionData,
+      executionError,
+    } = prepareStateData('passing');
 
-    await act(async () => {
-      renderWithRouter(
-        <ExecutionResults
-          clusterID={clusterID}
-          executionID={executionID}
-          onExecutionFetch={() => Promise.resolve({ data: executionResult })}
-          onCatalogFetch={() => Promise.resolve({ data: { items: catalog } })}
-          hostnames={hostnames}
-        />
-      );
-    });
+    const [StatefulExecutionResults] = withState(
+      <ExecutionResults
+        clusterID={clusterID}
+        clusterName="test-cluster"
+        cloudProvider="test-provider"
+        hostnames={hostnames}
+        catalogLoading={loading}
+        catalog={catalog}
+        catalogError={error}
+        executionLoading={executionLoading}
+        executionData={executionData}
+        executionError={executionError}
+      />,
+      initialState
+    );
 
-    expect(screen.getByText(hostname1)).toBeTruthy();
-    expect(screen.getByText(hostname2)).toBeTruthy();
+    renderWithRouter(StatefulExecutionResults);
+
+    expect(screen.getByText(hostnames[0].hostname)).toBeTruthy();
+    expect(screen.getByText(hostnames[1].hostname)).toBeTruthy();
     expect(screen.getAllByText(checkID)).toHaveLength(2);
+    expect(screen.getAllByText('2/2 expectations passed')).toBeTruthy();
   });
 
   it('should render ExecutionResults with running state', async () => {
-    const hostnames = hostnameFactory.buildList(2);
-    const executionResult = checksExecutionRunningFactory.build();
-    const { group_id: clusterID, execution_id: executionID } = executionResult;
+    const {
+      initialState,
+      clusterID,
+      hostnames,
+      loading,
+      catalog,
+      error,
+      executionLoading,
+      executionData,
+      executionError,
+    } = prepareStateData('running');
 
-    await act(async () => {
-      renderWithRouter(
-        <ExecutionResults
-          clusterID={clusterID}
-          executionID={executionID}
-          onExecutionFetch={() => Promise.resolve({ data: executionResult })}
-          onCatalogFetch={() => Promise.resolve({ data: { items: [] } })}
-          hostnames={hostnames}
-        />
-      );
-    });
+    const [StatefulExecutionResults] = withState(
+      <ExecutionResults
+        clusterID={clusterID}
+        hostnames={hostnames}
+        catalogLoading={loading}
+        catalog={catalog}
+        catalogError={error}
+        executionLoading={executionLoading}
+        executionData={executionData}
+        executionError={executionError}
+      />,
+      initialState
+    );
+
+    renderWithRouter(StatefulExecutionResults);
 
     expect(
       screen.getByText('Check execution currently running...')

--- a/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
@@ -129,7 +129,7 @@ describe('ExecutionResults', () => {
       executionError,
     } = prepareStateData('running');
 
-    const { getByText } = renderWithRouter(
+    const { container } = renderWithRouter(
       <ExecutionResults
         clusterID={clusterID}
         hostnames={hostnames}
@@ -141,7 +141,11 @@ describe('ExecutionResults', () => {
         executionError={executionError}
       />
     );
-
-    expect(getByText('Check execution currently running...')).toBeTruthy();
+    const svgEl = container.querySelector("[data-testid='eos-svg-component']");
+    const transform = svgEl.getAttribute('transform');
+    expect(svgEl.classList.toString()).toContain(
+      'inline-block fill-jungle-green-500'
+    );
+    expect(transform).toEqual('rotate(0) translate(0, 0) scale(1, 1)');
   });
 });

--- a/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
-import { renderWithRouter, withState } from '@lib/test-utils';
+import { renderWithRouter } from '@lib/test-utils';
 import {
   agentCheckResultFactory,
   checksExecutionCompletedFactory,
@@ -22,7 +21,7 @@ const prepareStateData = (checkExecutionStatus) => {
   });
   const executionResult = checksExecutionCompletedFactory.build({
     check_results: checkResults,
-    result: 'completed',
+    result: 'passing',
   });
 
   const {
@@ -66,19 +65,7 @@ const prepareStateData = (checkExecutionStatus) => {
     error: executionError,
   } = lastExecution;
 
-  const initialState = {
-    catalogNew: { loading, data: catalog, error },
-    lastExecutions: {
-      [clusterID]: {
-        loading: executionLoading,
-        error: executionError,
-        data: executionData,
-      },
-    },
-  };
-
   return {
-    initialState,
     clusterID,
     executionResult,
     loading,
@@ -98,7 +85,6 @@ const prepareStateData = (checkExecutionStatus) => {
 describe('ExecutionResults', () => {
   it('should render ExecutionResults with successfully fetched results', async () => {
     const {
-      initialState,
       clusterID,
       hostnames,
       checkID,
@@ -110,7 +96,7 @@ describe('ExecutionResults', () => {
       executionError,
     } = prepareStateData('passing');
 
-    const [StatefulExecutionResults] = withState(
+    const { getByText, getAllByText } = renderWithRouter(
       <ExecutionResults
         clusterID={clusterID}
         clusterName="test-cluster"
@@ -122,21 +108,17 @@ describe('ExecutionResults', () => {
         executionLoading={executionLoading}
         executionData={executionData}
         executionError={executionError}
-      />,
-      initialState
+      />
     );
 
-    renderWithRouter(StatefulExecutionResults);
-
-    expect(screen.getByText(hostnames[0].hostname)).toBeTruthy();
-    expect(screen.getByText(hostnames[1].hostname)).toBeTruthy();
-    expect(screen.getAllByText(checkID)).toHaveLength(2);
-    expect(screen.getAllByText('2/2 expectations passed')).toBeTruthy();
+    expect(getByText(hostnames[0].hostname)).toBeTruthy();
+    expect(getByText(hostnames[1].hostname)).toBeTruthy();
+    expect(getAllByText(checkID)).toHaveLength(2);
+    expect(getAllByText('2/2 expectations passed')).toBeTruthy();
   });
 
   it('should render ExecutionResults with running state', async () => {
     const {
-      initialState,
       clusterID,
       hostnames,
       loading,
@@ -147,7 +129,7 @@ describe('ExecutionResults', () => {
       executionError,
     } = prepareStateData('running');
 
-    const [StatefulExecutionResults] = withState(
+    const { getByText } = renderWithRouter(
       <ExecutionResults
         clusterID={clusterID}
         hostnames={hostnames}
@@ -157,14 +139,9 @@ describe('ExecutionResults', () => {
         executionLoading={executionLoading}
         executionData={executionData}
         executionError={executionError}
-      />,
-      initialState
+      />
     );
 
-    renderWithRouter(StatefulExecutionResults);
-
-    expect(
-      screen.getByText('Check execution currently running...')
-    ).toBeTruthy();
+    expect(getByText('Check execution currently running...')).toBeTruthy();
   });
 });

--- a/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
-
+import { getCatalog } from '@state/selectors/catalog';
+import { getLastExecution } from '@state/selectors/lastExecutions';
 import { getCluster } from '@state/selectors';
-
+import { updateLastExecution } from '@state/actions/lastExecutions';
 import ExecutionResults from './ExecutionResults';
 
 function ExecutionResultsPage() {
-  const { clusterID, executionID } = useParams();
+  const { clusterID } = useParams();
   const dispatch = useDispatch();
   const hostnames = useSelector((state) =>
     state.hostsList.hosts
@@ -16,10 +17,30 @@ function ExecutionResultsPage() {
   );
   const cluster = useSelector(getCluster(clusterID));
 
+  const {
+    loading: catalogLoading,
+    data: catalog,
+    error: catalogError,
+  } = useSelector(getCatalog());
+  const lastExecution = useSelector(getLastExecution(clusterID));
+
+  if (!lastExecution) {
+    return (
+      <h1 className="font-light font-sans text-center text-4xl text-gray-700">
+        No completed executions yet
+      </h1>
+    );
+  }
+
+  const {
+    loading: executionLoading,
+    data: executionData,
+    error: executionError,
+  } = lastExecution;
+
   return (
     <ExecutionResults
       clusterID={clusterID}
-      executionID={executionID}
       hostnames={hostnames}
       clusterName={cluster?.name}
       cloudProvider={cluster?.provider}
@@ -29,6 +50,13 @@ function ExecutionResultsPage() {
           payload: { provider: cluster?.provider },
         });
       }}
+      onLastExecutionUpdate={() => dispatch(updateLastExecution(clusterID))}
+      catalogLoading={catalogLoading}
+      catalog={catalog}
+      catalogError={catalogError}
+      executionData={executionLoading}
+      ecutionData={executionData}
+      executionError={executionError}
     />
   );
 }

--- a/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
@@ -44,12 +44,12 @@ function ExecutionResultsPage() {
       hostnames={hostnames}
       clusterName={cluster?.name}
       cloudProvider={cluster?.provider}
-      onCatalogRefresh={() => {
+      onCatalogRefresh={() =>
         dispatch({
           type: 'UPDATE_CATALOG',
           payload: { provider: cluster?.provider },
-        });
-      }}
+        })
+      }
       onLastExecutionUpdate={() => dispatch(updateLastExecution(clusterID))}
       catalogLoading={catalogLoading}
       catalog={catalog}

--- a/assets/js/lib/test-utils/factories/index.js
+++ b/assets/js/lib/test-utils/factories/index.js
@@ -39,6 +39,12 @@ export const catalogCheckFactory = Factory.define(() => ({
   remediation: faker.lorem.paragraph(),
 }));
 
+export const catalogFactory = Factory.define(() => ({
+  loading: faker.datatype.boolean(),
+  catalog: catalogCheckFactory.build(),
+  error: null,
+}));
+
 export const hostnameFactory = Factory.define(() => ({
   id: faker.datatype.uuid(),
   hostname: faker.hacker.noun(),

--- a/assets/js/lib/test-utils/index.jsx
+++ b/assets/js/lib/test-utils/index.jsx
@@ -30,7 +30,6 @@ const defaultInitialState = {
 
 export const withState = (component, initialState = {}) => {
   const store = mockStore(initialState);
-
   return [
     <Provider key="root" store={store}>
       {component}

--- a/assets/js/trento.jsx
+++ b/assets/js/trento.jsx
@@ -67,7 +67,7 @@ function App() {
                 element={<ChecksResults />}
               />
               <Route
-                path="clusters/:clusterID/executions/:executionID"
+                path="clusters/:clusterID/executions/last"
                 element={<ExecutionResultsPage />}
               />
               <Route path="hosts/:hostID" element={<HostDetails />} />


### PR DESCRIPTION
# Description

- `ExecutionResults` component now reads in it's state as props (provided by `ExecutionResultsPage`).
- Added a loading box when waiting for an execution to finish.
- Added notification box when there is a catalog error or execution error.
- Endpoint previously `clusters/:clusterID/executions/:executionID` is now `clusters/:clusterID/executions/last`

# How was this tested?

Updated `ExecutionResult` test
- Created a `catalogFactory` for mocking during testing