### PR TITLE
Add API backward compatibility check in pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,7 +148,7 @@ jobs:
 
   static-code-analysis:
     name: Static Code Analysis
-    needs: [elixir-deps, npm-deps]
+    needs: [elixir-deps, npm-deps, api-bc-check]
     runs-on: ubuntu-20.04
     steps:
       - name: Cancel Previous Runs
@@ -201,7 +201,7 @@ jobs:
 
   test:
     name: Test (Elixir ${{ matrix.elixir }}, OTP ${{ matrix.otp }})
-    needs: [elixir-deps, npm-deps]
+    needs: [elixir-deps, npm-deps, api-bc-check]
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -355,7 +355,7 @@ jobs:
 
   test-e2e:
     name: End to end tests
-    needs: [elixir-deps, npm-deps, npm-e2e-deps]
+    needs: [elixir-deps, npm-deps, npm-e2e-deps, api-bc-check]
     runs-on: ubuntu-20.04
     env:
       MIX_ENV: dev
@@ -454,6 +454,75 @@ jobs:
         with:
           name: e2e-screenshots
           path: test/e2e/cypress/screenshots/
+
+  api-bc-check:
+    name: API bc check
+    needs: [elixir-deps]
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - version: V1
+          - version: V2
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+          otp-version: ${{ env.OTP_VERSION }}
+      - name: Checkout current branch
+        uses: actions/checkout@v3
+      - name: Retrieve Cached Dependencies - current branch
+        uses: actions/cache@v3
+        id: mix-cache-current
+        with:
+          path: |
+            deps
+            _build/test
+            priv/plts
+          key: ${{ runner.os }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('mix.lock') }}
+      - name: Generate current openapi.json
+        run: |
+          mix openapi.spec.json --start-app=false --spec TrentoWeb.OpenApi.${{ matrix.version }}.ApiSpec /tmp/specs/current-spec.json
+
+      - name: Checkout main branch
+        uses: actions/checkout@v3
+        with:
+          ref: main
+      - name: Retrieve Cached Dependencies - main branch
+        uses: actions/cache@v3
+        id: mix-cache-main
+        with:
+          path: |
+            deps
+            _build/test
+            priv/plts
+          key: ${{ runner.os }}-${{ env.OTP_VERSION }}-${{ env.ELIXIR_VERSION }}-${{ hashFiles('mix.lock') }}
+      - name: Generate main openapi.json
+        run: |
+          mix openapi.spec.json --start-app=false --spec TrentoWeb.OpenApi.${{ matrix.version }}.ApiSpec /tmp/specs/main-spec.json
+      - name: Locate generated specs
+        run: mv /tmp/specs .
+      - name: Find difference between OpenAPI specifications
+        run: |
+          docker run -v "$(pwd)/specs:/specs" --rm openapitools/openapi-diff:2.0.1 \
+            /specs/main-spec.json \
+            /specs/current-spec.json \
+            --fail-on-incompatible \
+            --markdown /specs/changes.md \
+            --json /specs/changes.json \
+            --text /specs/changes.txt \
+            --html /specs/changes.html
+      - name: Upload OpenAPI diff report
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: openapi-diff-report-${{ matrix.version }}
+          path: specs/
 
   build-and-push-container-images:
     name: Build and push container images

--- a/lib/trento_web/openapi/v1/schema/host.ex
+++ b/lib/trento_web/openapi/v1/schema/host.ex
@@ -68,7 +68,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Host do
           title: "SlesSubscriptions",
           description: "A list of the available SLES Subscriptions on a host",
           type: :array,
-          items: SlesSubscription
+          items: %Schema{type: :string},
         },
         deregistered_at: %Schema{
           title: "DeregisteredAt",

--- a/lib/trento_web/openapi/v1/schema/host.ex
+++ b/lib/trento_web/openapi/v1/schema/host.ex
@@ -35,7 +35,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Host do
       type: :object,
       properties: %{
         id: %Schema{type: :string, description: "Host ID", format: :uuid},
-        hostname: %Schema{type: :string, description: "Host name"},
+        hostname: %Schema{type: :string, description: "Host namezzzz"},
         ip_addresses: %Schema{
           type: :array,
           description: "IP addresses",
@@ -68,7 +68,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Host do
           title: "SlesSubscriptions",
           description: "A list of the available SLES Subscriptions on a host",
           type: :array,
-          items: %Schema{type: :string},
+          items: SlesSubscription
         },
         deregistered_at: %Schema{
           title: "DeregisteredAt",

--- a/lib/trento_web/openapi/v1/schema/host.ex
+++ b/lib/trento_web/openapi/v1/schema/host.ex
@@ -35,7 +35,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Host do
       type: :object,
       properties: %{
         id: %Schema{type: :string, description: "Host ID", format: :uuid},
-        hostname: %Schema{type: :string, description: "Host namezzzz"},
+        hostname: %Schema{type: :string, description: "Host name"},
         ip_addresses: %Schema{
           type: :array,
           description: "IP addresses",


### PR DESCRIPTION
# Description

This PR introduces a backward compatibility check in the pipeline for our APIs, for both V1 and V2.
Relies on https://github.com/OpenAPITools/openapi-diff

- [Backward incompatible change makes stops the pipeline](https://github.com/trento-project/web/actions/runs/5752421716/job/15593405750#step:11:67)
- [Backward compatible change lets the pipeline continue](https://github.com/trento-project/web/actions/runs/5752530118/job/15593744241#step:11:66)
- [No changes pass](https://github.com/trento-project/web/actions/runs/5752614002/job/15594004127#step:11:50)

---

I tried this action at first https://github.com/marketplace/actions/openapi-diff-action but it was failing with a weird
> Error: The template is not valid. swimmwatch/openapi-diff-action/v1.0.1/action.yml (Line: 77, Col: 12): The maximum allowed memory size was exceeded while evaluating the following expression: format('compatible_val="{0}"
>

[see this run](https://github.com/trento-project/web/actions/runs/5751458228/job/15590268392#step:12:111)