### PR TITLE
Automatically accept changes on Chromatic

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -323,6 +323,7 @@ jobs:
         with:
           workingDir: assets
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          autoAcceptChanges: true
           skip: dependabot/**
 
   npm-e2e-deps:


### PR DESCRIPTION
Since we use factories and data coming from faker inside stories, every rendering gets new data. This way, Chromatic's visual changes tooling becomes super noisy in the CI. Disabling that for the moment.
