### PR TITLE
Display check failure message

### DIFF
--- a/assets/js/components/ExecutionResults/CheckResultDetail/ExpectationsResults.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/ExpectationsResults.jsx
@@ -10,28 +10,33 @@ function ExpectationsResults({
   errorMessage = 'An error occurred',
 }) {
   const renderedResults = isTargetHost
-    ? results.map(({ name, return_value }) => ({
+    ? results.map(({ name, return_value, failure_message }) => ({
         name,
         passing: !!return_value,
+        failureMessage: failure_message,
       }))
-    : results.map(({ name, result }) => ({
+    : results.map(({ name, result, failure_message }) => ({
         name,
         passing: !!result,
+        failureMessage: failure_message,
       }));
 
-  const expectationsEvaluations = renderedResults.map(({ name, passing }) => ({
-    title: name,
-    content: passing,
-    render: (isPassing) => (
-      <span
-        className={classNames({
-          'text-red-500': !isPassing,
-        })}
-      >
-        {isPassing ? 'Passing' : 'Failing'}
-      </span>
-    ),
-  }));
+  const expectationsEvaluations = renderedResults.map(
+    ({ name, passing, failureMessage }) => ({
+      title: name,
+      content: passing,
+      render: (isPassing) => (
+        <div
+          className={classNames({
+            'text-red-500': !isPassing,
+          })}
+        >
+          <span>{isPassing ? 'Passing' : 'Failing'}</span>
+          {failureMessage && <span className="block">{failureMessage}</span>}
+        </div>
+      ),
+    })
+  );
 
   return (
     <div className="w-full my-4 mr-4 bg-white shadow rounded-lg px-8 py-4">

--- a/assets/js/components/ExecutionResults/CheckResultDetail/ExpectationsResults.test.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/ExpectationsResults.test.jsx
@@ -5,7 +5,9 @@ import { faker } from '@faker-js/faker';
 
 import {
   executionExpectationEvaluationFactory,
+  failingExpectEvaluationFactory,
   expectationResultFactory,
+  failingExpectationResultFactory,
 } from '@lib/test-utils/factories';
 
 import '@testing-library/jest-dom';
@@ -13,12 +15,13 @@ import ExpectationsResults from './ExpectationsResults';
 
 describe('ExpectationsResults Component', () => {
   it('should render expect statements results', () => {
+    const failureMessage = faker.lorem.sentence();
     const results = [
       ...executionExpectationEvaluationFactory.buildList(3, {
         return_value: true,
       }),
-      ...executionExpectationEvaluationFactory.buildList(2, {
-        return_value: false,
+      ...failingExpectEvaluationFactory.buildList(2, {
+        failure_message: failureMessage,
       }),
     ];
 
@@ -28,22 +31,22 @@ describe('ExpectationsResults Component', () => {
 
     expect(screen.getAllByText('Passing')).toHaveLength(3);
     expect(screen.getAllByText('Failing')).toHaveLength(2);
+    expect(screen.getAllByText(failureMessage)).toHaveLength(2);
     expect(screen.getByText(expectationName1)).toBeVisible();
     expect(screen.getByText(expectationName3)).toBeVisible();
   });
 
   it('should render expect_same statements results', () => {
+    const failureMessage = faker.lorem.sentence();
     const results = [
-      ...expectationResultFactory.buildList(3, {
-        result: null,
+      ...failingExpectationResultFactory.buildList(7, {
+        type: 'expect_same',
+        failure_message: failureMessage,
       }),
       ...expectationResultFactory.buildList(2, {
-        result: undefined,
+        result: true,
+        type: 'expect_same',
       }),
-      ...expectationResultFactory.buildList(2, {
-        result: false,
-      }),
-      ...expectationResultFactory.buildList(2, { result: true }),
     ];
 
     const [
@@ -56,6 +59,7 @@ describe('ExpectationsResults Component', () => {
 
     expect(screen.getAllByText('Passing')).toHaveLength(2);
     expect(screen.getAllByText('Failing')).toHaveLength(7);
+    expect(screen.getAllByText(failureMessage)).toHaveLength(7);
     expect(screen.getByText(expectationName1)).toBeVisible();
     expect(screen.getByText(expectationName2)).toBeVisible();
     expect(screen.getByText(expectationName3)).toBeVisible();

--- a/assets/js/lib/test-utils/factories/executions.js
+++ b/assets/js/lib/test-utils/factories/executions.js
@@ -16,14 +16,29 @@ export const executionValueFactory = Factory.define(({ sequence }) => ({
 
 export const executionExpectationEvaluationFactory = Factory.define(
   ({ sequence, params }) => {
-    const name = params.name || `expectation_${sequence}`;
+    const {
+      name = `expectation_${sequence}`,
+      failure_message = params.failure_message
+        ? { failure_message: params.failure_message }
+        : {},
+    } = params;
 
     return {
       name,
       return_value: faker.datatype.number(),
       type: expectationReturnTypeEnum(),
+      ...failure_message,
     };
   }
+);
+
+export const failingExpectEvaluationFactory = Factory.define(({ params }) =>
+  executionExpectationEvaluationFactory.build({
+    ...params,
+    return_value: false,
+    type: 'expect',
+    failure_message: faker.lorem.sentence(),
+  })
 );
 
 export const executionExpectationEvaluationErrorFactory = Factory.define(
@@ -40,14 +55,29 @@ export const executionExpectationEvaluationErrorFactory = Factory.define(
 
 export const expectationResultFactory = Factory.define(
   ({ sequence, params }) => {
-    const name = params.name || `expectation_${sequence}`;
+    const {
+      name = `expectation_${sequence}`,
+      failure_message = params.failure_message
+        ? { failure_message: params.failure_message }
+        : {},
+    } = params;
 
     return {
       name,
       result: faker.datatype.boolean(),
       type: expectationReturnTypeEnum(),
+      ...failure_message,
     };
   }
+);
+
+export const failingExpectationResultFactory = Factory.define(({ params }) =>
+  expectationResultFactory.build({
+    ...params,
+    result: false,
+    type: expectationReturnTypeEnum(),
+    failure_message: faker.lorem.sentence(),
+  })
 );
 
 export const executionFactFactory = Factory.define(({ sequence }) => ({

--- a/assets/js/lib/test-utils/factories/executions.js
+++ b/assets/js/lib/test-utils/factories/executions.js
@@ -226,17 +226,6 @@ export const addPassingExpectation = (checkResult, type, expectationName) => {
   return addExpectation(checkResult, name, expectation, true);
 };
 
-export const addCriticalExpectation = (checkResult, type, expectationName) => {
-  const name = expectationName || faker.company.name();
-  const expectation = executionExpectationEvaluationFactory.build({
-    name,
-    type,
-    return_value: false,
-  });
-
-  return addExpectation(checkResult, name, expectation, false);
-};
-
 export const addExpectationWithError = (checkResult, expectationName) => {
   const name = expectationName || faker.company.name();
   const expectation = executionExpectationEvaluationErrorFactory.build({
@@ -249,9 +238,14 @@ export const addExpectationWithError = (checkResult, expectationName) => {
 export const addPassingExpectExpectation = (checkResult, expectationName) =>
   addPassingExpectation(checkResult, 'expect', expectationName);
 
-export const addCriticalExpectExpectation = (checkResult, expectationName) =>
-  addCriticalExpectation(checkResult, 'expect', expectationName);
+export const addCriticalExpectExpectation = (checkResult, expectationName) => {
+  const name = expectationName || faker.company.name();
+  const expectation = failingExpectEvaluationFactory.build({
+    name,
+  });
 
+  return addExpectation(checkResult, name, expectation, false);
+};
 export const addPassingExpectSameExpectation = (checkResult, expectationName) =>
   addPassingExpectation(checkResult, 'expect_same', expectationName);
 


### PR DESCRIPTION
# Description

This PR adds rendering of a check expectation's `failure_message` returned by wanda on a failing check.

Took the chance to tidy up a bit factories. More might come as we go.

@jagabomb I went for option 1 in figma just out of personal taste, however let me know if option two should be the way.

![image](https://github.com/trento-project/web/assets/8167114/8aa21c75-46de-4232-9f5e-c397570428b6)

## How was this tested?

Automated tests/storybook
