### PR TITLE
Catalog provider filter

### DIFF
--- a/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
@@ -22,8 +22,10 @@ const updatedProvider = {
   ...providerData,
 };
 
-const buildUpdateCatalogPayload = (provider) =>
-  checkProviderExists(provider) ? { provider } : {};
+const buildUpdateCatalogAction = (provider) => {
+  const payload = checkProviderExists(provider) ? { provider } : {};
+  return updateCatalog(payload);
+};
 
 // eslint-disable-next-line import/prefer-default-export
 function ChecksCatalog() {
@@ -37,7 +39,7 @@ function ChecksCatalog() {
   } = useSelector(getCatalog());
 
   useEffect(() => {
-    dispatch(updateCatalog(buildUpdateCatalogPayload(selectedProvider)));
+    dispatch(buildUpdateCatalogAction(selectedProvider));
   }, [dispatch, selectedProvider]);
   return (
     <>
@@ -51,9 +53,7 @@ function ChecksCatalog() {
         />
       </div>
       <CatalogContainer
-        onRefresh={() =>
-          dispatch(updateCatalog(buildUpdateCatalogPayload(selectedProvider)))
-        }
+        onRefresh={() => dispatch(buildUpdateCatalogAction(selectedProvider))}
         isCatalogEmpty={catalogData.length === 0}
         catalogError={catalogError}
         loading={loading}

--- a/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
@@ -44,7 +44,15 @@ function ChecksCatalog() {
   }, [dispatch, selectedProvider]);
   return (
     <>
-      <PageHeader className="font-bold">Checks catalog</PageHeader>
+      <div className="flex">
+        <PageHeader className="font-bold">Checks catalog</PageHeader>
+        <ProviderSelection
+          className="ml-auto"
+          providers={providerLabels}
+          selected={selectedProvider}
+          onChange={setProviderSelected}
+        />
+      </div>
       <CatalogContainer
         onRefresh={() =>
           dispatch(
@@ -58,11 +66,6 @@ function ChecksCatalog() {
         catalogError={catalogError}
         loading={loading}
       >
-        <ProviderSelection
-          providers={providerLabels}
-          selected={selectedProvider}
-          onChange={setProviderSelected}
-        />
         <div>
           {Object.entries(groupBy(catalogData, 'group')).map(
             ([group, checks], idx) => (

--- a/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
@@ -6,7 +6,10 @@ import { groupBy } from '@lib/lists';
 
 import { getCatalog } from '@state/selectors/catalog';
 import { updateCatalog } from '@state/actions/catalog';
-import { providerData } from '@components/ProviderLabel/ProviderLabel';
+import {
+  providerData,
+  checkProviderExists,
+} from '@components/ProviderLabel/ProviderLabel';
 import PageHeader from '@components/PageHeader';
 import CatalogContainer from './CatalogContainer';
 import CheckItem from './CheckItem';
@@ -19,7 +22,8 @@ const updatedProvider = {
   ...providerData,
 };
 
-const checkProviderExists = (provider) => providerData[provider] ? provider : null;
+const buildUpdateCatalogPayload = (provider) =>
+  checkProviderExists(provider) ? { provider } : {};
 
 // eslint-disable-next-line import/prefer-default-export
 function ChecksCatalog() {
@@ -33,7 +37,7 @@ function ChecksCatalog() {
   } = useSelector(getCatalog());
 
   useEffect(() => {
-    dispatch(updateCatalog({ provider: checkProviderExists(selectedProvider) }));
+    dispatch(updateCatalog(buildUpdateCatalogPayload(selectedProvider)));
   }, [dispatch, selectedProvider]);
   return (
     <>
@@ -48,7 +52,7 @@ function ChecksCatalog() {
       </div>
       <CatalogContainer
         onRefresh={() =>
-          dispatch(updateCatalog({ provider: checkProviderExists(selectedProvider) }))
+          dispatch(updateCatalog(buildUpdateCatalogPayload(selectedProvider)))
         }
         isCatalogEmpty={catalogData.length === 0}
         catalogError={catalogError}

--- a/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
@@ -6,22 +6,20 @@ import { groupBy } from '@lib/lists';
 
 import { getCatalog } from '@state/selectors/catalog';
 import { updateCatalog } from '@state/actions/catalog';
-import {
-  providerData,
-  getLabels,
-  getProviderByLabel,
-} from '@components/ProviderLabel/ProviderLabel';
+import { providerData } from '@components/ProviderLabel/ProviderLabel';
 import PageHeader from '@components/PageHeader';
 import CatalogContainer from './CatalogContainer';
 import CheckItem from './CheckItem';
 import ProviderSelection from './ProviderSelection';
 
-const ALL_FILTER = 'All';
+const ALL_FILTER = 'all';
+const ALL_FILTER_TEXT = 'All';
 const updatedProvider = {
-  default: { label: ALL_FILTER },
+  [ALL_FILTER]: { label: ALL_FILTER_TEXT },
   ...providerData,
 };
-const providerLabels = getLabels(updatedProvider);
+
+const checkProviderExists = (provider) => providerData[provider] ? provider : null;
 
 // eslint-disable-next-line import/prefer-default-export
 function ChecksCatalog() {
@@ -35,12 +33,7 @@ function ChecksCatalog() {
   } = useSelector(getCatalog());
 
   useEffect(() => {
-    const apiParams =
-      selectedProvider === ALL_FILTER
-        ? {}
-        : { provider: getProviderByLabel(updatedProvider, selectedProvider) };
-
-    dispatch(updateCatalog(apiParams));
+    dispatch(updateCatalog({ provider: checkProviderExists(selectedProvider) }));
   }, [dispatch, selectedProvider]);
   return (
     <>
@@ -48,19 +41,14 @@ function ChecksCatalog() {
         <PageHeader className="font-bold">Checks catalog</PageHeader>
         <ProviderSelection
           className="ml-auto"
-          providers={providerLabels}
+          providers={Object.keys(updatedProvider)}
           selected={selectedProvider}
           onChange={setProviderSelected}
         />
       </div>
       <CatalogContainer
         onRefresh={() =>
-          dispatch(
-            updateCatalog({
-              provider:
-                getProviderByLabel(providerData, selectedProvider) || null,
-            })
-          )
+          dispatch(updateCatalog({ provider: checkProviderExists(selectedProvider) }))
         }
         isCatalogEmpty={catalogData.length === 0}
         catalogError={catalogError}

--- a/assets/js/components/ChecksCatalog/ProviderSelection.jsx
+++ b/assets/js/components/ChecksCatalog/ProviderSelection.jsx
@@ -22,7 +22,6 @@ function ProviderSelection({ className, providers, selected, onChange }) {
       <Listbox value={selected} onChange={onChange}>
         <div className="relative mt-1">
           <Listbox.Button className="cloud-provider-selection-dropdown relative w-full py-2 pl-3 pr-10 text-left bg-white rounded-lg shadow-md cursor-default focus:outline-none focus-visible:ring-2 focus-visible:ring-opacity-75 focus-visible:ring-white focus-visible:ring-offset-orange-300 focus-visible:ring-offset-2 focus-visible:border-indigo-500 sm:text-sm">
-            {/* <ProviderLabel provider={selected} /> */}
             {displayOption(selected)}
             <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
               <ChevronUpDownIcon
@@ -55,7 +54,6 @@ function ProviderSelection({ className, providers, selected, onChange }) {
                           isSelected ? 'font-medium' : 'font-normal'
                         }`}
                       >
-                        {/* {<ProviderLabel provider={provider} />} */}
                         {displayOption(provider)}
                       </span>
                       {isSelected ? (

--- a/assets/js/components/ChecksCatalog/ProviderSelection.jsx
+++ b/assets/js/components/ChecksCatalog/ProviderSelection.jsx
@@ -3,9 +3,11 @@ import React, { Fragment } from 'react';
 import { Listbox, Transition } from '@headlessui/react';
 import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/20/solid';
 
-function ProviderSelection({ providers, selected, onChange }) {
+import classNames from 'classnames';
+
+function ProviderSelection({ className, providers, selected, onChange }) {
   return (
-    <div className="w-72 pb-4">
+    <div className={classNames("w-72 pb-4", className)}>
       <Listbox value={selected} onChange={onChange}>
         <div className="relative mt-1">
           <Listbox.Button className="cloud-provider-selection-dropdown relative w-full py-2 pl-3 pr-10 text-left bg-white rounded-lg shadow-md cursor-default focus:outline-none focus-visible:ring-2 focus-visible:ring-opacity-75 focus-visible:ring-white focus-visible:ring-offset-orange-300 focus-visible:ring-offset-2 focus-visible:border-indigo-500 sm:text-sm">

--- a/assets/js/components/ChecksCatalog/ProviderSelection.jsx
+++ b/assets/js/components/ChecksCatalog/ProviderSelection.jsx
@@ -7,13 +7,23 @@ import classNames from 'classnames';
 
 import ProviderLabel from '@components/ProviderLabel';
 
+import { checkProviderExists } from '@components/ProviderLabel/ProviderLabel';
+
+const displayOption = (provider) =>
+  checkProviderExists(provider) ? (
+    <ProviderLabel provider={provider} />
+  ) : (
+    <span>All</span>
+  );
+
 function ProviderSelection({ className, providers, selected, onChange }) {
   return (
     <div className={classNames('w-64 pb-4', className)}>
       <Listbox value={selected} onChange={onChange}>
         <div className="relative mt-1">
           <Listbox.Button className="cloud-provider-selection-dropdown relative w-full py-2 pl-3 pr-10 text-left bg-white rounded-lg shadow-md cursor-default focus:outline-none focus-visible:ring-2 focus-visible:ring-opacity-75 focus-visible:ring-white focus-visible:ring-offset-orange-300 focus-visible:ring-offset-2 focus-visible:border-indigo-500 sm:text-sm">
-            <ProviderLabel provider={selected} />
+            {/* <ProviderLabel provider={selected} /> */}
+            {displayOption(selected)}
             <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
               <ChevronUpDownIcon
                 className="w-5 h-5 text-gray-400"
@@ -45,7 +55,8 @@ function ProviderSelection({ className, providers, selected, onChange }) {
                           isSelected ? 'font-medium' : 'font-normal'
                         }`}
                       >
-                        {<ProviderLabel provider={provider} />}
+                        {/* {<ProviderLabel provider={provider} />} */}
+                        {displayOption(provider)}
                       </span>
                       {isSelected ? (
                         <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-green-600">

--- a/assets/js/components/ChecksCatalog/ProviderSelection.jsx
+++ b/assets/js/components/ChecksCatalog/ProviderSelection.jsx
@@ -5,13 +5,15 @@ import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/20/solid';
 
 import classNames from 'classnames';
 
+import ProviderLabel from '@components/ProviderLabel';
+
 function ProviderSelection({ className, providers, selected, onChange }) {
   return (
-    <div className={classNames("w-72 pb-4", className)}>
+    <div className={classNames('w-64 pb-4', className)}>
       <Listbox value={selected} onChange={onChange}>
         <div className="relative mt-1">
           <Listbox.Button className="cloud-provider-selection-dropdown relative w-full py-2 pl-3 pr-10 text-left bg-white rounded-lg shadow-md cursor-default focus:outline-none focus-visible:ring-2 focus-visible:ring-opacity-75 focus-visible:ring-white focus-visible:ring-offset-orange-300 focus-visible:ring-offset-2 focus-visible:border-indigo-500 sm:text-sm">
-            <span className="block truncate">{selected}</span>
+            <ProviderLabel provider={selected} />
             <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
               <ChevronUpDownIcon
                 className="w-5 h-5 text-gray-400"
@@ -43,7 +45,7 @@ function ProviderSelection({ className, providers, selected, onChange }) {
                           isSelected ? 'font-medium' : 'font-normal'
                         }`}
                       >
-                        {provider}
+                        {<ProviderLabel provider={provider} />}
                       </span>
                       {isSelected ? (
                         <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-green-600">

--- a/assets/js/components/ChecksCatalog/ProviderSelection.stories.jsx
+++ b/assets/js/components/ChecksCatalog/ProviderSelection.stories.jsx
@@ -1,7 +1,10 @@
 import React, { useState } from 'react';
+
+import { providerData } from '@components/ProviderLabel/ProviderLabel';
+
 import ProviderSelection from './ProviderSelection';
 
-const providers = ['azure', 'aws', 'gcp'];
+const providers = Object.keys(providerData);
 
 export default {
   title: 'ProviderSelection',

--- a/assets/js/components/ChecksCatalog/ProviderSelection.stories.jsx
+++ b/assets/js/components/ChecksCatalog/ProviderSelection.stories.jsx
@@ -19,3 +19,16 @@ export function Selection() {
     />
   );
 }
+
+export function SelectionWithAll() {
+  const providersWithAll = ['all'].concat(providers);
+  const [selected, setSelected] = useState('all');
+
+  return (
+    <ProviderSelection
+      providers={providersWithAll}
+      selected={selected}
+      onChange={setSelected}
+    />
+  );
+}

--- a/assets/js/components/ChecksCatalog/ProviderSelection.stories.jsx
+++ b/assets/js/components/ChecksCatalog/ProviderSelection.stories.jsx
@@ -1,0 +1,21 @@
+import React, { useState } from 'react';
+import ProviderSelection from './ProviderSelection';
+
+const providers = ['azure', 'aws', 'gcp'];
+
+export default {
+  title: 'ProviderSelection',
+  components: ProviderSelection,
+};
+
+export function Selection() {
+  const [selected, setSelected] = useState('azure');
+
+  return (
+    <ProviderSelection
+      providers={providers}
+      selected={selected}
+      onChange={setSelected}
+    />
+  );
+}

--- a/assets/js/components/ProviderLabel/ProviderLabel.jsx
+++ b/assets/js/components/ProviderLabel/ProviderLabel.jsx
@@ -36,14 +36,6 @@ export const providerData = {
   },
 };
 
-export const getLabels = (providerDataObject) =>
-  Object.values(providerDataObject).map((item) => item.label);
-
-export const getProviderByLabel = (providerDataObject, providerLabel) =>
-  Object.entries(providerDataObject).find(
-    ([_, value]) => value.label === providerLabel
-  )[0];
-
 function ProviderLabel({ provider }) {
   return (
     <span>

--- a/assets/js/components/ProviderLabel/ProviderLabel.jsx
+++ b/assets/js/components/ProviderLabel/ProviderLabel.jsx
@@ -36,6 +36,9 @@ export const providerData = {
   },
 };
 
+export const checkProviderExists = (provider) =>
+  providerData[provider] ? provider : null;
+
 function ProviderLabel({ provider }) {
   return (
     <span>

--- a/assets/js/components/ProviderLabel/ProviderLabel.stories.jsx
+++ b/assets/js/components/ProviderLabel/ProviderLabel.stories.jsx
@@ -2,34 +2,34 @@ import React from 'react';
 import ProviderLabel from '.';
 
 export default {
-    title: 'ProviderLabel',
-    components: ProviderLabel,
+  title: 'ProviderLabel',
+  components: ProviderLabel,
 };
 
 export function Azure() {
-    return <ProviderLabel provider="azure" />;
+  return <ProviderLabel provider="azure" />;
 }
 
 export function AWS() {
-    return <ProviderLabel provider="aws" />;
+  return <ProviderLabel provider="aws" />;
 }
 
 export function GCP() {
-    return <ProviderLabel provider="gcp" />;
+  return <ProviderLabel provider="gcp" />;
 }
 
 export function Nutanix() {
-    return <ProviderLabel provider="nutanix" />;
+  return <ProviderLabel provider="nutanix" />;
 }
 
 export function KVM() {
-    return <ProviderLabel provider="kvm" />;
+  return <ProviderLabel provider="kvm" />;
 }
 
 export function VMWare() {
-    return <ProviderLabel provider="vmware" />;
+  return <ProviderLabel provider="vmware" />;
 }
 
 export function Unknown() {
-    return <ProviderLabel provider="unknown" />;
+  return <ProviderLabel provider="unknown" />;
 }

--- a/assets/js/components/ProviderLabel/ProviderLabel.stories.jsx
+++ b/assets/js/components/ProviderLabel/ProviderLabel.stories.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import ProviderLabel from '.';
+
+export default {
+    title: 'ProviderLabel',
+    components: ProviderLabel,
+};
+
+export function Azure() {
+    return <ProviderLabel provider="azure" />;
+}
+
+export function AWS() {
+    return <ProviderLabel provider="aws" />;
+}
+
+export function GCP() {
+    return <ProviderLabel provider="gcp" />;
+}
+
+export function Nutanix() {
+    return <ProviderLabel provider="nutanix" />;
+}
+
+export function KVM() {
+    return <ProviderLabel provider="kvm" />;
+}
+
+export function VMWare() {
+    return <ProviderLabel provider="vmware" />;
+}
+
+export function Unknown() {
+    return <ProviderLabel provider="unknown" />;
+}

--- a/assets/js/components/ProviderLabel/ProviderLabel.test.jsx
+++ b/assets/js/components/ProviderLabel/ProviderLabel.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import ProviderLabel from './ProviderLabel';
+import ProviderLabel, { checkProviderExists } from './ProviderLabel';
 
 describe('Provider Label', () => {
   it('should display an icon and label with AWS as the provider', () => {
@@ -48,5 +48,13 @@ describe('Provider Label', () => {
     expect(container.querySelector('span')).toHaveTextContent(
       'Provider not recognized'
     );
+  });
+
+  it('should check if the provider exists', () => {
+    ['azure', 'aws', 'gcp', 'nutanix', 'kvm', 'vmware'].forEach((provider) => {
+      expect(checkProviderExists(provider)).toBeTruthy();
+    });
+
+    expect(checkProviderExists('other')).not.toBeTruthy();
   });
 });

--- a/assets/js/components/ProviderLabel/ProviderLabel.test.jsx
+++ b/assets/js/components/ProviderLabel/ProviderLabel.test.jsx
@@ -1,11 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import ProviderLabel, {
-  getProviderByLabel,
-  providerData,
-  getLabels,
-} from './ProviderLabel';
+import ProviderLabel from './ProviderLabel';
 
 describe('Provider Label', () => {
   it('should display an icon and label with AWS as the provider', () => {
@@ -52,27 +48,5 @@ describe('Provider Label', () => {
     expect(container.querySelector('span')).toHaveTextContent(
       'Provider not recognized'
     );
-  });
-
-  describe('Provider Labels functions: ', () => {
-    it('should return a list of all Provider labels', () => {
-      const expectedProviderLabels = [
-        'AWS',
-        'Azure',
-        'GCP',
-        'Nutanix',
-        'KVM',
-        'VMware',
-      ];
-      expect(getLabels(providerData)).toEqual(expectedProviderLabels);
-    });
-
-    it('should returns the key value of provider from the label value ', () => {
-      const label = 'AWS';
-      const expectedProviderLabels = 'aws';
-      expect(getProviderByLabel(providerData, label)).toEqual(
-        expectedProviderLabels
-      );
-    });
   });
 });


### PR DESCRIPTION
# Description

Use the new design in the provider selection filter in the catalog view. Some additional storybook stories added.
I didn't work on the whole catalog story as other work to add the accordion to the catalog is on progress, and it will impact completely this view.

**I'm sending the PR to `new-checks-ui` to not disturb the "almost ready realease". We can change if you want anyway.**

![gif](https://user-images.githubusercontent.com/36370954/234275909-144434fe-1f0b-4831-97c6-f396cc602636.gif)
![gif2](https://user-images.githubusercontent.com/36370954/234276227-8327d5f4-0af6-4e44-987a-8d8cdcc726e0.gif)


## How was this tested?

Old tests are enough as the functionality doesn't change.
