### PR TITLE
Ensa version domain

### DIFF
--- a/lib/trento/application/projectors/sap_system_projector.ex
+++ b/lib/trento/application/projectors/sap_system_projector.ex
@@ -14,7 +14,8 @@ defmodule Trento.SapSystemProjector do
     ApplicationInstanceRegistered,
     SapSystemDeregistered,
     SapSystemHealthChanged,
-    SapSystemRegistered
+    SapSystemRegistered,
+    SapSystemUpdated
   }
 
   alias TrentoWeb.V1.SapSystemView
@@ -32,7 +33,8 @@ defmodule Trento.SapSystemProjector do
       sid: sid,
       tenant: tenant,
       db_host: db_host,
-      health: health
+      health: health,
+      ensa_version: ensa_version
     },
     fn multi ->
       changeset =
@@ -41,7 +43,8 @@ defmodule Trento.SapSystemProjector do
           sid: sid,
           tenant: tenant,
           db_host: db_host,
-          health: health
+          health: health,
+          ensa_version: ensa_version
         })
 
       Ecto.Multi.insert(multi, :sap_system, changeset)
@@ -146,6 +149,21 @@ defmodule Trento.SapSystemProjector do
         )
 
       Ecto.Multi.delete(multi, :application_instance, deregistered_instance)
+    end
+  )
+
+  project(
+    %SapSystemUpdated{
+      sap_system_id: sap_system_id,
+      ensa_version: ensa_version
+    },
+    fn multi ->
+      changeset =
+        SapSystemReadModel.changeset(%SapSystemReadModel{id: sap_system_id}, %{
+          ensa_version: ensa_version
+        })
+
+      Ecto.Multi.update(multi, :sap_system, changeset)
     end
   )
 

--- a/lib/trento/application/read_models/sap_system_read_model.ex
+++ b/lib/trento/application/read_models/sap_system_read_model.ex
@@ -7,6 +7,7 @@ defmodule Trento.SapSystemReadModel do
 
   import Ecto.Changeset
 
+  require Trento.Domain.Enums.EnsaVersion, as: EnsaVersion
   require Trento.Domain.Enums.Health, as: Health
 
   alias Trento.{
@@ -23,6 +24,7 @@ defmodule Trento.SapSystemReadModel do
     field :tenant, :string
     field :db_host, :string
     field :health, Ecto.Enum, values: Health.values()
+    field :ensa_version, Ecto.Enum, values: EnsaVersion.values(), default: EnsaVersion.no_ensa()
 
     has_many :database_instances, DatabaseInstanceReadModel,
       references: :id,

--- a/lib/trento/domain/sap_system/application.ex
+++ b/lib/trento/domain/sap_system/application.ex
@@ -3,6 +3,8 @@ defmodule Trento.Domain.SapSystem.Application do
   This module represents a SAP System application.
   """
 
+  require Trento.Domain.Enums.EnsaVersion, as: EnsaVersion
+
   alias Trento.Domain.SapSystem.Instance
 
   @required_fields []
@@ -11,6 +13,7 @@ defmodule Trento.Domain.SapSystem.Application do
 
   deftype do
     field :sid, :string
+    field :ensa_version, Ecto.Enum, values: EnsaVersion.values(), default: EnsaVersion.no_ensa()
     embeds_many :instances, Instance
   end
 end

--- a/lib/trento/domain/sap_system/events/sap_system_registered.ex
+++ b/lib/trento/domain/sap_system/events/sap_system_registered.ex
@@ -5,6 +5,7 @@ defmodule Trento.Domain.Events.SapSystemRegistered do
 
   use Trento.Event
 
+  require Trento.Domain.Enums.EnsaVersion, as: EnsaVersion
   require Trento.Domain.Enums.Health, as: Health
 
   defevent do
@@ -13,5 +14,6 @@ defmodule Trento.Domain.Events.SapSystemRegistered do
     field :tenant, :string
     field :db_host, :string
     field :health, Ecto.Enum, values: Health.values()
+    field :ensa_version, Ecto.Enum, values: EnsaVersion.values(), default: EnsaVersion.no_ensa()
   end
 end

--- a/lib/trento/domain/sap_system/events/sap_system_updated.ex
+++ b/lib/trento/domain/sap_system/events/sap_system_updated.ex
@@ -1,0 +1,14 @@
+defmodule Trento.Domain.Events.SapSystemUpdated do
+  @moduledoc """
+  This event is emitted when some of the fields in the SAP system are updated
+  """
+
+  require Trento.Domain.Enums.EnsaVersion, as: EnsaVersion
+
+  use Trento.Event
+
+  defevent do
+    field :sap_system_id, Ecto.UUID
+    field :ensa_version, Ecto.Enum, values: EnsaVersion.values()
+  end
+end

--- a/lib/trento_web/openapi/v1/schema/sap_system.ex
+++ b/lib/trento_web/openapi/v1/schema/sap_system.ex
@@ -4,6 +4,8 @@ defmodule TrentoWeb.OpenApi.V1.Schema.SAPSystem do
   require OpenApiSpex
   alias OpenApiSpex.Schema
 
+  require Trento.Domain.Enums.EnsaVersion, as: EnsaVersion
+
   alias TrentoWeb.OpenApi.V1.Schema.{Database, ResourceHealth, Tags}
 
   defmodule ApplicationInstance do
@@ -53,6 +55,11 @@ defmodule TrentoWeb.OpenApi.V1.Schema.SAPSystem do
         tenant: %Schema{type: :string, description: "Tenant"},
         db_host: %Schema{type: :string, description: "Address of the connected Database"},
         health: ResourceHealth,
+        ensa_version: %Schema{
+          type: :string,
+          enum: EnsaVersion.values(),
+          description: "ENSA version of the SAP system"
+        },
         application_instances: %Schema{
           title: "ApplicationInstances",
           description: "A list of the discovered Application Instances for current SAP Systems",

--- a/priv/repo/migrations/20230606152133_add_ensa_version_to_sap_system_read_model.exs
+++ b/priv/repo/migrations/20230606152133_add_ensa_version_to_sap_system_read_model.exs
@@ -1,0 +1,9 @@
+defmodule Trento.Repo.Migrations.AddEnsaVersionToSapSystemReadModel do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sap_systems) do
+      add :ensa_version, :string, default: "no_ensa"
+    end
+  end
+end

--- a/priv/repo/migrations/20230613101433_add_ensa_version_to_sap_system_read_model.exs
+++ b/priv/repo/migrations/20230613101433_add_ensa_version_to_sap_system_read_model.exs
@@ -3,7 +3,7 @@ defmodule Trento.Repo.Migrations.AddEnsaVersionToSapSystemReadModel do
 
   def change do
     alter table(:sap_systems) do
-      add :ensa_version, :string, default: "no_ensa"
+      add :ensa_version, :string
     end
   end
 end

--- a/priv/repo/migrations/20230613102033_set_ensa_version_initial_value_to_sap_system_read_model.exs
+++ b/priv/repo/migrations/20230613102033_set_ensa_version_initial_value_to_sap_system_read_model.exs
@@ -1,0 +1,7 @@
+defmodule Trento.Repo.Migrations.SetEnsaVersionInitialValueToSapSystemReadModel do
+  use Ecto.Migration
+
+  def change do
+    execute "UPDATE sap_systems SET ensa_version = 'no_ensa'"
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -5,6 +5,7 @@ defmodule Trento.Factory do
 
   require Trento.Domain.Enums.Provider, as: Provider
   require Trento.Domain.Enums.ClusterType, as: ClusterType
+  require Trento.Domain.Enums.EnsaVersion, as: EnsaVersion
   require Trento.Domain.Enums.Health, as: Health
 
   alias Trento.Domain.{
@@ -262,7 +263,8 @@ defmodule Trento.Factory do
       sid: Faker.UUID.v4(),
       db_host: Faker.Internet.ip_v4_address(),
       tenant: Faker.Beer.hop(),
-      health: Health.passing()
+      health: Health.passing(),
+      ensa_version: EnsaVersion.ensa1()
     }
   end
 
@@ -370,6 +372,7 @@ defmodule Trento.Factory do
       tenant: Faker.Beer.hop(),
       db_host: Faker.Internet.ip_v4_address(),
       health: Health.unknown(),
+      ensa_version: EnsaVersion.ensa1(),
       deregistered_at: nil
     }
   end
@@ -457,7 +460,8 @@ defmodule Trento.Factory do
       https_port: 8443,
       start_priority: "0.3",
       host_id: Faker.UUID.v4(),
-      health: Health.passing()
+      health: Health.passing(),
+      ensa_version: EnsaVersion.ensa1()
     })
   end
 

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -3,6 +3,8 @@ defmodule Trento.SapSystemTest do
 
   import Trento.Factory
 
+  require Trento.Domain.Enums.EnsaVersion, as: EnsaVersion
+
   alias Trento.Domain.Commands.{
     DeregisterApplicationInstance,
     DeregisterDatabaseInstance,
@@ -27,7 +29,8 @@ defmodule Trento.SapSystemTest do
     SapSystemRegistered,
     SapSystemRolledUp,
     SapSystemRollUpRequested,
-    SapSystemTombstoned
+    SapSystemTombstoned,
+    SapSystemUpdated
   }
 
   alias Trento.Domain.SapSystem
@@ -346,6 +349,7 @@ defmodule Trento.SapSystemTest do
       https_port = 443
       start_priority = "0.9"
       host_id = Faker.UUID.v4()
+      ensa_version = EnsaVersion.ensa1()
 
       initial_events = [
         build(
@@ -380,7 +384,8 @@ defmodule Trento.SapSystemTest do
           https_port: https_port,
           start_priority: start_priority,
           host_id: host_id,
-          health: :passing
+          health: :passing,
+          ensa_version: ensa_version
         }),
         [
           %ApplicationInstanceRegistered{
@@ -400,7 +405,8 @@ defmodule Trento.SapSystemTest do
             sid: sid,
             db_host: db_host,
             tenant: tenant,
-            health: :passing
+            health: :passing,
+            ensa_version: ensa_version
           }
         ],
         fn state ->
@@ -408,6 +414,7 @@ defmodule Trento.SapSystemTest do
                    sid: ^sid,
                    application: %SapSystem.Application{
                      sid: ^sid,
+                     ensa_version: ^ensa_version,
                      instances: [
                        %SapSystem.Instance{
                          sid: ^sid,
@@ -426,6 +433,127 @@ defmodule Trento.SapSystemTest do
       )
     end
 
+    test "should update a SAP System ENSA version if it was not set" do
+      sap_system_id = Faker.UUID.v4()
+      sid = fake_sid()
+      ensa_version = EnsaVersion.ensa1()
+
+      initial_events = [
+        build(
+          :database_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid
+        ),
+        build(
+          :database_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid
+        ),
+        %{instance_number: instance_number, host_id: host_id} =
+          build(:application_instance_registered_event,
+            sap_system_id: sap_system_id,
+            sid: sid,
+            features: "MESSAGESERVER"
+          ),
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          features: "ABAP"
+        ),
+        build(
+          :sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          ensa_version: EnsaVersion.no_ensa()
+        )
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        build(:register_application_instance_command,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          instance_number: instance_number,
+          host_id: host_id,
+          features: "MESSAGESERVER",
+          ensa_version: ensa_version
+        ),
+        [
+          %SapSystemUpdated{
+            sap_system_id: sap_system_id,
+            ensa_version: ensa_version
+          }
+        ],
+        fn state ->
+          assert %SapSystem{
+                   sid: ^sid,
+                   application: %SapSystem.Application{
+                     sid: ^sid,
+                     ensa_version: ^ensa_version
+                   }
+                 } = state
+        end
+      )
+    end
+
+    test "should not update a SAP System ENSA version if the coming application instance does not have ENSA data" do
+      sap_system_id = Faker.UUID.v4()
+      sid = fake_sid()
+      ensa_version = EnsaVersion.ensa1()
+
+      initial_events = [
+        build(
+          :database_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid
+        ),
+        build(
+          :database_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid
+        ),
+        %{instance_number: instance_number, host_id: host_id} =
+          build(:application_instance_registered_event,
+            sap_system_id: sap_system_id,
+            sid: sid,
+            features: "MESSAGESERVER"
+          ),
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          features: "ABAP"
+        ),
+        build(
+          :sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          ensa_version: ensa_version
+        )
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        build(:register_application_instance_command,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          instance_number: instance_number,
+          host_id: host_id,
+          features: "MESSAGESERVER",
+          ensa_version: EnsaVersion.no_ensa()
+        ),
+        [],
+        fn state ->
+          assert %SapSystem{
+                   sid: ^sid,
+                   application: %SapSystem.Application{
+                     sid: ^sid,
+                     ensa_version: ^ensa_version
+                   }
+                 } = state
+        end
+      )
+    end
+
     test "should register a SAP System and add an application instance when an ABAP instance is already present and a new MESSAGESERVER instance is added" do
       sap_system_id = Faker.UUID.v4()
       sid = Faker.StarWars.planet()
@@ -436,6 +564,7 @@ defmodule Trento.SapSystemTest do
       https_port = 443
       start_priority = "0.9"
       host_id = Faker.UUID.v4()
+      ensa_version = EnsaVersion.ensa1()
 
       initial_events = [
         build(
@@ -470,7 +599,8 @@ defmodule Trento.SapSystemTest do
           https_port: https_port,
           start_priority: start_priority,
           host_id: host_id,
-          health: :passing
+          health: :passing,
+          ensa_version: ensa_version
         }),
         [
           %ApplicationInstanceRegistered{
@@ -490,7 +620,8 @@ defmodule Trento.SapSystemTest do
             sid: sid,
             db_host: db_host,
             tenant: tenant,
-            health: :passing
+            health: :passing,
+            ensa_version: ensa_version
           }
         ],
         fn state ->
@@ -526,6 +657,7 @@ defmodule Trento.SapSystemTest do
       https_port = 443
       start_priority = "0.9"
       host_id = Faker.UUID.v4()
+      ensa_version = EnsaVersion.ensa1()
 
       initial_events = [
         build(
@@ -555,7 +687,8 @@ defmodule Trento.SapSystemTest do
           https_port: https_port,
           start_priority: start_priority,
           host_id: host_id,
-          health: :passing
+          health: :passing,
+          ensa_version: ensa_version
         }),
         [
           %ApplicationInstanceRegistered{
@@ -601,6 +734,7 @@ defmodule Trento.SapSystemTest do
       https_port = 443
       start_priority = "0.9"
       host_id = Faker.UUID.v4()
+      ensa_version = EnsaVersion.ensa1()
 
       initial_events = [
         build(
@@ -630,7 +764,8 @@ defmodule Trento.SapSystemTest do
           https_port: https_port,
           start_priority: start_priority,
           host_id: host_id,
-          health: :passing
+          health: :passing,
+          ensa_version: ensa_version
         }),
         [
           %ApplicationInstanceRegistered{
@@ -673,8 +808,8 @@ defmodule Trento.SapSystemTest do
       initial_events = [
         build(:database_registered_event, sap_system_id: sap_system_id, sid: sid),
         build(:database_instance_registered_event, sap_system_id: sap_system_id, sid: sid),
-        build(:sap_system_registered_event, sap_system_id: sap_system_id, sid: sid),
-        build(:application_instance_registered_event, sap_system_id: sap_system_id, sid: sid)
+        build(:application_instance_registered_event, sap_system_id: sap_system_id, sid: sid),
+        build(:sap_system_registered_event, sap_system_id: sap_system_id, sid: sid)
       ]
 
       new_instance_db_host = Faker.Internet.ip_v4_address()
@@ -734,8 +869,8 @@ defmodule Trento.SapSystemTest do
       initial_events = [
         build(:database_registered_event, sap_system_id: sap_system_id),
         build(:database_instance_registered_event, sap_system_id: sap_system_id),
-        build(:sap_system_registered_event, sap_system_id: sap_system_id),
-        application_instance_registered_event
+        application_instance_registered_event,
+        build(:sap_system_registered_event, sap_system_id: sap_system_id)
       ]
 
       assert_events(
@@ -956,6 +1091,7 @@ defmodule Trento.SapSystemTest do
       instance_number = "00"
       features = "MESSAGESERVER"
       host_id = Faker.UUID.v4()
+      ensa_version = EnsaVersion.ensa1()
 
       initial_events = [
         build(
@@ -1004,13 +1140,15 @@ defmodule Trento.SapSystemTest do
             sid: sid,
             db_host: db_host,
             tenant: tenant,
-            health: :critical
+            health: :critical,
+            ensa_version: ensa_version
           }
         ],
         fn state ->
           assert %SapSystem{
                    health: :critical,
                    application: %SapSystem.Application{
+                     ensa_version: ^ensa_version,
                      instances: [
                        %SapSystem.Instance{
                          health: :critical
@@ -1105,8 +1243,8 @@ defmodule Trento.SapSystemTest do
           sap_system_id: sap_system_id,
           health: :warning
         ),
-        sap_system_registered_event,
-        application_instance_registered_event
+        application_instance_registered_event,
+        sap_system_registered_event
       ]
 
       assert_events_and_state(
@@ -1175,8 +1313,8 @@ defmodule Trento.SapSystemTest do
         build(:database_registered_event, sap_system_id: sap_system_id),
         database_instance_registered_event =
           build(:database_instance_registered_event, sap_system_id: sap_system_id),
-        build(:sap_system_registered_event, sap_system_id: sap_system_id),
-        build(:application_instance_registered_event, sap_system_id: sap_system_id)
+        build(:application_instance_registered_event, sap_system_id: sap_system_id),
+        build(:sap_system_registered_event, sap_system_id: sap_system_id)
       ]
 
       assert_events_and_state(
@@ -1216,6 +1354,9 @@ defmodule Trento.SapSystemTest do
         end
       )
     end
+
+    test "should update the SAP system if some of the fields have been changed" do
+    end
   end
 
   describe "rollup" do
@@ -1233,10 +1374,15 @@ defmodule Trento.SapSystemTest do
       database_instance_registered_event =
         build(:database_instance_registered_event, sap_system_id: sap_system_id, sid: sid)
 
+      application_instance_registered_event =
+        build(:application_instance_registered_event, sap_system_id: sap_system_id, sid: sid)
+
       initial_events = [
         build(:database_registered_event, sap_system_id: sap_system_id, sid: sid),
         database_instance_registered_event,
-        build(:sap_system_registered_event, sap_system_id: sap_system_id, sid: sid)
+        application_instance_registered_event,
+        %{ensa_version: ensa_version} =
+          build(:sap_system_registered_event, sap_system_id: sap_system_id, sid: sid)
       ]
 
       assert_events_and_state(
@@ -1248,6 +1394,21 @@ defmodule Trento.SapSystemTest do
             sap_system_id: sap_system_id,
             sid: sid,
             health: :passing,
+            application: %SapSystem.Application{
+              sid: sid,
+              ensa_version: ensa_version,
+              instances: [
+                %SapSystem.Instance{
+                  sid: sid,
+                  instance_number: application_instance_registered_event.instance_number,
+                  health: application_instance_registered_event.health,
+                  features: application_instance_registered_event.features,
+                  host_id: application_instance_registered_event.host_id,
+                  system_replication: nil,
+                  system_replication_status: nil
+                }
+              ]
+            },
             database: %SapSystem.Database{
               sid: sid,
               health: :passing,
@@ -1280,6 +1441,7 @@ defmodule Trento.SapSystemTest do
       initial_events = [
         build(:database_registered_event, sap_system_id: sap_system_id, sid: sid),
         build(:database_instance_registered_event, sap_system_id: sap_system_id, sid: sid),
+        build(:application_instance_registered_event, sap_system_id: sap_system_id, sid: sid),
         build(:sap_system_registered_event, sap_system_id: sap_system_id, sid: sid),
         %SapSystemRollUpRequested{
           sap_system_id: sap_system_id,
@@ -1318,19 +1480,22 @@ defmodule Trento.SapSystemTest do
       sap_system_registered_event =
         build(:sap_system_registered_event, sap_system_id: sap_system_id)
 
-      assert_state(
-        [
-          sap_system_registered_event,
-          %SapSystemRolledUp{
-            sap_system_id: sap_system_id,
-            snapshot: %SapSystem{
-              sap_system_id: sap_system_registered_event.sap_system_id,
-              sid: sap_system_registered_event.sid,
-              health: sap_system_registered_event.health,
-              rolling_up: false
-            }
+      initial_events = [
+        build(:application_instance_registered_event, sap_system_id: sap_system_id),
+        sap_system_registered_event,
+        %SapSystemRolledUp{
+          sap_system_id: sap_system_id,
+          snapshot: %SapSystem{
+            sap_system_id: sap_system_registered_event.sap_system_id,
+            sid: sap_system_registered_event.sid,
+            health: sap_system_registered_event.health,
+            rolling_up: false
           }
-        ],
+        }
+      ]
+
+      assert_state(
+        initial_events,
         [],
         fn sap_system ->
           refute sap_system.rolling_up


### PR DESCRIPTION
# Description
Add `ensa_version` detection and logic to the SAP system domain.

Some context:
I'm forced to add this new `SapSystemUpdated` event as we need to update already existing sap systems. If it was in a clean state, we wouldn't need it, as the ensa_version doesn't really change in a life-cycle of a SAP system.
The current update is **eventual consistent**. This means that if the SAP system is registered with non Message server or Enqueue replicator instances (primary application, for example), the `ensa_version` wouldn't update, so it would update once we receive a message from those application instances.

PD1: I have done a lot of changes in the tests, as they were running the order of events incorrectly. Since we changed the SAP systems registration part, the instances are registered before the SAP system itself. Without changing this order, all the tests were failing as the `Application` field was not being initialized.

PD2:  Frontend work is missing

## How was this tested?

Tests added
