### PR TITLE
Add database instance deregistration logic

### DIFF
--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -814,7 +814,7 @@ defmodule Trento.Domain.SapSystem do
          %SapSystem{
            sap_system_id: sap_system_id,
            database: %Database{
-             instances: []
+             sid: nil
            }
          },
          deregistered_at

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -99,6 +99,9 @@ defmodule Trento.Domain.SapSystem do
     embeds_one :application, Application
   end
 
+  # Stop everything during the rollup process
+  def execute(%SapSystem{rolling_up: true}, _), do: {:error, :sap_system_rolling_up}
+
   def execute(
         %SapSystem{sap_system_id: nil},
         %RegisterDatabaseInstance{
@@ -152,9 +155,6 @@ defmodule Trento.Domain.SapSystem do
       }
     ]
   end
-
-  # Stop everything during the rollup process
-  def execute(%SapSystem{rolling_up: true}, _), do: {:error, :sap_system_rolling_up}
 
   # When a RegisterDatabaseInstance command is received by an existing SAP System aggregate,
   # the SAP System aggregate registers the Database instance if it is not already registered
@@ -224,37 +224,6 @@ defmodule Trento.Domain.SapSystem do
     }
   end
 
-  # Deregister an application instance and emit a ApplicationInstanceDeregistered
-  # also emit SapSystemDeregistered event if this was the last application instance
-  def execute(
-        %SapSystem{
-          sap_system_id: sap_system_id
-        } = sap_system,
-        %DeregisterApplicationInstance{
-          instance_number: instance_number,
-          sap_system_id: sap_system_id,
-          host_id: host_id,
-          deregistered_at: deregistered_at
-        }
-      ) do
-    sap_system
-    |> Multi.new()
-    |> Multi.execute(fn _ ->
-      %ApplicationInstanceDeregistered{
-        sap_system_id: sap_system_id,
-        instance_number: instance_number,
-        host_id: host_id,
-        deregistered_at: deregistered_at
-      }
-    end)
-    |> Multi.execute(fn sap_system ->
-      maybe_emit_sap_system_deregistered_event(
-        sap_system,
-        deregistered_at
-      )
-    end)
-  end
-
   # Deregister a database instance and emit a DatabaseInstanceDeregistered
   # also potentially emit SapSystemDeregistered and DatabaseDeregistered events
   def execute(
@@ -284,72 +253,35 @@ defmodule Trento.Domain.SapSystem do
     end)
   end
 
-  def apply(
-        %SapSystem{database: %Database{instances: instances}} = sap_system,
-        %DatabaseInstanceDeregistered{
+  # Deregister an application instance and emit a ApplicationInstanceDeregistered
+  # also emit SapSystemDeregistered event if this was the last application instance
+  def execute(
+        %SapSystem{
+          sap_system_id: sap_system_id
+        } = sap_system,
+        %DeregisterApplicationInstance{
           instance_number: instance_number,
-          host_id: host_id
-        }
-      ) do
-    instances =
-      Enum.reject(instances, fn
-        %Instance{instance_number: ^instance_number, host_id: ^host_id} ->
-          true
-
-        _ ->
-          false
-      end)
-
-    %SapSystem{
-      sap_system
-      | database: %Database{
-          instances: instances
-        }
-    }
-  end
-
-  def apply(
-        %SapSystem{application: %Application{instances: instances}} = sap_system,
-        %ApplicationInstanceDeregistered{instance_number: instance_number, host_id: host_id}
-      ) do
-    instances =
-      Enum.reject(instances, fn
-        %Instance{instance_number: ^instance_number, host_id: ^host_id} ->
-          true
-
-        _ ->
-          false
-      end)
-
-    %SapSystem{
-      sap_system
-      | application: %Application{
-          instances: instances
-        }
-    }
-  end
-
-  def apply(
-        %SapSystem{database: database} = sap_system,
-        %DatabaseDeregistered{}
-      ) do
-    %SapSystem{
-      sap_system
-      | database: Map.put(database, :sid, nil)
-    }
-  end
-
-  def apply(
-        %SapSystem{} = sap_system,
-        %SapSystemDeregistered{
+          sap_system_id: sap_system_id,
+          host_id: host_id,
           deregistered_at: deregistered_at
         }
       ) do
-    %SapSystem{
-      sap_system
-      | deregistered_at: deregistered_at,
-        sid: nil
-    }
+    sap_system
+    |> Multi.new()
+    |> Multi.execute(fn _ ->
+      %ApplicationInstanceDeregistered{
+        sap_system_id: sap_system_id,
+        instance_number: instance_number,
+        host_id: host_id,
+        deregistered_at: deregistered_at
+      }
+    end)
+    |> Multi.execute(fn sap_system ->
+      maybe_emit_sap_system_deregistered_event(
+        sap_system,
+        deregistered_at
+      )
+    end)
   end
 
   def apply(
@@ -451,6 +383,15 @@ defmodule Trento.Domain.SapSystem do
     %SapSystem{sap_system | database: Map.put(database, :instances, instances)}
   end
 
+  def apply(%SapSystem{database: %Database{} = database} = sap_system, %DatabaseHealthChanged{
+        health: health
+      }) do
+    %SapSystem{
+      sap_system
+      | database: Map.put(database, :health, health)
+    }
+  end
+
   def apply(
         %SapSystem{application: nil} = sap_system,
         %ApplicationInstanceRegistered{
@@ -545,15 +486,6 @@ defmodule Trento.Domain.SapSystem do
     }
   end
 
-  def apply(%SapSystem{database: %Database{} = database} = sap_system, %DatabaseHealthChanged{
-        health: health
-      }) do
-    %SapSystem{
-      sap_system
-      | database: Map.put(database, :health, health)
-    }
-  end
-
   # Aggregate to rolling up state
   def apply(%SapSystem{} = sap_system, %SapSystemRollUpRequested{}) do
     %SapSystem{sap_system | rolling_up: true}
@@ -565,6 +497,111 @@ defmodule Trento.Domain.SapSystem do
       }) do
     snapshot
   end
+
+  def apply(
+        %SapSystem{database: %Database{instances: instances}} = sap_system,
+        %DatabaseInstanceDeregistered{
+          instance_number: instance_number,
+          host_id: host_id
+        }
+      ) do
+    instances =
+      Enum.reject(instances, fn
+        %Instance{instance_number: ^instance_number, host_id: ^host_id} ->
+          true
+
+        _ ->
+          false
+      end)
+
+    %SapSystem{
+      sap_system
+      | database: %Database{
+          instances: instances
+        }
+    }
+  end
+
+  def apply(
+        %SapSystem{application: %Application{instances: instances}} = sap_system,
+        %ApplicationInstanceDeregistered{instance_number: instance_number, host_id: host_id}
+      ) do
+    instances =
+      Enum.reject(instances, fn
+        %Instance{instance_number: ^instance_number, host_id: ^host_id} ->
+          true
+
+        _ ->
+          false
+      end)
+
+    %SapSystem{
+      sap_system
+      | application: %Application{
+          instances: instances
+        }
+    }
+  end
+
+  def apply(
+        %SapSystem{database: database} = sap_system,
+        %DatabaseDeregistered{}
+      ) do
+    %SapSystem{
+      sap_system
+      | database: Map.put(database, :sid, nil)
+    }
+  end
+
+  def apply(
+        %SapSystem{} = sap_system,
+        %SapSystemDeregistered{
+          deregistered_at: deregistered_at
+        }
+      ) do
+    %SapSystem{
+      sap_system
+      | deregistered_at: deregistered_at,
+        sid: nil
+    }
+  end
+
+  defp maybe_emit_database_instance_registered_event(
+         nil,
+         %RegisterDatabaseInstance{
+           sap_system_id: sap_system_id,
+           sid: sid,
+           tenant: tenant,
+           instance_number: instance_number,
+           instance_hostname: instance_hostname,
+           features: features,
+           http_port: http_port,
+           https_port: https_port,
+           start_priority: start_priority,
+           host_id: host_id,
+           system_replication: system_replication,
+           system_replication_status: system_replication_status,
+           health: health
+         }
+       ) do
+    %DatabaseInstanceRegistered{
+      sap_system_id: sap_system_id,
+      sid: sid,
+      tenant: tenant,
+      instance_number: instance_number,
+      instance_hostname: instance_hostname,
+      features: features,
+      http_port: http_port,
+      https_port: https_port,
+      start_priority: start_priority,
+      host_id: host_id,
+      system_replication: system_replication,
+      system_replication_status: system_replication_status,
+      health: health
+    }
+  end
+
+  defp maybe_emit_database_instance_registered_event(_, _), do: nil
 
   defp maybe_emit_database_instance_system_replication_changed_event(
          %Instance{
@@ -614,43 +651,6 @@ defmodule Trento.Domain.SapSystem do
 
   defp maybe_emit_database_instance_health_changed_event(_, _), do: nil
 
-  defp maybe_emit_database_instance_registered_event(
-         nil,
-         %RegisterDatabaseInstance{
-           sap_system_id: sap_system_id,
-           sid: sid,
-           tenant: tenant,
-           instance_number: instance_number,
-           instance_hostname: instance_hostname,
-           features: features,
-           http_port: http_port,
-           https_port: https_port,
-           start_priority: start_priority,
-           host_id: host_id,
-           system_replication: system_replication,
-           system_replication_status: system_replication_status,
-           health: health
-         }
-       ) do
-    %DatabaseInstanceRegistered{
-      sap_system_id: sap_system_id,
-      sid: sid,
-      tenant: tenant,
-      instance_number: instance_number,
-      instance_hostname: instance_hostname,
-      features: features,
-      http_port: http_port,
-      https_port: https_port,
-      start_priority: start_priority,
-      host_id: host_id,
-      system_replication: system_replication,
-      system_replication_status: system_replication_status,
-      health: health
-    }
-  end
-
-  defp maybe_emit_database_instance_registered_event(_, _), do: nil
-
   # Returns a DatabaseHealthChanged event if the newly computed aggregated health of all the instances
   # is different from the previous Database health.
   defp maybe_emit_database_health_changed_event(%SapSystem{
@@ -668,97 +668,6 @@ defmodule Trento.Domain.SapSystem do
         health: new_health
       }
     end
-  end
-
-  defp instances_have_abap?(instances) do
-    Enum.any?(instances, fn %{features: features} -> features =~ "ABAP" end)
-  end
-
-  def instances_have_messageserver?(instances) do
-    Enum.any?(instances, fn %{features: features} -> features =~ "MESSAGESERVER" end)
-  end
-
-  defp maybe_emit_sap_system_deregistered_event(
-         %SapSystem{sid: nil},
-         _deregistered_at
-       ),
-       do: []
-
-  defp maybe_emit_sap_system_deregistered_event(
-         %SapSystem{
-           sap_system_id: sap_system_id,
-           database: %Database{
-             instances: []
-           }
-         },
-         deregistered_at
-       ) do
-    %SapSystemDeregistered{sap_system_id: sap_system_id, deregistered_at: deregistered_at}
-  end
-
-  defp maybe_emit_sap_system_deregistered_event(
-         %SapSystem{
-           sap_system_id: sap_system_id,
-           application: %Application{
-             instances: instances
-           }
-         },
-         deregistered_at
-       ) do
-    unless instances_have_abap?(instances) and instances_have_messageserver?(instances) do
-      %SapSystemDeregistered{sap_system_id: sap_system_id, deregistered_at: deregistered_at}
-    end
-  end
-
-  defp maybe_emit_database_deregistered_event(
-         %SapSystem{
-           sap_system_id: sap_system_id,
-           database: %Database{
-             instances: []
-           }
-         },
-         deregistered_at
-       ) do
-    %DatabaseDeregistered{sap_system_id: sap_system_id, deregistered_at: deregistered_at}
-  end
-
-  defp maybe_emit_database_deregistered_event(
-         %SapSystem{
-           sap_system_id: sap_system_id,
-           database: %Database{
-             instances: instances
-           }
-         },
-         deregistered_at
-       ) do
-    has_primary? =
-      Enum.any?(instances, fn %{system_replication: system_replication} ->
-        system_replication == "Primary"
-      end)
-
-    has_secondary? =
-      Enum.any?(instances, fn %{system_replication: system_replication} ->
-        system_replication == "Secondary"
-      end)
-
-    if has_secondary? and !has_primary? do
-      %DatabaseDeregistered{
-        sap_system_id: sap_system_id,
-        deregistered_at: deregistered_at
-      }
-    end
-  end
-
-  defp maybe_emit_database_deregistered_event(_, _), do: nil
-
-  defp get_instance(instances, host_id, instance_number) do
-    Enum.find(instances, fn
-      %Instance{host_id: ^host_id, instance_number: ^instance_number} ->
-        true
-
-      _ ->
-        false
-    end)
   end
 
   defp emit_application_instance_registered_or_application_instance_health_changed(
@@ -893,5 +802,96 @@ defmodule Trento.Domain.SapSystem do
         health: new_health
       }
     end
+  end
+
+  defp maybe_emit_sap_system_deregistered_event(
+         %SapSystem{sid: nil},
+         _deregistered_at
+       ),
+       do: []
+
+  defp maybe_emit_sap_system_deregistered_event(
+         %SapSystem{
+           sap_system_id: sap_system_id,
+           database: %Database{
+             instances: []
+           }
+         },
+         deregistered_at
+       ) do
+    %SapSystemDeregistered{sap_system_id: sap_system_id, deregistered_at: deregistered_at}
+  end
+
+  defp maybe_emit_sap_system_deregistered_event(
+         %SapSystem{
+           sap_system_id: sap_system_id,
+           application: %Application{
+             instances: instances
+           }
+         },
+         deregistered_at
+       ) do
+    unless instances_have_abap?(instances) and instances_have_messageserver?(instances) do
+      %SapSystemDeregistered{sap_system_id: sap_system_id, deregistered_at: deregistered_at}
+    end
+  end
+
+  defp maybe_emit_database_deregistered_event(
+         %SapSystem{
+           sap_system_id: sap_system_id,
+           database: %Database{
+             instances: []
+           }
+         },
+         deregistered_at
+       ) do
+    %DatabaseDeregistered{sap_system_id: sap_system_id, deregistered_at: deregistered_at}
+  end
+
+  defp maybe_emit_database_deregistered_event(
+         %SapSystem{
+           sap_system_id: sap_system_id,
+           database: %Database{
+             instances: instances
+           }
+         },
+         deregistered_at
+       ) do
+    has_primary? =
+      Enum.any?(instances, fn %{system_replication: system_replication} ->
+        system_replication == "Primary"
+      end)
+
+    has_secondary? =
+      Enum.any?(instances, fn %{system_replication: system_replication} ->
+        system_replication == "Secondary"
+      end)
+
+    if has_secondary? and !has_primary? do
+      %DatabaseDeregistered{
+        sap_system_id: sap_system_id,
+        deregistered_at: deregistered_at
+      }
+    end
+  end
+
+  defp maybe_emit_database_deregistered_event(_, _), do: nil
+
+  defp instances_have_abap?(instances) do
+    Enum.any?(instances, fn %{features: features} -> features =~ "ABAP" end)
+  end
+
+  def instances_have_messageserver?(instances) do
+    Enum.any?(instances, fn %{features: features} -> features =~ "MESSAGESERVER" end)
+  end
+
+  defp get_instance(instances, host_id, instance_number) do
+    Enum.find(instances, fn
+      %Instance{host_id: ^host_id, instance_number: ^instance_number} ->
+        true
+
+      _ ->
+        false
+    end)
   end
 end

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -286,17 +286,6 @@ defmodule Trento.Domain.SapSystem do
 
   def apply(
         %SapSystem{database: %Database{instances: instances}} = sap_system,
-        %DatabaseInstanceDeregistered{}
-      )
-      when length(instances) == 1 do
-    %SapSystem{
-      sap_system
-      | database: nil
-    }
-  end
-
-  def apply(
-        %SapSystem{database: %Database{instances: instances}} = sap_system,
         %DatabaseInstanceDeregistered{
           instance_number: instance_number,
           host_id: host_id
@@ -338,13 +327,6 @@ defmodule Trento.Domain.SapSystem do
           instances: instances
         }
     }
-  end
-
-  def apply(
-        %SapSystem{database: nil} = sap_system,
-        %DatabaseDeregistered{}
-      ) do
-    sap_system
   end
 
   def apply(
@@ -706,7 +688,7 @@ defmodule Trento.Domain.SapSystem do
          %SapSystem{
            sap_system_id: sap_system_id,
            database: %Database{
-             instances: nil
+             instances: []
            }
          },
          deregistered_at
@@ -732,18 +714,8 @@ defmodule Trento.Domain.SapSystem do
          %SapSystem{
            sap_system_id: sap_system_id,
            database: %Database{
-             instances: nil
+             instances: []
            }
-         },
-         deregistered_at
-       ) do
-    %DatabaseDeregistered{sap_system_id: sap_system_id, deregistered_at: deregistered_at}
-  end
-
-  defp maybe_emit_database_deregistered_event(
-         %SapSystem{
-           sap_system_id: sap_system_id,
-           database: nil
          },
          deregistered_at
        ) do
@@ -770,20 +742,10 @@ defmodule Trento.Domain.SapSystem do
       end)
 
     if has_secondary? and !has_primary? do
-      [
-        %DatabaseDeregistered{
-          sap_system_id: sap_system_id,
-          deregistered_at: deregistered_at
-        }
-      ] ++
-        Enum.map(instances, fn %Instance{instance_number: instance_number, host_id: host_id} ->
-          %DatabaseInstanceDeregistered{
-            instance_number: instance_number,
-            host_id: host_id,
-            sap_system_id: sap_system_id,
-            deregistered_at: deregistered_at
-          }
-        end)
+      %DatabaseDeregistered{
+        sap_system_id: sap_system_id,
+        deregistered_at: deregistered_at
+      }
     end
   end
 

--- a/lib/trento/infrastructure/router.ex
+++ b/lib/trento/infrastructure/router.ex
@@ -13,6 +13,7 @@ defmodule Trento.Router do
     CompleteChecksExecution,
     DeregisterApplicationInstance,
     DeregisterClusterHost,
+    DeregisterDatabaseInstance,
     DeregisterHost,
     RegisterApplicationInstance,
     RegisterClusterHost,
@@ -61,6 +62,7 @@ defmodule Trento.Router do
 
   dispatch [
              DeregisterApplicationInstance,
+             DeregisterDatabaseInstance,
              RegisterApplicationInstance,
              RegisterDatabaseInstance,
              RollUpSapSystem

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -1489,7 +1489,11 @@ defmodule Trento.SapSystemTest do
         ],
         fn sap_system ->
           assert %SapSystem{
-                   database: nil,
+                   database: %Database{
+                     sid: nil,
+                     instances: [],
+                     health: nil
+                   },
                    application: nil,
                    deregistered_at: nil
                  } = sap_system
@@ -1555,12 +1559,6 @@ defmodule Trento.SapSystemTest do
             sap_system_id: sap_system_id,
             deregistered_at: deregistered_at
           },
-          %DatabaseInstanceDeregistered{
-            sap_system_id: sap_system_id,
-            host_id: secondary_database_host_id,
-            instance_number: instance_number_2,
-            deregistered_at: deregistered_at
-          },
           %SapSystemDeregistered{
             sap_system_id: sap_system_id,
             deregistered_at: deregistered_at
@@ -1568,7 +1566,15 @@ defmodule Trento.SapSystemTest do
         ],
         fn sap_system ->
           assert %SapSystem{
-                   database: nil,
+                   database: %Database{
+                     sid: nil,
+                     instances: [
+                       %Instance{
+                         instance_number: ^instance_number_2
+                       }
+                     ],
+                     health: nil
+                   },
                    application: %Application{
                      instances: [%Instance{instance_number: ^application_instance_number}]
                    },

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -1342,34 +1342,46 @@ defmodule Trento.SapSystemTest do
   end
 
   describe "deregistration" do
-    test "should deregister a single DB instance if no SR enabled" do
+    test "should deregister a Database and SAP system when the Primary database instance is removed" do
       sap_system_id = UUID.uuid4()
+      host_id = UUID.uuid4()
+      secondary_database_host_id = UUID.uuid4()
+      application_host_id = UUID.uuid4()
       deregistered_at = DateTime.utc_now()
-
-      instances =
-        [
-          %DatabaseInstanceRegistered{
-            instance_number: instance_number_1,
-            host_id: host_id
-          },
-          %DatabaseInstanceRegistered{
-            instance_number: instance_number_2
-          }
-        ] =
-        build_list(
-          2,
-          :database_instance_registered_event,
-          sap_system_id: sap_system_id,
-          system_replication: nil
-        )
+      instance_number_1 = "00"
+      instance_number_2 = "01"
+      application_instance_number = "00"
 
       assert_events_and_state(
         [
           build(
             :database_registered_event,
             sap_system_id: sap_system_id
+          ),
+          build(
+            :database_instance_registered_event,
+            sap_system_id: sap_system_id,
+            host_id: host_id,
+            instance_number: instance_number_1,
+            system_replication: "Primary"
+          ),
+          build(
+            :database_instance_registered_event,
+            sap_system_id: sap_system_id,
+            host_id: secondary_database_host_id,
+            instance_number: instance_number_2,
+            system_replication: "Secondary"
+          ),
+          build(
+            :application_instance_registered_event,
+            sap_system_id: sap_system_id,
+            host_id: application_host_id,
+            instance_number: application_instance_number
+          ),
+          build(
+            :sap_system_registered_event,
+            sap_system_id: sap_system_id
           )
-          | instances
         ],
         %DeregisterDatabaseInstance{
           sap_system_id: sap_system_id,
@@ -1377,17 +1389,37 @@ defmodule Trento.SapSystemTest do
           instance_number: instance_number_1,
           deregistered_at: deregistered_at
         },
-        %DatabaseInstanceDeregistered{
-          sap_system_id: sap_system_id,
-          host_id: host_id,
-          instance_number: instance_number_1,
-          deregistered_at: deregistered_at
-        },
+        [
+          %DatabaseInstanceDeregistered{
+            sap_system_id: sap_system_id,
+            host_id: host_id,
+            instance_number: instance_number_1,
+            deregistered_at: deregistered_at
+          },
+          %DatabaseDeregistered{
+            sap_system_id: sap_system_id,
+            deregistered_at: deregistered_at
+          },
+          %SapSystemDeregistered{
+            sap_system_id: sap_system_id,
+            deregistered_at: deregistered_at
+          }
+        ],
         fn sap_system ->
           assert %SapSystem{
                    database: %Database{
-                     instances: [%Instance{instance_number: ^instance_number_2}]
-                   }
+                     sid: nil,
+                     instances: [
+                       %Instance{
+                         instance_number: ^instance_number_2
+                       }
+                     ],
+                     health: nil
+                   },
+                   application: %Application{
+                     instances: [%Instance{instance_number: ^application_instance_number}]
+                   },
+                   deregistered_at: ^deregistered_at
                  } = sap_system
         end
       )
@@ -1501,46 +1533,34 @@ defmodule Trento.SapSystemTest do
       )
     end
 
-    test "should deregister a Database and SAP system when the Primary database instance is removed" do
+    test "should deregister a single DB instance if no SR enabled" do
       sap_system_id = UUID.uuid4()
-      host_id = UUID.uuid4()
-      secondary_database_host_id = UUID.uuid4()
-      application_host_id = UUID.uuid4()
       deregistered_at = DateTime.utc_now()
-      instance_number_1 = "00"
-      instance_number_2 = "01"
-      application_instance_number = "00"
+
+      instances =
+        [
+          %DatabaseInstanceRegistered{
+            instance_number: instance_number_1,
+            host_id: host_id
+          },
+          %DatabaseInstanceRegistered{
+            instance_number: instance_number_2
+          }
+        ] =
+        build_list(
+          2,
+          :database_instance_registered_event,
+          sap_system_id: sap_system_id,
+          system_replication: nil
+        )
 
       assert_events_and_state(
         [
           build(
             :database_registered_event,
             sap_system_id: sap_system_id
-          ),
-          build(
-            :database_instance_registered_event,
-            sap_system_id: sap_system_id,
-            host_id: host_id,
-            instance_number: instance_number_1,
-            system_replication: "Primary"
-          ),
-          build(
-            :database_instance_registered_event,
-            sap_system_id: sap_system_id,
-            host_id: secondary_database_host_id,
-            instance_number: instance_number_2,
-            system_replication: "Secondary"
-          ),
-          build(
-            :application_instance_registered_event,
-            sap_system_id: sap_system_id,
-            host_id: application_host_id,
-            instance_number: application_instance_number
-          ),
-          build(
-            :sap_system_registered_event,
-            sap_system_id: sap_system_id
           )
+          | instances
         ],
         %DeregisterDatabaseInstance{
           sap_system_id: sap_system_id,
@@ -1548,37 +1568,17 @@ defmodule Trento.SapSystemTest do
           instance_number: instance_number_1,
           deregistered_at: deregistered_at
         },
-        [
-          %DatabaseInstanceDeregistered{
-            sap_system_id: sap_system_id,
-            host_id: host_id,
-            instance_number: instance_number_1,
-            deregistered_at: deregistered_at
-          },
-          %DatabaseDeregistered{
-            sap_system_id: sap_system_id,
-            deregistered_at: deregistered_at
-          },
-          %SapSystemDeregistered{
-            sap_system_id: sap_system_id,
-            deregistered_at: deregistered_at
-          }
-        ],
+        %DatabaseInstanceDeregistered{
+          sap_system_id: sap_system_id,
+          host_id: host_id,
+          instance_number: instance_number_1,
+          deregistered_at: deregistered_at
+        },
         fn sap_system ->
           assert %SapSystem{
                    database: %Database{
-                     sid: nil,
-                     instances: [
-                       %Instance{
-                         instance_number: ^instance_number_2
-                       }
-                     ],
-                     health: nil
-                   },
-                   application: %Application{
-                     instances: [%Instance{instance_number: ^application_instance_number}]
-                   },
-                   deregistered_at: ^deregistered_at
+                     instances: [%Instance{instance_number: ^instance_number_2}]
+                   }
                  } = sap_system
         end
       )

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -1346,11 +1346,14 @@ defmodule Trento.SapSystemTest do
       sap_system_id = UUID.uuid4()
       host_id = UUID.uuid4()
       secondary_database_host_id = UUID.uuid4()
-      application_host_id = UUID.uuid4()
       deregistered_at = DateTime.utc_now()
-      instance_number_1 = "00"
-      instance_number_2 = "01"
-      application_instance_number = "00"
+      db_instance_number_1 = "00"
+      db_instance_number_2 = "01"
+
+      message_server_host_id = UUID.uuid4()
+      message_server_instance_number = "00"
+      abap_host_id = UUID.uuid4()
+      abap_instance_number = "01"
 
       assert_events_and_state(
         [
@@ -1362,21 +1365,29 @@ defmodule Trento.SapSystemTest do
             :database_instance_registered_event,
             sap_system_id: sap_system_id,
             host_id: host_id,
-            instance_number: instance_number_1,
+            instance_number: db_instance_number_1,
             system_replication: "Primary"
           ),
           build(
             :database_instance_registered_event,
             sap_system_id: sap_system_id,
             host_id: secondary_database_host_id,
-            instance_number: instance_number_2,
+            instance_number: db_instance_number_2,
             system_replication: "Secondary"
           ),
           build(
             :application_instance_registered_event,
             sap_system_id: sap_system_id,
-            host_id: application_host_id,
-            instance_number: application_instance_number
+            features: "MESSAGESERVER|ENQUE",
+            host_id: message_server_host_id,
+            instance_number: message_server_instance_number
+          ),
+          build(
+            :application_instance_registered_event,
+            sap_system_id: sap_system_id,
+            features: "ABAP|GATEWAY|ICMAN|IGS",
+            host_id: abap_host_id,
+            instance_number: abap_instance_number
           ),
           build(
             :sap_system_registered_event,
@@ -1386,14 +1397,14 @@ defmodule Trento.SapSystemTest do
         %DeregisterDatabaseInstance{
           sap_system_id: sap_system_id,
           host_id: host_id,
-          instance_number: instance_number_1,
+          instance_number: db_instance_number_1,
           deregistered_at: deregistered_at
         },
         [
           %DatabaseInstanceDeregistered{
             sap_system_id: sap_system_id,
             host_id: host_id,
-            instance_number: instance_number_1,
+            instance_number: db_instance_number_1,
             deregistered_at: deregistered_at
           },
           %DatabaseDeregistered{
@@ -1411,13 +1422,16 @@ defmodule Trento.SapSystemTest do
                      sid: nil,
                      instances: [
                        %Instance{
-                         instance_number: ^instance_number_2
+                         instance_number: ^db_instance_number_2
                        }
                      ],
                      health: nil
                    },
                    application: %Application{
-                     instances: [%Instance{instance_number: ^application_instance_number}]
+                     instances: [
+                       %Instance{instance_number: ^abap_instance_number},
+                       %Instance{instance_number: ^message_server_instance_number}
+                     ]
                    },
                    deregistered_at: ^deregistered_at
                  } = sap_system


### PR DESCRIPTION
# Description

This PR adds the _database instance_ deregistration logic to the `sap_system` aggregate.

## How was this tested?

Based on the deregistration flow chart, all of the possible scenarios have been added to the test cases.


Note: This PR derives from https://github.com/trento-project/web/pull/1343