### PR TITLE
Tags context

### DIFF
--- a/lib/trento/application/read_models/cluster_read_model.ex
+++ b/lib/trento/application/read_models/cluster_read_model.ex
@@ -11,6 +11,8 @@ defmodule Trento.ClusterReadModel do
   require Trento.Domain.Enums.ClusterType, as: ClusterType
   require Trento.Domain.Enums.Health, as: Health
 
+  alias Trento.Tags.Tag
+
   @type t :: %__MODULE__{}
 
   @derive {Jason.Encoder, except: [:__meta__, :__struct__]}
@@ -27,7 +29,7 @@ defmodule Trento.ClusterReadModel do
     field :hosts_number, :integer
     field :details, :map
 
-    has_many :tags, Trento.Tag, foreign_key: :resource_id
+    has_many :tags, Tag, foreign_key: :resource_id
 
     # Virtually enriched fields
     field :cib_last_written, :string, virtual: true

--- a/lib/trento/application/read_models/database_read_model.ex
+++ b/lib/trento/application/read_models/database_read_model.ex
@@ -10,6 +10,7 @@ defmodule Trento.DatabaseReadModel do
   require Trento.Domain.Enums.Health, as: Health
 
   alias Trento.DatabaseInstanceReadModel
+  alias Trento.Tags.Tag
 
   @type t :: %__MODULE__{}
 
@@ -19,7 +20,7 @@ defmodule Trento.DatabaseReadModel do
     field :sid, :string
     field :health, Ecto.Enum, values: Health.values()
 
-    has_many :tags, Trento.Tag, foreign_key: :resource_id
+    has_many :tags, Tag, foreign_key: :resource_id
 
     has_many :database_instances, DatabaseInstanceReadModel,
       references: :id,

--- a/lib/trento/application/read_models/host_read_model.ex
+++ b/lib/trento/application/read_models/host_read_model.ex
@@ -11,6 +11,7 @@ defmodule Trento.HostReadModel do
   require Trento.Domain.Enums.Provider, as: Provider
 
   alias Trento.SlesSubscriptionReadModel
+  alias Trento.Tags.Tag
 
   @type t :: %__MODULE__{}
 
@@ -28,7 +29,7 @@ defmodule Trento.HostReadModel do
     field :provider_data, :map
     field :saptune_status, :map
 
-    has_many :tags, Trento.Tag, foreign_key: :resource_id
+    has_many :tags, Tag, foreign_key: :resource_id
 
     has_many :sles_subscriptions, SlesSubscriptionReadModel,
       references: :id,

--- a/lib/trento/application/read_models/sap_system_read_model.ex
+++ b/lib/trento/application/read_models/sap_system_read_model.ex
@@ -15,6 +15,8 @@ defmodule Trento.SapSystemReadModel do
     DatabaseInstanceReadModel
   }
 
+  alias Trento.Tags.Tag
+
   @type t :: %__MODULE__{}
 
   @derive {Jason.Encoder, except: [:__meta__, :__struct__]}
@@ -36,7 +38,7 @@ defmodule Trento.SapSystemReadModel do
       foreign_key: :sap_system_id,
       preload_order: [asc: :instance_number, asc: :host_id]
 
-    has_many :tags, Trento.Tag, foreign_key: :resource_id
+    has_many :tags, Tag, foreign_key: :resource_id
 
     field :deregistered_at, :utc_datetime_usec
   end

--- a/lib/trento/tags.ex
+++ b/lib/trento/tags.ex
@@ -5,7 +5,7 @@ defmodule Trento.Tags do
 
   import Ecto.Query
 
-  alias Trento.Tag
+  alias Trento.Tags.Tag
 
   alias Trento.Repo
 

--- a/lib/trento/tags/tag.ex
+++ b/lib/trento/tags/tag.ex
@@ -1,4 +1,4 @@
-defmodule Trento.Tag do
+defmodule Trento.Tags.Tag do
   @moduledoc false
 
   use Ecto.Schema

--- a/lib/trento_web/controllers/v1/tags_controller.ex
+++ b/lib/trento_web/controllers/v1/tags_controller.ex
@@ -3,6 +3,7 @@ defmodule TrentoWeb.V1.TagsController do
   use OpenApiSpex.ControllerSpecs
 
   alias Trento.Tags
+  alias Trento.Tags.Tag
 
   alias TrentoWeb.OpenApi.V1.Schema
 
@@ -44,7 +45,7 @@ defmodule TrentoWeb.V1.TagsController do
       ) do
     %{value: value} = Map.get(conn, :body_params)
 
-    with {:ok, %Trento.Tag{value: value}} <- Tags.add_tag(value, id, resource_type) do
+    with {:ok, %Tag{value: value}} <- Tags.add_tag(value, id, resource_type) do
       conn
       |> put_status(:created)
       |> json(%{value: value})

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -71,9 +71,10 @@ defmodule Trento.Factory do
     HostReadModel,
     HostTelemetryReadModel,
     SapSystemReadModel,
-    SlesSubscriptionReadModel,
-    Tag
+    SlesSubscriptionReadModel
   }
+
+  alias Trento.Tags.Tag
 
   alias Trento.Integration.Discovery.{
     DiscardedDiscoveryEvent,

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -578,7 +578,7 @@ defmodule Trento.Factory do
 
   def tag_factory do
     %Tag{
-      value: sequence(:value, &"#{Faker.Beer.hop()}0#{&1}"),
+      value: sequence(:value, &"#{Faker.Color.name()}0#{&1}"),
       resource_id: Faker.UUID.v4(),
       resource_type: :host
     }

--- a/test/trento/tags_test.exs
+++ b/test/trento/tags_test.exs
@@ -35,6 +35,16 @@ defmodule Trento.TagsTest do
       assert nil == Repo.get_by(Tag, resource_id: resource_id)
     end
 
+    test "add_tag/3 does nothing on conflict with resource_id and value" do
+      %Tag{value: value, resource_id: resource_id, resource_type: type} = insert(:tag)
+
+      {:ok, %Tag{id: nil, value: ^value, resource_id: ^resource_id, resource_type: :host}} =
+        Tags.add_tag(value, resource_id, type)
+
+      assert %Tag{value: ^value, resource_id: ^resource_id, resource_type: :host} =
+               Repo.get_by(Tag, resource_id: resource_id)
+    end
+
     test "delete_tag/2 deletes a tag from a given resource" do
       %Tag{value: value, resource_id: resource_id} = insert(:tag)
       :ok = Tags.delete_tag(value, resource_id)

--- a/test/trento/tags_test.exs
+++ b/test/trento/tags_test.exs
@@ -5,15 +5,16 @@ defmodule Trento.TagsTest do
 
   import Trento.Factory
 
-  alias Trento.Repo
-
-  alias Trento.Tags
+  alias Trento.{
+    Repo,
+    Tags
+  }
 
   describe "tags" do
     alias Trento.Tags.Tag
 
     test "add_tag/3 adds a tag to the desired resource" do
-      value = Faker.StarWars.planet()
+      value = Faker.Color.name()
       resource_id = Faker.UUID.v4()
       type = "host"
 
@@ -25,7 +26,7 @@ defmodule Trento.TagsTest do
     end
 
     test "add_tag/3 returns an error if the type is unknown" do
-      value = Faker.StarWars.planet()
+      value = Faker.Color.name()
       resource_id = Faker.UUID.v4()
       type = "unknown"
 

--- a/test/trento/tags_test.exs
+++ b/test/trento/tags_test.exs
@@ -1,0 +1,48 @@
+defmodule Trento.TagsTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  use Trento.DataCase
+
+  import Trento.Factory
+
+  alias Trento.Repo
+
+  alias Trento.Tags
+
+  describe "tags" do
+    alias Trento.Tags.Tag
+
+    test "add_tag/3 adds a tag to the desired resource" do
+      value = Faker.StarWars.planet()
+      resource_id = Faker.UUID.v4()
+      type = "host"
+
+      {:ok, %Tag{value: ^value, resource_id: ^resource_id, resource_type: :host}} =
+        Tags.add_tag(value, resource_id, type)
+
+      assert %Tag{value: ^value, resource_id: ^resource_id, resource_type: :host} =
+               Repo.get_by(Tag, resource_id: resource_id)
+    end
+
+    test "add_tag/3 returns an error if the type is unknown" do
+      value = Faker.StarWars.planet()
+      resource_id = Faker.UUID.v4()
+      type = "unknown"
+
+      {:error, _} = Tags.add_tag(value, resource_id, type)
+
+      assert nil == Repo.get_by(Tag, resource_id: resource_id)
+    end
+
+    test "delete_tag/2 deletes a tag from a given resource" do
+      %Tag{value: value, resource_id: resource_id} = insert(:tag)
+      :ok = Tags.delete_tag(value, resource_id)
+      assert nil == Repo.get_by(Tag, resource_id: resource_id)
+    end
+
+    test "delete_tag/2 returns a not found error if the resource does not exist" do
+      %Tag{value: value} = insert(:tag)
+      {:error, :not_found} = Tags.delete_tag(value, Faker.UUID.v4())
+    end
+  end
+end

--- a/test/trento_web/controllers/v1/tags_controller_test.exs
+++ b/test/trento_web/controllers/v1/tags_controller_test.exs
@@ -3,7 +3,7 @@ defmodule TrentoWeb.V1.TagsControllerTest do
 
   import Trento.Factory
   alias Faker.Color
-  alias Trento.Tag
+  alias Trento.Tags.Tag
 
   describe "Tag Validation" do
     test "should decline tag with whitespace", %{conn: conn} do


### PR DESCRIPTION
# Description

Move the `tags` code to a proper phoenix content. Luckily enough, the `trento_web` part already follows correct conventions.
Based on: https://github.com/trento-project/docs/blob/main/adr/0010-web-dashboard-directory-structure-and-contexts.md

PD:
More references:
https://hexdocs.pm/phoenix/directory_structure.html#the-lib-hello-directory
https://hexdocs.pm/phoenix/contexts.html
https://hexdocs.pm/phoenix/testing_contexts.html

## How was this tested?

I have included some missing tests, mostly to give an example on how and where they should go.
