### PR TITLE
Align `primary` button style `disabled` state with UI proposal

### DIFF
--- a/assets/js/components/Button/Button.jsx
+++ b/assets/js/components/Button/Button.jsx
@@ -25,7 +25,7 @@ const getButtonClasses = (type) => {
     case 'default-fit':
       return 'bg-jungle-green-500 hover:opacity-75 focus:outline-none text-white w-fit transition ease-in duration-200 text-center font-semibold rounded shadow';
     default:
-      return 'bg-jungle-green-500 hover:opacity-75 focus:outline-none text-white w-full transition ease-in duration-200 text-center font-semibold rounded shadow';
+      return 'bg-jungle-green-500 hover:opacity-75 focus:outline-none text-white w-full transition ease-in duration-200 text-center font-semibold rounded shadow disabled:bg-gray-400';
   }
 };
 

--- a/assets/js/components/Button/Button.jsx
+++ b/assets/js/components/Button/Button.jsx
@@ -25,7 +25,7 @@ const getButtonClasses = (type) => {
     case 'default-fit':
       return 'bg-jungle-green-500 hover:opacity-75 focus:outline-none text-white w-fit transition ease-in duration-200 text-center font-semibold rounded shadow';
     default:
-      return 'bg-jungle-green-500 hover:opacity-75 focus:outline-none text-white w-full transition ease-in duration-200 text-center font-semibold rounded shadow disabled:bg-gray-400';
+      return 'bg-jungle-green-500 hover:opacity-75 focus:outline-none text-white w-full transition ease-in duration-200 text-center font-semibold rounded shadow disabled:bg-gray-400 disabled:text-gray-200';
   }
 };
 

--- a/assets/js/components/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/HanaClusterDetails.jsx
@@ -139,7 +139,7 @@ function HanaClusterDetails({
                 }}
                 disabled={startExecutionDisabled}
               >
-                <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub" />{' '}
+                <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub disabled:fill-gray-200" />{' '}
                 Start Execution
               </Button>
             </Tooltip>

--- a/assets/js/components/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/HanaClusterDetails.jsx
@@ -139,7 +139,11 @@ function HanaClusterDetails({
                 }}
                 disabled={startExecutionDisabled}
               >
-                <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub disabled:fill-gray-200" />{' '}
+                <EOS_PLAY_CIRCLE
+                  className={`${
+                    !startExecutionDisabled ? 'fill-white' : 'fill-gray-200'
+                  } inline-block align-sub`}
+                />{' '}
                 Start Execution
               </Button>
             </Tooltip>

--- a/assets/js/components/ClusterSettingsPage/ClusterSettingsPage.jsx
+++ b/assets/js/components/ClusterSettingsPage/ClusterSettingsPage.jsx
@@ -136,7 +136,13 @@ function ClusterSettingsPage() {
                 onClick={requestExecution}
                 disabled={!canStartExecution(selectedChecks, saving)}
               >
-                <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub disabled:fill-gray-200" />{' '}
+                <EOS_PLAY_CIRCLE
+                  className={`${
+                    canStartExecution(selectedChecks, saving)
+                      ? 'fill-white'
+                      : 'fill-gray-200'
+                  } inline-block align-sub`}
+                />{' '}
                 Start Execution
               </Button>
             </Tooltip>

--- a/assets/js/components/ClusterSettingsPage/ClusterSettingsPage.jsx
+++ b/assets/js/components/ClusterSettingsPage/ClusterSettingsPage.jsx
@@ -136,7 +136,7 @@ function ClusterSettingsPage() {
                 onClick={requestExecution}
                 disabled={!canStartExecution(selectedChecks, saving)}
               >
-                <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub" />{' '}
+                <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub disabled:fill-gray-200" />{' '}
                 Start Execution
               </Button>
             </Tooltip>

--- a/assets/js/components/HostDetails/HostChecksSelection.jsx
+++ b/assets/js/components/HostDetails/HostChecksSelection.jsx
@@ -62,7 +62,11 @@ function HostChecksSelection({
                 onClick={onStartExecution}
                 disabled={hostChecksExecutionEnabled}
               >
-                <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub disabled:fill-gray-200" />{' '}
+                <EOS_PLAY_CIRCLE
+                  className={`${
+                    !hostChecksExecutionEnabled ? 'fill-white' : 'fill-gray-200'
+                  } inline-block align-sub`}
+                />{' '}
                 Start Execution
               </Button>
             </Tooltip>

--- a/assets/js/components/HostDetails/HostChecksSelection.jsx
+++ b/assets/js/components/HostDetails/HostChecksSelection.jsx
@@ -62,7 +62,7 @@ function HostChecksSelection({
                 onClick={onStartExecution}
                 disabled={hostChecksExecutionEnabled}
               >
-                <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub" />{' '}
+                <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub disabled:fill-gray-200" />{' '}
                 Start Execution
               </Button>
             </Tooltip>

--- a/assets/js/components/HostDetails/HostDetails.jsx
+++ b/assets/js/components/HostDetails/HostDetails.jsx
@@ -133,7 +133,13 @@ function HostDetails({
                   onClick={requestHostChecksExecution}
                   disabled={!canStartExecution(selectedChecks, savingChecks)}
                 >
-                  <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub disabled:fill-gray-200" />{' '}
+                  <EOS_PLAY_CIRCLE
+                    className={`${
+                      canStartExecution(selectedChecks, savingChecks)
+                        ? 'fill-white'
+                        : 'fill-gray-200'
+                    } inline-block align-sub`}
+                  />{' '}
                   Start Execution
                 </Button>
               </Tooltip>

--- a/assets/js/components/HostDetails/HostDetails.jsx
+++ b/assets/js/components/HostDetails/HostDetails.jsx
@@ -133,7 +133,7 @@ function HostDetails({
                   onClick={requestHostChecksExecution}
                   disabled={!canStartExecution(selectedChecks, savingChecks)}
                 >
-                  <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub" />{' '}
+                  <EOS_PLAY_CIRCLE className="fill-white inline-block align-sub disabled:fill-gray-200" />{' '}
                   Start Execution
                 </Button>
               </Tooltip>


### PR DESCRIPTION
# Description

Currently the styling of the `primary`/default button in the `disabled` state does not reflect the UI proposal. This PR aligns the implementation with the proposal.

## How was this tested?

As this is purely a CSS styling change, the behaviour of the UI does not change, and therefore no tests were added.
