### PR TITLE
Determine host health

### DIFF
--- a/lib/trento/application/event_handlers/stream_roll_up_event_handler.ex
+++ b/lib/trento/application/event_handlers/stream_roll_up_event_handler.ex
@@ -46,7 +46,9 @@ defmodule Trento.StreamRollUpEventHandler do
     Trento.Domain.Events.HostRegistered,
     Trento.Domain.Events.ProviderUpdated,
     Trento.Domain.Events.SlesSubscriptionsUpdated,
-    Trento.Domain.Events.HostChecksSelected
+    Trento.Domain.Events.HostChecksSelected,
+    Trento.Domain.Events.HostChecksHealthChanged,
+    Trento.Domain.Events.HostHealthChanged
   ]
 
   @sap_system_events [

--- a/lib/trento/domain/host/commands/complete_checks_execution.ex
+++ b/lib/trento/domain/host/commands/complete_checks_execution.ex
@@ -1,0 +1,16 @@
+defmodule Trento.Domain.Commands.CompleteHostChecksExecution do
+  @moduledoc """
+  Complete the checks execution with the incoming result
+  """
+
+  @required_fields :all
+
+  use Trento.Command
+
+  require Trento.Domain.Enums.Health, as: Health
+
+  defcommand do
+    field :host_id, Ecto.UUID
+    field :health, Ecto.Enum, values: Health.values()
+  end
+end

--- a/lib/trento/domain/host/events/host_checks_health_changed.ex
+++ b/lib/trento/domain/host/events/host_checks_health_changed.ex
@@ -1,0 +1,14 @@
+defmodule Trento.Domain.Events.HostChecksHealthChanged do
+  @moduledoc """
+  This event is emitted when a host's checks result changes.
+  """
+
+  use Trento.Event
+
+  require Trento.Domain.Enums.Health, as: Health
+
+  defevent do
+    field :host_id, Ecto.UUID
+    field :checks_health, Ecto.Enum, values: Health.values()
+  end
+end

--- a/lib/trento/domain/host/events/host_health_changed.ex
+++ b/lib/trento/domain/host/events/host_health_changed.ex
@@ -1,0 +1,16 @@
+defmodule Trento.Domain.Events.HostHealthChanged do
+  @moduledoc """
+  This event is emitted when the health of a host changes because of
+  - an heartbeat failure/recovery
+  - a check's execution result
+  """
+
+  use Trento.Event
+
+  require Trento.Domain.Enums.Health, as: Health
+
+  defevent do
+    field :host_id, Ecto.UUID
+    field :health, Ecto.Enum, values: Health.values()
+  end
+end

--- a/lib/trento/infrastructure/router.ex
+++ b/lib/trento/infrastructure/router.ex
@@ -11,6 +11,7 @@ defmodule Trento.Router do
 
   alias Trento.Domain.Commands.{
     CompleteChecksExecution,
+    CompleteHostChecksExecution,
     DeregisterApplicationInstance,
     DeregisterClusterHost,
     DeregisterDatabaseInstance,
@@ -46,7 +47,8 @@ defmodule Trento.Router do
              SelectHostChecks,
              RollUpHost,
              RequestHostDeregistration,
-             DeregisterHost
+             DeregisterHost,
+             CompleteHostChecksExecution
            ],
            to: Host,
            lifespan: Host.Lifespan

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -34,8 +34,12 @@ defmodule Trento.Factory do
     DatabaseInstanceRegistered,
     DatabaseRegistered,
     DatabaseRestored,
+    HeartbeatFailed,
+    HeartbeatSucceded,
     HostAddedToCluster,
+    HostChecksHealthChanged,
     HostDetailsUpdated,
+    HostHealthChanged,
     HostRegistered,
     HostRemovedFromCluster,
     HostTombstoned,
@@ -683,6 +687,32 @@ defmodule Trento.Factory do
       socket_count: Enum.random(1..16),
       os_version: Faker.App.semver(),
       installation_source: Enum.random([:community, :suse, :unknown])
+    })
+  end
+
+  def heartbeat_succeded_factory do
+    HeartbeatSucceded.new!(%{
+      host_id: Faker.UUID.v4()
+    })
+  end
+
+  def heartbeat_failed_factory do
+    HeartbeatFailed.new!(%{
+      host_id: Faker.UUID.v4()
+    })
+  end
+
+  def host_checks_health_changed_factory do
+    %HostChecksHealthChanged{
+      host_id: Faker.UUID.v4(),
+      checks_health: Health.passing()
+    }
+  end
+
+  def host_health_changed_event_factory do
+    HostHealthChanged.new!(%{
+      host_id: Faker.UUID.v4(),
+      health: Health.passing()
     })
   end
 end


### PR DESCRIPTION
# Description

This PR introduces the `health` concept for the host aggregate.

It's final result is made up from the composition of `heartbeat` and `checks_health` (aka the result of the last execution for the current host).
Very likely in the near future host's health should also consider saptune information.

Notes/followups: 
- we currently are using the `checks_health` terminology which we refer to also as `checks result`. 
  I kept consistency with terminology used in the cluster aggregate
- https://github.com/trento-project/web/pull/1858
- https://github.com/trento-project/web/pull/1859
- we should update and upcast events like `HostRegistered`, `HostDetailsUpdated` (others?) to handle the new information at hand
- projections and readmodels/frontend are in line

## How was this tested?

Automated tests updated/added.
