### PR TITLE
Deregister hosts list frontend

### DIFF
--- a/assets/js/components/HostsList.jsx
+++ b/assets/js/components/HostsList.jsx
@@ -54,7 +54,7 @@ function HostsList() {
 
   const [searchParams, setSearchParams] = useSearchParams();
   const [cleanUpModalOpen, setCleanUpModalOpen] = useState(false);
-  const [selectedHost, setSelectedHost] = useState(undefined);
+  const [hostToDeregister, setHostToDeregister] = useState(undefined);
 
   const dispatch = useDispatch();
 
@@ -191,7 +191,7 @@ function HostsList() {
             <CleanUpButton
               cleaning={item.deregistering}
               onClick={() => {
-                setSelectedHost(item);
+                setHostToDeregister(item);
                 setCleanUpModalOpen(true);
               }}
             />
@@ -229,11 +229,11 @@ function HostsList() {
     <>
       <PageHeader className="font-bold">Hosts</PageHeader>
       <DeregistrationModal
-        hostname={selectedHost?.hostname}
+        hostname={hostToDeregister?.hostname}
         isOpen={!!cleanUpModalOpen}
         onCleanUp={() => {
           setCleanUpModalOpen(false);
-          dispatch(deregisterHost(selectedHost));
+          dispatch(deregisterHost(hostToDeregister));
         }}
         onCancel={() => {
           setCleanUpModalOpen(false);

--- a/assets/js/components/HostsList.jsx
+++ b/assets/js/components/HostsList.jsx
@@ -58,6 +58,16 @@ function HostsList() {
 
   const dispatch = useDispatch();
 
+  const openDeregistrationModal = (host) => {
+    setHostToDeregister(host);
+    setCleanUpModalOpen(true);
+  };
+
+  const cleanUpHost = (host) => {
+    setCleanUpModalOpen(false);
+    dispatch(deregisterHost(host));
+  };
+
   const config = {
     pagination: true,
     usePadding: false,
@@ -191,8 +201,7 @@ function HostsList() {
             <CleanUpButton
               cleaning={item.deregistering}
               onClick={() => {
-                setHostToDeregister(item);
-                setCleanUpModalOpen(true);
+                openDeregistrationModal(item);
               }}
             />
           ),
@@ -232,8 +241,7 @@ function HostsList() {
         hostname={hostToDeregister?.hostname}
         isOpen={!!cleanUpModalOpen}
         onCleanUp={() => {
-          setCleanUpModalOpen(false);
-          dispatch(deregisterHost(hostToDeregister));
+          cleanUpHost(hostToDeregister);
         }}
         onCancel={() => {
           setCleanUpModalOpen(false);

--- a/assets/js/state/hosts.js
+++ b/assets/js/state/hosts.js
@@ -79,6 +79,22 @@ export const hostsListSlice = createSlice({
         return host;
       });
     },
+    setHostDeregistering: (state, action) => {
+      state.hosts = state.hosts.map((host) => {
+        if (host.id === action.payload.id) {
+          return { ...host, deregistering: true };
+        }
+        return host;
+      });
+    },
+    setHostNotDeregistering: (state, action) => {
+      state.hosts = state.hosts.map((host) => {
+        if (host.id === action.payload.id) {
+          return { ...host, deregistering: false };
+        }
+        return host;
+      });
+    },
     startHostsLoading: (state) => {
       state.loading = true;
     },
@@ -95,6 +111,7 @@ export const CHECK_HOST_IS_DEREGISTERABLE = 'CHECK_HOST_IS_DEREGISTERABLE';
 export const CANCEL_CHECK_HOST_IS_DEREGISTERABLE =
   'CANCEL_CHECK_HOST_IS_DEREGISTERABLE';
 export const HOST_DEREGISTERED = 'HOST_DEREGISTERED';
+export const DEREGISTER_HOST = 'DEREGISTER_HOST';
 
 export const checkHostIsDeregisterable = createAction(
   CHECK_HOST_IS_DEREGISTERABLE
@@ -102,6 +119,7 @@ export const checkHostIsDeregisterable = createAction(
 export const cancelCheckHostIsDeregisterable = createAction(
   CANCEL_CHECK_HOST_IS_DEREGISTERABLE
 );
+export const deregisterHost = createAction(DEREGISTER_HOST);
 
 export const {
   setHosts,
@@ -113,6 +131,8 @@ export const {
   setHeartbeatCritical,
   setHostListDeregisterable,
   setHostNotDeregisterable,
+  setHostDeregistering,
+  setHostNotDeregistering,
   startHostsLoading,
   stopHostsLoading,
   removeHost,

--- a/assets/js/state/hosts.test.js
+++ b/assets/js/state/hosts.test.js
@@ -2,6 +2,8 @@ import hostsReducer, {
   removeHost,
   setHostListDeregisterable,
   setHostNotDeregisterable,
+  setHostDeregistering,
+  setHostNotDeregistering,
 } from '@state/hosts';
 import { hostFactory } from '@lib/test-utils/factories';
 
@@ -34,6 +36,34 @@ describe('Hosts reducer', () => {
 
     const expectedState = {
       hosts: [{ ...host1, deregisterable: false }, host2],
+    };
+
+    expect(hostsReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should set host in deregistering state', () => {
+    const [host1, host2] = hostFactory.buildList(2);
+    const initialState = { hosts: [host1, host2] };
+
+    const action = setHostDeregistering(host1);
+
+    const expectedState = {
+      hosts: [{ ...host1, deregistering: true }, host2],
+    };
+
+    expect(hostsReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should remove deregistering state from host', () => {
+    const [host1, host2] = hostFactory.buildList(2);
+    const initialState = {
+      hosts: [host1, host2],
+    };
+
+    const action = setHostNotDeregistering(host1);
+
+    const expectedState = {
+      hosts: [{ ...host1, deregistering: false }, host2],
     };
 
     expect(hostsReducer(initialState, action)).toEqual(expectedState);

--- a/assets/js/state/sagas/hosts.js
+++ b/assets/js/state/sagas/hosts.js
@@ -3,9 +3,14 @@ import {
   CHECK_HOST_IS_DEREGISTERABLE,
   CANCEL_CHECK_HOST_IS_DEREGISTERABLE,
   HOST_DEREGISTERED,
+  DEREGISTER_HOST,
   removeHost,
   setHostListDeregisterable,
+  setHostDeregistering,
+  setHostNotDeregistering,
 } from '@state/hosts';
+
+import { del } from '@lib/network';
 import { notify } from '@state/actions/notifications';
 
 export function* markDeregisterableHosts(hosts) {
@@ -43,10 +48,30 @@ export function* hostDeregistered({ payload }) {
   );
 }
 
+export function* deregisterHost({ payload }) {
+  yield put(setHostDeregistering(payload));
+  try {
+    yield call(del, `/hosts/${payload.id}`);
+  } catch (error) {
+    yield put(
+      notify({
+        text: `Error deregistering host ${payload?.hostname}.`,
+        icon: '❌',
+      })
+    );
+  } finally {
+    yield put(setHostNotDeregistering(payload));
+  }
+}
+
 export function* watchHostDeregisterable() {
   yield takeEvery(CHECK_HOST_IS_DEREGISTERABLE, checkHostDeregisterable);
 }
 
 export function* watchHostDeregistered() {
   yield takeEvery(HOST_DEREGISTERED, hostDeregistered);
+}
+
+export function* watchDeregisterHost() {
+  yield takeEvery(DEREGISTER_HOST, deregisterHost);
 }

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -70,6 +70,7 @@ import {
   markDeregisterableHosts,
   watchHostDeregistered,
   watchHostDeregisterable,
+  watchDeregisterHost,
 } from '@state/sagas/hosts';
 import { watchClusterDeregistered } from '@state/sagas/clusters';
 
@@ -428,5 +429,6 @@ export default function* rootSaga() {
     refreshHealthSummaryOnComnponentsHealthChange(),
     watchPerformLogin(),
     watchHostDeregisterable(),
+    watchDeregisterHost(),
   ]);
 }


### PR DESCRIPTION
# Description
Add deregistration button and modal.
It includes a simple saga to handle this.
We need to add the same button in the host details view, with the unique different that when the call is successful, we should navigate to the host list.

![deregister](https://github.com/trento-project/web/assets/36370954/f6e1f071-5d61-434a-b920-568c52a2f568)

## Blocked by
https://github.com/trento-project/web/pull/1599
https://github.com/trento-project/web/pull/1587

## How was this tested?

Tested
