### PR TITLE
Disable CronJobs when run from IEx in `dev`

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -84,15 +84,17 @@ config :trento, TrentoWeb.Endpoint,
     ]
   ]
 
-config :trento, Trento.Scheduler,
-  jobs: [
-    publish_telemetry: [
-      schedule: {:extended, "@hourly"}
-    ],
-    clusters_checks_execution: [
-      schedule: {:extended, "@hourly"}
+unless IEx.started?() do
+  config :trento, Trento.Scheduler,
+    jobs: [
+      publish_telemetry: [
+        schedule: {:extended, "@hourly"}
+      ],
+      clusters_checks_execution: [
+        schedule: {:extended, "@hourly"}
+      ]
     ]
-  ]
+end
 
 config :trento, Trento.Integration.Telemetry, adapter: Trento.Integration.Telemetry.ToLogger
 config :trento, Trento.Integration.Checks, adapter: Trento.Integration.Checks.MockRunner


### PR DESCRIPTION
# Description

_Quantum_ CronJobs can be disruptive to the development workflow, especially when run from _IEx_.

This change disables the Quantum CronJobs in `dev` when run from _IEx_.

## How was this tested?

By creating a dummy CronJob and adding it to the Quantum scheduler `jobs` list:
```Elixir
{"* * * * *", fn -> IO.puts("----- CronJob is running -----") end}
```

Running `iex -S mix phx.server` does not output the message.

(Without the `unless IEx.started?` check, the CronJob does run and output the test message)