### PR TITLE
Capture tests logs

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -33,5 +33,5 @@ Application.put_env(:joken, :current_time_adapter, Joken.CurrentTime.Mock)
 
 Application.ensure_all_started(:ex_machina, :faker)
 
-ExUnit.start()
+ExUnit.start(capture_log: true)
 Ecto.Adapters.SQL.Sandbox.mode(Trento.Repo, :manual)

--- a/test/trento/application/integration/checks/consumer_test.exs
+++ b/test/trento/application/integration/checks/consumer_test.exs
@@ -27,7 +27,6 @@ defmodule Trento.Integration.Checks.AMQP.ConsumerTest do
   end
 
   describe "handle_error/1" do
-    @tag capture_log: true
     test "should reject unknown events and move them to the dead letter queue" do
       pid = self()
 

--- a/test/trento/application/integration/checks/processor_test.exs
+++ b/test/trento/application/integration/checks/processor_test.exs
@@ -106,7 +106,6 @@ defmodule Trento.Integration.Checks.AMQP.ProcessorTest do
       refute_broadcast "checks_execution_completed", %{cluster_id: ^group_id}, 1000
     end
 
-    @tag capture_log: true
     test "should return error if the event cannot be decoded" do
       message = %GenRMQ.Message{payload: "bad-payload", attributes: %{}, channel: nil}
       assert {:error, :decoding_error} = Processor.process(message)

--- a/test/trento/application/integration/discovery/discovery_test.exs
+++ b/test/trento/application/integration/discovery/discovery_test.exs
@@ -106,7 +106,6 @@ defmodule Trento.Integration.DiscoveryTest do
     assert 0 == DiscardedDiscoveryEvent |> Trento.Repo.all() |> length()
   end
 
-  @tag capture_log: true
   test "should discard discovery events with invalid payload" do
     event = %{
       "agent_id" => "invalid_uuid",

--- a/test/trento/support/event_handler_failure_context_test.exs
+++ b/test/trento/support/event_handler_failure_context_test.exs
@@ -10,7 +10,6 @@ defmodule Trento.Support.EventHandlerFailureContextTest do
     {:ok, %{handler: handler}}
   end
 
-  @tag :capture_log
   test "should retry 3 times before shutting down and call the callback functions", %{
     handler: handler
   } do

--- a/test/trento_web/controllers/v1/prometheus_controller_test.exs
+++ b/test/trento_web/controllers/v1/prometheus_controller_test.exs
@@ -70,7 +70,6 @@ defmodule TrentoWeb.V1.PrometheusControllerTest do
            } = response
   end
 
-  @tag capture_log: true
   test "should return a 500 if the exporters status cannot be fetched", %{conn: conn} do
     expect(Trento.Integration.Prometheus.Mock, :get_exporters_status, fn _ ->
       {:error, :reason}


### PR DESCRIPTION
Stop logged output from showing up for all tests.
If the tests are not passing, logs are displayed