### PR TITLE
Fix Checks results filters

### DIFF
--- a/assets/js/components/ClusterDetails/ClusterDetailsNew.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetailsNew.jsx
@@ -214,7 +214,7 @@ export function ClusterDetailsNew() {
           <ChecksResultOverviewNew
             {...lastExecution}
             onCheckClick={(health) =>
-              navigate(`/clusters/${clusterID}/checks/results?health=${health}`)
+              navigate(`/clusters_new/${clusterID}/executions/last?health=${health}`)
             }
           />
         </div>

--- a/assets/js/components/ClusterDetails/ClusterDetailsNew.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetailsNew.jsx
@@ -214,7 +214,9 @@ export function ClusterDetailsNew() {
           <ChecksResultOverviewNew
             {...lastExecution}
             onCheckClick={(health) =>
-              navigate(`/clusters_new/${clusterID}/executions/last?health=${health}`)
+              navigate(
+                `/clusters_new/${clusterID}/executions/last?health=${health}`
+              )
             }
           />
         </div>

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -133,43 +133,39 @@ function ExecutionResults({
         onCatalogRefresh={onCatalogRefresh}
         usingNewChecksEngine
       >
-        {executionData?.targets.map(({ agent_id: hostID, checks }) => {
-          const filteredChecks = filterChecks(checks, predicates);
+        {executionData?.targets.map(({ agent_id: hostID, checks }) => (
+          <HostResultsWrapper
+            key={hostID}
+            hostname={hostnames.find(({ id }) => hostID === id)?.hostname}
+          >
+            {filterChecks(checks, predicates).map((checkID) => {
+              const { health, error, expectations, failedExpectations } =
+                getCheckHealthByAgent(checkResults, checkID, hostID);
 
-          return (
-            <HostResultsWrapper
-              key={hostID}
-              hostname={hostnames.find(({ id }) => hostID === id)?.hostname}
-            >
-              {filteredChecks.map((checkID) => {
-                const { health, error, expectations, failedExpectations } =
-                  getCheckHealthByAgent(checkResults, checkID, hostID);
-
-                const label = getLabel(
-                  executionData?.status,
-                  health,
-                  error,
-                  expectations,
-                  failedExpectations
-                );
-                return (
-                  <CheckResult
-                    key={checkID}
-                    checkId={checkID}
-                    description={getCheckDescription(catalog, checkID)}
-                    executionState={executionData?.status}
-                    health={health}
-                    label={label}
-                    onClick={() => {
-                      setModalOpen(true);
-                      setSelectedCheck(checkID);
-                    }}
-                  />
-                );
-              })}
-            </HostResultsWrapper>
-          );
-        })}
+              const label = getLabel(
+                executionData?.status,
+                health,
+                error,
+                expectations,
+                failedExpectations
+              );
+              return (
+                <CheckResult
+                  key={checkID}
+                  checkId={checkID}
+                  description={getCheckDescription(catalog, checkID)}
+                  executionState={executionData?.status}
+                  health={health}
+                  label={label}
+                  onClick={() => {
+                    setModalOpen(true);
+                    setSelectedCheck(checkID);
+                  }}
+                />
+              );
+            })}
+          </HostResultsWrapper>
+        ))}
       </ResultsContainer>
     </div>
   );

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -133,39 +133,43 @@ function ExecutionResults({
         onCatalogRefresh={onCatalogRefresh}
         usingNewChecksEngine
       >
-        {executionData?.targets.map(({ agent_id: hostID, checks }) => (
-          <HostResultsWrapper
-            key={hostID}
-            hostname={hostnames.find(({ id }) => hostID === id)?.hostname}
-          >
-            {filterChecks(checks, predicates).map((checkID) => {
-              const { health, error, expectations, failedExpectations } =
-                getCheckHealthByAgent(checkResults, checkID, hostID);
+        {executionData?.targets.map(({ agent_id: hostID, checks }) => {
+          const filteredChecks = filterChecks(checks, predicates);
 
-              const label = getLabel(
-                executionData?.status,
-                health,
-                error,
-                expectations,
-                failedExpectations
-              );
-              return (
-                <CheckResult
-                  key={checkID}
-                  checkId={checkID}
-                  description={getCheckDescription(catalog, checkID)}
-                  executionState={executionData?.status}
-                  health={health}
-                  label={label}
-                  onClick={() => {
-                    setModalOpen(true);
-                    setSelectedCheck(checkID);
-                  }}
-                />
-              );
-            })}
-          </HostResultsWrapper>
-        ))}
+          return (
+            <HostResultsWrapper
+              key={hostID}
+              hostname={hostnames.find(({ id }) => hostID === id)?.hostname}
+            >
+              {filteredChecks.map((checkID) => {
+                const { health, error, expectations, failedExpectations } =
+                  getCheckHealthByAgent(checkResults, checkID, hostID);
+
+                const label = getLabel(
+                  executionData?.status,
+                  health,
+                  error,
+                  expectations,
+                  failedExpectations
+                );
+                return (
+                  <CheckResult
+                    key={checkID}
+                    checkId={checkID}
+                    description={getCheckDescription(catalog, checkID)}
+                    executionState={executionData?.status}
+                    health={health}
+                    label={label}
+                    onClick={() => {
+                      setModalOpen(true);
+                      setSelectedCheck(checkID);
+                    }}
+                  />
+                );
+              })}
+            </HostResultsWrapper>
+          );
+        })}
       </ResultsContainer>
     </div>
   );

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -138,32 +138,57 @@ function ExecutionResults({
             key={hostID}
             hostname={hostnames.find(({ id }) => hostID === id)?.hostname}
           >
-            {filterChecks(checks, predicates).map((checkID) => {
-              const { health, error, expectations, failedExpectations } =
-                getCheckHealthByAgent(checkResults, checkID, hostID);
+            {checks
+              .map((checkID) => {
+                const { health, error, expectations, failedExpectations } =
+                  getCheckHealthByAgent(checkResults, checkID, hostID);
 
-              const label = getLabel(
-                executionData?.status,
-                health,
-                error,
-                expectations,
-                failedExpectations
-              );
-              return (
-                <CheckResult
-                  key={checkID}
-                  checkId={checkID}
-                  description={getCheckDescription(catalog, checkID)}
-                  executionState={executionData?.status}
-                  health={health}
-                  label={label}
-                  onClick={() => {
-                    setModalOpen(true);
-                    setSelectedCheck(checkID);
-                  }}
-                />
-              );
-            })}
+                return {
+                  checkID,
+                  error,
+                  expectations,
+                  failedExpectations,
+                  result: health,
+                };
+              })
+              .filter((check) => {
+                if (predicates.length === 0) {
+                  return true;
+                }
+
+                return predicates.some((predicate) => predicate(check));
+              })
+              .map(
+                ({
+                  checkID,
+                  result,
+                  error,
+                  expectations,
+                  failedExpectations,
+                }) => {
+                  const label = getLabel(
+                    executionData?.status,
+                    result,
+                    error,
+                    expectations,
+                    failedExpectations
+                  );
+                  return (
+                    <CheckResult
+                      key={checkID}
+                      checkId={checkID}
+                      description={getCheckDescription(catalog, checkID)}
+                      executionState={executionData?.status}
+                      health={result}
+                      label={label}
+                      onClick={() => {
+                        setModalOpen(true);
+                        setSelectedCheck(checkID);
+                      }}
+                    />
+                  );
+                }
+              )}
           </HostResultsWrapper>
         ))}
       </ResultsContainer>

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -17,9 +17,7 @@ import {
   getCheckResults,
   getCheckDescription,
 } from '@components/ChecksResults';
-import ChecksResultFilters, {
-  filterChecks,
-} from '@components/ChecksResults/ChecksResultFilters';
+import ChecksResultFilters from '@components/ChecksResults/ChecksResultFilters';
 import { UNKNOWN_PROVIDER } from '@components/ClusterDetails/ClusterSettings';
 import { ClusterInfoBox } from '@components/ClusterDetails';
 import NotificationBox from '@components/NotificationBox';

--- a/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
@@ -206,4 +206,88 @@ describe('ExecutionResults', () => {
     const svgText = screen.getByText('Select Checks now!');
     expect(svgText).toBeInTheDocument();
   });
+
+  it("should render ExecutionResults with successfully filtered 'passing' results", async () => {
+    const {
+      clusterID,
+      hostnames,
+      checks: [checkID1, checkID2],
+      loading,
+      catalog,
+      error,
+      executionLoading,
+      executionData,
+      executionError,
+    } = prepareStateData('passing');
+
+    renderWithRouter(
+      <ExecutionResults
+        clusterID={clusterID}
+        clusterName="test-cluster"
+        clusterScenario="hana_scale_up"
+        cloudProvider="azure"
+        hostnames={hostnames}
+        catalogLoading={loading}
+        catalog={catalog}
+        catalogError={error}
+        executionLoading={executionLoading}
+        executionData={executionData}
+        executionError={executionError}
+      />,
+      { route: `/clusters_new/${clusterID}/executions/last?health=passing` }
+    );
+
+    expect(screen.getByText('test-cluster')).toBeTruthy();
+    expect(screen.getByText('HANA scale-up')).toBeTruthy();
+    expect(screen.getByText('Azure')).toBeTruthy();
+    expect(screen.getByText(hostnames[0].hostname)).toBeTruthy();
+    expect(screen.getByText(hostnames[1].hostname)).toBeTruthy();
+    expect(screen.getAllByText(checkID1)).toHaveLength(2);
+    expect(screen.queryByText(checkID2)).toBeNull();
+    expect(screen.getAllByText('2/2 expectations passed')).toBeTruthy();
+  });
+
+  it("should render ExecutionResults with successfully filtered 'passing' and 'ciritcal' results", async () => {
+    const {
+      clusterID,
+      hostnames,
+      checks: [checkID1, checkID2],
+      loading,
+      catalog,
+      error,
+      executionLoading,
+      executionData,
+      executionError,
+    } = prepareStateData('passing');
+
+    renderWithRouter(
+      <ExecutionResults
+        clusterID={clusterID}
+        clusterName="test-cluster"
+        clusterScenario="hana_scale_up"
+        cloudProvider="azure"
+        hostnames={hostnames}
+        catalogLoading={loading}
+        catalog={catalog}
+        catalogError={error}
+        executionLoading={executionLoading}
+        executionData={executionData}
+        executionError={executionError}
+      />,
+      {
+        route: `/clusters_new/${clusterID}/executions/last?health=passing&health=critical
+    `,
+      }
+    );
+
+    expect(screen.getByText('test-cluster')).toBeTruthy();
+    expect(screen.getByText('HANA scale-up')).toBeTruthy();
+    expect(screen.getByText('Azure')).toBeTruthy();
+    expect(screen.getByText(hostnames[0].hostname)).toBeTruthy();
+    expect(screen.getByText(hostnames[1].hostname)).toBeTruthy();
+    expect(screen.getAllByText(checkID1)).toHaveLength(2);
+    expect(screen.getAllByText(checkID2)).toHaveLength(2);
+    expect(screen.getAllByText('2/2 expectations passed')).toBeTruthy();
+    expect(screen.getAllByText('1/2 expectations failed')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
# Description

Fixes changes to the new checks results filters from bd2f538.

Fixes [#1064](https://github.com/trento-project/web/pull/1064)

![filters](https://user-images.githubusercontent.com/113615552/209166463-6dec6ed0-45ef-4cea-ad44-d5485ab0c304.gif)

## How was this tested?

Added new tests for filtering in `ExecutionResults.test.jsx`.
