### PR TITLE
Add projector for host checks selection

### DIFF
--- a/lib/trento/application/projectors/cluster_projector.ex
+++ b/lib/trento/application/projectors/cluster_projector.ex
@@ -89,9 +89,6 @@ defmodule Trento.ClusterProjector do
       changeset =
         ClusterReadModel
         |> Repo.get(id)
-        # TODO: couldn't make it work with Ecto.Multi
-        # With following line when we receive an empty list of selected checks, the readmodel does not get updated
-        # %ClusterReadModel{id: id}
         |> ClusterReadModel.changeset(%{
           selected_checks: checks
         })

--- a/lib/trento/application/projectors/host_projector.ex
+++ b/lib/trento/application/projectors/host_projector.ex
@@ -94,9 +94,6 @@ defmodule Trento.HostProjector do
       changeset =
         HostReadModel
         |> Repo.get(id)
-        # TODO: couldn't make it work with Ecto.Multi
-        # With following line when we receive an empty list of selected checks, the readmodel does not get updated
-        # %ClusterReadModel{id: id}
         |> HostReadModel.changeset(%{
           selected_checks: checks
         })
@@ -250,17 +247,19 @@ defmodule Trento.HostProjector do
   end
 
   def after_update(
-        %HostChecksSelected{checks: checks},
+        %HostChecksSelected{host_id: host_id, checks: checks},
         _,
-        %{host: %HostReadModel{id: id}}
+        _
       ) do
+    host = %HostReadModel{id: host_id, selected_checks: checks}
+
     message =
       HostView.render(
-        "host_checks_updated.json",
-        %{host: %HostReadModel{id: id, selected_checks: checks}}
+        "host_details_updated.json",
+        %{host: host}
       )
 
-    TrentoWeb.Endpoint.broadcast("monitoring:hosts", "host_checks_updated", message)
+    TrentoWeb.Endpoint.broadcast("monitoring:hosts", "host_details_updated", message)
   end
 
   def after_update(_, _, _), do: :ok

--- a/lib/trento/application/read_models/host_read_model.ex
+++ b/lib/trento/application/read_models/host_read_model.ex
@@ -21,7 +21,7 @@ defmodule Trento.HostReadModel do
     field :agent_version, :string
     field :cluster_id, Ecto.UUID
     field :heartbeat, Ecto.Enum, values: [:critical, :passing, :unknown]
-
+    field :selected_checks, {:array, :string}, default: []
     field :provider, Ecto.Enum, values: Provider.values()
     field :provider_data, :map
 

--- a/lib/trento_web/views/v1/host_view.ex
+++ b/lib/trento_web/views/v1/host_view.ex
@@ -20,19 +20,6 @@ defmodule TrentoWeb.V1.HostView do
     |> Map.delete(:provider)
   end
 
-  def render("host_checks_updated.json", %{host: host}) do
-    render("host.json", %{host: host})
-    |> Map.delete(:sles_subscriptions)
-    |> Map.delete(:tags)
-    |> Map.delete(:cluster_id)
-    |> Map.delete(:heartbeat)
-    |> Map.delete(:provider)
-    |> Map.delete(:agent_version)
-    |> Map.delete(:hostname)
-    |> Map.delete(:ip_addresses)
-    |> Map.delete(:provider_data)
-  end
-
   def render("host_registered.json", %{host: host}) do
     render("host.json", %{host: host})
     |> Map.delete(:sles_subscriptions)

--- a/lib/trento_web/views/v1/host_view.ex
+++ b/lib/trento_web/views/v1/host_view.ex
@@ -20,6 +20,19 @@ defmodule TrentoWeb.V1.HostView do
     |> Map.delete(:provider)
   end
 
+  def render("host_checks_updated.json", %{host: host}) do
+    render("host.json", %{host: host})
+    |> Map.delete(:sles_subscriptions)
+    |> Map.delete(:tags)
+    |> Map.delete(:cluster_id)
+    |> Map.delete(:heartbeat)
+    |> Map.delete(:provider)
+    |> Map.delete(:agent_version)
+    |> Map.delete(:hostname)
+    |> Map.delete(:ip_addresses)
+    |> Map.delete(:provider_data)
+  end
+
   def render("host_registered.json", %{host: host}) do
     render("host.json", %{host: host})
     |> Map.delete(:sles_subscriptions)

--- a/priv/repo/migrations/20230616114036_add_selected_checks_to_hosts.exs
+++ b/priv/repo/migrations/20230616114036_add_selected_checks_to_hosts.exs
@@ -1,0 +1,9 @@
+defmodule Trento.Repo.Migrations.AddSelectedChecksToHosts do
+  use Ecto.Migration
+
+  def change do
+    alter table(:hosts) do
+      add :selected_checks, {:array, :string}, default: []
+    end
+  end
+end

--- a/test/trento/application/projectors/host_projector_test.exs
+++ b/test/trento/application/projectors/host_projector_test.exs
@@ -24,6 +24,7 @@ defmodule Trento.HostProjectorTest do
     HeartbeatFailed,
     HeartbeatSucceded,
     HostAddedToCluster,
+    HostChecksSelected,
     HostDetailsUpdated,
     ProviderUpdated
   }
@@ -164,6 +165,28 @@ defmodule Trento.HostProjectorTest do
                        provider_data: nil
                      },
                      1000
+  end
+
+  test "should update the selected_checks field when event is received" do
+    %{id: host_id} = insert(:host)
+
+    cases = [
+      %{checks: [Faker.StarWars.character(), Faker.StarWars.character()]},
+      %{checks: []}
+    ]
+
+    Enum.each(cases, fn %{checks: checks} ->
+      event = %HostChecksSelected{host_id: host_id, checks: checks}
+
+      ProjectorTestHelper.project(HostProjector, event, "host_projector")
+      host_projection = Repo.get!(HostReadModel, event.host_id)
+
+      assert event.checks == host_projection.selected_checks
+
+      assert_broadcast "host_details_updated",
+                       %{selected_checks: ^checks, id: ^host_id},
+                       1000
+    end)
   end
 
   test "should update the heartbeat field to passing status when HeartbeatSucceded is received",


### PR DESCRIPTION
# Description
This pull request introduces a new projector function, `Trento.HostProjector,` which handles host checks selection. Additionally, broadcasting functionality has been implemented to notify subscribed clients of any changes.

The database read model and migration have been updated to include a new column, selected_checks, in the hosts table.

## How was this tested?

Automated test was added + manually tested
