### PR TITLE
Display ASCS/ERS clusters SID in clusters view

### DIFF
--- a/assets/js/components/ClustersList.jsx
+++ b/assets/js/components/ClustersList.jsx
@@ -69,7 +69,9 @@ function ClustersList() {
         title: 'SID',
         key: 'sid',
         filterFromParams: true,
-        filter: true,
+        filter: (filter, key) => (element) =>
+          element[key].some((sid) => filter.includes(sid)),
+        render: (_, { sid }) => sid.join(', '),
       },
       {
         title: 'Hosts',
@@ -124,7 +126,7 @@ function ClustersList() {
     health: cluster.health,
     name: cluster.name,
     id: cluster.id,
-    sid: cluster.sid,
+    sid: (cluster.sid ? [cluster.sid] : []).concat(cluster.additional_sids),
     type: cluster.type,
     hosts_number: cluster.hosts_number,
     resources_number: cluster.resources_number,

--- a/assets/js/components/ClustersList.test.jsx
+++ b/assets/js/components/ClustersList.test.jsx
@@ -58,14 +58,18 @@ describe('ClustersList component', () => {
       },
       {
         filter: 'SID',
-        options: ['PRD', 'QAS'],
+        options: ['PRD', 'QAS', 'HA1', 'HA2'],
         state: {
           ...cleanInitialState,
           clustersList: {
             clusters: [].concat(
               clusterFactory.buildList(4),
               clusterFactory.buildList(2, { sid: 'PRD' }),
-              clusterFactory.buildList(2, { sid: 'QAS' })
+              clusterFactory.buildList(2, { sid: 'QAS' }),
+              clusterFactory.buildList(2, {
+                sid: null,
+                additional_sids: ['HA1', 'HA2'],
+              })
             ),
           },
         },
@@ -123,6 +127,24 @@ describe('ClustersList component', () => {
         });
       }
     );
+
+    it('should show SIDs delimited by comma in multi-sid clusters', () => {
+      const state = {
+        ...cleanInitialState,
+        clustersList: {
+          clusters: clusterFactory.buildList(1, {
+            sid: null,
+            additional_sids: ['HA1', 'HA2'],
+          }),
+        },
+      };
+
+      const [StatefulClustersList] = withState(<ClustersList />, state);
+
+      renderWithRouter(StatefulClustersList);
+
+      expect(screen.getByText('HA1, HA2')).toBeVisible();
+    });
 
     it('should put the filters values in the query string when filters are selected', () => {
       const tag = 'Tag1';

--- a/assets/js/lib/test-utils/factories/clusters.js
+++ b/assets/js/lib/test-utils/factories/clusters.js
@@ -11,6 +11,7 @@ export const clusterFactory = Factory.define(({ sequence }) => ({
   id: faker.datatype.uuid(),
   name: `${faker.name.firstName()}_${sequence}`,
   sid: faker.random.alphaNumeric(3, { casing: 'upper' }),
+  additional_sids: [],
   hosts_number: faker.datatype.number(),
   resources_number: faker.datatype.number(),
   type: clusterTypeEnum(),

--- a/lib/trento/application/usecases/clusters/clusters.ex
+++ b/lib/trento/application/usecases/clusters/clusters.ex
@@ -53,7 +53,7 @@ defmodule Trento.Clusters do
   @spec get_all_clusters :: [ClusterReadModel.t()]
   def get_all_clusters do
     from(c in ClusterReadModel,
-      order_by: [asc: c.name],
+      order_by: [asc: c.name, asc: c.id],
       preload: [:tags],
       where: is_nil(c.deregistered_at)
     )

--- a/test/e2e/cypress/fixtures/clusters-overview/available_clusters.js
+++ b/test/e2e/cypress/fixtures/clusters-overview/available_clusters.js
@@ -36,21 +36,21 @@ export const availableClusters = [
     type: 'HANA Scale Up',
   },
   {
+    id: '0eac831a-aa66-5f45-89a4-007fbd2c5714',
+    name: 'netweaver_cluster',
+    sid: 'NWP',
+    type: 'ASCS/ERS',
+  },
+  {
     id: '5284f376-c1f4-5178-8966-d490df3dab4f',
     name: 'netweaver_cluster',
-    sid: '',
+    sid: 'NWD',
     type: 'ASCS/ERS',
   },
   {
     id: 'fb861bce-d212-56b5-8786-74afd6eb58cb',
     name: 'netweaver_cluster',
-    sid: '',
-    type: 'ASCS/ERS',
-  },
-  {
-    id: '0eac831a-aa66-5f45-89a4-007fbd2c5714',
-    name: 'netweaver_cluster',
-    sid: '',
+    sid: 'NWQ',
     type: 'ASCS/ERS',
   },
 ];


### PR DESCRIPTION
# Description
Show `additional_sids` in the frontend.

![image](https://github.com/trento-project/web/assets/36370954/ce444d85-3342-4505-a072-f3be368e0cfe)

## How was this tested?

Tests added
