### PR TITLE
Replace "SAP INSTANCES" title in Trento dashboard/home page

### DIFF
--- a/assets/js/components/HealthSummary/HomeHealthSummary.jsx
+++ b/assets/js/components/HealthSummary/HomeHealthSummary.jsx
@@ -24,7 +24,7 @@ const healthSummaryTableConfig = {
       ),
     },
     {
-      title: 'SAP Instances',
+      title: 'Application instances',
       key: 'sapsystemHealth',
       className: 'text-center w-1/6',
       render: (content, item) => (


### PR DESCRIPTION
# Description
Almost what the title says, just a replace of the title from "SAP INSTANCES" to "APPLICATION INSTANCES" .
## Demo

### Before
![Screenshot from 2023-10-18 13-16-00](https://github.com/trento-project/web/assets/54111255/ae98fb65-2686-464b-96d8-cd1e279ab92d)


### After
![Screenshot from 2023-10-18 13-15-34](https://github.com/trento-project/web/assets/54111255/427f26b9-fc9e-44f0-8cb6-b93d242591db)

