### PR TITLE
Allow rollup on deregistered aggregates

### DIFF
--- a/lib/trento/domain/cluster/cluster.ex
+++ b/lib/trento/domain/cluster/cluster.ex
@@ -247,6 +247,16 @@ defmodule Trento.Domain.Cluster do
     |> maybe_update_cluster(command)
   end
 
+  def execute(
+        %Cluster{cluster_id: cluster_id} = snapshot,
+        %RollUpCluster{}
+      ) do
+    %ClusterRollUpRequested{
+      cluster_id: cluster_id,
+      snapshot: snapshot
+    }
+  end
+
   def execute(%Cluster{deregistered_at: deregistered_at}, _) when not is_nil(deregistered_at),
     do: {:error, :cluster_not_registered}
 
@@ -309,16 +319,6 @@ defmodule Trento.Domain.Cluster do
     |> Multi.new()
     |> Multi.execute(&maybe_emit_cluster_checks_health_changed_event(&1, command))
     |> Multi.execute(&maybe_emit_cluster_health_changed_event/1)
-  end
-
-  def execute(
-        %Cluster{cluster_id: cluster_id} = snapshot,
-        %RollUpCluster{}
-      ) do
-    %ClusterRollUpRequested{
-      cluster_id: cluster_id,
-      snapshot: snapshot
-    }
   end
 
   def execute(

--- a/lib/trento/domain/host/host.ex
+++ b/lib/trento/domain/host/host.ex
@@ -198,6 +198,16 @@ defmodule Trento.Domain.Host do
   end
 
   def execute(
+        %Host{host_id: host_id} = snapshot,
+        %RollUpHost{}
+      ) do
+    %HostRollUpRequested{
+      host_id: host_id,
+      snapshot: snapshot
+    }
+  end
+
+  def execute(
         %Host{deregistered_at: deregistered_at},
         _
       )
@@ -312,16 +322,6 @@ defmodule Trento.Domain.Host do
     %SlesSubscriptionsUpdated{
       host_id: host_id,
       subscriptions: subscriptions
-    }
-  end
-
-  def execute(
-        %Host{host_id: host_id} = snapshot,
-        %RollUpHost{}
-      ) do
-    %HostRollUpRequested{
-      host_id: host_id,
-      snapshot: snapshot
     }
   end
 

--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -278,14 +278,6 @@ defmodule Trento.Domain.SapSystem do
   end
 
   def execute(
-        %SapSystem{deregistered_at: deregistered_at},
-        _
-      )
-      when not is_nil(deregistered_at) do
-    {:error, :sap_system_not_registered}
-  end
-
-  def execute(
         %SapSystem{sap_system_id: sap_system_id} = snapshot,
         %RollUpSapSystem{}
       ) do
@@ -293,6 +285,14 @@ defmodule Trento.Domain.SapSystem do
       sap_system_id: sap_system_id,
       snapshot: snapshot
     }
+  end
+
+  def execute(
+        %SapSystem{deregistered_at: deregistered_at},
+        _
+      )
+      when not is_nil(deregistered_at) do
+    {:error, :sap_system_not_registered}
   end
 
   def apply(

--- a/test/trento/domain/cluster/cluster_test.exs
+++ b/test/trento/domain/cluster/cluster_test.exs
@@ -914,7 +914,6 @@ defmodule Trento.ClusterTest do
       commands_to_reject = [
         %CompleteChecksExecution{},
         %DeregisterClusterHost{},
-        %RollUpCluster{},
         %SelectChecks{},
         %RegisterClusterHost{}
       ]
@@ -922,6 +921,15 @@ defmodule Trento.ClusterTest do
       for command <- commands_to_reject do
         assert match?({:error, :cluster_not_registered}, aggregate_run(initial_events, command)),
                "Command #{inspect(command)} should be rejected by the aggregate"
+      end
+
+      commands_to_accept = [
+        %RollUpCluster{}
+      ]
+
+      for command <- commands_to_accept do
+        assert match?({:ok, _, _}, aggregate_run(initial_events, command)),
+               "Command #{inspect(command)} should be accepted by a deregistered cluster"
       end
     end
 

--- a/test/trento/domain/host/host_test.exs
+++ b/test/trento/domain/host/host_test.exs
@@ -744,7 +744,6 @@ defmodule Trento.HostTest do
       commands_to_reject = [
         %DeregisterHost{},
         %RequestHostDeregistration{},
-        %RollUpHost{},
         %UpdateHeartbeat{},
         %UpdateProvider{},
         %UpdateSlesSubscriptions{}
@@ -752,6 +751,15 @@ defmodule Trento.HostTest do
 
       for command <- commands_to_reject do
         assert_error(initial_events, command, {:error, :host_not_registered})
+      end
+
+      commands_to_accept = [
+        %RollUpHost{}
+      ]
+
+      for command <- commands_to_accept do
+        assert match?({:ok, _, _}, aggregate_run(initial_events, command)),
+               "Command #{inspect(command)} should be accepted by a deregistered host"
       end
     end
 

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -1794,24 +1794,13 @@ defmodule Trento.SapSystemTest do
         build(:register_database_instance_command),
         build(:register_application_instance_command),
         build(:deregister_database_instance_command, sap_system_id: sap_system_id),
-        build(:deregister_application_instance_command, sap_system_id: sap_system_id)
+        build(:deregister_application_instance_command, sap_system_id: sap_system_id),
+        build(:rollup_sap_system_command)
       ]
 
       for command <- commands_to_accept do
         assert match?({:ok, _, _}, aggregate_run(initial_events, command)),
                "Command #{inspect(command)} should be accepted by a deregistered SAP system"
-      end
-
-      commands_to_reject = [
-        build(:rollup_sap_system_command)
-      ]
-
-      for command <- commands_to_reject do
-        assert match?(
-                 {:error, :sap_system_not_registered},
-                 aggregate_run(initial_events, command)
-               ),
-               "Command #{inspect(command)} should be rejected by a deregistered SAP system"
       end
     end
 


### PR DESCRIPTION
# Description

This pr fixes the bug we currently have in aggregates, we reject commands when they are deregistered, but we need to allow the rollup command when deregistered to tombstone the aggregates.

This is caused by #1513 

## How was this tested?

Automated tests
