### PR TITLE
Update host health state based on saptune data

### DIFF
--- a/lib/trento/application/integration/discovery/discovery.ex
+++ b/lib/trento/application/integration/discovery/discovery.ex
@@ -137,7 +137,13 @@ defmodule Trento.Integration.Discovery do
     ClusterPolicy.handle(event, current_cluster_id)
   end
 
-  defp do_handle(%{"discovery_type" => "saptune_discovery"} = event), do: HostPolicy.handle(event)
+  defp do_handle(%{"discovery_type" => "saptune_discovery", "agent_id" => agent_id} = event) do
+    current_application_instances = SapSystems.get_application_instances_by_host_id(agent_id)
+    current_database_instances = SapSystems.get_database_instances_by_host_id(agent_id)
+    is_sap_running = length(current_application_instances ++ current_database_instances) > 0
+
+    HostPolicy.handle(event, is_sap_running)
+  end
 
   defp do_handle(%{"discovery_type" => "sap_system_discovery", "agent_id" => agent_id} = event) do
     current_application_instances = SapSystems.get_application_instances_by_host_id(agent_id)

--- a/lib/trento/application/integration/discovery/discovery.ex
+++ b/lib/trento/application/integration/discovery/discovery.ex
@@ -140,7 +140,7 @@ defmodule Trento.Integration.Discovery do
   defp do_handle(%{"discovery_type" => "saptune_discovery", "agent_id" => agent_id} = event) do
     current_application_instances = SapSystems.get_application_instances_by_host_id(agent_id)
     current_database_instances = SapSystems.get_database_instances_by_host_id(agent_id)
-    sap_running = length(current_application_instances ++ current_database_instances) > 0
+    sap_running = length(current_application_instances) + length(current_database_instances) > 0
 
     HostPolicy.handle(event, sap_running)
   end

--- a/lib/trento/application/integration/discovery/discovery.ex
+++ b/lib/trento/application/integration/discovery/discovery.ex
@@ -140,9 +140,9 @@ defmodule Trento.Integration.Discovery do
   defp do_handle(%{"discovery_type" => "saptune_discovery", "agent_id" => agent_id} = event) do
     current_application_instances = SapSystems.get_application_instances_by_host_id(agent_id)
     current_database_instances = SapSystems.get_database_instances_by_host_id(agent_id)
-    is_sap_running = length(current_application_instances ++ current_database_instances) > 0
+    sap_running = length(current_application_instances ++ current_database_instances) > 0
 
-    HostPolicy.handle(event, is_sap_running)
+    HostPolicy.handle(event, sap_running)
   end
 
   defp do_handle(%{"discovery_type" => "sap_system_discovery", "agent_id" => agent_id} = event) do

--- a/lib/trento/application/integration/discovery/policies/host_policy.ex
+++ b/lib/trento/application/integration/discovery/policies/host_policy.ex
@@ -87,13 +87,13 @@ defmodule Trento.Integration.Discovery.HostPolicy do
             "package_version" => package_version
           }
         },
-        is_sap_running
+        sap_running
       ) do
     build_update_saptune_command(
       agent_id,
       package_version,
       saptune_installed,
-      is_sap_running,
+      sap_running,
       nil
     )
   end
@@ -108,7 +108,7 @@ defmodule Trento.Integration.Discovery.HostPolicy do
             "package_version" => package_version
           }
         },
-        is_sap_running
+        sap_running
       ) do
     status
     |> format_saptune_payload_keys()
@@ -119,7 +119,7 @@ defmodule Trento.Integration.Discovery.HostPolicy do
           agent_id,
           package_version,
           saptune_installed,
-          is_sap_running,
+          sap_running,
           decoded_payload
         )
 
@@ -155,7 +155,7 @@ defmodule Trento.Integration.Discovery.HostPolicy do
          agent_id,
          package_version,
          saptune_installed,
-         is_sap_running,
+         sap_running,
          nil
        ),
        do:
@@ -163,7 +163,7 @@ defmodule Trento.Integration.Discovery.HostPolicy do
            host_id: agent_id,
            saptune_installed: saptune_installed,
            package_version: package_version,
-           is_sap_running: is_sap_running,
+           sap_running: sap_running,
            status: nil
          })
 
@@ -171,7 +171,7 @@ defmodule Trento.Integration.Discovery.HostPolicy do
          agent_id,
          package_version,
          saptune_installed,
-         is_sap_running,
+         sap_running,
          %SaptuneDiscoveryPayload{
            result: %{
              package_version: package_version,
@@ -193,7 +193,7 @@ defmodule Trento.Integration.Discovery.HostPolicy do
       host_id: agent_id,
       package_version: package_version,
       saptune_installed: saptune_installed,
-      is_sap_running: is_sap_running,
+      sap_running: sap_running,
       status: %{
         package_version: package_version,
         configured_version: configured_version,

--- a/lib/trento/domain/host/commands/update_saptune_status.ex
+++ b/lib/trento/domain/host/commands/update_saptune_status.ex
@@ -12,6 +12,7 @@ defmodule Trento.Domain.Commands.UpdateSaptuneStatus do
     field :host_id, Ecto.UUID
     field :package_version, :string
     field :saptune_installed, :boolean
+    field :is_sap_running, :boolean
     embeds_one :status, SaptuneStatus
   end
 end

--- a/lib/trento/domain/host/commands/update_saptune_status.ex
+++ b/lib/trento/domain/host/commands/update_saptune_status.ex
@@ -12,7 +12,7 @@ defmodule Trento.Domain.Commands.UpdateSaptuneStatus do
     field :host_id, Ecto.UUID
     field :package_version, :string
     field :saptune_installed, :boolean
-    field :is_sap_running, :boolean
+    field :sap_running, :boolean
     embeds_one :status, SaptuneStatus
   end
 end

--- a/lib/trento/domain/host/events/host_saptune_health_changed.ex
+++ b/lib/trento/domain/host/events/host_saptune_health_changed.ex
@@ -1,0 +1,14 @@
+defmodule Trento.Domain.Events.HostSaptuneHealthChanged do
+  @moduledoc """
+  This event is emitted when a host's saptune health changes.
+  """
+
+  use Trento.Event
+
+  require Trento.Domain.Enums.Health, as: Health
+
+  defevent do
+    field :host_id, Ecto.UUID
+    field :saptune_health, Ecto.Enum, values: Health.values()
+  end
+end

--- a/lib/trento/domain/host/host.ex
+++ b/lib/trento/domain/host/host.ex
@@ -432,13 +432,13 @@ defmodule Trento.Domain.Host do
         %UpdateSaptuneStatus{
           saptune_installed: true,
           package_version: package_version,
-          is_sap_running: is_sap_running,
+          sap_running: sap_running,
           status: nil
         }
       ) do
     host
     |> Multi.new()
-    |> Multi.execute(&maybe_emit_host_saptune_health_changed_event(&1, is_sap_running))
+    |> Multi.execute(&maybe_emit_host_saptune_health_changed_event(&1, sap_running))
     |> Multi.execute(&maybe_emit_host_health_changed_event/1)
   end
 
@@ -448,7 +448,7 @@ defmodule Trento.Domain.Host do
           host_id: host_id,
           saptune_installed: true,
           package_version: package_version,
-          is_sap_running: is_sap_running,
+          sap_running: sap_running,
           status: nil
         }
       ) do
@@ -462,7 +462,7 @@ defmodule Trento.Domain.Host do
         }
       }
     end)
-    |> Multi.execute(&maybe_emit_host_saptune_health_changed_event(&1, is_sap_running))
+    |> Multi.execute(&maybe_emit_host_saptune_health_changed_event(&1, sap_running))
     |> Multi.execute(&maybe_emit_host_health_changed_event/1)
   end
 
@@ -472,12 +472,12 @@ defmodule Trento.Domain.Host do
         } = host,
         %UpdateSaptuneStatus{
           status: status,
-          is_sap_running: is_sap_running
+          sap_running: sap_running
         }
       ) do
     host
     |> Multi.new()
-    |> Multi.execute(&maybe_emit_host_saptune_health_changed_event(&1, is_sap_running))
+    |> Multi.execute(&maybe_emit_host_saptune_health_changed_event(&1, sap_running))
     |> Multi.execute(&maybe_emit_host_health_changed_event/1)
   end
 
@@ -485,7 +485,7 @@ defmodule Trento.Domain.Host do
         %Host{} = host,
         %UpdateSaptuneStatus{
           host_id: host_id,
-          is_sap_running: is_sap_running,
+          sap_running: sap_running,
           status: status
         }
       ) do
@@ -497,7 +497,7 @@ defmodule Trento.Domain.Host do
         status: status
       }
     end)
-    |> Multi.execute(&maybe_emit_host_saptune_health_changed_event(&1, is_sap_running))
+    |> Multi.execute(&maybe_emit_host_saptune_health_changed_event(&1, sap_running))
     |> Multi.execute(&maybe_emit_host_health_changed_event/1)
   end
 

--- a/lib/trento/domain/host/host.ex
+++ b/lib/trento/domain/host/host.ex
@@ -683,7 +683,7 @@ defmodule Trento.Domain.Host do
   defp maybe_add_checks_health(healths, _, []), do: healths
   defp maybe_add_checks_health(healths, checks_health, _), do: [checks_health | healths]
 
-  defp add_saptune_health(healths, nil), do: [Health.warning() | healths]
+  defp add_saptune_health(healths, nil), do: [Health.passing() | healths]
 
   defp add_saptune_health(healths, %{package_version: package_version, tuning_state: tuning_state}) do
     if Version.compare(package_version, "3.1.0") == :lt do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -42,6 +42,7 @@ defmodule Trento.Factory do
     HostHealthChanged,
     HostRegistered,
     HostRemovedFromCluster,
+    HostSaptuneHealthChanged,
     HostTombstoned,
     SapSystemDeregistered,
     SapSystemRegistered,
@@ -707,6 +708,13 @@ defmodule Trento.Factory do
     %HostChecksHealthChanged{
       host_id: Faker.UUID.v4(),
       checks_health: Health.passing()
+    }
+  end
+
+  def host_saptune_health_changed_event_factory do
+    %HostSaptuneHealthChanged{
+      host_id: Faker.UUID.v4(),
+      saptune_health: Health.passing()
     }
   end
 

--- a/test/trento/application/integration/discovery/policies/host_policy_test.exs
+++ b/test/trento/application/integration/discovery/policies/host_policy_test.exs
@@ -277,12 +277,13 @@ defmodule Trento.Integration.Discovery.HostPolicyTest do
                host_id: "9cd46919-5f19-59aa-993e-cf3736c71053",
                saptune_installed: true,
                package_version: "3.0.0",
+               is_sap_running: true,
                status: nil
              }
            } =
              "saptune_discovery_empty_status"
              |> load_discovery_event_fixture()
-             |> HostPolicy.handle()
+             |> HostPolicy.handle(true)
   end
 
   test "should fail the validation of the saptune payload, when the payload is received malformed" do
@@ -292,7 +293,7 @@ defmodule Trento.Integration.Discovery.HostPolicyTest do
            } =
              "saptune_discovery_empty_result"
              |> load_discovery_event_fixture()
-             |> HostPolicy.handle()
+             |> HostPolicy.handle(true)
   end
 
   test "should emit update saptune command when a saptune_discovery is received" do
@@ -302,6 +303,7 @@ defmodule Trento.Integration.Discovery.HostPolicyTest do
                host_id: "9cd46919-5f19-59aa-993e-cf3736c71053",
                saptune_installed: true,
                package_version: "3.1.0",
+               is_sap_running: false,
                status: %SaptuneStatus{
                  package_version: "3.1.0",
                  configured_version: "3",
@@ -359,7 +361,7 @@ defmodule Trento.Integration.Discovery.HostPolicyTest do
            } =
              "saptune_discovery"
              |> load_discovery_event_fixture()
-             |> HostPolicy.handle()
+             |> HostPolicy.handle(false)
   end
 
   test "should emit update saptune command when a saptune_discovery without configuration is received" do
@@ -369,6 +371,7 @@ defmodule Trento.Integration.Discovery.HostPolicyTest do
                host_id: "9cd46919-5f19-59aa-993e-cf3736c71053",
                saptune_installed: true,
                package_version: "3.1.0",
+               is_sap_running: true,
                status: %SaptuneStatus{
                  package_version: "3.1.0",
                  configured_version: "3",
@@ -404,6 +407,6 @@ defmodule Trento.Integration.Discovery.HostPolicyTest do
            } =
              "saptune_discovery_not_configured"
              |> load_discovery_event_fixture()
-             |> HostPolicy.handle()
+             |> HostPolicy.handle(true)
   end
 end

--- a/test/trento/application/integration/discovery/policies/host_policy_test.exs
+++ b/test/trento/application/integration/discovery/policies/host_policy_test.exs
@@ -277,7 +277,7 @@ defmodule Trento.Integration.Discovery.HostPolicyTest do
                host_id: "9cd46919-5f19-59aa-993e-cf3736c71053",
                saptune_installed: true,
                package_version: "3.0.0",
-               is_sap_running: true,
+               sap_running: true,
                status: nil
              }
            } =
@@ -303,7 +303,7 @@ defmodule Trento.Integration.Discovery.HostPolicyTest do
                host_id: "9cd46919-5f19-59aa-993e-cf3736c71053",
                saptune_installed: true,
                package_version: "3.1.0",
-               is_sap_running: false,
+               sap_running: false,
                status: %SaptuneStatus{
                  package_version: "3.1.0",
                  configured_version: "3",
@@ -371,7 +371,7 @@ defmodule Trento.Integration.Discovery.HostPolicyTest do
                host_id: "9cd46919-5f19-59aa-993e-cf3736c71053",
                saptune_installed: true,
                package_version: "3.1.0",
-               is_sap_running: true,
+               sap_running: true,
                status: %SaptuneStatus{
                  package_version: "3.1.0",
                  configured_version: "3",

--- a/test/trento/domain/host/host_test.exs
+++ b/test/trento/domain/host/host_test.exs
@@ -380,12 +380,7 @@ defmodule Trento.HostTest do
 
     test "should ignore checks health when an empty checks selection is saved" do
       host_id = Faker.UUID.v4()
-      saptune_status = build(:saptune_status, package_version: "3.1.0", tuning_state: "compliant")
       host_registered_event = build(:host_registered_event, host_id: host_id)
-
-      saptune_updated_event =
-        build(:saptune_status_updated_event, host_id: host_id, status: saptune_status)
-
       heartbeat_succeded_event = build(:heartbeat_succeded, host_id: host_id)
 
       checks_selected_event = %HostChecksSelected{
@@ -405,7 +400,6 @@ defmodule Trento.HostTest do
       assert_events_and_state(
         [
           host_registered_event,
-          saptune_updated_event,
           heartbeat_succeded_event,
           checks_selected_event,
           host_checks_health_changed_event,
@@ -437,15 +431,10 @@ defmodule Trento.HostTest do
   describe "heartbeat" do
     test "should emit a successful heartbeat and health change for a Host that hasn't heartbeated yet" do
       host_id = Faker.UUID.v4()
-      saptune_status = build(:saptune_status, package_version: "3.1.0", tuning_state: "compliant")
-
-      initial_events = [
-        build(:host_registered_event, host_id: host_id),
-        build(:saptune_status_updated_event, host_id: host_id, status: saptune_status)
-      ]
+      host_registered_event = build(:host_registered_event, host_id: host_id)
 
       assert_events_and_state(
-        initial_events,
+        host_registered_event,
         UpdateHeartbeat.new!(%{
           host_id: host_id,
           heartbeat: Health.passing()
@@ -470,11 +459,9 @@ defmodule Trento.HostTest do
 
     test "should emit a successful heartbeat and health change for a Host previously in critical status" do
       host_id = Faker.UUID.v4()
-      saptune_status = build(:saptune_status, package_version: "3.1.0", tuning_state: "compliant")
 
       initial_events = [
         build(:host_registered_event, host_id: host_id),
-        build(:saptune_status_updated_event, host_id: host_id, status: saptune_status),
         %HeartbeatFailed{
           host_id: host_id
         }

--- a/test/trento/domain/host/host_test.exs
+++ b/test/trento/domain/host/host_test.exs
@@ -846,7 +846,7 @@ defmodule Trento.HostTest do
           host_id: host_id,
           saptune_installed: false,
           package_version: nil,
-          is_sap_running: false,
+          sap_running: false,
           status: nil
         }),
         %SaptuneStatusUpdated{
@@ -880,7 +880,7 @@ defmodule Trento.HostTest do
           host_id: host_id,
           saptune_installed: true,
           package_version: new_saptune_version,
-          is_sap_running: false,
+          sap_running: false,
           status: nil
         }),
         %SaptuneStatusUpdated{
@@ -920,7 +920,7 @@ defmodule Trento.HostTest do
           host_id: host_id,
           saptune_installed: true,
           package_version: "3.2.0",
-          is_sap_running: false,
+          sap_running: false,
           status: Map.from_struct(new_saptune_status)
         }),
         %SaptuneStatusUpdated{
@@ -954,7 +954,7 @@ defmodule Trento.HostTest do
           host_id: host_id,
           saptune_installed: true,
           package_version: Faker.App.semver(),
-          is_sap_running: false,
+          sap_running: false,
           status: Map.from_struct(saptune_status)
         }),
         [],
@@ -989,7 +989,7 @@ defmodule Trento.HostTest do
           host_id: host_id,
           saptune_installed: false,
           package_version: nil,
-          is_sap_running: false,
+          sap_running: false,
           status: nil
         }),
         [
@@ -1038,7 +1038,7 @@ defmodule Trento.HostTest do
           host_id: host_id,
           saptune_installed: false,
           package_version: nil,
-          is_sap_running: true,
+          sap_running: true,
           status: nil
         }),
         [
@@ -1076,7 +1076,7 @@ defmodule Trento.HostTest do
           host_id: host_id,
           saptune_installed: true,
           package_version: unsupported_version,
-          is_sap_running: true,
+          sap_running: true,
           status: nil
         }),
         [
@@ -1132,7 +1132,7 @@ defmodule Trento.HostTest do
             host_id: host_id,
             saptune_installed: true,
             package_version: suppported_version,
-            is_sap_running: true,
+            sap_running: true,
             status: Map.from_struct(saptune_status)
           }),
           [
@@ -1180,7 +1180,7 @@ defmodule Trento.HostTest do
           host_id: host_id,
           saptune_installed: true,
           package_version: unsupported_version,
-          is_sap_running: true,
+          sap_running: true,
           status: nil
         }),
         [

--- a/test/trento/domain/host/host_test.exs
+++ b/test/trento/domain/host/host_test.exs
@@ -379,7 +379,12 @@ defmodule Trento.HostTest do
 
     test "should ignore checks health when an empty checks selection is saved" do
       host_id = Faker.UUID.v4()
+      saptune_status = build(:saptune_status, package_version: "3.1.0", tuning_state: "compliant")
       host_registered_event = build(:host_registered_event, host_id: host_id)
+
+      saptune_updated_event =
+        build(:saptune_status_updated_event, host_id: host_id, status: saptune_status)
+
       heartbeat_succeded_event = build(:heartbeat_succeded, host_id: host_id)
 
       checks_selected_event = %HostChecksSelected{
@@ -399,6 +404,7 @@ defmodule Trento.HostTest do
       assert_events_and_state(
         [
           host_registered_event,
+          saptune_updated_event,
           heartbeat_succeded_event,
           checks_selected_event,
           host_checks_health_changed_event,
@@ -430,10 +436,15 @@ defmodule Trento.HostTest do
   describe "heartbeat" do
     test "should emit a successful heartbeat and health change for a Host that hasn't heartbeated yet" do
       host_id = Faker.UUID.v4()
-      host_registered_event = build(:host_registered_event, host_id: host_id)
+      saptune_status = build(:saptune_status, package_version: "3.1.0", tuning_state: "compliant")
+
+      initial_events = [
+        build(:host_registered_event, host_id: host_id),
+        build(:saptune_status_updated_event, host_id: host_id, status: saptune_status)
+      ]
 
       assert_events_and_state(
-        host_registered_event,
+        initial_events,
         UpdateHeartbeat.new!(%{
           host_id: host_id,
           heartbeat: Health.passing()
@@ -458,9 +469,11 @@ defmodule Trento.HostTest do
 
     test "should emit a successful heartbeat and health change for a Host previously in critical status" do
       host_id = Faker.UUID.v4()
+      saptune_status = build(:saptune_status, package_version: "3.1.0", tuning_state: "compliant")
 
       initial_events = [
         build(:host_registered_event, host_id: host_id),
+        build(:saptune_status_updated_event, host_id: host_id, status: saptune_status),
         %HeartbeatFailed{
           host_id: host_id
         }
@@ -940,6 +953,166 @@ defmodule Trento.HostTest do
         fn state ->
           assert %Host{
                    saptune_status: ^saptune_status
+                 } = state
+        end
+      )
+    end
+
+    test "should update host health to warning when saptune is not installed" do
+      host_id = Faker.UUID.v4()
+
+      initial_events = [
+        build(:host_registered_event, host_id: host_id),
+        build(:heartbeat_succeded, host_id: host_id),
+        build(:saptune_status_updated_event, host_id: host_id)
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        UpdateSaptuneStatus.new!(%{
+          host_id: host_id,
+          saptune_installed: false,
+          package_version: Faker.App.semver(),
+          status: nil
+        }),
+        [
+          %SaptuneStatusUpdated{
+            host_id: host_id,
+            status: nil
+          },
+          %HostHealthChanged{
+            host_id: host_id,
+            health: Health.warning()
+          }
+        ],
+        fn state ->
+          assert %Host{
+                   saptune_status: nil,
+                   health: Health.warning()
+                 } = state
+        end
+      )
+    end
+
+    test "should update host health to warning when saptune version is not supported" do
+      host_id = Faker.UUID.v4()
+      unsupported_version = "3.0.0"
+
+      initial_events = [
+        build(:host_registered_event, host_id: host_id),
+        build(:heartbeat_succeded, host_id: host_id)
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        UpdateSaptuneStatus.new!(%{
+          host_id: host_id,
+          saptune_installed: true,
+          package_version: unsupported_version,
+          status: nil
+        }),
+        [
+          %SaptuneStatusUpdated{
+            host_id: host_id,
+            status: %SaptuneStatus{
+              package_version: unsupported_version
+            }
+          },
+          %HostHealthChanged{
+            host_id: host_id,
+            health: Health.warning()
+          }
+        ],
+        fn state ->
+          assert %Host{
+                   saptune_status: %SaptuneStatus{
+                     package_version: ^unsupported_version
+                   },
+                   health: Health.warning()
+                 } = state
+        end
+      )
+    end
+
+    test "should update host health correctly according the received tuning state" do
+      scenarios = [
+        {"not compliant", Health.critical()},
+        {"not tuned", Health.warning()},
+        {"compliant", Health.passing()}
+      ]
+
+      for {tuning_state, health} <- scenarios do
+        host_id = Faker.UUID.v4()
+        suppported_version = "3.1.0"
+
+        saptune_status =
+          build(:saptune_status, package_version: "3.1.0", tuning_state: tuning_state)
+
+        initial_events = [
+          build(:host_registered_event, host_id: host_id),
+          build(:heartbeat_succeded, host_id: host_id)
+        ]
+
+        assert_events_and_state(
+          initial_events,
+          UpdateSaptuneStatus.new!(%{
+            host_id: host_id,
+            saptune_installed: true,
+            package_version: suppported_version,
+            status: Map.from_struct(saptune_status)
+          }),
+          [
+            %SaptuneStatusUpdated{
+              host_id: host_id,
+              status: saptune_status
+            },
+            %HostHealthChanged{
+              host_id: host_id,
+              health: health
+            }
+          ],
+          fn state ->
+            assert %Host{
+                     saptune_status: ^saptune_status,
+                     health: ^health
+                   } = state
+          end
+        )
+      end
+    end
+
+    test "should not update host health if the current health has the same value" do
+      host_id = Faker.UUID.v4()
+      unsupported_version = "3.0.0"
+
+      initial_events = [
+        build(:host_registered_event, host_id: host_id),
+        build(:heartbeat_succeded, host_id: host_id),
+        build(:host_health_changed_event, host_id: host_id, health: Health.warning())
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        UpdateSaptuneStatus.new!(%{
+          host_id: host_id,
+          saptune_installed: true,
+          package_version: unsupported_version,
+          status: nil
+        }),
+        [
+          %SaptuneStatusUpdated{
+            host_id: host_id,
+            status: %SaptuneStatus{
+              package_version: unsupported_version
+            }
+          }
+        ],
+        fn state ->
+          assert %Host{
+                   saptune_status: %SaptuneStatus{
+                     package_version: ^unsupported_version
+                   },
+                   health: Health.warning()
                  } = state
         end
       )

--- a/test/trento/domain/host/host_test.exs
+++ b/test/trento/domain/host/host_test.exs
@@ -966,7 +966,7 @@ defmodule Trento.HostTest do
       )
     end
 
-    test "should update saptune health to passing when a sap workload is removed and saptune is not installed" do
+    test "should update saptune health to passing when a SAP workload is removed and saptune is not installed" do
       host_id = Faker.UUID.v4()
 
       initial_events = [
@@ -1016,7 +1016,7 @@ defmodule Trento.HostTest do
       )
     end
 
-    test "should update saptune health to warning when a sap workload is found and saptune is not installed" do
+    test "should update saptune health to warning when a SAP workload is found and saptune is not installed" do
       host_id = Faker.UUID.v4()
 
       initial_events = [

--- a/test/trento/domain/host/host_test.exs
+++ b/test/trento/domain/host/host_test.exs
@@ -958,7 +958,7 @@ defmodule Trento.HostTest do
       )
     end
 
-    test "should update host health to warning when saptune is not installed" do
+    test "should update host health to passing when saptune is not installed" do
       host_id = Faker.UUID.v4()
 
       initial_events = [
@@ -982,13 +982,13 @@ defmodule Trento.HostTest do
           },
           %HostHealthChanged{
             host_id: host_id,
-            health: Health.warning()
+            health: Health.passing()
           }
         ],
         fn state ->
           assert %Host{
                    saptune_status: nil,
-                   health: Health.warning()
+                   health: Health.passing()
                  } = state
         end
       )


### PR DESCRIPTION
# Description

Use saptune state to change host health.
- If SAP workload is found in the host (meaning, a database or application instance is there):
    - saptune not installed -> warning
    - unsupported version -> warning
    - not compliant -> critical
    - not tuned -> warning
    - compliant -> passing
- If SAP workload is not found in the host:
    - passing 

In order to achieve this, I have added a new `is_sap_running` field to the `UpdateSaptuneStatus`. This field is used to determine if a SAP workload is there.
Together with this, we need store the `saptune_health` in the aggregate and create a new event to update it. Very similar of what we do with the checks health.

## How was this tested?

UT
