### PR TITLE
Fix instance movement logic

### DIFF
--- a/lib/trento/domain/sap_system/sap_system.ex
+++ b/lib/trento/domain/sap_system/sap_system.ex
@@ -1026,15 +1026,20 @@ defmodule Trento.Domain.SapSystem do
        ) do
     moving_instance =
       Enum.find(instances, fn instance ->
-        instance.instance_number == instance_number and instance.host_id != host_id
+        instance.instance_number == instance_number and instance.features == features and
+          instance.host_id != host_id
       end)
 
-    instance_in_same_host =
-      Enum.find(instances, fn instance ->
-        instance.instance_number == instance_number and instance.host_id == host_id
+    instance_in_same_host? =
+      Enum.any?(instances, fn instance ->
+        instance.instance_number == instance_number and instance.features == features and
+          instance.host_id == host_id
       end)
 
     cond do
+      instance_in_same_host? ->
+        nil
+
       cluster_id != nil and moving_instance != nil ->
         %ApplicationInstanceMoved{
           sap_system_id: sap_system_id,
@@ -1043,7 +1048,7 @@ defmodule Trento.Domain.SapSystem do
           new_host_id: host_id
         }
 
-      is_nil(instance_in_same_host) ->
+      true ->
         %ApplicationInstanceRegistered{
           sap_system_id: sap_system_id,
           sid: sid,
@@ -1056,9 +1061,6 @@ defmodule Trento.Domain.SapSystem do
           host_id: host_id,
           health: health
         }
-
-      true ->
-        nil
     end
   end
 


### PR DESCRIPTION
# Description
Fix instance movement logic.
- If the instance with same number, host and features exist -> nop
- The instance finding matching updated to check the `features` as well

## How was this tested?

UT test added together with manual testing
