### PR TITLE
UX improvements in ASCS/ERS and HANA cluster details view

### DIFF
--- a/assets/js/components/ClusterDetails/AscsErsClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/AscsErsClusterDetails.jsx
@@ -112,9 +112,9 @@ function AscsErsClusterDetails({
             ]}
           />
         </div>
-        <div className="mt-4 bg-white shadow rounded-lg py-8 px-8 xl:w-2/5 mr-4">
+        <div className="flex flex-col mt-4 bg-white shadow rounded-lg pt-8 px-8 xl:w-2/5 mr-4">
           <ListView
-            className="grid-rows-2 mb-10"
+            className="grid-rows-2"
             titleClassName="text-lg"
             orientation="vertical"
             data={[
@@ -138,7 +138,7 @@ function AscsErsClusterDetails({
               },
             ]}
           />
-          <div className="flex justify-center">
+          <div className="flex justify-center mt-auto pt-8 mb-2">
             <DottedPagination
               pages={sapSystems}
               onChange={setCurrentSapSystem}

--- a/assets/js/components/ClusterDetails/AscsErsClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/AscsErsClusterDetails.jsx
@@ -146,11 +146,11 @@ function AscsErsClusterDetails({
           </div>
         </div>
         <div className="mt-4 bg-white shadow rounded-lg py-4 xl:w-1/4">
-          <div className="flex flex-col items-center">
+          <div className="flex flex-col items-center h-full">
             <h1 className="text-center text-2xl font-bold">Check Results</h1>
             <h6 className="opacity-60 text-xs">Coming soon for ASCS/ERS</h6>
             <img
-              className="w-full"
+              className="h-full inline-block align-middle"
               alt="checks coming soon"
               src={ChecksComingSoon}
             />

--- a/assets/js/components/ClusterDetails/SBDDetails.jsx
+++ b/assets/js/components/ClusterDetails/SBDDetails.jsx
@@ -17,7 +17,7 @@ function SBDDetails({ sbdDevices }) {
           <h2 className="text-2xl font-bold">SBD/Fencing</h2>
         </div>
       </div>
-      <div className="mt-2 bg-white shadow rounded-lg py-4 px-8 tn-sbd-details">
+      <div className="mt-2 bg-white shadow rounded-lg py-4 px-8 space-y-2 tn-sbd-details">
         {sbdDevices.map(({ device, status }) => (
           <div key={device}>
             {getStatusPill(status)} {device}

--- a/assets/js/components/ClusterDetails/StoppedResources.jsx
+++ b/assets/js/components/ClusterDetails/StoppedResources.jsx
@@ -8,7 +8,7 @@ function StoppedResources({ resources }) {
       <div className="flex flex-direction-row">
         <h2 className="text-2xl font-bold self-center">Stopped resources</h2>
       </div>
-      <div className="mt-2">
+      <div className="mt-2 space-x-2">
         {resources.map(({ id }) => (
           <Pill className="bg-gray-200 text-gray-800" key={id}>
             {id}


### PR DESCRIPTION
# Description
UX improvemnts in ASCS/ERS and HANA cluster details page.

Have a look in storybook (`HanaClusterDetails` and `AscsErsClusterDetails`).
Changes:
- Add horizontal space in stopped resources elements
- Add vertical space in SBD devices
- Align `Checks coming soon` image to the center
- Align dotted pagination of the SAP systems box in the bottom

The alignment of the 2 top boxes in the ASCS/ERS clusters view is excluded, as it doesn't have a trivial fix. @jagabomb told me that he was fine with the current state, but we can create a new ticket to track this if he wants

## How was this tested?

Describe what kind of tests for this functionality have been added.
