### PR TITLE
Add reviewers to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    reviewers:
+      - "trento-project/mantainers"
   - package-ecosystem: "mix"
     directory: "/"
     schedule:
       interval: "daily"
+    reviewers:
+      - "trento-project/mantainers"
   - package-ecosystem: "npm"
     directory: "/assets"
     schedule:
       interval: "daily"
+    reviewers:
+      - "trento-project/mantainers"


### PR DESCRIPTION
By protecting the branch by waiting for 1 review at least, dependabot needs a list of reviewers.
