### PR TITLE
Fix application instance deletion after_update

### DIFF
--- a/lib/trento/application/projectors/database_projector.ex
+++ b/lib/trento/application/projectors/database_projector.ex
@@ -186,11 +186,12 @@ defmodule Trento.DatabaseProjector do
       sap_system_id: sap_system_id
     },
     fn multi ->
-      deregistered_instance = %DatabaseInstanceReadModel{
-        sap_system_id: sap_system_id,
-        instance_number: instance_number,
-        host_id: host_id
-      }
+      deregistered_instance =
+        Repo.get_by(DatabaseInstanceReadModel,
+          sap_system_id: sap_system_id,
+          instance_number: instance_number,
+          host_id: host_id
+        )
 
       Ecto.Multi.delete(multi, :database_instance, deregistered_instance)
     end
@@ -346,12 +347,12 @@ defmodule Trento.DatabaseProjector do
           sap_system_id: sap_system_id
         },
         _,
-        _
+        %{
+          database_instance: %DatabaseInstanceReadModel{
+            sid: sid
+          }
+        }
       ) do
-    %DatabaseReadModel{
-      sid: sid
-    } = Repo.get!(DatabaseReadModel, sap_system_id)
-
     TrentoWeb.Endpoint.broadcast(
       @databases_topic,
       "database_instance_deregistered",

--- a/lib/trento/application/projectors/sap_system_projector.ex
+++ b/lib/trento/application/projectors/sap_system_projector.ex
@@ -357,12 +357,10 @@ defmodule Trento.SapSystemProjector do
           sap_system_id: sap_system_id
         },
         _,
-        _
+        %{
+          application_instance: %ApplicationInstanceReadModel{sid: sid}
+        }
       ) do
-    %SapSystemReadModel{
-      sid: sid
-    } = Repo.get!(SapSystemReadModel, sap_system_id)
-
     TrentoWeb.Endpoint.broadcast(
       @sap_systems_topic,
       "application_instance_deregistered",

--- a/test/trento/application/projectors/database_projector_test.exs
+++ b/test/trento/application/projectors/database_projector_test.exs
@@ -270,11 +270,14 @@ defmodule Trento.DatabaseProjectorTest do
   test "should remove a database instance from the read model after a deregistration" do
     deregistered_at = DateTime.utc_now()
 
-    %{sid: sid} = insert(:database, id: sap_system_id = Faker.UUID.v4())
-    insert_list(4, :database_instance)
+    %{
+      sid: sid,
+      sap_system_id: sap_system_id,
+      instance_number: instance_number,
+      host_id: host_id
+    } = insert(:database_instance)
 
-    %{instance_number: instance_number, host_id: host_id} =
-      insert(:database_instance, sap_system_id: sap_system_id, sid: sid)
+    insert_list(4, :database_instance)
 
     event = %DatabaseInstanceDeregistered{
       instance_number: instance_number,

--- a/test/trento/application/projectors/sap_system_projector_test.exs
+++ b/test/trento/application/projectors/sap_system_projector_test.exs
@@ -279,10 +279,12 @@ defmodule Trento.SapSystemProjectorTest do
   test "should remove an application instance from the read model after a deregistration" do
     deregistered_at = DateTime.utc_now()
 
-    %{sid: sid} = insert(:sap_system, id: sap_system_id = Faker.UUID.v4())
-
-    %{instance_number: instance_number, host_id: host_id} =
-      insert(:application_instance, sap_system_id: sap_system_id, sid: sid)
+    %{
+      sid: sid,
+      sap_system_id: sap_system_id,
+      instance_number: instance_number,
+      host_id: host_id
+    } = insert(:application_instance)
 
     insert_list(4, :application_instance)
 


### PR DESCRIPTION
# Description

Fix the `application_instance` deletion.
With the old code, there was a risk that the `after_update` could try to get a non existing `SapSystemReadModel` (SAP system not registered yet because some App instance was missing). This causes a breaking failure.
Now, the instance deletion data is retrieved before the deletion and passed to the `after_update` in the 3rd argument.
