### PR TITLE
Remove redux logic from  TriggerChecksExecutionRequest component

### DIFF
--- a/assets/js/components/ChecksResults/ChecksResults.jsx
+++ b/assets/js/components/ChecksResults/ChecksResults.jsx
@@ -119,6 +119,7 @@ function ChecksResults() {
         clusterID={clusterID}
         hasAlreadyChecksResults={hasAlreadyChecksResults}
         selectedChecks={cluster?.selected_checks}
+        hosts={hosts}
         onCatalogRefresh={dispatchUpdateCatalog}
       >
         {sortHosts(hosts).map(({ host_id: hostID, reachable, msg }) => (

--- a/assets/js/components/ChecksResults/ChecksSelectionHints.jsx
+++ b/assets/js/components/ChecksResults/ChecksSelectionHints.jsx
@@ -11,7 +11,9 @@ import TrentoLogo from '@static/trento-icon.png';
 function ChecksSelectionHints({
   clusterId,
   selectedChecks = [],
+  hosts = [],
   usingNewChecksEngine = false,
+  onStartExecution = () => {},
 }) {
   const navigate = useNavigate();
 
@@ -56,6 +58,9 @@ function ChecksSelectionHints({
               cssClasses="rounded relative w-1/4 ml-0.5 bg-waterhole-blue mx-auto px-2 py-2 w-1/4 xs:w-full text-base"
               clusterId={clusterId}
               usingNewChecksEngine={usingNewChecksEngine}
+              hosts={hosts}
+              checks={selectedChecks}
+              onStartExecution={onStartExecution}
             >
               <EOS_PLAY_CIRCLE className="inline-block fill-white" /> Start
               Execution now

--- a/assets/js/components/ChecksResults/ResultsContainer.jsx
+++ b/assets/js/components/ChecksResults/ResultsContainer.jsx
@@ -11,8 +11,10 @@ function ResultsContainer({
   clusterID,
   hasAlreadyChecksResults,
   selectedChecks = [],
+  hosts = [],
   usingNewChecksEngine = false,
   onCatalogRefresh = () => {},
+  onStartExecution = () => {},
 }) {
   if (catalogError) {
     return (
@@ -30,7 +32,9 @@ function ResultsContainer({
       <ChecksSelectionHints
         clusterId={clusterID}
         selectedChecks={selectedChecks}
+        hosts={hosts}
         usingNewChecksEngine={usingNewChecksEngine}
+        onStartExecution={onStartExecution}
       />
     );
   }

--- a/assets/js/components/ClusterDetails/ChecksSelection.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelection.jsx
@@ -293,6 +293,7 @@ export function ChecksSelection({ clusterId, cluster }) {
         )}
         {localSavingSuccess && selectedChecks.length > 0 && (
           <SuggestTriggeringChecksExecutionAfterSettingsUpdated
+            cluster={cluster}
             clusterId={clusterId}
             onClose={() => setLocalSavingSuccess(null)}
           />

--- a/assets/js/components/ClusterDetails/ChecksSelection.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelection.jsx
@@ -2,6 +2,9 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
 import { Disclosure, Switch, Transition } from '@headlessui/react';
 
 import {
@@ -12,14 +15,14 @@ import {
 import classNames from 'classnames';
 import { remove, uniq } from '@lib/lists';
 
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
+import LoadingBox from '@components/LoadingBox';
+import NotificationBox from '@components/NotificationBox';
+import { executionRequested } from '@state/actions/lastExecutions';
+
 import {
   SavingFailedAlert,
   SuggestTriggeringChecksExecutionAfterSettingsUpdated,
 } from './ClusterSettings';
-import LoadingBox from '../LoadingBox';
-import NotificationBox from '../NotificationBox';
 
 const toggle = (list, element) =>
   list.includes(element)
@@ -293,9 +296,12 @@ export function ChecksSelection({ clusterId, cluster }) {
         )}
         {localSavingSuccess && selectedChecks.length > 0 && (
           <SuggestTriggeringChecksExecutionAfterSettingsUpdated
-            cluster={cluster}
             clusterId={clusterId}
+            selectedChecks={selectedChecks}
             onClose={() => setLocalSavingSuccess(null)}
+            onStartExecution={(clusterID, hosts, checks) =>
+              dispatch(executionRequested(clusterID, hosts, checks))
+            }
           />
         )}
       </div>

--- a/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
@@ -165,6 +165,7 @@ function ChecksSelectionNew({ clusterId, cluster }) {
             {localSavingSuccess && selectedChecks.length > 0 && (
               <SuggestTriggeringChecksExecutionAfterSettingsUpdated
                 clusterId={clusterId}
+                cluster={cluster}
                 usingNewChecksEngine
                 onClose={() => setLocalSavingSuccess(null)}
               />

--- a/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelectionNew.jsx
@@ -9,6 +9,7 @@ import { remove, uniq, toggle, groupBy } from '@lib/lists';
 import { getCatalog } from '@state/selectors/catalog';
 import { updateCatalog } from '@state/actions/catalog';
 import { checksSelected } from '@state/actions/cluster';
+import { executionRequested } from '@state/actions/lastExecutions';
 
 import CatalogContainer from '@components/ChecksCatalog/CatalogContainer';
 import {
@@ -165,9 +166,12 @@ function ChecksSelectionNew({ clusterId, cluster }) {
             {localSavingSuccess && selectedChecks.length > 0 && (
               <SuggestTriggeringChecksExecutionAfterSettingsUpdated
                 clusterId={clusterId}
-                cluster={cluster}
                 usingNewChecksEngine
+                selectedChecks={cluster.selected_checks}
                 onClose={() => setLocalSavingSuccess(null)}
+                onStartExecution={(clusterID, hosts, checks) =>
+                  dispatch(executionRequested(clusterID, hosts, checks))
+                }
               />
             )}
           </div>

--- a/assets/js/components/ClusterDetails/ClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetails.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 
 import Button from '@components/Button';
 
@@ -14,6 +14,7 @@ import ProviderLabel from '@components/ProviderLabel';
 import { groupBy } from '@lib/lists';
 
 import { getClusterName } from '@components/ClusterLink';
+import { getClusterHostIDs } from '@state/selectors/cluster';
 import HostLink from '@components/HostLink';
 
 import { EOS_SETTINGS, EOS_CLEAR_ALL, EOS_PLAY_CIRCLE } from 'eos-icons-react';
@@ -21,6 +22,7 @@ import { getCluster } from '@state/selectors';
 import classNames from 'classnames';
 import ChecksResultOverview from '@components/ClusterDetails/ChecksResultOverview';
 import { useChecksResult } from '@components/ClusterDetails/hooks';
+import { executionRequested } from '@state/actions/lastExecutions';
 import SiteDetails from './SiteDetails';
 
 export const truncatedClusterNameClasses = classNames(
@@ -75,7 +77,11 @@ function ClusterDetails() {
   const cluster = useSelector(getCluster(clusterID));
 
   const checkResults = useChecksResult(cluster);
-
+  const dispatch = useDispatch();
+  const onStartExecution = (clusterId, hosts, selectedChecks) => {
+    dispatch(executionRequested(clusterId, hosts, selectedChecks));
+  };
+  const hosts = useSelector(getClusterHostIDs(clusterID));
   const hostsData = useSelector((state) =>
     state.hostsList.hosts.reduce((accumulator, current) => {
       if (current.cluster_id === clusterID) {
@@ -136,6 +142,9 @@ function ClusterDetails() {
             cssClasses="rounded relative w-1/4 ml-0.5 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-gray-400"
             clusterId={clusterID}
             disabled={!hasSelectedChecks}
+            hosts={hosts}
+            checks={cluster.selected_checks}
+            onStartExecution={onStartExecution}
           >
             <EOS_PLAY_CIRCLE
               className={classNames('inline-block fill-jungle-green-500', {

--- a/assets/js/components/ClusterDetails/ClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetails.jsx
@@ -78,8 +78,8 @@ function ClusterDetails() {
 
   const checkResults = useChecksResult(cluster);
   const dispatch = useDispatch();
-  const onStartExecution = (clusterId, hosts, selectedChecks) => {
-    dispatch(executionRequested(clusterId, hosts, selectedChecks));
+  const onStartExecution = (_, hosts, selectedChecks) => {
+    dispatch(executionRequested(clusterID, hosts, selectedChecks));
   };
   const hosts = useSelector(getClusterHostIDs(clusterID));
   const hostsData = useSelector((state) =>

--- a/assets/js/components/ClusterDetails/ClusterDetailsNew.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetailsNew.jsx
@@ -18,7 +18,11 @@ import { getClusterName } from '@components/ClusterLink';
 import { EOS_SETTINGS, EOS_CLEAR_ALL, EOS_PLAY_CIRCLE } from 'eos-icons-react';
 
 import { getCluster } from '@state/selectors';
-import { updateLastExecution } from '@state/actions/lastExecutions';
+import { getClusterHostIDs } from '@state/selectors/cluster';
+import {
+  updateLastExecution,
+  executionRequested,
+} from '@state/actions/lastExecutions';
 import { getLastExecution } from '@state/selectors/lastExecutions';
 import SiteDetails from './SiteDetails';
 
@@ -74,9 +78,8 @@ export function ClusterDetailsNew() {
   const cluster = useSelector(getCluster(clusterID));
 
   const dispatch = useDispatch();
-
   const lastExecution = useSelector(getLastExecution(clusterID));
-
+  const hosts = useSelector(getClusterHostIDs(clusterID));
   useEffect(() => {
     dispatch(updateLastExecution(clusterID));
   }, [dispatch]);
@@ -145,6 +148,11 @@ export function ClusterDetailsNew() {
             clusterId={clusterID}
             disabled={!hasSelectedChecks}
             usingNewChecksEngine
+            hosts={hosts}
+            checks={cluster.selected_checks}
+            onStartExecution={(clusterId, hostList, selectedChecks) =>
+              dispatch(executionRequested(clusterId, hostList, selectedChecks))
+            }
           >
             <EOS_PLAY_CIRCLE
               className={classNames('inline-block fill-jungle-green-500', {

--- a/assets/js/components/ClusterDetails/ClusterDetailsNew.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetailsNew.jsx
@@ -150,8 +150,8 @@ export function ClusterDetailsNew() {
             usingNewChecksEngine
             hosts={hosts}
             checks={cluster.selected_checks}
-            onStartExecution={(clusterId, hostList, selectedChecks) =>
-              dispatch(executionRequested(clusterId, hostList, selectedChecks))
+            onStartExecution={(_, hostList, selectedChecks) =>
+              dispatch(executionRequested(clusterID, hostList, selectedChecks))
             }
           >
             <EOS_PLAY_CIRCLE

--- a/assets/js/components/ClusterDetails/ClusterSettings.jsx
+++ b/assets/js/components/ClusterDetails/ClusterSettings.jsx
@@ -115,10 +115,11 @@ export function SavingFailedAlert({ onClose = () => {}, children }) {
 }
 
 export function SuggestTriggeringChecksExecutionAfterSettingsUpdated({
-  cluster,
   clusterId,
   usingNewChecksEngine = false,
+  selectedChecks,
   onClose = () => {},
+  onStartExecution = () => {},
 }) {
   return (
     <div>
@@ -134,7 +135,8 @@ export function SuggestTriggeringChecksExecutionAfterSettingsUpdated({
           clusterId={clusterId}
           usingNewChecksEngine={usingNewChecksEngine}
           hosts={useSelector(getClusterHostIDs(clusterId))}
-          checks={cluster.selected_checks}
+          checks={selectedChecks}
+          onStartExecution={onStartExecution}
         >
           <EOS_PLAY_CIRCLE color="green" />
         </TriggerChecksExecutionRequest>

--- a/assets/js/components/ClusterDetails/ClusterSettings.jsx
+++ b/assets/js/components/ClusterDetails/ClusterSettings.jsx
@@ -13,6 +13,8 @@ import TriggerChecksExecutionRequest from '@components/TriggerChecksExecutionReq
 import { getClusterName } from '@components/ClusterLink';
 import WarningBanner from '@components/Banners/WarningBanner';
 import { ConnectionSettings, ClusterInfoBox } from '@components/ClusterDetails';
+import { getClusterHostIDs } from '@state/selectors/cluster';
+
 import { truncatedClusterNameClasses } from './ClusterDetails';
 
 export const UNKNOWN_PROVIDER = 'unknown';
@@ -113,6 +115,7 @@ export function SavingFailedAlert({ onClose = () => {}, children }) {
 }
 
 export function SuggestTriggeringChecksExecutionAfterSettingsUpdated({
+  cluster,
   clusterId,
   usingNewChecksEngine = false,
   onClose = () => {},
@@ -130,6 +133,8 @@ export function SuggestTriggeringChecksExecutionAfterSettingsUpdated({
           cssClasses="tn-checks-start-execute rounded-full group flex rounded-full items-center text-sm px-2 bg-jungle-green-500 text-white"
           clusterId={clusterId}
           usingNewChecksEngine={usingNewChecksEngine}
+          hosts={useSelector(getClusterHostIDs(clusterId))}
+          checks={cluster.selected_checks}
         >
           <EOS_PLAY_CIRCLE color="green" />
         </TriggerChecksExecutionRequest>

--- a/assets/js/components/ClusterDetails/ConnectionSettings.jsx
+++ b/assets/js/components/ClusterDetails/ConnectionSettings.jsx
@@ -1,12 +1,14 @@
 import { EOS_ERROR, EOS_LOADING_ANIMATED } from 'eos-icons-react';
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import Table from '@components/Table';
+import classNames from 'classnames';
 import { Switch } from '@headlessui/react';
 
-import classNames from 'classnames';
-import NotificationBox from '../NotificationBox';
-import LoadingBox from '../LoadingBox';
+import Table from '@components/Table';
+import NotificationBox from '@components/NotificationBox';
+import LoadingBox from '@components/LoadingBox';
+import { executionRequested } from '@state/actions/lastExecutions';
+
 import {
   SavingFailedAlert,
   SuggestTriggeringChecksExecutionAfterSettingsUpdated,
@@ -182,9 +184,12 @@ export function ConnectionSettings({ clusterId, cluster }) {
         )}
         {localSavingSuccess && cluster.selected_checks.length > 0 && (
           <SuggestTriggeringChecksExecutionAfterSettingsUpdated
-            cluster={cluster}
             clusterId={clusterId}
+            selectedChecks={cluster.selected_checks}
             onClose={() => setLocalSavingSuccess(null)}
+            onStartExecution={(clusterID, hosts, checks) =>
+              dispatch(executionRequested(clusterID, hosts, checks))
+            }
           />
         )}
       </div>

--- a/assets/js/components/ClusterDetails/ConnectionSettings.jsx
+++ b/assets/js/components/ClusterDetails/ConnectionSettings.jsx
@@ -182,6 +182,7 @@ export function ConnectionSettings({ clusterId, cluster }) {
         )}
         {localSavingSuccess && cluster.selected_checks.length > 0 && (
           <SuggestTriggeringChecksExecutionAfterSettingsUpdated
+            cluster={cluster}
             clusterId={clusterId}
             onClose={() => setLocalSavingSuccess(null)}
           />

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -56,10 +56,12 @@ function ExecutionResults({
   clusterSelectedChecks = [],
   onCatalogRefresh = () => {},
   onLastExecutionUpdate = () => {},
+  onStartExecution = () => {},
 }) {
   const [selectedCheck, setSelectedCheck] = useState(null);
   const [modalOpen, setModalOpen] = useState(false);
   const [predicates, setPredicates] = useState([]);
+  const hosts = hostnames.map((item) => item.id);
 
   if (catalogLoading) {
     return <LoadingBox text="Loading checks execution..." />;
@@ -128,8 +130,10 @@ function ExecutionResults({
         clusterID={clusterID}
         hasAlreadyChecksResults={!!(executionData || executionLoading)}
         selectedChecks={clusterSelectedChecks}
+        hosts={hosts}
         onCatalogRefresh={onCatalogRefresh}
         usingNewChecksEngine
+        onStartExecution={onStartExecution}
       >
         {executionData?.targets.map(({ agent_id: hostID, checks }) => (
           <HostResultsWrapper

--- a/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
@@ -189,7 +189,7 @@ describe('ExecutionResults', () => {
         clusterName={faker.animal.cat()}
         clusterScenario={faker.animal.cat()}
         cloudProvider={faker.animal.cat()}
-        hostnames
+        hostnames={[]}
         catalogLoading={false}
         catalog={[]}
         catalogError={null}

--- a/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
@@ -5,7 +5,10 @@ import { getCatalog } from '@state/selectors/catalog';
 import { getLastExecution } from '@state/selectors/lastExecutions';
 import { getCluster } from '@state/selectors';
 import { updateCatalog } from '@state/actions/catalog';
-import { updateLastExecution } from '@state/actions/lastExecutions';
+import {
+  updateLastExecution,
+  executionRequested,
+} from '@state/actions/lastExecutions';
 import ExecutionResults from './ExecutionResults';
 
 function ExecutionResultsPage() {
@@ -59,6 +62,9 @@ function ExecutionResultsPage() {
       executionData={executionData}
       executionError={executionError}
       clusterSelectedChecks={cluster?.selected_checks}
+      onStartExecution={(clusterId, hosts, selectedChecks) =>
+        dispatch(executionRequested(clusterId, hosts, selectedChecks))
+      }
     />
   );
 }

--- a/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.jsx
+++ b/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.jsx
@@ -1,25 +1,18 @@
 import React from 'react';
 import classNames from 'classnames';
-import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
-
-import {
-  getClusterHostIDs,
-  getClusterSelectedChecks,
-} from '@state/selectors/cluster';
-import { executionRequested } from '@state/actions/lastExecutions';
 
 function TriggerChecksExecutionRequest({
   clusterId,
   cssClasses,
   usingNewChecksEngine = false,
   children,
+  hosts = [],
+  checks = [],
+  onStartExecution = () => {},
   ...props
 }) {
-  const dispatch = useDispatch();
   const navigate = useNavigate();
-  const hosts = useSelector(getClusterHostIDs(clusterId));
-  const checks = useSelector(getClusterSelectedChecks(clusterId));
 
   return (
     <button
@@ -29,7 +22,8 @@ function TriggerChecksExecutionRequest({
       )}
       type="button"
       onClick={() => {
-        dispatch(executionRequested(clusterId, hosts, checks));
+        onStartExecution(clusterId, hosts, checks);
+
         navigate(
           usingNewChecksEngine
             ? `/clusters_new/${clusterId}/executions/last`

--- a/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.test.jsx
+++ b/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.test.jsx
@@ -1,66 +1,43 @@
 import React from 'react';
 
 import { screen, act } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { faker } from '@faker-js/faker';
-import { withState, renderWithRouter } from '@lib/test-utils';
-
-import { clusterFactory, hostFactory } from '@lib/test-utils/factories';
+import { renderWithRouter } from '@lib/test-utils';
+import userEvent from '@testing-library/user-event';
+import { hostFactory } from '@lib/test-utils/factories';
 
 import TriggerChecksExecutionRequest from './TriggerChecksExecutionRequest';
 
-describe('TriggerChecksExecutionRequest', () => {
-  it('should dispatch execution requested on click', async () => {
+describe('TriggerChecksExecutionRequest component', () => {
+  it('should dispatch execution requested on click and navigate to the correct url', async () => {
     const user = userEvent.setup();
-    const cluster1 = clusterFactory.build({
-      selected_checks: [faker.datatype.uuid(), faker.datatype.uuid()],
-    });
-    const cluster2 = clusterFactory.build({
-      selected_checks: [faker.datatype.uuid(), faker.datatype.uuid()],
-    });
-    const { id: clusterID1, selected_checks: clusterSelectedChecks1 } =
-      cluster1;
-    const { id: clusterID2 } = cluster2;
+    const onStartExecution = jest.fn();
+    const clusterId = faker.datatype.uuid();
+    const hosts = hostFactory.buildList(2);
+    const selectedChecks = [faker.datatype.uuid(), faker.datatype.uuid()];
 
-    const host1 = hostFactory.build({ cluster_id: clusterID1 });
-    const host2 = hostFactory.build({ cluster_id: clusterID1 });
-    const host3 = hostFactory.build({ cluster_id: clusterID2 });
-    const { id: hostID1 } = host1;
-    const { id: hostID2 } = host2;
-
-    const initialState = {
-      clustersList: {
-        clusters: [cluster1, cluster2],
-      },
-      hostsList: {
-        hosts: [host1, host2, host3],
-      },
-    };
-
-    const [statefulView, store] = withState(
-      <TriggerChecksExecutionRequest
-        clusterId={clusterID1}
-        usingNewChecksEngine
-      />,
-      initialState
+    await act(async () =>
+      renderWithRouter(
+        <TriggerChecksExecutionRequest
+          clusterId={clusterId}
+          usingNewChecksEngine
+          onStartExecution={onStartExecution}
+          hosts={hosts}
+          checks={selectedChecks}
+        />
+      )
     );
-
-    await act(async () => renderWithRouter(statefulView));
 
     const button = screen.getByRole('button');
     await user.click(button);
 
-    const actions = store.getActions();
-    const expectedActions = [
-      {
-        type: 'EXECUTION_REQUESTED',
-        payload: {
-          clusterID: clusterID1,
-          hosts: [hostID1, hostID2],
-          checks: clusterSelectedChecks1,
-        },
-      },
-    ];
-    expect(actions).toEqual(expectedActions);
+    expect(onStartExecution).toHaveBeenCalledWith(
+      clusterId,
+      hosts,
+      selectedChecks
+    );
+    expect(window.location.pathname).toBe(
+      `/clusters_new/${clusterId}/executions/last`
+    );
   });
 });


### PR DESCRIPTION
# Description

Move all redux logic from TriggerChecksExecutionRequest component to ExecutionResultsPage and ChecksResults component.
The component required parameters are passed as props now.

This is a WIP and requires of cleaning the code but here is a first idea of the upcoming refactor!
## How was this tested?

Existing Test still needs to be modified for the changes
