### PR TITLE
Add e2e tests for hosts health affected by saptune data

### DIFF
--- a/.photofinish.toml
+++ b/.photofinish.toml
@@ -286,6 +286,48 @@ files = [
     "./test/fixtures/scenarios/healthy-27-node-SAP-cluster/99cf8a3a-48d6-57a4-b302-6e4482227ab6_sap_system_discovery.json" 
 ]
 
+[host-vmdrbddev01-saptune-uninstalled]
+
+files = [
+    "./test/fixtures/scenarios/hosts-overview/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_saptune_discovery_uninstalled.json"
+]
+
+[host-vmdrbddev01-saptune-not-tuned]
+
+files = [
+    "./test/fixtures/scenarios/hosts-overview/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_saptune_discovery_not_tuned.json"
+]
+
+[host-vmhdbdev01-saptune-uninstalled]
+
+files = [
+    "./test/fixtures/scenarios/hosts-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_saptune_discovery_uninstalled.json"
+]
+
+[host-vmhdbdev01-saptune-unsupported]
+
+files = [
+    "./test/fixtures/scenarios/hosts-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_saptune_discovery_unsupported.json"
+]
+
+[host-vmhdbdev01-saptune-not-compliant]
+
+files = [
+    "./test/fixtures/scenarios/hosts-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_saptune_discovery_not_compliant.json"
+]
+
+[host-vmhdbdev01-saptune-not-tuned]
+
+files = [
+    "./test/fixtures/scenarios/hosts-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_saptune_discovery_not_tuned.json"
+]
+
+[host-vmhdbdev01-saptune-compliant]
+
+files = [
+    "./test/fixtures/scenarios/hosts-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_saptune_discovery_compliant.json"
+]
+
 [sapsystem-NWD-restore]
 
 files = [

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -154,54 +154,70 @@ context('Hosts Overview', () => {
         cy.get('svg.fill-jungle-green-500').its('length').should('eq', 10);
       });
     });
-    describe('Health is changed based on saptune state', () => {
+    describe('Health is changed based on saptune status', () => {
       const hostWithoutSap = 'vmdrbddev01';
       const hostWithSap = 'vmhdbdev01';
 
       it('should not change the health if saptune is not installed and a SAP workload is not running', () => {
         cy.loadScenario(`host-${hostWithoutSap}-saptune-uninstalled`);
         cy.contains('tr', hostWithoutSap).within(() => {
-          cy.get('td:nth-child(1) svg')
-            .should('have.class', 'fill-jungle-green-500');
+          cy.get('td:nth-child(1) svg').should(
+            'have.class',
+            'fill-jungle-green-500'
+          );
         });
       });
 
       it('should not change the health if saptune is installed and a SAP workload is not running', () => {
         cy.loadScenario(`host-${hostWithoutSap}-saptune-not-tuned`);
         cy.contains('tr', hostWithoutSap).within(() => {
-          cy.get('td:nth-child(1) svg')
-            .should('have.class', 'fill-jungle-green-500');    
+          cy.get('td:nth-child(1) svg').should(
+            'have.class',
+            'fill-jungle-green-500'
+          );
         });
       });
 
       it('should change the health to warning if saptune is not installed', () => {
         cy.loadScenario(`host-${hostWithSap}-saptune-uninstalled`);
         cy.contains('tr', hostWithSap).within(() => {
-          cy.get('td:nth-child(1) svg')
-            .should('have.class', 'fill-yellow-500');    
+          cy.get('td:nth-child(1) svg').should('have.class', 'fill-yellow-500');
         });
       });
 
       it('should change the health to warning if saptune version is unsupported', () => {
         cy.loadScenario(`host-${hostWithSap}-saptune-unsupported`);
         cy.contains('tr', hostWithSap).within(() => {
-          cy.get('td:nth-child(1) svg')
-            .should('have.class', 'fill-yellow-500');    
+          cy.get('td:nth-child(1) svg').should('have.class', 'fill-yellow-500');
         });
       });
 
       [
-        {state: 'not compliant', scenario: 'not-compliant', health: 'critical', icon: 'fill-red-500'},
-        {state: 'not tuned', scenario: 'not-tuned', health: 'warning', icon: 'fill-yellow-500'},
-        {state: 'compliant', scenario: 'compliant',health: 'passing', icon: 'fill-jungle-green-500'},
-      ].forEach(({state, scenario, health, icon}) => {
+        {
+          state: 'not compliant',
+          scenario: 'not-compliant',
+          health: 'critical',
+          icon: 'fill-red-500',
+        },
+        {
+          state: 'not tuned',
+          scenario: 'not-tuned',
+          health: 'warning',
+          icon: 'fill-yellow-500',
+        },
+        {
+          state: 'compliant',
+          scenario: 'compliant',
+          health: 'passing',
+          icon: 'fill-jungle-green-500',
+        },
+      ].forEach(({ state, scenario, health, icon }) => {
         it(`should change the health to ${health} if saptune tuning state is ${state}`, () => {
           cy.loadScenario(`host-${hostWithSap}-saptune-${scenario}`);
           cy.contains('tr', hostWithSap).within(() => {
-            cy.get('td:nth-child(1) svg')
-              .should('have.class', icon);    
+            cy.get('td:nth-child(1) svg').should('have.class', icon);
           });
-        })
+        });
       });
     });
     describe('Health is changed to critical when the heartbeat is not sent', () => {

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -154,6 +154,56 @@ context('Hosts Overview', () => {
         cy.get('svg.fill-jungle-green-500').its('length').should('eq', 10);
       });
     });
+    describe('Health is changed based on saptune state', () => {
+      const hostWithoutSap = 'vmdrbddev01';
+      const hostWithSap = 'vmhdbdev01';
+
+      it('should not change the health if saptune is not installed and a SAP workload is not running', () => {
+        cy.loadScenario(`host-${hostWithoutSap}-saptune-uninstalled`);
+        cy.contains('tr', hostWithoutSap).within(() => {
+          cy.get('td:nth-child(1) svg')
+            .should('have.class', 'fill-jungle-green-500');
+        });
+      });
+
+      it('should not change the health if saptune is installed and a SAP workload is not running', () => {
+        cy.loadScenario(`host-${hostWithoutSap}-saptune-not-tuned`);
+        cy.contains('tr', hostWithoutSap).within(() => {
+          cy.get('td:nth-child(1) svg')
+            .should('have.class', 'fill-jungle-green-500');    
+        });
+      });
+
+      it('should change the health to warning if saptune is not installed', () => {
+        cy.loadScenario(`host-${hostWithSap}-saptune-uninstalled`);
+        cy.contains('tr', hostWithSap).within(() => {
+          cy.get('td:nth-child(1) svg')
+            .should('have.class', 'fill-yellow-500');    
+        });
+      });
+
+      it('should change the health to warning if saptune version is unsupported', () => {
+        cy.loadScenario(`host-${hostWithSap}-saptune-unsupported`);
+        cy.contains('tr', hostWithSap).within(() => {
+          cy.get('td:nth-child(1) svg')
+            .should('have.class', 'fill-yellow-500');    
+        });
+      });
+
+      [
+        {state: 'not compliant', scenario: 'not-compliant', health: 'critical', icon: 'fill-red-500'},
+        {state: 'not tuned', scenario: 'not-tuned', health: 'warning', icon: 'fill-yellow-500'},
+        {state: 'compliant', scenario: 'compliant',health: 'passing', icon: 'fill-jungle-green-500'},
+      ].forEach(({state, scenario, health, icon}) => {
+        it(`should change the health to ${health} if saptune tuning state is ${state}`, () => {
+          cy.loadScenario(`host-${hostWithSap}-saptune-${scenario}`);
+          cy.contains('tr', hostWithSap).within(() => {
+            cy.get('td:nth-child(1) svg')
+              .should('have.class', icon);    
+          });
+        })
+      });
+    });
     describe('Health is changed to critical when the heartbeat is not sent', () => {
       before(() => {
         cy.visit('/hosts');

--- a/test/fixtures/scenarios/hosts-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_saptune_discovery_compliant.json
+++ b/test/fixtures/scenarios/hosts-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_saptune_discovery_compliant.json
@@ -1,0 +1,107 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "13e8c25c-3180-5a9a-95c8-51ec38e50cfc",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.1.0",
+    "status": {
+      "$schema": "file:///usr/share/saptune/schemas/1.0/saptune_status.schema.json",
+      "publish time": "2023-04-24 12:41:56.612",
+      "argv": "saptune --format json status",
+      "pid": 24623,
+      "command": "status",
+      "exit code": 4,
+      "result": {
+        "services": {
+          "saptune": [
+            "enabled",
+            "inactive"
+          ],
+          "sapconf": [],
+          "tuned": []
+        },
+        "systemd system state": "running",
+        "tuning state": "compliant",
+        "virtualization": "oracle",
+        "configured version": "3",
+        "package version": "3.1.0",
+        "Solution enabled": [
+          "NETWEAVER"
+        ],
+        "Notes enabled by Solution": [
+          {
+            "Solution ID": "NETWEAVER",
+            "Note list": [
+              "941735",
+              "1771258",
+              "2578899",
+              "2993054",
+              "1656250",
+              "900929"
+            ]
+          }
+        ],
+        "Solution applied": [
+          {
+            "Solution ID": "NETWEAVER",
+            "applied partially": false
+          }
+        ],
+        "Notes applied by Solution": [
+          {
+            "Solution ID": "NETWEAVER",
+            "Note list": [
+              "941735",
+              "1771258",
+              "2578899",
+              "2993054",
+              "1656250",
+              "900929"
+            ]
+          }
+        ],
+        "Notes enabled additionally": [],
+        "Notes enabled": [
+          "941735",
+          "1771258",
+          "2578899",
+          "2993054",
+          "1656250",
+          "900929"
+        ],
+        "Notes applied": [
+          "941735",
+          "1771258",
+          "2578899",
+          "2993054",
+          "1656250",
+          "900929"
+        ],
+        "staging": {
+          "staging enabled": false,
+          "Notes staged": [],
+          "Solutions staged": []
+        },
+        "remember message": "\nRegarding the tuning state of the system please use 'saptune note verify' for detailed information.\n\n"
+      },
+      "messages": [
+        {
+          "priority": "NOTICE",
+          "message": "actions.go:85: ATTENTION: You are running a test version (3.1.0 from 2022/11/28) of saptune which is not supported for production use\n"
+        },
+        {
+          "priority": "WARNING",
+          "message": "sysctl.go:73: Parameter 'kernel.shmmax' additional defined in the following sysctl config file /boot/sysctl.conf-5.3.18-150300.59.90-default(0xffffffffffffffff), /boot/sysctl.conf-5.3.18-150300.59.93-default(0xffffffffffffffff).\n"
+        },
+        {
+          "priority": "WARNING",
+          "message": "sysctl.go:73: Parameter 'kernel.shmall' additional defined in the following sysctl config file /boot/sysctl.conf-5.3.18-150300.59.90-default(0x0fffffffffffff00), /boot/sysctl.conf-5.3.18-150300.59.93-default(0x0fffffffffffff00).\n"
+        },
+        {
+          "priority": "NOTICE",
+          "message": "ini.go:308: block device related section settings detected: Traversing all block devices can take a considerable amount of time.\n"
+        }
+      ]
+    } 
+  } 
+}

--- a/test/fixtures/scenarios/hosts-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_saptune_discovery_not_compliant.json
+++ b/test/fixtures/scenarios/hosts-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_saptune_discovery_not_compliant.json
@@ -1,0 +1,107 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "13e8c25c-3180-5a9a-95c8-51ec38e50cfc",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.1.0",
+    "status": {
+      "$schema": "file:///usr/share/saptune/schemas/1.0/saptune_status.schema.json",
+      "publish time": "2023-04-24 12:41:56.612",
+      "argv": "saptune --format json status",
+      "pid": 24623,
+      "command": "status",
+      "exit code": 4,
+      "result": {
+        "services": {
+          "saptune": [
+            "enabled",
+            "inactive"
+          ],
+          "sapconf": [],
+          "tuned": []
+        },
+        "systemd system state": "running",
+        "tuning state": "not compliant",
+        "virtualization": "oracle",
+        "configured version": "3",
+        "package version": "3.1.0",
+        "Solution enabled": [
+          "NETWEAVER"
+        ],
+        "Notes enabled by Solution": [
+          {
+            "Solution ID": "NETWEAVER",
+            "Note list": [
+              "941735",
+              "1771258",
+              "2578899",
+              "2993054",
+              "1656250",
+              "900929"
+            ]
+          }
+        ],
+        "Solution applied": [
+          {
+            "Solution ID": "NETWEAVER",
+            "applied partially": false
+          }
+        ],
+        "Notes applied by Solution": [
+          {
+            "Solution ID": "NETWEAVER",
+            "Note list": [
+              "941735",
+              "1771258",
+              "2578899",
+              "2993054",
+              "1656250",
+              "900929"
+            ]
+          }
+        ],
+        "Notes enabled additionally": [],
+        "Notes enabled": [
+          "941735",
+          "1771258",
+          "2578899",
+          "2993054",
+          "1656250",
+          "900929"
+        ],
+        "Notes applied": [
+          "941735",
+          "1771258",
+          "2578899",
+          "2993054",
+          "1656250",
+          "900929"
+        ],
+        "staging": {
+          "staging enabled": false,
+          "Notes staged": [],
+          "Solutions staged": []
+        },
+        "remember message": "\nRegarding the tuning state of the system please use 'saptune note verify' for detailed information.\n\n"
+      },
+      "messages": [
+        {
+          "priority": "NOTICE",
+          "message": "actions.go:85: ATTENTION: You are running a test version (3.1.0 from 2022/11/28) of saptune which is not supported for production use\n"
+        },
+        {
+          "priority": "WARNING",
+          "message": "sysctl.go:73: Parameter 'kernel.shmmax' additional defined in the following sysctl config file /boot/sysctl.conf-5.3.18-150300.59.90-default(0xffffffffffffffff), /boot/sysctl.conf-5.3.18-150300.59.93-default(0xffffffffffffffff).\n"
+        },
+        {
+          "priority": "WARNING",
+          "message": "sysctl.go:73: Parameter 'kernel.shmall' additional defined in the following sysctl config file /boot/sysctl.conf-5.3.18-150300.59.90-default(0x0fffffffffffff00), /boot/sysctl.conf-5.3.18-150300.59.93-default(0x0fffffffffffff00).\n"
+        },
+        {
+          "priority": "NOTICE",
+          "message": "ini.go:308: block device related section settings detected: Traversing all block devices can take a considerable amount of time.\n"
+        }
+      ]
+    } 
+  } 
+}

--- a/test/fixtures/scenarios/hosts-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_saptune_discovery_not_tuned.json
+++ b/test/fixtures/scenarios/hosts-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_saptune_discovery_not_tuned.json
@@ -1,0 +1,107 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "13e8c25c-3180-5a9a-95c8-51ec38e50cfc",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.1.0",
+    "status": {
+      "$schema": "file:///usr/share/saptune/schemas/1.0/saptune_status.schema.json",
+      "publish time": "2023-04-24 12:41:56.612",
+      "argv": "saptune --format json status",
+      "pid": 24623,
+      "command": "status",
+      "exit code": 4,
+      "result": {
+        "services": {
+          "saptune": [
+            "enabled",
+            "inactive"
+          ],
+          "sapconf": [],
+          "tuned": []
+        },
+        "systemd system state": "running",
+        "tuning state": "not tuned",
+        "virtualization": "oracle",
+        "configured version": "3",
+        "package version": "3.1.0",
+        "Solution enabled": [
+          "NETWEAVER"
+        ],
+        "Notes enabled by Solution": [
+          {
+            "Solution ID": "NETWEAVER",
+            "Note list": [
+              "941735",
+              "1771258",
+              "2578899",
+              "2993054",
+              "1656250",
+              "900929"
+            ]
+          }
+        ],
+        "Solution applied": [
+          {
+            "Solution ID": "NETWEAVER",
+            "applied partially": false
+          }
+        ],
+        "Notes applied by Solution": [
+          {
+            "Solution ID": "NETWEAVER",
+            "Note list": [
+              "941735",
+              "1771258",
+              "2578899",
+              "2993054",
+              "1656250",
+              "900929"
+            ]
+          }
+        ],
+        "Notes enabled additionally": [],
+        "Notes enabled": [
+          "941735",
+          "1771258",
+          "2578899",
+          "2993054",
+          "1656250",
+          "900929"
+        ],
+        "Notes applied": [
+          "941735",
+          "1771258",
+          "2578899",
+          "2993054",
+          "1656250",
+          "900929"
+        ],
+        "staging": {
+          "staging enabled": false,
+          "Notes staged": [],
+          "Solutions staged": []
+        },
+        "remember message": "\nRegarding the tuning state of the system please use 'saptune note verify' for detailed information.\n\n"
+      },
+      "messages": [
+        {
+          "priority": "NOTICE",
+          "message": "actions.go:85: ATTENTION: You are running a test version (3.1.0 from 2022/11/28) of saptune which is not supported for production use\n"
+        },
+        {
+          "priority": "WARNING",
+          "message": "sysctl.go:73: Parameter 'kernel.shmmax' additional defined in the following sysctl config file /boot/sysctl.conf-5.3.18-150300.59.90-default(0xffffffffffffffff), /boot/sysctl.conf-5.3.18-150300.59.93-default(0xffffffffffffffff).\n"
+        },
+        {
+          "priority": "WARNING",
+          "message": "sysctl.go:73: Parameter 'kernel.shmall' additional defined in the following sysctl config file /boot/sysctl.conf-5.3.18-150300.59.90-default(0x0fffffffffffff00), /boot/sysctl.conf-5.3.18-150300.59.93-default(0x0fffffffffffff00).\n"
+        },
+        {
+          "priority": "NOTICE",
+          "message": "ini.go:308: block device related section settings detected: Traversing all block devices can take a considerable amount of time.\n"
+        }
+      ]
+    } 
+  } 
+}

--- a/test/fixtures/scenarios/hosts-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_saptune_discovery_uninstalled.json
+++ b/test/fixtures/scenarios/hosts-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_saptune_discovery_uninstalled.json
@@ -1,0 +1,9 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "13e8c25c-3180-5a9a-95c8-51ec38e50cfc",
+  "payload": {
+    "saptune_installed": false,
+    "package_version": "",
+    "status": null
+  } 
+}

--- a/test/fixtures/scenarios/hosts-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_saptune_discovery_unsupported.json
+++ b/test/fixtures/scenarios/hosts-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_saptune_discovery_unsupported.json
@@ -1,0 +1,9 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "13e8c25c-3180-5a9a-95c8-51ec38e50cfc",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.0.0",
+    "status": null
+  } 
+}

--- a/test/fixtures/scenarios/hosts-overview/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_saptune_discovery_not_tuned.json
+++ b/test/fixtures/scenarios/hosts-overview/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_saptune_discovery_not_tuned.json
@@ -1,0 +1,45 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "240f96b1-8d26-53b7-9e99-ffb0f2e735bf",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.1.0",
+    "status": {
+      "$schema": "file:///usr/share/saptune/schemas/1.0/saptune_status.schema.json",
+      "publish time": "2023-04-24 12:41:56.612",
+      "argv": "saptune --format json status",
+      "pid": 24623,
+      "command": "status",
+      "exit code": 4,
+      "result": {
+        "services": {
+          "saptune": [
+            "enabled",
+            "inactive"
+          ],
+          "sapconf": [],
+          "tuned": []
+        },
+        "systemd system state": "running",
+        "tuning state": "not tuned",
+        "virtualization": "oracle",
+        "configured version": "3",
+        "package version": "3.1.0",
+        "Solution enabled": [],
+        "Notes enabled by Solution": [],
+        "Solution applied": [],
+        "Notes applied by Solution": [],
+        "Notes enabled additionally": [],
+        "Notes enabled": [],
+        "Notes applied": [],
+        "staging": {
+          "staging enabled": false,
+          "Notes staged": [],
+          "Solutions staged": []
+        },
+        "remember message": "\nRegarding the tuning state of the system please use 'saptune note verify' for detailed information.\n\n"
+      },
+      "messages": []
+    } 
+  } 
+}

--- a/test/fixtures/scenarios/hosts-overview/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_saptune_discovery_uninstalled.json
+++ b/test/fixtures/scenarios/hosts-overview/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_saptune_discovery_uninstalled.json
@@ -1,0 +1,9 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "240f96b1-8d26-53b7-9e99-ffb0f2e735bf",
+  "payload": {
+    "saptune_installed": false,
+    "package_version": "",
+    "status": null
+  } 
+}


### PR DESCRIPTION
# Description

Add E2E tests to check the host health updates conditioned by saptune status.
It tests the changes from: https://github.com/trento-project/web/pull/1905

## How was this tested?

E2E tests
