### PR TITLE
Disable snapshotting for the Host aggregate

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -63,10 +63,6 @@ config :trento, Trento.Commanded,
   pubsub: :local,
   registry: :local,
   snapshotting: %{
-    Trento.Domain.Host => [
-      snapshot_every: 200,
-      snapshot_version: 1
-    ],
     Trento.Domain.SapSystem => [
       snapshot_every: 200,
       snapshot_version: 1


### PR DESCRIPTION
Since the host aggregate now has rollups, we need to disable commanded snapshotting.
See #1110 