### PR TITLE
Add Host Check Selection Domain logic

### DIFF
--- a/lib/trento/domain/host/commands/select_host_checks.ex
+++ b/lib/trento/domain/host/commands/select_host_checks.ex
@@ -1,0 +1,14 @@
+defmodule Trento.Domain.Commands.SelectHostChecks do
+  @moduledoc """
+  Select the checks to be executed on a host.
+  """
+
+  @required_fields :all
+
+  use Trento.Command
+
+  defcommand do
+    field :host_id, Ecto.UUID
+    field :checks, {:array, :string}
+  end
+end

--- a/lib/trento/domain/host/events/host_checks_selected.ex
+++ b/lib/trento/domain/host/events/host_checks_selected.ex
@@ -1,0 +1,12 @@
+defmodule Trento.Domain.Events.HostChecksSelected do
+  @moduledoc """
+  Event of the checks selected for a host.
+  """
+
+  use Trento.Event
+
+  defevent do
+    field :host_id, Ecto.UUID
+    field :checks, {:array, :string}
+  end
+end

--- a/lib/trento/infrastructure/router.ex
+++ b/lib/trento/infrastructure/router.ex
@@ -19,6 +19,7 @@ defmodule Trento.Router do
     RollUpHost,
     RollUpSapSystem,
     SelectChecks,
+    SelectHostChecks,
     UpdateHeartbeat,
     UpdateProvider,
     UpdateSlesSubscriptions
@@ -33,7 +34,8 @@ defmodule Trento.Router do
              UpdateHeartbeat,
              UpdateProvider,
              UpdateSlesSubscriptions,
-             RollUpHost
+             RollUpHost,
+             SelectHostChecks
            ],
            to: Host,
            lifespan: Host.Lifespan


### PR DESCRIPTION
# Description

This PR adds a new command `Trento.Domain.Commands.SelectHostChecks`, which allows the selection of host checks within the host aggregate. Upon execution, the command triggers the emission of the `Trento.Domain.Events.HostChecksSelected` event, leading to a change in the state.

We're deferring updating cluster related command/event pair related to check selection
`Trento.Domain.Commands.SelectChecks`/`Trento.Domain.Events.ChecksSelected`.
Not much for the command, but mainly for the event.

## How was this tested?

Automated tests.
