### PR TITLE
Fix navigation to a running execution detail

### DIFF
--- a/assets/js/state/selectors/lastExecutions.js
+++ b/assets/js/state/selectors/lastExecutions.js
@@ -21,7 +21,7 @@ const addHostnameToAgentsCheckResults = (
     ...executionData,
     data: {
       ...data,
-      check_results: check_results.map((checkResult) => ({
+      check_results: check_results?.map((checkResult) => ({
         ...checkResult,
         agents_check_results: checkResult?.agents_check_results.map(
           (target) => ({

--- a/assets/js/state/selectors/lastExecutions.test.js
+++ b/assets/js/state/selectors/lastExecutions.test.js
@@ -3,6 +3,7 @@ import {
   clusterFactory,
   catalogCheckFactory,
   checksExecutionCompletedForTargetsFactory,
+  checksExecutionRunningFactory,
 } from '@lib/test-utils/factories';
 import { getLastExecution, getLastExecutionData } from './lastExecutions';
 
@@ -99,5 +100,35 @@ describe('lastExecutions selector', () => {
     expect(
       lastExecution.data.check_results[0].agents_check_results[1].hostname
     ).toEqual(hostname2);
+  });
+
+  it('should properly handle running executions', () => {
+    const { id: clusterID } = clusterFactory.build();
+    const runningExecution = checksExecutionRunningFactory.build({
+      group_id: clusterID,
+    });
+
+    const state = {
+      clustersList: {
+        clusters: [],
+      },
+      hostsList: {
+        hosts: [],
+      },
+      catalog: {},
+      lastExecutions: {
+        [clusterID]: {
+          loading: false,
+          data: runningExecution,
+          error: null,
+        },
+      },
+    };
+
+    const { lastExecution } = getLastExecutionData(clusterID)(state);
+
+    expect(lastExecution.data.result).toBeNull();
+    expect(lastExecution.data.check_results).toBeUndefined();
+    expect(lastExecution.data.status).toEqual('running');
   });
 });


### PR DESCRIPTION
# Description

This fixes an issue when navigating to the detail of an already running execution.

Before
![running-execution-bug](https://github.com/trento-project/web/assets/8167114/4f2650aa-9f3c-46a8-8791-9d68d266847b)

After
![running-execution-fix](https://github.com/trento-project/web/assets/8167114/dea1cc6e-1165-4c9f-b1ce-92f5f158354f)

## How was this tested?

Automated test.
