### PR TITLE
Send cluster type to wanda

### DIFF
--- a/lib/trento/application/integration/checks/checks.ex
+++ b/lib/trento/application/integration/checks/checks.ex
@@ -10,9 +10,11 @@ defmodule Trento.Integration.Checks do
     Target
   }
 
+  alias Trento.Integration.Checks.ClusterExecutionEnv
+
   require Logger
 
-  @spec request_execution(String.t(), String.t(), map, [map], [String.t()]) ::
+  @spec request_execution(String.t(), String.t(), ClusterExecutionEnv.t(), [map], [String.t()]) ::
           :ok | {:error, :any}
   def request_execution(execution_id, cluster_id, env, hosts, selected_checks) do
     execution_requested =
@@ -37,14 +39,10 @@ defmodule Trento.Integration.Checks do
     end
   end
 
-  defp build_env(env) do
-    Enum.into(env, %{}, fn {k, v} -> {k, %{kind: build_env_entry(v)}} end)
+  defp build_env(%ClusterExecutionEnv{cluster_type: cluster_type, provider: provider}) do
+    %{
+      "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
+      "provider" => %{kind: {:string_value, Atom.to_string(provider)}}
+    }
   end
-
-  # :struct_value and :list_value are missing
-  defp build_env_entry(value) when is_binary(value), do: {:string_value, value}
-  defp build_env_entry(value) when is_boolean(value), do: {:bool_value, value}
-  defp build_env_entry(value) when is_number(value), do: {:number_value, value}
-  defp build_env_entry(value) when is_nil(value), do: {:null_value, value}
-  defp build_env_entry(value) when is_atom(value), do: {:string_value, Atom.to_string(value)}
 end

--- a/lib/trento/application/integration/checks/cluster_execution_env.ex
+++ b/lib/trento/application/integration/checks/cluster_execution_env.ex
@@ -1,0 +1,16 @@
+defmodule Trento.Integration.Checks.ClusterExecutionEnv do
+  @moduledoc """
+  Cluster checks execution env map
+  """
+
+  @required_fields :all
+  use Trento.Type
+
+  require Trento.Domain.Enums.Provider, as: Provider
+  require Trento.Domain.Enums.ClusterType, as: ClusterType
+
+  deftype do
+    field :cluster_type, Ecto.Enum, values: ClusterType.values()
+    field :provider, Ecto.Enum, values: Provider.values()
+  end
+end

--- a/lib/trento/application/usecases/clusters/clusters.ex
+++ b/lib/trento/application/usecases/clusters/clusters.ex
@@ -127,9 +127,9 @@ defmodule Trento.Clusters do
     Checks.request_execution(
       UUID.uuid4(),
       cluster_id,
-      %{
-        "provider" => provider,
-        "cluster_type" => cluster_type
+      %Checks.ClusterExecutionEnv{
+        provider: provider,
+        cluster_type: cluster_type
       },
       hosts_data,
       selected_checks

--- a/lib/trento/application/usecases/clusters/clusters.ex
+++ b/lib/trento/application/usecases/clusters/clusters.ex
@@ -114,6 +114,7 @@ defmodule Trento.Clusters do
   defp maybe_request_checks_execution(%{
          id: cluster_id,
          provider: provider,
+         type: cluster_type,
          selected_checks: selected_checks
        }) do
     hosts_data =
@@ -126,7 +127,10 @@ defmodule Trento.Clusters do
     Checks.request_execution(
       UUID.uuid4(),
       cluster_id,
-      provider,
+      %{
+        "provider" => provider,
+        "cluster_type" => cluster_type
+      },
       hosts_data,
       selected_checks
     )

--- a/test/trento/application/integration/checks/checks_test.exs
+++ b/test/trento/application/integration/checks/checks_test.exs
@@ -15,7 +15,15 @@ defmodule Trento.Integration.ChecksTest do
   test "should publish an ExecutionRequested event" do
     execution_id = UUID.uuid4()
     group_id = UUID.uuid4()
-    provider = :some_provider
+
+    env = %{
+      "string" => "string",
+      "bool" => false,
+      "number" => 1,
+      "nil" => nil,
+      "atom" => :atom
+    }
+
     selected_checks = ["check_1", "check_2"]
 
     hosts = [
@@ -31,7 +39,13 @@ defmodule Trento.Integration.ChecksTest do
                  %Target{agent_id: "agent_1", checks: ^selected_checks},
                  %Target{agent_id: "agent_2", checks: ^selected_checks}
                ],
-               env: %{"provider" => %{kind: {:string_value, "some_provider"}}}
+               env: %{
+                 "string" => %{kind: {:string_value, "string"}},
+                 "bool" => %{kind: {:bool_value, false}},
+                 "number" => %{kind: {:number_value, 1}},
+                 "nil" => %{kind: {:null_value, nil}},
+                 "atom" => %{kind: {:string_value, "atom"}}
+               }
              } = event
 
       :ok
@@ -41,7 +55,7 @@ defmodule Trento.Integration.ChecksTest do
              Checks.request_execution(
                execution_id,
                group_id,
-               provider,
+               env,
                hosts,
                selected_checks
              )

--- a/test/trento/application/integration/checks/checks_test.exs
+++ b/test/trento/application/integration/checks/checks_test.exs
@@ -12,16 +12,13 @@ defmodule Trento.Integration.ChecksTest do
     Target
   }
 
-  test "should publish an ExecutionRequested event" do
+  test "should publish an ExecutionRequested event with cluster env" do
     execution_id = UUID.uuid4()
     group_id = UUID.uuid4()
 
-    env = %{
-      "string" => "string",
-      "bool" => false,
-      "number" => 1,
-      "nil" => nil,
-      "atom" => :atom
+    env = %Checks.ClusterExecutionEnv{
+      cluster_type: :hana_scale_up,
+      provider: :azure
     }
 
     selected_checks = ["check_1", "check_2"]
@@ -40,11 +37,8 @@ defmodule Trento.Integration.ChecksTest do
                  %Target{agent_id: "agent_2", checks: ^selected_checks}
                ],
                env: %{
-                 "string" => %{kind: {:string_value, "string"}},
-                 "bool" => %{kind: {:bool_value, false}},
-                 "number" => %{kind: {:number_value, 1}},
-                 "nil" => %{kind: {:null_value, nil}},
-                 "atom" => %{kind: {:string_value, "atom"}}
+                 "cluster_type" => %{kind: {:string_value, "hana_scale_up"}},
+                 "provider" => %{kind: {:string_value, "azure"}}
                }
              } = event
 

--- a/test/trento/application/usecases/clusters_test.exs
+++ b/test/trento/application/usecases/clusters_test.exs
@@ -16,11 +16,16 @@ defmodule Trento.ClustersTest do
 
   describe "checks execution with wanda adapter" do
     test "should start a checks execution on demand if checks are selected" do
-      %{id: cluster_id} = insert(:cluster)
+      %{id: cluster_id, provider: provider, type: cluster_type} = insert(:cluster)
       insert_list(2, :host, cluster_id: cluster_id)
 
       expect(Trento.Infrastructure.Messaging.Adapter.Mock, :publish, fn "executions", message ->
         assert message.group_id == cluster_id
+
+        assert message.env == %{
+                 "provider" => %{kind: {:string_value, Atom.to_string(provider)}},
+                 "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}}
+               }
 
         :ok
       end)


### PR DESCRIPTION
# Description
Send the `cluster_type` to wanda in the `env` map.
It can be used as `env.cluster_type` in the checks.

I have made the checks module `request_execution` function generic, so it already receives the env map, so we can have different envs for different executions (for example, host executions might not need the cluster_type value).

This should already work as it is in wanda, but I will send a change to be able to map the env values with the correct map.
(even though we send strings by now)

@abravosuse Where should we document the available options for this env value? (`hana_scale_up`, `hana_scale_out`, `ascs_ers` and `unknonw` are the current values). I found out that we don't have any documentation for the available providers neither.

## How was this tested?

Tested
