### PR TITLE
Remove Check-related action buttons from Host Details view

### DIFF
--- a/assets/js/components/HostDetails/HostDetails.jsx
+++ b/assets/js/components/HostDetails/HostDetails.jsx
@@ -1,18 +1,14 @@
 import React, { useState } from 'react';
 import { get } from 'lodash';
-import { EOS_CLEAR_ALL, EOS_PLAY_CIRCLE, EOS_SETTINGS } from 'eos-icons-react';
 
 import { agentVersionWarning } from '@lib/agent';
 
-import Button from '@components/Button';
 import Table from '@components/Table';
 import PageHeader from '@components/PageHeader';
 import BackButton from '@components/BackButton';
 import WarningBanner from '@components/Banners/WarningBanner';
 import CleanUpButton from '@components/CleanUpButton';
 import DeregistrationModal from '@components/DeregistrationModal';
-import { canStartExecution } from '@components/ChecksSelection';
-import Tooltip from '@components/Tooltip';
 
 import SuseLogo from '@static/suse_logo.svg';
 import CheckResultsOverview from '@components/CheckResultsOverview';
@@ -41,14 +37,11 @@ function HostDetails({
   provider,
   providerData,
   sapInstances,
-  savingChecks,
   saptuneStatus = {},
-  selectedChecks = [],
   slesSubscriptions,
   catalog,
   lastExecution,
   cleanUpHost,
-  requestHostChecksExecution,
   navigate,
 }) {
   const [cleanUpModalOpen, setCleanUpModalOpen] = useState(false);
@@ -110,47 +103,6 @@ function HostDetails({
                   }}
                 />
               )}
-              <Button
-                type="primary-white"
-                className="inline-block mx-0.5 border-green-500 border"
-                size="small"
-                onClick={() => navigate(`/hosts/${hostID}/settings`)}
-              >
-                <EOS_SETTINGS className="inline-block fill-jungle-green-500" />{' '}
-                Check Selection
-              </Button>
-
-              <Button
-                type="primary-white"
-                className="mx-0.5 border-green-500 border"
-                size="small"
-                onClick={() => navigate(`/hosts/${hostID}/executions/last`)}
-              >
-                <EOS_CLEAR_ALL className="inline-block fill-jungle-green-500" />
-                Show Results
-              </Button>
-
-              <Tooltip
-                isEnabled={!canStartExecution(selectedChecks, savingChecks)}
-                content="Select some Checks first!"
-                place="bottom"
-              >
-                <Button
-                  type="primary"
-                  className="mx-1"
-                  onClick={requestHostChecksExecution}
-                  disabled={!canStartExecution(selectedChecks, savingChecks)}
-                >
-                  <EOS_PLAY_CIRCLE
-                    className={`${
-                      canStartExecution(selectedChecks, savingChecks)
-                        ? 'fill-white'
-                        : 'fill-gray-200'
-                    } inline-block align-sub`}
-                  />{' '}
-                  Start Execution
-                </Button>
-              </Tooltip>
             </div>
           </div>
           <div className="pb-3">

--- a/assets/js/components/HostDetails/HostDetails.test.jsx
+++ b/assets/js/components/HostDetails/HostDetails.test.jsx
@@ -13,7 +13,7 @@ import HostDetails from './HostDetails';
 
 describe('HostDetails component', () => {
   describe('Checks execution', () => {
-    it('should show the Checks related action buttons', () => {
+    it.skip('should show the Checks related action buttons', () => {
       renderWithRouter(<HostDetails agentVersion="1.0.0" />);
 
       expect(
@@ -27,7 +27,7 @@ describe('HostDetails component', () => {
       ).toBeVisible();
     });
 
-    it('should disable start execution button when checks are not selected', async () => {
+    it.skip('should disable start execution button when checks are not selected', async () => {
       const user = userEvent.setup();
 
       renderWithRouter(
@@ -41,7 +41,7 @@ describe('HostDetails component', () => {
       expect(screen.getByText('Select some Checks first!')).toBeInTheDocument();
     });
 
-    it('should enable start execution button when checks are selected', async () => {
+    it.skip('should enable start execution button when checks are selected', async () => {
       const user = userEvent.setup();
       const selectedChecks = [faker.animal.bear(), faker.animal.bear()];
 


### PR DESCRIPTION
# Description

After the implementation of PR [#1959](https://github.com/trento-project/web/pull/1959), it was decided that as no Host Checks are currently available, the presence of the Check-related action buttons would be confusing to the user.

For example, if no Checks are available, the user can still click the _Check Selection_ button to be taken to the _Check Settings_ page. However as there are no Checks available, the UI displays a message to the user that the Checks Catalog is empty and a button to try again. This can be a confusing UX flow.

![image](https://github.com/trento-project/web/assets/113615552/294a961e-eea3-46a1-bc68-d9323fc5d36e)

This change removes the Check-related action buttons from the UI in the _Host Details_ page to make the UI easier to understand.

![image](https://github.com/trento-project/web/assets/113615552/2a466160-b1a5-4fde-a4d2-3677157eb2e5)

## How was this tested?

Removed the tests checking for the presence of the checks-actions buttons
