### PR TITLE
Check based execution results

### DIFF
--- a/assets/js/components/ExecutionResults/CheckResultOutline.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultOutline.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { EXPECT, EXPECT_SAME } from '@lib/model';
+import TargetResult from './TargetResult';
+
+const TARGET_NODE = 'TARGET_NODE';
+const TARGET_CLUSTER = 'TARGET_CLUSTER';
+
+const isExpect = ({ type }) => type === EXPECT;
+const isExpectSame = ({ type }) => type === EXPECT_SAME;
+
+function CheckResultOutline({
+  checkID,
+  agentsCheckResults,
+  expectationResults,
+  clusterName,
+}) {
+  const expectExpectationsCount = expectationResults.filter(isExpect).length;
+  const expectResults = agentsCheckResults.map((agentCheckResult) => {
+    const { hostname, expectation_evaluations } = agentCheckResult;
+
+    const isAgentCheckError = !!agentCheckResult?.type;
+
+    const metExpectations = expectation_evaluations
+      ?.filter(isExpect)
+      .filter(({ return_value }) => return_value).length;
+
+    const expectationsSummary = isAgentCheckError
+      ? agentCheckResult.message
+      : `${metExpectations}/${expectExpectationsCount} Expectations met.`;
+
+    return {
+      target: TARGET_NODE,
+      targetName: hostname,
+      expectationsSummary,
+      isAgentCheckError:
+        isAgentCheckError || metExpectations < expectExpectationsCount,
+    };
+  });
+
+  const expectSameResults = expectationResults
+    .filter(isExpectSame)
+    .map(({ result }) => ({
+      target: TARGET_CLUSTER,
+      targetName: clusterName,
+      expectationsSummary: result
+        ? 'Value is the same on all targets'
+        : 'Value is not the same on all targets',
+      isAgentCheckError: !result,
+    }));
+
+  return (
+    <div className="p-5">
+      <div className="table w-full bg-white rounded shadow">
+        <div className="table-header-group bg-gray-100">
+          <div className="table-row">
+            <div className="table-cell w-1/5 p-2 text-left text-xs font-medium text-gray-500 uppercase">
+              Target
+            </div>
+            <div className="table-cell p-2 text-left text-xs font-medium text-gray-500 uppercase">
+              Expectations
+            </div>
+          </div>
+        </div>
+        <div className="table-row-group">
+          {[...expectSameResults, ...expectResults].map(
+            ({
+              target,
+              targetName,
+              expectationsSummary,
+              isAgentCheckError,
+            }) => (
+              <TargetResult
+                key={`${checkID}-${targetName}`}
+                isCluster={target === TARGET_CLUSTER}
+                targetName={targetName}
+                expectationsSummary={expectationsSummary}
+                isAgentCheckError={isAgentCheckError}
+              />
+            )
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default CheckResultOutline;

--- a/assets/js/components/ExecutionResults/ExecutionHeader.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionHeader.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import classNames from 'classnames';
+
+import BackButton from '@components/BackButton';
+import WarningBanner from '@components/Banners/WarningBanner';
+import { UNKNOWN_PROVIDER } from '@components/ClusterDetails/ClusterSettings';
+import { ClusterInfoBox } from '@components/ClusterDetails';
+
+import ChecksResultFilters from '@components/ExecutionResults/ChecksResultFilters';
+
+function ExecutionHeader({
+  clusterID,
+  clusterName,
+  cloudProvider,
+  clusterScenario,
+  onFilterChange = () => {},
+}) {
+  return (
+    <>
+      <BackButton url={`/clusters/${clusterID}`}>
+        Back to Cluster Details
+      </BackButton>
+      <div className="flex mb-4 justify-between">
+        <h1 className="text-3xl w-3/5">
+          <span className="font-medium">Checks Results for cluster</span>{' '}
+          <span
+            className={classNames(
+              'font-bold truncate w-60 inline-block align-top'
+            )}
+          >
+            {clusterName}
+          </span>
+        </h1>
+        <ChecksResultFilters onChange={onFilterChange} />
+      </div>
+      {cloudProvider === UNKNOWN_PROVIDER && (
+        <WarningBanner>
+          The following results are valid for on-premise bare metal platforms.
+          <br />
+          If you are running your HANA cluster on a different platform, please
+          use results with caution
+        </WarningBanner>
+      )}
+      <ClusterInfoBox haScenario={clusterScenario} provider={cloudProvider} />
+    </>
+  );
+}
+
+export default ExecutionHeader;

--- a/assets/js/components/ExecutionResults/ExecutionHeader.test.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionHeader.test.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+
+import { faker } from '@faker-js/faker';
+import { renderWithRouter } from '@lib/test-utils';
+
+import '@testing-library/jest-dom';
+import ExecutionHeader from './ExecutionHeader';
+
+describe('Cluster Checks results ExecutionHeader Component', () => {
+  it('should render a header with expected information', () => {
+    const clusterID = faker.datatype.uuid();
+    const clusterName = faker.animal.bear();
+    const cloudProvider = 'azure';
+    const clusterScenario = 'hana_scale_up';
+
+    renderWithRouter(
+      <ExecutionHeader
+        clusterID={clusterID}
+        clusterName={clusterName}
+        cloudProvider={cloudProvider}
+        clusterScenario={clusterScenario}
+      />
+    );
+
+    expect(screen.getByText('Azure')).toBeTruthy();
+    expect(screen.getByText('HANA scale-up')).toBeTruthy();
+    expect(screen.getByText(clusterName));
+  });
+
+  it('should render a header with a warning banner on an unknown provider detection', () => {
+    const clusterID = faker.datatype.uuid();
+    const clusterName = faker.animal.bear();
+    const cloudProvider = 'unknown';
+    const clusterScenario = 'hana_scale_up';
+
+    renderWithRouter(
+      <ExecutionHeader
+        clusterID={clusterID}
+        clusterName={clusterName}
+        cloudProvider={cloudProvider}
+        clusterScenario={clusterScenario}
+      />
+    );
+
+    expect(screen.getByText('Provider not recognized')).toBeTruthy();
+    expect(screen.getByText('HANA scale-up')).toBeTruthy();
+    expect(
+      screen.getByText(
+        /The following results are valid for on-premise bare metal platforms./
+      )
+    ).toBeTruthy();
+  });
+});

--- a/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 
-import userEvent from '@testing-library/user-event';
-
 import { faker } from '@faker-js/faker';
 import { renderWithRouter } from '@lib/test-utils';
 
@@ -12,54 +10,36 @@ import {
   hostnameFactory,
   addCriticalExpectation,
   addPassingExpectation,
-  agentCheckResultFactory,
   checksExecutionCompletedFactory,
-  checkResultFactory,
-  withEmptyExpectations,
+  emptyCheckResultFactory,
 } from '@lib/test-utils/factories';
 import '@testing-library/jest-dom/extend-expect';
 import ExecutionResults from './ExecutionResults';
 
 const prepareStateData = (checkExecutionStatus) => {
+  const checkID1 = faker.datatype.uuid();
+  const checkID2 = faker.datatype.uuid();
+
   const hostnames = hostnameFactory.buildList(2);
-  const [{ id: agentID1 }, { id: agentID2 }] = hostnames;
-  const agentCheckResult1 = agentCheckResultFactory.build({
-    agent_id: agentID1,
-  });
-  const agentCheckResult2 = agentCheckResultFactory.build({
-    agent_id: agentID2,
-  });
-  const agentCheckResult3 = agentCheckResultFactory.build({
-    agent_id: agentID1,
-  });
-  const agentCheckResult4 = agentCheckResultFactory.build({
-    agent_id: agentID2,
-  });
-  let checkResult1 = checkResultFactory.build({
-    agents_check_results: [agentCheckResult1, agentCheckResult2],
+  const [{ id: agent1 }, { id: agent2 }] = hostnames;
+  const targets = [agent1, agent2];
+
+  let checkResult1 = emptyCheckResultFactory.build({
+    checkID: checkID1,
+    targets,
     result: 'passing',
   });
-
-  checkResult1 = withEmptyExpectations(checkResult1);
+  checkResult1 = addPassingExpectation(checkResult1, 'expect');
   checkResult1 = addPassingExpectation(checkResult1, 'expect');
   checkResult1 = addPassingExpectation(checkResult1, 'expect_same');
 
-  let checkResult2 = checkResultFactory.build({
-    agents_check_results: [agentCheckResult3, agentCheckResult4],
+  let checkResult2 = emptyCheckResultFactory.build({
+    checkID: checkID2,
+    targets,
     result: 'critical',
   });
-
-  checkResult2 = withEmptyExpectations(checkResult2);
   checkResult2 = addPassingExpectation(checkResult2, 'expect');
   checkResult2 = addCriticalExpectation(checkResult2, 'expect');
-
-  const { check_id: checkID1 } = checkResult1;
-  const { check_id: checkID2 } = checkResult2;
-
-  const targets = [
-    { agent_id: agentID1, checks: [checkID1, checkID2] },
-    { agent_id: agentID2, checks: [checkID1, checkID2] },
-  ];
 
   const executionResult = checksExecutionCompletedFactory.build({
     check_results: [checkResult1, checkResult2],
@@ -69,11 +49,19 @@ const prepareStateData = (checkExecutionStatus) => {
 
   const { group_id: clusterID } = executionResult;
 
+  const aCheckDescription = faker.lorem.sentence();
+  const anotherCheckDescription = faker.lorem.sentence();
   const { loading, catalog, error } = catalogFactory.build({
     loading: false,
     catalog: [
-      catalogCheckFactory.build({ id: checkID1 }),
-      catalogCheckFactory.build({ id: checkID2 }),
+      catalogCheckFactory.build({
+        id: checkID1,
+        description: aCheckDescription,
+      }),
+      catalogCheckFactory.build({
+        id: checkID2,
+        description: anotherCheckDescription,
+      }),
     ],
     error: null,
   });
@@ -117,8 +105,7 @@ describe('ExecutionResults', () => {
       disconnect: () => null,
     }));
 
-    const user = userEvent.setup();
-
+    const clusterName = 'test-cluster';
     const {
       clusterID,
       hostnames,
@@ -135,7 +122,7 @@ describe('ExecutionResults', () => {
     renderWithRouter(
       <ExecutionResults
         clusterID={clusterID}
-        clusterName="test-cluster"
+        clusterName={clusterName}
         clusterScenario="hana_scale_up"
         cloudProvider="azure"
         hostnames={hostnames}
@@ -149,20 +136,29 @@ describe('ExecutionResults', () => {
       />
     );
 
-    expect(screen.getByText('test-cluster')).toBeTruthy();
-    expect(screen.getByText('HANA scale-up')).toBeTruthy();
-    expect(screen.getByText('Azure')).toBeTruthy();
-    expect(screen.getByText(hostnames[0].hostname)).toBeTruthy();
-    expect(screen.getByText(hostnames[1].hostname)).toBeTruthy();
-    expect(screen.getAllByText(checkID1)).toHaveLength(2);
-    expect(screen.getAllByText(checkID2)).toHaveLength(2);
-    expect(screen.getAllByText('2/2 expectations passed')).toBeTruthy();
-    expect(screen.getAllByText('1/2 expectations failed')).toBeTruthy();
+    expect(screen.getAllByText(clusterName)).toHaveLength(2);
+    expect(screen.getAllByText(hostnames[0].hostname)).toHaveLength(2);
+    expect(screen.getAllByText(hostnames[1].hostname)).toHaveLength(2);
+    expect(
+      screen.getAllByText('Value is the same on all targets')
+    ).toHaveLength(1);
+    expect(screen.getAllByText('2/2 Expectations met.')).toHaveLength(2);
+    expect(screen.getAllByText('1/2 Expectations met.')).toHaveLength(2);
 
-    const [{ remediation }] = catalog;
-    expect(screen.queryByText(remediation)).not.toBeInTheDocument();
-    await user.click(screen.getAllByText(checkID1)[0]);
-    expect(screen.getByText(remediation)).toBeVisible();
+    const mainTable = screen.getByRole('table');
+    const tableRows = mainTable.querySelectorAll('tbody > tr');
+
+    expect(tableRows).toHaveLength(2 * executionData.check_results.length);
+
+    expect(tableRows[0]).toHaveTextContent(checkID1);
+    expect(tableRows[1]).toHaveTextContent(clusterName);
+    expect(tableRows[1]).toHaveTextContent('Value is the same on all targets');
+    expect(tableRows[1]).toHaveTextContent(hostnames[0].hostname);
+    expect(tableRows[1]).toHaveTextContent('2/2 Expectations met.');
+
+    expect(tableRows[2]).toHaveTextContent(checkID2);
+    expect(tableRows[3]).toHaveTextContent(hostnames[1].hostname);
+    expect(tableRows[3]).toHaveTextContent('1/2 Expectations met');
   });
 
   it('should render the execution starting dialog, when an execution is not started yet', () => {
@@ -254,93 +250,5 @@ describe('ExecutionResults', () => {
     expect(hintText).toBeInTheDocument();
     const svgText = screen.getByText('Select Checks now');
     expect(svgText).toBeInTheDocument();
-  });
-
-  it("should render ExecutionResults with successfully filtered 'passing' results", async () => {
-    const {
-      clusterID,
-      hostnames,
-      checks: [checkID1, checkID2],
-      loading,
-      catalog,
-      error,
-      executionLoading,
-      executionData,
-      executionError,
-      executionStarted,
-    } = prepareStateData('passing');
-
-    renderWithRouter(
-      <ExecutionResults
-        clusterID={clusterID}
-        clusterName="test-cluster"
-        clusterScenario="hana_scale_up"
-        cloudProvider="azure"
-        hostnames={hostnames}
-        catalogLoading={loading}
-        catalog={catalog}
-        executionStarted={executionStarted}
-        catalogError={error}
-        executionLoading={executionLoading}
-        executionData={executionData}
-        executionError={executionError}
-      />,
-      { route: `/clusters/${clusterID}/executions/last?health=passing` }
-    );
-
-    expect(screen.getByText('test-cluster')).toBeTruthy();
-    expect(screen.getByText('HANA scale-up')).toBeTruthy();
-    expect(screen.getByText('Azure')).toBeTruthy();
-    expect(screen.getByText(hostnames[0].hostname)).toBeTruthy();
-    expect(screen.getByText(hostnames[1].hostname)).toBeTruthy();
-    expect(screen.getAllByText(checkID1)).toHaveLength(2);
-    expect(screen.queryByText(checkID2)).toBeNull();
-    expect(screen.getAllByText('2/2 expectations passed')).toBeTruthy();
-  });
-
-  it("should render ExecutionResults with successfully filtered 'passing' and 'ciritcal' results", async () => {
-    const {
-      clusterID,
-      hostnames,
-      checks: [checkID1, checkID2],
-      loading,
-      catalog,
-      executionStarted,
-      error,
-      executionLoading,
-      executionData,
-      executionError,
-    } = prepareStateData('passing');
-
-    renderWithRouter(
-      <ExecutionResults
-        clusterID={clusterID}
-        clusterName="test-cluster"
-        clusterScenario="hana_scale_up"
-        cloudProvider="azure"
-        hostnames={hostnames}
-        catalogLoading={loading}
-        catalog={catalog}
-        executionStarted={executionStarted}
-        catalogError={error}
-        executionLoading={executionLoading}
-        executionData={executionData}
-        executionError={executionError}
-      />,
-      {
-        route: `/clusters/${clusterID}/executions/last?health=passing&health=critical
-    `,
-      }
-    );
-
-    expect(screen.getByText('test-cluster')).toBeTruthy();
-    expect(screen.getByText('HANA scale-up')).toBeTruthy();
-    expect(screen.getByText('Azure')).toBeTruthy();
-    expect(screen.getByText(hostnames[0].hostname)).toBeTruthy();
-    expect(screen.getByText(hostnames[1].hostname)).toBeTruthy();
-    expect(screen.getAllByText(checkID1)).toHaveLength(2);
-    expect(screen.getAllByText(checkID2)).toHaveLength(2);
-    expect(screen.getAllByText('2/2 expectations passed')).toBeTruthy();
-    expect(screen.getAllByText('1/2 expectations failed')).toBeTruthy();
   });
 });

--- a/assets/js/components/ExecutionResults/TargetIcon.jsx
+++ b/assets/js/components/ExecutionResults/TargetIcon.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { EOS_COLLOCATION, EOS_DESKTOP_WINDOWS } from 'eos-icons-react';
+
+function TargetIcon({ isCluster = false }) {
+  return (
+    <span className="inline-flex bg-jungle-green-500 p-1 rounded-full">
+      {isCluster ? (
+        <EOS_COLLOCATION className="fill-white" />
+      ) : (
+        <EOS_DESKTOP_WINDOWS className="fill-white" />
+      )}
+    </span>
+  );
+}
+
+export default TargetIcon;

--- a/assets/js/components/ExecutionResults/TargetResult.jsx
+++ b/assets/js/components/ExecutionResults/TargetResult.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { EOS_KEYBOARD_ARROW_RIGHT } from 'eos-icons-react';
+import classNames from 'classnames';
+import TargetIcon from './TargetIcon';
+
+function TargetResult({
+  isCluster = false,
+  targetName,
+  expectationsSummary,
+  isAgentCheckError,
+}) {
+  return (
+    <div className="table-row border-b cursor-pointer">
+      <div className="table-cell p-2">
+        <div className="flex p-1" data-fix="vertical align content">
+          <TargetIcon isCluster={isCluster} />
+          <span className="ml-3 inline-flex">{targetName}</span>
+        </div>
+      </div>
+      <div className="table-cell p-2">
+        <div className="flex p-1 justify-between">
+          <span className={classNames({ 'text-red-500': isAgentCheckError })}>
+            {expectationsSummary}
+          </span>
+          <span>
+            <EOS_KEYBOARD_ARROW_RIGHT className="fill-gray-500" />
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default TargetResult;

--- a/assets/js/lib/model/index.js
+++ b/assets/js/lib/model/index.js
@@ -1,2 +1,5 @@
 export const DATABASE_TYPE = 'database';
 export const APPLICATION_TYPE = 'application';
+
+export const EXPECT = 'expect';
+export const EXPECT_SAME = 'expect_same';

--- a/assets/js/lib/test-utils/factories/executions.js
+++ b/assets/js/lib/test-utils/factories/executions.js
@@ -179,3 +179,24 @@ export const addExpectationWithError = (checkResult) => {
 
   return addExpectation(checkResult, name, expectation, false);
 };
+
+export const emptyCheckResultFactory = Factory.define(({ params }) => {
+  const checkID = params.checkID || faker.datatype.uuid();
+  const targets = params.targets || [
+    faker.datatype.uuid(),
+    faker.datatype.uuid(),
+  ];
+  const result = params.result || resultEnum();
+
+  const checkResult = checkResultFactory.build({
+    check_id: checkID,
+    agents_check_results: targets.map((agentId) =>
+      agentCheckResultFactory.build({
+        agent_id: agentId,
+      })
+    ),
+    result,
+  });
+
+  return withEmptyExpectations(checkResult);
+});

--- a/assets/js/state/selectors/cluster.js
+++ b/assets/js/state/selectors/cluster.js
@@ -10,6 +10,13 @@ export const getClusterHostIDs =
       .filter((host) => host.cluster_id === clusterID)
       .map(({ id: hostID }) => hostID);
 
+export const getClusterHostNames =
+  (clusterID) =>
+  ({ hostsList }) =>
+    hostsList.hosts
+      .filter(({ cluster_id }) => cluster_id === clusterID)
+      .map(({ id, hostname }) => ({ id, hostname }));
+
 export const getClusterName =
   (clusterID) =>
   ({ clustersList }) =>

--- a/assets/js/state/selectors/cluster.test.js
+++ b/assets/js/state/selectors/cluster.test.js
@@ -1,4 +1,9 @@
-import { getClusterHostIDs, getClusterName } from './cluster';
+import { hostFactory } from '@lib/test-utils/factories';
+import {
+  getClusterHostIDs,
+  getClusterHostNames,
+  getClusterName,
+} from './cluster';
 
 describe('Cluster selector', () => {
   it('should return the cluster hosts IDs', () => {
@@ -22,6 +27,41 @@ describe('Cluster selector', () => {
     };
 
     expect(getClusterHostIDs('cluster1')(state)).toEqual(['id1', 'id2']);
+  });
+
+  it('should return the cluster hosts names', () => {
+    const state = {
+      hostsList: {
+        hosts: [
+          hostFactory.build({
+            id: 'id1',
+            cluster_id: 'cluster1',
+            hostname: 'hostname-1',
+          }),
+          hostFactory.build({
+            id: 'id2',
+            cluster_id: 'cluster1',
+            hostname: 'hostname-2',
+          }),
+          hostFactory.build({
+            id: 'id3',
+            cluster_id: 'cluster2',
+            hostname: 'hostname-3',
+          }),
+        ],
+      },
+    };
+
+    expect(getClusterHostNames('cluster1')(state)).toEqual([
+      {
+        id: 'id1',
+        hostname: 'hostname-1',
+      },
+      {
+        id: 'id2',
+        hostname: 'hostname-2',
+      },
+    ]);
   });
 
   it('should return a cluster name', () => {


### PR DESCRIPTION
# Description

First iteration of a check based result visualization of executions.

<details>
  <summary>Some checks selected</summary>
  
![check-based-results-pt1](https://user-images.githubusercontent.com/8167114/221805682-7fde2455-f0e2-4891-b2c8-4ff5a34837d5.gif)

</details>

<details>
  <summary>All checks selected</summary>
  
![check-based-results-many](https://user-images.githubusercontent.com/8167114/221807970-706e7074-fff7-4b41-9bb3-4facf3bb5d77.gif)

</details>

<details>
  <summary>One target timing out</summary>
  
![one-agent-timeout](https://user-images.githubusercontent.com/8167114/221808860-36d93a85-effb-4c5f-980f-635798c0226b.gif)

</details>

<details>
  <summary>All targets timing out</summary>
  
![all-agents-timeout](https://user-images.githubusercontent.com/8167114/221809461-18b8fc5f-644c-46ef-9173-278955977bdf.gif)


</details>

This is an already a big enough PR, so the following has been deferred
- Add error handling on catalog/executionData loading failure
- Bind filtering by result
- Open remediation suggestion modal when clicking on check id 
- UI improvements (spacing, hovering, etc...)
- investigate/improve edge cases (ie timeout+expect_same)

## How was this tested?

Existing automated tests + newly added tests.
