### PR TITLE
Update storybook control type from string to text

### DIFF
--- a/assets/js/components/ChecksSelection/ChecksSelectionHeader.stories.jsx
+++ b/assets/js/components/ChecksSelection/ChecksSelectionHeader.stories.jsx
@@ -18,14 +18,14 @@ export default {
   ],
   argTypes: {
     targetID: {
-      control: 'string',
+      control: 'text',
       description: 'The target identifier',
       table: {
         type: { summary: 'string' },
       },
     },
     targetName: {
-      control: 'string',
+      control: 'text',
       description: 'The target name',
       table: {
         type: { summary: 'string' },

--- a/assets/js/components/HostDetails/HostDetails.stories.jsx
+++ b/assets/js/components/HostDetails/HostDetails.stories.jsx
@@ -24,7 +24,7 @@ export default {
   component: HostDetails,
   argTypes: {
     agentVersion: {
-      control: 'string',
+      control: 'text',
       description: 'The version of the installed agent',
       table: {
         type: { summary: 'string' },
@@ -55,7 +55,7 @@ export default {
       description: 'Status of the prometheus exporters',
     },
     grafanaPublicUrl: {
-      control: 'string',
+      control: 'text',
       description: 'Grafana dashboard public URL',
       table: {
         type: { summary: 'string' },
@@ -71,14 +71,14 @@ export default {
       },
     },
     hostID: {
-      control: 'string',
+      control: 'text',
       description: 'The host identifier',
       table: {
         type: { summary: 'string' },
       },
     },
     hostname: {
-      control: 'string',
+      control: 'text',
       description: 'The host name',
       table: {
         type: { summary: 'string' },
@@ -89,7 +89,7 @@ export default {
       description: 'IP addresses',
     },
     provider: {
-      control: 'string',
+      control: 'text',
       description: 'The discovered CSP where the host is running',
       table: {
         type: { summary: 'string' },


### PR DESCRIPTION
# Description
The "string" control type does not enable us to change the value of the story anymore. 
This is just a small patch to update it to the newer control type "text" from the string datatype.

See storybook docs: 
https://storybook.js.org/docs/react/essentials/controls#annotation