### PR TITLE
Supersede events

### DIFF
--- a/lib/trento/support/event.ex
+++ b/lib/trento/support/event.ex
@@ -8,14 +8,19 @@ defmodule Trento.Event do
   defmacro defevent(opts \\ [], do: block) do
     quote do
       @version Keyword.get(unquote(opts), :version, 1)
-      @superseded_by Keyword.get(unquote(opts), :superseded_by, __MODULE__)
+      @superseded_by Keyword.get(unquote(opts), :superseded_by, nil)
 
       deftype do
         field :version, :integer, default: @version
         unquote(block)
       end
 
-      def supersede, do: @superseded_by
+      def supersede do
+        case @superseded_by do
+          nil -> __MODULE__
+          superseded -> superseded.supersede()
+        end
+      end
 
       def upcast(params, metadata) do
         params

--- a/lib/trento/support/event.ex
+++ b/lib/trento/support/event.ex
@@ -8,11 +8,14 @@ defmodule Trento.Event do
   defmacro defevent(opts \\ [], do: block) do
     quote do
       @version Keyword.get(unquote(opts), :version, 1)
+      @superseeded_by Keyword.get(unquote(opts), :superseeded_by, __MODULE__)
 
       deftype do
         field :version, :integer, default: @version
         unquote(block)
       end
+
+      def superseed, do: @superseeded_by
 
       def upcast(params, metadata) do
         params

--- a/lib/trento/support/event.ex
+++ b/lib/trento/support/event.ex
@@ -8,14 +8,14 @@ defmodule Trento.Event do
   defmacro defevent(opts \\ [], do: block) do
     quote do
       @version Keyword.get(unquote(opts), :version, 1)
-      @superseeded_by Keyword.get(unquote(opts), :superseeded_by, __MODULE__)
+      @superseded_by Keyword.get(unquote(opts), :superseded_by, __MODULE__)
 
       deftype do
         field :version, :integer, default: @version
         unquote(block)
       end
 
-      def superseed, do: @superseeded_by
+      def supersede, do: @superseded_by
 
       def upcast(params, metadata) do
         params

--- a/lib/trento/support/event.ex
+++ b/lib/trento/support/event.ex
@@ -15,11 +15,10 @@ defmodule Trento.Event do
         unquote(block)
       end
 
-      def supersede do
-        case @superseded_by do
-          nil -> __MODULE__
-          superseded -> superseded.supersede()
-        end
+      if is_nil(@superseded_by) do
+        def supersede, do: __MODULE__
+      else
+        def supersede, do: @superseded_by.supersede()
       end
 
       def upcast(params, metadata) do

--- a/lib/trento/support/intermediate_event.ex
+++ b/lib/trento/support/intermediate_event.ex
@@ -19,10 +19,12 @@ defmodule Trento.Support.IntermediateEvent do
     alias Trento.Support.IntermediateEvent
 
     def upcast(%IntermediateEvent{module: module, term: term}, metadata) do
+      superseeded_module = module.superseed()
+
       event =
         term
-        |> module.upcast(metadata)
-        |> module.new!()
+        |> superseeded_module.upcast(metadata)
+        |> superseeded_module.new!()
 
       Logger.debug("Cast IntermediateEvent #{module}: #{inspect(term)} to: #{inspect(event)}")
 

--- a/lib/trento/support/intermediate_event.ex
+++ b/lib/trento/support/intermediate_event.ex
@@ -19,12 +19,12 @@ defmodule Trento.Support.IntermediateEvent do
     alias Trento.Support.IntermediateEvent
 
     def upcast(%IntermediateEvent{module: module, term: term}, metadata) do
-      superseeded_module = module.superseed()
+      superseded_module = module.supersede()
 
       event =
         term
-        |> superseeded_module.upcast(metadata)
-        |> superseeded_module.new!()
+        |> superseded_module.upcast(metadata)
+        |> superseded_module.new!()
 
       Logger.debug("Cast IntermediateEvent #{module}: #{inspect(term)} to: #{inspect(event)}")
 

--- a/test/support/structs/test_legacy_event.ex
+++ b/test/support/structs/test_legacy_event.ex
@@ -1,0 +1,9 @@
+defmodule TestLegacyEvent do
+  @moduledoc false
+
+  use Trento.Event
+
+  defevent superseeded_by: TestEvent do
+    field :data, :string
+  end
+end

--- a/test/support/structs/test_legacy_event.ex
+++ b/test/support/structs/test_legacy_event.ex
@@ -3,7 +3,7 @@ defmodule TestLegacyEvent do
 
   use Trento.Event
 
-  defevent superseeded_by: TestEvent do
+  defevent superseded_by: TestEvent do
     field :data, :string
   end
 end

--- a/test/support/structs/test_legacy_event_v1.ex
+++ b/test/support/structs/test_legacy_event_v1.ex
@@ -1,0 +1,9 @@
+defmodule TestLegacyEventV1 do
+  @moduledoc false
+
+  use Trento.Event
+
+  defevent superseded_by: TestLegacyEventV2 do
+    field :data, :string
+  end
+end

--- a/test/support/structs/test_legacy_event_v2.ex
+++ b/test/support/structs/test_legacy_event_v2.ex
@@ -1,4 +1,4 @@
-defmodule TestLegacyEvent do
+defmodule TestLegacyEventV2 do
   @moduledoc false
 
   use Trento.Event

--- a/test/trento/support/event_test.exs
+++ b/test/trento/support/event_test.exs
@@ -75,13 +75,13 @@ defmodule Trento.EventTest do
     end
   end
 
-  describe "superseed an event" do
-    test "event is superseeded" do
-      assert TestEvent == TestLegacyEvent.superseed()
+  describe "supersede an event" do
+    test "event is superseded" do
+      assert TestEvent == TestLegacyEvent.supersede()
     end
 
-    test "event is not superseeded" do
-      assert TestEvent == TestEvent.superseed()
+    test "event is not superseded" do
+      assert TestEvent == TestEvent.supersede()
     end
   end
 end

--- a/test/trento/support/event_test.exs
+++ b/test/trento/support/event_test.exs
@@ -74,4 +74,14 @@ defmodule Trento.EventTest do
                })
     end
   end
+
+  describe "superseed an event" do
+    test "event is superseeded" do
+      assert TestEvent == TestLegacyEvent.superseed()
+    end
+
+    test "event is not superseeded" do
+      assert TestEvent == TestEvent.superseed()
+    end
+  end
 end

--- a/test/trento/support/event_test.exs
+++ b/test/trento/support/event_test.exs
@@ -77,7 +77,11 @@ defmodule Trento.EventTest do
 
   describe "supersede an event" do
     test "event is superseded" do
-      assert TestEvent == TestLegacyEvent.supersede()
+      assert TestEvent == TestLegacyEventV2.supersede()
+    end
+
+    test "event is not superseded multiple times" do
+      assert TestEvent == TestLegacyEventV1.supersede()
     end
 
     test "event is not superseded" do

--- a/test/trento/support/intermediate_event_test.exs
+++ b/test/trento/support/intermediate_event_test.exs
@@ -26,7 +26,7 @@ defmodule Trento.Support.IntermediateEventTest do
 
     assert %TestEvent{data: value} ==
              Upcaster.upcast(
-               %IntermediateEvent{module: TestLegacyEvent, term: term},
+               %IntermediateEvent{module: TestLegacyEventV1, term: term},
                %{}
              )
   end

--- a/test/trento/support/intermediate_event_test.exs
+++ b/test/trento/support/intermediate_event_test.exs
@@ -20,7 +20,7 @@ defmodule Trento.Support.IntermediateEventTest do
              )
   end
 
-  test "upcast a superseeded event" do
+  test "upcast a superseded event" do
     value = Faker.StarWars.quote()
     term = %{"data" => value}
 

--- a/test/trento/support/intermediate_event_test.exs
+++ b/test/trento/support/intermediate_event_test.exs
@@ -1,0 +1,33 @@
+defmodule Trento.Support.IntermediateEventTest do
+  use ExUnit.Case
+
+  alias Commanded.Event.Upcaster
+  alias Trento.Support.IntermediateEvent
+
+  test "upcast an event" do
+    value = Faker.StarWars.quote()
+    term = %{"data" => value}
+
+    assert %TestUpcastedEvent{
+             version: 3,
+             data: value,
+             v2_field: "default string for v2 field",
+             v3_field: "default string for v3 field"
+           } ==
+             Upcaster.upcast(
+               %IntermediateEvent{module: TestUpcastedEvent, term: term},
+               %{}
+             )
+  end
+
+  test "upcast a superseeded event" do
+    value = Faker.StarWars.quote()
+    term = %{"data" => value}
+
+    assert %TestEvent{data: value} ==
+             Upcaster.upcast(
+               %IntermediateEvent{module: TestLegacyEvent, term: term},
+               %{}
+             )
+  end
+end


### PR DESCRIPTION
# Description

Change to add the option to `supersede` events with new events (to rename in our case). This feature allows us to rename events to the new "phoenix context" way.

For example, from `Trento.Domain.Events.HostRegistered` to `Trento.Hosts.Events.HostRegistered`.

The usage is pretty simple:
We can include a new `superseeded_by` opt to our events that are to be changed, pointing to the new event.
For example:
```
defmodule Trento.Domain.Events.HostRegistered do
  @moduledoc """
  This event is emitted when a host is registered.
  """

  use Trento.Event

  defevent version: 3, superseded_by: Trento.Hosts.Events.HostRegistered do
```

This way, already existing legacy events are renamed for the rest of the application usage (e.g. aggregate code, event handlers, etc).
**Important**. The legacy events must continue existing in the codebase, so we will need to move them to some `legacy` folder. The previously commented change must be done in the legacy code file. Together with that, we need to create the new event (`Trento.Hosts.Events.HostRegistered`) file, which in this case will have the same content, as we are simply renaming it.

**Some background about why this way**:
Entries in the EventStore are inmutable, we cannot change them, for example, renaming the content of the entries. There are even some sql rules to forbid that.
The way to rename or update events is with the `upcasting`.
Find here some info: https://github.com/commanded/commanded/blob/master/guides/Events.md#upcasting-events


## How was this tested?

UT added. I have tested it manually as well, and it worked fine in the scenarios that I tried.
