### PR TITLE
Do not render Values section when no values are available

### DIFF
--- a/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultDetail.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultDetail.jsx
@@ -53,9 +53,11 @@ function CheckResultDetail({
         isError={isError}
         errorMessage={message}
       />
-      {targetHost && (
-        <ExpectedValues isError={isError} expectedValues={values} />
-      )}
+      <ExpectedValues
+        isTargetHost={targetHost}
+        isError={isError}
+        expectedValues={values}
+      />
       <GatheredFacts
         isTargetHost={targetHost}
         gatheredFacts={gatheredFacts || []}

--- a/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultDetail.stories.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultDetail.stories.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   addPassingExpectExpectation,
   addPassingExpectSameExpectation,
@@ -7,6 +6,7 @@ import {
   checksExecutionCompletedFactory,
   checkResultFactory,
   addCriticalExpectExpectation,
+  withOverriddenValues,
 } from '@lib/test-utils/factories';
 
 import CheckResultDetail from './CheckResultDetail';
@@ -28,13 +28,22 @@ checkResult = addCriticalExpectExpectation(checkResult);
 checkResult = addCriticalExpectExpectation(checkResult);
 checkResult = addPassingExpectSameExpectation(checkResult, 'expectation_name');
 
+const checkResultWithoutValues = withOverriddenValues(checkResult, target1, []);
+
 const executionData = checksExecutionCompletedFactory.build({
   check_results: [checkResultFactory.build(), checkResult],
+});
+
+const executionDataWithoutValues = checksExecutionCompletedFactory.build({
+  check_results: [checkResultFactory.build(), checkResultWithoutValues],
 });
 
 export default {
   title: 'CheckResultDetail',
   component: CheckResultDetail,
+};
+
+export const Default = {
   args: {
     checkID,
     targetID: target1,
@@ -44,6 +53,9 @@ export default {
   },
 };
 
-export function Default(args) {
-  return <CheckResultDetail {...args} />;
-}
+export const WithoutValues = {
+  args: {
+    ...Default.args,
+    executionData: executionDataWithoutValues,
+  },
+};

--- a/assets/js/components/ExecutionResults/CheckResultDetail/ExpectedValues.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/ExpectedValues.jsx
@@ -2,7 +2,19 @@ import React from 'react';
 
 import ListView from '@components/ListView';
 
-function ExpectedValues({ expectedValues = [], isError = false }) {
+function ExpectedValues({
+  isTargetHost = true,
+  expectedValues = [],
+  isError = false,
+}) {
+  if (!isTargetHost) {
+    return null;
+  }
+
+  if (!isError && expectedValues.length === 0) {
+    return null;
+  }
+
   return (
     <div className="w-full my-4 mr-4 bg-white shadow rounded-lg px-8 py-4">
       <div className="text-lg font-bold">Values</div>

--- a/assets/js/components/ExecutionResults/CheckResultDetail/ExpectedValues.test.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/ExpectedValues.test.jsx
@@ -23,4 +23,10 @@ describe('ExpectedValues Component', () => {
 
     expect(screen.getByText('Expected Values unavailable')).toBeVisible();
   });
+
+  it('should not render when values are not available', () => {
+    render(<ExpectedValues expectedValues={[]} />);
+
+    expect(screen.queryByText('Values')).toBeNull();
+  });
 });

--- a/assets/js/lib/test-utils/factories/executions.js
+++ b/assets/js/lib/test-utils/factories/executions.js
@@ -252,3 +252,25 @@ export const emptyCheckResultFactory = Factory.define(({ params }) => {
 
   return withEmptyExpectations(checkResult);
 });
+
+export const withOverriddenValues = (
+  checkResult,
+  targetId,
+  overriddenValues
+) => {
+  const overridenResults = checkResult.agents_check_results.map(
+    (agentCheckResult) => {
+      if (targetId !== agentCheckResult.agent_id) return agentCheckResult;
+
+      return {
+        ...agentCheckResult,
+        values: overriddenValues,
+      };
+    }
+  );
+
+  return {
+    ...checkResult,
+    agents_check_results: overridenResults,
+  };
+};


### PR DESCRIPTION
# Description

This PR makes sure that the **Values** section in a check result detail is not rendered if there were no values to be rendered (ie the check has no `values` defined)

Scenarios are:
- cluster wide checks -> no values section
- target host + no values defined -> no Values section
- target host + values defined -> Values section + values
- target host + values defined + error -> Values section + error message

![no-values-detail](https://github.com/trento-project/web/assets/8167114/91a5f149-da21-457f-b470-8c2e3cb8f402)