### PR TITLE
Add single-hana-single-app dumped scenario

### DIFF
--- a/.photofinish.toml
+++ b/.photofinish.toml
@@ -2,6 +2,10 @@
 
 directories = ["./test/fixtures/scenarios/healthy-27-node-SAP-cluster"]
 
+[single-hana-single-app]
+
+directories = ["./test/fixtures/scenarios/single-hana-single-app"]
+
 [aws-landscape]
 
 directories = ["./test/fixtures/scenarios/aws-landscape"]

--- a/test/fixtures/scenarios/single-hana-single-app/c4914bd4-efa3-553a-9a52-e9b562e210e5_cloud_discovery.json
+++ b/test/fixtures/scenarios/single-hana-single-app/c4914bd4-efa3-553a-9a52-e9b562e210e5_cloud_discovery.json
@@ -1,0 +1,17 @@
+{
+  "agent_id": "c4914bd4-efa3-553a-9a52-e9b562e210e5",
+  "discovery_type": "cloud_discovery",
+  "payload": {
+    "Metadata": {
+      "account_id": "838635059921",
+      "ami_id": "ami-0a39d5742d9654b82",
+      "availability_zone": "eu-central-1a",
+      "data_disk_number": 7,
+      "instance_id": "i-0ea2438c9afdb078e",
+      "instance_type": "r6i.xlarge",
+      "region": "eu-central-1",
+      "vpc_id": "vpc-02a97b82ca71f2b68"
+    },
+    "Provider": "aws"
+  }
+}

--- a/test/fixtures/scenarios/single-hana-single-app/c4914bd4-efa3-553a-9a52-e9b562e210e5_host_discovery.json
+++ b/test/fixtures/scenarios/single-hana-single-app/c4914bd4-efa3-553a-9a52-e9b562e210e5_host_discovery.json
@@ -1,0 +1,19 @@
+{
+  "agent_id": "c4914bd4-efa3-553a-9a52-e9b562e210e5",
+  "discovery_type": "host_discovery",
+  "payload": {
+    "agent_version": "1.2.0+git.dev69.1681712424.63e3ee9",
+    "cpu_count": 4,
+    "hostname": "trento-hana01",
+    "installation_source": "Suse",
+    "ip_addresses": [
+      "127.0.0.1",
+      "::1",
+      "10.0.1.10",
+      "fe80::bc:ffff:fe56:bd6a"
+    ],
+    "os_version": "15-SP4",
+    "socket_count": 1,
+    "total_memory_mb": 31578
+  }
+}

--- a/test/fixtures/scenarios/single-hana-single-app/c4914bd4-efa3-553a-9a52-e9b562e210e5_sap_system_discovery.json
+++ b/test/fixtures/scenarios/single-hana-single-app/c4914bd4-efa3-553a-9a52-e9b562e210e5_sap_system_discovery.json
@@ -1,0 +1,229 @@
+{
+  "agent_id": "c4914bd4-efa3-553a-9a52-e9b562e210e5",
+  "discovery_type": "sap_system_discovery",
+  "payload": [
+    {
+      "DBAddress": "",
+      "Databases": [
+        {
+          "Active": "yes",
+          "Container": "",
+          "Database": "PRD",
+          "Group": "",
+          "GroupId": "",
+          "Host": "trento-hana01",
+          "SqlPort": "30015",
+          "User": "",
+          "UserId": ""
+        }
+      ],
+      "Id": "e058aaacf42f039937c4a43bf3df350b",
+      "Instances": [
+        {
+          "HdbnsutilSRstate": { "mode": "none", "online": "true" },
+          "Host": "trento-hana01",
+          "HostConfiguration": {
+            "failoverActualGroup": "default",
+            "failoverConfigGroup": "default",
+            "failoverStatus": "",
+            "host": "trento-hana01",
+            "hostActive": "yes",
+            "hostActualRoles": "worker",
+            "hostConfigRoles": "worker",
+            "hostStatus": "ok",
+            "indexServerActualRole": "master",
+            "indexServerConfigRole": "worker",
+            "nameServerActualRole": "master",
+            "nameServerConfigRole": "master 1",
+            "removeStatus": "",
+            "storageActualPartition": "1",
+            "storageConfigPartition": "1",
+            "storagePartition": "1",
+            "workerActualGroups": "default",
+            "workerConfigGroups": "default"
+          },
+          "Name": "HDB00",
+          "SAPControl": {
+            "Instances": [
+              {
+                "dispstatus": "SAPControl-GREEN",
+                "features": "HDB|HDB_WORKER",
+                "hostname": "trento-hana01",
+                "httpPort": 50013,
+                "httpsPort": 50014,
+                "instanceNr": 0,
+                "startPriority": "0.3"
+              }
+            ],
+            "Processes": [
+              {
+                "description": "HDB Daemon",
+                "dispstatus": "SAPControl-GREEN",
+                "elapsedtime": "0:46:57",
+                "name": "hdbdaemon",
+                "pid": 4869,
+                "starttime": "2023 04 19 07:28:10",
+                "textstatus": "Running"
+              },
+              {
+                "description": "HDB Compileserver",
+                "dispstatus": "SAPControl-GREEN",
+                "elapsedtime": "0:42:54",
+                "name": "hdbcompileserver",
+                "pid": 5600,
+                "starttime": "2023 04 19 07:32:13",
+                "textstatus": "Running"
+              },
+              {
+                "description": "HDB Deployment Infrastructure Server-PRD",
+                "dispstatus": "SAPControl-GREEN",
+                "elapsedtime": "0:41:06",
+                "name": "hdbdiserver",
+                "pid": 6500,
+                "starttime": "2023 04 19 07:34:01",
+                "textstatus": "Running"
+              },
+              {
+                "description": "HDB DocStore-PRD",
+                "dispstatus": "SAPControl-GREEN",
+                "elapsedtime": "0:42:52",
+                "name": "hdbdocstore",
+                "pid": 5737,
+                "starttime": "2023 04 19 07:32:15",
+                "textstatus": "Running"
+              },
+              {
+                "description": "HDB DPserver-PRD",
+                "dispstatus": "SAPControl-GREEN",
+                "elapsedtime": "0:42:52",
+                "name": "hdbdpserver",
+                "pid": 5740,
+                "starttime": "2023 04 19 07:32:15",
+                "textstatus": "Running"
+              },
+              {
+                "description": "HDB Indexserver-PRD",
+                "dispstatus": "SAPControl-GREEN",
+                "elapsedtime": "0:42:52",
+                "name": "hdbindexserver",
+                "pid": 5743,
+                "starttime": "2023 04 19 07:32:15",
+                "textstatus": "Running"
+              },
+              {
+                "description": "HDB Nameserver",
+                "dispstatus": "SAPControl-GREEN",
+                "elapsedtime": "0:46:34",
+                "name": "hdbnameserver",
+                "pid": 4976,
+                "starttime": "2023 04 19 07:28:33",
+                "textstatus": "Running"
+              },
+              {
+                "description": "HDB Preprocessor",
+                "dispstatus": "SAPControl-GREEN",
+                "elapsedtime": "0:42:54",
+                "name": "hdbpreprocessor",
+                "pid": 5603,
+                "starttime": "2023 04 19 07:32:13",
+                "textstatus": "Running"
+              },
+              {
+                "description": "HDB Web Dispatcher",
+                "dispstatus": "SAPControl-GREEN",
+                "elapsedtime": "0:41:06",
+                "name": "hdbwebdispatcher",
+                "pid": 6503,
+                "starttime": "2023 04 19 07:34:01",
+                "textstatus": "Running"
+              },
+              {
+                "description": "HDB XSEngine-PRD",
+                "dispstatus": "SAPControl-GREEN",
+                "elapsedtime": "0:42:52",
+                "name": "hdbxsengine",
+                "pid": 5746,
+                "starttime": "2023 04 19 07:32:15",
+                "textstatus": "Running"
+              }
+            ],
+            "Properties": [
+              {
+                "property": "Process List",
+                "propertytype": "NodeWebmethod",
+                "value": "GetProcessList"
+              },
+              {
+                "property": "Access Points",
+                "propertytype": "NodeWebmethod",
+                "value": "GetAccessPointList"
+              },
+              {
+                "property": "Parameter Documentation",
+                "propertytype": "NodeURL",
+                "value": "http://trento-hana01:50013/sapparamEN.html"
+              },
+              {
+                "property": "Protected Webmethods",
+                "propertytype": "Attribute",
+                "value": "ABAPAcknowledgeAlerts,ABAPCheckRFCDestinations,ABAPGetComponentList,ABAPGetSystemWPTable,ABAPGetWPTable,ABAPReadRawSyslog,ABAPReadSyslog,AnalyseLogFiles,Bootstrap,CheckParameter,CheckPSE,CheckUpdateSystem,ConfigureLogFileList,CreatePSECredential,CreateSnapshot,DeletePSE,DeleteSnapshots,EnqGetLockTable,EnqGetStatistic,EnqRemoveLocks,EnqRemoveUserLocks,GetAccessPointList,GetAlerts,GetAlertTree,GetCallstack,GetEnvironment,GetLogFileList,GetProcessParameter,GetQueueStatistic,GetStartProfile,GetSystemUpdateList,GetTraceFile,GetVersionInfo,GWCancelConnections,GWDeleteClients,GWDeleteConnections,GWGetConnectionList,GWGetClientList,HACheckConfig,HACheckFailoverConfig,HACheckMaintenanceMode,HAFailoverToNode,HAGetFailoverConfig,HASetMaintenanceMode,ICMGetCacheEntries,ICMGetConnectionList,ICMGetProxyConnectionList,ICMGetThreadList,InstanceStart,InstanceStop,J2EEControlCluster,J2EEControlComponents,J2EEControlProcess,J2EEDisableDbgSession,J2EEEnableDbgSession,J2EEGetApplicationAliasList,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetClusterMsgList,J2EEGetComponentList,J2EEGetEJBSessionList,J2EEGetProcessList,J2EEGetProcessList2,J2EEGetRemoteObjectList,J2EEGetSessionList,J2EEGetSharedTableInfo,J2EEGetThreadCallStack,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadTaskStack,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetWebSessionList,J2EEGetWebSessionList2,ListConfigFiles,ListDeveloperTraces,ListLogFiles,ListSnapshots,OSExecute,ParameterValue,ReadConfigFile,ReadDeveloperTrace,ReadLogFile,ReadSnapshot,RestartInstance,RestartService,RestartSystem,SendSignal,SetProcessParameter,SetProcessParameter2,ShmDetach,Shutdown,Start,StartBypassHA,StartSystem,Stop,StopBypassHA,StopService,StopSystem,StorePSE,UpdateInstancePSE,UpdateSCSInstance,UpdateSystem,UpdateSystemPKI,WebDispGetServerList,WebDispGetGroupList,WebDispGetVirtHostList,WebDispGetUrlPrefixList,GetAgentConfig,GetListOfMaByCusGrp,GetMcInLocalMs,GetMtesByRequestTable,GetMtListByMtclass,InfoGetTree,MscCustomizeWrite,MscDeleteLines,MscReadCache,MsGetLocalMsInfo,MsGetMteclsInLocalMs,MtChangeStatus,MtCustomizeWrite,MtDbsetToWpsetByTid,MtDestroyMarkNTry,MteGetByToolRunstatus,MtGetAllToCust,MtGetAllToolsToSet,MtGetMteinfo,MtGetTidByName,MtRead,MtReset,PerfCustomizeWrite,PerfRead,PerfReadSmoothData,ReadDirectory,ReadFile,ReadProfileParameters,ReferenceRead,Register,RequestLogonFile,SnglmgsCustomizeWrite,SystemObjectSetValue,TextAttrRead,ToolGetEffective,ToolSet,ToolSetRuntimeStatus,TriggerDataCollection,Unregister,UtilAlChangeStatus,UtilMtGetAidByTid,UtilMtGetTreeLocal,UtilMtReadAll,UtilReadRawalertByAid,UtilSnglmsgReadRawdata"
+              },
+              {
+                "property": "DBServices",
+                "propertytype": "Attribute",
+                "value": "YES"
+              },
+              {
+                "property": "HANA Roles",
+                "propertytype": "Attribute",
+                "value": "worker"
+              },
+              {
+                "property": "StartPriority",
+                "propertytype": "Attribute",
+                "value": "0.3"
+              },
+              {
+                "property": "SAPSYSTEM",
+                "propertytype": "Attribute",
+                "value": "00"
+              },
+              {
+                "property": "SAPSYSTEMNAME",
+                "propertytype": "Attribute",
+                "value": "PRD"
+              },
+              {
+                "property": "SAPLOCALHOST",
+                "propertytype": "Attribute",
+                "value": "trento-hana01"
+              },
+              {
+                "property": "INSTANCE_NAME",
+                "propertytype": "Attribute",
+                "value": "HDB00"
+              },
+              {
+                "property": "Webmethods",
+                "propertytype": "Attribute",
+                "value": "Start,InstanceStart,StartBypassHA,Bootstrap,Stop,InstanceStop,StopBypassHA,Shutdown,ParameterValue,GetProcessList,GetStartProfile,GetTraceFile,GetAlertTree,GetAlerts,RestartService,StopService,GetEnvironment,ListDeveloperTraces,ReadDeveloperTrace,RestartInstance,SendSignal,GetVersionInfo,GetQueueStatistic,GetInstanceProperties,OSExecute,ReadLogFile,AnalyseLogFiles,ListLogFiles,GetAccessPointList,GetSystemInstanceList,GetSystemUpdateList,StartSystem,StopSystem,RestartSystem,UpdateSystem,UpdateSCSInstance,CheckUpdateSystem,AccessCheck,GetProcessParameter,SetProcessParameter,SetProcessParameter2,CheckParameter,ShmDetach,GetNetworkId,GetSecNetworkId,RequestLogonFile,CreateSnapshot,ReadSnapshot,ListSnapshots,DeleteSnapshots,GetCallstack,ABAPReadSyslog,ABAPReadRawSyslog,ABAPGetWPTable,ABAPAcknowledgeAlerts,ABAPGetComponentList,ABAPCheckRFCDestinations,ABAPGetSystemWPTable,J2EEGetProcessList,J2EEGetProcessList2,J2EEControlProcess,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadCallStack,J2EEGetThreadTaskStack,J2EEGetSessionList,J2EEGetWebSessionList,J2EEGetWebSessionList2,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetApplicationAliasList,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetEJBSessionList,J2EEGetRemoteObjectList,J2EEGetClusterMsgList,J2EEGetSharedTableInfo,J2EEGetComponentList,J2EEControlComponents,ICMGetThreadList,ICMGetConnectionList,ICMGetCacheEntries,ICMGetProxyConnectionList,WebDispGetServerList,WebDispGetGroupList,WebDispGetVirtHostList,WebDispGetUrlPrefixList,EnqGetLockTable,EnqRemoveLocks,EnqRemoveUserLocks,EnqGetStatistic,GWCancelConnections,GWDeleteClients,GWDeleteConnections,GWGetConnectionList,GWGetClientList,UpdateSystemPKI,UpdateInstancePSE,StorePSE,DeletePSE,CheckPSE,HACheckConfig,HACheckFailoverConfig,HAGetFailoverConfig,HAFailoverToNode,HASetMaintenanceMode,HACheckMaintenanceMode,ListConfigFiles,ReadConfigFile"
+              }
+            ]
+          },
+          "SystemReplication": { "local_site_id": "0" },
+          "Type": 1
+        }
+      ],
+      "Profile": {
+        "HDB_LINKED_BINARIES": "yes",
+        "HDB_SHARED_BINARIES": "yes",
+        "SAPGLOBALHOST": "trento-hana01",
+        "SAPSYSTEMNAME": "PRD",
+        "hdbConfigType": "DEFAULT",
+        "ssl/ciphersuites": "135:PFS:HIGH::EC_P256:EC_HIGH"
+      },
+      "SID": "PRD",
+      "Type": 1
+    }
+  ]
+}

--- a/test/fixtures/scenarios/single-hana-single-app/c4914bd4-efa3-553a-9a52-e9b562e210e5_subscription_discovery.json
+++ b/test/fixtures/scenarios/single-hana-single-app/c4914bd4-efa3-553a-9a52-e9b562e210e5_subscription_discovery.json
@@ -1,0 +1,56 @@
+{
+  "agent_id": "c4914bd4-efa3-553a-9a52-e9b562e210e5",
+  "discovery_type": "subscription_discovery",
+  "payload": [
+    {
+      "arch": "x86_64",
+      "expires_at": "2024-03-29 10:06:56 UTC",
+      "identifier": "SLES_SAP",
+      "starts_at": "2019-03-20 09:55:32 UTC",
+      "status": "Registered",
+      "subscription_status": "ACTIVE",
+      "type": "internal",
+      "version": "15.4"
+    },
+    {
+      "arch": "x86_64",
+      "identifier": "sle-module-basesystem",
+      "status": "Registered",
+      "version": "15.4"
+    },
+    {
+      "arch": "x86_64",
+      "identifier": "sle-module-public-cloud",
+      "status": "Not Registered",
+      "version": "15.4"
+    },
+    {
+      "arch": "x86_64",
+      "identifier": "sle-module-server-applications",
+      "status": "Registered",
+      "version": "15.4"
+    },
+    {
+      "arch": "x86_64",
+      "identifier": "sle-module-desktop-applications",
+      "status": "Registered",
+      "version": "15.4"
+    },
+    {
+      "arch": "x86_64",
+      "expires_at": "2024-03-29 10:06:56 UTC",
+      "identifier": "sle-ha",
+      "starts_at": "2019-03-20 09:55:32 UTC",
+      "status": "Registered",
+      "subscription_status": "ACTIVE",
+      "type": "internal",
+      "version": "15.4"
+    },
+    {
+      "arch": "x86_64",
+      "identifier": "sle-module-sap-applications",
+      "status": "Registered",
+      "version": "15.4"
+    }
+  ]
+}

--- a/test/fixtures/scenarios/single-hana-single-app/e77ab524-c4e4-5381-bb59-5af8639d52a4_cloud_discovery.json
+++ b/test/fixtures/scenarios/single-hana-single-app/e77ab524-c4e4-5381-bb59-5af8639d52a4_cloud_discovery.json
@@ -1,0 +1,17 @@
+{
+  "agent_id": "e77ab524-c4e4-5381-bb59-5af8639d52a4",
+  "discovery_type": "cloud_discovery",
+  "payload": {
+    "Metadata": {
+      "account_id": "838635059921",
+      "ami_id": "ami-0e30116103fc0be89",
+      "availability_zone": "eu-central-1a",
+      "data_disk_number": 1,
+      "instance_id": "i-0a2cb8a39a01a668d",
+      "instance_type": "r5.large",
+      "region": "eu-central-1",
+      "vpc_id": "vpc-02a97b82ca71f2b68"
+    },
+    "Provider": "aws"
+  }
+}

--- a/test/fixtures/scenarios/single-hana-single-app/e77ab524-c4e4-5381-bb59-5af8639d52a4_host_discovery.json
+++ b/test/fixtures/scenarios/single-hana-single-app/e77ab524-c4e4-5381-bb59-5af8639d52a4_host_discovery.json
@@ -1,0 +1,26 @@
+{
+  "agent_id": "e77ab524-c4e4-5381-bb59-5af8639d52a4",
+  "discovery_type": "host_discovery",
+  "payload": {
+    "agent_version": "1.2.0+git.dev69.1681712424.63e3ee9",
+    "cpu_count": 2,
+    "hostname": "trento-vmnetweaver01",
+    "installation_source": "Suse",
+    "ip_addresses": [
+      "127.0.0.1",
+      "::1",
+      "10.0.2.30",
+      "192.168.1.30",
+      "192.168.1.31",
+      "fe80::f9:9cff:fe45:2cde",
+      "172.17.0.1",
+      "172.18.0.1",
+      "fe80::42:deff:fead:fa7d",
+      "fe80::8d3:33ff:feee:9701",
+      "fe80::ec17:89ff:feb6:a456"
+    ],
+    "os_version": "15-SP4",
+    "socket_count": 1,
+    "total_memory_mb": 15699
+  }
+}

--- a/test/fixtures/scenarios/single-hana-single-app/e77ab524-c4e4-5381-bb59-5af8639d52a4_sap_system_discovery.json
+++ b/test/fixtures/scenarios/single-hana-single-app/e77ab524-c4e4-5381-bb59-5af8639d52a4_sap_system_discovery.json
@@ -1,0 +1,390 @@
+{
+  "agent_id": "e77ab524-c4e4-5381-bb59-5af8639d52a4",
+  "discovery_type": "sap_system_discovery",
+  "payload": [
+    {
+      "DBAddress": "10.0.1.10",
+      "Databases": null,
+      "Id": "21a7a8cebb6154d189240e900db3fa26",
+      "Instances": [
+        {
+          "HdbnsutilSRstate": null,
+          "Host": "trento-vmnetweaver01",
+          "HostConfiguration": null,
+          "Name": "ASCS00",
+          "SAPControl": {
+            "Instances": [
+              {
+                "dispstatus": "SAPControl-GREEN",
+                "features": "MESSAGESERVER|ENQUE",
+                "hostname": "sapha1as",
+                "httpPort": 50013,
+                "httpsPort": 50014,
+                "instanceNr": 0,
+                "startPriority": "1"
+              },
+              {
+                "dispstatus": "SAPControl-GREEN",
+                "features": "ABAP|GATEWAY|ICMAN|IGS",
+                "hostname": "sapha1pas",
+                "httpPort": 50113,
+                "httpsPort": 50114,
+                "instanceNr": 1,
+                "startPriority": "3"
+              }
+            ],
+            "Processes": [
+              {
+                "description": "MessageServer",
+                "dispstatus": "SAPControl-GREEN",
+                "elapsedtime": "0:46:50",
+                "name": "msg_server",
+                "pid": 4216,
+                "starttime": "2023 04 19 07:28:22",
+                "textstatus": "Running"
+              },
+              {
+                "description": "Enqueue Server 2",
+                "dispstatus": "SAPControl-GREEN",
+                "elapsedtime": "0:46:50",
+                "name": "enq_server",
+                "pid": 4217,
+                "starttime": "2023 04 19 07:28:22",
+                "textstatus": "Running"
+              }
+            ],
+            "Properties": [
+              {
+                "property": "Process List",
+                "propertytype": "NodeWebmethod",
+                "value": "GetProcessList"
+              },
+              {
+                "property": "Access Points",
+                "propertytype": "NodeWebmethod",
+                "value": "GetAccessPointList"
+              },
+              {
+                "property": "Parameter Documentation",
+                "propertytype": "NodeURL",
+                "value": "http://sapha1as:50013/sapparamEN.html"
+              },
+              {
+                "property": "Kernel Update",
+                "propertytype": "NodeURL",
+                "value": "https://launchpad.support.sap.com/#/softwarecenter/template/products/_APP=00200682500000001943&_EVENT=DISPHIER&HEADER=Y&FUNCTIONBAR=N&EVENT=TREE&NE=NAVIGATE&ENR=73554900100200010526&V=MAINT"
+              },
+              {
+                "property": "Syslog",
+                "propertytype": "NodeWebmethod",
+                "value": "ABAPReadSyslog"
+              },
+              {
+                "property": "Enque Locks",
+                "propertytype": "NodeWebmethod",
+                "value": "EnqGetLockTable"
+              },
+              {
+                "property": "Enque Statistic",
+                "propertytype": "NodeWebmethod",
+                "value": "EnqGetStatistic"
+              },
+              {
+                "property": "Protected Webmethods",
+                "propertytype": "Attribute",
+                "value": "ABAPAcknowledgeAlerts,ABAPCheckRFCDestinations,ABAPGetComponentList,ABAPGetSystemWPTable,ABAPGetWPTable,ABAPReadRawSyslog,ABAPReadSyslog,AnalyseLogFiles,Bootstrap,CheckParameter,CheckPSE,CheckUpdateSystem,ConfigureLogFileList,CreatePSECredential,CreateSnapshot,DeletePSE,DeleteSnapshots,EnqGetLockTable,EnqGetStatistic,EnqRemoveLocks,EnqRemoveUserLocks,GetAccessPointList,GetAlerts,GetAlertTree,GetCallstack,GetEnvironment,GetLogFileList,GetProcessParameter,GetQueueStatistic,GetStartProfile,GetSystemUpdateList,GetTraceFile,GetVersionInfo,GWCancelConnections,GWDeleteClients,GWDeleteConnections,GWGetConnectionList,GWGetClientList,HACheckConfig,HACheckFailoverConfig,HACheckMaintenanceMode,HAFailoverToNode,HAGetFailoverConfig,HASetMaintenanceMode,ICMGetCacheEntries,ICMGetConnectionList,ICMGetProxyConnectionList,ICMGetThreadList,InstanceStart,InstanceStop,ListConfigFiles,ListDeveloperTraces,ListLogFiles,ListSnapshots,OSExecute,ParameterValue,ReadConfigFile,ReadDeveloperTrace,ReadLogFile,ReadSnapshot,RestartInstance,RestartService,RestartSystem,SendSignal,SetProcessParameter,SetProcessParameter2,ShmDetach,Shutdown,Start,StartBypassHA,StartSystem,Stop,StopBypassHA,StopService,StopSystem,StorePSE,UpdateInstancePSE,UpdateSCSInstance,UpdateSystem,UpdateSystemPKI,WebDispGetServerList,WebDispGetGroupList,WebDispGetVirtHostList,WebDispGetUrlPrefixList,GetAgentConfig,GetListOfMaByCusGrp,GetMcInLocalMs,GetMtesByRequestTable,GetMtListByMtclass,InfoGetTree,MscCustomizeWrite,MscDeleteLines,MscReadCache,MsGetLocalMsInfo,MsGetMteclsInLocalMs,MtChangeStatus,MtCustomizeWrite,MtDbsetToWpsetByTid,MtDestroyMarkNTry,MteGetByToolRunstatus,MtGetAllToCust,MtGetAllToolsToSet,MtGetMteinfo,MtGetTidByName,MtRead,MtReset,PerfCustomizeWrite,PerfRead,PerfReadSmoothData,ReadDirectory,ReadFile,ReadProfileParameters,ReferenceRead,Register,RequestLogonFile,SnglmgsCustomizeWrite,SystemObjectSetValue,TextAttrRead,ToolGetEffective,ToolSet,ToolSetRuntimeStatus,TriggerDataCollection,Unregister,UtilAlChangeStatus,UtilMtGetAidByTid,UtilMtGetTreeLocal,UtilMtReadAll,UtilReadRawalertByAid,UtilSnglmsgReadRawdata"
+              },
+              {
+                "property": "CentralServices",
+                "propertytype": "Attribute",
+                "value": "YES"
+              },
+              {
+                "property": "StartPriority",
+                "propertytype": "Attribute",
+                "value": "1"
+              },
+              {
+                "property": "SAPSYSTEM",
+                "propertytype": "Attribute",
+                "value": "00"
+              },
+              {
+                "property": "SAPSYSTEMNAME",
+                "propertytype": "Attribute",
+                "value": "HA1"
+              },
+              {
+                "property": "SAPLOCALHOST",
+                "propertytype": "Attribute",
+                "value": "sapha1as"
+              },
+              {
+                "property": "INSTANCE_NAME",
+                "propertytype": "Attribute",
+                "value": "ASCS00"
+              },
+              {
+                "property": "SupportsUpdateSCSInstance",
+                "propertytype": "Attribute",
+                "value": "YES"
+              },
+              {
+                "property": "Webmethods",
+                "propertytype": "Attribute",
+                "value": "Start,InstanceStart,StartBypassHA,Bootstrap,Stop,InstanceStop,StopBypassHA,Shutdown,ParameterValue,GetProcessList,GetStartProfile,GetTraceFile,GetAlertTree,GetAlerts,RestartService,StopService,GetEnvironment,ListDeveloperTraces,ReadDeveloperTrace,RestartInstance,SendSignal,GetVersionInfo,GetQueueStatistic,GetInstanceProperties,OSExecute,ReadLogFile,AnalyseLogFiles,ListLogFiles,GetAccessPointList,GetSystemInstanceList,GetSystemUpdateList,StartSystem,StopSystem,RestartSystem,UpdateSystem,UpdateSCSInstance,CheckUpdateSystem,AccessCheck,GetProcessParameter,SetProcessParameter,SetProcessParameter2,CheckParameter,ShmDetach,GetNetworkId,GetSecNetworkId,RequestLogonFile,CreateSnapshot,ReadSnapshot,ListSnapshots,DeleteSnapshots,GetCallstack,ABAPReadSyslog,ABAPReadRawSyslog,ABAPGetWPTable,ABAPAcknowledgeAlerts,ABAPGetComponentList,ABAPCheckRFCDestinations,ABAPGetSystemWPTable,ICMGetThreadList,ICMGetConnectionList,ICMGetCacheEntries,ICMGetProxyConnectionList,WebDispGetServerList,WebDispGetGroupList,WebDispGetVirtHostList,WebDispGetUrlPrefixList,EnqGetLockTable,EnqRemoveLocks,EnqRemoveUserLocks,EnqGetStatistic,GWCancelConnections,GWDeleteClients,GWDeleteConnections,GWGetConnectionList,GWGetClientList,UpdateSystemPKI,UpdateInstancePSE,StorePSE,DeletePSE,CheckPSE,HACheckConfig,HACheckFailoverConfig,HAGetFailoverConfig,HAFailoverToNode,HASetMaintenanceMode,HACheckMaintenanceMode,ListConfigFiles,ReadConfigFile"
+              }
+            ]
+          },
+          "SystemReplication": null,
+          "Type": 2
+        },
+        {
+          "HdbnsutilSRstate": null,
+          "Host": "trento-vmnetweaver01",
+          "HostConfiguration": null,
+          "Name": "D01",
+          "SAPControl": {
+            "Instances": [
+              {
+                "dispstatus": "SAPControl-GREEN",
+                "features": "MESSAGESERVER|ENQUE",
+                "hostname": "sapha1as",
+                "httpPort": 50013,
+                "httpsPort": 50014,
+                "instanceNr": 0,
+                "startPriority": "1"
+              },
+              {
+                "dispstatus": "SAPControl-GREEN",
+                "features": "ABAP|GATEWAY|ICMAN|IGS",
+                "hostname": "sapha1pas",
+                "httpPort": 50113,
+                "httpsPort": 50114,
+                "instanceNr": 1,
+                "startPriority": "3"
+              }
+            ],
+            "Processes": [
+              {
+                "description": "Dispatcher",
+                "dispstatus": "SAPControl-GREEN",
+                "elapsedtime": "0:40:30",
+                "name": "disp+work",
+                "pid": 5793,
+                "starttime": "2023 04 19 07:34:42",
+                "textstatus": "Running"
+              },
+              {
+                "description": "IGS Watchdog",
+                "dispstatus": "SAPControl-GREEN",
+                "elapsedtime": "0:40:30",
+                "name": "igswd_mt",
+                "pid": 5794,
+                "starttime": "2023 04 19 07:34:42",
+                "textstatus": "Running"
+              },
+              {
+                "description": "Gateway",
+                "dispstatus": "SAPControl-GREEN",
+                "elapsedtime": "0:40:29",
+                "name": "gwrd",
+                "pid": 5798,
+                "starttime": "2023 04 19 07:34:43",
+                "textstatus": "Running"
+              },
+              {
+                "description": "ICM",
+                "dispstatus": "SAPControl-GREEN",
+                "elapsedtime": "0:40:29",
+                "name": "icman",
+                "pid": 5799,
+                "starttime": "2023 04 19 07:34:43",
+                "textstatus": "Running"
+              }
+            ],
+            "Properties": [
+              {
+                "property": "Process List",
+                "propertytype": "NodeWebmethod",
+                "value": "GetProcessList"
+              },
+              {
+                "property": "Access Points",
+                "propertytype": "NodeWebmethod",
+                "value": "GetAccessPointList"
+              },
+              {
+                "property": "Parameter Documentation",
+                "propertytype": "NodeURL",
+                "value": "http://sapha1pas:50113/sapparamEN.html"
+              },
+              {
+                "property": "Kernel Update",
+                "propertytype": "NodeURL",
+                "value": "https://launchpad.support.sap.com/#/softwarecenter/template/products/_APP=00200682500000001943&_EVENT=DISPHIER&HEADER=Y&FUNCTIONBAR=N&EVENT=TREE&NE=NAVIGATE&ENR=73554900100200010526&V=MAINT"
+              },
+              {
+                "property": "Current Status",
+                "propertytype": "NodeWebmethod",
+                "value": "GetAlertTree"
+              },
+              {
+                "property": "Open Alerts",
+                "propertytype": "NodeWebmethod",
+                "value": "GetAlertTree"
+              },
+              {
+                "property": "Syslog",
+                "propertytype": "NodeWebmethod",
+                "value": "ABAPReadSyslog"
+              },
+              {
+                "property": "Gateway Connections",
+                "propertytype": "NodeWebmethod",
+                "value": "GWGetConnectionList"
+              },
+              {
+                "property": "Gateway Clients",
+                "propertytype": "NodeWebmethod",
+                "value": "GWGetClientList"
+              },
+              {
+                "property": "Queue Statistic",
+                "propertytype": "NodeWebmethod",
+                "value": "GetQueueStatistic"
+              },
+              {
+                "property": "ABAP WP Table",
+                "propertytype": "NodeWebmethod",
+                "value": "ABAPGetWPTable"
+              },
+              {
+                "property": "ICM",
+                "propertytype": "NodeURL",
+                "value": "HTTP://sapha1pas:0/sap/admin/public/index.html"
+              },
+              {
+                "property": "ICM Threads",
+                "propertytype": "NodeWebmethod",
+                "value": "ICMGetThreadList"
+              },
+              {
+                "property": "ICM Connections",
+                "propertytype": "NodeWebmethod",
+                "value": "ICMGetConnectionList"
+              },
+              {
+                "property": "ICM Cache",
+                "propertytype": "NodeWebmethod",
+                "value": "ICMGetCacheEntries"
+              },
+              {
+                "property": "ICM Proxy Connections",
+                "propertytype": "NodeWebmethod",
+                "value": "ICMGetProxyConnectionList"
+              },
+              {
+                "property": "Protected Webmethods",
+                "propertytype": "Attribute",
+                "value": "ABAPAcknowledgeAlerts,ABAPCheckRFCDestinations,ABAPGetComponentList,ABAPGetSystemWPTable,ABAPGetWPTable,ABAPReadRawSyslog,ABAPReadSyslog,AnalyseLogFiles,Bootstrap,CheckParameter,CheckPSE,CheckUpdateSystem,ConfigureLogFileList,CreatePSECredential,CreateSnapshot,DeletePSE,DeleteSnapshots,EnqGetLockTable,EnqGetStatistic,EnqRemoveLocks,EnqRemoveUserLocks,GetAccessPointList,GetAlerts,GetAlertTree,GetCallstack,GetEnvironment,GetLogFileList,GetProcessParameter,GetQueueStatistic,GetStartProfile,GetSystemUpdateList,GetTraceFile,GetVersionInfo,GWCancelConnections,GWDeleteClients,GWDeleteConnections,GWGetConnectionList,GWGetClientList,HACheckConfig,HACheckFailoverConfig,HACheckMaintenanceMode,HAFailoverToNode,HAGetFailoverConfig,HASetMaintenanceMode,ICMGetCacheEntries,ICMGetConnectionList,ICMGetProxyConnectionList,ICMGetThreadList,InstanceStart,InstanceStop,ListConfigFiles,ListDeveloperTraces,ListLogFiles,ListSnapshots,OSExecute,ParameterValue,ReadConfigFile,ReadDeveloperTrace,ReadLogFile,ReadSnapshot,RestartInstance,RestartService,RestartSystem,SendSignal,SetProcessParameter,SetProcessParameter2,ShmDetach,Shutdown,Start,StartBypassHA,StartSystem,Stop,StopBypassHA,StopService,StopSystem,StorePSE,UpdateInstancePSE,UpdateSCSInstance,UpdateSystem,UpdateSystemPKI,WebDispGetServerList,WebDispGetGroupList,WebDispGetVirtHostList,WebDispGetUrlPrefixList,GetAgentConfig,GetListOfMaByCusGrp,GetMcInLocalMs,GetMtesByRequestTable,GetMtListByMtclass,InfoGetTree,MscCustomizeWrite,MscDeleteLines,MscReadCache,MsGetLocalMsInfo,MsGetMteclsInLocalMs,MtChangeStatus,MtCustomizeWrite,MtDbsetToWpsetByTid,MtDestroyMarkNTry,MteGetByToolRunstatus,MtGetAllToCust,MtGetAllToolsToSet,MtGetMteinfo,MtGetTidByName,MtRead,MtReset,PerfCustomizeWrite,PerfRead,PerfReadSmoothData,ReadDirectory,ReadFile,ReadProfileParameters,ReferenceRead,Register,RequestLogonFile,SnglmgsCustomizeWrite,SystemObjectSetValue,TextAttrRead,ToolGetEffective,ToolSet,ToolSetRuntimeStatus,TriggerDataCollection,Unregister,UtilAlChangeStatus,UtilMtGetAidByTid,UtilMtGetTreeLocal,UtilMtReadAll,UtilReadRawalertByAid,UtilSnglmsgReadRawdata"
+              },
+              {
+                "property": "StartPriority",
+                "propertytype": "Attribute",
+                "value": "3"
+              },
+              {
+                "property": "SAPSYSTEM",
+                "propertytype": "Attribute",
+                "value": "01"
+              },
+              {
+                "property": "SAPSYSTEMNAME",
+                "propertytype": "Attribute",
+                "value": "HA1"
+              },
+              {
+                "property": "SAPLOCALHOST",
+                "propertytype": "Attribute",
+                "value": "sapha1pas"
+              },
+              {
+                "property": "INSTANCE_NAME",
+                "propertytype": "Attribute",
+                "value": "D01"
+              },
+              {
+                "property": "IGS",
+                "propertytype": "NodeURL",
+                "value": "http://sapha1pas:40180"
+              },
+              {
+                "property": "Webmethods",
+                "propertytype": "Attribute",
+                "value": "Start,InstanceStart,StartBypassHA,Bootstrap,Stop,InstanceStop,StopBypassHA,Shutdown,ParameterValue,GetProcessList,GetStartProfile,GetTraceFile,GetAlertTree,GetAlerts,RestartService,StopService,GetEnvironment,ListDeveloperTraces,ReadDeveloperTrace,RestartInstance,SendSignal,GetVersionInfo,GetQueueStatistic,GetInstanceProperties,OSExecute,ReadLogFile,AnalyseLogFiles,ListLogFiles,GetAccessPointList,GetSystemInstanceList,GetSystemUpdateList,StartSystem,StopSystem,RestartSystem,UpdateSystem,UpdateSCSInstance,CheckUpdateSystem,AccessCheck,GetProcessParameter,SetProcessParameter,SetProcessParameter2,CheckParameter,ShmDetach,GetNetworkId,GetSecNetworkId,RequestLogonFile,CreateSnapshot,ReadSnapshot,ListSnapshots,DeleteSnapshots,GetCallstack,ABAPReadSyslog,ABAPReadRawSyslog,ABAPGetWPTable,ABAPAcknowledgeAlerts,ABAPGetComponentList,ABAPCheckRFCDestinations,ABAPGetSystemWPTable,ICMGetThreadList,ICMGetConnectionList,ICMGetCacheEntries,ICMGetProxyConnectionList,WebDispGetServerList,WebDispGetGroupList,WebDispGetVirtHostList,WebDispGetUrlPrefixList,EnqGetLockTable,EnqRemoveLocks,EnqRemoveUserLocks,EnqGetStatistic,GWCancelConnections,GWDeleteClients,GWDeleteConnections,GWGetConnectionList,GWGetClientList,UpdateSystemPKI,UpdateInstancePSE,StorePSE,DeletePSE,CheckPSE,HACheckConfig,HACheckFailoverConfig,HAGetFailoverConfig,HAFailoverToNode,HASetMaintenanceMode,HACheckMaintenanceMode,ListConfigFiles,ReadConfigFile"
+              }
+            ]
+          },
+          "SystemReplication": null,
+          "Type": 2
+        }
+      ],
+      "Profile": {
+        "auth/rfc_authority_check": "6",
+        "SAPDBHOST": "10.0.1.10",
+        "wdisp/add_xforwardedfor_header": "TRUE",
+        "rdisp/btctime": "0",
+        "service/protectedwebmethods": "SDEFAULT",
+        "rdisp/gui_auto_logout": "1H",
+        "j2ee/dbname": "PRD",
+        "enq/serverinst": "00",
+        "dbs/hdb/schema": "SAPHANADB",
+        "is/HTTP/show_detailed_errors": "FALSE",
+        "rdisp/msserv": "sapmsHA1",
+        "LOGFORMAT": "%t %a %u1 %r %s %b %Lms %{Host}i %w1 %w2",
+        "icf/set_HTTPonly_flag_on_cookies": "0",
+        "icm/HTTP/ASJava/disable_url_session_tracking": "TRUE",
+        "dbs/hdb/dbname": "PRD",
+        "icm/security_log": "LOGFILE=dev_icm_sec_%y_%m,LEVEL=3,MAXFILES=2,MAXSIZEKB=50000,SWITCHTF=month",
+        "auth/check/calltransaction": "3",
+        "system/secure_communication": "ON",
+        "rsec/ssfs_datapath": "$(DIR_GLOBAL)$(DIR_SEP)security$(DIR_SEP)rsecssfs$(DIR_SEP)data",
+        "enque/process_location": "REMOTESA",
+        "rsdb/ssfs_connect": "0",
+        "SAPSYSTEMNAME": "HA1",
+        "rdisp/bufrefmode": "sendoff",
+        "rdisp/vbdelete": "0",
+        "vmcj/enable": "off",
+        "icm/HTTP/logging_0": "PREFIX=/,LOGFILE=http_%y_%m.log,MAXFILES=2,MAXSIZEKB=50000,SWITCHTF=month,",
+        "gw/sec_info": "$(DIR_GLOBAL)$(DIR_SEP)secinfo$(FT_DAT)",
+        "gw/reg_no_conn_info": "255",
+        "gw/rem_start": "DISABLED",
+        "rdisp/mshost": "sapha1as",
+        "rdisp/autoabaptime": "0",
+        "enq/enable": "TRUE",
+        "gw/acl_mode": "1",
+        "enq/serverhost": "sapha1as",
+        "ms/HTTP/logging_0": "PREFIX=/,LOGFILE=$(DIR_LOGGING)/ms-http-%y-%m-%d.log%o,MAXFILES=7,MAXSIZEKB=10000,SWITCHTF=day,LOGFORMAT=%t %a %u %r %s %b %{Host}i",
+        "SAPGLOBALHOST": "sapha1as",
+        "rfc/callback_security_method": "3",
+        "j2ee/dbhost": "10.0.1.10",
+        "icf/user_recheck": "1",
+        "rfc/ext_debugging": "0",
+        "login/disable_cpic": "1",
+        "rdisp/msserv_internal": "3900",
+        "login/password_hash_algorithm": "encoding=RFC2307,algorithm=iSSHA-512,iterations=15000,saltsize=256",
+        "ms/http_logging": "1",
+        "system/type": "ABAP",
+        "rsec/ssfs_keypath": "$(DIR_GLOBAL)$(DIR_SEP)security$(DIR_SEP)rsecssfs$(DIR_SEP)key",
+        "login/password_downwards_compatibility": "0",
+        "auth/object_disabling_active": "N",
+        "icm/HTTP/logging_client_0": "PREFIX=/,LOGFILE=http_client_%y_%m.log,MAXFILES=2,MAXSIZEKB=50000,SWITCHTF=month,",
+        "login/system_client": "000",
+        "j2ee/dbtype": "hdb"
+      },
+      "SID": "HA1",
+      "Type": 2
+    }
+  ]
+}

--- a/test/fixtures/scenarios/single-hana-single-app/e77ab524-c4e4-5381-bb59-5af8639d52a4_subscription_discovery.json
+++ b/test/fixtures/scenarios/single-hana-single-app/e77ab524-c4e4-5381-bb59-5af8639d52a4_subscription_discovery.json
@@ -1,0 +1,62 @@
+{
+  "agent_id": "e77ab524-c4e4-5381-bb59-5af8639d52a4",
+  "discovery_type": "subscription_discovery",
+  "payload": [
+    {
+      "arch": "x86_64",
+      "expires_at": "2024-03-29 10:06:56 UTC",
+      "identifier": "SLES_SAP",
+      "starts_at": "2019-03-20 09:55:32 UTC",
+      "status": "Registered",
+      "subscription_status": "ACTIVE",
+      "type": "internal",
+      "version": "15.4"
+    },
+    {
+      "arch": "x86_64",
+      "identifier": "sle-module-basesystem",
+      "status": "Registered",
+      "version": "15.4"
+    },
+    {
+      "arch": "x86_64",
+      "identifier": "sle-module-public-cloud",
+      "status": "Not Registered",
+      "version": "15.4"
+    },
+    {
+      "arch": "x86_64",
+      "identifier": "sle-module-server-applications",
+      "status": "Registered",
+      "version": "15.4"
+    },
+    {
+      "arch": "x86_64",
+      "identifier": "sle-module-desktop-applications",
+      "status": "Registered",
+      "version": "15.4"
+    },
+    {
+      "arch": "x86_64",
+      "expires_at": "2024-03-29 10:06:56 UTC",
+      "identifier": "sle-ha",
+      "starts_at": "2019-03-20 09:55:32 UTC",
+      "status": "Registered",
+      "subscription_status": "ACTIVE",
+      "type": "internal",
+      "version": "15.4"
+    },
+    {
+      "arch": "x86_64",
+      "identifier": "sle-module-sap-applications",
+      "status": "Registered",
+      "version": "15.4"
+    },
+    {
+      "arch": "x86_64",
+      "identifier": "PackageHub",
+      "status": "Registered",
+      "version": "15.4"
+    }
+  ]
+}


### PR DESCRIPTION
Add single-hana-single-app dumped scenario, to be used by `photofinish`.

The scenario contains:
- 1 machine with a single HANA (no system replication)
- 1 machine with ASCS and PAS instances (no HA)
- Both machines are running on aws

To run:
```
./photofinish run --url "http://localhost:4000/api/v1/collect" single-hana-single-app
```

> Sending the PR to `main` but you can rebase in the deregistration branch if you want to use it there