### PR TITLE
Freeze demo deployment stages in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -467,7 +467,7 @@ jobs:
   deploy-demo-env:
     name: Deploy updated images to the demo environment
     runs-on: self-hosted
-    if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch'
+    if: vars.DEPLOY_DEMO == 'true' && (github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch')
     env:
       IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/trento-web
     needs: build-demo-img
@@ -500,7 +500,7 @@ jobs:
   run-photofinish-demo-env:
     name: Use photofinish to push mock data to the demo environment
     runs-on: ubuntu-20.04
-    if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch'
+    if: vars.DEPLOY_DEMO == 'true' && (github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch')
     needs: deploy-demo-env
     env:
       TRENTO_DEMO_IP: ${{ secrets.TRENTO_DEMO_IP }}


### PR DESCRIPTION
Freeze demo deployment now as the transition from old runner to wanda has started.

In order to disable or enable the demo deployment, the repository variable `DEPLOY_DEMO` must be changed.
Set to `'true'` to enable. Everything else should disable it.
I already set it to `false`.

I don't know if we should document this somewhere, we don't really have any documentation about the CI or the demo environment by now
