### PR TITLE
Transition start execution running

### DIFF
--- a/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
@@ -158,7 +158,7 @@ function ChecksSelectionNew({ clusterId, cluster }) {
           {localSavingSuccess && selectedChecks.length > 0 && (
             <SuggestTriggeringChecksExecutionAfterSettingsUpdated
               clusterId={clusterId}
-              usingWanda={true}
+              usingWanda
               onClose={() => setLocalSavingSuccess(null)}
             />
           )}

--- a/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
@@ -158,6 +158,7 @@ function ChecksSelectionNew({ clusterId, cluster }) {
           {localSavingSuccess && selectedChecks.length > 0 && (
             <SuggestTriggeringChecksExecutionAfterSettingsUpdated
               clusterId={clusterId}
+              usingWanda={true}
               onClose={() => setLocalSavingSuccess(null)}
             />
           )}

--- a/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
@@ -158,7 +158,7 @@ function ChecksSelectionNew({ clusterId, cluster }) {
           {localSavingSuccess && selectedChecks.length > 0 && (
             <SuggestTriggeringChecksExecutionAfterSettingsUpdated
               clusterId={clusterId}
-              usingWanda
+              usingNewChecksEngine
               onClose={() => setLocalSavingSuccess(null)}
             />
           )}

--- a/assets/js/components/ClusterDetails/ClusterDetailsNew.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetailsNew.jsx
@@ -144,7 +144,7 @@ export function ClusterDetailsNew() {
             cssClasses="rounded relative w-1/4 ml-0.5 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-gray-400"
             clusterId={clusterID}
             disabled={!hasSelectedChecks}
-            usingWanda={true}
+            usingWanda
           >
             <EOS_PLAY_CIRCLE
               className={classNames('inline-block fill-jungle-green-500', {

--- a/assets/js/components/ClusterDetails/ClusterDetailsNew.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetailsNew.jsx
@@ -144,7 +144,7 @@ export function ClusterDetailsNew() {
             cssClasses="rounded relative w-1/4 ml-0.5 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-gray-400"
             clusterId={clusterID}
             disabled={!hasSelectedChecks}
-            usingWanda
+            usingNewChecksEngine
           >
             <EOS_PLAY_CIRCLE
               className={classNames('inline-block fill-jungle-green-500', {

--- a/assets/js/components/ClusterDetails/ClusterDetailsNew.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetailsNew.jsx
@@ -124,7 +124,7 @@ export function ClusterDetailsNew() {
             type="primary-white"
             className="w-1/4 mx-0.5 border-green-500 border"
             size="small"
-            onClick={() => navigate(`/clusters/${clusterID}/settings_new`)}
+            onClick={() => navigate(`/clusters_new/${clusterID}/settings`)}
           >
             <EOS_SETTINGS className="inline-block fill-jungle-green-500" />{' '}
             Settings
@@ -133,7 +133,9 @@ export function ClusterDetailsNew() {
             type="primary-white"
             className="w-1/4 mx-0.5 border-green-500 border"
             size="small"
-            onClick={() => navigate(`/clusters/${clusterID}/checks/results`)}
+            onClick={() =>
+              navigate(`/clusters_new/${clusterID}/executions/last`)
+            }
           >
             <EOS_CLEAR_ALL className="inline-block fill-jungle-green-500" />{' '}
             Show Results
@@ -142,6 +144,7 @@ export function ClusterDetailsNew() {
             cssClasses="rounded relative w-1/4 ml-0.5 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-gray-400"
             clusterId={clusterID}
             disabled={!hasSelectedChecks}
+            usingWanda={true}
           >
             <EOS_PLAY_CIRCLE
               className={classNames('inline-block fill-jungle-green-500', {

--- a/assets/js/components/ClusterDetails/ClusterSettings.jsx
+++ b/assets/js/components/ClusterDetails/ClusterSettings.jsx
@@ -18,13 +18,13 @@ import { truncatedClusterNameClasses } from './ClusterDetails';
 
 export const UNKNOWN_PROVIDER = 'unknown';
 
-export function ClusterSettings({ newChecksSelectionView = false }) {
+export function ClusterSettings({ usingWanda = false }) {
   const { clusterID } = useParams();
 
   const cluster = useSelector(getCluster(clusterID));
 
   const tabsSettings = {
-    'Checks Selection': newChecksSelectionView ? (
+    'Checks Selection': usingWanda ? (
       <ChecksSelectionNew clusterId={clusterID} cluster={cluster} />
     ) : (
       <ChecksSelection clusterId={clusterID} cluster={cluster} />
@@ -40,7 +40,11 @@ export function ClusterSettings({ newChecksSelectionView = false }) {
 
   return (
     <div className="w-full px-2 sm:px-0">
-      <BackButton url={`/clusters/${clusterID}`}>
+      <BackButton
+        url={
+          usingWanda ? `/clusters_new/${clusterID}` : `/clusters/${clusterID}`
+        }
+      >
         Back to Cluster Details
       </BackButton>
       <div className="flex mb-2">
@@ -117,6 +121,7 @@ export function SavingFailedAlert({ onClose = () => {}, children }) {
 
 export function SuggestTriggeringChecksExecutionAfterSettingsUpdated({
   clusterId,
+  usingWanda = false,
   onClose = () => {},
 }) {
   return (
@@ -131,6 +136,7 @@ export function SuggestTriggeringChecksExecutionAfterSettingsUpdated({
         <TriggerChecksExecutionRequest
           cssClasses="tn-checks-start-execute rounded-full group flex rounded-full items-center text-sm px-2 bg-jungle-green-500 text-white"
           clusterId={clusterId}
+          usingWanda={usingWanda}
         >
           <EOS_PLAY_CIRCLE color="green" />
         </TriggerChecksExecutionRequest>

--- a/assets/js/components/ClusterDetails/ClusterSettings.jsx
+++ b/assets/js/components/ClusterDetails/ClusterSettings.jsx
@@ -18,13 +18,13 @@ import { truncatedClusterNameClasses } from './ClusterDetails';
 
 export const UNKNOWN_PROVIDER = 'unknown';
 
-export function ClusterSettings({ usingWanda = false }) {
+export function ClusterSettings({ usingNewChecksEngine = false }) {
   const { clusterID } = useParams();
 
   const cluster = useSelector(getCluster(clusterID));
 
   const tabsSettings = {
-    'Checks Selection': usingWanda ? (
+    'Checks Selection': usingNewChecksEngine ? (
       <ChecksSelectionNew clusterId={clusterID} cluster={cluster} />
     ) : (
       <ChecksSelection clusterId={clusterID} cluster={cluster} />
@@ -42,7 +42,9 @@ export function ClusterSettings({ usingWanda = false }) {
     <div className="w-full px-2 sm:px-0">
       <BackButton
         url={
-          usingWanda ? `/clusters_new/${clusterID}` : `/clusters/${clusterID}`
+          usingNewChecksEngine
+            ? `/clusters_new/${clusterID}`
+            : `/clusters/${clusterID}`
         }
       >
         Back to Cluster Details
@@ -121,7 +123,7 @@ export function SavingFailedAlert({ onClose = () => {}, children }) {
 
 export function SuggestTriggeringChecksExecutionAfterSettingsUpdated({
   clusterId,
-  usingWanda = false,
+  usingNewChecksEngine = false,
   onClose = () => {},
 }) {
   return (
@@ -136,7 +138,7 @@ export function SuggestTriggeringChecksExecutionAfterSettingsUpdated({
         <TriggerChecksExecutionRequest
           cssClasses="tn-checks-start-execute rounded-full group flex rounded-full items-center text-sm px-2 bg-jungle-green-500 text-white"
           clusterId={clusterId}
-          usingWanda={usingWanda}
+          usingNewChecksEngine={usingNewChecksEngine}
         >
           <EOS_PLAY_CIRCLE color="green" />
         </TriggerChecksExecutionRequest>

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -47,7 +47,6 @@ function ExecutionResults({
   catalogLoading,
   catalog,
   catalogError,
-  executionLoading,
   executionData,
   executionError,
   onCatalogRefresh = () => {},
@@ -56,12 +55,7 @@ function ExecutionResults({
   const [selectedCheck, setSelectedCheck] = useState(null);
   const [modalOpen, setModalOpen] = useState(false);
 
-  useEffect(() => {
-    onCatalogRefresh();
-    onLastExecutionUpdate();
-  }, []);
-
-  if (catalogLoading || executionLoading) {
+  if (catalogLoading) {
     return <LoadingBox text="Loading checks execution..." />;
   }
 
@@ -100,7 +94,7 @@ function ExecutionResults({
           {getCheckDescription(catalog, selectedCheck)}
         </ReactMarkdown>
       </Modal>
-      <BackButton url={`/clusters/${clusterID}`}>
+      <BackButton url={`/clusters_new/${clusterID}`}>
         Back to Cluster Details
       </BackButton>
       <div className="flex mb-4 justify-between">

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import classNames from 'classnames';
 

--- a/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { getCatalog } from '@state/selectors/catalog';
 import { getLastExecution } from '@state/selectors/lastExecutions';
 import { getCluster } from '@state/selectors';
+import { updateCatalog } from '@state/actions/catalog';
 import { updateLastExecution } from '@state/actions/lastExecutions';
 import ExecutionResults from './ExecutionResults';
 
@@ -24,6 +25,20 @@ function ExecutionResultsPage() {
   } = useSelector(getCatalog());
   const lastExecution = useSelector(getLastExecution(clusterID));
 
+  useEffect(() => {
+    dispatch(updateCatalog());
+  }, []);
+
+  useEffect(() => {
+    if (lastExecution?.data?.status !== 'running') {
+      dispatch(updateLastExecution(clusterID));
+    }
+  }, []);
+
+  if (!cluster) {
+    return <div>Loading...</div>;
+  }
+
   if (!lastExecution) {
     return (
       <h1 className="font-light font-sans text-center text-4xl text-gray-700">
@@ -32,11 +47,7 @@ function ExecutionResultsPage() {
     );
   }
 
-  const {
-    loading: executionLoading,
-    data: executionData,
-    error: executionError,
-  } = lastExecution;
+  const { data: executionData, error: executionError } = lastExecution;
 
   return (
     <ExecutionResults
@@ -44,18 +55,12 @@ function ExecutionResultsPage() {
       hostnames={hostnames}
       clusterName={cluster?.name}
       cloudProvider={cluster?.provider}
-      onCatalogRefresh={() =>
-        dispatch({
-          type: 'UPDATE_CATALOG',
-          payload: { provider: cluster?.provider },
-        })
-      }
+      onCatalogRefresh={() => dispatch(updateCatalog())}
       onLastExecutionUpdate={() => dispatch(updateLastExecution(clusterID))}
       catalogLoading={catalogLoading}
       catalog={catalog}
       catalogError={catalogError}
-      executionData={executionLoading}
-      ecutionData={executionData}
+      executionData={executionData}
       executionError={executionError}
     />
   );

--- a/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.jsx
+++ b/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.jsx
@@ -20,6 +20,7 @@ export function TriggerChecksExecutionRequest({
   const navigate = useNavigate();
   const hosts = useSelector(getClusterHostIDs(clusterId));
   const checks = useSelector(getClusterSelectedChecks(clusterId));
+
   return (
     <button
       className={classNames(
@@ -29,7 +30,11 @@ export function TriggerChecksExecutionRequest({
       type="button"
       onClick={() => {
         dispatch(executionRequested(clusterId, hosts, checks));
-        navigate(`/clusters_new/${clusterId}/executions/last`);
+        navigate(
+          usingWanda
+            ? `/clusters_new/${clusterId}/executions/last`
+            : `/clusters/${clusterId}/checks/results`
+        );
       }}
       {...props}
     >

--- a/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.jsx
+++ b/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.jsx
@@ -1,17 +1,25 @@
 import React from 'react';
 import classNames from 'classnames';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
+
+import {
+  getClusterHostIDs,
+  getClusterSelectedChecks,
+} from '@state/selectors/cluster';
+import { executionRequested } from '@state/actions/lastExecutions';
 
 export function TriggerChecksExecutionRequest({
   clusterId,
   cssClasses,
+  usingWanda = false,
   children,
   ...props
 }) {
   const dispatch = useDispatch();
   const navigate = useNavigate();
-
+  const hosts = useSelector(getClusterHostIDs(clusterId));
+  const checks = useSelector(getClusterSelectedChecks(clusterId));
   return (
     <button
       className={classNames(
@@ -20,13 +28,8 @@ export function TriggerChecksExecutionRequest({
       )}
       type="button"
       onClick={() => {
-        dispatch({
-          type: 'REQUEST_CHECKS_EXECUTION',
-          payload: {
-            clusterID: clusterId,
-          },
-        });
-        navigate(`/clusters/${clusterId}/checks/results`);
+        dispatch(executionRequested(clusterId, hosts, checks));
+        navigate(`/clusters_new/${clusterId}/executions/last`);
       }}
       {...props}
     >

--- a/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.jsx
+++ b/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.jsx
@@ -9,7 +9,7 @@ import {
 } from '@state/selectors/cluster';
 import { executionRequested } from '@state/actions/lastExecutions';
 
-export function TriggerChecksExecutionRequest({
+function TriggerChecksExecutionRequest({
   clusterId,
   cssClasses,
   usingWanda = false,

--- a/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.jsx
+++ b/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.jsx
@@ -12,7 +12,7 @@ import { executionRequested } from '@state/actions/lastExecutions';
 function TriggerChecksExecutionRequest({
   clusterId,
   cssClasses,
-  usingWanda = false,
+  usingNewChecksEngine = false,
   children,
   ...props
 }) {
@@ -31,7 +31,7 @@ function TriggerChecksExecutionRequest({
       onClick={() => {
         dispatch(executionRequested(clusterId, hosts, checks));
         navigate(
-          usingWanda
+          usingNewChecksEngine
             ? `/clusters_new/${clusterId}/executions/last`
             : `/clusters/${clusterId}/checks/results`
         );

--- a/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.test.jsx
+++ b/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.test.jsx
@@ -2,47 +2,43 @@ import React from 'react';
 
 import { screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { faker } from '@faker-js/faker';
 import { withState, renderWithRouter } from '@lib/test-utils';
+
+import { clusterFactory, hostFactory } from '@lib/test-utils/factories';
 
 import TriggerChecksExecutionRequest from './TriggerChecksExecutionRequest';
 
 describe('TriggerChecksExecutionRequest', () => {
   it('should dispatch execution requested on click', async () => {
     const user = userEvent.setup();
+    const cluster1 = clusterFactory.build({
+      selected_checks: [faker.datatype.uuid(), faker.datatype.uuid()],
+    });
+    const cluster2 = clusterFactory.build({
+      selected_checks: [faker.datatype.uuid(), faker.datatype.uuid()],
+    });
+    const { id: clusterID1, selected_checks: clusterSelectedChecks1 } =
+      cluster1;
+    const { id: clusterID2 } = cluster2;
+
+    const host1 = hostFactory.build({ cluster_id: clusterID1 });
+    const host2 = hostFactory.build({ cluster_id: clusterID1 });
+    const host3 = hostFactory.build({ cluster_id: clusterID2 });
+    const { id: hostID1 } = host1;
+    const { id: hostID2 } = host2;
 
     const initialState = {
       clustersList: {
-        clusters: [
-          {
-            id: 'cluster1',
-            selected_checks: ['check1', 'check3'],
-          },
-          {
-            id: 'cluster2',
-            selected_checks: ['check3', 'check4'],
-          },
-        ],
+        clusters: [cluster1, cluster2],
       },
       hostsList: {
-        hosts: [
-          {
-            id: 'host1',
-            cluster_id: 'cluster1',
-          },
-          {
-            id: 'host2',
-            cluster_id: 'cluster1',
-          },
-          {
-            id: 'host3',
-            cluster_id: 'cluster2',
-          },
-        ],
+        hosts: [host1, host2, host3],
       },
     };
 
     const [statefulView, store] = withState(
-      <TriggerChecksExecutionRequest clusterId="cluster1" usingWanda />,
+      <TriggerChecksExecutionRequest clusterId={clusterID1} usingWanda />,
       initialState
     );
 
@@ -56,9 +52,9 @@ describe('TriggerChecksExecutionRequest', () => {
       {
         type: 'EXECUTION_REQUESTED',
         payload: {
-          clusterID: 'cluster1',
-          hosts: ['host1', 'host2'],
-          checks: ['check1', 'check3'],
+          clusterID: clusterID1,
+          hosts: [hostID1, hostID2],
+          checks: clusterSelectedChecks1,
         },
       },
     ];

--- a/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.test.jsx
+++ b/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.test.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import { screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { withState, renderWithRouter } from '@lib/test-utils';
+
+import TriggerChecksExecutionRequest from './TriggerChecksExecutionRequest';
+
+describe('TriggerChecksExecutionRequest', () => {
+  it('should dispatch execution requested on click', async () => {
+    const user = userEvent.setup();
+
+    const initialState = {
+      clustersList: {
+        clusters: [
+          {
+            id: 'cluster1',
+            selected_checks: ['check1', 'check3'],
+          },
+          {
+            id: 'cluster2',
+            selected_checks: ['check3', 'check4'],
+          },
+        ],
+      },
+      hostsList: {
+        hosts: [
+          {
+            id: 'host1',
+            cluster_id: 'cluster1',
+          },
+          {
+            id: 'host2',
+            cluster_id: 'cluster1',
+          },
+          {
+            id: 'host3',
+            cluster_id: 'cluster2',
+          },
+        ],
+      },
+    };
+
+    const [statefulView, store] = withState(
+      <TriggerChecksExecutionRequest clusterId="cluster1" usingWanda />,
+      initialState
+    );
+
+    await act(async () => renderWithRouter(statefulView));
+
+    const button = screen.getByRole('button');
+    await user.click(button);
+
+    const actions = store.getActions();
+    const expectedActions = [
+      {
+        type: 'EXECUTION_REQUESTED',
+        payload: {
+          clusterID: 'cluster1',
+          hosts: ['host1', 'host2'],
+          checks: ['check1', 'check3'],
+        },
+      },
+    ];
+    expect(actions).toEqual(expectedActions);
+  });
+});

--- a/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.test.jsx
+++ b/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.test.jsx
@@ -38,7 +38,10 @@ describe('TriggerChecksExecutionRequest', () => {
     };
 
     const [statefulView, store] = withState(
-      <TriggerChecksExecutionRequest clusterId={clusterID1} usingWanda />,
+      <TriggerChecksExecutionRequest
+        clusterId={clusterID1}
+        usingNewChecksEngine
+      />,
       initialState
     );
 

--- a/assets/js/lib/serialization/index.js
+++ b/assets/js/lib/serialization/index.js
@@ -31,7 +31,7 @@ export const keysToCamel = function keysToCamel(o) {
 export const urlEncode = function urlEncode(params) {
   const str = [];
   Object.entries(params).forEach(([key, value]) => {
-    str.push(`${encodeURIComponent(key)}=${encodeURIComponent(params[value])}`);
+    str.push(`${encodeURIComponent(key)}=${encodeURIComponent(value)}`);
   });
   return str.join('&');
 };

--- a/assets/js/lib/serialization/index.test.js
+++ b/assets/js/lib/serialization/index.test.js
@@ -1,0 +1,10 @@
+import { urlEncode } from '.';
+
+describe('Serialization', () => {
+  it('should encode the given params as url', async () => {
+    const url = urlEncode({ a: 'b', c: 'd', e: 'f' });
+    const expected = 'a=b&c=d&e=f';
+
+    expect(url).toEqual(expected);
+  });
+});

--- a/assets/js/lib/test-utils/factories/index.js
+++ b/assets/js/lib/test-utils/factories/index.js
@@ -45,6 +45,11 @@ export const catalogFactory = Factory.define(() => ({
   error: null,
 }));
 
+export const hostFactory = Factory.define(() => ({
+  id: faker.datatype.uuid(),
+  cluster_id: faker.datatype.uuid(),
+}));
+
 export const hostnameFactory = Factory.define(() => ({
   id: faker.datatype.uuid(),
   hostname: faker.hacker.noun(),

--- a/assets/js/state/actions/cluster.js
+++ b/assets/js/state/actions/cluster.js
@@ -1,6 +1,6 @@
-export const checksSelectedAction = 'CHECKS_SELECTED';
+export const CHECKS_SELECTED = 'CHECKS_SELECTED';
 
 export const checksSelected = (selectedChecks, clusterID) => ({
-  type: checksSelectedAction,
+  type: CHECKS_SELECTED,
   payload: { checks: selectedChecks, clusterID },
 });

--- a/assets/js/state/actions/lastExecutions.js
+++ b/assets/js/state/actions/lastExecutions.js
@@ -1,6 +1,12 @@
 export const UPDATE_LAST_EXECUTION = 'UPDATE_LAST_EXECUTION';
+export const EXECUTION_REQUESTED = 'EXECUTION_REQUESTED';
 
 export const updateLastExecution = (groupID) => ({
   type: UPDATE_LAST_EXECUTION,
   payload: { groupID },
+});
+
+export const executionRequested = (clusterID, hosts, checks) => ({
+  type: EXECUTION_REQUESTED,
+  payload: { clusterID, hosts, checks },
 });

--- a/assets/js/state/lastExecutions.js
+++ b/assets/js/state/lastExecutions.js
@@ -50,13 +50,13 @@ export const lastExecutionsSlice = createSlice({
     setExecutionRequested: (state, { payload }) => {
       const { clusterID: groupID, hosts, checks } = payload;
 
-      const targets = hosts.map((host) => ({ agent_id: host, checks: checks }));
+      const targets = hosts.map((host) => ({ agent_id: host, checks }));
 
       const lastExecutionState = {
         ...initialExecutionState,
         data: {
           status: 'running',
-          targets: targets,
+          targets,
         },
       };
 

--- a/assets/js/state/lastExecutions.js
+++ b/assets/js/state/lastExecutions.js
@@ -47,6 +47,21 @@ export const lastExecutionsSlice = createSlice({
 
       state[groupID] = lastExecutionState;
     },
+    setExecutionRequested: (state, { payload }) => {
+      const { clusterID: groupID, hosts, checks } = payload;
+
+      const targets = hosts.map((host) => ({ agent_id: host, checks: checks }));
+
+      const lastExecutionState = {
+        ...initialExecutionState,
+        data: {
+          status: 'running',
+          targets: targets,
+        },
+      };
+
+      state[groupID] = lastExecutionState;
+    },
   },
 });
 
@@ -55,6 +70,7 @@ export const {
   setLastExecution,
   setLastExecutionEmpty,
   setLastExecutionError,
+  setExecutionRequested,
 } = lastExecutionsSlice.actions;
 
 export default lastExecutionsSlice.reducer;

--- a/assets/js/state/lastExecutions.test.js
+++ b/assets/js/state/lastExecutions.test.js
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker';
 
 import lastExecutionsReducer, {
+  setExecutionRequested,
   setLastExecutionLoading,
   setLastExecutionEmpty,
   setLastExecutionError,
@@ -91,6 +92,36 @@ describe('lastExecutions reducer', () => {
     const expectedState = {
       someID: {
         data,
+        loading: false,
+        error: null,
+      },
+    };
+
+    expect(lastExecutionsReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should set on a execution requested state a given groupID', () => {
+    const initialState = {};
+
+    const checks = ['check1', 'check2'];
+
+    const data = {
+      clusterID: 'someID',
+      hosts: ['agent1', 'agent2'],
+      checks: checks,
+    };
+
+    const action = setExecutionRequested(data);
+
+    const expectedState = {
+      someID: {
+        data: {
+          status: 'running',
+          targets: [
+            { agent_id: 'agent1', checks: checks },
+            { agent_id: 'agent2', checks: checks },
+          ],
+        },
         loading: false,
         error: null,
       },

--- a/assets/js/state/lastExecutions.test.js
+++ b/assets/js/state/lastExecutions.test.js
@@ -108,7 +108,7 @@ describe('lastExecutions reducer', () => {
     const data = {
       clusterID: 'someID',
       hosts: ['agent1', 'agent2'],
-      checks: checks,
+      checks,
     };
 
     const action = setExecutionRequested(data);
@@ -118,8 +118,8 @@ describe('lastExecutions reducer', () => {
         data: {
           status: 'running',
           targets: [
-            { agent_id: 'agent1', checks: checks },
-            { agent_id: 'agent2', checks: checks },
+            { agent_id: 'agent1', checks },
+            { agent_id: 'agent2', checks },
           ],
         },
         loading: false,

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -69,7 +69,10 @@ import { setEulaVisible, setIsPremium } from '@state/settings';
 import { watchNotifications } from '@state/sagas/notifications';
 import { watchAcceptEula } from '@state/sagas/eula';
 import { watchCatalogUpdateNew } from '@state/sagas/catalog';
-import { watchUpdateLastExecution } from '@state/sagas/lastExecutions';
+import {
+  watchUpdateLastExecution,
+  watchRequestExecution,
+} from '@state/sagas/lastExecutions';
 
 import { getDatabase, getSapSystem } from '@state/selectors';
 import {
@@ -89,7 +92,8 @@ import {
   stopSavingClusterChecksSelection,
 } from '@state/clusterChecksSelection';
 
-import { checksSelectedAction } from '@state/actions/cluster';
+import { CHECKS_SELECTED } from '@state/actions/cluster';
+import { EXECUTION_REQUESTED } from '@state/actions/lastExecutions';
 
 const notify = ({ text, icon }) => ({
   type: 'NOTIFICATION',
@@ -275,7 +279,7 @@ function* checksSelected({ payload }) {
 }
 
 function* watchChecksSelected() {
-  yield takeEvery(checksSelectedAction, checksSelected);
+  yield takeEvery(CHECKS_SELECTED, checksSelected);
 }
 
 function* requestChecksExecution({ payload }) {
@@ -302,7 +306,7 @@ function* requestChecksExecution({ payload }) {
 }
 
 function* watchRequestChecksExecution() {
-  yield takeEvery('REQUEST_CHECKS_EXECUTION', requestChecksExecution);
+  yield takeEvery(EXECUTION_REQUESTED, requestChecksExecution);
 }
 
 function* checksExecutionStarted({ payload }) {
@@ -648,6 +652,7 @@ export default function* rootSaga() {
     watchCatalogUpdate(),
     watchCatalogUpdateNew(),
     watchUpdateLastExecution(),
+    watchRequestExecution(),
     watchAcceptEula(),
     refreshHealthSummaryOnComnponentsHealthChange(),
     watchClustrConnectionSettings(),

--- a/assets/js/state/sagas/lastExecutions.js
+++ b/assets/js/state/sagas/lastExecutions.js
@@ -1,12 +1,16 @@
 import { put, call, takeEvery } from 'redux-saga/effects';
 
-import { UPDATE_LAST_EXECUTION } from '@state/actions/lastExecutions';
+import {
+  UPDATE_LAST_EXECUTION,
+  EXECUTION_REQUESTED,
+} from '@state/actions/lastExecutions';
 import { getLastExecutionByGroupID } from '@lib/api/wanda';
 import {
   setLastExecutionLoading,
   setLastExecution,
   setLastExecutionEmpty,
   setLastExecutionError,
+  setExecutionRequested,
 } from '@state/lastExecutions';
 
 export function* updateLastExecution({ payload }) {
@@ -29,6 +33,14 @@ export function* updateLastExecution({ payload }) {
   }
 }
 
+export function* requestExecution({ payload }) {
+  yield put(setExecutionRequested(payload));
+}
+
 export function* watchUpdateLastExecution() {
   yield takeEvery(UPDATE_LAST_EXECUTION, updateLastExecution);
+}
+
+export function* watchRequestExecution() {
+  yield takeEvery(EXECUTION_REQUESTED, requestExecution);
 }

--- a/assets/js/state/selectors/cluster.js
+++ b/assets/js/state/selectors/cluster.js
@@ -1,0 +1,11 @@
+import { getCluster } from '@state/selectors';
+
+export const getClusterHostIDs =
+  (clusterID) =>
+  ({ hostsList }) =>
+    hostsList.hosts
+      .filter((host) => host.cluster_id === clusterID)
+      .map(({ id: hostID }) => hostID);
+
+export const getClusterSelectedChecks = (clusterID) => (state) =>
+  getCluster(clusterID)(state).selected_checks;

--- a/assets/js/state/selectors/cluster.test.js
+++ b/assets/js/state/selectors/cluster.test.js
@@ -1,0 +1,52 @@
+import { getClusterHostIDs, getClusterSelectedChecks } from './cluster';
+
+describe('Cluster selector', () => {
+  it('should return the cluster hosts IDs', () => {
+    const state = {
+      hostsList: {
+        hosts: [
+          {
+            id: 'id1',
+            cluster_id: 'cluster1',
+          },
+          {
+            id: 'id2',
+            cluster_id: 'cluster1',
+          },
+          {
+            id: 'id3',
+            cluster_id: 'cluster2',
+          },
+        ],
+      },
+    };
+
+    expect(getClusterHostIDs('cluster1')(state)).toEqual(['id1', 'id2']);
+  });
+
+  it('should return the cluster selected checks', () => {
+    const state = {
+      clustersList: {
+        clusters: [
+          {
+            id: 'cluster1',
+            selected_checks: ['check1', 'check2'],
+          },
+          {
+            id: 'cluster2',
+            selected_checks: ['check3', 'check4'],
+          },
+          {
+            id: 'cluster3',
+            selected_checks: ['check5', 'check6'],
+          },
+        ],
+      },
+    };
+
+    expect(getClusterSelectedChecks('cluster1')(state)).toEqual([
+      'check1',
+      'check2',
+    ]);
+  });
+});

--- a/assets/js/trento.jsx
+++ b/assets/js/trento.jsx
@@ -59,15 +59,15 @@ function App() {
                 element={<ClusterSettings />}
               />
               <Route
-                path="clusters/:clusterID/settings_new"
-                element={<ClusterSettings newChecksSelectionView />}
+                path="clusters_new/:clusterID/settings"
+                element={<ClusterSettings usingWanda />}
               />
               <Route
                 path="clusters/:clusterID/checks/results"
                 element={<ChecksResults />}
               />
               <Route
-                path="clusters/:clusterID/executions/last"
+                path="clusters_new/:clusterID/executions/last"
                 element={<ExecutionResultsPage />}
               />
               <Route path="hosts/:hostID" element={<HostDetails />} />

--- a/assets/js/trento.jsx
+++ b/assets/js/trento.jsx
@@ -60,7 +60,7 @@ function App() {
               />
               <Route
                 path="clusters_new/:clusterID/settings"
-                element={<ClusterSettings usingWanda />}
+                element={<ClusterSettings usingNewChecksEngine />}
               />
               <Route
                 path="clusters/:clusterID/checks/results"


### PR DESCRIPTION
Add transition since the execution is started until it is received from wanda. It uses a "fake it until make it" pattern which fakes the redux state setting an execution in a running state.
Now on, all wanda related views are under `clusters_new/${clusterID}` endpoint. This is done with the `usingWanda` boolean variable

![demo](https://user-images.githubusercontent.com/36370954/207907583-72d19cb4-bc52-4ae5-ad3e-76d666a01e55.gif)

PD: I have fixed many small (and not so small) details on the way
PD2: The gif is a bit faked, as in order to work we need to merge https://github.com/trento-project/web/pull/1032 first




