### PR TITLE
Visually identify premium checks in the ExecutionResults view

### DIFF
--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -41,7 +41,7 @@ const resultsTableConfig = {
       fontSize: 'text-base',
       className: 'bg-gray-50 border-b',
       render: (checkID, { onClick, premium }) => (
-        <div className="flex space-x-4 whitespace-nowrap text-jungle-green-500 justify-between">
+        <div className="flex  whitespace-nowrap text-jungle-green-500 justify-between">
           <span
             className="inline-block"
             aria-hidden="true"

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -6,11 +6,13 @@ import remarkGfm from 'remark-gfm';
 import Modal from '@components/Modal';
 
 import { getHostID } from '@state/selectors/cluster';
+import PremiumPill from '@components/PremiumPill';
 import {
   getCheckResults,
   getCheckDescription,
   getCheckRemediation,
   getCheckExpectations,
+  isPremium,
 } from './checksUtils';
 
 import ResultsContainer from './ResultsContainer';
@@ -38,8 +40,8 @@ const resultsTableConfig = {
       key: 'checkID',
       fontSize: 'text-base',
       className: 'bg-gray-50 border-b',
-      render: (checkID, { onClick }) => (
-        <div className="whitespace-nowrap text-jungle-green-500">
+      render: (checkID, { onClick, premium }) => (
+        <div className="flex space-x-4 whitespace-nowrap text-jungle-green-500 justify-between">
           <span
             className="inline-block"
             aria-hidden="true"
@@ -50,6 +52,7 @@ const resultsTableConfig = {
           >
             {checkID}
           </span>
+          <span>{premium ? <PremiumPill /> : ' '}</span>
         </div>
       ),
     },
@@ -124,7 +127,6 @@ function ExecutionResults({
       onLastExecutionUpdate();
     }
   };
-
   const tableData = getCheckResults(executionData)
     .filter((check) => {
       if (predicates.length === 0) {
@@ -147,6 +149,7 @@ function ExecutionResults({
         executionState: executionData?.status,
         description: getCheckDescription(catalog, checkID),
         expectations: getCheckExpectations(catalog, checkID),
+        premium: isPremium(catalog, checkID),
         expectationResults,
         agentsCheckResults: addHostnameToTargets(
           agentsCheckResults,
@@ -158,7 +161,6 @@ function ExecutionResults({
         },
       })
     );
-
   return (
     <ExecutionContainer
       catalogLoading={catalogLoading}

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -52,7 +52,7 @@ const resultsTableConfig = {
           >
             {checkID}
           </span>
-          <span>{premium ? <PremiumPill /> : ' '}</span>
+          {premium && <PremiumPill />}
         </div>
       ),
     },

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -41,9 +41,9 @@ const resultsTableConfig = {
       fontSize: 'text-base',
       className: 'bg-gray-50 border-b',
       render: (checkID, { onClick, premium }) => (
-        <div className="flex  whitespace-nowrap text-jungle-green-500 justify-between">
+        <div className="flex whitespace-nowrap text-jungle-green-500 justify-between">
           <span
-            className="inline-block"
+            className="inline-flex leading-5"
             aria-hidden="true"
             onClick={(e) => {
               e.stopPropagation();
@@ -52,7 +52,7 @@ const resultsTableConfig = {
           >
             {checkID}
           </span>
-          {premium && <PremiumPill />}
+          {premium && <PremiumPill className="ml-1" />}
         </div>
       ),
     },

--- a/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
@@ -542,7 +542,6 @@ describe('ExecutionResults', () => {
     const checkID = screen.getByText(checks[0]);
     const tableDataID = checkID.closest('div');
     expect(tableDataID).toHaveTextContent('Premium');
-    expect(screen.getByText('Premium')).toBeVisible();
     expect(screen.getAllByText('Premium')).toHaveLength(1);
   });
 });

--- a/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
@@ -70,6 +70,7 @@ const prepareStateData = (checkExecutionStatus) => {
       catalogCheckFactory.build({
         id: checkID1,
         description: aCheckDescription,
+        premium: true,
         expectations: [
           catalogExpectExpectationFactory.build({
             name: expectationName1,
@@ -85,6 +86,7 @@ const prepareStateData = (checkExecutionStatus) => {
       catalogCheckFactory.build({
         id: checkID2,
         description: anotherCheckDescription,
+        premium: false,
         expectations: [
           catalogExpectExpectationFactory.build({
             name: expectationName4,
@@ -510,5 +512,34 @@ describe('ExecutionResults', () => {
     expect(screen.getByText(description).textContent).toBe(description);
     userEvent.click(screen.getByText(description));
     expect(screen.queryByText(remediation)).not.toBeInTheDocument();
+  });
+
+  it('should render PremiumPill if a check in catalog is premium', () => {
+    const {
+      clusterID,
+      clusterHosts,
+      loading,
+      catalog,
+      executionError,
+      executionStarted,
+      executionResult,
+      checks,
+    } = prepareStateData('completed');
+
+    renderWithRouter(
+      <ExecutionResults
+        clusterID={clusterID}
+        clusterHosts={clusterHosts}
+        catalogLoading={loading}
+        catalog={catalog}
+        executionLoading={loading}
+        executionStarted={executionStarted}
+        executionData={executionResult}
+        executionError={executionError}
+        clusterSelectedChecks={checks}
+      />
+    );
+    expect(screen.getByText('Premium')).toBeVisible();
+    expect(screen.getAllByText('Premium')).toHaveLength(1);
   });
 });

--- a/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.test.jsx
@@ -525,7 +525,6 @@ describe('ExecutionResults', () => {
       executionResult,
       checks,
     } = prepareStateData('completed');
-
     renderWithRouter(
       <ExecutionResults
         clusterID={clusterID}
@@ -539,6 +538,10 @@ describe('ExecutionResults', () => {
         clusterSelectedChecks={checks}
       />
     );
+
+    const checkID = screen.getByText(checks[0]);
+    const tableDataID = checkID.closest('div');
+    expect(tableDataID).toHaveTextContent('Premium');
     expect(screen.getByText('Premium')).toBeVisible();
     expect(screen.getAllByText('Premium')).toHaveLength(1);
   });

--- a/assets/js/components/ExecutionResults/checksUtils.js
+++ b/assets/js/components/ExecutionResults/checksUtils.js
@@ -102,6 +102,14 @@ export const getCheckHealthByAgent = (checkResults, checkID, agentID) => {
   };
 };
 
+export const isPremium = (catalog, checkID) => {
+  const check = findCheck(catalog, checkID);
+  if (check) {
+    return check.premium;
+  }
+  return false;
+};
+
 export const getCheckDescription = (catalog, checkID) => {
   const check = findCheck(catalog, checkID);
   if (check) {

--- a/assets/js/components/ExecutionResults/checksUtils.test.js
+++ b/assets/js/components/ExecutionResults/checksUtils.test.js
@@ -20,6 +20,7 @@ import {
   getCheckHealthByAgent,
   getHosts,
   getCheckExpectations,
+  isPremium,
 } from './checksUtils';
 
 describe('checksUtils', () => {
@@ -178,6 +179,30 @@ describe('checksUtils', () => {
       const { health } = getCheckHealthByAgent([checkResult], checkID, agentID);
 
       expect(health).toBe('warning');
+    });
+
+    it('should return true or false if a check is premium or not', () => {
+      const checkIds = [
+        faker.datatype.uuid(),
+        faker.datatype.uuid(),
+        faker.datatype.uuid(),
+        faker.datatype.uuid(),
+      ];
+      const expectedPremiumValues = [
+        true,
+        false,
+        undefined,
+        faker.animal.cat(),
+      ];
+      const checkCatalog = checkIds.map((id, index) =>
+        catalogCheckFactory.build({ id, premium: expectedPremiumValues[index] })
+      );
+
+      checkIds.forEach((checkId, index) => {
+        expect(isPremium(checkCatalog, checkId)).toBe(
+          expectedPremiumValues[index]
+        );
+      });
     });
   });
 });

--- a/assets/js/components/ExecutionResults/checksUtils.test.js
+++ b/assets/js/components/ExecutionResults/checksUtils.test.js
@@ -182,7 +182,7 @@ describe('checksUtils', () => {
     });
 
     it('should return true or false if a check is premium or not', () => {
-      const checkIds = [
+      const checkIDs = [
         faker.datatype.uuid(),
         faker.datatype.uuid(),
         faker.datatype.uuid(),
@@ -194,12 +194,12 @@ describe('checksUtils', () => {
         undefined,
         faker.animal.cat(),
       ];
-      const checkCatalog = checkIds.map((id, index) =>
+      const checkCatalog = checkIDs.map((id, index) =>
         catalogCheckFactory.build({ id, premium: expectedPremiumValues[index] })
       );
 
-      checkIds.forEach((checkId, index) => {
-        expect(isPremium(checkCatalog, checkId)).toBe(
+      checkIDs.forEach((checkID, index) => {
+        expect(isPremium(checkCatalog, checkID)).toBe(
           expectedPremiumValues[index]
         );
       });


### PR DESCRIPTION
# Description
Adding Premium Pill to the ExecutionResults view to identify premium checks.
If a check is premium, the PremiumPill is rendered next to the CheckID of the check.

## Screenshot
## 1280 x 480
![Screenshot from 2023-04-03 14-19-29](https://user-images.githubusercontent.com/54111255/229507659-20a8db27-34b0-4989-a74f-b41aa2f13898.png)



##  1660 x 480
![Screenshot from 2023-04-03 14-20-26](https://user-images.githubusercontent.com/54111255/229507686-b82992fe-a2ee-4705-92bd-03623e4e7ae9.png)



## How was this tested?
Added test if a premium pill is rendered
Added test for checkUtils isPremium function