### PR TITLE
Remove app db instances state

### DIFF
--- a/assets/js/state/databases.js
+++ b/assets/js/state/databases.js
@@ -34,6 +34,9 @@ export const databasesListSlice = createSlice({
       state.databases = state.databases.filter(
         (database) => database.id !== id
       );
+      state.databaseInstances = state.databaseInstances.filter(
+        (databaseInstance) => databaseInstance.sap_system_id !== id
+      );
     },
     removeDatabaseInstance: (
       state,

--- a/assets/js/state/databases.test.js
+++ b/assets/js/state/databases.test.js
@@ -25,14 +25,24 @@ describe('Databases reducer', () => {
 
   it('should remove a database from state', () => {
     const [database1, database2] = databaseFactory.buildList(2);
+    const database1DatabaseInstances = databaseInstanceFactory.buildList({
+      sap_system_id: database1.id,
+    });
+    const database2DatabaseInstances = databaseInstanceFactory.buildList({
+      sap_system_id: database2.id,
+    });
     const initialState = {
       databases: [database1, database2],
+      databaseInstances: database1DatabaseInstances.concat(
+        database2DatabaseInstances
+      ),
     };
 
     const action = removeDatabase(database1);
 
     const expectedState = {
       databases: [database2],
+      databaseInstances: database2DatabaseInstances,
     };
 
     expect(databaseReducer(initialState, action)).toEqual(expectedState);

--- a/assets/js/state/sapSystems.js
+++ b/assets/js/state/sapSystems.js
@@ -147,6 +147,12 @@ export const sapSystemsListSlice = createSlice({
       state.sapSystems = state.sapSystems.filter(
         (sapSystem) => sapSystem.id !== id
       );
+      state.applicationInstances = state.applicationInstances.filter(
+        (applicationInstance) => applicationInstance.sap_system_id !== id
+      );
+      state.databaseInstances = state.databaseInstances.filter(
+        (databaseInstance) => databaseInstance.sap_system_id !== id
+      );
     },
     updateSAPSystem: (state, { payload }) => {
       state.sapSystems = state.sapSystems.map((sapSystem) => {

--- a/assets/js/state/sapSystems.test.js
+++ b/assets/js/state/sapSystems.test.js
@@ -8,19 +8,43 @@ import {
   sapSystemFactory,
   sapSystemApplicationInstanceFactory,
 } from '@lib/test-utils/factories/sapSystems';
+import { databaseInstanceFactory } from '@lib/test-utils/factories/databases';
 import { faker } from '@faker-js/faker';
 
 describe('SAP Systems reducer', () => {
   it('should remove SAP system from state', () => {
     const [sapSystem1, sapSystem2] = sapSystemFactory.buildList(2);
+    const sapSystem1ApplicationInstances =
+      sapSystemApplicationInstanceFactory.buildList({
+        sap_system_id: sapSystem1.id,
+      });
+    const sapSystem1DatabaseInstances = databaseInstanceFactory.buildList({
+      sap_system_id: sapSystem1.id,
+    });
+    const sapSystem2ApplicationInstances =
+      sapSystemApplicationInstanceFactory.buildList({
+        sap_system_id: sapSystem2.id,
+      });
+    const sapSystem2DatabaseInstances = databaseInstanceFactory.buildList({
+      sap_system_id: sapSystem2.id,
+    });
+
     const initialState = {
       sapSystems: [sapSystem1, sapSystem2],
+      applicationInstances: sapSystem1ApplicationInstances.concat(
+        sapSystem2ApplicationInstances
+      ),
+      databaseInstances: sapSystem1DatabaseInstances.concat(
+        sapSystem2DatabaseInstances
+      ),
     };
 
     const action = removeSAPSystem(sapSystem1);
 
     const expectedState = {
       sapSystems: [sapSystem2],
+      applicationInstances: sapSystem2ApplicationInstances,
+      databaseInstances: sapSystem2DatabaseInstances,
     };
 
     expect(sapSystemsReducer(initialState, action)).toEqual(expectedState);

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -233,5 +233,28 @@ context('Hosts Overview', () => {
         cy.get(`#host-${hostToDeregister.id}`).should('not.exist');
       });
     });
+
+    describe('Deregistration of hosts should update remaining hosts data', () => {
+      const sapSystemHostToDeregister = {
+        id: '7269ee51-5007-5849-aaa7-7c4a98b0c9ce',
+        sid: 'NWD',
+      };
+
+      before(() => {
+        cy.visit('/hosts');
+        cy.url().should('include', '/hosts');
+      });
+
+      beforeEach(() => {
+        cy.contains('button', '1').click(); // Move to 1st host list view page
+      });
+
+      it('should remove the SAP system sid from hosts belonging the deregistered SAP system', () => {
+        cy.contains('button', '2').click();
+        cy.contains('a', sapSystemHostToDeregister.sid).should('exist');
+        cy.deregisterHost(sapSystemHostToDeregister.id);
+        cy.contains('a', sapSystemHostToDeregister.sid).should('not.exist');
+      });
+    });
   });
 });


### PR DESCRIPTION
# Description
When a host belonging a SAP system is deregistered, the remaining hosts are still showing the deregistered SID entry in the host list view.
The fix removes those instances from the redux state.

**PD: Fixing this bug, causes the 100% ocurrence reproduction of the other bug, where the instances are not being shown on restoration.

![image](https://github.com/trento-project/web/assets/36370954/953a7c37-f862-4bee-b149-e4b9c7060fca)
