### PR TITLE
Bump BCI base image to 15.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV MIX_ENV=$MIX_ENV
 RUN mix phx.digest
 RUN mix release
 
-FROM registry.suse.com/bci/bci-base:15.3 AS trento
+FROM registry.suse.com/bci/bci-base:15.4 AS trento
 LABEL org.opencontainers.image.source="https://github.com/trento-project/web"
 ARG MIX_ENV=prod
 ENV LANG en_US.UTF-8

--- a/packaging/suse/Dockerfile
+++ b/packaging/suse/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /build/web/assets
 RUN npm run tailwind:build
 RUN npm run build
 
-FROM bci/bci-base:15.3 AS release
+FROM bci/bci-base:15.4 AS release
 # Workaround for https://github.com/openSUSE/obs-build/issues/487
 RUN zypper --non-interactive in sles-release
 RUN zypper -n in elixir elixir-hex erlang-rebar3
@@ -26,7 +26,7 @@ ENV VERSION=%%VERSION%%
 RUN mix phx.digest
 RUN mix release
 
-FROM bci/bci-base:15.3 AS trento
+FROM bci/bci-base:15.4 AS trento
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.suse.trento
 LABEL org.opencontainers.image.source="https://github.com/trento-project/web"


### PR DESCRIPTION
# Description

Updating base images to the latest 15.4 bci release.
This allows to keep deps aligned across container images as wanda needs a more up to date base image (for rust 1.66 based itself on 15.4)

Reminder to self: before merging update obs meta.