### PR TITLE
Cluster delta deregistration

### DIFF
--- a/lib/trento/application/integration/discovery/discovery.ex
+++ b/lib/trento/application/integration/discovery/discovery.ex
@@ -17,7 +17,14 @@ defmodule Trento.Integration.Discovery do
     SapSystemPolicy
   }
 
+  alias Trento.Clusters
+
   @type command :: struct
+
+  @doc """
+  Transform a discovery in a list of commands event by using the appropriate policy.
+  Store the event in the discovery events log for auditing purposes and dispatch the commands.
+  """
 
   @spec handle(map) :: :ok | {:error, any}
   def handle(event) do
@@ -33,6 +40,9 @@ defmodule Trento.Integration.Discovery do
     end
   end
 
+  @doc """
+  Get the discovery events that were handled to build the current state of the system.
+  """
   @spec get_current_discovery_events :: [DiscoveryEvent.t()]
   def get_current_discovery_events do
     subquery =
@@ -47,6 +57,9 @@ defmodule Trento.Integration.Discovery do
     Repo.all(query)
   end
 
+  @doc """
+  Get the discovery events that were dead-lettered.
+  """
   @spec get_discarded_discovery_events(number) :: [DiscardedDiscoveryEvent.t()]
   def get_discarded_discovery_events(event_number) do
     query =
@@ -57,6 +70,9 @@ defmodule Trento.Integration.Discovery do
     Repo.all(query)
   end
 
+  @doc """
+  Prune the discovery events log by removing the events older than the given number of days. 
+  """
   @spec prune_events(number) :: non_neg_integer()
   def prune_events(days) do
     end_datetime = Timex.shift(DateTime.utc_now(), days: -days)
@@ -69,6 +85,9 @@ defmodule Trento.Integration.Discovery do
     events_number
   end
 
+  @doc """
+  Prune the discarded discovery events log by removing the events older than the given number of days. 
+  """
   @spec prune_discarded_discovery_events(number) :: non_neg_integer()
   def prune_discarded_discovery_events(days) do
     end_datetime = Timex.shift(DateTime.utc_now(), days: -days)
@@ -112,8 +131,11 @@ defmodule Trento.Integration.Discovery do
   defp do_handle(%{"discovery_type" => "subscription_discovery"} = event),
     do: HostPolicy.handle(event)
 
-  defp do_handle(%{"discovery_type" => "ha_cluster_discovery"} = event),
-    do: ClusterPolicy.handle(event)
+  defp do_handle(%{"discovery_type" => "ha_cluster_discovery", "agent_id" => agent_id} = event) do
+    current_cluster_id = Clusters.get_cluster_id_by_host_id(agent_id)
+
+    ClusterPolicy.handle(event, current_cluster_id)
+  end
 
   defp do_handle(%{"discovery_type" => "sap_system_discovery"} = event),
     do: SapSystemPolicy.handle(event)

--- a/lib/trento/application/usecases/clusters/clusters.ex
+++ b/lib/trento/application/usecases/clusters/clusters.ex
@@ -61,6 +61,18 @@ defmodule Trento.Clusters do
     |> Repo.all()
   end
 
+  @spec get_cluster_id_by_host_id(String.t()) :: String.t() | nil
+  def get_cluster_id_by_host_id(host_id) do
+    query =
+      from c in ClusterReadModel,
+        join: h in HostReadModel,
+        on: h.cluster_id == c.id,
+        where: h.id == ^host_id,
+        select: c.id
+
+    Repo.one(query)
+  end
+
   @spec enrich_cluster_model(ClusterReadModel.t()) :: ClusterReadModel.t()
   def enrich_cluster_model(%ClusterReadModel{id: id} = cluster) do
     case Repo.get(ClusterEnrichmentData, id) do

--- a/test/fixtures/discovery/ha_cluster_discovery_unclustered.json
+++ b/test/fixtures/discovery/ha_cluster_discovery_unclustered.json
@@ -1,0 +1,5 @@
+{
+  "agent_id": "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
+  "discovery_type": "ha_cluster_discovery",
+  "payload": null
+}

--- a/test/trento/application/integration/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/application/integration/discovery/policies/cluster_policy_test.exs
@@ -10,7 +10,7 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
 
   alias Trento.Integration.Discovery.ClusterPolicy
 
-  alias Trento.Domain.Commands.RegisterClusterHost
+  alias Trento.Domain.Commands.{DeregisterClusterHost, RegisterClusterHost}
 
   alias Trento.Domain.{
     AscsErsClusterDetails,
@@ -23,317 +23,325 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
 
   test "should return the expected commands when a ha_cluster_discovery payload of type hana_scale_up is handled" do
     assert {:ok,
-            %RegisterClusterHost{
-              cib_last_written: "Fri Oct 18 11:48:22 2019",
-              cluster_id: "34a94290-2236-5e4d-8def-05beb32d14d4",
-              designated_controller: true,
-              details: %HanaClusterDetails{
-                fencing_type: "external/sbd",
-                nodes: [
-                  %HanaClusterNode{
-                    attributes: %{
-                      "hana_prd_clone_state" => "PROMOTED",
-                      "hana_prd_op_mode" => "logreplay",
-                      "hana_prd_remoteHost" => "node02",
-                      "hana_prd_roles" => "4:P:master1:master:worker:master",
-                      "hana_prd_site" => "PRIMARY_SITE_NAME",
-                      "hana_prd_srmode" => "sync",
-                      "hana_prd_sync_state" => "PRIM",
-                      "hana_prd_version" => "2.00.040.00.1553674765",
-                      "hana_prd_vhost" => "node01",
-                      "lpa_prd_lpt" => "1571392102",
-                      "master-rsc_SAPHana_PRD_HDB00" => "150"
+            [
+              %RegisterClusterHost{
+                cib_last_written: "Fri Oct 18 11:48:22 2019",
+                cluster_id: "34a94290-2236-5e4d-8def-05beb32d14d4",
+                designated_controller: true,
+                details: %HanaClusterDetails{
+                  fencing_type: "external/sbd",
+                  nodes: [
+                    %HanaClusterNode{
+                      attributes: %{
+                        "hana_prd_clone_state" => "PROMOTED",
+                        "hana_prd_op_mode" => "logreplay",
+                        "hana_prd_remoteHost" => "node02",
+                        "hana_prd_roles" => "4:P:master1:master:worker:master",
+                        "hana_prd_site" => "PRIMARY_SITE_NAME",
+                        "hana_prd_srmode" => "sync",
+                        "hana_prd_sync_state" => "PRIM",
+                        "hana_prd_version" => "2.00.040.00.1553674765",
+                        "hana_prd_vhost" => "node01",
+                        "lpa_prd_lpt" => "1571392102",
+                        "master-rsc_SAPHana_PRD_HDB00" => "150"
+                      },
+                      hana_status: "Primary",
+                      name: "node01",
+                      resources: [
+                        %ClusterResource{
+                          fail_count: 0,
+                          id: "stonith-sbd",
+                          role: "Started",
+                          status: "Active",
+                          type: "stonith:external/sbd"
+                        },
+                        %ClusterResource{
+                          fail_count: 2,
+                          id: "rsc_ip_PRD_HDB00",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:IPaddr2"
+                        },
+                        %ClusterResource{
+                          fail_count: 1_000_000,
+                          id: "rsc_SAPHana_PRD_HDB00",
+                          role: "Master",
+                          status: "Active",
+                          type: "ocf::suse:SAPHana"
+                        },
+                        %ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_SAPHanaTopology_PRD_HDB00",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::suse:SAPHanaTopology"
+                        },
+                        %ClusterResource{
+                          fail_count: nil,
+                          id: "clusterfs",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:Filesystem"
+                        },
+                        %ClusterResource{
+                          fail_count: nil,
+                          id: "rsc_ip_HA1_ASCS00",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:IPaddr2"
+                        },
+                        %ClusterResource{
+                          fail_count: nil,
+                          id: "rsc_fs_HA1_ASCS00",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:Filesystem"
+                        },
+                        %ClusterResource{
+                          fail_count: nil,
+                          id: "rsc_sap_HA1_ASCS00",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:SAPInstance"
+                        }
+                      ],
+                      site: "PRIMARY_SITE_NAME",
+                      virtual_ip: "192.168.123.200"
                     },
-                    hana_status: "Primary",
-                    name: "node01",
-                    resources: [
-                      %ClusterResource{
-                        fail_count: 0,
-                        id: "stonith-sbd",
-                        role: "Started",
-                        status: "Active",
-                        type: "stonith:external/sbd"
+                    %HanaClusterNode{
+                      attributes: %{
+                        "hana_prd_clone_state" => "DEMOTED",
+                        "hana_prd_op_mode" => "logreplay",
+                        "hana_prd_remoteHost" => "node01",
+                        "hana_prd_roles" => "4:S:master1:master:worker:master",
+                        "hana_prd_site" => "SECONDARY_SITE_NAME",
+                        "hana_prd_srmode" => "sync",
+                        "hana_prd_sync_state" => "SOK",
+                        "hana_prd_version" => "2.00.040.00.1553674765",
+                        "hana_prd_vhost" => "node02",
+                        "lpa_prd_lpt" => "30",
+                        "master-rsc_SAPHana_PRD_HDB00" => "100"
                       },
-                      %ClusterResource{
-                        fail_count: 2,
-                        id: "rsc_ip_PRD_HDB00",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::heartbeat:IPaddr2"
-                      },
-                      %ClusterResource{
-                        fail_count: 1_000_000,
-                        id: "rsc_SAPHana_PRD_HDB00",
-                        role: "Master",
-                        status: "Active",
-                        type: "ocf::suse:SAPHana"
-                      },
-                      %ClusterResource{
-                        fail_count: 0,
-                        id: "rsc_SAPHanaTopology_PRD_HDB00",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::suse:SAPHanaTopology"
-                      },
-                      %ClusterResource{
-                        fail_count: nil,
-                        id: "clusterfs",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::heartbeat:Filesystem"
-                      },
-                      %ClusterResource{
-                        fail_count: nil,
-                        id: "rsc_ip_HA1_ASCS00",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::heartbeat:IPaddr2"
-                      },
-                      %ClusterResource{
-                        fail_count: nil,
-                        id: "rsc_fs_HA1_ASCS00",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::heartbeat:Filesystem"
-                      },
-                      %ClusterResource{
-                        fail_count: nil,
-                        id: "rsc_sap_HA1_ASCS00",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::heartbeat:SAPInstance"
-                      }
-                    ],
-                    site: "PRIMARY_SITE_NAME",
-                    virtual_ip: "192.168.123.200"
-                  },
-                  %HanaClusterNode{
-                    attributes: %{
-                      "hana_prd_clone_state" => "DEMOTED",
-                      "hana_prd_op_mode" => "logreplay",
-                      "hana_prd_remoteHost" => "node01",
-                      "hana_prd_roles" => "4:S:master1:master:worker:master",
-                      "hana_prd_site" => "SECONDARY_SITE_NAME",
-                      "hana_prd_srmode" => "sync",
-                      "hana_prd_sync_state" => "SOK",
-                      "hana_prd_version" => "2.00.040.00.1553674765",
-                      "hana_prd_vhost" => "node02",
-                      "lpa_prd_lpt" => "30",
-                      "master-rsc_SAPHana_PRD_HDB00" => "100"
+                      hana_status: "Secondary",
+                      name: "node02",
+                      resources: [
+                        %ClusterResource{
+                          fail_count: 0,
+                          id: "test",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:Dummy"
+                        },
+                        %ClusterResource{
+                          fail_count: 300,
+                          id: "rsc_SAPHana_PRD_HDB00",
+                          role: "Slave",
+                          status: "Active",
+                          type: "ocf::suse:SAPHana"
+                        },
+                        %ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_SAPHanaTopology_PRD_HDB00",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::suse:SAPHanaTopology"
+                        },
+                        %ClusterResource{
+                          fail_count: nil,
+                          id: "clusterfs",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:Filesystem"
+                        },
+                        %ClusterResource{
+                          fail_count: nil,
+                          id: "rsc_ip_HA1_ERS10",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:IPaddr2"
+                        },
+                        %ClusterResource{
+                          fail_count: nil,
+                          id: "rsc_fs_HA1_ERS10",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:Filesystem"
+                        },
+                        %ClusterResource{
+                          fail_count: nil,
+                          id: "rsc_sap_HA1_ERS10",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:SAPInstance"
+                        }
+                      ],
+                      site: "SECONDARY_SITE_NAME",
+                      virtual_ip: nil
+                    }
+                  ],
+                  sbd_devices: [
+                    %SbdDevice{
+                      device: "/dev/vdc",
+                      status: "healthy"
                     },
-                    hana_status: "Secondary",
-                    name: "node02",
-                    resources: [
-                      %ClusterResource{
-                        fail_count: 0,
-                        id: "test",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::heartbeat:Dummy"
-                      },
-                      %ClusterResource{
-                        fail_count: 300,
-                        id: "rsc_SAPHana_PRD_HDB00",
-                        role: "Slave",
-                        status: "Active",
-                        type: "ocf::suse:SAPHana"
-                      },
-                      %ClusterResource{
-                        fail_count: 0,
-                        id: "rsc_SAPHanaTopology_PRD_HDB00",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::suse:SAPHanaTopology"
-                      },
-                      %ClusterResource{
-                        fail_count: nil,
-                        id: "clusterfs",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::heartbeat:Filesystem"
-                      },
-                      %ClusterResource{
-                        fail_count: nil,
-                        id: "rsc_ip_HA1_ERS10",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::heartbeat:IPaddr2"
-                      },
-                      %ClusterResource{
-                        fail_count: nil,
-                        id: "rsc_fs_HA1_ERS10",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::heartbeat:Filesystem"
-                      },
-                      %ClusterResource{
-                        fail_count: nil,
-                        id: "rsc_sap_HA1_ERS10",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::heartbeat:SAPInstance"
-                      }
-                    ],
-                    site: "SECONDARY_SITE_NAME",
-                    virtual_ip: nil
-                  }
-                ],
-                sbd_devices: [
-                  %SbdDevice{
-                    device: "/dev/vdc",
-                    status: "healthy"
-                  },
-                  %SbdDevice{
-                    device: "/dev/vdb",
-                    status: "healthy"
-                  }
-                ],
-                secondary_sync_state: "SOK",
-                sr_health_state: "4",
-                stopped_resources: [
-                  %ClusterResource{
-                    fail_count: nil,
-                    id: "test-stop",
-                    role: "Stopped",
-                    status: nil,
-                    type: "ocf::heartbeat:Dummy"
-                  },
-                  %ClusterResource{
-                    fail_count: nil,
-                    id: "clusterfs",
-                    role: "Stopped",
-                    status: nil,
-                    type: "ocf::heartbeat:Filesystem"
-                  },
-                  %ClusterResource{
-                    fail_count: nil,
-                    id: "clusterfs",
-                    role: "Stopped",
-                    status: nil,
-                    type: "ocf::heartbeat:Filesystem"
-                  }
-                ],
-                system_replication_mode: "sync",
-                system_replication_operation_mode: "logreplay"
-              },
-              host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
-              name: "hana_cluster",
-              sid: "PRD",
-              additional_sids: [],
-              type: :hana_scale_up,
-              hosts_number: 2,
-              resources_number: 8,
-              discovered_health: :passing,
-              provider: Provider.azure()
-            }} ==
+                    %SbdDevice{
+                      device: "/dev/vdb",
+                      status: "healthy"
+                    }
+                  ],
+                  secondary_sync_state: "SOK",
+                  sr_health_state: "4",
+                  stopped_resources: [
+                    %ClusterResource{
+                      fail_count: nil,
+                      id: "test-stop",
+                      role: "Stopped",
+                      status: nil,
+                      type: "ocf::heartbeat:Dummy"
+                    },
+                    %ClusterResource{
+                      fail_count: nil,
+                      id: "clusterfs",
+                      role: "Stopped",
+                      status: nil,
+                      type: "ocf::heartbeat:Filesystem"
+                    },
+                    %ClusterResource{
+                      fail_count: nil,
+                      id: "clusterfs",
+                      role: "Stopped",
+                      status: nil,
+                      type: "ocf::heartbeat:Filesystem"
+                    }
+                  ],
+                  system_replication_mode: "sync",
+                  system_replication_operation_mode: "logreplay"
+                },
+                host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
+                name: "hana_cluster",
+                sid: "PRD",
+                additional_sids: [],
+                type: :hana_scale_up,
+                hosts_number: 2,
+                resources_number: 8,
+                discovered_health: :passing,
+                provider: Provider.azure()
+              }
+            ]} ==
              "ha_cluster_discovery_hana_scale_up"
              |> load_discovery_event_fixture()
-             |> ClusterPolicy.handle()
+             |> ClusterPolicy.handle(nil)
   end
 
   test "should return the expected commands when a ha_cluster_discovery payload of type ascs_ers is handled" do
     assert {:ok,
-            %RegisterClusterHost{
-              cib_last_written: "Tue Jan 11 13:43:06 2022",
-              cluster_id: "0eac831a-aa66-5f45-89a4-007fbd2c5714",
-              designated_controller: false,
-              details: %AscsErsClusterDetails{
-                fencing_type: "external/sbd",
-                sap_systems: [
-                  %AscsErsClusterSapSystem{
-                    sid: "NWP",
-                    filesystem_resource_based: true,
-                    distributed: true
-                  }
-                ],
-                stopped_resources: [],
-                sbd_devices: [
-                  %SbdDevice{
-                    device:
-                      "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_e34218cd-0d9a-4b21-b6d5-a313980baa82",
-                    status: "healthy"
-                  }
-                ]
-              },
-              host_id: "4b30a6af-4b52-5bda-bccb-f2248a12c992",
-              name: "netweaver_cluster",
-              sid: nil,
-              additional_sids: ["NWP"],
-              type: :ascs_ers,
-              hosts_number: 2,
-              resources_number: 9,
-              discovered_health: :passing,
-              provider: Provider.azure()
-            }} ==
+            [
+              %RegisterClusterHost{
+                cib_last_written: "Tue Jan 11 13:43:06 2022",
+                cluster_id: "0eac831a-aa66-5f45-89a4-007fbd2c5714",
+                designated_controller: false,
+                details: %AscsErsClusterDetails{
+                  fencing_type: "external/sbd",
+                  sap_systems: [
+                    %AscsErsClusterSapSystem{
+                      sid: "NWP",
+                      filesystem_resource_based: true,
+                      distributed: true
+                    }
+                  ],
+                  stopped_resources: [],
+                  sbd_devices: [
+                    %SbdDevice{
+                      device:
+                        "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_e34218cd-0d9a-4b21-b6d5-a313980baa82",
+                      status: "healthy"
+                    }
+                  ]
+                },
+                host_id: "4b30a6af-4b52-5bda-bccb-f2248a12c992",
+                name: "netweaver_cluster",
+                sid: nil,
+                additional_sids: ["NWP"],
+                type: :ascs_ers,
+                hosts_number: 2,
+                resources_number: 9,
+                discovered_health: :passing,
+                provider: Provider.azure()
+              }
+            ]} ==
              "ha_cluster_discovery_ascs_ers"
              |> load_discovery_event_fixture()
-             |> ClusterPolicy.handle()
+             |> ClusterPolicy.handle(nil)
   end
 
   test "should return the expected commands when a ha_cluster_discovery payload of type ascs_ers with invalid data is handled" do
     assert {:ok,
-            %RegisterClusterHost{
-              cib_last_written: "Tue Jan 11 13:43:06 2022",
-              cluster_id: "0eac831a-aa66-5f45-89a4-007fbd2c5714",
-              designated_controller: false,
-              details: nil,
-              host_id: "4b30a6af-4b52-5bda-bccb-f2248a12c992",
-              name: "netweaver_cluster",
-              sid: nil,
-              additional_sids: [],
-              type: :unknown,
-              hosts_number: 2,
-              resources_number: 5,
-              discovered_health: :unknown,
-              provider: Provider.azure()
-            }} ==
+            [
+              %RegisterClusterHost{
+                cib_last_written: "Tue Jan 11 13:43:06 2022",
+                cluster_id: "0eac831a-aa66-5f45-89a4-007fbd2c5714",
+                designated_controller: false,
+                details: nil,
+                host_id: "4b30a6af-4b52-5bda-bccb-f2248a12c992",
+                name: "netweaver_cluster",
+                sid: nil,
+                additional_sids: [],
+                type: :unknown,
+                hosts_number: 2,
+                resources_number: 5,
+                discovered_health: :unknown,
+                provider: Provider.azure()
+              }
+            ]} ==
              "ha_cluster_discovery_ascs_ers_invalid"
              |> load_discovery_event_fixture()
-             |> ClusterPolicy.handle()
+             |> ClusterPolicy.handle(nil)
   end
 
   test "should return the expected commands when a ha_cluster_discovery payload of type ascs_ers with multi sid setup is handled" do
     assert {:ok,
-            %RegisterClusterHost{
-              cib_last_written: "Tue Jan 11 13:43:06 2022",
-              cluster_id: "0eac831a-aa66-5f45-89a4-007fbd2c5714",
-              designated_controller: false,
-              details: %AscsErsClusterDetails{
-                fencing_type: "external/sbd",
-                sap_systems: [
-                  %AscsErsClusterSapSystem{
-                    sid: "NWP",
-                    filesystem_resource_based: true,
-                    distributed: true
-                  },
-                  %AscsErsClusterSapSystem{
-                    sid: "NWD",
-                    filesystem_resource_based: true,
-                    distributed: true
-                  }
-                ],
-                stopped_resources: [],
-                sbd_devices: [
-                  %SbdDevice{
-                    device:
-                      "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_e34218cd-0d9a-4b21-b6d5-a313980baa82",
-                    status: "healthy"
-                  }
-                ]
-              },
-              host_id: "4b30a6af-4b52-5bda-bccb-f2248a12c992",
-              name: "netweaver_cluster",
-              sid: nil,
-              additional_sids: ["NWP", "NWD"],
-              type: :ascs_ers,
-              hosts_number: 2,
-              resources_number: 17,
-              discovered_health: :passing,
-              provider: Provider.azure()
-            }} ==
+            [
+              %RegisterClusterHost{
+                cib_last_written: "Tue Jan 11 13:43:06 2022",
+                cluster_id: "0eac831a-aa66-5f45-89a4-007fbd2c5714",
+                designated_controller: false,
+                details: %AscsErsClusterDetails{
+                  fencing_type: "external/sbd",
+                  sap_systems: [
+                    %AscsErsClusterSapSystem{
+                      sid: "NWP",
+                      filesystem_resource_based: true,
+                      distributed: true
+                    },
+                    %AscsErsClusterSapSystem{
+                      sid: "NWD",
+                      filesystem_resource_based: true,
+                      distributed: true
+                    }
+                  ],
+                  stopped_resources: [],
+                  sbd_devices: [
+                    %SbdDevice{
+                      device:
+                        "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_e34218cd-0d9a-4b21-b6d5-a313980baa82",
+                      status: "healthy"
+                    }
+                  ]
+                },
+                host_id: "4b30a6af-4b52-5bda-bccb-f2248a12c992",
+                name: "netweaver_cluster",
+                sid: nil,
+                additional_sids: ["NWP", "NWD"],
+                type: :ascs_ers,
+                hosts_number: 2,
+                resources_number: 17,
+                discovered_health: :passing,
+                provider: Provider.azure()
+              }
+            ]} ==
              "ha_cluster_discovery_ascs_ers_multi_sid"
              |> load_discovery_event_fixture()
-             |> ClusterPolicy.handle()
+             |> ClusterPolicy.handle(nil)
   end
 
   test "should set the filesystem_resource_based to false if no Filesystem resources are found" do
@@ -364,47 +372,51 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
     }
 
     assert {:ok,
-            %RegisterClusterHost{
-              details: %AscsErsClusterDetails{
-                sap_systems: [
-                  %AscsErsClusterSapSystem{
-                    sid: "NWP",
-                    filesystem_resource_based: false,
-                    distributed: true
-                  }
-                ]
+            [
+              %RegisterClusterHost{
+                details: %AscsErsClusterDetails{
+                  sap_systems: [
+                    %AscsErsClusterSapSystem{
+                      sid: "NWP",
+                      filesystem_resource_based: false,
+                      distributed: true
+                    }
+                  ]
+                }
               }
-            }} =
+            ]} =
              "ha_cluster_discovery_ascs_ers"
              |> load_discovery_event_fixture()
              |> put_in(["payload", "Cib", "Configuration", "Resources", "Groups"], [
                group_1,
                group_2
              ])
-             |> ClusterPolicy.handle()
+             |> ClusterPolicy.handle(nil)
   end
 
   describe "ascs/ers clusters health" do
     test "should set the health to critical when one of the nodes is unclean" do
       assert {:ok,
-              %RegisterClusterHost{
-                details: %AscsErsClusterDetails{
-                  sap_systems: [
-                    %AscsErsClusterSapSystem{
-                      sid: "NWP",
-                      distributed: false
-                    }
-                  ]
-                },
-                discovered_health: :critical
-              }} =
+              [
+                %RegisterClusterHost{
+                  details: %AscsErsClusterDetails{
+                    sap_systems: [
+                      %AscsErsClusterSapSystem{
+                        sid: "NWP",
+                        distributed: false
+                      }
+                    ]
+                  },
+                  discovered_health: :critical
+                }
+              ]} =
                "ha_cluster_discovery_ascs_ers"
                |> load_discovery_event_fixture()
                |> put_in(["payload", "Crmmon", "Nodes"], [
                  %{"Id" => "1", "Unclean" => true, "Online" => false, "Name" => "vmnwprd01"},
                  %{"Id" => "2", "Unclean" => false, "Online" => true, "Name" => "vmnwprd02"}
                ])
-               |> ClusterPolicy.handle()
+               |> ClusterPolicy.handle(nil)
     end
 
     test "should set the health to critical when the SAPInstance resource is Stopped" do
@@ -425,24 +437,26 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
         })
 
       assert {:ok,
-              %RegisterClusterHost{
-                details: %AscsErsClusterDetails{
-                  sap_systems: [
-                    %AscsErsClusterSapSystem{
-                      sid: "NWP",
-                      distributed: false
-                    }
-                  ]
-                },
-                discovered_health: :critical
-              }} =
+              [
+                %RegisterClusterHost{
+                  details: %AscsErsClusterDetails{
+                    sap_systems: [
+                      %AscsErsClusterSapSystem{
+                        sid: "NWP",
+                        distributed: false
+                      }
+                    ]
+                  },
+                  discovered_health: :critical
+                }
+              ]} =
                "ha_cluster_discovery_ascs_ers"
                |> load_discovery_event_fixture()
                |> put_in(["payload", "Crmmon", "Groups"], [
                  %{"Resources" => group_1_resources},
                  %{"Resources" => group_2_resources}
                ])
-               |> ClusterPolicy.handle()
+               |> ClusterPolicy.handle(nil)
     end
 
     test "should set the health to critical when the SAPInstance resourece is running the same node" do
@@ -461,24 +475,26 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
         })
 
       assert {:ok,
-              %RegisterClusterHost{
-                details: %AscsErsClusterDetails{
-                  sap_systems: [
-                    %AscsErsClusterSapSystem{
-                      sid: "NWP",
-                      distributed: false
-                    }
-                  ]
-                },
-                discovered_health: :critical
-              }} =
+              [
+                %RegisterClusterHost{
+                  details: %AscsErsClusterDetails{
+                    sap_systems: [
+                      %AscsErsClusterSapSystem{
+                        sid: "NWP",
+                        distributed: false
+                      }
+                    ]
+                  },
+                  discovered_health: :critical
+                }
+              ]} =
                "ha_cluster_discovery_ascs_ers"
                |> load_discovery_event_fixture()
                |> put_in(["payload", "Crmmon", "Groups"], [
                  %{"Resources" => group_1_resources},
                  %{"Resources" => group_2_resources}
                ])
-               |> ClusterPolicy.handle()
+               |> ClusterPolicy.handle(nil)
     end
 
     test "should set the health to critical when the SAPInstance is on failed state" do
@@ -499,497 +515,528 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
         })
 
       assert {:ok,
-              %RegisterClusterHost{
-                details: %AscsErsClusterDetails{
-                  sap_systems: [
-                    %AscsErsClusterSapSystem{
-                      sid: "NWP",
-                      distributed: false
-                    }
-                  ]
-                },
-                discovered_health: :critical
-              }} =
+              [
+                %RegisterClusterHost{
+                  details: %AscsErsClusterDetails{
+                    sap_systems: [
+                      %AscsErsClusterSapSystem{
+                        sid: "NWP",
+                        distributed: false
+                      }
+                    ]
+                  },
+                  discovered_health: :critical
+                }
+              ]} =
                "ha_cluster_discovery_ascs_ers"
                |> load_discovery_event_fixture()
                |> put_in(["payload", "Crmmon", "Groups"], [
                  %{"Resources" => group_1_resources},
                  %{"Resources" => group_2_resources}
                ])
-               |> ClusterPolicy.handle()
+               |> ClusterPolicy.handle(nil)
     end
   end
 
   test "should return the expected commands when a ha_cluster_discovery payload with aws provider" do
-    assert {
-             :ok,
-             %Trento.Domain.Commands.RegisterClusterHost{
-               cib_last_written: "Wed Apr 27 07:42:23 2022",
-               cluster_id: "3e83b9d1-00e8-544d-9e29-7a66d9ed7c1e",
-               designated_controller: true,
-               details: %Trento.Domain.HanaClusterDetails{
-                 fencing_type: "external/ec2",
-                 nodes: [
-                   %Trento.Domain.HanaClusterNode{
-                     attributes: %{
-                       "hana_prd_clone_state" => "PROMOTED",
-                       "hana_prd_op_mode" => "logreplay",
-                       "hana_prd_remoteHost" => "vmhana02",
-                       "hana_prd_roles" => "4:P:master1:master:worker:master",
-                       "hana_prd_site" => "Site1",
-                       "hana_prd_srmode" => "sync",
-                       "hana_prd_sync_state" => "PRIM",
-                       "hana_prd_version" => "2.00.052.00.1599235305",
-                       "hana_prd_vhost" => "vmhana01",
-                       "lpa_prd_lpt" => "1651045343",
-                       "master-rsc_SAPHana_PRD_HDB00" => "150"
-                     },
-                     hana_status: "Primary",
-                     name: "vmhana01",
-                     resources: [
-                       %Trento.Domain.ClusterResource{
-                         fail_count: 0,
-                         id: "rsc_aws_stonith_PRD_HDB00",
-                         role: "Started",
-                         status: "Active",
-                         type: "stonith:external/ec2"
-                       },
-                       %Trento.Domain.ClusterResource{
-                         fail_count: 0,
-                         id: "rsc_ip_PRD_HDB00",
-                         role: "Started",
-                         status: "Active",
-                         type: "ocf::suse:aws-vpc-move-ip"
-                       },
-                       %Trento.Domain.ClusterResource{
-                         fail_count: 0,
-                         id: "rsc_exporter_PRD_HDB00",
-                         role: "Started",
-                         status: "Active",
-                         type: "systemd:prometheus-hanadb_exporter@PRD_HDB00"
-                       },
-                       %Trento.Domain.ClusterResource{
-                         fail_count: 0,
-                         id: "rsc_SAPHana_PRD_HDB00",
-                         role: "Master",
-                         status: "Active",
-                         type: "ocf::suse:SAPHana"
-                       },
-                       %Trento.Domain.ClusterResource{
-                         fail_count: 0,
-                         id: "rsc_SAPHanaTopology_PRD_HDB00",
-                         role: "Started",
-                         status: "Active",
-                         type: "ocf::suse:SAPHanaTopology"
-                       }
-                     ],
-                     site: "Site1",
-                     virtual_ip: "192.168.1.10"
-                   },
-                   %Trento.Domain.HanaClusterNode{
-                     attributes: %{
-                       "hana_prd_clone_state" => "DEMOTED",
-                       "hana_prd_op_mode" => "logreplay",
-                       "hana_prd_remoteHost" => "vmhana01",
-                       "hana_prd_roles" => "4:S:master1:master:worker:master",
-                       "hana_prd_site" => "Site2",
-                       "hana_prd_srmode" => "sync",
-                       "hana_prd_sync_state" => "SOK",
-                       "hana_prd_version" => "2.00.052.00.1599235305",
-                       "hana_prd_vhost" => "vmhana02",
-                       "lpa_prd_lpt" => "30",
-                       "master-rsc_SAPHana_PRD_HDB00" => "100"
-                     },
-                     hana_status: "Secondary",
-                     name: "vmhana02",
-                     resources: [
-                       %Trento.Domain.ClusterResource{
-                         fail_count: 0,
-                         id: "rsc_SAPHana_PRD_HDB00",
-                         role: "Slave",
-                         status: "Active",
-                         type: "ocf::suse:SAPHana"
-                       },
-                       %Trento.Domain.ClusterResource{
-                         fail_count: 0,
-                         id: "rsc_SAPHanaTopology_PRD_HDB00",
-                         role: "Started",
-                         status: "Active",
-                         type: "ocf::suse:SAPHanaTopology"
-                       }
-                     ],
-                     site: "Site2",
-                     virtual_ip: nil
-                   }
-                 ],
-                 sbd_devices: [],
-                 secondary_sync_state: "SOK",
-                 sr_health_state: "4",
-                 stopped_resources: [],
-                 system_replication_mode: "sync",
-                 system_replication_operation_mode: "logreplay"
-               },
-               discovered_health: :passing,
-               host_id: "a3279fd0-0443-1234-9354-2d7909fd6bc6",
-               hosts_number: 2,
-               name: "hana_cluster",
-               provider: Provider.aws(),
-               resources_number: 7,
-               sid: "PRD",
-               additional_sids: [],
-               type: :hana_scale_up
-             }
-           } ==
+    assert {:ok,
+            [
+              %Trento.Domain.Commands.RegisterClusterHost{
+                cib_last_written: "Wed Apr 27 07:42:23 2022",
+                cluster_id: "3e83b9d1-00e8-544d-9e29-7a66d9ed7c1e",
+                designated_controller: true,
+                details: %Trento.Domain.HanaClusterDetails{
+                  fencing_type: "external/ec2",
+                  nodes: [
+                    %Trento.Domain.HanaClusterNode{
+                      attributes: %{
+                        "hana_prd_clone_state" => "PROMOTED",
+                        "hana_prd_op_mode" => "logreplay",
+                        "hana_prd_remoteHost" => "vmhana02",
+                        "hana_prd_roles" => "4:P:master1:master:worker:master",
+                        "hana_prd_site" => "Site1",
+                        "hana_prd_srmode" => "sync",
+                        "hana_prd_sync_state" => "PRIM",
+                        "hana_prd_version" => "2.00.052.00.1599235305",
+                        "hana_prd_vhost" => "vmhana01",
+                        "lpa_prd_lpt" => "1651045343",
+                        "master-rsc_SAPHana_PRD_HDB00" => "150"
+                      },
+                      hana_status: "Primary",
+                      name: "vmhana01",
+                      resources: [
+                        %Trento.Domain.ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_aws_stonith_PRD_HDB00",
+                          role: "Started",
+                          status: "Active",
+                          type: "stonith:external/ec2"
+                        },
+                        %Trento.Domain.ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_ip_PRD_HDB00",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::suse:aws-vpc-move-ip"
+                        },
+                        %Trento.Domain.ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_exporter_PRD_HDB00",
+                          role: "Started",
+                          status: "Active",
+                          type: "systemd:prometheus-hanadb_exporter@PRD_HDB00"
+                        },
+                        %Trento.Domain.ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_SAPHana_PRD_HDB00",
+                          role: "Master",
+                          status: "Active",
+                          type: "ocf::suse:SAPHana"
+                        },
+                        %Trento.Domain.ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_SAPHanaTopology_PRD_HDB00",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::suse:SAPHanaTopology"
+                        }
+                      ],
+                      site: "Site1",
+                      virtual_ip: "192.168.1.10"
+                    },
+                    %Trento.Domain.HanaClusterNode{
+                      attributes: %{
+                        "hana_prd_clone_state" => "DEMOTED",
+                        "hana_prd_op_mode" => "logreplay",
+                        "hana_prd_remoteHost" => "vmhana01",
+                        "hana_prd_roles" => "4:S:master1:master:worker:master",
+                        "hana_prd_site" => "Site2",
+                        "hana_prd_srmode" => "sync",
+                        "hana_prd_sync_state" => "SOK",
+                        "hana_prd_version" => "2.00.052.00.1599235305",
+                        "hana_prd_vhost" => "vmhana02",
+                        "lpa_prd_lpt" => "30",
+                        "master-rsc_SAPHana_PRD_HDB00" => "100"
+                      },
+                      hana_status: "Secondary",
+                      name: "vmhana02",
+                      resources: [
+                        %Trento.Domain.ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_SAPHana_PRD_HDB00",
+                          role: "Slave",
+                          status: "Active",
+                          type: "ocf::suse:SAPHana"
+                        },
+                        %Trento.Domain.ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_SAPHanaTopology_PRD_HDB00",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::suse:SAPHanaTopology"
+                        }
+                      ],
+                      site: "Site2",
+                      virtual_ip: nil
+                    }
+                  ],
+                  sbd_devices: [],
+                  secondary_sync_state: "SOK",
+                  sr_health_state: "4",
+                  stopped_resources: [],
+                  system_replication_mode: "sync",
+                  system_replication_operation_mode: "logreplay"
+                },
+                discovered_health: :passing,
+                host_id: "a3279fd0-0443-1234-9354-2d7909fd6bc6",
+                hosts_number: 2,
+                name: "hana_cluster",
+                provider: Provider.aws(),
+                resources_number: 7,
+                sid: "PRD",
+                additional_sids: [],
+                type: :hana_scale_up
+              }
+            ]} ==
              "ha_cluster_discovery_aws"
              |> load_discovery_event_fixture()
-             |> ClusterPolicy.handle()
+             |> ClusterPolicy.handle(nil)
   end
 
   test "should return the expected commands when a ha_cluster_discovery payload with gcp provider" do
-    assert {
-             :ok,
-             %Trento.Domain.Commands.RegisterClusterHost{
-               cib_last_written: "Wed Apr 27 07:02:35 2022",
-               cluster_id: "61b4f40d-5e1e-5b58-bdc1-7b855dd7ede2",
-               designated_controller: true,
-               details: %Trento.Domain.HanaClusterDetails{
-                 fencing_type: "fence_gce",
-                 nodes: [
-                   %Trento.Domain.HanaClusterNode{
-                     attributes: %{
-                       "hana_prd_clone_state" => "UNDEFINED",
-                       "hana_prd_op_mode" => "logreplay",
-                       "hana_prd_remoteHost" => "vmhana02",
-                       "hana_prd_roles" => "1:P:master1::worker:",
-                       "hana_prd_site" => "Site1",
-                       "hana_prd_srmode" => "sync",
-                       "hana_prd_version" => "2.00.057.00.1629894416",
-                       "hana_prd_vhost" => "vmhana01",
-                       "lpa_prd_lpt" => "1650871168",
-                       "master-rsc_SAPHana_PRD_HDB00" => "-9000"
-                     },
-                     hana_status: "Unknown",
-                     name: "vmhana01",
-                     resources: [
-                       %Trento.Domain.ClusterResource{
-                         fail_count: 0,
-                         id: "rsc_SAPHanaTopology_PRD_HDB00",
-                         role: "Started",
-                         status: "Active",
-                         type: "ocf::suse:SAPHanaTopology"
-                       },
-                       %Trento.Domain.ClusterResource{
-                         fail_count: 0,
-                         id: "rsc_ip_PRD_HDB00",
-                         role: "Started",
-                         status: "Active",
-                         type: "ocf::heartbeat:IPaddr2"
-                       },
-                       %Trento.Domain.ClusterResource{
-                         fail_count: 0,
-                         id: "rsc_socat_PRD_HDB00",
-                         role: "Started",
-                         status: "Active",
-                         type: "ocf::heartbeat:anything"
-                       }
-                     ],
-                     site: "Site1",
-                     virtual_ip: "10.0.0.12"
-                   },
-                   %Trento.Domain.HanaClusterNode{
-                     attributes: %{
-                       "hana_prd_clone_state" => "DEMOTED",
-                       "hana_prd_op_mode" => "logreplay",
-                       "hana_prd_remoteHost" => "vmhana01",
-                       "hana_prd_roles" => "4:S:master1:master:worker:master",
-                       "hana_prd_site" => "Site2",
-                       "hana_prd_srmode" => "sync",
-                       "hana_prd_version" => "2.00.057.00.1629894416",
-                       "hana_prd_vhost" => "vmhana02",
-                       "lpa_prd_lpt" => "30",
-                       "master-rsc_SAPHana_PRD_HDB00" => "-INFINITY"
-                     },
-                     hana_status: "Unknown",
-                     name: "vmhana02",
-                     resources: [
-                       %Trento.Domain.ClusterResource{
-                         fail_count: 0,
-                         id: "rsc_SAPHana_PRD_HDB00",
-                         role: "Slave",
-                         status: "Active",
-                         type: "ocf::suse:SAPHana"
-                       },
-                       %Trento.Domain.ClusterResource{
-                         fail_count: 0,
-                         id: "rsc_SAPHanaTopology_PRD_HDB00",
-                         role: "Started",
-                         status: "Active",
-                         type: "ocf::suse:SAPHanaTopology"
-                       }
-                     ],
-                     site: "Site2",
-                     virtual_ip: nil
-                   }
-                 ],
-                 sbd_devices: [],
-                 secondary_sync_state: "Unknown",
-                 sr_health_state: "Unknown",
-                 stopped_resources: [
-                   %Trento.Domain.ClusterResource{
-                     fail_count: nil,
-                     id: "rsc_gcp_stonith_PRD_HDB00_vmhana01",
-                     role: "Stopped",
-                     status: nil,
-                     type: "stonith:fence_gce"
-                   },
-                   %Trento.Domain.ClusterResource{
-                     fail_count: nil,
-                     id: "rsc_exporter_PRD_HDB00",
-                     role: "Stopped",
-                     status: nil,
-                     type: "systemd:prometheus-hanadb_exporter@PRD_HDB00"
-                   },
-                   %Trento.Domain.ClusterResource{
-                     fail_count: nil,
-                     id: "rsc_gcp_stonith_PRD_HDB00_vmhana02",
-                     role: "Stopped",
-                     status: nil,
-                     type: "stonith:fence_gce"
-                   },
-                   %Trento.Domain.ClusterResource{
-                     fail_count: nil,
-                     id: "rsc_SAPHana_PRD_HDB00",
-                     role: "Stopped",
-                     status: nil,
-                     type: "ocf::suse:SAPHana"
-                   }
-                 ],
-                 system_replication_mode: "sync",
-                 system_replication_operation_mode: "logreplay"
-               },
-               discovered_health: :critical,
-               host_id: "1dc79771-0a96-1234-b5b6-cd4d0aef6acc",
-               hosts_number: 2,
-               name: "hana_cluster",
-               provider: Provider.gcp(),
-               resources_number: 9,
-               sid: "PRD",
-               additional_sids: [],
-               type: :hana_scale_up
-             }
-           } ==
+    assert {:ok,
+            [
+              %Trento.Domain.Commands.RegisterClusterHost{
+                cib_last_written: "Wed Apr 27 07:02:35 2022",
+                cluster_id: "61b4f40d-5e1e-5b58-bdc1-7b855dd7ede2",
+                designated_controller: true,
+                details: %Trento.Domain.HanaClusterDetails{
+                  fencing_type: "fence_gce",
+                  nodes: [
+                    %Trento.Domain.HanaClusterNode{
+                      attributes: %{
+                        "hana_prd_clone_state" => "UNDEFINED",
+                        "hana_prd_op_mode" => "logreplay",
+                        "hana_prd_remoteHost" => "vmhana02",
+                        "hana_prd_roles" => "1:P:master1::worker:",
+                        "hana_prd_site" => "Site1",
+                        "hana_prd_srmode" => "sync",
+                        "hana_prd_version" => "2.00.057.00.1629894416",
+                        "hana_prd_vhost" => "vmhana01",
+                        "lpa_prd_lpt" => "1650871168",
+                        "master-rsc_SAPHana_PRD_HDB00" => "-9000"
+                      },
+                      hana_status: "Unknown",
+                      name: "vmhana01",
+                      resources: [
+                        %Trento.Domain.ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_SAPHanaTopology_PRD_HDB00",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::suse:SAPHanaTopology"
+                        },
+                        %Trento.Domain.ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_ip_PRD_HDB00",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:IPaddr2"
+                        },
+                        %Trento.Domain.ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_socat_PRD_HDB00",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:anything"
+                        }
+                      ],
+                      site: "Site1",
+                      virtual_ip: "10.0.0.12"
+                    },
+                    %Trento.Domain.HanaClusterNode{
+                      attributes: %{
+                        "hana_prd_clone_state" => "DEMOTED",
+                        "hana_prd_op_mode" => "logreplay",
+                        "hana_prd_remoteHost" => "vmhana01",
+                        "hana_prd_roles" => "4:S:master1:master:worker:master",
+                        "hana_prd_site" => "Site2",
+                        "hana_prd_srmode" => "sync",
+                        "hana_prd_version" => "2.00.057.00.1629894416",
+                        "hana_prd_vhost" => "vmhana02",
+                        "lpa_prd_lpt" => "30",
+                        "master-rsc_SAPHana_PRD_HDB00" => "-INFINITY"
+                      },
+                      hana_status: "Unknown",
+                      name: "vmhana02",
+                      resources: [
+                        %Trento.Domain.ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_SAPHana_PRD_HDB00",
+                          role: "Slave",
+                          status: "Active",
+                          type: "ocf::suse:SAPHana"
+                        },
+                        %Trento.Domain.ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_SAPHanaTopology_PRD_HDB00",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::suse:SAPHanaTopology"
+                        }
+                      ],
+                      site: "Site2",
+                      virtual_ip: nil
+                    }
+                  ],
+                  sbd_devices: [],
+                  secondary_sync_state: "Unknown",
+                  sr_health_state: "Unknown",
+                  stopped_resources: [
+                    %Trento.Domain.ClusterResource{
+                      fail_count: nil,
+                      id: "rsc_gcp_stonith_PRD_HDB00_vmhana01",
+                      role: "Stopped",
+                      status: nil,
+                      type: "stonith:fence_gce"
+                    },
+                    %Trento.Domain.ClusterResource{
+                      fail_count: nil,
+                      id: "rsc_exporter_PRD_HDB00",
+                      role: "Stopped",
+                      status: nil,
+                      type: "systemd:prometheus-hanadb_exporter@PRD_HDB00"
+                    },
+                    %Trento.Domain.ClusterResource{
+                      fail_count: nil,
+                      id: "rsc_gcp_stonith_PRD_HDB00_vmhana02",
+                      role: "Stopped",
+                      status: nil,
+                      type: "stonith:fence_gce"
+                    },
+                    %Trento.Domain.ClusterResource{
+                      fail_count: nil,
+                      id: "rsc_SAPHana_PRD_HDB00",
+                      role: "Stopped",
+                      status: nil,
+                      type: "ocf::suse:SAPHana"
+                    }
+                  ],
+                  system_replication_mode: "sync",
+                  system_replication_operation_mode: "logreplay"
+                },
+                discovered_health: :critical,
+                host_id: "1dc79771-0a96-1234-b5b6-cd4d0aef6acc",
+                hosts_number: 2,
+                name: "hana_cluster",
+                provider: Provider.gcp(),
+                resources_number: 9,
+                sid: "PRD",
+                additional_sids: [],
+                type: :hana_scale_up
+              }
+            ]} ==
              "ha_cluster_discovery_gcp"
              |> load_discovery_event_fixture()
-             |> ClusterPolicy.handle()
+             |> ClusterPolicy.handle(nil)
   end
 
   test "should return the expected commands when a ha_cluster_discovery payload does not have a Name field" do
     assert {:ok,
-            %RegisterClusterHost{
-              cib_last_written: "Fri Oct 18 11:48:22 2019",
-              cluster_id: "34a94290-2236-5e4d-8def-05beb32d14d4",
-              designated_controller: true,
-              details: %HanaClusterDetails{
-                fencing_type: "external/sbd",
-                nodes: [
-                  %HanaClusterNode{
-                    attributes: %{
-                      "hana_prd_clone_state" => "PROMOTED",
-                      "hana_prd_op_mode" => "logreplay",
-                      "hana_prd_remoteHost" => "node02",
-                      "hana_prd_roles" => "4:P:master1:master:worker:master",
-                      "hana_prd_site" => "PRIMARY_SITE_NAME",
-                      "hana_prd_srmode" => "sync",
-                      "hana_prd_sync_state" => "PRIM",
-                      "hana_prd_version" => "2.00.040.00.1553674765",
-                      "hana_prd_vhost" => "node01",
-                      "lpa_prd_lpt" => "1571392102",
-                      "master-rsc_SAPHana_PRD_HDB00" => "150"
+            [
+              %RegisterClusterHost{
+                cib_last_written: "Fri Oct 18 11:48:22 2019",
+                cluster_id: "34a94290-2236-5e4d-8def-05beb32d14d4",
+                designated_controller: true,
+                details: %HanaClusterDetails{
+                  fencing_type: "external/sbd",
+                  nodes: [
+                    %HanaClusterNode{
+                      attributes: %{
+                        "hana_prd_clone_state" => "PROMOTED",
+                        "hana_prd_op_mode" => "logreplay",
+                        "hana_prd_remoteHost" => "node02",
+                        "hana_prd_roles" => "4:P:master1:master:worker:master",
+                        "hana_prd_site" => "PRIMARY_SITE_NAME",
+                        "hana_prd_srmode" => "sync",
+                        "hana_prd_sync_state" => "PRIM",
+                        "hana_prd_version" => "2.00.040.00.1553674765",
+                        "hana_prd_vhost" => "node01",
+                        "lpa_prd_lpt" => "1571392102",
+                        "master-rsc_SAPHana_PRD_HDB00" => "150"
+                      },
+                      hana_status: "Primary",
+                      name: "node01",
+                      resources: [
+                        %ClusterResource{
+                          fail_count: 0,
+                          id: "stonith-sbd",
+                          role: "Started",
+                          status: "Active",
+                          type: "stonith:external/sbd"
+                        },
+                        %ClusterResource{
+                          fail_count: 2,
+                          id: "rsc_ip_PRD_HDB00",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:IPaddr2"
+                        },
+                        %ClusterResource{
+                          fail_count: 1_000_000,
+                          id: "rsc_SAPHana_PRD_HDB00",
+                          role: "Master",
+                          status: "Active",
+                          type: "ocf::suse:SAPHana"
+                        },
+                        %ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_SAPHanaTopology_PRD_HDB00",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::suse:SAPHanaTopology"
+                        },
+                        %ClusterResource{
+                          fail_count: nil,
+                          id: "clusterfs",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:Filesystem"
+                        },
+                        %ClusterResource{
+                          fail_count: nil,
+                          id: "rsc_ip_HA1_ASCS00",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:IPaddr2"
+                        },
+                        %ClusterResource{
+                          fail_count: nil,
+                          id: "rsc_fs_HA1_ASCS00",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:Filesystem"
+                        },
+                        %ClusterResource{
+                          fail_count: nil,
+                          id: "rsc_sap_HA1_ASCS00",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:SAPInstance"
+                        }
+                      ],
+                      site: "PRIMARY_SITE_NAME",
+                      virtual_ip: "192.168.123.200"
                     },
-                    hana_status: "Primary",
-                    name: "node01",
-                    resources: [
-                      %ClusterResource{
-                        fail_count: 0,
-                        id: "stonith-sbd",
-                        role: "Started",
-                        status: "Active",
-                        type: "stonith:external/sbd"
+                    %HanaClusterNode{
+                      attributes: %{
+                        "hana_prd_clone_state" => "DEMOTED",
+                        "hana_prd_op_mode" => "logreplay",
+                        "hana_prd_remoteHost" => "node01",
+                        "hana_prd_roles" => "4:S:master1:master:worker:master",
+                        "hana_prd_site" => "SECONDARY_SITE_NAME",
+                        "hana_prd_srmode" => "sync",
+                        "hana_prd_sync_state" => "SOK",
+                        "hana_prd_version" => "2.00.040.00.1553674765",
+                        "hana_prd_vhost" => "node02",
+                        "lpa_prd_lpt" => "30",
+                        "master-rsc_SAPHana_PRD_HDB00" => "100"
                       },
-                      %ClusterResource{
-                        fail_count: 2,
-                        id: "rsc_ip_PRD_HDB00",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::heartbeat:IPaddr2"
-                      },
-                      %ClusterResource{
-                        fail_count: 1_000_000,
-                        id: "rsc_SAPHana_PRD_HDB00",
-                        role: "Master",
-                        status: "Active",
-                        type: "ocf::suse:SAPHana"
-                      },
-                      %ClusterResource{
-                        fail_count: 0,
-                        id: "rsc_SAPHanaTopology_PRD_HDB00",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::suse:SAPHanaTopology"
-                      },
-                      %ClusterResource{
-                        fail_count: nil,
-                        id: "clusterfs",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::heartbeat:Filesystem"
-                      },
-                      %ClusterResource{
-                        fail_count: nil,
-                        id: "rsc_ip_HA1_ASCS00",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::heartbeat:IPaddr2"
-                      },
-                      %ClusterResource{
-                        fail_count: nil,
-                        id: "rsc_fs_HA1_ASCS00",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::heartbeat:Filesystem"
-                      },
-                      %ClusterResource{
-                        fail_count: nil,
-                        id: "rsc_sap_HA1_ASCS00",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::heartbeat:SAPInstance"
-                      }
-                    ],
-                    site: "PRIMARY_SITE_NAME",
-                    virtual_ip: "192.168.123.200"
-                  },
-                  %HanaClusterNode{
-                    attributes: %{
-                      "hana_prd_clone_state" => "DEMOTED",
-                      "hana_prd_op_mode" => "logreplay",
-                      "hana_prd_remoteHost" => "node01",
-                      "hana_prd_roles" => "4:S:master1:master:worker:master",
-                      "hana_prd_site" => "SECONDARY_SITE_NAME",
-                      "hana_prd_srmode" => "sync",
-                      "hana_prd_sync_state" => "SOK",
-                      "hana_prd_version" => "2.00.040.00.1553674765",
-                      "hana_prd_vhost" => "node02",
-                      "lpa_prd_lpt" => "30",
-                      "master-rsc_SAPHana_PRD_HDB00" => "100"
+                      hana_status: "Secondary",
+                      name: "node02",
+                      resources: [
+                        %ClusterResource{
+                          fail_count: 0,
+                          id: "test",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:Dummy"
+                        },
+                        %ClusterResource{
+                          fail_count: 300,
+                          id: "rsc_SAPHana_PRD_HDB00",
+                          role: "Slave",
+                          status: "Active",
+                          type: "ocf::suse:SAPHana"
+                        },
+                        %ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_SAPHanaTopology_PRD_HDB00",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::suse:SAPHanaTopology"
+                        },
+                        %ClusterResource{
+                          fail_count: nil,
+                          id: "clusterfs",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:Filesystem"
+                        },
+                        %ClusterResource{
+                          fail_count: nil,
+                          id: "rsc_ip_HA1_ERS10",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:IPaddr2"
+                        },
+                        %ClusterResource{
+                          fail_count: nil,
+                          id: "rsc_fs_HA1_ERS10",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:Filesystem"
+                        },
+                        %ClusterResource{
+                          fail_count: nil,
+                          id: "rsc_sap_HA1_ERS10",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:SAPInstance"
+                        }
+                      ],
+                      site: "SECONDARY_SITE_NAME",
+                      virtual_ip: nil
+                    }
+                  ],
+                  sbd_devices: [
+                    %SbdDevice{
+                      device: "/dev/vdc",
+                      status: "healthy"
                     },
-                    hana_status: "Secondary",
-                    name: "node02",
-                    resources: [
-                      %ClusterResource{
-                        fail_count: 0,
-                        id: "test",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::heartbeat:Dummy"
-                      },
-                      %ClusterResource{
-                        fail_count: 300,
-                        id: "rsc_SAPHana_PRD_HDB00",
-                        role: "Slave",
-                        status: "Active",
-                        type: "ocf::suse:SAPHana"
-                      },
-                      %ClusterResource{
-                        fail_count: 0,
-                        id: "rsc_SAPHanaTopology_PRD_HDB00",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::suse:SAPHanaTopology"
-                      },
-                      %ClusterResource{
-                        fail_count: nil,
-                        id: "clusterfs",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::heartbeat:Filesystem"
-                      },
-                      %ClusterResource{
-                        fail_count: nil,
-                        id: "rsc_ip_HA1_ERS10",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::heartbeat:IPaddr2"
-                      },
-                      %ClusterResource{
-                        fail_count: nil,
-                        id: "rsc_fs_HA1_ERS10",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::heartbeat:Filesystem"
-                      },
-                      %ClusterResource{
-                        fail_count: nil,
-                        id: "rsc_sap_HA1_ERS10",
-                        role: "Started",
-                        status: "Active",
-                        type: "ocf::heartbeat:SAPInstance"
-                      }
-                    ],
-                    site: "SECONDARY_SITE_NAME",
-                    virtual_ip: nil
-                  }
-                ],
-                sbd_devices: [
-                  %SbdDevice{
-                    device: "/dev/vdc",
-                    status: "healthy"
-                  },
-                  %SbdDevice{
-                    device: "/dev/vdb",
-                    status: "healthy"
-                  }
-                ],
-                secondary_sync_state: "SOK",
-                sr_health_state: "4",
-                stopped_resources: [
-                  %ClusterResource{
-                    fail_count: nil,
-                    id: "test-stop",
-                    role: "Stopped",
-                    status: nil,
-                    type: "ocf::heartbeat:Dummy"
-                  },
-                  %ClusterResource{
-                    fail_count: nil,
-                    id: "clusterfs",
-                    role: "Stopped",
-                    status: nil,
-                    type: "ocf::heartbeat:Filesystem"
-                  },
-                  %ClusterResource{
-                    fail_count: nil,
-                    id: "clusterfs",
-                    role: "Stopped",
-                    status: nil,
-                    type: "ocf::heartbeat:Filesystem"
-                  }
-                ],
-                system_replication_mode: "sync",
-                system_replication_operation_mode: "logreplay"
-              },
-              host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
-              name: nil,
-              sid: "PRD",
-              additional_sids: [],
-              type: :hana_scale_up,
-              hosts_number: 2,
-              resources_number: 8,
-              discovered_health: :passing,
-              provider: Provider.azure()
-            }} ==
+                    %SbdDevice{
+                      device: "/dev/vdb",
+                      status: "healthy"
+                    }
+                  ],
+                  secondary_sync_state: "SOK",
+                  sr_health_state: "4",
+                  stopped_resources: [
+                    %ClusterResource{
+                      fail_count: nil,
+                      id: "test-stop",
+                      role: "Stopped",
+                      status: nil,
+                      type: "ocf::heartbeat:Dummy"
+                    },
+                    %ClusterResource{
+                      fail_count: nil,
+                      id: "clusterfs",
+                      role: "Stopped",
+                      status: nil,
+                      type: "ocf::heartbeat:Filesystem"
+                    },
+                    %ClusterResource{
+                      fail_count: nil,
+                      id: "clusterfs",
+                      role: "Stopped",
+                      status: nil,
+                      type: "ocf::heartbeat:Filesystem"
+                    }
+                  ],
+                  system_replication_mode: "sync",
+                  system_replication_operation_mode: "logreplay"
+                },
+                host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
+                name: nil,
+                sid: "PRD",
+                additional_sids: [],
+                type: :hana_scale_up,
+                hosts_number: 2,
+                resources_number: 8,
+                discovered_health: :passing,
+                provider: Provider.azure()
+              }
+            ]} ==
              "ha_cluster_discovery_unnamed"
              |> load_discovery_event_fixture()
-             |> ClusterPolicy.handle()
+             |> ClusterPolicy.handle(nil)
+  end
+
+  describe "delta deregistration" do
+    test "should deregister the host from the current cluster and register to the new one" do
+      current_cluster_id = UUID.uuid4()
+
+      {:ok,
+       [
+         %DeregisterClusterHost{cluster_id: ^current_cluster_id},
+         %RegisterClusterHost{cluster_id: "34a94290-2236-5e4d-8def-05beb32d14d4"}
+       ]} =
+        "ha_cluster_discovery_hana_scale_up"
+        |> load_discovery_event_fixture()
+        |> ClusterPolicy.handle(current_cluster_id)
+    end
+
+    test "should deregister the host from the current cluster" do
+      current_cluster_id = UUID.uuid4()
+
+      {:ok,
+       [
+         %DeregisterClusterHost{cluster_id: ^current_cluster_id}
+       ]} =
+        "ha_cluster_discovery_unclustered"
+        |> load_discovery_event_fixture()
+        |> ClusterPolicy.handle(current_cluster_id)
+    end
   end
 end

--- a/test/trento/application/usecases/clusters_test.exs
+++ b/test/trento/application/usecases/clusters_test.exs
@@ -83,6 +83,22 @@ defmodule Trento.ClustersTest do
     end
   end
 
+  describe "get_cluster_id_by_host_id/1" do
+    test "should return nil if the host is not part of any cluster" do
+      assert nil == Clusters.get_cluster_id_by_host_id(UUID.uuid4())
+    end
+
+    test "should return the cluster_id" do
+      cluster_id = UUID.uuid4()
+      host_id = UUID.uuid4()
+
+      insert(:cluster, id: cluster_id)
+      insert(:host, id: host_id, cluster_id: cluster_id)
+
+      assert cluster_id == Clusters.get_cluster_id_by_host_id(host_id)
+    end
+  end
+
   describe "update cib_last_written" do
     test "should create a new enriched cluster entry" do
       cib_last_written = Date.to_string(Faker.Date.forward(0))


### PR DESCRIPTION
This PR introduces the "delta deregistration" process for clusters.
When a discovery payload is received, the current state is considered and extra deregistration commands are dispatched alongside the registration ones. 
This is done with the help of the read models.
Eventual consistency is acceptable in this case because the agent will emit the same event after a while, so eventually the desired state will be reached.