### PR TITLE
Allow additional classes to be specified on the clean up button

### DIFF
--- a/assets/js/components/Button/Button.jsx
+++ b/assets/js/components/Button/Button.jsx
@@ -5,6 +5,8 @@ const getSizeClasses = (size) => {
   switch (size) {
     case 'small':
       return 'py-1 px-2 text-sm';
+    case 'fit':
+      return 'text-sm';
     default:
       return 'py-2 px-4 text-base';
   }

--- a/assets/js/components/Button/Button.stories.jsx
+++ b/assets/js/components/Button/Button.stories.jsx
@@ -5,6 +5,17 @@ import Button from '.';
 export default {
   title: 'Button',
   component: Button,
+  argTypes: {
+    size: {
+      control: { type: 'radio' },
+      options: ['small', 'fit'],
+      description: 'Button size',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'small' },
+      },
+    },
+  },
 };
 
 export function Default() {
@@ -25,6 +36,10 @@ export function Transparent() {
 
 export function Small() {
   return <Button size="small">Hello world!</Button>;
+}
+
+export function Fit() {
+  return <Button size="fit">Hello world!</Button>;
 }
 
 export function SmallSecondary() {

--- a/assets/js/components/CleanUpButton/CleanUpButton.jsx
+++ b/assets/js/components/CleanUpButton/CleanUpButton.jsx
@@ -1,17 +1,21 @@
 import React from 'react';
 
 import { EOS_CLEANING_SERVICES } from 'eos-icons-react';
+import classNames from 'classnames';
 
 import Button from '@components/Button';
 import Spinner from '@components/Spinner';
 
-function CleanUpButton({ cleaning, onClick, className = '' }) {
-  const baseClasses = 'inline-block mx-0.5 border-green-500 border w-fit';
+function CleanUpButton({ cleaning, onClick, className }) {
+  const buttonClasses = classNames(
+    'inline-block mx-0.5 border-green-500 border w-fit',
+    className
+  );
 
   return (
     <Button
       type="primary-white"
-      className={`${baseClasses} ${className}`}
+      className={buttonClasses}
       size="small"
       disabled={cleaning}
       onClick={() => onClick()}

--- a/assets/js/components/CleanUpButton/CleanUpButton.jsx
+++ b/assets/js/components/CleanUpButton/CleanUpButton.jsx
@@ -5,11 +5,13 @@ import { EOS_CLEANING_SERVICES } from 'eos-icons-react';
 import Button from '@components/Button';
 import Spinner from '@components/Spinner';
 
-function CleanUpButton({ cleaning, onClick }) {
+function CleanUpButton({ cleaning, onClick, className = '' }) {
+  const baseClasses = 'inline-block mx-0.5 border-green-500 border w-fit';
+
   return (
     <Button
       type="primary-white"
-      className="inline-block mx-0.5 border-green-500 border w-fit"
+      className={`${baseClasses} ${className}`}
       size="small"
       disabled={cleaning}
       onClick={() => onClick()}

--- a/assets/js/components/CleanUpButton/CleanUpButton.jsx
+++ b/assets/js/components/CleanUpButton/CleanUpButton.jsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import Button from '@components/Button';
 import Spinner from '@components/Spinner';
 
-function CleanUpButton({ cleaning, onClick, className }) {
+function CleanUpButton({ className, size = 'small', cleaning, onClick }) {
   const buttonClasses = classNames(
     'inline-block mx-0.5 border-green-500 border w-fit',
     className
@@ -16,7 +16,7 @@ function CleanUpButton({ cleaning, onClick, className }) {
     <Button
       type="primary-white"
       className={buttonClasses}
-      size="small"
+      size={size}
       disabled={cleaning}
       onClick={() => onClick()}
     >

--- a/assets/js/components/CleanUpButton/CleanUpButton.stories.jsx
+++ b/assets/js/components/CleanUpButton/CleanUpButton.stories.jsx
@@ -13,6 +13,13 @@ export default {
       },
     },
     onClick: { action: 'Click button' },
+    className: {
+      control: 'text',
+      description: 'CSS classes',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
   },
 };
 
@@ -24,5 +31,12 @@ export const Cleaning = {
   args: {
     ...Default.args,
     cleaning: true,
+  },
+};
+
+export const NoOutline = {
+  args: {
+    ...Default.args,
+    className: 'border-none shadow-none',
   },
 };

--- a/assets/js/components/CleanUpButton/CleanUpButton.stories.jsx
+++ b/assets/js/components/CleanUpButton/CleanUpButton.stories.jsx
@@ -20,6 +20,15 @@ export default {
         type: { summary: 'string' },
       },
     },
+    size: {
+      control: { type: 'radio' },
+      options: ['small', 'fit'],
+      description: 'Button size',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'small' },
+      },
+    },
   },
 };
 
@@ -38,5 +47,6 @@ export const NoOutline = {
   args: {
     ...Default.args,
     className: 'border-none shadow-none',
+    size: 'fit',
   },
 };

--- a/assets/js/components/HostsList.jsx
+++ b/assets/js/components/HostsList.jsx
@@ -193,6 +193,7 @@ function HostsList() {
           content && (
             <CleanUpButton
               cleaning={item.deregistering}
+              className="border-none shadow-none"
               onClick={() => {
                 openDeregistrationModal(item);
               }}

--- a/assets/js/components/HostsList.jsx
+++ b/assets/js/components/HostsList.jsx
@@ -193,6 +193,7 @@ function HostsList() {
           content && (
             <CleanUpButton
               cleaning={item.deregistering}
+              size="fit"
               className="border-none shadow-none"
               onClick={() => {
                 openDeregistrationModal(item);


### PR DESCRIPTION
# Description
This PR:
 - Allows the CleanUpButton component to be provided with additional classes
 - Changes the HostList to remove the outlining of the Clean Up button by providing additional classes

This is also needed for the upcoming PR to include the Clean Up button in the sap system instances
![Captura desde 2023-08-23 10-12-57](https://github.com/trento-project/web/assets/2668401/e487294c-fdc4-49e5-a0b7-5ec4083b5434)
