### PR TITLE
Fix SR status broadcast on database instance registration

### DIFF
--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -195,10 +195,6 @@ defmodule Trento.Domain.SapSystem do
       )
       when not is_nil(deregistered_at) do
     [
-      %DatabaseRestored{
-        sap_system_id: sap_system_id,
-        health: health
-      },
       %DatabaseInstanceRegistered{
         sap_system_id: sap_system_id,
         sid: sid,
@@ -212,6 +208,10 @@ defmodule Trento.Domain.SapSystem do
         host_id: host_id,
         system_replication: system_replication,
         system_replication_status: system_replication_status,
+        health: health
+      },
+      %DatabaseRestored{
+        sap_system_id: sap_system_id,
         health: health
       }
     ]

--- a/test/e2e/cypress/e2e/databases_overview.cy.js
+++ b/test/e2e/cypress/e2e/databases_overview.cy.js
@@ -36,9 +36,9 @@ context('Databases Overview', () => {
       cy.contains('div', hdqDatabase.instances[1].name).should('exist');
     });
 
-    it.skip('should show the ACTIVE pill in the right host', () => {
+    it('should show the ACTIVE pill in the right host', () => {
       hdqDatabase.instances.forEach((instance) => {
-        cy.contains('div', instance.name).within(() => {
+        cy.contains('div.table-row', instance.name).within(() => {
           if (instance.state === 'ACTIVE') {
             cy.contains('ACTIVE').should('exist');
           } else {

--- a/test/trento/domain/sap_system/sap_system_test.exs
+++ b/test/trento/domain/sap_system/sap_system_test.exs
@@ -2001,10 +2001,6 @@ defmodule Trento.SapSystemTest do
         initial_events,
         command,
         [
-          %DatabaseRestored{
-            sap_system_id: sap_system_id,
-            health: command.health
-          },
           %DatabaseInstanceRegistered{
             sap_system_id: sap_system_id,
             sid: db_sid,
@@ -2018,6 +2014,10 @@ defmodule Trento.SapSystemTest do
             host_id: command.host_id,
             system_replication: command.system_replication,
             system_replication_status: command.system_replication_status,
+            health: command.health
+          },
+          %DatabaseRestored{
+            sap_system_id: sap_system_id,
             health: command.health
           }
         ],
@@ -2138,10 +2138,6 @@ defmodule Trento.SapSystemTest do
         initial_events,
         command,
         [
-          %DatabaseRestored{
-            sap_system_id: sap_system_id,
-            health: command.health
-          },
           %DatabaseInstanceRegistered{
             sap_system_id: sap_system_id,
             sid: db_sid,
@@ -2155,6 +2151,10 @@ defmodule Trento.SapSystemTest do
             host_id: command.host_id,
             system_replication: command.system_replication,
             system_replication_status: command.system_replication_status,
+            health: command.health
+          },
+          %DatabaseRestored{
+            sap_system_id: sap_system_id,
             health: command.health
           }
         ],
@@ -2277,10 +2277,6 @@ defmodule Trento.SapSystemTest do
         initial_events,
         command,
         [
-          %DatabaseRestored{
-            sap_system_id: sap_system_id,
-            health: command.health
-          },
           %DatabaseInstanceRegistered{
             sap_system_id: sap_system_id,
             sid: db_sid,
@@ -2294,6 +2290,10 @@ defmodule Trento.SapSystemTest do
             host_id: command.host_id,
             system_replication: command.system_replication,
             system_replication_status: command.system_replication_status,
+            health: command.health
+          },
+          %DatabaseRestored{
+            sap_system_id: sap_system_id,
             health: command.health
           }
         ],
@@ -2410,10 +2410,6 @@ defmodule Trento.SapSystemTest do
         initial_events,
         command,
         [
-          %DatabaseRestored{
-            sap_system_id: sap_system_id,
-            health: command.health
-          },
           %DatabaseInstanceRegistered{
             sap_system_id: sap_system_id,
             sid: db_sid,
@@ -2427,6 +2423,10 @@ defmodule Trento.SapSystemTest do
             host_id: command.host_id,
             system_replication: command.system_replication,
             system_replication_status: command.system_replication_status,
+            health: command.health
+          },
+          %DatabaseRestored{
+            sap_system_id: sap_system_id,
             health: command.health
           }
         ],


### PR DESCRIPTION
# Description

Fix system replication status broadcast on database instance registration.
Basically, we need all database instances to get the value for each type (primary/secondary).

I want to test this with the whole "restoration" fix for the instances (https://github.com/trento-project/web/pull/1673)

PD: I do agree that this got complex, so querying with a api call on this events as refactor would be a good idea.
PD2: In fact, it has "forced" me to change some domain events order to make it work without horrible "data enrichment" messages to the frontend...

## How was this tested?

Everything tested in the projection. I didn't add any test on the view, as the test would be the same.
