### PR TITLE
Handle fact value with null value

### DIFF
--- a/assets/js/components/ExecutionResults/CheckResultDetail/FactValue.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/FactValue.jsx
@@ -3,11 +3,13 @@ import React from 'react';
 import ObjectTree from '@components/ObjectTree';
 
 function FactValue({ className, data }) {
-  return typeof data === 'object' ? (
-    <ObjectTree className={className} data={data} />
-  ) : (
-    <span className={className}>{`${data}`}</span>
-  );
+  if (data === null) {
+    return <span className={className}>null</span>;
+  }
+  if (typeof data === 'object') {
+    return <ObjectTree className={className} data={data} />;
+  }
+  return <span className={className}>{`${data}`}</span>;
 }
 
 export default FactValue;

--- a/assets/js/components/ExecutionResults/CheckResultDetail/FactValue.test.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/FactValue.test.jsx
@@ -28,6 +28,11 @@ describe('FactValue component', () => {
       plain: true,
       stringRepresentation: 'true',
     },
+    {
+      type: 'null',
+      plain: null,
+      stringRepresentation: 'null',
+    },
   ];
 
   it.each(scalarScenarios)(

--- a/assets/js/components/ObjectTree/ObjectTree.stories.jsx
+++ b/assets/js/components/ObjectTree/ObjectTree.stories.jsx
@@ -10,5 +10,10 @@ export default {
 };
 
 export function Normal(args) {
-  return <ObjectTree data={objectTreeFactory.build()} {...args} />;
+  return (
+    <ObjectTree
+      data={objectTreeFactory.build({ empty_array: [], empty_object: {} })}
+      {...args}
+    />
+  );
 }

--- a/assets/js/components/ObjectTree/ObjectTree.test.jsx
+++ b/assets/js/components/ObjectTree/ObjectTree.test.jsx
@@ -42,7 +42,7 @@ describe('flattenTree and treeify', () => {
 
     const [
       {
-        children: [firstChildID, _second, _third, fourthChildID],
+        children: [firstChildID, _second, _third, fourthChildID, fifthChildID],
       },
     ] = children;
 
@@ -61,5 +61,7 @@ describe('flattenTree and treeify', () => {
 
     expect(children[firstComplexObjectChild].parent).toBe(fourthChildID);
     expect(children[secondComplexObjectChild].parent).toBe(fourthChildID);
+
+    expect(children[fifthChildID].value).toBe(null);
   });
 });

--- a/assets/js/components/ObjectTree/ObjectTree.test.jsx
+++ b/assets/js/components/ObjectTree/ObjectTree.test.jsx
@@ -9,7 +9,7 @@ import { flattenTree, treeify } from './tree';
 
 describe('ObjectTree component', () => {
   it('should render correctly', () => {
-    const data = objectTreeFactory.build();
+    const data = objectTreeFactory.build({ empty_array: [], empty_object: {} });
     const {
       number,
       string,
@@ -21,6 +21,7 @@ describe('ObjectTree component', () => {
 
     expect(screen.getByText(number)).toBeVisible();
     expect(screen.getByText(string)).toBeVisible();
+    expect(screen.getAllByText('{}')).toHaveLength(2);
     expect(screen.queryByText(nestedString)).toBeNull();
     expect(screen.queryByText(firstArrayElement)).toBeNull();
 

--- a/assets/js/components/ObjectTree/ObjectTreeNode.jsx
+++ b/assets/js/components/ObjectTree/ObjectTreeNode.jsx
@@ -1,7 +1,21 @@
 import React from 'react';
 import classNames from 'classnames';
 
+import { has } from 'lodash';
+
 import ObjectTreeIcon from './ObjectTreeIcon';
+
+const renderElement = (element) => {
+  if (element.value === null) {
+    return 'null';
+  }
+
+  if (!has(element, 'value') && element.children.length === 0) {
+    return '{}';
+  }
+
+  return element.value;
+};
 
 function ObjectTreeNode({
   element,
@@ -24,7 +38,7 @@ function ObjectTreeNode({
       {isBranch ? (
         <ObjectTreeIcon expanded={isExpanded} />
       ) : (
-        <span className="ml-2">{element.value}</span>
+        <span className="ml-2">{renderElement(element)}</span>
       )}
     </div>
   );

--- a/assets/js/components/ObjectTree/tree.js
+++ b/assets/js/components/ObjectTree/tree.js
@@ -46,6 +46,10 @@ export const treeify = (name, data) => ({
     const { [key]: element } = data;
     const dataType = typeof element;
 
+    if (element == null) {
+      return { name: key, value: null };
+    }
+
     if (dataType === 'object') {
       return treeify(key, element);
     }

--- a/assets/js/lib/test-utils/factories/index.js
+++ b/assets/js/lib/test-utils/factories/index.js
@@ -110,4 +110,5 @@ export const objectTreeFactory = Factory.define(() => ({
     nestedNumber: faker.number.int(),
     nestedString: faker.word.noun(),
   },
+  null: null,
 }));


### PR DESCRIPTION
# Description

Handle `null` value in the `ObjectTree`. Without this fix the `Object.keys(data)` above panics.
Related to: https://github.com/trento-project/wanda/pull/297

![image](https://github.com/trento-project/web/assets/36370954/acc5f5a5-becc-46b9-9ddf-9c0efba4c3b8)

PD: As the objectree treats arrays and objects as the same, I think having the `{}` is good enough.

## How was this tested?

UT added
