### PR TITLE
Make api key enablement configurable in runtime

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -79,8 +79,6 @@ config :trento, :pow,
   extensions: [PowPersistentSession],
   controller_callbacks: Pow.Extension.Phoenix.ControllerCallbacks
 
-config :trento, :api_key_authentication, enabled: true
-
 # Agent heartbeat interval. Adding one extra second to the agent 5s interval to avoid glitches
 config :trento, Trento.Heartbeats, interval: :timer.seconds(6)
 
@@ -158,8 +156,11 @@ config :trento, :jwt_authentication,
   # Seconds, 10 minutes
   access_token_expiration: 600,
   # Seconds, 6 hours
-  refresh_token_expiration: 21600,
-  enabled: true
+  refresh_token_expiration: 21600
+
+config :trento,
+  api_key_authentication_enabled: true,
+  jwt_authentication_enabled: true
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -117,13 +117,16 @@ config :phoenix, :stacktrace_depth, 20
 # Initialize plugs at runtime for faster development compilation
 config :phoenix, :plug_init_mode, :runtime
 
-config :trento, :api_key_authentication, enabled: false
+config :trento,
+  api_key_authentication_enabled: false
 
 config :joken,
   access_token_signer: "s2ZdE+3+ke1USHEJ5O45KT364KiXPYaB9cJPdH3p60t8yT0nkLexLBNw8TFSzC7k",
   refresh_token_signer: "L0wvcZh3ACQpibVhV/nh5jd/NaZWL4ijZxTxGJMGpacuXIBc4In3YCwXeVM98ygp"
 
 config :trento, :checks_service, base_url: "http://localhost:4001"
+
+config :unplug, :init_mode, :runtime
 
 # Override with local dev.local.exs file
 if File.exists?("#{__DIR__}/dev.local.exs") do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -140,6 +140,6 @@ if config_env() in [:prod, :demo] do
       ]
     ]
 
-  config :trento, :api_key_authentication,
-    enabled: System.get_env("ENABLE_API_KEY", "true") == "true"
+  config :trento,
+    api_key_authentication_enabled: System.get_env("ENABLE_API_KEY", "true") == "true"
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -139,4 +139,7 @@ if config_env() in [:prod, :demo] do
         schedule: "*/#{System.get_env("CHECKS_INTERVAL", "5")} * * * *"
       ]
     ]
+
+  config :trento, :api_key_authentication,
+    enabled: System.get_env("ENABLE_API_KEY", "true") == "true"
 end

--- a/config/test.exs
+++ b/config/test.exs
@@ -41,9 +41,9 @@ config :logger, level: :warn
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
 
-config :trento, :api_key_authentication, enabled: false
-
-config :trento, :jwt_authentication, enabled: false
+config :trento,
+  api_key_authentication_enabled: false,
+  jwt_authentication_enabled: false
 
 config :trento, Trento.Integration.Checks.AMQP.Consumer,
   processor: GenRMQ.Processor.Mock,

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -20,17 +20,17 @@ defmodule TrentoWeb.Router do
   end
 
   pipeline :protected_api do
-    if Application.compile_env!(:trento, [:jwt_authentication, :enabled]) do
-      plug Pow.Plug.RequireAuthenticated,
-        error_handler: TrentoWeb.Auth.ApiAuthErrorHandler
-    end
+    plug Unplug,
+      if: {Unplug.Predicates.AppConfigEquals, {:trento, :jwt_authentication_enabled, true}},
+      do: {Pow.Plug.RequireAuthenticated, error_handler: TrentoWeb.Auth.ApiAuthErrorHandler}
   end
 
   pipeline :apikey_authenticated do
-    if Application.compile_env!(:trento, [:api_key_authentication, :enabled]) do
-      plug Trento.Infrastructure.Auth.AuthenticateAPIKeyPlug,
-        error_handler: TrentoWeb.Auth.ApiAuthErrorHandler
-    end
+    plug Unplug,
+      if: {Unplug.Predicates.AppConfigEquals, {:trento, :api_key_authentication_enabled, true}},
+      do:
+        {Trento.Infrastructure.Auth.AuthenticateAPIKeyPlug,
+         error_handler: TrentoWeb.Auth.ApiAuthErrorHandler}
   end
 
   scope "/" do

--- a/mix.exs
+++ b/mix.exs
@@ -100,6 +100,7 @@ defmodule Trento.MixProject do
        github: "trento-project/contracts",
        ref: "b8e1036d0177c029ac40d34f237c366a7fb08bec",
        sparse: "elixir"},
+      {:unplug, "~> 1.0.0"},
       {:proper_case, "~> 1.3.1"},
       {:polymorphic_embed, "~> 2.0.0"},
       {:joken, "~> 2.5.0"}

--- a/mix.lock
+++ b/mix.lock
@@ -90,4 +90,5 @@
   "trento_contracts": {:git, "https://github.com/trento-project/contracts.git", "b8e1036d0177c029ac40d34f237c366a7fb08bec", [ref: "b8e1036d0177c029ac40d34f237c366a7fb08bec", sparse: "elixir"]},
   "tzdata": {:hex, :tzdata, "1.1.1", "20c8043476dfda8504952d00adac41c6eda23912278add38edc140ae0c5bcc46", [:mix], [{:hackney, "~> 1.17", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm", "a69cec8352eafcd2e198dea28a34113b60fdc6cb57eb5ad65c10292a6ba89787"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
+  "unplug": {:hex, :unplug, "1.0.0", "8ec2479de0baa9a6283c04a1cc616c5ca6c5b80b8ff1d857481bb2943368dbbc", [:mix], [{:plug, "~> 1.8", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm", "d171a85758aa412d4e85b809c203e1b1c4c76a4d6ab58e68dc9a8a8acd9b7c3a"},
 }


### PR DESCRIPTION
Make `api_key` usage enabled option configurable in runtime. It will come handy for e2e testing scenarios.

PD:
The other option was to provide the option to use a configurable api_key base value, but we decided to not implement this, as the current api_key implementation is not that good, and we might change it at some point, so going with the easy `disable` option was preferred. In any case, the api_key depends on the `secret_key_base`, so both this and the custom `api_key` should be fixed to have a unique key
