### PR TITLE
Return whole host read model in registered projection

### DIFF
--- a/lib/trento/application/projectors/host_projector.ex
+++ b/lib/trento/application/projectors/host_projector.ex
@@ -46,7 +46,8 @@ defmodule Trento.HostProjector do
 
       Ecto.Multi.insert(multi, :host, changeset,
         on_conflict: {:replace_all_except, [:cluster_id]},
-        conflict_target: [:id]
+        conflict_target: [:id],
+        returning: true
       )
     end
   )


### PR DESCRIPTION
# Description

Fix host registration sequence projection. Now the `cluster_id` is sent in the projection if it exists.
The frontend was having an error. The host entries `cluster_id` was not being updated properly in the redux state, if the `ClusterRegistered` and `HostAddedToCluster` events were received before the `HostRegistered` event.

This only happens the first time when all the messages from photofinish are received. The page refresh fixes it.
Maybe it is not a real scenario, as the real trento-agent has other order sending events.

The error, much more clusters should be there:
![image](https://github.com/trento-project/web/assets/36370954/ad8ab04c-0e07-42b1-a288-77d7932a02a2)
![image](https://github.com/trento-project/web/assets/36370954/55a4e55b-400f-422b-a347-b1b475926570)

