### PR TITLE
Application instances registration changes

### DIFF
--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -6,7 +6,7 @@ defmodule Trento.Domain.SapSystem do
 
   In order to have a fully registered SAP system, both the database and application
   composing this system must be registered.
-  The minimum set of application features is ABAP and MESSAGESERVER, otherwise, a complete Sap system cannot exist.
+  The minimum set of application features is ABAP and MESSAGESERVER. Otherwise, a complete SAP system cannot exist.
   And each of the two layers might be composed by multiple instances altogether.
   This means that a SAP system aggregate state can have multiple application/database instances.
 
@@ -37,11 +37,8 @@ defmodule Trento.Domain.SapSystem do
   2. New database instances/updates coming from already registered database instances are registered/applied.
   3. When a SAP system discovery with a new application instance is received, and the database associated to
      this application exists:
-      - If the application instance does not have ABAP or MESSAGESERVER as features, will be rejected
-      - If the application instance has ABAP or MESSAGESERVER as features, and is already present an ABAP or MESSAGESERVER application instance,
-        the application instance is registered together with the complete SAP system. The SAP system is fully registered now.
-      - If the application instance has ABAP or MESSAGESERVER as features, but there are no other instances with ABAP or MESSAGESERVER as features,
-        the application instance is registered without the complete sap system registration.
+      - Instances that are not MESSAGESERVER or ABAP will be added without completing a SAP system registration
+      - To have a fully registered SAP system, a MESSAGESERVER instance and one ABAP instance are required
   4. New application instances/updates coming from already registered application instances are registered/applied.
 
   Find additional information about the application/database association in `Trento.Domain.Commands.RegisterApplicationInstance`.
@@ -94,6 +91,7 @@ defmodule Trento.Domain.SapSystem do
     field :health, Ecto.Enum, values: Health.values()
     field :rolling_up, :boolean, default: false
     field :deregistered_at, :utc_datetime_usec, default: nil
+
 
     embeds_one :database, Database
     embeds_one :application, Application
@@ -180,10 +178,10 @@ defmodule Trento.Domain.SapSystem do
     |> Multi.execute(&maybe_emit_sap_system_health_changed_event/1)
   end
 
-  # Sap system not registered, application already present
+  # SAP system not registered, application already present
   # If the instance is not one of MESSAGESERVER or ABAP we discard.
   # Otherwise if the instance we want register together with already present instances
-  # have one MESSAGESERVER and one ABAP, we register the instance and the sap system
+  # have one MESSAGESERVER and one ABAP, we register the instance and the SAP system
   # OR
   # When a RegisterApplicationInstance command is received by an existing SAP System aggregate,
   # the SAP System aggregate registers the Application instance if it is not already registered

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -92,7 +92,6 @@ defmodule Trento.Domain.SapSystem do
     field :rolling_up, :boolean, default: false
     field :deregistered_at, :utc_datetime_usec, default: nil
 
-
     embeds_one :database, Database
     embeds_one :application, Application
   end
@@ -605,7 +604,7 @@ defmodule Trento.Domain.SapSystem do
     end
   end
 
-defp maybe_emit_sap_system_deregistered_event(
+  defp maybe_emit_sap_system_deregistered_event(
          %SapSystem{sid: nil},
          _deregistered_at
        ),

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -5,9 +5,11 @@ defmodule Trento.Domain.SapSystem do
   **The HANA database is the only supported database type.**
 
   In order to have a fully registered SAP system, both the database and application
-  composing this system must be registered. And each of the two layers might be composed
-  by multiple instances altogether. This means that a SAP system aggregate state can have
-  multiple application/database instances.
+  composing this system must be registered.
+  The minimum set of application features is ABAP and MESSAGESERVER, otherwise, a complete Sap system cannot exist.
+  And each of the two layers might be composed by multiple instances altogether.
+  This means that a SAP system aggregate state can have multiple application/database instances.
+
 
   ## SAP instance
 
@@ -33,9 +35,13 @@ defmodule Trento.Domain.SapSystem do
      At this point, the registration process starts and the database is registered.
      Any application instance discovery message without an associated database is ignored.
   2. New database instances/updates coming from already registered database instances are registered/applied.
-  3. A SAP system discovery with a new application instance is received, and the database associated to
-     this application exists, the application instance is registered together with the complete
-     SAP system. The SAP system is fully registered now.
+  3. When a SAP system discovery with a new application instance is received, and the database associated to
+     this application exists:
+      - If the application instance does not have ABAP or MESSAGESERVER as features, will be rejected
+      - If the application instance has ABAP or MESSAGESERVER as features, and is already present an ABAP or MESSAGESERVER application instance,
+        the application instance is registered together with the complete SAP system. The SAP system is fully registered now.
+      - If the application instance has ABAP or MESSAGESERVER as features, but there are no other instances with ABAP or MESSAGESERVER as features,
+        the application instance is registered without the complete sap system registration.
   4. New application instances/updates coming from already registered application instances are registered/applied.
 
   Find additional information about the application/database association in `Trento.Domain.Commands.RegisterApplicationInstance`.
@@ -206,7 +212,6 @@ defmodule Trento.Domain.SapSystem do
         health: health
       }
     else
-      # TODO: Check error
       {:error, :sap_system_not_registered}
     end
   end
@@ -235,7 +240,6 @@ defmodule Trento.Domain.SapSystem do
       end)
       |> Multi.execute(&maybe_emit_sap_system_health_changed_event/1)
     else
-      # TODO: Check error
       {:error, :sap_system_not_registered}
     end
   end

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -217,9 +217,9 @@ defmodule Trento.Domain.SapSystem do
   end
 
   # Sap system not registered, application already present
-  # If the istance is not one of MESSAGESERVER or ABAP we discard.
-  # Otherwise if the istance we want register together with already present istances
-  # have one MESSAGESERVER and one ABAP, we register the istance and the sap system
+  # If the instance is not one of MESSAGESERVER or ABAP we discard.
+  # Otherwise if the instance we want register together with already present instances
+  # have one MESSAGESERVER and one ABAP, we register the instance and the sap system
   def execute(
         %SapSystem{sid: nil, application: %Application{}} = sap_system,
         %RegisterApplicationInstance{

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -236,7 +236,7 @@ defmodule Trento.Domain.SapSystem do
       instances_features =
         instances
         |> Enum.map(& &1.features)
-        |> Enum.concat(features)
+        |> Kernel.++([features])
         |> Enum.join()
 
       events =
@@ -291,7 +291,7 @@ defmodule Trento.Domain.SapSystem do
             }
         end
 
-      events = events ++ event
+      events = events ++ [event]
 
       sap_system
       |> Multi.new()
@@ -301,47 +301,6 @@ defmodule Trento.Domain.SapSystem do
       # TODO: Check error
       {:error, :sap_system_not_registered}
     end
-  end
-
-  # When an Application is discovered, the SAP System completes the registration process.
-  def execute(
-        %SapSystem{application: nil},
-        %RegisterApplicationInstance{
-          sap_system_id: sap_system_id,
-          sid: sid,
-          instance_number: instance_number,
-          instance_hostname: instance_hostname,
-          tenant: tenant,
-          db_host: db_host,
-          features: features,
-          http_port: http_port,
-          https_port: https_port,
-          start_priority: start_priority,
-          host_id: host_id,
-          health: health
-        }
-      ) do
-    [
-      %SapSystemRegistered{
-        sap_system_id: sap_system_id,
-        sid: sid,
-        tenant: tenant,
-        db_host: db_host,
-        health: health
-      },
-      %ApplicationInstanceRegistered{
-        sap_system_id: sap_system_id,
-        sid: sid,
-        instance_number: instance_number,
-        instance_hostname: instance_hostname,
-        features: features,
-        http_port: http_port,
-        https_port: https_port,
-        start_priority: start_priority,
-        host_id: host_id,
-        health: health
-      }
-    ]
   end
 
   # When a RegisterApplicationInstance command is received by an existing SAP System aggregate,

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -332,13 +332,12 @@ defmodule Trento.SapSystemTest do
       )
     end
 
-    test "should register a SAP System and add an application instance" do
+    test "should register a SAP System and add an application instance when is already present a MESSAGESERVER instance and one ABAP istance is added" do
       sap_system_id = Faker.UUID.v4()
       sid = Faker.StarWars.planet()
       db_host = Faker.Internet.ip_v4_address()
       tenant = Faker.Beer.style()
       instance_hostname = Faker.Airports.iata()
-      features = Faker.Pokemon.name()
       http_port = 80
       https_port = 443
       start_priority = "0.9"
@@ -355,6 +354,11 @@ defmodule Trento.SapSystemTest do
           sap_system_id: sap_system_id,
           sid: sid,
           tenant: tenant
+        ),
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          features: "MESSAGESERVER"
         )
       ]
 
@@ -367,7 +371,7 @@ defmodule Trento.SapSystemTest do
           tenant: tenant,
           instance_number: "00",
           instance_hostname: instance_hostname,
-          features: features,
+          features: "ABAP",
           http_port: http_port,
           https_port: https_port,
           start_priority: start_priority,
@@ -387,7 +391,7 @@ defmodule Trento.SapSystemTest do
             sid: sid,
             instance_number: "00",
             instance_hostname: instance_hostname,
-            features: features,
+            features: "ABAP",
             http_port: http_port,
             https_port: https_port,
             start_priority: start_priority,
@@ -404,9 +408,12 @@ defmodule Trento.SapSystemTest do
                        %SapSystem.Instance{
                          sid: ^sid,
                          instance_number: "00",
-                         features: ^features,
+                         features: "ABAP",
                          host_id: ^host_id,
                          health: :passing
+                       },
+                       %SapSystem.Instance{
+                         features: "MESSAGESERVER"
                        }
                      ]
                    }

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -332,7 +332,7 @@ defmodule Trento.SapSystemTest do
       )
     end
 
-    test "should register a SAP System and add an application instance when is already present a MESSAGESERVER instance and one ABAP instance is added" do
+    test "should register a SAP System and add an application instance when a MESSAGESERVER instance is already present and a new ABAP instance is added" do
       sap_system_id = Faker.UUID.v4()
       sid = Faker.StarWars.planet()
       db_host = Faker.Internet.ip_v4_address()
@@ -422,7 +422,7 @@ defmodule Trento.SapSystemTest do
       )
     end
 
-    test "should register a SAP System and add an application instance when is already present a ABAP instance and one MESSAGESERVER instance is added" do
+    test "should register a SAP System and add an application instance when an ABAP instance is already present and a new MESSAGESERVER instance is added" do
       sap_system_id = Faker.UUID.v4()
       sid = Faker.StarWars.planet()
       db_host = Faker.Internet.ip_v4_address()
@@ -512,7 +512,7 @@ defmodule Trento.SapSystemTest do
       )
     end
 
-    test "should add an application instance to a non registered sap system when the instance is ABAP without complete a sap system registration" do
+    test "should add an application instance to a non registered SAP system when the instance is ABAP without complete a sap system registration" do
       sap_system_id = Faker.UUID.v4()
       sid = Faker.StarWars.planet()
       db_host = Faker.Internet.ip_v4_address()
@@ -587,7 +587,7 @@ defmodule Trento.SapSystemTest do
       )
     end
 
-    test "should app an application instance to a non registered sap system when the instance is MESSAGESERVER without complete a sap system registration" do
+    test "should add an application instance to a non registered SAP system when the instance is MESSAGESERVER without completing a SAP system registration" do
       sap_system_id = Faker.UUID.v4()
       sid = Faker.StarWars.planet()
       db_host = Faker.Internet.ip_v4_address()

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -557,7 +557,7 @@ defmodule Trento.SapSystemTest do
       )
     end
 
-    test "should app an application istance to a non registered sap system when the instance is ABAP without complete a sap system registration" do
+    test "should app an application instance to a non registered sap system when the instance is ABAP without complete a sap system registration" do
       sap_system_id = Faker.UUID.v4()
       sid = Faker.StarWars.planet()
       db_host = Faker.Internet.ip_v4_address()
@@ -632,7 +632,7 @@ defmodule Trento.SapSystemTest do
       )
     end
 
-    test "should app an application istance to a non registered sap system when the instance is MESSAGESERVER without complete a sap system registration" do
+    test "should app an application instance to a non registered sap system when the instance is MESSAGESERVER without complete a sap system registration" do
       sap_system_id = Faker.UUID.v4()
       sid = Faker.StarWars.planet()
       db_host = Faker.Internet.ip_v4_address()

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -512,52 +512,7 @@ defmodule Trento.SapSystemTest do
       )
     end
 
-    test "should not register an application instance to a not registered sap system if the instance is not an ABAP or MESSAGESERVER instance" do
-      sap_system_id = Faker.UUID.v4()
-      sid = Faker.StarWars.planet()
-      db_host = Faker.Internet.ip_v4_address()
-      tenant = Faker.Beer.style()
-      instance_hostname = Faker.Airports.iata()
-      http_port = 80
-      https_port = 443
-      start_priority = "0.9"
-      host_id = Faker.UUID.v4()
-
-      initial_events = [
-        build(
-          :database_registered_event,
-          sap_system_id: sap_system_id,
-          sid: sid
-        ),
-        build(
-          :database_instance_registered_event,
-          sap_system_id: sap_system_id,
-          sid: sid,
-          tenant: tenant
-        )
-      ]
-
-      assert_error(
-        initial_events,
-        RegisterApplicationInstance.new!(%{
-          sap_system_id: sap_system_id,
-          sid: sid,
-          db_host: db_host,
-          tenant: tenant,
-          instance_number: "00",
-          instance_hostname: instance_hostname,
-          features: "HDB_WORKER",
-          http_port: http_port,
-          https_port: https_port,
-          start_priority: start_priority,
-          host_id: host_id,
-          health: :passing
-        }),
-        {:error, :sap_system_not_registered}
-      )
-    end
-
-    test "should app an application instance to a non registered sap system when the instance is ABAP without complete a sap system registration" do
+    test "should add an application instance to a non registered sap system when the instance is ABAP without complete a sap system registration" do
       sap_system_id = Faker.UUID.v4()
       sid = Faker.StarWars.planet()
       db_host = Faker.Internet.ip_v4_address()
@@ -610,7 +565,8 @@ defmodule Trento.SapSystemTest do
             start_priority: start_priority,
             host_id: host_id,
             health: :passing
-          }
+          },
+          %SapSystemHealthChanged{health: :passing}
         ],
         fn state ->
           assert %SapSystem{
@@ -685,7 +641,8 @@ defmodule Trento.SapSystemTest do
             start_priority: start_priority,
             host_id: host_id,
             health: :passing
-          }
+          },
+          %SapSystemHealthChanged{health: :passing}
         ],
         fn state ->
           assert %SapSystem{

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -565,8 +565,7 @@ defmodule Trento.SapSystemTest do
             start_priority: start_priority,
             host_id: host_id,
             health: :passing
-          },
-          %SapSystemHealthChanged{health: :passing}
+          }
         ],
         fn state ->
           assert %SapSystem{
@@ -641,8 +640,7 @@ defmodule Trento.SapSystemTest do
             start_priority: start_priority,
             host_id: host_id,
             health: :passing
-          },
-          %SapSystemHealthChanged{health: :passing}
+          }
         ],
         fn state ->
           assert %SapSystem{

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -379,13 +379,6 @@ defmodule Trento.SapSystemTest do
           health: :passing
         }),
         [
-          %SapSystemRegistered{
-            sap_system_id: sap_system_id,
-            sid: sid,
-            db_host: db_host,
-            tenant: tenant,
-            health: :passing
-          },
           %ApplicationInstanceRegistered{
             sap_system_id: sap_system_id,
             sid: sid,
@@ -396,6 +389,13 @@ defmodule Trento.SapSystemTest do
             https_port: https_port,
             start_priority: start_priority,
             host_id: host_id,
+            health: :passing
+          },
+          %SapSystemRegistered{
+            sap_system_id: sap_system_id,
+            sid: sid,
+            db_host: db_host,
+            tenant: tenant,
             health: :passing
           }
         ],
@@ -469,13 +469,6 @@ defmodule Trento.SapSystemTest do
           health: :passing
         }),
         [
-          %SapSystemRegistered{
-            sap_system_id: sap_system_id,
-            sid: sid,
-            db_host: db_host,
-            tenant: tenant,
-            health: :passing
-          },
           %ApplicationInstanceRegistered{
             sap_system_id: sap_system_id,
             sid: sid,
@@ -486,6 +479,13 @@ defmodule Trento.SapSystemTest do
             https_port: https_port,
             start_priority: start_priority,
             host_id: host_id,
+            health: :passing
+          },
+          %SapSystemRegistered{
+            sap_system_id: sap_system_id,
+            sid: sid,
+            db_host: db_host,
+            tenant: tenant,
             health: :passing
           }
         ],
@@ -1031,13 +1031,6 @@ defmodule Trento.SapSystemTest do
           health: :critical
         ),
         [
-          %SapSystemRegistered{
-            sap_system_id: sap_system_id,
-            sid: sid,
-            db_host: db_host,
-            tenant: tenant,
-            health: :critical
-          },
           build(
             :application_instance_registered_event,
             sap_system_id: sap_system_id,
@@ -1046,7 +1039,14 @@ defmodule Trento.SapSystemTest do
             features: features,
             host_id: host_id,
             health: :critical
-          )
+          ),
+          %SapSystemRegistered{
+            sap_system_id: sap_system_id,
+            sid: sid,
+            db_host: db_host,
+            tenant: tenant,
+            health: :critical
+          }
         ],
         fn state ->
           assert %SapSystem{


### PR DESCRIPTION
# Description

Implement changes in application instance registration and complete Sap System registration.

In order to register a Sap System, ABAP and MESSAGESERVER are the minimum sets of features.

Without them we cannot register a sap system.
ABAP and MESSAGESERVER instances are added as application instances when the sap system is not completely registered, other types of instances are discarded.

Once a Sap system is proper registered, all the types of instances are added to the sapsystem.



## How was this tested?

AUTOMATED TESTS
