### PR TITLE
Chore: auth clean-up

### DIFF
--- a/lib/trento_web/views/session_view.ex
+++ b/lib/trento_web/views/session_view.ex
@@ -10,7 +10,7 @@ defmodule TrentoWeb.SessionView do
   end
 
   def render("invalid_credentials.json", _args) do
-    %{error: "Invalid email or password"}
+    %{error: "Invalid username or password"}
   end
 
   def render("unauthorized.json", _args) do

--- a/test/trento_web/auth/jwt_auth_plug_test.exs
+++ b/test/trento_web/auth/jwt_auth_plug_test.exs
@@ -37,7 +37,7 @@ defmodule TrentoWeb.JWTAuthPlugTest do
   end
 
   describe "renew/2" do
-    test "should put in conn private a renewd access token if the refresh token is valid", %{
+    test "should renew a token and put it in the conn private if the refresh token is valid", %{
       conn: conn
     } do
       valid_refresh = RefreshToken.generate_refresh_token!(%{"sub" => 1})

--- a/test/trento_web/auth/jwt_auth_plug_test.exs
+++ b/test/trento_web/auth/jwt_auth_plug_test.exs
@@ -16,6 +16,18 @@ defmodule TrentoWeb.JWTAuthPlugTest do
 
   setup [:set_mox_from_context, :verify_on_exit!]
 
+  setup do
+    stub(
+      Joken.CurrentTime.Mock,
+      :current_time,
+      fn ->
+        1_671_715_992
+      end
+    )
+
+    :ok
+  end
+
   describe "delete/2" do
     test "should no-op and return the passed conn", %{conn: conn} do
       res_conn = JWTAuthPlug.delete(conn, @pow_config)
@@ -28,15 +40,6 @@ defmodule TrentoWeb.JWTAuthPlugTest do
     test "should put in conn private a renewd access token if the refresh token is valid", %{
       conn: conn
     } do
-      expect(
-        Joken.CurrentTime.Mock,
-        :current_time,
-        8,
-        fn ->
-          1_671_715_992
-        end
-      )
-
       valid_refresh = RefreshToken.generate_refresh_token!(%{"sub" => 1})
 
       {:ok, res_conn} = JWTAuthPlug.renew(conn, valid_refresh)
@@ -52,28 +55,10 @@ defmodule TrentoWeb.JWTAuthPlugTest do
     end
 
     test "should return an error if the refresh token is malformed", %{conn: conn} do
-      expect(
-        Joken.CurrentTime.Mock,
-        :current_time,
-        0,
-        fn ->
-          1_671_715_992
-        end
-      )
-
       {:error, _reason} = JWTAuthPlug.renew(conn, "invalid")
     end
 
     test "should return an error if the refresh token signature is invalid", %{conn: conn} do
-      expect(
-        Joken.CurrentTime.Mock,
-        :current_time,
-        0,
-        fn ->
-          1_671_715_992
-        end
-      )
-
       bad_refresh =
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0cmVudG8tcHJvamVjdCIsImV4cCI6MTY3MTU1NjY5MiwiaWF0IjoxNjcxNTQ5NDkyLCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vdHJlbnRvLXByb2plY3Qvd2ViIiwianRpIjoiMnNwOGlxMmkxNnRlbHNycWE4MDAwMWM4IiwibmJmIjoxNjcxNTQ5NDkyLCJzdWIiOjEsInR5cCI6IlJlZnJlc2gifQ.Ctg1bAbWgk2Fr69v7bwT7oxR9XUa1-iNtoZTYbzHOIk"
 
@@ -83,15 +68,6 @@ defmodule TrentoWeb.JWTAuthPlugTest do
     test "should return an error is the refresh token signature is valid but it's expired", %{
       conn: conn
     } do
-      expect(
-        Joken.CurrentTime.Mock,
-        :current_time,
-        1,
-        fn ->
-          1_671_715_992
-        end
-      )
-
       expired_refresh =
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0cmVudG8tcHJvamVjdCIsImV4cCI6MTY3MTY2MzQxNCwiaWF0IjoxNjcxNjQxODE0LCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vdHJlbnRvLXByb2plY3Qvd2ViIiwianRpIjoiMnNwaTNzMGZzNmZqcHE5dnVrMDAwNWUxIiwibmJmIjoxNjcxNjQxODE0LCJzdWIiOjEsInR5cCI6IlJlZnJlc2gifQ.FdPblWJ23PDBv5V2EhVNsaW4_-gZP0M9wnwYAlGOa1E"
 
@@ -102,15 +78,6 @@ defmodule TrentoWeb.JWTAuthPlugTest do
 
   describe "create/3" do
     test "should add to the conn the access/refresh token pair and the expiration", %{conn: conn} do
-      expect(
-        Joken.CurrentTime.Mock,
-        :current_time,
-        6,
-        fn ->
-          1_671_715_992
-        end
-      )
-
       user = %{id: 1}
 
       assert {res_conn, ^user} = JWTAuthPlug.create(conn, user, @pow_config)
@@ -127,15 +94,6 @@ defmodule TrentoWeb.JWTAuthPlugTest do
 
   describe "fetch/2" do
     test "should fetch a user when the jwt is valid", %{conn: conn} do
-      expect(
-        Joken.CurrentTime.Mock,
-        :current_time,
-        5,
-        fn ->
-          1_671_715_992
-        end
-      )
-
       jwt = AccessToken.generate_access_token!(%{"sub" => 1})
 
       conn = Plug.Conn.put_req_header(conn, "authorization", "Bearer " <> jwt)
@@ -150,15 +108,6 @@ defmodule TrentoWeb.JWTAuthPlugTest do
     end
 
     test "should not fetch a user when the jwt signature is invalid", %{conn: conn} do
-      expect(
-        Joken.CurrentTime.Mock,
-        :current_time,
-        0,
-        fn ->
-          1_671_641_814
-        end
-      )
-
       bad_jwt =
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0cmVudG8tcHJvamVjdCIsImV4cCI6MTY3MTU1NjY5MiwiaWF0IjoxNjcxNTQ5NDkyLCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vdHJlbnRvLXByb2plY3Qvd2ViIiwianRpIjoiMnNwOGlxMmkxNnRlbHNycWE4MDAwMWM4IiwibmJmIjoxNjcxNTQ5NDkyLCJzdWIiOjF9.PRqQgJkfxrusFtvkwk-2utMNde0TZN9zcx7ncmVxvk8"
 
@@ -168,28 +117,10 @@ defmodule TrentoWeb.JWTAuthPlugTest do
     end
 
     test "should not fetch user when the header is missing", %{conn: conn} do
-      expect(
-        Joken.CurrentTime.Mock,
-        :current_time,
-        0,
-        fn ->
-          1_671_641_814
-        end
-      )
-
       assert {_res_conn, nil} = JWTAuthPlug.fetch(conn, @pow_config)
     end
 
     test "should not fetch user when the jwt is malformed", %{conn: conn} do
-      expect(
-        Joken.CurrentTime.Mock,
-        :current_time,
-        0,
-        fn ->
-          1_671_641_814
-        end
-      )
-
       bad_jwt = "do you know jwt?"
 
       conn = Plug.Conn.put_req_header(conn, "authorization", "Bearer " <> bad_jwt)
@@ -198,15 +129,6 @@ defmodule TrentoWeb.JWTAuthPlugTest do
     end
 
     test "should not fetch user when the jwt signature is valid but it's expired", %{conn: conn} do
-      expect(
-        Joken.CurrentTime.Mock,
-        :current_time,
-        1,
-        fn ->
-          1_671_715_992
-        end
-      )
-
       expired_jwt =
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0cmVudG8tcHJvamVjdCIsImV4cCI6MTY3MTY0MjQxNCwiaWF0IjoxNjcxNjQxODE0LCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vdHJlbnRvLXByb2plY3Qvd2ViIiwianRpIjoiMnNwaTFvbmxxbml1ZnE5dnVrMDAwMG9hIiwibmJmIjoxNjcxNjQxODE0LCJzdWIiOjEsInR5cCI6IkJlYXJlciJ9.oub6_NsHcVIyd0de14Lzk3SuCMMgr8O-sSWLr7Gxcp8"
 

--- a/test/trento_web/controllers/session_controller_test.exs
+++ b/test/trento_web/controllers/session_controller_test.exs
@@ -192,7 +192,7 @@ defmodule TrentoWeb.SessionControllerTest do
 
       resp = json_response(conn, 401)
 
-      assert %{"error" => "Invalid email or password"} = resp
+      assert %{"error" => "Invalid username or password"} = resp
     end
   end
 end


### PR DESCRIPTION
Changes the wrong field name in auth error (we use a username not an email to authenticate).
Removal of repetition in JWT auth plug test.