### PR TITLE
Exclude checks result from host's health when empty selection is saved

### DIFF
--- a/lib/trento/domain/host/host.ex
+++ b/lib/trento/domain/host/host.ex
@@ -389,17 +389,20 @@ defmodule Trento.Domain.Host do
   end
 
   def execute(
-        %Host{
-          host_id: host_id
-        },
+        %Host{} = host,
         %SelectHostChecks{
           checks: selected_checks
         }
       ) do
-    %HostChecksSelected{
-      host_id: host_id,
-      checks: selected_checks
-    }
+    host
+    |> Multi.new()
+    |> Multi.execute(
+      &%HostChecksSelected{
+        host_id: &1.host_id,
+        checks: selected_checks
+      }
+    )
+    |> Multi.execute(&maybe_emit_host_health_changed_event/1)
   end
 
   def execute(


### PR DESCRIPTION
# Description

This PR makes sure to ignore the checks result from the host's aggregated health computation when an empty selection is saved.

Imagine a host whose heartbeat is successful, but the latest checks execution is warning: the resulting host health would be warning.
If we now deselect all the checks for the host and save the empty selection, no other execution would run and the checks_health would remain in warning, keeping also the host's aggregated health in warning state, which would not make sense if there are no selected checks.

## How was this tested?

Automated test added
