### PR TITLE
Refactor cluster details

### DIFF
--- a/assets/js/components/ClusterDetails/ChecksSelection.test.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelection.test.jsx
@@ -126,7 +126,9 @@ describe('ClusterDetails ChecksSelection component', () => {
     const expectedActions = [
       {
         type: 'UPDATE_CATALOG',
-        payload: {},
+        payload: {
+          provider: cluster.provider,
+        },
       },
       {
         type: 'CHECKS_SELECTED',

--- a/assets/js/components/ClusterDetails/ClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetails.jsx
@@ -67,8 +67,7 @@ export function ClusterDetails({
   clusterNodes,
   details,
   lastExecution,
-  executionRequested,
-  dispatch,
+  onStartExecution,
   navigate,
 }) {
   return (
@@ -109,21 +108,7 @@ export function ClusterDetails({
               disabled={!hasSelectedChecks}
               hosts={hosts}
               checks={selectedChecks}
-              onStartExecution={(
-                _,
-                hostList,
-                checks,
-                navigateFunction
-              ) =>
-                dispatch(
-                  executionRequested(
-                    clusterID,
-                    hostList,
-                    checks,
-                    navigateFunction
-                  )
-                )
-              }
+              onStartExecution={onStartExecution}
             >
               <EOS_PLAY_CIRCLE
                 className={classNames('inline-block fill-jungle-green-500', {
@@ -158,9 +143,7 @@ export function ClusterDetails({
               {
                 title: 'Cluster type',
                 content:
-                  clusterType === 'hana_scale_up'
-                    ? 'HANA scale-up'
-                    : 'Unknown',
+                  clusterType === 'hana_scale_up' ? 'HANA scale-up' : 'Unknown',
               },
               {
                 title: 'SAPHanaSR health state',
@@ -172,19 +155,15 @@ export function ClusterDetails({
               },
               {
                 title: 'HANA log replication mode',
-                content:
-                  details && details.system_replication_mode,
+                content: details && details.system_replication_mode,
               },
               {
                 title: 'HANA secondary sync state',
-                content:
-                  details && details.secondary_sync_state,
+                content: details && details.secondary_sync_state,
               },
               {
                 title: 'HANA log operation mode',
-                content:
-                  details &&
-                  details.system_replication_operation_mode,
+                content: details && details.system_replication_operation_mode,
               },
             ]}
           />
@@ -212,18 +191,16 @@ export function ClusterDetails({
       </div>
 
       <div className="mt-2 tn-site-details">
-        {Object.entries(groupBy(details.nodes, 'site')).map(
-          ([siteName]) => (
-            <div key={siteName} className={`tn-site-details-${siteName} mt-4`}>
-              <h3 className="text-l font-bold tn-site-name">{siteName}</h3>
-              <Table
-                className="tn-site-table"
-                config={siteDetailsConfig}
-                data={clusterNodes.filter(({ site }) => site === siteName)}
-              />
-            </div>
-          )
-        )}
+        {Object.entries(groupBy(details.nodes, 'site')).map(([siteName]) => (
+          <div key={siteName} className={`tn-site-details-${siteName} mt-4`}>
+            <h3 className="text-l font-bold tn-site-name">{siteName}</h3>
+            <Table
+              className="tn-site-table"
+              config={siteDetailsConfig}
+              data={clusterNodes.filter(({ site }) => site === siteName)}
+            />
+          </div>
+        ))}
       </div>
       <SBDDetails sbdDevices={details.sbd_devices} />
     </div>

--- a/assets/js/components/ClusterDetails/ClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetails.jsx
@@ -54,7 +54,7 @@ const siteDetailsConfig = {
   ],
 };
 
-export function ClusterDetails({
+function ClusterDetails({
   clusterID,
   clusterName,
   selectedChecks,
@@ -206,3 +206,5 @@ export function ClusterDetails({
     </div>
   );
 }
+
+export default ClusterDetails;

--- a/assets/js/components/ClusterDetails/ClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetails.jsx
@@ -8,7 +8,6 @@ import BackButton from '@components/BackButton';
 import Button from '@components/Button';
 
 import ListView from '@components/ListView';
-import Pill from '@components/Pill';
 import Table from '@components/Table';
 import Tooltip from '@components/Tooltip';
 import TriggerChecksExecutionRequest from '@components/TriggerChecksExecutionRequest';
@@ -18,6 +17,8 @@ import ProviderLabel from '@components/ProviderLabel';
 import { EOS_SETTINGS, EOS_CLEAR_ALL, EOS_PLAY_CIRCLE } from 'eos-icons-react';
 
 import SiteDetails from './SiteDetails';
+import SBDDetails from './SBDDetails';
+import StoppedResources from './StoppedResources';
 
 const siteDetailsConfig = {
   usePadding: false,
@@ -52,13 +53,6 @@ const siteDetailsConfig = {
     },
   ],
 };
-
-const getStatusPill = (status) =>
-  status === 'healthy' ? (
-    <Pill className="bg-green-200 text-green-800 mr-2">Healthy</Pill>
-  ) : (
-    <Pill className="bg-red-200 text-red-800 mr-2">Unhealthy</Pill>
-  );
 
 export function ClusterDetails({
   clusterID,
@@ -208,20 +202,7 @@ export function ClusterDetails({
       </div>
 
       {details && details.stopped_resources.length > 0 && (
-        <div className="mt-16">
-          <div className="flex flex-direction-row">
-            <h2 className="text-2xl font-bold self-center">
-              Stopped resources
-            </h2>
-          </div>
-          <div className="mt-2">
-            {details.stopped_resources.map(({ id }) => (
-              <Pill className="bg-gray-200 text-gray-800" key={id}>
-                {id}
-              </Pill>
-            ))}
-          </div>
-        </div>
+        <StoppedResources resources={details.stopped_resources} />
       )}
 
       <div className="mt-8">
@@ -244,19 +225,7 @@ export function ClusterDetails({
           )
         )}
       </div>
-
-      <div className="mt-8">
-        <div>
-          <h2 className="text-2xl font-bold">SBD/Fencing</h2>
-        </div>
-      </div>
-      <div className="mt-2 bg-white shadow rounded-lg py-4 px-8 tn-sbd-details">
-        {details.sbd_devices.map(({ device, status }) => (
-          <div key={device}>
-            {getStatusPill(status)} {device}
-          </div>
-        ))}
-      </div>
+      <SBDDetails sbdDevices={details.sbd_devices} />
     </div>
   );
 }

--- a/assets/js/components/ClusterDetails/ClusterDetails.stories.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetails.stories.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+import {
+  clusterFactory,
+  checksExecutionCompletedFactory,
+  hostFactory,
+} from '@lib/test-utils/factories';
+
+import ClusterDetails from './ClusterDetails';
+
+export default {
+  title: 'ClusterDetails',
+  components: ClusterDetails,
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+};
+
+function ContainerWrapper({ children }) {
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 md:px-8">{children}</div>
+  );
+}
+
+export function Hana() {
+  const {
+    id,
+    name,
+    sid,
+    type,
+    selected_checks,
+    provider,
+    cib_last_written,
+    details,
+  } = clusterFactory.build({ type: 'hana_scale_up' });
+
+  const lastExecution = {
+    data: checksExecutionCompletedFactory.build({
+      result: 'passing',
+      passing_count: 3,
+      warning_count: 2,
+      critical_count: 1,
+    }),
+  };
+
+  const hosts = [
+    hostFactory.build({ hostname: details.nodes[0].name }),
+    hostFactory.build({ hostname: details.nodes[1].name }),
+  ];
+  const clusterNodes = details.nodes.map((node) => ({
+    ...node,
+    ...hosts.find(({ hostname }) => hostname === node.name),
+  }));
+
+  return (
+    <ContainerWrapper>
+      <ClusterDetails
+        clusterID={id}
+        clusterName={name}
+        selectedChecks={selected_checks}
+        hasSelectedChecks
+        hosts={hosts.map(({ id: hostID }) => hostID)}
+        clusterType={type}
+        cibLastWritten={cib_last_written}
+        sid={sid}
+        provider={provider}
+        clusterNodes={clusterNodes}
+        details={details}
+        lastExecution={lastExecution}
+        onStartExecution={() => {}}
+        navigate={() => {}}
+      />
+    </ContainerWrapper>
+  );
+}

--- a/assets/js/components/ClusterDetails/ClusterDetails.stories.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetails.stories.jsx
@@ -9,6 +9,36 @@ import {
 
 import ClusterDetails from './ClusterDetails';
 
+const {
+  id: clusterID,
+  name: clusterName,
+  sid,
+  type: clusterType,
+  selected_checks: selectedChecks,
+  provider,
+  cib_last_written: cibLastWritten,
+  details,
+} = clusterFactory.build({ type: 'hana_scale_up' });
+
+const lastExecution = {
+  data: checksExecutionCompletedFactory.build({
+    result: 'passing',
+    passing_count: 3,
+    warning_count: 2,
+    critical_count: 1,
+  }),
+};
+
+const hosts = [
+  hostFactory.build({ hostname: details.nodes[0].name }),
+  hostFactory.build({ hostname: details.nodes[1].name }),
+];
+
+const clusterNodes = details.nodes.map((node) => ({
+  ...node,
+  ...hosts.find(({ hostname }) => hostname === node.name),
+}));
+
 export default {
   title: 'ClusterDetails',
   components: ClusterDetails,
@@ -27,54 +57,26 @@ function ContainerWrapper({ children }) {
   );
 }
 
-export function Hana() {
-  const {
-    id,
-    name,
+export const Hana = {
+  args: {
+    clusterID,
+    clusterName,
+    selectedChecks,
+    hasSelectedChecks: true,
+    hosts: hosts.map(({ id: hostID }) => hostID),
+    clusterType,
+    cibLastWritten,
     sid,
-    type,
-    selected_checks,
     provider,
-    cib_last_written,
+    clusterNodes,
     details,
-  } = clusterFactory.build({ type: 'hana_scale_up' });
-
-  const lastExecution = {
-    data: checksExecutionCompletedFactory.build({
-      result: 'passing',
-      passing_count: 3,
-      warning_count: 2,
-      critical_count: 1,
-    }),
-  };
-
-  const hosts = [
-    hostFactory.build({ hostname: details.nodes[0].name }),
-    hostFactory.build({ hostname: details.nodes[1].name }),
-  ];
-  const clusterNodes = details.nodes.map((node) => ({
-    ...node,
-    ...hosts.find(({ hostname }) => hostname === node.name),
-  }));
-
-  return (
+    lastExecution,
+    onStartExecution: () => {},
+    navigate: () => {},
+  },
+  render: (args) => (
     <ContainerWrapper>
-      <ClusterDetails
-        clusterID={id}
-        clusterName={name}
-        selectedChecks={selected_checks}
-        hasSelectedChecks
-        hosts={hosts.map(({ id: hostID }) => hostID)}
-        clusterType={type}
-        cibLastWritten={cib_last_written}
-        sid={sid}
-        provider={provider}
-        clusterNodes={clusterNodes}
-        details={details}
-        lastExecution={lastExecution}
-        onStartExecution={() => {}}
-        navigate={() => {}}
-      />
+      <ClusterDetails {...args} />
     </ContainerWrapper>
-  );
-}
+  ),
+};

--- a/assets/js/components/ClusterDetails/ClusterDetailsPage.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetailsPage.jsx
@@ -1,0 +1,76 @@
+import React, { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useSelector, useDispatch } from 'react-redux';
+
+import {
+  getCluster,
+  getClusterHosts,
+  getClusterHostIDs,
+} from '@state/selectors/cluster';
+import {
+  updateLastExecution,
+  executionRequested,
+} from '@state/actions/lastExecutions';
+import { getLastExecution } from '@state/selectors/lastExecutions';
+import { ClusterDetails } from './ClusterDetails';
+import { getClusterName } from '../ClusterLink';
+
+export function ClusterDetailsPage() {
+  const { clusterID } = useParams();
+  const navigate = useNavigate();
+
+  const cluster = useSelector(getCluster(clusterID));
+
+  const dispatch = useDispatch();
+  const lastExecution = useSelector(getLastExecution(clusterID));
+  const hosts = useSelector(getClusterHostIDs(clusterID));
+  useEffect(() => {
+    dispatch(updateLastExecution(clusterID));
+  }, [dispatch]);
+
+  const clusterHosts = useSelector(getClusterHosts(clusterID));
+
+  if (!cluster) {
+    return <div>Loading...</div>;
+  }
+
+  const renderedNodes = cluster.details?.nodes?.map((node) => ({
+    ...node,
+    ...clusterHosts.find(({ hostname }) => hostname === node.name),
+  }));
+
+  const hasSelectedChecks = cluster.selected_checks.length > 0;
+
+  return (
+    <ClusterDetails
+      clusterID={clusterID}
+      clusterName={getClusterName(clusterID)}
+      selectedChecks={cluster.selected_checks}
+      hasSelectedChecks={hasSelectedChecks}
+      hosts={hosts}
+      clusterType={cluster.type}
+      cibLastWritten={cluster.cib_last_written}
+      sid={cluster.sid}
+      provider={cluster.provider}
+      clusterNodes={renderedNodes}
+      details={cluster.details}
+      lastExecution={lastExecution}
+      onStartExecution={(
+        _,
+        hostList,
+        checks,
+        navigateFunction
+      ) =>
+        dispatch(
+          executionRequested(
+            clusterID,
+            hostList,
+            checks,
+            navigateFunction
+          )
+        )
+      }
+      navigate={navigate}
+    />
+  );
+}

--- a/assets/js/components/ClusterDetails/ClusterDetailsPage.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetailsPage.jsx
@@ -12,7 +12,7 @@ import {
   executionRequested,
 } from '@state/actions/lastExecutions';
 import { getLastExecution } from '@state/selectors/lastExecutions';
-import { ClusterDetails } from './ClusterDetails';
+import ClusterDetails from './ClusterDetails';
 import { getClusterName } from '../ClusterLink';
 
 export function ClusterDetailsPage() {
@@ -44,7 +44,7 @@ export function ClusterDetailsPage() {
   return (
     <ClusterDetails
       clusterID={clusterID}
-      clusterName={getClusterName(clusterID)}
+      clusterName={getClusterName(cluster)}
       selectedChecks={cluster.selected_checks}
       hasSelectedChecks={hasSelectedChecks}
       hosts={hosts}

--- a/assets/js/components/ClusterDetails/ClusterDetailsPage.jsx
+++ b/assets/js/components/ClusterDetails/ClusterDetailsPage.jsx
@@ -55,19 +55,9 @@ export function ClusterDetailsPage() {
       clusterNodes={renderedNodes}
       details={cluster.details}
       lastExecution={lastExecution}
-      onStartExecution={(
-        _,
-        hostList,
-        checks,
-        navigateFunction
-      ) =>
+      onStartExecution={(_, hostList, checks, navigateFunction) =>
         dispatch(
-          executionRequested(
-            clusterID,
-            hostList,
-            checks,
-            navigateFunction
-          )
+          executionRequested(clusterID, hostList, checks, navigateFunction)
         )
       }
       navigate={navigate}

--- a/assets/js/components/ClusterDetails/SBDDetails.jsx
+++ b/assets/js/components/ClusterDetails/SBDDetails.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import Pill from '@components/Pill';
+
+const getStatusPill = (status) =>
+  status === 'healthy' ? (
+    <Pill className="bg-green-200 text-green-800 mr-2">Healthy</Pill>
+  ) : (
+    <Pill className="bg-red-200 text-red-800 mr-2">Unhealthy</Pill>
+  );
+
+function SBDDetails({ sbdDevices }) {
+  return (
+    <>
+      <div className="mt-8">
+        <div>
+          <h2 className="text-2xl font-bold">SBD/Fencing</h2>
+        </div>
+      </div>
+      <div className="mt-2 bg-white shadow rounded-lg py-4 px-8 tn-sbd-details">
+        {sbdDevices.map(({ device, status }) => (
+          <div key={device}>
+            {getStatusPill(status)} {device}
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}
+
+export default SBDDetails;

--- a/assets/js/components/ClusterDetails/StoppedResources.jsx
+++ b/assets/js/components/ClusterDetails/StoppedResources.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import Pill from '@components/Pill';
+
+function StoppedResources({ resources }) {
+  return (
+    <div className="mt-16">
+      <div className="flex flex-direction-row">
+        <h2 className="text-2xl font-bold self-center">Stopped resources</h2>
+      </div>
+      <div className="mt-2">
+        {resources.map(({ id }) => (
+          <Pill className="bg-gray-200 text-gray-800" key={id}>
+            {id}
+          </Pill>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default StoppedResources;

--- a/assets/js/components/ClusterDetails/index.js
+++ b/assets/js/components/ClusterDetails/index.js
@@ -1,7 +1,7 @@
-import { ClusterDetails } from './ClusterDetails';
+import { ClusterDetailsPage } from './ClusterDetailsPage';
 
 export { ClusterSettings } from './ClusterSettings';
 export { ExecutionIcon } from './ExecutionIcon';
 export { ClusterInfoBox } from './ClusterInfoBox';
 
-export default ClusterDetails;
+export default ClusterDetailsPage;

--- a/assets/js/lib/test-utils/factories/clusters.js
+++ b/assets/js/lib/test-utils/factories/clusters.js
@@ -1,11 +1,42 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { faker } from '@faker-js/faker';
 import { Factory } from 'fishery';
+import day from 'dayjs';
 
-import { resultEnum } from '.';
+import { resultEnum, cloudProviderEnum } from '.';
 
 const clusterTypeEnum = () =>
   faker.helpers.arrayElement(['unknown', 'hana_scale_up']);
+
+const hanaStatus = () => faker.helpers.arrayElement(['Primary', 'Failed']);
+
+export const clusterResourceFactory = Factory.define(() => ({
+  id: faker.datatype.uuid(),
+  role: faker.animal.bear(),
+  status: faker.animal.bird(),
+  type: faker.animal.cat(),
+  fail_count: faker.datatype.number(),
+}));
+
+export const clusterDetailsNodesFactory = Factory.define(() => ({
+  name: faker.animal.dog(),
+  site: faker.address.city(),
+  virtual_ip: faker.internet.ip(),
+  hana_status: hanaStatus(),
+  attributes: Array.from({ length: 5 }).reduce(
+    (acc, _) => ({
+      ...acc,
+      ...{ [faker.animal.cat()]: faker.animal.dog() },
+    }),
+    {}
+  ),
+  resources: clusterResourceFactory.buildList(5),
+}));
+
+export const sbdDevicesFactory = Factory.define(() => ({
+  device: faker.system.filePath(),
+  status: faker.helpers.arrayElement(['healthy', 'unhealthy']),
+}));
 
 export const clusterFactory = Factory.define(({ sequence }) => ({
   id: faker.datatype.uuid(),
@@ -16,4 +47,16 @@ export const clusterFactory = Factory.define(({ sequence }) => ({
   type: clusterTypeEnum(),
   health: resultEnum(),
   selected_checks: [],
+  provider: cloudProviderEnum(),
+  cib_last_written: day(faker.date.recent()).format(),
+  details: {
+    fencing_type: 'external/sbd',
+    nodes: clusterDetailsNodesFactory.buildList(2),
+    sbd_devices: sbdDevicesFactory.buildList(3),
+    secondary_sync_state: 'SOK',
+    sr_health_state: '4',
+    stopped_resources: clusterResourceFactory.buildList(2),
+    system_replication_mode: 'sync',
+    system_replication_operation_mode: 'logreplay',
+  },
 }));

--- a/assets/js/lib/test-utils/factories/hosts.js
+++ b/assets/js/lib/test-utils/factories/hosts.js
@@ -14,7 +14,7 @@ const slesSubscriptionIdentifierEnum = () =>
     'sle-ha',
   ]);
 
-const cloudProviderEnum = () =>
+export const cloudProviderEnum = () =>
   faker.helpers.arrayElement(['azure', 'aws', 'gcp', 'nutanix']);
 
 const heartbeatEnum = () =>

--- a/assets/js/trento.jsx
+++ b/assets/js/trento.jsx
@@ -13,7 +13,9 @@ import Home from '@components/Home';
 import AboutPage from '@components/AboutPage';
 import HostsList from '@components/HostsList';
 import ClustersList from '@components/ClustersList';
-import ClusterDetails, { ClusterSettings } from '@components/ClusterDetails';
+import ClusterDetailsPage, {
+  ClusterSettings,
+} from '@components/ClusterDetails';
 import { ExecutionResultsPage } from '@components/ExecutionResults';
 import SapSystemsOverview from '@components/SapSystemsOverview';
 import HostDetails from '@components/HostDetails';
@@ -71,7 +73,7 @@ function App() {
                   <Route path="databases/:id" element={<DatabaseDetails />} />
                   <Route
                     path="clusters/:clusterID"
-                    element={<ClusterDetails />}
+                    element={<ClusterDetailsPage />}
                   />
                   <Route
                     path="clusters/:clusterID/settings"


### PR DESCRIPTION
# Description

Refactor of the `ClusterDetails` page to make it more pure. This enables its reusability (for future ASCS/ERS cluster details) and storybook stories addition. It includes the `ClusterDetailsPage` which does all the data management and `ClusterDetails` is now just a visualization component.

The unique real change it the usage of already existing selectors to create the `rendererNodes` constant.

I have extracted some sub-components (SBD and stopped resources sections) as they are required in ASCS/ERS cluster details as well.

![cluster_details_story](https://github.com/trento-project/web/assets/36370954/b6d17b11-38f1-4772-900a-9f695812d3e8)


## How was this tested?

Storybook added. Previous e2e tests should test the same.
I didn't add any new jest test as the content is exactly as it was before, but if you think I should add them, I will.
