### PR TITLE
Move application instances

### DIFF
--- a/lib/trento/domain/sap_system/events/application_instance_moved.ex
+++ b/lib/trento/domain/sap_system/events/application_instance_moved.ex
@@ -1,6 +1,6 @@
 defmodule Trento.Domain.Events.ApplicationInstanceMoved do
   @moduledoc """
-  This event is emitted when a database application is moved from a host to another.
+  This event is emitted when an application instance is moved from a host to another.
   """
 
   use Trento.Event

--- a/lib/trento/domain/sap_system/events/application_instance_moved.ex
+++ b/lib/trento/domain/sap_system/events/application_instance_moved.ex
@@ -1,0 +1,14 @@
+defmodule Trento.Domain.Events.ApplicationInstanceMoved do
+  @moduledoc """
+  This event is emitted when a database application is moved from a host to another.
+  """
+
+  use Trento.Event
+
+  defevent do
+    field :sap_system_id, Ecto.UUID
+    field :instance_number, :string
+    field :old_host_id, Ecto.UUID
+    field :new_host_id, Ecto.UUID
+  end
+end

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -367,7 +367,8 @@ defmodule Trento.SapSystemTest do
         build(:application_instance_registered_event,
           sap_system_id: sap_system_id,
           sid: sid,
-          features: "MESSAGESERVER"
+          features: "MESSAGESERVER",
+          instance_number: "00"
         )
       ]
 
@@ -468,7 +469,7 @@ defmodule Trento.SapSystemTest do
           sap_system_id: sap_system_id,
           sid: sid,
           features: "ABAP",
-          instance_number: "10",
+          instance_number: instance_number,
           instance_hostname: instance_hostname,
           http_port: http_port,
           https_port: https_port,
@@ -518,7 +519,7 @@ defmodule Trento.SapSystemTest do
                      instances: [
                        %SapSystem.Instance{
                          sid: ^sid,
-                         instance_number: "10",
+                         instance_number: ^instance_number,
                          host_id: ^new_host_id
                        },
                        %SapSystem.Instance{

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -512,19 +512,14 @@ defmodule Trento.SapSystemTest do
         ],
         fn state ->
           assert %SapSystem{
-                   sid: ^sid,
                    application: %SapSystem.Application{
-                     sid: ^sid,
-                     ensa_version: ^ensa_version,
                      instances: [
                        %SapSystem.Instance{
                          sid: ^sid,
                          instance_number: ^instance_number,
                          host_id: ^new_host_id
-                       },
-                       %SapSystem.Instance{
-                         features: "MESSAGESERVER"
                        }
+                       | _
                      ]
                    }
                  } = state


### PR DESCRIPTION
This PR introduces the necessary business logic to implement a new feature that enables the movement of application instances from one host to another. The primary changes involve updating the `host_id` field and emitting the `ApplicationInstanceMoved` event within the `SapSystem` aggregate.
Refactoring was required to separate the `Multi` chain within the `RegisterApplicationInstance` execute clause. 

Additionally, corresponding tests were updated to accommodate these changes and a new test was introduced.