### PR TITLE
Fix saptune domain clause

### DIFF
--- a/lib/trento/domain/host/host.ex
+++ b/lib/trento/domain/host/host.ex
@@ -424,11 +424,10 @@ defmodule Trento.Domain.Host do
 
   def execute(
         %Host{
-          saptune_status:
-            %{
-              package_version: package_version
-            } = host
-        },
+          saptune_status: %{
+            package_version: package_version
+          }
+        } = host,
         %UpdateSaptuneStatus{
           saptune_installed: true,
           package_version: package_version,


### PR DESCRIPTION
# Description

Stupid mistake in the clause...
It was causing an error in a pretty standard scenario, as it was passing the saptune status, instead of the expected host domain state:
```
09:08:39.533 [error] ** (FunctionClauseError) no function clause matching in Trento.Domain.Host.maybe_emit_host_saptune_health_changed_event/2
    (trento 2.1.0-git.dev273.1698996215.8d6c8aa7) lib/trento/domain/host/host.ex:686: Trento.Domain.Host.maybe_emit_host_saptune_health_changed_event(%Trento.Domain.SaptuneStatus{applied_notes: [], applied_solution: nil, configured_version: nil, enabled_notes: [], enabled_solution: nil, package_version: "3.0.2", services: [], staging: nil, tuning_state: nil}, true)
```

## How was this tested?

New UT added. The unique lines that were not tested causes the error, murphy's law XD
