### PR TITLE
Add endpoint to deregister a host

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -162,6 +162,9 @@ config :trento,
   api_key_authentication_enabled: true,
   jwt_authentication_enabled: true
 
+config :trento,
+  deregistration_debounce: :timer.seconds(0)
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -82,6 +82,10 @@ config :trento, :pow,
 # Agent heartbeat interval. Adding one extra second to the agent 5s interval to avoid glitches
 config :trento, Trento.Heartbeats, interval: :timer.seconds(6)
 
+# This is passed to the frontend as the time after the last heartbeat
+# to wait before displaying the deregistration button
+config :trento, deregistration_debounce: :timer.seconds(0)
+
 config :trento, Trento.Scheduler,
   jobs: [
     heartbeat_check: [
@@ -161,9 +165,6 @@ config :trento, :jwt_authentication,
 config :trento,
   api_key_authentication_enabled: true,
   jwt_authentication_enabled: true
-
-config :trento,
-  deregistration_debounce: :timer.seconds(0)
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/test.exs
+++ b/config/test.exs
@@ -41,6 +41,13 @@ config :logger, level: :warn
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
 
+# Agent heartbeat interval. Adding one extra second to the agent 5s interval to avoid glitches
+config :trento, Trento.Heartbeats, interval: :timer.seconds(6)
+
+# This is passed to the frontend as the time after the last heartbeat
+# to wait before displaying the deregistration button
+config :trento, deregistration_debounce: :timer.seconds(5)
+
 config :trento,
   api_key_authentication_enabled: false,
   jwt_authentication_enabled: false

--- a/lib/trento/application/integration/discovery/protocol/enrich_request_host_deregistration.ex
+++ b/lib/trento/application/integration/discovery/protocol/enrich_request_host_deregistration.ex
@@ -21,27 +21,25 @@ defimpl Trento.Support.Middleware.Enrichable,
           | {:error, :host_alive}
           | {:error, :host_not_registered}
   def enrich(%RequestHostDeregistration{host_id: host_id} = command, _) do
-    host_exists = Repo.exists?(HostReadModel, id: host_id)
+    with true <- Repo.exists?(HostReadModel, id: host_id),
+         :ok <- host_deregisterable(host_id) do
+      {:ok, command}
+    else
+      {:error, :host_alive} -> {:error, :host_alive}
+      _ -> {:error, :host_not_registered}
+    end
+  end
 
+  @spec host_deregisterable(Ecto.UUID) :: :ok | {:error, :host_alive}
+  defp host_deregisterable(host_id) do
     query =
       from(h in Heartbeat,
         where:
-          h.timestamp >
-            ^DateTime.add(DateTime.utc_now(), -@total_deregistration_debounce, :millisecond) and
+          ^DateTime.utc_now() <
+            datetime_add(h.timestamp, @total_deregistration_debounce, "millisecond") and
             h.agent_id == ^host_id
       )
 
-    heartbeat_invalid = Repo.exists?(query)
-
-    cond do
-      host_exists and heartbeat_invalid ->
-        {:error, :host_alive}
-
-      host_exists and not heartbeat_invalid ->
-        {:ok, command}
-
-      true ->
-        {:error, :host_not_registered}
-    end
+    if Repo.exists?(query), do: {:error, :host_alive}, else: :ok
   end
 end

--- a/lib/trento/application/integration/discovery/protocol/enrich_request_host_deregistration.ex
+++ b/lib/trento/application/integration/discovery/protocol/enrich_request_host_deregistration.ex
@@ -1,0 +1,47 @@
+defimpl Trento.Support.Middleware.Enrichable,
+  for: Trento.Domain.Commands.RequestHostDeregistration do
+  alias Trento.Domain.Commands.RequestHostDeregistration
+
+  alias Trento.Repo
+
+  alias Trento.Heartbeat
+  alias Trento.HostReadModel
+
+  import Ecto.Query
+
+  @heartbeat_interval Application.compile_env!(:trento, Trento.Heartbeats)[:interval]
+  @deregistration_debounce Application.compile_env!(
+                             :trento,
+                             :deregistration_debounce
+                           )
+  @total_deregistration_debounce @heartbeat_interval + @deregistration_debounce
+
+  @spec enrich(RequestHostDeregistration.t(), map) ::
+          {:ok, RequestHostDeregistration.t()}
+          | {:error, :host_alive}
+          | {:error, :host_not_registered}
+  def enrich(%RequestHostDeregistration{host_id: host_id} = command, _) do
+    host_exists = Repo.exists?(HostReadModel, id: host_id)
+
+    query =
+      from(h in Heartbeat,
+        where:
+          h.timestamp >
+            ^DateTime.add(DateTime.utc_now(), -@total_deregistration_debounce, :millisecond) and
+            h.agent_id == ^host_id
+      )
+
+    heartbeat_invalid = Repo.exists?(query)
+
+    cond do
+      host_exists and heartbeat_invalid ->
+        {:error, :host_alive}
+
+      host_exists and not heartbeat_invalid ->
+        {:ok, command}
+
+      true ->
+        {:error, :host_not_registered}
+    end
+  end
+end

--- a/lib/trento/application/integration/discovery/protocol/enrich_request_host_deregistration.ex
+++ b/lib/trento/application/integration/discovery/protocol/enrich_request_host_deregistration.ex
@@ -23,13 +23,16 @@ defimpl Trento.Support.Middleware.Enrichable,
   end
 
   defp host_deregisterable(
-         %HostReadModel{heartbeat_timestamp: nil},
+         %HostReadModel{heartbeat_timestamp: nil, deregistered_at: nil},
          %RequestHostDeregistration{} = command
        ),
        do: {:ok, command}
 
   defp host_deregisterable(
-         %HostReadModel{heartbeat_timestamp: %Trento.Heartbeat{timestamp: timestamp}},
+         %HostReadModel{
+           heartbeat_timestamp: %Trento.Heartbeat{timestamp: timestamp},
+           deregistered_at: nil
+         },
          %RequestHostDeregistration{} = command
        ) do
     if :lt ==

--- a/lib/trento/application/read_models/host_read_model.ex
+++ b/lib/trento/application/read_models/host_read_model.ex
@@ -32,6 +32,10 @@ defmodule Trento.HostReadModel do
       foreign_key: :host_id,
       preload_order: [desc: :identifier]
 
+    has_one :heartbeat_timestamp, Trento.Heartbeat,
+      references: :id,
+      foreign_key: :agent_id
+
     field :deregistered_at, :utc_datetime_usec
   end
 

--- a/lib/trento/application/usecases/hosts/heartbeat.ex
+++ b/lib/trento/application/usecases/hosts/heartbeat.ex
@@ -7,6 +7,7 @@ defmodule Trento.Heartbeat do
 
   @type t :: %__MODULE__{}
 
+  @derive {Jason.Encoder, except: [:__meta__, :__struct__]}
   @primary_key {:agent_id, :string, autogenerate: false}
   schema "heartbeats" do
     field :timestamp, :utc_datetime_usec

--- a/lib/trento/application/usecases/hosts/hosts.ex
+++ b/lib/trento/application/usecases/hosts/hosts.ex
@@ -6,11 +6,21 @@ defmodule Trento.Hosts do
   import Ecto.Query
 
   alias Trento.{
+    Heartbeat,
     HostReadModel,
+    Repo,
     SlesSubscriptionReadModel
   }
 
-  alias Trento.Repo
+  alias Trento.Support.DateService
+
+  alias Trento.Domain.Commands.RequestHostDeregistration
+
+  @heartbeat_interval Application.compile_env!(:trento, Trento.Heartbeats)[:interval]
+  @deregistration_debounce Application.compile_env!(
+                             :trento,
+                             :deregistration_debounce
+                           )
 
   @spec get_all_hosts :: [HostReadModel.t()]
   def get_all_hosts do
@@ -18,7 +28,7 @@ defmodule Trento.Hosts do
     |> where([h], not is_nil(h.hostname) and is_nil(h.deregistered_at))
     |> order_by(asc: :hostname)
     |> Repo.all()
-    |> Repo.preload([:sles_subscriptions, :tags])
+    |> Repo.preload([:sles_subscriptions, :tags, :heartbeat_timestamp])
   end
 
   @spec get_all_sles_subscriptions :: non_neg_integer()
@@ -34,6 +44,42 @@ defmodule Trento.Hosts do
 
       subscription_count ->
         subscription_count
+    end
+  end
+
+  @spec deregister_host(Ecto.UUID.t(), DateService) :: :ok | {:error, any}
+  def deregister_host(host_id, date_service \\ DateService) do
+    case Repo.get_by(HostReadModel, id: host_id) do
+      nil ->
+        {:error, :host_not_found}
+
+      _ ->
+        maybe_dispatch_host_deregistration_request(host_id, date_service)
+    end
+  end
+
+  defp commanded,
+    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
+
+  defp maybe_dispatch_host_deregistration_request(host_id, date_service) do
+    now = date_service.utc_now()
+    total_deregistration_debounce = @heartbeat_interval + @deregistration_debounce
+
+    query =
+      from h in Heartbeat,
+        where:
+          h.timestamp >
+            ^DateTime.add(now, -total_deregistration_debounce, :millisecond) and
+            h.agent_id == ^host_id
+
+    case Repo.exists?(query) do
+      false ->
+        commanded().dispatch(
+          RequestHostDeregistration.new!(%{host_id: host_id, requested_at: now})
+        )
+
+      true ->
+        {:error, :host_alive}
     end
   end
 end

--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -58,6 +58,13 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"422", reason: "Unknown discovery type.")
   end
 
+  def call(conn, {:error, :host_alive}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(ErrorView)
+    |> render(:"422", reason: "Requested operation not allowed for live hosts.")
+  end
+
   def call(conn, {:error, [error | _]}), do: call(conn, {:error, error})
 
   def call(conn, {:error, _}) do

--- a/lib/trento_web/controllers/page_controller.ex
+++ b/lib/trento_web/controllers/page_controller.ex
@@ -5,9 +5,12 @@ defmodule TrentoWeb.PageController do
     grafana_public_url = Application.fetch_env!(:trento, :grafana)[:public_url]
     check_service_base_url = Application.fetch_env!(:trento, :checks_service)[:base_url]
 
+    deregistration_debounce = Application.fetch_env!(:trento, :deregistration_debounce)
+
     render(conn, "index.html",
       grafana_public_url: grafana_public_url,
-      check_service_base_url: check_service_base_url
+      check_service_base_url: check_service_base_url,
+      deregistration_debounce: deregistration_debounce
     )
   end
 end

--- a/lib/trento_web/controllers/v1/host_controller.ex
+++ b/lib/trento_web/controllers/v1/host_controller.ex
@@ -53,7 +53,7 @@ defmodule TrentoWeb.V1.HostController do
     case Hosts.deregister_host(host_id) do
       :ok -> send_resp(conn, 204, "")
       {:error, :host_alive} -> send_resp(conn, 422, "")
-      {:error, _} -> send_resp(conn, 404, "")
+      {:error, error} -> {:error, error}
     end
   end
 

--- a/lib/trento_web/controllers/v1/host_controller.ex
+++ b/lib/trento_web/controllers/v1/host_controller.ex
@@ -52,7 +52,6 @@ defmodule TrentoWeb.V1.HostController do
   def delete(conn, %{id: host_id}) do
     case Hosts.deregister_host(host_id) do
       :ok -> send_resp(conn, 204, "")
-      {:error, :host_alive} -> send_resp(conn, 422, "")
       {:error, error} -> {:error, error}
     end
   end

--- a/lib/trento_web/controllers/v1/host_controller.ex
+++ b/lib/trento_web/controllers/v1/host_controller.ex
@@ -7,9 +7,12 @@ defmodule TrentoWeb.V1.HostController do
     Hosts
   }
 
-  alias TrentoWeb.OpenApi.Schema.{
+  alias TrentoWeb.OpenApi.V1.Schema
+
+  alias TrentoWeb.OpenApi.V1.Schema.{
     BadRequest,
-    NotFound
+    NotFound,
+    UnprocessableEntity
   }
 
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
@@ -44,8 +47,8 @@ defmodule TrentoWeb.V1.HostController do
     ],
     responses: [
       no_content: "The host has been deregistered",
-      not_found: TrentoWeb.OpenApi.Schema.NotFound.response(),
-      unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
+      not_found: NotFound.response(),
+      unprocessable_entity: UnprocessableEntity.response()
     ]
 
   @spec delete(Plug.Conn.t(), map) :: Plug.Conn.t()

--- a/lib/trento_web/controllers/v1/host_controller.ex
+++ b/lib/trento_web/controllers/v1/host_controller.ex
@@ -7,7 +7,10 @@ defmodule TrentoWeb.V1.HostController do
     Hosts
   }
 
-  alias TrentoWeb.OpenApi.V1.Schema
+  alias TrentoWeb.OpenApi.Schema.{
+    BadRequest,
+    NotFound
+  }
 
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
   action_fallback TrentoWeb.FallbackController
@@ -29,6 +32,31 @@ defmodule TrentoWeb.V1.HostController do
     render(conn, "hosts.json", hosts: hosts)
   end
 
+  operation :delete,
+    summary: "Deregister a host",
+    description: "Deregister a host agent from Trento",
+    parameters: [
+      id: [
+        in: :path,
+        required: true,
+        type: %OpenApiSpex.Schema{type: :string, format: :uuid}
+      ]
+    ],
+    responses: [
+      no_content: "The host has been deregistered",
+      not_found: TrentoWeb.OpenApi.Schema.NotFound.response(),
+      unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
+    ]
+
+  @spec delete(Plug.Conn.t(), map) :: Plug.Conn.t()
+  def delete(conn, %{id: host_id}) do
+    case Hosts.deregister_host(host_id) do
+      :ok -> send_resp(conn, 204, "")
+      {:error, :host_alive} -> send_resp(conn, 422, "")
+      {:error, _} -> send_resp(conn, 404, "")
+    end
+  end
+
   operation :heartbeat,
     summary: "Signal that an agent is alive",
     tags: ["Agent"],
@@ -42,8 +70,8 @@ defmodule TrentoWeb.V1.HostController do
     ],
     responses: [
       no_content: "The heartbeat has been updated",
-      not_found: Schema.NotFound.response(),
-      bad_request: Schema.BadRequest.response(),
+      not_found: NotFound.response(),
+      bad_request: BadRequest.response(),
       unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
     ]
 

--- a/lib/trento_web/openapi/v1/schema/host.ex
+++ b/lib/trento_web/openapi/v1/schema/host.ex
@@ -80,9 +80,12 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Host do
         heartbeat_timestamp: %Schema{
           title: "HeartbeatTimestamp",
           description: "Timestamp of the last heartbeat received from the host",
-          type: :string,
+          type: :object,
           nullable: true,
-          format: :"date-time"
+          properties: %{
+            agent_id: %Schema{type: :string, description: "Host ID", format: :uuid},
+            timestamp: %Schema{type: :string, format: :"date-time"}
+          }
         }
       }
     })

--- a/lib/trento_web/openapi/v1/schema/host.ex
+++ b/lib/trento_web/openapi/v1/schema/host.ex
@@ -69,6 +69,20 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Host do
           description: "A list of the available SLES Subscriptions on a host",
           type: :array,
           items: SlesSubscription
+        },
+        deregistered_at: %Schema{
+          title: "DeregisteredAt",
+          description: "Timestamp of the last deregistration of the host",
+          type: :string,
+          nullable: true,
+          format: :"date-time"
+        },
+        heartbeat_timestamp: %Schema{
+          title: "HeartbeatTimestamp",
+          description: "Timestamp of the last heartbeat received from the host",
+          type: :string,
+          nullable: true,
+          format: :"date-time"
         }
       }
     })

--- a/lib/trento_web/openapi/v1/schema/unprocessable_entity.ex
+++ b/lib/trento_web/openapi/v1/schema/unprocessable_entity.ex
@@ -1,0 +1,35 @@
+defmodule TrentoWeb.OpenApi.V1.Schema.UnprocessableEntity do
+  @moduledoc """
+  422 - Unprocessable Entity
+  """
+  require OpenApiSpex
+
+  alias OpenApiSpex.Operation
+  alias OpenApiSpex.Schema
+
+  OpenApiSpex.schema(%{
+    type: :object,
+    properties: %{
+      errors: %Schema{
+        type: :array,
+        items: %Schema{
+          type: :object,
+          properties: %{
+            title: %Schema{type: :string, example: "Invalid value"},
+            detail: %Schema{type: :string, example: "null value where string expected"}
+          },
+          required: [:title, :detail]
+        }
+      }
+    },
+    required: [:errors]
+  })
+
+  def response do
+    Operation.response(
+      "Unprocessable Entity",
+      "application/json",
+      __MODULE__
+    )
+  end
+end

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -84,6 +84,8 @@ defmodule TrentoWeb.Router do
       get "/sap_systems/health", HealthOverviewController, :overview
       get "/databases", SapSystemController, :list_databases
 
+      delete "/hosts/:id", HostController, :delete
+
       post "/clusters/:cluster_id/checks", ClusterController, :select_checks
 
       post "/clusters/:cluster_id/checks/request_execution",

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -84,8 +84,6 @@ defmodule TrentoWeb.Router do
       get "/sap_systems/health", HealthOverviewController, :overview
       get "/databases", SapSystemController, :list_databases
 
-      delete "/hosts/:id", HostController, :delete
-
       post "/clusters/:cluster_id/checks", ClusterController, :select_checks
 
       post "/clusters/:cluster_id/checks/request_execution",
@@ -95,6 +93,8 @@ defmodule TrentoWeb.Router do
       post "/hosts/:id/tags", TagsController, :add_tag,
         assigns: %{resource_type: :host},
         as: :hosts_tagging
+
+      delete "/hosts/:id", HostController, :delete
 
       delete "/hosts/:id/tags/:value", TagsController, :remove_tag, as: :hosts_tagging
 

--- a/lib/trento_web/templates/page/index.html.heex
+++ b/lib/trento_web/templates/page/index.html.heex
@@ -3,7 +3,8 @@
 <script>
 const config = {
     grafanaPublicUrl: '<%= @grafana_public_url %>',
-    checksServiceBaseUrl: '<%= @check_service_base_url %>'
+    checksServiceBaseUrl: '<%= @check_service_base_url %>',
+    deregistrationDebounce: '<%= @deregistration_debounce %>',
 };
 </script>
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -96,7 +96,8 @@ defmodule Trento.Factory do
       cluster_id: Faker.UUID.v4(),
       heartbeat: :unknown,
       provider: Enum.random(Provider.values()),
-      provider_data: nil
+      provider_data: nil,
+      deregistered_at: nil
     }
   end
 

--- a/test/trento/application/integration/discovery/protocol/enrich_request_host_deregistration_test.exs
+++ b/test/trento/application/integration/discovery/protocol/enrich_request_host_deregistration_test.exs
@@ -55,7 +55,11 @@ defmodule Trento.EnrichRequestHostDeregistrationTest do
       insert(:heartbeat,
         agent_id: id,
         timestamp:
-          DateTime.add(DateTime.utc_now(), -(@total_deregistration_debounce - 2_000), :millisecond)
+          DateTime.add(
+            DateTime.utc_now(),
+            -(@total_deregistration_debounce - 2_000),
+            :millisecond
+          )
       )
 
       command = RequestHostDeregistration.new!(%{host_id: id, requested_at: now})

--- a/test/trento/application/integration/discovery/protocol/enrich_request_host_deregistration_test.exs
+++ b/test/trento/application/integration/discovery/protocol/enrich_request_host_deregistration_test.exs
@@ -1,0 +1,63 @@
+defmodule Trento.EnrichRequestHostDeregistrationTest do
+  use ExUnit.Case
+  use Trento.DataCase
+
+  import Trento.Factory
+
+  alias Trento.Domain.Commands.RequestHostDeregistration
+  alias Trento.Support.Middleware.Enrichable
+
+  describe "enrich RequestHostDeregistration" do
+    test "should return the original command if a host with critical health is requested to be deregistered" do
+      now = DateTime.utc_now()
+
+      %{id: id} = insert(:host)
+      insert(:heartbeat, agent_id: id, timestamp: DateTime.add(DateTime.utc_now(), -30, :second))
+
+      command = RequestHostDeregistration.new!(%{host_id: id, requested_at: now})
+
+      assert {:ok, %RequestHostDeregistration{host_id: id, requested_at: now}} ==
+               Enrichable.enrich(command, %{})
+    end
+
+    test "should return the original command if a host with unknown health is requested to be deregistered after debounce" do
+      now = DateTime.utc_now()
+
+      %{id: id} = insert(:host)
+
+      command = RequestHostDeregistration.new!(%{host_id: id, requested_at: now})
+
+      assert {:ok, %RequestHostDeregistration{host_id: id, requested_at: now}} ==
+               Enrichable.enrich(command, %{})
+    end
+
+    test "should return an error if a host with critical health is requested to be deregistered before debounce timer" do
+      now = DateTime.utc_now()
+
+      %{id: id} = insert(:host)
+      insert(:heartbeat, agent_id: id, timestamp: DateTime.add(DateTime.utc_now(), -6, :second))
+
+      command = RequestHostDeregistration.new!(%{host_id: id, requested_at: now})
+
+      assert {:error, :host_alive} == Enrichable.enrich(command, %{})
+    end
+
+    test "should return an error if a host with passing health is requested to be deregistered" do
+      now = DateTime.utc_now()
+
+      %{id: id} = insert(:host)
+      insert(:heartbeat, agent_id: id, timestamp: DateTime.add(DateTime.utc_now(), -1, :second))
+
+      command = RequestHostDeregistration.new!(%{host_id: id, requested_at: now})
+
+      assert {:error, :host_alive} == Enrichable.enrich(command, %{})
+    end
+
+    test "should return error if host does not exist" do
+      command =
+        RequestHostDeregistration.new!(%{host_id: UUID.uuid4(), requested_at: DateTime.utc_now()})
+
+      assert {:error, :host_not_registered} == Enrichable.enrich(command, %{})
+    end
+  end
+end

--- a/test/trento/application/usecases/hosts_test.exs
+++ b/test/trento/application/usecases/hosts_test.exs
@@ -10,9 +10,9 @@ defmodule Trento.HostsTest do
 
   alias Trento.SlesSubscriptionReadModel
 
-  require Trento.Domain.Enums.Health, as: Health
-
   @moduletag :integration
+
+  setup :verify_on_exit!
 
   describe "SLES Subscriptions" do
     test "No SLES4SAP Subscriptions detected" do
@@ -39,72 +39,6 @@ defmodule Trento.HostsTest do
 
       assert Enum.map(registered_hosts, & &1.id) == hosts_ids
       refute deregistered_host.id in hosts_ids
-    end
-  end
-
-  describe "deregister_host" do
-    test "should deregister a host with unknown health" do
-      expect(
-        Trento.Commanded.Mock,
-        :dispatch,
-        fn %Trento.Domain.Commands.RequestHostDeregistration{} ->
-          :ok
-        end
-      )
-
-      %{id: id} = insert(:host, heartbeat: Health.unknown())
-      assert :ok = Hosts.deregister_host(id)
-    end
-
-    test "should deregister a host with critical health" do
-      expect(
-        Trento.Commanded.Mock,
-        :dispatch,
-        fn %Trento.Domain.Commands.RequestHostDeregistration{} ->
-          :ok
-        end
-      )
-
-      %{id: id} = insert(:host, heartbeat: Health.critical())
-      assert :ok = Hosts.deregister_host(id)
-    end
-
-    test "should not deregister a host with passing health" do
-      expect(
-        Trento.Commanded.Mock,
-        :dispatch,
-        fn %Trento.Domain.Commands.RequestHostDeregistration{} ->
-          :error
-        end
-      )
-
-      %{id: id} = insert(:host, heartbeat: Health.passing())
-      assert :error = Hosts.deregister_host(id)
-    end
-
-    test "should return an error when the host does not exist" do
-      assert {:error, :host_not_found} = Hosts.deregister_host(UUID.uuid4())
-    end
-
-    test "should return an error if deregistration requested within the debounce period" do
-      last_heartbeat = DateTime.utc_now()
-
-      expect(
-        Trento.Support.DateService.Mock,
-        :utc_now,
-        fn -> last_heartbeat end
-      )
-
-      %{id: id} = insert(:host, heartbeat: Health.critical())
-      insert(:heartbeat, agent_id: id, timestamp: Trento.Support.DateService.Mock.utc_now())
-
-      expect(
-        Trento.Support.DateService.Mock,
-        :utc_now,
-        fn -> DateTime.add(last_heartbeat, 500, :millisecond) end
-      )
-
-      assert {:error, :host_alive} = Hosts.deregister_host(id, Trento.Support.DateService.Mock)
     end
   end
 end

--- a/test/trento/application/usecases/hosts_test.exs
+++ b/test/trento/application/usecases/hosts_test.exs
@@ -3,11 +3,14 @@ defmodule Trento.HostsTest do
   use Trento.DataCase
 
   import Trento.Factory
+  import Mox
 
   alias Trento.Hosts
   alias Trento.Repo
 
   alias Trento.SlesSubscriptionReadModel
+
+  require Trento.Domain.Enums.Health, as: Health
 
   @moduletag :integration
 
@@ -36,6 +39,72 @@ defmodule Trento.HostsTest do
 
       assert Enum.map(registered_hosts, & &1.id) == hosts_ids
       refute deregistered_host.id in hosts_ids
+    end
+  end
+
+  describe "deregister_host" do
+    test "should deregister a host with unknown health" do
+      expect(
+        Trento.Commanded.Mock,
+        :dispatch,
+        fn %Trento.Domain.Commands.RequestHostDeregistration{} ->
+          :ok
+        end
+      )
+
+      %{id: id} = insert(:host, heartbeat: Health.unknown())
+      assert :ok = Hosts.deregister_host(id)
+    end
+
+    test "should deregister a host with critical health" do
+      expect(
+        Trento.Commanded.Mock,
+        :dispatch,
+        fn %Trento.Domain.Commands.RequestHostDeregistration{} ->
+          :ok
+        end
+      )
+
+      %{id: id} = insert(:host, heartbeat: Health.critical())
+      assert :ok = Hosts.deregister_host(id)
+    end
+
+    test "should not deregister a host with passing health" do
+      expect(
+        Trento.Commanded.Mock,
+        :dispatch,
+        fn %Trento.Domain.Commands.RequestHostDeregistration{} ->
+          :error
+        end
+      )
+
+      %{id: id} = insert(:host, heartbeat: Health.passing())
+      assert :error = Hosts.deregister_host(id)
+    end
+
+    test "should return an error when the host does not exist" do
+      assert {:error, :host_not_found} = Hosts.deregister_host(UUID.uuid4())
+    end
+
+    test "should return an error if deregistration requested within the debounce period" do
+      last_heartbeat = DateTime.utc_now()
+
+      expect(
+        Trento.Support.DateService.Mock,
+        :utc_now,
+        fn -> last_heartbeat end
+      )
+
+      %{id: id} = insert(:host, heartbeat: Health.critical())
+      insert(:heartbeat, agent_id: id, timestamp: Trento.Support.DateService.Mock.utc_now())
+
+      expect(
+        Trento.Support.DateService.Mock,
+        :utc_now,
+        fn -> DateTime.add(last_heartbeat, 500, :millisecond) end
+      )
+
+      assert {:error, :host_alive} = Hosts.deregister_host(id, Trento.Support.DateService.Mock)
     end
   end
 end

--- a/test/trento_web/controllers/v1/host_controller_test.exs
+++ b/test/trento_web/controllers/v1/host_controller_test.exs
@@ -11,6 +11,10 @@ defmodule TrentoWeb.V1.HostControllerTest do
 
   setup [:set_mox_from_context, :verify_on_exit!]
 
+  setup do
+    %{api_spec: ApiSpec.spec()}
+  end
+
   describe "list" do
     test "should list all hosts", %{conn: conn} do
       %{id: host_id} = insert(:host)
@@ -66,7 +70,7 @@ defmodule TrentoWeb.V1.HostControllerTest do
       |> response(204)
     end
 
-    test "should send 422 response if the host is still alive", %{conn: conn} do
+    test "should send 422 response if the host is still alive", %{conn: conn, api_spec: api_spec} do
       %{id: host_id} = insert(:host)
 
       expect(
@@ -79,10 +83,11 @@ defmodule TrentoWeb.V1.HostControllerTest do
 
       conn
       |> delete("/api/v1/hosts/#{host_id}")
-      |> response(422)
+      |> json_response(422)
+      |> assert_schema("UnprocessableEntity", api_spec)
     end
 
-    test "should return 404 if the host was not found", %{conn: conn} do
+    test "should return 404 if the host was not found", %{conn: conn, api_spec: api_spec} do
       %{id: host_id} = insert(:host)
 
       expect(
@@ -95,7 +100,8 @@ defmodule TrentoWeb.V1.HostControllerTest do
 
       conn
       |> delete("/api/v1/hosts/#{host_id}")
-      |> response(:not_found)
+      |> json_response(404)
+      |> assert_schema("NotFound", api_spec)
     end
   end
 end


### PR DESCRIPTION
# Description

Adds endpoint `DELETE /api/v1/hosts/{host_id}` to request the server to deregister a host.

Response behaviour:

- If last heartbeat is after timeout period: `204`
- If last heartbeat is within timeout period: `422`
- If host with ID `host_id` doesn't exist: `404`
- If attempting to deregister a host that is already deregistered: `404`

## How was this tested?

By adding unit tests
