### PR TITLE
Fix 404 page when wrong filtered catalog is being used in execution results page

### DIFF
--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -7,6 +7,7 @@ import HealthIcon from '@components/Health';
 import Modal from '@components/Modal';
 import PremiumPill from '@components/PremiumPill';
 import Table from '@components/Table';
+import LoadingBox from '@components/LoadingBox';
 import {
   getCatalogCategoryList,
   getCheckResults,
@@ -116,6 +117,10 @@ function ExecutionResults({
       onLastExecutionUpdate();
     }
   };
+
+  if (catalogLoading) {
+    return <LoadingBox text="Loading checks catalog" />;
+  }
 
   const checksResults = getCheckResults(executionData);
   const catalogCategoryList = getCatalogCategoryList(catalog, checksResults);

--- a/assets/js/components/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.jsx
@@ -7,7 +7,7 @@ import HealthIcon from '@components/Health';
 import Modal from '@components/Modal';
 import PremiumPill from '@components/PremiumPill';
 import Table from '@components/Table';
-import LoadingBox from '@components/LoadingBox';
+
 import {
   getCatalogCategoryList,
   getCheckResults,
@@ -117,11 +117,6 @@ function ExecutionResults({
       onLastExecutionUpdate();
     }
   };
-
-  if (catalogLoading) {
-    return <LoadingBox text="Loading checks catalog" />;
-  }
-
   const checksResults = getCheckResults(executionData);
   const catalogCategoryList = getCatalogCategoryList(catalog, checksResults);
   const tableData = checksResults

--- a/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
@@ -11,6 +11,7 @@ import {
   REQUESTED_EXECUTION_STATE,
   RUNNING_STATES,
 } from '@state/lastExecutions';
+import LoadingBox from '@components/LoadingBox';
 import ExecutionResults from './ExecutionResults';
 
 function ExecutionResultsPage() {
@@ -40,7 +41,7 @@ function ExecutionResultsPage() {
   }, [cloudProvider]);
 
   if (!cluster) {
-    return <div>Loading...</div>;
+    return <LoadingBox text="Loading ..." />;
   }
 
   return (

--- a/assets/js/components/ExecutionResults/checksUtils.js
+++ b/assets/js/components/ExecutionResults/checksUtils.js
@@ -44,10 +44,10 @@ export const getCatalogCategoryList = (catalog, checksResults = []) => {
   }
   return [
     ...new Set(
-      checksResults.map(({ check_id }) => {
-        const result = catalog.find((check) => check.id === check_id);
-        return !result ? '' : result.group;
-      })
+      checksResults.map(
+        ({ check_id }) =>
+          catalog.find((check) => check.id === check_id)?.group || ''
+      )
     ),
   ].sort();
 };

--- a/assets/js/components/ExecutionResults/checksUtils.js
+++ b/assets/js/components/ExecutionResults/checksUtils.js
@@ -44,9 +44,10 @@ export const getCatalogCategoryList = (catalog, checksResults = []) => {
   }
   return [
     ...new Set(
-      checksResults.map(
-        ({ check_id }) => catalog.find((check) => check.id === check_id).group
-      )
+      checksResults.map(({ check_id }) => {
+        const result = catalog.find((check) => check.id === check_id);
+        return !result ? '' : result.group;
+      })
     ),
   ].sort();
 };


### PR DESCRIPTION
# Description
This pull request addresses a bug that occurs when navigating to the checks catalog view and selecting a provider filter (e.g., "gcp," "kvm," or "aws") different from the previously executed provider. Proceeding to the cluster details view and clicking the "Show Results" button, a 404 error page is encountered.

The underlying issue is a slow loading of the catalog, which triggers the error. To resolve this behavior, the pull request introduces several changes. Firstly, a loading state is implemented to improve data handling and ensure proper catalog loading. Additionally, the loading transition is enhanced by incorporating the LoadingBox component, resulting in a smoother user experience.

## Before Fix
[bug.webm](https://github.com/trento-project/web/assets/54111255/e2917f56-05fb-48ce-b8d1-2c32437b07ed)

## After Fix
[bugFix.webm](https://github.com/trento-project/web/assets/54111255/ad27f6cb-c584-4c5b-a167-b5d71202205a)

