### PR TITLE
Fix Check selection hint style

### DIFF
--- a/assets/js/components/ExecutionResults/ChecksSelectionHints.jsx
+++ b/assets/js/components/ExecutionResults/ChecksSelectionHints.jsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 
 import { EOS_SETTINGS, EOS_PLAY_CIRCLE } from 'eos-icons-react';
 
-import Button from '@components/Button';
 import TriggerChecksExecutionRequest from '@components/TriggerChecksExecutionRequest';
 
 import TrentoLogo from '@static/trento-icon.png';
@@ -38,26 +37,27 @@ function ChecksSelectionHints({
         </div>
         <div className="w-full text-center">
           {!hasSelectedChecks && (
-            <Button
-              className="bg-waterhole-blue mx-auto px-2 py-2 w-1/4 xs:w-full"
+            <button
+              type="button"
+              className="items-center text-sm px-2 py-2 text-jungle-green-500 bg-white border border-green-500 hover:opacity-75 focus:outline-none transition ease-in duration-200 text-center font-semibold rounded shadow relative w-1/4 ml-0.5 mx-auto xs:w-full"
               onClick={() => {
                 navigate(`/clusters/${clusterId}/settings`);
               }}
             >
-              <EOS_SETTINGS className="inline-block fill-white mr-1" />
+              <EOS_SETTINGS className="inline-block fill-jungle-green-500 mr-1" />
               Select Checks now!
-            </Button>
+            </button>
           )}
           {hasSelectedChecks && (
             <TriggerChecksExecutionRequest
-              cssClasses="rounded relative w-1/4 ml-0.5 bg-waterhole-blue mx-auto px-2 py-2 w-1/4 xs:w-full text-base"
+              cssClasses="rounded relative w-1/4 ml-0.5 mx-auto px-2 py-2 xs:w-full text-base"
               clusterId={clusterId}
               hosts={hosts}
               checks={selectedChecks}
               onStartExecution={onStartExecution}
             >
-              <EOS_PLAY_CIRCLE className="inline-block fill-white" /> Start
-              Execution now
+              <EOS_PLAY_CIRCLE className="inline-block fill-jungle-green-500" />{' '}
+              Start Execution now
             </TriggerChecksExecutionRequest>
           )}
         </div>

--- a/assets/js/components/ExecutionResults/ChecksSelectionHints.jsx
+++ b/assets/js/components/ExecutionResults/ChecksSelectionHints.jsx
@@ -39,25 +39,25 @@ function ChecksSelectionHints({
           {!hasSelectedChecks && (
             <button
               type="button"
-              className="items-center text-sm px-2 py-2 text-jungle-green-500 bg-white border border-green-500 hover:opacity-75 focus:outline-none transition ease-in duration-200 text-center font-semibold rounded shadow relative w-1/4 ml-0.5 mx-auto xs:w-full"
+              className="flex justify-center items-center text-sm px-2 py-2 text-jungle-green-500 bg-white border border-green-500 hover:opacity-75 focus:outline-none transition ease-in duration-200 text-center font-semibold rounded shadow relative w-1/4 mx-auto xs:w-full"
               onClick={() => {
                 navigate(`/clusters/${clusterId}/settings`);
               }}
             >
               <EOS_SETTINGS className="inline-block fill-jungle-green-500 mr-1" />
-              Select Checks now!
+              Select Checks now
             </button>
           )}
           {hasSelectedChecks && (
             <TriggerChecksExecutionRequest
-              cssClasses="rounded relative w-1/4 ml-0.5 mx-auto px-2 py-2 xs:w-full text-base"
+              cssOverride="flex justify-center items-center mx-auto bg-jungle-green-500 hover:opacity-75 focus:outline-none text-white transition ease-in duration-200 text-center font-semibold rounded shadow rounded relative w-1/4 mx-auto px-2 py-2 xs:w-full text-base text-sm"
               clusterId={clusterId}
               hosts={hosts}
               checks={selectedChecks}
               onStartExecution={onStartExecution}
             >
-              <EOS_PLAY_CIRCLE className="inline-block fill-jungle-green-500" />{' '}
-              Start Execution now
+              <EOS_PLAY_CIRCLE className="inline-block fill-white mr-1" /> Start
+              Execution
             </TriggerChecksExecutionRequest>
           )}
         </div>

--- a/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
@@ -252,7 +252,7 @@ describe('ExecutionResults', () => {
       'It looks like you have not configured any checks for the current cluster. Select your desired checks to be executed.'
     );
     expect(hintText).toBeInTheDocument();
-    const svgText = screen.getByText('Select Checks now!');
+    const svgText = screen.getByText('Select Checks now');
     expect(svgText).toBeInTheDocument();
   });
 

--- a/assets/js/components/ExecutionResults/ResultsContainer.test.jsx
+++ b/assets/js/components/ExecutionResults/ResultsContainer.test.jsx
@@ -20,7 +20,7 @@ describe('ChecksResults ResultsContainer component', () => {
       <ResultsContainer catalogError={false} hasAlreadyChecksResults={false} />
     );
 
-    expect(screen.getByRole('button')).toHaveTextContent('Select Checks now!');
+    expect(screen.getByRole('button')).toHaveTextContent('Select Checks now');
   });
 
   it('should render a hello', () => {

--- a/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.jsx
+++ b/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.jsx
@@ -9,16 +9,16 @@ function TriggerChecksExecutionRequest({
   hosts = [],
   checks = [],
   onStartExecution = () => {},
+  cssOverride = null,
   ...props
 }) {
   const navigate = useNavigate();
+  const baseStyle =
+    'items-center text-sm border-green-500 px-2 text-jungle-green-500 bg-white border border-green hover:opacity-75 focus:outline-none transition ease-in duration-200 text-center font-semibold rounded shadow';
 
   return (
     <button
-      className={classNames(
-        'items-center text-sm border-green-500 px-2 text-jungle-green-500 bg-white border border-green hover:opacity-75 focus:outline-none transition ease-in duration-200 text-center font-semibold rounded shadow',
-        cssClasses
-      )}
+      className={cssOverride || classNames(baseStyle, cssClasses)}
       type="button"
       onClick={() => {
         onStartExecution(clusterId, hosts, checks);


### PR DESCRIPTION
# Description

In the execution page if there's no last execution and there's no check selected the user gets a suggestion to select some checks first - aka a button to go to the checks selection page - which is inconsistent with the rest of the styling.

![image](https://user-images.githubusercontent.com/8167114/219701663-478c606d-1d08-4b1a-ad7f-8319b56ed739.png)

Changed so the style matches the hint to start a checks execution

Scenario 1: No checks selected and no last execution available -> hint to select checks

![image](https://user-images.githubusercontent.com/8167114/219702684-a727d416-d40a-4804-ba4c-ad76044540b9.png)

Scenario 1: Some checks selected and no last execution available -> hint to start execution

![image](https://user-images.githubusercontent.com/8167114/219702140-fad2d584-6c15-4c56-95ba-5d9338ab1b27.png)

Extra point: adjusted icons color which was lost.

## How was this tested?
Visually :smile: 

@abravosuse @jagabomb makes sense?