### PR TITLE
[POC] HANA scale-up e2e tests with a real cluster 

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,135 @@
+# This workflow requires the following secrets:
+# `SSH_PUBLIC_KEY`, `SSH_PRIVATE_KEY` ssh keys to access the e2e machines
+# `AWS_SECRET_ACCESS_KEY`, `AWS_ACCESS_KEY_ID` aws credentials, 
+# used by terraform to deploy the infrastructure.
+# 
+# An artifact containing the terraform state is uploaded in case something goes wrong, 
+# so it's easy to destroy the infrastructure.
+
+name: e2e tests
+
+on:
+  workflow_dispatch:
+   
+jobs:
+  e2e_tests:
+    name: E2E tests
+    runs-on: ubuntu-latest
+    env:  
+      TF_VAR_aws_region: 'eu-central-1'
+      TF_VAR_aws_secret_key: '${{ secrets.AWS_SECRET_ACCESS_KEY }}'
+      TF_VAR_aws_access_key_id: '${{ secrets.AWS_ACCESS_KEY_ID }}'
+      TF_VAR_public_key: '${{ secrets.SSH_PUBLIC_KEY }}' 
+      TF_VAR_hana_instancetype: 'r6i.xlarge'
+      TF_VAR_hana_image_ids: '["ami-073792bfce1223304", "ami-0c3df2b35c3b0ec6f"]'
+      TF_VAR_trento_server_image_id: 'ami-073792bfce1223304'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'npm'
+          cache-dependency-path: test/e2e/package-lock.json
+      - name: Checkout terraform repo
+        uses: actions/checkout@v3
+        with:
+          repository: fabriziosestito/trento-e2e
+          path: terraform
+      - name: Use branch workspace
+        uses: dflook/terraform-new-workspace@v1
+        with:
+          path: terraform/deployments/aws
+          workspace: 'trentoe2e'
+          # workspace: ${{ github.head_ref }}
+      - name: Deploy test infrastructure
+        uses: dflook/terraform-apply@v1
+        continue-on-error: true
+        with:
+          path: terraform/deployments/aws
+          workspace: 'trentoe2e'
+          # workspace: ${{ github.head_ref }}
+          auto_approve: true
+      - name: Upload tfstate
+        uses: actions/upload-artifact@v3
+        if: ${{ !env.ACT }}
+        with:
+          name: terraform-state
+          path: terraform/deployments/aws/terraform.tfstate.d
+      - name: Get outputs
+        uses: dflook/terraform-output@v1
+        id: tf-outputs
+        with:
+          path: terraform/deployments/aws
+          workspace: 'trentoe2e'
+          # workspace: ${{ github.head_ref }}
+      - name: Checkout ansible repo        
+        uses: actions/checkout@v3
+        with:
+          repository: CDimonaco/trento-ansible
+          path: ansible
+      - name: Add pipx_bin to path        
+        if: ${{ env.ACT }}
+        run: echo '/opt/pipx_bin' >> $GITHUB_PATH 
+      - name: Install galaxy deps
+        run: ansible-galaxy install -r ansible/requirements.yml
+      - name: Run playbook
+        uses: dawidd6/action-ansible-playbook@v2
+        continue-on-error: true
+        with:
+          playbook: ansible/playbook.yml
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          inventory: |
+            all:
+              vars:
+                ansible_user: ec2-user
+              children:
+                trento-server:
+                  hosts:
+                    server:
+                      ansible_host: ${{ steps.tf-outputs.outputs.trento_server_public_ip }} 
+                agents:
+                  hosts:
+                    hana01:
+                      ansible_host: ${{ fromJson(steps.tf-outputs.outputs.hana_public_ip)[0] }}  
+                    hana02:
+                      ansible_host: ${{ fromJson(steps.tf-outputs.outputs.hana_public_ip)[1] }}  
+          options: |
+            --extra-vars "web_postgres_password='pass' \ 
+            wanda_postgres_password='wanda' \ 
+            rabbitmq_password='trento' \
+            grafana_api_url='http://localhost' \
+            prometheus_url='http://localhost' \
+            web_admin_password='adminpassword' \
+            enable_api_key='false' \
+            trento_server_name='trento' \
+            trento_server_url='http://${{ steps.tf-outputs.outputs.trento_server_ip }}' \
+            rabbitmq_host='${{ steps.tf-outputs.outputs.trento_server_ip }}:5672' \
+            api_key='api-key'"
+      - name: Cypress run
+        uses: cypress-io/github-action@v5
+        env:
+          CYPRESS_BASE_URL: http://${{ steps.tf-outputs.outputs.trento_server_public_ip }} 
+          CYPRESS_REAL_CLUSTER_TESTS: true
+        continue-on-error: true
+        with:
+          working-directory: test/e2e
+          spec: cypress/e2e/hana_scale_up_checks.cy.js
+      - name: Destroy
+        uses: dflook/terraform-destroy-workspace@v1
+        continue-on-error: true
+        with:
+          path: terraform/deployments/aws
+          workspace: 'trentoe2e'
+      - name: Install aws-delete-vpc
+        uses: jaxxstorm/action-install-gh-release@v1.10.0
+        with:
+          repo: isovalent/aws-delete-vpc
+          cache: enable
+      - name: Destroy VPC
+        env:
+          AWS_REGION: 'eu-central-1'
+          AWS_SECRET_ACCESS_KEY: '${{ secrets.AWS_SECRET_ACCESS_KEY }}'
+          AWS_ACCESS_KEY_ID: '${{ secrets.AWS_ACCESS_KEY_ID }}'
+        run: aws-delete-vpc --vpc-id ${{ steps.tf-outputs.outputs.vpc_id }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Checkout ansible repo        
         uses: actions/checkout@v3
         with:
-          repository: CDimonaco/trento-ansible
+          repository: trento-project/ansible
           path: ansible
       - name: Add pipx_bin to path        
         if: ${{ env.ACT }}
@@ -89,6 +89,14 @@ jobs:
                   hosts:
                     server:
                       ansible_host: ${{ steps.tf-outputs.outputs.trento_server_public_ip }} 
+                postgres-hosts:
+                  hosts:
+                    server:
+                      ansible_host: ${{ steps.tf-outputs.outputs.trento_server_public_ip }}
+                rabbitmq-hosts:
+                  hosts:
+                    server:
+                      ansible_host: ${{ steps.tf-outputs.outputs.trento_server_public_ip }}
                 agents:
                   hosts:
                     hana01:

--- a/test/e2e/cypress/e2e/hana_scale_up_checks.cy.js
+++ b/test/e2e/cypress/e2e/hana_scale_up_checks.cy.js
@@ -1,0 +1,67 @@
+if (Cypress.env('REAL_CLUSTER_TESTS')) {
+  context('HANA scale-up checks', () => {
+    const clusterID = 'd2522281-2c76-52dc-8500-10bdf2cc6664';
+
+    const PASSING = 'fill-jungle-green-500';
+    const WARNING = 'fill-yellow-500';
+    const CRITICAL = 'fill-red-500';
+
+    const expectedCheckResults = [
+      ['00081D', PASSING],
+      ['156F64', PASSING],
+      ['15F7A8', PASSING],
+      ['21FCA6', PASSING],
+      ['24ABCB', PASSING],
+      ['32CFC6', WARNING],
+      ['33403D', PASSING],
+      ['53D035', PASSING],
+      ['6E9B82', PASSING],
+      ['7E0221', PASSING],
+      ['822E47', PASSING],
+      ['845CC9', PASSING],
+      ['A1244C', PASSING],
+      ['C620DC', PASSING],
+      ['D78671', PASSING],
+      ['DA114A', WARNING],
+      ['FB0E0D', PASSING],
+      ['205AF7', PASSING],
+      ['373DB8', CRITICAL],
+      ['790926', WARNING],
+      ['9FAAD0', PASSING],
+      ['9FEFB0', PASSING],
+      ['CAEFF1', PASSING],
+      ['D028B9', PASSING],
+      ['DC5429', PASSING],
+      ['F50AF5', PASSING],
+    ];
+
+    before(() => {
+      cy.visit(`/clusters/${clusterID}`);
+      cy.url().should('include', `/clusters/${clusterID}`);
+    });
+
+    describe('Run checks', () => {
+      it('should run checks with expected results', () => {
+        cy.get('button').contains('Settings').click();
+
+        cy.get('.tn-check-switch').click({ multiple: true });
+        cy.get('button').contains('Select Checks for Execution').click();
+        cy.get('button').contains('Back to Cluster Details').click();
+        cy.get('button').contains('Start Execution').click();
+
+        cy.get('table').each((_, index) => {
+          cy.get('table').eq(index).find('.tn-check-result-row').as('rows');
+
+          cy.get('@rows').each((_, index) => {
+            const [id, result] = expectedCheckResults[index];
+
+            cy.get('@rows').eq(index).as('row').contains(id);
+            cy.get('@row')
+              .find('[data-testid="eos-svg-component"]')
+              .should('have.class', result);
+          });
+        });
+      });
+    });
+  });
+}

--- a/test/e2e/cypress/support/e2e.js
+++ b/test/e2e/cypress/support/e2e.js
@@ -23,7 +23,9 @@ import './commands';
 //
 
 before(() => {
-  cy.loadScenario('healthy-27-node-SAP-cluster');
+  if (!Cypress.env('REAL_CLUSTER_TESTS')) {
+    cy.loadScenario('healthy-27-node-SAP-cluster');
+  }
   cy.acceptEula();
   cy.initiateSession();
 });

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "test",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
This PR is a PoC that adds an automated test that spins up a HANA scale-up cluster.
The test involves running checks and comparing the output with the expected results.

It can be used as a base to script other automated tests or scenarios.

It uses Terraform to deploy a real infrastructure on AWS, ansible to deploy trento server and the agents, and cypress to run the e2e tests.
Destroying the infrastructure requires a workaround since the VPC is created with some dependencies that Terraform doesn't seem to be able to manage.
I've added a Cypress env variable to skip photofinish scenario loading at the beginning of the test, and to make the test skippable in the current e2e tests. Maybe in the future we should separate the test folders.
As for now, the action can be triggered by a `workflow_dispatch` event  (manually) and only works with the rolling version of trento. 
In the future, we could consider deploying a specific commit, generalize the version for another scenario, and use [composite actions](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action).
