### PR TITLE
Add `absent_at` field to projectors and broadcast events

### DIFF
--- a/lib/trento/application/projectors/sap_system_projector.ex
+++ b/lib/trento/application/projectors/sap_system_projector.ex
@@ -11,6 +11,8 @@ defmodule Trento.SapSystemProjector do
   alias Trento.Domain.Events.{
     ApplicationInstanceDeregistered,
     ApplicationInstanceHealthChanged,
+    ApplicationInstanceMarkedAbsent,
+    ApplicationInstanceMarkedPresent,
     ApplicationInstanceMoved,
     ApplicationInstanceRegistered,
     SapSystemDeregistered,
@@ -137,6 +139,51 @@ defmodule Trento.SapSystemProjector do
           host_id: host_id
         )
         |> ApplicationInstanceReadModel.changeset(%{health: health})
+
+      Ecto.Multi.update(multi, :application_instance, changeset)
+    end
+  )
+
+  project(
+    %ApplicationInstanceMarkedAbsent{
+      sap_system_id: sap_system_id,
+      instance_number: instance_number,
+      host_id: host_id,
+      absent_at: absent_at
+    },
+    fn multi ->
+      changeset =
+        ApplicationInstanceReadModel
+        |> Repo.get_by(
+          sap_system_id: sap_system_id,
+          instance_number: instance_number,
+          host_id: host_id
+        )
+        |> ApplicationInstanceReadModel.changeset(%{
+          absent_at: absent_at
+        })
+
+      Ecto.Multi.update(multi, :application_instance, changeset)
+    end
+  )
+
+  project(
+    %ApplicationInstanceMarkedPresent{
+      sap_system_id: sap_system_id,
+      instance_number: instance_number,
+      host_id: host_id
+    },
+    fn multi ->
+      changeset =
+        ApplicationInstanceReadModel
+        |> Repo.get_by(
+          sap_system_id: sap_system_id,
+          instance_number: instance_number,
+          host_id: host_id
+        )
+        |> ApplicationInstanceReadModel.changeset(%{
+          absent_at: nil
+        })
 
       Ecto.Multi.update(multi, :application_instance, changeset)
     end
@@ -345,6 +392,53 @@ defmodule Trento.SapSystemProjector do
       @sap_systems_topic,
       "sap_system_restored",
       SapSystemView.render("sap_system_restored.json", sap_system: enriched_sap_system)
+    )
+  end
+
+  @impl true
+  def after_update(
+        %ApplicationInstanceMarkedAbsent{
+          instance_number: instance_number,
+          host_id: host_id,
+          sap_system_id: sap_system_id,
+          absent_at: absent_at
+        },
+        _,
+        %{application_instance: %ApplicationInstanceReadModel{sid: sid}}
+      ) do
+    TrentoWeb.Endpoint.broadcast(
+      @sap_systems_topic,
+      "application_instance_absent_at_changed",
+      SapSystemView.render("instance_absent_at_changed.json",
+        instance_number: instance_number,
+        host_id: host_id,
+        sap_system_id: sap_system_id,
+        sid: sid,
+        absent_at: absent_at
+      )
+    )
+  end
+
+  @impl true
+  def after_update(
+        %ApplicationInstanceMarkedPresent{
+          instance_number: instance_number,
+          host_id: host_id,
+          sap_system_id: sap_system_id
+        },
+        _,
+        %{application_instance: %ApplicationInstanceReadModel{sid: sid}}
+      ) do
+    TrentoWeb.Endpoint.broadcast(
+      @sap_systems_topic,
+      "application_instance_absent_at_changed",
+      SapSystemView.render("instance_absent_at_changed.json",
+        instance_number: instance_number,
+        host_id: host_id,
+        sap_system_id: sap_system_id,
+        sid: sid,
+        absent_at: nil
+      )
     )
   end
 

--- a/lib/trento_web/views/v1/sap_system_view.ex
+++ b/lib/trento_web/views/v1/sap_system_view.ex
@@ -97,6 +97,21 @@ defmodule TrentoWeb.V1.SapSystemView do
 
   def render("application_instance_health_changed.json", %{health: health}), do: health
 
+  def render("instance_absent_at_changed.json", %{
+        instance_number: instance_number,
+        host_id: host_id,
+        sap_system_id: sap_system_id,
+        sid: sid,
+        absent_at: absent_at
+      }),
+      do: %{
+        instance_number: instance_number,
+        host_id: host_id,
+        sap_system_id: sap_system_id,
+        sid: sid,
+        absent_at: absent_at
+      }
+
   def render("sap_systems.json", %{sap_systems: sap_systems}) do
     render_many(sap_systems, __MODULE__, "sap_system.json")
   end

--- a/test/trento/application/projectors/sap_system_projector_test.exs
+++ b/test/trento/application/projectors/sap_system_projector_test.exs
@@ -18,6 +18,8 @@ defmodule Trento.SapSystemProjectorTest do
   alias Trento.Domain.Events.{
     ApplicationInstanceDeregistered,
     ApplicationInstanceHealthChanged,
+    ApplicationInstanceMarkedAbsent,
+    ApplicationInstanceMarkedPresent,
     ApplicationInstanceMoved,
     SapSystemDeregistered,
     SapSystemHealthChanged,
@@ -208,6 +210,85 @@ defmodule Trento.SapSystemProjectorTest do
         host_id: ^host_id,
         instance_number: ^instance_number,
         sap_system_id: ^sap_system_id
+      },
+      1000
+    )
+  end
+
+  test "should broadcast application_instance_absent_at_changed when ApplicationInstanceMarkedAbsent event is received" do
+    insert(:sap_system, id: sap_system_id = Faker.UUID.v4())
+    event = build(:application_instance_registered_event, sap_system_id: sap_system_id)
+
+    ProjectorTestHelper.project(SapSystemProjector, event, "sap_system_projector")
+
+    %{
+      host_id: host_id,
+      instance_number: instance_number,
+      sid: sid
+    } =
+      Repo.get_by(ApplicationInstanceReadModel,
+        sap_system_id: event.sap_system_id,
+        instance_number: event.instance_number,
+        host_id: event.host_id
+      )
+
+    absent_at = DateTime.utc_now()
+
+    marked_absent_event = %ApplicationInstanceMarkedAbsent{
+      instance_number: instance_number,
+      host_id: host_id,
+      sap_system_id: sap_system_id,
+      absent_at: absent_at
+    }
+
+    ProjectorTestHelper.project(SapSystemProjector, marked_absent_event, "sap_system_projector")
+
+    assert_broadcast(
+      "application_instance_absent_at_changed",
+      %{
+        instance_number: ^instance_number,
+        host_id: ^host_id,
+        sap_system_id: ^sap_system_id,
+        sid: ^sid,
+        absent_at: ^absent_at
+      },
+      1000
+    )
+  end
+
+  test "should broadcast application_instance_absent_at_changed when ApplicationInstanceMarkedPresent event is received" do
+    insert(:sap_system, id: sap_system_id = Faker.UUID.v4())
+    event = build(:application_instance_registered_event, sap_system_id: sap_system_id)
+
+    ProjectorTestHelper.project(SapSystemProjector, event, "sap_system_projector")
+
+    %{
+      host_id: host_id,
+      instance_number: instance_number,
+      sid: sid
+    } =
+      Repo.get_by(ApplicationInstanceReadModel,
+        sap_system_id: event.sap_system_id,
+        instance_number: event.instance_number,
+        host_id: event.host_id
+      )
+
+    marked_present_event = %ApplicationInstanceMarkedPresent{
+      instance_number: instance_number,
+      host_id: host_id,
+      sap_system_id: sap_system_id
+    }
+
+    ProjectorTestHelper.project(SapSystemProjector, marked_present_event, "sap_system_projector")
+
+    assert_broadcast(
+      "application_instance_absent_at_changed",
+      %{
+        instance_number: ^instance_number,
+        host_id: ^host_id,
+        sap_system_id: ^sap_system_id,
+        sid: ^sid,
+        absent_at: nil
       },
       1000
     )


### PR DESCRIPTION
# Description

This change makes the SAP system and database projectors listen to the `*MarkedAsAbsent`/`*MarkedAsPresent` events, whereupon they update the read models and broadcast this change through the websocket channel as events named `application_instance_absent_at_changed`/`database_instance_absent_at_changed`

## How was this tested?

Added unit tests for the new behaviour in the projectors
