### PR TITLE
Add cluster nodes details to ASCS/ERS cluster details view

### DIFF
--- a/assets/js/components/ClusterDetails/AscsErsClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/AscsErsClusterDetails.jsx
@@ -13,6 +13,7 @@ import ChecksComingSoon from '@static/checks-coming-soon.svg';
 import SBDDetails from './SBDDetails';
 import SiteDetails from './SiteDetails';
 import StoppedResources from './StoppedResources';
+import { enrichNodes } from './HanaClusterDetails';
 
 const nodeDetailsConfig = {
   usePadding: false,
@@ -65,10 +66,7 @@ function AscsErsClusterDetails({
   useEffect(() => {
     const enrichedSapSystems = details?.sap_systems.map((sapSystem) => ({
       ...sapSystem,
-      nodes: sapSystem?.nodes.map((node) => ({
-        ...node,
-        ...hosts.find(({ hostname }) => hostname === node.name),
-      })),
+      nodes: enrichNodes(sapSystem?.nodes, hosts),
     }));
 
     setSapSystems(enrichedSapSystems);
@@ -141,7 +139,10 @@ function AscsErsClusterDetails({
             ]}
           />
           <div className="flex justify-center">
-            <DottedPagination pages={sapSystems} onChange={setCurrentSapSystem} />
+            <DottedPagination
+              pages={sapSystems}
+              onChange={setCurrentSapSystem}
+            />
           </div>
         </div>
         <div className="mt-4 bg-white shadow rounded-lg py-4 xl:w-1/4">

--- a/assets/js/components/ClusterDetails/AscsErsClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/AscsErsClusterDetails.jsx
@@ -60,7 +60,7 @@ function AscsErsClusterDetails({
   details,
 }) {
   const [sapSystems, setSapSystems] = useState([]);
-  const [currentSapSystem, setSapSystem] = useState(null);
+  const [currentSapSystem, setCurrentSapSystem] = useState(null);
 
   useEffect(() => {
     const enrichedSapSystems = details?.sap_systems.map((sapSystem) => ({
@@ -72,7 +72,7 @@ function AscsErsClusterDetails({
     }));
 
     setSapSystems(enrichedSapSystems);
-    setSapSystem(enrichedSapSystems[0]);
+    setCurrentSapSystem(enrichedSapSystems[0]);
   }, [hosts, details]);
 
   return (
@@ -141,7 +141,7 @@ function AscsErsClusterDetails({
             ]}
           />
           <div className="flex justify-center">
-            <DottedPagination pages={sapSystems} onChange={setSapSystem} />
+            <DottedPagination pages={sapSystems} onChange={setCurrentSapSystem} />
           </div>
         </div>
         <div className="mt-4 bg-white shadow rounded-lg py-4 xl:w-1/4">

--- a/assets/js/components/ClusterDetails/AscsErsClusterDetails.stories.jsx
+++ b/assets/js/components/ClusterDetails/AscsErsClusterDetails.stories.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
+import { faker } from '@faker-js/faker';
+
 import {
+  addHostsToAscsErsClusterDetails,
   ascsErsClusterDetailsFactory,
+  ascsErsClusterNodeFactory,
+  ascsErsSapSystemFactory,
   clusterFactory,
 } from '@lib/test-utils/factories';
 
@@ -14,6 +19,27 @@ const {
   cib_last_written: cibLastWritten,
   details,
 } = clusterFactory.build({ type: 'ascs_ers' });
+
+const multiSidDetails = ascsErsClusterDetailsFactory.build({
+  sap_systems_count: 3,
+});
+
+const nodes = [
+  ascsErsClusterNodeFactory.build({
+    roles: ['ascs', 'ers'],
+    virtual_ips: [faker.internet.ip(), faker.internet.ip()],
+    filesystems: [faker.system.filePath(), faker.system.filePath()],
+  }),
+  ascsErsClusterNodeFactory.build({
+    roles: [],
+    virtual_ips: [],
+    filesystems: [],
+  }),
+];
+
+const failoverDetails = ascsErsClusterDetailsFactory.build({
+  sap_systems: [ascsErsSapSystemFactory.build({ nodes, distributed: false })],
+});
 
 export default {
   title: 'AscsErsClusterDetails',
@@ -38,6 +64,7 @@ export const Single = {
     clusterName,
     cibLastWritten,
     provider,
+    hosts: addHostsToAscsErsClusterDetails(details),
     details,
   },
   render: (args) => (
@@ -50,7 +77,23 @@ export const Single = {
 export const MultiSID = {
   args: {
     ...Single.args,
-    details: ascsErsClusterDetailsFactory.build({ sap_systems_count: 3 }),
+    hosts: addHostsToAscsErsClusterDetails(multiSidDetails),
+    details: multiSidDetails,
+  },
+  render: (args) => (
+    <ContainerWrapper>
+      <AscsErsClusterDetails {...args} />
+    </ContainerWrapper>
+  ),
+};
+
+export const Failover = {
+  args: {
+    clusterName,
+    cibLastWritten,
+    provider,
+    hosts: addHostsToAscsErsClusterDetails(failoverDetails),
+    details: failoverDetails,
   },
   render: (args) => (
     <ContainerWrapper>

--- a/assets/js/components/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/HanaClusterDetails.jsx
@@ -20,6 +20,12 @@ import SiteDetails from './SiteDetails';
 import SBDDetails from './SBDDetails';
 import StoppedResources from './StoppedResources';
 
+export const enrichNodes = (clusterNodes, hosts) =>
+  clusterNodes?.map((node) => ({
+    ...node,
+    ...hosts.find(({ hostname }) => hostname === node.name),
+  }));
+
 const siteDetailsConfig = {
   usePadding: false,
   columns: [
@@ -69,10 +75,7 @@ function HanaClusterDetails({
   onStartExecution,
   navigate,
 }) {
-  const enrichedNodes = details?.nodes?.map((node) => ({
-    ...node,
-    ...hosts.find(({ hostname }) => hostname === node.name),
-  }));
+  const enrichedNodes = enrichNodes(details?.nodes, hosts);
 
   return (
     <div>

--- a/assets/js/lib/test-utils/factories/clusters.js
+++ b/assets/js/lib/test-utils/factories/clusters.js
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker';
 import { Factory } from 'fishery';
 import day from 'dayjs';
 
-import { resultEnum, cloudProviderEnum } from '.';
+import { resultEnum, cloudProviderEnum, hostFactory } from '.';
 
 const clusterTypeEnum = () =>
   faker.helpers.arrayElement(['unknown', 'hana_scale_up']);
@@ -111,3 +111,8 @@ export const clusterFactory = Factory.define(({ sequence, params }) => {
     details,
   };
 });
+
+export const addHostsToAscsErsClusterDetails = (details) =>
+  details.sap_systems
+    .flatMap(({ nodes }) => nodes)
+    .map(({ name }) => hostFactory.build({ hostname: name }));


### PR DESCRIPTION
# Description

Last episode in `ASCS/ERS` frontend series!
Include the nodes table in the details view.

Have a look in the published storybook to see the changes. `AscsErsClusterDetails` section.
New story for failover added, to see how multiple role, virtual ip, filesystem look in the nodes table.

## How was this tested?

Tests and storybook updated
