### PR TITLE
Added 3 categories for Storybook structure

### DIFF
--- a/assets/js/components/AboutPage/AboutPage.stories.jsx
+++ b/assets/js/components/AboutPage/AboutPage.stories.jsx
@@ -11,7 +11,7 @@ const fetchAboutPageData = () =>
   });
 
 export default {
-  title: 'AboutPage',
+  title: 'Layouts/AboutPage',
   component: AboutPage,
 
   args: {

--- a/assets/js/components/Accordion/Accordion.stories.jsx
+++ b/assets/js/components/Accordion/Accordion.stories.jsx
@@ -4,7 +4,7 @@ import PremiumPill from '@components/PremiumPill';
 import Accordion from '.';
 
 export default {
-  title: 'Accordion',
+  title: 'Components/Accordion',
   component: Accordion,
   argTypes: {
     header: {

--- a/assets/js/components/Banners/WarningBanner.stories.jsx
+++ b/assets/js/components/Banners/WarningBanner.stories.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import WarningBanner from './WarningBanner';
 
 export default {
-  title: 'WarningBanner',
+  title: 'Components/WarningBanner',
   component: WarningBanner,
 };
 

--- a/assets/js/components/Button/Button.stories.jsx
+++ b/assets/js/components/Button/Button.stories.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Button from '.';
 
 export default {
-  title: 'Button',
+  title: 'Components/Button',
   component: Button,
   argTypes: {
     size: {

--- a/assets/js/components/CheckResultsOverview/CheckResultsOverview.stories.jsx
+++ b/assets/js/components/CheckResultsOverview/CheckResultsOverview.stories.jsx
@@ -2,7 +2,7 @@ import { faker } from '@faker-js/faker';
 import CheckResultsOverview from './CheckResultsOverview';
 
 export default {
-  title: 'CheckResultsOverview',
+  title: 'Layouts/CheckResultsOverview',
   component: CheckResultsOverview,
 };
 

--- a/assets/js/components/ChecksCatalog/ProviderSelection.stories.jsx
+++ b/assets/js/components/ChecksCatalog/ProviderSelection.stories.jsx
@@ -7,7 +7,7 @@ import ProviderSelection from './ProviderSelection';
 const providers = Object.keys(providerData);
 
 export default {
-  title: 'ProviderSelection',
+  title: 'Components/ProviderSelection',
   components: ProviderSelection,
 };
 

--- a/assets/js/components/ChecksSelection/ChecksSelection.stories.jsx
+++ b/assets/js/components/ChecksSelection/ChecksSelection.stories.jsx
@@ -26,7 +26,7 @@ const selectedChecks = [
 const targetID = faker.string.uuid();
 
 export default {
-  title: 'ChecksSelection',
+  title: 'Patterns/ChecksSelection',
   component: ChecksSelection,
   argTypes: {
     className: {

--- a/assets/js/components/ChecksSelection/ChecksSelectionHeader.stories.jsx
+++ b/assets/js/components/ChecksSelection/ChecksSelectionHeader.stories.jsx
@@ -7,7 +7,7 @@ import BackButton from '@components/BackButton';
 import ChecksSelectionHeader from './ChecksSelectionHeader';
 
 export default {
-  title: 'ChecksSelectionHeader',
+  title: 'Patterns/ChecksSelectionHeader',
   component: ChecksSelectionHeader,
   decorators: [
     (Story) => (

--- a/assets/js/components/CleanUpButton/CleanUpButton.stories.jsx
+++ b/assets/js/components/CleanUpButton/CleanUpButton.stories.jsx
@@ -1,7 +1,7 @@
 import CleanUpButton from '.';
 
 export default {
-  title: 'CleanUpButton',
+  title: 'Components/CleanUpButton',
   component: CleanUpButton,
   argTypes: {
     cleaning: {

--- a/assets/js/components/ClusterDetails/AscsErsClusterDetails.stories.jsx
+++ b/assets/js/components/ClusterDetails/AscsErsClusterDetails.stories.jsx
@@ -43,7 +43,7 @@ const failoverDetails = ascsErsClusterDetailsFactory.build({
 });
 
 export default {
-  title: 'AscsErsClusterDetails',
+  title: 'Layouts/AscsErsClusterDetails',
   components: AscsErsClusterDetails,
   decorators: [
     (Story) => (

--- a/assets/js/components/ClusterDetails/HanaClusterDetails.stories.jsx
+++ b/assets/js/components/ClusterDetails/HanaClusterDetails.stories.jsx
@@ -45,7 +45,7 @@ function ContainerWrapper({ children }) {
 }
 
 export default {
-  title: 'HanaClusterDetails',
+  title: 'Layouts/HanaClusterDetails',
   components: HanaClusterDetails,
   decorators: [
     (Story) => (

--- a/assets/js/components/DatabaseDetails/DatabaseDetails.stories.jsx
+++ b/assets/js/components/DatabaseDetails/DatabaseDetails.stories.jsx
@@ -32,7 +32,7 @@ function ContainerWrapper({ children }) {
 }
 
 export default {
-  title: 'DatabaseDetails',
+  title: 'Layouts/DatabaseDetails',
   components: GenericSystemDetails,
   argTypes: {
     system: {

--- a/assets/js/components/DatabasesOverview/DatabasesOverview.stories.jsx
+++ b/assets/js/components/DatabasesOverview/DatabasesOverview.stories.jsx
@@ -59,7 +59,7 @@ function ContainerWrapper({ children }) {
 }
 
 export default {
-  title: 'DatabasesOverview',
+  title: 'Layouts/DatabasesOverview',
   components: DatabasesOverview,
   argTypes: {
     databases: {

--- a/assets/js/components/DeregistrationModal/DeregistrationModal.stories.jsx
+++ b/assets/js/components/DeregistrationModal/DeregistrationModal.stories.jsx
@@ -6,7 +6,7 @@ import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model';
 import DeregistrationModal from '.';
 
 export default {
-  title: 'DeregistrationModal',
+  title: 'Patterns/DeregistrationModal',
   component: DeregistrationModal,
   argTypes: {
     contentType: {

--- a/assets/js/components/DottedPagination/DottedPagination.stories.jsx
+++ b/assets/js/components/DottedPagination/DottedPagination.stories.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import DottedPagination from '.';
 
 export default {
-  title: 'DottedPagination',
+  title: 'Components/DottedPagination',
   component: DottedPagination,
   argTypes: {
     pages: {

--- a/assets/js/components/Eula/Community.stories.jsx
+++ b/assets/js/components/Eula/Community.stories.jsx
@@ -4,7 +4,7 @@ import { action } from '@storybook/addon-actions';
 import Community from './Community';
 
 export default {
-  title: 'Eula Community',
+  title: 'Patterns/Eula Community',
   component: Community,
   args: { visible: true, dispatch: action() },
 };

--- a/assets/js/components/Eula/Premium.stories.jsx
+++ b/assets/js/components/Eula/Premium.stories.jsx
@@ -4,7 +4,7 @@ import { action } from '@storybook/addon-actions';
 import Premium from './Premium';
 
 export default {
-  title: 'Eula Premium',
+  title: 'Patterns/Eula Premium',
   component: Premium,
   args: { visible: true, dispatch: action() },
 };

--- a/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultDetail.stories.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/CheckResultDetail.stories.jsx
@@ -55,7 +55,7 @@ const executionDataWithoutValues = checksExecutionCompletedFactory.build({
 });
 
 export default {
-  title: 'CheckResultDetail',
+  title: 'Layouts/CheckResultDetail',
   component: CheckResultDetail,
 };
 

--- a/assets/js/components/ExecutionResults/CheckResultDetail/ExpectationsResults.stories.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/ExpectationsResults.stories.jsx
@@ -7,7 +7,7 @@ import {
 import ExpectationsResults from './ExpectationsResults';
 
 export default {
-  title: 'ExpectationsResults',
+  title: 'Patterns/ExpectationsResults',
   component: ExpectationsResults,
 };
 

--- a/assets/js/components/ExecutionResults/CheckResultDetail/ExpectedValues.stories.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/ExpectedValues.stories.jsx
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker';
 import ExpectedValues from './ExpectedValues';
 
 export default {
-  title: 'ExpectedValues',
+  title: 'Patterns/ExpectedValues',
   component: ExpectedValues,
 };
 

--- a/assets/js/components/ExecutionResults/CheckResultDetail/GatheredFacts.stories.jsx
+++ b/assets/js/components/ExecutionResults/CheckResultDetail/GatheredFacts.stories.jsx
@@ -14,7 +14,7 @@ const factValues = {
   ],
 };
 export default {
-  title: 'GatheredFacts',
+  title: 'Patterns/GatheredFacts',
   component: GatheredFacts,
 };
 

--- a/assets/js/components/ExecutionResults/ExecutionResults.stories.jsx
+++ b/assets/js/components/ExecutionResults/ExecutionResults.stories.jsx
@@ -329,7 +329,7 @@ const fetchCatalog = () =>
   });
 
 export default {
-  title: 'ExecutionResults',
+  title: 'Layouts/ExecutionResults',
   components: ExecutionResults,
   decorators: [
     (Story) => (

--- a/assets/js/components/Health/HealthIcon.stories.jsx
+++ b/assets/js/components/Health/HealthIcon.stories.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import HealthIcon from '.';
 
 export default {
-  title: 'HealthIcon',
+  title: 'Components/HealthIcon',
   component: HealthIcon,
 };
 

--- a/assets/js/components/HealthSummary/HomeHealthSummary.stories.jsx
+++ b/assets/js/components/HealthSummary/HomeHealthSummary.stories.jsx
@@ -30,7 +30,7 @@ function ContainerWrapper({ children }) {
 }
 
 export default {
-  title: 'HomeHealthSummary',
+  title: 'Layouts/HomeHealthSummary',
   components: HomeHealthSummary,
   decorators: [
     (Story) => (

--- a/assets/js/components/HostDetails/HostDetails.stories.jsx
+++ b/assets/js/components/HostDetails/HostDetails.stories.jsx
@@ -20,7 +20,7 @@ function ContainerWrapper({ children }) {
 }
 
 export default {
-  title: 'HostDetails',
+  title: 'Layouts/HostDetails',
   component: HostDetails,
   argTypes: {
     agentVersion: {

--- a/assets/js/components/ListView/ListView.stories.jsx
+++ b/assets/js/components/ListView/ListView.stories.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import ListView from '.';
 
 export default {
-  title: 'ListView',
+  title: 'Components/ListView',
   component: ListView,
   argTypes: {
     orientation: {

--- a/assets/js/components/NotFound/NotFound.stories.jsx
+++ b/assets/js/components/NotFound/NotFound.stories.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import NotFound from '.';
 
 export default {
-  title: 'NotFound',
+  title: 'Layouts/NotFound',
   component: NotFound,
   args: { buttonText: 'Go back home', onNavigate: () => {} },
 };

--- a/assets/js/components/ObjectTree/ObjectTree.stories.jsx
+++ b/assets/js/components/ObjectTree/ObjectTree.stories.jsx
@@ -5,7 +5,7 @@ import { objectTreeFactory } from '@lib/test-utils/factories';
 import ObjectTree from '.';
 
 export default {
-  title: 'ObjectTree',
+  title: 'Components/ObjectTree',
   component: ObjectTree,
 };
 

--- a/assets/js/components/Pill/Pill.stories.jsx
+++ b/assets/js/components/Pill/Pill.stories.jsx
@@ -5,7 +5,7 @@ import Tooltip from '@components/Tooltip';
 import Pill from '.';
 
 export default {
-  title: 'Pill',
+  title: 'Components/Pill',
   component: Pill,
 };
 

--- a/assets/js/components/PremiumPill/PremiumPill.stories.jsx
+++ b/assets/js/components/PremiumPill/PremiumPill.stories.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PremiumPill from '.';
 
 export default {
-  title: 'PremiumPill',
+  title: 'Components/PremiumPill',
   component: PremiumPill,
 };
 

--- a/assets/js/components/ProviderLabel/ProviderLabel.stories.jsx
+++ b/assets/js/components/ProviderLabel/ProviderLabel.stories.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ProviderLabel from '.';
 
 export default {
-  title: 'ProviderLabel',
+  title: 'Components/ProviderLabel',
   components: ProviderLabel,
 };
 

--- a/assets/js/components/SapSystemDetails/SapSystemDetails.stories.jsx
+++ b/assets/js/components/SapSystemDetails/SapSystemDetails.stories.jsx
@@ -36,7 +36,7 @@ function ContainerWrapper({ children }) {
 }
 
 export default {
-  title: 'SapSystemDetails',
+  title: 'Layouts/SapSystemDetails',
   components: GenericSystemDetails,
   argTypes: {
     system: {

--- a/assets/js/components/SapSystemsOverview/SapSystemsOverview.stories.jsx
+++ b/assets/js/components/SapSystemsOverview/SapSystemsOverview.stories.jsx
@@ -59,7 +59,7 @@ function ContainerWrapper({ children }) {
 }
 
 export default {
-  title: 'SapSystemsOverview',
+  title: 'Layouts/SapSystemsOverview',
   components: SapSystemsOverview,
   argTypes: {
     sapSystems: {

--- a/assets/js/components/SaptuneDetails/SaptuneDetails.stories.jsx
+++ b/assets/js/components/SaptuneDetails/SaptuneDetails.stories.jsx
@@ -25,7 +25,7 @@ function ContainerWrapper({ children }) {
 }
 
 export default {
-  title: 'SaptuneDetails',
+  title: 'Layouts/SaptuneDetails',
   component: SaptuneDetails,
   argTypes: {
     appliedNotes: {

--- a/assets/js/components/Spinner.stories.jsx
+++ b/assets/js/components/Spinner.stories.jsx
@@ -1,7 +1,7 @@
 import Spinner from './Spinner';
 
 export default {
-  title: 'Spinner',
+  title: 'Components/Spinner',
   component: Spinner,
 };
 

--- a/assets/js/components/Table/Table.stories.jsx
+++ b/assets/js/components/Table/Table.stories.jsx
@@ -7,7 +7,7 @@ export default {
    * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
-  title: 'Table',
+  title: 'Components/Table',
   component: Table,
 };
 

--- a/assets/js/components/Tags/Tags.stories.jsx
+++ b/assets/js/components/Tags/Tags.stories.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Tags from '.';
 
 export default {
-  title: 'Tags',
+  title: 'Components/Tags',
   component: Tags,
   argTypes: { onChange: { action: 'tag changed' } },
 };

--- a/assets/js/components/Tooltip/Tooltip.stories.jsx
+++ b/assets/js/components/Tooltip/Tooltip.stories.jsx
@@ -4,7 +4,7 @@ import Tooltip from '.';
 import { PLACES } from './Tooltip';
 
 export default {
-  title: 'Tooltip',
+  title: 'Components/Tooltip',
   component: Tooltip,
   argTypes: {
     content: {


### PR DESCRIPTION
# Description

This PR attempts to create some structure in Storybook. It introduces three categories: **Components**, **Patterns** (placeholder title for now) and **Layouts**. These categories will group components based on the amount of elements creating each component. Similarly to the Atomic Design approach we are using **Components** as or smallest element, then we have **Patterns** which consist of a group of Components and lastly we have the biggest being **Layouts** which are a combination of Patterns and Components.

By having these categories it will help to quickly identify outstanding components, and which stories are related to page layouts for example.

Fixes # (issue)
A growing list of unorganised components.

## How was this tested?
Visually

<img width="1440" alt="Screenshot 2023-10-11 at 13 11 55" src="https://github.com/trento-project/web/assets/40714533/17f218be-de6a-43ea-a370-0724f4767d5a">