### PR TITLE
Cluster restoration

### DIFF
--- a/lib/trento/domain/cluster/cluster.ex
+++ b/lib/trento/domain/cluster/cluster.ex
@@ -207,7 +207,7 @@ defmodule Trento.Domain.Cluster do
 
   # Restoration, when a RegisterClusterHost command is received for a deregistered Cluster
   # the cluster is restored, the host is added to cluster and if the host is a DC
-  # cluster details will be updated
+  # cluster details are be updated
   def execute(
         %Cluster{deregistered_at: deregistered_at, cluster_id: cluster_id},
         %RegisterClusterHost{

--- a/lib/trento/domain/cluster/cluster.ex
+++ b/lib/trento/domain/cluster/cluster.ex
@@ -207,7 +207,7 @@ defmodule Trento.Domain.Cluster do
 
   # Restoration, when a RegisterClusterHost command is received for a deregistered Cluster
   # the cluster is restored, the host is added to cluster and if the host is a DC
-  # cluster details are be updated
+  # cluster details are updated
   def execute(
         %Cluster{deregistered_at: deregistered_at, cluster_id: cluster_id},
         %RegisterClusterHost{

--- a/lib/trento/domain/cluster/events/cluster_restored.ex
+++ b/lib/trento/domain/cluster/events/cluster_restored.ex
@@ -1,0 +1,11 @@
+defmodule Trento.Domain.Events.ClusterRestored do
+  @moduledoc """
+  This event is emitted after a cluster is restored from a deregistered state
+  """
+
+  use Trento.Event
+
+  defevent do
+    field :cluster_id, Ecto.UUID
+  end
+end

--- a/test/trento/application/projectors/cluster_projector_test.exs
+++ b/test/trento/application/projectors/cluster_projector_test.exs
@@ -208,12 +208,13 @@ defmodule Trento.ClusterProjectorTest do
   end
 
   test "should set deregistered_at field to nil when ClusterRestored is received" do
-    insert(:cluster,
-      id: cluster_id = Faker.UUID.v4(),
-      name: name = "deregistered_cluster",
-      selected_checks: [],
-      deregistered_at: DateTime.utc_now()
-    )
+    %{id: cluster_id, name: name, type: type} =
+      insert(:cluster,
+        id: Faker.UUID.v4(),
+        name: "deregistered_cluster",
+        selected_checks: [],
+        deregistered_at: DateTime.utc_now()
+      )
 
     event = ClusterRestored.new!(%{cluster_id: cluster_id})
 
@@ -227,7 +228,7 @@ defmodule Trento.ClusterProjectorTest do
                        cib_last_written: nil,
                        id: ^cluster_id,
                        name: ^name,
-                       type: :hana_scale_up
+                       type: ^type
                      },
                      1000
   end

--- a/test/trento/domain/cluster/cluster_test.exs
+++ b/test/trento/domain/cluster/cluster_test.exs
@@ -778,7 +778,7 @@ defmodule Trento.ClusterTest do
   end
 
   describe "deregistration" do
-    test "should restore a deregistered cluster when a RegisterHost command from a non DC host is received" do
+    test "should restore a deregistered cluster when a RegisterClusterHost command from a non DC host is received" do
       host_one_id = UUID.uuid4()
       host_two_id = UUID.uuid4()
 
@@ -799,7 +799,7 @@ defmodule Trento.ClusterTest do
 
       new_host_id = UUID.uuid4()
 
-      restoration_event =
+      restoration_command =
         build(
           :register_cluster_host,
           cluster_id: cluster_id,
@@ -809,7 +809,7 @@ defmodule Trento.ClusterTest do
 
       assert_events_and_state(
         initial_events,
-        [restoration_event],
+        [restoration_command],
         [
           %ClusterRestored{
             cluster_id: cluster_id
@@ -825,7 +825,7 @@ defmodule Trento.ClusterTest do
       )
     end
 
-    test "should restore a deregistered cluster and perform the cluster update procedure when a RegisterHost command from a DC host is received" do
+    test "should restore a deregistered cluster and perform the cluster update procedure when a RegisterClusterHost command from a DC host is received" do
       host_one_id = UUID.uuid4()
       host_two_id = UUID.uuid4()
 
@@ -846,7 +846,7 @@ defmodule Trento.ClusterTest do
 
       new_host_id = UUID.uuid4()
 
-      restoration_event =
+      restoration_command =
         build(
           :register_cluster_host,
           cluster_id: cluster_id,
@@ -857,7 +857,7 @@ defmodule Trento.ClusterTest do
 
       assert_events_and_state(
         initial_events,
-        [restoration_event],
+        [restoration_command],
         [
           %ClusterRestored{
             cluster_id: cluster_id
@@ -868,14 +868,14 @@ defmodule Trento.ClusterTest do
           },
           %ClusterDetailsUpdated{
             cluster_id: cluster_id,
-            name: restoration_event.name,
-            type: restoration_event.type,
-            sid: restoration_event.sid,
-            additional_sids: restoration_event.additional_sids,
-            provider: restoration_event.provider,
-            resources_number: restoration_event.resources_number,
-            hosts_number: restoration_event.hosts_number,
-            details: restoration_event.details
+            name: restoration_command.name,
+            type: restoration_command.type,
+            sid: restoration_command.sid,
+            additional_sids: restoration_command.additional_sids,
+            provider: restoration_command.provider,
+            resources_number: restoration_command.resources_number,
+            hosts_number: restoration_command.hosts_number,
+            details: restoration_command.details
           },
           %ClusterDiscoveredHealthChanged{
             cluster_id: cluster_id,


### PR DESCRIPTION
# Description

Cluster aggregate restoration.

When a deregistered cluster receives a RegisterClusterHost command:

- If the host is not a dc, the cluster is restored and the host added to cluster
- If the host is a dc, the cluster is restored, the host is added to cluster and the update cluster procedure is performed, similar to the registration

## How was this tested?

Automated tests
