### PR TITLE
Add Checks warning banner when provider is VMware

### DIFF
--- a/assets/js/components/ClusterDetails/ClusterSettings.jsx
+++ b/assets/js/components/ClusterDetails/ClusterSettings.jsx
@@ -16,6 +16,23 @@ import { getCluster, getClusterHostIDs } from '@state/selectors/cluster';
 
 export const UNKNOWN_PROVIDER = 'unknown';
 
+const warningBanners = {
+  [UNKNOWN_PROVIDER]: (
+    <WarningBanner>
+      The following catalog is valid for on-premise bare metal platforms.
+      <br />
+      If you are running your HANA cluster on a different platform, please use
+      results with caution
+    </WarningBanner>
+  ),
+  vmware: (
+    <WarningBanner>
+      Configuration checks for HANA scale-up performance optimized clusters on
+      VMware are still in experimental phase. Please use results with caution.
+    </WarningBanner>
+  ),
+};
+
 export function ClusterSettings() {
   const { clusterID } = useParams();
 
@@ -35,14 +52,7 @@ export function ClusterSettings() {
         <span className="font-bold">{getClusterName(cluster)}</span>
       </PageHeader>
       <ClusterInfoBox haScenario={cluster.type} provider={cluster.provider} />
-      {cluster.provider === UNKNOWN_PROVIDER && (
-        <WarningBanner>
-          The following catalog is valid for on-premise bare metal platforms.
-          <br />
-          If you are running your HANA cluster on a different platform, please
-          use results with caution
-        </WarningBanner>
-      )}
+      {warningBanners[cluster.provider] ?? null}
       <ChecksSelection clusterId={clusterID} cluster={cluster} />
     </div>
   );

--- a/assets/js/components/ClusterDetails/ClusterSettings.jsx
+++ b/assets/js/components/ClusterDetails/ClusterSettings.jsx
@@ -16,7 +16,7 @@ import { getCluster, getClusterHostIDs } from '@state/selectors/cluster';
 
 export const UNKNOWN_PROVIDER = 'unknown';
 
-export const warningBanners = {
+export const providerWarningBanners = {
   [UNKNOWN_PROVIDER]: (
     <WarningBanner>
       The following catalog is valid for on-premise bare metal platforms.
@@ -51,8 +51,8 @@ export function ClusterSettings() {
         Cluster Settings for{' '}
         <span className="font-bold">{getClusterName(cluster)}</span>
       </PageHeader>
+      {providerWarningBanners[cluster.provider] ?? null}
       <ClusterInfoBox haScenario={cluster.type} provider={cluster.provider} />
-      {warningBanners[cluster.provider] ?? null}
       <ChecksSelection clusterId={clusterID} cluster={cluster} />
     </div>
   );

--- a/assets/js/components/ClusterDetails/ClusterSettings.jsx
+++ b/assets/js/components/ClusterDetails/ClusterSettings.jsx
@@ -42,6 +42,8 @@ export function ClusterSettings() {
     return <div>Loading...</div>;
   }
 
+  const warning = providerWarningBanners[cluster.provider];
+
   return (
     <div className="w-full px-2 sm:px-0">
       <BackButton url={`/clusters/${clusterID}`}>
@@ -51,7 +53,7 @@ export function ClusterSettings() {
         Cluster Settings for{' '}
         <span className="font-bold">{getClusterName(cluster)}</span>
       </PageHeader>
-      {providerWarningBanners[cluster.provider] ?? null}
+      {warning}
       <ClusterInfoBox haScenario={cluster.type} provider={cluster.provider} />
       <ChecksSelection clusterId={clusterID} cluster={cluster} />
     </div>

--- a/assets/js/components/ClusterDetails/ClusterSettings.jsx
+++ b/assets/js/components/ClusterDetails/ClusterSettings.jsx
@@ -16,7 +16,7 @@ import { getCluster, getClusterHostIDs } from '@state/selectors/cluster';
 
 export const UNKNOWN_PROVIDER = 'unknown';
 
-const warningBanners = {
+export const warningBanners = {
   [UNKNOWN_PROVIDER]: (
     <WarningBanner>
       The following catalog is valid for on-premise bare metal platforms.

--- a/assets/js/components/ClusterDetails/ClusterSettings.test.jsx
+++ b/assets/js/components/ClusterDetails/ClusterSettings.test.jsx
@@ -8,7 +8,7 @@ import { withState, defaultInitialState } from '@lib/test-utils';
 import { catalogCheckFactory } from '@lib/test-utils/factories';
 
 import { Route, Routes, MemoryRouter } from 'react-router-dom';
-import { ClusterSettings } from './ClusterSettings';
+import { ClusterSettings, UNKNOWN_PROVIDER } from './ClusterSettings';
 
 describe('ClusterDetails ClusterSettings component', () => {
   it('should render the cluster info box and the catalog container', async () => {
@@ -40,6 +40,86 @@ describe('ClusterDetails ClusterSettings component', () => {
     expect(screen.getByText(group)).toBeVisible();
     expect(
       screen.getByRole('button', { name: 'Select Checks for Execution' })
+    ).toBeVisible();
+  });
+
+  it('given VMware provider, should render the warning banner', async () => {
+    const group = faker.animal.cat();
+    const catalog = catalogCheckFactory.buildList(2, { group });
+
+    const [StatefulChecksSettings, state] = withState(<ClusterSettings />, {
+      ...defaultInitialState,
+      catalog: { loading: false, data: catalog, error: null },
+      clustersList: {
+        clusters: defaultInitialState.clustersList.clusters.map((cluster) => ({
+          ...cluster,
+          provider: 'vmware',
+        })),
+      },
+    });
+
+    const {
+      clusters: [, , , { id: clusterID }],
+    } = state.getState().clustersList;
+
+    render(
+      <MemoryRouter initialEntries={[`/clusters/${clusterID}/settings`]}>
+        <Routes>
+          <Route
+            path="clusters/:clusterID/settings"
+            element={StatefulChecksSettings}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Provider')).toBeVisible();
+    expect(screen.getByText('VMware')).toBeVisible();
+    expect(screen.getByText(group)).toBeVisible();
+    expect(
+      screen.getByText(
+        'Configuration checks for HANA scale-up performance optimized clusters on VMware are still in experimental phase. Please use results with caution.'
+      )
+    ).toBeVisible();
+  });
+
+  it('given unknown provider, should render the warning banner', async () => {
+    const group = faker.animal.cat();
+    const catalog = catalogCheckFactory.buildList(2, { group });
+
+    const [StatefulChecksSettings, state] = withState(<ClusterSettings />, {
+      ...defaultInitialState,
+      catalog: { loading: false, data: catalog, error: null },
+      clustersList: {
+        clusters: defaultInitialState.clustersList.clusters.map((cluster) => ({
+          ...cluster,
+          provider: UNKNOWN_PROVIDER,
+        })),
+      },
+    });
+
+    const {
+      clusters: [, , , { id: clusterID }],
+    } = state.getState().clustersList;
+
+    render(
+      <MemoryRouter initialEntries={[`/clusters/${clusterID}/settings`]}>
+        <Routes>
+          <Route
+            path="clusters/:clusterID/settings"
+            element={StatefulChecksSettings}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Provider')).toBeVisible();
+    expect(screen.getByText('Provider not recognized')).toBeVisible();
+    expect(screen.getByText(group)).toBeVisible();
+    expect(
+      screen.getByText(
+        /The following catalog is valid for on-premise bare metal platforms.*If you are running your HANA cluster on a different platform, please use results with caution/
+      )
     ).toBeVisible();
   });
 });

--- a/assets/js/components/ClusterDetails/ClusterSettings.test.jsx
+++ b/assets/js/components/ClusterDetails/ClusterSettings.test.jsx
@@ -4,7 +4,11 @@ import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { faker } from '@faker-js/faker';
-import { withState, defaultInitialState } from '@lib/test-utils';
+import {
+  withState,
+  defaultInitialState,
+  renderWithRouterMatch,
+} from '@lib/test-utils';
 import { catalogCheckFactory, clusterFactory } from '@lib/test-utils/factories';
 
 import { Route, Routes, MemoryRouter } from 'react-router-dom';
@@ -57,16 +61,10 @@ describe('ClusterDetails ClusterSettings component', () => {
 
     const [StatefulChecksSettings] = withState(<ClusterSettings />, state);
 
-    render(
-      <MemoryRouter initialEntries={[`/clusters/${clusterID}/settings`]}>
-        <Routes>
-          <Route
-            path="clusters/:clusterID/settings"
-            element={StatefulChecksSettings}
-          />
-        </Routes>
-      </MemoryRouter>
-    );
+    renderWithRouterMatch(StatefulChecksSettings, {
+      path: 'clusters/:clusterID/settings',
+      route: `/clusters/${clusterID}/settings`,
+    });
 
     expect(screen.getByText('Provider')).toBeVisible();
     expect(screen.getByText('VMware')).toBeVisible();
@@ -94,16 +92,10 @@ describe('ClusterDetails ClusterSettings component', () => {
 
     const [StatefulChecksSettings] = withState(<ClusterSettings />, state);
 
-    render(
-      <MemoryRouter initialEntries={[`/clusters/${clusterID}/settings`]}>
-        <Routes>
-          <Route
-            path="clusters/:clusterID/settings"
-            element={StatefulChecksSettings}
-          />
-        </Routes>
-      </MemoryRouter>
-    );
+    renderWithRouterMatch(StatefulChecksSettings, {
+      path: 'clusters/:clusterID/settings',
+      route: `/clusters/${clusterID}/settings`,
+    });
 
     expect(screen.getByText('Provider')).toBeVisible();
     expect(screen.getByText('Provider not recognized')).toBeVisible();

--- a/assets/js/components/ClusterDetails/ClusterSettings.test.jsx
+++ b/assets/js/components/ClusterDetails/ClusterSettings.test.jsx
@@ -5,7 +5,7 @@ import '@testing-library/jest-dom';
 
 import { faker } from '@faker-js/faker';
 import { withState, defaultInitialState } from '@lib/test-utils';
-import { catalogCheckFactory } from '@lib/test-utils/factories';
+import { catalogCheckFactory, clusterFactory } from '@lib/test-utils/factories';
 
 import { Route, Routes, MemoryRouter } from 'react-router-dom';
 import { ClusterSettings, UNKNOWN_PROVIDER } from './ClusterSettings';
@@ -46,21 +46,16 @@ describe('ClusterDetails ClusterSettings component', () => {
   it('given VMware provider, should render the warning banner', async () => {
     const group = faker.animal.cat();
     const catalog = catalogCheckFactory.buildList(2, { group });
+    const clusters = clusterFactory.buildList(1, { provider: 'vmware' });
 
-    const [StatefulChecksSettings, state] = withState(<ClusterSettings />, {
+    const state = {
       ...defaultInitialState,
       catalog: { loading: false, data: catalog, error: null },
-      clustersList: {
-        clusters: defaultInitialState.clustersList.clusters.map((cluster) => ({
-          ...cluster,
-          provider: 'vmware',
-        })),
-      },
-    });
+      clustersList: { clusters },
+    };
+    const { id: clusterID } = clusters[0];
 
-    const {
-      clusters: [, , , { id: clusterID }],
-    } = state.getState().clustersList;
+    const [StatefulChecksSettings] = withState(<ClusterSettings />, state);
 
     render(
       <MemoryRouter initialEntries={[`/clusters/${clusterID}/settings`]}>
@@ -86,21 +81,18 @@ describe('ClusterDetails ClusterSettings component', () => {
   it('given unknown provider, should render the warning banner', async () => {
     const group = faker.animal.cat();
     const catalog = catalogCheckFactory.buildList(2, { group });
-
-    const [StatefulChecksSettings, state] = withState(<ClusterSettings />, {
-      ...defaultInitialState,
-      catalog: { loading: false, data: catalog, error: null },
-      clustersList: {
-        clusters: defaultInitialState.clustersList.clusters.map((cluster) => ({
-          ...cluster,
-          provider: UNKNOWN_PROVIDER,
-        })),
-      },
+    const clusters = clusterFactory.buildList(1, {
+      provider: UNKNOWN_PROVIDER,
     });
 
-    const {
-      clusters: [, , , { id: clusterID }],
-    } = state.getState().clustersList;
+    const state = {
+      ...defaultInitialState,
+      catalog: { loading: false, data: catalog, error: null },
+      clustersList: { clusters },
+    };
+    const { id: clusterID } = clusters[0];
+
+    const [StatefulChecksSettings] = withState(<ClusterSettings />, state);
 
     render(
       <MemoryRouter initialEntries={[`/clusters/${clusterID}/settings`]}>

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -103,7 +103,10 @@ function ExecutionResults({
       />
     );
   }
+
   const checkResults = getCheckResults(executionData);
+  const warning = providerWarningBanners[cloudProvider];
+
   return (
     <div>
       <Modal
@@ -135,7 +138,7 @@ function ExecutionResults({
           onChange={(newPredicates) => setPredicates(newPredicates)}
         />
       </div>
-      {providerWarningBanners[cloudProvider] ?? null}
+      {warning}
       <ClusterInfoBox haScenario={clusterScenario} provider={cloudProvider} />
       <ResultsContainer
         catalogError={false}

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -7,9 +7,8 @@ import remarkGfm from 'remark-gfm';
 import { EOS_ERROR } from 'eos-icons-react';
 import Modal from '@components/Modal';
 import BackButton from '@components/BackButton';
-import WarningBanner from '@components/Banners/WarningBanner';
 import LoadingBox from '@components/LoadingBox';
-import { UNKNOWN_PROVIDER } from '@components/ClusterDetails/ClusterSettings';
+import { warningBanners } from '@components/ClusterDetails/ClusterSettings';
 import { ClusterInfoBox } from '@components/ClusterDetails';
 import NotificationBox from '@components/NotificationBox';
 
@@ -136,14 +135,7 @@ function ExecutionResults({
           onChange={(newPredicates) => setPredicates(newPredicates)}
         />
       </div>
-      {cloudProvider === UNKNOWN_PROVIDER && (
-        <WarningBanner>
-          The following results are valid for on-premise bare metal platforms.
-          <br />
-          If you are running your HANA cluster on a different platform, please
-          use results with caution
-        </WarningBanner>
-      )}
+      {warningBanners[cloudProvider] ?? null}
       <ClusterInfoBox haScenario={clusterScenario} provider={cloudProvider} />
       <ResultsContainer
         catalogError={false}

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -8,7 +8,7 @@ import { EOS_ERROR } from 'eos-icons-react';
 import Modal from '@components/Modal';
 import BackButton from '@components/BackButton';
 import LoadingBox from '@components/LoadingBox';
-import { warningBanners } from '@components/ClusterDetails/ClusterSettings';
+import { providerWarningBanners } from '@components/ClusterDetails/ClusterSettings';
 import { ClusterInfoBox } from '@components/ClusterDetails';
 import NotificationBox from '@components/NotificationBox';
 
@@ -135,7 +135,7 @@ function ExecutionResults({
           onChange={(newPredicates) => setPredicates(newPredicates)}
         />
       </div>
-      {warningBanners[cloudProvider] ?? null}
+      {providerWarningBanners[cloudProvider] ?? null}
       <ClusterInfoBox haScenario={clusterScenario} provider={cloudProvider} />
       <ResultsContainer
         catalogError={false}

--- a/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
@@ -349,7 +349,6 @@ describe('ExecutionResults', () => {
     const {
       clusterID,
       hostnames,
-      checks: [checkID1, checkID2],
       loading,
       catalog,
       error,
@@ -377,26 +376,18 @@ describe('ExecutionResults', () => {
       { route: `/clusters/${clusterID}/executions/last?health=passing` }
     );
 
-    expect(screen.getByText('test-cluster')).toBeTruthy();
-    expect(screen.getByText('HANA scale-up')).toBeTruthy();
     expect(screen.getByText('VMware')).toBeTruthy();
     expect(
       screen.getByText(
         'Configuration checks for HANA scale-up performance optimized clusters on VMware are still in experimental phase. Please use results with caution.'
       )
     ).toBeTruthy();
-    expect(screen.getByText(hostnames[0].hostname)).toBeTruthy();
-    expect(screen.getByText(hostnames[1].hostname)).toBeTruthy();
-    expect(screen.getAllByText(checkID1)).toHaveLength(2);
-    expect(screen.queryByText(checkID2)).toBeNull();
-    expect(screen.getAllByText('2/2 expectations passed')).toBeTruthy();
   });
 
   it('given provider is unknown, should render ExecutionResults with warning banner', async () => {
     const {
       clusterID,
       hostnames,
-      checks: [checkID1, checkID2],
       loading,
       catalog,
       error,
@@ -424,18 +415,11 @@ describe('ExecutionResults', () => {
       { route: `/clusters/${clusterID}/executions/last?health=passing` }
     );
 
-    expect(screen.getByText('test-cluster')).toBeTruthy();
-    expect(screen.getByText('HANA scale-up')).toBeTruthy();
     expect(screen.getByText('Provider not recognized')).toBeTruthy();
     expect(
       screen.getByText(
         /The following catalog is valid for on-premise bare metal platforms.*If you are running your HANA cluster on a different platform, please use results with caution/
       )
     ).toBeTruthy();
-    expect(screen.getByText(hostnames[0].hostname)).toBeTruthy();
-    expect(screen.getByText(hostnames[1].hostname)).toBeTruthy();
-    expect(screen.getAllByText(checkID1)).toHaveLength(2);
-    expect(screen.queryByText(checkID2)).toBeNull();
-    expect(screen.getAllByText('2/2 expectations passed')).toBeTruthy();
   });
 });

--- a/assets/js/lib/test-utils/index.jsx
+++ b/assets/js/lib/test-utils/index.jsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import { runSaga } from 'redux-saga';
 
@@ -49,6 +49,20 @@ export const renderWithRouter = (ui, { route = '/' } = {}) => {
     ...render(ui, { wrapper: BrowserRouter }),
   };
 };
+
+export function renderWithRouterMatch(ui, { path = '/', route = '/' } = {}) {
+  window.history.pushState({}, 'Test page', route);
+
+  return {
+    ...render(
+      <BrowserRouter>
+        <Routes>
+          <Route path={path} element={ui} />
+        </Routes>
+      </BrowserRouter>
+    ),
+  };
+}
 
 export async function recordSaga(saga, initialAction, state = {}) {
   const dispatched = [];


### PR DESCRIPTION
# Description

Displays a warning banner in _Cluster Settings_ and _Execution Results_ views when cluster provider is VMware because no default Checks values have been established at this point in time for VMware.

### Old Cluster Settings layout

![image](https://user-images.githubusercontent.com/113615552/223668849-671c9382-ea9b-4742-97a5-aea7463d3159.png)

### New Cluster Settings layout

![image](https://user-images.githubusercontent.com/113615552/223677463-0ac92ef3-510d-4688-833c-a2fd38db005b.png)

### Execution Results

![image](https://user-images.githubusercontent.com/113615552/223669256-4fc3c35e-6df0-4d00-b296-4e055215c8f8.png)


## How was this tested?

Added React render tests for when provider is VMware or `unknown` in _Cluster Settings_ and _Execution Results_ views.
