### PR TITLE
Allow custom css in table rows

### DIFF
--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -24,6 +24,7 @@ import ExecutionContainer from './ExecutionContainer';
 
 const resultsTableConfig = {
   usePadding: false,
+  rowClassName: 'tn-check-result-row',
   columns: [
     {
       title: 'Id',

--- a/assets/js/components/Table/CollapsibleTableRow.jsx
+++ b/assets/js/components/Table/CollapsibleTableRow.jsx
@@ -1,4 +1,5 @@
 import React, { Fragment, useState } from 'react';
+import classNames from 'classnames';
 
 function CollapsibleTableRow({
   columns,
@@ -6,13 +7,16 @@ function CollapsibleTableRow({
   collapsibleDetailRenderer,
   renderCells = () => {},
   colSpan = 1,
+  className,
 }) {
   const [rowExpanded, toggleRow] = useState(false);
 
   return (
     <>
       <tr
-        className={collapsibleDetailRenderer ? 'cursor-pointer' : ''}
+        className={classNames(className, {
+          'cursor-pointer': !!collapsibleDetailRenderer,
+        })}
         onClick={() => {
           if (collapsibleDetailRenderer) {
             toggleRow(!rowExpanded);

--- a/assets/js/components/Table/Table.jsx
+++ b/assets/js/components/Table/Table.jsx
@@ -64,6 +64,7 @@ function Table({
   const {
     columns,
     collapsibleDetailRenderer = undefined,
+    rowClassName = '',
     pagination,
     usePadding = true,
   } = config;
@@ -182,6 +183,7 @@ function Table({
                       renderCells={renderCells}
                       columns={columns}
                       colSpan={columns.length}
+                      className={rowClassName}
                     />
                   ))
                 )}

--- a/assets/js/components/Table/Table.test.jsx
+++ b/assets/js/components/Table/Table.test.jsx
@@ -62,6 +62,24 @@ describe('Table component', () => {
     column3: faker.animal.dog(),
   }));
 
+  it('should allow custom classes for table rows', () => {
+    const data = tableDataFactory.buildList(10);
+    const customRowClassName = 'custom-row-classname';
+
+    render(
+      <Table
+        config={{ rowClassName: customRowClassName, ...tableConfig }}
+        data={data}
+        setSearchParams={() => {}}
+      />
+    );
+
+    screen
+      .getByRole('table')
+      .querySelectorAll('tbody > tr')
+      .forEach((tableRow) => expect(tableRow).toHaveClass(customRowClassName));
+  });
+
   describe('filtering', () => {
     it('should filter by the chosen filter option with default filter', async () => {
       const data = tableDataFactory.buildList(10);


### PR DESCRIPTION
# Description

While working on e2e tests we realized that we lost a custom css class in `ExecutionResults` which might become useful in e2e testing.

This PR allows to provide a custom css class for `tr`s in Table components.

## How was this tested?

Automated test added
