### PR TITLE
Load selectable checks for a host

### DIFF
--- a/assets/js/components/ChecksSelection/ChecksSelection.jsx
+++ b/assets/js/components/ChecksSelection/ChecksSelection.jsx
@@ -67,7 +67,7 @@ function ChecksSelection({
   useEffect(() => {
     onUpdateCatalog();
     onClear();
-  }, [onUpdateCatalog, onClear]);
+  }, []);
 
   const onCheckSelectionGroupChange = (checks, groupSelected) => {
     const groupChecks = checks.map((check) => check.id);
@@ -83,7 +83,7 @@ function ChecksSelection({
     <div className={classNames('bg-white rounded p-3', className)}>
       <CatalogContainer
         onRefresh={onUpdateCatalog}
-        isCatalogEmpty={catalog.size === 0}
+        isCatalogEmpty={catalog.length === 0}
         catalogError={catalogError}
         loading={loading}
       >
@@ -128,7 +128,7 @@ function ChecksSelection({
                   <EOS_LOADING_ANIMATED color="green" size={25} />
                 </span>
               ) : (
-                'Select Checks for Execution'
+                'Save Check Selection'
               )}
             </button>
             {error && (

--- a/assets/js/components/ChecksSelection/ChecksSelection.stories.jsx
+++ b/assets/js/components/ChecksSelection/ChecksSelection.stories.jsx
@@ -99,6 +99,13 @@ export const Default = {
   },
 };
 
+export const Empty = {
+  args: {
+    ...Default.args,
+    catalog: [],
+  },
+};
+
 export const Loading = {
   args: {
     ...Default.args,

--- a/assets/js/components/ChecksSelection/ChecksSelection.test.jsx
+++ b/assets/js/components/ChecksSelection/ChecksSelection.test.jsx
@@ -141,7 +141,7 @@ describe('ChecksSelection component', () => {
     const switches = screen.getAllByRole('switch');
 
     await user.click(switches[0]);
-    await user.click(screen.getByText('Select Checks for Execution'));
+    await user.click(screen.getByText('Save Check Selection'));
 
     expect(onSave).toBeCalledWith([checkID1, checkID2], targetID);
     expect(onUpdateCatalog).toBeCalled();

--- a/assets/js/components/ClusterDetails/ChecksSelection.jsx
+++ b/assets/js/components/ClusterDetails/ChecksSelection.jsx
@@ -105,7 +105,7 @@ function ChecksSelection({ clusterId, cluster }) {
     <div className="bg-white rounded p-3">
       <CatalogContainer
         onRefresh={() => dispatch(updateCatalog(catalogEnv))}
-        isCatalogEmpty={catalogData.size === 0}
+        isCatalogEmpty={catalogData.length === 0}
         catalogError={catalogError}
         loading={loading}
       >

--- a/assets/js/components/HostDetails/HostChecksSelection.jsx
+++ b/assets/js/components/HostDetails/HostChecksSelection.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PageHeader from '@components/PageHeader';
+import BackButton from '@components/BackButton';
+import { HostInfoBox } from '@components/HostDetails';
+
+import ChecksSelection from '@components/ChecksSelection/ChecksSelection';
+
+function HostChecksSelection({
+  host,
+  catalog,
+  catalogError,
+  catalogLoading,
+  onUpdateCatalog,
+}) {
+  const { hostID } = host;
+
+  return (
+    <div className="w-full px-2 sm:px-0">
+      <BackButton url={`/hosts/${hostID}`}>Back to Host Details</BackButton>
+      <PageHeader>
+        Check Settings for <span className="font-bold">{host.hostname}</span>
+      </PageHeader>
+      <HostInfoBox provider={host.provider} agentVersion={host.agent_version} />
+      <ChecksSelection
+        targetID={hostID}
+        catalog={catalog}
+        catalogError={catalogError}
+        loading={catalogLoading}
+        selected={host.selected_checks}
+        onSave={(_selectedChecks, _hostID) => {
+          // TODO: dispatch check selection for a host
+        }}
+        onUpdateCatalog={() => onUpdateCatalog()}
+        onClear={() => {
+          // TODO
+        }}
+        saving={false}
+        error={null}
+        success={false}
+      />
+    </div>
+  );
+}
+
+export default HostChecksSelection;

--- a/assets/js/components/HostDetails/HostChecksSelection.jsx
+++ b/assets/js/components/HostDetails/HostChecksSelection.jsx
@@ -1,32 +1,34 @@
 import React from 'react';
 import PageHeader from '@components/PageHeader';
 import BackButton from '@components/BackButton';
-import { HostInfoBox } from '@components/HostDetails';
-
 import ChecksSelection from '@components/ChecksSelection/ChecksSelection';
 
+import HostInfoBox from './HostInfoBox';
+
 function HostChecksSelection({
-  host,
+  hostID,
+  hostName,
+  provider,
+  agentVersion,
+  selectedChecks,
   catalog,
   catalogError,
   catalogLoading,
   onUpdateCatalog,
 }) {
-  const { hostID } = host;
-
   return (
     <div className="w-full px-2 sm:px-0">
       <BackButton url={`/hosts/${hostID}`}>Back to Host Details</BackButton>
       <PageHeader>
-        Check Settings for <span className="font-bold">{host.hostname}</span>
+        Check Settings for <span className="font-bold">{hostName}</span>
       </PageHeader>
-      <HostInfoBox provider={host.provider} agentVersion={host.agent_version} />
+      <HostInfoBox provider={provider} agentVersion={agentVersion} />
       <ChecksSelection
         targetID={hostID}
         catalog={catalog}
         catalogError={catalogError}
         loading={catalogLoading}
-        selected={host.selected_checks}
+        selected={selectedChecks}
         onSave={(_selectedChecks, _hostID) => {
           // TODO: dispatch check selection for a host
         }}

--- a/assets/js/components/HostDetails/HostChecksSelection.stories.jsx
+++ b/assets/js/components/HostDetails/HostChecksSelection.stories.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { faker } from '@faker-js/faker';
+import { MemoryRouter } from 'react-router-dom';
+
+import { catalogCheckFactory, hostFactory } from '@lib/test-utils/factories';
+import HostChecksSelection from './HostChecksSelection';
+
+const catalog = [
+  ...catalogCheckFactory.buildList(3, { group: faker.animal.cat() }),
+  ...catalogCheckFactory.buildList(6, { group: faker.animal.dog() }),
+  ...catalogCheckFactory.buildList(2, { group: faker.lorem.word() }),
+];
+
+const selectedChecks = [
+  catalog[0].id,
+  catalog[1].id,
+  catalog[2].id,
+  catalog[5].id,
+  catalog[6].id,
+];
+
+const host = hostFactory.build({ provider: 'azure' });
+
+export default {
+  title: 'HostChecksSelection',
+  component: HostChecksSelection,
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+  argTypes: {
+    host: {
+      control: 'object',
+      description: 'The host for which to select checks',
+      table: {
+        type: { summary: 'object' },
+      },
+    },
+    catalog: {
+      control: 'object',
+      description: 'Catalog data',
+      table: {
+        type: { summary: 'object' },
+      },
+    },
+    catalogError: {
+      control: 'text',
+      description: 'Error occurred while loading che relevant checks catalog',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: null },
+      },
+    },
+    catalogLoading: {
+      control: { type: 'boolean' },
+      description: 'Whether the catalog is loading',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: false },
+      },
+    },
+    onUpdateCatalog: {
+      action: 'Update catalog',
+      description: 'Called on mount to load the catalog for the host.',
+    },
+  },
+};
+
+export const Default = {
+  args: {
+    host: { ...host, selected_checks: selectedChecks },
+    catalog,
+    catalogError: null,
+    catalogLoading: false,
+    onUpdateCatalog: () => {},
+  },
+};

--- a/assets/js/components/HostDetails/HostChecksSelection.stories.jsx
+++ b/assets/js/components/HostDetails/HostChecksSelection.stories.jsx
@@ -19,7 +19,10 @@ const selectedChecks = [
   catalog[6].id,
 ];
 
-const host = hostFactory.build({ provider: 'azure' });
+const host = hostFactory.build({
+  provider: 'azure',
+  selected_checks: selectedChecks,
+});
 
 export default {
   title: 'HostChecksSelection',
@@ -32,12 +35,37 @@ export default {
     ),
   ],
   argTypes: {
-    host: {
-      control: 'object',
-      description: 'The host for which to select checks',
+    hostID: {
+      control: 'string',
+      description: 'The host identifier',
       table: {
-        type: { summary: 'object' },
+        type: { summary: 'string' },
       },
+    },
+    hostName: {
+      control: 'string',
+      description: 'The host name',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    provider: {
+      control: 'string',
+      description: 'The discovered CSP where the host is running',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    agentVersion: {
+      control: 'string',
+      description: 'The version of the installed agent',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    selectedChecks: {
+      control: 'array',
+      description: 'The check selection',
     },
     catalog: {
       control: 'object',
@@ -48,7 +76,7 @@ export default {
     },
     catalogError: {
       control: 'text',
-      description: 'Error occurred while loading che relevant checks catalog',
+      description: 'Error occurred while loading the relevant checks catalog',
       table: {
         type: { summary: 'string' },
         defaultValue: { summary: null },
@@ -71,7 +99,11 @@ export default {
 
 export const Default = {
   args: {
-    host: { ...host, selected_checks: selectedChecks },
+    hostID: host.id,
+    hostName: host.hostname,
+    provider: host.provider,
+    agentVersion: host.agent_version,
+    selectedChecks: host.selected_checks,
     catalog,
     catalogError: null,
     catalogLoading: false,

--- a/assets/js/components/HostDetails/HostChecksSelection.test.jsx
+++ b/assets/js/components/HostDetails/HostChecksSelection.test.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { faker } from '@faker-js/faker';
+import { catalogCheckFactory, hostFactory } from '@lib/test-utils/factories';
+
+import HostChecksSelection from './HostChecksSelection';
+import { renderWithRouter } from '../../lib/test-utils';
+
+describe('HostChecksSelection component', () => {
+  it('should render host check selection', async () => {
+    const group0 = faker.animal.cat();
+    const group1 = faker.animal.dog();
+    const group2 = faker.lorem.word();
+    const catalog = [
+      ...catalogCheckFactory.buildList(2, { group: group0 }),
+      ...catalogCheckFactory.buildList(2, { group: group1 }),
+      ...catalogCheckFactory.buildList(2, { group: group2 }),
+    ];
+
+    const onUpdateCatalog = jest.fn();
+
+    const host = hostFactory.build({ provider: 'azure' });
+
+    const { agent_version: agentVersion } = host;
+
+    renderWithRouter(
+      <HostChecksSelection
+        host={host}
+        catalog={catalog}
+        catalogError={null}
+        catalogLoading={false}
+        onUpdateCatalog={onUpdateCatalog}
+      />
+    );
+
+    expect(screen.getByText('Provider')).toBeVisible();
+    expect(screen.getByText('Azure')).toBeVisible();
+    expect(screen.getByText('Agent version')).toBeVisible();
+    expect(screen.getByText(agentVersion)).toBeVisible();
+    expect(screen.getByText(group0)).toBeVisible();
+    expect(screen.getByText(group1)).toBeVisible();
+    expect(screen.getByText(group2)).toBeVisible();
+    expect(
+      screen.getByRole('button', { name: 'Back to Host Details' })
+    ).toBeVisible();
+    expect(
+      screen.getByRole('button', { name: 'Save Check Selection' })
+    ).toBeVisible();
+    expect(onUpdateCatalog).toHaveBeenCalled();
+  });
+});

--- a/assets/js/components/HostDetails/HostChecksSelection.test.jsx
+++ b/assets/js/components/HostDetails/HostChecksSelection.test.jsx
@@ -22,13 +22,21 @@ describe('HostChecksSelection component', () => {
 
     const onUpdateCatalog = jest.fn();
 
-    const host = hostFactory.build({ provider: 'azure' });
-
-    const { agent_version: agentVersion } = host;
+    const {
+      id: hostID,
+      hostname: hostName,
+      provider,
+      agent_version: agentVersion,
+      selected_checks: selectedChecks,
+    } = hostFactory.build({ provider: 'azure' });
 
     renderWithRouter(
       <HostChecksSelection
-        host={host}
+        hostID={hostID}
+        hostName={hostName}
+        provider={provider}
+        agentVersion={agentVersion}
+        selectedChecks={selectedChecks}
         catalog={catalog}
         catalogError={null}
         catalogLoading={false}

--- a/assets/js/components/HostDetails/HostInfoBox.jsx
+++ b/assets/js/components/HostDetails/HostInfoBox.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import ListView from '@components/ListView';
+import ProviderLabel from '@components/ProviderLabel';
+
+function HostInfoBox({ provider, agentVersion }) {
+  return (
+    <div className="my-4 bg-white shadow rounded-lg px-8 py-4">
+      <ListView
+        orientation="vertical"
+        data={[
+          {
+            title: 'Provider',
+            content: provider,
+            render: (content) => <ProviderLabel provider={content} />,
+          },
+          { title: 'Agent version', content: agentVersion },
+          {
+            title: '',
+            content: '',
+          },
+        ]}
+      />
+    </div>
+  );
+}
+
+export default HostInfoBox;

--- a/assets/js/components/HostDetails/HostInfoBox.jsx
+++ b/assets/js/components/HostDetails/HostInfoBox.jsx
@@ -16,6 +16,7 @@ function HostInfoBox({ provider, agentVersion }) {
           },
           { title: 'Agent version', content: agentVersion },
           {
+            // This empty item in the list view is a hack to get the desired spacing rendered
             title: '',
             content: '',
           },

--- a/assets/js/components/HostDetails/HostInfoBox.test.jsx
+++ b/assets/js/components/HostDetails/HostInfoBox.test.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import HostInfoBox from './HostInfoBox';
+
+describe('Host Info Box', () => {
+  const scenarios = [
+    {
+      agentVersion: '1.1.0+git.dev17.1660137228.fe5ba8a',
+      provider: 'aws',
+      providerText: 'AWS',
+    },
+    {
+      agentVersion: '1.2.0+git.dev17.1660137228.fe5ba8a',
+      provider: 'aws',
+      providerText: 'AWS',
+    },
+    {
+      agentVersion: '2.0.0+git.dev17.1660137228.fe5ba8a',
+      provider: 'azure',
+      providerText: 'Azure',
+    },
+    {
+      agentVersion: '1.1.0',
+      provider: 'gcp',
+      providerText: 'GCP',
+    },
+    {
+      agentVersion: '1.2.0',
+      provider: 'kvm',
+      providerText: 'KVM',
+    },
+    {
+      agentVersion: '2.0.0',
+      provider: 'vmware',
+      providerText: 'VMware',
+    },
+    {
+      agentVersion: '2.1.0',
+      provider: 'nutanix',
+      providerText: 'Nutanix',
+    },
+  ];
+
+  it.each(scenarios)(
+    'should display host info box for $providerText',
+    ({ agentVersion, provider, providerText }) => {
+      render(<HostInfoBox provider={provider} agentVersion={agentVersion} />);
+      expect(screen.getByText(providerText)).toBeTruthy();
+      expect(screen.getByText(agentVersion)).toBeTruthy();
+    }
+  );
+});

--- a/assets/js/components/HostDetails/HostSettingsPage.jsx
+++ b/assets/js/components/HostDetails/HostSettingsPage.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
+
+import LoadingBox from '@components/LoadingBox';
+
+import { updateCatalog } from '@state/actions/catalog';
+import { getCatalog } from '@state/selectors/catalog';
+import { getHost } from '@state/selectors';
+import HostChecksSelection from './HostChecksSelection';
+
+function HostSettingsPage() {
+  const dispatch = useDispatch();
+
+  const { hostID } = useParams();
+  const host = useSelector(getHost(hostID));
+
+  const {
+    data: catalog,
+    error: catalogError,
+    loading: catalogLoading,
+  } = useSelector(getCatalog());
+
+  if (!host) {
+    return <LoadingBox text="Loading..." />;
+  }
+
+  return (
+    <HostChecksSelection
+      host={host}
+      catalog={catalog}
+      catalogError={catalogError}
+      catalogLoading={catalogLoading}
+      onUpdateCatalog={() =>
+        dispatch(
+          updateCatalog({
+            provider: host.provider,
+            target_type: 'host',
+          })
+        )
+      }
+    />
+  );
+}
+
+export default HostSettingsPage;

--- a/assets/js/components/HostDetails/HostSettingsPage.jsx
+++ b/assets/js/components/HostDetails/HostSettingsPage.jsx
@@ -24,10 +24,20 @@ function HostSettingsPage() {
   if (!host) {
     return <LoadingBox text="Loading..." />;
   }
+  const {
+    hostname: hostName,
+    provider,
+    agent_version: agentVersion,
+    selected_checks: selectedChecks,
+  } = host;
 
   return (
     <HostChecksSelection
-      host={host}
+      hostID={hostID}
+      hostName={hostName}
+      provider={provider}
+      agentVersion={agentVersion}
+      selectedChecks={selectedChecks}
       catalog={catalog}
       catalogError={catalogError}
       catalogLoading={catalogLoading}

--- a/assets/js/components/HostDetails/HostSettingsPage.test.jsx
+++ b/assets/js/components/HostDetails/HostSettingsPage.test.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { faker } from '@faker-js/faker';
+import {
+  withState,
+  defaultInitialState,
+  renderWithRouterMatch,
+} from '@lib/test-utils';
+import { catalogCheckFactory, hostFactory } from '@lib/test-utils/factories';
+
+import HostSettingsPage from './HostSettingsPage';
+
+describe('HostSettingsPage component', () => {
+  it('should render a loading box', () => {
+    const state = {
+      ...defaultInitialState,
+      hostsList: { hosts: [] },
+    };
+
+    const [StatefulHostSettingsPage] = withState(<HostSettingsPage />, state);
+
+    renderWithRouterMatch(StatefulHostSettingsPage, {
+      path: 'hosts/:hostID/settings',
+      route: `/hosts/${faker.datatype.uuid()}/settings`,
+    });
+
+    expect(screen.getByText('Loading...')).toBeVisible();
+    expect(screen.queryByText('Provider')).not.toBeTruthy();
+    expect(screen.queryByText('Agent version')).not.toBeTruthy();
+    expect(
+      screen.queryByRole('button', { name: 'Save Check Selection' })
+    ).not.toBeTruthy();
+  });
+
+  it('should render the host checks selection', () => {
+    const group0 = faker.animal.cat();
+    const group1 = faker.animal.dog();
+    const group2 = faker.lorem.word();
+    const catalog = [
+      ...catalogCheckFactory.buildList(2, { group: group0 }),
+      ...catalogCheckFactory.buildList(2, { group: group1 }),
+      ...catalogCheckFactory.buildList(2, { group: group2 }),
+    ];
+    const hosts = hostFactory.buildList(3, { provider: 'azure' });
+
+    const state = {
+      ...defaultInitialState,
+      catalog: { ...defaultInitialState.catalog, data: catalog },
+      hostsList: { hosts },
+    };
+    const { id: hostID, agent_version: agentVersion } = hosts[1];
+
+    const [StatefulHostSettingsPage] = withState(<HostSettingsPage />, state);
+
+    renderWithRouterMatch(StatefulHostSettingsPage, {
+      path: 'hosts/:hostID/settings',
+      route: `/hosts/${hostID}/settings`,
+    });
+
+    expect(screen.getByText('Provider')).toBeVisible();
+    expect(screen.getByText('Azure')).toBeVisible();
+    expect(screen.getByText('Agent version')).toBeVisible();
+    expect(screen.getByText(agentVersion)).toBeVisible();
+    expect(screen.getByText(group0)).toBeVisible();
+    expect(screen.getByText(group1)).toBeVisible();
+    expect(screen.getByText(group2)).toBeVisible();
+
+    expect(
+      screen.getByRole('button', { name: 'Save Check Selection' })
+    ).toBeVisible();
+  });
+});

--- a/assets/js/components/HostDetails/index.js
+++ b/assets/js/components/HostDetails/index.js
@@ -1,8 +1,6 @@
 import HostDetails from './HostDetails';
-import HostInfoBox from './HostInfoBox';
 import HostSettingsPage from './HostSettingsPage';
 
-export { HostInfoBox };
 export { HostSettingsPage };
 
 export default HostDetails;

--- a/assets/js/components/HostDetails/index.js
+++ b/assets/js/components/HostDetails/index.js
@@ -1,3 +1,8 @@
 import HostDetails from './HostDetails';
+import HostInfoBox from './HostInfoBox';
+import HostSettingsPage from './HostSettingsPage';
+
+export { HostInfoBox };
+export { HostSettingsPage };
 
 export default HostDetails;

--- a/assets/js/lib/test-utils/factories/hosts.js
+++ b/assets/js/lib/test-utils/factories/hosts.js
@@ -57,5 +57,6 @@ export const hostFactory = Factory.define(({ params, sequence }) => {
     },
     sles_subscriptions: slesSubscriptionFactory.buildList(4, { host_id: id }),
     deregisterable: false,
+    selected_checks: [],
   };
 });

--- a/assets/js/lib/test-utils/index.jsx
+++ b/assets/js/lib/test-utils/index.jsx
@@ -27,6 +27,7 @@ export const defaultInitialState = {
     ),
   },
   clusterChecksSelection: {},
+  catalog: { loading: false, data: [], error: null },
 };
 
 export const withState = (component, initialState = {}) => {

--- a/assets/js/trento.jsx
+++ b/assets/js/trento.jsx
@@ -30,6 +30,7 @@ import { me } from '@lib/auth';
 import { networkClient } from '@lib/network';
 import Guard from '@components/Guard';
 import CheckResultDetailPage from '@components/ExecutionResults/CheckResultDetail';
+import HostSettingsPage from '@components/HostDetails/HostSettingsPage';
 import DatabaseDetails from './components/DatabaseDetails';
 import SapSystemDetails from './components/SapSystemDetails/SapSystemDetails';
 import { store } from './state';
@@ -59,6 +60,10 @@ function App() {
                 <Route element={<Layout />}>
                   <Route index element={<Home />} />
                   <Route index path="hosts" element={<HostsList />} />
+                  <Route
+                    path="hosts/:hostID/settings"
+                    element={<HostSettingsPage />}
+                  />
                   <Route path="clusters" element={<ClustersList />} />
                   <Route path="sap_systems" element={<SapSystemsOverview />} />
                   <Route path="databases" element={<DatabasesOverview />} />

--- a/assets/js/trento.jsx
+++ b/assets/js/trento.jsx
@@ -18,7 +18,7 @@ import ClusterDetailsPage, {
 } from '@components/ClusterDetails';
 import { ExecutionResultsPage } from '@components/ExecutionResults';
 import SapSystemsOverview from '@components/SapSystemsOverview';
-import HostDetails from '@components/HostDetails';
+import HostDetails, { HostSettingsPage } from '@components/HostDetails';
 import DatabasesOverview from '@components/DatabasesOverview';
 import ChecksCatalog from '@components/ChecksCatalog';
 import NotFound from '@components/NotFound';
@@ -30,7 +30,6 @@ import { me } from '@lib/auth';
 import { networkClient } from '@lib/network';
 import Guard from '@components/Guard';
 import CheckResultDetailPage from '@components/ExecutionResults/CheckResultDetail';
-import HostSettingsPage from '@components/HostDetails/HostSettingsPage';
 import DatabaseDetails from './components/DatabaseDetails';
 import SapSystemDetails from './components/SapSystemDetails/SapSystemDetails';
 import { store } from './state';


### PR DESCRIPTION
# Description

First of a series of PRs that will bring checks to hosts.

The main thing that this change allows to do is to load the selectable checks for a specific host

![image](https://github.com/trento-project/web/assets/8167114/e18cd945-7708-463c-9a8d-2fed5dc44ef8)

You can browse to `/hosts/:hostID/settings` and see it loads the catalog for the host.

If running it locally make sure to have at least one check in wanda with `env.target_type == "host"` in the `when` condition, otherwise since there is no host checks currently available the page would be empty (story added)

![image](https://github.com/trento-project/web/assets/8167114/c76f1928-0ac4-4857-9201-2df867f361bf)

We need to iterate multiple times to get to the final state of the design, so what we're focusing on now is making it work, then make it beautiful. Otherwise the PRs would be huge.

Next: add state/saga for the host check selection and trigger the API call when clicking on Save Check Selection.

## How was this tested?

Automated tests.