### PR TITLE
Setup ci demo wanda

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -483,7 +483,7 @@ jobs:
     runs-on: self-hosted
     if: vars.DEPLOY_DEMO == 'true' && (github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch')
     env:
-      IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/trento-web
+      IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}
     needs: build-demo-img
     steps:
       - name: Start a local k8s cluster
@@ -507,8 +507,11 @@ jobs:
           helm upgrade -i trento --wait . \
             --set trento-web.adminUser.password="${{ secrets.DEMO_PASSWORD }}" \
             --set trento-web.image.pullPolicy=Always \
-            --set trento-web.image.repository="${IMAGE_REPOSITORY}" \
-            --set trento-web.image.tag="demo"
+            --set trento-web.image.repository="${IMAGE_REPOSITORY}/trento-web" \
+            --set trento-web.image.tag="demo" \
+            --set trento-wanda.image.pullPolicy=Always \
+            --set trento-wanda.image.repository="${IMAGE_REPOSITORY}/trento-wanda" \
+            --set trento-wanda.image.tag="demo"
 
   run-photofinish-demo-env:
     name: Use photofinish to push mock data to the demo environment

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -505,7 +505,6 @@ jobs:
           cd helm-charts-rolling/charts/trento-server
           helm dependency update
           helm upgrade -i trento --wait . \
-            --set-file trento-runner.privateKey=/home/azureuser/.ssh/id_rsa \
             --set trento-web.adminUser.password="${{ secrets.DEMO_PASSWORD }}" \
             --set trento-web.image.pullPolicy=Always \
             --set trento-web.image.repository="${IMAGE_REPOSITORY}" \

--- a/config/demo.exs
+++ b/config/demo.exs
@@ -23,7 +23,5 @@ config :trento, Trento.Scheduler,
     ]
   ]
 
-config :trento, Trento.Integration.Checks, adapter: Trento.Integration.Checks.MockRunner
-
 config :trento, Trento.Integration.Prometheus,
   adapter: Trento.Integration.Prometheus.MockPrometheusApi


### PR DESCRIPTION
Remove some legacy runner leftovers and add wanda image values to deploy on demo
PD: on draft as we should have the wanda side finished first, with the `demo` image published in our registry. Once that is done, we could merge this
