### PR TITLE
Fix login error

### DIFF
--- a/assets/js/components/Login.jsx
+++ b/assets/js/components/Login.jsx
@@ -37,6 +37,8 @@ export default function Login() {
     dispatch(performLogin({ username, password }));
   };
 
+  const isUnauthorized = authError && authError.code === 401;
+
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
@@ -69,7 +71,7 @@ export default function Login() {
                   required
                   className={classNames(
                     'appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-jungle-green-500 focus:border-jungle-green-500 sm:text-sm',
-                    { 'border-red-300': authError && authError.code === 401 }
+                    { 'border-red-300': isUnauthorized }
                   )}
                 />
               </div>
@@ -95,7 +97,7 @@ export default function Login() {
                   className={classNames(
                     'appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-jungle-green-500 focus:border-jungle-green-500 sm:text-sm',
                     {
-                      'border-red-300': authError && authError.code === 401,
+                      'border-red-300': isUnauthorized,
                       'disabled:opacity-50': authInProgress,
                     }
                   )}

--- a/assets/js/components/Login.jsx
+++ b/assets/js/components/Login.jsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { toast } from 'react-hot-toast';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { performLogin } from '@state/actions/auth';
+import classNames from 'classnames';
 
 export default function Login() {
   const [username, setUsername] = useState('');
@@ -17,8 +18,10 @@ export default function Login() {
   const [searchParams] = useSearchParams();
 
   useEffect(() => {
-    if (authError) {
-      toast.error('An error occurred during login, try again');
+    if (authError && authError.code !== 401) {
+      toast.error(
+        `An error occurred during login, try again: ${authError.message}`
+      );
     }
   }, [authError]);
 
@@ -64,7 +67,10 @@ export default function Login() {
                   name="username"
                   autoComplete="username"
                   required
-                  className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-jungle-green-500 focus:border-jungle-green-500 sm:text-sm"
+                  className={classNames(
+                    'appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-jungle-green-500 focus:border-jungle-green-500 sm:text-sm',
+                    { 'border-red-300': authError && authError.code === 401 }
+                  )}
                 />
               </div>
             </div>
@@ -86,16 +92,30 @@ export default function Login() {
                   onChange={(e) => setPassword(e.target.value)}
                   autoComplete="current-password"
                   required
-                  className="appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-jungle-green-500 focus:border-jungle-green-500 sm:text-sm"
+                  className={classNames(
+                    'appearance-none block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-jungle-green-500 focus:border-jungle-green-500 sm:text-sm',
+                    {
+                      'border-red-300': authError && authError.code === 401,
+                      'disabled:opacity-50': authInProgress,
+                    }
+                  )}
                 />
               </div>
             </div>
+            {authError && authError.code === 401 && (
+              <p className="text-sm text-center text-red-500">
+                Invalid credentials
+              </p>
+            )}
             <div>
               <button
                 type="submit"
                 disabled={authInProgress}
                 data-testid="login-submit"
-                className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-jungle-green-500 hover:opacity-75 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-jungle-green-500"
+                className={classNames(
+                  'w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-jungle-green-500 hover:opacity-75 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-jungle-green-500',
+                  { 'disabled:opacity-50': authInProgress }
+                )}
               >
                 Login
               </button>

--- a/assets/js/components/Login.test.jsx
+++ b/assets/js/components/Login.test.jsx
@@ -35,7 +35,26 @@ describe('Login component', () => {
     expect(window.location.pathname).toEqual('/');
   });
 
-  it('should show a toast with an error if there are authorization errors', async () => {
+  it('should show a message if the authentication request returns a 401', async () => {
+    const [StatefulLogin] = withState(<Login />, {
+      user: {
+        authError: { message: 'Unauthorized', code: 401 },
+      },
+    });
+
+    renderWithRouter(StatefulLogin);
+
+    await waitFor(() => screen.getByText('Invalid credentials'));
+
+    ['username', 'password'].forEach((id) => {
+      const element = screen.getByTestId(`login-${id}`);
+      expect(element).toHaveClass('border-red-300');
+    });
+  });
+
+  it('should show a toast if an error occurs during the authentication and the error code is not 401', async () => {
+    const error = { message: 'Error', code: 500 };
+
     const [StatefulLogin] = withState(
       <>
         <Toaster position="top-right" />
@@ -43,7 +62,7 @@ describe('Login component', () => {
       </>,
       {
         user: {
-          authError: true,
+          authError: error,
         },
       }
     );
@@ -51,7 +70,9 @@ describe('Login component', () => {
     renderWithRouter(StatefulLogin);
 
     await waitFor(() =>
-      screen.getByText('An error occurred during login, try again')
+      screen.getByText(
+        `An error occurred during login, try again: ${error.message}`
+      )
     );
   });
 

--- a/assets/js/state/sagas/user.js
+++ b/assets/js/state/sagas/user.js
@@ -25,7 +25,7 @@ export function* performLogin({ payload: { username, password } }) {
     yield put(setUserAsLogged());
   } catch (error) {
     yield put(
-      setAuthError({ message: error.message, code: error.response.status })
+      setAuthError({ message: error.message, code: error.response?.status })
     );
     yield call(clearCredentialsFromStore);
   }

--- a/assets/js/state/sagas/user.js
+++ b/assets/js/state/sagas/user.js
@@ -24,7 +24,9 @@ export function* performLogin({ payload: { username, password } }) {
     yield call(storeRefreshToken, refreshToken);
     yield put(setUserAsLogged());
   } catch (error) {
-    yield put(setAuthError({ error: error.message }));
+    yield put(
+      setAuthError({ message: error.message, code: error.response.status })
+    );
     yield call(clearCredentialsFromStore);
   }
 }

--- a/assets/js/state/sagas/user.test.js
+++ b/assets/js/state/sagas/user.test.js
@@ -42,7 +42,10 @@ describe('user login saga', () => {
 
     expect(dispatched).toContainEqual(setAuthInProgress());
     expect(dispatched).toContainEqual(
-      setAuthError({ error: 'Request failed with status code 401' })
+      setAuthError({
+        message: 'Request failed with status code 401',
+        code: 401,
+      })
     );
     expect(getAccessTokenFromStore()).toEqual(null);
     expect(getRefreshTokenFromStore()).toEqual(null);

--- a/assets/js/state/user.js
+++ b/assets/js/state/user.js
@@ -14,10 +14,11 @@ export const userSlice = createSlice({
   reducers: {
     setAuthInProgress(state, _payload) {
       state.authInProgress = true;
+      state.authError = null;
     },
-    setAuthError(state, { payload: { error } }) {
+    setAuthError(state, { payload: { message, code } }) {
       state.authInProgress = false;
-      state.authError = error;
+      state.authError = { message, code };
     },
     setUserAsLogged(state, _payload) {
       state.loggedIn = true;

--- a/assets/js/state/user.test.js
+++ b/assets/js/state/user.test.js
@@ -18,8 +18,12 @@ describe('user reducer', () => {
   });
 
   it('should set the authorization error when setAuthError is dispatched', () => {
-    const error = faker.commerce.productAdjective();
-    const action = setAuthError({ error });
+    const error = {
+      message: faker.commerce.productAdjective(),
+      code: faker.internet.httpStatusCode(),
+    };
+    const action = setAuthError({ ...error });
+
     expect(userReducer(initialState, action)).toEqual({
       ...initialState,
       authError: error,


### PR DESCRIPTION
This PR fixes the login page. 

Before:

On a 401 we were showing a toast with a generic error message.
There was a bug and the toast was shown only once after the first attempt.

After:
We show an invalid credential message and we highlight with a red border the form fields if we get a 401.
We show a toast when any other error occurs.

It also disables the login button when submitting the form.
![login](https://user-images.githubusercontent.com/828651/214522246-5929bf9e-011e-4a6d-a68b-c475ae085dec.gif)
