### PR TITLE
Sapsystem rollup

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -61,13 +61,7 @@ config :trento, Trento.Commanded,
     event_store: Trento.EventStore
   ],
   pubsub: :local,
-  registry: :local,
-  snapshotting: %{
-    Trento.Domain.SapSystem => [
-      snapshot_every: 200,
-      snapshot_version: 1
-    ]
-  }
+  registry: :local
 
 config :trento, Trento.StreamRollUpEventHandler, max_stream_version: 10_000
 

--- a/lib/trento/application/event_handlers/roll_up_event_handler.ex
+++ b/lib/trento/application/event_handlers/roll_up_event_handler.ex
@@ -15,7 +15,9 @@ defmodule Trento.RollUpEventHandler do
     ClusterRolledUp,
     ClusterRollUpRequested,
     HostRolledUp,
-    HostRollUpRequested
+    HostRollUpRequested,
+    SapSystemRolledUp,
+    SapSystemRollUpRequested
   }
 
   def handle(
@@ -36,6 +38,18 @@ defmodule Trento.RollUpEventHandler do
   def handle(%HostRollUpRequested{host_id: stream_id, snapshot: snapshot}, _) do
     roll_up_event = %HostRolledUp{
       host_id: stream_id,
+      snapshot: snapshot
+    }
+
+    now = DateTime.to_iso8601(DateTime.utc_now())
+    archive_stream_id = "#{stream_id}-archived-#{now}"
+
+    RollUp.roll_up_aggregate(stream_id, roll_up_event, archive_stream_id)
+  end
+
+  def handle(%SapSystemRollUpRequested{sap_system_id: stream_id, snapshot: snapshot}, _) do
+    roll_up_event = %SapSystemRolledUp{
+      sap_system_id: stream_id,
       snapshot: snapshot
     }
 

--- a/lib/trento/application/event_handlers/stream_roll_up_event_handler.ex
+++ b/lib/trento/application/event_handlers/stream_roll_up_event_handler.ex
@@ -15,7 +15,8 @@ defmodule Trento.StreamRollUpEventHandler do
 
   alias Trento.Domain.Commands.{
     RollUpCluster,
-    RollUpHost
+    RollUpHost,
+    RollUpSapSystem
   }
 
   require Logger
@@ -39,6 +40,18 @@ defmodule Trento.StreamRollUpEventHandler do
     Trento.Domain.Events.HostRegistered,
     Trento.Domain.Events.ProviderUpdated,
     Trento.Domain.Events.SlesSubscriptionsUpdated
+  ]
+
+  @sap_system_events [
+    Trento.Domain.Events.ApplicationInstanceHealthChanged,
+    Trento.Domain.Events.ApplicationInstanceRegistered,
+    Trento.Domain.Events.DatabaseHealthChanged,
+    Trento.Domain.Events.DatabaseInstanceHealthChanged,
+    Trento.Domain.Events.DatabaseInstanceRegistered,
+    Trento.Domain.Events.DatabaseInstanceSystemReplicationChanged,
+    Trento.Domain.Events.DatabaseRegistered,
+    Trento.Domain.Events.SapSystemHealthChanged,
+    Trento.Domain.Events.SapSystemRegistered
   ]
 
   def handle(%event_type{host_id: host_id}, %{
@@ -75,6 +88,27 @@ defmodule Trento.StreamRollUpEventHandler do
       )
 
       commanded().dispatch(%RollUpCluster{cluster_id: cluster_id},
+        consistency: :strong
+      )
+    else
+      :ok
+    end
+  end
+
+  def handle(%event_type{sap_system_id: sap_system_id}, %{
+        stream_version: event_stream_version
+      })
+      when event_type in @sap_system_events and event_stream_version > @max_stream_version do
+    # This is needed to check if an event already triggered a roll-up
+    {:ok, %EventStore.Streams.StreamInfo{stream_version: stream_version}} =
+      Trento.EventStore.stream_info(sap_system_id)
+
+    if stream_version > @max_stream_version do
+      Logger.info(
+        "Rolling up sapsystem: #{sap_system_id} because  #{stream_version} > #{@max_stream_version}"
+      )
+
+      commanded().dispatch(%RollUpSapSystem{sap_system_id: sap_system_id},
         consistency: :strong
       )
     else

--- a/lib/trento/application/event_handlers/stream_roll_up_event_handler.ex
+++ b/lib/trento/application/event_handlers/stream_roll_up_event_handler.ex
@@ -105,7 +105,7 @@ defmodule Trento.StreamRollUpEventHandler do
 
     if stream_version > @max_stream_version do
       Logger.info(
-        "Rolling up sapsystem: #{sap_system_id} because  #{stream_version} > #{@max_stream_version}"
+        "Rolling up sap system: #{sap_system_id} because  #{stream_version} > #{@max_stream_version}"
       )
 
       commanded().dispatch(%RollUpSapSystem{sap_system_id: sap_system_id},

--- a/lib/trento/domain/sap_system/commands/rollup_sap_system.ex
+++ b/lib/trento/domain/sap_system/commands/rollup_sap_system.ex
@@ -1,0 +1,13 @@
+defmodule Trento.Domain.Commands.RollUpSapSystem do
+  @moduledoc """
+  Start a sap_system aggregate rollup
+  """
+
+  @required_fields :all
+
+  use Trento.Command
+
+  defcommand do
+    field :sap_system_id, Ecto.UUID
+  end
+end

--- a/lib/trento/domain/sap_system/commands/rollup_sap_system.ex
+++ b/lib/trento/domain/sap_system/commands/rollup_sap_system.ex
@@ -1,6 +1,6 @@
 defmodule Trento.Domain.Commands.RollUpSapSystem do
   @moduledoc """
-  Start a sap_system aggregate rollup
+  Start a sap system aggregate rollup.
   """
 
   @required_fields :all

--- a/lib/trento/domain/sap_system/events/sap_system_roll_up_requested.ex
+++ b/lib/trento/domain/sap_system/events/sap_system_roll_up_requested.ex
@@ -1,0 +1,13 @@
+defmodule Trento.Domain.Events.SapSystemRollUpRequested do
+  @moduledoc """
+  This event is emitted when an sap system roll-up is requested.
+  It is used to trigger the stream archiving process and it contains the snapshot of the sap system aggregate.
+  """
+
+  use Trento.Event
+
+  defevent resource: "sap_system" do
+    field :sap_system_id, Ecto.UUID
+    embeds_one :snapshot, Trento.Domain.SapSystem
+  end
+end

--- a/lib/trento/domain/sap_system/events/sap_system_rolled_up.ex
+++ b/lib/trento/domain/sap_system/events/sap_system_rolled_up.ex
@@ -1,7 +1,7 @@
 defmodule Trento.Domain.Events.SapSystemRolledUp do
   @moduledoc """
   This event is emitted when a sap system roll-up is requested.
-  It is used to trigger the stream archiving process and it contains the snapshot of the host aggregate.
+  It is used to trigger the stream archiving process and it contains the snapshot of the sap system aggregate.
   """
 
   use Trento.Event

--- a/lib/trento/domain/sap_system/events/sap_system_rolled_up.ex
+++ b/lib/trento/domain/sap_system/events/sap_system_rolled_up.ex
@@ -1,0 +1,13 @@
+defmodule Trento.Domain.Events.SapSystemRolledUp do
+  @moduledoc """
+  This event is emitted when a sap system roll-up is requested.
+  It is used to trigger the stream archiving process and it contains the snapshot of the host aggregate.
+  """
+
+  use Trento.Event
+
+  defevent resource: "sap_system" do
+    field :sap_system_id, Ecto.UUID
+    embeds_one :snapshot, Trento.Domain.SapSystem
+  end
+end

--- a/lib/trento/domain/sap_system/lifespan.ex
+++ b/lib/trento/domain/sap_system/lifespan.ex
@@ -1,0 +1,28 @@
+defmodule Trento.Domain.SapSystem.Lifespan do
+  @moduledoc """
+  SapSystem aggregate lifespan.
+
+  It controls the lifespan of the aggregate GenServer representing a sap system.
+  """
+
+  @behaviour Commanded.Aggregates.AggregateLifespan
+
+  alias Commanded.Aggregates.DefaultLifespan
+
+  alias Trento.Domain.Events.SapSystemRollUpRequested
+
+  @doc """
+  The SapSystem aggregate will be stopped after a SapSystemRollUpRequested event is received.
+  This is needed to reset the aggregate version, so the aggregate can start appending events to the new stream.
+  """
+  def after_event(%SapSystemRollUpRequested{}), do: :stop
+  def after_event(event), do: DefaultLifespan.after_event(event)
+
+  def after_command(command), do: DefaultLifespan.after_command(command)
+
+  @doc """
+   If the aggregate is rolling up, it will be stopped to avoid processing any other event.
+  """
+  def after_error(:sap_system_rolling_up), do: :stop
+  def after_error(error), do: DefaultLifespan.after_error(error)
+end

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -67,9 +67,9 @@ defmodule Trento.Domain.SapSystem do
     DatabaseInstanceSystemReplicationChanged,
     DatabaseRegistered,
     SapSystemHealthChanged,
+    SapSystemRegistered,
     SapSystemRolledUp,
-    SapSystemRollUpRequested,
-    SapSystemRegistered
+    SapSystemRollUpRequested
   }
 
   alias Trento.Domain.HealthService

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -54,7 +54,8 @@ defmodule Trento.Domain.SapSystem do
 
   alias Trento.Domain.Commands.{
     RegisterApplicationInstance,
-    RegisterDatabaseInstance
+    RegisterDatabaseInstance,
+    RollUpSapSystem
   }
 
   alias Trento.Domain.Events.{
@@ -66,6 +67,8 @@ defmodule Trento.Domain.SapSystem do
     DatabaseInstanceSystemReplicationChanged,
     DatabaseRegistered,
     SapSystemHealthChanged,
+    SapSystemRolledUp,
+    SapSystemRollUpRequested,
     SapSystemRegistered
   }
 
@@ -79,6 +82,7 @@ defmodule Trento.Domain.SapSystem do
     field :sap_system_id, Ecto.UUID
     field :sid, :string
     field :health, Ecto.Enum, values: Health.values()
+    field :rolling_up, :boolean, default: false
 
     embeds_one :database, Database
     embeds_one :application, Application
@@ -127,6 +131,9 @@ defmodule Trento.Domain.SapSystem do
       }
     ]
   end
+
+  # Stop everything during the rollup process
+  def execute(%SapSystem{rolling_up: true}, _), do: {:error, :sap_system_rolling_up}
 
   # When a RegisterDatabaseInstance command is received by an existing SAP System aggregate,
   # the SAP System aggregate registers the Database instance if it is not already registered
@@ -252,6 +259,24 @@ defmodule Trento.Domain.SapSystem do
     |> Multi.new()
     |> Multi.execute(fn _ -> event end)
     |> Multi.execute(&maybe_emit_sap_system_health_changed_event/1)
+  end
+
+  # Start the rollup flow
+  def execute(
+        %SapSystem{sap_system_id: nil},
+        %RollUpSapSystem{}
+      ) do
+    {:error, :sap_system_not_registered}
+  end
+
+  def execute(
+        %SapSystem{sap_system_id: sap_system_id} = snapshot,
+        %RollUpSapSystem{}
+      ) do
+    %SapSystemRollUpRequested{
+      sap_system_id: sap_system_id,
+      snapshot: snapshot
+    }
   end
 
   def apply(
@@ -454,6 +479,18 @@ defmodule Trento.Domain.SapSystem do
       sap_system
       | database: Map.put(database, :health, health)
     }
+  end
+
+  # Aggregate to rolling up state
+  def apply(%SapSystem{} = sap_system, %SapSystemRollUpRequested{}) do
+    %SapSystem{sap_system | rolling_up: true}
+  end
+
+  # Hydrate the aggregate with a rollup snapshot after rollup ends
+  def apply(%SapSystem{}, %SapSystemRolledUp{
+        snapshot: snapshot
+      }) do
+    snapshot
   end
 
   defp maybe_emit_database_instance_system_replication_changed_event(

--- a/lib/trento/infrastructure/router.ex
+++ b/lib/trento/infrastructure/router.ex
@@ -17,6 +17,7 @@ defmodule Trento.Router do
     RegisterHost,
     RollUpCluster,
     RollUpHost,
+    RollUpSapSystem,
     SelectChecks,
     UpdateHeartbeat,
     UpdateProvider,
@@ -51,6 +52,7 @@ defmodule Trento.Router do
 
   identify SapSystem, by: :sap_system_id
 
-  dispatch [RegisterApplicationInstance, RegisterDatabaseInstance],
-    to: SapSystem
+  dispatch [RegisterApplicationInstance, RegisterDatabaseInstance, RollUpSapSystem],
+    to: SapSystem,
+    lifespan: SapSystem.Lifespan
 end

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -5,7 +5,8 @@ defmodule Trento.SapSystemTest do
 
   alias Trento.Domain.Commands.{
     RegisterApplicationInstance,
-    RegisterDatabaseInstance
+    RegisterDatabaseInstance,
+    RollUpSapSystem
   }
 
   alias Trento.Domain.Events.{
@@ -17,7 +18,9 @@ defmodule Trento.SapSystemTest do
     DatabaseInstanceSystemReplicationChanged,
     DatabaseRegistered,
     SapSystemHealthChanged,
-    SapSystemRegistered
+    SapSystemRegistered,
+    SapSystemRolledUp,
+    SapSystemRollUpRequested
   }
 
   alias Trento.Domain.SapSystem
@@ -847,6 +850,130 @@ defmodule Trento.SapSystemTest do
         ],
         fn state ->
           assert %SapSystem{health: :warning} = state
+        end
+      )
+    end
+  end
+
+  describe "rollup" do
+    test "should not accept a rollup command if a sap_system was not registered yet" do
+      assert_error(
+        RollUpSapSystem.new!(%{sap_system_id: Faker.UUID.v4()}),
+        {:error, :sap_system_not_registered}
+      )
+    end
+
+    test "should change the sap_system state to rolling up" do
+      sap_system_id = UUID.uuid4()
+      sid = UUID.uuid4()
+
+      database_instance_registered_event =
+        build(:database_instance_registered_event, sap_system_id: sap_system_id, sid: sid)
+
+      events = [
+        build(:database_registered_event, sap_system_id: sap_system_id, sid: sid),
+        database_instance_registered_event,
+        build(:sap_system_registered_event, sap_system_id: sap_system_id, sid: sid)
+      ]
+
+      assert_events_and_state(
+        events,
+        RollUpSapSystem.new!(%{sap_system_id: sap_system_id}),
+        %SapSystemRollUpRequested{
+          sap_system_id: sap_system_id,
+          snapshot: %SapSystem{
+            sap_system_id: sap_system_id,
+            sid: sid,
+            health: :passing,
+            database: %SapSystem.Database{
+              sid: sid,
+              health: :passing,
+              instances: [
+                %SapSystem.Instance{
+                  sid: sid,
+                  instance_number: database_instance_registered_event.instance_number,
+                  health: database_instance_registered_event.health,
+                  features: database_instance_registered_event.features,
+                  host_id: database_instance_registered_event.host_id,
+                  system_replication: database_instance_registered_event.system_replication,
+                  system_replication_status:
+                    database_instance_registered_event.system_replication_status
+                }
+              ]
+            },
+            rolling_up: false
+          }
+        },
+        fn %SapSystem{rolling_up: rolling_up} ->
+          assert rolling_up
+        end
+      )
+    end
+
+    test "should not accept commands if a sap_system is in rolling up state" do
+      sap_system_id = UUID.uuid4()
+      sid = UUID.uuid4()
+
+      events = [
+        build(:database_registered_event, sap_system_id: sap_system_id, sid: sid),
+        build(:database_instance_registered_event, sap_system_id: sap_system_id, sid: sid),
+        build(:sap_system_registered_event, sap_system_id: sap_system_id, sid: sid),
+        %SapSystemRollUpRequested{
+          sap_system_id: sap_system_id,
+          snapshot: %SapSystem{}
+        }
+      ]
+
+      assert_error(
+        events,
+        RegisterDatabaseInstance.new!(%{
+          sap_system_id: sap_system_id,
+          sid: Faker.StarWars.planet(),
+          tenant: Faker.UUID.v4(),
+          host_id: Faker.UUID.v4(),
+          instance_number: "00",
+          features: Faker.Pokemon.name(),
+          http_port: 8080,
+          https_port: 8443,
+          health: :passing
+        }),
+        {:error, :sap_system_rolling_up}
+      )
+
+      assert_error(
+        events,
+        RollUpSapSystem.new!(%{
+          sap_system_id: sap_system_id
+        }),
+        {:error, :sap_system_rolling_up}
+      )
+    end
+
+    test "should apply the rollup event and rehydrate the aggregate" do
+      sap_system_id = UUID.uuid4()
+
+      sap_system_registered_event =
+        build(:sap_system_registered_event, sap_system_id: sap_system_id)
+
+      assert_state(
+        [
+          sap_system_registered_event,
+          %SapSystemRolledUp{
+            sap_system_id: sap_system_id,
+            snapshot: %SapSystem{
+              sap_system_id: sap_system_registered_event.sap_system_id,
+              sid: sap_system_registered_event.sid,
+              health: sap_system_registered_event.health,
+              rolling_up: false
+            }
+          }
+        ],
+        [],
+        fn sap_system ->
+          refute sap_system.rolling_up
+          assert sap_system.sap_system_id == sap_system_registered_event.sap_system_id
+          assert sap_system.sid == sap_system_registered_event.sid
+          assert sap_system.health == sap_system_registered_event.health
         end
       )
     end

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -870,14 +870,14 @@ defmodule Trento.SapSystemTest do
       database_instance_registered_event =
         build(:database_instance_registered_event, sap_system_id: sap_system_id, sid: sid)
 
-      events = [
+      initial_events = [
         build(:database_registered_event, sap_system_id: sap_system_id, sid: sid),
         database_instance_registered_event,
         build(:sap_system_registered_event, sap_system_id: sap_system_id, sid: sid)
       ]
 
       assert_events_and_state(
-        events,
+        initial_events,
         RollUpSapSystem.new!(%{sap_system_id: sap_system_id}),
         %SapSystemRollUpRequested{
           sap_system_id: sap_system_id,
@@ -914,7 +914,7 @@ defmodule Trento.SapSystemTest do
       sap_system_id = UUID.uuid4()
       sid = UUID.uuid4()
 
-      events = [
+      initial_events = [
         build(:database_registered_event, sap_system_id: sap_system_id, sid: sid),
         build(:database_instance_registered_event, sap_system_id: sap_system_id, sid: sid),
         build(:sap_system_registered_event, sap_system_id: sap_system_id, sid: sid),
@@ -925,7 +925,7 @@ defmodule Trento.SapSystemTest do
       ]
 
       assert_error(
-        events,
+        initial_events,
         RegisterDatabaseInstance.new!(%{
           sap_system_id: sap_system_id,
           sid: Faker.StarWars.planet(),
@@ -941,7 +941,7 @@ defmodule Trento.SapSystemTest do
       )
 
       assert_error(
-        events,
+        initial_events,
         RollUpSapSystem.new!(%{
           sap_system_id: sap_system_id
         }),


### PR DESCRIPTION
# Description

This PR continues the effort started by PRs  #1009 and  #1237 to implement rollup for the sap system. Check the description of PR #544 for more information about what exactly rollups are.


## How was this tested?
Tests have been added to:
 - ensure sap system aggregate correctly handles all rollup scenarios
 - rollup is triggered when it should
