### PR TITLE
Host restoration

### DIFF
--- a/lib/trento/domain/host/events/host_restored.ex
+++ b/lib/trento/domain/host/events/host_restored.ex
@@ -1,0 +1,11 @@
+defmodule Trento.Domain.Events.HostRestored do
+  @moduledoc """
+    This event is emitted when an host is restored from a deregistered state
+  """
+
+  use Trento.Event
+
+  defevent do
+    field :host_id, Ecto.UUID
+  end
+end

--- a/lib/trento/domain/host/events/host_restored.ex
+++ b/lib/trento/domain/host/events/host_restored.ex
@@ -1,6 +1,6 @@
 defmodule Trento.Domain.Events.HostRestored do
   @moduledoc """
-    This event is emitted when an host is restored from a deregistered state
+  This event is emitted when a host is restored from a deregistered state
   """
 
   use Trento.Event

--- a/lib/trento/domain/host/host.ex
+++ b/lib/trento/domain/host/host.ex
@@ -197,6 +197,14 @@ defmodule Trento.Domain.Host do
     ]
   end
 
+  def execute(
+        %Host{deregistered_at: deregistered_at},
+        _
+      )
+      when not is_nil(deregistered_at) do
+    {:error, :host_not_registered}
+  end
+
   # Host exists but details didn't change
   def execute(
         %Host{
@@ -221,14 +229,6 @@ defmodule Trento.Domain.Host do
         }
       ) do
     []
-  end
-
-  def execute(
-        %Host{deregistered_at: deregistered_at},
-        _
-      )
-      when not is_nil(deregistered_at) do
-    {:error, :host_not_registered}
   end
 
   def execute(

--- a/lib/trento/domain/host/host.ex
+++ b/lib/trento/domain/host/host.ex
@@ -131,7 +131,7 @@ defmodule Trento.Domain.Host do
     {:error, :host_not_registered}
   end
 
-  # Restore the host when a registerhost command is received for a deregistered host
+  # Restore the host when a RegisterHost command is received for a deregistered host
   def execute(
         %Host{
           host_id: host_id,

--- a/lib/trento/domain/host/host.ex
+++ b/lib/trento/domain/host/host.ex
@@ -45,6 +45,7 @@ defmodule Trento.Domain.Host do
     HostDeregistrationRequested,
     HostDetailsUpdated,
     HostRegistered,
+    HostRestored,
     HostRolledUp,
     HostRollUpRequested,
     HostTombstoned,
@@ -122,6 +123,80 @@ defmodule Trento.Domain.Host do
     }
   end
 
+  # Reject all the commands, except for the registration ones when the host_id does not exists
+  def execute(
+        %Host{host_id: nil},
+        _
+      ) do
+    {:error, :host_not_registered}
+  end
+
+  # Restore the host when a registerhost command is received for a deregistered host
+  def execute(
+        %Host{
+          host_id: host_id,
+          hostname: hostname,
+          ip_addresses: ip_addresses,
+          agent_version: agent_version,
+          cpu_count: cpu_count,
+          total_memory_mb: total_memory_mb,
+          socket_count: socket_count,
+          os_version: os_version,
+          installation_source: installation_source,
+          deregistered_at: deregistered_at
+        },
+        %RegisterHost{
+          hostname: hostname,
+          ip_addresses: ip_addresses,
+          agent_version: agent_version,
+          cpu_count: cpu_count,
+          total_memory_mb: total_memory_mb,
+          socket_count: socket_count,
+          os_version: os_version,
+          installation_source: installation_source
+        }
+      )
+      when not is_nil(deregistered_at) do
+    %HostRestored{
+      host_id: host_id
+    }
+  end
+
+  def execute(
+        %Host{
+          host_id: host_id,
+          deregistered_at: deregistered_at
+        },
+        %RegisterHost{
+          hostname: hostname,
+          ip_addresses: ip_addresses,
+          agent_version: agent_version,
+          cpu_count: cpu_count,
+          total_memory_mb: total_memory_mb,
+          socket_count: socket_count,
+          os_version: os_version,
+          installation_source: installation_source
+        }
+      )
+      when not is_nil(deregistered_at) do
+    [
+      %HostRestored{
+        host_id: host_id
+      },
+      %HostDetailsUpdated{
+        host_id: host_id,
+        hostname: hostname,
+        ip_addresses: ip_addresses,
+        agent_version: agent_version,
+        cpu_count: cpu_count,
+        total_memory_mb: total_memory_mb,
+        socket_count: socket_count,
+        os_version: os_version,
+        installation_source: installation_source
+      }
+    ]
+  end
+
   # Host exists but details didn't change
   def execute(
         %Host{
@@ -146,14 +221,6 @@ defmodule Trento.Domain.Host do
         }
       ) do
     []
-  end
-
-  # Reject all the commands, except for the registration ones when the host_id does not exists
-  def execute(
-        %Host{host_id: nil},
-        _
-      ) do
-    {:error, :host_not_registered}
   end
 
   def execute(
@@ -400,4 +467,9 @@ defmodule Trento.Domain.Host do
 
   def apply(%Host{} = host, %HostDeregistrationRequested{}), do: host
   def apply(%Host{} = host, %HostTombstoned{}), do: host
+
+  # Restoration
+  def apply(%Host{} = host, %HostRestored{}) do
+    %Host{host | deregistered_at: nil}
+  end
 end

--- a/test/trento/application/projectors/host_projector_test.exs
+++ b/test/trento/application/projectors/host_projector_test.exs
@@ -410,7 +410,7 @@ defmodule Trento.HostProjectorTest do
       provider: provider,
       provider_data: provider_data,
       deregistered_at: deregistered_at
-    } = host_projection = Repo.get!(HostReadModel, host_id)
+    } = Repo.get!(HostReadModel, host_id)
 
     assert nil == deregistered_at
 

--- a/test/trento/domain/host/host_test.exs
+++ b/test/trento/domain/host/host_test.exs
@@ -652,7 +652,7 @@ defmodule Trento.HostTest do
   end
 
   describe "deregistration" do
-    test "should restore the host when a RegisterHost command with no new host information is received by a deregistered host" do
+    test "should restore a deregistered host when a RegisterHost command with no new host information is received" do
       host_id = Faker.UUID.v4()
 
       initial_events = [
@@ -691,7 +691,7 @@ defmodule Trento.HostTest do
       )
     end
 
-    test "should restore and update the host when a RegisterHost command with new host information is received by a deregistered host" do
+    test "should restore and update a deregistered host when a RegisterHost command with new host information is received" do
       host_id = Faker.UUID.v4()
 
       initial_events = [


### PR DESCRIPTION
# Description

Host aggregate restoration.

Readmodel restore included, right know we broadcast a host registered event with the restored host details.
We can change this behavior to another broadcast payload later

## How was this tested?

Automated tests
