### PR TITLE
Host Check result detail

### DIFF
--- a/assets/js/components/ClusterSettingsPage/ClusterSettingsPage.jsx
+++ b/assets/js/components/ClusterSettingsPage/ClusterSettingsPage.jsx
@@ -27,6 +27,23 @@ import WarningBanner from '@components/Banners/WarningBanner';
 
 import { UNKNOWN_PROVIDER, VMWARE_PROVIDER, TARGET_CLUSTER } from '@lib/model';
 
+const catalogWarningBanner = {
+  [UNKNOWN_PROVIDER]: (
+    <WarningBanner>
+      The following catalog is valid for on-premise bare metal platforms.
+      <br />
+      If you are running your HANA cluster on a different platform, please use
+      results with caution
+    </WarningBanner>
+  ),
+  [VMWARE_PROVIDER]: (
+    <WarningBanner>
+      Configuration checks for HANA scale-up performance optimized clusters on
+      VMware are still in experimental phase. Please use results with caution.
+    </WarningBanner>
+  ),
+};
+
 function ClusterSettingsPage() {
   const navigate = useNavigate();
   const dispatch = useDispatch();
@@ -119,23 +136,7 @@ function ClusterSettingsPage() {
           </div>
         </div>
       </div>
-
-      {provider === UNKNOWN_PROVIDER && (
-        <WarningBanner>
-          The following catalog is valid for on-premise bare metal platforms.
-          <br />
-          If you are running your HANA cluster on a different platform, please
-          use results with caution
-        </WarningBanner>
-      )}
-      {provider === VMWARE_PROVIDER && (
-        <WarningBanner>
-          Configuration checks for HANA scale-up performance optimized clusters
-          on VMware are still in experimental phase. Please use results with
-          caution.
-        </WarningBanner>
-      )}
-
+      {catalogWarningBanner[provider]}
       <ClusterInfoBox haScenario={type} provider={provider} />
       <ChecksSelection
         catalog={catalog}

--- a/assets/js/components/ExecutionResults/CheckResultDetail/BackToTargetExecution.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/BackToTargetExecution.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { TARGET_CLUSTER, TARGET_HOST } from '@lib/model';
+
+import BackButton from '@components/BackButton';
+
+function BackToTargetExecution({ targetID, targetType }) {
+  let targetExecutionURL;
+  switch (targetType) {
+    case TARGET_CLUSTER:
+      targetExecutionURL = `/clusters/${targetID}/executions/last`;
+      break;
+    case TARGET_HOST:
+      targetExecutionURL = `/hosts/${targetID}/executions/last`;
+      break;
+    default:
+      return null;
+  }
+  return (
+    <BackButton url={targetExecutionURL}>Back to Check Results</BackButton>
+  );
+}
+
+export default BackToTargetExecution;

--- a/assets/js/components/ExecutionResults/CheckResultDetail/BackToTargetExecution.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/BackToTargetExecution.jsx
@@ -5,19 +5,17 @@ import { TARGET_CLUSTER, TARGET_HOST } from '@lib/model';
 import BackButton from '@components/BackButton';
 
 function BackToTargetExecution({ targetID, targetType }) {
-  let targetExecutionURL;
-  switch (targetType) {
-    case TARGET_CLUSTER:
-      targetExecutionURL = `/clusters/${targetID}/executions/last`;
-      break;
-    case TARGET_HOST:
-      targetExecutionURL = `/hosts/${targetID}/executions/last`;
-      break;
-    default:
-      return null;
-  }
+  const targetTypeToExecutionURL = {
+    [TARGET_CLUSTER]: `/clusters/${targetID}/executions/last`,
+    [TARGET_HOST]: `/hosts/${targetID}/executions/last`,
+  };
+
+  const targetExecutionURL = targetTypeToExecutionURL[targetType];
+
   return (
-    <BackButton url={targetExecutionURL}>Back to Check Results</BackButton>
+    targetExecutionURL && (
+      <BackButton url={targetExecutionURL}>Back to Check Results</BackButton>
+    )
   );
 }
 

--- a/assets/js/components/ExecutionResults/CheckResultDetail/CheckDetailHeader.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/CheckDetailHeader.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 
-import { UNKNOWN_PROVIDER, VMWARE_PROVIDER } from '@lib/model';
-
 import HealthIcon from '@components/Health/HealthIcon';
-import WarningBanner from '@components/Banners/WarningBanner';
+import { clusterWarningBanner } from '@components/ExecutionResults/ExecutionHeader';
 import CheckResultInfoBox from './CheckResultInfoBox';
 import { isTargetCluster } from '../checksUtils';
 import BackToTargetExecution from './BackToTargetExecution';
@@ -30,21 +28,7 @@ function CheckDetailHeader({
           <span className="font-medium">{checkDescription}</span>
         </h1>
       </div>
-      {targetCluster && cloudProvider === UNKNOWN_PROVIDER && (
-        <WarningBanner>
-          The following results are valid for on-premise bare metal platforms.
-          <br />
-          If you are running your HANA cluster on a different platform, please
-          use results with caution
-        </WarningBanner>
-      )}
-      {targetCluster && cloudProvider === VMWARE_PROVIDER && (
-        <WarningBanner>
-          Configuration checks for HANA scale-up performance optimized clusters
-          on VMware are still in experimental phase. Please use results with
-          caution.
-        </WarningBanner>
-      )}
+      {targetCluster && clusterWarningBanner[cloudProvider]}
       <CheckResultInfoBox
         checkID={checkID}
         resultTargetType={resultTargetType}

--- a/assets/js/components/ExecutionResults/CheckResultDetail/CheckDetailHeader.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/CheckDetailHeader.jsx
@@ -1,25 +1,27 @@
 import React from 'react';
 
-import BackButton from '@components/BackButton';
+import { UNKNOWN_PROVIDER, VMWARE_PROVIDER } from '@lib/model';
+
 import HealthIcon from '@components/Health/HealthIcon';
 import WarningBanner from '@components/Banners/WarningBanner';
-import { UNKNOWN_PROVIDER, VMWARE_PROVIDER } from '@lib/model';
 import CheckResultInfoBox from './CheckResultInfoBox';
+import { isTargetCluster } from '../checksUtils';
+import BackToTargetExecution from './BackToTargetExecution';
 
 function CheckDetailHeader({
-  clusterID,
   checkID,
   checkDescription,
+  targetID,
   targetType,
-  targetName,
+  resultTargetType,
+  resultTargetName,
   cloudProvider,
   result,
 }) {
+  const targetCluster = isTargetCluster(targetType);
   return (
     <>
-      <BackButton url={`/clusters/${clusterID}/executions/last`}>
-        Back to Check Results
-      </BackButton>
+      <BackToTargetExecution targetID={targetID} targetType={targetType} />
       <div className="flex mb-4 justify-between">
         <h1 className="flex text-3xl">
           <span className="inline-flex self-center mr-3">
@@ -28,7 +30,7 @@ function CheckDetailHeader({
           <span className="font-medium">{checkDescription}</span>
         </h1>
       </div>
-      {cloudProvider === UNKNOWN_PROVIDER && (
+      {targetCluster && cloudProvider === UNKNOWN_PROVIDER && (
         <WarningBanner>
           The following results are valid for on-premise bare metal platforms.
           <br />
@@ -36,7 +38,7 @@ function CheckDetailHeader({
           use results with caution
         </WarningBanner>
       )}
-      {cloudProvider === VMWARE_PROVIDER && (
+      {targetCluster && cloudProvider === VMWARE_PROVIDER && (
         <WarningBanner>
           Configuration checks for HANA scale-up performance optimized clusters
           on VMware are still in experimental phase. Please use results with
@@ -45,8 +47,8 @@ function CheckDetailHeader({
       )}
       <CheckResultInfoBox
         checkID={checkID}
-        targetType={targetType}
-        targetName={targetName}
+        resultTargetType={resultTargetType}
+        resultTargetName={resultTargetName}
         provider={cloudProvider}
       />
     </>

--- a/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultInfoBox.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultInfoBox.jsx
@@ -9,7 +9,12 @@ const targetTypeString = {
   [TARGET_CLUSTER]: 'Cluster',
 };
 
-function CheckResultInfoBox({ checkID, targetType, targetName, provider }) {
+function CheckResultInfoBox({
+  checkID,
+  resultTargetType,
+  resultTargetName,
+  provider,
+}) {
   return (
     <div className="w-full my-4 mr-4 bg-white shadow rounded-lg px-8 py-4">
       <ListView
@@ -22,8 +27,8 @@ function CheckResultInfoBox({ checkID, targetType, targetName, provider }) {
             content: checkID,
           },
           {
-            title: targetTypeString[targetType] || 'Unknown target type',
-            content: targetName,
+            title: targetTypeString[resultTargetType] || 'Unknown target type',
+            content: resultTargetName,
           },
           {
             title: 'Provider',

--- a/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultInfoBox.test.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultInfoBox.test.jsx
@@ -8,25 +8,25 @@ describe('CheckResultInfoBox Component', () => {
   const scenarios = [
     {
       checkID: faker.datatype.uuid(),
-      targetType: 'cluster',
+      resultTargetType: 'cluster',
       expectedTargetTypeText: 'Cluster',
-      targetName: faker.lorem.word(),
+      resultTargetName: faker.lorem.word(),
       provider: 'aws',
       expectedProviderText: 'AWS',
     },
     {
       checkID: faker.datatype.uuid(),
-      targetType: 'host',
+      resultTargetType: 'host',
       expectedTargetTypeText: 'Host',
-      targetName: faker.lorem.word(),
+      resultTargetName: faker.lorem.word(),
       provider: 'azure',
       expectedProviderText: 'Azure',
     },
     {
       checkID: faker.datatype.uuid(),
-      targetType: 'foobar',
+      resultTargetType: 'foobar',
       expectedTargetTypeText: 'Unknown target type',
-      targetName: faker.lorem.word(),
+      resultTargetName: faker.lorem.word(),
       provider: 'azure',
       expectedProviderText: 'Azure',
     },
@@ -36,24 +36,24 @@ describe('CheckResultInfoBox Component', () => {
     'should display a proper check result info box for check "$checkID" on target of type "$targetType" named "$targetName"',
     ({
       checkID,
-      targetType,
+      resultTargetType,
       expectedTargetTypeText,
-      targetName,
+      resultTargetName,
       provider,
       expectedProviderText,
     }) => {
       const { getByText } = render(
         <CheckResultInfoBox
           checkID={checkID}
-          targetType={targetType}
-          targetName={targetName}
+          resultTargetType={resultTargetType}
+          resultTargetName={resultTargetName}
           provider={provider}
         />
       );
       expect(getByText(checkID)).toBeTruthy();
       expect(getByText(expectedProviderText)).toBeTruthy();
       expect(getByText(expectedTargetTypeText)).toBeTruthy();
-      expect(getByText(targetName)).toBeTruthy();
+      expect(getByText(resultTargetName)).toBeTruthy();
     }
   );
 });

--- a/assets/js/components/ExecutionResults/CheckResultOutline.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultOutline.jsx
@@ -56,6 +56,24 @@ const extractExpectSameResults = (
     })
   );
 
+const getTargetCheckDetailURL = (
+  targetID,
+  targetType,
+  targetName,
+  checkID,
+  resultTargetType,
+  resultTargetName
+) => {
+  switch (targetType) {
+    case TARGET_CLUSTER:
+      return `/clusters/${targetID}/executions/last/${checkID}/${resultTargetType}/${resultTargetName}`;
+    case TARGET_HOST:
+      return `/hosts/${targetID}/executions/last/${checkID}/host/${targetName}`;
+    default:
+      return null;
+  }
+};
+
 function CheckResultOutline({
   checkID,
   targetID,
@@ -101,12 +119,17 @@ function CheckResultOutline({
                 targetName={resultTargetName}
                 expectationsSummary={expectationsSummary}
                 isAgentCheckError={agentCheckError}
-                onClick={() =>
-                  // todo navigate also to host execution results when targetType is host
-                  navigate(
-                    `/clusters/${targetID}/executions/last/${checkID}/${resultTargetType}/${resultTargetName}`
-                  )
-                }
+                onClick={() => {
+                  const targetCheckDetailURL = getTargetCheckDetailURL(
+                    targetID,
+                    targetType,
+                    targetName,
+                    checkID,
+                    resultTargetType,
+                    resultTargetName
+                  );
+                  targetCheckDetailURL && navigate(targetCheckDetailURL);
+                }}
               />
             )
           )}

--- a/assets/js/components/ExecutionResults/CheckResultOutline.test.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultOutline.test.jsx
@@ -36,7 +36,7 @@ const expectSameStatementResult = (expectationName, result) =>
   });
 
 describe('CheckResultOutline Component', () => {
-  it('should render a proper outline for a successful result', async () => {
+  it('should render a proper outline for a successful cluster check result', async () => {
     const user = userEvent.setup();
 
     const clusterID = faker.datatype.uuid();
@@ -125,6 +125,57 @@ describe('CheckResultOutline Component', () => {
 
     expect(window.location.pathname).toEqual(
       `/clusters/${clusterID}/executions/last/${checkID}/cluster/${clusterName}`
+    );
+  });
+
+  it('should render a proper outline for a successful host check result', async () => {
+    const user = userEvent.setup();
+
+    const hostID = faker.datatype.uuid();
+    const hostName = faker.lorem.word();
+    const checkID = faker.datatype.uuid();
+
+    const expectationName = faker.datatype.uuid();
+
+    const expectations = [
+      catalogExpectExpectationFactory.build({
+        name: expectationName,
+      }),
+    ];
+
+    let checkResult = emptyCheckResultFactory.build({
+      checkID,
+      targets: [hostID],
+      result: 'passing',
+    });
+    checkResult = addPassingExpectExpectation(checkResult, expectationName);
+
+    const agentsCheckResults = agentsCheckResultsWithHostname(
+      checkResult.agents_check_results,
+      [{ id: hostID, hostname: hostName }]
+    );
+
+    const expectationResults = [expectStatementResult(expectationName, true)];
+
+    renderWithRouter(
+      <CheckResultOutline
+        targetID={hostID}
+        checkID={checkID}
+        targetName={hostName}
+        targetType="host"
+        expectations={expectations}
+        agentsCheckResults={agentsCheckResults}
+        expectationResults={expectationResults}
+      />
+    );
+
+    expect(screen.getAllByText(hostName)).toHaveLength(1);
+    expect(screen.getAllByText('1/1 Expectations met.')).toHaveLength(1);
+
+    await act(async () => user.click(screen.getAllByText(hostName)[0]));
+
+    expect(window.location.pathname).toEqual(
+      `/hosts/${hostID}/executions/last/${checkID}/host/${hostName}`
     );
   });
 

--- a/assets/js/components/ExecutionResults/ExecutionHeader.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionHeader.jsx
@@ -9,6 +9,23 @@ import { isTargetCluster } from './checksUtils';
 import BackToTargetDetails from './BackToTargetDetails';
 import TargetInfoBox from './TargetInfoBox';
 
+export const clusterWarningBanner = {
+  [UNKNOWN_PROVIDER]: (
+    <WarningBanner>
+      The following results are valid for on-premise bare metal platforms.
+      <br />
+      If you are running your HANA cluster on a different platform, please use
+      results with caution
+    </WarningBanner>
+  ),
+  [VMWARE_PROVIDER]: (
+    <WarningBanner>
+      Configuration checks for HANA scale-up performance optimized clusters on
+      VMware are still in experimental phase. Please use results with caution.
+    </WarningBanner>
+  ),
+};
+
 function ExecutionHeader({
   targetID,
   targetName,
@@ -39,21 +56,7 @@ function ExecutionHeader({
           onSave={onFilterSave}
         />
       </div>
-      {targetCluster && target.provider === UNKNOWN_PROVIDER && (
-        <WarningBanner>
-          The following results are valid for on-premise bare metal platforms.
-          <br />
-          If you are running your HANA cluster on a different platform, please
-          use results with caution
-        </WarningBanner>
-      )}
-      {targetCluster && target.provider === VMWARE_PROVIDER && (
-        <WarningBanner>
-          Configuration checks for HANA scale-up performance optimized clusters
-          on VMware are still in experimental phase. Please use results with
-          caution.
-        </WarningBanner>
-      )}
+      {targetCluster && clusterWarningBanner[target.provider]}
       <TargetInfoBox targetType={targetType} target={target} />
     </>
   );

--- a/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResultsPage.jsx
@@ -16,20 +16,8 @@ import {
   RUNNING_STATES,
 } from '@state/lastExecutions';
 import LoadingBox from '@components/LoadingBox';
-import { TARGET_CLUSTER, TARGET_HOST } from '@lib/model';
 import ExecutionResults from './ExecutionResults';
-import { isTargetCluster, isTargetHost } from './checksUtils';
-
-const getTargetName = (target, targetType) => {
-  switch (targetType) {
-    case TARGET_CLUSTER:
-      return target.name;
-    case TARGET_HOST:
-      return target.hostname;
-    default:
-      return null;
-  }
-};
+import { getTargetName, isTargetCluster, isTargetHost } from './checksUtils';
 
 function ExecutionResultsPage({ targetType }) {
   const { targetID } = useParams();

--- a/assets/js/components/ExecutionResults/checksUtils.js
+++ b/assets/js/components/ExecutionResults/checksUtils.js
@@ -169,3 +169,14 @@ export const getExpectSameFacts = (expectations, agentsCheckResults) =>
         }, {}),
     },
   }));
+
+export const getTargetName = (target, targetType) => {
+  switch (targetType) {
+    case TARGET_CLUSTER:
+      return target.name;
+    case TARGET_HOST:
+      return target.hostname;
+    default:
+      return null;
+  }
+};

--- a/assets/js/components/ExecutionResults/checksUtils.test.js
+++ b/assets/js/components/ExecutionResults/checksUtils.test.js
@@ -11,6 +11,7 @@ import {
   expectationResultFactory,
   agentsCheckResultsWithHostname,
   hostFactory,
+  clusterFactory,
   executionExpectationEvaluationErrorFactory,
   failingExpectEvaluationFactory,
 } from '@lib/test-utils/factories';
@@ -34,6 +35,7 @@ import {
   getExpectSameStatementsResults,
   getExpectSameFacts,
   getExpectStatementsResults,
+  getTargetName,
 } from './checksUtils';
 
 describe('checksUtils', () => {
@@ -511,6 +513,29 @@ describe('checksUtils', () => {
       expect(isPremium(checkCatalog, checkID)).toBe(
         expectedPremiumValues[index]
       );
+    });
+  });
+
+  describe('target name detection', () => {
+    it('should detect a cluster target name', () => {
+      const targetName = faker.lorem.word();
+      const target = clusterFactory.build({ name: targetName });
+
+      expect(getTargetName(target, 'cluster')).toBe(targetName);
+    });
+
+    it('should detect a host target name', () => {
+      const targetName = faker.lorem.word();
+      const target = hostFactory.build({ hostname: targetName });
+
+      expect(getTargetName(target, 'host')).toBe(targetName);
+    });
+
+    it('should not detect target name for unknown targets', () => {
+      const targetName = faker.lorem.word();
+      const target = hostFactory.build({ hostname: targetName });
+
+      expect(getTargetName(target, 'unknown-target')).toBeNull();
     });
   });
 });

--- a/assets/js/lib/test-utils/factories/executions.js
+++ b/assets/js/lib/test-utils/factories/executions.js
@@ -6,7 +6,7 @@ import { hostFactory, randomObjectFactory } from '.';
 export const checksExecutionStatusEnum = () =>
   faker.helpers.arrayElement(['running', 'completed', 'requested']);
 
-const resultEnum = () =>
+export const resultEnum = () =>
   faker.helpers.arrayElement(['passing', 'critical', 'warning']);
 
 const expectationReturnTypeEnum = () =>

--- a/assets/js/trento.jsx
+++ b/assets/js/trento.jsx
@@ -103,6 +103,10 @@ function App() {
                       <CheckResultDetailPage targetType={TARGET_CLUSTER} />
                     }
                   />
+                  <Route
+                    path="hosts/:targetID/executions/last/:checkID/:resultTargetType/:resultTargetName"
+                    element={<CheckResultDetailPage targetType={TARGET_HOST} />}
+                  />
                 </Route>
               </Route>
             </Route>


### PR DESCRIPTION
# Description

This PR introduces the Check Result detail for a host check execution.

- functionality on the cluster checks execution is kept working as previously
- back and forth navigation from detail to overview is target type aware
- filters are kept between pages

For consistency URL structure for host check detail has been kept the same as cluster check detail

```
/clusters/:targetID/executions/last/:checkID/:resultTargetType/:resultTargetName
/hosts/:targetID/executions/last/:checkID/:resultTargetType/:resultTargetName
```
even though in the host context `:resultTargetType` is always `host` and `:resultTargetName` is always the name of the host for which we are running checks.

## How was this tested?

Automated tests updated/added.

<details>
  <summary>Click here to see how to leverage trento playground for testing</summary>
  
see https://github.com/trento-project/playground 

1. add a host check in the catalog
```yaml
id: "TRNT01"
name: A host check
group: Trento
description: Trento agent service is enabled and running
remediation: lorem ipsum

when: env.target_type == "host"

facts:
  - name: trento_agent_service_state
    gatherer: systemd
    argument: trento-agent

values:
  - name: expected_trento_agent_service_state
    default: active

expectations:
  - name: trento_agent_service_state_active
    expect: facts.trento_agent_service_state == values.expected_trento_agent_service_state
    failure_message: Trento agent service was expected to be active (enabled and running) but returned value is '${facts.trento_agent_service_state}'
```
2. configure how fact gathering should behave for the check in `fake_facts.yaml`
```yaml
targets:
  # nodes on cluster hana_cluster_1 7965f822-0254-5858-abca-f6e8b4c27714
  target1: 0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4
  target2: 13e8c25c-3180-5a9a-95c8-51ec38e50cfc

  # nodes on cluster hana_cluster_2 fa0d74a3-9240-5d9e-99fa-61c4137acf81
  target3: 99cf8a3a-48d6-57a4-b302-6e4482227ab6
  target4: e0c182db-32ff-55c6-a9eb-2b82dd21bc8b

  # nodes on cluster hana_cluster_3 469e7be5-4e20-5007-b044-c6f540a87493
  target5: 9cd46919-5f19-59aa-993e-cf3736c71053
  target6: b767b3e9-e802-587e-a442-541d093b86b9

  # vmdrbddev01
  target7: 240f96b1-8d26-53b7-9e99-ffb0f2e735bf

facts:
  # other fact config

  "TRNT01":
    trento_agent_service_state:
      target1: active
      target2: active
      target3: active
      target4: active
      target5: active
      target6: active      
      target7: inactive

```
</details>

![host-check-result-detail](https://github.com/trento-project/web/assets/8167114/2b1cbfc1-c294-4b35-9392-d2c7e07a4862)