### PR TITLE
Remove router warnings

### DIFF
--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -20,14 +20,14 @@ defmodule TrentoWeb.Router do
   end
 
   pipeline :protected_api do
-    if Application.fetch_env!(:trento, :jwt_authentication)[:enabled] do
+    if Application.compile_env!(:trento, [:jwt_authentication, :enabled]) do
       plug Pow.Plug.RequireAuthenticated,
         error_handler: TrentoWeb.Auth.ApiAuthErrorHandler
     end
   end
 
   pipeline :apikey_authenticated do
-    if Application.fetch_env!(:trento, :api_key_authentication)[:enabled] do
+    if Application.compile_env!(:trento, [:api_key_authentication, :enabled]) do
       plug Trento.Infrastructure.Auth.AuthenticateAPIKeyPlug,
         error_handler: TrentoWeb.Auth.ApiAuthErrorHandler
     end


### PR DESCRIPTION
Since we don't need any runtime configuration to enable and disable `Pow.Plug.RequireAuthenticated` and `Trento.Infrastructure.Auth.AuthenticateAPIKeyPlug`, we can safely use `compile_env` instead of `get_env` and make the compiler happy.