### PR TITLE
Sap system restoration

### DIFF
--- a/lib/trento/application/projectors/database_projector.ex
+++ b/lib/trento/application/projectors/database_projector.ex
@@ -164,7 +164,6 @@ defmodule Trento.DatabaseProjector do
   project(
     %DatabaseRestored{
       sap_system_id: sap_system_id,
-      sid: sid,
       health: health
     },
     fn multi ->
@@ -173,7 +172,7 @@ defmodule Trento.DatabaseProjector do
       changeset =
         DatabaseReadModel.changeset(
           db,
-          %{deregistered_at: nil, sid: sid, health: health}
+          %{deregistered_at: nil, health: health}
         )
 
       Ecto.Multi.update(multi, :database, changeset)

--- a/lib/trento/application/projectors/sap_system_projector.ex
+++ b/lib/trento/application/projectors/sap_system_projector.ex
@@ -138,7 +138,6 @@ defmodule Trento.SapSystemProjector do
   project(
     %SapSystemRestored{
       sap_system_id: sap_system_id,
-      sid: sid,
       tenant: tenant,
       db_host: db_host,
       health: health
@@ -148,7 +147,6 @@ defmodule Trento.SapSystemProjector do
 
       changeset =
         SapSystemReadModel.changeset(sap_system, %{
-          sid: sid,
           tenant: tenant,
           db_host: db_host,
           health: health,

--- a/lib/trento/application/projectors/sap_system_projector.ex
+++ b/lib/trento/application/projectors/sap_system_projector.ex
@@ -15,6 +15,7 @@ defmodule Trento.SapSystemProjector do
     SapSystemDeregistered,
     SapSystemHealthChanged,
     SapSystemRegistered,
+    SapSystemRestored,
     SapSystemUpdated
   }
 
@@ -135,6 +136,30 @@ defmodule Trento.SapSystemProjector do
   )
 
   project(
+    %SapSystemRestored{
+      sap_system_id: sap_system_id,
+      sid: sid,
+      tenant: tenant,
+      db_host: db_host,
+      health: health
+    },
+    fn multi ->
+      sap_system = Repo.get!(SapSystemReadModel, sap_system_id)
+
+      changeset =
+        SapSystemReadModel.changeset(sap_system, %{
+          sid: sid,
+          tenant: tenant,
+          db_host: db_host,
+          health: health,
+          deregistered_at: nil
+        })
+
+      Ecto.Multi.update(multi, :sap_system, changeset)
+    end
+  )
+
+  project(
     %ApplicationInstanceDeregistered{
       instance_number: instance_number,
       host_id: host_id,
@@ -170,6 +195,7 @@ defmodule Trento.SapSystemProjector do
   @sap_systems_topic "monitoring:sap_systems"
 
   @impl true
+  @spec after_update(any, any, any) :: :ok | {:error, any}
   def after_update(
         %SapSystemRegistered{},
         _,
@@ -255,6 +281,21 @@ defmodule Trento.SapSystemProjector do
         id: sap_system_id,
         sid: sid
       )
+    )
+  end
+
+  @impl true
+  def after_update(
+        %SapSystemRestored{sap_system_id: sap_system_id},
+        _,
+        _
+      ) do
+    sap_system = Repo.get!(SapSystemReadModel, sap_system_id)
+
+    TrentoWeb.Endpoint.broadcast(
+      @sap_systems_topic,
+      "sap_system_registered",
+      SapSystemView.render("sap_system_registered.json", sap_system: sap_system)
     )
   end
 

--- a/lib/trento/domain/sap_system/events/database_restored.ex
+++ b/lib/trento/domain/sap_system/events/database_restored.ex
@@ -1,0 +1,15 @@
+defmodule Trento.Domain.Events.DatabaseRestored do
+  @moduledoc """
+  This event is emitted when a database is restored.
+  """
+
+  use Trento.Event
+
+  require Trento.Domain.Enums.Health, as: Health
+
+  defevent do
+    field :sap_system_id, Ecto.UUID
+    field :sid, :string
+    field :health, Ecto.Enum, values: Health.values()
+  end
+end

--- a/lib/trento/domain/sap_system/events/database_restored.ex
+++ b/lib/trento/domain/sap_system/events/database_restored.ex
@@ -9,7 +9,6 @@ defmodule Trento.Domain.Events.DatabaseRestored do
 
   defevent do
     field :sap_system_id, Ecto.UUID
-    field :sid, :string
     field :health, Ecto.Enum, values: Health.values()
   end
 end

--- a/lib/trento/domain/sap_system/events/sap_system_restored.ex
+++ b/lib/trento/domain/sap_system/events/sap_system_restored.ex
@@ -1,0 +1,17 @@
+defmodule Trento.Domain.Events.SapSystemRestored do
+  @moduledoc """
+  This event is emitted when a sap system is restored.
+  """
+
+  use Trento.Event
+
+  require Trento.Domain.Enums.Health, as: Health
+
+  defevent do
+    field :sap_system_id, Ecto.UUID
+    field :sid, :string
+    field :tenant, :string
+    field :db_host, :string
+    field :health, Ecto.Enum, values: Health.values()
+  end
+end

--- a/lib/trento/domain/sap_system/events/sap_system_restored.ex
+++ b/lib/trento/domain/sap_system/events/sap_system_restored.ex
@@ -9,7 +9,6 @@ defmodule Trento.Domain.Events.SapSystemRestored do
 
   defevent do
     field :sap_system_id, Ecto.UUID
-    field :sid, :string
     field :tenant, :string
     field :db_host, :string
     field :health, Ecto.Enum, values: Health.values()

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -260,7 +260,6 @@ defmodule Trento.Domain.SapSystem do
     |> Multi.execute(fn sap_system ->
       maybe_emit_sap_system_restored_event(sap_system, instance)
     end)
-    |> Multi.execute(&maybe_emit_sap_system_health_changed_event/1)
   end
 
   # SAP system not registered, application already present

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -197,8 +197,7 @@ defmodule Trento.Domain.SapSystem do
     [
       %DatabaseRestored{
         sap_system_id: sap_system_id,
-        health: health,
-        sid: sid
+        health: health
       },
       %DatabaseInstanceRegistered{
         sap_system_id: sap_system_id,
@@ -695,8 +694,7 @@ defmodule Trento.Domain.SapSystem do
   def apply(
         %SapSystem{database: database} = sap_system,
         %DatabaseRestored{
-          health: health,
-          sid: sid
+          health: health
         }
       ) do
     %SapSystem{
@@ -704,7 +702,6 @@ defmodule Trento.Domain.SapSystem do
       | database: %Database{
           database
           | health: health,
-            sid: sid,
             deregistered_at: nil
         }
     }

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -252,7 +252,7 @@ defmodule Trento.Domain.SapSystem do
     sap_system
     |> Multi.new()
     |> Multi.execute(fn sap_system ->
-      emit_application_instance_registered_or_application_instance_health_changed(
+      maybe_emit_application_instance_registered_or_moved_event(
         sap_system,
         instance
       )

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -720,13 +720,11 @@ defmodule Trento.Domain.SapSystem do
   end
 
   def apply(%SapSystem{} = sap_system, %SapSystemRestored{
-        sid: sid,
         health: health
       }) do
     %SapSystem{
       sap_system
-      | sid: sid,
-        health: health,
+      | health: health,
         deregistered_at: nil
     }
   end
@@ -937,7 +935,6 @@ defmodule Trento.Domain.SapSystem do
          %SapSystem{application: %Application{instances: instances}},
          %RegisterApplicationInstance{
            sap_system_id: sap_system_id,
-           sid: sid,
            tenant: tenant,
            db_host: db_host,
            health: health
@@ -948,7 +945,6 @@ defmodule Trento.Domain.SapSystem do
         db_host: db_host,
         health: health,
         sap_system_id: sap_system_id,
-        sid: sid,
         tenant: tenant
       }
     end

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -695,15 +695,13 @@ defmodule Trento.Domain.SapSystem do
   def apply(
         %SapSystem{database: database} = sap_system,
         %DatabaseRestored{
-          sap_system_id: sap_system_id,
           health: health,
           sid: sid
         }
       ) do
     %SapSystem{
       sap_system
-      | sap_system_id: sap_system_id,
-        database: %Database{
+      | database: %Database{
           database
           | health: health,
             sid: sid,

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -21,6 +21,7 @@ defmodule Trento.Factory do
   }
 
   alias Trento.Domain.Events.{
+    ApplicationInstanceDeregistered,
     ApplicationInstanceRegistered,
     ClusterDeregistered,
     ClusterRegistered,
@@ -29,6 +30,7 @@ defmodule Trento.Factory do
     DatabaseInstanceDeregistered,
     DatabaseInstanceRegistered,
     DatabaseRegistered,
+    DatabaseRestored,
     HostAddedToCluster,
     HostDetailsUpdated,
     HostRegistered,
@@ -267,6 +269,14 @@ defmodule Trento.Factory do
     })
   end
 
+  def database_restored_event_factory do
+    DatabaseRestored.new!(%{
+      sap_system_id: Faker.UUID.v4(),
+      sid: Faker.UUID.v4(),
+      health: Health.passing()
+    })
+  end
+
   def deregister_database_instance_command_factory do
     DeregisterDatabaseInstance.new!(%{
       sap_system_id: Faker.UUID.v4(),
@@ -296,6 +306,15 @@ defmodule Trento.Factory do
       host_id: Faker.UUID.v4(),
       health: Health.passing()
     }
+  end
+
+  def application_instance_deregistered_event_factory do
+    ApplicationInstanceDeregistered.new!(%{
+      sap_system_id: Faker.UUID.v4(),
+      deregistered_at: DateTime.utc_now(),
+      instance_number: "00",
+      host_id: Faker.UUID.v4()
+    })
   end
 
   def deregister_application_instance_command_factory do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -272,7 +272,6 @@ defmodule Trento.Factory do
   def database_restored_event_factory do
     DatabaseRestored.new!(%{
       sap_system_id: Faker.UUID.v4(),
-      sid: Faker.UUID.v4(),
       health: Health.passing()
     })
   end

--- a/test/trento/application/projectors/database_projector_test.exs
+++ b/test/trento/application/projectors/database_projector_test.exs
@@ -317,7 +317,6 @@ defmodule Trento.DatabaseProjectorTest do
 
     event = %DatabaseRestored{
       sap_system_id: sap_system_id,
-      sid: "NWD",
       health: :passing
     }
 
@@ -325,7 +324,6 @@ defmodule Trento.DatabaseProjectorTest do
 
     projection = Repo.get(DatabaseReadModel, sap_system_id)
     assert nil == projection.deregistered_at
-    assert "NWD" == projection.sid
     assert :passing == projection.health
 
     assert_broadcast "database_registered",

--- a/test/trento/application/projectors/sap_system_projector_test.exs
+++ b/test/trento/application/projectors/sap_system_projector_test.exs
@@ -200,8 +200,7 @@ defmodule Trento.SapSystemProjectorTest do
       sap_system_id: sap_system_id,
       tenant: tenant,
       db_host: new_db_host,
-      health: new_health,
-      sid: sid
+      health: new_health
     }
 
     ProjectorTestHelper.project(SapSystemProjector, event, "sap_system_projector")

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -2703,7 +2703,6 @@ defmodule Trento.SapSystemTest do
           },
           %SapSystemRestored{
             sap_system_id: sap_system_id,
-            sid: application_sid,
             tenant: command.tenant,
             db_host: command.db_host,
             health: command.health

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -2003,7 +2003,6 @@ defmodule Trento.SapSystemTest do
         [
           %DatabaseRestored{
             sap_system_id: sap_system_id,
-            sid: db_sid,
             health: command.health
           },
           %DatabaseInstanceRegistered{
@@ -2141,7 +2140,6 @@ defmodule Trento.SapSystemTest do
         [
           %DatabaseRestored{
             sap_system_id: sap_system_id,
-            sid: db_sid,
             health: command.health
           },
           %DatabaseInstanceRegistered{
@@ -2281,7 +2279,6 @@ defmodule Trento.SapSystemTest do
         [
           %DatabaseRestored{
             sap_system_id: sap_system_id,
-            sid: db_sid,
             health: command.health
           },
           %DatabaseInstanceRegistered{
@@ -2415,7 +2412,6 @@ defmodule Trento.SapSystemTest do
         [
           %DatabaseRestored{
             sap_system_id: sap_system_id,
-            sid: db_sid,
             health: command.health
           },
           %DatabaseInstanceRegistered{
@@ -2546,8 +2542,7 @@ defmodule Trento.SapSystemTest do
           sap_system_id: sap_system_id
         ),
         build(:database_restored_event,
-          sap_system_id: sap_system_id,
-          sid: db_sid
+          sap_system_id: sap_system_id
         )
       ]
 
@@ -2677,8 +2672,7 @@ defmodule Trento.SapSystemTest do
           sap_system_id: sap_system_id
         ),
         build(:database_restored_event,
-          sap_system_id: sap_system_id,
-          sid: db_sid
+          sap_system_id: sap_system_id
         )
       ]
 

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -29,6 +29,7 @@ defmodule Trento.SapSystemTest do
     SapSystemDeregistered,
     SapSystemHealthChanged,
     SapSystemRegistered,
+    SapSystemRestored,
     SapSystemRolledUp,
     SapSystemRollUpRequested,
     SapSystemTombstoned,
@@ -2451,6 +2452,275 @@ defmodule Trento.SapSystemTest do
                        },
                        %Instance{}
                      ]
+                   }
+                 } = sap_system
+        end
+      )
+    end
+
+    test "should not restore a sap system when no abap/messageserver instances are present" do
+      sap_system_id = UUID.uuid4()
+
+      primary_database_host_id = UUID.uuid4()
+      secondary_database_host_id = UUID.uuid4()
+
+      deregistered_at = DateTime.utc_now()
+
+      db_instance_number_1 = "00"
+      db_instance_number_2 = "01"
+
+      db_sid = fake_sid()
+      application_sid = fake_sid()
+
+      message_server_host_id = UUID.uuid4()
+      message_server_instance_number = "00"
+      abap_host_id = UUID.uuid4()
+      abap_instance_number = "01"
+
+      initial_events = [
+        build(
+          :database_registered_event,
+          sap_system_id: sap_system_id,
+          sid: db_sid
+        ),
+        build(
+          :database_instance_registered_event,
+          sap_system_id: sap_system_id,
+          host_id: primary_database_host_id,
+          sid: db_sid,
+          instance_number: db_instance_number_1,
+          system_replication: "Primary"
+        ),
+        build(
+          :database_instance_registered_event,
+          sap_system_id: sap_system_id,
+          host_id: secondary_database_host_id,
+          instance_number: db_instance_number_2,
+          system_replication: "Secondary",
+          sid: db_sid
+        ),
+        build(
+          :application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          features: "MESSAGESERVER|ENQUE",
+          host_id: message_server_host_id,
+          instance_number: message_server_instance_number,
+          sid: application_sid
+        ),
+        build(
+          :application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          features: "ABAP|GATEWAY|ICMAN|IGS",
+          host_id: abap_host_id,
+          instance_number: abap_instance_number,
+          sid: application_sid
+        ),
+        build(
+          :sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: application_sid
+        ),
+        build(:database_instance_deregistered_event,
+          sap_system_id: sap_system_id,
+          host_id: primary_database_host_id,
+          instance_number: db_instance_number_1,
+          deregistered_at: deregistered_at
+        ),
+        build(:database_deregistered_event,
+          sap_system_id: sap_system_id,
+          deregistered_at: deregistered_at
+        ),
+        build(:sap_system_deregistered_event,
+          sap_system_id: sap_system_id,
+          deregistered_at: deregistered_at
+        ),
+        build(:application_instance_deregistered_event,
+          sap_system_id: sap_system_id,
+          deregistered_at: deregistered_at,
+          instance_number: message_server_instance_number,
+          host_id: message_server_host_id
+        ),
+        build(:database_instance_registered_event,
+          system_replication: "Primary",
+          sid: db_sid,
+          sap_system_id: sap_system_id
+        ),
+        build(:database_restored_event,
+          sap_system_id: sap_system_id,
+          sid: db_sid
+        )
+      ]
+
+      command =
+        build(
+          :register_application_instance_command,
+          sap_system_id: sap_system_id,
+          sid: application_sid,
+          db_host: primary_database_host_id,
+          features: "IGS"
+        )
+
+      assert_events_and_state(
+        initial_events,
+        command,
+        [
+          %ApplicationInstanceRegistered{
+            sap_system_id: sap_system_id,
+            sid: application_sid,
+            host_id: command.host_id,
+            instance_number: command.instance_number,
+            instance_hostname: command.instance_hostname,
+            features: command.features,
+            http_port: command.http_port,
+            https_port: command.https_port,
+            start_priority: command.start_priority,
+            health: command.health
+          }
+        ],
+        fn sap_system ->
+          assert %SapSystem{
+                   deregistered_at: ^deregistered_at,
+                   database: %Database{
+                     deregistered_at: nil,
+                     sid: ^db_sid
+                   }
+                 } = sap_system
+        end
+      )
+    end
+
+    test "should restore a sap system when abap/messageserver instances are present" do
+      sap_system_id = UUID.uuid4()
+
+      primary_database_host_id = UUID.uuid4()
+      secondary_database_host_id = UUID.uuid4()
+
+      deregistered_at = DateTime.utc_now()
+
+      db_instance_number_1 = "00"
+      db_instance_number_2 = "01"
+
+      db_sid = fake_sid()
+      application_sid = fake_sid()
+
+      message_server_host_id = UUID.uuid4()
+      message_server_instance_number = "00"
+      abap_host_id = UUID.uuid4()
+      abap_instance_number = "01"
+
+      initial_events = [
+        build(
+          :database_registered_event,
+          sap_system_id: sap_system_id,
+          sid: db_sid
+        ),
+        build(
+          :database_instance_registered_event,
+          sap_system_id: sap_system_id,
+          host_id: primary_database_host_id,
+          sid: db_sid,
+          instance_number: db_instance_number_1,
+          system_replication: "Primary"
+        ),
+        build(
+          :database_instance_registered_event,
+          sap_system_id: sap_system_id,
+          host_id: secondary_database_host_id,
+          instance_number: db_instance_number_2,
+          system_replication: "Secondary",
+          sid: db_sid
+        ),
+        build(
+          :application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          features: "MESSAGESERVER|ENQUE",
+          host_id: message_server_host_id,
+          instance_number: message_server_instance_number,
+          sid: application_sid
+        ),
+        build(
+          :application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          features: "ABAP|GATEWAY|ICMAN|IGS",
+          host_id: abap_host_id,
+          instance_number: abap_instance_number,
+          sid: application_sid
+        ),
+        build(
+          :sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: application_sid
+        ),
+        build(:database_instance_deregistered_event,
+          sap_system_id: sap_system_id,
+          host_id: primary_database_host_id,
+          instance_number: db_instance_number_1,
+          deregistered_at: deregistered_at
+        ),
+        build(:database_deregistered_event,
+          sap_system_id: sap_system_id,
+          deregistered_at: deregistered_at
+        ),
+        build(:sap_system_deregistered_event,
+          sap_system_id: sap_system_id,
+          deregistered_at: deregistered_at
+        ),
+        build(:application_instance_deregistered_event,
+          sap_system_id: sap_system_id,
+          deregistered_at: deregistered_at,
+          instance_number: message_server_instance_number,
+          host_id: message_server_host_id
+        ),
+        build(:database_instance_registered_event,
+          system_replication: "Primary",
+          sid: db_sid,
+          sap_system_id: sap_system_id
+        ),
+        build(:database_restored_event,
+          sap_system_id: sap_system_id,
+          sid: db_sid
+        )
+      ]
+
+      command =
+        build(
+          :register_application_instance_command,
+          sap_system_id: sap_system_id,
+          sid: application_sid,
+          db_host: primary_database_host_id,
+          features: "MESSAGESERVER"
+        )
+
+      assert_events_and_state(
+        initial_events,
+        command,
+        [
+          %ApplicationInstanceRegistered{
+            sap_system_id: sap_system_id,
+            sid: application_sid,
+            host_id: command.host_id,
+            instance_number: command.instance_number,
+            instance_hostname: command.instance_hostname,
+            features: command.features,
+            http_port: command.http_port,
+            https_port: command.https_port,
+            start_priority: command.start_priority,
+            health: command.health
+          },
+          %SapSystemRestored{
+            sap_system_id: sap_system_id,
+            sid: application_sid,
+            tenant: command.tenant,
+            db_host: command.db_host,
+            health: command.health
+          }
+        ],
+        fn sap_system ->
+          assert %SapSystem{
+                   deregistered_at: nil,
+                   database: %Database{
+                     deregistered_at: nil,
+                     sid: ^db_sid
                    }
                  } = sap_system
         end

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -25,6 +25,7 @@ defmodule Trento.SapSystemTest do
     DatabaseInstanceRegistered,
     DatabaseInstanceSystemReplicationChanged,
     DatabaseRegistered,
+    DatabaseRestored,
     SapSystemDeregistered,
     SapSystemHealthChanged,
     SapSystemRegistered,
@@ -1817,6 +1818,645 @@ defmodule Trento.SapSystemTest do
   end
 
   describe "deregistration" do
+    test "should not restore a deregistered database when the registering database instance has Secondary role" do
+      sap_system_id = UUID.uuid4()
+
+      primary_database_host_id = UUID.uuid4()
+      secondary_database_host_id = UUID.uuid4()
+
+      deregistered_at = DateTime.utc_now()
+
+      db_instance_number_1 = "00"
+      db_instance_number_2 = "01"
+
+      db_sid = fake_sid()
+      application_sid = fake_sid()
+
+      message_server_host_id = UUID.uuid4()
+      message_server_instance_number = "00"
+      abap_host_id = UUID.uuid4()
+      abap_instance_number = "01"
+
+      initial_events = [
+        build(
+          :database_registered_event,
+          sap_system_id: sap_system_id,
+          sid: db_sid
+        ),
+        build(
+          :database_instance_registered_event,
+          sap_system_id: sap_system_id,
+          host_id: primary_database_host_id,
+          sid: db_sid,
+          instance_number: db_instance_number_1,
+          system_replication: "Primary"
+        ),
+        build(
+          :database_instance_registered_event,
+          sap_system_id: sap_system_id,
+          host_id: secondary_database_host_id,
+          instance_number: db_instance_number_2,
+          system_replication: "Secondary",
+          sid: db_sid
+        ),
+        build(
+          :application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          features: "MESSAGESERVER|ENQUE",
+          host_id: message_server_host_id,
+          instance_number: message_server_instance_number,
+          sid: application_sid
+        ),
+        build(
+          :application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          features: "ABAP|GATEWAY|ICMAN|IGS",
+          host_id: abap_host_id,
+          instance_number: abap_instance_number,
+          sid: application_sid
+        ),
+        build(
+          :sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: application_sid
+        ),
+        build(:database_instance_deregistered_event,
+          sap_system_id: sap_system_id,
+          host_id: primary_database_host_id,
+          instance_number: db_instance_number_1,
+          deregistered_at: deregistered_at
+        ),
+        build(:database_deregistered_event,
+          sap_system_id: sap_system_id,
+          deregistered_at: deregistered_at
+        ),
+        build(:sap_system_deregistered_event,
+          sap_system_id: sap_system_id,
+          deregistered_at: deregistered_at
+        )
+      ]
+
+      command =
+        build(:register_database_instance_command,
+          system_replication: "Secondary",
+          sid: db_sid,
+          sap_system_id: sap_system_id
+        )
+
+      assert_error(
+        initial_events,
+        command,
+        {:error, :sap_system_not_registered}
+      )
+    end
+
+    test "should restore a deregistered database when the registering database instance has system replication disabled, with database instance leftovers" do
+      sap_system_id = UUID.uuid4()
+
+      primary_database_host_id = UUID.uuid4()
+      secondary_database_host_id = UUID.uuid4()
+
+      deregistered_at = DateTime.utc_now()
+
+      db_instance_number_1 = "00"
+      db_instance_number_2 = "01"
+
+      db_sid = fake_sid()
+      application_sid = fake_sid()
+
+      message_server_host_id = UUID.uuid4()
+      message_server_instance_number = "00"
+      abap_host_id = UUID.uuid4()
+      abap_instance_number = "01"
+
+      initial_events = [
+        build(
+          :database_registered_event,
+          sap_system_id: sap_system_id,
+          sid: db_sid
+        ),
+        build(
+          :database_instance_registered_event,
+          sap_system_id: sap_system_id,
+          host_id: primary_database_host_id,
+          sid: db_sid,
+          instance_number: db_instance_number_1,
+          system_replication: "Primary"
+        ),
+        build(
+          :database_instance_registered_event,
+          sap_system_id: sap_system_id,
+          host_id: secondary_database_host_id,
+          instance_number: db_instance_number_2,
+          system_replication: "Secondary",
+          sid: db_sid
+        ),
+        build(
+          :application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          features: "MESSAGESERVER|ENQUE",
+          host_id: message_server_host_id,
+          instance_number: message_server_instance_number,
+          sid: application_sid
+        ),
+        build(
+          :application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          features: "ABAP|GATEWAY|ICMAN|IGS",
+          host_id: abap_host_id,
+          instance_number: abap_instance_number,
+          sid: application_sid
+        ),
+        build(
+          :sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: application_sid
+        ),
+        build(:database_instance_deregistered_event,
+          sap_system_id: sap_system_id,
+          host_id: primary_database_host_id,
+          instance_number: db_instance_number_1,
+          deregistered_at: deregistered_at
+        ),
+        build(:database_deregistered_event,
+          sap_system_id: sap_system_id,
+          deregistered_at: deregistered_at
+        ),
+        build(:sap_system_deregistered_event,
+          sap_system_id: sap_system_id,
+          deregistered_at: deregistered_at
+        )
+      ]
+
+      %{features: features, instance_number: instance_number, health: health} =
+        command =
+        build(:register_database_instance_command,
+          system_replication: nil,
+          sid: db_sid,
+          sap_system_id: sap_system_id
+        )
+
+      assert_events_and_state(
+        initial_events,
+        command,
+        [
+          %DatabaseRestored{
+            sap_system_id: sap_system_id,
+            sid: db_sid,
+            health: command.health
+          },
+          %DatabaseInstanceRegistered{
+            sap_system_id: sap_system_id,
+            sid: db_sid,
+            tenant: command.tenant,
+            instance_number: command.instance_number,
+            instance_hostname: command.instance_hostname,
+            features: command.features,
+            http_port: command.http_port,
+            https_port: command.https_port,
+            start_priority: command.start_priority,
+            host_id: command.host_id,
+            system_replication: command.system_replication,
+            system_replication_status: command.system_replication_status,
+            health: command.health
+          }
+        ],
+        fn sap_system ->
+          assert %SapSystem{
+                   deregistered_at: ^deregistered_at,
+                   database: %Database{
+                     deregistered_at: nil,
+                     sid: ^db_sid,
+                     instances: [
+                       %Instance{
+                         sid: ^db_sid,
+                         instance_number: ^instance_number,
+                         features: ^features,
+                         health: ^health
+                       },
+                       %Instance{}
+                     ]
+                   }
+                 } = sap_system
+        end
+      )
+    end
+
+    test "should restore a deregistered database when the registering database instance has system replication disabled, without database instance leftovers" do
+      sap_system_id = UUID.uuid4()
+
+      primary_database_host_id = UUID.uuid4()
+      secondary_database_host_id = UUID.uuid4()
+
+      deregistered_at = DateTime.utc_now()
+
+      db_instance_number_1 = "00"
+      db_instance_number_2 = "01"
+
+      db_sid = fake_sid()
+      application_sid = fake_sid()
+
+      message_server_host_id = UUID.uuid4()
+      message_server_instance_number = "00"
+      abap_host_id = UUID.uuid4()
+      abap_instance_number = "01"
+
+      initial_events = [
+        build(
+          :database_registered_event,
+          sap_system_id: sap_system_id,
+          sid: db_sid
+        ),
+        build(
+          :database_instance_registered_event,
+          sap_system_id: sap_system_id,
+          host_id: primary_database_host_id,
+          sid: db_sid,
+          instance_number: db_instance_number_1,
+          system_replication: "Primary"
+        ),
+        build(
+          :database_instance_registered_event,
+          sap_system_id: sap_system_id,
+          host_id: secondary_database_host_id,
+          instance_number: db_instance_number_2,
+          system_replication: "Secondary",
+          sid: db_sid
+        ),
+        build(
+          :application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          features: "MESSAGESERVER|ENQUE",
+          host_id: message_server_host_id,
+          instance_number: message_server_instance_number,
+          sid: application_sid
+        ),
+        build(
+          :application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          features: "ABAP|GATEWAY|ICMAN|IGS",
+          host_id: abap_host_id,
+          instance_number: abap_instance_number,
+          sid: application_sid
+        ),
+        build(
+          :sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: application_sid
+        ),
+        build(:database_instance_deregistered_event,
+          sap_system_id: sap_system_id,
+          host_id: primary_database_host_id,
+          instance_number: db_instance_number_1,
+          deregistered_at: deregistered_at
+        ),
+        build(:database_instance_deregistered_event,
+          sap_system_id: sap_system_id,
+          host_id: secondary_database_host_id,
+          instance_number: db_instance_number_2,
+          deregistered_at: deregistered_at
+        ),
+        build(:database_deregistered_event,
+          sap_system_id: sap_system_id,
+          deregistered_at: deregistered_at
+        ),
+        build(:sap_system_deregistered_event,
+          sap_system_id: sap_system_id,
+          deregistered_at: deregistered_at
+        )
+      ]
+
+      %{features: features, instance_number: instance_number, health: health} =
+        command =
+        build(:register_database_instance_command,
+          system_replication: nil,
+          sid: db_sid,
+          sap_system_id: sap_system_id
+        )
+
+      assert_events_and_state(
+        initial_events,
+        command,
+        [
+          %DatabaseRestored{
+            sap_system_id: sap_system_id,
+            sid: db_sid,
+            health: command.health
+          },
+          %DatabaseInstanceRegistered{
+            sap_system_id: sap_system_id,
+            sid: db_sid,
+            tenant: command.tenant,
+            instance_number: command.instance_number,
+            instance_hostname: command.instance_hostname,
+            features: command.features,
+            http_port: command.http_port,
+            https_port: command.https_port,
+            start_priority: command.start_priority,
+            host_id: command.host_id,
+            system_replication: command.system_replication,
+            system_replication_status: command.system_replication_status,
+            health: command.health
+          }
+        ],
+        fn sap_system ->
+          assert Kernel.length(sap_system.database.instances) == 1
+
+          assert %SapSystem{
+                   deregistered_at: ^deregistered_at,
+                   database: %Database{
+                     deregistered_at: nil,
+                     sid: ^db_sid,
+                     instances: [
+                       %Instance{
+                         sid: ^db_sid,
+                         instance_number: ^instance_number,
+                         features: ^features,
+                         health: ^health,
+                         system_replication: nil
+                       }
+                     ]
+                   }
+                 } = sap_system
+        end
+      )
+    end
+
+    test "should restore a deregistered database when the registering database instance is a primary, without database instance leftovers" do
+      sap_system_id = UUID.uuid4()
+
+      primary_database_host_id = UUID.uuid4()
+      secondary_database_host_id = UUID.uuid4()
+
+      deregistered_at = DateTime.utc_now()
+
+      db_instance_number_1 = "00"
+      db_instance_number_2 = "01"
+
+      db_sid = fake_sid()
+      application_sid = fake_sid()
+
+      message_server_host_id = UUID.uuid4()
+      message_server_instance_number = "00"
+      abap_host_id = UUID.uuid4()
+      abap_instance_number = "01"
+
+      initial_events = [
+        build(
+          :database_registered_event,
+          sap_system_id: sap_system_id,
+          sid: db_sid
+        ),
+        build(
+          :database_instance_registered_event,
+          sap_system_id: sap_system_id,
+          host_id: primary_database_host_id,
+          sid: db_sid,
+          instance_number: db_instance_number_1,
+          system_replication: "Primary"
+        ),
+        build(
+          :database_instance_registered_event,
+          sap_system_id: sap_system_id,
+          host_id: secondary_database_host_id,
+          instance_number: db_instance_number_2,
+          system_replication: "Secondary",
+          sid: db_sid
+        ),
+        build(
+          :application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          features: "MESSAGESERVER|ENQUE",
+          host_id: message_server_host_id,
+          instance_number: message_server_instance_number,
+          sid: application_sid
+        ),
+        build(
+          :application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          features: "ABAP|GATEWAY|ICMAN|IGS",
+          host_id: abap_host_id,
+          instance_number: abap_instance_number,
+          sid: application_sid
+        ),
+        build(
+          :sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: application_sid
+        ),
+        build(:database_instance_deregistered_event,
+          sap_system_id: sap_system_id,
+          host_id: primary_database_host_id,
+          instance_number: db_instance_number_1,
+          deregistered_at: deregistered_at
+        ),
+        build(:database_instance_deregistered_event,
+          sap_system_id: sap_system_id,
+          host_id: secondary_database_host_id,
+          instance_number: db_instance_number_2,
+          deregistered_at: deregistered_at
+        ),
+        build(:database_deregistered_event,
+          sap_system_id: sap_system_id,
+          deregistered_at: deregistered_at
+        ),
+        build(:sap_system_deregistered_event,
+          sap_system_id: sap_system_id,
+          deregistered_at: deregistered_at
+        )
+      ]
+
+      %{features: features, instance_number: instance_number, health: health} =
+        command =
+        build(:register_database_instance_command,
+          system_replication: "Primary",
+          sid: db_sid,
+          sap_system_id: sap_system_id
+        )
+
+      assert_events_and_state(
+        initial_events,
+        command,
+        [
+          %DatabaseRestored{
+            sap_system_id: sap_system_id,
+            sid: db_sid,
+            health: command.health
+          },
+          %DatabaseInstanceRegistered{
+            sap_system_id: sap_system_id,
+            sid: db_sid,
+            tenant: command.tenant,
+            instance_number: command.instance_number,
+            instance_hostname: command.instance_hostname,
+            features: command.features,
+            http_port: command.http_port,
+            https_port: command.https_port,
+            start_priority: command.start_priority,
+            host_id: command.host_id,
+            system_replication: command.system_replication,
+            system_replication_status: command.system_replication_status,
+            health: command.health
+          }
+        ],
+        fn sap_system ->
+          assert Kernel.length(sap_system.database.instances) == 1
+
+          assert %SapSystem{
+                   deregistered_at: ^deregistered_at,
+                   database: %Database{
+                     deregistered_at: nil,
+                     sid: ^db_sid,
+                     instances: [
+                       %Instance{
+                         sid: ^db_sid,
+                         instance_number: ^instance_number,
+                         features: ^features,
+                         health: ^health,
+                         system_replication: "Primary"
+                       }
+                     ]
+                   }
+                 } = sap_system
+        end
+      )
+    end
+
+    test "should restore a deregistered database when the registering database instance is a primary, with database instance leftovers" do
+      sap_system_id = UUID.uuid4()
+
+      primary_database_host_id = UUID.uuid4()
+      secondary_database_host_id = UUID.uuid4()
+
+      deregistered_at = DateTime.utc_now()
+
+      db_instance_number_1 = "00"
+      db_instance_number_2 = "01"
+
+      db_sid = fake_sid()
+      application_sid = fake_sid()
+
+      message_server_host_id = UUID.uuid4()
+      message_server_instance_number = "00"
+      abap_host_id = UUID.uuid4()
+      abap_instance_number = "01"
+
+      initial_events = [
+        build(
+          :database_registered_event,
+          sap_system_id: sap_system_id,
+          sid: db_sid
+        ),
+        build(
+          :database_instance_registered_event,
+          sap_system_id: sap_system_id,
+          host_id: primary_database_host_id,
+          sid: db_sid,
+          instance_number: db_instance_number_1,
+          system_replication: "Primary"
+        ),
+        build(
+          :database_instance_registered_event,
+          sap_system_id: sap_system_id,
+          host_id: secondary_database_host_id,
+          instance_number: db_instance_number_2,
+          system_replication: "Secondary",
+          sid: db_sid
+        ),
+        build(
+          :application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          features: "MESSAGESERVER|ENQUE",
+          host_id: message_server_host_id,
+          instance_number: message_server_instance_number,
+          sid: application_sid
+        ),
+        build(
+          :application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          features: "ABAP|GATEWAY|ICMAN|IGS",
+          host_id: abap_host_id,
+          instance_number: abap_instance_number,
+          sid: application_sid
+        ),
+        build(
+          :sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: application_sid
+        ),
+        build(:database_instance_deregistered_event,
+          sap_system_id: sap_system_id,
+          host_id: primary_database_host_id,
+          instance_number: db_instance_number_1,
+          deregistered_at: deregistered_at
+        ),
+        build(:database_deregistered_event,
+          sap_system_id: sap_system_id,
+          deregistered_at: deregistered_at
+        ),
+        build(:sap_system_deregistered_event,
+          sap_system_id: sap_system_id,
+          deregistered_at: deregistered_at
+        )
+      ]
+
+      %{features: features, instance_number: instance_number, health: health} =
+        command =
+        build(:register_database_instance_command,
+          system_replication: "Primary",
+          sid: db_sid,
+          sap_system_id: sap_system_id
+        )
+
+      assert_events_and_state(
+        initial_events,
+        command,
+        [
+          %DatabaseRestored{
+            sap_system_id: sap_system_id,
+            sid: db_sid,
+            health: command.health
+          },
+          %DatabaseInstanceRegistered{
+            sap_system_id: sap_system_id,
+            sid: db_sid,
+            tenant: command.tenant,
+            instance_number: command.instance_number,
+            instance_hostname: command.instance_hostname,
+            features: command.features,
+            http_port: command.http_port,
+            https_port: command.https_port,
+            start_priority: command.start_priority,
+            host_id: command.host_id,
+            system_replication: command.system_replication,
+            system_replication_status: command.system_replication_status,
+            health: command.health
+          }
+        ],
+        fn sap_system ->
+          assert Kernel.length(sap_system.database.instances) == 2
+
+          assert %SapSystem{
+                   deregistered_at: ^deregistered_at,
+                   database: %Database{
+                     deregistered_at: nil,
+                     sid: ^db_sid,
+                     instances: [
+                       %Instance{
+                         sid: ^db_sid,
+                         instance_number: ^instance_number,
+                         features: ^features,
+                         health: ^health,
+                         system_replication: "Primary"
+                       },
+                       %Instance{}
+                     ]
+                   }
+                 } = sap_system
+        end
+      )
+    end
+
     test "should reject all the commands except for the registration/instance deregistration ones, when the SAP system is deregistered" do
       sap_system_id = UUID.uuid4()
 


### PR DESCRIPTION
# Description

Sap system  aggregate restoration

The flow is the same as registration, with the key difference that when the same conditions are met we fire a restoration event instead of registration one.

It could be possible that we have some leftovers in old database/application instances, in the case in which the user has not cleaned up the instances from an already deregistered sap system.

In that case the restoration process follows the same rules, without caring of leftovers, we assume that the user will take care of that, we guarantee that the new instances will follow the right path for restoration and correctness in our domain.


## How was this tested?

Automated tests
