### PR TITLE
Normalize redux state content as snake_case

### DIFF
--- a/assets/js/components/HealthSummary/HomeHealthSummary.jsx
+++ b/assets/js/components/HealthSummary/HomeHealthSummary.jsx
@@ -141,6 +141,20 @@ function HomeHealthSummary({ sapSystemsHealth, loading }) {
     setQueryValues({ health: newFilters });
   };
 
+  const normalizedSummaryData = summaryData.map((summaryDataEntry) => ({
+    applicationClusterHealth: summaryDataEntry.application_cluster_health,
+    applicationClusterId: summaryDataEntry.application_cluster_id,
+    databaseClusterHealth: summaryDataEntry.database_cluster_health,
+    databaseClusterId: summaryDataEntry.database_cluster_id,
+    databaseHealth: summaryDataEntry.database_health,
+    databaseId: summaryDataEntry.database_id,
+    hostsHealth: summaryDataEntry.hosts_health,
+    id: summaryDataEntry.id,
+    sapsystemHealth: summaryDataEntry.sapsystem_health,
+    sid: summaryDataEntry.sid,
+    tenant: summaryDataEntry.tenant,
+  }));
+
   return loading ? (
     <div>Loading...</div>
   ) : (
@@ -154,7 +168,7 @@ function HomeHealthSummary({ sapSystemsHealth, loading }) {
         onFilterChange={onFiltersChange}
         activeFilters={activeFilters}
       />
-      <Table config={healthSummaryTableConfig} data={summaryData} />
+      <Table config={healthSummaryTableConfig} data={normalizedSummaryData} />
     </div>
   );
 }

--- a/assets/js/components/HealthSummary/HomeHealthSummary.stories.jsx
+++ b/assets/js/components/HealthSummary/HomeHealthSummary.stories.jsx
@@ -7,20 +7,20 @@ import HomeHealthSummary from './HomeHealthSummary';
 
 const randomSummary = healthSummaryFactory.buildList(3);
 const healthySummary = healthSummaryFactory.buildList(3, {
-  applicationClusterHealth: 'passing',
-  databaseClusterHealth: 'passing',
-  databaseHealth: 'passing',
-  hostsHealth: 'passing',
-  sapsystemHealth: 'passing',
+  application_cluster_health: 'passing',
+  database_cluster_health: 'passing',
+  database_health: 'passing',
+  hosts_health: 'passing',
+  sapsystem_health: 'passing',
 });
 const unClusteredSummary = healthSummaryFactory.buildList(3, {
-  applicationClusterId: null,
-  databaseClusterId: null,
-  applicationClusterHealth: 'unknown',
-  databaseClusterHealth: 'unknown',
-  databaseHealth: 'passing',
-  hostsHealth: 'passing',
-  sapsystemHealth: 'passing',
+  application_cluster_id: null,
+  database_cluster_id: null,
+  application_cluster_health: 'unknown',
+  database_cluster_health: 'unknown',
+  database_health: 'passing',
+  hosts_health: 'passing',
+  sapsystem_health: 'passing',
 });
 
 function ContainerWrapper({ children }) {

--- a/assets/js/components/HealthSummary/HomeHealthSummary.test.jsx
+++ b/assets/js/components/HealthSummary/HomeHealthSummary.test.jsx
@@ -10,34 +10,34 @@ import HomeHealthSummary from './HomeHealthSummary';
 
 const homeHealthSummaryData = [
   healthSummaryFactory.build({
-    applicationClusterHealth: 'passing',
-    databaseClusterHealth: 'passing',
-    databaseHealth: 'passing',
-    hostsHealth: 'critical',
-    sapsystemHealth: 'passing',
+    application_cluster_health: 'passing',
+    database_cluster_health: 'passing',
+    database_health: 'passing',
+    hosts_health: 'critical',
+    sapsystem_health: 'passing',
     sid: 'NWD',
     tenant: 'HDD',
   }),
   healthSummaryFactory.build({
-    applicationClusterHealth: 'passing',
-    databaseHealth: 'passing',
-    hostsHealth: 'critical',
-    sapsystemHealth: 'passing',
+    application_cluster_health: 'passing',
+    database_health: 'passing',
+    hosts_health: 'critical',
+    sapsystem_health: 'passing',
   }),
   healthSummaryFactory.build({
-    databaseClusterHealth: 'passing',
-    databaseHealth: 'passing',
-    hostsHealth: 'critical',
-    sapsystemHealth: 'passing',
+    database_cluster_health: 'passing',
+    database_health: 'passing',
+    hosts_health: 'critical',
+    sapsystem_health: 'passing',
   }),
   healthSummaryFactory.build({
-    applicationClusterId: null,
-    databaseClusterId: null,
-    applicationClusterHealth: 'unknown',
-    databaseClusterHealth: 'unknown',
-    databaseHealth: 'passing',
-    hostsHealth: 'critical',
-    sapsystemHealth: 'passing',
+    application_cluster_id: null,
+    database_cluster_id: null,
+    application_cluster_health: 'unknown',
+    database_cluster_health: 'unknown',
+    database_health: 'passing',
+    hosts_health: 'critical',
+    sapsystem_health: 'passing',
   }),
 ];
 
@@ -65,7 +65,12 @@ describe('HomeHealthSummary component', () => {
         loading={false}
       />
     );
-    const [{ applicationClusterId, databaseClusterId }] = homeHealthSummaryData;
+    const [
+      {
+        application_cluster_id: applicationClusterId,
+        database_cluster_id: databaseClusterId,
+      },
+    ] = homeHealthSummaryData;
 
     expect(
       container

--- a/assets/js/lib/serialization/index.js
+++ b/assets/js/lib/serialization/index.js
@@ -1,33 +1,3 @@
-const isArray = function isArray(a) {
-  return Array.isArray(a);
-};
-
-const isObject = function isObject(o) {
-  return o === Object(o) && !isArray(o) && typeof o !== 'function';
-};
-
-const toCamel = (s) =>
-  s.replace(/([-_][a-z])/gi, ($1) =>
-    $1.toUpperCase().replace('-', '').replace('_', '')
-  );
-
-export const keysToCamel = function keysToCamel(o) {
-  if (isObject(o)) {
-    const n = {};
-
-    Object.keys(o).forEach((k) => {
-      n[toCamel(k)] = keysToCamel(o[k]);
-    });
-
-    return n;
-  }
-  if (isArray(o)) {
-    return o.map((i) => keysToCamel(i));
-  }
-
-  return o;
-};
-
 export const urlEncode = function urlEncode(params) {
   const str = [];
   Object.entries(params).forEach(([key, value]) => {

--- a/assets/js/lib/test-utils/factories/index.js
+++ b/assets/js/lib/test-utils/factories/index.js
@@ -51,15 +51,15 @@ export const checkFactory = Factory.define(() => ({
 }));
 
 export const healthSummaryFactory = Factory.define(() => ({
-  applicationClusterId: faker.string.uuid(),
-  applicationClusterHealth: healthEnum(),
-  databaseHealth: healthEnum(),
-  databaseId: faker.string.uuid(),
-  databaseClusterId: faker.string.uuid(),
-  databaseClusterHealth: healthEnum(),
-  hostsHealth: healthEnum(),
+  application_cluster_id: faker.string.uuid(),
+  application_cluster_health: healthEnum(),
+  database_health: healthEnum(),
+  database_id: faker.string.uuid(),
+  database_cluster_id: faker.string.uuid(),
+  database_cluster_health: healthEnum(),
+  hosts_health: healthEnum(),
   id: faker.string.uuid(),
-  sapsystemHealth: healthEnum(),
+  sapsystem_health: healthEnum(),
   sid: faker.string.alphanumeric(3, { casing: 'upper' }),
   tenant: faker.string.alphanumeric(3, { casing: 'upper' }),
 }));

--- a/assets/js/state/healthSummary.js
+++ b/assets/js/state/healthSummary.js
@@ -1,15 +1,19 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 // interface SapSystemHealthSummary {
-//  clusterId:       string,
-//  clustersHealth:  string,
-//  databaseHealth:  string,
-//  databaseId:      string,
-//  hostsHealth:     string,
-//  id:              string,
-//  sapsystemHealth: string,
-//  sid:             string,
-//  tenant:          string,
+//  application_cluster_health: string,
+//  application_cluster_id:     string,
+//  cluster_id:                 string,
+//  clusters_health:            string,
+//  database_cluster_health:    string,
+//  database_cluster_id:        string,
+//  database_health:            string,
+//  database_id:                string,
+//  hosts_health:               string,
+//  id:                         string,
+//  sapsystem_health:           string,
+//  sid:                        string,
+//  tenant:                     string,
 // }
 
 const initialState = {

--- a/assets/js/state/healthSummary.js
+++ b/assets/js/state/healthSummary.js
@@ -1,24 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-// interface SapSystemHealthSummary {
-//  application_cluster_health: string,
-//  application_cluster_id:     string,
-//  cluster_id:                 string,
-//  clusters_health:            string,
-//  database_cluster_health:    string,
-//  database_cluster_id:        string,
-//  database_health:            string,
-//  database_id:                string,
-//  hosts_health:               string,
-//  id:                         string,
-//  sapsystem_health:           string,
-//  sid:                        string,
-//  tenant:                     string,
-// }
-
 const initialState = {
   loading: false,
-  sapSystemsHealth: [], // SapSystemHealthSummary[]
+  sapSystemsHealth: [],
   error: '',
 };
 

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -9,7 +9,6 @@ import {
   debounce,
   takeLatest,
 } from 'redux-saga/effects';
-import { keysToCamel } from '@lib/serialization';
 
 import {
   HOST_DEREGISTERED,
@@ -108,7 +107,7 @@ function* loadSapSystemsHealthSummary() {
   yield put(startHealthSummaryLoading());
   const { data: healthSummary } = yield call(get, '/sap_systems/health');
 
-  yield put(setHealthSummary(keysToCamel(healthSummary)));
+  yield put(setHealthSummary(healthSummary));
   yield put(stopHealthSummaryLoading());
 }
 


### PR DESCRIPTION
# Description

Remove the last existence of camelCased redux state content and normalize its usage in snake_case. This way, the component is responsible of transforming the data in the best way. Now, all the factories produce the data as it is supplied by the backend.
Now, the need to have something like `keysToCamel` goes away

## How was this tested?

Tests updated
