### PR TITLE
E2e test deregistration cascading

### DIFF
--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -154,22 +154,14 @@ context('Clusters Overview', () => {
     const hanaCluster1 = {
       name: 'hana_cluster_1',
       hosts: [
-        {
-          id: '13e8c25c-3180-5a9a-95c8-51ec38e50cfc',
-          name: 'vmhdbdev01',
-        },
-        {
-          id: '0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4',
-          name: 'vmhdbdev02',
-        },
+        '13e8c25c-3180-5a9a-95c8-51ec38e50cfc',
+        '0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4',
       ],
     };
 
-    before(() => {});
-
     it(`should not display '${hanaCluster1.name}' after deregistering all its nodes`, () => {
-      cy.deregisterHost(hanaCluster1.hosts[0].id);
-      cy.deregisterHost(hanaCluster1.hosts[1].id);
+      cy.deregisterHost(hanaCluster1.hosts[0]);
+      cy.deregisterHost(hanaCluster1.hosts[1]);
       cy.contains(hanaCluster1.name).should('not.exist');
     });
   });

--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -8,7 +8,7 @@ const clusterIdByName = (clusterName) =>
   availableClusters.find(({ name }) => name === clusterName).id;
 
 context('Clusters Overview', () => {
-  beforeEach(() => {
+  before(() => {
     cy.visit('/clusters');
     cy.url().should('include', '/clusters');
   });
@@ -122,31 +122,56 @@ context('Clusters Overview', () => {
           .should('have.class', 'fill-red-500');
       });
     });
+  });
 
-    describe('Clusters Tagging', () => {
-      before(() => {
-        cy.removeTagsFromView();
-      });
-      const clustersByMatchingPattern = (pattern) => (clusterName) =>
-        clusterName.includes(pattern);
-      const taggingRules = [
-        ['hana_cluster_1', 'env1'],
-        ['hana_cluster_2', 'env2'],
-        ['hana_cluster_3', 'env3'],
-      ];
+  describe('Clusters Tagging', () => {
+    before(() => {
+      cy.removeTagsFromView();
+    });
+    const clustersByMatchingPattern = (pattern) => (clusterName) =>
+      clusterName.includes(pattern);
+    const taggingRules = [
+      ['hana_cluster_1', 'env1'],
+      ['hana_cluster_2', 'env2'],
+      ['hana_cluster_3', 'env3'],
+    ];
 
-      taggingRules.forEach(([pattern, tag]) => {
-        describe(`Add tag '${tag}' to all clusters with '${pattern}' in the cluster name`, () => {
-          availableClusters
-            .map(({ name }) => name)
-            .filter(clustersByMatchingPattern(pattern))
-            .forEach((clusterName) => {
-              it(`should tag cluster '${clusterName}'`, () => {
-                cy.addTagByColumnValue(clusterName, tag);
-              });
+    taggingRules.forEach(([pattern, tag]) => {
+      describe(`Add tag '${tag}' to all clusters with '${pattern}' in the cluster name`, () => {
+        availableClusters
+          .map(({ name }) => name)
+          .filter(clustersByMatchingPattern(pattern))
+          .forEach((clusterName) => {
+            it(`should tag cluster '${clusterName}'`, () => {
+              cy.addTagByColumnValue(clusterName, tag);
             });
-        });
+          });
       });
+    });
+  });
+
+  describe('Deregistration', () => {
+    const hana_cluster_1 = {
+      name: 'hana_cluster_1',
+      hosts: [
+        {
+          id: '13e8c25c-3180-5a9a-95c8-51ec38e50cfc',
+          name: 'vmhdbdev01',
+        },
+        {
+          id: '0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4',
+          name: 'vmhdbdev02',
+        },
+      ],
+    };
+
+    before(() => {
+      cy.deregisterHost(hana_cluster_1.hosts[0].id);
+      cy.deregisterHost(hana_cluster_1.hosts[1].id);
+    });
+
+    it(`should not display '${hana_cluster_1.name}' after deregistering all its nodes`, () => {
+      cy.contains(hana_cluster_1.name).should('not.exist');
     });
   });
 });

--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -151,7 +151,7 @@ context('Clusters Overview', () => {
   });
 
   describe('Deregistration', () => {
-    const hana_cluster_1 = {
+    const hanaCluster1 = {
       name: 'hana_cluster_1',
       hosts: [
         {
@@ -165,13 +165,12 @@ context('Clusters Overview', () => {
       ],
     };
 
-    before(() => {
-      cy.deregisterHost(hana_cluster_1.hosts[0].id);
-      cy.deregisterHost(hana_cluster_1.hosts[1].id);
-    });
+    before(() => {});
 
-    it(`should not display '${hana_cluster_1.name}' after deregistering all its nodes`, () => {
-      cy.contains(hana_cluster_1.name).should('not.exist');
+    it(`should not display '${hanaCluster1.name}' after deregistering all its nodes`, () => {
+      cy.deregisterHost(hanaCluster1.hosts[0].id);
+      cy.deregisterHost(hanaCluster1.hosts[1].id);
+      cy.contains(hanaCluster1.name).should('not.exist');
     });
   });
 });

--- a/test/e2e/cypress/e2e/databases_overview.cy.js
+++ b/test/e2e/cypress/e2e/databases_overview.cy.js
@@ -1,0 +1,24 @@
+context('Databases Overview', () => {
+  before(() => {
+    cy.visit('/databases');
+    cy.url().should('include', '/databases');
+  });
+
+  describe('Deregistration', () => {
+    const hdq_database = {
+      sid: 'HDQ',
+      hana_primary: {
+        name: 'vmhdbqas01',
+        id: '99cf8a3a-48d6-57a4-b302-6e4482227ab6',
+      },
+    };
+
+    before(() => {
+      cy.deregisterHost(hdq_database.hana_primary.id);
+    });
+
+    it(`should not display DB ${hdq_database.hana_primary.name} after deregistering the primary instance`, () => {
+      cy.contains(hdq_database.sid).should('not.exist');
+    });
+  });
+});

--- a/test/e2e/cypress/e2e/databases_overview.cy.js
+++ b/test/e2e/cypress/e2e/databases_overview.cy.js
@@ -5,7 +5,7 @@ context('Databases Overview', () => {
   });
 
   describe('Deregistration', () => {
-    const hdq_database = {
+    const hdqDatabase = {
       sid: 'HDQ',
       hana_primary: {
         name: 'vmhdbqas01',
@@ -14,11 +14,11 @@ context('Databases Overview', () => {
     };
 
     before(() => {
-      cy.deregisterHost(hdq_database.hana_primary.id);
+      cy.deregisterHost(hdqDatabase.hana_primary.id);
     });
 
-    it(`should not display DB ${hdq_database.hana_primary.name} after deregistering the primary instance`, () => {
-      cy.contains(hdq_database.sid).should('not.exist');
+    it(`should not display DB ${hdqDatabase.sid} after deregistering the primary instance`, () => {
+      cy.contains(hdqDatabase.sid).should('not.exist');
     });
   });
 });

--- a/test/e2e/cypress/e2e/databases_overview.cy.js
+++ b/test/e2e/cypress/e2e/databases_overview.cy.js
@@ -7,17 +7,14 @@ context('Databases Overview', () => {
   describe('Deregistration', () => {
     const hdqDatabase = {
       sid: 'HDQ',
-      hana_primary: {
+      hanaPrimary: {
         name: 'vmhdbqas01',
         id: '99cf8a3a-48d6-57a4-b302-6e4482227ab6',
       },
     };
 
-    before(() => {
-      cy.deregisterHost(hdqDatabase.hana_primary.id);
-    });
-
     it(`should not display DB ${hdqDatabase.sid} after deregistering the primary instance`, () => {
+      cy.deregisterHost(hdqDatabase.hanaPrimary.id);
       cy.contains(hdqDatabase.sid).should('not.exist');
     });
   });

--- a/test/e2e/cypress/e2e/hana_cluster_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_cluster_details.cy.js
@@ -272,12 +272,12 @@ context('HANA cluster details', () => {
     };
 
     before(() => {
-      cy.deregisterHost(hostToDeregister.id);
       cy.visit(`/clusters/${availableHanaCluster.id}`);
       cy.url().should('include', `/clusters/${availableHanaCluster.id}`);
     });
 
     it(`should not include a working link to ${hostToDeregister.name} in the list of sites`, () => {
+      cy.deregisterHost(hostToDeregister.id);
       cy.get(`.tn-site-details-${hostToDeregister.sid}`)
         .contains('a', hostToDeregister.name)
         .should('not.exist');

--- a/test/e2e/cypress/e2e/hana_cluster_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_cluster_details.cy.js
@@ -263,4 +263,24 @@ context('HANA cluster details', () => {
       cy.get('li').first().contains(5000);
     });
   });
+
+  describe('Deregistration', () => {
+    const hostToDeregister = {
+      name: 'vmhdbprd02',
+      id: 'b767b3e9-e802-587e-a442-541d093b86b9',
+      sid: 'WDF',
+    };
+
+    before(() => {
+      cy.deregisterHost(hostToDeregister.id);
+      cy.visit(`/clusters/${availableHanaCluster.id}`);
+      cy.url().should('include', `/clusters/${availableHanaCluster.id}`);
+    });
+
+    it(`should not include a working link to ${hostToDeregister.name} in the list of sites`, () => {
+      cy.get(`.tn-site-details-${hostToDeregister.sid}`)
+        .contains('a', hostToDeregister.name)
+        .should('not.exist');
+    });
+  });
 });

--- a/test/e2e/cypress/e2e/hana_database_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_database_details.cy.js
@@ -130,11 +130,8 @@ context('HANA database details', () => {
   });
 
   describe('Deregistration', () => {
-    before(() => {
-      cy.deregisterHost(attachedHosts[0].AgentId);
-    });
-
     it(`should not include host ${attachedHosts[0].Name} in the list of hosts`, () => {
+      cy.deregisterHost(attachedHosts[0].AgentId);
       cy.contains(attachedHosts[0].Name).should('not.exist');
     });
   });

--- a/test/e2e/cypress/e2e/hana_database_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_database_details.cy.js
@@ -128,4 +128,14 @@ context('HANA database details', () => {
       });
     });
   });
+
+  describe('Deregistration', () => {
+    before(() => {
+      cy.deregisterHost(attachedHosts[0].AgentId);
+    });
+
+    it(`should not include host ${attachedHosts[0].Name} in the list of hosts`, () => {
+      cy.contains(attachedHosts[0].Name).should('not.exist');
+    });
+  });
 });

--- a/test/e2e/cypress/e2e/sap_system_details.cy.js
+++ b/test/e2e/cypress/e2e/sap_system_details.cy.js
@@ -132,4 +132,21 @@ context('SAP system details', () => {
       });
     });
   });
+
+  describe('Deregistration', () => {
+    const hostToDeregister = {
+      name: 'vmnwdev02',
+      id: 'fb2c6b8a-9915-5969-a6b7-8b5a42de1971',
+    };
+
+    before(() => {
+      cy.visit(`/sap_systems/${selectedSystem.Id}`);
+      cy.url().should('include', `/sap_systems/${selectedSystem.Id}`);
+      cy.deregisterHost(hostToDeregister.id);
+    });
+
+    it(`should not include ${hostToDeregister.name} in the list of hosts`, () => {
+      cy.contains(hostToDeregister.name).should('not.exist');
+    });
+  });
 });

--- a/test/e2e/cypress/e2e/sap_system_details.cy.js
+++ b/test/e2e/cypress/e2e/sap_system_details.cy.js
@@ -137,16 +137,13 @@ context('SAP system details', () => {
     const hostToDeregister = {
       name: 'vmnwdev02',
       id: 'fb2c6b8a-9915-5969-a6b7-8b5a42de1971',
+      features: 'ENQREP',
     };
-
-    before(() => {
-      cy.visit(`/sap_systems/${selectedSystem.Id}`);
-      cy.url().should('include', `/sap_systems/${selectedSystem.Id}`);
-    });
 
     it(`should not include ${hostToDeregister.name} in the list of hosts`, () => {
       cy.deregisterHost(hostToDeregister.id);
       cy.contains(hostToDeregister.name).should('not.exist');
+      cy.contains(hostToDeregister.features).should('not.exist');
     });
   });
 });

--- a/test/e2e/cypress/e2e/sap_system_details.cy.js
+++ b/test/e2e/cypress/e2e/sap_system_details.cy.js
@@ -142,10 +142,10 @@ context('SAP system details', () => {
     before(() => {
       cy.visit(`/sap_systems/${selectedSystem.Id}`);
       cy.url().should('include', `/sap_systems/${selectedSystem.Id}`);
-      cy.deregisterHost(hostToDeregister.id);
     });
 
     it(`should not include ${hostToDeregister.name} in the list of hosts`, () => {
+      cy.deregisterHost(hostToDeregister.id);
       cy.contains(hostToDeregister.name).should('not.exist');
     });
   });

--- a/test/e2e/cypress/e2e/sap_systems_overview.cy.js
+++ b/test/e2e/cypress/e2e/sap_systems_overview.cy.js
@@ -293,20 +293,50 @@ context('SAP Systems Overview', () => {
   });
 
   describe('Deregistration', () => {
-    const sap_system_nwp = {
+    const sapSystemNwp = {
       sid: 'NWP',
-      hana_primary: {
+      hanaPrimary: {
         name: 'vmhdbprd01',
         id: '9cd46919-5f19-59aa-993e-cf3736c71053',
       },
     };
 
-    before(() => {
-      cy.deregisterHost(sap_system_nwp.hana_primary.id);
+    const sapSystemNwq = {
+      sid: 'NWQ',
+      messageserverInstance: {
+        name: 'vmnwqas01',
+        id: '25677e37-fd33-5005-896c-9275b1284534',
+      },
+    };
+
+    const sapSystemNwd = {
+      sid: 'NWD',
+      applicationInstances: [
+        {
+          name: 'vmnwdev03',
+          id: '9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f',
+        },
+        {
+          name: 'vmnwdev04',
+          id: '1b0e9297-97dd-55d6-9874-8efde4d84c90',
+        },
+      ],
+    };
+
+    it(`should not display SAP System ${sapSystemNwp.sid} after deregistering the primary instance`, () => {
+      cy.deregisterHost(sapSystemNwp.hanaPrimary.id);
+      cy.contains(sapSystemNwp.sid).should('not.exist');
     });
 
-    it(`should not display SAP System ${sap_system_nwp.sid} after deregistering the primary instance`, () => {
-      cy.contains(sap_system_nwp.sid).should('not.exist');
+    it(`should not display SAP System ${sapSystemNwq.sid} after deregistering the instance running the messageserver`, () => {
+      cy.deregisterHost(sapSystemNwq.messageserverInstance.id);
+      cy.contains(sapSystemNwq.sid).should('not.exist');
+    });
+
+    it(`should not display SAP System ${sapSystemNwd.sid} after deregistering both application instances`, () => {
+      cy.deregisterHost(sapSystemNwd.applicationInstances[0].id);
+      cy.deregisterHost(sapSystemNwd.applicationInstances[1].id);
+      cy.contains(sapSystemNwd.sid).should('not.exist');
     });
   });
 });

--- a/test/e2e/cypress/e2e/sap_systems_overview.cy.js
+++ b/test/e2e/cypress/e2e/sap_systems_overview.cy.js
@@ -291,4 +291,22 @@ context('SAP Systems Overview', () => {
       cy.get('table.table-fixed').should('not.contain', 'DAA');
     });
   });
+
+  describe('Deregistration', () => {
+    const sap_system_nwp = {
+      sid: 'NWP',
+      hana_primary: {
+        name: 'vmhdbprd01',
+        id: '9cd46919-5f19-59aa-993e-cf3736c71053',
+      },
+    };
+
+    before(() => {
+      cy.deregisterHost(sap_system_nwp.hana_primary.id);
+    });
+
+    it(`should not display SAP System ${sap_system_nwp.sid} after deregistering the primary instance`, () => {
+      cy.contains(sap_system_nwp.sid).should('not.exist');
+    });
+  });
 });

--- a/test/e2e/cypress/support/commands.js
+++ b/test/e2e/cypress/support/commands.js
@@ -212,3 +212,26 @@ Cypress.Commands.add('requestChecksExecution', (clusterId) => {
     });
   });
 });
+
+Cypress.Commands.add('deregisterHost', (hostId) => {
+  const [webAPIHost, webAPIPort] = [
+    Cypress.env('web_api_host'),
+    Cypress.env('web_api_port'),
+  ];
+
+  const headers = {
+    'Content-Type': 'application/json;charset=UTF-8',
+  };
+
+  apiLogin().then(({ accessToken }) => {
+    const url = `http://${webAPIHost}:${webAPIPort}/api/v1/hosts/${hostId}`;
+    cy.request({
+      method: 'DELETE',
+      url: url,
+      headers: headers,
+      auth: {
+        bearer: accessToken,
+      },
+    });
+  });
+});


### PR DESCRIPTION
# Description
This PR adds tests to confirm that a deregistration of a host also removes the affected data from other views. Included in this PR are tests for:
 - clusters overview: a cluster should be removed when all its hosts are removed
 - databases overview: deregistering a primary instance should remove the database
 - hana cluster details: linking to a unregistered host should be disabled
 - hana db details: a deregistered host should not be present in the list of hosts
 - sap system details: a deregistered host should not be present in the list of hosts
 - sap system overview: deregistering the primary instance of the db should remove the sap system