### PR TITLE
Node details label for ASCS/ERS cluster details

### DIFF
--- a/assets/js/components/ClusterDetails/AscsErsClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/AscsErsClusterDetails.jsx
@@ -51,7 +51,13 @@ const nodeDetailsConfig = {
       className: 'table-col-xs',
       render: (_, item) => {
         const { attributes, resources } = item;
-        return <AttributesDetails title="Node Details" attributes={attributes} resources={resources} />;
+        return (
+          <AttributesDetails
+            title="Node Details"
+            attributes={attributes}
+            resources={resources}
+          />
+        );
       },
     },
   ],

--- a/assets/js/components/ClusterDetails/AscsErsClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/AscsErsClusterDetails.jsx
@@ -13,7 +13,7 @@ import { renderEnsaVersion } from '@components/SapSystemDetails';
 import ChecksComingSoon from '@static/checks-coming-soon.svg';
 
 import SBDDetails from './SBDDetails';
-import SiteDetails from './SiteDetails';
+import AttributesDetails from './AttributesDetails';
 import StoppedResources from './StoppedResources';
 import { enrichNodes } from './HanaClusterDetails';
 
@@ -51,7 +51,7 @@ const nodeDetailsConfig = {
       className: 'table-col-xs',
       render: (_, item) => {
         const { attributes, resources } = item;
-        return <SiteDetails attributes={attributes} resources={resources} />;
+        return <AttributesDetails title="Node Details" attributes={attributes} resources={resources} />;
       },
     },
   ],

--- a/assets/js/components/ClusterDetails/AscsErsClusterDetails.test.jsx
+++ b/assets/js/components/ClusterDetails/AscsErsClusterDetails.test.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
 import { screen, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom';
-import { renderWithRouter } from '@lib/test-utils';
 import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import { renderWithRouter } from '@lib/test-utils';
 
 import {
   buildHostsFromAscsErsClusterDetails,
@@ -196,6 +197,8 @@ describe('ClusterDetails AscsErsClusterDetails component', () => {
   });
 
   it('should not display a host link for unregistered hosts', () => {
+    const user = userEvent.setup();
+
     const {
       name,
       cib_last_written: cibLastWritten,
@@ -221,5 +224,40 @@ describe('ClusterDetails AscsErsClusterDetails component', () => {
     );
 
     expect(unregisteredHostContainer).not.toHaveAttribute('href');
+  });
+
+  it('should display infos about node details',async () => {
+    const {
+      name,
+      cib_last_written: cibLastWritten,
+      provider,
+      details,
+    } = clusterFactory.build({
+      type: 'ascs_ers',
+    });
+
+    const sapSystems = buildSapSystemsFromAscsErsClusterDetails(details);
+
+    renderWithRouter(
+      <AscsErsClusterDetails
+        clusterName={name}
+        cibLastWritten={cibLastWritten}
+        provider={provider}
+        hosts={buildHostsFromAscsErsClusterDetails(details)}
+        sapSystems={sapSystems}
+        details={details}
+      />
+    );
+
+    const resources = sapSystems[0]
+
+    console.log(resources)
+    await userEvent.click(screen.getAllByText('Details')[0])
+
+    expect(screen.getByText("Node Details")).toBeInTheDocument();
+    expect(screen.getByText("Attributes")).toBeInTheDocument();
+    expect(screen.getByText("Resources")).toBeInTheDocument();
+
+    
   });
 });

--- a/assets/js/components/ClusterDetails/AscsErsClusterDetails.test.jsx
+++ b/assets/js/components/ClusterDetails/AscsErsClusterDetails.test.jsx
@@ -197,8 +197,6 @@ describe('ClusterDetails AscsErsClusterDetails component', () => {
   });
 
   it('should not display a host link for unregistered hosts', () => {
-    const user = userEvent.setup();
-
     const {
       name,
       cib_last_written: cibLastWritten,
@@ -226,7 +224,7 @@ describe('ClusterDetails AscsErsClusterDetails component', () => {
     expect(unregisteredHostContainer).not.toHaveAttribute('href');
   });
 
-  it('should display infos about node details',async () => {
+  it('should display infos about node details', async () => {
     const {
       name,
       cib_last_written: cibLastWritten,
@@ -234,9 +232,14 @@ describe('ClusterDetails AscsErsClusterDetails component', () => {
       details,
     } = clusterFactory.build({
       type: 'ascs_ers',
+      details: ascsErsClusterDetailsFactory.build({ sap_systems_count: 2 }),
     });
 
     const sapSystems = buildSapSystemsFromAscsErsClusterDetails(details);
+
+    const {
+      nodes: [{ attributes, resources }],
+    } = details.sap_systems[0];
 
     renderWithRouter(
       <AscsErsClusterDetails
@@ -249,15 +252,27 @@ describe('ClusterDetails AscsErsClusterDetails component', () => {
       />
     );
 
-    const resources = sapSystems[0]
+    await userEvent.click(screen.getAllByText('Details')[0]);
 
-    console.log(resources)
-    await userEvent.click(screen.getAllByText('Details')[0])
+    expect(screen.getByText('Node Details')).toBeInTheDocument();
+    expect(screen.getByText('Attributes')).toBeInTheDocument();
+    expect(screen.getByText('Resources')).toBeInTheDocument();
 
-    expect(screen.getByText("Node Details")).toBeInTheDocument();
-    expect(screen.getByText("Attributes")).toBeInTheDocument();
-    expect(screen.getByText("Resources")).toBeInTheDocument();
+    Object.keys(resources[0]).forEach((key) => {
+      expect(screen.getByText(key)).toBeInTheDocument();
+      screen.getAllByText(resources[0][key]).forEach((element) => {
+        expect(element).toBeInTheDocument();
+      });
+    });
 
-    
+    Object.keys(attributes).forEach((key) => {
+      screen.getAllByText(key).forEach((element) => {
+        expect(element).toBeInTheDocument();
+      });
+
+      screen.getAllByText(attributes[key]).forEach((element) => {
+        expect(element).toBeInTheDocument();
+      });
+    });
   });
 });

--- a/assets/js/components/ClusterDetails/AttributesDetails.jsx
+++ b/assets/js/components/ClusterDetails/AttributesDetails.jsx
@@ -31,11 +31,7 @@ function AttributesDetails({ attributes, resources, title }) {
       <Button type="primary" size="small" onClick={() => setModalOpen(true)}>
         Details
       </Button>
-      <Modal
-        title={title}
-        open={modalOpen}
-        onClose={() => setModalOpen(false)}
-      >
+      <Modal title={title} open={modalOpen} onClose={() => setModalOpen(false)}>
         <h3 className="font-medium">Attributes</h3>
         <Table
           config={attributesTableConfig}

--- a/assets/js/components/ClusterDetails/AttributesDetails.jsx
+++ b/assets/js/components/ClusterDetails/AttributesDetails.jsx
@@ -4,7 +4,7 @@ import Button from '@components/Button';
 import Modal from '@components/Modal';
 import Table from '@components/Table';
 
-function SiteDetails({ attributes, resources }) {
+function AttributesDetails({ attributes, resources, title }) {
   const [modalOpen, setModalOpen] = useState(false);
 
   const attributesTableConfig = {
@@ -24,15 +24,15 @@ function SiteDetails({ attributes, resources }) {
             key,
           })),
         }
-      : { usePAdding: false, columns: [] };
+      : { usePadding: false, columns: [] };
 
   return (
-    <>
+    <Fragment>
       <Button type="primary" size="small" onClick={() => setModalOpen(true)}>
         Details
       </Button>
       <Modal
-        title="Site details"
+        title={title}
         open={modalOpen}
         onClose={() => setModalOpen(false)}
       >
@@ -48,8 +48,8 @@ function SiteDetails({ attributes, resources }) {
         <h3 className="font-medium">Resources</h3>
         <Table config={resourcesTableConfig} data={resources} />
       </Modal>
-    </>
+    </Fragment>
   );
 }
 
-export default SiteDetails;
+export default AttributesDetails;

--- a/assets/js/components/ClusterDetails/AttributesDetails.jsx
+++ b/assets/js/components/ClusterDetails/AttributesDetails.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from 'react';
+import React, { useState } from 'react';
 
 import Button from '@components/Button';
 import Modal from '@components/Modal';
@@ -27,7 +27,7 @@ function AttributesDetails({ attributes, resources, title }) {
       : { usePadding: false, columns: [] };
 
   return (
-    <Fragment>
+    <>
       <Button type="primary" size="small" onClick={() => setModalOpen(true)}>
         Details
       </Button>
@@ -44,7 +44,7 @@ function AttributesDetails({ attributes, resources, title }) {
         <h3 className="font-medium">Resources</h3>
         <Table config={resourcesTableConfig} data={resources} />
       </Modal>
-    </Fragment>
+    </>
   );
 }
 

--- a/assets/js/components/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/HanaClusterDetails.jsx
@@ -55,7 +55,13 @@ const siteDetailsConfig = {
       className: 'table-col-xs',
       render: (_, item) => {
         const { attributes, resources } = item;
-        return <AttributesDetails title="Site Details" attributes={attributes} resources={resources} />;
+        return (
+          <AttributesDetails
+            title="Site Details"
+            attributes={attributes}
+            resources={resources}
+          />
+        );
       },
     },
   ],

--- a/assets/js/components/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/HanaClusterDetails.jsx
@@ -17,8 +17,8 @@ import SapSystemLink from '@components/SapSystemLink';
 import { EOS_SETTINGS, EOS_CLEAR_ALL, EOS_PLAY_CIRCLE } from 'eos-icons-react';
 
 import { RUNNING_STATES } from '@state/lastExecutions';
-import SiteDetails from './SiteDetails';
 import SBDDetails from './SBDDetails';
+import AttributesDetails from './AttributesDetails';
 import StoppedResources from './StoppedResources';
 
 export const enrichNodes = (clusterNodes, hosts) =>
@@ -55,7 +55,7 @@ const siteDetailsConfig = {
       className: 'table-col-xs',
       render: (_, item) => {
         const { attributes, resources } = item;
-        return <SiteDetails attributes={attributes} resources={resources} />;
+        return <AttributesDetails title="Site Details" attributes={attributes} resources={resources} />;
       },
     },
   ],

--- a/assets/js/components/ClusterDetails/HanaClusterDetails.test.jsx
+++ b/assets/js/components/ClusterDetails/HanaClusterDetails.test.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { faker } from '@faker-js/faker';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
 import { renderWithRouter } from '@lib/test-utils';
@@ -11,7 +13,7 @@ import {
   checksExecutionRunningFactory,
   sapSystemFactory,
 } from '@lib/test-utils/factories';
-import { faker } from '@faker-js/faker';
+
 import HanaClusterDetails from './HanaClusterDetails';
 
 describe('HanaClusterDetails component', () => {
@@ -224,5 +226,63 @@ describe('HanaClusterDetails component', () => {
       'href',
       `/hosts/${host.id}`
     );
+  });
+
+  it('should display infos about node details', async () => {
+    const {
+      clusterID,
+      clusterName,
+      cib_last_written: cibLastWritten,
+      type: clusterType,
+      sid,
+      provider,
+      details,
+    } = clusterFactory.build();
+
+    const hosts = hostFactory.buildList(2, { cluster_id: clusterID });
+
+    const {
+      nodes: [{ attributes, resources }],
+    } = details;
+
+    renderWithRouter(
+      <HanaClusterDetails
+        clusterID={clusterID}
+        clusterName={clusterName}
+        selectedChecks={[]}
+        hasSelectedChecks={false}
+        hosts={hosts}
+        clusterType={clusterType}
+        cibLastWritten={cibLastWritten}
+        sid={sid}
+        provider={provider}
+        sapSystems={[]}
+        details={details}
+        lastExecution={null}
+      />
+    );
+
+    await userEvent.click(screen.getAllByText('Details')[0]);
+
+    expect(screen.getByText('Site Details')).toBeInTheDocument();
+    expect(screen.getByText('Attributes')).toBeInTheDocument();
+    expect(screen.getByText('Resources')).toBeInTheDocument();
+
+    Object.keys(resources[0]).forEach((key) => {
+      expect(screen.getByText(key)).toBeInTheDocument();
+      screen.getAllByText(resources[0][key]).forEach((element) => {
+        expect(element).toBeInTheDocument();
+      });
+    });
+
+    Object.keys(attributes).forEach((key) => {
+      screen.getAllByText(key).forEach((element) => {
+        expect(element).toBeInTheDocument();
+      });
+
+      screen.getAllByText(attributes[key]).forEach((element) => {
+        expect(element).toBeInTheDocument();
+      });
+    });
   });
 });


### PR DESCRIPTION
# Description
Fixes "Site details" wrong label in ASCS/ERS cluster page.

Took the chance to increase a little bit the coverage.

## How was this tested?
Automatic tests, Storybook stories already present
