### PR TITLE
Database registration changes

### DIFF
--- a/lib/trento/application/usecases/clusters/clusters.ex
+++ b/lib/trento/application/usecases/clusters/clusters.ex
@@ -126,10 +126,9 @@ defmodule Trento.Clusters do
        }) do
     hosts_data =
       Repo.all(
-        from(h in HostReadModel,
+        from h in HostReadModel,
           select: %{host_id: h.id},
           where: h.cluster_id == ^cluster_id and is_nil(h.deregistered_at)
-        )
       )
 
     Checks.request_execution(

--- a/lib/trento/application/usecases/clusters/clusters.ex
+++ b/lib/trento/application/usecases/clusters/clusters.ex
@@ -126,9 +126,10 @@ defmodule Trento.Clusters do
        }) do
     hosts_data =
       Repo.all(
-        from h in HostReadModel,
+        from(h in HostReadModel,
           select: %{host_id: h.id},
           where: h.cluster_id == ^cluster_id and is_nil(h.deregistered_at)
+        )
       )
 
     Checks.request_execution(

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -90,10 +90,9 @@ defmodule Trento.Domain.SapSystem do
   end
 
   def execute(
-        %SapSystem{},
+        %SapSystem{sap_system_id: nil},
         %RegisterDatabaseInstance{
-          system_replication: "Secondary",
-          system_replication_status: "ACTIVE"
+          system_replication: "Secondary"
         }
       ),
       do: {:error, :sap_system_not_registered}

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -96,7 +96,7 @@ defmodule Trento.Domain.SapSystem do
           system_replication_status: "ACTIVE"
         }
       ),
-      do: {:error, :database_instance_not_primary}
+      do: {:error, :sap_system_not_registered}
 
   # First time that a Database instance is registered, the SAP System starts its registration process.
   # We accept the database instance when the system replication is disabled or when enabled, only if the database

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -98,7 +98,7 @@ defmodule Trento.Domain.SapSystem do
       do: {:error, :sap_system_not_registered}
 
   # First time that a Database instance is registered, the SAP System starts its registration process.
-  # Database instance are accepted when the system replication is disabled or when enabled, only if the database
+  # Database instances are accepted when the system replication is disabled or when enabled, only if the database
   # has a primary role
   # When an Application is discovered, the SAP System completes the registration process.
   def execute(

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -28,8 +28,9 @@ defmodule Trento.Domain.SapSystem do
 
   That being said, this is the logical order of events in order to register a full system:
 
-  1. A SAP system discovery message with a new database instance is received. At this point, the
-     registration process starts and the database is registered.
+  1. A SAP system discovery message with a new database instance is received.
+     We ignore database with Secondary role in a system replicated scenarios.
+     At this point, the registration process starts and the database is registered.
      Any application instance discovery message without an associated database is ignored.
   2. New database instances/updates coming from already registered database instances are registered/applied.
   3. A SAP system discovery with a new application instance is received, and the database associated to

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -29,7 +29,7 @@ defmodule Trento.Domain.SapSystem do
   That being said, this is the logical order of events in order to register a full system:
 
   1. A SAP system discovery message with a new database instance is received.
-     We ignore database with Secondary role in a system replicated scenarios.
+     Database instances with Secondary role in a system replication scenario are discarded.
      At this point, the registration process starts and the database is registered.
      Any application instance discovery message without an associated database is ignored.
   2. New database instances/updates coming from already registered database instances are registered/applied.
@@ -99,7 +99,7 @@ defmodule Trento.Domain.SapSystem do
       do: {:error, :sap_system_not_registered}
 
   # First time that a Database instance is registered, the SAP System starts its registration process.
-  # We accept the database instance when the system replication is disabled or when enabled, only if the database
+  # Database instance are accepted when the system replication is disabled or when enabled, only if the database
   # has a primary role
   # When an Application is discovered, the SAP System completes the registration process.
   def execute(

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -88,7 +88,18 @@ defmodule Trento.Domain.SapSystem do
     embeds_one :application, Application
   end
 
+  def execute(
+        %SapSystem{},
+        %RegisterDatabaseInstance{
+          system_replication: "Secondary",
+          system_replication_status: "ACTIVE"
+        }
+      ),
+      do: {:error, :database_instance_not_primary}
+
   # First time that a Database instance is registered, the SAP System starts its registration process.
+  # We accept the database instance when the system replication is disabled or when enabled, only if the database
+  # has a primary role
   # When an Application is discovered, the SAP System completes the registration process.
   def execute(
         %SapSystem{sap_system_id: nil},

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -35,7 +35,7 @@ defmodule Trento.SapSystemTest do
 
       assert_error(
         command,
-        {:error, :database_instance_not_primary}
+        {:error, :sap_system_not_registered}
       )
     end
 
@@ -78,7 +78,7 @@ defmodule Trento.SapSystemTest do
       assert_error(
         initial_events,
         command,
-        {:error, :database_instance_not_primary}
+        {:error, :sap_system_not_registered}
       )
     end
 

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -26,7 +26,7 @@ defmodule Trento.SapSystemTest do
   alias Trento.Domain.SapSystem
 
   describe "SAP System registration" do
-    test "should fail when a sap system not exists and the database instance has Secondary role" do
+    test "should fail when a sap system does not exists and the database instance has Secondary role" do
       command =
         build(:register_database_instance_command,
           system_replication: "Secondary"

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -26,57 +26,13 @@ defmodule Trento.SapSystemTest do
   alias Trento.Domain.SapSystem
 
   describe "SAP System registration" do
-    test "should fail when a sap system not exists and the database instance has Secondary role with system replication ACTIVE" do
+    test "should fail when a sap system not exists and the database instance has Secondary role" do
       command =
         build(:register_database_instance_command,
-          system_replication: "Secondary",
-          system_replication_status: "ACTIVE"
+          system_replication: "Secondary"
         )
 
       assert_error(
-        command,
-        {:error, :sap_system_not_registered}
-      )
-    end
-
-    test "should fail when a sap system already exists and the database instance has Secondary role with system replication ACTIVE" do
-      sap_system_id = Faker.UUID.v4()
-      sid = Faker.StarWars.planet()
-      tenant = Faker.Beer.style()
-      instance_number = "00"
-      features = Faker.Pokemon.name()
-      host_id = Faker.UUID.v4()
-
-      initial_events = [
-        build(
-          :database_registered_event,
-          sap_system_id: sap_system_id,
-          sid: sid
-        ),
-        build(
-          :database_instance_registered_event,
-          sap_system_id: sap_system_id,
-          sid: sid,
-          tenant: tenant,
-          instance_number: "10"
-        )
-      ]
-
-      command =
-        build(
-          :register_database_instance_command,
-          sap_system_id: sap_system_id,
-          sid: sid,
-          tenant: tenant,
-          instance_number: instance_number,
-          features: features,
-          host_id: host_id,
-          system_replication: "Secondary",
-          system_replication_status: "ACTIVE"
-        )
-
-      assert_error(
-        initial_events,
         command,
         {:error, :sap_system_not_registered}
       )
@@ -107,8 +63,7 @@ defmodule Trento.SapSystemTest do
           https_port: https_port,
           start_priority: start_priority,
           host_id: host_id,
-          system_replication: "Primary",
-          system_replication_status: "",
+          system_replication: nil,
           health: :passing
         }),
         [
@@ -128,7 +83,7 @@ defmodule Trento.SapSystemTest do
             https_port: https_port,
             start_priority: start_priority,
             host_id: host_id,
-            system_replication: "Primary",
+            system_replication: nil,
             system_replication_status: nil,
             health: :passing
           }
@@ -144,7 +99,7 @@ defmodule Trento.SapSystemTest do
             instances: [
               %SapSystem.Instance{
                 sid: sid,
-                system_replication: "Primary",
+                system_replication: nil,
                 system_replication_status: nil,
                 instance_number: instance_number,
                 features: features,


### PR DESCRIPTION
# Description

This PR aims to change the database registration process in sap systems.
We want to ignore database instances that are Secondary in a system replicated scenario.

We accept only database instances that are **not replicated** or **Primary** instances in a replicated scenario.


## How was this tested?

Automated tests
