### PR TITLE
Add filter to Execution Results page

### DIFF
--- a/assets/js/components/ChecksResults/ChecksResultFilters.jsx
+++ b/assets/js/components/ChecksResults/ChecksResultFilters.jsx
@@ -4,17 +4,17 @@ import Filter from '@components/Table/Filter';
 
 export const RESULT_FILTER_FIELD = 'result';
 
+export const filterChecks = (checks, predicates) => {
+  if (predicates.length === 0) return checks;
+
+  return checks.filter((check) =>
+    predicates.some((predicate) => predicate(check))
+  );
+};
+
 export const useFilteredChecks = (cluster) => {
   const [filtersPredicates, setFiltersPredicates] = useState([]);
   const [filteredChecks, setFilteredChecks] = useState([]);
-
-  const filterChecks = (checks, predicates) => {
-    if (predicates.length === 0) return checks;
-
-    return checks.filter((check) =>
-      predicates.some((predicate) => predicate(check))
-    );
-  };
 
   const checksForHost = (hostID) =>
     filteredChecks

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -17,9 +17,13 @@ import {
   getCheckResults,
   getCheckDescription,
 } from '@components/ChecksResults';
+import ChecksResultFilters, {
+  useFilteredChecks,
+} from '@components/ChecksResults/ChecksResultFilters';
 import { UNKNOWN_PROVIDER } from '@components/ClusterDetails/ClusterSettings';
 import { ClusterInfoBox } from '@components/ClusterDetails';
 import NotificationBox from '@components/NotificationBox';
+import { sortChecks } from '@components/ChecksResults/checksUtils';
 
 const truncatedClusterNameClasses =
   'font-bold truncate w-60 inline-block align-top';
@@ -41,6 +45,7 @@ const getLabel = (status, health, error, expectations, failedExpectations) => {
 };
 
 function ExecutionResults({
+  cluster,
   clusterID,
   clusterName,
   clusterScenario,
@@ -56,6 +61,9 @@ function ExecutionResults({
 }) {
   const [selectedCheck, setSelectedCheck] = useState(null);
   const [modalOpen, setModalOpen] = useState(false);
+
+  const { filteredChecksyByHost, setFiltersPredicates } =
+    useFilteredChecks(cluster);
 
   if (catalogLoading) {
     return <LoadingBox text="Loading checks execution..." />;
@@ -108,6 +116,11 @@ function ExecutionResults({
             {clusterName}
           </span>
         </h1>
+        <ChecksResultFilters
+          onChange={(filtersPredicates) =>
+            setFiltersPredicates(filtersPredicates)
+          }
+        />
       </div>
       {cloudProvider === UNKNOWN_PROVIDER && (
         <WarningBanner>
@@ -125,12 +138,12 @@ function ExecutionResults({
         selectedChecks={checkResults}
         onCatalogRefresh={onCatalogRefresh}
       >
-        {executionData?.targets.map(({ agent_id: hostID, checks }) => (
+        {executionData?.targets.map(({ agent_id: hostID }) => (
           <HostResultsWrapper
             key={hostID}
             hostname={hostnames.find(({ id }) => hostID === id)?.hostname}
           >
-            {checks.map((checkID) => {
+            {sortChecks(filteredChecksyByHost(hostID)).map((checkID) => {
               const { health, error, expectations, failedExpectations } =
                 getCheckHealthByAgent(checkResults, checkID, hostID);
 

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -132,43 +132,39 @@ function ExecutionResults({
         selectedChecks={checkResults}
         onCatalogRefresh={onCatalogRefresh}
       >
-        {executionData?.targets.map(({ agent_id: hostID, checks }) => {
-          const filteredChecks = filterChecks(checks, predicates);
+        {executionData?.targets.map(({ agent_id: hostID, checks }) => (
+          <HostResultsWrapper
+            key={hostID}
+            hostname={hostnames.find(({ id }) => hostID === id)?.hostname}
+          >
+            {filterChecks(checks, predicates).map((checkID) => {
+              const { health, error, expectations, failedExpectations } =
+                getCheckHealthByAgent(checkResults, checkID, hostID);
 
-          return (
-            <HostResultsWrapper
-              key={hostID}
-              hostname={hostnames.find(({ id }) => hostID === id)?.hostname}
-            >
-              {filteredChecks.map((checkID) => {
-                const { health, error, expectations, failedExpectations } =
-                  getHealth(checkResults, checkID, hostID);
-
-                const label = getLabel(
-                  executionData?.status,
-                  health,
-                  error,
-                  expectations,
-                  failedExpectations
-                );
-                return (
-                  <CheckResult
-                    key={checkID}
-                    checkId={checkID}
-                    description={getCheckDescription(catalog, checkID)}
-                    executionState={executionData?.status}
-                    health={health}
-                    label={label}
-                    onClick={() => {
-                      setModalOpen(true);
-                      setSelectedCheck(checkID);
-                    }}
-                  />
-                );
-              })}
-            </HostResultsWrapper>
-          );
-        })}
+              const label = getLabel(
+                executionData?.status,
+                health,
+                error,
+                expectations,
+                failedExpectations
+              );
+              return (
+                <CheckResult
+                  key={checkID}
+                  checkId={checkID}
+                  description={getCheckDescription(catalog, checkID)}
+                  executionState={executionData?.status}
+                  health={health}
+                  label={label}
+                  onClick={() => {
+                    setModalOpen(true);
+                    setSelectedCheck(checkID);
+                  }}
+                />
+              );
+            })}
+          </HostResultsWrapper>
+        ))}
       </ResultsContainer>
     </div>
   );

--- a/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
@@ -135,9 +135,9 @@ describe('ExecutionResults', () => {
       />
     );
 
-    expect(screen.getByText("test-cluster")).toBeTruthy();
-    expect(screen.getByText("HANA scale-up")).toBeTruthy();
-    expect(screen.getByText("Azure")).toBeTruthy();
+    expect(screen.getByText('test-cluster')).toBeTruthy();
+    expect(screen.getByText('HANA scale-up')).toBeTruthy();
+    expect(screen.getByText('Azure')).toBeTruthy();
     expect(screen.getByText(hostnames[0].hostname)).toBeTruthy();
     expect(screen.getByText(hostnames[1].hostname)).toBeTruthy();
     expect(screen.getAllByText(checkID1)).toHaveLength(2);

--- a/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
@@ -51,6 +51,7 @@ function ExecutionResultsPage() {
 
   return (
     <ExecutionResults
+      cluster={cluster}
       clusterID={clusterID}
       hostnames={hostnames}
       clusterName={cluster?.name}

--- a/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
@@ -51,7 +51,6 @@ function ExecutionResultsPage() {
 
   return (
     <ExecutionResults
-      cluster={cluster}
       clusterID={clusterID}
       hostnames={hostnames}
       clusterName={cluster?.name}


### PR DESCRIPTION
# Description

This change adds a filter to the new Execution Results page, the same as the current Checks Results page.

## How was this tested?

Adjusted `ExecutionResults.test.jsx` to accommodate for the addition of the filter.
