### PR TITLE
Basic deregistration leftovers

### DIFF
--- a/lib/trento/domain/sap_system/database.ex
+++ b/lib/trento/domain/sap_system/database.ex
@@ -14,7 +14,7 @@ defmodule Trento.Domain.SapSystem.Database do
   deftype do
     field :sid, :string
     embeds_many :instances, Instance
-    field :deregistered_at, :utc_datetime_usec, default: nil
+    field :deregistered_at, :utc_datetime_usec
     field :health, Ecto.Enum, values: Health.values()
   end
 end

--- a/lib/trento/domain/sap_system/database.ex
+++ b/lib/trento/domain/sap_system/database.ex
@@ -14,6 +14,7 @@ defmodule Trento.Domain.SapSystem.Database do
   deftype do
     field :sid, :string
     embeds_many :instances, Instance
+    field :deregistered_at, :utc_datetime_usec, default: nil
     field :health, Ecto.Enum, values: Health.values()
   end
 end

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -814,12 +814,10 @@ defmodule Trento.Domain.SapSystem do
   defp maybe_emit_sap_system_deregistered_event(
          %SapSystem{
            sap_system_id: sap_system_id,
-           database: %Database{
-             sid: nil
-           }
+           database: %Database{deregistered_at: database_deregistered_at}
          },
          deregistered_at
-       ) do
+       ) when not is_nil(database_deregistered_at) do
     %SapSystemDeregistered{sap_system_id: sap_system_id, deregistered_at: deregistered_at}
   end
 

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -853,7 +853,8 @@ defmodule Trento.Domain.SapSystem do
          %SapSystem{
            sap_system_id: sap_system_id,
            database: %Database{
-             instances: instances
+             instances: instances,
+             deregistered_at: nil
            }
          },
          deregistered_at

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -499,7 +499,7 @@ defmodule Trento.Domain.SapSystem do
   end
 
   def apply(
-        %SapSystem{database: %Database{instances: instances}} = sap_system,
+        %SapSystem{database: %Database{instances: instances} = database} = sap_system,
         %DatabaseInstanceDeregistered{
           instance_number: instance_number,
           host_id: host_id
@@ -517,13 +517,14 @@ defmodule Trento.Domain.SapSystem do
     %SapSystem{
       sap_system
       | database: %Database{
-          instances: instances
+          database
+          | instances: instances
         }
     }
   end
 
   def apply(
-        %SapSystem{application: %Application{instances: instances}} = sap_system,
+        %SapSystem{application: %Application{instances: instances} = application} = sap_system,
         %ApplicationInstanceDeregistered{instance_number: instance_number, host_id: host_id}
       ) do
     instances =
@@ -538,7 +539,8 @@ defmodule Trento.Domain.SapSystem do
     %SapSystem{
       sap_system
       | application: %Application{
-          instances: instances
+          application
+          | instances: instances
         }
     }
   end

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -817,7 +817,8 @@ defmodule Trento.Domain.SapSystem do
            database: %Database{deregistered_at: database_deregistered_at}
          },
          deregistered_at
-       ) when not is_nil(database_deregistered_at) do
+       )
+       when not is_nil(database_deregistered_at) do
     %SapSystemDeregistered{sap_system_id: sap_system_id, deregistered_at: deregistered_at}
   end
 

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -547,11 +547,11 @@ defmodule Trento.Domain.SapSystem do
 
   def apply(
         %SapSystem{database: database} = sap_system,
-        %DatabaseDeregistered{}
+        %DatabaseDeregistered{deregistered_at: deregistered_at}
       ) do
     %SapSystem{
       sap_system
-      | database: Map.put(database, :sid, nil)
+      | database: Map.put(database, :deregistered_at, deregistered_at)
     }
   end
 

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -839,6 +839,7 @@ defmodule Trento.Domain.SapSystem do
          %SapSystem{
            sap_system_id: sap_system_id,
            database: %Database{
+             deregistered_at: nil,
              instances: []
            }
          },

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -563,8 +563,7 @@ defmodule Trento.Domain.SapSystem do
       ) do
     %SapSystem{
       sap_system
-      | deregistered_at: deregistered_at,
-        sid: nil
+      | deregistered_at: deregistered_at
     }
   end
 

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -814,6 +814,7 @@ defmodule Trento.Domain.SapSystem do
   defp maybe_emit_sap_system_deregistered_event(
          %SapSystem{
            sap_system_id: sap_system_id,
+           deregistered_at: nil,
            database: %Database{deregistered_at: database_deregistered_at}
          },
          deregistered_at
@@ -825,6 +826,7 @@ defmodule Trento.Domain.SapSystem do
   defp maybe_emit_sap_system_deregistered_event(
          %SapSystem{
            sap_system_id: sap_system_id,
+           deregistered_at: nil,
            application: %Application{
              instances: instances
            }
@@ -835,6 +837,8 @@ defmodule Trento.Domain.SapSystem do
       %SapSystemDeregistered{sap_system_id: sap_system_id, deregistered_at: deregistered_at}
     end
   end
+
+  defp maybe_emit_sap_system_deregistered_event(_, _), do: nil
 
   defp maybe_emit_database_deregistered_event(
          %SapSystem{

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -1635,7 +1635,7 @@ defmodule Trento.SapSystemTest do
       )
     end
 
-    test "should deregister the primary instance, the entire database and then the secondary instance without deregistering the database a second time, SAP system not registered" do
+    test "should deregister the primary instance, the entire database and then the secondary instance, SAP system not registered" do
       sap_system_id = UUID.uuid4()
       primary_database_host_id = UUID.uuid4()
       secondary_database_host_id = UUID.uuid4()
@@ -2339,7 +2339,7 @@ defmodule Trento.SapSystemTest do
       )
     end
 
-    test "should deregister the primary instance of database, the SAP system and deregister the ABAP application instance without deregistering the SAP system a second time" do
+    test "should deregister the primary instance of database, the SAP system and deregister the ABAP application instance" do
       sap_system_id = UUID.uuid4()
       deregistered_at = DateTime.utc_now()
 

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -1705,7 +1705,7 @@ defmodule Trento.SapSystemTest do
       )
     end
 
-    test "should correctly deregister the database in a scale out scenarion, with two primary and two secondary, no SAP system registered" do
+    test "should correctly deregister the database in a scale out scenario, with two primary and two secondary, no SAP system registered" do
       sap_system_id = UUID.uuid4()
       first_primary_database_host_id = UUID.uuid4()
       other_primary_database_host_id = UUID.uuid4()


### PR DESCRIPTION
# Description

Basic deregistration leftovers, we need to address this issues

- Ensure that the application and database are updated with fields and not overwritten with new fields and old fields nil.
- Ensure that the database/application deregistered events, are emitted once.

   Currently the database deregistered event is emitted more than once

    When the primary instance is deregistered
    After the last database instance is deregistered

- Fix faulty tests in the sap system aggregate
- Ensure no sid at nil is set on database when deregistered
- Add deregistered_at timestamp when the database is deregistered
- Remove sid to nil in sap system aggregate when the sap system is deregistered

## How was this tested?

Automated tests
