### PR TITLE
Fix wrong filtered catalog being used in execution results page

### DIFF
--- a/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
@@ -28,14 +28,16 @@ function ExecutionResultsPage() {
     },
   } = useSelector(getLastExecutionData(clusterID));
 
+  const cloudProvider = cluster?.provider;
+
   useEffect(() => {
-    if (catalog.length === 0) {
-      dispatch(updateCatalog());
+    if (cloudProvider) {
+      dispatch(updateCatalog({ provider: cloudProvider }));
     }
     if (!executionData) {
       dispatch(updateLastExecution(clusterID));
     }
-  }, []);
+  }, [cloudProvider]);
 
   if (!cluster) {
     return <div>Loading...</div>;
@@ -47,7 +49,7 @@ function ExecutionResultsPage() {
       clusterHosts={clusterHosts}
       clusterName={cluster?.name}
       clusterScenario={cluster?.type}
-      cloudProvider={cluster?.provider}
+      cloudProvider={cloudProvider}
       onCatalogRefresh={() => dispatch(updateCatalog())}
       onLastExecutionUpdate={() => dispatch(updateLastExecution(clusterID))}
       catalogLoading={catalogLoading}


### PR DESCRIPTION
# Description

This PR fixes a bug where a previously filtered catalog state by a given provider is not what is needed in the execution results page where the cluster provider might differ from the provider used for the previous filtering in the catalog.

Example: filtering by GCP in the catalog loads a state that is not what is needed for the execution results of a cluster discovered on Azure.

This fix comes with a cost: landing on the execution results page triggers a refresh of the catalog.
Note that navigating from the execution results to the check detail does not retrigger the refresh, however navigating back from check detail to execution results does trigger a refresh.

![fix-catalog-loading-in-check-results](https://user-images.githubusercontent.com/8167114/236395247-89d21612-22a1-42c4-94be-862f30cca01a.gif)

## How was this tested?

Manually.