### PR TITLE
Improve scalar values support in FactValue

### DIFF
--- a/assets/js/components/ExecutionResults/CheckResultDetail/FactValue.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/FactValue.jsx
@@ -6,7 +6,7 @@ function FactValue({ className, data }) {
   return typeof data === 'object' ? (
     <ObjectTree className={className} data={data} />
   ) : (
-    <span className={className}>{data}</span>
+    <span className={className}>{`${data}`}</span>
   );
 }
 

--- a/assets/js/components/ExecutionResults/CheckResultDetail/FactValue.test.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/FactValue.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { faker } from '@faker-js/faker';
 import '@testing-library/jest-dom';
 
 import { randomObjectFactory } from '@lib/test-utils/factories';
@@ -8,13 +7,37 @@ import { randomObjectFactory } from '@lib/test-utils/factories';
 import FactValue from './FactValue';
 
 describe('FactValue component', () => {
-  it('should render just a scalar value', () => {
-    const plainString = faker.hacker.noun();
+  const scalarScenarios = [
+    {
+      type: 'string',
+      plain: 'a string',
+      stringRepresentation: 'a string',
+    },
+    {
+      type: 'number - integer',
+      plain: 42,
+      stringRepresentation: '42',
+    },
+    {
+      type: 'number - float',
+      plain: 42.5,
+      stringRepresentation: '42.5',
+    },
+    {
+      type: 'boolean',
+      plain: true,
+      stringRepresentation: 'true',
+    },
+  ];
 
-    render(<FactValue data={plainString} />);
+  it.each(scalarScenarios)(
+    'should render just a scalar value of type "$type"',
+    ({ plain, stringRepresentation }) => {
+      render(<FactValue data={plain} />);
 
-    expect(screen.getByText(plainString)).toBeVisible();
-  });
+      expect(screen.getByText(stringRepresentation)).toBeVisible();
+    }
+  );
 
   it('should render just an object tree', () => {
     const data = randomObjectFactory.build();


### PR DESCRIPTION
# Description

Improves support for `boolean` values in `FactValue` component.

Before
![image](https://github.com/trento-project/web/assets/8167114/3ecaab50-aac9-4524-8118-2ec7d97bfdd5)

After
![image](https://github.com/trento-project/web/assets/8167114/a13665c0-9abb-4926-88c9-3cfd63896378)


## How was this tested?

Extended tests.