### PR TITLE
Improve renderSolution function if solution is empty

### DIFF
--- a/assets/js/components/SaptuneDetails/SaptuneDetails.jsx
+++ b/assets/js/components/SaptuneDetails/SaptuneDetails.jsx
@@ -47,7 +47,6 @@ const renderSolution = (solution) => {
   if (!solution) {
     return <span>-</span>;
   }
-
   const { id, notes, partial } = solution;
 
   return (
@@ -73,7 +72,6 @@ function SaptuneDetails({
 }) {
   const { hostID: paramHostID } = useParams();
   const resolvedHostID = hostID || paramHostID;
-
   return (
     <div>
       <BackButton url={`/hosts/${resolvedHostID}`}>

--- a/assets/js/components/SaptuneDetails/SaptuneDetails.jsx
+++ b/assets/js/components/SaptuneDetails/SaptuneDetails.jsx
@@ -43,12 +43,20 @@ const renderNotes = (notes) => {
   return notes.map((noteID, index) => [index > 0 && ', ', renderNote(noteID)]);
 };
 
-const renderSolution = ({ id, notes, partial }) => (
-  <span>
-    {id} ({renderNotes(notes)}
-    {partial ? '-> Partial' : ''})
-  </span>
-);
+const renderSolution = (solution) => {
+  if (!solution) {
+    return <span>-</span>;
+  }
+
+  const { id, notes, partial } = solution;
+
+  return (
+    <span>
+      {id} ({renderNotes(notes)}
+      {partial ? '-> Partial' : ''})
+    </span>
+  );
+};
 
 function SaptuneDetails({
   appliedNotes,

--- a/assets/js/components/SaptuneDetails/SaptuneDetails.test.jsx
+++ b/assets/js/components/SaptuneDetails/SaptuneDetails.test.jsx
@@ -110,4 +110,36 @@ describe('SaptuneDetails', () => {
       staging.solutions_ids
     );
   });
+
+  it('should display dashes for enabled and applied solutions when solution is null', () => {
+    const solution = null;
+
+    const {
+      configured_version: configuredVersion,
+      package_version: packageVersion,
+      services,
+      staging,
+      tuning_state: tuningState,
+    } = saptuneStatusFactory.build();
+    const { hostname, id: hostID } = hostFactory.build();
+    renderWithRouter(
+      <SaptuneDetails
+        appliedSolution={solution}
+        enabledSolution={solution}
+        hostname={hostname}
+        hostID={hostID}
+        configuredVersion={configuredVersion}
+        packageVersion={packageVersion}
+        services={services}
+        staging={staging}
+        tuningState={tuningState}
+      />
+    );
+    expect(screen.getByText('Enabled Solution').nextSibling).toHaveTextContent(
+      `-`
+    );
+    expect(screen.getByText('Applied Solution').nextSibling).toHaveTextContent(
+      `-`
+    );
+  });
 });

--- a/assets/js/components/SaptuneDetails/SaptuneDetails.test.jsx
+++ b/assets/js/components/SaptuneDetails/SaptuneDetails.test.jsx
@@ -111,53 +111,44 @@ describe('SaptuneDetails', () => {
     );
   });
 
-  it.each([
-    { solution: null },
-    { solution: { notes: [] } },
-    { solution: undefined },
-  ])(
-    'should display dashes for "Enabled Solution," "Applied Solution," "Staged Notes," and "Staged Solutions" when the solution is null, and staging is disabled',
+  it('should display empty values when no data is coming', () => {
+    const staging = { enabled: false, notes: [], solutions_ids: [] };
 
-    ({ solution }) => {
-      const staging = { enabled: false, notes: [], solutions_ids: [] };
+    const {
+      configured_version: configuredVersion,
+      package_version: packageVersion,
+      services,
+      tuning_state: tuningState,
+    } = saptuneStatusFactory.build();
+    const { hostname, id: hostID } = hostFactory.build();
+    renderWithRouter(
+      <SaptuneDetails
+        appliedNotes={[]}
+        appliedSolution={null}
+        configuredVersion={configuredVersion}
+        enabledNotes={[]}
+        enabledSolution={null}
+        hostID={hostID}
+        hostname={hostname}
+        packageVersion={packageVersion}
+        services={services}
+        staging={staging}
+        tuningState={tuningState}
+      />
+    );
+    expect(screen.getByText('Enabled Solution').nextSibling).toHaveTextContent(
+      `-`
+    );
+    expect(screen.getByText('Applied Solution').nextSibling).toHaveTextContent(
+      `-`
+    );
 
-      const {
-        configured_version: configuredVersion,
-        package_version: packageVersion,
-        services,
-
-        tuning_state: tuningState,
-      } = saptuneStatusFactory.build();
-      const { hostname, id: hostID } = hostFactory.build();
-      renderWithRouter(
-        <SaptuneDetails
-          appliedSolution={solution}
-          enabledSolution={solution}
-          hostname={hostname}
-          hostID={hostID}
-          configuredVersion={configuredVersion}
-          packageVersion={packageVersion}
-          services={services}
-          staging={staging}
-          tuningState={tuningState}
-        />
-      );
-      expect(
-        screen.getByText('Enabled Solution').nextSibling
-      ).toHaveTextContent(`-`);
-      expect(
-        screen.getByText('Applied Solution').nextSibling
-      ).toHaveTextContent(`-`);
-
-      expect(screen.getByText('Staging').nextSibling).toHaveTextContent(
-        `Disabled`
-      );
-      expect(screen.getByText('Staged Notes').nextSibling).toHaveTextContent(
-        `-`
-      );
-      expect(
-        screen.getByText('Staged Solutions').nextSibling
-      ).toHaveTextContent(`-`);
-    }
-  );
+    expect(screen.getByText('Staging').nextSibling).toHaveTextContent(
+      `Disabled`
+    );
+    expect(screen.getByText('Staged Notes').nextSibling).toHaveTextContent(`-`);
+    expect(screen.getByText('Staged Solutions').nextSibling).toHaveTextContent(
+      `-`
+    );
+  });
 });

--- a/assets/js/components/SaptuneDetails/SaptuneDetails.test.jsx
+++ b/assets/js/components/SaptuneDetails/SaptuneDetails.test.jsx
@@ -111,35 +111,53 @@ describe('SaptuneDetails', () => {
     );
   });
 
-  it('should display dashes for enabled and applied solutions when solution is null', () => {
-    const solution = null;
+  it.each([
+    { solution: null },
+    { solution: { notes: [] } },
+    { solution: undefined },
+  ])(
+    'should display dashes for "Enabled Solution," "Applied Solution," "Staged Notes," and "Staged Solutions" when the solution is null, and staging is disabled',
 
-    const {
-      configured_version: configuredVersion,
-      package_version: packageVersion,
-      services,
-      staging,
-      tuning_state: tuningState,
-    } = saptuneStatusFactory.build();
-    const { hostname, id: hostID } = hostFactory.build();
-    renderWithRouter(
-      <SaptuneDetails
-        appliedSolution={solution}
-        enabledSolution={solution}
-        hostname={hostname}
-        hostID={hostID}
-        configuredVersion={configuredVersion}
-        packageVersion={packageVersion}
-        services={services}
-        staging={staging}
-        tuningState={tuningState}
-      />
-    );
-    expect(screen.getByText('Enabled Solution').nextSibling).toHaveTextContent(
-      `-`
-    );
-    expect(screen.getByText('Applied Solution').nextSibling).toHaveTextContent(
-      `-`
-    );
-  });
+    ({ solution }) => {
+      const staging = { enabled: false, notes: [], solutions_ids: [] };
+
+      const {
+        configured_version: configuredVersion,
+        package_version: packageVersion,
+        services,
+
+        tuning_state: tuningState,
+      } = saptuneStatusFactory.build();
+      const { hostname, id: hostID } = hostFactory.build();
+      renderWithRouter(
+        <SaptuneDetails
+          appliedSolution={solution}
+          enabledSolution={solution}
+          hostname={hostname}
+          hostID={hostID}
+          configuredVersion={configuredVersion}
+          packageVersion={packageVersion}
+          services={services}
+          staging={staging}
+          tuningState={tuningState}
+        />
+      );
+      expect(
+        screen.getByText('Enabled Solution').nextSibling
+      ).toHaveTextContent(`-`);
+      expect(
+        screen.getByText('Applied Solution').nextSibling
+      ).toHaveTextContent(`-`);
+
+      expect(screen.getByText('Staging').nextSibling).toHaveTextContent(
+        `Disabled`
+      );
+      expect(screen.getByText('Staged Notes').nextSibling).toHaveTextContent(
+        `-`
+      );
+      expect(
+        screen.getByText('Staged Solutions').nextSibling
+      ).toHaveTextContent(`-`);
+    }
+  );
 });

--- a/assets/js/components/SaptuneDetails/SaptuneDetails.test.jsx
+++ b/assets/js/components/SaptuneDetails/SaptuneDetails.test.jsx
@@ -142,6 +142,12 @@ describe('SaptuneDetails', () => {
     expect(screen.getByText('Applied Solution').nextSibling).toHaveTextContent(
       `-`
     );
+    expect(screen.getByText('Enabled Notes').nextSibling).toHaveTextContent(
+      `-`
+    );
+    expect(screen.getByText('Applied Notes').nextSibling).toHaveTextContent(
+      `-`
+    );
 
     expect(screen.getByText('Staging').nextSibling).toHaveTextContent(
       `Disabled`


### PR DESCRIPTION
# Description

A quick fix to ensure that SaptuneDetails is rendered properly if solutions are empty
If solution is empty then applied and enabled solution will render '-'

## Demo
![image](https://github.com/trento-project/web/assets/54111255/e2067311-5fcd-41a5-9f51-a90737324238)
![image](https://github.com/trento-project/web/assets/54111255/e6f3df09-33fe-4e59-858f-d8b522d8247e)


## How was this tested? 
Added automated test