### PR TITLE
Sap system delta deregistration

### DIFF
--- a/lib/trento/application/integration/discovery/discovery.ex
+++ b/lib/trento/application/integration/discovery/discovery.ex
@@ -17,7 +17,7 @@ defmodule Trento.Integration.Discovery do
     SapSystemPolicy
   }
 
-  alias Trento.Clusters
+  alias Trento.{Clusters, SapSystems}
 
   @type command :: struct
 
@@ -137,8 +137,12 @@ defmodule Trento.Integration.Discovery do
     ClusterPolicy.handle(event, current_cluster_id)
   end
 
-  defp do_handle(%{"discovery_type" => "sap_system_discovery"} = event),
-    do: SapSystemPolicy.handle(event)
+  defp do_handle(%{"discovery_type" => "sap_system_discovery", "agent_id" => agent_id} = event) do
+    current_application_instances = SapSystems.get_application_instances_by_host_id(agent_id)
+    current_database_instances = SapSystems.get_database_instances_by_host_id(agent_id)
+
+    SapSystemPolicy.handle(event, current_application_instances ++ current_database_instances)
+  end
 
   defp do_handle(_),
     do: {:error, :unknown_discovery_type}

--- a/lib/trento/application/integration/discovery/policies/cluster_policy.ex
+++ b/lib/trento/application/integration/discovery/policies/cluster_policy.ex
@@ -62,7 +62,7 @@ defmodule Trento.Integration.Discovery.ClusterPolicy do
     do: nil
 
   defp build_deregister_cluster_host_command(agent_id, cluster_id, current_cluster_id) do
-    if cluster_id != current_cluster_id do
+    if generate_cluster_id(cluster_id) != current_cluster_id do
       DeregisterClusterHost.new!(%{
         host_id: agent_id,
         cluster_id: current_cluster_id,
@@ -568,6 +568,7 @@ defmodule Trento.Integration.Discovery.ClusterPolicy do
        }),
        do: cib_last_written
 
+  defp generate_cluster_id(nil), do: nil
   defp generate_cluster_id(id), do: UUID.uuid5(@uuid_namespace, id)
 
   defp parse_cluster_health(details, cluster_type)

--- a/lib/trento/application/usecases/sap_systems/sap_systems.ex
+++ b/lib/trento/application/usecases/sap_systems/sap_systems.ex
@@ -6,6 +6,8 @@ defmodule Trento.SapSystems do
   import Ecto.Query
 
   alias Trento.{
+    ApplicationInstanceReadModel,
+    DatabaseInstanceReadModel,
     DatabaseReadModel,
     SapSystemReadModel
   }
@@ -25,7 +27,7 @@ defmodule Trento.SapSystems do
     ])
   end
 
-  @spec get_all_databases :: [map]
+  @spec get_all_databases :: [DatabaseReadModel.t()]
   def get_all_databases do
     DatabaseReadModel
     |> order_by(asc: :sid)
@@ -34,5 +36,19 @@ defmodule Trento.SapSystems do
       :database_instances,
       :tags
     ])
+  end
+
+  @spec get_application_instances_by_host_id(String.t()) :: [ApplicationInstanceReadModel.t()]
+  def get_application_instances_by_host_id(host_id) do
+    ApplicationInstanceReadModel
+    |> where([a], a.host_id == ^host_id)
+    |> Repo.all()
+  end
+
+  @spec get_database_instances_by_host_id(String.t()) :: [DatabaseInstanceReadModel.t()]
+  def get_database_instances_by_host_id(host_id) do
+    DatabaseInstanceReadModel
+    |> where([d], d.host_id == ^host_id)
+    |> Repo.all()
   end
 end

--- a/test/fixtures/discovery/sap_system_discovery_empty.json
+++ b/test/fixtures/discovery/sap_system_discovery_empty.json
@@ -1,0 +1,5 @@
+{
+  "agent_id": "9cd46919-5f19-59aa-993e-cf3736c71053",
+  "discovery_type": "sap_system_discovery",
+  "payload": []
+}

--- a/test/trento/application/integration/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/application/integration/discovery/policies/cluster_policy_test.exs
@@ -1315,5 +1315,17 @@ defmodule Trento.Integration.Discovery.ClusterPolicyTest do
         |> load_discovery_event_fixture()
         |> ClusterPolicy.handle(current_cluster_id)
     end
+
+    test "should not deregister the host if the cluster does not change" do
+      current_cluster_id = "34a94290-2236-5e4d-8def-05beb32d14d4"
+
+      assert {:ok,
+              [
+                %RegisterClusterHost{cluster_id: ^current_cluster_id}
+              ]} =
+               "ha_cluster_discovery_hana_scale_up"
+               |> load_discovery_event_fixture()
+               |> ClusterPolicy.handle(current_cluster_id)
+    end
   end
 end

--- a/test/trento/application/usecases/sap_systems_test.exs
+++ b/test/trento/application/usecases/sap_systems_test.exs
@@ -68,4 +68,38 @@ defmodule Trento.SapSystemsTest do
              ] = SapSystems.get_all_databases()
     end
   end
+
+  describe "get_application_instances_by_host_id/1" do
+    test "should return an empty list if no application instances were found" do
+      assert [] == SapSystems.get_application_instances_by_host_id(UUID.uuid4())
+    end
+
+    test "should return all the instances with the matching host_id" do
+      host_id = UUID.uuid4()
+      insert_list(10, :application_instance_without_host, host_id: host_id)
+      insert_list(10, :application_instance_without_host)
+
+      application_instances = SapSystems.get_application_instances_by_host_id(host_id)
+
+      assert 10 == length(application_instances)
+      assert Enum.all?(application_instances, &(&1.host_id == host_id))
+    end
+  end
+
+  describe "get_database_instances_by_host_id/1" do
+    test "should return empty if no database instances were found" do
+      assert [] == SapSystems.get_application_instances_by_host_id(UUID.uuid4())
+    end
+
+    test "should return all the instances with the matching host_id" do
+      host_id = UUID.uuid4()
+      insert_list(10, :database_instance_without_host, host_id: host_id)
+      insert_list(10, :database_instance_without_host)
+
+      database_instances = SapSystems.get_database_instances_by_host_id(host_id)
+
+      assert 10 == length(database_instances)
+      assert Enum.all?(database_instances, &(&1.host_id == host_id))
+    end
+  end
 end


### PR DESCRIPTION
The PR adds delta deregistration for SAP systems.
This logic is similar to #1386, except that we need the instances list to calculate the difference.
Also, it fixes the cluster deregistration logic, which was not computing the ID correctly.