### PR TITLE
Fix sap system domain apply ordering issues

### DIFF
--- a/lib/trento/domain/sap_system/application.ex
+++ b/lib/trento/domain/sap_system/application.ex
@@ -3,8 +3,6 @@ defmodule Trento.Domain.SapSystem.Application do
   This module represents a SAP System application.
   """
 
-  require Trento.Domain.Enums.EnsaVersion, as: EnsaVersion
-
   alias Trento.Domain.SapSystem.Instance
 
   @required_fields []
@@ -13,7 +11,6 @@ defmodule Trento.Domain.SapSystem.Application do
 
   deftype do
     field :sid, :string
-    field :ensa_version, Ecto.Enum, values: EnsaVersion.values(), default: EnsaVersion.no_ensa()
     embeds_many :instances, Instance
   end
 end

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -412,9 +412,9 @@ defmodule Trento.SapSystemTest do
         fn state ->
           assert %SapSystem{
                    sid: ^sid,
+                   ensa_version: ^ensa_version,
                    application: %SapSystem.Application{
                      sid: ^sid,
-                     ensa_version: ^ensa_version,
                      instances: [
                        %SapSystem.Instance{
                          sid: ^sid,
@@ -487,9 +487,9 @@ defmodule Trento.SapSystemTest do
         fn state ->
           assert %SapSystem{
                    sid: ^sid,
+                   ensa_version: ^ensa_version,
                    application: %SapSystem.Application{
-                     sid: ^sid,
-                     ensa_version: ^ensa_version
+                     sid: ^sid
                    }
                  } = state
         end
@@ -545,9 +545,9 @@ defmodule Trento.SapSystemTest do
         fn state ->
           assert %SapSystem{
                    sid: ^sid,
+                   ensa_version: ^ensa_version,
                    application: %SapSystem.Application{
-                     sid: ^sid,
-                     ensa_version: ^ensa_version
+                     sid: ^sid
                    }
                  } = state
         end
@@ -603,9 +603,9 @@ defmodule Trento.SapSystemTest do
         fn state ->
           assert %SapSystem{
                    sid: ^sid,
+                   ensa_version: ^ensa_version,
                    application: %SapSystem.Application{
-                     sid: ^sid,
-                     ensa_version: ^ensa_version
+                     sid: ^sid
                    }
                  } = state
         end
@@ -1205,8 +1205,8 @@ defmodule Trento.SapSystemTest do
         fn state ->
           assert %SapSystem{
                    health: :critical,
+                   ensa_version: ^ensa_version,
                    application: %SapSystem.Application{
-                     ensa_version: ^ensa_version,
                      instances: [
                        %SapSystem.Instance{
                          health: :critical
@@ -1452,9 +1452,9 @@ defmodule Trento.SapSystemTest do
             sap_system_id: sap_system_id,
             sid: sid,
             health: :passing,
+            ensa_version: ensa_version,
             application: %SapSystem.Application{
               sid: sid,
-              ensa_version: ensa_version,
               instances: [
                 %SapSystem.Instance{
                   sid: sid,


### PR DESCRIPTION
# Description

## Context
It turned out that the changes I did adding the `SapSystemUpdated` event broke the event casting from an event store created using `main` branch.
The sequence of events changes in the `deregistration` branch, but it must still respect the old ordering, as this was how it was created before.

Adding the `ensa_version` in the `Application` object broke the thing, as it changed how many pattern matching events were used (as some of them expected a `nil` value for this field).

Broken applies:
https://github.com/trento-project/web/blob/deregistration/lib/trento/domain/sap_system/sap_system.ex#L407
https://github.com/trento-project/web/blob/deregistration/lib/trento/domain/sap_system/sap_system.ex#L494

## Solution
The best solution is to move the `ensa_version` to the `SapSystem` aggregate itself. Domain wise is still totally correct, as one SAP system has one ENSA version. I thought that putting it in the `Application` was more explicit, but it broke many parts of the domain logic.

Having the field in the main object, makes the order of events not important as the `application` related events only change the `application` embed, and main SAP system related events change the fields of the main aggregate object.

Luckily, these changes were still in a "secondary" branch, so we can accept changes in aggregate format pretty unharmed.


