### PR TITLE
Reject commands when aggregate deregistered

### DIFF
--- a/lib/trento/domain/cluster/cluster.ex
+++ b/lib/trento/domain/cluster/cluster.ex
@@ -233,7 +233,10 @@ defmodule Trento.Domain.Cluster do
   end
 
   def execute(%Cluster{cluster_id: nil}, _),
-    do: {:error, :cluster_not_found}
+    do: {:error, :cluster_not_registered}
+
+  def execute(%Cluster{deregistered_at: deregistered_at}, _) when not is_nil(deregistered_at),
+    do: {:error, :cluster_not_registered}
 
   # Checks selected
   def execute(

--- a/lib/trento/domain/cluster/cluster.ex
+++ b/lib/trento/domain/cluster/cluster.ex
@@ -201,6 +201,12 @@ defmodule Trento.Domain.Cluster do
     ]
   end
 
+  def execute(%Cluster{cluster_id: nil}, _),
+    do: {:error, :cluster_not_registered}
+
+  def execute(%Cluster{deregistered_at: deregistered_at}, _) when not is_nil(deregistered_at),
+    do: {:error, :cluster_not_registered}
+
   # If the cluster is already registered, and the host was never discovered before, it is added to the cluster.
   def execute(
         %Cluster{} = cluster,
@@ -231,12 +237,6 @@ defmodule Trento.Domain.Cluster do
     end)
     |> Multi.execute(fn cluster -> maybe_emit_cluster_health_changed_event(cluster) end)
   end
-
-  def execute(%Cluster{cluster_id: nil}, _),
-    do: {:error, :cluster_not_registered}
-
-  def execute(%Cluster{deregistered_at: deregistered_at}, _) when not is_nil(deregistered_at),
-    do: {:error, :cluster_not_registered}
 
   # Checks selected
   def execute(

--- a/lib/trento/domain/host/host.ex
+++ b/lib/trento/domain/host/host.ex
@@ -148,6 +148,22 @@ defmodule Trento.Domain.Host do
     []
   end
 
+  # Reject all the commands, except for the registration ones when the host_id does not exists
+  def execute(
+        %Host{host_id: nil},
+        _
+      ) do
+    {:error, :host_not_registered}
+  end
+
+  def execute(
+        %Host{deregistered_at: deregistered_at},
+        _
+      )
+      when not is_nil(deregistered_at) do
+    {:error, :host_not_registered}
+  end
+
   def execute(
         %Host{},
         %RegisterHost{
@@ -173,22 +189,6 @@ defmodule Trento.Domain.Host do
       os_version: os_version,
       installation_source: installation_source
     }
-  end
-
-  # Reject all the commands, except for the registration ones when the host_id does not exists
-  def execute(
-        %Host{host_id: nil},
-        _
-      ) do
-    {:error, :host_not_registered}
-  end
-
-  def execute(
-        %Host{deregistered_at: deregistered_at},
-        _
-      )
-      when not is_nil(deregistered_at) do
-    {:error, :host_not_registered}
   end
 
   def execute(

--- a/lib/trento/domain/host/host.ex
+++ b/lib/trento/domain/host/host.ex
@@ -184,6 +184,14 @@ defmodule Trento.Domain.Host do
   end
 
   def execute(
+        %Host{deregistered_at: deregistered_at},
+        _
+      )
+      when not is_nil(deregistered_at) do
+    {:error, :host_not_registered}
+  end
+
+  def execute(
         %Host{host_id: host_id, heartbeat: heartbeat},
         %UpdateHeartbeat{heartbeat: :passing}
       )

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -207,22 +207,11 @@ defmodule Trento.Domain.SapSystem do
     |> Multi.execute(&maybe_emit_sap_system_health_changed_event/1)
   end
 
-  # Start the rollup flow
   def execute(
         %SapSystem{sap_system_id: nil},
         _
       ) do
     {:error, :sap_system_not_registered}
-  end
-
-  def execute(
-        %SapSystem{sap_system_id: sap_system_id} = snapshot,
-        %RollUpSapSystem{}
-      ) do
-    %SapSystemRollUpRequested{
-      sap_system_id: sap_system_id,
-      snapshot: snapshot
-    }
   end
 
   # Deregister a database instance and emit a DatabaseInstanceDeregistered
@@ -285,6 +274,24 @@ defmodule Trento.Domain.SapSystem do
       )
     end)
     |> Multi.execute(&maybe_emit_sap_system_tombstoned_event/1)
+  end
+
+  def execute(
+        %SapSystem{deregistered_at: deregistered_at},
+        _
+      )
+      when not is_nil(deregistered_at) do
+    {:error, :sap_system_not_registered}
+  end
+
+  def execute(
+        %SapSystem{sap_system_id: sap_system_id} = snapshot,
+        %RollUpSapSystem{}
+      ) do
+    %SapSystemRollUpRequested{
+      sap_system_id: sap_system_id,
+      snapshot: snapshot
+    }
   end
 
   def apply(

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -24,6 +24,8 @@ defmodule Trento.Factory do
     ClusterDeregistered,
     ClusterRegistered,
     ClusterTombstoned,
+    DatabaseDeregistered,
+    DatabaseInstanceDeregistered,
     DatabaseInstanceRegistered,
     DatabaseRegistered,
     HostAddedToCluster,
@@ -31,16 +33,20 @@ defmodule Trento.Factory do
     HostRegistered,
     HostRemovedFromCluster,
     HostTombstoned,
+    SapSystemDeregistered,
     SapSystemRegistered,
     SapSystemTombstoned,
     SlesSubscriptionsUpdated
   }
 
   alias Trento.Domain.Commands.{
+    DeregisterApplicationInstance,
+    DeregisterDatabaseInstance,
     RegisterApplicationInstance,
     RegisterClusterHost,
     RegisterDatabaseInstance,
-    RegisterHost
+    RegisterHost,
+    RollUpSapSystem
   }
 
   alias Trento.{
@@ -251,6 +257,31 @@ defmodule Trento.Factory do
     }
   end
 
+  def database_instance_deregistered_event_factory do
+    DatabaseInstanceDeregistered.new!(%{
+      instance_number: "00",
+      host_id: Faker.UUID.v4(),
+      sap_system_id: Faker.UUID.v4(),
+      deregistered_at: DateTime.utc_now()
+    })
+  end
+
+  def deregister_database_instance_command_factory do
+    DeregisterDatabaseInstance.new!(%{
+      sap_system_id: Faker.UUID.v4(),
+      deregistered_at: DateTime.utc_now(),
+      host_id: Faker.UUID.v4(),
+      instance_number: "00"
+    })
+  end
+
+  def database_deregistered_event_factory do
+    DatabaseDeregistered.new!(%{
+      sap_system_id: Faker.UUID.v4(),
+      deregistered_at: DateTime.utc_now()
+    })
+  end
+
   def application_instance_registered_event_factory do
     %ApplicationInstanceRegistered{
       sap_system_id: Faker.UUID.v4(),
@@ -264,6 +295,15 @@ defmodule Trento.Factory do
       host_id: Faker.UUID.v4(),
       health: Health.passing()
     }
+  end
+
+  def deregister_application_instance_command_factory do
+    DeregisterApplicationInstance.new!(%{
+      sap_system_id: Faker.UUID.v4(),
+      deregistered_at: DateTime.utc_now(),
+      instance_number: "00",
+      host_id: Faker.UUID.v4()
+    })
   end
 
   def database_registered_event_factory do
@@ -282,6 +322,19 @@ defmodule Trento.Factory do
       tenant: Faker.Beer.hop(),
       health: Health.passing()
     }
+  end
+
+  def sap_system_deregistered_event_factory do
+    SapSystemDeregistered.new!(%{
+      sap_system_id: Faker.UUID.v4(),
+      deregistered_at: DateTime.utc_now()
+    })
+  end
+
+  def rollup_sap_system_command_factory do
+    RollUpSapSystem.new!(%{
+      sap_system_id: Faker.UUID.v4()
+    })
   end
 
   def hana_cluster_details_value_object do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -37,7 +37,8 @@ defmodule Trento.Factory do
   alias Trento.Domain.Commands.{
     RegisterApplicationInstance,
     RegisterClusterHost,
-    RegisterDatabaseInstance
+    RegisterDatabaseInstance,
+    RegisterHost
   }
 
   alias Trento.{
@@ -536,5 +537,19 @@ defmodule Trento.Factory do
       "dispstatus" => "SAPControl-GREEN",
       "pid" => Enum.random(0..100)
     }
+  end
+
+  def register_host_command_factory do
+    RegisterHost.new!(%{
+      host_id: Faker.UUID.v4(),
+      hostname: Faker.StarWars.character(),
+      ip_addresses: [Faker.Internet.ip_v4_address()],
+      agent_version: Faker.App.semver(),
+      cpu_count: Enum.random(1..16),
+      total_memory_mb: Enum.random(1..128),
+      socket_count: Enum.random(1..16),
+      os_version: Faker.App.semver(),
+      installation_source: Enum.random([:community, :suse, :unknown])
+    })
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -21,6 +21,7 @@ defmodule Trento.Factory do
 
   alias Trento.Domain.Events.{
     ApplicationInstanceRegistered,
+    ClusterDeregistered,
     ClusterRegistered,
     ClusterTombstoned,
     DatabaseInstanceRegistered,
@@ -28,6 +29,7 @@ defmodule Trento.Factory do
     HostAddedToCluster,
     HostDetailsUpdated,
     HostRegistered,
+    HostRemovedFromCluster,
     HostTombstoned,
     SapSystemRegistered,
     SapSystemTombstoned,
@@ -127,6 +129,21 @@ defmodule Trento.Factory do
       discovered_health: Health.passing(),
       designated_controller: true
     }
+  end
+
+  def host_removed_from_cluster_event_factory do
+    HostRemovedFromCluster.new!(%{
+      host_id: Faker.UUID.v4(),
+      cluster_id: Faker.UUID.v4(),
+      deregistered_at: DateTime.utc_now()
+    })
+  end
+
+  def cluster_deregistered_event_factory do
+    ClusterDeregistered.new!(%{
+      cluster_id: Faker.UUID.v4(),
+      deregistered_at: DateTime.utc_now()
+    })
   end
 
   def cluster_registered_event_factory do

--- a/test/trento/domain/cluster/cluster_test.exs
+++ b/test/trento/domain/cluster/cluster_test.exs
@@ -777,7 +777,7 @@ defmodule Trento.ClusterTest do
   end
 
   describe "deregistration" do
-    test "should reject all the commands except for registration ones when the host is deregistered" do
+    test "should reject all the commands when the host is deregistered" do
       host_one_id = UUID.uuid4()
       host_two_id = UUID.uuid4()
 
@@ -800,17 +800,14 @@ defmodule Trento.ClusterTest do
         %CompleteChecksExecution{},
         %DeregisterClusterHost{},
         %RollUpCluster{},
-        %SelectChecks{}
+        %SelectChecks{},
+        %RegisterClusterHost{}
       ]
 
       for command <- commands_to_reject do
-        assert_error(initial_events, command, {:error, :cluster_not_registered})
+        assert match?({:error, :cluster_not_registered}, aggregate_run(initial_events, command)),
+               "Command #{inspect(command)} should be rejected by the aggregate"
       end
-
-      register_cluster_host_command = build(:register_cluster_host)
-      # We just care that there are no errors
-
-      assert {:ok, _, _} = aggregate_run(initial_events, register_cluster_host_command)
     end
 
     test "should emit the HostRemovedFromCluster event after a DeregisterClusterHost command and remove the host from the cluster aggregate state" do

--- a/test/trento/domain/host/host_test.exs
+++ b/test/trento/domain/host/host_test.exs
@@ -669,8 +669,7 @@ defmodule Trento.HostTest do
         %RollUpHost{},
         %UpdateHeartbeat{},
         %UpdateProvider{},
-        %UpdateSlesSubscriptions{},
-        %HostDetailsUpdated{}
+        %UpdateSlesSubscriptions{}
       ]
 
       for command <- commands_to_reject do

--- a/test/trento/domain/host/host_test.exs
+++ b/test/trento/domain/host/host_test.exs
@@ -669,28 +669,13 @@ defmodule Trento.HostTest do
         %RollUpHost{},
         %UpdateHeartbeat{},
         %UpdateProvider{},
-        %UpdateSlesSubscriptions{}
+        %UpdateSlesSubscriptions{},
+        %HostDetailsUpdated{}
       ]
 
       for command <- commands_to_reject do
         assert_error(initial_events, command, {:error, :host_not_registered})
       end
-
-      register_host_command = build(:register_host_command, host_id: host_id)
-
-      assert_events(initial_events, [register_host_command], [
-        %HostDetailsUpdated{
-          agent_version: register_host_command.agent_version,
-          cpu_count: register_host_command.cpu_count,
-          host_id: register_host_command.host_id,
-          hostname: register_host_command.hostname,
-          installation_source: register_host_command.installation_source,
-          ip_addresses: register_host_command.ip_addresses,
-          os_version: register_host_command.os_version,
-          socket_count: register_host_command.socket_count,
-          total_memory_mb: register_host_command.total_memory_mb
-        }
-      ])
     end
 
     test "should emit the HostDeregistered and HostTombstoned events" do

--- a/test/trento/domain/host/host_test.exs
+++ b/test/trento/domain/host/host_test.exs
@@ -651,6 +651,48 @@ defmodule Trento.HostTest do
   end
 
   describe "deregistration" do
+    test "should reject all the commands except the registration ones when the host is deregistered" do
+      host_id = Faker.UUID.v4()
+      dat = DateTime.utc_now()
+
+      initial_events = [
+        build(:host_registered_event, host_id: host_id),
+        %HostDeregistered{
+          host_id: host_id,
+          deregistered_at: dat
+        }
+      ]
+
+      commands_to_reject = [
+        %DeregisterHost{},
+        %RequestHostDeregistration{},
+        %RollUpHost{},
+        %UpdateHeartbeat{},
+        %UpdateProvider{},
+        %UpdateSlesSubscriptions{}
+      ]
+
+      for command <- commands_to_reject do
+        assert_error(initial_events, command, {:error, :host_not_registered})
+      end
+
+      register_host_command = build(:register_host_command, host_id: host_id)
+
+      assert_events(initial_events, [register_host_command], [
+        %HostDetailsUpdated{
+          agent_version: register_host_command.agent_version,
+          cpu_count: register_host_command.cpu_count,
+          host_id: register_host_command.host_id,
+          hostname: register_host_command.hostname,
+          installation_source: register_host_command.installation_source,
+          ip_addresses: register_host_command.ip_addresses,
+          os_version: register_host_command.os_version,
+          socket_count: register_host_command.socket_count,
+          total_memory_mb: register_host_command.total_memory_mb
+        }
+      ])
+    end
+
     test "should emit the HostDeregistered and HostTombstoned events" do
       host_id = Faker.UUID.v4()
       dat = DateTime.utc_now()


### PR DESCRIPTION
# Description

The aggregates, when deregistered, should reject all commands except the registration ones, which could potentially trigger a restore of the aggregate.

The SAP system aggregate has a particular behavior, it should reject all the commands except for:

- Database/Application instance registration, which could trigger a restore
- Database/Application instance deregistration, because even if the aggregate is deregistered, I could have some application/database instance dangling, and I want to remove that before tombstoning the aggregate


## How was this tested?

Automated tests
