### PR TITLE
Fix typo on tuning word

### DIFF
--- a/assets/js/components/HostDetails/HostDetails.test.jsx
+++ b/assets/js/components/HostDetails/HostDetails.test.jsx
@@ -165,7 +165,7 @@ describe('HostDetails component', () => {
         screen.getByText('Configured Version').nextSibling
       ).toHaveTextContent(configuredVersion);
 
-      expect(screen.getByText('Tunning').nextSibling).toHaveTextContent(
+      expect(screen.getByText('Tuning').nextSibling).toHaveTextContent(
         new RegExp(tuningState, 'i')
       );
     });

--- a/assets/js/components/HostDetails/SaptuneSummary.jsx
+++ b/assets/js/components/HostDetails/SaptuneSummary.jsx
@@ -33,7 +33,7 @@ function SaptuneSummary({
             content: <SaptuneVersion version={saptuneVersion} />,
           },
           {
-            title: 'Tunning',
+            title: 'Tuning',
             content: <SaptuneTuningState state={saptuneTuning} />,
           },
           {

--- a/assets/js/components/HostDetails/SaptuneSummary.test.jsx
+++ b/assets/js/components/HostDetails/SaptuneSummary.test.jsx
@@ -33,7 +33,7 @@ describe('SaptuneSummary component', () => {
       screen.getByText('Configured Version').nextSibling
     ).toHaveTextContent(configuredVersion);
 
-    expect(screen.getByText('Tunning').nextSibling).toHaveTextContent(
+    expect(screen.getByText('Tuning').nextSibling).toHaveTextContent(
       new RegExp(tuningState, 'i')
     );
   });


### PR DESCRIPTION
Fix typo on. `Tunning` -> `Tuning`
