### PR TITLE
Properly handle multiple errors returned

### DIFF
--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -58,7 +58,7 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"422", reason: "Unknown discovery type.")
   end
 
-  def call(conn, {:error, [error | _]}), do: call(conn, error)
+  def call(conn, {:error, [error | _]}), do: call(conn, {:error, error})
 
   def call(conn, {:error, _}) do
     conn


### PR DESCRIPTION
# Description
PR #1405 allowed the fallback controller to handle a list of errors being returned. We where stripping away the error and just returning the reason. It now returns the `call(conn, {:error, reason}`.

## How was this tested?
Manually, using photofinish.
