### PR TITLE
Improve error handling on checks results page

### DIFF
--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -3,9 +3,7 @@ import Table from '@components/Table';
 
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { EOS_ERROR } from 'eos-icons-react';
 import LoadingBox from '@components/LoadingBox';
-import NotificationBox from '@components/NotificationBox';
 
 import { getCheckResults, getCheckDescription } from './checksUtils';
 
@@ -93,7 +91,7 @@ function ExecutionResults({
 
   const hosts = hostnames.map((item) => item.id);
 
-  if (catalogLoading) {
+  if (catalogLoading || executionLoading) {
     return <LoadingBox text="Loading checks execution..." />;
   }
 
@@ -101,27 +99,14 @@ function ExecutionResults({
     return <LoadingBox text="Checks execution starting..." />;
   }
 
-  if (catalogError || executionError) {
-    return (
-      <NotificationBox
-        icon={<EOS_ERROR className="m-auto" color="red" size="xl" />}
-        text={
-          catalogError && executionError
-            ? `${catalogError}\n${executionError}`
-            : catalogError || executionError
-        }
-        buttonText="Try again"
-        buttonOnClick={() => {
-          if (catalogError) {
-            onCatalogRefresh();
-          }
-          if (executionError) {
-            onLastExecutionUpdate();
-          }
-        }}
-      />
-    );
-  }
+  const onContentRefresh = () => {
+    if (catalogError) {
+      onCatalogRefresh();
+    }
+    if (executionError) {
+      onLastExecutionUpdate();
+    }
+  };
 
   const tableData = getCheckResults(executionData)
     .filter((check) => {
@@ -158,12 +143,16 @@ function ExecutionResults({
         onFilterChange={(newPredicates) => setPredicates(newPredicates)}
       />
       <ResultsContainer
-        catalogError={false}
+        error={catalogError || executionError}
+        errorContent={[
+          catalogError ? `Failed loading catalog: ${catalogError}` : null,
+          executionError ? `Failed loading execution: ${executionError}` : null,
+        ]}
         clusterID={clusterID}
         hasAlreadyChecksResults={!!(executionData || executionLoading)}
         selectedChecks={clusterSelectedChecks}
         hosts={hosts}
-        onCatalogRefresh={onCatalogRefresh}
+        onContentRefresh={onContentRefresh}
         onStartExecution={onStartExecution}
       >
         <Table config={resultsTableConfig} data={tableData} />

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -80,6 +80,7 @@ function ExecutionResults({
   catalogError,
   executionLoading,
   executionStarted,
+  executionRunning,
   executionData,
   executionError,
   clusterSelectedChecks = [],
@@ -97,6 +98,10 @@ function ExecutionResults({
 
   if (!executionStarted) {
     return <LoadingBox text="Checks execution starting..." />;
+  }
+
+  if (executionRunning) {
+    return <LoadingBox text="Checks execution running..." />;
   }
 
   const onContentRefresh = () => {

--- a/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
@@ -202,7 +202,7 @@ describe('ExecutionResults', () => {
       executionStarted,
     } = prepareStateData('running');
 
-    const { container } = renderWithRouter(
+    renderWithRouter(
       <ExecutionResults
         clusterID={clusterID}
         hostnames={hostnames}
@@ -211,16 +211,12 @@ describe('ExecutionResults', () => {
         catalogError={error}
         executionStarted={executionStarted}
         executionLoading={executionLoading}
+        executionRunning
         executionData={executionData}
         executionError={executionError}
       />
     );
-    const svgEl = container.querySelector("[data-testid='eos-svg-component']");
-    const transform = svgEl.getAttribute('transform');
-    expect(svgEl.classList.toString()).toContain(
-      'inline-block fill-jungle-green-500'
-    );
-    expect(transform).toEqual('rotate(0) translate(0, 0) scale(1, 1)');
+    screen.getByText('Checks execution running...');
   });
 
   it('should render ChecksSelectionHints when executionData is null or executionLoading is false', async () => {

--- a/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
@@ -15,6 +15,8 @@ import {
 } from '@state/lastExecutions';
 import ExecutionResults from './ExecutionResults';
 
+const runningStates = [RUNNING_EXECUTION_STATE, REQUESTED_EXECUTION_STATE];
+
 function ExecutionResultsPage() {
   const { clusterID } = useParams();
   const dispatch = useDispatch();
@@ -54,7 +56,6 @@ function ExecutionResultsPage() {
     <ExecutionResults
       clusterID={clusterID}
       hostnames={hostnames}
-      executionStarted={executionData?.status !== REQUESTED_EXECUTION_STATE}
       clusterName={cluster?.name}
       clusterScenario={cluster?.type}
       cloudProvider={cluster?.provider}
@@ -64,6 +65,8 @@ function ExecutionResultsPage() {
       catalog={catalog}
       catalogError={catalogError}
       executionLoading={executionLoading}
+      executionStarted={executionData?.status !== REQUESTED_EXECUTION_STATE}
+      executionRunning={runningStates.includes(executionData?.status)}
       executionData={executionData}
       executionError={executionError}
       clusterSelectedChecks={cluster?.selected_checks}

--- a/assets/js/components/ExecutionResults/ResultsContainer.jsx
+++ b/assets/js/components/ExecutionResults/ResultsContainer.jsx
@@ -6,23 +6,26 @@ import NotificationBox from '@components/NotificationBox';
 import ChecksSelectionHints from './ChecksSelectionHints';
 
 function ResultsContainer({
-  catalogError,
+  error,
+  errorContent,
   children,
   clusterID,
   hasAlreadyChecksResults,
   selectedChecks = [],
   hosts = [],
-  onCatalogRefresh = () => {},
+  onContentRefresh = () => {},
   onStartExecution = () => {},
 }) {
-  if (catalogError) {
+  if (error) {
     return (
-      <NotificationBox
-        icon={<EOS_ERROR className="m-auto" color="red" size="xl" />}
-        text={catalogError}
-        buttonText="Try again"
-        buttonOnClick={onCatalogRefresh}
-      />
+      <div className="bg-white rounded p-3 shadow">
+        <NotificationBox
+          icon={<EOS_ERROR className="m-auto" color="red" size="xl" />}
+          text={errorContent}
+          buttonText="Try again"
+          buttonOnClick={onContentRefresh}
+        />
+      </div>
     );
   }
 

--- a/assets/js/components/ExecutionResults/ResultsContainer.test.jsx
+++ b/assets/js/components/ExecutionResults/ResultsContainer.test.jsx
@@ -10,14 +10,24 @@ import ResultsContainer from './ResultsContainer';
 
 describe('ChecksResults ResultsContainer component', () => {
   it('should render the notification box', () => {
-    renderWithRouter(<ResultsContainer catalogError />);
+    renderWithRouter(<ResultsContainer error />);
 
+    expect(screen.getByRole('button')).toHaveTextContent('Try again');
+  });
+
+  it('should render the notification box with several errors', () => {
+    renderWithRouter(
+      <ResultsContainer error errorContent={['error 1', 'error 2']} />
+    );
+
+    expect(screen.getByText('error 1')).toBeTruthy();
+    expect(screen.getByText('error 2')).toBeTruthy();
     expect(screen.getByRole('button')).toHaveTextContent('Try again');
   });
 
   it('should render the suggestion box', () => {
     renderWithRouter(
-      <ResultsContainer catalogError={false} hasAlreadyChecksResults={false} />
+      <ResultsContainer error={false} hasAlreadyChecksResults={false} />
     );
 
     expect(screen.getByRole('button')).toHaveTextContent('Select Checks now');
@@ -25,7 +35,7 @@ describe('ChecksResults ResultsContainer component', () => {
 
   it('should render a hello', () => {
     renderWithRouter(
-      <ResultsContainer catalogError={false} hasAlreadyChecksResults>
+      <ResultsContainer error={false} hasAlreadyChecksResults>
         <span data-testid="hello">Hello World!</span>
       </ResultsContainer>
     );

--- a/assets/js/components/NotificationBox.jsx
+++ b/assets/js/components/NotificationBox.jsx
@@ -2,6 +2,17 @@ import React from 'react';
 
 import Button from '@components/Button';
 
+const extractTextContent = (text) =>
+  Array.isArray(text)
+    ? text
+        .filter((textRow) => !!textRow)
+        .map((textRow) => (
+          <span key={textRow} className="block">
+            {textRow}
+          </span>
+        ))
+    : text;
+
 function NotificationBox({ icon, text, buttonText, buttonOnClick }) {
   return (
     <div className="shadow-lg rounded-2xl p-4 bg-white dark:bg-gray-800 w-1/2 m-auto">
@@ -9,7 +20,7 @@ function NotificationBox({ icon, text, buttonText, buttonOnClick }) {
         <div className="flex h-full flex-col justify-between">
           {icon}
           <p className="text-gray-600 dark:text-gray-100 text-md py-2 px-6">
-            {text}
+            {extractTextContent(text)}
           </p>
           {buttonText ? (
             <div className="flex items-center justify-center gap-4 mt-8">

--- a/assets/js/components/NotificationBox.test.jsx
+++ b/assets/js/components/NotificationBox.test.jsx
@@ -1,0 +1,56 @@
+import { faker } from '@faker-js/faker';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import NotificationBox from './NotificationBox';
+
+describe('NotificationBox Component', () => {
+  it('should display a Notification box with a single text message', async () => {
+    const user = userEvent.setup();
+
+    const icon = faker.color.human();
+    const text = faker.lorem.sentence();
+    const buttonText = faker.lorem.word();
+    const buttonOnClick = jest.fn();
+
+    render(
+      <NotificationBox
+        icon={icon}
+        text={text}
+        buttonText={buttonText}
+        buttonOnClick={buttonOnClick}
+      />
+    );
+
+    const button = screen.getByRole('button');
+
+    expect(screen.getByText(icon)).toBeTruthy();
+    expect(screen.getByText(text)).toBeTruthy();
+    expect(button).toHaveTextContent(buttonText);
+
+    await act(async () => user.click(button));
+
+    expect(buttonOnClick).toHaveBeenCalled();
+  });
+
+  it('should display a Notification box with a list of text messages', () => {
+    const icon = faker.color.human();
+    const buttonText = faker.lorem.word();
+    const buttonOnClick = jest.fn();
+
+    const texts = [faker.lorem.sentence(), faker.lorem.sentence()];
+
+    render(
+      <NotificationBox
+        icon={icon}
+        text={texts}
+        buttonText={buttonText}
+        buttonOnClick={buttonOnClick}
+      />
+    );
+
+    texts.forEach((text) => expect(screen.getByText(text)).toBeTruthy());
+  });
+});


### PR DESCRIPTION
# Description

Improves error handling on Checks results page.

<details>
  <summary>Click here to see last execution loading failure</summary>
  
![loading-last-execution-failure](https://user-images.githubusercontent.com/8167114/222774120-244ca4bc-a36b-448e-80d3-78057c7aadda.gif)

</details>

<details>
  <summary>Click here to see catalog loading failure</summary>
  
![loading-catalog-failure](https://user-images.githubusercontent.com/8167114/222774312-5b53a9a2-afb9-4c1c-8ae5-0018c1608195.gif)

</details>

<details>
  <summary>Click here to see a composite failure</summary>
  
![loading-composite-failure](https://user-images.githubusercontent.com/8167114/222774401-b9f7e736-89e6-4ff2-a601-a861de9511b8.gif)

</details>

Extra consideration: we might want to streamline how we handle failures and make it consistent through the app

/summon @jagabomb 

<details>
  <summary>Click here to see how the catalog fails</summary>
  
![image](https://user-images.githubusercontent.com/8167114/222775627-29568f3a-b580-4b0f-880a-667818b62833.png)

</details>


## How was this tested?

Visually + automated tests
