### PR TITLE
Fix some act wrapping warnings

### DIFF
--- a/assets/js/components/ClustersList.test.jsx
+++ b/assets/js/components/ClustersList.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, fireEvent } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import 'intersection-observer';
 import '@testing-library/jest-dom';
 import { clusterFactory } from '@lib/test-utils/factories';
@@ -109,12 +109,13 @@ describe('ClustersList component', () => {
 
         renderWithRouter(StatefulClustersList);
 
-        options.forEach((option) => {
+        options.forEach(async (option) => {
           filterTable(filter, option);
-
-          const table = screen.getByRole('table');
-          expect(table.querySelectorAll('tbody > tr')).toHaveLength(
-            expectedRows
+          screen.getByRole('table');
+          const table = await waitFor(() =>
+            expect(table.querySelectorAll('tbody > tr')).toHaveLength(
+              expectedRows
+            )
           );
 
           clearFilter(filter);
@@ -123,8 +124,9 @@ describe('ClustersList component', () => {
     );
 
     it('should put the filters values in the query string when filters are selected', () => {
+      const tag = 'Tag1';
       const clusters = clusterFactory.buildList(1, {
-        tags: [{ value: 'Tag1' }],
+        tags: [{ value: tag }],
       });
       const state = {
         ...cleanInitialState,
@@ -138,18 +140,18 @@ describe('ClustersList component', () => {
       const [StatefulClustersList] = withState(<ClustersList />, state);
       renderWithRouter(StatefulClustersList);
 
-      ['Health', 'Name', 'SID', 'Type', 'Tags'].forEach((filter) => {
-        fireEvent.click(screen.getByTestId(`filter-${filter}`));
-
-        fireEvent.click(
-          screen
-            .getByTestId(`filter-${filter}-options`)
-            .querySelector('li > div > span').firstChild
-        );
+      [
+        ['Health', health],
+        ['Name', name],
+        ['SID', sid],
+        ['Type', type],
+        ['Tags', tag],
+      ].forEach(([filter, option]) => {
+        filterTable(filter, option);
       });
 
       expect(window.location.search).toEqual(
-        `?health=${health}&name=${name}&sid=${sid}&type=${type}&tags=Tag1`
+        `?health=${health}&name=${name}&sid=${sid}&type=${type}&tags=${tag}`
       );
     });
   });

--- a/assets/js/components/DatabasesOverview/DatabasesOverview.test.jsx
+++ b/assets/js/components/DatabasesOverview/DatabasesOverview.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, fireEvent } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import 'intersection-observer';
 import '@testing-library/jest-dom';
 import { databaseFactory } from '@lib/test-utils/factories';
@@ -82,13 +82,14 @@ describe('DatabasesOverview component', () => {
 
         renderWithRouter(StatefulDatbaseList);
 
-        options.forEach((option) => {
+        options.forEach(async (option) => {
           filterTable(filter, option);
-
-          const table = screen.getByRole('table');
-          expect(
-            table.querySelectorAll('tbody > tr.cursor-pointer')
-          ).toHaveLength(expectedRows);
+          screen.getByRole('table');
+          const table = await waitFor(() =>
+            expect(
+              table.querySelectorAll('tbody > tr.cursor-pointer')
+            ).toHaveLength(expectedRows)
+          );
 
           clearFilter(filter);
         });
@@ -116,14 +117,12 @@ describe('DatabasesOverview component', () => {
       );
       renderWithRouter(StatefulDatabasesOverview);
 
-      ['Health', 'SID', 'Tags'].forEach((filter) => {
-        fireEvent.click(screen.getByTestId(`filter-${filter}`));
-
-        fireEvent.click(
-          screen
-            .getByTestId(`filter-${filter}-options`)
-            .querySelector('li > div > span').firstChild
-        );
+      [
+        ['Health', health],
+        ['SID', sid],
+        ['Tags', tags[0].value],
+      ].forEach(([filter, option]) => {
+        filterTable(filter, option);
       });
 
       expect(window.location.search).toEqual(

--- a/assets/js/components/HostsList.test.jsx
+++ b/assets/js/components/HostsList.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, fireEvent } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import 'intersection-observer';
 import '@testing-library/jest-dom';
 import { hostFactory } from '@lib/test-utils/factories';
@@ -149,12 +149,13 @@ describe('HostsLists component', () => {
 
         renderWithRouter(StatefulHostsList);
 
-        options.forEach((option) => {
+        options.forEach(async (option) => {
           filterTable(filter, option);
-
-          const table = screen.getByRole('table');
-          expect(table.querySelectorAll('tbody > tr')).toHaveLength(
-            expectedRows
+          screen.getByRole('table');
+          const table = await waitFor(() =>
+            expect(table.querySelectorAll('tbody > tr')).toHaveLength(
+              expectedRows
+            )
           );
 
           clearFilter(filter);
@@ -167,13 +168,14 @@ describe('HostsLists component', () => {
         id: 'host1',
         tags: [{ value: 'Tag1' }],
       });
+      const sid = 'PRD';
       const state = {
         ...cleanInitialState,
         hostsList: {
           hosts,
         },
         sapSystemsList: {
-          applicationInstances: [{ sid: 'PRD', host_id: 'host1' }],
+          applicationInstances: [{ sid, host_id: 'host1' }],
           databaseInstances: [],
         },
       };
@@ -183,18 +185,17 @@ describe('HostsLists component', () => {
       const [StatefulHostsList] = withState(<HostsList />, state);
       renderWithRouter(StatefulHostsList);
 
-      ['Health', 'Hostname', 'SID', 'Tags'].forEach((filter) => {
-        fireEvent.click(screen.getByTestId(`filter-${filter}`));
-
-        fireEvent.click(
-          screen
-            .getByTestId(`filter-${filter}-options`)
-            .querySelector('li > div > span').firstChild
-        );
+      [
+        ['Health', heartbeat],
+        ['Hostname', hostname],
+        ['SID', sid],
+        ['Tags', tags[0].value],
+      ].forEach(([filter, option]) => {
+        filterTable(filter, option);
       });
 
       expect(window.location.search).toEqual(
-        `?heartbeat=${heartbeat}&hostname=${hostname}&sid=PRD&tags=${tags[0].value}`
+        `?heartbeat=${heartbeat}&hostname=${hostname}&sid=${sid}&tags=${tags[0].value}`
       );
     });
   });

--- a/assets/js/components/SapSystemsOverview/SapSystemsOverview.test.jsx
+++ b/assets/js/components/SapSystemsOverview/SapSystemsOverview.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, fireEvent } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import 'intersection-observer';
 import '@testing-library/jest-dom';
 import { sapSystemFactory } from '@lib/test-utils/factories';
@@ -89,13 +89,14 @@ describe('SapSystemsOverviews component', () => {
 
         renderWithRouter(StatefulSapSystemList);
 
-        options.forEach((option) => {
+        options.forEach(async (option) => {
           filterTable(filter, option);
-
-          const table = screen.getByRole('table');
-          expect(
-            table.querySelectorAll('tbody > tr.cursor-pointer')
-          ).toHaveLength(expectedRows);
+          screen.getByRole('table');
+          const table = await waitFor(() =>
+            expect(
+              table.querySelectorAll('tbody > tr.cursor-pointer')
+            ).toHaveLength(expectedRows)
+          );
 
           clearFilter(filter);
         });
@@ -124,14 +125,12 @@ describe('SapSystemsOverviews component', () => {
       );
       renderWithRouter(StatefulSapSystemsOverview);
 
-      ['Health', 'SID', 'Tags'].forEach((filter) => {
-        fireEvent.click(screen.getByTestId(`filter-${filter}`));
-
-        fireEvent.click(
-          screen
-            .getByTestId(`filter-${filter}-options`)
-            .querySelector('li > div > span').firstChild
-        );
+      [
+        ['Health', health],
+        ['SID', sid],
+        ['Tags', tags[0].value],
+      ].forEach(([filter, option]) => {
+        filterTable(filter, option);
       });
 
       expect(window.location.search).toEqual(

--- a/assets/js/components/Table/Table.test.jsx
+++ b/assets/js/components/Table/Table.test.jsx
@@ -1,12 +1,6 @@
 import React from 'react';
 
-import {
-  screen,
-  fireEvent,
-  render,
-  waitFor,
-  act,
-} from '@testing-library/react';
+import { screen, fireEvent, render, waitFor } from '@testing-library/react';
 import 'intersection-observer';
 import '@testing-library/jest-dom';
 
@@ -18,9 +12,7 @@ import Table from './Table';
 export const filterTable = (name, option) => {
   const filterContainer = screen.getByTestId(`filter-${name}`);
 
-  act(() => {
-    fireEvent.click(filterContainer);
-  });
+  fireEvent.click(filterContainer);
 
   const optionContainer = Array.from(
     screen
@@ -28,18 +20,14 @@ export const filterTable = (name, option) => {
       .querySelectorAll('li > div > span')
   ).find((f) => f.textContent === option);
 
-  act(() => {
-    fireEvent.click(optionContainer);
-    fireEvent.click(screen.getByTestId(`filter-${name}`));
-  });
+  fireEvent.click(optionContainer);
+  fireEvent.click(screen.getByTestId(`filter-${name}`));
 };
 
 export const clearFilter = (name) => {
   const filterContainer = screen.getByTestId(`filter-${name}-clear`);
 
-  act(() => {
-    fireEvent.click(filterContainer);
-  });
+  fireEvent.click(filterContainer);
 };
 
 describe('Table component', () => {


### PR DESCRIPTION
Fix some of the `Warning: An update to TransitionChild2 inside a test was not wrapped in act(...).` we have in our jest tests.
These were actually even happening in `testing-library/react` version `13.4.0`.
Many others are still there after upgrading the previous package to `14.0.0`.
Simply, we get ride of some of them.

We shouldn't need to wrap the fireEvent/userEvent/getByRole calls in act, as this is already done in their code and the `waitFor` should be used by the expectations.

PD: This is not related to errors related to: https://github.com/testing-library/react-testing-library/issues/1180