### PR TITLE
Add error message to Deregistration Modal

### DIFF
--- a/assets/js/components/DeregistrationModal/DeregistrationModal.jsx
+++ b/assets/js/components/DeregistrationModal/DeregistrationModal.jsx
@@ -8,6 +8,7 @@ import Button from '@components/Button';
 function DeregistrationModal({
   hostname,
   isOpen = false,
+  isError = false,
   onCleanUp,
   onCancel,
 }) {
@@ -22,6 +23,14 @@ function DeregistrationModal({
         discovered by the agent in this host, including the host itself and any
         other component depending on it.
       </div>
+      {isError && (
+        <div
+          className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 mt-3 rounded relative"
+          role="alert"
+        >
+          Error occurred when requesting deregistration of host
+        </div>
+      )}
       <div className="flex justify-start gap-2 mt-4">
         <Button
           type="default-fit"

--- a/assets/js/components/DeregistrationModal/DeregistrationModal.stories.jsx
+++ b/assets/js/components/DeregistrationModal/DeregistrationModal.stories.jsx
@@ -17,12 +17,17 @@ export default {
       description: 'Sets the visibility of the modal',
       control: false,
     },
+    isError: {
+      type: 'boolean',
+      description: 'Sets the visibility of the error message',
+      control: { type: 'boolean' },
+    },
     onCleanUp: {
       description: 'Callback function to run when "Clean up" button is clicked',
       action: 'Deregistration',
       control: false,
     },
-    onClose: {
+    onCancel: {
       description: 'Callback function to run when "Cancel" button is clicked',
       action: 'Cancel',
       control: false,
@@ -30,7 +35,7 @@ export default {
   },
 };
 
-function ButtonToOpenModal({ hostname }) {
+function ButtonToOpenModal({ hostname, isError }) {
   const [open, setOpen] = useState(false);
   const [deregistered, setDeregistered] = useState(false);
 
@@ -38,7 +43,7 @@ function ButtonToOpenModal({ hostname }) {
     <>
       <Button
         type="default-fit"
-        className={`inline-block mx-0.5 border-green-500 border w-fit ${
+        className={`inline-block mx-0.5 border-green-500 border w-fit mr-2 ${
           deregistered ? 'bg-rose-500' : 'bg-jungle-green-500'
         }`}
         size="small"
@@ -49,9 +54,20 @@ function ButtonToOpenModal({ hostname }) {
           : 'Click me to open modal'}
       </Button>
 
+      {deregistered && (
+        <Button
+          type="primary-white-fit"
+          size="small"
+          onClick={() => setDeregistered(false)}
+        >
+          Reset
+        </Button>
+      )}
+
       <DeregistrationModal
         hostname={hostname}
         isOpen={open}
+        isError={isError}
         onCleanUp={() => {
           setDeregistered(true);
           setOpen(false);
@@ -65,6 +81,14 @@ function ButtonToOpenModal({ hostname }) {
 export const Default = {
   args: {
     hostname: 'example host',
+  },
+  render: (args) => <ButtonToOpenModal {...args} />,
+};
+
+export const Error = {
+  args: {
+    hostname: 'example host',
+    isError: true,
   },
   render: (args) => <ButtonToOpenModal {...args} />,
 };

--- a/assets/js/components/DeregistrationModal/DeregistrationModal.test.jsx
+++ b/assets/js/components/DeregistrationModal/DeregistrationModal.test.jsx
@@ -12,6 +12,7 @@ describe('Deregistration Modal component', () => {
       <DeregistrationModal
         hostname={hostname}
         isOpen
+        isError={false}
         onCleanUp={() => {}}
         onCancel={() => {}}
       />
@@ -22,5 +23,41 @@ describe('Deregistration Modal component', () => {
       await screen.findByRole('button', { name: /Clean up/i })
     ).toBeTruthy();
     expect(await screen.findByRole('button', { name: /Cancel/i })).toBeTruthy();
+    await expect(
+      screen.findByText(
+        `Error occurred when requesting deregistration of host ${hostname}`
+      )
+    ).rejects.toThrow();
+  });
+
+  it('should render deregistration modal correctly when error', async () => {
+    window.IntersectionObserver = jest.fn().mockImplementation(() => ({
+      observe: () => null,
+      disconnect: () => null,
+    }));
+
+    const hostname = faker.name.firstName();
+
+    render(
+      <DeregistrationModal
+        hostname={hostname}
+        isOpen
+        isError
+        onCleanUp={() => {}}
+        onCancel={() => {}}
+      />
+    );
+
+    expect(await screen.findByText(hostname, { exact: false })).toBeTruthy();
+    expect(
+      await screen.findByRole('button', { name: /Clean up/i })
+    ).toBeTruthy();
+    expect(await screen.findByRole('button', { name: /Cancel/i })).toBeTruthy();
+    expect(
+      await screen.findByText(
+        `Error occurred when requesting deregistration of host`,
+        { exact: false }
+      )
+    ).toBeTruthy();
   });
 });


### PR DESCRIPTION
# Description

Adds an error message to Deregistration Modal. This will be displayed to the user when an error occurs after requesting to deregister a Host by clicking the "Clean up" button.

## How was this tested?

Added unit tests, updated Storybook.
