### PR TITLE
Add url error handling for the CheckResultDetailPage

### DIFF
--- a/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultDetailPage.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultDetailPage.jsx
@@ -17,9 +17,10 @@ import {
 } from '@state/lastExecutions';
 import { getHostID } from '@state/selectors/cluster';
 import ExecutionContainer from '@components/ExecutionResults/ExecutionContainer';
+import NotFound from '@components/NotFound/NotFound';
 import ResultsContainer from '@components/ExecutionResults/ResultsContainer';
 import CheckResultDetail from './CheckResultDetail';
-import NotFound from '../../NotFound/NotFound';
+
 import {
   getCheckDescription,
   getCheckExpectations,

--- a/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultDetailPage.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultDetailPage.jsx
@@ -17,7 +17,7 @@ import {
 } from '@state/lastExecutions';
 import { getHostID } from '@state/selectors/cluster';
 import ExecutionContainer from '@components/ExecutionResults/ExecutionContainer';
-import NotFound from '@components/NotFound/NotFound';
+import NotFound from '@components/NotFound';
 import ResultsContainer from '@components/ExecutionResults/ResultsContainer';
 import CheckResultDetail from './CheckResultDetail';
 
@@ -32,11 +32,7 @@ import CheckDetailHeader from './CheckDetailHeader';
 function CheckResultDetailPage() {
   const { clusterID, checkID, targetType, targetName } = useParams();
   const dispatch = useDispatch();
-  const navigateToUrl = useNavigate();
-
-  function onNavigate(path) {
-    navigateToUrl(path);
-  }
+  const navigate = useNavigate();
 
   const {
     clusterHosts,
@@ -51,6 +47,7 @@ function CheckResultDetailPage() {
   const clustersIDList = useSelector((state) =>
     state.clustersList.clusters.map((clusterObj) => clusterObj.id)
   );
+
   useEffect(() => {
     if (catalog.length === 0) {
       dispatch(updateCatalog());
@@ -64,7 +61,7 @@ function CheckResultDetailPage() {
     return (
       <NotFound
         buttonText="Go back to cluster overview"
-        onNavigate={() => onNavigate('/clusters/')}
+        onNavigate={() => navigate('/clusters/')}
       />
     );
   }
@@ -93,7 +90,7 @@ function CheckResultDetailPage() {
     return (
       <NotFound
         buttonText="Go back to last execution"
-        onNavigate={() => onNavigate(`/clusters/${clusterID}/executions/last`)}
+        onNavigate={() => navigate(`/clusters/${clusterID}/executions/last`)}
       />
     );
   }
@@ -138,9 +135,9 @@ function CheckResultDetailPage() {
             dispatch(updateLastExecution(clusterID));
           }
         }}
-        onStartExecution={(clusterId, hosts, selectedChecks, navigate) =>
+        onStartExecution={(clusterId, hosts, selectedChecks, onNavigate) =>
           dispatch(
-            executionRequested(clusterId, hosts, selectedChecks, navigate)
+            executionRequested(clusterId, hosts, selectedChecks, onNavigate)
           )
         }
       >

--- a/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultDetailPage.test.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultDetailPage.test.jsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react';
+import { faker } from '@faker-js/faker';
+
+import '@testing-library/jest-dom';
+import { renderWithRouterMatch, withState } from '@lib/test-utils';
+import {
+  clusterFactory,
+  hostFactory,
+  catalogCheckFactory,
+  checksExecutionCompletedForTargetsFactory,
+} from '@lib/test-utils/factories';
+
+import CheckResultDetailPage from '.';
+
+describe('CheckResultDetailPage Component', () => {
+  const initialStore = () => {
+    const aCluster = clusterFactory.build();
+    const { id: clusterID } = aCluster;
+    const hostsList = [
+      hostFactory.build({ cluster_id: clusterID }),
+      hostFactory.build({ cluster_id: clusterID }),
+    ];
+    const [
+      { id: agent1, hostname: hostname1 },
+      { id: agent2, hostname: hostname2 },
+    ] = hostsList;
+
+    const checksCatalog = catalogCheckFactory.buildList(3);
+    const completedExecution = checksExecutionCompletedForTargetsFactory.build({
+      targets: [agent1, agent2],
+      check_id: [checksCatalog[0].id, checksCatalog[1].id],
+    });
+
+    const initialState = {
+      clustersList: {
+        clusters: [aCluster, clusterFactory.build()],
+      },
+      hostsList: {
+        hosts: [
+          hostFactory.build({
+            id: agent1,
+            cluster_id: clusterID,
+            hostname: hostname1,
+          }),
+          hostFactory.build({
+            id: agent2,
+            cluster_id: clusterID,
+            hostname: hostname2,
+          }),
+          hostFactory.build(),
+        ],
+      },
+      catalog: {
+        loading: false,
+        data: checksCatalog,
+        error: null,
+      },
+      lastExecutions: {
+        [clusterID]: {
+          loading: false,
+          data: completedExecution,
+          error: null,
+        },
+      },
+    };
+    return initialState;
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should not render CheckResultDetailPage when clusterID in the url is false', () => {
+    const reduxStore = initialStore();
+    const falseClusterID = faker.animal.bear();
+    const [StatefulCheckResultDetailPage] = withState(
+      <CheckResultDetailPage />,
+      reduxStore
+    );
+    renderWithRouterMatch(StatefulCheckResultDetailPage, {
+      path: 'clusters/:clusterID/executions/last/:checkID/:targetType/:targetName',
+      route: `/clusters/${falseClusterID}/executions/last/${reduxStore.catalog.data[0].id}/host/${reduxStore.hostsList.hosts[0].hostname}`,
+    });
+
+    expect(screen.getByText('Go back to cluster overview')).toBeTruthy();
+    fireEvent.click(screen.getByText('Go back to cluster overview'));
+    expect(window.location.pathname).toEqual('/clusters/');
+  });
+
+  it('should not render CheckResultDetailPage when checkID in the url is false', () => {
+    const reduxStore = initialStore();
+    const falseCheckID = faker.animal.bear();
+    const [StatefulCheckResultDetailPage] = withState(
+      <CheckResultDetailPage />,
+      reduxStore
+    );
+
+    renderWithRouterMatch(StatefulCheckResultDetailPage, {
+      path: 'clusters/:clusterID/executions/last/:checkID/:targetType/:targetName',
+      route: `/clusters/${reduxStore.clustersList.clusters[0].id}/executions/last/${falseCheckID}/host/${reduxStore.hostsList.hosts[0].hostname}`,
+    });
+
+    expect(screen.getByText('Go back to last execution')).toBeTruthy();
+    fireEvent.click(screen.getByText('Go back to last execution'));
+    expect(window.location.pathname).toEqual(
+      `/clusters/${reduxStore.clustersList.clusters[0].id}/executions/last`
+    );
+  });
+  it('should not render CheckResultDetailPage when targetType in the url is false', () => {
+    const reduxStore = initialStore();
+    const invalidTargetType = 'falseTargetType';
+    const [StatefulCheckResultDetailPage] = withState(
+      <CheckResultDetailPage />,
+      reduxStore
+    );
+    renderWithRouterMatch(StatefulCheckResultDetailPage, {
+      path: 'clusters/:clusterID/executions/last/:checkID/:targetType/:targetName',
+      route: `/clusters/${reduxStore.clustersList.clusters[0].id}/executions/last/${reduxStore.catalog.data[0].id}/${invalidTargetType}/${reduxStore.hostsList.hosts[0].hostname}`,
+    });
+    expect(screen.getByText('Go back to last execution')).toBeTruthy();
+    fireEvent.click(screen.getByText('Go back to last execution'));
+    expect(window.location.pathname).toEqual(
+      `/clusters/${reduxStore.clustersList.clusters[0].id}/executions/last`
+    );
+  });
+
+  it('should not render CheckResultDetailPage when targetName in the url is false', () => {
+    const reduxStore = initialStore();
+    const invalidTargetName = faker.random.word();
+    const [StatefulCheckResultDetailPage] = withState(
+      <CheckResultDetailPage />,
+      reduxStore
+    );
+    renderWithRouterMatch(StatefulCheckResultDetailPage, {
+      path: 'clusters/:clusterID/executions/last/:checkID/:targetType/:targetName',
+      route: `/clusters/${reduxStore.clustersList.clusters[0].id}/executions/last/${reduxStore.catalog.data[0].id}/host/${invalidTargetName}`,
+    });
+    expect(screen.getByText('Go back to last execution')).toBeTruthy();
+    fireEvent.click(screen.getByText('Go back to last execution'));
+    expect(window.location.pathname).toEqual(
+      `/clusters/${reduxStore.clustersList.clusters[0].id}/executions/last`
+    );
+  });
+
+  it('should render CheckResultDetailPage when the parts of url [ClusterID, CheckID, TargetType, TargetName] are valid', () => {
+    const reduxStore = initialStore();
+    const validClusterID = reduxStore.clustersList.clusters[0].id;
+    const validCheckID = reduxStore.catalog.data[0].id;
+    const validTargetType = 'host';
+    const validTargetName = reduxStore.hostsList.hosts[0].hostname;
+    const [StatefulCheckResultDetailPage] = withState(
+      <CheckResultDetailPage />,
+      reduxStore
+    );
+    renderWithRouterMatch(StatefulCheckResultDetailPage, {
+      path: 'clusters/:clusterID/executions/last/:checkID/:targetType/:targetName',
+      route: `/clusters/${validClusterID}/executions/last/${validCheckID}/${validTargetType}/${validTargetName}`,
+    });
+
+    expect(screen.getByText('Check ID')).toBeInTheDocument();
+    expect(screen.getByText(validCheckID)).toBeInTheDocument();
+    expect(screen.getByText('Host')).toBeInTheDocument();
+    expect(screen.getByText(validTargetName)).toBeInTheDocument();
+  });
+});

--- a/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultDetailPage.test.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultDetailPage.test.jsx
@@ -3,6 +3,7 @@ import { screen, fireEvent } from '@testing-library/react';
 import { faker } from '@faker-js/faker';
 
 import '@testing-library/jest-dom';
+
 import { renderWithRouterMatch, withState } from '@lib/test-utils';
 import {
   clusterFactory,
@@ -26,7 +27,7 @@ describe('CheckResultDetailPage Component', () => {
       { id: agent2, hostname: hostname2 },
     ] = hostsList;
 
-    const checksCatalog = catalogCheckFactory.buildList(3);
+    const checksCatalog = catalogCheckFactory.buildList(2);
     const completedExecution = checksExecutionCompletedForTargetsFactory.build({
       targets: [agent1, agent2],
       check_id: [checksCatalog[0].id, checksCatalog[1].id],
@@ -71,8 +72,18 @@ describe('CheckResultDetailPage Component', () => {
     jest.resetAllMocks();
   });
 
+  const getValidStoreData = (reduxStore) => {
+    const validClusterID = reduxStore.clustersList.clusters[0].id;
+    const validCheckID = reduxStore.catalog.data[0].id;
+    const validTargetType = 'host';
+    const validTargetName = reduxStore.hostsList.hosts[0].hostname;
+    return { validClusterID, validCheckID, validTargetType, validTargetName };
+  };
+
   it('should not render CheckResultDetailPage when clusterID in the url is false', () => {
     const reduxStore = initialStore();
+    const { validCheckID, validTargetName, validTargetType } =
+      getValidStoreData(reduxStore);
     const falseClusterID = faker.animal.bear();
     const [StatefulCheckResultDetailPage] = withState(
       <CheckResultDetailPage />,
@@ -80,7 +91,7 @@ describe('CheckResultDetailPage Component', () => {
     );
     renderWithRouterMatch(StatefulCheckResultDetailPage, {
       path: 'clusters/:clusterID/executions/last/:checkID/:targetType/:targetName',
-      route: `/clusters/${falseClusterID}/executions/last/${reduxStore.catalog.data[0].id}/host/${reduxStore.hostsList.hosts[0].hostname}`,
+      route: `/clusters/${falseClusterID}/executions/last/${validCheckID}/${validTargetType}/${validTargetName}`,
     });
 
     expect(screen.getByText('Go back to cluster overview')).toBeTruthy();
@@ -90,6 +101,8 @@ describe('CheckResultDetailPage Component', () => {
 
   it('should not render CheckResultDetailPage when checkID in the url is false', () => {
     const reduxStore = initialStore();
+    const { validClusterID, validTargetType, validTargetName } =
+      getValidStoreData(reduxStore);
     const falseCheckID = faker.animal.bear();
     const [StatefulCheckResultDetailPage] = withState(
       <CheckResultDetailPage />,
@@ -98,17 +111,20 @@ describe('CheckResultDetailPage Component', () => {
 
     renderWithRouterMatch(StatefulCheckResultDetailPage, {
       path: 'clusters/:clusterID/executions/last/:checkID/:targetType/:targetName',
-      route: `/clusters/${reduxStore.clustersList.clusters[0].id}/executions/last/${falseCheckID}/host/${reduxStore.hostsList.hosts[0].hostname}`,
+      route: `/clusters/${validClusterID}/executions/last/${falseCheckID}/${validTargetType}/${validTargetName}`,
     });
 
     expect(screen.getByText('Go back to last execution')).toBeTruthy();
     fireEvent.click(screen.getByText('Go back to last execution'));
     expect(window.location.pathname).toEqual(
-      `/clusters/${reduxStore.clustersList.clusters[0].id}/executions/last`
+      `/clusters/${validClusterID}/executions/last`
     );
   });
+
   it('should not render CheckResultDetailPage when targetType in the url is false', () => {
     const reduxStore = initialStore();
+    const { validClusterID, validCheckID, validTargetName } =
+      getValidStoreData(reduxStore);
     const invalidTargetType = 'falseTargetType';
     const [StatefulCheckResultDetailPage] = withState(
       <CheckResultDetailPage />,
@@ -116,17 +132,19 @@ describe('CheckResultDetailPage Component', () => {
     );
     renderWithRouterMatch(StatefulCheckResultDetailPage, {
       path: 'clusters/:clusterID/executions/last/:checkID/:targetType/:targetName',
-      route: `/clusters/${reduxStore.clustersList.clusters[0].id}/executions/last/${reduxStore.catalog.data[0].id}/${invalidTargetType}/${reduxStore.hostsList.hosts[0].hostname}`,
+      route: `/clusters/${validClusterID}/executions/last/${validCheckID}/${invalidTargetType}/${validTargetName}`,
     });
     expect(screen.getByText('Go back to last execution')).toBeTruthy();
     fireEvent.click(screen.getByText('Go back to last execution'));
     expect(window.location.pathname).toEqual(
-      `/clusters/${reduxStore.clustersList.clusters[0].id}/executions/last`
+      `/clusters/${validClusterID}/executions/last`
     );
   });
 
   it('should not render CheckResultDetailPage when targetName in the url is false', () => {
     const reduxStore = initialStore();
+    const { validClusterID, validCheckID, validTargetType } =
+      getValidStoreData(reduxStore);
     const invalidTargetName = faker.random.word();
     const [StatefulCheckResultDetailPage] = withState(
       <CheckResultDetailPage />,
@@ -134,21 +152,20 @@ describe('CheckResultDetailPage Component', () => {
     );
     renderWithRouterMatch(StatefulCheckResultDetailPage, {
       path: 'clusters/:clusterID/executions/last/:checkID/:targetType/:targetName',
-      route: `/clusters/${reduxStore.clustersList.clusters[0].id}/executions/last/${reduxStore.catalog.data[0].id}/host/${invalidTargetName}`,
+      route: `/clusters/${validClusterID}/executions/last/${validCheckID}/${validTargetType}/${invalidTargetName}`,
     });
     expect(screen.getByText('Go back to last execution')).toBeTruthy();
     fireEvent.click(screen.getByText('Go back to last execution'));
     expect(window.location.pathname).toEqual(
-      `/clusters/${reduxStore.clustersList.clusters[0].id}/executions/last`
+      `/clusters/${validClusterID}/executions/last`
     );
   });
 
   it('should render CheckResultDetailPage when the parts of url [ClusterID, CheckID, TargetType, TargetName] are valid', () => {
     const reduxStore = initialStore();
-    const validClusterID = reduxStore.clustersList.clusters[0].id;
-    const validCheckID = reduxStore.catalog.data[0].id;
-    const validTargetType = 'host';
-    const validTargetName = reduxStore.hostsList.hosts[0].hostname;
+    const { validClusterID, validCheckID, validTargetType, validTargetName } =
+      getValidStoreData(reduxStore);
+
     const [StatefulCheckResultDetailPage] = withState(
       <CheckResultDetailPage />,
       reduxStore

--- a/assets/js/components/NotFound/NotFound.jsx
+++ b/assets/js/components/NotFound/NotFound.jsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import Button from '@components/Button';
 import TrentoLogo from '@static/trento-icon.png';
-import { useNavigate } from 'react-router-dom';
 
 function NotFound({ onNavigate, buttonText = 'Go back home' }) {
-  const navigate = useNavigate();
-
   return (
     <main className="bg-white relative overflow-hidden h-screen">
       <div className="container mx-auto h-screen pt-32 md:pt-0 px-6 z-10 flex items-center justify-between">
@@ -18,7 +15,13 @@ function NotFound({ onNavigate, buttonText = 'Go back home' }) {
             </h1>
             <Button
               className="px-2 py-2 w-36 mt-16"
-              onClick={() => (onNavigate ? onNavigate() : navigate('/'))}
+              onClick={() => {
+                if (onNavigate) {
+                  onNavigate();
+                } else {
+                  window.location.href = '/';
+                }
+              }}
             >
               {buttonText}
             </Button>

--- a/assets/js/components/NotFound/NotFound.jsx
+++ b/assets/js/components/NotFound/NotFound.jsx
@@ -7,8 +7,8 @@ function NotFound({ onNavigate, buttonText = 'Go back home' }) {
     <main className="bg-white relative overflow-hidden h-screen">
       <div className="container mx-auto h-screen pt-32 md:pt-0 px-6 z-10 flex items-center justify-between">
         <div className="container mx-auto px-6 flex flex-col-reverse lg:flex-row justify-between items-center relative">
-          <div className="w-full mb-16 md:mb-8 text-center lg:text-left">
-            <h1 className="font-light font-sans text-center lg:text-left text-5xl lg:text-8xl mt-12 md:mt-0 text-gray-700">
+          <div className="w-full mb-16 md:mb-8 text-center lg:text-left pr-10">
+            <h1 className="font-light font-sans text-center lg:text-left text-5xl lg:text-8xl mt-12 md:mt-0 text-gray-700 ">
               Sorry,
               <br />
               the page is in another castle.

--- a/assets/js/components/NotFound/NotFound.jsx
+++ b/assets/js/components/NotFound/NotFound.jsx
@@ -1,14 +1,13 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
-
 import Button from '@components/Button';
 import TrentoLogo from '@static/trento-icon.png';
+import { useNavigate } from 'react-router-dom';
 
-function NotFound() {
+function NotFound({ onNavigate, buttonText = 'Go back home' }) {
   const navigate = useNavigate();
 
   return (
-    <main className="bg-white relative overflow-hidden h-screen relative">
+    <main className="bg-white relative overflow-hidden h-screen">
       <div className="container mx-auto h-screen pt-32 md:pt-0 px-6 z-10 flex items-center justify-between">
         <div className="container mx-auto px-6 flex flex-col-reverse lg:flex-row justify-between items-center relative">
           <div className="w-full mb-16 md:mb-8 text-center lg:text-left">
@@ -19,11 +18,9 @@ function NotFound() {
             </h1>
             <Button
               className="px-2 py-2 w-36 mt-16"
-              onClick={() => {
-                navigate('/');
-              }}
+              onClick={() => (onNavigate ? onNavigate() : navigate('/'))}
             >
-              Go back home
+              {buttonText}
             </Button>
           </div>
           <div className="block w-full mx-auto md:mt-0 relative max-w-md lg:max-w-2xl">

--- a/assets/js/components/NotFound/NotFound.stories.jsx
+++ b/assets/js/components/NotFound/NotFound.stories.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import NotFound from '.';
+
+export default {
+  title: 'NotFound',
+  component: NotFound,
+  args: { buttonText: 'Go back home' },
+};
+
+export function Default(args) {
+  return <NotFound {...args} />;
+}

--- a/assets/js/components/NotFound/NotFound.stories.jsx
+++ b/assets/js/components/NotFound/NotFound.stories.jsx
@@ -5,7 +5,7 @@ import NotFound from '.';
 export default {
   title: 'NotFound',
   component: NotFound,
-  args: { buttonText: 'Go back home' },
+  args: { buttonText: 'Go back home', onNavigate: () => {} },
 };
 
 export function Default(args) {

--- a/assets/js/components/NotFound/NotFound.test.jsx
+++ b/assets/js/components/NotFound/NotFound.test.jsx
@@ -1,28 +1,20 @@
 import React from 'react';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, render } from '@testing-library/react';
 import { faker } from '@faker-js/faker';
-import { useNavigate } from 'react-router-dom';
 
 import { renderWithRouter } from '@lib/test-utils';
 
 import NotFound from '.';
 
-jest.mock('react-router-dom', () => ({
-  useNavigate: jest.fn(),
-}));
-
 describe('NotFound', () => {
   it('should render NotFound component correctly with default parameter values', () => {
-    const navigate = jest.fn();
-    useNavigate.mockReturnValue(navigate);
-    renderWithRouter(<NotFound />);
+    render(<NotFound />);
 
     expect(
       screen.getByText(/Sorry,.*the page is in another castle/)
     ).toBeTruthy();
 
     expect(screen.getByText('Go back home')).toBeTruthy();
-
     fireEvent.click(screen.getByText('Go back home'));
     expect(window.location.pathname).toEqual('/');
   });
@@ -31,7 +23,6 @@ describe('NotFound', () => {
     const url = faker.internet.url();
     const buttonText = faker.lorem.word();
     const navigate = jest.fn();
-    useNavigate.mockReturnValue(navigate);
     renderWithRouter(
       <NotFound buttonText={buttonText} onNavigate={() => navigate(url)} />
     );
@@ -40,7 +31,6 @@ describe('NotFound', () => {
     ).toBeTruthy();
 
     expect(screen.getByText(buttonText)).toBeTruthy();
-
     fireEvent.click(screen.getByText(buttonText));
     expect(navigate).toHaveBeenCalledWith(url);
   });

--- a/assets/js/components/NotFound/NotFound.test.jsx
+++ b/assets/js/components/NotFound/NotFound.test.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import { faker } from '@faker-js/faker';
+import { useNavigate } from 'react-router-dom';
+
+import { renderWithRouter } from '@lib/test-utils';
+
+import NotFound from '.';
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn(),
+}));
+
+describe('NotFound', () => {
+  it('should render correctly', () => {
+    const navigate = jest.fn();
+    useNavigate.mockReturnValue(navigate);
+    renderWithRouter(<NotFound />);
+
+    expect(
+      screen.getByText(/Sorry,.*the page is in another castle/)
+    ).toBeTruthy();
+
+    const backButton = screen.getByText('Go back home');
+    expect(backButton).toBeTruthy();
+
+    fireEvent.click(backButton);
+    expect(navigate).toHaveBeenCalledWith('/');
+  });
+
+  it('should render correctly with passed props', () => {
+    const url = faker.internet.url();
+    const buttonText = faker.lorem.word();
+    const navigate = jest.fn();
+    useNavigate.mockReturnValue(navigate);
+    renderWithRouter(
+      <NotFound buttonText={buttonText} onNavigate={() => navigate(url)} />
+    );
+    expect(
+      screen.getByText(/Sorry,.*the page is in another castle/)
+    ).toBeTruthy();
+
+    const backButton = screen.getByText(buttonText);
+    expect(backButton).toBeTruthy();
+
+    fireEvent.click(backButton);
+    expect(navigate).toHaveBeenCalledWith(url);
+  });
+});

--- a/assets/js/components/NotFound/NotFound.test.jsx
+++ b/assets/js/components/NotFound/NotFound.test.jsx
@@ -12,7 +12,7 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe('NotFound', () => {
-  it('should render correctly', () => {
+  it('should render NotFound component correctly with default parameter values', () => {
     const navigate = jest.fn();
     useNavigate.mockReturnValue(navigate);
     renderWithRouter(<NotFound />);
@@ -21,14 +21,13 @@ describe('NotFound', () => {
       screen.getByText(/Sorry,.*the page is in another castle/)
     ).toBeTruthy();
 
-    const backButton = screen.getByText('Go back home');
-    expect(backButton).toBeTruthy();
+    expect(screen.getByText('Go back home')).toBeTruthy();
 
-    fireEvent.click(backButton);
-    expect(navigate).toHaveBeenCalledWith('/');
+    fireEvent.click(screen.getByText('Go back home'));
+    expect(window.location.pathname).toEqual('/');
   });
 
-  it('should render correctly with passed props', () => {
+  it('should render NotFound correctly with passed props', () => {
     const url = faker.internet.url();
     const buttonText = faker.lorem.word();
     const navigate = jest.fn();
@@ -40,10 +39,9 @@ describe('NotFound', () => {
       screen.getByText(/Sorry,.*the page is in another castle/)
     ).toBeTruthy();
 
-    const backButton = screen.getByText(buttonText);
-    expect(backButton).toBeTruthy();
+    expect(screen.getByText(buttonText)).toBeTruthy();
 
-    fireEvent.click(backButton);
+    fireEvent.click(screen.getByText(buttonText));
     expect(navigate).toHaveBeenCalledWith(url);
   });
 });

--- a/assets/js/lib/model/index.js
+++ b/assets/js/lib/model/index.js
@@ -6,3 +6,6 @@ export const EXPECT_SAME = 'expect_same';
 
 export const TARGET_HOST = 'host';
 export const TARGET_CLUSTER = 'cluster';
+
+export const isValidTargetType = (targetType) =>
+  [TARGET_HOST, TARGET_CLUSTER].includes(targetType);

--- a/assets/js/lib/test-utils/factories/executions.js
+++ b/assets/js/lib/test-utils/factories/executions.js
@@ -131,10 +131,21 @@ export const checksExecutionCompletedForTargetsFactory = Factory.define(
       faker.datatype.uuid(),
       faker.datatype.uuid(),
     ];
-    const checkResults = checkResultFactory.buildList(2, {
-      agents_check_results: targets.map(checkResultForTarget),
-    });
 
+    const checkResults = params.check_id
+      ? [
+          checkResultFactory.build({
+            agents_check_results: targets.map(checkResultForTarget),
+            check_id: params.check_id[0],
+          }),
+          checkResultFactory.build({
+            agents_check_results: targets.map(checkResultForTarget),
+            check_id: params.check_id[1],
+          }),
+        ]
+      : checkResultFactory.buildList(2, {
+          agents_check_results: targets.map(checkResultForTarget),
+        });
     return checksExecutionCompletedFactory.build({
       check_results: checkResults,
     });

--- a/assets/js/lib/test-utils/factories/executions.js
+++ b/assets/js/lib/test-utils/factories/executions.js
@@ -133,19 +133,16 @@ export const checksExecutionCompletedForTargetsFactory = Factory.define(
     ];
 
     const checkResults = params.check_id
-      ? [
+      ? params.check_id.map((checkID) =>
           checkResultFactory.build({
             agents_check_results: targets.map(checkResultForTarget),
-            check_id: params.check_id[0],
-          }),
-          checkResultFactory.build({
-            agents_check_results: targets.map(checkResultForTarget),
-            check_id: params.check_id[1],
-          }),
-        ]
+            check_id: checkID,
+          })
+        )
       : checkResultFactory.buildList(2, {
           agents_check_results: targets.map(checkResultForTarget),
         });
+
     return checksExecutionCompletedFactory.build({
       check_results: checkResults,
     });


### PR DESCRIPTION
# Description

In the Check Detail Page served at  `/clusters/:clusterID/executions/last/:checkID/:targetType/:targetName` the combination of checkID, targetType, targetName and clusterID determines the information that is shown.

An URL with wrong parameters would still render the CheckResultDetailPage component.
This behavior is unwanted and should render a NotFound page. After discussing if the NotFound page should be rendered as a full view, we decided to render it inside for improved UI.

To handle this cases, follow changes were made:

* Added URL validation for CheckResultDetailPage.
* Refactored the NotFound component, it accepts parameters, in order to change the button text and navigation path.


## Demo

### Invalid clusterID
[invalid_clusterID.webm](https://user-images.githubusercontent.com/54111255/234282012-a7aa0ab3-bb19-41be-93e3-a35ec4ca70e4.webm)



### Invalid checkID, targetType, targetName
[invalidUrlParams.webm](https://user-images.githubusercontent.com/54111255/234282117-33361306-2b12-4e08-8b0f-28e72f887409.webm)


### NotFound story
![NotFoundStorybook](https://user-images.githubusercontent.com/54111255/234869834-d3dc44bc-7e41-41aa-b570-4ba87fb07c52.png)



## How was this tested?
* Added NotFound component test
* Added NotFound story
* Added CheckResultDetailPage test
