### PR TITLE
Add missing target_type query param to catalog when loading execution results page

### DIFF
--- a/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
@@ -37,7 +37,9 @@ function ExecutionResultsPage() {
 
   useEffect(() => {
     if (cloudProvider) {
-      dispatch(updateCatalog({ provider: cloudProvider }));
+      dispatch(
+        updateCatalog({ provider: cloudProvider, target_type: 'cluster' })
+      );
     }
     if (!executionData) {
       dispatch(updateLastExecution(clusterID));


### PR DESCRIPTION
# Description

Adds a missing `target_type=cluster` when loading the execution results page.