### PR TITLE
Add resourceType when querying for checks in cluster checks selection

### DIFF
--- a/assets/js/components/ClusterDetails/ChecksSelection.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelection.jsx
@@ -56,10 +56,13 @@ function ChecksSelection({ clusterId, cluster }) {
   const [localSavingError, setLocalSavingError] = useState(null);
   const [localSavingSuccess, setLocalSavingSuccess] = useState(null);
   const [groupSelection, setGroupSelection] = useState([]);
-  const { provider } = cluster;
+  const catalogEnv = {
+    provider: cluster.provider,
+    resource_type: 'cluster',
+  };
 
   useEffect(() => {
-    dispatch(updateCatalog({ provider }));
+    dispatch(updateCatalog(catalogEnv));
   }, [dispatch]);
 
   useEffect(() => {
@@ -101,7 +104,7 @@ function ChecksSelection({ clusterId, cluster }) {
   return (
     <div className="bg-white rounded p-3">
       <CatalogContainer
-        onRefresh={() => dispatch(updateCatalog({ provider }))}
+        onRefresh={() => dispatch(updateCatalog(catalogEnv))}
         isCatalogEmpty={catalogData.size === 0}
         catalogError={catalogError}
         loading={loading}

--- a/assets/js/components/ClusterDetails/ChecksSelection.test.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelection.test.jsx
@@ -128,6 +128,7 @@ describe('ClusterDetails ChecksSelection component', () => {
         type: 'UPDATE_CATALOG',
         payload: {
           provider: cluster.provider,
+          resource_type: 'cluster',
         },
       },
       {


### PR DESCRIPTION
# Description

Adds a `resource_type=cluster` in the query made to wanda when loading the catalog in cluster checks selection.

## How was this tested?

Test updated.