### PR TITLE
E2e restoration

### DIFF
--- a/.photofinish.toml
+++ b/.photofinish.toml
@@ -203,14 +203,14 @@ files = [
     "./test/fixtures/scenarios/host-details/9cd46919-5f19-59aa-993e-cf3736c71053_cloud_discovery_unknown.json",
 ]
 
-[host-vmdrbddev01-restore]
+[host-vmhdbdev01-restore]
 
 files = [
-    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_host_discovery.json",
-    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_subscription_discovery.json",
-    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_cloud_discovery.json",
-    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_ha_cluster_discovery.json",
-    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_sap_system_discovery.json"
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_host_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_subscription_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_cloud_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_sap_system_discovery.json"
 ]
 
 [host-vmhdbprd02-restore]

--- a/.photofinish.toml
+++ b/.photofinish.toml
@@ -212,3 +212,28 @@ files = [
     "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_ha_cluster_discovery.json",
     "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_sap_system_discovery.json"
 ]
+
+[sapsystem-NWD-restore]
+
+files = [
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_cloud_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_ha_cluster_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_host_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_sap_system_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_subscription_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_cloud_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_ha_cluster_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_host_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_subscription_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_cloud_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_ha_cluster_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_host_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_subscription_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/1b0e9297-97dd-55d6-9874-8efde4d84c90_cloud_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/1b0e9297-97dd-55d6-9874-8efde4d84c90_ha_cluster_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/1b0e9297-97dd-55d6-9874-8efde4d84c90_host_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/1b0e9297-97dd-55d6-9874-8efde4d84c90_subscription_discovery.json",
+]

--- a/.photofinish.toml
+++ b/.photofinish.toml
@@ -237,3 +237,18 @@ files = [
     "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery.json",
     "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/1b0e9297-97dd-55d6-9874-8efde4d84c90_subscription_discovery.json",
 ]
+
+[cluster-hana_cluster_1-restore]
+
+files = [
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_cloud_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_host_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_sap_system_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_subscription_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_cloud_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_ha_cluster_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_host_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_subscription_discovery.json",    
+]

--- a/.photofinish.toml
+++ b/.photofinish.toml
@@ -213,6 +213,16 @@ files = [
     "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_sap_system_discovery.json"
 ]
 
+[host-vmhdbprd02-restore]
+
+files = [
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_host_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_subscription_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_cloud_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_ha_cluster_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_sap_system_discovery.json"
+]
+
 [sapsystem-NWD-restore]
 
 files = [

--- a/.photofinish.toml
+++ b/.photofinish.toml
@@ -202,3 +202,13 @@ files = [
 files = [
     "./test/fixtures/scenarios/host-details/9cd46919-5f19-59aa-993e-cf3736c71053_cloud_discovery_unknown.json",
 ]
+
+[host-vmdrbddev01-restore]
+
+files = [
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_host_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_subscription_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_cloud_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_ha_cluster_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_sap_system_discovery.json"
+]

--- a/.photofinish.toml
+++ b/.photofinish.toml
@@ -243,6 +243,16 @@ files = [
     "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery.json" 
 ]
 
+[host-vmhdbqas01-restore]
+
+files = [
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/99cf8a3a-48d6-57a4-b302-6e4482227ab6_host_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/99cf8a3a-48d6-57a4-b302-6e4482227ab6_subscription_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/99cf8a3a-48d6-57a4-b302-6e4482227ab6_cloud_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/99cf8a3a-48d6-57a4-b302-6e4482227ab6_ha_cluster_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/99cf8a3a-48d6-57a4-b302-6e4482227ab6_sap_system_discovery.json" 
+]
+
 [sapsystem-NWD-restore]
 
 files = [

--- a/.photofinish.toml
+++ b/.photofinish.toml
@@ -233,6 +233,16 @@ files = [
     "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery.json"
 ]
 
+[host-vmhdbdev02-restore]
+
+files = [
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_host_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_subscription_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_cloud_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_ha_cluster_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery.json" 
+]
+
 [sapsystem-NWD-restore]
 
 files = [

--- a/.photofinish.toml
+++ b/.photofinish.toml
@@ -223,6 +223,16 @@ files = [
     "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_sap_system_discovery.json"
 ]
 
+[host-vmnwdev02-restore]
+
+files = [
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_host_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_subscription_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_cloud_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_ha_cluster_discovery.json",
+    "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery.json"
+]
+
 [sapsystem-NWD-restore]
 
 files = [

--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -165,4 +165,19 @@ context('Clusters Overview', () => {
       cy.contains(hanaCluster1.name).should('not.exist');
     });
   });
+
+  describe('Restoration', () => {
+    const hanaClusterToRestore = {
+      name: 'hana_cluster_1',
+      hosts: [
+        '13e8c25c-3180-5a9a-95c8-51ec38e50cfc',
+        '0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4',
+      ],
+    };
+
+    it(`should show cluster ${hanaClusterToRestore.name}`, () => {
+      cy.loadScenario(`cluster-${hanaClusterToRestore.name}-restore`);
+      cy.contains(hanaClusterToRestore.name).should('exist');
+    });
+  });
 });

--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -7,6 +7,12 @@ import {
 const clusterIdByName = (clusterName) =>
   availableClusters.find(({ name }) => name === clusterName).id;
 
+const clusterTags = {
+  hana_cluster_1: 'env1',
+  hana_cluster_2: 'env2',
+  hana_cluster_3: 'env3',
+};
+
 context('Clusters Overview', () => {
   before(() => {
     cy.visit('/clusters');
@@ -131,9 +137,9 @@ context('Clusters Overview', () => {
     const clustersByMatchingPattern = (pattern) => (clusterName) =>
       clusterName.includes(pattern);
     const taggingRules = [
-      ['hana_cluster_1', 'env1'],
-      ['hana_cluster_2', 'env2'],
-      ['hana_cluster_3', 'env3'],
+      ['hana_cluster_1', clusterTags.hana_cluster_1],
+      ['hana_cluster_2', clusterTags.hana_cluster_2],
+      ['hana_cluster_3', clusterTags.hana_cluster_3],
     ];
 
     taggingRules.forEach(([pattern, tag]) => {
@@ -165,9 +171,12 @@ context('Clusters Overview', () => {
       cy.contains(hanaCluster1.name).should('not.exist');
     });
 
-    it(`should show cluster ${hanaCluster1.name} after registering it again`, () => {
+    it(`should show cluster ${hanaCluster1.name} after registering it again with the previous tags`, () => {
       cy.loadScenario(`cluster-${hanaCluster1.name}-restore`);
       cy.contains(hanaCluster1.name).should('exist');
+      cy.contains('tr', hanaCluster1.name).within(() => {
+        cy.contains(clusterTags[hanaCluster1.name]).should('exist');
+      });
     });
   });
 });

--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -164,20 +164,10 @@ context('Clusters Overview', () => {
       cy.deregisterHost(hanaCluster1.hosts[1]);
       cy.contains(hanaCluster1.name).should('not.exist');
     });
-  });
 
-  describe('Restoration', () => {
-    const hanaClusterToRestore = {
-      name: 'hana_cluster_1',
-      hosts: [
-        '13e8c25c-3180-5a9a-95c8-51ec38e50cfc',
-        '0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4',
-      ],
-    };
-
-    it(`should show cluster ${hanaClusterToRestore.name}`, () => {
-      cy.loadScenario(`cluster-${hanaClusterToRestore.name}-restore`);
-      cy.contains(hanaClusterToRestore.name).should('exist');
+    it(`should show cluster ${hanaCluster1.name} after registering it again`, () => {
+      cy.loadScenario(`cluster-${hanaCluster1.name}-restore`);
+      cy.contains(hanaCluster1.name).should('exist');
     });
   });
 });

--- a/test/e2e/cypress/e2e/databases_overview.cy.js
+++ b/test/e2e/cypress/e2e/databases_overview.cy.js
@@ -7,20 +7,31 @@ context('Databases Overview', () => {
   describe('Deregistration', () => {
     const hdqDatabase = {
       sid: 'HDQ',
-      hanaPrimary: {
-        name: 'vmhdbqas01',
-        id: '99cf8a3a-48d6-57a4-b302-6e4482227ab6',
-      },
+      instances: [
+        {
+          name: 'vmhdbqas01',
+          id: '99cf8a3a-48d6-57a4-b302-6e4482227ab6',
+        },
+        {
+          name: 'vmhdbqas02',
+          id: 'e0c182db-32ff-55c6-a9eb-2b82dd21bc8b',
+        },
+      ],
     };
 
     it(`should not display DB ${hdqDatabase.sid} after deregistering the primary instance`, () => {
-      cy.deregisterHost(hdqDatabase.hanaPrimary.id);
+      cy.deregisterHost(hdqDatabase.instances[0].id);
       cy.contains(hdqDatabase.sid).should('not.exist');
     });
 
     it(`should display DB ${hdqDatabase.sid} again after restoring the primary instance`, () => {
-      cy.loadScenario(`host-${hdqDatabase.hanaPrimary.name}-restore`);
-      cy.contains(hdqDatabase.sid).should('exist');
+      cy.loadScenario(`host-${hdqDatabase.instances[0].name}-restore`);
+    });
+
+    it(`should include both instances in DB ${hdqDatabase.sid} after restoring the primary instance`, () => {
+      cy.contains('tr', hdqDatabase.sid).should('exist').click();
+      cy.contains(hdqDatabase.instances[0].name).should('exist');
+      cy.contains(hdqDatabase.instances[1].name).should('exist');
     });
   });
 });

--- a/test/e2e/cypress/e2e/databases_overview.cy.js
+++ b/test/e2e/cypress/e2e/databases_overview.cy.js
@@ -11,10 +11,12 @@ context('Databases Overview', () => {
         {
           name: 'vmhdbqas01',
           id: '99cf8a3a-48d6-57a4-b302-6e4482227ab6',
+          state: '',
         },
         {
           name: 'vmhdbqas02',
           id: 'e0c182db-32ff-55c6-a9eb-2b82dd21bc8b',
+          state: 'ACTIVE',
         },
       ],
     };
@@ -26,17 +28,23 @@ context('Databases Overview', () => {
 
     it(`should display DB ${hdqDatabase.sid} again after restoring the primary instance`, () => {
       cy.loadScenario(`host-${hdqDatabase.instances[0].name}-restore`);
+      cy.contains('tr', hdqDatabase.sid).should('exist').click();
     });
 
     it(`should include both instances in DB ${hdqDatabase.sid} after restoring the primary instance`, () => {
-      cy.contains('tr', hdqDatabase.sid).should('exist').click();
       cy.contains('div', hdqDatabase.instances[0].name).should('exist');
       cy.contains('div', hdqDatabase.instances[1].name).should('exist');
     });
 
     it('should show the ACTIVE pill in the right host', () => {
-      cy.contains('div', hdqDatabase.instances[1].name).within(() => {
-        cy.contains('ACTIVE');
+      hdqDatabase.instances.forEach((instance) => {
+        cy.contains('div', instance.name).within(() => {
+          if (instance.state === 'ACTIVE') {
+            cy.contains('ACTIVE').should('exist');
+          } else {
+            cy.contains('ACTIVE').should('not.exist');
+          }
+        });
       });
     });
   });

--- a/test/e2e/cypress/e2e/databases_overview.cy.js
+++ b/test/e2e/cypress/e2e/databases_overview.cy.js
@@ -18,4 +18,19 @@ context('Databases Overview', () => {
       cy.contains(hdqDatabase.sid).should('not.exist');
     });
   });
+
+  describe('Restoration', () => {
+    const databaseToRestore = {
+      sid: 'HDQ',
+      hanaPrimary: {
+        name: 'vmhdbqas01',
+        id: '99cf8a3a-48d6-57a4-b302-6e4482227ab6',
+      },
+    };
+
+    it(`should display DB ${databaseToRestore.sid} again after restoring the primary instance`, () => {
+      cy.loadScenario(`host-${databaseToRestore.hanaPrimary.name}-restore`);
+      cy.contains(databaseToRestore.sid).should('exist');
+    });
+  });
 });

--- a/test/e2e/cypress/e2e/databases_overview.cy.js
+++ b/test/e2e/cypress/e2e/databases_overview.cy.js
@@ -17,20 +17,10 @@ context('Databases Overview', () => {
       cy.deregisterHost(hdqDatabase.hanaPrimary.id);
       cy.contains(hdqDatabase.sid).should('not.exist');
     });
-  });
 
-  describe('Restoration', () => {
-    const databaseToRestore = {
-      sid: 'HDQ',
-      hanaPrimary: {
-        name: 'vmhdbqas01',
-        id: '99cf8a3a-48d6-57a4-b302-6e4482227ab6',
-      },
-    };
-
-    it(`should display DB ${databaseToRestore.sid} again after restoring the primary instance`, () => {
-      cy.loadScenario(`host-${databaseToRestore.hanaPrimary.name}-restore`);
-      cy.contains(databaseToRestore.sid).should('exist');
+    it(`should display DB ${hdqDatabase.sid} again after restoring the primary instance`, () => {
+      cy.loadScenario(`host-${hdqDatabase.hanaPrimary.name}-restore`);
+      cy.contains(hdqDatabase.sid).should('exist');
     });
   });
 });

--- a/test/e2e/cypress/e2e/databases_overview.cy.js
+++ b/test/e2e/cypress/e2e/databases_overview.cy.js
@@ -30,8 +30,14 @@ context('Databases Overview', () => {
 
     it(`should include both instances in DB ${hdqDatabase.sid} after restoring the primary instance`, () => {
       cy.contains('tr', hdqDatabase.sid).should('exist').click();
-      cy.contains(hdqDatabase.instances[0].name).should('exist');
-      cy.contains(hdqDatabase.instances[1].name).should('exist');
+      cy.contains('div', hdqDatabase.instances[0].name).should('exist');
+      cy.contains('div', hdqDatabase.instances[1].name).should('exist');
+    });
+
+    it('should show the ACTIVE pill in the right host', () => {
+      cy.contains('div', hdqDatabase.instances[1].name).within(() => {
+        cy.contains('ACTIVE');
+      });
     });
   });
 });

--- a/test/e2e/cypress/e2e/hana_cluster_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_cluster_details.cy.js
@@ -283,7 +283,7 @@ context('HANA cluster details', () => {
         .should('not.exist');
     });
 
-    it(`should show host ${hostToDeregister.name} again with a working link after restorign it`, () => {
+    it(`should show host ${hostToDeregister.name} again with a working link after restoring it`, () => {
       cy.loadScenario(`host-${hostToDeregister.name}-restore`);
       cy.get(`.tn-site-details-${hostToDeregister.sid}`)
         .contains('a', hostToDeregister.name)

--- a/test/e2e/cypress/e2e/hana_cluster_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_cluster_details.cy.js
@@ -283,4 +283,19 @@ context('HANA cluster details', () => {
         .should('not.exist');
     });
   });
+
+  describe('Restoration', () => {
+    const hostToRestore = {
+      name: 'vmhdbprd02',
+      id: 'b767b3e9-e802-587e-a442-541d093b86b9',
+      sid: 'WDF',
+    };
+
+    it(`should show host ${hostToRestore.name} again with a working link`, () => {
+      cy.loadScenario(`host-${hostToRestore.name}-restore`);
+      cy.get(`.tn-site-details-${hostToRestore.sid}`)
+        .contains('a', hostToRestore.name)
+        .should('exist');
+    });
+  });
 });

--- a/test/e2e/cypress/e2e/hana_cluster_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_cluster_details.cy.js
@@ -282,19 +282,11 @@ context('HANA cluster details', () => {
         .contains('a', hostToDeregister.name)
         .should('not.exist');
     });
-  });
 
-  describe('Restoration', () => {
-    const hostToRestore = {
-      name: 'vmhdbprd02',
-      id: 'b767b3e9-e802-587e-a442-541d093b86b9',
-      sid: 'WDF',
-    };
-
-    it(`should show host ${hostToRestore.name} again with a working link`, () => {
-      cy.loadScenario(`host-${hostToRestore.name}-restore`);
-      cy.get(`.tn-site-details-${hostToRestore.sid}`)
-        .contains('a', hostToRestore.name)
+    it(`should show host ${hostToDeregister.name} again with a working link after restorign it`, () => {
+      cy.loadScenario(`host-${hostToDeregister.name}-restore`);
+      cy.get(`.tn-site-details-${hostToDeregister.sid}`)
+        .contains('a', hostToDeregister.name)
         .should('exist');
     });
   });

--- a/test/e2e/cypress/e2e/hana_database_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_database_details.cy.js
@@ -135,4 +135,11 @@ context('HANA database details', () => {
       cy.contains(attachedHosts[0].Name).should('not.exist');
     });
   });
+
+  describe('Restoration', () => {
+    it(`should include host ${attachedHosts[0].Name} again in the list of hosts`, () => {
+      cy.loadScenario(`host-${attachedHosts[0].Name}-restore`);
+      cy.contains(attachedHosts[0].Name).should('exist');
+    });
+  });
 });

--- a/test/e2e/cypress/e2e/hana_database_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_database_details.cy.js
@@ -134,10 +134,8 @@ context('HANA database details', () => {
       cy.deregisterHost(attachedHosts[0].AgentId);
       cy.contains(attachedHosts[0].Name).should('not.exist');
     });
-  });
 
-  describe('Restoration', () => {
-    it(`should include host ${attachedHosts[0].Name} again in the list of hosts`, () => {
+    it(`should include host ${attachedHosts[0].Name} again in the list of hosts after restoring it`, () => {
       cy.loadScenario(`host-${attachedHosts[0].Name}-restore`);
       cy.contains(attachedHosts[0].Name).should('exist');
     });

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -173,8 +173,9 @@ context('Hosts Overview', () => {
 
   describe('Deregistration', () => {
     const hostToDeregister = {
-      name: 'vmdrbddev01',
-      id: '240f96b1-8d26-53b7-9e99-ffb0f2e735bf',
+      name: 'vmhdbdev01',
+      id: '13e8c25c-3180-5a9a-95c8-51ec38e50cfc',
+      tablePos: 7,
     };
 
     describe('Clean-up buttons should be visible only when needed', () => {
@@ -191,7 +192,8 @@ context('Hosts Overview', () => {
       });
 
       it('should show all other cleanup buttons', () => {
-        for (let i = 2; i < 11; i++) {
+        for (let i = 1; i < 11; i++) {
+          if (i == hostToDeregister.tablePos) continue;
           cy.get(`tr:nth-child(${i})`)
             .contains('button', 'Clean up')
             .should('exist');
@@ -201,7 +203,7 @@ context('Hosts Overview', () => {
       it(`should display the cleanup button for host ${hostToDeregister.name} once heartbeat is lost`, () => {
         cy.task('stopAgentsHeartbeat');
 
-        cy.get('tr:nth-child(1)')
+        cy.get(`tr:nth-child(${hostToDeregister.tablePos})`)
           .contains('button', 'Clean up', { timeout: 15000 })
           .should('exist');
       });
@@ -215,7 +217,7 @@ context('Hosts Overview', () => {
       });
 
       it('should allow to deregister a host after clean up confirmation', () => {
-        cy.get('tr:nth-child(1)')
+        cy.get(`tr:nth-child(${hostToDeregister.tablePos})`)
           .contains('button', 'Clean up', { timeout: 15000 })
           .click();
 
@@ -234,7 +236,7 @@ context('Hosts Overview', () => {
       });
 
       describe('Restoration', () => {
-        it(`should show host ${hostToDeregister.name} registered again`, () => {
+        it(`should show host ${hostToDeregister.name} registered again after restoring the host`, () => {
           cy.loadScenario(`host-${hostToDeregister.name}-restore`);
           cy.contains('tr', hostToDeregister.name).should('exist');
         });
@@ -249,6 +251,7 @@ context('Hosts Overview', () => {
         before(() => {
           cy.visit('/hosts');
           cy.url().should('include', '/hosts');
+          cy.loadScenario(`sapsystem-${sapSystemHostToDeregister.sid}-restore`);
         });
 
         beforeEach(() => {

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -232,40 +232,35 @@ context('Hosts Overview', () => {
 
         cy.get(`#host-${hostToDeregister.id}`).should('not.exist');
       });
-    });
 
-    describe('Deregistration of hosts should update remaining hosts data', () => {
-      const sapSystemHostToDeregister = {
-        id: '7269ee51-5007-5849-aaa7-7c4a98b0c9ce',
-        sid: 'NWD',
-      };
-
-      before(() => {
-        cy.visit('/hosts');
-        cy.url().should('include', '/hosts');
+      describe('Restoration', () => {
+        it(`should show host ${hostToDeregister.name} registered again`, () => {
+          cy.loadScenario(`host-${hostToDeregister.name}-restore`);
+          cy.contains('tr', hostToDeregister.name).should('exist');
+        });
       });
 
-      beforeEach(() => {
-        cy.contains('button', '1').click(); // Move to 1st host list view page
-      });
+      describe('Deregistration of hosts should update remaining hosts data', () => {
+        const sapSystemHostToDeregister = {
+          id: '7269ee51-5007-5849-aaa7-7c4a98b0c9ce',
+          sid: 'NWD',
+        };
 
-      it('should remove the SAP system sid from hosts belonging the deregistered SAP system', () => {
-        cy.contains('button', '2').click();
-        cy.contains('a', sapSystemHostToDeregister.sid).should('exist');
-        cy.deregisterHost(sapSystemHostToDeregister.id);
-        cy.contains('a', sapSystemHostToDeregister.sid).should('not.exist');
-      });
-    });
+        before(() => {
+          cy.visit('/hosts');
+          cy.url().should('include', '/hosts');
+        });
 
-    describe('Restoration', () => {
-      const hostToRestore = {
-        name: 'vmdrbddev01',
-        id: '240f96b1-8d26-53b7-9e99-ffb0f2e735bf',
-      };
+        beforeEach(() => {
+          cy.contains('button', '1').click(); // Move to 1st host list view page
+        });
 
-      it(`should show host ${hostToRestore.name} registered again`, () => {
-        cy.loadScenario(`host-${hostToRestore.name}-restore`);
-        cy.contains(hostToRestore.name).should('exist');
+        it('should remove the SAP system sid from hosts belonging the deregistered SAP system', () => {
+          cy.contains('button', '2').click();
+          cy.contains('a', sapSystemHostToDeregister.sid).should('exist');
+          cy.deregisterHost(sapSystemHostToDeregister.id);
+          cy.contains('a', sapSystemHostToDeregister.sid).should('not.exist');
+        });
       });
     });
   });

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -175,7 +175,6 @@ context('Hosts Overview', () => {
     const hostToDeregister = {
       name: 'vmhdbdev01',
       id: '13e8c25c-3180-5a9a-95c8-51ec38e50cfc',
-      tablePos: 7,
       tag: 'tag1',
     };
 
@@ -193,20 +192,10 @@ context('Hosts Overview', () => {
       });
 
       it('should show all other cleanup buttons', () => {
-        for (let i = 1; i < 11; i++) {
-          if (i == hostToDeregister.tablePos) continue;
-          cy.get(`tr:nth-child(${i})`)
-            .contains('button', 'Clean up')
-            .should('exist');
-        }
-      });
-
-      it(`should display the cleanup button for host ${hostToDeregister.name} once heartbeat is lost`, () => {
-        cy.task('stopAgentsHeartbeat');
-
-        cy.get(`tr:nth-child(${hostToDeregister.tablePos})`)
-          .contains('button', 'Clean up', { timeout: 15000 })
-          .should('exist');
+        cy.get('tbody tr')
+          .find('button')
+          .should('have.length', 9)
+          .contains('Clean up');
       });
     });
 
@@ -219,9 +208,15 @@ context('Hosts Overview', () => {
       });
 
       it('should allow to deregister a host after clean up confirmation', () => {
-        cy.get(`tr:nth-child(${hostToDeregister.tablePos})`)
-          .contains('button', 'Clean up', { timeout: 15000 })
-          .click();
+        cy.contains(
+          `The host ${hostToDeregister.name} heartbeat is failing`
+        ).should('exist');
+
+        cy.contains('tr', hostToDeregister.name).within(() => {
+          cy.get('td:nth-child(9)')
+            .contains('Clean up', { timeout: 15000 })
+            .click();
+        });
 
         cy.get('#headlessui-portal-root').as('modal');
 

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -256,5 +256,17 @@ context('Hosts Overview', () => {
         cy.contains('a', sapSystemHostToDeregister.sid).should('not.exist');
       });
     });
+
+    describe('Restoration', () => {
+      const hostToRestore = {
+        name: 'vmdrbddev01',
+        id: '240f96b1-8d26-53b7-9e99-ffb0f2e735bf',
+      };
+
+      it(`should show host ${hostToRestore.name} registered again`, () => {
+        cy.loadScenario(`host-${hostToRestore.name}-restore`);
+        cy.contains(hostToRestore.name).should('exist');
+      });
+    });
   });
 });

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -176,6 +176,7 @@ context('Hosts Overview', () => {
       name: 'vmhdbdev01',
       id: '13e8c25c-3180-5a9a-95c8-51ec38e50cfc',
       tablePos: 7,
+      tag: 'tag1',
     };
 
     describe('Clean-up buttons should be visible only when needed', () => {
@@ -214,6 +215,7 @@ context('Hosts Overview', () => {
         cy.visit('/hosts');
         cy.url().should('include', '/hosts');
         cy.task('stopAgentsHeartbeat');
+        cy.addTagByColumnValue(hostToDeregister.name, hostToDeregister.tag);
       });
 
       it('should allow to deregister a host after clean up confirmation', () => {
@@ -236,9 +238,12 @@ context('Hosts Overview', () => {
       });
 
       describe('Restoration', () => {
-        it(`should show host ${hostToDeregister.name} registered again after restoring the host`, () => {
+        it(`should show host ${hostToDeregister.name} registered again after restoring the host with the tag`, () => {
           cy.loadScenario(`host-${hostToDeregister.name}-restore`);
-          cy.contains('tr', hostToDeregister.name).should('exist');
+          cy.contains(hostToDeregister.name).should('exist');
+          cy.contains('tr', hostToDeregister.name).within(() => {
+            cy.contains(hostToDeregister.tag).should('exist');
+          });
         });
       });
 

--- a/test/e2e/cypress/e2e/sap_system_details.cy.js
+++ b/test/e2e/cypress/e2e/sap_system_details.cy.js
@@ -146,4 +146,18 @@ context('SAP system details', () => {
       cy.contains(hostToDeregister.features).should('not.exist');
     });
   });
+
+  describe('Restoration', () => {
+    const hostToRestore = {
+      name: 'vmnwdev02',
+      id: 'fb2c6b8a-9915-5969-a6b7-8b5a42de1971',
+      features: 'ENQREP',
+    };
+
+    it(`should include ${hostToRestore.name} again in the list of hosts`, () => {
+      cy.loadScenario(`host-${hostToRestore.name}-restore`);
+      cy.contains(hostToRestore.name).should('exist');
+      cy.contains(hostToRestore.features).should('exist');
+    });
+  });
 });

--- a/test/e2e/cypress/e2e/sap_system_details.cy.js
+++ b/test/e2e/cypress/e2e/sap_system_details.cy.js
@@ -145,19 +145,11 @@ context('SAP system details', () => {
       cy.contains(hostToDeregister.name).should('not.exist');
       cy.contains(hostToDeregister.features).should('not.exist');
     });
-  });
 
-  describe('Restoration', () => {
-    const hostToRestore = {
-      name: 'vmnwdev02',
-      id: 'fb2c6b8a-9915-5969-a6b7-8b5a42de1971',
-      features: 'ENQREP',
-    };
-
-    it(`should include ${hostToRestore.name} again in the list of hosts`, () => {
-      cy.loadScenario(`host-${hostToRestore.name}-restore`);
-      cy.contains(hostToRestore.name).should('exist');
-      cy.contains(hostToRestore.features).should('exist');
+    it(`should include ${hostToDeregister.name} again in the list of hosts`, () => {
+      cy.loadScenario(`host-${hostToDeregister.name}-restore`);
+      cy.contains(hostToDeregister.name).should('exist');
+      cy.contains(hostToDeregister.features).should('exist');
     });
   });
 });

--- a/test/e2e/cypress/e2e/sap_systems_overview.cy.js
+++ b/test/e2e/cypress/e2e/sap_systems_overview.cy.js
@@ -338,34 +338,10 @@ context('SAP Systems Overview', () => {
       cy.deregisterHost(sapSystemNwd.applicationInstances[1].id);
       cy.contains(sapSystemNwd.sid).should('not.exist');
     });
-  });
 
-  describe('Restoration', () => {
-    const sapSystemToRestore = {
-      sid: 'NWD',
-      hosts: [
-        {
-          name: 'vmnwdev01',
-          id: '7269ee51-5007-5849-aaa7-7c4a98b0c9ce',
-        },
-        {
-          name: 'vmnwdev02',
-          id: 'fb2c6b8a-9915-5969-a6b7-8b5a42de1971',
-        },
-        {
-          name: 'vmnwdev03',
-          id: '9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f',
-        },
-        {
-          name: 'vmnwdev04',
-          id: '1b0e9297-97dd-55d6-9874-8efde4d84c90',
-        },
-      ],
-    };
-
-    it(`should show host ${sapSystemToRestore.sid} registered again`, () => {
-      cy.loadScenario(`sapsystem-${sapSystemToRestore.sid}-restore`);
-      cy.contains(sapSystemToRestore.sid).should('exist');
+    it(`should show host ${sapSystemNwd.sid} registered again after restoring it`, () => {
+      cy.loadScenario(`sapsystem-${sapSystemNwd.sid}-restore`);
+      cy.contains(sapSystemNwd.sid).should('exist');
     });
   });
 });

--- a/test/e2e/cypress/e2e/sap_systems_overview.cy.js
+++ b/test/e2e/cypress/e2e/sap_systems_overview.cy.js
@@ -339,4 +339,33 @@ context('SAP Systems Overview', () => {
       cy.contains(sapSystemNwd.sid).should('not.exist');
     });
   });
+
+  describe('Restoration', () => {
+    const sapSystemToRestore = {
+      sid: 'NWD',
+      hosts: [
+        {
+          name: 'vmnwdev01',
+          id: '7269ee51-5007-5849-aaa7-7c4a98b0c9ce',
+        },
+        {
+          name: 'vmnwdev02',
+          id: 'fb2c6b8a-9915-5969-a6b7-8b5a42de1971',
+        },
+        {
+          name: 'vmnwdev03',
+          id: '9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f',
+        },
+        {
+          name: 'vmnwdev04',
+          id: '1b0e9297-97dd-55d6-9874-8efde4d84c90',
+        },
+      ],
+    };
+
+    it(`should show host ${sapSystemToRestore.sid} registered again`, () => {
+      cy.loadScenario(`sapsystem-${sapSystemToRestore.sid}-restore`);
+      cy.contains(sapSystemToRestore.sid).should('exist');
+    });
+  });
 });


### PR DESCRIPTION
# Description

This PR adds e2e tests for the restoration of hosts after they have been deregistered. It checks that the right details are restored and visible in:
 - hosts overview
 - sap systems overview
 - clusters overview
 - dbs overview
 - cluster details
 - sap system details
 - hana db details
 
Notice that to do this, we have added additional photofinish scenarios that reuse the existing discovery json messages.
