### PR TITLE
Add application cluster column to health summary view

### DIFF
--- a/assets/js/components/HealthSummary/HomeHealthSummary.jsx
+++ b/assets/js/components/HealthSummary/HomeHealthSummary.jsx
@@ -13,6 +13,7 @@ const healthSummaryTableConfig = {
     {
       title: 'SID',
       key: 'sid',
+      className: 'w-1/6',
       render: (content, item) => (
         <Link
           className="text-jungle-green-500 hover:opacity-75"
@@ -25,7 +26,7 @@ const healthSummaryTableConfig = {
     {
       title: 'SAP Instances',
       key: 'sapsystemHealth',
-      className: 'text-center',
+      className: 'text-center w-1/6',
       render: (content, item) => (
         <Link to={`/sap_systems/${item.id}`}>
           <HealthIcon health={content} centered />
@@ -33,9 +34,25 @@ const healthSummaryTableConfig = {
       ),
     },
     {
+      title: 'Application cluster',
+      key: 'applicationClusterHealth',
+      className: 'text-center w-1/6',
+      render: (content, item) => {
+        const linkToCluster = `/clusters/${item.applicationClusterId}`;
+
+        return item?.applicationClusterId ? (
+          <Link to={linkToCluster}>
+            <HealthIcon health={content} centered />
+          </Link>
+        ) : (
+          <HealthIcon health={content} centered hoverOpacity={false} />
+        );
+      },
+    },
+    {
       title: 'Database',
       key: 'databaseHealth',
-      className: 'text-center',
+      className: 'text-center w-1/6',
       render: (content, item) => {
         const linkToDatabase = `/databases/${item.databaseId}`;
         return (
@@ -46,13 +63,13 @@ const healthSummaryTableConfig = {
       },
     },
     {
-      title: 'Pacemaker Clusters',
-      key: 'clustersHealth',
-      className: 'text-center',
+      title: 'Database cluster',
+      key: 'databaseClusterHealth',
+      className: 'text-center w-1/6',
       render: (content, item) => {
-        const linkToCluster = `/clusters/${item.clusterId}`;
+        const linkToCluster = `/clusters/${item.databaseClusterId}`;
 
-        return item?.clusterId ? (
+        return item?.databaseClusterId ? (
           <Link to={linkToCluster}>
             <HealthIcon health={content} centered />
           </Link>
@@ -64,7 +81,7 @@ const healthSummaryTableConfig = {
     {
       title: 'Hosts',
       key: 'hostsHealth',
-      className: 'text-center',
+      className: 'text-center w-1/6',
       render: (content, item) => {
         const linkToHosts = `/hosts?sid=${item.sid}&sid=${item.tenant}`;
         return (

--- a/assets/js/components/HealthSummary/HomeHealthSummary.stories.jsx
+++ b/assets/js/components/HealthSummary/HomeHealthSummary.stories.jsx
@@ -7,14 +7,17 @@ import HomeHealthSummary from './HomeHealthSummary';
 
 const randomSummary = healthSummaryFactory.buildList(3);
 const healthySummary = healthSummaryFactory.buildList(3, {
-  clustersHealth: 'passing',
+  applicationClusterHealth: 'passing',
+  databaseClusterHealth: 'passing',
   databaseHealth: 'passing',
   hostsHealth: 'passing',
   sapsystemHealth: 'passing',
 });
 const unClusteredSummary = healthSummaryFactory.buildList(3, {
-  clusterId: null,
-  clustersHealth: 'unknown',
+  applicationClusterId: null,
+  databaseClusterId: null,
+  applicationClusterHealth: 'unknown',
+  databaseClusterHealth: 'unknown',
   databaseHealth: 'passing',
   hostsHealth: 'passing',
   sapsystemHealth: 'passing',

--- a/assets/js/components/HealthSummary/HomeHealthSummary.test.jsx
+++ b/assets/js/components/HealthSummary/HomeHealthSummary.test.jsx
@@ -10,7 +10,8 @@ import HomeHealthSummary from './HomeHealthSummary';
 
 const homeHealthSummaryData = [
   healthSummaryFactory.build({
-    clustersHealth: 'passing',
+    applicationClusterHealth: 'passing',
+    databaseClusterHealth: 'passing',
     databaseHealth: 'passing',
     hostsHealth: 'critical',
     sapsystemHealth: 'passing',
@@ -18,20 +19,22 @@ const homeHealthSummaryData = [
     tenant: 'HDD',
   }),
   healthSummaryFactory.build({
-    clustersHealth: 'passing',
+    applicationClusterHealth: 'passing',
     databaseHealth: 'passing',
     hostsHealth: 'critical',
     sapsystemHealth: 'passing',
   }),
   healthSummaryFactory.build({
-    clustersHealth: 'passing',
+    databaseClusterHealth: 'passing',
     databaseHealth: 'passing',
     hostsHealth: 'critical',
     sapsystemHealth: 'passing',
   }),
   healthSummaryFactory.build({
-    clusterId: null,
-    clustersHealth: 'unknown',
+    applicationClusterId: null,
+    databaseClusterId: null,
+    applicationClusterHealth: 'unknown',
+    databaseClusterHealth: 'unknown',
     databaseHealth: 'passing',
     hostsHealth: 'critical',
     sapsystemHealth: 'passing',
@@ -55,28 +58,38 @@ describe('HomeHealthSummary component', () => {
     ).toContain(`/sap_systems/${id}`);
   });
 
-  it('should have a clickable PACEMAKER CLUSTER icon with link to the belonging cluster when available', () => {
+  it('should have clickable cluster icons with links to the correct cluster when available', () => {
     const { container } = renderWithRouter(
       <HomeHealthSummary
         sapSystemsHealth={homeHealthSummaryData}
         loading={false}
       />
     );
-    const [{ clusterId }] = homeHealthSummaryData;
+    const [{ applicationClusterId, databaseClusterId }] = homeHealthSummaryData;
 
     expect(
       container
-        .querySelector(':nth-child(1) > :nth-child(4) > a')
+        .querySelector(':nth-child(1) > :nth-child(3) > a')
         .getAttribute('href')
-    ).toContain(`/clusters/${clusterId}`);
+    ).toContain(`/clusters/${applicationClusterId}`);
 
     expect(
-      container.querySelector(':nth-child(4) > :nth-child(4) > a')
+      container
+        .querySelector(':nth-child(1) > :nth-child(5) > a')
+        .getAttribute('href')
+    ).toContain(`/clusters/${databaseClusterId}`);
+
+    expect(
+      container.querySelector(':nth-child(4) > :nth-child(3) > a')
+    ).toBeNull();
+
+    expect(
+      container.querySelector(':nth-child(4) > :nth-child(5) > a')
     ).toBeNull();
 
     expect(
       container
-        .querySelector(':nth-child(4) > :nth-child(4) > svg')
+        .querySelector(':nth-child(4) > :nth-child(3) > svg')
         .classList.toString()
     ).toContain('hover:opacity-100');
   });
@@ -93,7 +106,7 @@ describe('HomeHealthSummary component', () => {
 
     expect(
       container
-        .querySelector(':nth-child(1) > :nth-child(5) > a')
+        .querySelector(':nth-child(1) > :nth-child(6) > a')
         .getAttribute('href')
     ).toContain('/hosts?sid=NWD&sid=HDD');
   });

--- a/assets/js/lib/test-utils/factories/index.js
+++ b/assets/js/lib/test-utils/factories/index.js
@@ -51,10 +51,12 @@ export const checkFactory = Factory.define(() => ({
 }));
 
 export const healthSummaryFactory = Factory.define(() => ({
-  clusterId: faker.datatype.uuid(),
-  clustersHealth: healthEnum(),
+  applicationClusterId: faker.datatype.uuid(),
+  applicationClusterHealth: healthEnum(),
   databaseHealth: healthEnum(),
   databaseId: faker.datatype.uuid(),
+  databaseClusterId: faker.datatype.uuid(),
+  databaseClusterHealth: healthEnum(),
   hostsHealth: healthEnum(),
   id: faker.datatype.uuid(),
   sapsystemHealth: healthEnum(),


### PR DESCRIPTION
# Description

**Leaving in draft, to avoid yet much more conflicts... It will be merged once `deregistration` comes to `main`**

Add and split `Application cluster` and `Database cluster` columns in the Health summary view.

![image](https://github.com/trento-project/web/assets/36370954/59febbab-a0c8-4bf0-9305-b92f2032c6e5)
![image](https://github.com/trento-project/web/assets/36370954/294cb01b-1053-42ef-b5f3-fd593237a8f6)


@jagabomb @abravosuse Could you review the styling/naming? Have a look in storybook link, `HomeHealthSummary` as well

## How was this tested?

Tested
