### PR TITLE
Add remediation content

### DIFF
--- a/assets/js/components/ChecksResults/checksUtils.js
+++ b/assets/js/components/ChecksResults/checksUtils.js
@@ -112,5 +112,8 @@ export const getCheckDescription = (catalog, checkID) => {
 
 export const getCheckRemediation = (catalog, checkID) => {
   const check = findCheck(catalog, checkID);
-  return check?.remediation;
+  if (check) {
+    return check.remediation;
+  }
+  return null;
 };

--- a/assets/js/components/ChecksResults/checksUtils.js
+++ b/assets/js/components/ChecksResults/checksUtils.js
@@ -109,3 +109,8 @@ export const getCheckDescription = (catalog, checkID) => {
   }
   return null;
 };
+
+export const getCheckRemediation = (catalog, checkID) => {
+  const check = findCheck(catalog, checkID);
+  return check?.remediation;
+};

--- a/assets/js/components/ChecksResults/checksUtils.test.js
+++ b/assets/js/components/ChecksResults/checksUtils.test.js
@@ -14,6 +14,7 @@ import {
 
 import {
   getCheckDescription,
+  getCheckRemediation,
   getCheckResults,
   getChecks,
   getCheckHealthByAgent,
@@ -69,6 +70,13 @@ describe('checksUtils', () => {
     const [{ id, description }] = catalog;
 
     expect(getCheckDescription(catalog, id)).toBe(description);
+  });
+
+  it('getCheckRemediation should return a check remediation', () => {
+    const catalog = catalogCheckFactory.buildList(2);
+    const [{ id, remediation }] = catalog;
+
+    expect(getCheckRemediation(catalog, id)).toBe(remediation);
   });
 
   describe('getCheckHealthByAgent', () => {

--- a/assets/js/components/ChecksResults/checksUtils.test.js
+++ b/assets/js/components/ChecksResults/checksUtils.test.js
@@ -77,6 +77,7 @@ describe('checksUtils', () => {
     const [{ id, remediation }] = catalog;
 
     expect(getCheckRemediation(catalog, id)).toBe(remediation);
+    expect(getCheckRemediation(catalog, 'wont-be-found')).toBe(null);
   });
 
   describe('getCheckHealthByAgent', () => {

--- a/assets/js/components/ChecksResults/index.js
+++ b/assets/js/components/ChecksResults/index.js
@@ -8,6 +8,7 @@ import {
   getCheckHealthByAgent,
   getCheckResults,
   getCheckDescription,
+  getCheckRemediation,
 } from './checksUtils';
 
 export {
@@ -19,6 +20,7 @@ export {
   getCheckHealthByAgent,
   getCheckResults,
   getCheckDescription,
+  getCheckRemediation,
 };
 
 export default ChecksResults;

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -16,6 +16,7 @@ import {
   getCheckHealthByAgent,
   getCheckResults,
   getCheckDescription,
+  getCheckRemediation,
 } from '@components/ChecksResults';
 import ChecksResultFilters from '@components/ChecksResults/ChecksResultFilters';
 import { UNKNOWN_PROVIDER } from '@components/ClusterDetails/ClusterSettings';
@@ -95,7 +96,7 @@ function ExecutionResults({
         onClose={() => setModalOpen(false)}
       >
         <ReactMarkdown className="markdown" remarkPlugins={[remarkGfm]}>
-          {getCheckDescription(catalog, selectedCheck)}
+          {getCheckRemediation(catalog, selectedCheck)}
         </ReactMarkdown>
       </Modal>
       <BackButton url={`/clusters_new/${clusterID}`}>

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -42,6 +42,14 @@ const getLabel = (status, health, error, expectations, failedExpectations) => {
   return `${failedExpectations}/${expectations} expectations failed`;
 };
 
+function asMarkdownContent(content) {
+  return (
+    <ReactMarkdown className="markdown" remarkPlugins={[remarkGfm]}>
+      {content}
+    </ReactMarkdown>
+  );
+}
+
 function ExecutionResults({
   clusterID,
   clusterName,
@@ -91,13 +99,11 @@ function ExecutionResults({
   return (
     <div>
       <Modal
-        title={getCheckDescription(catalog, selectedCheck)}
+        title={asMarkdownContent(getCheckDescription(catalog, selectedCheck))}
         open={modalOpen}
         onClose={() => setModalOpen(false)}
       >
-        <ReactMarkdown className="markdown" remarkPlugins={[remarkGfm]}>
-          {getCheckRemediation(catalog, selectedCheck)}
-        </ReactMarkdown>
+        {asMarkdownContent(getCheckRemediation(catalog, selectedCheck))}
       </Modal>
       <BackButton url={`/clusters_new/${clusterID}`}>
         Back to Cluster Details

--- a/assets/js/components/Modal/Modal.jsx
+++ b/assets/js/components/Modal/Modal.jsx
@@ -1,15 +1,18 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useRef } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 
 function Modal({ children, open, onClose, title }) {
+  const refContent = useRef(null);
+
   return (
     <Transition appear show={open} as={Fragment}>
       <Dialog
+        initialFocus={refContent}
         as="div"
         className="fixed inset-0 z-50 overflow-y-auto"
         onClose={onClose}
       >
-        <div className="min-h-screen px-4 text-center">
+        <div ref={refContent} className="min-h-screen px-4 text-center">
           <Transition.Child
             as={Fragment}
             enter="ease-out duration-300"


### PR DESCRIPTION
# Description

Adds the remediation content in the dialog that opens when clicking on a check row in ExecutionResults

![remediation-suggestion-dialog](https://user-images.githubusercontent.com/8167114/212629183-2435d644-87c0-4152-bf0a-550f8051846c.gif)

## How was this tested?

Automatic test added