### PR TITLE
Handle evaluation errors

### DIFF
--- a/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultDetail.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultDetail.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import {
   getAgentCheckResultByAgentID,
+  getExpectStatementsResults,
   getExpectSameStatementsResults,
-  getExpectStatements,
   getClusterCheckResults,
   isAgentCheckError,
   isTargetHost,
@@ -15,7 +15,7 @@ import GatheredFacts from './GatheredFacts';
 
 function CheckResultDetail({
   checkID,
-  expectations,
+  expectations = [],
   targetID,
   targetType,
   executionData,
@@ -38,7 +38,7 @@ function CheckResultDetail({
   const isError = isAgentCheckError(targetResult);
 
   const targetExpectationsResults = targetHost
-    ? getExpectStatements(expectation_evaluations)
+    ? getExpectStatementsResults(expectations, expectation_evaluations)
     : getExpectSameStatementsResults(expectations, expectation_results);
 
   const gatheredFacts = targetHost

--- a/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultDetail.stories.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultDetail.stories.jsx
@@ -7,6 +7,8 @@ import {
   checkResultFactory,
   addCriticalExpectExpectation,
   withOverriddenValues,
+  catalogExpectExpectationFactory,
+  catalogExpectSameExpectationFactory,
 } from '@lib/test-utils/factories';
 
 import CheckResultDetail from './CheckResultDetail';
@@ -15,18 +17,32 @@ const clusterHosts = hostFactory.buildList(2);
 const [{ id: target1 }, { id: target2 }] = clusterHosts;
 const targetType = 'host';
 
+const catalogExpectations = [
+  ...catalogExpectExpectationFactory.buildList(5),
+  catalogExpectSameExpectationFactory.build(),
+];
+
+const [
+  { name: expectationName1 },
+  { name: expectationName2 },
+  { name: expectationName3 },
+  { name: expectationName4 },
+  { name: expectationName5 },
+  { name: expectationName6 },
+] = catalogExpectations;
+
 let checkResult = emptyCheckResultFactory.build({
   targets: [target1, target2],
 });
 
 const { check_id: checkID } = checkResult;
 
-checkResult = addPassingExpectExpectation(checkResult);
-checkResult = addPassingExpectExpectation(checkResult);
-checkResult = addCriticalExpectExpectation(checkResult);
-checkResult = addCriticalExpectExpectation(checkResult);
-checkResult = addCriticalExpectExpectation(checkResult);
-checkResult = addPassingExpectSameExpectation(checkResult, 'expectation_name');
+checkResult = addPassingExpectExpectation(checkResult, expectationName1);
+checkResult = addPassingExpectExpectation(checkResult, expectationName2);
+checkResult = addCriticalExpectExpectation(checkResult, expectationName3);
+checkResult = addCriticalExpectExpectation(checkResult, expectationName4);
+checkResult = addCriticalExpectExpectation(checkResult, expectationName5);
+checkResult = addPassingExpectSameExpectation(checkResult, expectationName6);
 
 const checkResultWithoutValues = withOverriddenValues(checkResult, target1, []);
 
@@ -49,7 +65,7 @@ export const Default = {
     targetID: target1,
     targetType,
     executionData,
-    expectations: [],
+    expectations: catalogExpectations,
   },
 };
 

--- a/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultDetail.test.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultDetail.test.jsx
@@ -16,6 +16,7 @@ import {
   executionFactFactory,
   agentCheckResultFactory,
   agentsCheckResultsWithHostname,
+  catalogExpectExpectationFactory,
   catalogExpectSameExpectationFactory,
   executionExpectationEvaluationFactory,
   expectationResultFactory,
@@ -31,6 +32,20 @@ describe('CheckResultDetail Component', () => {
     const [{ id: target1 }, { id: target2 }] = clusterHosts;
     const targetType = 'host';
 
+    const expectations = [
+      ...catalogExpectExpectationFactory.buildList(5),
+      catalogExpectSameExpectationFactory.build(),
+    ];
+
+    const [
+      { name: expectationName1 },
+      { name: expectationName2 },
+      { name: expectationName3 },
+      { name: expectationName4 },
+      { name: expectationName5 },
+      { name: expectationName6 },
+    ] = expectations;
+
     let checkResult = emptyCheckResultFactory.build({
       targets: [target1, target2],
     });
@@ -39,14 +54,14 @@ describe('CheckResultDetail Component', () => {
       agents_check_results: [{ values, facts }, _],
     } = checkResult;
 
-    checkResult = addPassingExpectExpectation(checkResult);
-    checkResult = addPassingExpectExpectation(checkResult);
-    checkResult = addCriticalExpectExpectation(checkResult);
-    checkResult = addCriticalExpectExpectation(checkResult);
-    checkResult = addCriticalExpectExpectation(checkResult);
+    checkResult = addPassingExpectExpectation(checkResult, expectationName1);
+    checkResult = addPassingExpectExpectation(checkResult, expectationName2);
+    checkResult = addCriticalExpectExpectation(checkResult, expectationName3);
+    checkResult = addCriticalExpectExpectation(checkResult, expectationName4);
+    checkResult = addCriticalExpectExpectation(checkResult, expectationName5);
     checkResult = addPassingExpectSameExpectation(
       checkResult,
-      'expectation_name'
+      expectationName6
     );
 
     const executionData = checksExecutionCompletedFactory.build({
@@ -59,7 +74,7 @@ describe('CheckResultDetail Component', () => {
         targetID={target1}
         targetType={targetType}
         executionData={executionData}
-        expectations={[]}
+        expectations={expectations}
       />
     );
 

--- a/assets/js/components/ExecutionResults/CheckResultDetail/ExpectationsResults.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/ExpectationsResults.jsx
@@ -10,19 +10,21 @@ function ExpectationsResults({
   errorMessage = 'An error occurred',
 }) {
   const renderedResults = isTargetHost
-    ? results.map(({ name, return_value, failure_message }) => ({
+    ? results.map(({ name, return_value, failure_message, message }) => ({
         name,
         passing: !!return_value,
         failureMessage: failure_message,
+        evaluationErrorMessage: message,
       }))
-    : results.map(({ name, result, failure_message }) => ({
+    : results.map(({ name, result, failure_message, message }) => ({
         name,
         passing: !!result,
         failureMessage: failure_message,
+        evaluationErrorMessage: message,
       }));
 
   const expectationsEvaluations = renderedResults.map(
-    ({ name, passing, failureMessage }) => ({
+    ({ name, passing, failureMessage, evaluationErrorMessage }) => ({
       title: name,
       content: passing,
       render: (isPassing) => (
@@ -33,6 +35,9 @@ function ExpectationsResults({
         >
           <span>{isPassing ? 'Passing' : 'Failing'}</span>
           {failureMessage && <span className="block">{failureMessage}</span>}
+          {evaluationErrorMessage && (
+            <span className="block">{evaluationErrorMessage}</span>
+          )}
         </div>
       ),
     })

--- a/assets/js/components/ExecutionResults/CheckResultDetail/ExpectationsResults.stories.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/ExpectationsResults.stories.jsx
@@ -1,4 +1,9 @@
 import { faker } from '@faker-js/faker';
+import {
+  executionExpectationEvaluationErrorFactory,
+  failingExpectEvaluationFactory,
+} from '@lib/test-utils/factories';
+
 import ExpectationsResults from './ExpectationsResults';
 
 export default {
@@ -15,5 +20,19 @@ export const Default = {
     ],
     isError: false,
     errorMessage: 'An error occurred',
+  },
+};
+
+export const WithFailureMessage = {
+  args: {
+    ...Default.args,
+    results: [failingExpectEvaluationFactory.build()],
+  },
+};
+
+export const WithEvaluationError = {
+  args: {
+    ...Default.args,
+    results: [executionExpectationEvaluationErrorFactory.build()],
   },
 };

--- a/assets/js/components/ExecutionResults/CheckResultDetail/ExpectationsResults.test.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/ExpectationsResults.test.jsx
@@ -5,6 +5,7 @@ import { faker } from '@faker-js/faker';
 
 import {
   executionExpectationEvaluationFactory,
+  executionExpectationEvaluationErrorFactory,
   failingExpectEvaluationFactory,
   expectationResultFactory,
   failingExpectationResultFactory,
@@ -16,12 +17,17 @@ import ExpectationsResults from './ExpectationsResults';
 describe('ExpectationsResults Component', () => {
   it('should render expect statements results', () => {
     const failureMessage = faker.lorem.sentence();
+    const evaluationErrorMessage = faker.lorem.sentence();
     const results = [
       ...executionExpectationEvaluationFactory.buildList(3, {
         return_value: true,
       }),
       ...failingExpectEvaluationFactory.buildList(2, {
         failure_message: failureMessage,
+      }),
+      executionExpectationEvaluationErrorFactory.build({
+        name: 'erroring_evaluation',
+        message: evaluationErrorMessage,
       }),
     ];
 
@@ -30,8 +36,9 @@ describe('ExpectationsResults Component', () => {
     render(<ExpectationsResults results={results} />);
 
     expect(screen.getAllByText('Passing')).toHaveLength(3);
-    expect(screen.getAllByText('Failing')).toHaveLength(2);
+    expect(screen.getAllByText('Failing')).toHaveLength(3);
     expect(screen.getAllByText(failureMessage)).toHaveLength(2);
+    expect(screen.getAllByText(evaluationErrorMessage)).toHaveLength(1);
     expect(screen.getByText(expectationName1)).toBeVisible();
     expect(screen.getByText(expectationName3)).toBeVisible();
   });

--- a/assets/js/components/ExecutionResults/checksUtils.js
+++ b/assets/js/components/ExecutionResults/checksUtils.js
@@ -90,10 +90,21 @@ export const getExpectStatements = (expectationList) =>
 export const getExpectSameStatements = (expectationList) =>
   expectationList.filter(isExpectSame);
 
-export const getExpectSameStatementResult = (expectationResults, name) => {
-  const expectSameStatement = getExpectSameStatements(expectationResults).find(
-    ({ name: resultExpectationName }) => name === resultExpectationName
+const expectationByName =
+  (expectationName) =>
+  ({ name }) =>
+    name === expectationName;
+
+export const getExpectStatementsResults = (
+  expectations,
+  expectationEvaluations
+) =>
+  getExpectStatements(expectations).map(
+    ({ name }) => expectationEvaluations.find(expectationByName(name)) || {}
   );
+
+export const getExpectSameStatementResult = (expectationResults, name) => {
+  const expectSameStatement = expectationResults.find(expectationByName(name));
 
   if (!expectSameStatement) {
     return { name, result: null };

--- a/assets/js/lib/test-utils/factories/executions.js
+++ b/assets/js/lib/test-utils/factories/executions.js
@@ -16,12 +16,11 @@ export const executionValueFactory = Factory.define(({ sequence }) => ({
 
 export const executionExpectationEvaluationFactory = Factory.define(
   ({ sequence, params }) => {
-    const {
-      name = `expectation_${sequence}`,
-      failure_message = params.failure_message
-        ? { failure_message: params.failure_message }
-        : {},
-    } = params;
+    const { name = `expectation_${sequence}` } = params;
+
+    const failure_message = params.failure_message
+      ? { failure_message: params.failure_message }
+      : {};
 
     return {
       name,
@@ -55,12 +54,11 @@ export const executionExpectationEvaluationErrorFactory = Factory.define(
 
 export const expectationResultFactory = Factory.define(
   ({ sequence, params }) => {
-    const {
-      name = `expectation_${sequence}`,
-      failure_message = params.failure_message
-        ? { failure_message: params.failure_message }
-        : {},
-    } = params;
+    const { name = `expectation_${sequence}` } = params;
+
+    const failure_message = params.failure_message
+      ? { failure_message: params.failure_message }
+      : {};
 
     return {
       name,


### PR DESCRIPTION
# Description

This PR fixes a bug that doesn't correctly allow for rendering of evaluation errors (ie. rhai script fails)

Before
![image](https://github.com/trento-project/web/assets/8167114/4b704914-c804-4011-a05d-df2d65ceacc5)

After
![image](https://github.com/trento-project/web/assets/8167114/bdea43dd-0c1e-4708-b5c0-92c65a3cb547)

Side effect: check [373DB8](https://github.com/trento-project/wanda/blob/main/priv/catalog/373DB8.yaml#L69) needs to be fixed.

## How was this tested?

Tests and stories updated.