### PR TITLE
Send email notification on host health going critical

### DIFF
--- a/guides/alerting/alerting.md
+++ b/guides/alerting/alerting.md
@@ -3,7 +3,7 @@
 Alerting feature notifies the SAP Administrator about important updated in the Landscape being monitored/observed by Trento.
 
 Some of the notified events:
-- **Host heartbeat failed**
+- **Host Health detected critical**
 - **Cluster Health detected critical**
 - **Database Health detected critical**
 - **SAP System Health detected critical**

--- a/lib/trento/application/event_handlers/alerts_event_handler.ex
+++ b/lib/trento/application/event_handlers/alerts_event_handler.ex
@@ -10,17 +10,18 @@ defmodule Trento.AlertsEventHandler do
   alias Trento.Domain.Events.{
     ClusterHealthChanged,
     DatabaseHealthChanged,
-    HeartbeatFailed,
+    HostHealthChanged,
     SapSystemHealthChanged
   }
 
   alias Trento.Application.UseCases.Alerting
 
   def handle(
-        %HeartbeatFailed{host_id: host_id},
+        %HostHealthChanged{host_id: host_id, health: health},
         _metadata
-      ) do
-    Alerting.notify_heartbeat_failed(host_id)
+      )
+      when health == :critical do
+    Alerting.notify_critical_host_health(host_id)
   end
 
   def handle(

--- a/lib/trento/application/usecases/alerting/alerting.ex
+++ b/lib/trento/application/usecases/alerting/alerting.ex
@@ -15,9 +15,9 @@ defmodule Trento.Application.UseCases.Alerting do
 
   require Logger
 
-  @spec notify_heartbeat_failed(String.t()) :: :ok
-  def notify_heartbeat_failed(host_id),
-    do: maybe_notify_heartbeat_failed(enabled?(), host_id)
+  @spec notify_critical_host_health(String.t()) :: :ok
+  def notify_critical_host_health(host_id),
+    do: maybe_notify_critical_host_health(enabled?(), host_id)
 
   @spec notify_critical_cluster_health(String.t()) :: :ok
   def notify_critical_cluster_health(cluster_id),
@@ -33,12 +33,14 @@ defmodule Trento.Application.UseCases.Alerting do
 
   defp enabled?, do: Application.fetch_env!(:trento, :alerting)[:enabled]
 
-  defp maybe_notify_heartbeat_failed(false, _), do: :ok
+  defp maybe_notify_critical_host_health(false, _), do: :ok
 
-  defp maybe_notify_heartbeat_failed(true, host_id) do
+  defp maybe_notify_critical_host_health(true, host_id) do
     %HostReadModel{hostname: hostname} = Trento.Repo.get!(HostReadModel, host_id)
 
-    deliver_notification(EmailAlert.alert("Host", "hostname", hostname, "heartbeat failed"))
+    deliver_notification(
+      EmailAlert.alert("Host", "hostname", hostname, "health is now in critical state")
+    )
   end
 
   defp maybe_notify_critical_cluster_health(false, _), do: :ok

--- a/lib/trento/application/usecases/alerting/email/templates/critical.html.eex
+++ b/lib/trento/application/usecases/alerting/email/templates/critical.html.eex
@@ -381,7 +381,7 @@
                         Reason: <b><%= @alerting_reason %></b>
                         </p>
                       </div>
-                      <p>Check your Trento installation for remediations suggestions.</p>
+                      <p>Check the corresponding Details View in the Trento Console for remediation suggestions.</p>
                       <p>Thanks for your attention.</p>
                     </td>
                   </tr>

--- a/test/trento/application/usecases/alerting_test.exs
+++ b/test/trento/application/usecases/alerting_test.exs
@@ -29,7 +29,7 @@ defmodule Trento.Application.UseCases.AlertingTest do
       Application.put_env(:trento, :alerting, enabled: false)
       host_id = Faker.UUID.v4()
 
-      Alerting.notify_heartbeat_failed(host_id)
+      Alerting.notify_critical_host_health(host_id)
 
       assert_no_email_sent()
     end
@@ -70,11 +70,11 @@ defmodule Trento.Application.UseCases.AlertingTest do
   end
 
   describe "Alerting the configured recipient about crucial facts with email notifications" do
-    test "Notify Host heartbeating failure" do
+    test "Notify Host Health going critical" do
       host_id = Faker.UUID.v4()
       host = insert(:host, id: host_id)
 
-      Alerting.notify_heartbeat_failed(host_id)
+      Alerting.notify_critical_host_health(host_id)
       assert_email_sent(subject: "Trento Alert: Host #{host.hostname} needs attention.")
     end
 


### PR DESCRIPTION
# Description

This PR makes sure an email notification is sent when a `HostHealthChanged` event is emitted and the health is `critical` instead of on a `HeartbeatFailed`.

## How was this tested?

Automated tests updated.

![image](https://github.com/trento-project/web/assets/8167114/1af42a1f-7fd8-4662-8e69-5ce465688c9c)
