### PR TITLE
Jest table filter tests on the overview pages

### DIFF
--- a/assets/js/components/ClustersList.test.jsx
+++ b/assets/js/components/ClustersList.test.jsx
@@ -4,7 +4,7 @@ import 'intersection-observer';
 import '@testing-library/jest-dom';
 import { clusterFactory } from '@lib/test-utils/factories';
 import { filterTable, clearFilter } from '@components/Table/Table.test';
-import { renderWithRouter, withState } from '../lib/test-utils';
+import { renderWithRouter, withState } from '@lib/test-utils';
 
 import ClustersList from './ClustersList';
 

--- a/assets/js/components/ClustersList.test.jsx
+++ b/assets/js/components/ClustersList.test.jsx
@@ -2,14 +2,140 @@ import React from 'react';
 import { screen, fireEvent } from '@testing-library/react';
 import 'intersection-observer';
 import '@testing-library/jest-dom';
+import { clusterFactory } from '@lib/test-utils/factories';
+import { filterTable, clearFilter } from '@components/Table/Table.test';
+import { renderWithRouter, withState } from '../lib/test-utils';
 
 import ClustersList from './ClustersList';
-import { renderWithRouter, withDefaultState } from '../lib/test-utils';
 
 describe('ClustersList component', () => {
-  describe('query string filtering behavior', () => {
+  describe('filtering', () => {
+    const cleanInitialState = {
+      hostsList: {
+        hosts: [],
+      },
+      clustersList: {
+        clusters: [],
+      },
+      sapSystemsList: {
+        sapSystems: [],
+        applicationInstances: [],
+        databaseInstances: [],
+      },
+    };
+
+    const scenarios = [
+      {
+        filter: 'Health',
+        options: ['unknown', 'passing', 'warning', 'critical'],
+        state: {
+          ...cleanInitialState,
+          clustersList: {
+            clusters: [].concat(
+              clusterFactory.buildList(2, { health: 'unknown' }),
+              clusterFactory.buildList(2, { health: 'passing' }),
+              clusterFactory.buildList(2, { health: 'warning' }),
+              clusterFactory.buildList(2, { health: 'critical' })
+            ),
+          },
+        },
+        expectedRows: 2,
+      },
+      {
+        filter: 'Name',
+        options: ['cluster1', 'cluster2'],
+        state: {
+          ...cleanInitialState,
+          clustersList: {
+            clusters: [].concat(
+              clusterFactory.buildList(4),
+              clusterFactory.buildList(1, { name: 'cluster1' }),
+              clusterFactory.buildList(1, { name: 'cluster2' })
+            ),
+          },
+        },
+        expectedRows: 1,
+      },
+      {
+        filter: 'SID',
+        options: ['PRD', 'QAS'],
+        state: {
+          ...cleanInitialState,
+          clustersList: {
+            clusters: [].concat(
+              clusterFactory.buildList(4),
+              clusterFactory.buildList(2, { sid: 'PRD' }),
+              clusterFactory.buildList(2, { sid: 'QAS' })
+            ),
+          },
+        },
+        expectedRows: 2,
+      },
+      {
+        filter: 'Type',
+        options: ['hana_scale_up'],
+        state: {
+          ...cleanInitialState,
+          clustersList: {
+            clusters: [].concat(
+              clusterFactory.buildList(2, { type: 'unknown' }),
+              clusterFactory.buildList(2, { type: 'hana_scale_up' })
+            ),
+          },
+        },
+        expectedRows: 2,
+      },
+      {
+        filter: 'Tags',
+        options: ['Tag1', 'Tag2'],
+        state: {
+          ...cleanInitialState,
+          clustersList: {
+            clusters: [].concat(
+              clusterFactory.buildList(2),
+              clusterFactory.buildList(2, { tags: [{ value: 'Tag1' }] }),
+              clusterFactory.buildList(2, { tags: [{ value: 'Tag2' }] })
+            ),
+          },
+        },
+        expectedRows: 2,
+      },
+    ];
+
+    it.each(scenarios)(
+      'should filter the table content by $filter filter',
+      ({ filter, options, state, expectedRows }) => {
+        const [StatefulClustersList] = withState(<ClustersList />, state);
+
+        renderWithRouter(StatefulClustersList);
+
+        options.forEach((option) => {
+          filterTable(filter, option);
+
+          const table = screen.getByRole('table');
+          expect(table.querySelectorAll('tbody > tr')).toHaveLength(
+            expectedRows
+          );
+
+          clearFilter(filter);
+        });
+      }
+    );
+
     it('should put the filters values in the query string when filters are selected', () => {
-      const [StatefulClustersList] = withDefaultState(<ClustersList />);
+      const clusters = clusterFactory.buildList(1, {
+        tags: [{ value: 'Tag1' }],
+      });
+      const state = {
+        ...cleanInitialState,
+        clustersList: {
+          clusters,
+        },
+      };
+
+      const { health, name, sid, type } = clusters[0];
+
+      const [StatefulClustersList] = withState(<ClustersList />, state);
       renderWithRouter(StatefulClustersList);
 
       ['Health', 'Name', 'SID', 'Type', 'Tags'].forEach((filter) => {
@@ -23,7 +149,7 @@ describe('ClustersList component', () => {
       });
 
       expect(window.location.search).toEqual(
-        '?health=unknown&name=drbd_cluster&sid=HDD&type=unknown&tags=tag1'
+        `?health=${health}&name=${name}&sid=${sid}&type=${type}&tags=Tag1`
       );
     });
   });

--- a/assets/js/components/DatabasesOverview/DatabasesOverview.test.jsx
+++ b/assets/js/components/DatabasesOverview/DatabasesOverview.test.jsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react';
+import 'intersection-observer';
+import '@testing-library/jest-dom';
+import { databaseFactory } from '@lib/test-utils/factories';
+import { renderWithRouter, withState } from '@lib/test-utils';
+import { filterTable, clearFilter } from '@components/Table/Table.test';
+
+import DatabasesOverview from './DatabasesOverview';
+
+describe('DatabasesOverview component', () => {
+  describe('filtering', () => {
+    const cleanInitialState = {
+      hostsList: {
+        hosts: [],
+      },
+      clustersList: {
+        clusters: [],
+      },
+      databasesList: {
+        databases: [],
+        databaseInstances: [],
+      },
+    };
+
+    const scenarios = [
+      {
+        filter: 'Health',
+        options: ['unknown', 'passing', 'warning', 'critical'],
+        state: {
+          ...cleanInitialState,
+          databasesList: {
+            databases: [].concat(
+              databaseFactory.buildList(2, { health: 'unknown' }),
+              databaseFactory.buildList(2, { health: 'passing' }),
+              databaseFactory.buildList(2, { health: 'warning' }),
+              databaseFactory.buildList(2, { health: 'critical' })
+            ),
+            databaseInstances: [],
+          },
+        },
+        expectedRows: 2,
+      },
+      {
+        filter: 'SID',
+        options: ['PRD', 'QAS'],
+        state: {
+          ...cleanInitialState,
+          databasesList: {
+            databases: [].concat(
+              databaseFactory.buildList(4),
+              databaseFactory.buildList(2, { sid: 'PRD' }),
+              databaseFactory.buildList(2, { sid: 'QAS' })
+            ),
+            databaseInstances: [],
+          },
+        },
+        expectedRows: 2,
+      },
+      {
+        filter: 'Tags',
+        options: ['Tag1', 'Tag2'],
+        state: {
+          ...cleanInitialState,
+          databasesList: {
+            databases: [].concat(
+              databaseFactory.buildList(2),
+              databaseFactory.buildList(2, { tags: [{ value: 'Tag1' }] }),
+              databaseFactory.buildList(2, { tags: [{ value: 'Tag2' }] })
+            ),
+            databaseInstances: [],
+          },
+        },
+        expectedRows: 2,
+      },
+    ];
+
+    it.each(scenarios)(
+      'should filter the table content by $filter filter',
+      ({ filter, options, state, expectedRows }) => {
+        const [StatefulDatbaseList] = withState(<DatabasesOverview />, state);
+
+        renderWithRouter(StatefulDatbaseList);
+
+        options.forEach((option) => {
+          filterTable(filter, option);
+
+          const table = screen.getByRole('table');
+          expect(
+            table.querySelectorAll('tbody > tr.cursor-pointer')
+          ).toHaveLength(expectedRows);
+
+          clearFilter(filter);
+        });
+      }
+    );
+
+    it('should put the filters values in the query string when filters are selected', () => {
+      const databases = databaseFactory.buildList(1, {
+        tags: [{ value: 'Tag1' }],
+      });
+
+      const state = {
+        ...cleanInitialState,
+        databasesList: {
+          databases,
+          databaseInstances: [],
+        },
+      };
+
+      const { health, sid, tags } = databases[0];
+
+      const [StatefulDatabasesOverview] = withState(
+        <DatabasesOverview />,
+        state
+      );
+      renderWithRouter(StatefulDatabasesOverview);
+
+      ['Health', 'SID', 'Tags'].forEach((filter) => {
+        fireEvent.click(screen.getByTestId(`filter-${filter}`));
+
+        fireEvent.click(
+          screen
+            .getByTestId(`filter-${filter}-options`)
+            .querySelector('li > div > span').firstChild
+        );
+      });
+
+      expect(window.location.search).toEqual(
+        `?health=${health}&sid=${sid}&tags=${tags[0].value}`
+      );
+    });
+  });
+});

--- a/assets/js/components/SapSystemsOverview/SapSystemsOverview.test.jsx
+++ b/assets/js/components/SapSystemsOverview/SapSystemsOverview.test.jsx
@@ -2,16 +2,125 @@ import React from 'react';
 import { screen, fireEvent } from '@testing-library/react';
 import 'intersection-observer';
 import '@testing-library/jest-dom';
-
-import { renderWithRouter, withDefaultState } from '@lib/test-utils';
+import { sapSystemFactory } from '@lib/test-utils/factories';
+import { renderWithRouter, withState } from '@lib/test-utils';
+import { filterTable, clearFilter } from '@components/Table/Table.test';
 
 import SapSystemsOverview from './SapSystemsOverview';
 
 describe('SapSystemsOverviews component', () => {
-  describe('query string filtering behavior', () => {
+  describe('filtering', () => {
+    const cleanInitialState = {
+      hostsList: {
+        hosts: [],
+      },
+      clustersList: {
+        clusters: [],
+      },
+      sapSystemsList: {
+        sapSystems: [],
+        applicationInstances: [],
+        databaseInstances: [],
+      },
+    };
+
+    const scenarios = [
+      {
+        filter: 'Health',
+        options: ['unknown', 'passing', 'warning', 'critical'],
+        state: {
+          ...cleanInitialState,
+          sapSystemsList: {
+            sapSystems: [].concat(
+              sapSystemFactory.buildList(2, { health: 'unknown' }),
+              sapSystemFactory.buildList(2, { health: 'passing' }),
+              sapSystemFactory.buildList(2, { health: 'warning' }),
+              sapSystemFactory.buildList(2, { health: 'critical' })
+            ),
+            applicationInstances: [],
+            databaseInstances: [],
+          },
+        },
+        expectedRows: 2,
+      },
+      {
+        filter: 'SID',
+        options: ['PRD', 'QAS'],
+        state: {
+          ...cleanInitialState,
+          sapSystemsList: {
+            sapSystems: [].concat(
+              sapSystemFactory.buildList(4),
+              sapSystemFactory.buildList(2, { sid: 'PRD' }),
+              sapSystemFactory.buildList(2, { sid: 'QAS' })
+            ),
+            applicationInstances: [],
+            databaseInstances: [],
+          },
+        },
+        expectedRows: 2,
+      },
+      {
+        filter: 'Tags',
+        options: ['Tag1', 'Tag2'],
+        state: {
+          ...cleanInitialState,
+          sapSystemsList: {
+            sapSystems: [].concat(
+              sapSystemFactory.buildList(2),
+              sapSystemFactory.buildList(2, { tags: [{ value: 'Tag1' }] }),
+              sapSystemFactory.buildList(2, { tags: [{ value: 'Tag2' }] })
+            ),
+            applicationInstances: [],
+            databaseInstances: [],
+          },
+        },
+        expectedRows: 2,
+      },
+    ];
+
+    it.each(scenarios)(
+      'should filter the table content by $filter filter',
+      ({ filter, options, state, expectedRows }) => {
+        const [StatefulSapSystemList] = withState(
+          <SapSystemsOverview />,
+          state
+        );
+
+        renderWithRouter(StatefulSapSystemList);
+
+        options.forEach((option) => {
+          filterTable(filter, option);
+
+          const table = screen.getByRole('table');
+          expect(
+            table.querySelectorAll('tbody > tr.cursor-pointer')
+          ).toHaveLength(expectedRows);
+
+          clearFilter(filter);
+        });
+      }
+    );
+
     it('should put the filters values in the query string when filters are selected', () => {
-      const [StatefulSapSystemsOverview] = withDefaultState(
-        <SapSystemsOverview />
+      const sapSystems = sapSystemFactory.buildList(1, {
+        tags: [{ value: 'Tag1' }],
+      });
+
+      const state = {
+        ...cleanInitialState,
+        sapSystemsList: {
+          sapSystems,
+          applicationInstances: [],
+          databaseInstances: [],
+        },
+      };
+
+      const { health, sid, tags } = sapSystems[0];
+
+      const [StatefulSapSystemsOverview] = withState(
+        <SapSystemsOverview />,
+        state
       );
       renderWithRouter(StatefulSapSystemsOverview);
 
@@ -26,7 +135,7 @@ describe('SapSystemsOverviews component', () => {
       });
 
       expect(window.location.search).toEqual(
-        '?health=passing&sid=NWD&tags=tag1'
+        `?health=${health}&sid=${sid}&tags=${tags[0].value}`
       );
     });
   });

--- a/assets/js/lib/test-utils/factories/clusters.js
+++ b/assets/js/lib/test-utils/factories/clusters.js
@@ -1,0 +1,19 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { faker } from '@faker-js/faker';
+import { Factory } from 'fishery';
+
+import { resultEnum } from '.';
+
+const clusterTypeEnum = () =>
+  faker.helpers.arrayElement(['unknown', 'hana_scale_up']);
+
+export const clusterFactory = Factory.define(({ sequence }) => ({
+  id: faker.datatype.uuid(),
+  name: `${faker.name.firstName()}_${sequence}`,
+  sid: faker.random.alphaNumeric(3, { casing: 'upper' }),
+  hosts_number: faker.datatype.number(),
+  resources_number: faker.datatype.number(),
+  type: clusterTypeEnum(),
+  health: resultEnum(),
+  selected_checks: [],
+}));

--- a/assets/js/lib/test-utils/factories/databases.js
+++ b/assets/js/lib/test-utils/factories/databases.js
@@ -1,0 +1,25 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { faker } from '@faker-js/faker';
+import { Factory } from 'fishery';
+
+const healthEnum = () => faker.helpers.arrayElement(['passing', 'critical']);
+
+export const databaseInstanceFactory = Factory.define(() => ({
+  sap_system_id: faker.datatype.uuid(),
+  sid: faker.random.alpha({ casing: 'upper', count: 3 }),
+}));
+
+export const databaseFactory = Factory.define(({ params }) => {
+  const id = params.id || faker.datatype.uuid();
+  const sid = faker.random.alpha({ casing: 'upper', count: 3 });
+
+  return {
+    id,
+    sid,
+    health: healthEnum(),
+    database_instances: databaseInstanceFactory.buildList(2, {
+      sap_system_id: id,
+      sid,
+    }),
+  };
+});

--- a/assets/js/lib/test-utils/factories/hosts.js
+++ b/assets/js/lib/test-utils/factories/hosts.js
@@ -40,6 +40,7 @@ export const hostFactory = Factory.define(({ params }) => {
   return {
     id,
     agent_version: '1.1.0+git.dev17.1660137228.fe5ba8a',
+    hostname: faker.name.firstName(),
     cluster_id: faker.datatype.uuid(),
     ip_addresses: [faker.internet.ip()],
     provider: cloudProviderEnum(),

--- a/assets/js/lib/test-utils/factories/index.js
+++ b/assets/js/lib/test-utils/factories/index.js
@@ -5,6 +5,7 @@ import { Factory } from 'fishery';
 export * from './executions';
 export * from './hosts';
 export * from './sapSystems';
+export * from './clusters';
 
 const healthEnum = () =>
   faker.helpers.arrayElement(['requested', 'running', 'not_running']);
@@ -57,9 +58,4 @@ export const aboutFactory = Factory.define(() => ({
   flavor: faker.animal.cat(),
   sles_subscriptions: faker.datatype.number(),
   version: faker.system.networkInterface(),
-}));
-
-export const clusterFactory = Factory.define(() => ({
-  id: faker.datatype.uuid(),
-  selected_checks: [],
 }));

--- a/assets/js/lib/test-utils/factories/index.js
+++ b/assets/js/lib/test-utils/factories/index.js
@@ -6,6 +6,7 @@ export * from './executions';
 export * from './hosts';
 export * from './sapSystems';
 export * from './clusters';
+export * from './databases';
 
 const healthEnum = () =>
   faker.helpers.arrayElement(['requested', 'running', 'not_running']);

--- a/assets/js/lib/test-utils/factories/sapSystems.js
+++ b/assets/js/lib/test-utils/factories/sapSystems.js
@@ -23,14 +23,14 @@ export const sapSystemApplicationInstanceFactory = Factory.define(() => ({
   httpsPort: faker.internet.port(),
   instanceHostname: faker.hacker.noun(),
   instanceNumber: faker.datatype.number({ min: 10, max: 99 }).toString(),
-  sid: faker.random.alpha({ casing: 'upper', count: 3 }),
+  sid: faker.random.alphaNumeric(3, { casing: 'upper' }),
   startPriority: faker.datatype.number({ min: 1, max: 9 }).toString(),
   sapSystemId: faker.datatype.uuid(),
 }));
 
 export const sapSystemFactory = Factory.define(({ params }) => {
   const sapSystemId = params.sapSystemId || faker.datatype.uuid();
-  const sid = faker.random.alpha({ casing: 'upper', count: 3 });
+  const sid = faker.random.alphaNumeric(3, { casing: 'upper' });
 
   return {
     dbHost: faker.internet.ip(),
@@ -42,7 +42,7 @@ export const sapSystemFactory = Factory.define(({ params }) => {
     }),
     sid,
     tags: [],
-    tenant: faker.random.alpha({ casing: 'upper', count: 3 }),
+    tenant: faker.random.alphaNumeric(3, { casing: 'upper' }),
     hosts: hostFactory.buildList(5),
   };
 });


### PR DESCRIPTION
# Description
Move tables filtering tests from cypress to jest. This makes the testing more reliable. Besides, now all filters are covered, and adding new scenarios is pretty simple.
The tests are pretty much identical across all the table views: hosts, clusters, sap systems and databases, but I have decided to add all of them. This is mainly because the filter function for each filter box is specific.

The code is based in scenario tables, which later on are used in the test. Even though the code looks similar, some duplication is better here, to avoid having more complex code.

The most generic table filtering tests are done in the specific `Table.test.jsx` file, as we don't really need specific tables and data for it. (Edit: now done in: https://github.com/trento-project/web/pull/1216)

Finally, it removes the cypress tests (Edit: now done in: https://github.com/trento-project/web/pull/1215)