### PR TITLE
Handle properly the not found scenario in exporters_status

### DIFF
--- a/lib/trento_web/controllers/v1/prometheus_controller.ex
+++ b/lib/trento_web/controllers/v1/prometheus_controller.ex
@@ -32,13 +32,17 @@ defmodule TrentoWeb.V1.PrometheusController do
     responses: [
       ok:
         {"The status for the prometheus exporter", "application/json",
-         Schema.Prometheus.ExporterStatus}
+         Schema.Prometheus.ExporterStatus},
+      not_found: Schema.NotFound.response()
     ]
 
   def exporters_status(conn, %{"id" => host_id}) do
     case Prometheus.get_exporters_status(host_id) do
       {:ok, exporters_status} ->
         render(conn, "exporters_status.json", status: exporters_status)
+
+      {:error, :host_not_found} ->
+        {:error, {:not_found, "Host not found"}}
 
       {:error, reason} ->
         Logger.error("Failed to get exporters status:", error: inspect(reason))

--- a/test/trento/application/integration/prometheus/adapters/prometheus_api_test.exs
+++ b/test/trento/application/integration/prometheus/adapters/prometheus_api_test.exs
@@ -1,0 +1,10 @@
+defmodule Trento.Integration.Prometheus.PrometheusApiTest do
+  use ExUnit.Case
+  use Trento.DataCase
+
+  alias Trento.Integration.Prometheus.PrometheusApi
+
+  test "should return host not found is the host is not registered" do
+    assert {:error, :host_not_found} == PrometheusApi.get_exporters_status(Faker.UUID.v4())
+  end
+end


### PR DESCRIPTION
Add `not found` specific error to the prometheus `exporters_status` endpoint. The code checks if the host was registered, and if not, it returns not found
