### PR TITLE
Identify sap systems ensa version

### DIFF
--- a/lib/trento/application/integration/discovery/policies/sap_system_policy.ex
+++ b/lib/trento/application/integration/discovery/policies/sap_system_policy.ex
@@ -3,6 +3,8 @@ defmodule Trento.Integration.Discovery.SapSystemPolicy do
   This module contains functions to transform SAP system related integration events into commands..
   """
 
+  require Trento.Domain.Enums.EnsaVersion, as: EnsaVersion
+
   alias Trento.Domain.Commands.{
     DeregisterApplicationInstance,
     DeregisterDatabaseInstance,
@@ -129,7 +131,8 @@ defmodule Trento.Integration.Discovery.SapSystemPolicy do
         https_port: parse_https_port(instance),
         start_priority: parse_start_priority(instance),
         host_id: host_id,
-        health: parse_dispstatus(instance)
+        health: parse_dispstatus(instance),
+        ensa_version: parse_ensa_version(instance)
       })
     end)
   end
@@ -224,4 +227,16 @@ defmodule Trento.Integration.Discovery.SapSystemPolicy do
          SystemReplication: %SystemReplication{overall_replication_status: status}
        }),
        do: status
+
+  defp parse_ensa_version(%Instance{SAPControl: %SapControl{Processes: processes}}) do
+    Enum.find_value(processes, nil, fn
+      %{name: "enserver"} -> EnsaVersion.ensa1()
+      %{name: "enrepserver"} -> EnsaVersion.ensa1()
+      %{name: "enq_server"} -> EnsaVersion.ensa2()
+      %{name: "enq_replicator"} -> EnsaVersion.ensa2()
+      _ -> nil
+    end)
+  end
+
+  defp parse_ensa_version(_), do: nil
 end

--- a/lib/trento/application/integration/discovery/policies/sap_system_policy.ex
+++ b/lib/trento/application/integration/discovery/policies/sap_system_policy.ex
@@ -229,7 +229,7 @@ defmodule Trento.Integration.Discovery.SapSystemPolicy do
        do: status
 
   defp parse_ensa_version(%Instance{SAPControl: %SapControl{Processes: processes}}) do
-    Enum.find_value(processes, nil, fn
+    Enum.find_value(processes, EnsaVersion.no_ensa(), fn
       %{name: "enserver"} -> EnsaVersion.ensa1()
       %{name: "enrepserver"} -> EnsaVersion.ensa1()
       %{name: "enq_server"} -> EnsaVersion.ensa2()
@@ -238,5 +238,5 @@ defmodule Trento.Integration.Discovery.SapSystemPolicy do
     end)
   end
 
-  defp parse_ensa_version(_), do: nil
+  defp parse_ensa_version(_), do: EnsaVersion.no_ensa()
 end

--- a/lib/trento/domain/enums/ensa_version.ex
+++ b/lib/trento/domain/enums/ensa_version.ex
@@ -1,0 +1,7 @@
+defmodule Trento.Domain.Enums.EnsaVersion do
+  @moduledoc """
+  Type that represents the supported ENSA versions.
+  """
+
+  use Trento.Support.Enum, values: [:ensa1, :ensa2, nil]
+end

--- a/lib/trento/domain/enums/ensa_version.ex
+++ b/lib/trento/domain/enums/ensa_version.ex
@@ -3,5 +3,5 @@ defmodule Trento.Domain.Enums.EnsaVersion do
   Type that represents the supported ENSA versions.
   """
 
-  use Trento.Support.Enum, values: [:ensa1, :ensa2, nil]
+  use Trento.Support.Enum, values: [:no_ensa, :ensa1, :ensa2]
 end

--- a/lib/trento/domain/sap_system/commands/register_application_instance.ex
+++ b/lib/trento/domain/sap_system/commands/register_application_instance.ex
@@ -29,6 +29,7 @@ defmodule Trento.Domain.Commands.RegisterApplicationInstance do
 
   use Trento.Command
 
+  require Trento.Domain.Enums.EnsaVersion, as: EnsaVersion
   require Trento.Domain.Enums.Health, as: Health
 
   defcommand do
@@ -44,5 +45,6 @@ defmodule Trento.Domain.Commands.RegisterApplicationInstance do
     field :https_port, :integer
     field :start_priority, :string
     field :health, Ecto.Enum, values: Health.values()
+    field :ensa_version, Ecto.Enum, values: EnsaVersion.values()
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -528,4 +528,13 @@ defmodule Trento.Factory do
       sap_system_id: Faker.UUID.v4()
     })
   end
+
+  def sapcontrol_process_factory do
+    %{
+      "name" => Faker.Pokemon.name(),
+      "description" => Faker.StarWars.planet(),
+      "dispstatus" => "SAPControl-GREEN",
+      "pid" => Enum.random(0..100)
+    }
+  end
 end

--- a/test/trento/application/integration/discovery/policies/sap_system_policy_test.exs
+++ b/test/trento/application/integration/discovery/policies/sap_system_policy_test.exs
@@ -4,6 +4,8 @@ defmodule Trento.Integration.Discovery.SapSystemPolicyTest do
 
   import Trento.Factory
 
+  require Trento.Domain.Enums.EnsaVersion, as: EnsaVersion
+
   import Trento.Integration.DiscoveryFixturesHelper
 
   alias Trento.Integration.Discovery.SapSystemPolicy
@@ -66,7 +68,8 @@ defmodule Trento.Integration.Discovery.SapSystemPolicyTest do
                 sap_system_id: nil,
                 sid: "HA1",
                 tenant: "PRD",
-                health: :passing
+                health: :passing,
+                ensa_version: nil
               }
             ]} =
              "sap_system_discovery_application"
@@ -91,6 +94,50 @@ defmodule Trento.Integration.Discovery.SapSystemPolicyTest do
              "sap_system_discovery_application_diagnostics"
              |> load_discovery_event_fixture()
              |> SapSystemPolicy.handle([])
+  end
+
+  test "should return the expected commands when a sap_system payload of type application with ensa version is handled" do
+    Enum.each(
+      [
+        ["enserver", EnsaVersion.ensa1()],
+        ["enrepserver", EnsaVersion.ensa1()],
+        ["enq_server", EnsaVersion.ensa2()],
+        ["enq_replicator", EnsaVersion.ensa2()]
+      ],
+      fn [process_name, expected_ensa_version] ->
+        assert {:ok,
+                [
+                  %RegisterApplicationInstance{
+                    ensa_version: ^expected_ensa_version
+                  }
+                ]} =
+                 "sap_system_discovery_application"
+                 |> load_discovery_event_fixture()
+                 |> update_in(
+                   ["payload"],
+                   &Enum.map(&1, fn sap_system ->
+                     update_in(
+                       sap_system,
+                       ["Instances"],
+                       fn instances ->
+                         Enum.map(instances, fn instance ->
+                           put_in(
+                             instance,
+                             ["SAPControl", "Processes"],
+                             [
+                               build(:sapcontrol_process),
+                               build(:sapcontrol_process, %{"name" => process_name}),
+                               build(:sapcontrol_process)
+                             ]
+                           )
+                         end)
+                       end
+                     )
+                   end)
+                 )
+                 |> SapSystemPolicy.handle([])
+      end
+    )
   end
 
   test "should return an empty list of commands if an empty payload is received" do

--- a/test/trento/application/integration/discovery/policies/sap_system_policy_test.exs
+++ b/test/trento/application/integration/discovery/policies/sap_system_policy_test.exs
@@ -69,7 +69,7 @@ defmodule Trento.Integration.Discovery.SapSystemPolicyTest do
                 sid: "HA1",
                 tenant: "PRD",
                 health: :passing,
-                ensa_version: nil
+                ensa_version: EnsaVersion.no_ensa()
               }
             ]} =
              "sap_system_discovery_application"


### PR DESCRIPTION
# Description

Identify the ENSA version of the SAP system application from the sap system discovery payloads.
The ENSA version belongs to the Application part of the SAP system (even though one sap system have one ENSA version).

Being ENSA1 or ENSA2 depends on the processes running on the application.

After this I need to move this field to the domain part and the persistence layer to send it to the frontend finally.

## How was this tested?
Tested using already existing fixture files with some "basic" modifications.
