### PR TITLE
Reduce flakyness

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -278,6 +278,7 @@ jobs:
     name: Chromatic deployment
     needs: [elixir-deps, npm-deps]
     runs-on: ubuntu-20.04
+    if: github.event_name != 'repository_dispatch'
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -445,7 +445,6 @@ jobs:
           cypress_photofinish_binary: $(whereis photofinish | cut -d" " -f2)
         with:
           working-directory: test/e2e
-          headless: true
           wait-on-timeout: 30
           config: baseUrl=http://localhost:4000
       - name: Upload cypress test screenshots

--- a/test/e2e/cypress/e2e/checks_catalog.cy.js
+++ b/test/e2e/cypress/e2e/checks_catalog.cy.js
@@ -68,8 +68,9 @@ context('Checks catalog', () => {
   describe('Individual checks data is expanded', () => {
     it('should expand check data when clicked', () => {
       cy.get('.check-panel').should('not.exist');
+      cy.get('div.check-row').should('have.length', 4);
       cy.get('div.check-row').first().click();
-      cy.get(`.check-panel`).should('exist');
+      cy.get(`.check-panel`).should('be.visible');
     });
   });
 

--- a/test/e2e/cypress/e2e/host_details.cy.js
+++ b/test/e2e/cypress/e2e/host_details.cy.js
@@ -359,12 +359,14 @@ context('Host Details', () => {
   describe('Deregistration', () => {
     describe('"Clean up" button should be visible only for an unhealthy host', () => {
       it('should not display the "Clean up" button for healthy host', () => {
-        cy.task('startAgentHeartbeat', [selectedHost.id]);
         cy.contains('button', 'Clean up').should('not.exist');
       });
 
       it('should show the "Clean up" button once heartbeat is lost and debounce period has elapsed', () => {
         cy.task('stopAgentsHeartbeat');
+        cy.contains(`The host ${selectedHost.hostName} heartbeat is failing.`, {
+          timeout: 15000,
+        }).should('exist');
         cy.contains('button', 'Clean up', { timeout: 15000 }).should('exist');
       });
     });

--- a/test/e2e/cypress/e2e/host_details.cy.js
+++ b/test/e2e/cypress/e2e/host_details.cy.js
@@ -366,7 +366,7 @@ context('Host Details', () => {
         cy.task('stopAgentsHeartbeat');
         cy.contains(`The host ${selectedHost.hostName} heartbeat is failing.`, {
           timeout: 15000,
-        }).should('exist');
+        });
         cy.contains('button', 'Clean up', { timeout: 15000 }).should('exist');
       });
     });


### PR DESCRIPTION
# Description
I've been tasking a look at the past month's CI failures, and in an attempt to reduce the red there:

 - remove the deprecated `headless: true`. for the cypress action. It's default since 8.0
 - switch `exist` with `be.visible` which should be more specific. This should not affect flakyness but should be more robust (We could actually take a look at other tests and see where we can also update this)
 - on the test that I saw most of the flakyness at (checks_catalog), `cy.get('div.check-row').should('have.length', 4);` has been added to block the execution until the rows about to be clicked are visible.
 - a `contains` that looks for the heartbeat toast before trying to click the button has been added in the host_details which was another test that showed failures from time to time.
 - chromatic deployment action showed failures when being run from the repository_dispatch that gets triggered from wanda repo, so it now checks if `action_name` is `repository_dispatch` to avoid running.