### PR TITLE
Improve tooltip styling

### DIFF
--- a/assets/js/components/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/HanaClusterDetails.jsx
@@ -121,7 +121,10 @@ function HanaClusterDetails({
               />{' '}
               <span>Start Execution</span>
               {!hasSelectedChecks && (
-                <Tooltip tooltipText="Select some Checks first!" />
+                <Tooltip
+                  tooltipText="Select some Checks first!"
+                  width="-translate-x-1/4"
+                />
               )}
             </TriggerChecksExecutionRequest>
           </div>

--- a/assets/js/components/Tooltip/Tooltip.jsx
+++ b/assets/js/components/Tooltip/Tooltip.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import classNames from 'classnames';
 
-function Tooltip({ children, tooltipText, width = 'w-full' }) {
+function Tooltip({ children, tooltipText, width = '' }) {
   const tipRef = React.createRef(null);
 
   const handleMouseEnter = () => {
@@ -29,7 +29,7 @@ function Tooltip({ children, tooltipText, width = 'w-full' }) {
       <div
         className={classNames(
           width,
-          'absolute whitespace-no-wrap bg-gradient-to-r from-black to-gray-700 text-white px-4 py-2 rounded flex items-center transition-all duration-150'
+          'absolute whitespace-no-wrap bg-black text-white px-4 py-2 rounded flex items-center transition-all duration-150'
         )}
         style={{ top: '100%', opacity: 0 }}
         ref={tipRef}


### PR DESCRIPTION
# Description

Fixes a tiny inconsistency of the tooltip suggesting to select some checks before being able to trigger an execution.

Before
![image](https://github.com/trento-project/web/assets/8167114/2d0094cb-9c98-464b-b655-fc1d76fe4f5f)

After
![image](https://github.com/trento-project/web/assets/8167114/503ed72d-a0c2-4448-b4f6-ae84dc7b2a4a)

I removed the gradient bg colouring out of personal taste.

If we want to consider using a better Tooltip component and not a custom one let's track it and consider available options:
- https://popper.js.org/react-popper/
- https://github.com/atomiks/tippyjs-react
- https://github.com/ReactTooltip/react-tooltip
- others?

## How was this tested?
No need for test change