### PR TITLE
Make `HostReadModel.last_heartbeat_timestamp` a virtual field

### DIFF
--- a/lib/trento/application/integration/discovery/protocol/enrich_request_host_deregistration.ex
+++ b/lib/trento/application/integration/discovery/protocol/enrich_request_host_deregistration.ex
@@ -18,9 +18,8 @@ defimpl Trento.Support.Middleware.Enrichable,
           {:ok, RequestHostDeregistration.t()}
           | {:error, :host_alive}
           | {:error, :host_not_registered}
-  def enrich(%RequestHostDeregistration{host_id: host_id} = command, _) do
-    host_deregisterable(Hosts.get_host_by_id(host_id), command)
-  end
+  def enrich(%RequestHostDeregistration{host_id: host_id} = command, _),
+    do: host_deregisterable(Hosts.get_host_by_id(host_id), command)
 
   defp host_deregisterable(
          %HostReadModel{last_heartbeat_timestamp: nil, deregistered_at: nil},

--- a/lib/trento/application/read_models/host_read_model.ex
+++ b/lib/trento/application/read_models/host_read_model.ex
@@ -32,9 +32,7 @@ defmodule Trento.HostReadModel do
       foreign_key: :host_id,
       preload_order: [desc: :identifier]
 
-    has_one :heartbeat_timestamp, Trento.Heartbeat,
-      references: :id,
-      foreign_key: :agent_id
+    field :last_heartbeat_timestamp, :utc_datetime_usec, virtual: true
 
     field :deregistered_at, :utc_datetime_usec
   end

--- a/lib/trento/application/usecases/hosts/heartbeat.ex
+++ b/lib/trento/application/usecases/hosts/heartbeat.ex
@@ -7,7 +7,6 @@ defmodule Trento.Heartbeat do
 
   @type t :: %__MODULE__{}
 
-  @derive {Jason.Encoder, except: [:__meta__, :__struct__]}
   @primary_key {:agent_id, :string, autogenerate: false}
   schema "heartbeats" do
     field :timestamp, :utc_datetime_usec

--- a/lib/trento/application/usecases/hosts/hosts.ex
+++ b/lib/trento/application/usecases/hosts/hosts.ex
@@ -26,7 +26,7 @@ defmodule Trento.Hosts do
     |> Repo.preload([:sles_subscriptions, :tags])
   end
 
-  @spec get_host_by_id(Ecto.UUID.t()) :: HostReadModel.t()
+  @spec get_host_by_id(Ecto.UUID.t()) :: HostReadModel.t() | nil
   def get_host_by_id(id) do
     HostReadModel
     |> where([h], h.id == ^id)

--- a/lib/trento/application/usecases/hosts/hosts.ex
+++ b/lib/trento/application/usecases/hosts/hosts.ex
@@ -29,7 +29,7 @@ defmodule Trento.Hosts do
   @spec get_host_by_id(Ecto.UUID.t()) :: HostReadModel.t() | nil
   def get_host_by_id(id) do
     HostReadModel
-    |> where([h], h.id == ^id)
+    |> where([h], h.id == ^id and is_nil(h.deregistered_at))
     |> enrich_host_read_model_query()
     |> Repo.one()
     |> Repo.preload([:sles_subscriptions, :tags])

--- a/lib/trento/application/usecases/hosts/hosts.ex
+++ b/lib/trento/application/usecases/hosts/hosts.ex
@@ -26,6 +26,15 @@ defmodule Trento.Hosts do
     |> Repo.preload([:sles_subscriptions, :tags])
   end
 
+  @spec get_host_by_id(Ecto.UUID.t()) :: HostReadModel.t()
+  def get_host_by_id(id) do
+    HostReadModel
+    |> where([h], h.id == ^id)
+    |> enrich_host_read_model_query()
+    |> Repo.one()
+    |> Repo.preload([:sles_subscriptions, :tags])
+  end
+
   @spec get_all_sles_subscriptions :: non_neg_integer()
   def get_all_sles_subscriptions do
     query =

--- a/lib/trento_web/openapi/v1/schema/host.ex
+++ b/lib/trento_web/openapi/v1/schema/host.ex
@@ -77,15 +77,12 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Host do
           nullable: true,
           format: :"date-time"
         },
-        heartbeat_timestamp: %Schema{
-          title: "HeartbeatTimestamp",
+        last_heartbeat_timestamp: %Schema{
+          title: "LastHeartbeatTimestamp",
           description: "Timestamp of the last heartbeat received from the host",
-          type: :object,
+          type: :string,
           nullable: true,
-          properties: %{
-            agent_id: %Schema{type: :string, description: "Host ID", format: :uuid},
-            timestamp: %Schema{type: :string, format: :"date-time"}
-          }
+          format: :"date-time"
         }
       }
     })

--- a/test/trento/application/usecases/hosts_test.exs
+++ b/test/trento/application/usecases/hosts_test.exs
@@ -51,4 +51,22 @@ defmodule Trento.HostsTest do
       refute deregistered_host.id in hosts_ids
     end
   end
+
+  describe "get_host_by_id/1" do
+    test "should return host" do
+      %Trento.HostReadModel{id: id} = insert(:host)
+      %Trento.Heartbeat{timestamp: timestamp} = insert(:heartbeat, agent_id: id)
+
+      host = Hosts.get_host_by_id(id)
+
+      assert host.id == id
+      assert host.last_heartbeat_timestamp == timestamp
+    end
+
+    test "should return nil if host does not exist" do
+      host = Hosts.get_host_by_id(UUID.uuid4())
+
+      assert host == nil
+    end
+  end
 end

--- a/test/trento/application/usecases/hosts_test.exs
+++ b/test/trento/application/usecases/hosts_test.exs
@@ -44,7 +44,6 @@ defmodule Trento.HostsTest do
       hosts_ids = Enum.map(hosts, & &1.id)
 
       assert Enum.map(registered_hosts, & &1.id) == hosts_ids
-      assert Enum.map(hosts, & &1.id) == Enum.map(last_heartbeats, & &1.agent_id)
 
       assert Enum.map(hosts, & &1.last_heartbeat_timestamp) ==
                Enum.map(last_heartbeats, & &1.timestamp)

--- a/test/trento/application/usecases/hosts_test.exs
+++ b/test/trento/application/usecases/hosts_test.exs
@@ -63,6 +63,14 @@ defmodule Trento.HostsTest do
       assert host.last_heartbeat_timestamp == timestamp
     end
 
+    test "should return nil if host is deregistered" do
+      %Trento.HostReadModel{id: id} = insert(:host, deregistered_at: DateTime.utc_now())
+
+      host = Hosts.get_host_by_id(id)
+
+      assert host == nil
+    end
+
     test "should return nil if host does not exist" do
       host = Hosts.get_host_by_id(UUID.uuid4())
 


### PR DESCRIPTION
# Description

Renames `HostReadModel.heartbeat_timestamp` to `HostReadModel.last_heartbeat_timestamp`.

Changes `HostReadModel.last_heartbeat_timestamp` to use a virtual field instead of an association with the `Heartbeat` table.

## How was this tested?

Updated test for `get_all_hosts/0`, the existing unit tests should validate that the rest of the behaviour remains the same.

Added tests for new function `get_host_by_id/1`

