### PR TITLE
Add SAP System deregistration side effects

### DIFF
--- a/lib/trento/application/projectors/sap_system_projector.ex
+++ b/lib/trento/application/projectors/sap_system_projector.ex
@@ -210,7 +210,9 @@ defmodule Trento.SapSystemProjector do
     TrentoWeb.Endpoint.broadcast(
       @sap_systems_topic,
       "sap_system_deregistered",
-      %{id: sap_system_id}
+      SapSystemView.render("sap_system_deregistered.json",
+        sap_system_id: sap_system_id
+      )
     )
   end
 

--- a/lib/trento/application/projectors/sap_system_projector.ex
+++ b/lib/trento/application/projectors/sap_system_projector.ex
@@ -11,6 +11,7 @@ defmodule Trento.SapSystemProjector do
   alias Trento.Domain.Events.{
     ApplicationInstanceHealthChanged,
     ApplicationInstanceRegistered,
+    SapSystemDeregistered,
     SapSystemHealthChanged,
     SapSystemRegistered
   }
@@ -111,6 +112,22 @@ defmodule Trento.SapSystemProjector do
     end
   )
 
+  project(
+    %SapSystemDeregistered{
+      sap_system_id: sap_system_id,
+      deregistered_at: deregistered_at
+    },
+    fn multi ->
+      changeset =
+        SapSystemReadModel.changeset(
+          %SapSystemReadModel{id: sap_system_id},
+          %{deregistered_at: deregistered_at}
+        )
+
+      Ecto.Multi.update(multi, :sap_system, changeset)
+    end
+  )
+
   @sap_systems_topic "monitoring:sap_systems"
 
   @impl true
@@ -181,6 +198,19 @@ defmodule Trento.SapSystemProjector do
           health: health
         }
       )
+    )
+  end
+
+  @impl true
+  def after_update(
+        %SapSystemDeregistered{sap_system_id: sap_system_id},
+        _,
+        _
+      ) do
+    TrentoWeb.Endpoint.broadcast(
+      @sap_systems_topic,
+      "sap_system_deregistered",
+      %{id: sap_system_id}
     )
   end
 

--- a/lib/trento/application/read_models/sap_system_read_model.ex
+++ b/lib/trento/application/read_models/sap_system_read_model.ex
@@ -35,6 +35,8 @@ defmodule Trento.SapSystemReadModel do
       preload_order: [asc: :instance_number, asc: :host_id]
 
     has_many :tags, Trento.Tag, foreign_key: :resource_id
+
+    field :deregistered_at, :utc_datetime_usec
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()

--- a/lib/trento/application/usecases/sap_systems/health_summary_service.ex
+++ b/lib/trento/application/usecases/sap_systems/health_summary_service.ex
@@ -24,6 +24,7 @@ defmodule Trento.SapSystems.HealthSummaryService do
   @spec get_health_summary :: [map()]
   def get_health_summary do
     SapSystemReadModel
+    |> where([s], is_nil(s.deregistered_at))
     |> order_by(asc: :sid)
     |> Repo.all()
     |> Repo.preload(application_instances: :host)
@@ -59,8 +60,7 @@ defmodule Trento.SapSystems.HealthSummaryService do
     |> HealthService.compute_aggregated_health()
   end
 
-  @spec compute_clusters_health(instance_list) ::
-          Health.t()
+  @spec compute_clusters_health(instance_list) :: Health.t()
   defp compute_clusters_health(instances) do
     instances
     |> reject_unclustered_instances()

--- a/lib/trento/application/usecases/sap_systems/sap_systems.ex
+++ b/lib/trento/application/usecases/sap_systems/sap_systems.ex
@@ -15,11 +15,14 @@ defmodule Trento.SapSystems do
   @spec get_all_sap_systems :: [SapSystemReadModel.t()]
   def get_all_sap_systems do
     SapSystemReadModel
+    |> where([s], is_nil(s.deregistered_at))
     |> order_by(asc: :sid)
     |> Repo.all()
-    |> Repo.preload(:application_instances)
-    |> Repo.preload(:database_instances)
-    |> Repo.preload(:tags)
+    |> Repo.preload([
+      :application_instances,
+      :database_instances,
+      :tags
+    ])
   end
 
   @spec get_all_databases :: [map]
@@ -27,7 +30,9 @@ defmodule Trento.SapSystems do
     DatabaseReadModel
     |> order_by(asc: :sid)
     |> Repo.all()
-    |> Repo.preload(:database_instances)
-    |> Repo.preload(:tags)
+    |> Repo.preload([
+      :database_instances,
+      :tags
+    ])
   end
 end

--- a/lib/trento_web/views/v1/sap_system_view.ex
+++ b/lib/trento_web/views/v1/sap_system_view.ex
@@ -123,6 +123,9 @@ defmodule TrentoWeb.V1.SapSystemView do
 
   def render("sap_system_health_changed.json", %{health: health}), do: health
 
+  def render("sap_system_deregistered.json", %{sap_system_id: sap_system_id}),
+    do: %{sap_system_id: sap_system_id}
+
   defp add_system_replication_status_to_secondary_instance(
          %{database_instances: database_instances} = sap_system
        ) do

--- a/priv/repo/migrations/20230505124514_add_deregistered_at_to_sap_system_read_model.exs
+++ b/priv/repo/migrations/20230505124514_add_deregistered_at_to_sap_system_read_model.exs
@@ -1,0 +1,9 @@
+defmodule Trento.Repo.Migrations.AddDeregisteredAtToSapSystemReadModel do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sap_systems) do
+      add :deregistered_at, :utc_datetime_usec
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -311,7 +311,8 @@ defmodule Trento.Factory do
       sid: Faker.StarWars.planet(),
       tenant: Faker.Beer.hop(),
       db_host: Faker.Internet.ip_v4_address(),
-      health: Health.unknown()
+      health: Health.unknown(),
+      deregistered_at: nil
     }
   end
 

--- a/test/trento/application/projectors/sap_system_projector_test.exs
+++ b/test/trento/application/projectors/sap_system_projector_test.exs
@@ -170,7 +170,7 @@ defmodule Trento.SapSystemProjectorTest do
     projection = Repo.get(SapSystemReadModel, sap_system_id)
 
     assert_broadcast "sap_system_deregistered",
-                     %{id: ^sap_system_id},
+                     %{sap_system_id: ^sap_system_id},
                      1000
 
     assert deregistered_at == projection.deregistered_at

--- a/test/trento/application/usecases/health_summary_service_test.exs
+++ b/test/trento/application/usecases/health_summary_service_test.exs
@@ -59,6 +59,8 @@ defmodule Trento.HealthSummaryServiceTest do
         sid: sid
       } = insert(:sap_system, health: Health.critical())
 
+      insert(:sap_system, deregistered_at: DateTime.utc_now())
+
       database_instance =
         insert(
           :database_instance_without_host,

--- a/test/trento/application/usecases/sap_systems_test.exs
+++ b/test/trento/application/usecases/sap_systems_test.exs
@@ -14,13 +14,15 @@ defmodule Trento.SapSystemsTest do
   @moduletag :integration
 
   describe "sap_systems" do
-    test "should retrieve all the existing sap systems and the related instances" do
+    test "should retrieve all the currently registered existing sap systems and the related instances" do
       %SapSystemReadModel{
         id: sap_system_id,
         sid: sid,
         tenant: tenant,
         db_host: db_host
       } = insert(:sap_system)
+
+      insert(:sap_system, deregistered_at: DateTime.utc_now())
 
       application_instances =
         Enum.sort_by(


### PR DESCRIPTION
# Description

This PR adds SAP System deregistration side effects.

Changes SAP System Projector: when `SapSystemDeregistered` event is received, update Read Model's `deregistered_at` field.

Updates Usecase `get_all_sap_systems()` to filter out deregistered SAP Systems.

## How was this tested?

Added unit tests for Projector and Usecase. Confirmed coverage of new changes via Coveralls.
