### PR TITLE
Revert HeartbeatSucceeded to old name

### DIFF
--- a/lib/trento/application/event_handlers/stream_roll_up_event_handler.ex
+++ b/lib/trento/application/event_handlers/stream_roll_up_event_handler.ex
@@ -35,7 +35,7 @@ defmodule Trento.StreamRollUpEventHandler do
 
   @host_events [
     Trento.Domain.Events.HeartbeatFailed,
-    Trento.Domain.Events.HeartbeatSucceeded,
+    Trento.Domain.Events.HeartbeatSucceded,
     Trento.Domain.Events.HostDetailsUpdated,
     Trento.Domain.Events.HostRegistered,
     Trento.Domain.Events.ProviderUpdated,

--- a/lib/trento/application/projectors/host_projector.ex
+++ b/lib/trento/application/projectors/host_projector.ex
@@ -14,7 +14,7 @@ defmodule Trento.HostProjector do
 
   alias Trento.Domain.Events.{
     HeartbeatFailed,
-    HeartbeatSucceeded,
+    HeartbeatSucceded,
     HostAddedToCluster,
     HostDeregistered,
     HostDetailsUpdated,
@@ -117,7 +117,7 @@ defmodule Trento.HostProjector do
   )
 
   project(
-    %HeartbeatSucceeded{host_id: id},
+    %HeartbeatSucceded{host_id: id},
     fn multi ->
       changeset =
         HostReadModel.changeset(%HostReadModel{id: id}, %{
@@ -228,7 +228,7 @@ defmodule Trento.HostProjector do
   end
 
   def after_update(
-        %HeartbeatSucceeded{host_id: id},
+        %HeartbeatSucceded{host_id: id},
         _,
         _
       ) do

--- a/lib/trento/domain/host/events/heartbeat_succeded.ex
+++ b/lib/trento/domain/host/events/heartbeat_succeded.ex
@@ -1,4 +1,4 @@
-defmodule Trento.Domain.Events.HeartbeatSucceeded do
+defmodule Trento.Domain.Events.HeartbeatSucceded do
   @moduledoc """
   Heartbeat succeeded event
   """

--- a/lib/trento/domain/host/host.ex
+++ b/lib/trento/domain/host/host.ex
@@ -40,7 +40,7 @@ defmodule Trento.Domain.Host do
 
   alias Trento.Domain.Events.{
     HeartbeatFailed,
-    HeartbeatSucceeded,
+    HeartbeatSucceded,
     HostDeregistered,
     HostDeregistrationRequested,
     HostDetailsUpdated,
@@ -187,7 +187,7 @@ defmodule Trento.Domain.Host do
         %UpdateHeartbeat{heartbeat: :passing}
       )
       when heartbeat != :passing do
-    %HeartbeatSucceeded{host_id: host_id}
+    %HeartbeatSucceded{host_id: host_id}
   end
 
   def execute(
@@ -350,7 +350,7 @@ defmodule Trento.Domain.Host do
 
   def apply(
         %Host{} = host,
-        %HeartbeatSucceeded{host_id: host_id}
+        %HeartbeatSucceded{host_id: host_id}
       ) do
     %Host{
       host

--- a/test/trento/application/projectors/host_projector_test.exs
+++ b/test/trento/application/projectors/host_projector_test.exs
@@ -22,7 +22,7 @@ defmodule Trento.HostProjectorTest do
 
   alias Trento.Domain.Events.{
     HeartbeatFailed,
-    HeartbeatSucceeded,
+    HeartbeatSucceded,
     HostAddedToCluster,
     HostDeregistered,
     HostDetailsUpdated,
@@ -189,9 +189,9 @@ defmodule Trento.HostProjectorTest do
                      1000
   end
 
-  test "should update the heartbeat field to passing status when HeartbeatSucceeded is received",
+  test "should update the heartbeat field to passing status when HeartbeatSucceded is received",
        %{host_id: host_id} do
-    event = %HeartbeatSucceeded{
+    event = %HeartbeatSucceded{
       host_id: host_id
     }
 

--- a/test/trento/domain/host/host_test.exs
+++ b/test/trento/domain/host/host_test.exs
@@ -15,7 +15,7 @@ defmodule Trento.HostTest do
 
   alias Trento.Domain.Events.{
     HeartbeatFailed,
-    HeartbeatSucceeded,
+    HeartbeatSucceded,
     HostDeregistered,
     HostDeregistrationRequested,
     HostDetailsUpdated,
@@ -159,7 +159,7 @@ defmodule Trento.HostTest do
   end
 
   describe "heartbeat" do
-    test "should emit a HeartbeatSucceeded event if the Host never received a heartbeat already" do
+    test "should emit a HeartbeatSucceded event if the Host never received a heartbeat already" do
       host_id = Faker.UUID.v4()
       host_registered_event = build(:host_registered_event, host_id: host_id)
 
@@ -169,7 +169,7 @@ defmodule Trento.HostTest do
           host_id: host_id,
           heartbeat: :passing
         }),
-        %HeartbeatSucceeded{
+        %HeartbeatSucceded{
           host_id: host_id
         },
         fn state ->
@@ -180,7 +180,7 @@ defmodule Trento.HostTest do
       )
     end
 
-    test "should emit a HeartbeatSucceeded event if the Host is in a critical status" do
+    test "should emit a HeartbeatSucceded event if the Host is in a critical status" do
       host_id = Faker.UUID.v4()
 
       initial_events = [
@@ -196,7 +196,7 @@ defmodule Trento.HostTest do
           host_id: host_id,
           heartbeat: :passing
         }),
-        %HeartbeatSucceeded{
+        %HeartbeatSucceded{
           host_id: host_id
         },
         fn state ->
@@ -207,12 +207,12 @@ defmodule Trento.HostTest do
       )
     end
 
-    test "should not emit a HeartbeatSucceeded event if the Host is in a passing status already" do
+    test "should not emit a HeartbeatSucceded event if the Host is in a passing status already" do
       host_id = Faker.UUID.v4()
 
       initial_events = [
         build(:host_registered_event, host_id: host_id),
-        %HeartbeatSucceeded{
+        %HeartbeatSucceded{
           host_id: host_id
         }
       ]
@@ -232,7 +232,7 @@ defmodule Trento.HostTest do
 
       initial_events = [
         build(:host_registered_event, host_id: host_id),
-        %HeartbeatSucceeded{
+        %HeartbeatSucceded{
           host_id: host_id
         }
       ]


### PR DESCRIPTION
# Description

Revert `HeartbeatSucceeded` event name to `HeartbeatSucceded` to avoid commanded errors in replay.

The `additional_sids` addition doesn't break the events, as the domain schema has a default value for that field.

Simply with this change, the app works fine once `deregistration` branch is merged in `main`
