### PR TITLE
Add extra second to heartbeat interval to avoid glitches

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -91,7 +91,8 @@ config :trento, :pow,
 
 config :trento, :api_key_authentication, enabled: true
 
-config :trento, Trento.Heartbeats, interval: :timer.seconds(5)
+# Agent heartbeat interval. Adding one extra second to the agent 5s interval to avoid glitches
+config :trento, Trento.Heartbeats, interval: :timer.seconds(6)
 
 config :trento, Trento.Scheduler,
   jobs: [


### PR DESCRIPTION
Add extra second to heartbeat interval to avoid glitches.

We found a super rare occasion when the host health was jumping between passing/critical. It happened because some extreme synchronization between the agent heartbeat and checking interval in the server.
