### PR TITLE
Fix margin between filter elements

### DIFF
--- a/assets/js/components/Table/Filter.jsx
+++ b/assets/js/components/Table/Filter.jsx
@@ -23,7 +23,7 @@ function Filter({ options, title, value, onChange }) {
   useOnClickOutside(ref, () => setOpen(false));
 
   return (
-    <div className="w-64 top-16" ref={ref}>
+    <div className="flex-1 w-64 top-16 ml-2" ref={ref}>
       <div className="mt-1 relative">
         {value !== '' && (
           <button


### PR DESCRIPTION
# Description

Fix margins and alignment  of the drop down filters. 
Adds space between the filters

Before:
![Screenshot from 2023-03-01 16-09-38](https://user-images.githubusercontent.com/54111255/222180127-e9e729b1-a618-4e31-92b9-8154079cad39.png)


After:
![Screenshot from 2023-03-01 16-07-41](https://user-images.githubusercontent.com/54111255/222179895-1f6f3851-1c4a-4374-a6c3-e5b454de7911.png)


