### PR TITLE
Instance deregistration sagas

### DIFF
--- a/assets/js/state/databases.js
+++ b/assets/js/state/databases.js
@@ -98,7 +98,7 @@ export const databasesListSlice = createSlice({
         }
       );
     },
-    setDatabaseInstanceNotDeregistering: (state, { payload: instance }) => {
+    unsetDatabaseInstanceDeregistering: (state, { payload: instance }) => {
       state.databaseInstances = updateInstance(
         state.databaseInstances,
         instance,
@@ -140,7 +140,7 @@ export const {
   addTagToDatabase,
   removeTagFromDatabase,
   setDatabaseInstanceDeregistering,
-  setDatabaseInstanceNotDeregistering,
+  unsetDatabaseInstanceDeregistering,
 } = databasesListSlice.actions;
 
 export default databasesListSlice.reducer;

--- a/assets/js/state/databases.js
+++ b/assets/js/state/databases.js
@@ -1,4 +1,4 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createAction, createSlice } from '@reduxjs/toolkit';
 import { instancesMatch, upsertInstances, updateInstance } from './instances';
 
 const initialState = {
@@ -89,6 +89,24 @@ export const databasesListSlice = createSlice({
         }
       );
     },
+    setDatabaseInstanceDeregistering: (state, { payload: instance }) => {
+      state.databaseInstances = updateInstance(
+        state.databaseInstances,
+        instance,
+        {
+          deregistering: true,
+        }
+      );
+    },
+    setDatabaseInstanceNotDeregistering: (state, { payload: instance }) => {
+      state.databaseInstances = updateInstance(
+        state.databaseInstances,
+        instance,
+        {
+          deregistering: false,
+        }
+      );
+    },
   },
 });
 
@@ -102,6 +120,11 @@ export const DATABASE_INSTANCE_HEALTH_CHANGED =
   'DATABASE_INSTANCE_HEALTH_CHANGED';
 export const DATABASE_INSTANCE_SYSTEM_REPLICATION_CHANGED =
   'DATABASE_INSTANCE_SYSTEM_REPLICATION_CHANGED';
+export const DEREGISTER_DATABASE_INSTANCE = 'DEREGISTER_DATABASE_INSTANCE';
+
+export const deregisterDatabaseInstance = createAction(
+  DEREGISTER_DATABASE_INSTANCE
+);
 
 export const {
   startDatabasesLoading,
@@ -116,6 +139,8 @@ export const {
   updateDatabaseInstanceSystemReplication,
   addTagToDatabase,
   removeTagFromDatabase,
+  setDatabaseInstanceDeregistering,
+  setDatabaseInstanceNotDeregistering,
 } = databasesListSlice.actions;
 
 export default databasesListSlice.reducer;

--- a/assets/js/state/databases.test.js
+++ b/assets/js/state/databases.test.js
@@ -4,6 +4,8 @@ import databaseReducer, {
   upsertDatabaseInstances,
   updateDatabaseInstanceHealth,
   updateDatabaseInstanceSystemReplication,
+  setDatabaseInstanceDeregistering,
+  setDatabaseInstanceNotDeregistering,
 } from '@state/databases';
 import {
   databaseFactory,
@@ -120,6 +122,48 @@ describe('Databases reducer', () => {
           ...instance,
           system_replication: newSystemReplication,
           system_replication_status: newStatus,
+        },
+      ],
+    };
+
+    expect(databaseReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should set database instance in deregistering state', () => {
+    const instance = databaseInstanceFactory.build();
+
+    const initialState = {
+      databaseInstances: [instance],
+    };
+
+    const action = setDatabaseInstanceDeregistering(instance);
+
+    const expectedState = {
+      databaseInstances: [
+        {
+          ...instance,
+          deregistering: true,
+        },
+      ],
+    };
+
+    expect(databaseReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should remove deregistering state from database instance', () => {
+    const instance = databaseInstanceFactory.build();
+
+    const initialState = {
+      databaseInstances: [instance],
+    };
+
+    const action = setDatabaseInstanceNotDeregistering(instance);
+
+    const expectedState = {
+      databaseInstances: [
+        {
+          ...instance,
+          deregistering: false,
         },
       ],
     };

--- a/assets/js/state/databases.test.js
+++ b/assets/js/state/databases.test.js
@@ -5,7 +5,7 @@ import databaseReducer, {
   updateDatabaseInstanceHealth,
   updateDatabaseInstanceSystemReplication,
   setDatabaseInstanceDeregistering,
-  setDatabaseInstanceNotDeregistering,
+  unsetDatabaseInstanceDeregistering,
 } from '@state/databases';
 import {
   databaseFactory,
@@ -157,7 +157,7 @@ describe('Databases reducer', () => {
       databaseInstances: [instance],
     };
 
-    const action = setDatabaseInstanceNotDeregistering(instance);
+    const action = unsetDatabaseInstanceDeregistering(instance);
 
     const expectedState = {
       databaseInstances: [

--- a/assets/js/state/hosts.js
+++ b/assets/js/state/hosts.js
@@ -95,7 +95,7 @@ export const hostsListSlice = createSlice({
         return host;
       });
     },
-    setHostNotDeregistering: (state, action) => {
+    unsetHostDeregistering: (state, action) => {
       state.hosts = state.hosts.map((host) => {
         if (host.id === action.payload.id) {
           return { ...host, deregistering: false };
@@ -142,7 +142,7 @@ export const {
   setHostListDeregisterable,
   setHostNotDeregisterable,
   setHostDeregistering,
-  setHostNotDeregistering,
+  unsetHostDeregistering,
   startHostsLoading,
   stopHostsLoading,
   removeHost,

--- a/assets/js/state/hosts.test.js
+++ b/assets/js/state/hosts.test.js
@@ -4,7 +4,7 @@ import hostsReducer, {
   setHostListDeregisterable,
   setHostNotDeregisterable,
   setHostDeregistering,
-  setHostNotDeregistering,
+  unsetHostDeregistering,
   updateSelectedChecks,
 } from '@state/hosts';
 import { hostFactory } from '@lib/test-utils/factories';
@@ -62,7 +62,7 @@ describe('Hosts reducer', () => {
       hosts: [host1, host2],
     };
 
-    const action = setHostNotDeregistering(host1);
+    const action = unsetHostDeregistering(host1);
 
     const expectedState = {
       hosts: [{ ...host1, deregistering: false }, host2],

--- a/assets/js/state/sagas/databases.js
+++ b/assets/js/state/sagas/databases.js
@@ -19,7 +19,7 @@ import {
   removeDatabase,
   removeDatabaseInstance,
   setDatabaseInstanceDeregistering,
-  setDatabaseInstanceNotDeregistering,
+  unsetDatabaseInstanceDeregistering,
 } from '@state/databases';
 
 import {
@@ -28,7 +28,7 @@ import {
   updateSAPSystemDatabaseInstanceHealth,
   updateSAPSystemDatabaseInstanceSystemReplication,
   setDatabaseInstanceDeregisteringToSAPSystem,
-  setDatabaseInstanceNotDeregisteringToSAPSystem,
+  unsetDatabaseInstanceDeregisteringToSAPSystem,
 } from '@state/sapSystems';
 
 import { getDatabase } from '@state/selectors/sapSystem';
@@ -130,8 +130,8 @@ export function* deregisterDatabaseInstance({
       })
     );
   } finally {
-    yield put(setDatabaseInstanceNotDeregistering(payload));
-    yield put(setDatabaseInstanceNotDeregisteringToSAPSystem(payload));
+    yield put(unsetDatabaseInstanceDeregistering(payload));
+    yield put(unsetDatabaseInstanceDeregisteringToSAPSystem(payload));
   }
 }
 

--- a/assets/js/state/sagas/databases.test.js
+++ b/assets/js/state/sagas/databases.test.js
@@ -125,7 +125,7 @@ describe('SAP Systems sagas', () => {
     ]);
   });
 
-  it('should notify error on database instance deregistration request', async () => {
+  it('should notify an error on database instance deregistration request failure', async () => {
     const instance = databaseInstanceFactory.build();
     const { sid, sap_system_id, host_id, instance_number } = instance;
 

--- a/assets/js/state/sagas/databases.test.js
+++ b/assets/js/state/sagas/databases.test.js
@@ -13,13 +13,13 @@ import {
   removeDatabaseInstance,
   appendDatabase,
   setDatabaseInstanceDeregistering,
-  setDatabaseInstanceNotDeregistering,
+  unsetDatabaseInstanceDeregistering,
 } from '@state/databases';
 import {
   removeDatabaseInstanceFromSapSystem,
   upsertDatabaseInstancesToSapSystem,
   setDatabaseInstanceDeregisteringToSAPSystem,
-  setDatabaseInstanceNotDeregisteringToSAPSystem,
+  unsetDatabaseInstanceDeregisteringToSAPSystem,
 } from '@state/sapSystems';
 import {
   databaseFactory,
@@ -120,8 +120,8 @@ describe('SAP Systems sagas', () => {
     expect(dispatched).toEqual([
       setDatabaseInstanceDeregistering(instance),
       setDatabaseInstanceDeregisteringToSAPSystem(instance),
-      setDatabaseInstanceNotDeregistering(instance),
-      setDatabaseInstanceNotDeregisteringToSAPSystem(instance),
+      unsetDatabaseInstanceDeregistering(instance),
+      unsetDatabaseInstanceDeregisteringToSAPSystem(instance),
     ]);
   });
 
@@ -146,8 +146,8 @@ describe('SAP Systems sagas', () => {
         text: `Error deregistering instance ${instance_number} from ${sid}.`,
         icon: '❌',
       }),
-      setDatabaseInstanceNotDeregistering(instance),
-      setDatabaseInstanceNotDeregisteringToSAPSystem(instance),
+      unsetDatabaseInstanceDeregistering(instance),
+      unsetDatabaseInstanceDeregisteringToSAPSystem(instance),
     ]);
   });
 });

--- a/assets/js/state/sagas/hosts.js
+++ b/assets/js/state/sagas/hosts.js
@@ -10,7 +10,7 @@ import {
   removeHost,
   setHostListDeregisterable,
   setHostDeregistering,
-  setHostNotDeregistering,
+  unsetHostDeregistering,
   appendHost,
 } from '@state/hosts';
 
@@ -67,7 +67,7 @@ export function* deregisterHost({
       })
     );
   } finally {
-    yield put(setHostNotDeregistering(payload));
+    yield put(unsetHostDeregistering(payload));
   }
 }
 

--- a/assets/js/state/sagas/hosts.test.js
+++ b/assets/js/state/sagas/hosts.test.js
@@ -15,7 +15,7 @@ import {
   setHostListDeregisterable,
   removeHost,
   setHostDeregistering,
-  setHostNotDeregistering,
+  unsetHostDeregistering,
   appendHost,
 } from '@state/hosts';
 
@@ -93,7 +93,7 @@ describe('Hosts sagas', () => {
 
     expect(dispatched).toEqual([
       setHostDeregistering(payload),
-      setHostNotDeregistering(payload),
+      unsetHostDeregistering(payload),
     ]);
   });
 
@@ -111,7 +111,7 @@ describe('Hosts sagas', () => {
         text: `Error deregistering host ${hostname}.`,
         icon: '❌',
       }),
-      setHostNotDeregistering(payload),
+      unsetHostDeregistering(payload),
     ]);
   });
 

--- a/assets/js/state/sagas/sapSystems.js
+++ b/assets/js/state/sagas/sapSystems.js
@@ -22,7 +22,7 @@ import {
   removeSAPSystem,
   updateSAPSystem,
   setApplicationInstanceDeregistering,
-  setApplicationInstanceNotDeregistering,
+  unsetApplicationInstanceDeregistering,
 } from '@state/sapSystems';
 import { getSapSystem } from '@state/selectors/sapSystem';
 import { notify } from '@state/actions/notifications';
@@ -130,7 +130,7 @@ export function* deregisterApplicationInstance({
       })
     );
   } finally {
-    yield put(setApplicationInstanceNotDeregistering(payload));
+    yield put(unsetApplicationInstanceDeregistering(payload));
   }
 }
 

--- a/assets/js/state/sagas/sapSystems.js
+++ b/assets/js/state/sagas/sapSystems.js
@@ -1,4 +1,6 @@
-import { put, select, takeEvery } from 'redux-saga/effects';
+import { call, put, select, takeEvery } from 'redux-saga/effects';
+import { del } from '@lib/network';
+
 import {
   SAP_SYSTEM_REGISTERED,
   SAP_SYSTEM_HEALTH_CHANGED,
@@ -9,6 +11,7 @@ import {
   SAP_SYSTEM_DEREGISTERED,
   SAP_SYSTEM_RESTORED,
   SAP_SYSTEM_UPDATED,
+  DEREGISTER_APPLICATION_INSTANCE,
   appendSapsystem,
   updateSapSystemHealth,
   upsertDatabaseInstancesToSapSystem,
@@ -18,6 +21,8 @@ import {
   updateApplicationInstanceHealth,
   removeSAPSystem,
   updateSAPSystem,
+  setApplicationInstanceDeregistering,
+  setApplicationInstanceNotDeregistering,
 } from '@state/sapSystems';
 import { getSapSystem } from '@state/selectors/sapSystem';
 import { notify } from '@state/actions/notifications';
@@ -107,6 +112,28 @@ export function* sapSystemUpdated({ payload }) {
   yield put(updateSAPSystem(payload));
 }
 
+export function* deregisterApplicationInstance({
+  payload,
+  payload: { sid, sap_system_id, host_id, instance_number },
+}) {
+  yield put(setApplicationInstanceDeregistering(payload));
+  try {
+    yield call(
+      del,
+      `/sap_systems/${sap_system_id}/hosts/${host_id}/instances/${instance_number}`
+    );
+  } catch (error) {
+    yield put(
+      notify({
+        text: `Error deregistering instance ${instance_number} from ${sid}.`,
+        icon: '❌',
+      })
+    );
+  } finally {
+    yield put(setApplicationInstanceNotDeregistering(payload));
+  }
+}
+
 export function* watchSapSystem() {
   yield takeEvery(SAP_SYSTEM_REGISTERED, sapSystemRegistered);
   yield takeEvery(SAP_SYSTEM_HEALTH_CHANGED, sapSystemHealthChanged);
@@ -126,4 +153,8 @@ export function* watchSapSystem() {
   yield takeEvery(SAP_SYSTEM_DEREGISTERED, sapSystemDeregistered);
   yield takeEvery(SAP_SYSTEM_RESTORED, sapSystemRestored);
   yield takeEvery(SAP_SYSTEM_UPDATED, sapSystemUpdated);
+  yield takeEvery(
+    DEREGISTER_APPLICATION_INSTANCE,
+    deregisterApplicationInstance
+  );
 }

--- a/assets/js/state/sagas/sapSystems.test.js
+++ b/assets/js/state/sagas/sapSystems.test.js
@@ -1,3 +1,5 @@
+import MockAdapter from 'axios-mock-adapter';
+
 import { recordSaga } from '@lib/test-utils';
 import {
   applicationInstanceMoved,
@@ -5,6 +7,7 @@ import {
   sapSystemDeregistered,
   sapSystemRestored,
   sapSystemUpdated,
+  deregisterApplicationInstance,
 } from '@state/sagas/sapSystems';
 import {
   appendSapsystem,
@@ -14,7 +17,10 @@ import {
   upsertApplicationInstances,
   removeApplicationInstance,
   updateSAPSystem,
+  setApplicationInstanceDeregistering,
+  setApplicationInstanceNotDeregistering,
 } from '@state/sapSystems';
+import { networkClient } from '@lib/network';
 import { notify } from '@state/actions/notifications';
 import {
   sapSystemFactory,
@@ -22,7 +28,19 @@ import {
 } from '@lib/test-utils/factories';
 import { faker } from '@faker-js/faker';
 
+const axiosMock = new MockAdapter(networkClient);
+
 describe('SAP Systems sagas', () => {
+  beforeEach(() => {
+    axiosMock.reset();
+    jest.spyOn(console, 'error').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    /* eslint-disable-next-line */
+    console.error.mockRestore();
+  });
+
   it('should remove the SAP system', async () => {
     const { id, sid } = sapSystemFactory.build();
 
@@ -91,5 +109,49 @@ describe('SAP Systems sagas', () => {
     });
 
     expect(dispatched).toContainEqual(updateSAPSystem({ id, ensa_version }));
+  });
+
+  it('should deregister the application instance', async () => {
+    const instance = sapSystemApplicationInstanceFactory.build();
+    const { sap_system_id, host_id, instance_number } = instance;
+
+    axiosMock
+      .onDelete(
+        `/sap_systems/${sap_system_id}/hosts/${host_id}/instances/${instance_number}`
+      )
+      .reply(204, {});
+
+    const dispatched = await recordSaga(deregisterApplicationInstance, {
+      payload: instance,
+    });
+
+    expect(dispatched).toEqual([
+      setApplicationInstanceDeregistering(instance),
+      setApplicationInstanceNotDeregistering(instance),
+    ]);
+  });
+
+  it('should notify error on application instance deregistration request', async () => {
+    const instance = sapSystemApplicationInstanceFactory.build();
+    const { sid, sap_system_id, host_id, instance_number } = instance;
+
+    axiosMock
+      .onDelete(
+        `/sap_systems/${sap_system_id}/hosts/${host_id}/instances/${instance_number}`
+      )
+      .reply(404, {});
+
+    const dispatched = await recordSaga(deregisterApplicationInstance, {
+      payload: instance,
+    });
+
+    expect(dispatched).toEqual([
+      setApplicationInstanceDeregistering(instance),
+      notify({
+        text: `Error deregistering instance ${instance_number} from ${sid}.`,
+        icon: '❌',
+      }),
+      setApplicationInstanceNotDeregistering(instance),
+    ]);
   });
 });

--- a/assets/js/state/sagas/sapSystems.test.js
+++ b/assets/js/state/sagas/sapSystems.test.js
@@ -131,7 +131,7 @@ describe('SAP Systems sagas', () => {
     ]);
   });
 
-  it('should notify error on application instance deregistration request', async () => {
+  it('should notify an error on application instance deregistration request failure', async () => {
     const instance = sapSystemApplicationInstanceFactory.build();
     const { sid, sap_system_id, host_id, instance_number } = instance;
 

--- a/assets/js/state/sagas/sapSystems.test.js
+++ b/assets/js/state/sagas/sapSystems.test.js
@@ -18,7 +18,7 @@ import {
   removeApplicationInstance,
   updateSAPSystem,
   setApplicationInstanceDeregistering,
-  setApplicationInstanceNotDeregistering,
+  unsetApplicationInstanceDeregistering,
 } from '@state/sapSystems';
 import { networkClient } from '@lib/network';
 import { notify } from '@state/actions/notifications';
@@ -127,7 +127,7 @@ describe('SAP Systems sagas', () => {
 
     expect(dispatched).toEqual([
       setApplicationInstanceDeregistering(instance),
-      setApplicationInstanceNotDeregistering(instance),
+      unsetApplicationInstanceDeregistering(instance),
     ]);
   });
 
@@ -151,7 +151,7 @@ describe('SAP Systems sagas', () => {
         text: `Error deregistering instance ${instance_number} from ${sid}.`,
         icon: '❌',
       }),
-      setApplicationInstanceNotDeregistering(instance),
+      unsetApplicationInstanceDeregistering(instance),
     ]);
   });
 });

--- a/assets/js/state/sapSystems.js
+++ b/assets/js/state/sapSystems.js
@@ -1,4 +1,4 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createAction, createSlice } from '@reduxjs/toolkit';
 import { instancesMatch, upsertInstances, updateInstance } from './instances';
 
 const initialState = {
@@ -149,6 +149,40 @@ export const sapSystemsListSlice = createSlice({
         }
       );
     },
+    setApplicationInstanceDeregistering: (state, { payload: instance }) => {
+      state.applicationInstances = updateInstance(
+        state.applicationInstances,
+        instance,
+        { deregistering: true }
+      );
+    },
+    setApplicationInstanceNotDeregistering: (state, { payload: instance }) => {
+      state.applicationInstances = updateInstance(
+        state.applicationInstances,
+        instance,
+        { deregistering: false }
+      );
+    },
+    setDatabaseInstanceDeregisteringToSAPSystem: (
+      state,
+      { payload: instance }
+    ) => {
+      state.databaseInstances = updateInstance(
+        state.databaseInstances,
+        instance,
+        { deregistering: true }
+      );
+    },
+    setDatabaseInstanceNotDeregisteringToSAPSystem: (
+      state,
+      { payload: instance }
+    ) => {
+      state.databaseInstances = updateInstance(
+        state.databaseInstances,
+        instance,
+        { deregistering: false }
+      );
+    },
   },
 });
 
@@ -164,6 +198,12 @@ export const APPLICATION_INSTANCE_HEALTH_CHANGED =
 export const SAP_SYSTEM_DEREGISTERED = 'SAP_SYSTEM_DEREGISTERED';
 export const SAP_SYSTEM_RESTORED = 'SAP_SYSTEM_RESTORED';
 export const SAP_SYSTEM_UPDATED = 'SAP_SYSTEM_UPDATED';
+export const DEREGISTER_APPLICATION_INSTANCE =
+  'DEREGISTER_APPLICATION_INSTANCE';
+
+export const deregisterApplicationInstance = createAction(
+  DEREGISTER_APPLICATION_INSTANCE
+);
 
 export const {
   startSapSystemsLoading,
@@ -183,6 +223,10 @@ export const {
   removeTagFromSAPSystem,
   removeSAPSystem,
   updateSAPSystem,
+  setApplicationInstanceDeregistering,
+  setApplicationInstanceNotDeregistering,
+  setDatabaseInstanceDeregisteringToSAPSystem,
+  setDatabaseInstanceNotDeregisteringToSAPSystem,
 } = sapSystemsListSlice.actions;
 
 export default sapSystemsListSlice.reducer;

--- a/assets/js/state/sapSystems.js
+++ b/assets/js/state/sapSystems.js
@@ -156,7 +156,7 @@ export const sapSystemsListSlice = createSlice({
         { deregistering: true }
       );
     },
-    setApplicationInstanceNotDeregistering: (state, { payload: instance }) => {
+    unsetApplicationInstanceDeregistering: (state, { payload: instance }) => {
       state.applicationInstances = updateInstance(
         state.applicationInstances,
         instance,
@@ -173,7 +173,7 @@ export const sapSystemsListSlice = createSlice({
         { deregistering: true }
       );
     },
-    setDatabaseInstanceNotDeregisteringToSAPSystem: (
+    unsetDatabaseInstanceDeregisteringToSAPSystem: (
       state,
       { payload: instance }
     ) => {
@@ -224,9 +224,9 @@ export const {
   removeSAPSystem,
   updateSAPSystem,
   setApplicationInstanceDeregistering,
-  setApplicationInstanceNotDeregistering,
+  unsetApplicationInstanceDeregistering,
   setDatabaseInstanceDeregisteringToSAPSystem,
-  setDatabaseInstanceNotDeregisteringToSAPSystem,
+  unsetDatabaseInstanceDeregisteringToSAPSystem,
 } = sapSystemsListSlice.actions;
 
 export default sapSystemsListSlice.reducer;

--- a/assets/js/state/sapSystems.test.js
+++ b/assets/js/state/sapSystems.test.js
@@ -9,6 +9,10 @@ import sapSystemsReducer, {
   removeApplicationInstance,
   removeDatabaseInstanceFromSapSystem,
   updateSAPSystem,
+  setApplicationInstanceDeregistering,
+  setApplicationInstanceNotDeregistering,
+  setDatabaseInstanceDeregisteringToSAPSystem,
+  setDatabaseInstanceNotDeregisteringToSAPSystem,
 } from '@state/sapSystems';
 import {
   sapSystemFactory,
@@ -254,6 +258,90 @@ describe('SAP Systems reducer', () => {
 
     const expectedState = {
       applicationInstances: [initialInstances[1], ...newInstances],
+    };
+
+    expect(sapSystemsReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should set application instance in deregistering state', () => {
+    const instance = sapSystemApplicationInstanceFactory.build();
+
+    const initialState = {
+      applicationInstances: [instance],
+    };
+
+    const action = setApplicationInstanceDeregistering(instance);
+
+    const expectedState = {
+      applicationInstances: [
+        {
+          ...instance,
+          deregistering: true,
+        },
+      ],
+    };
+
+    expect(sapSystemsReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should remove deregistering state from application instance', () => {
+    const instance = sapSystemApplicationInstanceFactory.build();
+
+    const initialState = {
+      applicationInstances: [instance],
+    };
+
+    const action = setApplicationInstanceNotDeregistering(instance);
+
+    const expectedState = {
+      applicationInstances: [
+        {
+          ...instance,
+          deregistering: false,
+        },
+      ],
+    };
+
+    expect(sapSystemsReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should set database instance in deregistering state', () => {
+    const instance = databaseInstanceFactory.build();
+
+    const initialState = {
+      databaseInstances: [instance],
+    };
+
+    const action = setDatabaseInstanceDeregisteringToSAPSystem(instance);
+
+    const expectedState = {
+      databaseInstances: [
+        {
+          ...instance,
+          deregistering: true,
+        },
+      ],
+    };
+
+    expect(sapSystemsReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should remove deregistering state from database instance', () => {
+    const instance = databaseInstanceFactory.build();
+
+    const initialState = {
+      databaseInstances: [instance],
+    };
+
+    const action = setDatabaseInstanceNotDeregisteringToSAPSystem(instance);
+
+    const expectedState = {
+      databaseInstances: [
+        {
+          ...instance,
+          deregistering: false,
+        },
+      ],
     };
 
     expect(sapSystemsReducer(initialState, action)).toEqual(expectedState);

--- a/assets/js/state/sapSystems.test.js
+++ b/assets/js/state/sapSystems.test.js
@@ -10,9 +10,9 @@ import sapSystemsReducer, {
   removeDatabaseInstanceFromSapSystem,
   updateSAPSystem,
   setApplicationInstanceDeregistering,
-  setApplicationInstanceNotDeregistering,
+  unsetApplicationInstanceDeregistering,
   setDatabaseInstanceDeregisteringToSAPSystem,
-  setDatabaseInstanceNotDeregisteringToSAPSystem,
+  unsetDatabaseInstanceDeregisteringToSAPSystem,
 } from '@state/sapSystems';
 import {
   sapSystemFactory,
@@ -291,7 +291,7 @@ describe('SAP Systems reducer', () => {
       applicationInstances: [instance],
     };
 
-    const action = setApplicationInstanceNotDeregistering(instance);
+    const action = unsetApplicationInstanceDeregistering(instance);
 
     const expectedState = {
       applicationInstances: [
@@ -333,7 +333,7 @@ describe('SAP Systems reducer', () => {
       databaseInstances: [instance],
     };
 
-    const action = setDatabaseInstanceNotDeregisteringToSAPSystem(instance);
+    const action = unsetDatabaseInstanceDeregisteringToSAPSystem(instance);
 
     const expectedState = {
       databaseInstances: [


### PR DESCRIPTION
# Description

Add instances deregistration sagas.

It skips by now the navigation part. I guess we should navigate from the SAP system/Database details view when all the instances are deregistered. But it is not trivial, so I think it will be better to work on that once we have the whole flow working, as i'm not sure how it will behave.

## How was this tested?

Tests added
