### PR TITLE
Fix start execution interaction

### DIFF
--- a/assets/js/components/ClusterDetails/ChecksResultOverview.jsx
+++ b/assets/js/components/ClusterDetails/ChecksResultOverview.jsx
@@ -2,7 +2,13 @@ import React from 'react';
 import { format } from 'date-fns';
 
 import Spinner from '@components/Spinner';
+import {
+  REQUESTED_EXECUTION_STATE,
+  RUNNING_EXECUTION_STATE,
+} from '@state/lastExecutions';
 import CheckResultCount from './CheckResultCount';
+
+const pendingStates = [RUNNING_EXECUTION_STATE, REQUESTED_EXECUTION_STATE];
 
 function ChecksResultOverview({
   data,
@@ -10,7 +16,7 @@ function ChecksResultOverview({
   loading = false,
   onCheckClick,
 }) {
-  if (loading || data?.status === 'running') {
+  if (loading || pendingStates.includes(data?.status)) {
     return (
       <div className="flex flex-col items-center mt-2 px-4">
         <Spinner />

--- a/assets/js/components/ClusterDetails/ChecksSelection.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelection.jsx
@@ -169,8 +169,10 @@ function ChecksSelection({ clusterId, cluster }) {
                 clusterId={clusterId}
                 selectedChecks={cluster.selected_checks}
                 onClose={() => setLocalSavingSuccess(null)}
-                onStartExecution={(clusterID, hosts, checks) =>
-                  dispatch(executionRequested(clusterID, hosts, checks))
+                onStartExecution={(clusterID, hosts, checks, navigate) =>
+                  dispatch(
+                    executionRequested(clusterID, hosts, checks, navigate)
+                  )
                 }
               />
             )}

--- a/assets/js/components/ClusterDetails/ClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetails.jsx
@@ -150,9 +150,19 @@ export function ClusterDetails() {
               disabled={!hasSelectedChecks}
               hosts={hosts}
               checks={cluster.selected_checks}
-              onStartExecution={(_, hostList, selectedChecks) =>
+              onStartExecution={(
+                _,
+                hostList,
+                selectedChecks,
+                navigateFunction
+              ) =>
                 dispatch(
-                  executionRequested(clusterID, hostList, selectedChecks)
+                  executionRequested(
+                    clusterID,
+                    hostList,
+                    selectedChecks,
+                    navigateFunction
+                  )
                 )
               }
             >

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -154,7 +154,7 @@ function ExecutionResults({
         onCatalogRefresh={onCatalogRefresh}
         onStartExecution={onStartExecution}
       >
-        {executionData?.targets.map(({ agent_id: hostID, checks }) => (
+        {executionData?.targets?.map(({ agent_id: hostID, checks }) => (
           <HostResultsWrapper
             key={hostID}
             hostname={hostnames.find(({ id }) => hostID === id)?.hostname}

--- a/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
@@ -67,8 +67,8 @@ function ExecutionResultsPage() {
       executionData={executionData}
       executionError={executionError}
       clusterSelectedChecks={cluster?.selected_checks}
-      onStartExecution={(clusterId, hosts, selectedChecks) =>
-        dispatch(executionRequested(clusterId, hosts, selectedChecks))
+      onStartExecution={(clusterId, hosts, selectedChecks, navigate) =>
+        dispatch(executionRequested(clusterId, hosts, selectedChecks, navigate))
       }
     />
   );

--- a/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.jsx
+++ b/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.jsx
@@ -21,9 +21,7 @@ function TriggerChecksExecutionRequest({
       className={cssOverride || classNames(baseStyle, cssClasses)}
       type="button"
       onClick={() => {
-        onStartExecution(clusterId, hosts, checks);
-
-        navigate(`/clusters/${clusterId}/executions/last`);
+        onStartExecution(clusterId, hosts, checks, navigate);
       }}
       {...props}
     >

--- a/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.test.jsx
+++ b/assets/js/components/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.test.jsx
@@ -11,7 +11,13 @@ import TriggerChecksExecutionRequest from './TriggerChecksExecutionRequest';
 describe('TriggerChecksExecutionRequest component', () => {
   it('should dispatch execution requested on click and navigate to the correct url', async () => {
     const user = userEvent.setup();
-    const onStartExecution = jest.fn();
+
+    const onStartExecution = jest.fn(
+      (clusterId, _hosts, _selectedChecks, navigate) => {
+        navigate(`/clusters/${clusterId}/executions/last`);
+      }
+    );
+
     const clusterId = faker.datatype.uuid();
     const hosts = hostFactory.buildList(2);
     const selectedChecks = [faker.datatype.uuid(), faker.datatype.uuid()];
@@ -33,7 +39,8 @@ describe('TriggerChecksExecutionRequest component', () => {
     expect(onStartExecution).toHaveBeenCalledWith(
       clusterId,
       hosts,
-      selectedChecks
+      selectedChecks,
+      expect.any(Function)
     );
     expect(window.location.pathname).toBe(
       `/clusters/${clusterId}/executions/last`

--- a/assets/js/lib/api/checks.js
+++ b/assets/js/lib/api/checks.js
@@ -14,8 +14,8 @@ export const getLastExecutionByGroupID = (groupID) =>
     defaultConfig
   );
 
-export const triggerChecksExecution = (clusterId) =>
-  networkClient.post(`/clusters/${clusterId}/checks/request_execution`);
+export const triggerChecksExecution = (clusterID) =>
+  networkClient.post(`/clusters/${clusterID}/checks/request_execution`);
 
 export const getCatalog = (env) =>
   networkClient.get(`/api/v1/checks/catalog`, {

--- a/assets/js/lib/api/checks.js
+++ b/assets/js/lib/api/checks.js
@@ -14,6 +14,9 @@ export const getLastExecutionByGroupID = (groupID) =>
     defaultConfig
   );
 
+export const triggerChecksExecution = (clusterId) =>
+  networkClient.post(`/clusters/${clusterId}/checks/request_execution`);
+
 export const getCatalog = (env) =>
   networkClient.get(`/api/v1/checks/catalog`, {
     ...defaultConfig,

--- a/assets/js/lib/test-utils/index.jsx
+++ b/assets/js/lib/test-utils/index.jsx
@@ -50,12 +50,13 @@ export const renderWithRouter = (ui, { route = '/' } = {}) => {
   };
 };
 
-export async function recordSaga(saga, initialAction) {
+export async function recordSaga(saga, initialAction, state = {}) {
   const dispatched = [];
 
   await runSaga(
     {
       dispatch: (action) => dispatched.push(action),
+      getState: () => state,
     },
     saga,
     initialAction

--- a/assets/js/state/actions/lastExecutions.js
+++ b/assets/js/state/actions/lastExecutions.js
@@ -6,7 +6,7 @@ export const updateLastExecution = (groupID) => ({
   payload: { groupID },
 });
 
-export const executionRequested = (clusterID, hosts, checks) => ({
+export const executionRequested = (clusterID, hosts, checks, navigate) => ({
   type: EXECUTION_REQUESTED,
-  payload: { clusterID, hosts, checks },
+  payload: { clusterID, hosts, checks, navigate },
 });

--- a/assets/js/state/actions/notifications.js
+++ b/assets/js/state/actions/notifications.js
@@ -1,0 +1,6 @@
+export const NOTIFICATION = 'NOTIFICATION';
+
+export const notify = ({ text, icon }) => ({
+  type: NOTIFICATION,
+  payload: { text, icon },
+});

--- a/assets/js/state/lastExecutions.js
+++ b/assets/js/state/lastExecutions.js
@@ -54,17 +54,14 @@ export const lastExecutionsSlice = createSlice({
     setExecutionStarted: (state, { payload }) => {
       const { groupID: clusterID, targets } = payload;
 
-      if (typeof state[clusterID] === 'undefined') {
-        state[clusterID] = initialExecutionState;
-      }
-
-      if (state[clusterID].data === null) {
-        state[clusterID].data = {};
-      }
-
-      state[clusterID].data.targets = targets;
-      state[clusterID].data.status = RUNNING_EXECUTION_STATE;
-      state[clusterID].error = null;
+      const lastExecutionState = {
+        ...initialExecutionState,
+        data: {
+          status: RUNNING_EXECUTION_STATE,
+          targets,
+        },
+      };
+      state[clusterID] = lastExecutionState;
     },
     setExecutionRequested: (state, { payload }) => {
       const { clusterID: groupID, hosts, checks } = payload;

--- a/assets/js/state/lastExecutions.js
+++ b/assets/js/state/lastExecutions.js
@@ -54,6 +54,14 @@ export const lastExecutionsSlice = createSlice({
     setExecutionStarted: (state, { payload }) => {
       const { groupID: clusterID, targets } = payload;
 
+      if (typeof state[clusterID] === 'undefined') {
+        state[clusterID] = initialExecutionState;
+      }
+
+      if (state[clusterID].data === null) {
+        state[clusterID].data = {};
+      }
+
       state[clusterID].data.targets = targets;
       state[clusterID].data.status = RUNNING_EXECUTION_STATE;
       state[clusterID].error = null;

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -84,14 +84,10 @@ import {
 
 import { CHECKS_SELECTED } from '@state/actions/cluster';
 import { EXECUTION_REQUESTED } from '@state/actions/lastExecutions';
+import { notify } from '@state/actions/notifications';
 import { initSocketConnection } from '@lib/network/socket';
 import processChannelEvents from '@state/channels';
 import { store } from '@state';
-
-const notify = ({ text, icon }) => ({
-  type: 'NOTIFICATION',
-  payload: { text, icon },
-});
 
 const getClusterName = (clusterID) => (state) =>
   state.clustersList.clusters.reduce((acc, cluster) => {

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -75,6 +75,7 @@ import {
 import { watchPerformLogin } from '@state/sagas/user';
 
 import { getDatabase, getSapSystem } from '@state/selectors';
+import { getClusterName } from '@state/selectors/cluster';
 import {
   setClusterChecksSelectionSavingError,
   setClusterChecksSelectionSavingSuccess,
@@ -88,14 +89,6 @@ import { notify } from '@state/actions/notifications';
 import { initSocketConnection } from '@lib/network/socket';
 import processChannelEvents from '@state/channels';
 import { store } from '@state';
-
-const getClusterName = (clusterID) => (state) =>
-  state.clustersList.clusters.reduce((acc, cluster) => {
-    if (cluster.id === clusterID) {
-      acc = cluster.name;
-    }
-    return acc;
-  }, '');
 
 function* loadSapSystemsHealthSummary() {
   yield put(startHealthSummaryLoading());

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -84,7 +84,6 @@ import {
 } from '@state/clusterChecksSelection';
 
 import { CHECKS_SELECTED } from '@state/actions/cluster';
-import { EXECUTION_REQUESTED } from '@state/actions/lastExecutions';
 import { notify } from '@state/actions/notifications';
 import { initSocketConnection } from '@lib/network/socket';
 import processChannelEvents from '@state/channels';
@@ -274,33 +273,6 @@ function* checksSelected({ payload }) {
 
 function* watchChecksSelected() {
   yield takeEvery(CHECKS_SELECTED, checksSelected);
-}
-
-function* requestChecksExecution({ payload }) {
-  const clusterName = yield select(getClusterName(payload.clusterID));
-  yield call(
-    post,
-    `/clusters/${payload.clusterID}/checks/request_execution`,
-    {}
-  );
-
-  yield put(
-    appendEntryToLiveFeed({
-      source: clusterName,
-      message: 'Checks execution requested.',
-    })
-  );
-
-  yield put(
-    notify({
-      text: `Checks execution requested, cluster: ${clusterName}`,
-      icon: '🐰',
-    })
-  );
-}
-
-function* watchRequestChecksExecution() {
-  yield takeEvery(EXECUTION_REQUESTED, requestChecksExecution);
 }
 
 function* checksExecutionStarted({ payload }) {
@@ -564,7 +536,6 @@ export default function* rootSaga() {
     watchClusterCibLastWrittenUpdated(),
     watchNotifications(),
     watchChecksSelected(),
-    watchRequestChecksExecution(),
     watchChecksExecutionStarted(),
     watchChecksExecutionCompleted(),
     watchChecksResultsUpdated(),

--- a/assets/js/state/sagas/lastExecutions.test.js
+++ b/assets/js/state/sagas/lastExecutions.test.js
@@ -9,12 +9,17 @@ import {
   setLastExecution,
   setLastExecutionEmpty,
   setLastExecutionError,
+  setExecutionRequested,
 } from '@state/lastExecutions';
-import { updateLastExecution } from './lastExecutions';
+import { notify } from '@state/actions/notifications';
+import { updateLastExecution, requestExecution } from './lastExecutions';
 
 const axiosMock = new MockAdapter(networkClient);
 const lastExecutionURL = (groupID) =>
   `/api/v1/checks/groups/${groupID}/executions/last`;
+
+const triggerChecksExecutionURL = (clusterId) =>
+  `/clusters/${clusterId}/checks/request_execution`;
 
 describe('lastExecutions saga', () => {
   beforeEach(() => {
@@ -61,7 +66,7 @@ describe('lastExecutions saga', () => {
     expect(dispatched).toContainEqual(setLastExecutionEmpty(groupID));
   });
 
-  it('should the last execution for a given groupID with an error', async () => {
+  it('should update the last execution for a given groupID with an error', async () => {
     const groupID = faker.datatype.uuid();
 
     axiosMock.onGet(lastExecutionURL(groupID)).networkError();
@@ -73,6 +78,66 @@ describe('lastExecutions saga', () => {
     expect(dispatched).toContainEqual(setLastExecutionLoading(groupID));
     expect(dispatched).toContainEqual(
       setLastExecutionError({ groupID, error: 'Network Error' })
+    );
+  });
+
+  it('should set the last execution to requested state', async () => {
+    const clusterID = faker.datatype.uuid();
+    const clusterName = faker.animal.cat();
+    const hosts = [faker.datatype.uuid(), faker.datatype.uuid()];
+    const checks = [faker.color.human(), faker.color.human()];
+
+    axiosMock.onPost(triggerChecksExecutionURL(clusterID)).reply(202, {});
+
+    const payload = { clusterID, hosts, checks };
+    const dispatched = await recordSaga(
+      requestExecution,
+      {
+        payload,
+      },
+      {
+        clustersList: {
+          clusters: [{ id: clusterID, name: clusterName }],
+        },
+      }
+    );
+
+    expect(dispatched).toContainEqual(setExecutionRequested(payload));
+    expect(dispatched).toContainEqual(
+      notify({
+        text: `Checks execution requested, cluster: ${clusterName}`,
+        icon: '🐰',
+      })
+    );
+  });
+
+  it('should not set the last execution to requested state on failure', async () => {
+    const clusterID = faker.datatype.uuid();
+    const clusterName = faker.animal.cat();
+    const hosts = [faker.datatype.uuid(), faker.datatype.uuid()];
+    const checks = [faker.color.human(), faker.color.human()];
+
+    axiosMock.onPost(triggerChecksExecutionURL(clusterID)).reply(400, {});
+
+    const payload = { clusterID, hosts, checks };
+    const dispatched = await recordSaga(
+      requestExecution,
+      {
+        payload,
+      },
+      {
+        clustersList: {
+          clusters: [{ id: clusterID, name: clusterName }],
+        },
+      }
+    );
+
+    expect(dispatched).not.toContainEqual(setExecutionRequested(payload));
+    expect(dispatched).toContainEqual(
+      notify({
+        text: `Unable to start execution for cluster: ${clusterName}`,
+        icon: '❌',
+      })
     );
   });
 });

--- a/assets/js/state/selectors/cluster.js
+++ b/assets/js/state/selectors/cluster.js
@@ -7,5 +7,10 @@ export const getClusterHostIDs =
       .filter((host) => host.cluster_id === clusterID)
       .map(({ id: hostID }) => hostID);
 
+export const getClusterName =
+  (clusterID) =>
+  ({ clustersList }) =>
+    getCluster(clusterID)({ clustersList })?.name || '';
+
 export const getClusterSelectedChecks = (clusterID) => (state) =>
   getCluster(clusterID)(state).selected_checks;

--- a/assets/js/state/selectors/cluster.test.js
+++ b/assets/js/state/selectors/cluster.test.js
@@ -1,4 +1,8 @@
-import { getClusterHostIDs, getClusterSelectedChecks } from './cluster';
+import {
+  getClusterHostIDs,
+  getClusterSelectedChecks,
+  getClusterName,
+} from './cluster';
 
 describe('Cluster selector', () => {
   it('should return the cluster hosts IDs', () => {
@@ -48,5 +52,24 @@ describe('Cluster selector', () => {
       'check1',
       'check2',
     ]);
+  });
+
+  it('should return a cluster name', () => {
+    const state = {
+      clustersList: {
+        clusters: [
+          {
+            id: 'cluster1',
+            name: 'cluster-name',
+          },
+          {
+            id: 'cluster2',
+          },
+        ],
+      },
+    };
+
+    expect(getClusterName('cluster1')(state)).toEqual('cluster-name');
+    expect(getClusterName('cluster2')(state)).toEqual('');
   });
 });


### PR DESCRIPTION
# Description

Alternative approach to https://github.com/trento-project/web/pull/1125 (no [react context](https://beta.reactjs.org/learn/passing-data-deeply-with-context) involved)

Currently if a request to `POST /api/clusters/:cluster_id/checks/request_execution` fails the error is not caught on the client causing the webapp to crash.

<details>
  <summary>See gif</summary>
  
  ![failing-request-execution-bug](https://user-images.githubusercontent.com/8167114/213126937-51cf9897-34a9-4ee8-a8a2-79c3b88c8fe5.gif)
</details>

The agreed behaviour is that a user gets redirected to the checks execution detail only if requesting the execution to start succeeds, otherwise an error notification is shown and the user stays in the page from where the action was triggered.

<details>
  <summary>On failed execution start</summary>
  
  ![failed-execution-start](https://user-images.githubusercontent.com/8167114/219632454-78b71aca-5c2f-4ece-a3d7-1ae4e6fd60f6.gif)
</details>
<details>
  <summary>On successful execution start</summary>
  
  ![successful-execution-start](https://user-images.githubusercontent.com/8167114/219634844-a7a751d5-ea10-4c66-95d4-d783dea6f219.gif)
</details>

Outline of the changes:
- passes `navigate` as an argument to `onStartExecution`
- fixed lastExecution saga
- minor cleanupz

## How was this tested?

Manually + existing automated tests + added needed tests
