### PR TITLE
Use absolute urls for documentation assets

### DIFF
--- a/guides/authentication/spa_flow.md
+++ b/guides/authentication/spa_flow.md
@@ -4,15 +4,15 @@ The trento single page application, leverages the JWT authentication mechanism o
 
 ## Login Diagram
 
-![Login diagram](../assets/trento-spa-login.png)
+![Login diagram](https://raw.githubusercontent.com/trento-project/web/main/guides/assets/trento-spa-login.png)
 
 ## Refresh Token Success Diagram
 
-![Refresh token success diagram](../assets/trento-spa-refresh.png)
+![Refresh token success diagram](https://raw.githubusercontent.com/trento-project/web/main/guides/assets/trento-spa-refresh.png)
 
 ## Refresh Token Failure Diagram
 
-![Refresh token failure diagram](../assets/trento-spa-refresh-failed.png)
+![Refresh token failure diagram](https://raw.githubusercontent.com/trento-project/web/main/guides/assets/trento-spa-refresh-failed.png)
 
 
 All the login/logout procedures are handled by the `SPA` using route guards and authentication providers hooked into the network calls.

--- a/guides/monitoring/monitoring.md
+++ b/guides/monitoring/monitoring.md
@@ -17,4 +17,4 @@ On a full Trento installation monitoring is enabled by default and the configura
 
 ---
 
-![Monitoring Architecture](../assets/trento-monitoring.png)
+![Monitoring Architecture](https://raw.githubusercontent.com/trento-project/web/main/guides/assets/trento-monitoring.png)


### PR DESCRIPTION
This should fix broken images in our website

https://www.trento-project.io/web/spa_flow.html
https://www.trento-project.io/web/monitoring.html