### PR TITLE
Only broadcast `HostRemovedFromCluster` when a host is part of a cluster

### DIFF
--- a/lib/trento/application/projectors/host_projector.ex
+++ b/lib/trento/application/projectors/host_projector.ex
@@ -281,7 +281,8 @@ defmodule Trento.HostProjector do
         %{host: %Trento.HostReadModel{cluster_id: nil}}
       ) do
     TrentoWeb.Endpoint.broadcast("monitoring:hosts", "host_details_updated", %{
-      id: host_id
+      id: host_id,
+      cluster_id: nil
     })
   end
 

--- a/lib/trento/application/projectors/host_projector.ex
+++ b/lib/trento/application/projectors/host_projector.ex
@@ -276,6 +276,16 @@ defmodule Trento.HostProjector do
   end
 
   def after_update(
+        %HostRemovedFromCluster{host_id: host_id},
+        _,
+        %{host: %Trento.HostReadModel{cluster_id: nil}}
+      ) do
+    TrentoWeb.Endpoint.broadcast("monitoring:hosts", "host_details_updated", %{
+      id: host_id
+    })
+  end
+
+  def after_update(
         %HostDetailsUpdated{},
         _,
         %{host: host}

--- a/test/trento/application/projectors/host_projector_test.exs
+++ b/test/trento/application/projectors/host_projector_test.exs
@@ -148,13 +148,12 @@ defmodule Trento.HostProjectorTest do
     }
 
     ProjectorTestHelper.project(HostProjector, event, "host_projector")
+    projection = Repo.get!(HostReadModel, host_id)
+    assert nil == projection.cluster_id
 
     assert_broadcast "host_details_updated",
                      %{id: ^host_id},
                      1000
-
-    projection = Repo.get!(HostReadModel, host_id)
-    assert nil == projection.cluster_id
   end
 
   test "should not set the cluster_id to nil if a HostRemovedFromCluster event is received and the host is not part of the cluster anymore" do
@@ -173,13 +172,12 @@ defmodule Trento.HostProjectorTest do
     }
 
     ProjectorTestHelper.project(HostProjector, event, "host_projector")
+    projection = Repo.get!(HostReadModel, host_id)
+    assert cluster_id == projection.cluster_id
 
     refute_broadcast "host_details_updated",
                      %{id: ^host_id},
                      1000
-
-    projection = Repo.get!(HostReadModel, host_id)
-    assert cluster_id == projection.cluster_id
   end
 
   test "should update an existing host when HostDetailsUpdated event is received", %{

--- a/test/trento/application/projectors/host_projector_test.exs
+++ b/test/trento/application/projectors/host_projector_test.exs
@@ -177,9 +177,7 @@ defmodule Trento.HostProjectorTest do
 
     assert cluster_id == projection.cluster_id
 
-    refute_broadcast "host_details_updated",
-                     %{id: ^host_id},
-                     100
+    refute_broadcast "host_details_updated", %{id: ^host_id}
   end
 
   test "should update an existing host when HostDetailsUpdated event is received", %{

--- a/test/trento/application/projectors/host_projector_test.exs
+++ b/test/trento/application/projectors/host_projector_test.exs
@@ -152,7 +152,7 @@ defmodule Trento.HostProjectorTest do
     assert nil == projection.cluster_id
 
     assert_broadcast "host_details_updated",
-                     %{id: ^host_id},
+                     %{id: ^host_id, cluster_id: nil},
                      1000
   end
 

--- a/test/trento/application/projectors/host_projector_test.exs
+++ b/test/trento/application/projectors/host_projector_test.exs
@@ -148,8 +148,12 @@ defmodule Trento.HostProjectorTest do
     }
 
     ProjectorTestHelper.project(HostProjector, event, "host_projector")
-    projection = Repo.get!(HostReadModel, host_id)
 
+    assert_broadcast "host_details_updated",
+                     %{id: ^host_id},
+                     1000
+
+    projection = Repo.get!(HostReadModel, host_id)
     assert nil == projection.cluster_id
   end
 
@@ -169,8 +173,12 @@ defmodule Trento.HostProjectorTest do
     }
 
     ProjectorTestHelper.project(HostProjector, event, "host_projector")
-    projection = Repo.get!(HostReadModel, host_id)
 
+    refute_broadcast "host_details_updated",
+                     %{id: ^host_id},
+                     1000
+
+    projection = Repo.get!(HostReadModel, host_id)
     assert cluster_id == projection.cluster_id
   end
 

--- a/test/trento/application/projectors/host_projector_test.exs
+++ b/test/trento/application/projectors/host_projector_test.exs
@@ -149,6 +149,7 @@ defmodule Trento.HostProjectorTest do
 
     ProjectorTestHelper.project(HostProjector, event, "host_projector")
     projection = Repo.get!(HostReadModel, host_id)
+
     assert nil == projection.cluster_id
 
     assert_broadcast "host_details_updated",
@@ -173,6 +174,7 @@ defmodule Trento.HostProjectorTest do
 
     ProjectorTestHelper.project(HostProjector, event, "host_projector")
     projection = Repo.get!(HostReadModel, host_id)
+
     assert cluster_id == projection.cluster_id
 
     refute_broadcast "host_details_updated",

--- a/test/trento/application/projectors/host_projector_test.exs
+++ b/test/trento/application/projectors/host_projector_test.exs
@@ -179,7 +179,7 @@ defmodule Trento.HostProjectorTest do
 
     refute_broadcast "host_details_updated",
                      %{id: ^host_id},
-                     1000
+                     100
   end
 
   test "should update an existing host when HostDetailsUpdated event is received", %{


### PR DESCRIPTION
Description
===========

Relates to https://github.com/trento-project/web/pull/1474

> This PR fixes possible concurrency issues when a host is removed from a cluster (delta-deregistration flow).
> The issue is caused by two aggregates acting concurrently, so the HostAddedToCluster event and HostRemovedFromCluster event ordering is not guaranteed.
>
> The solution is to change the projector logic to skip the event if the host is not part of the cluster anymore.
>
> **We still need to conditionally broadcast to the FE the event, but this will come once the FE PR is merged.**

This change will broadcast `HostRemovedFromCluster` _only_ when a given host is part of a cluster.

How was this tested?
--------------------

Added conditions in unit tests to assert for the existence/nonexistence of the broadcast messages when `HostRemovedFromCluster` is called