### PR TITLE
DatabaseDeregistered side effects

### DIFF
--- a/lib/trento/application/read_models/database_read_model.ex
+++ b/lib/trento/application/read_models/database_read_model.ex
@@ -18,7 +18,6 @@ defmodule Trento.DatabaseReadModel do
   schema "databases" do
     field :sid, :string
     field :health, Ecto.Enum, values: Health.values()
-    field :deregistered_at, :utc_datetime_usec
 
     has_many :tags, Trento.Tag, foreign_key: :resource_id
 
@@ -26,6 +25,8 @@ defmodule Trento.DatabaseReadModel do
       references: :id,
       foreign_key: :sap_system_id,
       preload_order: [asc: :instance_number, asc: :host_id]
+
+    field :deregistered_at, :utc_datetime_usec
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()

--- a/lib/trento/application/read_models/database_read_model.ex
+++ b/lib/trento/application/read_models/database_read_model.ex
@@ -18,6 +18,7 @@ defmodule Trento.DatabaseReadModel do
   schema "databases" do
     field :sid, :string
     field :health, Ecto.Enum, values: Health.values()
+    field :deregistered_at, :utc_datetime_usec
 
     has_many :tags, Trento.Tag, foreign_key: :resource_id
 

--- a/lib/trento/application/usecases/sap_systems/sap_systems.ex
+++ b/lib/trento/application/usecases/sap_systems/sap_systems.ex
@@ -30,6 +30,7 @@ defmodule Trento.SapSystems do
   @spec get_all_databases :: [DatabaseReadModel.t()]
   def get_all_databases do
     DatabaseReadModel
+    |> where([d], is_nil(d.deregistered_at))
     |> order_by(asc: :sid)
     |> Repo.all()
     |> Repo.preload([

--- a/lib/trento_web/views/v1/sap_system_view.ex
+++ b/lib/trento_web/views/v1/sap_system_view.ex
@@ -125,6 +125,12 @@ defmodule TrentoWeb.V1.SapSystemView do
 
   def render("sap_system_deregistered.json", %{id: id, sid: sid}), do: %{id: id, sid: sid}
 
+  def render("database_deregistered.json", %{
+        id: id,
+        sid: sid
+      }),
+      do: %{id: id, sid: sid}
+
   defp add_system_replication_status_to_secondary_instance(
          %{database_instances: database_instances} = sap_system
        ) do

--- a/lib/trento_web/views/v1/sap_system_view.ex
+++ b/lib/trento_web/views/v1/sap_system_view.ex
@@ -125,11 +125,7 @@ defmodule TrentoWeb.V1.SapSystemView do
 
   def render("sap_system_deregistered.json", %{id: id, sid: sid}), do: %{id: id, sid: sid}
 
-  def render("database_deregistered.json", %{
-        id: id,
-        sid: sid
-      }),
-      do: %{id: id, sid: sid}
+  def render("database_deregistered.json", %{id: id, sid: sid}), do: %{id: id, sid: sid}
 
   defp add_system_replication_status_to_secondary_instance(
          %{database_instances: database_instances} = sap_system

--- a/priv/repo/migrations/20230608105745_add_deregistered_at_field_db_rm.exs
+++ b/priv/repo/migrations/20230608105745_add_deregistered_at_field_db_rm.exs
@@ -1,0 +1,9 @@
+defmodule Trento.Repo.Migrations.AddDeregisteredAtFieldDbRm do
+  use Ecto.Migration
+
+  def change do
+    alter table(:databases) do
+      add :deregistered_at, :utc_datetime_usec
+    end
+  end
+end

--- a/priv/repo/migrations/20230608105745_add_deregistered_at_to_database_read_model.exs
+++ b/priv/repo/migrations/20230608105745_add_deregistered_at_to_database_read_model.exs
@@ -1,4 +1,4 @@
-defmodule Trento.Repo.Migrations.AddDeregisteredAtFieldDbRm do
+defmodule Trento.Repo.Migrations.AddDeregisteredAtToDatabaseReadModel do
   use Ecto.Migration
 
   def change do

--- a/test/trento/application/projectors/database_projector_test.exs
+++ b/test/trento/application/projectors/database_projector_test.exs
@@ -16,7 +16,6 @@ defmodule Trento.DatabaseProjectorTest do
   alias Trento.Domain.Events.{
     DatabaseDeregistered,
     DatabaseHealthChanged,
-    # DatabaseInstanceDeregistered,
     DatabaseInstanceHealthChanged,
     DatabaseInstanceSystemReplicationChanged
   }

--- a/test/trento/application/projectors/database_projector_test.exs
+++ b/test/trento/application/projectors/database_projector_test.exs
@@ -14,7 +14,9 @@ defmodule Trento.DatabaseProjectorTest do
   }
 
   alias Trento.Domain.Events.{
+    DatabaseDeregistered,
     DatabaseHealthChanged,
+    # DatabaseInstanceDeregistered,
     DatabaseInstanceHealthChanged,
     DatabaseInstanceSystemReplicationChanged
   }
@@ -241,5 +243,26 @@ defmodule Trento.DatabaseProjectorTest do
                        health: :critical
                      },
                      1000
+  end
+
+  test "should update the database read model after a deregistration" do
+    deregistered_at = DateTime.utc_now()
+
+    insert(:database, id: sap_system_id = Faker.UUID.v4())
+
+    event = %DatabaseDeregistered{
+      sap_system_id: sap_system_id,
+      deregistered_at: deregistered_at
+    }
+
+    ProjectorTestHelper.project(DatabaseProjector, event, "database_projector")
+
+    projection = %{sid: sid} = Repo.get(DatabaseReadModel, sap_system_id)
+
+    assert_broadcast "database_deregistered",
+                     %{id: ^sap_system_id, sid: ^sid},
+                     1000
+
+    assert deregistered_at == projection.deregistered_at
   end
 end

--- a/test/trento/application/usecases/sap_systems_test.exs
+++ b/test/trento/application/usecases/sap_systems_test.exs
@@ -48,11 +48,13 @@ defmodule Trento.SapSystemsTest do
              ] = SapSystems.get_all_sap_systems()
     end
 
-    test "should retrieve all the existing databases and the related instances" do
+    test "should retrieve all the currently registered existing databases and the related instances" do
       %DatabaseReadModel{
         id: sap_system_id,
         sid: sid
       } = insert(:database)
+
+      insert(:database, deregistered_at: DateTime.utc_now())
 
       database_instances =
         Enum.sort_by(


### PR DESCRIPTION
# Description

This PR 
 - adds a deregistered_at field to the DatabaseReadModel
 - handles the side effects for the DatabaseDeregistered events
 - filters deregistered databases for the `get_all_databases` usecase


## How was this tested?

Tests where added on the projector and the usecases.
