### PR TITLE
Add health to host read model

### DIFF
--- a/lib/trento/application/read_models/host_read_model.ex
+++ b/lib/trento/application/read_models/host_read_model.ex
@@ -22,7 +22,7 @@ defmodule Trento.HostReadModel do
     field :agent_version, :string
     field :cluster_id, Ecto.UUID
     field :heartbeat, Ecto.Enum, values: [:critical, :passing, :unknown]
-    field :health, Ecto.Enum, values: Health.values()
+    field :health, Ecto.Enum, values: Health.values(), default: Health.unknown()
     field :selected_checks, {:array, :string}, default: []
     field :provider, Ecto.Enum, values: Provider.values()
     field :provider_data, :map

--- a/lib/trento/application/read_models/host_read_model.ex
+++ b/lib/trento/application/read_models/host_read_model.ex
@@ -7,6 +7,7 @@ defmodule Trento.HostReadModel do
 
   import Ecto.Changeset
 
+  require Trento.Domain.Enums.Health, as: Health
   require Trento.Domain.Enums.Provider, as: Provider
 
   alias Trento.SlesSubscriptionReadModel
@@ -21,6 +22,7 @@ defmodule Trento.HostReadModel do
     field :agent_version, :string
     field :cluster_id, Ecto.UUID
     field :heartbeat, Ecto.Enum, values: [:critical, :passing, :unknown]
+    field :health, Ecto.Enum, values: Health.values()
     field :selected_checks, {:array, :string}, default: []
     field :provider, Ecto.Enum, values: Provider.values()
     field :provider_data, :map

--- a/lib/trento/domain/host/events/host_registered.ex
+++ b/lib/trento/domain/host/events/host_registered.ex
@@ -5,7 +5,7 @@ defmodule Trento.Domain.Events.HostRegistered do
 
   use Trento.Event
 
-  defevent version: 2 do
+  defevent version: 3 do
     field :host_id, Ecto.UUID
     field :hostname, :string
     field :ip_addresses, {:array, :string}
@@ -18,7 +18,9 @@ defmodule Trento.Domain.Events.HostRegistered do
     field :installation_source, Ecto.Enum, values: [:community, :suse, :unknown]
 
     field :heartbeat, Ecto.Enum, values: [:unknown]
+    field :health, Ecto.Enum, values: [:unknown]
   end
 
   def upcast(params, _, 2), do: Map.put(params, "installation_source", :unknown)
+  def upcast(params, _, 3), do: Map.put(params, "health", :unknown)
 end

--- a/lib/trento_web/views/v1/host_view.ex
+++ b/lib/trento_web/views/v1/host_view.ex
@@ -17,6 +17,7 @@ defmodule TrentoWeb.V1.HostView do
     |> Map.delete(:tags)
     |> Map.delete(:cluster_id)
     |> Map.delete(:heartbeat)
+    |> Map.delete(:health)
     |> Map.delete(:provider)
   end
 
@@ -38,5 +39,9 @@ defmodule TrentoWeb.V1.HostView do
         host: %{id: id, saptune_status: status, hostname: hostname}
       }) do
     %{id: id, status: status, hostname: hostname}
+  end
+
+  def render("host_health_changed.json", %{host: %{id: id, health: health}}) do
+    %{id: id, health: health}
   end
 end

--- a/priv/repo/migrations/20230926082236_add_host_health.exs
+++ b/priv/repo/migrations/20230926082236_add_host_health.exs
@@ -1,0 +1,9 @@
+defmodule Trento.Repo.Migrations.AddHostHealth do
+  use Ecto.Migration
+
+  def change do
+    alter table(:hosts) do
+      add :health, :string
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -118,6 +118,7 @@ defmodule Trento.Factory do
       agent_version: Faker.StarWars.planet(),
       cluster_id: Faker.UUID.v4(),
       heartbeat: :unknown,
+      health: :unknown,
       provider: Enum.random(Provider.values()),
       provider_data: nil,
       deregistered_at: nil,

--- a/test/trento/domain/host/events/host_registered_test.exs
+++ b/test/trento/domain/host/events/host_registered_test.exs
@@ -15,7 +15,7 @@ defmodule Trento.Domain.Events.HostRegisteredTest do
       os_version = Faker.App.version()
 
       assert %HostRegistered{
-               version: 2,
+               version: 3,
                host_id: host_id,
                hostname: hostname,
                ip_addresses: ip_addresses,
@@ -24,7 +24,9 @@ defmodule Trento.Domain.Events.HostRegisteredTest do
                total_memory_mb: total_memory_mb,
                socket_count: socket_count,
                os_version: os_version,
-               installation_source: :unknown
+               installation_source: :unknown,
+               heartbeat: :unknown,
+               health: :unknown
              } ==
                %{
                  "host_id" => host_id,
@@ -34,7 +36,8 @@ defmodule Trento.Domain.Events.HostRegisteredTest do
                  "cpu_count" => cpu_count,
                  "total_memory_mb" => total_memory_mb,
                  "socket_count" => socket_count,
-                 "os_version" => os_version
+                 "os_version" => os_version,
+                 "heartbeat" => :unknown
                }
                |> HostRegistered.upcast(%{})
                |> HostRegistered.new!()

--- a/test/trento_web/views/v1/host_view_test.exs
+++ b/test/trento_web/views/v1/host_view_test.exs
@@ -1,0 +1,36 @@
+defmodule TrentoWeb.V1.HostViewTest do
+  @moduledoc false
+
+  use TrentoWeb.ConnCase, async: true
+
+  import Phoenix.View
+  import Trento.Factory
+
+  alias TrentoWeb.V1.HostView
+
+  alias Trento.HostReadModel
+
+  test "should render health changed relevant information" do
+    %HostReadModel{id: id} = host = build(:host, health: :passing)
+
+    assert %{id: id, health: :passing} ==
+             render(HostView, "host_health_changed.json", %{host: host})
+  end
+
+  test "should render host details relevant information" do
+    host = build(:host)
+
+    rendered_map = render(HostView, "host_details_updated.json", %{host: host})
+
+    ignored_properties = [
+      :sles_subscriptions,
+      :tags,
+      :cluster_id,
+      :heartbeat,
+      :health,
+      :provider
+    ]
+
+    assert Enum.all?(ignored_properties, &(!Map.has_key?(rendered_map, &1)))
+  end
+end


### PR DESCRIPTION
# Description

This PR adds the aggregated health of a host to the host read model

- migration added
- host read model has also `health` defaulting to `:unknown`
- on a  `HostHealthChanged` event the health is projected to the read model and broadcasted via websocket
- `HostView` takes `health` into account where necessary (ie ignored in `host_details_updated`)
- `HostRegistered` is upcasted to contain also host's aggregated `health`

Frontend will follow up.

## How was this tested?

Automated tests updated/added
