### PR TITLE
Host checks execution api

### DIFF
--- a/lib/trento/application/event_handlers/stream_roll_up_event_handler.ex
+++ b/lib/trento/application/event_handlers/stream_roll_up_event_handler.ex
@@ -45,7 +45,8 @@ defmodule Trento.StreamRollUpEventHandler do
     Trento.Domain.Events.HostDetailsUpdated,
     Trento.Domain.Events.HostRegistered,
     Trento.Domain.Events.ProviderUpdated,
-    Trento.Domain.Events.SlesSubscriptionsUpdated
+    Trento.Domain.Events.SlesSubscriptionsUpdated,
+    Trento.Domain.Events.HostChecksSelected
   ]
 
   @sap_system_events [

--- a/lib/trento/application/integration/checks/host_executions_env.ex
+++ b/lib/trento/application/integration/checks/host_executions_env.ex
@@ -1,0 +1,14 @@
+defmodule Trento.Integration.Checks.HostExecutionEnv do
+  @moduledoc """
+  Host checks execution env map
+  """
+
+  @required_fields :all
+  use Trento.Type
+
+  require Trento.Domain.Enums.Provider, as: Provider
+
+  deftype do
+    field :provider, Ecto.Enum, values: Provider.values()
+  end
+end

--- a/lib/trento/application/integration/checks/target_type.ex
+++ b/lib/trento/application/integration/checks/target_type.ex
@@ -1,0 +1,15 @@
+defmodule Trento.Integration.Checks.TargetType do
+  @moduledoc """
+  Type that represents the possible target types for a check execution.
+  """
+
+  use Trento.Support.Enum, values: [:cluster, :host]
+
+  def from_string("cluster"), do: cluster()
+  def from_string("host"), do: host()
+  def from_string(_), do: nil
+
+  def to_string(cluster()), do: "cluster"
+  def to_string(host()), do: "host"
+  def to_string(_), do: nil
+end

--- a/lib/trento/application/usecases/clusters/clusters.ex
+++ b/lib/trento/application/usecases/clusters/clusters.ex
@@ -152,7 +152,8 @@ defmodule Trento.Clusters do
         cluster_type: cluster_type
       },
       hosts_data,
-      selected_checks
+      selected_checks,
+      :cluster
     )
   end
 

--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -74,6 +74,13 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"422", reason: "Requested operation not allowed for present SAP instances.")
   end
 
+  def call(conn, {:error, :no_checks_selected}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(ErrorView)
+    |> render(:"422", reason: "No checks were selected for the target.")
+  end
+
   def call(conn, {:error, [error | _]}), do: call(conn, {:error, error})
 
   def call(conn, {:error, _}) do

--- a/lib/trento_web/controllers/v1/cluster_controller.ex
+++ b/lib/trento_web/controllers/v1/cluster_controller.ex
@@ -37,7 +37,7 @@ defmodule TrentoWeb.V1.ClusterController do
       ]
     ],
     responses: [
-      accepted: "The Command has been accepted and the Requested execution is scheduled",
+      accepted: "The Command has been accepted and the Requested Cluster execution is scheduled",
       not_found: Schema.NotFound.response(),
       bad_request: Schema.BadRequest.response(),
       unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()

--- a/lib/trento_web/controllers/v1/host_controller.ex
+++ b/lib/trento_web/controllers/v1/host_controller.ex
@@ -109,4 +109,29 @@ defmodule TrentoWeb.V1.HostController do
       |> json(%{})
     end
   end
+
+  operation :request_checks_execution,
+    summary: "Request Checks Execution for a Host",
+    tags: ["Checks"],
+    description: "Trigger execution of the latest Checks Selection on the target infrastructure",
+    parameters: [
+      id: [
+        in: :path,
+        required: true,
+        type: %OpenApiSpex.Schema{type: :string, format: :uuid}
+      ]
+    ],
+    responses: [
+      accepted: "The Command has been accepted and the Requested Host execution is scheduled",
+      not_found: Schema.NotFound.response(),
+      unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
+    ]
+
+  def request_checks_execution(conn, %{id: host_id}) do
+    with :ok <- Hosts.request_checks_execution(host_id) do
+      conn
+      |> put_status(:accepted)
+      |> json(%{})
+    end
+  end
 end

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -97,6 +97,10 @@ defmodule TrentoWeb.Router do
            ClusterController,
            :request_checks_execution
 
+      post "/hosts/:id/checks/request_execution",
+           HostController,
+           :request_checks_execution
+
       post "/hosts/:id/tags", TagsController, :add_tag,
         assigns: %{resource_type: :host},
         as: :hosts_tagging

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -112,7 +112,8 @@ defmodule Trento.Factory do
       heartbeat: :unknown,
       provider: Enum.random(Provider.values()),
       provider_data: nil,
-      deregistered_at: nil
+      deregistered_at: nil,
+      selected_checks: Enum.map(0..4, fn _ -> Faker.StarWars.planet() end)
     }
   end
 

--- a/test/trento/application/integration/checks/checks_test.exs
+++ b/test/trento/application/integration/checks/checks_test.exs
@@ -5,6 +5,7 @@ defmodule Trento.Integration.ChecksTest do
 
   import Mox
 
+  alias Trento.Domain.Commands.CompleteChecksExecution
   alias Trento.Integration.Checks
 
   alias Trento.Checks.V1.{
@@ -12,46 +13,155 @@ defmodule Trento.Integration.ChecksTest do
     Target
   }
 
-  test "should publish an ExecutionRequested event with cluster env" do
-    execution_id = UUID.uuid4()
-    group_id = UUID.uuid4()
+  require Trento.Domain.Enums.Health, as: Health
 
-    env = %Checks.ClusterExecutionEnv{
-      cluster_type: :hana_scale_up,
-      provider: :azure
-    }
+  describe "Cluster Checks Execution" do
+    test "should publish an ExecutionRequested event for a cluster" do
+      execution_id = UUID.uuid4()
+      group_id = UUID.uuid4()
 
-    selected_checks = ["check_1", "check_2"]
+      env = %Checks.ClusterExecutionEnv{
+        cluster_type: :hana_scale_up,
+        provider: :azure
+      }
 
-    hosts = [
-      %{host_id: "agent_1"},
-      %{host_id: "agent_2"}
-    ]
+      selected_checks = ["check_1", "check_2"]
 
-    expect(Trento.Infrastructure.Messaging.Adapter.Mock, :publish, fn "executions", event ->
-      assert %ExecutionRequested{
-               execution_id: ^execution_id,
-               group_id: ^group_id,
-               targets: [
-                 %Target{agent_id: "agent_1", checks: ^selected_checks},
-                 %Target{agent_id: "agent_2", checks: ^selected_checks}
-               ],
-               env: %{
-                 "cluster_type" => %{kind: {:string_value, "hana_scale_up"}},
-                 "provider" => %{kind: {:string_value, "azure"}}
-               }
-             } = event
+      hosts = [
+        %{host_id: "agent_1"},
+        %{host_id: "agent_2"}
+      ]
 
-      :ok
-    end)
+      expect(Trento.Infrastructure.Messaging.Adapter.Mock, :publish, fn "executions", event ->
+        assert %ExecutionRequested{
+                 execution_id: ^execution_id,
+                 group_id: ^group_id,
+                 targets: [
+                   %Target{agent_id: "agent_1", checks: ^selected_checks},
+                   %Target{agent_id: "agent_2", checks: ^selected_checks}
+                 ],
+                 env: %{
+                   "cluster_type" => %{kind: {:string_value, "hana_scale_up"}},
+                   "provider" => %{kind: {:string_value, "azure"}}
+                 },
+                 target_type: "cluster"
+               } = event
 
-    assert :ok =
-             Checks.request_execution(
-               execution_id,
-               group_id,
-               env,
-               hosts,
-               selected_checks
-             )
+        :ok
+      end)
+
+      assert :ok =
+               Checks.request_execution(
+                 execution_id,
+                 group_id,
+                 env,
+                 hosts,
+                 selected_checks,
+                 :cluster
+               )
+    end
+
+    test "should complete a cluster checks execution" do
+      execution_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+
+      expect(Trento.Commanded.Mock, :dispatch, fn command, _ ->
+        assert %CompleteChecksExecution{
+                 cluster_id: ^group_id,
+                 health: Health.passing()
+               } = command
+
+        :ok
+      end)
+
+      assert :ok =
+               Checks.complete_execution(
+                 execution_id,
+                 group_id,
+                 :passing,
+                 :cluster
+               )
+    end
+  end
+
+  describe "Host Checks Execution" do
+    test "should publish an ExecutionRequested event for a host" do
+      execution_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+
+      env = %Checks.HostExecutionEnv{
+        provider: :azure
+      }
+
+      selected_checks = ["check_1", "check_2"]
+
+      expect(Trento.Infrastructure.Messaging.Adapter.Mock, :publish, fn "executions", event ->
+        assert %ExecutionRequested{
+                 execution_id: ^execution_id,
+                 group_id: ^group_id,
+                 targets: [
+                   %Target{agent_id: ^group_id, checks: ^selected_checks}
+                 ],
+                 env: %{
+                   "provider" => %{kind: {:string_value, "azure"}}
+                 },
+                 target_type: "host"
+               } = event
+
+        :ok
+      end)
+
+      assert :ok =
+               Checks.request_execution(
+                 execution_id,
+                 group_id,
+                 env,
+                 [%{host_id: group_id}],
+                 selected_checks,
+                 :host
+               )
+    end
+
+    test "should complete a host checks execution" do
+      execution_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+
+      expect(Trento.Commanded.Mock, :dispatch, 0, fn _command, _opts ->
+        # TODO: assert that the proper command related to host check execution is dispatched
+        nil
+      end)
+
+      assert :ok =
+               Checks.complete_execution(
+                 execution_id,
+                 group_id,
+                 :passing,
+                 :host
+               )
+    end
+  end
+
+  describe "Unsupported targets" do
+    test "should return an error when trying to start execution for an unsupported target type" do
+      assert {:error, :target_not_supported} =
+               Checks.request_execution(
+                 Faker.UUID.v4(),
+                 Faker.UUID.v4(),
+                 %{some: "env"},
+                 [%{host_id: Faker.UUID.v4()}],
+                 [Faker.Lorem.word()],
+                 :other_target_type
+               )
+    end
+
+    test "should return an error when trying to complete execution for an unsupported target type" do
+      assert {:error, :target_not_supported} =
+               Checks.complete_execution(
+                 Faker.UUID.v4(),
+                 Faker.UUID.v4(),
+                 :passing,
+                 :other_target_type
+               )
+    end
   end
 end

--- a/test/trento/application/usecases/clusters_test.exs
+++ b/test/trento/application/usecases/clusters_test.exs
@@ -29,6 +29,8 @@ defmodule Trento.ClustersTest do
                  "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}}
                }
 
+        assert message.target_type == "cluster"
+
         :ok
       end)
 


### PR DESCRIPTION
# Description

Disclaimer: don't be scared, mainly tests

This PR exposes a new endpoint to request checks execution for a host.
- an execution can be started only for registered hosts
- an execution can be started only for non empty selections (cluster endpoint needs to be fixed about this)
- target type is provided to the ExecutionRequested message
- target type is handled on ExecutionStarted and ExecutionCompleted
- unsupported target types are handled


## How was this tested?

Automated tests ajdusted/added plus manual test in integration with wanda.