### PR TITLE
Add test to check for Clean up button visibility

### DIFF
--- a/assets/js/components/CleanUpButton/CleanUpButton.jsx
+++ b/assets/js/components/CleanUpButton/CleanUpButton.jsx
@@ -13,6 +13,7 @@ function CleanUpButton({ cleaning, onClick }) {
       size="small"
       disabled={cleaning}
       onClick={() => onClick()}
+      data-testid="cleanup-button"
     >
       {cleaning === true ? (
         <Spinner className="justify-center flex" />

--- a/assets/js/components/DeregistrationModal/DeregistrationModal.jsx
+++ b/assets/js/components/DeregistrationModal/DeregistrationModal.jsx
@@ -24,18 +24,14 @@ function DeregistrationModal({
       </div>
       <div className="flex justify-start gap-2 mt-4">
         <Button
+          data-testid="cleanup-confirm"
           type="default-fit"
           className="inline-block mx-0.5 border-green-500 border w-fit"
           size="small"
           onClick={onCleanUp}
         >
           <EOS_CLEANING_SERVICES size="base" className="fill-white inline" />
-          <span
-            id="cleanup-confirm"
-            className="text-white text-sm font-bold pl-1.5"
-          >
-            Clean up
-          </span>
+          <span className="text-white text-sm font-bold pl-1.5">Clean up</span>
         </Button>
         <Button
           type="primary-white-fit"

--- a/assets/js/components/DeregistrationModal/DeregistrationModal.jsx
+++ b/assets/js/components/DeregistrationModal/DeregistrationModal.jsx
@@ -30,7 +30,12 @@ function DeregistrationModal({
           onClick={onCleanUp}
         >
           <EOS_CLEANING_SERVICES size="base" className="fill-white inline" />
-          <span className="text-white text-sm font-bold pl-1.5">Clean up</span>
+          <span
+            id="cleanup-confirm"
+            className="text-white text-sm font-bold pl-1.5"
+          >
+            Clean up
+          </span>
         </Button>
         <Button
           type="primary-white-fit"

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -172,7 +172,7 @@ context('Hosts Overview', () => {
   });
 
   describe('Deregistration', () => {
-    const host = {
+    const hostToDeregister = {
       name: 'vmdrbddev01',
       id: '240f96b1-8d26-53b7-9e99-ffb0f2e735bf',
     };
@@ -181,11 +181,11 @@ context('Hosts Overview', () => {
       before(() => {
         cy.visit('/hosts');
         cy.url().should('include', '/hosts');
-        cy.task('startAgentHeartbeat', [host.id]);
+        cy.task('startAgentHeartbeat', [hostToDeregister.id]);
       });
 
-      it(`should not display a clean-up button for host ${host.name}`, () => {
-        cy.contains(host.name).within(() => {
+      it(`should not display a clean-up button for host ${hostToDeregister.name}`, () => {
+        cy.contains(hostToDeregister.name).within(() => {
           cy.get('td:nth-child(9)').should('not.exist');
         });
       });
@@ -198,7 +198,7 @@ context('Hosts Overview', () => {
         }
       });
 
-      it(`should display the cleanup button for host ${host.name} once heartbeat is lost`, () => {
+      it(`should display the cleanup button for host ${hostToDeregister.name} once heartbeat is lost`, () => {
         cy.task('stopAgentsHeartbeat');
 
         cy.get('tr:nth-child(1) > .w-48 > [data-testid="cleanup-button"]', {
@@ -226,7 +226,7 @@ context('Hosts Overview', () => {
 
         cy.get('[data-testid="cleanup-confirm"]').click();
 
-        cy.contains(host.name).should('not.exist');
+        cy.contains(hostToDeregister.name).should('not.exist');
       });
     });
   });

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -171,7 +171,7 @@ context('Hosts Overview', () => {
     });
   });
 
-  describe('Clean-up', () => {
+  describe('Deregistration', () => {
     describe('Clean-up buttons should be visible only when needed', () => {
       const heartbeatTargets = agents();
       const failingHost = heartbeatTargets.shift();
@@ -180,9 +180,10 @@ context('Hosts Overview', () => {
       });
 
       it('should hide all Clean-up buttons when heartbeat starts except the first one', () => {
-        cy.get(
-          ':nth-child(1) > .w-48 > .bg-white > .text-jungle-green-500'
-        ).should('contain.text', 'Clean up');
+        cy.get('tr:nth-child(1) > td:nth-child(9)').should(
+          'contain.text',
+          'Clean up'
+        );
 
         for (let i = 2; i < 11; i++) {
           cy.get(
@@ -191,7 +192,7 @@ context('Hosts Overview', () => {
         }
       });
 
-      it('should display a confirmation to remove the host after clicking on Clean up', () => {
+      it('should allow to deregister a host after clean up confirmation', () => {
         cy.get(
           ':nth-child(1) > .w-48 > .bg-white > .text-jungle-green-500'
         ).click();
@@ -200,10 +201,8 @@ context('Hosts Overview', () => {
           'contain.text',
           'This action will cause Trento to stop tracking all the components discovered by the agent in this host, including the host itself and any other component depending on it.'
         );
-      });
 
-      it('should remove a host after confirming host cleanup', () => {
-        cy.get('.bg-jungle-green-500').click();
+        cy.get('#cleanup-confirm').click();
         cy.get(`#host-${failingHost}`).should('not.exist');
       });
     });

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -172,38 +172,61 @@ context('Hosts Overview', () => {
   });
 
   describe('Deregistration', () => {
+    const host = {
+      name: 'vmdrbddev01',
+      id: '240f96b1-8d26-53b7-9e99-ffb0f2e735bf',
+    };
+
     describe('Clean-up buttons should be visible only when needed', () => {
-      const heartbeatTargets = agents();
-      const failingHost = heartbeatTargets.shift();
       before(() => {
-        cy.task('startAgentHeartbeat', heartbeatTargets);
+        cy.visit('/hosts');
+        cy.url().should('include', '/hosts');
+        cy.task('startAgentHeartbeat', [host.id]);
       });
 
-      it('should hide all Clean-up buttons when heartbeat starts except the first one', () => {
-        cy.get('tr:nth-child(1) > td:nth-child(9)').should(
-          'contain.text',
-          'Clean up'
-        );
+      it(`should not display a clean-up button for host ${host.name}`, () => {
+        cy.contains(host.name).within(() => {
+          cy.get('td:nth-child(9)').should('not.exist');
+        });
+      });
 
+      it('should show all other cleanup buttons', () => {
         for (let i = 2; i < 11; i++) {
-          cy.get(
-            `:nth-child(${i}) > .w-48 > .bg-white > .text-jungle-green-500`
-          ).should('not.exist');
+          cy.get(`tr:nth-child(${i})`).within(() => {
+            cy.get('[data-testid="cleanup-button"]').should('exist');
+          });
         }
       });
 
+      it(`should display the cleanup button for host ${host.name} once heartbeat is lost`, () => {
+        cy.task('stopAgentsHeartbeat');
+
+        cy.get('tr:nth-child(1) > .w-48 > [data-testid="cleanup-button"]', {
+          timeout: 15000,
+        }).should('exist');
+      });
+    });
+
+    describe('Clean-up button should deregister a host', () => {
+      before(() => {
+        cy.visit('/hosts');
+        cy.url().should('include', '/hosts');
+        cy.task('stopAgentsHeartbeat');
+      });
+
       it('should allow to deregister a host after clean up confirmation', () => {
-        cy.get(
-          ':nth-child(1) > .w-48 > .bg-white > .text-jungle-green-500'
-        ).click();
+        cy.get('tr:nth-child(1) > .w-48 > [data-testid="cleanup-button"]', {
+          timeout: 15000,
+        }).click();
 
         cy.get('.min-h-screen > .w-full').should(
           'contain.text',
           'This action will cause Trento to stop tracking all the components discovered by the agent in this host, including the host itself and any other component depending on it.'
         );
 
-        cy.get('#cleanup-confirm').click();
-        cy.get(`#host-${failingHost}`).should('not.exist');
+        cy.get('[data-testid="cleanup-confirm"]').click();
+
+        cy.contains(host.name).should('not.exist');
       });
     });
   });

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -173,20 +173,38 @@ context('Hosts Overview', () => {
 
   describe('Clean-up', () => {
     describe('Clean-up buttons should be visible only when needed', () => {
+      const heartbeatTargets = agents();
+      const failingHost = heartbeatTargets.shift();
       before(() => {
-        const heartbeatTargets = agents();
-        heartbeatTargets.shift();
         cy.task('startAgentHeartbeat', heartbeatTargets);
       });
 
       it('should hide all Clean-up buttons when heartbeat starts except the first one', () => {
         cy.get(
-          ':nth-child(2) > .w-48 > .bg-white > .text-jungle-green-500'
-        ).should('not.exist');
-
-        cy.get(
           ':nth-child(1) > .w-48 > .bg-white > .text-jungle-green-500'
         ).should('contain.text', 'Clean up');
+
+        for (let i = 2; i < 11; i++) {
+          cy.get(
+            `:nth-child(${i}) > .w-48 > .bg-white > .text-jungle-green-500`
+          ).should('not.exist');
+        }
+      });
+
+      it('should display a confirmation to remove the host after clicking on Clean up', () => {
+        cy.get(
+          ':nth-child(1) > .w-48 > .bg-white > .text-jungle-green-500'
+        ).click();
+
+        cy.get('.min-h-screen > .w-full').should(
+          'contain.text',
+          'This action will cause Trento to stop tracking all the components discovered by the agent in this host, including the host itself and any other component depending on it.'
+        );
+      });
+
+      it('should remove a host after confirming host cleanup', () => {
+        cy.get('.bg-jungle-green-500').click();
+        cy.get(`#host-${failingHost}`).should('not.exist');
       });
     });
   });

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -170,4 +170,24 @@ context('Hosts Overview', () => {
       });
     });
   });
+
+  describe('Clean-up', () => {
+    describe('Clean-up buttons should be visible only when needed', () => {
+      before(() => {
+        const heartbeatTargets = agents();
+        heartbeatTargets.shift();
+        cy.task('startAgentHeartbeat', heartbeatTargets);
+      });
+
+      it('should hide all Clean-up buttons when heartbeat starts except the first one', () => {
+        cy.get(
+          ':nth-child(2) > .w-48 > .bg-white > .text-jungle-green-500'
+        ).should('not.exist');
+
+        cy.get(
+          ':nth-child(1) > .w-48 > .bg-white > .text-jungle-green-500'
+        ).should('contain.text', 'Clean up');
+      });
+    });
+  });
 });


### PR DESCRIPTION
# Description
This PR simply adds:
 - e2e test to check if the "Clean up" button in the hosts overview is only displayed after a failed heartbeat
 - e2e test to check if the "Clean up" button displays a confirmation and removes the host after confirmation
