### PR TITLE
Add some margin between cluster-wide facts

### DIFF
--- a/assets/js/components/ExecutionResults/CheckResultDetail/GatheredFacts.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/GatheredFacts.jsx
@@ -36,7 +36,7 @@ function GatheredFacts({ isTargetHost = true, gatheredFacts = [] }) {
 
       {!isTargetHost &&
         gatheredFacts.map(({ name, value }) => (
-          <FactValue key={name} className="text-sm" data={value} />
+          <FactValue key={name} className="mt-3 text-sm" data={value} />
         ))}
     </div>
   );


### PR DESCRIPTION
Nothing fancy. Just re-adding some space between cluster wide gathered facts.

From
![image](https://user-images.githubusercontent.com/8167114/232456509-6d56e663-e205-471e-8d31-751bdafab49b.png)

To
![image](https://user-images.githubusercontent.com/8167114/232456553-fddc2d72-e3e4-45f0-999b-9896715ac8d4.png)

