### PR TITLE
Handle `:database_not_registered` errors

### DIFF
--- a/lib/trento/application/integration/discovery/protocol/enrich_register_application_instance.ex
+++ b/lib/trento/application/integration/discovery/protocol/enrich_register_application_instance.ex
@@ -21,7 +21,7 @@ defimpl Trento.Support.Middleware.Enrichable,
         {:ok, %RegisterApplicationInstance{command | sap_system_id: sap_system_id}}
 
       nil ->
-        {:error, :database_not_found}
+        {:error, :database_not_registered}
     end
   end
 end

--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -25,7 +25,12 @@ defmodule TrentoWeb.FallbackController do
   end
 
   def call(conn, {:error, reason})
-      when reason in [:host_not_registered, :cluster_not_registered, :sap_system_not_registered] do
+      when reason in [
+             :host_not_registered,
+             :cluster_not_registered,
+             :sap_system_not_registered,
+             :database_not_registered
+           ] do
     conn
     |> put_status(:not_found)
     |> put_view(ErrorView)
@@ -52,6 +57,8 @@ defmodule TrentoWeb.FallbackController do
     |> put_view(ErrorView)
     |> render(:"422", reason: "Unknown discovery type.")
   end
+
+  def call(conn, {:error, [error | _]}), do: call(conn, error)
 
   def call(conn, {:error, _}) do
     conn

--- a/test/trento/application/integration/discovery/protocol/enrich_register_application_instance_test.exs
+++ b/test/trento/application/integration/discovery/protocol/enrich_register_application_instance_test.exs
@@ -56,7 +56,7 @@ defmodule Trento.EnrichRegisterApplicationInstanceTest do
         health: :passing
       )
 
-    assert {:error, :database_not_found} = Enrichable.enrich(command, %{})
+    assert {:error, :database_not_registered} = Enrichable.enrich(command, %{})
   end
 
   test "should return an error if the database was not found" do
@@ -77,6 +77,6 @@ defmodule Trento.EnrichRegisterApplicationInstanceTest do
         health: :passing
       )
 
-    assert {:error, :database_not_found} = Enrichable.enrich(command, %{})
+    assert {:error, :database_not_registered} = Enrichable.enrich(command, %{})
   end
 end


### PR DESCRIPTION
# Description

Fixes issues encountered when running [Photofinish](https://github.com/trento-project/photofinish). Received status `500` responses because of unhandled `{:error, :database_not_found}` errors.

Renamed error `:database_not_found` -> `:database_not_registered`

## How was this tested?

Current unit tests enforce current behaviour
