### PR TITLE
Cluster deregistration process manager & aggregate changes

### DIFF
--- a/lib/trento/application/process_managers/deregistration_process_manager.ex
+++ b/lib/trento/application/process_managers/deregistration_process_manager.ex
@@ -29,6 +29,7 @@ defmodule Trento.DeregistrationProcessManager do
     HostDeregistered,
     HostDeregistrationRequested,
     HostRegistered,
+    HostRemovedFromCluster,
     HostRolledUp
   }
 
@@ -53,6 +54,7 @@ defmodule Trento.DeregistrationProcessManager do
   def interested?(%ClusterRolledUp{snapshot: %{hosts: hosts}}), do: {:start, hosts}
 
   def interested?(%HostDeregistrationRequested{host_id: host_id}), do: {:continue, host_id}
+  def interested?(%HostRemovedFromCluster{host_id: host_id}), do: {:continue, host_id}
 
   def interested?(%HostDeregistered{host_id: host_id}), do: {:stop, host_id}
 
@@ -91,5 +93,9 @@ defmodule Trento.DeregistrationProcessManager do
         cluster_id: cluster_id
       }) do
     %DeregistrationProcessManager{state | cluster_id: cluster_id}
+  end
+
+  def apply(%DeregistrationProcessManager{} = state, %HostRemovedFromCluster{}) do
+    %DeregistrationProcessManager{state | cluster_id: nil}
   end
 end

--- a/lib/trento/application/process_managers/deregistration_process_manager.ex
+++ b/lib/trento/application/process_managers/deregistration_process_manager.ex
@@ -18,19 +18,24 @@ defmodule Trento.DeregistrationProcessManager do
     name: "deregistration_process_manager"
 
   deftype do
-    field :host_id, Ecto.UUID
+    field :cluster_id, Ecto.UUID
   end
 
   alias Trento.DeregistrationProcessManager
 
   alias Trento.Domain.Events.{
+    ClusterRolledUp,
+    HostAddedToCluster,
     HostDeregistered,
     HostDeregistrationRequested,
     HostRegistered,
     HostRolledUp
   }
 
-  alias Trento.Domain.Commands.DeregisterHost
+  alias Trento.Domain.Commands.{
+    DeregisterClusterHost,
+    DeregisterHost
+  }
 
   @doc """
     The process manager is interested in HostRegistered which starts or joins an existing process
@@ -44,22 +49,47 @@ defmodule Trento.DeregistrationProcessManager do
   """
   def interested?(%HostRegistered{host_id: host_id}), do: {:start, host_id}
   def interested?(%HostRolledUp{host_id: host_id}), do: {:start, host_id}
+  def interested?(%HostAddedToCluster{host_id: host_id}), do: {:start, host_id}
+  def interested?(%ClusterRolledUp{snapshot: %{hosts: hosts}}), do: {:start, hosts}
+
   def interested?(%HostDeregistrationRequested{host_id: host_id}), do: {:continue, host_id}
+
   def interested?(%HostDeregistered{host_id: host_id}), do: {:stop, host_id}
+
   def interested?(_event), do: false
 
-  def handle(%DeregistrationProcessManager{}, %HostDeregistrationRequested{
+  # Deregister host that doesn't belong to any cluster
+  def handle(%DeregistrationProcessManager{cluster_id: nil}, %HostDeregistrationRequested{
         host_id: host_id,
         requested_at: requested_at
       }) do
     %DeregisterHost{host_id: host_id, deregistered_at: requested_at}
   end
 
-  def apply(%DeregistrationProcessManager{} = state, %HostRegistered{host_id: host_id}) do
-    %DeregistrationProcessManager{state | host_id: host_id}
+  # First step in host deregistration when host belongs to a cluster
+  def handle(%DeregistrationProcessManager{cluster_id: cluster_id}, %HostDeregistrationRequested{
+        host_id: host_id,
+        requested_at: requested_at
+      }) do
+    [
+      %DeregisterClusterHost{
+        host_id: host_id,
+        cluster_id: cluster_id,
+        deregistered_at: requested_at
+      },
+      %DeregisterHost{host_id: host_id, deregistered_at: requested_at}
+    ]
   end
 
-  def apply(%DeregistrationProcessManager{} = state, %HostRolledUp{host_id: host_id}) do
-    %DeregistrationProcessManager{state | host_id: host_id}
+  def apply(%DeregistrationProcessManager{} = state, %ClusterRolledUp{
+        cluster_id: cluster_id
+      }) do
+    %DeregistrationProcessManager{state | cluster_id: cluster_id}
+  end
+
+  def apply(%DeregistrationProcessManager{} = state, %HostAddedToCluster{
+        cluster_id: cluster_id
+      }) do
+    %DeregistrationProcessManager{state | cluster_id: cluster_id}
   end
 end

--- a/lib/trento/application/process_managers/deregistration_process_manager.ex
+++ b/lib/trento/application/process_managers/deregistration_process_manager.ex
@@ -48,14 +48,15 @@ defmodule Trento.DeregistrationProcessManager do
 
     The process manager starts with a Deregistration request and stops when the host is fully deregistered.
   """
+  # Start the Process Manager
   def interested?(%HostRegistered{host_id: host_id}), do: {:start, host_id}
   def interested?(%HostRolledUp{host_id: host_id}), do: {:start, host_id}
   def interested?(%HostAddedToCluster{host_id: host_id}), do: {:start, host_id}
   def interested?(%ClusterRolledUp{snapshot: %{hosts: hosts}}), do: {:start, hosts}
-
+  # Continue the Process Manager
   def interested?(%HostDeregistrationRequested{host_id: host_id}), do: {:continue, host_id}
   def interested?(%HostRemovedFromCluster{host_id: host_id}), do: {:continue, host_id}
-
+  # Stop the Process Manager
   def interested?(%HostDeregistered{host_id: host_id}), do: {:stop, host_id}
 
   def interested?(_event), do: false

--- a/lib/trento/domain/cluster/cluster.ex
+++ b/lib/trento/domain/cluster/cluster.ex
@@ -504,16 +504,16 @@ defmodule Trento.Domain.Cluster do
   end
 
   defp maybe_emit_cluster_deregistered_event(
-         %Cluster{cluster_id: cluster_id, hosts: hosts},
+         %Cluster{cluster_id: cluster_id, hosts: []},
          %DeregisterClusterHost{
            cluster_id: cluster_id,
            deregistered_at: deregistered_at
          }
        ) do
-    if Enum.empty?(hosts) do
-      %ClusterDeregistered{cluster_id: cluster_id, deregistered_at: deregistered_at}
-    end
+    %ClusterDeregistered{cluster_id: cluster_id, deregistered_at: deregistered_at}
   end
+
+  defp maybe_emit_cluster_deregistered_event(_, _), do: nil
 
   defp maybe_add_checks_health(healths, _, []), do: healths
   defp maybe_add_checks_health(healths, checks_health, _), do: [checks_health | healths]

--- a/lib/trento/domain/cluster/cluster.ex
+++ b/lib/trento/domain/cluster/cluster.ex
@@ -277,12 +277,10 @@ defmodule Trento.Domain.Cluster do
     cluster
     |> Multi.new()
     |> Multi.execute(fn _ ->
-      [
-        %HostRemovedFromCluster{
-          cluster_id: cluster_id,
-          host_id: host_id
-        }
-      ]
+      %HostRemovedFromCluster{
+        cluster_id: cluster_id,
+        host_id: host_id
+      }
     end)
     |> Multi.execute(&maybe_emit_cluster_deregistered_event(&1, command))
   end
@@ -396,10 +394,10 @@ defmodule Trento.Domain.Cluster do
     snapshot
   end
 
-  def apply(%Cluster{hosts: hosts, hosts_number: hosts_number} = cluster, %HostRemovedFromCluster{
+  def apply(%Cluster{hosts: hosts} = cluster, %HostRemovedFromCluster{
         host_id: host_id
       }) do
-    %Cluster{cluster | hosts: List.delete(hosts, host_id), hosts_number: hosts_number - 1}
+    %Cluster{cluster | hosts: List.delete(hosts, host_id)}
   end
 
   # Deregistration
@@ -506,13 +504,13 @@ defmodule Trento.Domain.Cluster do
   end
 
   defp maybe_emit_cluster_deregistered_event(
-         %Cluster{cluster_id: cluster_id, hosts_number: hosts_number},
+         %Cluster{cluster_id: cluster_id, hosts: hosts},
          %DeregisterClusterHost{
            cluster_id: cluster_id,
            deregistered_at: deregistered_at
          }
        ) do
-    if hosts_number == 0 do
+    if length(hosts) == 0 do
       %ClusterDeregistered{cluster_id: cluster_id, deregistered_at: deregistered_at}
     end
   end

--- a/lib/trento/domain/cluster/cluster.ex
+++ b/lib/trento/domain/cluster/cluster.ex
@@ -510,7 +510,7 @@ defmodule Trento.Domain.Cluster do
            deregistered_at: deregistered_at
          }
        ) do
-    if length(hosts) == 0 do
+    if Enum.empty?(hosts) do
       %ClusterDeregistered{cluster_id: cluster_id, deregistered_at: deregistered_at}
     end
   end

--- a/lib/trento/domain/cluster/lifespan.ex
+++ b/lib/trento/domain/cluster/lifespan.ex
@@ -9,13 +9,21 @@ defmodule Trento.Domain.Cluster.Lifespan do
 
   alias Commanded.Aggregates.DefaultLifespan
 
-  alias Trento.Domain.Events.ClusterRollUpRequested
+  alias Trento.Domain.Events.{
+    ClusterDeregistered,
+    ClusterRollUpRequested
+  }
 
   @doc """
   The cluster aggregate will be stopped after a ClusterRollUpRequested event is received.
   This is needed to reset the aggregate version, so the aggregate can start appending events to the new stream.
+
+  The cluster aggregate will be stopped after a ClusterDeregistered event is received.
+  This event is emitted when all hosts belonging to a cluster have been decommissioned,
+  meaning the cluster aggregate can be safely stopped.
   """
   def after_event(%ClusterRollUpRequested{}), do: :stop
+  def after_event(%ClusterDeregistered{}), do: :stop
   def after_event(event), do: DefaultLifespan.after_event(event)
 
   def after_command(command), do: DefaultLifespan.after_command(command)

--- a/lib/trento/infrastructure/router.ex
+++ b/lib/trento/infrastructure/router.ex
@@ -11,6 +11,7 @@ defmodule Trento.Router do
 
   alias Trento.Domain.Commands.{
     CompleteChecksExecution,
+    DeregisterClusterHost,
     DeregisterHost,
     RegisterApplicationInstance,
     RegisterClusterHost,
@@ -46,6 +47,7 @@ defmodule Trento.Router do
     by: :cluster_id
 
   dispatch [
+             DeregisterClusterHost,
              RollUpCluster,
              RegisterClusterHost,
              SelectChecks,

--- a/test/trento/application/process_managers/deregistration_process_manager_test.exs
+++ b/test/trento/application/process_managers/deregistration_process_manager_test.exs
@@ -65,6 +65,13 @@ defmodule Trento.DeregistrationProcessManagerTest do
       assert {:stop, ^host_id} =
                DeregistrationProcessManager.interested?(%HostDeregistered{host_id: host_id})
     end
+
+    test "should continue the process manager when HostRemovedFromCluster arrives" do
+      host_id = UUID.uuid4()
+
+      assert {:continue, ^host_id} =
+               DeregistrationProcessManager.interested?(%HostRemovedFromCluster{host_id: host_id})
+    end
   end
 
   describe "host deregistration procedure" do

--- a/test/trento/application/process_managers/deregistration_process_manager_test.exs
+++ b/test/trento/application/process_managers/deregistration_process_manager_test.exs
@@ -7,6 +7,7 @@ defmodule Trento.DeregistrationProcessManagerTest do
     HostDeregistered,
     HostDeregistrationRequested,
     HostRegistered,
+    HostRemovedFromCluster,
     HostRolledUp
   }
 
@@ -100,6 +101,22 @@ defmodule Trento.DeregistrationProcessManagerTest do
 
       assert ^initial_state = state
       assert %DeregisterHost{host_id: ^host_id, deregistered_at: ^requested_at} = commands
+    end
+
+    test "should update the state and remove the cluster id when HostRemovedFromCluster event is emitted" do
+      initial_state = %DeregistrationProcessManager{}
+      cluster_id = UUID.uuid4()
+      host_id = UUID.uuid4()
+
+      events = [
+        %HostAddedToCluster{cluster_id: cluster_id, host_id: host_id},
+        %HostRemovedFromCluster{host_id: host_id}
+      ]
+
+      {commands, state} = reduce_events(events, initial_state)
+
+      assert [] == commands
+      assert %DeregistrationProcessManager{cluster_id: nil} = state
     end
   end
 

--- a/test/trento/application/process_managers/deregistration_process_manager_test.exs
+++ b/test/trento/application/process_managers/deregistration_process_manager_test.exs
@@ -2,6 +2,8 @@ defmodule Trento.DeregistrationProcessManagerTest do
   use ExUnit.Case
 
   alias Trento.Domain.Events.{
+    ClusterRolledUp,
+    HostAddedToCluster,
     HostDeregistered,
     HostDeregistrationRequested,
     HostRegistered,
@@ -9,6 +11,7 @@ defmodule Trento.DeregistrationProcessManagerTest do
   }
 
   alias Trento.DeregistrationProcessManager
+  alias Trento.Domain.Cluster
   alias Trento.Domain.Commands.DeregisterHost
 
   describe "events interested" do
@@ -24,6 +27,22 @@ defmodule Trento.DeregistrationProcessManagerTest do
 
       assert {:start, ^host_id} =
                DeregistrationProcessManager.interested?(%HostRolledUp{host_id: host_id})
+    end
+
+    test "should start the process manager when HostAddedToCluster arrives" do
+      host_id = UUID.uuid4()
+
+      assert {:start, ^host_id} =
+               DeregistrationProcessManager.interested?(%HostAddedToCluster{host_id: host_id})
+    end
+
+    test "should start the process manager when ClusterRolledUp arrives" do
+      cluster_hosts = [UUID.uuid4(), UUID.uuid4()]
+
+      assert {:start, ^cluster_hosts} =
+               DeregistrationProcessManager.interested?(%ClusterRolledUp{
+                 snapshot: %Cluster{hosts: cluster_hosts}
+               })
     end
 
     test "should continue the process manager when HostDeregistrationRequested arrives" do
@@ -44,34 +63,36 @@ defmodule Trento.DeregistrationProcessManagerTest do
   end
 
   describe "host deregistration procedure" do
-    test "should update the state with the proper host id when HostRegistered event is emitted" do
+    test "should update the state with the proper cluster id when ClusterRolledUp event is emitted" do
       initial_state = %DeregistrationProcessManager{}
-      host_id = UUID.uuid4()
+      cluster_id = UUID.uuid4()
+      cluster_hosts = [UUID.uuid4(), UUID.uuid4()]
 
-      events = [%HostRegistered{host_id: host_id}]
+      events = [%ClusterRolledUp{cluster_id: cluster_id, snapshot: cluster_hosts}]
 
       {commands, state} = reduce_events(events, initial_state)
 
       assert [] == commands
-      assert %DeregistrationProcessManager{host_id: ^host_id} = state
+      assert %DeregistrationProcessManager{cluster_id: ^cluster_id} = state
     end
 
-    test "should update the state with the proper host when HostRolledUp event is emitted" do
+    test "should update the state with the proper cluster id when HostAddedToCluster event is emitted" do
       initial_state = %DeregistrationProcessManager{}
+      cluster_id = UUID.uuid4()
       host_id = UUID.uuid4()
 
-      events = [%HostRolledUp{host_id: host_id}]
+      events = [%HostAddedToCluster{cluster_id: cluster_id, host_id: host_id}]
 
       {commands, state} = reduce_events(events, initial_state)
 
       assert [] == commands
-      assert %DeregistrationProcessManager{host_id: ^host_id} = state
+      assert %DeregistrationProcessManager{cluster_id: ^cluster_id} = state
     end
 
     test "should dispatch DeregisterHost command when HostDeregistrationRequested is emitted" do
       host_id = UUID.uuid4()
       requested_at = DateTime.utc_now()
-      initial_state = %DeregistrationProcessManager{host_id: host_id}
+      initial_state = %DeregistrationProcessManager{}
 
       events = [%HostDeregistrationRequested{host_id: host_id, requested_at: requested_at}]
 

--- a/test/trento/domain/cluster/cluster_test.exs
+++ b/test/trento/domain/cluster/cluster_test.exs
@@ -789,7 +789,7 @@ defmodule Trento.ClusterTest do
           }
         ],
         fn cluster ->
-          assert %Cluster{hosts: [^host_2_id], hosts_number: 1} = cluster
+          assert %Cluster{hosts: [^host_2_id]} = cluster
         end
       )
     end

--- a/test/trento/domain/cluster/cluster_test.exs
+++ b/test/trento/domain/cluster/cluster_test.exs
@@ -3,7 +3,6 @@ defmodule Trento.ClusterTest do
 
   import Trento.Factory
 
-  alias Trento.Domain.Events.HostRemovedFromCluster
   alias Trento.Support.StructHelper
 
   alias Trento.Domain.Commands.{
@@ -28,7 +27,8 @@ defmodule Trento.ClusterTest do
     ClusterRolledUp,
     ClusterRollUpRequested,
     HostAddedToCluster,
-    HostChecksExecutionCompleted
+    HostChecksExecutionCompleted,
+    HostRemovedFromCluster
   }
 
   alias Trento.Domain.Cluster


### PR DESCRIPTION
# Description

This PR adds the required changes to the 
 - deregistration process manager
 - cluster aggregate
to handle the removal of a host from a cluster.

In addition to this, we've also removed the host_id from the state of the process manager as it's basically 1:1 with the `process_uuid` that identifies each instance of the process manager and is thus not needed.