### PR TITLE
Add database deregistered event usage to redux

### DIFF
--- a/assets/js/state/channels.js
+++ b/assets/js/state/channels.js
@@ -45,6 +45,7 @@ const processChannelEvents = (reduxStore, socket) => {
   ]);
   registerEvents(reduxStore, socket, 'monitoring:databases', [
     'database_registered',
+    'database_deregistered',
     'database_health_changed',
     'database_instance_registered',
     'database_instance_deregistered',

--- a/assets/js/state/databases.js
+++ b/assets/js/state/databases.js
@@ -30,6 +30,11 @@ export const databasesListSlice = createSlice({
     appendDatabaseInstance: (state, action) => {
       state.databaseInstances = [...state.databaseInstances, action.payload];
     },
+    removeDatabase: (state, { payload: { id } }) => {
+      state.databases = state.databases.filter(
+        (database) => !(database.id === id)
+      );
+    },
     removeDatabaseInstance: (
       state,
       { payload: { sap_system_id, host_id, instance_number } }
@@ -92,6 +97,7 @@ export const databasesListSlice = createSlice({
 });
 
 export const DATABASE_REGISTERED = 'DATABASE_REGISTERED';
+export const DATABASE_DEREGISTERED = 'DATABASE_DEREGISTERED';
 export const DATABASE_HEALTH_CHANGED = 'DATABASE_HEALTH_CHANGED';
 export const DATABASE_INSTANCE_REGISTERED = 'DATABASE_INSTANCE_REGISTERED';
 export const DATABASE_INSTANCE_DEREGISTERED = 'DATABASE_INSTANCE_DEREGISTERED';
@@ -105,6 +111,7 @@ export const {
   stopDatabasesLoading,
   setDatabases,
   appendDatabase,
+  removeDatabase,
   removeDatabaseInstance,
   appendDatabaseInstance,
   updateDatabaseHealth,

--- a/assets/js/state/databases.js
+++ b/assets/js/state/databases.js
@@ -32,7 +32,7 @@ export const databasesListSlice = createSlice({
     },
     removeDatabase: (state, { payload: { id } }) => {
       state.databases = state.databases.filter(
-        (database) => !(database.id === id)
+        (database) => database.id !== id
       );
     },
     removeDatabaseInstance: (

--- a/assets/js/state/databases.test.js
+++ b/assets/js/state/databases.test.js
@@ -1,8 +1,14 @@
-import databaseReducer, { removeDatabaseInstance } from '@state/databases';
-import { databaseInstanceFactory } from '@lib/test-utils/factories/databases';
+import databaseReducer, {
+  removeDatabase,
+  removeDatabaseInstance,
+} from '@state/databases';
+import {
+  databaseFactory,
+  databaseInstanceFactory,
+} from '@lib/test-utils/factories/databases';
 
 describe('Databases reducer', () => {
-  it('should remove a datase instance from state', () => {
+  it('should remove a database instance from state', () => {
     const [instance1, instance2] = databaseInstanceFactory.buildList(2);
     const initialState = {
       databaseInstances: [instance1, instance2],
@@ -12,6 +18,21 @@ describe('Databases reducer', () => {
 
     const expectedState = {
       databaseInstances: [instance2],
+    };
+
+    expect(databaseReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should remove a database from state', () => {
+    const [database1, database2] = databaseFactory.buildList(2);
+    const initialState = {
+      databases: [database1, database2],
+    };
+
+    const action = removeDatabase(database1);
+
+    const expectedState = {
+      databases: [database2],
     };
 
     expect(databaseReducer(initialState, action)).toEqual(expectedState);

--- a/assets/js/state/sagas/databases.js
+++ b/assets/js/state/sagas/databases.js
@@ -1,6 +1,7 @@
 import { put, select, takeEvery } from 'redux-saga/effects';
 import {
   DATABASE_REGISTERED,
+  DATABASE_DEREGISTERED,
   DATABASE_HEALTH_CHANGED,
   DATABASE_INSTANCE_REGISTERED,
   DATABASE_INSTANCE_DEREGISTERED,
@@ -11,6 +12,7 @@ import {
   updateDatabaseHealth,
   updateDatabaseInstanceHealth,
   updateDatabaseInstanceSystemReplication,
+  removeDatabase,
   removeDatabaseInstance,
 } from '@state/databases';
 
@@ -77,6 +79,16 @@ function* databaseInstanceRegistered({ payload }) {
   );
 }
 
+export function* databaseDeregistered({ payload }) {
+  yield put(removeDatabase(payload));
+  yield put(
+    notify({
+      text: `The database ${payload.sid} has been deregistered.`,
+      icon: 'ℹ️',
+    })
+  );
+}
+
 export function* databaseInstanceDeregistered({ payload }) {
   yield put(removeDatabaseInstance(payload));
   yield put(removeDatabaseInstanceFromSapSystem(payload));
@@ -106,6 +118,7 @@ function* databaseInstanceSystemReplicationChanged({ payload }) {
 
 export function* watchDatabase() {
   yield takeEvery(DATABASE_REGISTERED, databaseRegistered);
+  yield takeEvery(DATABASE_DEREGISTERED, databaseDeregistered);
   yield takeEvery(DATABASE_HEALTH_CHANGED, databaseHealthChanged);
   yield takeEvery(DATABASE_INSTANCE_REGISTERED, databaseInstanceRegistered);
   yield takeEvery(DATABASE_INSTANCE_DEREGISTERED, databaseInstanceDeregistered);

--- a/assets/js/state/sagas/databases.test.js
+++ b/assets/js/state/sagas/databases.test.js
@@ -40,18 +40,13 @@ describe('SAP Systems sagas', () => {
   });
 
   it('should remove the database', async () => {
-    const { sap_system_id: id, sid } = databaseFactory.build();
+    const { id, sid } = databaseFactory.build();
 
     const dispatched = await recordSaga(databaseDeregistered, {
       payload: { id, sid },
     });
 
-    expect(dispatched).toContainEqual(
-      removeDatabase({
-        id,
-        sid,
-      })
-    );
+    expect(dispatched).toContainEqual(removeDatabase({ id, sid }));
 
     expect(dispatched).toContainEqual(
       notify({

--- a/assets/js/state/sagas/databases.test.js
+++ b/assets/js/state/sagas/databases.test.js
@@ -1,8 +1,14 @@
 import { recordSaga } from '@lib/test-utils';
-import { databaseInstanceDeregistered } from '@state/sagas/databases';
-import { removeDatabaseInstance } from '@state/databases';
+import {
+  databaseDeregistered,
+  databaseInstanceDeregistered,
+} from '@state/sagas/databases';
+import { removeDatabase, removeDatabaseInstance } from '@state/databases';
 import { removeDatabaseInstanceFromSapSystem } from '@state/sapSystems';
-import { databaseInstanceFactory } from '@lib/test-utils/factories';
+import {
+  databaseFactory,
+  databaseInstanceFactory,
+} from '@lib/test-utils/factories';
 import { notify } from '@state/actions/notifications';
 
 describe('SAP Systems sagas', () => {
@@ -28,6 +34,28 @@ describe('SAP Systems sagas', () => {
     expect(dispatched).toContainEqual(
       notify({
         text: `The database instance ${instance_number} has been deregistered from ${sid}.`,
+        icon: 'ℹ️',
+      })
+    );
+  });
+
+  it('should remove the database', async () => {
+    const { sap_system_id: id, sid } = databaseFactory.build();
+
+    const dispatched = await recordSaga(databaseDeregistered, {
+      payload: { id, sid },
+    });
+
+    expect(dispatched).toContainEqual(
+      removeDatabase({
+        id,
+        sid,
+      })
+    );
+
+    expect(dispatched).toContainEqual(
+      notify({
+        text: `The database ${sid} has been deregistered.`,
         icon: 'ℹ️',
       })
     );


### PR DESCRIPTION
# Description

Listen to `datatabase_deregistered` event, it was missing.
