### PR TITLE
Add SAP System de/registration logic to Process Manager

### DIFF
--- a/lib/trento/application/process_managers/deregistration_process_manager.ex
+++ b/lib/trento/application/process_managers/deregistration_process_manager.ex
@@ -4,12 +4,38 @@ defmodule Trento.DeregistrationProcessManager do
     for the deregistration procedure for the aggregates
 
     This represents a transaction to ensure that the procedure of deregistering domain aggregates
-    follows a certain path and satisfies some requisities.
+    follows a certain path and satisfies some requisites.
 
     For more information see https://hexdocs.pm/commanded/process-managers.html
   """
 
-  @required_fields []
+  defmodule Instance do
+    @moduledoc """
+    An application or database instance and which SAP System it belongs to.
+    """
+    @required_fields :all
+    use Trento.Type
+
+    deftype do
+      field :sap_system_id, Ecto.UUID
+      field :instance_number, :string
+    end
+  end
+
+  defmodule Instance do
+    @moduledoc """
+    An application or database instance and which SAP System it belongs to.
+    """
+    @required_fields :all
+    use Trento.Type
+
+    deftype do
+      field :sap_system_id, Ecto.UUID
+      field :instance_number, :string
+    end
+  end
+
+  @required_fields :all
 
   use Trento.Type
 
@@ -19,61 +45,108 @@ defmodule Trento.DeregistrationProcessManager do
 
   deftype do
     field :cluster_id, Ecto.UUID
+    embeds_many :application_instances, Instance
+    embeds_many :database_instances, Instance
   end
 
   alias Trento.DeregistrationProcessManager
 
   alias Trento.Domain.Events.{
+    ApplicationInstanceDeregistered,
+    ApplicationInstanceRegistered,
     ClusterRolledUp,
+    DatabaseInstanceDeregistered,
+    DatabaseInstanceRegistered,
     HostAddedToCluster,
     HostDeregistered,
     HostDeregistrationRequested,
     HostRegistered,
     HostRemovedFromCluster,
-    HostRolledUp
+    HostRolledUp,
+    SapSystemRolledUp
   }
 
   alias Trento.Domain.Commands.{
+    DeregisterApplicationInstance,
     DeregisterClusterHost,
+    DeregisterDatabaseInstance,
     DeregisterHost
   }
 
+  alias Trento.Domain.SapSystem
+
   @doc """
-    The process manager is interested in HostRegistered which starts or joins an existing process
-    manager for the host identified by a host_id field.
-    The process manager is interested in HostDeregistered which stops a process manager for the host identified by host_id.
+    The Process Manager is started by the following events (provided the instance hasn't been started already):
+    - HostRegistered starts a Process Manager for a newly registered host.
+    - HostAddedToCluster starts a Process Manager when a Host gets added to a Cluster, as this event may arrive
+      prior to the HostRegistered event.
+    - DatabaseInstanceRegistered starts a Process Manager when an instance gets added to a SAP system, as this
+      event may arrive prior to the HostRegistered event.
+    - ApplicationInstanceRegistered starts a Process Manager when an instance gets added to a SAP system, as this
+      event may arrive prior to the HostRegistered event.
+    - "Rolled-Up" events:
+        - HostRolledUp starts the Process Manager as the HostRegistered event might have been rolled up.
+        - ClusterRolledUp starts the Process Manager as the HostAddedToCluster event might have been rolled up.
+        - SapSystemRolledUp starts the Process Manager as the DatabaseInstanceRegistered/ApplicationInstanceRegistered
+          events might have been rolled up.
 
-    We consider also the host rollup case, starting a process manager when the host rolled up arrived, so we identify a registered host
-    without the HostRegistered event, because that event could be rolled up and then we have to consider also the rolled up host as registered.
-
-    The process manager starts with a Deregistration request and stops when the host is fully deregistered.
+    HostDeregistered stops a Process Manager for the Host identified by host_id.
   """
   # Start the Process Manager
   def interested?(%HostRegistered{host_id: host_id}), do: {:start, host_id}
   def interested?(%HostRolledUp{host_id: host_id}), do: {:start, host_id}
   def interested?(%HostAddedToCluster{host_id: host_id}), do: {:start, host_id}
   def interested?(%ClusterRolledUp{snapshot: %{hosts: hosts}}), do: {:start, hosts}
+  def interested?(%DatabaseInstanceRegistered{host_id: host_id}), do: {:start, host_id}
+  def interested?(%ApplicationInstanceRegistered{host_id: host_id}), do: {:start, host_id}
+
+  def interested?(%SapSystemRolledUp{
+        snapshot: %SapSystem{
+          database: %SapSystem.Database{instances: db_instances},
+          application: %SapSystem.Application{instances: app_instances}
+        }
+      }),
+      do:
+        {:start,
+         (db_instances ++ app_instances)
+         |> Enum.map(fn %SapSystem.Instance{host_id: host_id} -> host_id end)
+         |> Enum.uniq()}
+
   # Continue the Process Manager
   def interested?(%HostDeregistrationRequested{host_id: host_id}), do: {:continue, host_id}
   def interested?(%HostRemovedFromCluster{host_id: host_id}), do: {:continue, host_id}
+  def interested?(%DatabaseInstanceDeregistered{host_id: host_id}), do: {:continue, host_id}
+  def interested?(%ApplicationInstanceDeregistered{host_id: host_id}), do: {:continue, host_id}
   # Stop the Process Manager
   def interested?(%HostDeregistered{host_id: host_id}), do: {:stop, host_id}
 
   def interested?(_event), do: false
 
-  # Deregister host that doesn't belong to any cluster
-  def handle(%DeregistrationProcessManager{cluster_id: nil}, %HostDeregistrationRequested{
-        host_id: host_id,
-        requested_at: requested_at
-      }) do
+  def handle(
+        %DeregistrationProcessManager{
+          cluster_id: nil,
+          application_instances: [],
+          database_instances: []
+        },
+        %HostDeregistrationRequested{
+          host_id: host_id,
+          requested_at: requested_at
+        }
+      ) do
     %DeregisterHost{host_id: host_id, deregistered_at: requested_at}
   end
 
-  # First step in host deregistration when host belongs to a cluster
-  def handle(%DeregistrationProcessManager{cluster_id: cluster_id}, %HostDeregistrationRequested{
-        host_id: host_id,
-        requested_at: requested_at
-      }) do
+  def handle(
+        %DeregistrationProcessManager{
+          cluster_id: cluster_id,
+          application_instances: [],
+          database_instances: []
+        },
+        %HostDeregistrationRequested{
+          host_id: host_id,
+          requested_at: requested_at
+        }
+      ) do
     [
       %DeregisterClusterHost{
         host_id: host_id,
@@ -84,10 +157,47 @@ defmodule Trento.DeregistrationProcessManager do
     ]
   end
 
-  def apply(%DeregistrationProcessManager{} = state, %ClusterRolledUp{
-        cluster_id: cluster_id
-      }) do
-    %DeregistrationProcessManager{state | cluster_id: cluster_id}
+  def handle(
+        %DeregistrationProcessManager{
+          cluster_id: cluster_id,
+          database_instances: database_instances,
+          application_instances: application_instances
+        },
+        %HostDeregistrationRequested{
+          host_id: host_id,
+          requested_at: requested_at
+        }
+      ) do
+    List.flatten([
+      %DeregisterClusterHost{
+        host_id: host_id,
+        cluster_id: cluster_id,
+        deregistered_at: requested_at
+      },
+      Enum.map(database_instances, fn %Instance{
+                                        sap_system_id: sap_system_id,
+                                        instance_number: instance_number
+                                      } ->
+        %DeregisterDatabaseInstance{
+          sap_system_id: sap_system_id,
+          instance_number: instance_number,
+          host_id: host_id,
+          deregistered_at: requested_at
+        }
+      end),
+      Enum.map(application_instances, fn %Instance{
+                                           sap_system_id: sap_system_id,
+                                           instance_number: instance_number
+                                         } ->
+        %DeregisterApplicationInstance{
+          sap_system_id: sap_system_id,
+          instance_number: instance_number,
+          host_id: host_id,
+          deregistered_at: requested_at
+        }
+      end),
+      %DeregisterHost{host_id: host_id, deregistered_at: requested_at}
+    ])
   end
 
   def apply(%DeregistrationProcessManager{} = state, %HostAddedToCluster{
@@ -98,5 +208,115 @@ defmodule Trento.DeregistrationProcessManager do
 
   def apply(%DeregistrationProcessManager{} = state, %HostRemovedFromCluster{}) do
     %DeregistrationProcessManager{state | cluster_id: nil}
+  end
+
+  def apply(%DeregistrationProcessManager{} = state, %ClusterRolledUp{
+        cluster_id: cluster_id
+      }) do
+    %DeregistrationProcessManager{state | cluster_id: cluster_id}
+  end
+
+  def apply(
+        %DeregistrationProcessManager{database_instances: database_instances} = state,
+        %DatabaseInstanceRegistered{
+          sap_system_id: sap_system_id,
+          instance_number: instance_number
+        }
+      ) do
+    %DeregistrationProcessManager{
+      state
+      | database_instances: [
+          %Instance{
+            sap_system_id: sap_system_id,
+            instance_number: instance_number
+          }
+          | database_instances
+        ]
+    }
+  end
+
+  def apply(
+        %DeregistrationProcessManager{application_instances: application_instances} = state,
+        %ApplicationInstanceRegistered{
+          sap_system_id: sap_system_id,
+          instance_number: instance_number
+        }
+      ) do
+    %DeregistrationProcessManager{
+      state
+      | application_instances: [
+          %Instance{
+            sap_system_id: sap_system_id,
+            instance_number: instance_number
+          }
+          | application_instances
+        ]
+    }
+  end
+
+  def apply(
+        %DeregistrationProcessManager{
+          database_instances: database_instances,
+          application_instances: application_instances
+        } = state,
+        %SapSystemRolledUp{
+          sap_system_id: snapshot_sap_system_id,
+          snapshot: %SapSystem{
+            database: %SapSystem.Database{instances: snapshot_database_instances},
+            application: %SapSystem.Application{instances: snapshot_application_instances}
+          }
+        }
+      ) do
+    %DeregistrationProcessManager{
+      state
+      | database_instances:
+          snapshot_database_instances
+          |> Enum.map(fn %SapSystem.Instance{
+                           instance_number: instance_number
+                         } ->
+            %Instance{sap_system_id: snapshot_sap_system_id, instance_number: instance_number}
+          end)
+          |> Enum.concat(database_instances)
+          |> Enum.uniq(),
+        application_instances:
+          snapshot_application_instances
+          |> Enum.map(fn %SapSystem.Instance{
+                           instance_number: instance_number
+                         } ->
+            %Instance{sap_system_id: snapshot_sap_system_id, instance_number: instance_number}
+          end)
+          |> Enum.concat(application_instances)
+          |> Enum.uniq()
+    }
+  end
+
+  def apply(
+        %DeregistrationProcessManager{database_instances: database_instances} = state,
+        %DatabaseInstanceDeregistered{instance_number: instance_number}
+      ) do
+    %DeregistrationProcessManager{
+      state
+      | database_instances:
+          Enum.reject(database_instances, fn %Instance{
+                                               instance_number: current_instance_number
+                                             } ->
+            current_instance_number == instance_number
+          end)
+    }
+  end
+
+  def apply(
+        %DeregistrationProcessManager{application_instances: application_instances} = state,
+        %ApplicationInstanceDeregistered{instance_number: instance_number}
+      ) do
+    %DeregistrationProcessManager{
+      state
+      | application_instances:
+          Enum.reject(application_instances, fn %Instance{
+                                                  instance_number: current_instance_number
+                                                } ->
+            current_instance_number == instance_number
+          end)
+    }
   end
 end

--- a/lib/trento/application/process_managers/deregistration_process_manager.ex
+++ b/lib/trento/application/process_managers/deregistration_process_manager.ex
@@ -22,19 +22,6 @@ defmodule Trento.DeregistrationProcessManager do
     end
   end
 
-  defmodule Instance do
-    @moduledoc """
-    An application or database instance and which SAP System it belongs to.
-    """
-    @required_fields :all
-    use Trento.Type
-
-    deftype do
-      field :sap_system_id, Ecto.UUID
-      field :instance_number, :string
-    end
-  end
-
   @required_fields :all
 
   use Trento.Type

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -11,6 +11,7 @@ defmodule Trento.Factory do
     ClusterNode,
     ClusterResource,
     HanaClusterDetails,
+    SapSystem,
     SbdDevice,
     SlesSubscription
   }
@@ -347,6 +348,16 @@ defmodule Trento.Factory do
   def application_instance_factory do
     host = build(:host)
     build(:application_instance_without_host, host_id: host.id, host: host)
+  end
+
+  def sap_system_instance_factory do
+    %SapSystem.Instance{
+      sid: Faker.UUID.v4(),
+      instance_number: String.pad_leading(sequence(:instance_number, &"#{&1}"), 2, "0"),
+      features: Faker.Pokemon.name(),
+      host_id: Faker.UUID.v4(),
+      health: :passing
+    }
   end
 
   def discovery_event_factory do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -356,7 +356,7 @@ defmodule Trento.Factory do
       instance_number: String.pad_leading(sequence(:instance_number, &"#{&1}"), 2, "0"),
       features: Faker.Pokemon.name(),
       host_id: Faker.UUID.v4(),
-      health: :passing
+      health: Health.passing()
     }
   end
 

--- a/test/trento/application/process_managers/deregistration_process_manager_test.exs
+++ b/test/trento/application/process_managers/deregistration_process_manager_test.exs
@@ -1,21 +1,36 @@
 defmodule Trento.DeregistrationProcessManagerTest do
   use ExUnit.Case
 
+  import Trento.Factory
+
   alias Trento.Domain.Events.{
+    ApplicationInstanceDeregistered,
+    ApplicationInstanceRegistered,
     ClusterRolledUp,
+    DatabaseInstanceDeregistered,
+    DatabaseInstanceRegistered,
     HostAddedToCluster,
     HostDeregistered,
     HostDeregistrationRequested,
     HostRegistered,
     HostRemovedFromCluster,
-    HostRolledUp
+    HostRolledUp,
+    SapSystemRolledUp
   }
 
   alias Trento.DeregistrationProcessManager
-  alias Trento.Domain.Cluster
+
+  alias Trento.DeregistrationProcessManager.Instance
+
+  alias Trento.Domain.{
+    Cluster,
+    SapSystem
+  }
 
   alias Trento.Domain.Commands.{
+    DeregisterApplicationInstance,
     DeregisterClusterHost,
+    DeregisterDatabaseInstance,
     DeregisterHost
   }
 
@@ -50,11 +65,79 @@ defmodule Trento.DeregistrationProcessManagerTest do
                })
     end
 
+    test "should start the process manager when DatabaseInstanceRegistered event arrives" do
+      host_id = UUID.uuid4()
+
+      assert {:start, ^host_id} =
+               DeregistrationProcessManager.interested?(%DatabaseInstanceRegistered{
+                 host_id: host_id
+               })
+    end
+
+    test "should start the process manager when ApplicationInstanceRegistered event arrives" do
+      host_id = UUID.uuid4()
+
+      assert {:start, ^host_id} =
+               DeregistrationProcessManager.interested?(%ApplicationInstanceRegistered{
+                 host_id: host_id
+               })
+    end
+
+    test "should start process managers when SapSystemRolledUp arrives" do
+      db_host_id = UUID.uuid4()
+      app_host_id = UUID.uuid4()
+
+      database_instances = [
+        build(:sap_system_instance, host_id: db_host_id)
+      ]
+
+      application_instances = [
+        build(:sap_system_instance, host_id: app_host_id)
+      ]
+
+      assert {:start, [^db_host_id, ^app_host_id]} =
+               DeregistrationProcessManager.interested?(%SapSystemRolledUp{
+                 snapshot: %SapSystem{
+                   database: %SapSystem.Database{
+                     instances: database_instances
+                   },
+                   application: %SapSystem.Application{
+                     instances: application_instances
+                   }
+                 }
+               })
+    end
+
     test "should continue the process manager when HostDeregistrationRequested arrives" do
       host_id = UUID.uuid4()
 
       assert {:continue, ^host_id} =
                DeregistrationProcessManager.interested?(%HostDeregistrationRequested{
+                 host_id: host_id
+               })
+    end
+
+    test "should continue the process manager when HostRemovedFromCluster arrives" do
+      host_id = UUID.uuid4()
+
+      assert {:continue, ^host_id} =
+               DeregistrationProcessManager.interested?(%HostRemovedFromCluster{host_id: host_id})
+    end
+
+    test "should continue the process manager when DatabaseInstanceDeregistered arrives" do
+      host_id = UUID.uuid4()
+
+      assert {:continue, ^host_id} =
+               DeregistrationProcessManager.interested?(%DatabaseInstanceDeregistered{
+                 host_id: host_id
+               })
+    end
+
+    test "should continue the process manager when ApplicationInstanceDeregistered arrives" do
+      host_id = UUID.uuid4()
+
+      assert {:continue, ^host_id} =
+               DeregistrationProcessManager.interested?(%ApplicationInstanceDeregistered{
                  host_id: host_id
                })
     end
@@ -65,29 +148,9 @@ defmodule Trento.DeregistrationProcessManagerTest do
       assert {:stop, ^host_id} =
                DeregistrationProcessManager.interested?(%HostDeregistered{host_id: host_id})
     end
-
-    test "should continue the process manager when HostRemovedFromCluster arrives" do
-      host_id = UUID.uuid4()
-
-      assert {:continue, ^host_id} =
-               DeregistrationProcessManager.interested?(%HostRemovedFromCluster{host_id: host_id})
-    end
   end
 
-  describe "host deregistration procedure" do
-    test "should update the state with the proper cluster id when ClusterRolledUp event is emitted" do
-      initial_state = %DeregistrationProcessManager{}
-      cluster_id = UUID.uuid4()
-      cluster_hosts = [UUID.uuid4(), UUID.uuid4()]
-
-      events = [%ClusterRolledUp{cluster_id: cluster_id, snapshot: cluster_hosts}]
-
-      {commands, state} = reduce_events(events, initial_state)
-
-      assert [] == commands
-      assert %DeregistrationProcessManager{cluster_id: ^cluster_id} = state
-    end
-
+  describe "host registration procedure" do
     test "should update the state with the proper cluster id when HostAddedToCluster event is emitted" do
       initial_state = %DeregistrationProcessManager{}
       cluster_id = UUID.uuid4()
@@ -101,6 +164,153 @@ defmodule Trento.DeregistrationProcessManagerTest do
       assert %DeregistrationProcessManager{cluster_id: ^cluster_id} = state
     end
 
+    test "should add database instance with the proper host id when DatabaseInstanceRegistered event is emitted" do
+      initial_state = %DeregistrationProcessManager{
+        database_instances: [],
+        application_instances: []
+      }
+
+      host_id = UUID.uuid4()
+      sap_system_id = UUID.uuid4()
+      instance_number = "01"
+
+      events = [
+        %DatabaseInstanceRegistered{
+          host_id: host_id,
+          sap_system_id: sap_system_id,
+          instance_number: instance_number
+        }
+      ]
+
+      {commands, state} = reduce_events(events, initial_state)
+
+      assert [] == commands
+
+      assert %DeregistrationProcessManager{
+               database_instances: [
+                 %Instance{
+                   sap_system_id: ^sap_system_id,
+                   instance_number: ^instance_number
+                 }
+               ],
+               application_instances: []
+             } = state
+    end
+
+    test "should add application instance when ApplicationInstanceRegistered event is emitted" do
+      sap_system_id_1 = UUID.uuid4()
+      instance_number_1 = "01"
+
+      initial_state = %DeregistrationProcessManager{
+        database_instances: [],
+        application_instances: [
+          %Instance{
+            sap_system_id: sap_system_id_1,
+            instance_number: instance_number_1
+          }
+        ]
+      }
+
+      host_id = UUID.uuid4()
+      sap_system_id_2 = UUID.uuid4()
+      instance_number_2 = "01"
+
+      events = [
+        %ApplicationInstanceRegistered{
+          host_id: host_id,
+          sap_system_id: sap_system_id_2,
+          instance_number: instance_number_2
+        }
+      ]
+
+      {commands, state} = reduce_events(events, initial_state)
+
+      assert [] == commands
+
+      assert %DeregistrationProcessManager{
+               database_instances: [],
+               application_instances: [
+                 %Instance{
+                   sap_system_id: ^sap_system_id_2,
+                   instance_number: ^instance_number_2
+                 },
+                 %Instance{
+                   sap_system_id: ^sap_system_id_1,
+                   instance_number: ^instance_number_1
+                 }
+               ]
+             } = state
+    end
+
+    test "should update the state with the proper cluster id when ClusterRolledUp event is emitted" do
+      initial_state = %DeregistrationProcessManager{}
+      cluster_id = UUID.uuid4()
+      cluster_hosts = [UUID.uuid4(), UUID.uuid4()]
+
+      events = [
+        %ClusterRolledUp{cluster_id: cluster_id, snapshot: %Cluster{hosts: cluster_hosts}}
+      ]
+
+      {commands, state} = reduce_events(events, initial_state)
+
+      assert [] == commands
+      assert %DeregistrationProcessManager{cluster_id: ^cluster_id} = state
+    end
+
+    test "should update state after when SapSystemRolledUp event received" do
+      sap_system_id = UUID.uuid4()
+      database_instance_number = "00"
+      application_instance_number = "01"
+
+      initial_state = %DeregistrationProcessManager{
+        database_instances: [],
+        application_instances: []
+      }
+
+      events = [
+        %SapSystemRolledUp{
+          sap_system_id: sap_system_id,
+          snapshot: %SapSystem{
+            database: %SapSystem.Database{
+              instances: [
+                %SapSystem.Instance{
+                  instance_number: database_instance_number
+                }
+              ]
+            },
+            application: %SapSystem.Application{
+              instances: [
+                %SapSystem.Instance{
+                  instance_number: application_instance_number
+                }
+              ]
+            }
+          }
+        }
+      ]
+
+      {commands, state} = reduce_events(events, initial_state)
+
+      assert [] == commands
+
+      assert %DeregistrationProcessManager{
+               database_instances: [
+                 %Instance{
+                   sap_system_id: ^sap_system_id,
+                   instance_number: ^database_instance_number
+                 }
+               ],
+               application_instances: [
+                 %Instance{
+                   sap_system_id: ^sap_system_id,
+                   instance_number: ^application_instance_number
+                 }
+               ]
+             } = state
+    end
+  end
+
+  describe "host deregistration procedure" do
     test "should dispatch DeregisterHost command when HostDeregistrationRequested is emitted" do
       host_id = UUID.uuid4()
       requested_at = DateTime.utc_now()
@@ -114,11 +324,16 @@ defmodule Trento.DeregistrationProcessManagerTest do
       assert %DeregisterHost{host_id: ^host_id, deregistered_at: ^requested_at} = commands
     end
 
-    test "should dispatch DeregisterClusterHost and then DeregisterHost commands when HostDeregistrationRequested is emitted and the host belongs to a cluster" do
+    test "should dispatch commands when HostDeregistrationRequested is emitted and the host belongs to a cluster and has no instances associated" do
       host_id = UUID.uuid4()
       cluster_id = UUID.uuid4()
       requested_at = DateTime.utc_now()
-      initial_state = %DeregistrationProcessManager{cluster_id: cluster_id}
+
+      initial_state = %DeregistrationProcessManager{
+        cluster_id: cluster_id,
+        database_instances: [],
+        application_instances: []
+      }
 
       events = [%HostDeregistrationRequested{host_id: host_id, requested_at: requested_at}]
 
@@ -130,6 +345,52 @@ defmodule Trento.DeregistrationProcessManagerTest do
                %DeregisterClusterHost{
                  host_id: ^host_id,
                  cluster_id: ^cluster_id,
+                 deregistered_at: ^requested_at
+               },
+               %DeregisterHost{host_id: ^host_id, deregistered_at: ^requested_at}
+             ] = commands
+    end
+
+    test "should dispatch commands when HostDeregistrationRequested is emitted and the host belongs to a cluster and has instances associated" do
+      host_id = UUID.uuid4()
+      cluster_id = UUID.uuid4()
+      sap_system_id = UUID.uuid4()
+      db_instance_number = "00"
+      app_instance_number = "01"
+      requested_at = DateTime.utc_now()
+
+      initial_state = %DeregistrationProcessManager{
+        cluster_id: cluster_id,
+        database_instances: [
+          %Instance{sap_system_id: sap_system_id, instance_number: db_instance_number}
+        ],
+        application_instances: [
+          %Instance{sap_system_id: sap_system_id, instance_number: app_instance_number}
+        ]
+      }
+
+      events = [%HostDeregistrationRequested{host_id: host_id, requested_at: requested_at}]
+
+      {commands, state} = reduce_events(events, initial_state)
+
+      assert ^initial_state = state
+
+      assert [
+               %DeregisterClusterHost{
+                 host_id: ^host_id,
+                 cluster_id: ^cluster_id,
+                 deregistered_at: ^requested_at
+               },
+               %DeregisterDatabaseInstance{
+                 sap_system_id: ^sap_system_id,
+                 instance_number: ^db_instance_number,
+                 host_id: ^host_id,
+                 deregistered_at: ^requested_at
+               },
+               %DeregisterApplicationInstance{
+                 sap_system_id: ^sap_system_id,
+                 instance_number: ^app_instance_number,
+                 host_id: ^host_id,
                  deregistered_at: ^requested_at
                },
                %DeregisterHost{host_id: ^host_id, deregistered_at: ^requested_at}
@@ -150,6 +411,78 @@ defmodule Trento.DeregistrationProcessManagerTest do
 
       assert [] == commands
       assert %DeregistrationProcessManager{cluster_id: nil} = state
+    end
+
+    test "should remove instance from state when DatabaseInstanceDeregistered event received" do
+      sap_system_id = UUID.uuid4()
+      instance_number = "00"
+
+      initial_state = %DeregistrationProcessManager{
+        database_instances: [
+          %Instance{
+            sap_system_id: sap_system_id,
+            instance_number: instance_number
+          }
+        ],
+        application_instances: []
+      }
+
+      host_id = UUID.uuid4()
+      deregistered_at = DateTime.utc_now()
+
+      events = [
+        %DatabaseInstanceDeregistered{
+          instance_number: instance_number,
+          host_id: host_id,
+          sap_system_id: sap_system_id,
+          deregistered_at: deregistered_at
+        }
+      ]
+
+      {commands, state} = reduce_events(events, initial_state)
+
+      assert [] == commands
+
+      assert %DeregistrationProcessManager{
+               database_instances: [],
+               application_instances: []
+             } = state
+    end
+
+    test "should remove instance from state when ApplicationInstanceDeregistered event received" do
+      sap_system_id = UUID.uuid4()
+      instance_number = "00"
+
+      initial_state = %DeregistrationProcessManager{
+        database_instances: [],
+        application_instances: [
+          %Instance{
+            sap_system_id: sap_system_id,
+            instance_number: instance_number
+          }
+        ]
+      }
+
+      host_id = UUID.uuid4()
+      deregistered_at = DateTime.utc_now()
+
+      events = [
+        %ApplicationInstanceDeregistered{
+          instance_number: instance_number,
+          host_id: host_id,
+          sap_system_id: sap_system_id,
+          deregistered_at: deregistered_at
+        }
+      ]
+
+      {commands, state} = reduce_events(events, initial_state)
+
+      assert [] == commands
+
+      assert %DeregistrationProcessManager{
+               database_instances: [],
+               application_instances: []
+             } = state
     end
   end
 


### PR DESCRIPTION
# Description

Adds behaviour for processing `DatabaseInstanceRegistered`, `ApplicationInstanceRegistered`, `SapSystemRolledUp`, `DatabaseInstanceDeregistered` & `ApplicationInstanceDeregistered` events.

Adds `application_instances` & `database_instances` lists to the Process Manager state.

## How was this tested?

Added unit tests for each scenario.
