### PR TITLE
Add select host checks endpoint

### DIFF
--- a/lib/trento/application/usecases/hosts/hosts.ex
+++ b/lib/trento/application/usecases/hosts/hosts.ex
@@ -5,10 +5,14 @@ defmodule Trento.Hosts do
 
   import Ecto.Query
 
+  require Logger
+
   alias Trento.{
     HostReadModel,
     SlesSubscriptionReadModel
   }
+
+  alias Trento.Domain.Commands.SelectHostChecks
 
   alias Trento.Repo
 
@@ -36,4 +40,16 @@ defmodule Trento.Hosts do
         subscription_count
     end
   end
+
+  @spec select_checks(String.t(), [String.t()]) :: :ok | {:error, any}
+  def select_checks(host_id, checks) do
+    Logger.debug("Selecting checks, host: #{host_id}")
+
+    with {:ok, command} <- SelectHostChecks.new(%{host_id: host_id, checks: checks}) do
+      commanded().dispatch(command)
+    end
+  end
+
+  defp commanded,
+    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
 end

--- a/lib/trento_web/controllers/v1/cluster_controller.ex
+++ b/lib/trento_web/controllers/v1/cluster_controller.ex
@@ -52,7 +52,7 @@ defmodule TrentoWeb.V1.ClusterController do
   end
 
   operation :select_checks,
-    summary: "Select Checks",
+    summary: "Select Checks for a Cluster",
     tags: ["Checks"],
     description: "Select the Checks eligible for execution on the target infrastructure",
     parameters: [

--- a/lib/trento_web/controllers/v1/host_controller.ex
+++ b/lib/trento_web/controllers/v1/host_controller.ex
@@ -2,6 +2,8 @@ defmodule TrentoWeb.V1.HostController do
   use TrentoWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
+  alias TrentoWeb.OpenApi.Schema
+
   alias Trento.{
     Heartbeats,
     Hosts
@@ -10,15 +12,13 @@ defmodule TrentoWeb.V1.HostController do
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
   action_fallback TrentoWeb.FallbackController
 
-  tags ["Target Infrastructure"]
-
   operation :list,
+    tags: ["Target Infrastructure"],
     summary: "List hosts",
     description: "List all the discovered hosts on the target infrastructure",
     responses: [
       ok:
-        {"A collection of the discovered hosts", "application/json",
-         TrentoWeb.OpenApi.Schema.Host.HostsCollection}
+        {"A collection of the discovered hosts", "application/json", Schema.Host.HostsCollection}
     ]
 
   @spec list(Plug.Conn.t(), map) :: Plug.Conn.t()
@@ -41,14 +41,42 @@ defmodule TrentoWeb.V1.HostController do
     ],
     responses: [
       no_content: "The heartbeat has been updated",
-      not_found: TrentoWeb.OpenApi.Schema.NotFound.response(),
-      bad_request: TrentoWeb.OpenApi.Schema.BadRequest.response(),
+      not_found: Schema.NotFound.response(),
+      bad_request: Schema.BadRequest.response(),
       unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
     ]
 
   def heartbeat(conn, %{id: id}) do
     with :ok <- Heartbeats.heartbeat(id) do
       send_resp(conn, 204, "")
+    end
+  end
+
+  operation :select_checks,
+    summary: "Select Checks for a Host",
+    tags: ["Checks"],
+    description: "Select the Checks eligible for execution on the target infrastructure",
+    parameters: [
+      id: [
+        in: :path,
+        required: true,
+        type: %OpenApiSpex.Schema{type: :string, format: :uuid}
+      ]
+    ],
+    request_body: {"Checks Selection", "application/json", Schema.Checks.ChecksSelectionRequest},
+    responses: [
+      accepted: "The Selection has been successfully collected",
+      not_found: Schema.NotFound.response(),
+      unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
+    ]
+
+  def select_checks(%{body_params: body_params} = conn, %{id: host_id}) do
+    %{checks: checks} = body_params
+
+    with :ok <- Hosts.select_checks(host_id, checks) do
+      conn
+      |> put_status(:accepted)
+      |> json(%{})
     end
   end
 end

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -76,6 +76,7 @@ defmodule TrentoWeb.Router do
       get "/databases", SapSystemController, :list_databases
 
       post "/clusters/:cluster_id/checks", ClusterController, :select_checks
+      post "/hosts/:id/checks", HostController, :select_checks
 
       post "/clusters/:cluster_id/checks/request_execution",
            ClusterController,

--- a/test/trento/application/usecases/hosts_test.exs
+++ b/test/trento/application/usecases/hosts_test.exs
@@ -2,10 +2,14 @@ defmodule Trento.HostsTest do
   use ExUnit.Case
   use Trento.DataCase
 
+  import Mox
+
   import Trento.Factory
 
   alias Trento.Hosts
   alias Trento.Repo
+
+  alias Trento.Domain.Commands.SelectHostChecks
 
   alias Trento.SlesSubscriptionReadModel
 
@@ -23,6 +27,44 @@ defmodule Trento.HostsTest do
 
       assert 12 = SlesSubscriptionReadModel |> Repo.all() |> length()
       assert 6 = Hosts.get_all_sles_subscriptions()
+    end
+  end
+
+  describe "Check Selection" do
+    test "should dispatch command on Check Selection" do
+      host_id = Faker.UUID.v4()
+      selected_checks = Enum.map(0..4, fn _ -> Faker.UUID.v4() end)
+
+      expect(
+        Trento.Commanded.Mock,
+        :dispatch,
+        fn %SelectHostChecks{
+             host_id: ^host_id,
+             checks: ^selected_checks
+           } ->
+          :ok
+        end
+      )
+
+      assert :ok = Hosts.select_checks(host_id, selected_checks)
+    end
+
+    test "should return command dispatching error" do
+      host_id = Faker.UUID.v4()
+      selected_checks = Enum.map(0..4, fn _ -> Faker.UUID.v4() end)
+
+      expect(
+        Trento.Commanded.Mock,
+        :dispatch,
+        fn %SelectHostChecks{
+             host_id: ^host_id,
+             checks: ^selected_checks
+           } ->
+          {:error, :some_error}
+        end
+      )
+
+      assert {:error, :some_error} = Hosts.select_checks(host_id, selected_checks)
     end
   end
 end


### PR DESCRIPTION
# Description

Exposes a `POST /api/v1/hosts/:id/checks` for host checks selection.

## How was this tested?
Automated test.