### PR TITLE
Rename resource_type to target_type in catalog interaction

### DIFF
--- a/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
@@ -25,7 +25,7 @@ const updatedProvider = {
 
 const buildUpdateCatalogAction = (provider) => {
   const payload = checkProviderExists(provider)
-    ? { provider, resource_type: 'cluster' }
+    ? { provider, target_type: 'cluster' }
     : {};
   return updateCatalog(payload);
 };

--- a/assets/js/components/ChecksCatalog/ChecksCatalog.test.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalog.test.jsx
@@ -71,7 +71,7 @@ describe('ChecksCatalog ChecksCatalog component', () => {
       },
       {
         type: 'UPDATE_CATALOG',
-        payload: { provider: 'aws', resource_type: 'cluster' },
+        payload: { provider: 'aws', target_type: 'cluster' },
       },
     ];
     expect(actions).toEqual(expectedActions);

--- a/assets/js/components/ClusterDetails/ChecksSelection.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelection.jsx
@@ -58,7 +58,7 @@ function ChecksSelection({ clusterId, cluster }) {
   const [groupSelection, setGroupSelection] = useState([]);
   const catalogEnv = {
     provider: cluster.provider,
-    resource_type: 'cluster',
+    target_type: 'cluster',
   };
 
   useEffect(() => {

--- a/assets/js/components/ClusterDetails/ChecksSelection.test.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelection.test.jsx
@@ -128,7 +128,7 @@ describe('ClusterDetails ChecksSelection component', () => {
         type: 'UPDATE_CATALOG',
         payload: {
           provider: cluster.provider,
-          resource_type: 'cluster',
+          target_type: 'cluster',
         },
       },
       {

--- a/test/e2e/cypress/e2e/checks_catalog.cy.js
+++ b/test/e2e/cypress/e2e/checks_catalog.cy.js
@@ -47,7 +47,7 @@ context('Checks catalog', () => {
     ].forEach(([provider, label, checkCount]) => {
       it(`should query the correct checks data filtered by provider ${label}`, () => {
         cy.intercept(
-          `${checksCatalogURL}?provider=${provider}&resource_type=cluster`,
+          `${checksCatalogURL}?provider=${provider}&target_type=cluster`,
           {
             body: { items: catalog.slice(0, checkCount) },
           }


### PR DESCRIPTION
Just a renaming of `resource_type` to `target_type` when communicating with wanda.