### PR TITLE
Fix Hosts query without the soft deleted hosts exclusion

### DIFF
--- a/lib/trento/application/integration/prometheus/prometheus.ex
+++ b/lib/trento/application/integration/prometheus/prometheus.ex
@@ -3,13 +3,11 @@ defmodule Trento.Integration.Prometheus do
   Prometheus integration service
   """
 
-  alias Trento.Repo
-
-  alias Trento.HostReadModel
+  alias Trento.Hosts
 
   @spec get_targets :: [map]
   def get_targets do
-    Repo.all(HostReadModel)
+    Hosts.get_all_hosts()
   end
 
   @spec get_exporters_status(String.t()) :: {:ok, map} | {:error, any}

--- a/lib/trento/application/usecases/clusters/clusters.ex
+++ b/lib/trento/application/usecases/clusters/clusters.ex
@@ -108,7 +108,7 @@ defmodule Trento.Clusters do
       Repo.all(
         from h in HostReadModel,
           select: %{host_id: h.id},
-          where: h.cluster_id == ^cluster_id
+          where: h.cluster_id == ^cluster_id and is_nil(h.deregistered_at)
       )
 
     Checks.request_execution(

--- a/test/trento/application/usecases/clusters_test.exs
+++ b/test/trento/application/usecases/clusters_test.exs
@@ -17,11 +17,12 @@ defmodule Trento.ClustersTest do
   describe "checks execution with wanda adapter" do
     test "should start a checks execution on demand if checks are selected" do
       %{id: cluster_id} = insert(:cluster)
+      insert(:host, deregistered_at: DateTime.utc_now(), cluster_id: cluster_id)
       insert_list(2, :host, cluster_id: cluster_id)
 
       expect(Trento.Infrastructure.Messaging.Adapter.Mock, :publish, fn "executions", message ->
         assert message.group_id == cluster_id
-
+        assert length(message.targets) == 2
         :ok
       end)
 

--- a/test/trento_web/controllers/v1/prometheus_controller_test.exs
+++ b/test/trento_web/controllers/v1/prometheus_controller_test.exs
@@ -8,13 +8,20 @@ defmodule TrentoWeb.V1.PrometheusControllerTest do
   import Trento.Factory
 
   test "should return the expected targets", %{conn: conn} do
+    insert(:host, deregistered_at: DateTime.utc_now())
     insert_list(2, :host)
+
     api_spec = ApiSpec.spec()
 
-    conn
-    |> get("/api/v1/prometheus/targets")
-    |> json_response(200)
-    |> assert_schema("HttpSTDTargetList", api_spec)
+    response =
+      conn
+      |> get("/api/v1/prometheus/targets")
+      |> json_response(200)
+
+    targets_ids = Enum.map(response, &Map.get(&1, "labels")["agentID"])
+
+    assert length(targets_ids) == 2
+    assert_schema(response, "HttpSTDTargetList", api_spec)
   end
 
   test "should return the expected targets when some host does not have any IP address", %{


### PR DESCRIPTION
# Description

After the PR https://github.com/trento-project/web/pull/1252, we had some HostReadModel queries without the deleted hosts excluded. 

This pr aims to fix that, adding in involved text case assertion to check that the deleted hosts are excluded.

## How was this tested?

Automated tests
