### PR TITLE
Add tooltip above `Start Execution` button

### DIFF
--- a/assets/js/components/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/HanaClusterDetails.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import { groupBy } from 'lodash';
-import classNames from 'classnames';
 import PageHeader from '@components/PageHeader';
 import BackButton from '@components/BackButton';
 import Button from '@components/Button';
@@ -9,7 +8,6 @@ import Button from '@components/Button';
 import ListView from '@components/ListView';
 import Table from '@components/Table';
 import Tooltip from '@components/Tooltip';
-import TriggerChecksExecutionRequest from '@components/TriggerChecksExecutionRequest';
 import ClusterNodeLink from '@components/ClusterDetails/ClusterNodeLink';
 import ChecksResultOverview from '@components/ClusterDetails/ChecksResultOverview';
 import ProviderLabel from '@components/ProviderLabel';
@@ -133,21 +131,17 @@ function HanaClusterDetails({
               content="Select some Checks first!"
               place="bottom"
             >
-              <TriggerChecksExecutionRequest
-                cssClasses="flex rounded relative ml-0.5 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-gray-400"
-                targetID={clusterID}
+              <Button
+                type="primary"
+                className="mx-1"
+                onClick={() => {
+                  onStartExecution(clusterID, hosts, selectedChecks, navigate);
+                }}
                 disabled={startExecutionDisabled}
-                hosts={hosts.map(({ id }) => id)}
-                checks={selectedChecks}
-                onStartExecution={onStartExecution}
               >
-                <EOS_PLAY_CIRCLE
-                  className={classNames('inline-block fill-jungle-green-500', {
-                    'fill-slate-500': startExecutionDisabled,
-                  })}
-                />{' '}
-                <span>Start Execution</span>
-              </TriggerChecksExecutionRequest>
+                <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub" />{' '}
+                Start Execution
+              </Button>
             </Tooltip>
           </div>
         </div>

--- a/assets/js/components/ClusterDetails/HanaClusterDetails.test.jsx
+++ b/assets/js/components/ClusterDetails/HanaClusterDetails.test.jsx
@@ -100,9 +100,7 @@ describe('HanaClusterDetails component', () => {
         />
       );
 
-      expect(
-        screen.getByText(`Start Execution`).closest('button')
-      ).toBeDisabled();
+      expect(screen.getByText('Start Execution')).toBeDisabled();
     }
   );
 
@@ -285,4 +283,63 @@ describe('HanaClusterDetails component', () => {
       });
     });
   });
+
+  const suggestionScenarios = [
+    {
+      selectedChecks: [],
+      hasSelectedChecks: false,
+      suggestionExpectation: (tooltipSuggestion) => {
+        tooltipSuggestion.toBeVisible();
+      },
+    },
+    {
+      selectedChecks: [faker.datatype.uuid()],
+      hasSelectedChecks: true,
+      suggestionExpectation: (tooltipSuggestion) => {
+        tooltipSuggestion.not.toBeInTheDocument();
+      },
+    },
+  ];
+
+  it.each(suggestionScenarios)(
+    'should suggest to the user to select some checks only when the selection is empty',
+    async ({ selectedChecks, hasSelectedChecks, suggestionExpectation }) => {
+      const user = userEvent.setup();
+
+      const {
+        clusterID,
+        clusterName,
+        cib_last_written: cibLastWritten,
+        type: clusterType,
+        sid,
+        provider,
+        details,
+      } = clusterFactory.build();
+
+      const hosts = hostFactory.buildList(2, { cluster_id: clusterID });
+
+      renderWithRouter(
+        <HanaClusterDetails
+          clusterID={clusterID}
+          clusterName={clusterName}
+          selectedChecks={selectedChecks}
+          hasSelectedChecks={hasSelectedChecks}
+          hosts={hosts}
+          clusterType={clusterType}
+          cibLastWritten={cibLastWritten}
+          sid={sid}
+          provider={provider}
+          sapSystems={[]}
+          details={details}
+          lastExecution={null}
+        />
+      );
+
+      const startExecutionButton = screen.getByText('Start Execution');
+      await user.hover(startExecutionButton);
+      suggestionExpectation(
+        expect(screen.queryByText('Select some Checks first!'))
+      );
+    }
+  );
 });

--- a/assets/js/components/ClusterSettingsPage/ClusterSettingsPage.jsx
+++ b/assets/js/components/ClusterSettingsPage/ClusterSettingsPage.jsx
@@ -24,6 +24,7 @@ import PageHeader from '@components/PageHeader';
 import BackButton from '@components/BackButton';
 import LoadingBox from '@components/LoadingBox';
 import WarningBanner from '@components/Banners/WarningBanner';
+import Tooltip from '@components/Tooltip';
 
 import { UNKNOWN_PROVIDER, VMWARE_PROVIDER, TARGET_CLUSTER } from '@lib/model';
 
@@ -124,15 +125,21 @@ function ClusterSettingsPage() {
             >
               Save Checks Selection
             </Button>
-            <Button
-              type="primary"
-              className="mx-1"
-              onClick={requestExecution}
-              disabled={!canStartExecution(selectedChecks, saving)}
+            <Tooltip
+              className="w-56"
+              content="Click Start Execution or wait for Trento to periodically run checks."
+              visible={canStartExecution(selectedChecks, saving)}
             >
-              <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub" />{' '}
-              Start Execution
-            </Button>
+              <Button
+                type="primary"
+                className="mx-1"
+                onClick={requestExecution}
+                disabled={!canStartExecution(selectedChecks, saving)}
+              >
+                <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub" />{' '}
+                Start Execution
+              </Button>
+            </Tooltip>
           </div>
         </div>
       </div>

--- a/assets/js/components/ClusterSettingsPage/ClusterSettingsPage.test.jsx
+++ b/assets/js/components/ClusterSettingsPage/ClusterSettingsPage.test.jsx
@@ -102,4 +102,47 @@ describe('ClusterDetails ClusterSettings component', () => {
       )
     ).toBeVisible();
   });
+
+  const suggestionScenarios = [
+    {
+      cluster: clusterFactory.build({
+        selected_checks: [],
+      }),
+      suggestionExpectation: (tooltipSuggestion) => {
+        tooltipSuggestion.not.toBeInTheDocument();
+      },
+    },
+    {
+      cluster: clusterFactory.build({
+        selected_checks: [faker.datatype.uuid()],
+      }),
+      suggestionExpectation: (tooltipSuggestion) => {
+        tooltipSuggestion.toBeVisible();
+      },
+    },
+  ];
+
+  it.each(suggestionScenarios)(
+    'should suggest to the user to start an execution when the selection is not empty',
+    ({ cluster, suggestionExpectation }) => {
+      const { id: clusterID } = cluster;
+      const [StatefulClusterSettings] = withState(<ClusterSettingsPage />, {
+        ...defaultInitialState,
+        clustersList: { clusters: [cluster] },
+      });
+
+      renderWithRouterMatch(StatefulClusterSettings, {
+        path: 'clusters/:clusterID/settings',
+        route: `/clusters/${clusterID}/settings`,
+      });
+
+      suggestionExpectation(
+        expect(
+          screen.queryByText(
+            'Click Start Execution or wait for Trento to periodically run checks.'
+          )
+        )
+      );
+    }
+  );
 });

--- a/assets/js/components/HostDetails/HostChecksSelection.jsx
+++ b/assets/js/components/HostDetails/HostChecksSelection.jsx
@@ -5,6 +5,7 @@ import PageHeader from '@components/PageHeader';
 import BackButton from '@components/BackButton';
 import Button from '@components/Button';
 import ChecksSelection from '@components/ChecksSelection';
+import Tooltip from '@components/Tooltip';
 
 import HostInfoBox from './HostInfoBox';
 
@@ -23,6 +24,7 @@ function HostChecksSelection({
   onSelectedChecksChange,
   hostChecksExecutionEnabled,
   onStartExecution = () => {},
+  checksExecutionTooltipVisible,
 }) {
   return (
     <div className="w-full px-2 sm:px-0">
@@ -44,15 +46,20 @@ function HostChecksSelection({
             >
               Save Checks Selection
             </Button>
-            <Button
-              type="primary"
-              className="mx-1"
-              onClick={onStartExecution}
-              disabled={hostChecksExecutionEnabled}
+            <Tooltip
+              content="Click Start Execution or wait for Trento to periodically run checks."
+              visible={checksExecutionTooltipVisible}
             >
-              <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub" />{' '}
-              Start Execution
-            </Button>
+              <Button
+                type="primary"
+                className="mx-1"
+                onClick={onStartExecution}
+                disabled={hostChecksExecutionEnabled}
+              >
+                <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub" />{' '}
+                Start Execution
+              </Button>
+            </Tooltip>
           </div>
         </div>
       </div>

--- a/assets/js/components/HostDetails/HostChecksSelection.jsx
+++ b/assets/js/components/HostDetails/HostChecksSelection.jsx
@@ -47,6 +47,7 @@ function HostChecksSelection({
               Save Checks Selection
             </Button>
             <Tooltip
+              className="w-56"
               content="Click Start Execution or wait for Trento to periodically run checks."
               visible={checksExecutionTooltipVisible}
             >

--- a/assets/js/components/HostDetails/HostChecksSelection.jsx
+++ b/assets/js/components/HostDetails/HostChecksSelection.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { EOS_PLAY_CIRCLE } from 'eos-icons-react';
 
 import PageHeader from '@components/PageHeader';
@@ -9,23 +9,28 @@ import Tooltip from '@components/Tooltip';
 
 import HostInfoBox from './HostInfoBox';
 
+const defaultSavedSelection = [];
+
 function HostChecksSelection({
   hostID,
   hostName,
   provider,
   agentVersion,
-  selectedChecks,
   catalog,
   catalogError,
   catalogLoading,
   onUpdateCatalog,
   isSavingSelection,
   onSaveSelection,
-  onSelectedChecksChange,
   hostChecksExecutionEnabled,
   onStartExecution = () => {},
-  checksExecutionTooltipVisible,
+  savedHostSelection = defaultSavedSelection,
 }) {
+  const [selection, setSelection] = useState([]);
+  useEffect(() => {
+    setSelection(savedHostSelection);
+  }, [savedHostSelection]);
+
   return (
     <div className="w-full px-2 sm:px-0">
       <BackButton url={`/hosts/${hostID}`}>Back to Host Details</BackButton>
@@ -41,7 +46,7 @@ function HostChecksSelection({
             <Button
               type="primary"
               className="mx-1"
-              onClick={() => onSaveSelection(selectedChecks, hostID, hostName)}
+              onClick={() => onSaveSelection(selection, hostID, hostName)}
               disabled={isSavingSelection}
             >
               Save Checks Selection
@@ -49,7 +54,7 @@ function HostChecksSelection({
             <Tooltip
               className="w-56"
               content="Click Start Execution or wait for Trento to periodically run checks."
-              visible={checksExecutionTooltipVisible}
+              visible={savedHostSelection?.length > 0}
             >
               <Button
                 type="primary"
@@ -70,9 +75,9 @@ function HostChecksSelection({
         catalog={catalog}
         catalogError={catalogError}
         loading={catalogLoading}
-        selectedChecks={selectedChecks}
+        selectedChecks={selection}
         onUpdateCatalog={() => onUpdateCatalog()}
-        onChange={onSelectedChecksChange}
+        onChange={setSelection}
       />
     </div>
   );

--- a/assets/js/components/HostDetails/HostChecksSelection.stories.jsx
+++ b/assets/js/components/HostDetails/HostChecksSelection.stories.jsx
@@ -109,10 +109,6 @@ export default {
     onStartExecution: {
       description: 'Starts the host checks execution',
     },
-    checksExecutionTooltipVisible: {
-      description:
-        'Whether to display the tooltip above the start execution button',
-    },
   },
 };
 
@@ -128,6 +124,5 @@ export const Default = {
     catalogLoading: false,
     isSavingSelection: false,
     hostChecksExecutionEnabled: false,
-    checksExecutionTooltipVisible: false,
   },
 };

--- a/assets/js/components/HostDetails/HostChecksSelection.stories.jsx
+++ b/assets/js/components/HostDetails/HostChecksSelection.stories.jsx
@@ -110,8 +110,9 @@ export default {
       description: 'Starts the host checks execution',
     },
     checksExecutionTooltipVisible: {
-      description: 'Whether to display the tooltip above the start execution button',
-    }
+      description:
+        'Whether to display the tooltip above the start execution button',
+    },
   },
 };
 

--- a/assets/js/components/HostDetails/HostChecksSelection.stories.jsx
+++ b/assets/js/components/HostDetails/HostChecksSelection.stories.jsx
@@ -109,6 +109,9 @@ export default {
     onStartExecution: {
       description: 'Starts the host checks execution',
     },
+    checksExecutionTooltipVisible: {
+      description: 'Whether to display the tooltip above the start execution button',
+    }
   },
 };
 
@@ -124,5 +127,6 @@ export const Default = {
     catalogLoading: false,
     isSavingSelection: false,
     hostChecksExecutionEnabled: false,
+    checksExecutionTooltipVisible: false,
   },
 };

--- a/assets/js/components/HostDetails/HostChecksSelection.test.jsx
+++ b/assets/js/components/HostDetails/HostChecksSelection.test.jsx
@@ -36,13 +36,11 @@ describe('HostChecksSelection component', () => {
         hostName={hostName}
         provider={provider}
         agentVersion={agentVersion}
-        selectedChecks={selectedChecks}
         catalog={catalog}
         catalogError={null}
         catalogLoading={false}
         onUpdateCatalog={onUpdateCatalog}
         hostSelectedChecks={selectedChecks}
-        checksExecutionTooltipVisible
       />
     );
 
@@ -59,47 +57,11 @@ describe('HostChecksSelection component', () => {
     expect(
       screen.getByRole('button', { name: 'Save Checks Selection' })
     ).toBeVisible();
-    expect(screen.getByRole('tooltip')).toBeVisible();
-    expect(onUpdateCatalog).toHaveBeenCalled();
-  });
-
-  it('should not render tooltip when render host check selection', async () => {
-    const group0 = faker.animal.cat();
-    const group1 = faker.animal.dog();
-    const group2 = faker.lorem.word();
-    const catalog = [
-      ...catalogCheckFactory.buildList(2, { group: group0 }),
-      ...catalogCheckFactory.buildList(2, { group: group1 }),
-      ...catalogCheckFactory.buildList(2, { group: group2 }),
-    ];
-
-    const onUpdateCatalog = jest.fn();
-
-    const {
-      id: hostID,
-      hostname: hostName,
-      provider,
-      agent_version: agentVersion,
-      selected_checks: selectedChecks,
-    } = hostFactory.build({ provider: 'azure' });
-
-    renderWithRouter(
-      <HostChecksSelection
-        hostID={hostID}
-        hostName={hostName}
-        provider={provider}
-        agentVersion={agentVersion}
-        selectedChecks={selectedChecks}
-        catalog={catalog}
-        catalogError={null}
-        catalogLoading={false}
-        onUpdateCatalog={onUpdateCatalog}
-        hostSelectedChecks={selectedChecks}
-        checksExecutionTooltipVisible={false}
-      />
-    );
-
-    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'Click Start Execution or wait for Trento to periodically run checks.'
+      )
+    ).not.toBeInTheDocument();
     expect(onUpdateCatalog).toHaveBeenCalled();
   });
 });

--- a/assets/js/components/HostDetails/HostChecksSelection.test.jsx
+++ b/assets/js/components/HostDetails/HostChecksSelection.test.jsx
@@ -42,6 +42,7 @@ describe('HostChecksSelection component', () => {
         catalogLoading={false}
         onUpdateCatalog={onUpdateCatalog}
         hostSelectedChecks={selectedChecks}
+        checksExecutionTooltipVisible
       />
     );
 
@@ -58,6 +59,47 @@ describe('HostChecksSelection component', () => {
     expect(
       screen.getByRole('button', { name: 'Save Checks Selection' })
     ).toBeVisible();
+    expect(screen.getByRole('tooltip')).toBeVisible();
+    expect(onUpdateCatalog).toHaveBeenCalled();
+  });
+
+  it('should not render tooltip when render host check selection', async () => {
+    const group0 = faker.animal.cat();
+    const group1 = faker.animal.dog();
+    const group2 = faker.lorem.word();
+    const catalog = [
+      ...catalogCheckFactory.buildList(2, { group: group0 }),
+      ...catalogCheckFactory.buildList(2, { group: group1 }),
+      ...catalogCheckFactory.buildList(2, { group: group2 }),
+    ];
+
+    const onUpdateCatalog = jest.fn();
+
+    const {
+      id: hostID,
+      hostname: hostName,
+      provider,
+      agent_version: agentVersion,
+      selected_checks: selectedChecks,
+    } = hostFactory.build({ provider: 'azure' });
+
+    renderWithRouter(
+      <HostChecksSelection
+        hostID={hostID}
+        hostName={hostName}
+        provider={provider}
+        agentVersion={agentVersion}
+        selectedChecks={selectedChecks}
+        catalog={catalog}
+        catalogError={null}
+        catalogLoading={false}
+        onUpdateCatalog={onUpdateCatalog}
+        hostSelectedChecks={selectedChecks}
+        checksExecutionTooltipVisible={false}
+      />
+    );
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
     expect(onUpdateCatalog).toHaveBeenCalled();
   });
 });

--- a/assets/js/components/HostDetails/HostDetails.jsx
+++ b/assets/js/components/HostDetails/HostDetails.jsx
@@ -15,6 +15,7 @@ import WarningBanner from '@components/Banners/WarningBanner';
 import CleanUpButton from '@components/CleanUpButton';
 import DeregistrationModal from '@components/DeregistrationModal';
 import { canStartExecution } from '@components/ChecksSelection';
+import Tooltip from '@components/Tooltip';
 
 import SuseLogo from '@static/suse_logo.svg';
 import ChecksComingSoon from '@static/checks-coming-soon.svg';
@@ -51,6 +52,8 @@ function HostDetails({
   navigate,
 }) {
   const [cleanUpModalOpen, setCleanUpModalOpen] = useState(false);
+  const [checksExecutionTooltipVisible, setChecksExecutionTooltipVisible] =
+    useState(true);
 
   const versionWarningMessage = agentVersionWarning(agentVersion);
 
@@ -129,15 +132,23 @@ function HostDetails({
                 <span>Show Results</span>
               </Button>
 
-              <Button
-                type="primary"
-                className="mx-1"
-                onClick={requestHostChecksExecution}
-                disabled={!canStartExecution(selectedChecks, savingChecks)}
+              <Tooltip
+                content="Click Start Execution or wait for Trento to periodically run checks."
+                visible={checksExecutionTooltipVisible && canStartExecution(selectedChecks, savingChecks)}
               >
-                <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub" />{' '}
-                Start Execution
-              </Button>
+                <Button
+                  type="primary"
+                  className="mx-1"
+                  onClick={() => {
+                    requestHostChecksExecution();
+                    setChecksExecutionTooltipVisible(false);
+                  }}
+                  disabled={!canStartExecution(selectedChecks, savingChecks)}
+                >
+                  <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub" />{' '}
+                  Start Execution
+                </Button>
+              </Tooltip>
             </div>
           </div>
           <div className="pb-3">

--- a/assets/js/components/HostDetails/HostDetails.jsx
+++ b/assets/js/components/HostDetails/HostDetails.jsx
@@ -52,8 +52,6 @@ function HostDetails({
   navigate,
 }) {
   const [cleanUpModalOpen, setCleanUpModalOpen] = useState(false);
-  const [checksExecutionTooltipVisible, setChecksExecutionTooltipVisible] =
-    useState(true);
 
   const versionWarningMessage = agentVersionWarning(agentVersion);
 
@@ -134,15 +132,12 @@ function HostDetails({
 
               <Tooltip
                 content="Click Start Execution or wait for Trento to periodically run checks."
-                visible={checksExecutionTooltipVisible && canStartExecution(selectedChecks, savingChecks)}
+                visible={canStartExecution(selectedChecks, savingChecks)}
               >
                 <Button
                   type="primary"
                   className="mx-1"
-                  onClick={() => {
-                    requestHostChecksExecution();
-                    setChecksExecutionTooltipVisible(false);
-                  }}
+                  onClick={requestHostChecksExecution}
                   disabled={!canStartExecution(selectedChecks, savingChecks)}
                 >
                   <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub" />{' '}

--- a/assets/js/components/HostDetails/HostDetails.jsx
+++ b/assets/js/components/HostDetails/HostDetails.jsx
@@ -131,6 +131,7 @@ function HostDetails({
               </Button>
 
               <Tooltip
+                className="w-56"
                 content="Click Start Execution or wait for Trento to periodically run checks."
                 visible={canStartExecution(selectedChecks, savingChecks)}
               >

--- a/assets/js/components/HostDetails/HostDetails.jsx
+++ b/assets/js/components/HostDetails/HostDetails.jsx
@@ -131,9 +131,9 @@ function HostDetails({
               </Button>
 
               <Tooltip
-                className="w-56"
-                content="Click Start Execution or wait for Trento to periodically run checks."
-                visible={canStartExecution(selectedChecks, savingChecks)}
+                isEnabled={!canStartExecution(selectedChecks, savingChecks)}
+                content="Select some Checks first!"
+                place="bottom"
               >
                 <Button
                   type="primary"

--- a/assets/js/components/HostDetails/HostDetails.test.jsx
+++ b/assets/js/components/HostDetails/HostDetails.test.jsx
@@ -26,26 +26,33 @@ describe('HostDetails component', () => {
       ).toBeVisible();
     });
 
-    it('should disable start execution button when checks are not selected', () => {
+    it('should disable start execution button when checks are not selected', async () => {
+      const user = userEvent.setup();
+
       renderWithRouter(
         <HostDetails agentVersion="1.0.0" selectedChecks={[]} />
       );
 
-      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
       const startExecutionButton = screen.getByText('Start Execution');
       expect(startExecutionButton).toBeDisabled();
+
+      await user.hover(startExecutionButton);
+      expect(screen.getByRole('tooltip')).toBeInTheDocument();
     });
 
-    it('should enable start execution button when checks are selected', () => {
+    it('should enable start execution button when checks are selected', async () => {
+      const user = userEvent.setup();
       const selectedChecks = [faker.animal.bear(), faker.animal.bear()];
 
       renderWithRouter(
         <HostDetails agentVersion="1.0.0" selectedChecks={selectedChecks} />
       );
 
-      expect(screen.getByRole('tooltip')).toBeVisible();
       const startExecutionButton = screen.getByText('Start Execution');
       expect(startExecutionButton).toBeEnabled();
+
+      await user.hover(startExecutionButton);
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
     });
   });
 

--- a/assets/js/components/HostDetails/HostDetails.test.jsx
+++ b/assets/js/components/HostDetails/HostDetails.test.jsx
@@ -37,7 +37,7 @@ describe('HostDetails component', () => {
       expect(startExecutionButton).toBeDisabled();
 
       await user.hover(startExecutionButton);
-      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+      expect(screen.getByText('Select some Checks first!')).toBeInTheDocument();
     });
 
     it('should enable start execution button when checks are selected', async () => {
@@ -52,7 +52,9 @@ describe('HostDetails component', () => {
       expect(startExecutionButton).toBeEnabled();
 
       await user.hover(startExecutionButton);
-      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Select some Checks first!')
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/assets/js/components/HostDetails/HostDetails.test.jsx
+++ b/assets/js/components/HostDetails/HostDetails.test.jsx
@@ -31,6 +31,7 @@ describe('HostDetails component', () => {
         <HostDetails agentVersion="1.0.0" selectedChecks={[]} />
       );
 
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
       const startExecutionButton = screen.getByText('Start Execution');
       expect(startExecutionButton).toBeDisabled();
     });
@@ -42,6 +43,7 @@ describe('HostDetails component', () => {
         <HostDetails agentVersion="1.0.0" selectedChecks={selectedChecks} />
       );
 
+      expect(screen.getByRole('tooltip')).toBeVisible();
       const startExecutionButton = screen.getByText('Start Execution');
       expect(startExecutionButton).toBeEnabled();
     });

--- a/assets/js/components/HostDetails/HostSettingsPage.jsx
+++ b/assets/js/components/HostDetails/HostSettingsPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 
@@ -23,14 +23,6 @@ function HostSettingsPage() {
   const hostSelectedChecks = useSelector((state) =>
     getHostSelectedChecks(state, hostID)
   );
-  const [selection, setSelection] = useState([]);
-  useEffect(() => {
-    if (host) {
-      setSelection(hostSelectedChecks);
-    }
-  }, [hostSelectedChecks]);
-  const [checksExecutionTooltipVisible, setChecksExecutionTooltipVisible] =
-    useState(hostSelectedChecks?.length > 0);
 
   const {
     data: catalog,
@@ -65,12 +57,10 @@ function HostSettingsPage() {
         checks: newSelection,
       })
     );
-    setChecksExecutionTooltipVisible(newSelection?.length > 0);
   };
 
   const requestHostChecksExecution = () => {
     dispatch(hostExecutionRequested(host, hostSelectedChecks, navigate));
-    setChecksExecutionTooltipVisible(false);
   };
 
   return (
@@ -85,11 +75,9 @@ function HostSettingsPage() {
       onUpdateCatalog={refreshCatalog}
       isSavingSelection={saving}
       onSaveSelection={saveSelection}
-      selectedChecks={selection}
       hostChecksExecutionEnabled={hostChecksExecutionEnabled}
-      onSelectedChecksChange={setSelection}
       onStartExecution={requestHostChecksExecution}
-      checksExecutionTooltipVisible={checksExecutionTooltipVisible}
+      savedHostSelection={hostSelectedChecks}
     />
   );
 }

--- a/assets/js/components/HostDetails/HostSettingsPage.jsx
+++ b/assets/js/components/HostDetails/HostSettingsPage.jsx
@@ -29,6 +29,8 @@ function HostSettingsPage() {
       setSelection(hostSelectedChecks);
     }
   }, [hostSelectedChecks]);
+  const [checksExecutionTooltipVisible, setChecksExecutionTooltipVisible] =
+    useState(hostSelectedChecks?.length > 0);
 
   const {
     data: catalog,
@@ -55,7 +57,7 @@ function HostSettingsPage() {
       })
     );
 
-  const saveSelection = (newSelection, targetID, targetName) =>
+  const saveSelection = (newSelection, targetID, targetName) => {
     dispatch(
       hostChecksSelected({
         hostID: targetID,
@@ -63,9 +65,12 @@ function HostSettingsPage() {
         checks: newSelection,
       })
     );
+    setChecksExecutionTooltipVisible(newSelection?.length > 0);
+  };
 
   const requestHostChecksExecution = () => {
     dispatch(hostExecutionRequested(host, hostSelectedChecks, navigate));
+    setChecksExecutionTooltipVisible(false);
   };
 
   return (
@@ -84,6 +89,7 @@ function HostSettingsPage() {
       hostChecksExecutionEnabled={hostChecksExecutionEnabled}
       onSelectedChecksChange={setSelection}
       onStartExecution={requestHostChecksExecution}
+      checksExecutionTooltipVisible={checksExecutionTooltipVisible}
     />
   );
 }


### PR DESCRIPTION
# Description

This PR present 3 main visual changes:

## Checks Selection tooltip

Adds a tooltip above the `Start Execution` button in the _Cluster Settings_ and _Host Checks Selection_ pages that says:

>Click Start Execution or wait for Trento to periodically run checks.

If no checks or no _new_ checks are saved on the page, this tooltip does not appear.

## _Host Details_ page tooltip

This PR also adds the tooltip for

>Select some Checks first!

that appears below the `Start Execution` button in the _Host Details_ page; in order ot align the behaviour as seen in the _Cluster Details_ page.

## Align _Cluster Details_ page

This PR also aligns the styling of the `Start Execution` button in the _Cluster Details_ page with the rest of the app.


## How was this tested?

Added assertions in React component tests to test appearance/disappearance of tooltip.

Updated Storybooks.
