### PR TITLE
Cluster deregistered side effects

### DIFF
--- a/lib/trento/application/projectors/cluster_projector.ex
+++ b/lib/trento/application/projectors/cluster_projector.ex
@@ -12,6 +12,7 @@ defmodule Trento.ClusterProjector do
 
   alias Trento.Domain.Events.{
     ChecksSelected,
+    ClusterDeregistered,
     ClusterDetailsUpdated,
     ClusterHealthChanged,
     ClusterRegistered
@@ -22,6 +23,21 @@ defmodule Trento.ClusterProjector do
   alias Trento.Repo
 
   import Trento.Clusters, only: [enrich_cluster_model: 1]
+
+  project(
+    %ClusterDeregistered{
+      cluster_id: cluster_id,
+      deregistered_at: deregistered_at
+    },
+    fn multi ->
+      changeset =
+        ClusterReadModel.changeset(%ClusterReadModel{id: cluster_id}, %{
+          deregistered_at: deregistered_at
+        })
+
+      Ecto.Multi.update(multi, :cluster, changeset)
+    end
+  )
 
   project(
     %ClusterRegistered{
@@ -147,6 +163,16 @@ defmodule Trento.ClusterProjector do
     TrentoWeb.Endpoint.broadcast("monitoring:clusters", "cluster_health_changed", %{
       cluster_id: cluster_id,
       health: health
+    })
+  end
+
+  @impl true
+  def after_update(%ClusterDeregistered{cluster_id: cluster_id}, _, _) do
+    %ClusterReadModel{name: name} = Repo.get!(ClusterReadModel, cluster_id)
+
+    TrentoWeb.Endpoint.broadcast("monitoring:clusters", "cluster_deregistered", %{
+      cluster_id: cluster_id,
+      name: name
     })
   end
 

--- a/lib/trento/application/projectors/cluster_projector.ex
+++ b/lib/trento/application/projectors/cluster_projector.ex
@@ -25,21 +25,6 @@ defmodule Trento.ClusterProjector do
   import Trento.Clusters, only: [enrich_cluster_model: 1]
 
   project(
-    %ClusterDeregistered{
-      cluster_id: cluster_id,
-      deregistered_at: deregistered_at
-    },
-    fn multi ->
-      changeset =
-        ClusterReadModel.changeset(%ClusterReadModel{id: cluster_id}, %{
-          deregistered_at: deregistered_at
-        })
-
-      Ecto.Multi.update(multi, :cluster, changeset)
-    end
-  )
-
-  project(
     %ClusterRegistered{
       cluster_id: id,
       name: name,
@@ -66,6 +51,21 @@ defmodule Trento.ClusterProjector do
         })
 
       Ecto.Multi.insert(multi, :cluster, changeset)
+    end
+  )
+
+  project(
+    %ClusterDeregistered{
+      cluster_id: cluster_id,
+      deregistered_at: deregistered_at
+    },
+    fn multi ->
+      changeset =
+        ClusterReadModel.changeset(%ClusterReadModel{id: cluster_id}, %{
+          deregistered_at: deregistered_at
+        })
+
+      Ecto.Multi.update(multi, :cluster, changeset)
     end
   )
 

--- a/lib/trento/application/projectors/host_projector.ex
+++ b/lib/trento/application/projectors/host_projector.ex
@@ -19,6 +19,7 @@ defmodule Trento.HostProjector do
     HostDeregistered,
     HostDetailsUpdated,
     HostRegistered,
+    HostRemovedFromCluster,
     ProviderUpdated
   }
 
@@ -78,6 +79,20 @@ defmodule Trento.HostProjector do
         on_conflict: {:replace, [:cluster_id]},
         conflict_target: [:id]
       )
+    end
+  )
+
+  project(
+    %HostRemovedFromCluster{
+      host_id: id
+    },
+    fn multi ->
+      query =
+        Ecto.Query.from(h in HostReadModel,
+          where: is_nil(h.deregistered_at) and h.id == ^id
+        )
+
+      Ecto.Multi.update_all(multi, :host, query, set: [cluster_id: nil])
     end
   )
 

--- a/lib/trento/application/projectors/host_projector.ex
+++ b/lib/trento/application/projectors/host_projector.ex
@@ -84,15 +84,16 @@ defmodule Trento.HostProjector do
 
   project(
     %HostRemovedFromCluster{
-      host_id: id
+      host_id: id,
+      cluster_id: cluster_id
     },
     fn multi ->
-      query =
-        Ecto.Query.from(h in HostReadModel,
-          where: is_nil(h.deregistered_at) and h.id == ^id
-        )
+      changeset =
+        HostReadModel.changeset(%HostReadModel{id: id, cluster_id: cluster_id}, %{
+          cluster_id: nil
+        })
 
-      Ecto.Multi.update_all(multi, :host, query, set: [cluster_id: nil])
+      Ecto.Multi.update(multi, :host, changeset)
     end
   )
 

--- a/lib/trento/application/read_models/cluster_read_model.ex
+++ b/lib/trento/application/read_models/cluster_read_model.ex
@@ -30,6 +30,8 @@ defmodule Trento.ClusterReadModel do
 
     # Virtually enriched fields
     field :cib_last_written, :string, virtual: true
+
+    field :deregistered_at, :utc_datetime_usec
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()

--- a/lib/trento/application/usecases/clusters/clusters.ex
+++ b/lib/trento/application/usecases/clusters/clusters.ex
@@ -35,7 +35,6 @@ defmodule Trento.Clusters do
       )
 
     query
-    |> first
     |> Repo.one()
     |> maybe_request_checks_execution()
   end

--- a/lib/trento/application/usecases/clusters/clusters.ex
+++ b/lib/trento/application/usecases/clusters/clusters.ex
@@ -67,8 +67,8 @@ defmodule Trento.Clusters do
       from(c in ClusterReadModel,
         select: c.id,
         where:
-          c.type == ^ClusterType.hana_scale_up() or
-            (c.type == ^ClusterType.hana_scale_out() and is_nil(c.deregistered_at))
+          (c.type == ^ClusterType.hana_scale_up() or
+             c.type == ^ClusterType.hana_scale_out()) and is_nil(c.deregistered_at)
       )
 
     query

--- a/priv/repo/migrations/20230323161309_add_deregistered_at_to_cluster_read_model.exs
+++ b/priv/repo/migrations/20230323161309_add_deregistered_at_to_cluster_read_model.exs
@@ -1,0 +1,9 @@
+defmodule Trento.Repo.Migrations.AddDeregisteredAtToClusterReadModel do
+  use Ecto.Migration
+
+  def change do
+    alter table(:clusters) do
+      add :deregistered_at, :utc_datetime_usec
+    end
+  end
+end

--- a/test/trento/application/projectors/cluster_projector_test.exs
+++ b/test/trento/application/projectors/cluster_projector_test.exs
@@ -189,7 +189,7 @@ defmodule Trento.ClusterProjectorTest do
   end
 
   test "should update the deregistered_at field when ClusterDeregistered is received" do
-    insert(:cluster, id: cluster_id = Faker.UUID.v4())
+    insert(:cluster, id: cluster_id = Faker.UUID.v4(), name: name = "deregistered_cluster")
     deregistered_at = DateTime.utc_now()
 
     event = ClusterDeregistered.new!(%{cluster_id: cluster_id, deregistered_at: deregistered_at})
@@ -198,6 +198,10 @@ defmodule Trento.ClusterProjectorTest do
     cluster_projection = Repo.get!(ClusterReadModel, event.cluster_id)
 
     assert event.deregistered_at == cluster_projection.deregistered_at
+
+    assert_broadcast "cluster_deregistered",
+                     %{cluster_id: ^cluster_id, name: ^name},
+                     1000
   end
 
   test "should broadcast cluster_health_changed after the ClusterHealthChanged event" do

--- a/test/trento/application/projectors/host_projector_test.exs
+++ b/test/trento/application/projectors/host_projector_test.exs
@@ -26,6 +26,7 @@ defmodule Trento.HostProjectorTest do
     HostAddedToCluster,
     HostDeregistered,
     HostDetailsUpdated,
+    HostRemovedFromCluster,
     ProviderUpdated
   }
 
@@ -127,6 +128,27 @@ defmodule Trento.HostProjectorTest do
     assert nil == host_projection.hostname
 
     refute_broadcast "host_details_updated", %{id: ^host_id, cluster_id: ^cluster_id}, 1000
+  end
+
+  test "should project a host without the cluster when HostRemovedFromCluster event is received and the host is not deregistered yet" do
+    insert(:cluster, id: cluster_id = Faker.UUID.v4())
+
+    insert(
+      :host,
+      id: host_id = UUID.uuid4(),
+      hostname: Faker.StarWars.character(),
+      cluster_id: cluster_id
+    )
+
+    event = %HostRemovedFromCluster{
+      host_id: host_id,
+      cluster_id: cluster_id
+    }
+
+    ProjectorTestHelper.project(HostProjector, event, "host_projector")
+    projection = Repo.get!(HostReadModel, host_id)
+
+    assert nil == projection.cluster_id
   end
 
   test "should update an existing host when HostDetailsUpdated event is received", %{

--- a/test/trento/application/projectors/host_projector_test.exs
+++ b/test/trento/application/projectors/host_projector_test.exs
@@ -130,7 +130,7 @@ defmodule Trento.HostProjectorTest do
     refute_broadcast "host_details_updated", %{id: ^host_id, cluster_id: ^cluster_id}, 1000
   end
 
-  test "should project a host without the cluster when HostRemovedFromCluster event is received and the host is not deregistered yet" do
+  test "should project a host without the cluster when HostRemovedFromCluster event is received" do
     insert(:cluster, id: cluster_id = Faker.UUID.v4())
 
     insert(

--- a/test/trento/application/usecases/clusters_test.exs
+++ b/test/trento/application/usecases/clusters_test.exs
@@ -59,12 +59,23 @@ defmodule Trento.ClustersTest do
   end
 
   describe "get clusters" do
-    test "should return enriched clusters" do
+    test "should not return soft deleted clusters" do
       cib_last_written = Date.to_string(Faker.Date.forward(0))
       cluster_id = Faker.UUID.v4()
 
       insert(:cluster, id: cluster_id)
       insert(:cluster, deregistered_at: DateTime.utc_now())
+      insert(:cluster_enrichment_data, cluster_id: cluster_id)
+
+      [%ClusterReadModel{id: ^cluster_id, cib_last_written: ^cib_last_written}] =
+        Clusters.get_all_clusters()
+    end
+
+    test "should return enriched clusters" do
+      cib_last_written = Date.to_string(Faker.Date.forward(0))
+      cluster_id = Faker.UUID.v4()
+
+      insert(:cluster, id: cluster_id)
       insert(:cluster_enrichment_data, cluster_id: cluster_id)
 
       [%ClusterReadModel{id: ^cluster_id, cib_last_written: ^cib_last_written}] =

--- a/test/trento/application/usecases/clusters_test.exs
+++ b/test/trento/application/usecases/clusters_test.exs
@@ -64,6 +64,7 @@ defmodule Trento.ClustersTest do
       cluster_id = Faker.UUID.v4()
 
       insert(:cluster, id: cluster_id)
+      insert(:cluster, deregistered_at: DateTime.utc_now())
       insert(:cluster_enrichment_data, cluster_id: cluster_id)
 
       [%ClusterReadModel{id: ^cluster_id, cib_last_written: ^cib_last_written}] =


### PR DESCRIPTION
# Description

ClusterReadModel soft delete side effects.

We should exclude from the query in which is involved the `ClusterReadModel`, the soft-deleted entities.

This Schema is not involved in any association.

## How was this tested?

Automated tests
