### PR TITLE
Restore a SAP system only when the database is present

### DIFF
--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -931,8 +931,12 @@ defmodule Trento.Domain.SapSystem do
     end
   end
 
+  # Restore a SAP system when the database is registered
   defp maybe_emit_sap_system_restored_event(
-         %SapSystem{application: %Application{instances: instances}},
+         %SapSystem{
+           application: %Application{instances: instances},
+           database: %Database{deregistered_at: nil}
+         },
          %RegisterApplicationInstance{
            sap_system_id: sap_system_id,
            tenant: tenant,
@@ -949,6 +953,9 @@ defmodule Trento.Domain.SapSystem do
       }
     end
   end
+
+  # Do not restore SAP system if the database is not registered
+  defp maybe_emit_sap_system_restored_event(%SapSystem{}, %RegisterApplicationInstance{}), do: nil
 
   defp maybe_emit_sap_system_registered_or_updated_event(
          %SapSystem{sid: nil, application: %Application{instances: instances}},


### PR DESCRIPTION
# Description

This pr fix a SAP system restore bug, we want to restore the SAP system only if the database is present.

## How was this tested?

Automated tests
