### PR TITLE
Rollup fixes

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -67,10 +67,6 @@ config :trento, Trento.Commanded,
       snapshot_every: 200,
       snapshot_version: 1
     ],
-    Trento.Domain.Cluster => [
-      snapshot_every: 200,
-      snapshot_version: 1
-    ],
     Trento.Domain.SapSystem => [
       snapshot_every: 200,
       snapshot_version: 1

--- a/lib/trento/domain/cluster/lifespan.ex
+++ b/lib/trento/domain/cluster/lifespan.ex
@@ -23,6 +23,6 @@ defmodule Trento.Domain.Cluster.Lifespan do
   @doc """
    If the aggregate is rolling up, it will be stopped to avoid processing any other event.
   """
-  def after_error({:error, :cluster_rolling_up}), do: :stop
+  def after_error(:cluster_rolling_up), do: :stop
   def after_error(error), do: DefaultLifespan.after_error(error)
 end


### PR DESCRIPTION
This PR fixes the rollup flow since it could happen that a snapshot is built concurrently with the rollup execution, causing the snapshot to be taken with a lock.
It also fixes the aggregate lifespan that wasn't stopping the aggregate correctly if the aggregate is locked due to a bad pattern match.