### PR TITLE
Check base url injected into the client via global config object

### DIFF
--- a/assets/build.js
+++ b/assets/build.js
@@ -10,24 +10,9 @@ config();
 
 const resolvePath = (p) => path.resolve(__dirname, p);
 
-const stringify = (variable) => {
-  if (!variable) {
-    return JSON.stringify('');
-  }
-  return JSON.stringify(variable);
-};
-
-const WANDA_URL =
-  process.env.NODE_ENV === 'production' ? '' : stringify(process.env.WANDA_URL);
-
-const define = {
-  'process.env.WANDA_URL': WANDA_URL,
-};
-
 const watching = Boolean(process.env.ESBUILD_WATCH);
 
 const buildConfig = {
-  define,
   entryPoints: ['js/app.js', 'js/trento.jsx'],
   outdir: resolvePath('../priv/static/assets'),
   bundle: true,

--- a/assets/build.js
+++ b/assets/build.js
@@ -4,9 +4,6 @@
 const path = require('path');
 const alias = require('esbuild-plugin-path-alias');
 const esbuild = require('esbuild');
-const { config } = require('dotenv');
-
-config();
 
 const resolvePath = (p) => path.resolve(__dirname, p);
 

--- a/assets/jest.config.js
+++ b/assets/jest.config.js
@@ -63,7 +63,11 @@ module.exports = {
   // globalTeardown: undefined,
 
   // A set of global variables that need to be available in all test environments
-  // globals: {},
+  globals: {
+    config: {
+      checksServiceBaseUrl: '',
+    },
+  },
 
   // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
   // maxWorkers: "50%",

--- a/assets/js/lib/api/checks.js
+++ b/assets/js/lib/api/checks.js
@@ -1,6 +1,8 @@
 import { networkClient } from '@lib/network';
 
-const baseURL = process.env.WANDA_URL;
+// eslint-disable-next-line no-undef
+const baseURL = config.checksServiceBaseUrl;
+
 const defaultConfig = { baseURL };
 
 export const getExecutionResult = (executionID) =>

--- a/assets/package.json
+++ b/assets/package.json
@@ -47,7 +47,6 @@
     "classnames": "^2.3.2",
     "date-fns": "^2.29.3",
     "dayjs": "^1.11.7",
-    "dotenv": "^16.0.3",
     "eos-icons-react": "^2.4.0",
     "postcss-import": "^15.1.0",
     "react": "^18.2.0",

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -127,3 +127,5 @@ config :trento, :api_key_authentication, enabled: false
 config :joken,
   access_token_signer: "s2ZdE+3+ke1USHEJ5O45KT364KiXPYaB9cJPdH3p60t8yT0nkLexLBNw8TFSzC7k",
   refresh_token_signer: "L0wvcZh3ACQpibVhV/nh5jd/NaZWL4ijZxTxGJMGpacuXIBc4In3YCwXeVM98ygp"
+
+config :trento, :checks_service, base_url: "http://localhost:4001"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -85,13 +85,7 @@ if config_env() in [:prod, :demo] do
       connection: amqp_url
     ]
 
-  config :trento, :checks_service,
-    base_url:
-      System.get_env("CHECKS_SERVICE_BASE_URL") ||
-        raise("""
-        environment variable CHECKS_SERVICE_BASE_URL is missing.
-        For example: /check_service
-        """)
+  config :trento, :checks_service, base_url: System.get_env("CHECKS_SERVICE_BASE_URL") || ""
 
   config :trento, :grafana,
     user: System.get_env("GRAFANA_USER") || "admin",

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -85,6 +85,14 @@ if config_env() in [:prod, :demo] do
       connection: amqp_url
     ]
 
+  config :trento, :checks_service,
+    base_url:
+      System.get_env("CHECKS_SERVICE_BASE_URL") ||
+        raise("""
+        environment variable CHECKS_SERVICE_BASE_URL is missing.
+        For example: /check_service
+        """)
+
   config :trento, :grafana,
     user: System.get_env("GRAFANA_USER") || "admin",
     password: System.get_env("GRAFANA_PASSWORD") || "admin",

--- a/guides/development/hack_on_the_trento.md
+++ b/guides/development/hack_on_the_trento.md
@@ -47,11 +47,10 @@ mix setup
 
 ## Connect Trento Web with [Wanda](https://github.com/trento-project/wanda)
 
-By default, Wanda can be accessed on port 4001. To connect Trento Web to Wanda, create a .env file in the assets directory.
+By default, Wanda can be accessed on port 4001.
 
-```
-echo "WANDA_URL=http://localhost:4001" > assets/.env
-```
+The wanda url is provided with the configuration parameter `:trento, :checks_service, :base_url`.
+
 
 **Guide** how to set up [Wanda](https://github.com/trento-project/wanda/blob/main/guides/development/hack_on_wanda.md).
 

--- a/lib/trento_web/controllers/page_controller.ex
+++ b/lib/trento_web/controllers/page_controller.ex
@@ -3,7 +3,11 @@ defmodule TrentoWeb.PageController do
 
   def index(conn, _params) do
     grafana_public_url = Application.fetch_env!(:trento, :grafana)[:public_url]
+    check_service_base_url = Application.fetch_env!(:trento, :checks_service)[:base_url]
 
-    render(conn, "index.html", grafana_public_url: grafana_public_url)
+    render(conn, "index.html",
+      grafana_public_url: grafana_public_url,
+      check_service_base_url: check_service_base_url
+    )
   end
 end

--- a/lib/trento_web/templates/page/index.html.heex
+++ b/lib/trento_web/templates/page/index.html.heex
@@ -3,6 +3,7 @@
 <script>
 const config = {
     grafanaPublicUrl: '<%= @grafana_public_url %>',
+    checksServiceBaseUrl: '<%= @check_service_base_url %>'
 };
 </script>
 


### PR DESCRIPTION
# Description

The base url of the check service, was previously injected into the frontend via an env variable (WANDA_URL), populated at build time. 

This behavior leads to a bug where the user cannot add the base url of the check service because that can be only set at assets build time, when we build the image basically. We need to give the user the ability to specify on which path/url is present the check service in their infrastructure. This can be a path "/check_service" or a full url like we can see on the development configuration.

This configuration is then used by axios to compose the base url of the checks frontend library.

This is similar to grafana public url handling.

Jest configuration updated to perform tests with the global config.

The helm chart needs to be updated.

## How was this tested?

Automated tests
