### PR TITLE
Add additional ascs/ers cluster details discovery

### DIFF
--- a/lib/trento/application/integration/discovery/policies/cluster_policy.ex
+++ b/lib/trento/application/integration/discovery/policies/cluster_policy.ex
@@ -549,19 +549,19 @@ defmodule Trento.Integration.Discovery.ClusterPolicy do
     end)
   end
 
-  defp parse_resource_by_type(resources, type, attribute_name),
-    do:
-      resources
-      |> Enum.filter(fn
-        %{type: ^type} -> true
+  defp parse_resource_by_type(resources, type, attribute_name) do
+    resources
+    |> Enum.filter(fn
+      %{type: ^type} -> true
+      _ -> nil
+    end)
+    |> Enum.map(fn %{instance_attributes: instance_attributes} ->
+      Enum.find_value(instance_attributes, nil, fn
+        %{name: ^attribute_name, value: value} -> value
         _ -> nil
       end)
-      |> Enum.map(fn %{instance_attributes: instance_attributes} ->
-        Enum.find_value(instance_attributes, nil, fn
-          %{name: ^attribute_name, value: value} -> value
-          _ -> nil
-        end)
-      end)
+    end)
+  end
 
   defp parse_cib_last_written(%{
          crmmon: %{summary: %{last_change: %{time: cib_last_written}}}

--- a/lib/trento/application/integration/discovery/policies/cluster_policy.ex
+++ b/lib/trento/application/integration/discovery/policies/cluster_policy.ex
@@ -553,7 +553,7 @@ defmodule Trento.Integration.Discovery.ClusterPolicy do
     resources
     |> Enum.filter(fn
       %{type: ^type} -> true
-      _ -> nil
+      _ -> false
     end)
     |> Enum.map(fn %{instance_attributes: instance_attributes} ->
       Enum.find_value(instance_attributes, nil, fn

--- a/lib/trento/application/integration/discovery/policies/cluster_policy.ex
+++ b/lib/trento/application/integration/discovery/policies/cluster_policy.ex
@@ -495,6 +495,9 @@ defmodule Trento.Integration.Discovery.ClusterPolicy do
     |> Enum.count() == 2
   end
 
+  # Parse details from each node for a specific sid.
+  # The runtime information of where the resource is running belongs to crmmon payload,
+  # but the data itself is in the cib payload, so both payloads must be crossed.
   defp parse_ascs_ers_cluster_nodes(
          %{
            provider: provider,

--- a/lib/trento/domain/value_objects/ascs_ers_cluster_node.ex
+++ b/lib/trento/domain/value_objects/ascs_ers_cluster_node.ex
@@ -1,0 +1,23 @@
+defmodule Trento.Domain.AscsErsClusterNode do
+  @moduledoc """
+  Represents the node of a ASCS/ERS cluster.
+  """
+
+  @required_fields [
+    :name
+  ]
+
+  use Trento.Type
+
+  alias Trento.Domain.ClusterResource
+
+  deftype do
+    field :name, :string
+    field :roles, {:array, Ecto.Enum}, values: [:ascs, :ers]
+    field :virtual_ips, {:array, :string}
+    field :filesystems, {:array, :string}
+    field :attributes, {:map, :string}
+
+    embeds_many :resources, ClusterResource
+  end
+end

--- a/lib/trento/domain/value_objects/ascs_ers_cluster_sap_system.ex
+++ b/lib/trento/domain/value_objects/ascs_ers_cluster_sap_system.ex
@@ -6,14 +6,19 @@ defmodule Trento.Domain.AscsErsClusterSapSystem do
   @required_fields [
     :sid,
     :filesystem_resource_based,
-    :distributed
+    :distributed,
+    :nodes
   ]
 
   use Trento.Type
+
+  alias Trento.Domain.AscsErsClusterNode
 
   deftype do
     field :sid, :string
     field :filesystem_resource_based, :boolean
     field :distributed, :boolean
+
+    embeds_many :nodes, AscsErsClusterNode
   end
 end


### PR DESCRIPTION
# Description
Add additional detail fields to ASCS/ERS clusters.
Specifically node based details (have a look on the updated structs):
- Roles
- Filesystems
- Virtual IPs
(these fields must be lists, as one node can have multiple sap instances running, like ASCS and ERS together on case of failover)

Everything is discovered from the cib/crmmon payloads.

This is how we store the data:
![image](https://github.com/trento-project/web/assets/36370954/786a86a9-c818-441a-b8e4-19e8fff373a1)

PD: The API schemas will be updated afterwards

## How was this tested?

Tests added using fixtures modifications to avoid adding individual huge fixture files, with only one different field
