### PR TITLE
Saptune status projection

### DIFF
--- a/lib/trento/application/read_models/host_read_model.ex
+++ b/lib/trento/application/read_models/host_read_model.ex
@@ -24,6 +24,7 @@ defmodule Trento.HostReadModel do
     field :selected_checks, {:array, :string}, default: []
     field :provider, Ecto.Enum, values: Provider.values()
     field :provider_data, :map
+    field :saptune_status, :map
 
     has_many :tags, Trento.Tag, foreign_key: :resource_id
 

--- a/lib/trento_web/openapi/v1/schema/host.ex
+++ b/lib/trento_web/openapi/v1/schema/host.ex
@@ -4,7 +4,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Host do
   require OpenApiSpex
   alias OpenApiSpex.Schema
 
-  alias TrentoWeb.OpenApi.V1.Schema.{Provider, SlesSubscription, Tags}
+  alias TrentoWeb.OpenApi.V1.Schema.{Provider, SaptuneStatus, SlesSubscription, Tags}
 
   defmodule IPv4 do
     @moduledoc false
@@ -70,6 +70,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Host do
           type: :array,
           items: SlesSubscription
         },
+        saptune_status: SaptuneStatus,
         deregistered_at: %Schema{
           title: "DeregisteredAt",
           description: "Timestamp of the last deregistration of the host",

--- a/lib/trento_web/openapi/v1/schema/saptune_status.ex
+++ b/lib/trento_web/openapi/v1/schema/saptune_status.ex
@@ -1,0 +1,136 @@
+defmodule TrentoWeb.OpenApi.V1.Schema.SaptuneStatus do
+  @moduledoc false
+
+  require OpenApiSpex
+
+  alias OpenApiSpex.Schema
+
+  defmodule Service do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "Saptune service",
+      description: "Saptune service",
+      type: :object,
+      properties: %{
+        name: %Schema{
+          type: :string,
+          description: "Saptune service name"
+        },
+        enabled: %Schema{
+          type: :string,
+          description: "Enabled state as string"
+        },
+        active: %Schema{
+          type: :string,
+          description: "Active state as string"
+        }
+      }
+    })
+  end
+
+  defmodule Note do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "Saptune note",
+      description: "Saptune note",
+      type: :object,
+      properties: %{
+        id: %Schema{
+          type: :string,
+          description: "Saptune note ID"
+        },
+        additionally_enabled: %Schema{
+          type: :boolean,
+          description: "Note is additionally enabled"
+        }
+      }
+    })
+  end
+
+  defmodule Solution do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "Saptune solution",
+      description: "Saptune solution",
+      type: :object,
+      properties: %{
+        id: %Schema{
+          type: :boolean,
+          description: "Saptune solution ID"
+        },
+        notes: %Schema{
+          type: :array,
+          description: "Solution note IDs",
+          items: %Schema{type: :string}
+        },
+        partial: %Schema{
+          type: :boolean,
+          description: "Solution is partially applied"
+        }
+      }
+    })
+  end
+
+  defmodule Staging do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "Saptune staging",
+      description: "Saptune staging data",
+      type: :object,
+      properties: %{
+        enabled: %Schema{
+          type: :boolean,
+          description: "Saptune staging is enabled"
+        },
+        notes: %Schema{
+          type: :array,
+          description: "Staged saptune note IDs",
+          items: %Schema{type: :string}
+        },
+        solutions_ids: %Schema{
+          type: :array,
+          description: "Staged saptune solution IDs",
+          items: %Schema{type: :string}
+        }
+      }
+    })
+  end
+
+  OpenApiSpex.schema(%{
+    title: "Saptune status",
+    description: "Saptune status output on the host",
+    type: :object,
+    nullable: true,
+    properties: %{
+      package_version: %Schema{type: :string, description: "Saptune package version"},
+      configured_version: %Schema{type: :string, description: "Saptune configure version"},
+      tuning_state: %Schema{type: :string, description: "Saptune tuning state"},
+      services: %Schema{
+        title: "Saptune services",
+        description: "A list of saptune services",
+        type: :array,
+        items: Service
+      },
+      enabled_nodes: %Schema{
+        title: "Enabled notes",
+        description: "A list of enabled notes",
+        type: :array,
+        items: Note
+      },
+      applied_notes: %Schema{
+        title: "Applied notes",
+        description: "A list of applied notes",
+        type: :array,
+        items: Note
+      },
+      enabled_solution: Solution,
+      applied_solution: Solution,
+      staging: Staging
+    },
+    required: [:package_version]
+  })
+end

--- a/lib/trento_web/views/v1/host_view.ex
+++ b/lib/trento_web/views/v1/host_view.ex
@@ -33,4 +33,10 @@ defmodule TrentoWeb.V1.HostView do
   def render("heartbeat_result.json", %{host: %{id: id, hostname: hostname}}) do
     %{id: id, hostname: hostname}
   end
+
+  def render("saptune_status_updated.json", %{
+        host: %{id: id, saptune_status: status, hostname: hostname}
+      }) do
+    %{id: id, status: status, hostname: hostname}
+  end
 end

--- a/priv/repo/migrations/20230905141817_add_saptune_status_host_read_model.exs
+++ b/priv/repo/migrations/20230905141817_add_saptune_status_host_read_model.exs
@@ -1,0 +1,9 @@
+defmodule Trento.Repo.Migrations.AddSaptuneStatusHostReadModel do
+  use Ecto.Migration
+
+  def change do
+    alter table(:hosts) do
+      add :saptune_status, :map
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -117,7 +117,8 @@ defmodule Trento.Factory do
       provider: Enum.random(Provider.values()),
       provider_data: nil,
       deregistered_at: nil,
-      selected_checks: Enum.map(0..4, fn _ -> Faker.StarWars.planet() end)
+      selected_checks: Enum.map(0..4, fn _ -> Faker.StarWars.planet() end),
+      saptune_status: nil
     }
   end
 


### PR DESCRIPTION
# Description

Saptune status projection.

The read model and the view follows a flat hierarchy adding `saptune_status` directly. In the future we could have other entries like `saptune_notes` or `saptune_solutions`.
We could have other "tree" kind of representations as well. Check the open api schema to see how it looks like

## How was this tested?

Tested with UT
