### PR TITLE
Refactor check selection saga

### DIFF
--- a/assets/js/lib/test-utils/index.jsx
+++ b/assets/js/lib/test-utils/index.jsx
@@ -28,6 +28,7 @@ export const defaultInitialState = {
   },
   clusterChecksSelection: {},
   hostChecksSelection: {},
+  checksSelection: { host: {}, cluster: {} },
   catalog: { loading: false, data: [], error: null },
 };
 

--- a/assets/js/state/checksSelection.js
+++ b/assets/js/state/checksSelection.js
@@ -1,0 +1,66 @@
+import { createAction, createSlice } from '@reduxjs/toolkit';
+import { TARGET_CLUSTER, TARGET_HOST } from '@lib/model';
+
+const SAVING = 'saving';
+const SUCCESSFULLY_SAVED = 'successfully_saved';
+const SAVING_FAILED = 'saving_failed';
+
+const supportsTarget = (target) =>
+  [TARGET_CLUSTER, TARGET_HOST].includes(target);
+
+const initialState = {
+  [TARGET_HOST]: {},
+  [TARGET_CLUSTER]: {},
+};
+
+const updateTargetState = (state, targetType, targetID, newState) => {
+  state[targetType] = {
+    ...state[targetType],
+    [targetID]: newState,
+  };
+};
+
+export const checksSelectionSlice = createSlice({
+  name: 'checksSelection',
+  initialState,
+  reducers: {
+    startSavingChecksSelection: (
+      state,
+      { payload: { targetID, targetType } }
+    ) => {
+      if (supportsTarget(targetType)) {
+        updateTargetState(state, targetType, targetID, {
+          status: SAVING,
+        });
+      }
+    },
+    markSavingSuccessful: (state, { payload: { targetID, targetType } }) => {
+      if (supportsTarget(targetType)) {
+        updateTargetState(state, targetType, targetID, {
+          status: SUCCESSFULLY_SAVED,
+        });
+      }
+    },
+    markSavingFailed: (state, { payload: { targetID, targetType } }) => {
+      if (supportsTarget(targetType)) {
+        updateTargetState(state, targetType, targetID, {
+          status: SAVING_FAILED,
+        });
+      }
+    },
+  },
+});
+
+export const HOST_CHECKS_SELECTED = 'HOST_CHECKS_SELECTED';
+export const hostChecksSelected = createAction(HOST_CHECKS_SELECTED);
+
+export const CLUSTER_CHECKS_SELECTED = 'CLUSTER_CHECKS_SELECTED';
+export const clusterChecksSelected = createAction(CLUSTER_CHECKS_SELECTED);
+
+export const {
+  startSavingChecksSelection,
+  markSavingSuccessful,
+  markSavingFailed,
+} = checksSelectionSlice.actions;
+
+export default checksSelectionSlice.reducer;

--- a/assets/js/state/checksSelection.js
+++ b/assets/js/state/checksSelection.js
@@ -34,12 +34,12 @@ export const checksSelectionSlice = createSlice({
         status: SAVING,
       });
     },
-    markSavingSuccessful: (state, { payload: { targetID, targetType } }) => {
+    setSavingSuccessful: (state, { payload: { targetID, targetType } }) => {
       updateTargetState(state, targetType, targetID, {
         status: SUCCESSFULLY_SAVED,
       });
     },
-    markSavingFailed: (state, { payload: { targetID, targetType } }) => {
+    setSavingFailed: (state, { payload: { targetID, targetType } }) => {
       updateTargetState(state, targetType, targetID, {
         status: SAVING_FAILED,
       });
@@ -55,8 +55,8 @@ export const clusterChecksSelected = createAction(CLUSTER_CHECKS_SELECTED);
 
 export const {
   startSavingChecksSelection,
-  markSavingSuccessful,
-  markSavingFailed,
+  setSavingSuccessful,
+  setSavingFailed,
 } = checksSelectionSlice.actions;
 
 export default checksSelectionSlice.reducer;

--- a/assets/js/state/checksSelection.js
+++ b/assets/js/state/checksSelection.js
@@ -1,9 +1,9 @@
 import { createAction, createSlice } from '@reduxjs/toolkit';
 import { TARGET_CLUSTER, TARGET_HOST } from '@lib/model';
 
-const SAVING = 'saving';
-const SUCCESSFULLY_SAVED = 'successfully_saved';
-const SAVING_FAILED = 'saving_failed';
+const SAVING = 'SAVING';
+const SUCCESSFULLY_SAVED = 'SUCCESSFULLY_SAVED';
+const SAVING_FAILED = 'SAVING_FAILED';
 
 const supportsTarget = (target) =>
   [TARGET_CLUSTER, TARGET_HOST].includes(target);
@@ -14,10 +14,12 @@ const initialState = {
 };
 
 const updateTargetState = (state, targetType, targetID, newState) => {
-  state[targetType] = {
-    ...state[targetType],
-    [targetID]: newState,
-  };
+  if (supportsTarget(targetType)) {
+    state[targetType] = {
+      ...state[targetType],
+      [targetID]: newState,
+    };
+  }
 };
 
 export const checksSelectionSlice = createSlice({
@@ -28,25 +30,19 @@ export const checksSelectionSlice = createSlice({
       state,
       { payload: { targetID, targetType } }
     ) => {
-      if (supportsTarget(targetType)) {
-        updateTargetState(state, targetType, targetID, {
-          status: SAVING,
-        });
-      }
+      updateTargetState(state, targetType, targetID, {
+        status: SAVING,
+      });
     },
     markSavingSuccessful: (state, { payload: { targetID, targetType } }) => {
-      if (supportsTarget(targetType)) {
-        updateTargetState(state, targetType, targetID, {
-          status: SUCCESSFULLY_SAVED,
-        });
-      }
+      updateTargetState(state, targetType, targetID, {
+        status: SUCCESSFULLY_SAVED,
+      });
     },
     markSavingFailed: (state, { payload: { targetID, targetType } }) => {
-      if (supportsTarget(targetType)) {
-        updateTargetState(state, targetType, targetID, {
-          status: SAVING_FAILED,
-        });
-      }
+      updateTargetState(state, targetType, targetID, {
+        status: SAVING_FAILED,
+      });
     },
   },
 });

--- a/assets/js/state/checksSelection.test.js
+++ b/assets/js/state/checksSelection.test.js
@@ -31,7 +31,7 @@ describe('Checks Selection reducer', () => {
 
       const newState = checksSelectionReducer(initialState, action);
 
-      expect(newState[targetType][targetID]).toEqual({ status: 'saving' });
+      expect(newState[targetType][targetID]).toEqual({ status: 'SAVING' });
     }
   );
 
@@ -43,7 +43,7 @@ describe('Checks Selection reducer', () => {
       const newState = checksSelectionReducer(initialState, action);
 
       expect(newState[targetType][targetID]).toEqual({
-        status: 'successfully_saved',
+        status: 'SUCCESSFULLY_SAVED',
       });
     }
   );
@@ -56,7 +56,7 @@ describe('Checks Selection reducer', () => {
       const newState = checksSelectionReducer(initialState, action);
 
       expect(newState[targetType][targetID]).toEqual({
-        status: 'saving_failed',
+        status: 'SAVING_FAILED',
       });
     }
   );

--- a/assets/js/state/checksSelection.test.js
+++ b/assets/js/state/checksSelection.test.js
@@ -1,0 +1,91 @@
+import { faker } from '@faker-js/faker';
+import checksSelectionReducer, {
+  startSavingChecksSelection,
+  markSavingSuccessful,
+  markSavingFailed,
+} from '@state/checksSelection';
+
+describe('Checks Selection reducer', () => {
+  const initialState = {
+    host: {},
+    cluster: {},
+  };
+
+  const scenarios = [
+    {
+      name: 'Host checks selection',
+      targetID: faker.datatype.uuid(),
+      targetType: 'host',
+    },
+    {
+      name: 'Cluster checks selection',
+      targetID: faker.datatype.uuid(),
+      targetType: 'cluster',
+    },
+  ];
+
+  it.each(scenarios)(
+    '$name: should mark a check selection as saving',
+    ({ targetID, targetType }) => {
+      const action = startSavingChecksSelection({ targetID, targetType });
+
+      const newState = checksSelectionReducer(initialState, action);
+
+      expect(newState[targetType][targetID]).toEqual({ status: 'saving' });
+    }
+  );
+
+  it.each(scenarios)(
+    '$name: should mark a check selection as completed successfully',
+    ({ targetID, targetType }) => {
+      const action = markSavingSuccessful({ targetID, targetType });
+
+      const newState = checksSelectionReducer(initialState, action);
+
+      expect(newState[targetType][targetID]).toEqual({
+        status: 'successfully_saved',
+      });
+    }
+  );
+
+  it.each(scenarios)(
+    '$name: should mark a check selection as completed with failure',
+    ({ targetID, targetType }) => {
+      const action = markSavingFailed({ targetID, targetType });
+
+      const newState = checksSelectionReducer(initialState, action);
+
+      expect(newState[targetType][targetID]).toEqual({
+        status: 'saving_failed',
+      });
+    }
+  );
+
+  it.each([faker.lorem.word(4), faker.lorem.word(5), faker.lorem.word(6)])(
+    'should ignore unsupported targets',
+    (targetType) => {
+      const state = {
+        host: {
+          [faker.datatype.uuid()]: { status: 'saving' },
+          [faker.datatype.uuid()]: { status: 'saving_failed' },
+        },
+        cluster: {
+          [faker.datatype.uuid()]: { status: 'successfully_saved' },
+        },
+      };
+
+      [
+        startSavingChecksSelection,
+        markSavingSuccessful,
+        markSavingFailed,
+      ].forEach((actionFunction) => {
+        const targetID = faker.datatype.uuid();
+        const action = actionFunction({ targetID, targetType });
+
+        const newState = checksSelectionReducer(state, action);
+
+        expect(newState).toEqual(state);
+      });
+    }
+  );
+});

--- a/assets/js/state/checksSelection.test.js
+++ b/assets/js/state/checksSelection.test.js
@@ -1,8 +1,8 @@
 import { faker } from '@faker-js/faker';
 import checksSelectionReducer, {
   startSavingChecksSelection,
-  markSavingSuccessful,
-  markSavingFailed,
+  setSavingSuccessful,
+  setSavingFailed,
 } from '@state/checksSelection';
 
 describe('Checks Selection reducer', () => {
@@ -38,7 +38,7 @@ describe('Checks Selection reducer', () => {
   it.each(scenarios)(
     '$name: should mark a check selection as completed successfully',
     ({ targetID, targetType }) => {
-      const action = markSavingSuccessful({ targetID, targetType });
+      const action = setSavingSuccessful({ targetID, targetType });
 
       const newState = checksSelectionReducer(initialState, action);
 
@@ -51,7 +51,7 @@ describe('Checks Selection reducer', () => {
   it.each(scenarios)(
     '$name: should mark a check selection as completed with failure',
     ({ targetID, targetType }) => {
-      const action = markSavingFailed({ targetID, targetType });
+      const action = setSavingFailed({ targetID, targetType });
 
       const newState = checksSelectionReducer(initialState, action);
 
@@ -76,8 +76,8 @@ describe('Checks Selection reducer', () => {
 
       [
         startSavingChecksSelection,
-        markSavingSuccessful,
-        markSavingFailed,
+        setSavingSuccessful,
+        setSavingFailed,
       ].forEach((actionFunction) => {
         const targetID = faker.datatype.uuid();
         const action = actionFunction({ targetID, targetType });

--- a/assets/js/state/sagas/checksSelection.js
+++ b/assets/js/state/sagas/checksSelection.js
@@ -8,8 +8,8 @@ import { notify } from '@state/actions/notifications';
 import {
   HOST_CHECKS_SELECTED,
   startSavingChecksSelection,
-  markSavingSuccessful,
-  markSavingFailed,
+  setSavingSuccessful,
+  setSavingFailed,
 } from '@state/checksSelection';
 
 import { updateSelectedChecks as updateHostSelectedChecks } from '@state/hosts';
@@ -44,7 +44,7 @@ function* checksSelected({ targetID, targetType, targetName, checks }) {
   try {
     yield saveChecksSelection(targetID, targetType, checks);
 
-    yield put(markSavingSuccessful({ targetID, targetType }));
+    yield put(setSavingSuccessful({ targetID, targetType }));
     yield put(
       notify({
         text: `Checks selection for ${targetName} saved`,
@@ -52,7 +52,7 @@ function* checksSelected({ targetID, targetType, targetName, checks }) {
       })
     );
   } catch (error) {
-    yield put(markSavingFailed({ targetID, targetType }));
+    yield put(setSavingFailed({ targetID, targetType }));
     yield put(
       notify({
         text: `Unable to save selection for ${targetName}`,

--- a/assets/js/state/sagas/checksSelection.js
+++ b/assets/js/state/sagas/checksSelection.js
@@ -1,0 +1,76 @@
+import { put, call, takeEvery } from 'redux-saga/effects';
+import { post } from '@lib/network';
+
+import { TARGET_HOST } from '@lib/model';
+
+import { notify } from '@state/actions/notifications';
+
+import {
+  HOST_CHECKS_SELECTED,
+  startSavingChecksSelection,
+  markSavingSuccessful,
+  markSavingFailed,
+} from '@state/checksSelection';
+
+import { updateSelectedChecks as updateHostSelectedChecks } from '@state/hosts';
+
+function* saveHostChecksSelection({ hostID, checks }) {
+  yield call(post, `/hosts/${hostID}/checks`, {
+    checks,
+  });
+  yield put(
+    updateHostSelectedChecks({
+      hostID,
+      checks,
+    })
+  );
+}
+
+function* saveChecksSelection(targetID, targetType, checks) {
+  switch (targetType) {
+    case TARGET_HOST:
+      yield saveHostChecksSelection({
+        hostID: targetID,
+        checks,
+      });
+      break;
+    default:
+  }
+}
+
+function* checksSelected({ targetID, targetType, targetName, checks }) {
+  yield put(startSavingChecksSelection({ targetID, targetType }));
+
+  try {
+    yield saveChecksSelection(targetID, targetType, checks);
+
+    yield put(markSavingSuccessful({ targetID, targetType }));
+    yield put(
+      notify({
+        text: `Checks selection for ${targetName} saved`,
+        icon: '💾',
+      })
+    );
+  } catch (error) {
+    yield put(markSavingFailed({ targetID, targetType }));
+    yield put(
+      notify({
+        text: `Unable to save selection for ${targetName}`,
+        icon: '❌',
+      })
+    );
+  }
+}
+
+export function* selectHostChecks({ payload: { hostID, hostName, checks } }) {
+  yield checksSelected({
+    targetID: hostID,
+    targetType: TARGET_HOST,
+    targetName: hostName,
+    checks,
+  });
+}
+
+export function* watchChecksSelection() {
+  yield takeEvery(HOST_CHECKS_SELECTED, selectHostChecks);
+}

--- a/assets/js/state/sagas/checksSelection.test.js
+++ b/assets/js/state/sagas/checksSelection.test.js
@@ -10,8 +10,8 @@ import { updateSelectedChecks as updateHostSelectedChecks } from '@state/hosts';
 
 import {
   startSavingChecksSelection,
-  markSavingSuccessful,
-  markSavingFailed,
+  setSavingSuccessful,
+  setSavingFailed,
 } from '@state/checksSelection';
 
 import { notify } from '@state/actions/notifications';
@@ -47,7 +47,7 @@ describe('Checks Selection saga', () => {
           hostID,
           checks,
         }),
-        markSavingSuccessful(payload),
+        setSavingSuccessful(payload),
         notify({
           text: `Checks selection for ${hostName} saved`,
           icon: '💾',
@@ -76,7 +76,7 @@ describe('Checks Selection saga', () => {
 
       expect(dispatched).toEqual([
         startSavingChecksSelection(payload),
-        markSavingFailed(payload),
+        setSavingFailed(payload),
         notify({
           text: `Unable to save selection for ${hostName}`,
           icon: '❌',

--- a/assets/js/state/sagas/checksSelection.test.js
+++ b/assets/js/state/sagas/checksSelection.test.js
@@ -1,0 +1,87 @@
+import { faker } from '@faker-js/faker';
+import { recordSaga } from '@lib/test-utils';
+
+import { networkClient } from '@lib/network';
+import MockAdapter from 'axios-mock-adapter';
+
+import { hostFactory } from '@lib/test-utils/factories';
+
+import { updateSelectedChecks as updateHostSelectedChecks } from '@state/hosts';
+
+import {
+  startSavingChecksSelection,
+  markSavingSuccessful,
+  markSavingFailed,
+} from '@state/checksSelection';
+
+import { notify } from '@state/actions/notifications';
+
+import { selectHostChecks } from './checksSelection';
+
+const axiosMock = new MockAdapter(networkClient);
+
+describe('Checks Selection saga', () => {
+  describe('Host Checks Selection', () => {
+    it('should successfully save check selection for a host', async () => {
+      const { id: hostID, hostname: hostName } = hostFactory.build();
+      const checks = [faker.datatype.uuid(), faker.datatype.uuid()];
+
+      axiosMock.onPost(`/hosts/${hostID}/checks`).reply(202, {});
+
+      const dispatched = await recordSaga(selectHostChecks, {
+        payload: {
+          hostID,
+          hostName,
+          checks,
+        },
+      });
+
+      const payload = {
+        targetID: hostID,
+        targetType: 'host',
+      };
+
+      expect(dispatched).toEqual([
+        startSavingChecksSelection(payload),
+        updateHostSelectedChecks({
+          hostID,
+          checks,
+        }),
+        markSavingSuccessful(payload),
+        notify({
+          text: `Checks selection for ${hostName} saved`,
+          icon: '💾',
+        }),
+      ]);
+    });
+
+    it('should not save check selection for a host on request failure', async () => {
+      const { id: hostID, hostname: hostName } = hostFactory.build();
+      const checks = [faker.datatype.uuid(), faker.datatype.uuid()];
+
+      axiosMock.onPost(`/hosts/${hostID}/checks`).reply(400, {});
+
+      const dispatched = await recordSaga(selectHostChecks, {
+        payload: {
+          hostID,
+          hostName,
+          checks,
+        },
+      });
+
+      const payload = {
+        targetID: hostID,
+        targetType: 'host',
+      };
+
+      expect(dispatched).toEqual([
+        startSavingChecksSelection(payload),
+        markSavingFailed(payload),
+        notify({
+          text: `Unable to save selection for ${hostName}`,
+          icon: '❌',
+        }),
+      ]);
+    });
+  });
+});

--- a/assets/js/state/selectors/checksSelection.js
+++ b/assets/js/state/selectors/checksSelection.js
@@ -1,0 +1,6 @@
+import { TARGET_HOST } from '@lib/model';
+
+export const getHostCheckSelection =
+  (hostID) =>
+  ({ checksSelection }) =>
+    checksSelection?.[TARGET_HOST][hostID] || {};

--- a/assets/js/state/selectors/checksSelection.test.js
+++ b/assets/js/state/selectors/checksSelection.test.js
@@ -1,0 +1,32 @@
+import { faker } from '@faker-js/faker';
+import { getHostCheckSelection } from './checksSelection';
+
+describe('Checks Selection selector', () => {
+  it(`should get a host's check selection state`, () => {
+    const hostID = faker.datatype.uuid();
+    expect(
+      getHostCheckSelection(hostID)({
+        checksSelection: {
+          host: {
+            [faker.datatype.uuid()]: { status: 'successfully_saved' },
+            [hostID]: { status: 'saving' },
+          },
+        },
+      })
+    ).toEqual({ status: 'saving' });
+  });
+
+  it(`should not get a host's check selection state if not present`, () => {
+    const hostWithoutSelection = faker.datatype.uuid();
+    expect(
+      getHostCheckSelection(hostWithoutSelection)({
+        checksSelection: {
+          host: {
+            [faker.datatype.uuid()]: { status: 'successfully_saved' },
+            [faker.datatype.uuid()]: { status: 'saving' },
+          },
+        },
+      })
+    ).toEqual({});
+  });
+});


### PR DESCRIPTION
# Description

This PR adds a centralized saga/state/selectors for `checkSelection` aiming to support hosts and clusters now and other target types later. 

Following up, this will be hooked in host checks selection and cluster checks selection.

## How was this tested?

Automated tests.
