### PR TITLE
Use databasesList slice properly to get db instances

### DIFF
--- a/assets/js/components/ClustersList.test.jsx
+++ b/assets/js/components/ClustersList.test.jsx
@@ -22,6 +22,9 @@ describe('ClustersList component', () => {
         applicationInstances: [],
         databaseInstances: [],
       },
+      databasesList: {
+        databaseInstances: [],
+      },
     };
 
     const scenarios = [

--- a/assets/js/state/selectors/sapSystem.js
+++ b/assets/js/state/selectors/sapSystem.js
@@ -30,7 +30,7 @@ export const getEnrichedApplicationInstances = createSelector(
 );
 
 export const getEnrichedDatabaseInstances = createSelector(
-  [(state) => enrichInstances(state.sapSystemsList.databaseInstances)(state)],
+  [(state) => enrichInstances(state.databasesList.databaseInstances)(state)],
   (enrichedInstances) => enrichedInstances
 );
 
@@ -110,7 +110,7 @@ export const getInstancesOnHost = createSelector(
 export const getAllSAPInstances = createSelector(
   [
     (state) => state.sapSystemsList.applicationInstances,
-    (state) => state.sapSystemsList.databaseInstances,
+    (state) => state.databasesList.databaseInstances,
   ],
   (applicationInstances, databaseInstances) =>
     applicationInstances

--- a/assets/js/state/selectors/sapSystem.test.js
+++ b/assets/js/state/selectors/sapSystem.test.js
@@ -73,7 +73,7 @@ describe('sapSystem selector', () => {
     ];
 
     const state = {
-      sapSystemsList: {
+      databasesList: {
         databaseInstances,
       },
       hostsList: {
@@ -232,6 +232,8 @@ describe('sapSystem selector', () => {
           { id: 1, name: 'APP1' },
           { id: 2, name: 'APP2' },
         ],
+      },
+      databasesList: {
         databaseInstances: [
           { id: 3, name: 'DB1' },
           { id: 4, name: 'DB2' },

--- a/test/e2e/cypress/e2e/databases_overview.cy.js
+++ b/test/e2e/cypress/e2e/databases_overview.cy.js
@@ -21,6 +21,13 @@ context('Databases Overview', () => {
       ],
     };
 
+    const nwqSystem = {
+      sid: 'NWQ',
+      ascsInstance: {
+        id: '25677e37-fd33-5005-896c-9275b1284534',
+      },
+    };
+
     it(`should not display DB ${hdqDatabase.sid} after deregistering the primary instance`, () => {
       cy.deregisterHost(hdqDatabase.instances[0].id);
       cy.contains(hdqDatabase.sid).should('not.exist');
@@ -46,6 +53,15 @@ context('Databases Overview', () => {
           }
         });
       });
+    });
+
+    it('should not deregister database instances if the SAP system using the database is deregistered', () => {
+      cy.deregisterHost(nwqSystem.ascsInstance.id);
+      cy.contains(
+        'p',
+        `The SAP System ${nwqSystem.sid} has been deregistered.`
+      );
+      cy.get('.table-row-group > div.table-row').should('have.length', 6);
     });
   });
 


### PR DESCRIPTION
# Description

Fixes 2 selectors which uses the `sapSystems` slice incorrectly to get data of `databasesList` slice.
This creates the situation that if the SAP system using the database is deregistered, the database instances are not returned anymore, leaving "empty" HANA database (without instances).
I have checked, and as far as I could test, it doesn't have any "not wanted" side-effect

## How was this tested?

Tests updated. I did some manual testing as well.
