### PR TITLE
Remove host aggregate changeset

### DIFF
--- a/lib/trento/domain/host/host.ex
+++ b/lib/trento/domain/host/host.ex
@@ -88,12 +88,6 @@ defmodule Trento.Domain.Host do
       on_replace: :update
   end
 
-  def changeset(event, attrs) do
-    event
-    |> cast(attrs, [:host_id, :provider])
-    |> cast_polymorphic_embed(:provider_data, required: false)
-  end
-
   # Stop everything during the rollup process
   def execute(%Host{rolling_up: true}, _), do: {:error, :host_rolling_up}
 


### PR DESCRIPTION
# Description

Remove host aggregate `changeset` function. 
Initially, it was added to handle the polymorphic embed, but now this is handled by the `deftype` already.
Having this was causing an issue in the Host rollup, as the snapshot has this `Host` type, and the changeset function was not casting most of the values.
