### PR TITLE
Fix "no tuning" value by "not tuned"

### DIFF
--- a/assets/js/components/HostDetails/HostDetails.stories.jsx
+++ b/assets/js/components/HostDetails/HostDetails.stories.jsx
@@ -172,7 +172,7 @@ export const Default = {
     saptuneStatus: {
       package_version: '3.1.0',
       configured_version: '3',
-      tuning_state: 'no tuning',
+      tuning_state: 'not tuned',
     },
     lastExecution: {
       data: {

--- a/assets/js/components/HostDetails/HostDetails.test.jsx
+++ b/assets/js/components/HostDetails/HostDetails.test.jsx
@@ -7,6 +7,7 @@ import { faker } from '@faker-js/faker';
 
 import { renderWithRouter } from '@lib/test-utils';
 import { hostFactory, saptuneStatusFactory } from '@lib/test-utils/factories';
+import { TUNING_VALUES } from '@components/SaptuneDetails/SaptuneDetails.test';
 
 import HostDetails from './HostDetails';
 
@@ -161,7 +162,7 @@ describe('HostDetails component', () => {
       ).toHaveTextContent(configuredVersion);
 
       expect(screen.getByText('Tuning').nextSibling).toHaveTextContent(
-        new RegExp(tuningState, 'i')
+        TUNING_VALUES[tuningState]
       );
     });
   });

--- a/assets/js/components/HostDetails/SaptuneSummary.test.jsx
+++ b/assets/js/components/HostDetails/SaptuneSummary.test.jsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 
 import { SUPPORTED_VERSION } from '@lib/saptune';
 import { saptuneStatusFactory } from '@lib/test-utils/factories';
+import { TUNING_VALUES } from '@components/SaptuneDetails/SaptuneDetails.test';
 
 import SaptuneSummary from './SaptuneSummary';
 
@@ -35,7 +36,7 @@ describe('SaptuneSummary component', () => {
     ).toHaveTextContent(configuredVersion);
 
     expect(screen.getByText('Tuning').nextSibling).toHaveTextContent(
-      new RegExp(tuningState, 'i')
+      TUNING_VALUES[tuningState]
     );
   });
 

--- a/assets/js/components/SaptuneDetails/SaptuneDetails.stories.jsx
+++ b/assets/js/components/SaptuneDetails/SaptuneDetails.stories.jsx
@@ -79,7 +79,7 @@ export default {
     },
     tuningState: {
       control: 'select',
-      options: ['compliant', 'not compliant', 'no tuning'],
+      options: ['compliant', 'not compliant', 'not tuned'],
       description: 'The tuning state of saptune',
     },
   },

--- a/assets/js/components/SaptuneDetails/SaptuneDetails.test.jsx
+++ b/assets/js/components/SaptuneDetails/SaptuneDetails.test.jsx
@@ -13,6 +13,12 @@ import {
 
 import SaptuneDetails from './SaptuneDetails';
 
+export const TUNING_VALUES = {
+  compliant: 'Compliant',
+  'not compliant': 'Not compliant',
+  'not tuned': 'No tuning',
+};
+
 describe('SaptuneDetails', () => {
   it('should render saptune details correctly', () => {
     const customSaptuneService = {
@@ -75,7 +81,7 @@ describe('SaptuneDetails', () => {
       screen.getByText('Configured Version').nextSibling
     ).toHaveTextContent(configuredVersion);
     expect(screen.getByText('Tuning').nextSibling).toHaveTextContent(
-      new RegExp(tuningState, 'i')
+      TUNING_VALUES[tuningState]
     );
     expect(screen.getByText('saptune.service').nextSibling).toHaveTextContent(
       `${customSaptuneService.enabled}/${customSaptuneService.active}`

--- a/assets/js/components/SaptuneDetails/SaptuneTuningState.jsx
+++ b/assets/js/components/SaptuneDetails/SaptuneTuningState.jsx
@@ -5,7 +5,7 @@ import HealthIcon from '@components/Health/HealthIcon';
 function SaptuneTuningState({ state }) {
   switch (state) {
     case 'compliant':
-      return 'Compliant';
+      return <span>Compliant</span>;
     case 'not compliant':
       return (
         <div className="flex">
@@ -13,7 +13,7 @@ function SaptuneTuningState({ state }) {
           <span className="ml-1">Not compliant</span>
         </div>
       );
-    case 'no tuning':
+    case 'not tuned':
       return (
         <div className="flex">
           <HealthIcon health="warning" />

--- a/assets/js/components/SaptuneDetails/SaptuneTuningState.test.jsx
+++ b/assets/js/components/SaptuneDetails/SaptuneTuningState.test.jsx
@@ -12,7 +12,7 @@ describe('SpatuneTuningState', () => {
       text: 'Not compliant',
       iconClass: 'fill-red-500',
     },
-    { state: 'no tuning', text: 'No tuning', iconClass: 'fill-yellow-500' },
+    { state: 'not tuned', text: 'No tuning', iconClass: 'fill-yellow-500' },
     { state: null, text: '-', icon: null },
   ])(
     'should render correctly the $state state',

--- a/assets/js/lib/test-utils/factories/hosts.js
+++ b/assets/js/lib/test-utils/factories/hosts.js
@@ -24,7 +24,7 @@ const heartbeatEnum = () =>
   faker.helpers.arrayElement(['unknown', 'critical', 'passing']);
 
 const saptuneTuningStateEnum = () =>
-  faker.helpers.arrayElement(['compliant', 'not compliant', 'no tuning']);
+  faker.helpers.arrayElement(['compliant', 'not compliant', 'not tuned']);
 
 export const slesSubscriptionFactory = Factory.define(() => ({
   arch: 'x86_64',

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -208,7 +208,7 @@ defmodule Trento.Factory do
     %SaptuneStatus{
       package_version: Faker.App.semver(),
       configured_version: Enum.random(["1", "2", "3"]),
-      tuning_state: Enum.random(["compliant", "not compliat", "no tuning"])
+      tuning_state: Enum.random(["compliant", "not compliant", "not tuned"])
     }
   end
 


### PR DESCRIPTION
# Description

By mistake I used the `no tuning` backend value when it should be `not tuned`.
I just used the frontend value :facepalm: 

## How was this tested?

Old tests are working
