### PR TITLE
Add V2 scope to /api/clusters endpoint

### DIFF
--- a/lib/trento/application/projectors/cluster_projector.ex
+++ b/lib/trento/application/projectors/cluster_projector.ex
@@ -8,7 +8,7 @@ defmodule Trento.ClusterProjector do
     repo: Trento.Repo,
     name: "cluster_projector"
 
-  alias TrentoWeb.V1.ClusterView
+  alias TrentoWeb.V2.ClusterView
 
   alias Trento.Domain.Events.{
     ChecksSelected,

--- a/lib/trento_web/controllers/v2/cluster_controller.ex
+++ b/lib/trento_web/controllers/v2/cluster_controller.ex
@@ -1,0 +1,27 @@
+defmodule TrentoWeb.V2.ClusterController do
+  use TrentoWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Trento.Clusters
+
+  alias TrentoWeb.OpenApi.V2.Schema
+
+  plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
+  action_fallback TrentoWeb.FallbackController
+
+  operation :list,
+    summary: "List Pacemaker Clusters",
+    tags: ["Target Infrastructure"],
+    description: "List all the discovered Pacemaker Clusters on the target infrastructure",
+    responses: [
+      ok:
+        {"A collection of the discovered Pacemaker Clusters", "application/json",
+         Schema.Cluster.PacemakerClustersCollection}
+    ]
+
+  def list(conn, _) do
+    clusters = Clusters.get_all_clusters()
+
+    render(conn, "clusters.json", clusters: clusters)
+  end
+end

--- a/lib/trento_web/openapi/v1/schema/cluster.ex
+++ b/lib/trento_web/openapi/v1/schema/cluster.ex
@@ -2,7 +2,6 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Cluster do
   @moduledoc false
 
   require OpenApiSpex
-  require Trento.Domain.Enums.ClusterType, as: ClusterType
 
   alias OpenApiSpex.Schema
 
@@ -37,13 +36,11 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Cluster do
         site: %Schema{type: :string},
         hana_status: %Schema{type: :string},
         attributes: %Schema{
-          title: "ClusterNodeAttributes",
-          type: :array,
-          items: %Schema{type: :string}
+          type: :object,
+          description: "Node attributes"
         },
         virtual_ip: %Schema{type: :string},
         resources: %Schema{
-          title: "ClustrNodeResources",
           description: "A list of Cluster resources",
           type: :array,
           items: ClusterResource
@@ -57,7 +54,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Cluster do
 
     OpenApiSpex.schema(%{
       title: "SbdDevice",
-      description: "Ad Sbd Device",
+      description: "SBD Device",
       type: :object,
       properties: %{
         device: %Schema{type: :string},
@@ -83,22 +80,20 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Cluster do
         sr_health_state: %Schema{type: :string, description: "SR health state"},
         fencing_type: %Schema{type: :string, description: "Fencing Type"},
         stopped_resources: %Schema{
-          title: "ClusterResource",
           description: "A list of the stopped resources on this HANA Cluster",
           type: :array,
           items: ClusterResource
         },
         nodes: %Schema{
-          title: "HanaClusterNodes",
           type: :array,
           items: HanaClusterNode
         },
         sbd_devices: %Schema{
-          title: "SbdDevice",
           type: :array,
           items: SbdDevice
         }
-      }
+      },
+      required: [:nodes]
     })
   end
 
@@ -106,7 +101,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Cluster do
     @moduledoc false
 
     OpenApiSpex.schema(%{
-      title: "PacemakerClusterDetail",
+      title: "PacemakerClusterDetails",
       description: "Details of the detected PacemakerCluster",
       nullable: true,
       oneOf: [
@@ -135,7 +130,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Cluster do
         type: %Schema{
           type: :string,
           description: "Detected type of the cluster",
-          enum: ClusterType.values()
+          enum: [:hana_scale_up, :hana_scale_out, :unknown]
         },
         selected_checks: %Schema{
           title: "SelectedChecks",

--- a/lib/trento_web/openapi/v2/api_spec.ex
+++ b/lib/trento_web/openapi/v2/api_spec.ex
@@ -1,0 +1,8 @@
+defmodule TrentoWeb.OpenApi.V2.ApiSpec do
+  @moduledoc """
+  OpenApi specification entry point for V2 version
+  """
+
+  use TrentoWeb.OpenApi.ApiSpec,
+    api_version: "v2"
+end

--- a/lib/trento_web/openapi/v2/schema/cluster.ex
+++ b/lib/trento_web/openapi/v2/schema/cluster.ex
@@ -1,0 +1,175 @@
+defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
+  @moduledoc false
+
+  require OpenApiSpex
+  require Trento.Domain.Enums.ClusterType, as: ClusterType
+
+  alias OpenApiSpex.Schema
+
+  alias TrentoWeb.OpenApi.V1.Schema.{Cluster, Provider, ResourceHealth, Tags}
+
+  defmodule AscsErsClusterNode do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "AscsErsClusterNode",
+      description: "ASCS/ERS Cluster Node",
+      type: :object,
+      properties: %{
+        attributes: %Schema{
+          type: :object,
+          description: "Node attributes"
+        },
+        filesystems: %Schema{
+          type: :array,
+          items: %Schema{type: :string},
+          description: "List of filesystems managed in this node"
+        },
+        name: %Schema{
+          type: :string,
+          description: "Node name"
+        },
+        resources: %Schema{
+          type: :array,
+          items: Cluster.ClusterResource,
+          description: "A list of Cluster resources"
+        },
+        roles: %Schema{
+          type: :array,
+          items: %Schema{type: :string, enum: ["ascs", "ers"]},
+          description: "List of roles managed in this node"
+        },
+        virtual_ips: %Schema{
+          type: :array,
+          items: %Schema{type: :string},
+          description: "List of virtual IPs managed in this node"
+        }
+      }
+    })
+  end
+
+  defmodule AscsErsClusterSAPSystem do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "AscsErsClusterSAPSystem",
+      description: "SAP system managed by a ASCS/ERS cluster",
+      type: :object,
+      properties: %{
+        distributed: %Schema{
+          type: :boolean,
+          description: "ASCS and ERS instances are distributed and running in different nodes"
+        },
+        filesystem_resource_based: %Schema{
+          type: :boolean,
+          description:
+            "ACSS and ERS filesystems are handled by the cluster with the Filesystem resource agent"
+        },
+        nodes: %Schema{
+          type: :array,
+          items: AscsErsClusterNode,
+          description: "List of ASCS/ERS nodes for this SAP system"
+        }
+      }
+    })
+  end
+
+  defmodule AscsErsClusterDetails do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "AscsErsClusterDetails",
+      description: "Details of a ASCS/ERS Pacemaker Cluster",
+      type: :object,
+      properties: %{
+        fencing_type: %Schema{
+          type: :string,
+          description: "Fencing type"
+        },
+        sap_systems: %Schema{
+          type: :array,
+          items: AscsErsClusterSAPSystem,
+          description: "List of managed SAP systems in a single or multi SID cluster"
+        },
+        sbd_devices: %Schema{
+          type: :array,
+          items: Cluster.SbdDevice,
+          description: "List of SBD devices used in the cluster"
+        },
+        stopped_resources: %Schema{
+          type: :array,
+          items: Cluster.ClusterResource,
+          description: "List of the stopped resources on this HANA Cluster"
+        }
+      },
+      required: [:sap_systems]
+    })
+  end
+
+  defmodule Details do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "PacemakerClusterDetails",
+      description: "Details of the detected PacemakerCluster",
+      nullable: true,
+      oneOf: [
+        AscsErsClusterDetails,
+        Cluster.HanaClusterDetails
+      ]
+    })
+  end
+
+  defmodule PacemakerCluster do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "PacemakerCluster",
+      description: "A discovered Pacemaker Cluster on the target infrastructure",
+      type: :object,
+      properties: %{
+        id: %Schema{type: :string, description: "Cluster ID", format: :uuid},
+        name: %Schema{type: :string, description: "Cluster name"},
+        sid: %Schema{type: :string, description: "SID"},
+        additional_sids: %Schema{
+          type: :array,
+          items: %Schema{type: :string},
+          description: "Additionally discovered SIDs, such as ASCS/ERS cluster SIDs"
+        },
+        provider: Provider.SupportedProviders,
+        type: %Schema{
+          type: :string,
+          description: "Detected type of the cluster",
+          enum: ClusterType.values()
+        },
+        selected_checks: %Schema{
+          title: "SelectedChecks",
+          description: "A list ids of the checks selected for execution on this cluster",
+          type: :array,
+          items: %Schema{type: :string}
+        },
+        health: ResourceHealth,
+        resources_number: %Schema{type: :integer, description: "Resource number", nullable: true},
+        hosts_number: %Schema{type: :integer, description: "Hosts number", nullable: true},
+        cib_last_written: %Schema{
+          type: :string,
+          description: "CIB last written date",
+          nullable: true
+        },
+        details: Details,
+        tags: Tags
+      }
+    })
+  end
+
+  defmodule PacemakerClustersCollection do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "PacemakerClustersCollection",
+      description: "A list of the discovered Pacemaker Clusters",
+      type: :array,
+      items: PacemakerCluster
+    })
+  end
+end

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -3,7 +3,7 @@ defmodule TrentoWeb.Router do
   use Pow.Phoenix.Router
 
   # From newest to oldest
-  @available_api_versions ["v1"]
+  @available_api_versions ["v2", "v1"]
 
   pipeline :browser do
     plug :accepts, ["html"]
@@ -22,6 +22,11 @@ defmodule TrentoWeb.Router do
   pipeline :api_v1 do
     plug :api
     plug OpenApiSpex.Plug.PutApiSpec, module: TrentoWeb.OpenApi.V1.ApiSpec
+  end
+
+  pipeline :api_v2 do
+    plug :api
+    plug OpenApiSpex.Plug.PutApiSpec, module: TrentoWeb.OpenApi.V2.ApiSpec
   end
 
   pipeline :protected_api do
@@ -44,7 +49,8 @@ defmodule TrentoWeb.Router do
     get "/api/doc", OpenApiSpex.Plug.SwaggerUI,
       path: "/api/v1/openapi",
       urls: [
-        %{url: "/api/v1/openapi", name: "Version 1"}
+        %{url: "/api/v1/openapi", name: "Version 1"},
+        %{url: "/api/v2/openapi", name: "Version 2"}
       ]
   end
 
@@ -119,6 +125,12 @@ defmodule TrentoWeb.Router do
 
       get "/hosts/:id/exporters_status", PrometheusController, :exporters_status
     end
+
+    scope "/v2", TrentoWeb.V2 do
+      pipe_through [:api_v2]
+
+      get "/clusters", ClusterController, :list
+    end
   end
 
   scope "/api" do
@@ -147,6 +159,11 @@ defmodule TrentoWeb.Router do
 
     scope "/v1" do
       pipe_through :api_v1
+      get "/openapi", OpenApiSpex.Plug.RenderSpec, []
+    end
+
+    scope "/v2" do
+      pipe_through :api_v2
       get "/openapi", OpenApiSpex.Plug.RenderSpec, []
     end
   end

--- a/lib/trento_web/views/v1/cluster_view.ex
+++ b/lib/trento_web/views/v1/cluster_view.ex
@@ -23,33 +23,6 @@ defmodule TrentoWeb.V1.ClusterView do
     |> Map.put(:id, data.cluster_id)
   end
 
-  def render("settings.json", %{settings: settings}) do
-    render_many(settings, __MODULE__, "setting.json", as: :setting)
-  end
-
-  def render("setting.json", %{
-        setting: %{
-          host_id: host_id,
-          hostname: hostname,
-          user: user,
-          provider_data: provider_data
-        }
-      }) do
-    %{
-      host_id: host_id,
-      hostname: hostname,
-      user: user,
-      default_user: determine_default_connection_user(provider_data)
-    }
-  end
-
-  defp determine_default_connection_user(%{
-         "admin_username" => admin_username
-       }),
-       do: admin_username
-
-  defp determine_default_connection_user(_), do: "root"
-
   defp adapt_v1(%{type: type} = cluster) when type in [:hana_scale_up, :hana_scale_out, :unknown],
     do: cluster
 

--- a/lib/trento_web/views/v1/cluster_view.ex
+++ b/lib/trento_web/views/v1/cluster_view.ex
@@ -9,6 +9,7 @@ defmodule TrentoWeb.V1.ClusterView do
     cluster
     |> Map.from_struct()
     |> Map.delete(:__meta__)
+    |> adapt_v1()
   end
 
   def render("cluster_registered.json", %{cluster: cluster}) do
@@ -48,4 +49,13 @@ defmodule TrentoWeb.V1.ClusterView do
        do: admin_username
 
   defp determine_default_connection_user(_), do: "root"
+
+  defp adapt_v1(%{type: type} = cluster) when type in [:hana_scale_up, :hana_scale_out, :unknown],
+    do: cluster
+
+  defp adapt_v1(cluster) do
+    cluster
+    |> Map.replace(:type, :unknown)
+    |> Map.replace(:details, nil)
+  end
 end

--- a/lib/trento_web/views/v2/cluster_view.ex
+++ b/lib/trento_web/views/v2/cluster_view.ex
@@ -10,4 +10,15 @@ defmodule TrentoWeb.V2.ClusterView do
     |> Map.from_struct()
     |> Map.delete(:__meta__)
   end
+
+  def render("cluster_registered.json", %{cluster: cluster}) do
+    Map.delete(render("cluster.json", %{cluster: cluster}), :tags)
+  end
+
+  def render("cluster_details_updated.json", %{data: data}) do
+    data
+    |> Map.from_struct()
+    |> Map.delete(:cluster_id)
+    |> Map.put(:id, data.cluster_id)
+  end
 end

--- a/lib/trento_web/views/v2/cluster_view.ex
+++ b/lib/trento_web/views/v2/cluster_view.ex
@@ -1,0 +1,13 @@
+defmodule TrentoWeb.V2.ClusterView do
+  use TrentoWeb, :view
+
+  def render("clusters.json", %{clusters: clusters}) do
+    render_many(clusters, __MODULE__, "cluster.json")
+  end
+
+  def render("cluster.json", %{cluster: cluster}) do
+    cluster
+    |> Map.from_struct()
+    |> Map.delete(:__meta__)
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -8,6 +8,9 @@ defmodule Trento.Factory do
   require Trento.Domain.Enums.Health, as: Health
 
   alias Trento.Domain.{
+    AscsErsClusterDetails,
+    AscsErsClusterNode,
+    AscsErsClusterSapSystem,
     ClusterResource,
     HanaClusterDetails,
     HanaClusterNode,
@@ -301,6 +304,54 @@ defmodule Trento.Factory do
       ],
       system_replication_mode: "sync",
       system_replication_operation_mode: "logreplay"
+    }
+  end
+
+  def ascs_ers_cluster_node_factory do
+    %AscsErsClusterNode{
+      name: Faker.Pokemon.name(),
+      roles: [Enum.random(["ascs", "ers"])],
+      virtual_ips: [Faker.Internet.ip_v4_address()],
+      filesystems: [Faker.File.file_name()],
+      attributes: %{
+        Faker.Pokemon.name() => Faker.Pokemon.name()
+      },
+      resources: build_list(5, :cluster_resource)
+    }
+  end
+
+  def ascs_ers_cluster_sap_system_factory do
+    %AscsErsClusterSapSystem{
+      sid: sequence(:sid, &"PR#{&1}"),
+      filesystem_resource_based: Enum.random([false, true]),
+      distributed: Enum.random([false, true]),
+      nodes: build_list(2, :ascs_ers_cluster_node)
+    }
+  end
+
+  def sbd_device_factory do
+    %SbdDevice{
+      device: Faker.File.file_name(),
+      status: Enum.random(["healthy", "unhealthy"])
+    }
+  end
+
+  def cluster_resource_factory do
+    %ClusterResource{
+      id: Faker.UUID.v4(),
+      type: Faker.StarWars.planet(),
+      role: Faker.Beer.hop(),
+      status: Faker.Pokemon.name(),
+      fail_count: Enum.random(0..100)
+    }
+  end
+
+  def ascs_ers_cluster_details_factory do
+    %AscsErsClusterDetails{
+      fencing_type: Faker.Beer.hop(),
+      sap_systems: build_list(2, :ascs_ers_cluster_sap_system),
+      sbd_devices: build_list(2, :sbd_device),
+      stopped_resources: build_list(2, :cluster_resource)
     }
   end
 

--- a/test/trento_web/controllers/v2/cluster_controller_test.exs
+++ b/test/trento_web/controllers/v2/cluster_controller_test.exs
@@ -1,0 +1,24 @@
+defmodule TrentoWeb.V2.ClusterControllerTest do
+  use TrentoWeb.ConnCase, async: true
+
+  import OpenApiSpex.TestAssertions
+  import Mox
+  import Trento.Factory
+
+  alias TrentoWeb.OpenApi.V2.ApiSpec
+
+  setup [:set_mox_from_context, :verify_on_exit!]
+
+  describe "list" do
+    test "should be compliant with ASCS/ERS clusters schema", %{conn: conn} do
+      insert(:cluster, details: build(:ascs_ers_cluster_details))
+
+      api_spec = ApiSpec.spec()
+
+      conn
+      |> get("/api/v2/clusters")
+      |> json_response(200)
+      |> assert_schema("PacemakerClustersCollection", api_spec)
+    end
+  end
+end

--- a/test/trento_web/views/v1/cluster_view_test.exs
+++ b/test/trento_web/views/v1/cluster_view_test.exs
@@ -1,0 +1,15 @@
+defmodule TrentoWeb.V1.ClusterViewTest do
+  use TrentoWeb.ConnCase, async: true
+
+  import Phoenix.View
+  import Trento.Factory
+
+  alias TrentoWeb.V1.ClusterView
+
+  test "should adapt the cluster view to V1 version" do
+    cluster = build(:cluster, type: :ascs_ers, details: build(:ascs_ers_cluster_details))
+
+    assert %{type: :unknown, details: nil} =
+             render(ClusterView, "cluster.json", %{cluster: cluster})
+  end
+end


### PR DESCRIPTION
# Description

Follow up for: https://github.com/trento-project/web/pull/1468

Include the `v2` scope for the `/api/clusters` endpoint.
The `v1` has been updated to be backward compatible.

## How was this tested?

Tested
