### PR TITLE
Add end-to-end deregistration tests for Host Details page

### DIFF
--- a/assets/js/components/CleanUpButton/CleanUpButton.jsx
+++ b/assets/js/components/CleanUpButton/CleanUpButton.jsx
@@ -13,7 +13,6 @@ function CleanUpButton({ cleaning, onClick }) {
       size="small"
       disabled={cleaning}
       onClick={() => onClick()}
-      data-testid="cleanup-button"
     >
       {cleaning === true ? (
         <Spinner className="justify-center flex" />

--- a/assets/js/components/DeregistrationModal/DeregistrationModal.jsx
+++ b/assets/js/components/DeregistrationModal/DeregistrationModal.jsx
@@ -24,7 +24,6 @@ function DeregistrationModal({
       </div>
       <div className="flex justify-start gap-2 mt-4">
         <Button
-          data-testid="cleanup-confirm"
           type="default-fit"
           className="inline-block mx-0.5 border-green-500 border w-fit"
           size="small"

--- a/test/e2e/cypress/e2e/host_details.cy.js
+++ b/test/e2e/cypress/e2e/host_details.cy.js
@@ -355,4 +355,37 @@ context('Host Details', () => {
       cy.get('span').find('svg').should('exist');
     });
   });
+
+  describe('Deregistration', () => {
+    describe('"Clean up" button should be visible only for an unhealthy host', () => {
+      it('should not display the "Clean up" button for healthy host', () => {
+        cy.task('startAgentHeartbeat', [selectedHost.id]);
+        cy.contains('button', 'Clean up').should('not.exist');
+      });
+
+      it('should show the "Clean up" button once heartbeat is lost and debounce preiod has elapsed', () => {
+        cy.task('stopAgentsHeartbeat');
+        cy.contains('button', 'Clean up', { timeout: 15000 }).should('exist');
+      });
+    });
+
+    describe('"Clean up" button should deregister a host', () => {
+      before(() => {
+        cy.task('stopAgentsHeartbeat');
+      });
+
+      it('should allow to deregister a host after clean-up confirmation', () => {
+        cy.contains('button', 'Clean up', { timeout: 15000 }).click();
+
+        cy.get('#headlessui-portal-root .w-full').should(
+          'contain.text',
+          `Clean up data discovered by agent on host ${selectedHost.hostName}`
+        );
+
+        cy.contains('#headlessui-portal-root button', 'Clean up').click();
+        cy.get('#headlessui-portal-root').should('not.exist');
+        cy.url().should('eq', Cypress.config().baseUrl + '/hosts');
+      });
+    });
+  });
 });

--- a/test/e2e/cypress/e2e/host_details.cy.js
+++ b/test/e2e/cypress/e2e/host_details.cy.js
@@ -363,7 +363,7 @@ context('Host Details', () => {
         cy.contains('button', 'Clean up').should('not.exist');
       });
 
-      it('should show the "Clean up" button once heartbeat is lost and debounce preiod has elapsed', () => {
+      it('should show the "Clean up" button once heartbeat is lost and debounce period has elapsed', () => {
         cy.task('stopAgentsHeartbeat');
         cy.contains('button', 'Clean up', { timeout: 15000 }).should('exist');
       });
@@ -377,14 +377,18 @@ context('Host Details', () => {
       it('should allow to deregister a host after clean-up confirmation', () => {
         cy.contains('button', 'Clean up', { timeout: 15000 }).click();
 
-        cy.get('#headlessui-portal-root .w-full').should(
-          'contain.text',
-          `Clean up data discovered by agent on host ${selectedHost.hostName}`
-        );
+        cy.get('#headlessui-portal-root').as('modal');
 
-        cy.contains('#headlessui-portal-root button', 'Clean up').click();
-        cy.get('#headlessui-portal-root').should('not.exist');
-        cy.url().should('eq', Cypress.config().baseUrl + '/hosts');
+        cy.get('@modal')
+          .find('.w-full')
+          .should(
+            'contain.text',
+            `Clean up data discovered by agent on host ${selectedHost.hostName}`
+          );
+        cy.get('@modal').contains('button', 'Clean up').click();
+
+        cy.get('@modal').should('not.exist');
+        cy.url().should('eq', cy.config().baseUrl + '/hosts');
       });
     });
   });

--- a/test/e2e/cypress/e2e/host_details.cy.js
+++ b/test/e2e/cypress/e2e/host_details.cy.js
@@ -389,6 +389,7 @@ context('Host Details', () => {
 
         cy.get('@modal').should('not.exist');
         cy.url().should('eq', cy.config().baseUrl + '/hosts');
+        cy.get(`#host-${selectedHost.agentId}`).should('not.exist');
       });
     });
   });

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -192,18 +192,18 @@ context('Hosts Overview', () => {
 
       it('should show all other cleanup buttons', () => {
         for (let i = 2; i < 11; i++) {
-          cy.get(`tr:nth-child(${i})`).within(() => {
-            cy.get('[data-testid="cleanup-button"]').should('exist');
-          });
+          cy.get(`tr:nth-child(${i})`)
+            .contains('button', 'Clean up')
+            .should('exist');
         }
       });
 
       it(`should display the cleanup button for host ${hostToDeregister.name} once heartbeat is lost`, () => {
         cy.task('stopAgentsHeartbeat');
 
-        cy.get('tr:nth-child(1) > .w-48 > [data-testid="cleanup-button"]', {
-          timeout: 15000,
-        }).should('exist');
+        cy.get('tr:nth-child(1)')
+          .contains('button', 'Clean up', { timeout: 15000 })
+          .should('exist');
       });
     });
 
@@ -215,18 +215,22 @@ context('Hosts Overview', () => {
       });
 
       it('should allow to deregister a host after clean up confirmation', () => {
-        cy.get('tr:nth-child(1) > .w-48 > [data-testid="cleanup-button"]', {
-          timeout: 15000,
-        }).click();
+        cy.get('tr:nth-child(1)')
+          .contains('button', 'Clean up', { timeout: 15000 })
+          .click();
 
-        cy.get('.min-h-screen > .w-full').should(
-          'contain.text',
-          'This action will cause Trento to stop tracking all the components discovered by the agent in this host, including the host itself and any other component depending on it.'
-        );
+        cy.get('#headlessui-portal-root').as('modal');
 
-        cy.get('[data-testid="cleanup-confirm"]').click();
+        cy.get('@modal')
+          .find('.w-full')
+          .should(
+            'contain.text',
+            'This action will cause Trento to stop tracking all the components discovered by the agent in this host, including the host itself and any other component depending on it.'
+          );
 
-        cy.contains(hostToDeregister.name).should('not.exist');
+        cy.get('@modal').contains('button', 'Clean up').click();
+
+        cy.get(`#host-${hostToDeregister.id}`).should('not.exist');
       });
     });
   });

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -225,7 +225,7 @@ context('Hosts Overview', () => {
           .find('.w-full')
           .should(
             'contain.text',
-            'This action will cause Trento to stop tracking all the components discovered by the agent in this host, including the host itself and any other component depending on it.'
+            `Clean up data discovered by agent on host ${hostToDeregister.name}`
           );
 
         cy.get('@modal').contains('button', 'Clean up').click();


### PR DESCRIPTION
# Description

Adds end-to-end deregistration tests for the Host Details page.

## How was this tested?

By adding end-to-end deregistration tests for the Host Details page.
