### PR TITLE
Fix remaining act warning

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -36,7 +36,6 @@
         "@storybook/addon-interactions": "^6.5.16",
         "@storybook/addon-links": "^6.5.16",
         "@storybook/react": "^6.5.16",
-        "@storybook/testing-library": "^0.0.13",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
@@ -10182,35 +10181,6 @@
         "url": "https://opencollective.com/storybook"
       }
     },
-    "node_modules/@storybook/testing-library": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@storybook/testing-library/-/testing-library-0.0.13.tgz",
-      "integrity": "sha512-vRMeIGer4EjJkTgI8sQyK9W431ekPWYCWL//OmSDJ64IT3h7FnW7Xg6p+eqM3oII98/O5pcya5049GxnjaPtxw==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/client-logger": "^6.4.0",
-        "@storybook/instrumenter": "^6.4.0",
-        "@testing-library/dom": "^8.3.0",
-        "@testing-library/user-event": "^13.2.1",
-        "ts-dedent": "^2.2.0"
-      }
-    },
-    "node_modules/@storybook/testing-library/node_modules/@testing-library/user-event": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
-      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": ">=7.21.4"
-      }
-    },
     "node_modules/@storybook/theming": {
       "version": "6.5.16",
       "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.5.16.tgz",
@@ -10262,22 +10232,22 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.13.0.tgz",
-      "integrity": "sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.0.1.tgz",
+      "integrity": "sha512-fTOVsMY9QLFCCXRHG3Ese6cMH5qIWwSbgxZsgeF5TNsy81HKaZ4kgehnSF8FsR3OF+numlIV2YcU79MzbnhSig==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^4.2.0",
+        "@types/aria-query": "^5.0.1",
         "aria-query": "^5.0.0",
         "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.4.4",
+        "lz-string": "^1.5.0",
         "pretty-format": "^27.0.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@testing-library/jest-dom": {
@@ -10346,31 +10316,6 @@
         "react-dom": "^18.0.0"
       }
     },
-    "node_modules/@testing-library/react/node_modules/@testing-library/dom": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.0.0.tgz",
-      "integrity": "sha512-+/TLgKNFsYUshOY/zXsQOk+PlFQK+eyJ9T13IDVNJEi+M+Un7xlJK+FZKkbGSnf0+7E1G6PlDhkSYQ/GFiruBQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "^5.0.0",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.4.4",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/@types/aria-query": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
-      "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
-      "dev": true
-    },
     "node_modules/@testing-library/user-event": {
       "version": "14.4.3",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
@@ -10394,9 +10339,9 @@
       }
     },
     "node_modules/@types/aria-query": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
-      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
+      "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
       "dev": true
     },
     "node_modules/@types/babel__core": {
@@ -22068,9 +22013,9 @@
       }
     },
     "node_modules/lz-string": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "bin": {
         "lz-string": "bin/bin.js"
@@ -38810,30 +38755,6 @@
         "regenerator-runtime": "^0.13.7"
       }
     },
-    "@storybook/testing-library": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@storybook/testing-library/-/testing-library-0.0.13.tgz",
-      "integrity": "sha512-vRMeIGer4EjJkTgI8sQyK9W431ekPWYCWL//OmSDJ64IT3h7FnW7Xg6p+eqM3oII98/O5pcya5049GxnjaPtxw==",
-      "dev": true,
-      "requires": {
-        "@storybook/client-logger": "^6.4.0",
-        "@storybook/instrumenter": "^6.4.0",
-        "@testing-library/dom": "^8.3.0",
-        "@testing-library/user-event": "^13.2.1",
-        "ts-dedent": "^2.2.0"
-      },
-      "dependencies": {
-        "@testing-library/user-event": {
-          "version": "13.5.0",
-          "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
-          "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.12.5"
-          }
-        }
-      }
-    },
     "@storybook/theming": {
       "version": "6.5.16",
       "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.5.16.tgz",
@@ -38869,18 +38790,18 @@
       }
     },
     "@testing-library/dom": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.13.0.tgz",
-      "integrity": "sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.0.1.tgz",
+      "integrity": "sha512-fTOVsMY9QLFCCXRHG3Ese6cMH5qIWwSbgxZsgeF5TNsy81HKaZ4kgehnSF8FsR3OF+numlIV2YcU79MzbnhSig==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^4.2.0",
+        "@types/aria-query": "^5.0.1",
         "aria-query": "^5.0.0",
         "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.4.4",
+        "lz-string": "^1.5.0",
         "pretty-format": "^27.0.2"
       }
     },
@@ -38932,30 +38853,6 @@
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^9.0.0",
         "@types/react-dom": "^18.0.0"
-      },
-      "dependencies": {
-        "@testing-library/dom": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.0.0.tgz",
-          "integrity": "sha512-+/TLgKNFsYUshOY/zXsQOk+PlFQK+eyJ9T13IDVNJEi+M+Un7xlJK+FZKkbGSnf0+7E1G6PlDhkSYQ/GFiruBQ==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/runtime": "^7.12.5",
-            "@types/aria-query": "^5.0.1",
-            "aria-query": "^5.0.0",
-            "chalk": "^4.1.0",
-            "dom-accessibility-api": "^0.5.9",
-            "lz-string": "^1.4.4",
-            "pretty-format": "^27.0.2"
-          }
-        },
-        "@types/aria-query": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
-          "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
-          "dev": true
-        }
       }
     },
     "@testing-library/user-event": {
@@ -38972,9 +38869,9 @@
       "dev": true
     },
     "@types/aria-query": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
-      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
+      "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
       "dev": true
     },
     "@types/babel__core": {
@@ -48106,9 +48003,9 @@
       }
     },
     "lz-string": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true
     },
     "make-dir": {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -36,6 +36,7 @@
         "@storybook/addon-interactions": "^6.5.16",
         "@storybook/addon-links": "^6.5.16",
         "@storybook/react": "^6.5.16",
+        "@storybook/testing-library": "^0.0.13",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
@@ -10179,6 +10180,35 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/testing-library": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@storybook/testing-library/-/testing-library-0.0.13.tgz",
+      "integrity": "sha512-vRMeIGer4EjJkTgI8sQyK9W431ekPWYCWL//OmSDJ64IT3h7FnW7Xg6p+eqM3oII98/O5pcya5049GxnjaPtxw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "^6.4.0",
+        "@storybook/instrumenter": "^6.4.0",
+        "@testing-library/dom": "^8.3.0",
+        "@testing-library/user-event": "^13.2.1",
+        "ts-dedent": "^2.2.0"
+      }
+    },
+    "node_modules/@storybook/testing-library/node_modules/@testing-library/user-event": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
+      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@storybook/theming": {
@@ -38755,6 +38785,30 @@
         "regenerator-runtime": "^0.13.7"
       }
     },
+    "@storybook/testing-library": {
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@storybook/testing-library/-/testing-library-0.0.13.tgz",
+      "integrity": "sha512-vRMeIGer4EjJkTgI8sQyK9W431ekPWYCWL//OmSDJ64IT3h7FnW7Xg6p+eqM3oII98/O5pcya5049GxnjaPtxw==",
+      "dev": true,
+      "requires": {
+        "@storybook/client-logger": "^6.4.0",
+        "@storybook/instrumenter": "^6.4.0",
+        "@testing-library/dom": "^9.0.1",
+        "@testing-library/user-event": "^13.2.1",
+        "ts-dedent": "^2.2.0"
+      },
+      "dependencies": {
+        "@testing-library/user-event": {
+          "version": "13.5.0",
+          "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
+          "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.12.5"
+          }
+        }
+      }
+    },
     "@storybook/theming": {
       "version": "6.5.16",
       "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.5.16.tgz",
@@ -38851,7 +38905,7 @@
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^9.0.0",
+        "@testing-library/dom": "^9.0.1",
         "@types/react-dom": "^18.0.0"
       }
     },

--- a/assets/package.json
+++ b/assets/package.json
@@ -10,7 +10,6 @@
     "@storybook/addon-interactions": "^6.5.16",
     "@storybook/addon-links": "^6.5.16",
     "@storybook/react": "^6.5.16",
-    "@storybook/testing-library": "^0.0.13",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/assets/package.json
+++ b/assets/package.json
@@ -10,6 +10,7 @@
     "@storybook/addon-interactions": "^6.5.16",
     "@storybook/addon-links": "^6.5.16",
     "@storybook/react": "^6.5.16",
+    "@storybook/testing-library": "^0.0.13",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
@@ -57,6 +58,9 @@
     "react-router-dom": "^6.8.2",
     "redux-saga": "^1.2.2",
     "remark-gfm": "^3.0.1"
+  },
+  "overrides": {
+    "@testing-library/dom": "^9.0.1"
   },
   "scripts": {
     "tailwind:build": "tailwindcss --postcss --minify --input=css/app.css --output=../priv/static/assets/app.css",


### PR DESCRIPTION
Boring story about the npm depedency tree havoc coming:

It turns out that we are having the act warning because the `testing-library/dom` version we use in `testing-library/react`  and `testing-library/user-event` don't match: https://testing-library.com/docs/user-event/install

And this is happening (at least one reason) because `@storybook/testing-library` needs a lower version of it, and due how the dependency tree is created, the user-event uses the incorrect version.
If we remove the `@storybook/testing-library` everything works fine.

Going technical, this happens because `testing-library/user-event` has `testing-library/dom` as `peerDependency`, `storybook/testing-library` has it as main dependency as well as `testing-library/react`. This 2nd installs the `dom` library in its internal tree. This means that the version of the `dom` that is in the main `node_modules` tree comes from `storybook` creating the missmatch.

Other potential solution is to force the version of `testing-library/dom` to a good one, but this is discouraged.

More ref: https://github.com/testing-library/user-event/issues/1104


