### PR TITLE
Discover ASCS/ERS clusters health and initial details

### DIFF
--- a/lib/trento/application/integration/discovery/payloads/cluster/crmmon_discovery_payload.ex
+++ b/lib/trento/application/integration/discovery/payloads/cluster/crmmon_discovery_payload.ex
@@ -165,6 +165,13 @@ defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload.Crmmon do
 
     embeds_one :summary, Summary
 
+    embeds_many :nodes, Node, primary_key: false do
+      field :id, :string
+      field :name, :string
+      field :online, :boolean
+      field :unclean, :boolean
+    end
+
     embeds_many :resources, CrmmonResource
 
     embeds_many :groups, CrmmonGroup, primary_key: false do
@@ -205,12 +212,19 @@ defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload.Crmmon do
     crmmon
     |> cast(transformed_attrs, [:version])
     |> cast_embed(:summary)
+    |> cast_embed(:nodes, with: &nodes_changeset/2)
     |> cast_embed(:resources)
     |> cast_embed(:groups, with: &groups_changeset/2)
     |> cast_embed(:clones, with: &clones_changeset/2)
     |> cast_embed(:node_history)
     |> cast_embed(:node_attributes, with: &node_attributes_changeset/2)
     |> validate_required_fields(@required_fields)
+  end
+
+  defp nodes_changeset(nodes, attrs) do
+    nodes
+    |> cast(attrs, [:id, :name, :online, :unclean])
+    |> validate_required_fields([:id, :name])
   end
 
   defp groups_changeset(groups, attrs) do
@@ -239,11 +253,11 @@ defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload.Crmmon do
   defp node_attributes_changeset(node_attributes, attrs) do
     node_attributes
     |> cast(attrs, [])
-    |> cast_embed(:nodes, with: &nodes_changeset/2)
+    |> cast_embed(:nodes, with: &node_attributes_nodes_changeset/2)
     |> validate_required_fields([:nodes])
   end
 
-  defp nodes_changeset(nodes, attrs) do
+  defp node_attributes_nodes_changeset(nodes, attrs) do
     nodes
     |> cast(attrs, [:name])
     |> cast_embed(:attributes, with: &attributes_changeset/2)
@@ -257,9 +271,11 @@ defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload.Crmmon do
   end
 
   defp transform_nil_lists(
-         %{"groups" => groups, "clones" => clones, "resources" => resources} = attrs
+         %{"nodes" => nodes, "groups" => groups, "clones" => clones, "resources" => resources} =
+           attrs
        ) do
     attrs
+    |> Map.put("nodes", ListHelper.to_list(nodes))
     |> Map.put("groups", ListHelper.to_list(groups))
     |> Map.put("clones", ListHelper.to_list(clones))
     |> Map.put("resources", ListHelper.to_list(resources))

--- a/lib/trento/application/integration/discovery/payloads/cluster/crmmon_discovery_payload.ex
+++ b/lib/trento/application/integration/discovery/payloads/cluster/crmmon_discovery_payload.ex
@@ -224,7 +224,7 @@ defmodule Trento.Integration.Discovery.ClusterDiscoveryPayload.Crmmon do
   defp nodes_changeset(nodes, attrs) do
     nodes
     |> cast(attrs, [:id, :name, :online, :unclean])
-    |> validate_required_fields([:id, :name])
+    |> validate_required([:id, :name])
   end
 
   defp groups_changeset(groups, attrs) do

--- a/lib/trento/domain/cluster/cluster.ex
+++ b/lib/trento/domain/cluster/cluster.ex
@@ -61,6 +61,7 @@ defmodule Trento.Domain.Cluster do
   alias Commanded.Aggregate.Multi
 
   alias Trento.Domain.{
+    AscsErsClusterDetails,
     Cluster,
     HanaClusterDetails,
     HealthService
@@ -119,7 +120,15 @@ defmodule Trento.Domain.Cluster do
     field :rolling_up, :boolean, default: false
     field :deregistered_at, :utc_datetime_usec, default: nil
 
-    embeds_one :details, HanaClusterDetails
+    field :details, PolymorphicEmbed,
+      types: [
+        hana_scale_up: [
+          module: HanaClusterDetails,
+          identify_by_fields: [:system_replication_mode]
+        ],
+        ascs_ers: [module: AscsErsClusterDetails, identify_by_fields: [:sap_systems]]
+      ],
+      on_replace: :update
   end
 
   def execute(%Cluster{rolling_up: true}, _), do: {:error, :cluster_rolling_up}

--- a/lib/trento/domain/cluster/commands/register_cluster_host.ex
+++ b/lib/trento/domain/cluster/commands/register_cluster_host.ex
@@ -18,7 +18,10 @@ defmodule Trento.Domain.Commands.RegisterClusterHost do
   require Trento.Domain.Enums.ClusterType, as: ClusterType
   require Trento.Domain.Enums.Health, as: Health
 
-  alias Trento.Domain.HanaClusterDetails
+  alias Trento.Domain.{
+    AscsErsClusterDetails,
+    HanaClusterDetails
+  }
 
   defcommand do
     field :cluster_id, Ecto.UUID
@@ -34,6 +37,14 @@ defmodule Trento.Domain.Commands.RegisterClusterHost do
     field :discovered_health, Ecto.Enum, values: Health.values()
     field :cib_last_written, :string
 
-    embeds_one :details, HanaClusterDetails
+    field :details, PolymorphicEmbed,
+      types: [
+        hana_scale_up: [
+          module: HanaClusterDetails,
+          identify_by_fields: [:system_replication_mode]
+        ],
+        ascs_ers: [module: AscsErsClusterDetails, identify_by_fields: [:sap_systems]]
+      ],
+      on_replace: :update
   end
 end

--- a/lib/trento/domain/cluster/events/cluster_details_updated.ex
+++ b/lib/trento/domain/cluster/events/cluster_details_updated.ex
@@ -8,7 +8,10 @@ defmodule Trento.Domain.Events.ClusterDetailsUpdated do
   require Trento.Domain.Enums.Provider, as: Provider
   require Trento.Domain.Enums.ClusterType, as: ClusterType
 
-  alias Trento.Domain.HanaClusterDetails
+  alias Trento.Domain.{
+    AscsErsClusterDetails,
+    HanaClusterDetails
+  }
 
   defevent do
     field :cluster_id, Ecto.UUID
@@ -20,6 +23,14 @@ defmodule Trento.Domain.Events.ClusterDetailsUpdated do
     field :resources_number, :integer
     field :hosts_number, :integer
 
-    embeds_one :details, HanaClusterDetails
+    field :details, PolymorphicEmbed,
+      types: [
+        hana_scale_up: [
+          module: HanaClusterDetails,
+          identify_by_fields: [:system_replication_mode]
+        ],
+        ascs_ers: [module: AscsErsClusterDetails, identify_by_fields: [:sap_systems]]
+      ],
+      on_replace: :update
   end
 end

--- a/lib/trento/domain/cluster/events/cluster_registered.ex
+++ b/lib/trento/domain/cluster/events/cluster_registered.ex
@@ -9,7 +9,10 @@ defmodule Trento.Domain.Events.ClusterRegistered do
   require Trento.Domain.Enums.ClusterType, as: ClusterType
   require Trento.Domain.Enums.Health, as: Health
 
-  alias Trento.Domain.HanaClusterDetails
+  alias Trento.Domain.{
+    AscsErsClusterDetails,
+    HanaClusterDetails
+  }
 
   defevent do
     field :cluster_id, Ecto.UUID
@@ -22,6 +25,14 @@ defmodule Trento.Domain.Events.ClusterRegistered do
     field :hosts_number, :integer
     field :health, Ecto.Enum, values: Health.values()
 
-    embeds_one :details, HanaClusterDetails
+    field :details, PolymorphicEmbed,
+      types: [
+        hana_scale_up: [
+          module: HanaClusterDetails,
+          identify_by_fields: [:system_replication_mode]
+        ],
+        ascs_ers: [module: AscsErsClusterDetails, identify_by_fields: [:sap_systems]]
+      ],
+      on_replace: :update
   end
 end

--- a/lib/trento/domain/value_objects/ascs_ers_cluster_details.ex
+++ b/lib/trento/domain/value_objects/ascs_ers_cluster_details.ex
@@ -1,0 +1,26 @@
+defmodule Trento.Domain.AscsErsClusterDetails do
+  @moduledoc """
+  Represents the details of a ASCS/ERS cluster.
+  """
+
+  @required_fields [
+    :fencing_type,
+    :sap_systems
+  ]
+
+  use Trento.Type
+
+  alias Trento.Domain.{
+    AscsErsClusterSapSystem,
+    ClusterResource,
+    SbdDevice
+  }
+
+  deftype do
+    field :fencing_type, :string
+
+    embeds_many :sap_systems, AscsErsClusterSapSystem
+    embeds_many :stopped_resources, ClusterResource
+    embeds_many :sbd_devices, SbdDevice
+  end
+end

--- a/lib/trento/domain/value_objects/ascs_ers_cluster_sap_system.ex
+++ b/lib/trento/domain/value_objects/ascs_ers_cluster_sap_system.ex
@@ -1,0 +1,19 @@
+defmodule Trento.Domain.AscsErsClusterSapSystem do
+  @moduledoc """
+  Represents ASCS/ERS cluster SAP system.
+  """
+
+  @required_fields [
+    :sid,
+    :filesystem_resource_based,
+    :distributed
+  ]
+
+  use Trento.Type
+
+  deftype do
+    field :sid, :string
+    field :filesystem_resource_based, :boolean
+    field :distributed, :boolean
+  end
+end

--- a/lib/trento/domain/value_objects/hana_cluster_details.ex
+++ b/lib/trento/domain/value_objects/hana_cluster_details.ex
@@ -13,8 +13,8 @@ defmodule Trento.Domain.HanaClusterDetails do
   use Trento.Type
 
   alias Trento.Domain.{
-    ClusterNode,
     ClusterResource,
+    HanaClusterNode,
     SbdDevice
   }
 
@@ -26,7 +26,7 @@ defmodule Trento.Domain.HanaClusterDetails do
     field :fencing_type, :string
 
     embeds_many :stopped_resources, ClusterResource
-    embeds_many :nodes, ClusterNode
+    embeds_many :nodes, HanaClusterNode
     embeds_many :sbd_devices, SbdDevice
   end
 end

--- a/lib/trento/domain/value_objects/hana_cluster_node.ex
+++ b/lib/trento/domain/value_objects/hana_cluster_node.ex
@@ -1,4 +1,4 @@
-defmodule Trento.Domain.ClusterNode do
+defmodule Trento.Domain.HanaClusterNode do
   @moduledoc """
   Represents the node of a HANA cluster.
   """

--- a/lib/trento_web/openapi/schema/cluster.ex
+++ b/lib/trento_web/openapi/schema/cluster.ex
@@ -25,12 +25,12 @@ defmodule TrentoWeb.OpenApi.Schema.Cluster do
     })
   end
 
-  defmodule ClusterNode do
+  defmodule HanaClusterNode do
     @moduledoc false
 
     OpenApiSpex.schema(%{
-      title: "ClusterNode",
-      description: "A Cluster Node",
+      title: "HanaClusterNode",
+      description: "A HANA Cluster Node",
       type: :object,
       properties: %{
         name: %Schema{type: :string},
@@ -44,7 +44,7 @@ defmodule TrentoWeb.OpenApi.Schema.Cluster do
         virtual_ip: %Schema{type: :string},
         resources: %Schema{
           title: "ClustrNodeResources",
-          description: "A list of ClusterNodes",
+          description: "A list of Cluster resources",
           type: :array,
           items: ClusterResource
         }
@@ -91,7 +91,7 @@ defmodule TrentoWeb.OpenApi.Schema.Cluster do
         nodes: %Schema{
           title: "HanaClusterNodes",
           type: :array,
-          items: ClusterNode
+          items: HanaClusterNode
         },
         sbd_devices: %Schema{
           title: "SbdDevice",

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -8,9 +8,9 @@ defmodule Trento.Factory do
   require Trento.Domain.Enums.Health, as: Health
 
   alias Trento.Domain.{
-    ClusterNode,
     ClusterResource,
     HanaClusterDetails,
+    HanaClusterNode,
     SapSystem,
     SbdDevice,
     SlesSubscription
@@ -263,7 +263,7 @@ defmodule Trento.Factory do
     %HanaClusterDetails{
       fencing_type: "external/sbd",
       nodes: [
-        %ClusterNode{
+        %HanaClusterNode{
           attributes: %{"attribute" => Faker.Beer.name()},
           hana_status: "Secondary",
           name: Faker.StarWars.character(),
@@ -422,5 +422,37 @@ defmodule Trento.Factory do
       system_replication_status: "ACTIVE",
       health: Health.passing()
     })
+  end
+
+  def cib_resource_factory do
+    %{
+      "Id" => Faker.UUID.v4(),
+      "Type" => Faker.StarWars.planet(),
+      "Class" => "ocf",
+      "Provider" => "heartbeat",
+      "Operations" => [],
+      "MetaAttributes" => %{},
+      "InstanceAttributes" => []
+    }
+  end
+
+  def crm_resource_factory do
+    %{
+      "Id" => Faker.UUID.v4(),
+      "Node" => %{
+        "Id" => "1",
+        "Name" => Faker.StarWars.planet(),
+        "Cached" => true
+      },
+      "Role" => "Started",
+      "Agent" => Faker.Pokemon.name(),
+      "Active" => true,
+      "Failed" => false,
+      "Blocked" => false,
+      "Managed" => true,
+      "Orphaned" => false,
+      "FailureIgnored" => false,
+      "NodesRunningOn" => 1
+    }
   end
 end

--- a/test/trento/application/integration/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/application/integration/discovery/policies/cluster_policy_test.exs
@@ -401,8 +401,8 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
                "ha_cluster_discovery_ascs_ers"
                |> load_discovery_event_fixture()
                |> put_in(["payload", "Crmmon", "Nodes"], [
-                 %{"Unclean" => true, "Online" => false, "Name" => "vmnwprd01"},
-                 %{"Unclean" => false, "Online" => true, "Name" => "vmnwprd02"}
+                 %{"Id" => "1", "Unclean" => true, "Online" => false, "Name" => "vmnwprd01"},
+                 %{"Id" => "2", "Unclean" => false, "Online" => true, "Name" => "vmnwprd02"}
                ])
                |> ClusterPolicy.handle()
     end

--- a/test/trento/application/projectors/cluster_projector_test.exs
+++ b/test/trento/application/projectors/cluster_projector_test.exs
@@ -61,7 +61,7 @@ defmodule Trento.ClusterProjectorTest do
                        details: %Trento.Domain.HanaClusterDetails{
                          fencing_type: "external/sbd",
                          nodes: [
-                           %Trento.Domain.ClusterNode{
+                           %Trento.Domain.HanaClusterNode{
                              attributes: _,
                              hana_status: "Secondary",
                              name: _,
@@ -145,7 +145,7 @@ defmodule Trento.ClusterProjectorTest do
                        details: %Trento.Domain.HanaClusterDetails{
                          fencing_type: "external/sbd",
                          nodes: [
-                           %Trento.Domain.ClusterNode{
+                           %Trento.Domain.HanaClusterNode{
                              attributes: _,
                              hana_status: "Secondary",
                              name: _,


### PR DESCRIPTION
# Description

Discovery of the ASCS/ERS clusters health.
In order to achieve that, we need to start building the cluster details.
In this case, the details is composed by a list of SAP systems (for a multi-sid environment) where each of the systems has its own details. Together with them, some common fields like `sbd` and `stopped_resources` are used.

Each sap system has the `distributed` field (check in the code docstring what this means).
If any of the sap systems in the cluster is **not** distributed, the health is set to `critical`.

PD: I have excluded the API schema updates in general. We will work on them once we have the whole details structure, to not overwhelm these PRs.

## How was this tested?

In order to test it properly, i have avoided continuing adding more and more fixtures files, as each single tests need new values. I have combined some factories together with the `put_in` function to update already existing fixtures for my purpose.
