### PR TITLE
Deregistration side effects

### DIFF
--- a/lib/trento/application/integration/discovery/protocol/enrich_register_application_instance.ex
+++ b/lib/trento/application/integration/discovery/protocol/enrich_register_application_instance.ex
@@ -14,7 +14,7 @@ defimpl Trento.Support.Middleware.Enrichable,
       from d in DatabaseInstanceReadModel,
         join: h in HostReadModel,
         on: d.host_id == h.id,
-        where: ^db_host in h.ip_addresses and ^tenant == d.tenant
+        where: ^db_host in h.ip_addresses and ^tenant == d.tenant and is_nil(h.deregistered_at)
 
     case Repo.one(query) do
       %DatabaseInstanceReadModel{sap_system_id: sap_system_id} ->

--- a/lib/trento/application/read_models/application_instance_read_model.ex
+++ b/lib/trento/application/read_models/application_instance_read_model.ex
@@ -27,7 +27,10 @@ defmodule Trento.ApplicationInstanceReadModel do
     field :host_id, Ecto.UUID, primary_key: true
     field :health, Ecto.Enum, values: Health.values()
 
-    has_one :host, HostReadModel, references: :host_id, foreign_key: :id
+    has_one :host, HostReadModel,
+      references: :host_id,
+      foreign_key: :id,
+      where: [deregistered_at: nil]
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()

--- a/lib/trento/application/read_models/database_instance_read_model.ex
+++ b/lib/trento/application/read_models/database_instance_read_model.ex
@@ -30,7 +30,10 @@ defmodule Trento.DatabaseInstanceReadModel do
     field :system_replication_status, :string, default: ""
     field :health, Ecto.Enum, values: Health.values()
 
-    has_one :host, HostReadModel, references: :host_id, foreign_key: :id
+    has_one :host, HostReadModel,
+      references: :host_id,
+      foreign_key: :id,
+      where: [deregistered_at: nil]
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()

--- a/lib/trento/application/read_models/host_read_model.ex
+++ b/lib/trento/application/read_models/host_read_model.ex
@@ -31,6 +31,8 @@ defmodule Trento.HostReadModel do
       references: :id,
       foreign_key: :host_id,
       preload_order: [desc: :identifier]
+
+    field :deregistered_at, :utc_datetime_usec
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()

--- a/lib/trento/application/usecases/hosts/hosts.ex
+++ b/lib/trento/application/usecases/hosts/hosts.ex
@@ -15,7 +15,7 @@ defmodule Trento.Hosts do
   @spec get_all_hosts :: [HostReadModel.t()]
   def get_all_hosts do
     HostReadModel
-    |> where([h], not is_nil(h.hostname))
+    |> where([h], not is_nil(h.hostname) and is_nil(h.deregistered_at))
     |> order_by(asc: :hostname)
     |> Repo.all()
     |> Repo.preload([:sles_subscriptions, :tags])

--- a/priv/repo/migrations/20230309094053_add_deregistered_at_to_host_read_model.exs
+++ b/priv/repo/migrations/20230309094053_add_deregistered_at_to_host_read_model.exs
@@ -1,0 +1,9 @@
+defmodule Trento.Repo.Migrations.AddDeregisteredAtToHostReadModel do
+  use Ecto.Migration
+
+  def change do
+    alter table(:hosts) do
+      add :deregistered_at, :utc_datetime_usec
+    end
+  end
+end

--- a/test/trento/application/integration/discovery/protocol/enrich_register_application_instance_test.exs
+++ b/test/trento/application/integration/discovery/protocol/enrich_register_application_instance_test.exs
@@ -31,7 +31,7 @@ defmodule Trento.EnrichRegisterApplicationInstanceTest do
              Enrichable.enrich(command, %{})
   end
 
-  test "should not return an enriched command if the database instance host has been deregistered" do
+  test "should return a database not found error if the database instance host has been deregistered" do
     deregistered_host = insert(:host, deregistered_at: DateTime.utc_now())
 
     %{

--- a/test/trento/application/integration/discovery/protocol/enrich_register_application_instance_test.exs
+++ b/test/trento/application/integration/discovery/protocol/enrich_register_application_instance_test.exs
@@ -31,6 +31,34 @@ defmodule Trento.EnrichRegisterApplicationInstanceTest do
              Enrichable.enrich(command, %{})
   end
 
+  test "should not return an enriched command if the database instance host has been deregistered" do
+    deregistered_host = insert(:host, deregistered_at: DateTime.utc_now())
+
+    %{
+      tenant: tenant,
+      host: %{ip_addresses: [ip]}
+    } =
+      insert(:database_instance_without_host,
+        host_id: deregistered_host.id,
+        host: deregistered_host
+      )
+
+    command =
+      build(
+        :register_application_instance_command,
+        sap_system_id: nil,
+        sid: Faker.StarWars.planet(),
+        db_host: ip,
+        tenant: tenant,
+        instance_number: "00",
+        features: Faker.Pokemon.name(),
+        host_id: Faker.UUID.v4(),
+        health: :passing
+      )
+
+    assert {:error, :database_not_found} = Enrichable.enrich(command, %{})
+  end
+
   test "should return an error if the database was not found" do
     %{
       tenant: tenant

--- a/test/trento/application/projectors/host_projector_test.exs
+++ b/test/trento/application/projectors/host_projector_test.exs
@@ -24,8 +24,8 @@ defmodule Trento.HostProjectorTest do
     HeartbeatFailed,
     HeartbeatSucceded,
     HostAddedToCluster,
-    HostDetailsUpdated,
     HostDeregistered,
+    HostDetailsUpdated,
     ProviderUpdated
   }
 

--- a/test/trento/application/projectors/host_projector_test.exs
+++ b/test/trento/application/projectors/host_projector_test.exs
@@ -344,4 +344,28 @@ defmodule Trento.HostProjectorTest do
                      },
                      1000
   end
+
+  test "should update the deregistered_at field when HostDeregistered is received",
+       %{
+         host_id: host_id
+       } do
+    timestamp = DateTime.utc_now()
+
+    event = %HostDeregistered{
+      host_id: host_id,
+      deregistered_at: timestamp
+    }
+
+    ProjectorTestHelper.project(HostProjector, event, "host_projector")
+    host_projection = Repo.get!(HostReadModel, event.host_id)
+
+    assert timestamp == host_projection.deregistered_at
+
+    assert_broadcast "host_deregistered",
+                     %{
+                       id: ^host_id,
+                       hostname: ^hostname
+                     },
+                     1000
+  end
 end

--- a/test/trento/application/projectors/host_projector_test.exs
+++ b/test/trento/application/projectors/host_projector_test.exs
@@ -359,7 +359,7 @@ defmodule Trento.HostProjectorTest do
     }
 
     ProjectorTestHelper.project(HostProjector, event, "host_projector")
-    host_projection = Repo.get!(HostReadModel, event.host_id)
+    host_projection = Repo.get!(HostReadModel, host_id)
 
     assert timestamp == host_projection.deregistered_at
 

--- a/test/trento/application/projectors/host_projector_test.exs
+++ b/test/trento/application/projectors/host_projector_test.exs
@@ -25,6 +25,7 @@ defmodule Trento.HostProjectorTest do
     HeartbeatSucceded,
     HostAddedToCluster,
     HostDetailsUpdated,
+    HostDeregistered,
     ProviderUpdated
   }
 
@@ -45,9 +46,9 @@ defmodule Trento.HostProjectorTest do
   end
 
   setup do
-    %HostReadModel{id: host_id} = insert(:host)
+    %HostReadModel{id: host_id, hostname: hostname} = insert(:host)
 
-    %{host_id: host_id}
+    %{host_id: host_id, hostname: hostname}
   end
 
   test "should project a new host when HostRegistered event is received" do
@@ -347,7 +348,8 @@ defmodule Trento.HostProjectorTest do
 
   test "should update the deregistered_at field when HostDeregistered is received",
        %{
-         host_id: host_id
+         host_id: host_id,
+         hostname: hostname
        } do
     timestamp = DateTime.utc_now()
 

--- a/test/trento/application/usecases/hosts_test.exs
+++ b/test/trento/application/usecases/hosts_test.exs
@@ -25,4 +25,16 @@ defmodule Trento.HostsTest do
       assert 6 = Hosts.get_all_sles_subscriptions()
     end
   end
+
+  describe "Hosts listing" do
+    test "should filter unregistered hosts" do
+      %{id: host_id} = insert(:host)
+      insert(:host, deregistered_at: DateTime.utc_now())
+
+      hosts = Hosts.get_all_hosts()
+
+      assert length(hosts) == 1
+      assert [%{id: ^host_id}] = hosts
+    end
+  end
 end

--- a/test/trento/application/usecases/hosts_test.exs
+++ b/test/trento/application/usecases/hosts_test.exs
@@ -26,15 +26,16 @@ defmodule Trento.HostsTest do
     end
   end
 
-  describe "Hosts listing" do
-    test "should filter unregistered hosts" do
-      %{id: host_id} = insert(:host)
-      insert(:host, deregistered_at: DateTime.utc_now())
+  describe "get_all_hosts/0" do
+    test "should list all hosts except the deregistered ones" do
+      registered_hosts = Enum.map(0..9, fn i -> insert(:host, hostname: "hostname_#{i}") end)
+      deregistered_host = insert(:host, deregistered_at: DateTime.utc_now())
 
       hosts = Hosts.get_all_hosts()
+      hosts_ids = Enum.map(hosts, & &1.id)
 
-      assert length(hosts) == 1
-      assert [%{id: ^host_id}] = hosts
+      assert Enum.map(registered_hosts, & &1.id) == hosts_ids
+      refute deregistered_host.id in hosts_ids
     end
   end
 end

--- a/test/trento_web/controllers/v1/host_controller_test.exs
+++ b/test/trento_web/controllers/v1/host_controller_test.exs
@@ -24,23 +24,6 @@ defmodule TrentoWeb.V1.HostControllerTest do
       |> json_response(200)
       |> assert_schema("HostsCollection", api_spec)
     end
-
-    test "should filter unregistered hosts", %{conn: conn} do
-      %{id: host_id} = insert(:host)
-      insert(:host, deregistered_at: DateTime.utc_now())
-
-      insert_list(2, :sles_subscription, host_id: host_id)
-      insert_list(2, :tag, resource_id: host_id)
-
-      api_spec = ApiSpec.spec()
-
-      conn = get(conn, "/api/v1/hosts")
-
-      resp = json_response(conn, 200)
-
-      assert length(resp) == 1
-      assert [%{"id" => ^host_id}] = resp
-    end
   end
 
   describe "heartbeat" do

--- a/test/trento_web/controllers/v1/host_controller_test.exs
+++ b/test/trento_web/controllers/v1/host_controller_test.exs
@@ -24,6 +24,23 @@ defmodule TrentoWeb.V1.HostControllerTest do
       |> json_response(200)
       |> assert_schema("HostsCollection", api_spec)
     end
+
+    test "should filter unregistered hosts", %{conn: conn} do
+      %{id: host_id} = insert(:host)
+      insert(:host, deregistered_at: DateTime.utc_now())
+
+      insert_list(2, :sles_subscription, host_id: host_id)
+      insert_list(2, :tag, resource_id: host_id)
+
+      api_spec = ApiSpec.spec()
+
+      conn = get(conn, "/api/v1/hosts")
+
+      resp = json_response(conn, 200)
+
+      assert length(resp) == 1
+      assert [%{"id" => ^host_id}] = resp
+    end
   end
 
   describe "heartbeat" do


### PR DESCRIPTION
# Description

This PR handles side effects of the `HostDeregistered` event.

- Host _Read Model_ now includes a `deregistered_at` field.
- The _Projector_ handles the `HostDeregistered` event and sets the `deregistered_at` field in the _Read Model_.
- _Deregistered_ Hosts are filtered in the Hosts _Usecase_, (currently used by the _Hosts Controller_) as well as in the Ecto associations for the _Application Instance Read Model_ and _Database Instance Read Model_.

## How was this tested?

Added units tests for the Host _Usecase_ and _Projector_.
