### PR TITLE
Increase timeout for Rabbit consumer tests

### DIFF
--- a/test/trento/application/integration/checks/consumer_test.exs
+++ b/test/trento/application/integration/checks/consumer_test.exs
@@ -22,7 +22,7 @@ defmodule Trento.Integration.Checks.AMQP.ConsumerTest do
 
       assert :ok = Publisher.publish_message(message, "results")
 
-      assert_receive :consumed, 1_000
+      assert_receive :consumed, 5_000
     end
   end
 
@@ -51,7 +51,7 @@ defmodule Trento.Integration.Checks.AMQP.ConsumerTest do
 
       :ok = AMQP.Channel.close(chan)
 
-      assert_receive :consumed, 1_000
+      assert_receive :consumed, 5_000
     end
   end
 end


### PR DESCRIPTION
# Description

Increased the timeout for RabbitMQ consumer tests because apparently with this larger suite a bigger timeout is needed.
