### PR TITLE
Rename sections in Expectations Details view

### DIFF
--- a/assets/js/components/ExecutionResults/CheckResultDetail/ExpectationsResults.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/ExpectationsResults.jsx
@@ -40,7 +40,7 @@ function ExpectationsResults({
 
   return (
     <div className="w-full my-4 mr-4 bg-white shadow rounded-lg px-8 py-4">
-      <div className="text-lg font-bold">Expectations</div>
+      <div className="text-lg font-bold">Evaluation Results</div>
       {isError ? (
         <div className="mt-3 text-red-500">{errorMessage}</div>
       ) : (

--- a/assets/js/components/ExecutionResults/CheckResultDetail/ExpectationsResults.stories.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/ExpectationsResults.stories.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { faker } from '@faker-js/faker';
 import ExpectationsResults from './ExpectationsResults';
 
 export default {
@@ -7,8 +8,8 @@ export default {
   args: {
     isTargetHost: true,
     results: [
-      { name: 'First passing  Evaluationresult', return_value: true },
-      { name: 'Second failing Evaluation result', return_value: false },
+      { name: faker.animal.bear(), return_value: true },
+      { name: faker.animal.bear(), return_value: false },
     ],
     isError: false,
     errorMessage: 'An error occurred',

--- a/assets/js/components/ExecutionResults/CheckResultDetail/ExpectationsResults.stories.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/ExpectationsResults.stories.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import ExpectationsResults from './ExpectationsResults';
+
+export default {
+  title: 'ExpectationsResults',
+  component: ExpectationsResults,
+  args: {
+    isTargetHost: true,
+    results: [
+      { name: 'First passing  Evaluationresult', return_value: true },
+      { name: 'Second failing Evaluation result', return_value: false },
+    ],
+    isError: false,
+    errorMessage: 'An error occurred',
+  },
+};
+
+export function Default(args) {
+  return <ExpectationsResults {...args} />;
+}

--- a/assets/js/components/ExecutionResults/CheckResultDetail/ExpectationsResults.stories.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/ExpectationsResults.stories.jsx
@@ -1,10 +1,12 @@
-import React from 'react';
 import { faker } from '@faker-js/faker';
 import ExpectationsResults from './ExpectationsResults';
 
 export default {
   title: 'ExpectationsResults',
   component: ExpectationsResults,
+};
+
+export const Default = {
   args: {
     isTargetHost: true,
     results: [
@@ -15,7 +17,3 @@ export default {
     errorMessage: 'An error occurred',
   },
 };
-
-export function Default(args) {
-  return <ExpectationsResults {...args} />;
-}

--- a/assets/js/components/ExecutionResults/CheckResultDetail/ExpectedValues.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/ExpectedValues.jsx
@@ -17,7 +17,7 @@ function ExpectedValues({
 
   return (
     <div className="w-full my-4 mr-4 bg-white shadow rounded-lg px-8 py-4">
-      <div className="text-lg font-bold">Values</div>
+      <div className="text-lg font-bold">Expected Values</div>
       {isError ? (
         <div className="mt-3 text-red-500 text-sm">
           Expected Values unavailable

--- a/assets/js/components/ExecutionResults/CheckResultDetail/ExpectedValues.stories.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/ExpectedValues.stories.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { faker } from '@faker-js/faker';
 
 import ExpectedValues from './ExpectedValues';
@@ -6,6 +5,9 @@ import ExpectedValues from './ExpectedValues';
 export default {
   title: 'ExpectedValues',
   component: ExpectedValues,
+};
+
+export const Default = {
   args: {
     isTargetHost: true,
     expectedValues: [
@@ -15,7 +17,3 @@ export default {
     isError: false,
   },
 };
-
-export function Default(args) {
-  return <ExpectedValues {...args} />;
-}

--- a/assets/js/components/ExecutionResults/CheckResultDetail/ExpectedValues.stories.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/ExpectedValues.stories.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { faker } from '@faker-js/faker';
+
 import ExpectedValues from './ExpectedValues';
 
 export default {
@@ -7,8 +9,8 @@ export default {
   args: {
     isTargetHost: true,
     expectedValues: [
-      { name: 'First passing  Evaluationresult', value: 10 },
-      { name: 'Second failing Evaluation result', value: 20 },
+      { name: faker.animal.bear(), value: faker.datatype.number() },
+      { name: faker.animal.bear(), value: faker.datatype.number() },
     ],
     isError: false,
   },

--- a/assets/js/components/ExecutionResults/CheckResultDetail/ExpectedValues.stories.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/ExpectedValues.stories.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ExpectedValues from './ExpectedValues';
+
+export default {
+  title: 'ExpectedValues',
+  component: ExpectedValues,
+  args: {
+    isTargetHost: true,
+    expectedValues: [
+      { name: 'First passing  Evaluationresult', value: 10 },
+      { name: 'Second failing Evaluation result', value: 20 },
+    ],
+    isError: false,
+  },
+};
+
+export function Default(args) {
+  return <ExpectedValues {...args} />;
+}

--- a/assets/js/components/ExecutionResults/CheckResultDetail/GatheredFacts.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/GatheredFacts.jsx
@@ -24,7 +24,6 @@ function GatheredFacts({ isTargetHost = true, gatheredFacts = [] }) {
       {gatheredFacts.length === 0 && (
         <div className="mt-3 text-sm text-red-500">No facts were gathered</div>
       )}
-
       {isTargetHost && (
         <ListView
           className="grid-flow-row mt-3 text-sm"

--- a/assets/js/components/ExecutionResults/CheckResultDetail/GatheredFacts.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/GatheredFacts.jsx
@@ -19,7 +19,7 @@ const gatheredFactsToListView = (gatheredFacts) =>
 function GatheredFacts({ isTargetHost = true, gatheredFacts = [] }) {
   return (
     <div className="w-full my-4 mr-4 bg-white shadow rounded-lg px-8 py-4">
-      <div className="text-lg font-bold">Facts</div>
+      <div className="text-lg font-bold">Gathered Facts</div>
 
       {gatheredFacts.length === 0 && (
         <div className="mt-3 text-sm text-red-500">No facts were gathered</div>

--- a/assets/js/components/ExecutionResults/CheckResultDetail/GatheredFacts.stories.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/GatheredFacts.stories.jsx
@@ -1,6 +1,19 @@
 import React from 'react';
+import { faker } from '@faker-js/faker';
+
 import GatheredFacts from './GatheredFacts';
 
+const factValues = {
+  application: faker.animal.bear(),
+  firewall: faker.lorem.sentence(),
+  protocol: faker.animal.bear(),
+  harddrive: faker.animal.bear(),
+  pixel: [
+    faker.lorem.sentence(),
+    faker.lorem.sentence(),
+    [faker.lorem.sentence(), faker.lorem.sentence()],
+  ],
+};
 export default {
   title: 'GatheredFacts',
   component: GatheredFacts,
@@ -8,16 +21,14 @@ export default {
     isTargetHost: true,
     gatheredFacts: [
       {
-        name: 'Bail Prestor Organa',
-        value: '1',
-        type: 'best type',
-        message: 'wow',
+        value: factValues,
+        type: faker.lorem.sentence(),
+        message: faker.lorem.sentence(),
+        name: faker.animal.bear(),
       },
       {
-        name: 'Yoda',
-        value: '2',
-        type: 'second best type',
-        message: 'second wow',
+        value: factValues,
+        name: faker.animal.bear(),
       },
     ],
   },

--- a/assets/js/components/ExecutionResults/CheckResultDetail/GatheredFacts.stories.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/GatheredFacts.stories.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import GatheredFacts from './GatheredFacts';
+
+export default {
+  title: 'GatheredFacts',
+  component: GatheredFacts,
+  args: {
+    isTargetHost: true,
+    gatheredFacts: [
+      {
+        name: 'Bail Prestor Organa',
+        value: '1',
+        type: 'best type',
+        message: 'wow',
+      },
+      {
+        name: 'Yoda',
+        value: '2',
+        type: 'second best type',
+        message: 'second wow',
+      },
+    ],
+  },
+};
+
+export function Default(args) {
+  return <GatheredFacts {...args} />;
+}

--- a/assets/js/components/ExecutionResults/CheckResultDetail/GatheredFacts.stories.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/GatheredFacts.stories.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { faker } from '@faker-js/faker';
 
 import GatheredFacts from './GatheredFacts';
@@ -17,6 +16,9 @@ const factValues = {
 export default {
   title: 'GatheredFacts',
   component: GatheredFacts,
+};
+
+export const Default = {
   args: {
     isTargetHost: true,
     gatheredFacts: [
@@ -33,7 +35,3 @@ export default {
     ],
   },
 };
-
-export function Default(args) {
-  return <GatheredFacts {...args} />;
-}


### PR DESCRIPTION
# Description

Currently, the structure of the view mirrors the structure of the check itself, using sections named "Expectations," "Values," and "Facts" for expect type expectations, and "Expectations" and "Facts" for expect_same type expectations.

These section names might not be immediately clear to users who are not familiar with the checks DSL.

## For expect type expectations:

- "Expectations" section will be renamed to "Evaluation Results"
- "Values" section will be renamed to "Expected Values"
- "Facts" section will be renamed to "Gathered Facts"
## For expect_same type expectations:

- "Expectations" section will be renamed to "Evaluation Results"
- "Facts" section will remain unchanged as "Gathered Facts"


## Demo

### ExpectationsResults

[ExpectationsResults.webm](https://github.com/trento-project/web/assets/54111255/526ee93f-f50e-43b4-95ec-56bd0995b926)

### ExpectedValues

[ExpectedValues.webm](https://github.com/trento-project/web/assets/54111255/30ac0b17-12d1-4698-9689-d4f3232002c4)

### Gathered Facts

[GatheredFacts.webm](https://github.com/trento-project/web/assets/54111255/073f522c-8b60-4879-a7e4-fdf6eb457da4)



