### PR TITLE
Add ability to deregister hosts in Hosts List

### DIFF
--- a/assets/js/components/Button/Button.jsx
+++ b/assets/js/components/Button/Button.jsx
@@ -16,8 +16,6 @@ const getButtonClasses = (type) => {
       return 'bg-white hover:opacity-75 focus:outline-none text-jungle-green-500 w-fit transition ease-in duration-200 text-center font-semibold rounded shadow';
     case 'primary-white':
       return 'bg-white hover:opacity-75 focus:outline-none text-jungle-green-500 w-full transition ease-in duration-200 text-center font-semibold rounded shadow';
-    case 'primary-white-fit':
-      return 'bg-white hover:opacity-75 focus:outline-none text-jungle-green-500 w-fit transition ease-in duration-200 text-center font-semibold rounded shadow';
     case 'transparent':
       return 'bg-transparent hover:opacity-75 focus:outline-none w-full transition ease-in duration-200 font-semibold';
     case 'secondary':

--- a/assets/js/components/Button/Button.jsx
+++ b/assets/js/components/Button/Button.jsx
@@ -12,6 +12,8 @@ const getSizeClasses = (size) => {
 
 const getButtonClasses = (type) => {
   switch (type) {
+    case 'primary-white-fit':
+      return 'bg-white hover:opacity-75 focus:outline-none text-jungle-green-500 w-fit transition ease-in duration-200 text-center font-semibold rounded shadow';
     case 'primary-white':
       return 'bg-white hover:opacity-75 focus:outline-none text-jungle-green-500 w-full transition ease-in duration-200 text-center font-semibold rounded shadow';
     case 'primary-white-fit':

--- a/assets/js/components/HostDetails/HostDetails.jsx
+++ b/assets/js/components/HostDetails/HostDetails.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
+import { EOS_CLEANING_SERVICES } from 'eos-icons-react';
 
 import { networkClient } from '@lib/network';
 import { agentVersionWarning } from '@lib/agent';
@@ -10,6 +11,7 @@ import Table from '@components/Table';
 
 import PageHeader from '@components/PageHeader';
 import BackButton from '@components/BackButton';
+import Button from '@components/Button';
 import ClusterLink from '@components/ClusterLink';
 import WarningBanner from '@components/Banners/WarningBanner';
 import SuseLogo from '@static/suse_logo.svg';
@@ -57,28 +59,46 @@ function HostDetails() {
   return (
     <div>
       <BackButton url="/hosts">Back to Hosts</BackButton>
-      <div className="flex">
-        <PageHeader>
-          Host Details: <span className="font-bold">{host.hostname}</span>
-        </PageHeader>
-        <StatusPill
-          className="self-center ml-4 shadow"
-          heartbeat={host.heartbeat}
-        >
-          Agent
-        </StatusPill>
+      <div className="flex justify-between">
+        <div className="flex">
+          <PageHeader>
+            Host Details: <span className="font-bold">{host.hostname}</span>
+          </PageHeader>
+          <StatusPill
+            className="self-center ml-4 shadow"
+            heartbeat={host.heartbeat}
+          >
+            Agent
+          </StatusPill>
 
-        {Object.entries(exportersStatus).map(
-          ([exporterName, exporterStatus]) => (
-            <StatusPill
-              key={exporterName}
-              className="self-center ml-4 shadow"
-              heartbeat={exporterStatus}
-            >
-              {exporterName}
-            </StatusPill>
-          )
-        )}
+          {Object.entries(exportersStatus).map(
+            ([exporterName, exporterStatus]) => (
+              <StatusPill
+                key={exporterName}
+                className="self-center ml-4 shadow"
+                heartbeat={exporterStatus}
+              >
+                {exporterName}
+              </StatusPill>
+            )
+          )}
+        </div>
+        <div className="flex w-fit">
+          <Button
+            type="primary-white"
+            className="inline-block mx-0.5 border-green-500 border w-fit"
+            size="small"
+            onClick={() => 123}
+          >
+            <EOS_CLEANING_SERVICES
+              size="base"
+              className="fill-jungle-green-500 inline"
+            />
+            <span className="text-jungle-green-500 text-sm font-bold pl-1.5">
+              Clean up
+            </span>
+          </Button>
+        </div>
       </div>
       {versionWarningMessage && (
         <WarningBanner>{versionWarningMessage}</WarningBanner>

--- a/assets/js/components/HostDetails/HostDetails.jsx
+++ b/assets/js/components/HostDetails/HostDetails.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
-import { EOS_CLEANING_SERVICES } from 'eos-icons-react';
 
 import { networkClient } from '@lib/network';
 import { agentVersionWarning } from '@lib/agent';
@@ -11,9 +10,7 @@ import Table from '@components/Table';
 
 import PageHeader from '@components/PageHeader';
 import BackButton from '@components/BackButton';
-import Button from '@components/Button';
 import ClusterLink from '@components/ClusterLink';
-import DeregistrationModal from '@components/DeregistrationModal';
 import WarningBanner from '@components/Banners/WarningBanner';
 import SuseLogo from '@static/suse_logo.svg';
 import {
@@ -39,7 +36,6 @@ function HostDetails() {
   const { grafanaPublicUrl } = config;
 
   const [exportersStatus, setExportersStatus] = useState([]);
-  const [modalIsOpen, setModalIsOpen] = useState(false);
 
   const getExportersStatus = async () => {
     const { data } = await networkClient.get(
@@ -60,56 +56,29 @@ function HostDetails() {
 
   return (
     <div>
-      <DeregistrationModal
-        host={host}
-        isOpen={modalIsOpen}
-        onCleanUp={() => {
-          // eslint-disable-next-line no-console
-          console.log('clicked the big red button!');
-        }}
-        onCancel={() => setModalIsOpen(false)}
-      />
       <BackButton url="/hosts">Back to Hosts</BackButton>
-      <div className="flex justify-between">
-        <div className="flex">
-          <PageHeader>
-            Host Details: <span className="font-bold">{host.hostname}</span>
-          </PageHeader>
-          <StatusPill
-            className="self-center ml-4 shadow"
-            heartbeat={host.heartbeat}
-          >
-            Agent
-          </StatusPill>
+      <div className="flex">
+        <PageHeader>
+          Host Details: <span className="font-bold">{host.hostname}</span>
+        </PageHeader>
+        <StatusPill
+          className="self-center ml-4 shadow"
+          heartbeat={host.heartbeat}
+        >
+          Agent
+        </StatusPill>
 
-          {Object.entries(exportersStatus).map(
-            ([exporterName, exporterStatus]) => (
-              <StatusPill
-                key={exporterName}
-                className="self-center ml-4 shadow"
-                heartbeat={exporterStatus}
-              >
-                {exporterName}
-              </StatusPill>
-            )
-          )}
-        </div>
-        <div className="flex w-fit">
-          <Button
-            type="primary-white"
-            className="inline-block mx-0.5 border-green-500 border w-fit"
-            size="small"
-            onClick={() => setModalIsOpen(true)}
-          >
-            <EOS_CLEANING_SERVICES
-              size="base"
-              className="fill-jungle-green-500 inline"
-            />
-            <span className="text-jungle-green-500 text-sm font-bold pl-1.5">
-              Clean up
-            </span>
-          </Button>
-        </div>
+        {Object.entries(exportersStatus).map(
+          ([exporterName, exporterStatus]) => (
+            <StatusPill
+              key={exporterName}
+              className="self-center ml-4 shadow"
+              heartbeat={exporterStatus}
+            >
+              {exporterName}
+            </StatusPill>
+          )
+        )}
       </div>
       {versionWarningMessage && (
         <WarningBanner>{versionWarningMessage}</WarningBanner>

--- a/assets/js/components/HostDetails/HostDetails.jsx
+++ b/assets/js/components/HostDetails/HostDetails.jsx
@@ -63,11 +63,11 @@ function HostDetails() {
       <DeregistrationModal
         host={host}
         isOpen={modalIsOpen}
-        onClose={() => setModalIsOpen(false)}
         onCleanUp={() => {
           // eslint-disable-next-line no-console
           console.log('clicked the big red button!');
         }}
+        onCancel={() => setModalIsOpen(false)}
       />
       <BackButton url="/hosts">Back to Hosts</BackButton>
       <div className="flex justify-between">

--- a/assets/js/components/HostDetails/HostDetails.jsx
+++ b/assets/js/components/HostDetails/HostDetails.jsx
@@ -13,6 +13,7 @@ import PageHeader from '@components/PageHeader';
 import BackButton from '@components/BackButton';
 import Button from '@components/Button';
 import ClusterLink from '@components/ClusterLink';
+import DeregistrationModal from '@components/DeregistrationModal';
 import WarningBanner from '@components/Banners/WarningBanner';
 import SuseLogo from '@static/suse_logo.svg';
 import {
@@ -38,6 +39,7 @@ function HostDetails() {
   const { grafanaPublicUrl } = config;
 
   const [exportersStatus, setExportersStatus] = useState([]);
+  const [modalIsOpen, setModalIsOpen] = useState(false);
 
   const getExportersStatus = async () => {
     const { data } = await networkClient.get(
@@ -58,6 +60,15 @@ function HostDetails() {
 
   return (
     <div>
+      <DeregistrationModal
+        host={host}
+        isOpen={modalIsOpen}
+        onClose={() => setModalIsOpen(false)}
+        onCleanUp={() => {
+          // eslint-disable-next-line no-console
+          console.log('clicked the big red button!');
+        }}
+      />
       <BackButton url="/hosts">Back to Hosts</BackButton>
       <div className="flex justify-between">
         <div className="flex">
@@ -88,7 +99,7 @@ function HostDetails() {
             type="primary-white"
             className="inline-block mx-0.5 border-green-500 border w-fit"
             size="small"
-            onClick={() => 123}
+            onClick={() => setModalIsOpen(true)}
           >
             <EOS_CLEANING_SERVICES
               size="base"

--- a/assets/js/components/HostsList.jsx
+++ b/assets/js/components/HostsList.jsx
@@ -58,17 +58,20 @@ function HostsList() {
   const [cleanUpModalVisible, setCleanUpModalVisible] = useState(false);
   const [selectedHost, setSelectedHost] = useState(undefined);
 
-  console.log(hosts)
-
   const dispatch = useDispatch();
 
-  const displayCleanUpButton = ({ heartbeat, last_heartbeat_timestamp }) => {
+  const displayCleanUpButton = ({
+    heartbeat,
+    last_heartbeat_timestamp,
+    isDeregisterable,
+  }) => {
     const lastHeartbeat = new Date(last_heartbeat_timestamp);
     const deregistrationDisabledPeriod = new Date(
       lastHeartbeat.getTime() + deregistrationDebounce
     );
 
     return (
+      isDeregisterable ||
       heartbeat === 'unknown' ||
       (heartbeat === 'critical' &&
         new Date(Date.now()) > deregistrationDisabledPeriod)
@@ -247,14 +250,14 @@ function HostsList() {
     <>
       <PageHeader className="font-bold">Hosts</PageHeader>
       <DeregistrationModal
-        hostName={selectedHost.hostname}
+        hostname={selectedHost?.hostname}
         isOpen={!!selectedHost}
         onCleanUp={() => {
           // eslint-disable-next-line no-console
           console.log('clicked the big red button!');
           setSelectedHost(undefined);
         }}
-        onClose={() => setSelectedHost(undefined)}
+        onCancel={() => setSelectedHost(undefined)}
       />
       <div className="bg-white rounded-lg shadow">
         <HealthSummary {...counters} className="px-4 py-2" />

--- a/assets/js/components/HostsList.jsx
+++ b/assets/js/components/HostsList.jsx
@@ -45,6 +45,9 @@ const removeTag = (tag, hostId) => {
 };
 
 function HostsList() {
+  // eslint-disable-next-line no-undef
+  const deregistrationDebounce = config?.deregistrationDebounce ?? 0;
+
   const hosts = useSelector((state) => state.hostsList.hosts);
   const clusters = useSelector((state) => state.clustersList.clusters);
   const { applicationInstances, databaseInstances } = useSelector(
@@ -60,7 +63,7 @@ function HostsList() {
   // eslint-disable-next-line no-console
   console.log('hosts', hosts);
 
-  const config = {
+  const tableConfig = {
     pagination: true,
     usePadding: false,
     columns: [
@@ -191,7 +194,9 @@ function HostsList() {
         render: (_content, host) => (
           <Button
             type="primary-white"
-            className="inline-block mx-0.5 border-green-500 border w-fit"
+            className={`inline-block mx-0.5 border-green-500 border w-fit ${
+              host.heartbeat === 'passing' ? 'invisible' : 'visible'
+            }`}
             size="small"
             onClick={() => {
               setSelectedHost(host);
@@ -249,7 +254,7 @@ function HostsList() {
       <div className="bg-white rounded-lg shadow">
         <HealthSummary {...counters} className="px-4 py-2" />
         <Table
-          config={config}
+          config={tableConfig}
           data={data}
           searchParams={searchParams}
           setSearchParams={setSearchParams}

--- a/assets/js/components/HostsList.jsx
+++ b/assets/js/components/HostsList.jsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { useSearchParams } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import { EOS_CLEANING_SERVICES, EOS_WARNING_OUTLINED } from 'eos-icons-react';
 
 import Table from '@components/Table';
+import DeregistrationModal from '@components/DeregistrationModal';
 import HealthIcon from '@components/Health/HealthIcon';
 import Tags from '@components/Tags';
 import HostLink from '@components/HostLink';
@@ -16,6 +17,7 @@ import HealthSummary from '@components/HealthSummary/HealthSummary';
 import { getCounters } from '@components/HealthSummary/summarySelection';
 import ProviderLabel from '@components/ProviderLabel';
 import Tooltip from '@components/Tooltip';
+import Button from '@components/Button';
 
 import { addTagToHost, removeTagFromHost } from '@state/hosts';
 import { post, del } from '@lib/network';
@@ -50,8 +52,13 @@ function HostsList() {
   );
 
   const [searchParams, setSearchParams] = useSearchParams();
+  // const [cleanUpModalVisible, setCleanUpModalVisible] = useState(false);
+  const [selectedHost, setSelectedHost] = useState(undefined);
 
   const dispatch = useDispatch();
+
+  // eslint-disable-next-line no-console
+  console.log('hosts', hosts);
 
   const config = {
     pagination: true,
@@ -181,8 +188,16 @@ function HostsList() {
         title: '',
         key: 'Clean up',
         className: 'w-48',
-        render: () => (
-          <span>
+        render: (_content, host) => (
+          <Button
+            type="primary-white"
+            className="inline-block mx-0.5 border-green-500 border w-fit"
+            size="small"
+            onClick={() => {
+              setSelectedHost(host);
+              // setCleanUpModalVisible(!cleanUpModalVisible);
+            }}
+          >
             <EOS_CLEANING_SERVICES
               size="base"
               className="fill-jungle-green-500 inline"
@@ -190,7 +205,7 @@ function HostsList() {
             <span className="text-jungle-green-500 text-sm font-bold pl-1.5">
               Clean up
             </span>
-          </span>
+          </Button>
         ),
       },
     ],
@@ -222,6 +237,15 @@ function HostsList() {
   return (
     <>
       <PageHeader className="font-bold">Hosts</PageHeader>
+      <DeregistrationModal
+        host={selectedHost}
+        isOpen={!!selectedHost}
+        onClose={() => setSelectedHost(undefined)}
+        onCleanUp={() => {
+          // eslint-disable-next-line no-console
+          console.log('clicked the big red button!');
+        }}
+      />
       <div className="bg-white rounded-lg shadow">
         <HealthSummary {...counters} className="px-4 py-2" />
         <Table

--- a/assets/js/components/HostsList.jsx
+++ b/assets/js/components/HostsList.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { useSearchParams } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
-import { EOS_WARNING_OUTLINED } from 'eos-icons-react';
+import { EOS_CLEANING_SERVICES, EOS_WARNING_OUTLINED } from 'eos-icons-react';
 
 import Table from '@components/Table';
 import HealthIcon from '@components/Health/HealthIcon';
@@ -175,6 +175,22 @@ function HostsList() {
               );
             }}
           />
+        ),
+      },
+      {
+        title: '',
+        key: 'Clean up',
+        className: 'w-48',
+        render: () => (
+          <span>
+            <EOS_CLEANING_SERVICES
+              size="base"
+              className="fill-jungle-green-500 inline"
+            />
+            <span className="text-jungle-green-500 text-sm font-bold pl-1.5">
+              Clean up
+            </span>
+          </span>
         ),
       },
     ],

--- a/assets/js/components/HostsList.jsx
+++ b/assets/js/components/HostsList.jsx
@@ -252,9 +252,8 @@ function HostsList() {
       <DeregistrationModal
         hostname={selectedHost?.hostname}
         isOpen={!!selectedHost}
-        onCleanUp={() => {
-          // eslint-disable-next-line no-console
-          console.log('clicked the big red button!');
+        onCleanUp={async () => {
+          await del(`/hosts/${selectedHost.id}`);
           setSelectedHost(undefined);
         }}
         onCancel={() => setSelectedHost(undefined)}

--- a/assets/js/components/HostsList.jsx
+++ b/assets/js/components/HostsList.jsx
@@ -60,6 +60,12 @@ function HostsList() {
 
   const dispatch = useDispatch();
 
+  const requestDeregistration = async (id) => {
+    await del(`/hosts/${id}`);
+    // FIXME: handle unhappy path here
+    setSelectedHost(undefined);
+  }
+
   const displayCleanUpButton = ({
     heartbeat,
     last_heartbeat_timestamp,
@@ -252,10 +258,7 @@ function HostsList() {
       <DeregistrationModal
         hostname={selectedHost?.hostname}
         isOpen={!!selectedHost}
-        onCleanUp={async () => {
-          await del(`/hosts/${selectedHost.id}`);
-          setSelectedHost(undefined);
-        }}
+        onCleanUp={() => requestDeregistration(selectedHost.id)}
         onCancel={() => setSelectedHost(undefined)}
       />
       <div className="bg-white rounded-lg shadow">

--- a/assets/js/components/HostsList.test.jsx
+++ b/assets/js/components/HostsList.test.jsx
@@ -97,6 +97,34 @@ describe('HostsLists component', () => {
         )
       ).toBeInTheDocument();
     });
+
+    // jest.useFakeTimers();
+    it.only('should display correct visibility of \'Clean Up\' button', () => {
+      const hostPassing = hostFactory.build({ heartbeat: 'passing' });
+      const hostCritical = hostFactory.build({ heartbeat: 'critical' });
+      const hostUnknown = hostFactory.build({ heartbeat: 'unknown' });
+
+      const state = {
+        ...defaultInitialState,
+        hostsList: {
+          hosts: [hostPassing, hostCritical, hostUnknown]
+        },
+      };
+
+      const [StatefulHostsList] = withState(<HostsList />, state);
+
+      renderWithRouter(StatefulHostsList);
+
+      const table = screen.getByRole('table');
+      const hostPassingCleanUpButton = table.querySelector('tr:nth-child(1) > td:nth-child(9) > button');
+      expect(hostPassingCleanUpButton).toHaveClass('invisible');
+
+      const hostCriticalCleanUpButton = table.querySelector('tr:nth-child(2) > td:nth-child(9) > button');
+      expect(hostCriticalCleanUpButton).toHaveClass('visible');
+
+      const hostUnknownCleanUpButton = table.querySelector('tr:nth-child(3) > td:nth-child(9) > button');
+      expect(hostUnknownCleanUpButton).toHaveClass('visible');
+    });
   });
 
   describe('filtering', () => {

--- a/assets/js/lib/test-utils/factories/hosts.js
+++ b/assets/js/lib/test-utils/factories/hosts.js
@@ -56,5 +56,6 @@ export const hostFactory = Factory.define(({ params, sequence }) => {
       vm_size: faker.hacker.noun(),
     },
     sles_subscriptions: slesSubscriptionFactory.buildList(4, { host_id: id }),
+    last_heartbeat_timestamp: (new Date()).toISOString(),
   };
 });

--- a/assets/js/lib/test-utils/factories/hosts.js
+++ b/assets/js/lib/test-utils/factories/hosts.js
@@ -56,6 +56,6 @@ export const hostFactory = Factory.define(({ params, sequence }) => {
       vm_size: faker.hacker.noun(),
     },
     sles_subscriptions: slesSubscriptionFactory.buildList(4, { host_id: id }),
-    last_heartbeat_timestamp: (new Date()).toISOString(),
+    last_heartbeat_timestamp: new Date().toISOString(),
   };
 });

--- a/assets/js/lib/test-utils/factories/hosts.js
+++ b/assets/js/lib/test-utils/factories/hosts.js
@@ -57,5 +57,6 @@ export const hostFactory = Factory.define(({ params, sequence }) => {
     },
     sles_subscriptions: slesSubscriptionFactory.buildList(4, { host_id: id }),
     last_heartbeat_timestamp: new Date().toISOString(),
+    isDeregisterable: false,
   };
 });

--- a/assets/js/state/hosts.js
+++ b/assets/js/state/hosts.js
@@ -59,6 +59,22 @@ export const hostsListSlice = createSlice({
         return host;
       });
     },
+    setHostDeregisterable: (state, action) => {
+      state.hosts = state.hosts.map((host) => {
+        if (host.id === action.payload.id) {
+          host.isDeregisterable = true;
+        }
+        return host;
+      });
+    },
+    setHostNotDeregisterable: (state, action) => {
+      state.hosts = state.hosts.map((host) => {
+        if (host.id === action.payload.id) {
+          host.isDeregisterable = false;
+        }
+        return host;
+      });
+    },
     startHostsLoading: (state) => {
       state.loading = true;
     },
@@ -79,10 +95,12 @@ export const {
   updateHost,
   addTagToHost,
   removeTagFromHost,
-  startHostsLoading,
-  stopHostsLoading,
   setHeartbeatPassing,
   setHeartbeatCritical,
+  setHostDeregisterable,
+  setHostNotDeregisterable,
+  startHostsLoading,
+  stopHostsLoading,
   removeHost,
 } = hostsListSlice.actions;
 

--- a/assets/js/state/hosts.test.js
+++ b/assets/js/state/hosts.test.js
@@ -1,4 +1,8 @@
-import hostsReducer, { removeHost } from '@state/hosts';
+import hostsReducer, {
+  removeHost,
+  setHostDeregisterable,
+  setHostNotDeregisterable,
+} from '@state/hosts';
 import { hostFactory } from '@lib/test-utils/factories';
 
 describe('Hosts reducer', () => {
@@ -12,6 +16,36 @@ describe('Hosts reducer', () => {
 
     const expectedState = {
       hosts: [host2],
+    };
+
+    expect(hostsReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should mark host as deregisterable', () => {
+    const [host1, host2] = hostFactory.buildList(2);
+    const initialState = {
+      hosts: [host1, host2],
+    };
+
+    const action = setHostDeregisterable(host1);
+
+    const expectedState = {
+      hosts: [{ ...host1, isDeregisterable: true }, host2],
+    };
+
+    expect(hostsReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should mark host as not deregisterable', () => {
+    const [host1, host2] = hostFactory.buildList(2);
+    const initialState = {
+      hosts: [{ ...host1, isDeregisterable: true }, host2],
+    };
+
+    const action = setHostNotDeregisterable(host1);
+
+    const expectedState = {
+      hosts: [{ ...host1, isDeregisterable: false }, host2],
     };
 
     expect(hostsReducer(initialState, action)).toEqual(expectedState);

--- a/assets/js/state/sagas/hosts.js
+++ b/assets/js/state/sagas/hosts.js
@@ -1,6 +1,16 @@
-import { put, takeEvery } from 'redux-saga/effects';
-import { HOST_DEREGISTERED, removeHost } from '@state/hosts';
+import { delay, put, takeEvery } from 'redux-saga/effects';
+import {
+  HOST_DEREGISTERED,
+  removeHost,
+  setHostDeregisterable,
+} from '@state/hosts';
 import { notify } from '@state/actions/notifications';
+
+export function* hostDeregisterable({ payload }) {
+  // eslint-disable-next-line no-undef
+  yield delay(config.deregistrationDebounce ?? 0);
+  yield put(setHostDeregisterable(payload));
+}
 
 export function* hostDeregistered({ payload }) {
   yield put(removeHost(payload));

--- a/assets/js/state/sagas/hosts.test.js
+++ b/assets/js/state/sagas/hosts.test.js
@@ -1,6 +1,6 @@
 import { recordSaga } from '@lib/test-utils';
-import { hostDeregistered } from '@state/sagas/hosts';
-import { removeHost } from '@state/hosts';
+import { hostDeregistered, hostDeregisterable } from '@state/sagas/hosts';
+import { removeHost, setHostDeregisterable } from '@state/hosts';
 import { hostFactory } from '@lib/test-utils/factories';
 
 describe('Hosts sagas', () => {
@@ -13,5 +13,16 @@ describe('Hosts sagas', () => {
     });
 
     expect(dispatched).toContainEqual(removeHost(payload));
+  });
+
+  it('should mark the host as deregisterable', async () => {
+    const { id, hostname } = hostFactory.build();
+    const payload = { id, hostname };
+
+    const dispatched = await recordSaga(hostDeregisterable, {
+      payload,
+    });
+
+    expect(dispatched).toContainEqual(setHostDeregisterable(payload));
   });
 });

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -14,6 +14,7 @@ import {
   setHosts,
   appendHost,
   updateHost,
+  setHostNotDeregisterable,
   startHostsLoading,
   stopHostsLoading,
   setHeartbeatPassing,
@@ -62,7 +63,7 @@ import { watchAcceptEula } from '@state/sagas/eula';
 import { watchCatalogUpdate } from '@state/sagas/catalog';
 import { watchSapSystem } from '@state/sagas/sapSystems';
 import { watchDatabase } from '@state/sagas/databases';
-import { watchHostDeregistered } from '@state/sagas/hosts';
+import { watchHostDeregistered, hostDeregisterable } from '@state/sagas/hosts';
 import { watchClusterDeregistered } from '@state/sagas/clusters';
 
 import {
@@ -176,6 +177,7 @@ function* watchHostDetailsUpdated() {
 }
 
 function* heartbeatSucceded({ payload }) {
+  yield put(setHostNotDeregisterable(payload));
   yield put(setHeartbeatPassing(payload));
   yield put(
     notify({
@@ -190,6 +192,7 @@ function* watchHeartbeatSucceded() {
 }
 
 function* heartbeatFailed({ payload }) {
+  yield hostDeregisterable({ payload });
   yield put(setHeartbeatCritical(payload));
   yield put(
     notify({

--- a/lib/trento_web/templates/page/index.html.heex
+++ b/lib/trento_web/templates/page/index.html.heex
@@ -4,7 +4,7 @@
 const config = {
     grafanaPublicUrl: '<%= @grafana_public_url %>',
     checksServiceBaseUrl: '<%= @check_service_base_url %>',
-    deregistrationDebounce: '<%= @deregistration_debounce %>',
+    deregistrationDebounce: <%= @deregistration_debounce %>,
 };
 </script>
 

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -170,4 +170,52 @@ context('Hosts Overview', () => {
       });
     });
   });
+
+  describe('Host Deregistration', () => {
+    describe('Hosts List should correctly display the deregistration buttons', () => {
+      before(() => {
+        cy.visit('/hosts');
+        cy.url().should('include', '/hosts');
+        // cy.task('startAgentHeartbeat', agents());
+      });
+
+      it("clicking 'Clean Up' button, then clicking 'Cancel' button in modal should not deregister Host", () => {
+        cy.get(`tr:has(#host-${availableHosts1stPage[0].id})`).as('firstHost');
+
+        cy.get(`@firstHost`)
+          .find('button')
+          .should('contain', 'Clean up')
+          .click();
+
+        cy.get('#headlessui-portal-root').as('deregistrationModal');
+
+        cy.get('@deregistrationModal', { timeout: 15000 })
+          .find('button')
+          .contains('Cancel')
+          .click();
+        cy.get('@deregistrationModal', { timeout: 15000 }).should('not.exist');
+
+        cy.get('@firstHost').should('exist');
+      });
+
+      it("clicking 'Clean Up' button, then clicking confirmation button in modal should deregister Host", () => {
+        cy.get(`tr:has(#host-${availableHosts1stPage[0].id})`).as('firstHost');
+
+        cy.get(`@firstHost`)
+          .find('button')
+          .should('contain', 'Clean up')
+          .click();
+
+        cy.get('#headlessui-portal-root').as('deregistrationModal');
+
+        cy.get('@deregistrationModal', { timeout: 15000 })
+          .find('button')
+          .contains('Clean up')
+          .click();
+        cy.get('@deregistrationModal', { timeout: 15000 }).should('not.exist');
+
+        cy.get('@firstHost', { timeout: 15000 }).should('not.exist');
+      });
+    });
+  });
 });


### PR DESCRIPTION
# Description

Adds button in the Hosts List page that when pressed, triggers deregistration of the selected Host.

The buttons are _only_ visible if a Host has `unknown` or `critical` health.

For the `critical` health case, the button only appears once `config.deregistrationDebounce` milliseconds have passed since the last heartbeat of the `critical` Host.

Upon clicking the button, a modal appears asking the user to confirm their intention to deregister the Host.

## How was this tested?

Added frontend and end-to-end tests for these new components.
