### PR TITLE
Restrict SUSE Dockerfile target arch to x86_64

### DIFF
--- a/packaging/suse/Dockerfile
+++ b/packaging/suse/Dockerfile
@@ -3,6 +3,7 @@
 #!BuildTag: trento/trento-web:%%VERSION%%
 #!BuildTag: trento/trento-web:%%VERSION%%-build%RELEASE%
 #!UseOBSRepositories
+#!ExclusiveArch: x86_64
 
 FROM bci/nodejs:16 AS assets-build
 ADD web.tar.gz /build/


### PR DESCRIPTION
# Description

This PR just avoids building non-x86_64 images in OBS which are not supported anyways and can cause issues during releases
