### PR TITLE
Fix e2e

### DIFF
--- a/assets/js/components/Table/Filter.jsx
+++ b/assets/js/components/Table/Filter.jsx
@@ -21,12 +21,14 @@ function Filter({ options, title, value, onChange }) {
     .filter((option) => option.toLowerCase().includes(query.toLowerCase()));
 
   useOnClickOutside(ref, () => setOpen(false));
+
   return (
     <div className="w-64 w-72 top-16 mr-4" ref={ref}>
       <div className="mt-1 relative">
         {value !== '' && (
           <button
             type="button"
+            data-testid={`filter-${title}-clear`}
             className="block absolute z-20 right-0 h-full pr-2 flex items-center"
             onClick={() => onChange([])}
           >

--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -136,15 +136,14 @@ context('Clusters Overview', () => {
         tagsScenarios.forEach(([tag, expectedTaggedClusters]) => {
           it(`should have ${expectedTaggedClusters} clusters tagged with tag '${tag}'`, () => {
             cy.get('[data-testid="filter-Tags"]').click();
-            cy.get('.max-h-56').contains(tag).click();
+            cy.get('.max-h-56', { timeout: 150000 }).contains(tag).click();
             cy.clickOutside();
 
             cy.get('.tn-clustername')
               .its('length')
               .should('eq', expectedTaggedClusters);
 
-            cy.get('[data-testid="filter-Tags"]').click();
-            cy.get('.max-h-56').contains(tag).click();
+            cy.get('[data-testid="filter-Tags-clear"]').click();
             cy.clickOutside();
           });
         });
@@ -165,8 +164,7 @@ context('Clusters Overview', () => {
               .its('length')
               .should('eq', expectedClustersWithThisHealth);
 
-            cy.get('[data-testid="filter-Health"]').click();
-            cy.get('.max-h-56', { timeout: 150000 }).contains(health).click();
+            cy.get('[data-testid="filter-Health-clear"]').click();
             cy.clickOutside();
           });
         });
@@ -190,10 +188,7 @@ context('Clusters Overview', () => {
               .its('length')
               .should('eq', expectedRelatedClusters);
 
-            cy.get('[data-testid="filter-SID"]').click();
-            cy.get('.max-h-56', { timeout: 150000 })
-              .contains(sapsystem)
-              .click();
+            cy.get('[data-testid="filter-SID-clear"]').click();
             cy.clickOutside();
           });
         });
@@ -211,15 +206,18 @@ context('Clusters Overview', () => {
           ([clusterName, expectedRelatedClusters]) => {
             it(`should have ${expectedRelatedClusters} clusters related to name '${clusterName}'`, () => {
               cy.get('[data-testid="filter-Name"]').click();
-              cy.get('.max-h-56').contains(clusterName).click();
+              cy.get('.max-h-56', { timeout: 150000 })
+                .contains(clusterName)
+                .click();
               cy.clickOutside();
 
               cy.get('.tn-clustername')
                 .its('length')
                 .should('eq', expectedRelatedClusters);
 
-              cy.get('[data-testid="filter-Name"]').click();
-              cy.get('.max-h-56').contains(clusterName).click();
+              cy.get('[data-testid="filter-Name-clear"]', {
+                timeout: 150000,
+              }).click();
               cy.clickOutside();
             });
           }


### PR DESCRIPTION
Turns out opening a dropdown, selecting an item and then reopening it right after makes an end to end test extremely prone to flakiness.

In this PR we try to use the clear function of a filter, that should avoid the second dropdown interaction, therefore making the test more reliable.