### PR TITLE
Update health summary endpoint

### DIFF
--- a/lib/trento/application/usecases/sap_systems/health_summary_service.ex
+++ b/lib/trento/application/usecases/sap_systems/health_summary_service.ex
@@ -19,8 +19,6 @@ defmodule Trento.SapSystems.HealthSummaryService do
 
   alias Trento.Repo
 
-  @type instance_list :: [DatabaseInstanceReadModel.t() | ApplicationInstanceReadModel.t()]
-
   @spec get_health_summary :: [map()]
   def get_health_summary do
     SapSystemReadModel
@@ -62,7 +60,10 @@ defmodule Trento.SapSystems.HealthSummaryService do
     |> HealthService.compute_aggregated_health()
   end
 
-  @spec compute_cluster_health(instance_list) :: Health.t()
+  @spec compute_cluster_health(
+          [DatabaseInstanceReadModel.t()]
+          | [ApplicationInstanceReadModel.t()]
+        ) :: Health.t()
   defp compute_cluster_health(instances) do
     cluster_id =
       Enum.find_value(instances, nil, fn
@@ -77,7 +78,8 @@ defmodule Trento.SapSystems.HealthSummaryService do
     end
   end
 
-  @spec compute_hosts_health(instance_list) :: Health.t()
+  @spec compute_hosts_health([DatabaseInstanceReadModel.t() | ApplicationInstanceReadModel.t()]) ::
+          Health.t()
   defp compute_hosts_health(instances) do
     instances
     |> Enum.filter(fn %{host: host} -> host end)

--- a/lib/trento/application/usecases/sap_systems/health_summary_service.ex
+++ b/lib/trento/application/usecases/sap_systems/health_summary_service.ex
@@ -47,8 +47,12 @@ defmodule Trento.SapSystems.HealthSummaryService do
       sid: sid,
       sapsystem_health: health,
       database_health: compute_database_health(database_instances),
-      clusters_health: compute_clusters_health(all_instances),
+      application_cluster_health:
+        compute_cluster_health(application_instances, [ClusterType.ascs_ers()]),
+      database_cluster_health:
+        compute_cluster_health(database_instances, [ClusterType.hana_scale_up()]),
       hosts_health: compute_hosts_health(all_instances),
+      application_instances: application_instances,
       database_instances: database_instances
     }
   end
@@ -60,14 +64,22 @@ defmodule Trento.SapSystems.HealthSummaryService do
     |> HealthService.compute_aggregated_health()
   end
 
-  @spec compute_clusters_health(instance_list) :: Health.t()
-  defp compute_clusters_health(instances) do
+  @spec compute_cluster_health(instance_list, [ClusterType.t()]) :: Health.t()
+  defp compute_cluster_health(instances, cluster_types) do
     instances
     |> reject_unclustered_instances()
     |> clusters_from_instance()
-    |> keep_only_hana_scale_up_clusters()
+    |> filter_by_cluster_type(cluster_types)
     |> health_from_cluster()
     |> HealthService.compute_aggregated_health()
+  end
+
+  @spec reject_unclustered_instances(instance_list) :: instance_list
+  defp reject_unclustered_instances(instances) do
+    Enum.reject(instances, fn
+      %{host: %{cluster_id: nil}} -> true
+      _ -> false
+    end)
   end
 
   @spec clusters_from_instance(instance_list) :: [ClusterReadModel.t()]
@@ -79,25 +91,19 @@ defmodule Trento.SapSystems.HealthSummaryService do
     |> Enum.map(fn cluster_id -> Repo.get!(ClusterReadModel, cluster_id) end)
   end
 
+  @spec filter_by_cluster_type([ClusterReadModel.t()], [ClusterType.t()]) :: [
+          ClusterReadModel.t()
+        ]
+  defp filter_by_cluster_type(clusters, cluster_types) do
+    Enum.filter(clusters, fn
+      %ClusterReadModel{type: type} -> type in cluster_types
+      _ -> false
+    end)
+  end
+
   @spec health_from_cluster([ClusterReadModel.t()]) :: [String.t()]
   defp health_from_cluster(clusters) do
     Enum.map(clusters, fn %ClusterReadModel{health: health} -> health end)
-  end
-
-  @spec reject_unclustered_instances(instance_list) :: instance_list
-  defp reject_unclustered_instances(instances) do
-    Enum.reject(instances, fn
-      %{host: %{cluster_id: nil}} -> true
-      _ -> false
-    end)
-  end
-
-  @spec keep_only_hana_scale_up_clusters([ClusterReadModel.t()]) :: [ClusterReadModel.t()]
-  defp keep_only_hana_scale_up_clusters(clusters) do
-    Enum.filter(clusters, fn
-      %ClusterReadModel{type: ClusterType.hana_scale_up()} -> true
-      _ -> false
-    end)
   end
 
   @spec compute_hosts_health(instance_list) :: Health.t()

--- a/lib/trento_web/openapi/v1/schema/sap_system.ex
+++ b/lib/trento_web/openapi/v1/schema/sap_system.ex
@@ -93,10 +93,35 @@ defmodule TrentoWeb.OpenApi.V1.Schema.SAPSystem do
       properties: %{
         id: %Schema{type: :string, description: "SAP System ID", format: :uuid},
         sid: %Schema{type: :string, description: "SID"},
+        cluster_id: %Schema{
+          type: :string,
+          description: "Cluster ID",
+          format: :uuid,
+          deprecated: true
+        },
+        application_cluster_id: %Schema{
+          type: :string,
+          description: "Application cluster ID",
+          format: :uuid
+        },
+        database_cluster_id: %Schema{
+          type: :string,
+          description: "Database cluster ID",
+          format: :uuid
+        },
+        database_id: %Schema{type: :string, description: "Database ID", format: :uuid},
         sapsystem_health: ResourceHealth,
         database_health: ResourceHealth,
         hosts_health: ResourceHealth,
-        clusters_health: ResourceHealth
+        clusters_heatlh: %Schema{
+          allOf: [
+            ResourceHealth,
+            %Schema{deprecated: true}
+          ]
+        },
+        application_cluster_health: ResourceHealth,
+        database_cluster_health: ResourceHealth,
+        tenant: %Schema{type: :string, description: "Tenant database SID"}
       }
     })
   end

--- a/lib/trento_web/views/v1/health_overview_view.ex
+++ b/lib/trento_web/views/v1/health_overview_view.ex
@@ -1,7 +1,10 @@
 defmodule TrentoWeb.V1.HealthOverviewView do
   use TrentoWeb, :view
 
-  alias Trento.DatabaseInstanceReadModel
+  alias Trento.{
+    ApplicationInstanceReadModel,
+    DatabaseInstanceReadModel
+  }
 
   def render("overview.json", %{health_infos: health_infos}) do
     render_many(health_infos, __MODULE__, "health_summary.json", as: :summary)
@@ -12,9 +15,11 @@ defmodule TrentoWeb.V1.HealthOverviewView do
           id: id,
           sid: sid,
           sapsystem_health: sapsystem_health,
+          application_instances: application_instances,
           database_instances: database_instances,
           database_health: database_health,
-          clusters_health: clusters_health,
+          application_cluster_health: application_cluster_health,
+          database_cluster_health: database_cluster_health,
           hosts_health: hosts_health
         }
       }) do
@@ -23,9 +28,15 @@ defmodule TrentoWeb.V1.HealthOverviewView do
       sid: sid,
       sapsystem_health: sapsystem_health,
       database_health: database_health,
-      clusters_health: clusters_health,
+      # deprecated field
+      clusters_health: database_cluster_health,
+      application_cluster_health: application_cluster_health,
+      database_cluster_health: database_cluster_health,
       hosts_health: hosts_health,
+      # deprecated field
       cluster_id: extract_cluster_id(database_instances),
+      application_cluster_id: extract_cluster_id(application_instances),
+      database_cluster_id: extract_cluster_id(database_instances),
       database_id: extract_database_id(database_instances),
       tenant: extract_tenant(database_instances)
     }
@@ -37,8 +48,12 @@ defmodule TrentoWeb.V1.HealthOverviewView do
   defp extract_database_id([%DatabaseInstanceReadModel{sap_system_id: sap_system_id} | _]),
     do: sap_system_id
 
-  @spec extract_cluster_id([DatabaseInstanceReadModel.t()]) :: String.t()
+  @spec extract_cluster_id([ApplicationInstanceReadModel.t() | DatabaseInstanceReadModel.t()]) ::
+          String.t()
   defp extract_cluster_id([]), do: nil
+
+  defp extract_cluster_id([%ApplicationInstanceReadModel{host: %{cluster_id: cluster_id}} | _]),
+    do: cluster_id
 
   defp extract_cluster_id([%DatabaseInstanceReadModel{host: %{cluster_id: cluster_id}} | _]),
     do: cluster_id

--- a/lib/trento_web/views/v1/health_overview_view.ex
+++ b/lib/trento_web/views/v1/health_overview_view.ex
@@ -42,14 +42,14 @@ defmodule TrentoWeb.V1.HealthOverviewView do
     }
   end
 
-  @spec extract_database_id([DatabaseInstanceReadModel.t()]) :: String.t()
+  @spec extract_database_id([DatabaseInstanceReadModel.t()]) :: String.t() | nil
   defp extract_database_id([]), do: nil
 
   defp extract_database_id([%DatabaseInstanceReadModel{sap_system_id: sap_system_id} | _]),
     do: sap_system_id
 
-  @spec extract_cluster_id([ApplicationInstanceReadModel.t() | DatabaseInstanceReadModel.t()]) ::
-          String.t()
+  @spec extract_cluster_id([ApplicationInstanceReadModel.t()] | [DatabaseInstanceReadModel.t()]) ::
+          String.t() | nil
   defp extract_cluster_id([]), do: nil
 
   defp extract_cluster_id([%DatabaseInstanceReadModel{host: %{cluster_id: cluster_id}} | _]),
@@ -63,7 +63,7 @@ defmodule TrentoWeb.V1.HealthOverviewView do
     end)
   end
 
-  @spec extract_tenant([DatabaseInstanceReadModel.t()]) :: String.t()
+  @spec extract_tenant([DatabaseInstanceReadModel.t()]) :: String.t() | nil
   defp extract_tenant([]), do: nil
 
   defp extract_tenant([%DatabaseInstanceReadModel{tenant: tenant} | _]),

--- a/lib/trento_web/views/v1/health_overview_view.ex
+++ b/lib/trento_web/views/v1/health_overview_view.ex
@@ -52,11 +52,16 @@ defmodule TrentoWeb.V1.HealthOverviewView do
           String.t()
   defp extract_cluster_id([]), do: nil
 
-  defp extract_cluster_id([%ApplicationInstanceReadModel{host: %{cluster_id: cluster_id}} | _]),
-    do: cluster_id
-
   defp extract_cluster_id([%DatabaseInstanceReadModel{host: %{cluster_id: cluster_id}} | _]),
     do: cluster_id
+
+  defp extract_cluster_id(application_instances) do
+    Enum.find_value(application_instances, nil, fn
+      %{host: %{cluster_id: nil}} -> false
+      %{host: %{cluster_id: cluster_id}} -> cluster_id
+      _ -> false
+    end)
+  end
 
   @spec extract_tenant([DatabaseInstanceReadModel.t()]) :: String.t()
   defp extract_tenant([]), do: nil

--- a/test/trento/application/usecases/health_summary_service_test.exs
+++ b/test/trento/application/usecases/health_summary_service_test.exs
@@ -32,7 +32,6 @@ defmodule Trento.HealthSummaryServiceTest do
       insert(
         :database_instance_without_host,
         sap_system_id: sap_system_id,
-        sid: "HDD",
         host_id: a_host_id
       )
 
@@ -79,7 +78,6 @@ defmodule Trento.HealthSummaryServiceTest do
           :database_instance,
           sap_system_id: sap_system_id,
           instance_number: "00",
-          sid: "HDD",
           host_id: db_host_id,
           health: Health.warning(),
           host: db_host
@@ -88,7 +86,6 @@ defmodule Trento.HealthSummaryServiceTest do
           :database_instance,
           sap_system_id: sap_system_id,
           instance_number: "01",
-          sid: "HDD",
           host_id: db_host_id_2,
           health: Health.passing(),
           host: db_host_2
@@ -151,7 +148,6 @@ defmodule Trento.HealthSummaryServiceTest do
           :database_instance,
           sap_system_id: sap_system_id,
           instance_number: "00",
-          sid: "HDD",
           host_id: db_host_id,
           health: Health.warning(),
           host: db_host

--- a/test/trento/application/usecases/health_summary_service_test.exs
+++ b/test/trento/application/usecases/health_summary_service_test.exs
@@ -11,6 +11,7 @@ defmodule Trento.HealthSummaryServiceTest do
   require Trento.Domain.Enums.ClusterType, as: ClusterType
 
   alias Trento.{
+    ClusterReadModel,
     HostReadModel,
     SapSystemReadModel
   }
@@ -48,49 +49,86 @@ defmodule Trento.HealthSummaryServiceTest do
     end
 
     test "should determine health summary for a SAP System" do
-      %Trento.ClusterReadModel{id: cluster_id} =
+      %ClusterReadModel{id: db_cluster_id} =
         insert(:cluster, type: ClusterType.hana_scale_up(), health: Health.passing())
 
-      %Trento.HostReadModel{id: host_1_id} =
-        host_one = insert(:host, cluster_id: cluster_id, heartbeat: :unknown)
+      %ClusterReadModel{id: app_cluster_id} =
+        insert(:cluster, type: ClusterType.ascs_ers(), health: Health.warning())
 
-      %Trento.SapSystemReadModel{
+      %HostReadModel{id: db_host_id} =
+        db_host = insert(:host, cluster_id: db_cluster_id, heartbeat: Health.unknown())
+
+      %HostReadModel{id: db_host_id_2} =
+        db_host_2 = insert(:host, cluster_id: nil, heartbeat: Health.passing())
+
+      %HostReadModel{id: app_host_id} =
+        app_host = insert(:host, cluster_id: app_cluster_id, heartbeat: Health.passing())
+
+      %HostReadModel{id: app_host_id_2} =
+        app_host_2 = insert(:host, cluster_id: nil, heartbeat: Health.critical())
+
+      %SapSystemReadModel{
         id: sap_system_id,
         sid: sid
       } = insert(:sap_system, health: Health.critical())
 
       insert(:sap_system, deregistered_at: DateTime.utc_now())
 
-      database_instance =
+      database_instances = [
         insert(
-          :database_instance_without_host,
+          :database_instance,
           sap_system_id: sap_system_id,
+          instance_number: "00",
           sid: "HDD",
-          host_id: host_1_id,
-          health: Health.warning()
+          host_id: db_host_id,
+          health: Health.warning(),
+          host: db_host
+        ),
+        insert(
+          :database_instance,
+          sap_system_id: sap_system_id,
+          instance_number: "01",
+          sid: "HDD",
+          host_id: db_host_id_2,
+          health: Health.passing(),
+          host: db_host_2
         )
+      ]
 
-      insert(
-        :application_instance_without_host,
-        sap_system_id: sap_system_id,
-        sid: sid,
-        host_id: host_1_id,
-        health: Health.critical()
-      )
-
-      expected_db_instance = %{database_instance | host: host_one}
+      application_instances = [
+        insert(
+          :application_instance,
+          sap_system_id: sap_system_id,
+          instance_number: "10",
+          sid: sid,
+          host_id: app_host_id,
+          health: Health.passing(),
+          host: app_host
+        ),
+        insert(
+          :application_instance,
+          sap_system_id: sap_system_id,
+          instance_number: "11",
+          sid: sid,
+          host_id: app_host_id_2,
+          health: Health.critical(),
+          host: app_host_2
+        )
+      ]
 
       assert [
                %{
-                 id: ^sap_system_id,
-                 sid: ^sid,
-                 sapsystem_health: :critical,
-                 database_health: :warning,
-                 clusters_health: :passing,
-                 hosts_health: :unknown,
-                 database_instances: [^expected_db_instance]
+                 id: sap_system_id,
+                 sid: sid,
+                 sapsystem_health: Health.critical(),
+                 database_health: Health.warning(),
+                 database_cluster_health: Health.passing(),
+                 application_cluster_health: Health.warning(),
+                 hosts_health: Health.unknown(),
+                 database_instances: database_instances,
+                 application_instances: application_instances
                }
-             ] = HealthSummaryService.get_health_summary()
+             ] == HealthSummaryService.get_health_summary()
     end
   end
 end

--- a/test/trento_web/views/v1/health_overview_view_test.exs
+++ b/test/trento_web/views/v1/health_overview_view_test.exs
@@ -1,48 +1,65 @@
 defmodule TrentoWeb.V1.HealthOverviewViewTest do
   use TrentoWeb.ConnCase, async: true
 
-  alias Trento.{
-    DatabaseInstanceReadModel,
-    HostReadModel
-  }
+  import Trento.Factory
 
   import Phoenix.View
+
+  require Trento.Domain.Enums.Health, as: Health
 
   test "renders overview.json" do
     sap_system_id = UUID.uuid4()
     sid = UUID.uuid4()
     tenant = UUID.uuid4()
-    cluster_id = UUID.uuid4()
+    app_cluster_id = UUID.uuid4()
+    db_cluster_id = UUID.uuid4()
+
+    application_instances =
+      build_list(
+        2,
+        :application_instance_without_host,
+        sap_system_id: sap_system_id,
+        host: build(:host, cluster_id: app_cluster_id)
+      )
+
+    database_instances =
+      build_list(
+        2,
+        :database_instance_without_host,
+        sap_system_id: sap_system_id,
+        host: build(:host, cluster_id: db_cluster_id),
+        tenant: tenant
+      )
 
     assert [
              %{
-               cluster_id: ^cluster_id,
-               clusters_health: :critical,
-               database_health: :passing,
-               database_id: ^sap_system_id,
-               hosts_health: :warning,
-               id: ^sap_system_id,
-               sapsystem_health: :passing,
-               sid: ^sid,
-               tenant: ^tenant
+               cluster_id: db_cluster_id,
+               clusters_health: Health.warning(),
+               application_cluster_id: app_cluster_id,
+               database_cluster_id: db_cluster_id,
+               application_cluster_health: Health.critical(),
+               database_cluster_health: Health.warning(),
+               database_health: Health.passing(),
+               database_id: sap_system_id,
+               hosts_health: Health.warning(),
+               id: sap_system_id,
+               sapsystem_health: Health.passing(),
+               sid: sid,
+               tenant: tenant
              }
-           ] =
+           ] ==
              render(TrentoWeb.V1.HealthOverviewView, "overview.json", %{
                health_infos: [
                  %{
                    id: sap_system_id,
                    sid: sid,
-                   sapsystem_health: :passing,
-                   database_instances: [
-                     %DatabaseInstanceReadModel{
-                       host: %HostReadModel{cluster_id: cluster_id},
-                       sap_system_id: sap_system_id,
-                       tenant: tenant
-                     }
-                   ],
-                   database_health: :passing,
-                   clusters_health: :critical,
-                   hosts_health: :warning
+                   sapsystem_health: Health.passing(),
+                   database_health: Health.passing(),
+                   application_cluster_health: Health.critical(),
+                   database_cluster_health: Health.warning(),
+                   hosts_health: Health.warning(),
+                   application_instances: application_instances,
+                   database_instances: database_instances
                  }
                ]
              })

--- a/test/trento_web/views/v1/health_overview_view_test.exs
+++ b/test/trento_web/views/v1/health_overview_view_test.exs
@@ -7,61 +7,114 @@ defmodule TrentoWeb.V1.HealthOverviewViewTest do
 
   require Trento.Domain.Enums.Health, as: Health
 
-  test "renders overview.json" do
-    sap_system_id = UUID.uuid4()
-    sid = UUID.uuid4()
-    tenant = UUID.uuid4()
-    app_cluster_id = UUID.uuid4()
-    db_cluster_id = UUID.uuid4()
+  describe "renders overview.json" do
+    test "should render all the fields" do
+      sap_system_id = UUID.uuid4()
+      sid = UUID.uuid4()
+      tenant = UUID.uuid4()
+      app_cluster_id = UUID.uuid4()
+      db_cluster_id = UUID.uuid4()
 
-    application_instances =
-      build_list(
-        2,
-        :application_instance_without_host,
-        sap_system_id: sap_system_id,
-        host: build(:host, cluster_id: app_cluster_id)
-      )
+      application_instances =
+        build_list(1, :application_instance_without_host,
+          sap_system_id: sap_system_id,
+          host: build(:host, cluster_id: nil)
+        ) ++
+          build_list(
+            2,
+            :application_instance_without_host,
+            sap_system_id: sap_system_id,
+            host: build(:host, cluster_id: app_cluster_id)
+          )
 
-    database_instances =
-      build_list(
-        2,
-        :database_instance_without_host,
-        sap_system_id: sap_system_id,
-        host: build(:host, cluster_id: db_cluster_id),
-        tenant: tenant
-      )
+      database_instances =
+        build_list(
+          2,
+          :database_instance_without_host,
+          sap_system_id: sap_system_id,
+          host: build(:host, cluster_id: db_cluster_id),
+          tenant: tenant
+        )
 
-    assert [
-             %{
-               cluster_id: db_cluster_id,
-               clusters_health: Health.warning(),
-               application_cluster_id: app_cluster_id,
-               database_cluster_id: db_cluster_id,
-               application_cluster_health: Health.critical(),
-               database_cluster_health: Health.warning(),
-               database_health: Health.passing(),
-               database_id: sap_system_id,
-               hosts_health: Health.warning(),
-               id: sap_system_id,
-               sapsystem_health: Health.passing(),
-               sid: sid,
-               tenant: tenant
-             }
-           ] ==
-             render(TrentoWeb.V1.HealthOverviewView, "overview.json", %{
-               health_infos: [
-                 %{
-                   id: sap_system_id,
-                   sid: sid,
-                   sapsystem_health: Health.passing(),
-                   database_health: Health.passing(),
-                   application_cluster_health: Health.critical(),
-                   database_cluster_health: Health.warning(),
-                   hosts_health: Health.warning(),
-                   application_instances: application_instances,
-                   database_instances: database_instances
-                 }
-               ]
-             })
+      assert [
+               %{
+                 cluster_id: db_cluster_id,
+                 clusters_health: Health.warning(),
+                 application_cluster_id: app_cluster_id,
+                 database_cluster_id: db_cluster_id,
+                 application_cluster_health: Health.critical(),
+                 database_cluster_health: Health.warning(),
+                 database_health: Health.passing(),
+                 database_id: sap_system_id,
+                 hosts_health: Health.warning(),
+                 id: sap_system_id,
+                 sapsystem_health: Health.passing(),
+                 sid: sid,
+                 tenant: tenant
+               }
+             ] ==
+               render(TrentoWeb.V1.HealthOverviewView, "overview.json", %{
+                 health_infos: [
+                   %{
+                     id: sap_system_id,
+                     sid: sid,
+                     sapsystem_health: Health.passing(),
+                     database_health: Health.passing(),
+                     application_cluster_health: Health.critical(),
+                     database_cluster_health: Health.warning(),
+                     hosts_health: Health.warning(),
+                     application_instances: application_instances,
+                     database_instances: database_instances
+                   }
+                 ]
+               })
+    end
+
+    test "should send empty cluster ids" do
+      sap_system_id = UUID.uuid4()
+
+      application_instances =
+        build_list(
+          2,
+          :application_instance_without_host,
+          sap_system_id: sap_system_id,
+          host: build(:host, cluster_id: nil)
+        )
+
+      database_instances =
+        build_list(
+          2,
+          :database_instance_without_host,
+          sap_system_id: sap_system_id,
+          host: build(:host, cluster_id: nil),
+          tenant: UUID.uuid4()
+        )
+
+      assert [
+               %{
+                 cluster_id: nil,
+                 clusters_health: Health.unknown(),
+                 application_cluster_id: nil,
+                 database_cluster_id: nil,
+                 application_cluster_health: Health.unknown(),
+                 database_cluster_health: Health.unknown()
+               }
+             ] =
+               render(TrentoWeb.V1.HealthOverviewView, "overview.json", %{
+                 health_infos: [
+                   %{
+                     id: sap_system_id,
+                     sid: UUID.uuid4(),
+                     sapsystem_health: Health.passing(),
+                     database_health: Health.passing(),
+                     application_cluster_health: Health.unknown(),
+                     database_cluster_health: Health.unknown(),
+                     hosts_health: Health.warning(),
+                     application_instances: application_instances,
+                     database_instances: database_instances
+                   }
+                 ]
+               })
+    end
   end
 end


### PR DESCRIPTION
# Description

Update the `/sap_systems/health` endpoint view.
Now, we need to show the database cluster and the application cluster in the home view, in individual columns, so the endpoint now sends them as `application_cluster_id/application_cluster_health` and `database_cluster_id/database_cluster_health`.

The old `clusters_health` and `cluster_id` get deprecated (better to deprecate rather than creating a new version, wdyt?).
This is how it looks like in the swagger view:
![image](https://github.com/trento-project/web/assets/36370954/6213bcbe-7dfa-4e06-8869-74aec0f5cd44)


## How was this tested?

Unit tested
