### PR TITLE
Broadcast tags and value objects in restore events

### DIFF
--- a/lib/trento/application/projectors/cluster_projector.ex
+++ b/lib/trento/application/projectors/cluster_projector.ex
@@ -196,14 +196,17 @@ defmodule Trento.ClusterProjector do
 
   @impl true
   def after_update(%ClusterRestored{cluster_id: cluster_id}, _, _) do
-    cluster = Repo.get!(ClusterReadModel, cluster_id)
+    cluster =
+      ClusterReadModel
+      |> Repo.get!(cluster_id)
+      |> Repo.preload([:tags])
 
     restored_cluster = enrich_cluster_model(cluster)
 
     TrentoWeb.Endpoint.broadcast(
       "monitoring:clusters",
       "cluster_registered",
-      ClusterView.render("cluster_registered.json", cluster: restored_cluster)
+      ClusterView.render("cluster_restored.json", cluster: restored_cluster)
     )
   end
 

--- a/lib/trento/application/projectors/database_projector.ex
+++ b/lib/trento/application/projectors/database_projector.ex
@@ -304,12 +304,15 @@ defmodule Trento.DatabaseProjector do
         _,
         _
       ) do
-    database = Repo.get!(DatabaseReadModel, sap_system_id)
+    database =
+      DatabaseReadModel
+      |> Repo.get!(sap_system_id)
+      |> Repo.preload([:tags])
 
     TrentoWeb.Endpoint.broadcast(
       @databases_topic,
       "database_registered",
-      SapSystemView.render("database_registered.json", database: database)
+      SapSystemView.render("database_restored.json", database: database)
     )
   end
 

--- a/lib/trento/application/projectors/host_projector.ex
+++ b/lib/trento/application/projectors/host_projector.ex
@@ -224,12 +224,15 @@ defmodule Trento.HostProjector do
         _,
         _
       ) do
-    host = Repo.get!(HostReadModel, id)
+    host =
+      HostReadModel
+      |> Repo.get!(id)
+      |> Repo.preload([:sles_subscriptions, :tags])
 
     TrentoWeb.Endpoint.broadcast(
       "monitoring:hosts",
       "host_registered",
-      HostView.render("host_registered.json", host: host)
+      HostView.render("host_restored.json", host: host)
     )
   end
 

--- a/lib/trento/application/projectors/sap_system_projector.ex
+++ b/lib/trento/application/projectors/sap_system_projector.ex
@@ -337,12 +337,15 @@ defmodule Trento.SapSystemProjector do
         _,
         _
       ) do
-    sap_system = Repo.get!(SapSystemReadModel, sap_system_id)
+    sap_system =
+      SapSystemReadModel
+      |> Repo.get!(sap_system_id)
+      |> Repo.preload([:tags])
 
     TrentoWeb.Endpoint.broadcast(
       @sap_systems_topic,
       "sap_system_registered",
-      SapSystemView.render("sap_system_registered.json", sap_system: sap_system)
+      SapSystemView.render("sap_system_restored.json", sap_system: sap_system)
     )
   end
 

--- a/lib/trento_web/views/v1/host_view.ex
+++ b/lib/trento_web/views/v1/host_view.ex
@@ -26,6 +26,10 @@ defmodule TrentoWeb.V1.HostView do
     |> Map.delete(:tags)
   end
 
+  def render("host_restored.json", %{host: host}) do
+    render("host.json", %{host: host})
+  end
+
   def render("heartbeat_result.json", %{host: %{id: id, hostname: hostname}}) do
     %{id: id, hostname: hostname}
   end

--- a/lib/trento_web/views/v1/sap_system_view.ex
+++ b/lib/trento_web/views/v1/sap_system_view.ex
@@ -36,6 +36,13 @@ defmodule TrentoWeb.V1.SapSystemView do
     |> Map.delete(:database_instances)
   end
 
+  def render("database_restored.json", %{database: database}) do
+    database
+    |> Map.from_struct()
+    |> Map.delete(:__meta__)
+    |> Map.delete(:database_instances)
+  end
+
   def render("database_health_changed.json", %{health: health}), do: health
 
   def render("database_instance_health_changed.json", %{
@@ -122,6 +129,14 @@ defmodule TrentoWeb.V1.SapSystemView do
     |> Map.delete(:database_instances)
     |> Map.delete(:application_instances)
     |> Map.delete(:tags)
+  end
+
+  def render("sap_system_restored.json", %{sap_system: sap_system}) do
+    sap_system
+    |> Map.from_struct()
+    |> Map.delete(:__meta__)
+    |> Map.delete(:database_instances)
+    |> Map.delete(:application_instances)
   end
 
   def render("sap_system_updated.json", %{id: id, ensa_version: ensa_version}),

--- a/lib/trento_web/views/v2/cluster_view.ex
+++ b/lib/trento_web/views/v2/cluster_view.ex
@@ -15,6 +15,10 @@ defmodule TrentoWeb.V2.ClusterView do
     Map.delete(render("cluster.json", %{cluster: cluster}), :tags)
   end
 
+  def render("cluster_restored.json", %{cluster: cluster}) do
+    render("cluster.json", %{cluster: cluster})
+  end
+
   def render("cluster_details_updated.json", %{data: data}) do
     data
     |> Map.from_struct()

--- a/test/trento/application/projectors/sap_system_projector_test.exs
+++ b/test/trento/application/projectors/sap_system_projector_test.exs
@@ -240,6 +240,8 @@ defmodule Trento.SapSystemProjectorTest do
     %{tenant: tenant, id: sap_system_id, sid: sid} =
       insert(:sap_system, deregistered_at: DateTime.utc_now())
 
+    insert_list(5, :tag, resource_id: sap_system_id)
+
     new_db_host = Faker.Internet.ip_v4_address()
     new_health = :passing
 
@@ -252,7 +254,11 @@ defmodule Trento.SapSystemProjectorTest do
 
     ProjectorTestHelper.project(SapSystemProjector, event, "sap_system_projector")
 
-    projection = Repo.get(SapSystemReadModel, sap_system_id)
+    %{tags: tags} =
+      projection =
+      SapSystemReadModel
+      |> Repo.get(sap_system_id)
+      |> Repo.preload([:tags])
 
     assert_broadcast(
       "sap_system_registered",
@@ -261,7 +267,8 @@ defmodule Trento.SapSystemProjectorTest do
         health: ^new_health,
         id: ^sap_system_id,
         sid: ^sid,
-        tenant: ^tenant
+        tenant: ^tenant,
+        tags: ^tags
       },
       1000
     )


### PR DESCRIPTION
# Description

Broadcast preloaded objects in restoration events. Otherwise, objects such as `tags` and `sles_subscriptions` are not shown on restoration, and the user is forced to refresh the page to get them.

## How was this tested?

Tested on projections
