### PR TITLE
Projectors refactor

### DIFF
--- a/lib/trento/application/projectors/cluster_projector.ex
+++ b/lib/trento/application/projectors/cluster_projector.ex
@@ -63,8 +63,10 @@ defmodule Trento.ClusterProjector do
       deregistered_at: deregistered_at
     },
     fn multi ->
+      cluster = Repo.get!(ClusterReadModel, cluster_id)
+
       changeset =
-        ClusterReadModel.changeset(%ClusterReadModel{id: cluster_id}, %{
+        ClusterReadModel.changeset(cluster, %{
           deregistered_at: deregistered_at
         })
 
@@ -101,8 +103,10 @@ defmodule Trento.ClusterProjector do
       details: details
     },
     fn multi ->
+      cluster = Repo.get!(ClusterReadModel, id)
+
       changeset =
-        ClusterReadModel.changeset(%ClusterReadModel{id: id}, %{
+        ClusterReadModel.changeset(cluster, %{
           name: name,
           sid: sid,
           additional_sids: additional_sids,
@@ -135,7 +139,9 @@ defmodule Trento.ClusterProjector do
   )
 
   project(%ClusterHealthChanged{cluster_id: cluster_id, health: health}, fn multi ->
-    changeset = ClusterReadModel.changeset(%ClusterReadModel{id: cluster_id}, %{health: health})
+    cluster = Repo.get!(ClusterReadModel, cluster_id)
+
+    changeset = ClusterReadModel.changeset(cluster, %{health: health})
 
     Ecto.Multi.update(multi, :cluster, changeset)
   end)

--- a/lib/trento/application/projectors/cluster_projector.ex
+++ b/lib/trento/application/projectors/cluster_projector.ex
@@ -63,10 +63,10 @@ defmodule Trento.ClusterProjector do
       deregistered_at: deregistered_at
     },
     fn multi ->
-      cluster = Repo.get!(ClusterReadModel, cluster_id)
-
       changeset =
-        ClusterReadModel.changeset(cluster, %{
+        ClusterReadModel
+        |> Repo.get!(cluster_id)
+        |> ClusterReadModel.changeset(%{
           deregistered_at: deregistered_at
         })
 
@@ -79,10 +79,10 @@ defmodule Trento.ClusterProjector do
       cluster_id: cluster_id
     },
     fn multi ->
-      cluster = Repo.get!(ClusterReadModel, cluster_id)
-
       changeset =
-        ClusterReadModel.changeset(cluster, %{
+        ClusterReadModel
+        |> Repo.get!(cluster_id)
+        |> ClusterReadModel.changeset(%{
           deregistered_at: nil
         })
 
@@ -103,10 +103,10 @@ defmodule Trento.ClusterProjector do
       details: details
     },
     fn multi ->
-      cluster = Repo.get!(ClusterReadModel, id)
-
       changeset =
-        ClusterReadModel.changeset(cluster, %{
+        ClusterReadModel
+        |> Repo.get!(id)
+        |> ClusterReadModel.changeset(%{
           name: name,
           sid: sid,
           additional_sids: additional_sids,
@@ -139,9 +139,10 @@ defmodule Trento.ClusterProjector do
   )
 
   project(%ClusterHealthChanged{cluster_id: cluster_id, health: health}, fn multi ->
-    cluster = Repo.get!(ClusterReadModel, cluster_id)
-
-    changeset = ClusterReadModel.changeset(cluster, %{health: health})
+    changeset =
+      ClusterReadModel
+      |> Repo.get!(cluster_id)
+      |> ClusterReadModel.changeset(%{health: health})
 
     Ecto.Multi.update(multi, :cluster, changeset)
   end)

--- a/lib/trento/application/projectors/cluster_projector.ex
+++ b/lib/trento/application/projectors/cluster_projector.ex
@@ -191,9 +191,9 @@ defmodule Trento.ClusterProjector do
   end
 
   @impl true
-  def after_update(%ClusterDeregistered{cluster_id: cluster_id}, _, _) do
-    %ClusterReadModel{name: name} = Repo.get!(ClusterReadModel, cluster_id)
-
+  def after_update(%ClusterDeregistered{cluster_id: cluster_id}, _, %{
+        cluster: %ClusterReadModel{name: name}
+      }) do
     TrentoWeb.Endpoint.broadcast("monitoring:clusters", "cluster_deregistered", %{
       id: cluster_id,
       name: name

--- a/lib/trento/application/projectors/database_projector.ex
+++ b/lib/trento/application/projectors/database_projector.ex
@@ -50,9 +50,10 @@ defmodule Trento.DatabaseProjector do
       health: health
     },
     fn multi ->
-      db = Repo.get!(DatabaseReadModel, sap_system_id)
-
-      changeset = DatabaseReadModel.changeset(db, %{health: health})
+      changeset =
+        DatabaseReadModel
+        |> Repo.get!(sap_system_id)
+        |> DatabaseReadModel.changeset(%{health: health})
 
       Ecto.Multi.update(multi, :database, changeset)
     end
@@ -104,18 +105,14 @@ defmodule Trento.DatabaseProjector do
       health: health
     },
     fn multi ->
-      db_instance =
-        Repo.get_by(DatabaseInstanceReadModel,
+      changeset =
+        DatabaseInstanceReadModel
+        |> Repo.get_by(
           sap_system_id: sap_system_id,
           instance_number: instance_number,
           host_id: host_id
         )
-
-      changeset =
-        DatabaseInstanceReadModel.changeset(
-          db_instance,
-          %{health: health}
-        )
+        |> DatabaseInstanceReadModel.changeset(%{health: health})
 
       Ecto.Multi.update(multi, :database_instance, changeset)
     end
@@ -130,21 +127,17 @@ defmodule Trento.DatabaseProjector do
       system_replication_status: system_replication_status
     },
     fn multi ->
-      db_instance =
-        Repo.get_by(DatabaseInstanceReadModel,
+      changeset =
+        DatabaseInstanceReadModel
+        |> Repo.get_by(
           sap_system_id: sap_system_id,
           instance_number: instance_number,
           host_id: host_id
         )
-
-      changeset =
-        DatabaseInstanceReadModel.changeset(
-          db_instance,
-          %{
-            system_replication: system_replication,
-            system_replication_status: system_replication_status
-          }
-        )
+        |> DatabaseInstanceReadModel.changeset(%{
+          system_replication: system_replication,
+          system_replication_status: system_replication_status
+        })
 
       Ecto.Multi.update(multi, :database_instance, changeset)
     end
@@ -156,13 +149,10 @@ defmodule Trento.DatabaseProjector do
       deregistered_at: deregistered_at
     },
     fn multi ->
-      db = Repo.get!(DatabaseReadModel, sap_system_id)
-
       changeset =
-        DatabaseReadModel.changeset(
-          db,
-          %{deregistered_at: deregistered_at}
-        )
+        DatabaseReadModel
+        |> Repo.get!(sap_system_id)
+        |> DatabaseReadModel.changeset(%{deregistered_at: deregistered_at})
 
       Ecto.Multi.update(multi, :database, changeset)
     end
@@ -174,13 +164,10 @@ defmodule Trento.DatabaseProjector do
       health: health
     },
     fn multi ->
-      db = Repo.get!(DatabaseReadModel, sap_system_id)
-
       changeset =
-        DatabaseReadModel.changeset(
-          db,
-          %{deregistered_at: nil, health: health}
-        )
+        DatabaseReadModel
+        |> Repo.get!(sap_system_id)
+        |> DatabaseReadModel.changeset(%{deregistered_at: nil, health: health})
 
       Ecto.Multi.update(multi, :database, changeset)
     end

--- a/lib/trento/application/projectors/host_projector.ex
+++ b/lib/trento/application/projectors/host_projector.ex
@@ -57,10 +57,10 @@ defmodule Trento.HostProjector do
       deregistered_at: deregistered_at
     },
     fn multi ->
-      host = Repo.get!(HostReadModel, id)
-
       changeset =
-        HostReadModel.changeset(host, %{
+        HostReadModel
+        |> Repo.get!(id)
+        |> HostReadModel.changeset(%{
           deregistered_at: deregistered_at
         })
 
@@ -73,10 +73,10 @@ defmodule Trento.HostProjector do
       host_id: id
     },
     fn multi ->
-      host = Repo.get!(HostReadModel, id)
-
       changeset =
-        HostReadModel.changeset(host, %{
+        HostReadModel
+        |> Repo.get!(id)
+        |> HostReadModel.changeset(%{
           deregistered_at: nil
         })
 
@@ -134,10 +134,10 @@ defmodule Trento.HostProjector do
       agent_version: agent_version
     },
     fn multi ->
-      host = Repo.get!(HostReadModel, id)
-
       changeset =
-        HostReadModel.changeset(host, %{
+        HostReadModel
+        |> Repo.get!(id)
+        |> HostReadModel.changeset(%{
           hostname: hostname,
           ip_addresses: ip_addresses,
           agent_version: agent_version
@@ -167,10 +167,10 @@ defmodule Trento.HostProjector do
   project(
     %HeartbeatSucceded{host_id: id},
     fn multi ->
-      host = Repo.get!(HostReadModel, id)
-
       changeset =
-        HostReadModel.changeset(host, %{
+        HostReadModel
+        |> Repo.get!(id)
+        |> HostReadModel.changeset(%{
           heartbeat: :passing
         })
 
@@ -181,10 +181,10 @@ defmodule Trento.HostProjector do
   project(
     %HeartbeatFailed{host_id: id},
     fn multi ->
-      host = Repo.get!(HostReadModel, id)
-
       changeset =
-        HostReadModel.changeset(host, %{
+        HostReadModel
+        |> Repo.get!(id)
+        |> HostReadModel.changeset(%{
           heartbeat: :critical
         })
 
@@ -195,10 +195,10 @@ defmodule Trento.HostProjector do
   project(
     %ProviderUpdated{host_id: id, provider: provider, provider_data: provider_data},
     fn multi ->
-      host = Repo.get!(HostReadModel, id)
-
       changeset =
-        HostReadModel.changeset(host, %{
+        HostReadModel
+        |> Repo.get!(id)
+        |> HostReadModel.changeset(%{
           provider: provider,
           provider_data: handle_provider_data(provider_data)
         })

--- a/lib/trento/application/projectors/host_projector.ex
+++ b/lib/trento/application/projectors/host_projector.ex
@@ -283,7 +283,7 @@ defmodule Trento.HostProjector do
   def after_update(
         %HostRemovedFromCluster{host_id: host_id},
         _,
-        %{host: %Trento.HostReadModel{cluster_id: nil}}
+        %{host: %HostReadModel{cluster_id: nil}}
       ) do
     TrentoWeb.Endpoint.broadcast("monitoring:hosts", "host_details_updated", %{
       id: host_id,

--- a/lib/trento/application/projectors/sap_system_projector.ex
+++ b/lib/trento/application/projectors/sap_system_projector.ex
@@ -59,9 +59,10 @@ defmodule Trento.SapSystemProjector do
       health: health
     },
     fn multi ->
-      sap_system = Repo.get!(SapSystemReadModel, sap_system_id)
-
-      changeset = SapSystemReadModel.changeset(sap_system, %{health: health})
+      changeset =
+        SapSystemReadModel
+        |> Repo.get!(sap_system_id)
+        |> SapSystemReadModel.changeset(%{health: health})
 
       Ecto.Multi.update(multi, :sap_system, changeset)
     end
@@ -107,14 +108,15 @@ defmodule Trento.SapSystemProjector do
       new_host_id: new_host_id
     },
     fn multi ->
-      instance =
-        Repo.get_by(ApplicationInstanceReadModel,
+      changeset =
+        ApplicationInstanceReadModel
+        |> Repo.get_by(
           sap_system_id: sap_system_id,
           instance_number: instance_number,
           host_id: old_host_id
         )
+        |> ApplicationInstanceReadModel.changeset(%{host_id: new_host_id})
 
-      changeset = ApplicationInstanceReadModel.changeset(instance, %{host_id: new_host_id})
       Ecto.Multi.update(multi, :application_instance, changeset)
     end
   )
@@ -127,18 +129,14 @@ defmodule Trento.SapSystemProjector do
       health: health
     },
     fn multi ->
-      instance =
-        Repo.get_by(ApplicationInstanceReadModel,
+      changeset =
+        ApplicationInstanceReadModel
+        |> Repo.get_by(
           sap_system_id: sap_system_id,
           instance_number: instance_number,
           host_id: host_id
         )
-
-      changeset =
-        ApplicationInstanceReadModel.changeset(
-          instance,
-          %{health: health}
-        )
+        |> ApplicationInstanceReadModel.changeset(%{health: health})
 
       Ecto.Multi.update(multi, :application_instance, changeset)
     end
@@ -150,13 +148,10 @@ defmodule Trento.SapSystemProjector do
       deregistered_at: deregistered_at
     },
     fn multi ->
-      sap_system = Repo.get!(SapSystemReadModel, sap_system_id)
-
       changeset =
-        SapSystemReadModel.changeset(
-          sap_system,
-          %{deregistered_at: deregistered_at}
-        )
+        SapSystemReadModel
+        |> Repo.get!(sap_system_id)
+        |> SapSystemReadModel.changeset(%{deregistered_at: deregistered_at})
 
       Ecto.Multi.update(multi, :sap_system, changeset)
     end
@@ -170,10 +165,10 @@ defmodule Trento.SapSystemProjector do
       health: health
     },
     fn multi ->
-      sap_system = Repo.get!(SapSystemReadModel, sap_system_id)
-
       changeset =
-        SapSystemReadModel.changeset(sap_system, %{
+        SapSystemReadModel
+        |> Repo.get!(sap_system_id)
+        |> SapSystemReadModel.changeset(%{
           tenant: tenant,
           db_host: db_host,
           health: health,
@@ -208,10 +203,10 @@ defmodule Trento.SapSystemProjector do
       ensa_version: ensa_version
     },
     fn multi ->
-      sap_system = Repo.get!(SapSystemReadModel, sap_system_id)
-
       changeset =
-        SapSystemReadModel.changeset(sap_system, %{
+        SapSystemReadModel
+        |> Repo.get!(sap_system_id)
+        |> SapSystemReadModel.changeset(%{
           ensa_version: ensa_version
         })
 


### PR DESCRIPTION
# Description

This pr refactor the usage of projectors, using the changesets with the current entity as the base entity for the changes.

Removes the queries from `after_update` callbacks, only the necessary association preloads for broadcasts are present.

## How was this tested?

Automated tests
