### PR TITLE
Hackweek - Log panels querying data from loki

### DIFF
--- a/assets/js/components/HostDetails/HostDetails.jsx
+++ b/assets/js/components/HostDetails/HostDetails.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { get } from 'lodash';
 
 import { agentVersionWarning } from '@lib/agent';
@@ -17,6 +17,8 @@ import StatusPill from './StatusPill';
 import ProviderDetails from './ProviderDetails';
 import SaptuneSummary from './SaptuneSummary';
 import HostSummary from './HostSummary';
+//import Logs, { buildLogFilesEntries, journalDefaultEntries } from './Logs';
+import Logs, { buildLogFilesEntries, buildJournalEntries } from './Logs';
 
 import {
   subscriptionsTableConfiguration,
@@ -45,6 +47,8 @@ function HostDetails({
   navigate,
 }) {
   const [cleanUpModalOpen, setCleanUpModalOpen] = useState(false);
+  const [fileLogEntries, setFileLogEntries] = useState({});
+  const [journalUnitEntries, setJournalEntries] = useState({});
 
   const versionWarningMessage = agentVersionWarning(agentVersion);
 
@@ -71,6 +75,11 @@ function HostDetails({
   const lastExecutionData = get(lastExecution, 'data');
   const lastExecutionLoading = get(lastExecution, 'loading');
   const lastExecutionError = get(lastExecution, 'error');
+
+  useEffect(() => {
+    buildLogFilesEntries(setFileLogEntries);
+    buildJournalEntries(setJournalEntries);
+  }, []);
 
   return (
     <>
@@ -185,6 +194,20 @@ function HostDetails({
             config={subscriptionsTableConfiguration}
             data={slesSubscriptions}
           />
+        </div>
+
+        <div className="mt-8">
+          <div className="mb-4">
+            <h2 className="text-2xl font-bold"> Journal Logs</h2>
+          </div>
+          <Logs hostname={hostname} entries={journalUnitEntries} />
+        </div>
+
+        <div className="mt-8">
+          <div className="mb-4">
+            <h2 className="text-2xl font-bold"> File Logs</h2>
+          </div>
+          <Logs hostname={hostname} entries={fileLogEntries} />
         </div>
       </div>
     </>

--- a/assets/js/components/HostDetails/Logs.jsx
+++ b/assets/js/components/HostDetails/Logs.jsx
@@ -1,0 +1,134 @@
+import React, { useState } from 'react';
+import { Tab } from '@headlessui/react';
+import { queryOne, getLabelValues } from '@lib/api/logs';
+import Button from '@components/Button';
+import Table from '@components/Table';
+import classNames from 'classnames';
+import { EOS_REFRESH } from 'eos-icons-react';
+import { set } from 'lodash';
+
+// export const journalDefaultEntries = {
+//   'init.scope': {
+//     name: 'init.scope',
+//   },
+//   'k3s.service': {
+//     name: 'k3s.service',
+//   },
+//   'smartd.service': {
+//     name: 'smartd.service',
+//   },
+// };
+
+export const buildJournalEntries = async (setJournalEntries) => {
+  const units = await getLabelValues('unit');
+  const unitEntries = units.reduce(
+    (acc, unit) =>
+      set(acc, [unit], {
+        name: unit,
+        query: (unitValues) =>
+          `{unit="${unitValues.name}",hostname="${unitValues.hostname}"}`,
+      }),
+    {}
+  );
+  setJournalEntries(unitEntries);
+}
+
+export const buildLogFilesEntries = async (setFileLogEntries) => {
+  const files = await getLabelValues('filename');
+  const logEntries = files.reduce(
+    (acc, filename) =>
+      set(acc, [filename], {
+        name: filename,
+        query: (fileValues) =>
+          `{job="my-logs",filename="${filename}", hostname="${fileValues.hostname}"}`,
+      }),
+    {}
+  );
+  setFileLogEntries(logEntries);
+}
+
+const logsTableConfiguration = {
+  usePadding: false,
+  columns: [
+    {
+      title: 'Time',
+      key: 'time',
+      render: (content) => new Date(content / 1000000).toISOString(),
+    },
+    {
+      title: 'Value',
+      key: 'value',
+    },
+  ],
+};
+
+const renderPanel = (query) => <LogsPanel query={query} />;
+
+const buildQuery = (values) =>
+  `{unit="${values.name}",hostname="${values.hostname}"}`;
+
+function Logs({ hostname, entries }) {
+  return (
+    <div className="w-full px-2 sm:px-0">
+      <Tab.Group>
+        <Tab.List className="flex space-x-1 rounded-xl bg-blue-900/20 p-1">
+          {Object.keys(entries).map((entry) => (
+            <Tab
+              key={entry}
+              className={({ selected }) =>
+                classNames(
+                  'w-full rounded-lg py-2.5 text-sm font-medium leading-5 text-blue-700',
+                  'ring-white/60 ring-offset-2 ring-offset-blue-400 focus:outline-none focus:ring-2',
+                  selected
+                    ? 'bg-white shadow'
+                    : 'text-blue-100 hover:bg-white/[0.12] hover:text-white'
+                )
+              }
+            >
+              {entry}
+            </Tab>
+          ))}
+        </Tab.List>
+        <Tab.Panels className="mt-2">
+          {Object.values(entries).map(
+            ({ name, render = renderPanel, query = buildQuery }) => (
+              <Tab.Panel
+                key={name}
+                unmount={false}
+                className={classNames(
+                  'rounded-xl bg-white p-3',
+                  'ring-white/60 ring-offset-2 ring-offset-blue-400 focus:outline-none focus:ring-2'
+                )}
+              >
+                {render(query({ name, hostname }))}
+              </Tab.Panel>
+            )
+          )}
+        </Tab.Panels>
+      </Tab.Group>
+    </div>
+  );
+}
+
+function LogsPanel({ query }) {
+  const [logs, setLogs] = useState([]);
+
+  return (
+    <>
+      <Table config={logsTableConfiguration} data={logs} withPadding={false} />
+      <Button
+        syze="small"
+        type="default-fit"
+        className="mt-3"
+        onClick={async () => {
+          const newLogs = await queryOne(query);
+          setLogs(newLogs);
+        }}
+      >
+        <EOS_REFRESH className="fill-white" />
+      </Button>
+    </>
+  );
+}
+
+export default Logs;

--- a/assets/js/components/Table/Table.jsx
+++ b/assets/js/components/Table/Table.jsx
@@ -158,7 +158,7 @@ function Table({
             'pt-4': withPadding,
           })}
         >
-          <div className="min-w-fit shadow rounded-lg">
+          <div className="min-w-fit shadow rounded-lg max-h-96 overflow-scroll">
             <table className="min-w-full leading-normal table-fixed">
               <thead>
                 <tr>

--- a/assets/js/lib/api/logs.js
+++ b/assets/js/lib/api/logs.js
@@ -1,0 +1,37 @@
+import axios from 'axios';
+
+export const lokiClient = axios.create({
+  baseURL: 'http://localhost:3123/api/',
+});
+
+export const getLabelValues = async (label) => {
+  try {
+    const {
+      data: { data: filenames },
+    } = await lokiClient.get(`label/${label}/values`);
+
+    return filenames;
+  } catch (error) {
+    return error;
+  }
+};
+
+export const queryOne = async (query) => {
+  try {
+    const params = new URLSearchParams();
+    params.append('query', query);
+    const {
+      data: {
+        data: { result },
+      },
+    } = await lokiClient.post('/query_range', params);
+    if (result.length > 0) {
+      const { values } = result[0];
+      return values.map(([time, value]) => ({ time, value }));
+    }
+
+    return [];
+  } catch (error) {
+    return error;
+  }
+};

--- a/priv/data/nginx.conf
+++ b/priv/data/nginx.conf
@@ -1,0 +1,22 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    server {
+        listen       3123;
+        server_name  localhost;
+        charset UTF-8;
+
+        location /api/ { 
+            proxy_http_version 1.1;
+            proxy_pass http://localhost:3100/loki/api/v1/;
+     
+            add_header Access-Control-Allow-Origin * always;
+            add_header Access-Control-Allow-Methods "POST, GET, OPTIONS" always;
+            add_header Access-Control-Allow-Headers "Origin, Authorization, Accept" always;
+            add_header Access-Control-Allow-Credentials true always;
+        }
+    }
+}
+

--- a/priv/data/promtail.yaml
+++ b/priv/data/promtail.yaml
@@ -1,0 +1,31 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://localhost:3100/loki/api/v1/push # update to point to your loki deployment
+
+scrape_configs:
+  - job_name: journal
+    journal:
+      max_age: 12h
+      labels:
+        job: systemd-journal
+    relabel_configs:
+      - source_labels: ['__journal__systemd_unit']
+        target_label: 'unit'
+      - source_labels: ['__journal__hostname']
+        target_label: 'hostname'
+        
+  - job_name: my_logs
+    static_configs:
+    - labels:
+        job: my-logs
+        hostname: linux-afj9 # set your hostname here
+        __path__: '/var/log/my_logs/*.log'
+    relabel_configs:
+      - source_labels: ['__address__']
+        target_label: 'address'


### PR DESCRIPTION
# Description

This PR shows some work done during SUSE's hackweek 2023.
I tried to see how we could integrate log parsing with tools such as loki and promtail.
As a result, I found out that it is pretty trivial to setup loki/promtail and visualize some basic journald and log files logs.

Here a demo:
![logs](https://github.com/trento-project/web/assets/36370954/6d3cb7ac-4762-4001-9a5c-93a832d8bd1d)

If somebody is interested and trying it out:
1. Install promtail in the machine where the trento-agent is running. You can get the binary from openSUSE repositories using `zypper in promtail`. You can download the binary or use any official container as well.
2. Start promtail using the configuration file supplied in this PR. If you are using `systemd`, you need to edit the `/etc/sysconfig/promtail` to point the new configuration file (or copy the configuration file to the path used in the default file). You can change the config file to select the folder where you want to monitor the log files.
3. Start promtail
4. Start loki in you server, where web is running for example. I have used `docker-compose` for that with this [docker-compose.yaml](https://raw.githubusercontent.com/grafana/loki/v2.9.1/production/docker-compose.yaml) file. I have commented out `promtail` and `grafana`, as I didn't need them.
5. Unfortunately, we cannot query `loki` directly from the browser without having `cors` errors. To avoid, that I have deployed a nginx reverse proxy with some basic `cors` configuration. You can find the configuration I used in the PR as well. Start `nginx` using that file.
6. If you don't use the `nginx` way I used, you might need to change the `api.logs.js` file content to update the hardcoded address I coded there.
7. Start the `web` project.

With all these steps, you should be able to see your target machine logs in the Host details view as showed in the demo gif.
