### PR TITLE
Notify user when cluster health changes

### DIFF
--- a/assets/js/state/clusters.js
+++ b/assets/js/state/clusters.js
@@ -104,6 +104,7 @@ export const clustersListSlice = createSlice({
 export const CLUSTER_DEREGISTERED = 'CLUSTER_DEREGISTERED';
 export const CLUSTER_RESTORED = 'CLUSTER_RESTORED';
 export const CLUSTER_CHECKS_SELECTED = 'CLUSTER_CHECKS_SELECTED';
+export const CLUSTER_HEALTH_CHANGED = 'CLUSTER_HEALTH_CHANGED';
 export const checksSelected = createAction(CLUSTER_CHECKS_SELECTED);
 
 export const {

--- a/assets/js/state/sagas/clusters.js
+++ b/assets/js/state/sagas/clusters.js
@@ -29,11 +29,13 @@ export function* clusterRestored({ payload }) {
   );
 }
 
-export function* clusterHealthChanged({ payload: { cluster_id, health } }) {
-  yield put(updateClusterHealth({ cluster_id, health }));
+export function* clusterHealthChanged({
+  payload: { cluster_id, name, health },
+}) {
+  yield put(updateClusterHealth({ cluster_id, name, health }));
   yield put(
     notify({
-      text: `Cluster ${cluster_id} health changed to ${health}.`,
+      text: `Cluster ${name} health changed to ${health}.`,
       icon: 'ℹ️',
     })
   );

--- a/assets/js/state/sagas/clusters.js
+++ b/assets/js/state/sagas/clusters.js
@@ -4,6 +4,7 @@ import { notify } from '@state/actions/notifications';
 import {
   CLUSTER_DEREGISTERED,
   CLUSTER_RESTORED,
+  CLUSTER_HEALTH_CHANGED,
   appendCluster,
   removeCluster,
   updateClusterHealth,
@@ -42,7 +43,7 @@ export function* clusterHealthChanged({
 }
 
 export function* watchClusterHealthChanged() {
-  yield takeEvery('CLUSTER_HEALTH_CHANGED', clusterHealthChanged);
+  yield takeEvery(CLUSTER_HEALTH_CHANGED, clusterHealthChanged);
 }
 
 export function* watchClusterDeregistered() {

--- a/assets/js/state/sagas/clusters.js
+++ b/assets/js/state/sagas/clusters.js
@@ -6,6 +6,7 @@ import {
   CLUSTER_RESTORED,
   appendCluster,
   removeCluster,
+  updateClusterHealth,
 } from '@state/clusters';
 
 export function* clusterDeregistered({ payload: { name, id } }) {
@@ -26,6 +27,20 @@ export function* clusterRestored({ payload }) {
       icon: 'ℹ️',
     })
   );
+}
+
+export function* clusterHealthChanged({ payload: { cluster_id, health } }) {
+  yield put(updateClusterHealth({ cluster_id, health }));
+  yield put(
+    notify({
+      text: `Cluster ${cluster_id} health changed to ${health}.`,
+      icon: 'ℹ️',
+    })
+  );
+}
+
+export function* watchClusterHealthChanged() {
+  yield takeEvery('CLUSTER_HEALTH_CHANGED', clusterHealthChanged);
 }
 
 export function* watchClusterDeregistered() {

--- a/assets/js/state/sagas/clusters.test.js
+++ b/assets/js/state/sagas/clusters.test.js
@@ -2,8 +2,16 @@ import { recordSaga } from '@lib/test-utils';
 
 import { clusterFactory } from '@lib/test-utils/factories';
 
-import { clusterDeregistered, clusterRestored, clusterHealthChanged } from '@state/sagas/clusters';
-import { removeCluster, appendCluster, updateClusterHealth } from '@state/clusters';
+import {
+  clusterDeregistered,
+  clusterRestored,
+  clusterHealthChanged,
+} from '@state/sagas/clusters';
+import {
+  removeCluster,
+  appendCluster,
+  updateClusterHealth,
+} from '@state/clusters';
 import { notify } from '@state/actions/notifications';
 
 describe('Clusters sagas', () => {
@@ -32,16 +40,16 @@ describe('Clusters sagas', () => {
   });
 
   it('should update health status of a cluster', async () => {
-    const { id: cluster_id, health } = clusterFactory.build();
+    const { id: cluster_id, name, health } = clusterFactory.build();
 
     const dispatched = await recordSaga(clusterHealthChanged, {
-      payload: { cluster_id, health },
+      payload: { cluster_id, name, health },
     });
 
     expect(dispatched).toEqual([
-      updateClusterHealth({ cluster_id, health }),
+      updateClusterHealth({ cluster_id, name, health }),
       notify({
-        text: `Cluster ${cluster_id} health changed to ${health}.`,
+        text: `Cluster ${name} health changed to ${health}.`,
         icon: 'ℹ️',
       }),
     ]);

--- a/assets/js/state/sagas/clusters.test.js
+++ b/assets/js/state/sagas/clusters.test.js
@@ -2,8 +2,8 @@ import { recordSaga } from '@lib/test-utils';
 
 import { clusterFactory } from '@lib/test-utils/factories';
 
-import { clusterDeregistered, clusterRestored } from '@state/sagas/clusters';
-import { removeCluster, appendCluster } from '@state/clusters';
+import { clusterDeregistered, clusterRestored, clusterHealthChanged } from '@state/sagas/clusters';
+import { removeCluster, appendCluster, updateClusterHealth } from '@state/clusters';
 import { notify } from '@state/actions/notifications';
 
 describe('Clusters sagas', () => {
@@ -26,6 +26,22 @@ describe('Clusters sagas', () => {
       appendCluster(payload),
       notify({
         text: `Cluster ${payload.name} has been restored.`,
+        icon: 'ℹ️',
+      }),
+    ]);
+  });
+
+  it('should update health status of a cluster', async () => {
+    const { id: cluster_id, health } = clusterFactory.build();
+
+    const dispatched = await recordSaga(clusterHealthChanged, {
+      payload: { cluster_id, health },
+    });
+
+    expect(dispatched).toEqual([
+      updateClusterHealth({ cluster_id, health }),
+      notify({
+        text: `Cluster ${cluster_id} health changed to ${health}.`,
         icon: 'ℹ️',
       }),
     ]);

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -35,7 +35,6 @@ import {
   updateCluster,
   updateCibLastWritten,
   updateChecksResults,
-  updateClusterHealth,
   startClustersLoading,
   stopClustersLoading,
 } from '@state/clusters';
@@ -84,6 +83,7 @@ import {
 import {
   watchClusterDeregistered,
   watchClusterRestored,
+  watchClusterHealthChanged,
 } from '@state/sagas/clusters';
 import {
   watchUpdateLastExecution,
@@ -285,14 +285,6 @@ function* checksResultsUpdated({ payload }) {
 
 function* watchChecksResultsUpdated() {
   yield takeEvery('CHECKS_RESULTS_UPDATED', checksResultsUpdated);
-}
-
-function* clusterHealthChanged({ payload }) {
-  yield put(updateClusterHealth(payload));
-}
-
-function* watchClusterHealthChanged() {
-  yield takeEvery('CLUSTER_HEALTH_CHANGED', clusterHealthChanged);
 }
 
 function* refreshHealthSummaryOnComponentsHealthChange() {

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -30,6 +30,7 @@ import {
 import {
   CLUSTER_DEREGISTERED,
   CLUSTER_RESTORED,
+  CLUSTER_HEALTH_CHANGED,
   setClusters,
   appendCluster,
   updateCluster,
@@ -332,7 +333,7 @@ function* refreshHealthSummaryOnComponentsHealthChange() {
   );
   yield debounce(
     debounceDuration,
-    'CLUSTER_HEALTH_CHANGED',
+    CLUSTER_HEALTH_CHANGED,
     loadSapSystemsHealthSummary
   );
   yield debounce(

--- a/lib/trento/application/projectors/cluster_projector.ex
+++ b/lib/trento/application/projectors/cluster_projector.ex
@@ -184,11 +184,10 @@ defmodule Trento.ClusterProjector do
     })
   end
 
-  def after_update(%ClusterHealthChanged{cluster_id: cluster_id, health: health}, _, _) do
-    TrentoWeb.Endpoint.broadcast("monitoring:clusters", "cluster_health_changed", %{
-      cluster_id: cluster_id,
-      health: health
-    })
+  def after_update(%ClusterHealthChanged{}, _, %{cluster: %ClusterReadModel{} = cluster}) do
+    message = ClusterView.render("cluster_health_changed.json", %{cluster: cluster})
+
+    TrentoWeb.Endpoint.broadcast("monitoring:clusters", "cluster_health_changed", message)
   end
 
   @impl true

--- a/lib/trento_web/views/v2/cluster_view.ex
+++ b/lib/trento_web/views/v2/cluster_view.ex
@@ -25,4 +25,8 @@ defmodule TrentoWeb.V2.ClusterView do
     |> Map.delete(:cluster_id)
     |> Map.put(:id, data.cluster_id)
   end
+
+  def render("cluster_health_changed.json", %{cluster: %{id: id, name: name, health: health}}) do
+    %{cluster_id: id, name: name, health: health}
+  end
 end

--- a/test/trento/application/projectors/cluster_projector_test.exs
+++ b/test/trento/application/projectors/cluster_projector_test.exs
@@ -241,12 +241,9 @@ defmodule Trento.ClusterProjectorTest do
   end
 
   test "should broadcast cluster_health_changed after the ClusterHealthChanged event" do
-    insert(:cluster, id: cluster_id = Faker.UUID.v4())
+    %{id: cluster_id, name: name, health: health} = insert(:cluster)
 
-    event = %ClusterHealthChanged{
-      cluster_id: cluster_id,
-      health: :passing
-    }
+    event = %ClusterHealthChanged{cluster_id: cluster_id, health: health}
 
     ProjectorTestHelper.project(
       ClusterProjector,
@@ -255,7 +252,7 @@ defmodule Trento.ClusterProjectorTest do
     )
 
     assert_broadcast "cluster_health_changed",
-                     %{cluster_id: ^cluster_id, health: :passing},
+                     %{cluster_id: ^cluster_id, name: ^name, health: ^health},
                      1000
   end
 end

--- a/test/trento_web/views/v2/cluster_view_test.exs
+++ b/test/trento_web/views/v2/cluster_view_test.exs
@@ -1,0 +1,17 @@
+defmodule TrentoWeb.V2.ClusterViewTest do
+  use TrentoWeb.ConnCase, async: true
+
+  import Phoenix.View
+  import Trento.Factory
+
+  alias TrentoWeb.V2.ClusterView
+
+  alias Trento.ClusterReadModel
+
+  test "should render health changed relevant information" do
+    %ClusterReadModel{id: id, name: name, health: health} = cluster = build(:cluster)
+
+    assert %{cluster_id: id, name: name, health: health} ==
+             render(ClusterView, "cluster_health_changed.json", %{cluster: cluster})
+  end
+end


### PR DESCRIPTION
# Description

This change notifies the user when a cluster's health changes.

Changes made:
- Created a new Phoenix view `cluster_health_changed.json` to use when broadcasting the `cluster_health_changed` websocket event.
- This view now also contains the cluster name as well as the previous cluster ID and health. The cluster name is required when displaying the notification to the user
- The Saga watching for the `cluster_health_changed` websocket event now displays a notification to the user stating that the cluster's health has changed


## How was this tested?

- Added test for new Phoenix view `cluster_health_changed.json`
- Updated projector test
- Added test for Saga
