### PR TITLE
Add application instance deregistration logic

### DIFF
--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -702,9 +702,14 @@ defmodule Trento.Domain.SapSystem do
   end
 
   defp maybe_emit_sap_system_deregistered_event(
+         %SapSystem{sid: nil},
+         _deregistered_at
+       ),
+       do: []
+
+  defp maybe_emit_sap_system_deregistered_event(
          %SapSystem{
            sap_system_id: sap_system_id,
-           sid: sid,
            application: %Application{
              instances: instances
            }
@@ -716,7 +721,7 @@ defmodule Trento.Domain.SapSystem do
     has_messageserver? =
       Enum.any?(instances, fn %{features: features} -> features =~ "MESSAGESERVER" end)
 
-    unless has_abap? and has_messageserver? and !is_nil(sid) do
+    unless has_abap? and has_messageserver? do
       %SapSystemDeregistered{sap_system_id: sap_system_id, deregistered_at: deregistered_at}
     end
   end

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -305,7 +305,7 @@ defmodule Trento.Domain.SapSystem do
           sap_system_id: sap_system_id,
           host_id: host_id,
           deregistered_at: deregistered_at
-        } = command
+        }
       ) do
     sap_system
     |> Multi.new()
@@ -320,7 +320,7 @@ defmodule Trento.Domain.SapSystem do
     |> Multi.execute(fn sap_system ->
       maybe_emit_sap_system_deregistration_events(
         sap_system,
-        command
+        deregistered_at
       )
     end)
   end
@@ -347,16 +347,14 @@ defmodule Trento.Domain.SapSystem do
   end
 
   def apply(
-        %SapSystem{application: %Application{instances: []}} = sap_system,
+        %SapSystem{} = sap_system,
         %SapSystemDeregistered{
-          sap_system_id: sap_system_id,
           deregistered_at: deregistered_at
         }
       ) do
     %SapSystem{
       sap_system
-      | sap_system_id: sap_system_id,
-        deregistered_at: deregistered_at
+      | deregistered_at: deregistered_at
     }
   end
 
@@ -710,10 +708,7 @@ defmodule Trento.Domain.SapSystem do
              instances: instances
            }
          },
-         %DeregisterApplicationInstance{
-           sap_system_id: sap_system_id,
-           deregistered_at: deregistered_at
-         }
+         deregistered_at
        ) do
     if !Enum.any?(instances, fn %Instance{features: features} ->
          String.contains?(features, "MESSAGESERVER")

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -710,12 +710,12 @@ defmodule Trento.Domain.SapSystem do
          },
          deregistered_at
        ) do
-    if !Enum.any?(instances, fn %Instance{features: features} ->
-         String.contains?(features, "MESSAGESERVER")
-       end) ||
-         !Enum.any?(instances, fn %Instance{features: features} ->
-           String.contains?(features, "ABAP")
-         end) do
+    has_abap? = Enum.any?(instances, fn instance -> instance.features =~ "ABAP" end)
+
+    has_messageserver? =
+      Enum.any?(instances, fn instance -> instance.features =~ "MESSAGESERVER" end)
+
+    unless has_abap? and has_messageserver? do
       Enum.map(instances, fn %Instance{instance_number: instance_number, host_id: host_id} ->
         %ApplicationInstanceDeregistered{
           sap_system_id: sap_system_id,

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -354,7 +354,8 @@ defmodule Trento.Domain.SapSystem do
       ) do
     %SapSystem{
       sap_system
-      | deregistered_at: deregistered_at
+      | deregistered_at: deregistered_at,
+        sid: nil
     }
   end
 

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -54,12 +54,14 @@ defmodule Trento.Domain.SapSystem do
   }
 
   alias Trento.Domain.Commands.{
+    DeregisterApplicationInstance,
     RegisterApplicationInstance,
     RegisterDatabaseInstance,
     RollUpSapSystem
   }
 
   alias Trento.Domain.Events.{
+    ApplicationInstanceDeregistered,
     ApplicationInstanceHealthChanged,
     ApplicationInstanceRegistered,
     DatabaseHealthChanged,
@@ -67,6 +69,7 @@ defmodule Trento.Domain.SapSystem do
     DatabaseInstanceRegistered,
     DatabaseInstanceSystemReplicationChanged,
     DatabaseRegistered,
+    SapSystemDeregistered,
     SapSystemHealthChanged,
     SapSystemRegistered,
     SapSystemRolledUp,
@@ -84,6 +87,7 @@ defmodule Trento.Domain.SapSystem do
     field :sid, :string
     field :health, Ecto.Enum, values: Health.values()
     field :rolling_up, :boolean, default: false
+    field :deregistered_at, :utc_datetime_usec, default: nil
 
     embeds_one :database, Database
     embeds_one :application, Application
@@ -287,6 +291,72 @@ defmodule Trento.Domain.SapSystem do
     %SapSystemRollUpRequested{
       sap_system_id: sap_system_id,
       snapshot: snapshot
+    }
+  end
+
+  # Deregister an application instance and emit a ApplicationInstanceDeregistered
+  # also emit SapSystemDeregistered event if this was the last application instance
+  def execute(
+        %SapSystem{
+          sap_system_id: sap_system_id
+        } = sap_system,
+        %DeregisterApplicationInstance{
+          instance_number: instance_number,
+          sap_system_id: sap_system_id,
+          host_id: host_id,
+          deregistered_at: deregistered_at
+        } = command
+      ) do
+    sap_system
+    |> Multi.new()
+    |> Multi.execute(fn _ ->
+      %ApplicationInstanceDeregistered{
+        sap_system_id: sap_system_id,
+        instance_number: instance_number,
+        host_id: host_id,
+        deregistered_at: deregistered_at
+      }
+    end)
+    |> Multi.execute(fn sap_system ->
+      maybe_emit_sap_system_deregistration_events(
+        sap_system,
+        command
+      )
+    end)
+  end
+
+  def apply(
+        %SapSystem{application: %Application{instances: instances}} = sap_system,
+        %ApplicationInstanceDeregistered{instance_number: instance_number, host_id: host_id}
+      ) do
+    instances =
+      Enum.reject(instances, fn
+        %Instance{instance_number: ^instance_number, host_id: ^host_id} ->
+          true
+
+        _ ->
+          false
+      end)
+
+    %SapSystem{
+      sap_system
+      | application: %Application{
+          instances: instances
+        }
+    }
+  end
+
+  def apply(
+        %SapSystem{application: %Application{instances: []}} = sap_system,
+        %SapSystemDeregistered{
+          sap_system_id: sap_system_id,
+          deregistered_at: deregistered_at
+        }
+      ) do
+    %SapSystem{
+      sap_system
+      | sap_system_id: sap_system_id,
+        deregistered_at: deregistered_at
     }
   end
 
@@ -630,6 +700,36 @@ defmodule Trento.Domain.SapSystem do
         sap_system_id: sap_system_id,
         health: new_health
       }
+    end
+  end
+
+  defp maybe_emit_sap_system_deregistration_events(
+         %SapSystem{
+           sap_system_id: sap_system_id,
+           application: %Application{
+             instances: instances
+           }
+         },
+         %DeregisterApplicationInstance{
+           sap_system_id: sap_system_id,
+           deregistered_at: deregistered_at
+         }
+       ) do
+    if !Enum.any?(instances, fn %Instance{features: features} ->
+         String.contains?(features, "MESSAGESERVER")
+       end) ||
+         !Enum.any?(instances, fn %Instance{features: features} ->
+           String.contains?(features, "ABAP")
+         end) do
+      Enum.map(instances, fn %Instance{instance_number: instance_number, host_id: host_id} ->
+        %ApplicationInstanceDeregistered{
+          sap_system_id: sap_system_id,
+          instance_number: instance_number,
+          host_id: host_id,
+          deregistered_at: deregistered_at
+        }
+      end) ++
+        [%SapSystemDeregistered{sap_system_id: sap_system_id, deregistered_at: deregistered_at}]
     end
   end
 

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -716,7 +716,7 @@ defmodule Trento.Domain.SapSystem do
     has_messageserver? =
       Enum.any?(instances, fn %{features: features} -> features =~ "MESSAGESERVER" end)
 
-    unless has_abap? and has_messageserver? and sid != nil do
+    unless has_abap? and has_messageserver? and !is_nil(sid) do
       %SapSystemDeregistered{sap_system_id: sap_system_id, deregistered_at: deregistered_at}
     end
   end

--- a/lib/trento/infrastructure/router.ex
+++ b/lib/trento/infrastructure/router.ex
@@ -11,6 +11,7 @@ defmodule Trento.Router do
 
   alias Trento.Domain.Commands.{
     CompleteChecksExecution,
+    DeregisterApplicationInstance,
     DeregisterClusterHost,
     DeregisterHost,
     RegisterApplicationInstance,
@@ -58,7 +59,12 @@ defmodule Trento.Router do
 
   identify SapSystem, by: :sap_system_id
 
-  dispatch [RegisterApplicationInstance, RegisterDatabaseInstance, RollUpSapSystem],
-    to: SapSystem,
-    lifespan: SapSystem.Lifespan
+  dispatch [
+             DeregisterApplicationInstance,
+             RegisterApplicationInstance,
+             RegisterDatabaseInstance,
+             RollUpSapSystem
+           ],
+           to: SapSystem,
+           lifespan: SapSystem.Lifespan
 end

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -1419,6 +1419,7 @@ defmodule Trento.SapSystemTest do
         },
         fn sap_system ->
           assert %SapSystem{
+                   sid: nil,
                    database: %Database{
                      instances: [
                        %Instance{
@@ -1430,7 +1431,7 @@ defmodule Trento.SapSystemTest do
                    application: %Application{
                      instances: []
                    },
-                   deregistered_at: ^deregistered_at
+                   deregistered_at: nil
                  } = sap_system
         end
       )

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -4,12 +4,14 @@ defmodule Trento.SapSystemTest do
   import Trento.Factory
 
   alias Trento.Domain.Commands.{
+    DeregisterApplicationInstance,
     RegisterApplicationInstance,
     RegisterDatabaseInstance,
     RollUpSapSystem
   }
 
   alias Trento.Domain.Events.{
+    ApplicationInstanceDeregistered,
     ApplicationInstanceHealthChanged,
     ApplicationInstanceRegistered,
     DatabaseHealthChanged,
@@ -17,6 +19,7 @@ defmodule Trento.SapSystemTest do
     DatabaseInstanceRegistered,
     DatabaseInstanceSystemReplicationChanged,
     DatabaseRegistered,
+    SapSystemDeregistered,
     SapSystemHealthChanged,
     SapSystemRegistered,
     SapSystemRolledUp,
@@ -24,6 +27,12 @@ defmodule Trento.SapSystemTest do
   }
 
   alias Trento.Domain.SapSystem
+
+  alias Trento.Domain.SapSystem.{
+    Application,
+    Database,
+    Instance
+  }
 
   describe "SAP System registration" do
     test "should fail when a sap system does not exists and the database instance has Secondary role" do
@@ -1060,6 +1069,409 @@ defmodule Trento.SapSystemTest do
           assert sap_system.sap_system_id == sap_system_registered_event.sap_system_id
           assert sap_system.sid == sap_system_registered_event.sid
           assert sap_system.health == sap_system_registered_event.health
+        end
+      )
+    end
+  end
+
+  describe "deregistration" do
+    test "should deregister an ENQREP Application Instance" do
+      sap_system_id = UUID.uuid4()
+      deregistered_at = DateTime.utc_now()
+
+      database_host_id = UUID.uuid4()
+      message_server_host_id = UUID.uuid4()
+      abap_host_id = UUID.uuid4()
+      enqrep_host_id = UUID.uuid4()
+
+      database_instance_number = "00"
+      message_server_instance_number = "01"
+      abap_instance_number = "02"
+      enqrep_server_instance_number = "03"
+
+      assert_events_and_state(
+        [
+          build(
+            :database_registered_event,
+            sap_system_id: sap_system_id
+          ),
+          build(
+            :database_instance_registered_event,
+            sap_system_id: sap_system_id,
+            host_id: database_host_id,
+            instance_number: database_instance_number
+          ),
+          build(
+            :application_instance_registered_event,
+            sap_system_id: sap_system_id,
+            features: "MESSAGESERVER|ENQUE",
+            host_id: message_server_host_id,
+            instance_number: message_server_instance_number
+          ),
+          build(
+            :application_instance_registered_event,
+            sap_system_id: sap_system_id,
+            features: "ABAP|GATEWAY|ICMAN|IGS",
+            host_id: abap_host_id,
+            instance_number: abap_instance_number
+          ),
+          build(
+            :sap_system_registered_event,
+            sap_system_id: sap_system_id
+          ),
+          build(
+            :application_instance_registered_event,
+            sap_system_id: sap_system_id,
+            host_id: enqrep_host_id,
+            instance_number: enqrep_server_instance_number,
+            features: "ENQREP"
+          )
+        ],
+        %DeregisterApplicationInstance{
+          sap_system_id: sap_system_id,
+          host_id: enqrep_host_id,
+          instance_number: enqrep_server_instance_number,
+          deregistered_at: deregistered_at
+        },
+        [
+          %ApplicationInstanceDeregistered{
+            sap_system_id: sap_system_id,
+            host_id: enqrep_host_id,
+            instance_number: enqrep_server_instance_number,
+            deregistered_at: deregistered_at
+          }
+        ],
+        fn sap_system ->
+          assert %SapSystem{
+                   database: %Database{
+                     instances: [
+                       %Instance{
+                         instance_number: ^database_instance_number,
+                         host_id: ^database_host_id
+                       }
+                     ]
+                   },
+                   application: %Application{
+                     instances: [
+                       %Instance{
+                         host_id: ^abap_host_id,
+                         instance_number: ^abap_instance_number
+                       },
+                       %Instance{
+                         host_id: ^message_server_host_id,
+                         instance_number: ^message_server_instance_number
+                       }
+                     ]
+                   }
+                 } = sap_system
+        end
+      )
+    end
+
+    test "should deregister an ABAP Application Instance" do
+      sap_system_id = UUID.uuid4()
+      deregistered_at = DateTime.utc_now()
+
+      database_host_id = UUID.uuid4()
+      message_server_host_id = UUID.uuid4()
+      abap_host_id = UUID.uuid4()
+      abap_2_host_id = UUID.uuid4()
+      enqrep_host_id = UUID.uuid4()
+
+      database_instance_number = "00"
+      message_server_instance_number = "01"
+      abap_instance_number = "02"
+      abap_2_instance_number = "03"
+      enqrep_server_instance_number = "04"
+
+      assert_events_and_state(
+        [
+          build(
+            :database_registered_event,
+            sap_system_id: sap_system_id
+          ),
+          build(
+            :database_instance_registered_event,
+            sap_system_id: sap_system_id,
+            host_id: database_host_id,
+            instance_number: database_instance_number
+          ),
+          build(
+            :application_instance_registered_event,
+            sap_system_id: sap_system_id,
+            features: "MESSAGESERVER|ENQUE",
+            host_id: message_server_host_id,
+            instance_number: message_server_instance_number
+          ),
+          build(
+            :application_instance_registered_event,
+            sap_system_id: sap_system_id,
+            features: "ABAP|GATEWAY|ICMAN|IGS",
+            host_id: abap_host_id,
+            instance_number: abap_instance_number
+          ),
+          build(
+            :application_instance_registered_event,
+            sap_system_id: sap_system_id,
+            features: "ABAP|GATEWAY|ICMAN|IGS",
+            host_id: abap_2_host_id,
+            instance_number: abap_2_instance_number
+          ),
+          build(
+            :sap_system_registered_event,
+            sap_system_id: sap_system_id
+          ),
+          build(
+            :application_instance_registered_event,
+            sap_system_id: sap_system_id,
+            host_id: enqrep_host_id,
+            instance_number: enqrep_server_instance_number,
+            features: "ENQREP"
+          )
+        ],
+        %DeregisterApplicationInstance{
+          sap_system_id: sap_system_id,
+          host_id: abap_2_host_id,
+          instance_number: abap_2_instance_number,
+          deregistered_at: deregistered_at
+        },
+        [
+          %ApplicationInstanceDeregistered{
+            sap_system_id: sap_system_id,
+            host_id: abap_2_host_id,
+            instance_number: abap_2_instance_number,
+            deregistered_at: deregistered_at
+          }
+        ],
+        fn sap_system ->
+          assert %SapSystem{
+                   database: %Database{
+                     instances: [
+                       %Instance{
+                         instance_number: ^database_instance_number,
+                         host_id: ^database_host_id
+                       }
+                     ]
+                   },
+                   application: %Application{
+                     instances: [
+                       %Instance{
+                         host_id: ^enqrep_host_id,
+                         instance_number: ^enqrep_server_instance_number
+                       },
+                       %Instance{
+                         host_id: ^abap_host_id,
+                         instance_number: ^abap_instance_number
+                       },
+                       %Instance{
+                         host_id: ^message_server_host_id,
+                         instance_number: ^message_server_instance_number
+                       }
+                     ]
+                   }
+                 } = sap_system
+        end
+      )
+    end
+
+    test "should deregister last ABAP Application Instance, and deregister SAP System" do
+      sap_system_id = UUID.uuid4()
+      deregistered_at = DateTime.utc_now()
+
+      database_host_id = UUID.uuid4()
+      message_server_host_id = UUID.uuid4()
+      abap_host_id = UUID.uuid4()
+      enqrep_host_id = UUID.uuid4()
+
+      database_instance_number = "00"
+      message_server_instance_number = "01"
+      abap_instance_number = "02"
+      enqrep_server_instance_number = "03"
+
+      assert_events_and_state(
+        [
+          build(
+            :database_registered_event,
+            sap_system_id: sap_system_id
+          ),
+          build(
+            :database_instance_registered_event,
+            sap_system_id: sap_system_id,
+            host_id: database_host_id,
+            instance_number: database_instance_number
+          ),
+          build(
+            :application_instance_registered_event,
+            sap_system_id: sap_system_id,
+            features: "MESSAGESERVER|ENQUE",
+            host_id: message_server_host_id,
+            instance_number: message_server_instance_number
+          ),
+          build(
+            :application_instance_registered_event,
+            sap_system_id: sap_system_id,
+            features: "ABAP|GATEWAY|ICMAN|IGS",
+            host_id: abap_host_id,
+            instance_number: abap_instance_number
+          ),
+          build(
+            :sap_system_registered_event,
+            sap_system_id: sap_system_id
+          ),
+          build(
+            :application_instance_registered_event,
+            sap_system_id: sap_system_id,
+            host_id: enqrep_host_id,
+            instance_number: enqrep_server_instance_number,
+            features: "ENQREP"
+          )
+        ],
+        %DeregisterApplicationInstance{
+          sap_system_id: sap_system_id,
+          host_id: abap_host_id,
+          instance_number: abap_instance_number,
+          deregistered_at: deregistered_at
+        },
+        [
+          %ApplicationInstanceDeregistered{
+            sap_system_id: sap_system_id,
+            host_id: abap_host_id,
+            instance_number: abap_instance_number,
+            deregistered_at: deregistered_at
+          },
+          %ApplicationInstanceDeregistered{
+            sap_system_id: sap_system_id,
+            host_id: enqrep_host_id,
+            instance_number: enqrep_server_instance_number,
+            deregistered_at: deregistered_at
+          },
+          %ApplicationInstanceDeregistered{
+            sap_system_id: sap_system_id,
+            host_id: message_server_host_id,
+            instance_number: message_server_instance_number,
+            deregistered_at: deregistered_at
+          },
+          %SapSystemDeregistered{
+            sap_system_id: sap_system_id,
+            deregistered_at: deregistered_at
+          }
+        ],
+        fn sap_system ->
+          assert %SapSystem{
+                   database: %Database{
+                     instances: [
+                       %Instance{
+                         instance_number: ^database_instance_number,
+                         host_id: ^database_host_id
+                       }
+                     ]
+                   },
+                   application: %Application{
+                     instances: []
+                   },
+                   deregistered_at: ^deregistered_at
+                 } = sap_system
+        end
+      )
+    end
+
+    test "should deregister Message Server, and deregister SAP System" do
+      sap_system_id = UUID.uuid4()
+      deregistered_at = DateTime.utc_now()
+
+      database_host_id = UUID.uuid4()
+      message_server_host_id = UUID.uuid4()
+      abap_host_id = UUID.uuid4()
+      enqrep_host_id = UUID.uuid4()
+
+      database_instance_number = "00"
+      message_server_instance_number = "01"
+      abap_instance_number = "02"
+      enqrep_server_instance_number = "03"
+
+      assert_events_and_state(
+        [
+          build(
+            :database_registered_event,
+            sap_system_id: sap_system_id
+          ),
+          build(
+            :database_instance_registered_event,
+            sap_system_id: sap_system_id,
+            host_id: database_host_id,
+            instance_number: database_instance_number
+          ),
+          build(
+            :application_instance_registered_event,
+            sap_system_id: sap_system_id,
+            features: "MESSAGESERVER|ENQUE",
+            host_id: message_server_host_id,
+            instance_number: message_server_instance_number
+          ),
+          build(
+            :application_instance_registered_event,
+            sap_system_id: sap_system_id,
+            features: "ABAP|GATEWAY|ICMAN|IGS",
+            host_id: abap_host_id,
+            instance_number: abap_instance_number
+          ),
+          build(
+            :sap_system_registered_event,
+            sap_system_id: sap_system_id
+          ),
+          build(
+            :application_instance_registered_event,
+            sap_system_id: sap_system_id,
+            host_id: enqrep_host_id,
+            instance_number: enqrep_server_instance_number,
+            features: "ENQREP"
+          )
+        ],
+        %DeregisterApplicationInstance{
+          sap_system_id: sap_system_id,
+          host_id: message_server_host_id,
+          instance_number: message_server_instance_number,
+          deregistered_at: deregistered_at
+        },
+        [
+          %ApplicationInstanceDeregistered{
+            sap_system_id: sap_system_id,
+            host_id: message_server_host_id,
+            instance_number: message_server_instance_number,
+            deregistered_at: deregistered_at
+          },
+          %ApplicationInstanceDeregistered{
+            sap_system_id: sap_system_id,
+            host_id: enqrep_host_id,
+            instance_number: enqrep_server_instance_number,
+            deregistered_at: deregistered_at
+          },
+          %ApplicationInstanceDeregistered{
+            sap_system_id: sap_system_id,
+            host_id: abap_host_id,
+            instance_number: abap_instance_number,
+            deregistered_at: deregistered_at
+          },
+          %SapSystemDeregistered{
+            sap_system_id: sap_system_id,
+            deregistered_at: deregistered_at
+          }
+        ],
+        fn sap_system ->
+          assert %SapSystem{
+                   database: %Database{
+                     instances: [
+                       %Instance{
+                         instance_number: ^database_instance_number,
+                         host_id: ^database_host_id
+                       }
+                     ]
+                   },
+                   application: %Application{
+                     instances: []
+                   },
+                   deregistered_at: ^deregistered_at
+                 } = sap_system
         end
       )
     end

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -1168,7 +1168,7 @@ defmodule Trento.SapSystemTest do
       )
     end
 
-    test "should deregister an ABAP Application Instance" do
+    test "should deregister an ABAP Application Instance without deregistering the SAP system" do
       sap_system_id = UUID.uuid4()
       deregistered_at = DateTime.utc_now()
 
@@ -1346,6 +1346,7 @@ defmodule Trento.SapSystemTest do
         ],
         fn sap_system ->
           assert %SapSystem{
+                   sid: nil,
                    database: %Database{
                      instances: [
                        %Instance{


### PR DESCRIPTION
# Description

This PR adds the application instance deregistration logic to the sap_system aggregate. Upon deregistering a host, it should remove the relevant application instances and eventually sap systems, depending on the role of the deregistered host.

Note: This PR derives from https://github.com/trento-project/web/pull/1343 and is a subset of it. A follow-up PR will contain the database instance deregistration logic.

## How was this tested?
Based on the deregistration flow chart, all of the possible scenarios have been added to the test cases.


