### PR TITLE
Fix host checks selection ui

### DIFF
--- a/assets/js/components/HostDetails/HostChecksSelection.jsx
+++ b/assets/js/components/HostDetails/HostChecksSelection.jsx
@@ -21,7 +21,7 @@ function HostChecksSelection({
   isSavingSelection,
   onSaveSelection,
   onSelectedChecksChange,
-  enableHostChecksExecution,
+  hostChecksExecutionEnabled,
 }) {
   return (
     <div className="w-full px-2 sm:px-0">
@@ -47,7 +47,7 @@ function HostChecksSelection({
               type="primary"
               className="mx-1"
               onClick={() => {}}
-              disabled={enableHostChecksExecution}
+              disabled={hostChecksExecutionEnabled}
             >
               <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub" />{' '}
               Start Execution

--- a/assets/js/components/HostDetails/HostChecksSelection.jsx
+++ b/assets/js/components/HostDetails/HostChecksSelection.jsx
@@ -4,9 +4,7 @@ import { EOS_PLAY_CIRCLE } from 'eos-icons-react';
 import PageHeader from '@components/PageHeader';
 import BackButton from '@components/BackButton';
 import Button from '@components/Button';
-import ChecksSelection, {
-  canStartExecution,
-} from '@components/ChecksSelection';
+import ChecksSelection from '@components/ChecksSelection';
 
 import HostInfoBox from './HostInfoBox';
 
@@ -16,7 +14,6 @@ function HostChecksSelection({
   provider,
   agentVersion,
   selectedChecks,
-  hostSelectedChecks,
   catalog,
   catalogError,
   catalogLoading,
@@ -24,6 +21,7 @@ function HostChecksSelection({
   isSavingSelection,
   onSaveSelection,
   onSelectedChecksChange,
+  enableHostChecksExecution,
 }) {
   return (
     <div className="w-full px-2 sm:px-0">
@@ -49,9 +47,7 @@ function HostChecksSelection({
               type="primary"
               className="mx-1"
               onClick={() => {}}
-              disabled={
-                !canStartExecution(hostSelectedChecks, isSavingSelection)
-              }
+              disabled={enableHostChecksExecution}
             >
               <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub" />{' '}
               Start Execution

--- a/assets/js/components/HostDetails/HostChecksSelection.jsx
+++ b/assets/js/components/HostDetails/HostChecksSelection.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { EOS_PLAY_CIRCLE } from 'eos-icons-react';
 
 import PageHeader from '@components/PageHeader';
@@ -16,15 +16,15 @@ function HostChecksSelection({
   provider,
   agentVersion,
   selectedChecks,
+  hostSelectedChecks,
   catalog,
   catalogError,
   catalogLoading,
   onUpdateCatalog,
   isSavingSelection,
   onSaveSelection,
+  onSelectedChecksChange,
 }) {
-  const [selection, setSelection] = useState(selectedChecks);
-
   return (
     <div className="w-full px-2 sm:px-0">
       <BackButton url={`/hosts/${hostID}`}>Back to Host Details</BackButton>
@@ -40,7 +40,7 @@ function HostChecksSelection({
             <Button
               type="primary"
               className="mx-1"
-              onClick={() => onSaveSelection(selection, hostID, hostName)}
+              onClick={() => onSaveSelection(selectedChecks, hostID, hostName)}
               disabled={isSavingSelection}
             >
               Save Checks Selection
@@ -49,7 +49,9 @@ function HostChecksSelection({
               type="primary"
               className="mx-1"
               onClick={() => {}}
-              disabled={!canStartExecution(selectedChecks, isSavingSelection)}
+              disabled={
+                !canStartExecution(hostSelectedChecks, isSavingSelection)
+              }
             >
               <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub" />{' '}
               Start Execution
@@ -63,9 +65,9 @@ function HostChecksSelection({
         catalog={catalog}
         catalogError={catalogError}
         loading={catalogLoading}
-        selectedChecks={selection}
+        selectedChecks={selectedChecks}
         onUpdateCatalog={() => onUpdateCatalog()}
-        onChange={setSelection}
+        onChange={onSelectedChecksChange}
       />
     </div>
   );

--- a/assets/js/components/HostDetails/HostChecksSelection.test.jsx
+++ b/assets/js/components/HostDetails/HostChecksSelection.test.jsx
@@ -41,6 +41,7 @@ describe('HostChecksSelection component', () => {
         catalogError={null}
         catalogLoading={false}
         onUpdateCatalog={onUpdateCatalog}
+        hostSelectedChecks={selectedChecks}
       />
     );
 

--- a/assets/js/components/HostDetails/HostDetails.jsx
+++ b/assets/js/components/HostDetails/HostDetails.jsx
@@ -19,11 +19,10 @@ import WarningBanner from '@components/Banners/WarningBanner';
 import CleanUpButton from '@components/CleanUpButton';
 import DeregistrationModal from '@components/DeregistrationModal';
 import SuseLogo from '@static/suse_logo.svg';
-import {
-  getInstancesOnHost,
-  getClusterByHost,
-  getHost,
-} from '@state/selectors';
+import { getInstancesOnHost, getClusterByHost } from '@state/selectors';
+
+import { getHost } from '@state/selectors/host';
+
 import { deregisterHost } from '@state/hosts';
 import StatusPill from './StatusPill';
 import ProviderDetails from './ProviderDetails';

--- a/assets/js/components/HostDetails/HostSettingsPage.jsx
+++ b/assets/js/components/HostDetails/HostSettingsPage.jsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 
 import LoadingBox from '@components/LoadingBox';
+import { canStartExecution } from '@components/ChecksSelection';
 
 import { TARGET_HOST } from '@lib/model';
 
@@ -24,7 +25,7 @@ function HostSettingsPage() {
     if (host) {
       setSelection(hostSelectedChecks);
     }
-  }, [host]);
+  }, [hostSelectedChecks]);
 
   const {
     data: catalog,
@@ -33,6 +34,10 @@ function HostSettingsPage() {
   } = useSelector(getCatalog());
 
   const saving = useSelector(isSaving(TARGET_HOST, hostID));
+  const enableHostChecksExecution = !canStartExecution(
+    hostSelectedChecks,
+    saving
+  );
 
   if (!host) {
     return <LoadingBox text="Loading..." />;
@@ -55,6 +60,7 @@ function HostSettingsPage() {
         checks: newSelection,
       })
     );
+
   return (
     <HostChecksSelection
       hostID={hostID}
@@ -68,7 +74,7 @@ function HostSettingsPage() {
       isSavingSelection={saving}
       onSaveSelection={saveSelection}
       selectedChecks={selection}
-      hostSelectedChecks={hostSelectedChecks}
+      enableHostChecksExecution={enableHostChecksExecution}
       onSelectedChecksChange={setSelection}
     />
   );

--- a/assets/js/components/HostDetails/HostSettingsPage.jsx
+++ b/assets/js/components/HostDetails/HostSettingsPage.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 
@@ -9,9 +9,8 @@ import { TARGET_HOST } from '@lib/model';
 import { hostChecksSelected } from '@state/checksSelection';
 import { updateCatalog } from '@state/actions/catalog';
 import { getCatalog } from '@state/selectors/catalog';
-import { getHost } from '@state/selectors';
+import { getHost, getHostSelectedChecks } from '@state/selectors';
 import { isSaving } from '@state/selectors/checksSelection';
-
 import HostChecksSelection from './HostChecksSelection';
 
 function HostSettingsPage() {
@@ -19,6 +18,13 @@ function HostSettingsPage() {
 
   const { hostID } = useParams();
   const host = useSelector(getHost(hostID));
+  const hostSelectedChecks = useSelector(getHostSelectedChecks(hostID));
+  const [selection, setSelection] = useState([]);
+  useEffect(() => {
+    if (host) {
+      setSelection(hostSelectedChecks);
+    }
+  }, [host]);
 
   const {
     data: catalog,
@@ -31,13 +37,7 @@ function HostSettingsPage() {
   if (!host) {
     return <LoadingBox text="Loading..." />;
   }
-
-  const {
-    hostname: hostName,
-    provider,
-    agent_version: agentVersion,
-    selected_checks: selectedChecks,
-  } = host;
+  const { hostname: hostName, provider, agent_version: agentVersion } = host;
 
   const refreshCatalog = () =>
     dispatch(
@@ -55,20 +55,21 @@ function HostSettingsPage() {
         checks: newSelection,
       })
     );
-
   return (
     <HostChecksSelection
       hostID={hostID}
       hostName={hostName}
       provider={provider}
       agentVersion={agentVersion}
-      selectedChecks={selectedChecks}
       catalog={catalog}
       catalogError={catalogError}
       catalogLoading={catalogLoading}
       onUpdateCatalog={refreshCatalog}
       isSavingSelection={saving}
       onSaveSelection={saveSelection}
+      selectedChecks={selection}
+      hostSelectedChecks={hostSelectedChecks}
+      onSelectedChecksChange={setSelection}
     />
   );
 }

--- a/assets/js/components/HostDetails/HostSettingsPage.jsx
+++ b/assets/js/components/HostDetails/HostSettingsPage.jsx
@@ -9,7 +9,7 @@ import { TARGET_HOST } from '@lib/model';
 import { hostChecksSelected } from '@state/checksSelection';
 import { updateCatalog } from '@state/actions/catalog';
 import { getCatalog } from '@state/selectors/catalog';
-import { getHost, getHostSelectedChecks } from '@state/selectors';
+import { getHost, getHostSelectedChecks } from '@state/selectors/host';
 import { isSaving } from '@state/selectors/checksSelection';
 import HostChecksSelection from './HostChecksSelection';
 

--- a/assets/js/components/HostDetails/HostSettingsPage.jsx
+++ b/assets/js/components/HostDetails/HostSettingsPage.jsx
@@ -34,7 +34,7 @@ function HostSettingsPage() {
   } = useSelector(getCatalog());
 
   const saving = useSelector(isSaving(TARGET_HOST, hostID));
-  const enableHostChecksExecution = !canStartExecution(
+  const hostChecksExecutionEnabled = !canStartExecution(
     hostSelectedChecks,
     saving
   );
@@ -74,7 +74,7 @@ function HostSettingsPage() {
       isSavingSelection={saving}
       onSaveSelection={saveSelection}
       selectedChecks={selection}
-      enableHostChecksExecution={enableHostChecksExecution}
+      hostChecksExecutionEnabled={hostChecksExecutionEnabled}
       onSelectedChecksChange={setSelection}
     />
   );

--- a/assets/js/components/InstanceOverview/InstanceOverview.jsx
+++ b/assets/js/components/InstanceOverview/InstanceOverview.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { getHost } from '@state/selectors';
+import { getHost } from '@state/selectors/host';
 import { getCluster } from '@state/selectors/cluster';
 import HealthIcon from '@components/Health';
 import { Features } from '@components/SapSystemDetails';

--- a/assets/js/state/selectors/host.js
+++ b/assets/js/state/selectors/host.js
@@ -1,0 +1,11 @@
+import { get } from 'lodash';
+
+const defaultEmptyArray = [];
+
+export const getHost = (id) => (state) =>
+  state.hostsList.hosts.find((host) => host.id === id);
+
+export const getHostSelectedChecks = (hostID) => (state) => {
+  const host = getHost(hostID)(state);
+  return get(host, 'selected_checks', defaultEmptyArray);
+};

--- a/assets/js/state/selectors/host.test.js
+++ b/assets/js/state/selectors/host.test.js
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { hostFactory } from '@lib/test-utils/factories';
-import { getHostSelectedChecks } from './index';
+import { getHostSelectedChecks } from './host';
 
 describe('host selector', () => {
   it('should return selected checks for a host', () => {

--- a/assets/js/state/selectors/index.js
+++ b/assets/js/state/selectors/index.js
@@ -1,22 +1,12 @@
 import { keysToCamel } from '@lib/serialization';
 import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model';
 import { getCluster } from '@state/selectors/cluster';
-import { get } from 'lodash';
-
-const defaultEmptyArray = [];
+import { getHost } from '@state/selectors/host';
 
 export const isIdByKey =
   (key, id) =>
   ({ [key]: keyToLookup }) =>
     keyToLookup === id;
-
-export const getHost = (id) => (state) =>
-  state.hostsList.hosts.find((host) => host.id === id);
-
-export const getHostSelectedChecks = (hostID) => (state) => {
-  const host = getHost(hostID)(state);
-  return get(host, 'selected_checks', defaultEmptyArray);
-};
 
 const enrichInstances = (instances, sapSystemId, state) =>
   instances

--- a/assets/js/state/selectors/index.js
+++ b/assets/js/state/selectors/index.js
@@ -1,6 +1,9 @@
 import { keysToCamel } from '@lib/serialization';
 import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model';
 import { getCluster } from '@state/selectors/cluster';
+import { get } from 'lodash';
+
+const defaultEmptyArray = [];
 
 export const isIdByKey =
   (key, id) =>
@@ -9,6 +12,11 @@ export const isIdByKey =
 
 export const getHost = (id) => (state) =>
   state.hostsList.hosts.find((host) => host.id === id);
+
+export const getHostSelectedChecks = (hostID) => (state) => {
+  const host = getHost(hostID)(state);
+  return get(host, 'selected_checks', defaultEmptyArray);
+};
 
 const enrichInstances = (instances, sapSystemId, state) =>
   instances

--- a/assets/js/state/selectors/index.test.js
+++ b/assets/js/state/selectors/index.test.js
@@ -1,0 +1,35 @@
+import { faker } from '@faker-js/faker';
+import { hostFactory } from '@lib/test-utils/factories';
+import { getHostSelectedChecks } from './index';
+
+describe('host selector', () => {
+  it('should return selected checks for a host', () => {
+    const hostID1 = faker.datatype.uuid();
+    const hostID2 = faker.datatype.uuid();
+    const checkID1 = faker.datatype.uuid();
+    const checkID2 = faker.datatype.uuid();
+    const checks1 = [checkID1, checkID2];
+    const checks2 = [];
+
+    const host1 = hostFactory.build({
+      id: hostID1,
+      selected_checks: checks1,
+    });
+
+    const host2 = hostFactory.build({
+      id: hostID2,
+      selected_checks: checks2,
+    });
+
+    const state = {
+      hostsList: {
+        hosts: [host1, host2],
+      },
+    };
+
+    expect(getHostSelectedChecks(hostID1)(state)).not.toEqual(checks2);
+    expect(getHostSelectedChecks(hostID1)(state)).toEqual(checks1);
+    expect(getHostSelectedChecks(hostID2)(state)).not.toEqual(checks1);
+    expect(getHostSelectedChecks(hostID2)(state)).toEqual(checks2);
+  });
+});


### PR DESCRIPTION
# Description
This PR addresses an issue where the selected "checks" were not being updated correctly when saved in the host checks selection view. I've added a useEffect to ensure proper state updates, see demo.

Furthermore, I've refactored the code by moving the state to the container component HostSettingsPage. 
Also added a helper redux selector function to get all hosts from a check.

## DEMO before changes
![host_check_selection_broadcast_before](https://github.com/trento-project/web/assets/54111255/850a11a1-209c-484f-aaf9-ec3cf268279e)



## DEMO after changes
![host_check_selection_broadcast](https://github.com/trento-project/web/assets/54111255/5e5fa8c2-e784-4bb1-a0cf-a8512a3cb9ba)

## How was this tested?
Updated existing test
Added a test for new getHostSelectedChecks function 
