### PR TITLE
Extend Catalog filtering

### DIFF
--- a/assets/js/components/ChecksCatalog/CheckItem.jsx
+++ b/assets/js/components/ChecksCatalog/CheckItem.jsx
@@ -31,7 +31,7 @@ function CheckItem({
                 <TargetIcon
                   targetType={targetType}
                   containerClassName="inline-flex bg-jungle-green-500 p-1 rounded-full self-center"
-                  iconClassName="fill-white"
+                  className="fill-white"
                 />
               </div>
             )}

--- a/assets/js/components/ChecksCatalog/CheckItem.jsx
+++ b/assets/js/components/ChecksCatalog/CheckItem.jsx
@@ -28,7 +28,11 @@ function CheckItem({
           <div className="check-row flex">
             {hasTargetType && (
               <div className="pl-6 inline-flex">
-                <TargetIcon targetType={targetType} />
+                <TargetIcon
+                  targetType={targetType}
+                  containerClassName="inline-flex bg-jungle-green-500 p-1 rounded-full self-center"
+                  iconClassName="fill-white"
+                />
               </div>
             )}
             <div

--- a/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
@@ -3,7 +3,6 @@ import { groupBy } from 'lodash';
 
 import { providers, targetTypes } from '@lib/model';
 import { clusterTypes, getClusterTypeLabel } from '@lib/model/clusters';
-import { ensaVersions, getEnsaVersionLabel } from '@lib/model/sapSystems';
 import PageHeader from '@components/PageHeader';
 import Accordion from '@components/Accordion';
 import Select, { OPTION_ALL } from '@components/Select';
@@ -22,33 +21,26 @@ const targetTypeOptionRenderer = (targetType) => (
     iconClassName="inline mr-2 h-4"
   />
 );
-const clusterTypeOptionRenderer = getClusterTypeLabel;
-const ensaVersionOptionRenderer = getEnsaVersionLabel;
 
 function ChecksCatalog({ catalogData, catalogError, loading, updateCatalog }) {
   const [selectedProvider, setProviderSelected] = useState(OPTION_ALL);
   const [selectedTargetType, setSelectedTargetType] = useState(OPTION_ALL);
   const [selectedClusterType, setSelectedClusterType] = useState(OPTION_ALL);
-  const [selectedEnsaVersion, setSelectedEnsaVersion] = useState(OPTION_ALL);
 
   useEffect(() => {
     updateCatalog({
       selectedProvider,
       selectedTargetType,
       selectedClusterType,
-      selectedEnsaVersion,
     });
-  }, [
-    selectedProvider,
-    selectedTargetType,
-    selectedClusterType,
-    selectedEnsaVersion,
-  ]);
+  }, [selectedProvider, selectedTargetType, selectedClusterType]);
 
   return (
     <>
-      <PageHeader className="font-bold">Checks catalog</PageHeader>
       <div className="flex items-center space-x-4">
+        <PageHeader className="font-bold flex-1 w-64 pb-4">
+          Checks catalog
+        </PageHeader>
         <Select
           optionsName="targets"
           className="ml-auto"
@@ -61,17 +53,9 @@ function ChecksCatalog({ catalogData, catalogError, loading, updateCatalog }) {
           optionsName="cluster types"
           className="ml-auto"
           options={[OPTION_ALL, ...clusterTypes]}
-          renderOption={clusterTypeOptionRenderer}
+          renderOption={getClusterTypeLabel}
           value={selectedClusterType}
           onChange={setSelectedClusterType}
-        />
-        <Select
-          optionsName="ENSA versions"
-          className="ml-auto"
-          options={[OPTION_ALL, ...ensaVersions]}
-          renderOption={ensaVersionOptionRenderer}
-          value={selectedEnsaVersion}
-          onChange={setSelectedEnsaVersion}
         />
         <Select
           optionsName="providers"

--- a/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { groupBy } from 'lodash';
 
-import { providers, targetTypes } from '@lib/model';
+import {
+  providers,
+  targetTypes,
+  TARGET_HOST,
+  TARGET_CLUSTER,
+} from '@lib/model';
 import { clusterTypes, getClusterTypeLabel } from '@lib/model/clusters';
 import PageHeader from '@components/PageHeader';
 import Accordion from '@components/Accordion';
@@ -15,11 +20,10 @@ const providerOptionRenderer = (provider) => (
   <ProviderLabel provider={provider} />
 );
 const targetTypeOptionRenderer = (targetType) => (
-  <TargetIcon
-    targetType={targetType}
-    withLabel
-    iconClassName="inline mr-2 h-4"
-  />
+  <TargetIcon targetType={targetType} className="inline mr-2 h-4">
+    {targetType === TARGET_CLUSTER && 'Clusters'}
+    {targetType === TARGET_HOST && 'Hosts'}
+  </TargetIcon>
 );
 
 function ChecksCatalog({ catalogData, catalogError, loading, updateCatalog }) {

--- a/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
@@ -1,29 +1,78 @@
 import React, { useEffect, useState } from 'react';
 import { groupBy } from 'lodash';
 
-import { providers } from '@lib/model';
+import { providers, targetTypes } from '@lib/model';
+import { clusterTypes, getClusterTypeLabel } from '@lib/model/clusters';
+import { ensaVersions, getEnsaVersionLabel } from '@lib/model/sapSystems';
 import PageHeader from '@components/PageHeader';
 import Accordion from '@components/Accordion';
 import Select, { OPTION_ALL } from '@components/Select';
 import ProviderLabel from '@components/ProviderLabel';
+import TargetIcon from '@components/TargetIcon';
 import CatalogContainer from './CatalogContainer';
 import CheckItem from './CheckItem';
 
 const providerOptionRenderer = (provider) => (
   <ProviderLabel provider={provider} />
 );
+const targetTypeOptionRenderer = (targetType) => (
+  <TargetIcon
+    targetType={targetType}
+    withLabel
+    iconClassName="inline mr-2 h-4"
+  />
+);
+const clusterTypeOptionRenderer = getClusterTypeLabel;
+const ensaVersionOptionRenderer = getEnsaVersionLabel;
 
 function ChecksCatalog({ catalogData, catalogError, loading, updateCatalog }) {
   const [selectedProvider, setProviderSelected] = useState(OPTION_ALL);
+  const [selectedTargetType, setSelectedTargetType] = useState(OPTION_ALL);
+  const [selectedClusterType, setSelectedClusterType] = useState(OPTION_ALL);
+  const [selectedEnsaVersion, setSelectedEnsaVersion] = useState(OPTION_ALL);
 
   useEffect(() => {
-    updateCatalog(selectedProvider);
-  }, [selectedProvider]);
+    updateCatalog({
+      selectedProvider,
+      selectedTargetType,
+      selectedClusterType,
+      selectedEnsaVersion,
+    });
+  }, [
+    selectedProvider,
+    selectedTargetType,
+    selectedClusterType,
+    selectedEnsaVersion,
+  ]);
 
   return (
     <>
-      <div className="flex">
-        <PageHeader className="font-bold">Checks catalog</PageHeader>
+      <PageHeader className="font-bold">Checks catalog</PageHeader>
+      <div className="flex items-center space-x-4">
+        <Select
+          optionsName="targets"
+          className="ml-auto"
+          options={[OPTION_ALL, ...targetTypes]}
+          renderOption={targetTypeOptionRenderer}
+          value={selectedTargetType}
+          onChange={setSelectedTargetType}
+        />
+        <Select
+          optionsName="cluster types"
+          className="ml-auto"
+          options={[OPTION_ALL, ...clusterTypes]}
+          renderOption={clusterTypeOptionRenderer}
+          value={selectedClusterType}
+          onChange={setSelectedClusterType}
+        />
+        <Select
+          optionsName="ENSA versions"
+          className="ml-auto"
+          options={[OPTION_ALL, ...ensaVersions]}
+          renderOption={ensaVersionOptionRenderer}
+          value={selectedEnsaVersion}
+          onChange={setSelectedEnsaVersion}
+        />
         <Select
           optionsName="providers"
           className="ml-auto"

--- a/assets/js/components/ChecksCatalog/ChecksCatalog.test.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalog.test.jsx
@@ -39,10 +39,15 @@ describe('ChecksCatalog ChecksCatalog component', () => {
     const checks2 = screen.getAllByRole('listitem');
     expect(checks2.length).toBe(10);
 
-    expect(mockUpdateCatalog).toHaveBeenCalledWith('all');
+    expect(mockUpdateCatalog).toHaveBeenCalledWith({
+      selectedClusterType: 'all',
+      selectedEnsaVersion: 'all',
+      selectedProvider: 'all',
+      selectedTargetType: 'all',
+    });
   });
 
-  it('should query the catalog with the correct provider', async () => {
+  it('should query the catalog with the correct filters', async () => {
     const user = userEvent.setup();
 
     const catalogData = catalogCheckFactory.buildList(5);
@@ -56,12 +61,46 @@ describe('ChecksCatalog ChecksCatalog component', () => {
     );
 
     await user.click(screen.getByText('All providers'));
+    await user.click(screen.getByText('AWS'));
 
-    const providerFilter = screen.getByText('AWS');
+    await user.click(screen.getByText('All targets'));
+    await user.click(screen.getByText('Clusters'));
 
-    await user.click(providerFilter);
+    await user.click(screen.getByText('All cluster types'));
+    await user.click(screen.getByText('ASCS/ERS'));
 
-    expect(mockUpdateCatalog).toHaveBeenNthCalledWith(1, 'all');
-    expect(mockUpdateCatalog).toHaveBeenNthCalledWith(2, 'aws');
+    await user.click(screen.getByText('All ENSA versions'));
+    await user.click(screen.getByText('ENSA1'));
+
+    expect(mockUpdateCatalog).toHaveBeenNthCalledWith(1, {
+      selectedClusterType: 'all',
+      selectedEnsaVersion: 'all',
+      selectedProvider: 'all',
+      selectedTargetType: 'all',
+    });
+    expect(mockUpdateCatalog).toHaveBeenNthCalledWith(2, {
+      selectedClusterType: 'all',
+      selectedEnsaVersion: 'all',
+      selectedProvider: 'aws',
+      selectedTargetType: 'all',
+    });
+    expect(mockUpdateCatalog).toHaveBeenNthCalledWith(3, {
+      selectedClusterType: 'all',
+      selectedEnsaVersion: 'all',
+      selectedProvider: 'aws',
+      selectedTargetType: 'cluster',
+    });
+    expect(mockUpdateCatalog).toHaveBeenNthCalledWith(4, {
+      selectedClusterType: 'ascs_ers',
+      selectedEnsaVersion: 'all',
+      selectedProvider: 'aws',
+      selectedTargetType: 'cluster',
+    });
+    expect(mockUpdateCatalog).toHaveBeenNthCalledWith(5, {
+      selectedClusterType: 'ascs_ers',
+      selectedEnsaVersion: 'ensa1',
+      selectedProvider: 'aws',
+      selectedTargetType: 'cluster',
+    });
   });
 });

--- a/assets/js/components/ChecksCatalog/ChecksCatalog.test.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalog.test.jsx
@@ -41,7 +41,6 @@ describe('ChecksCatalog ChecksCatalog component', () => {
 
     expect(mockUpdateCatalog).toHaveBeenCalledWith({
       selectedClusterType: 'all',
-      selectedEnsaVersion: 'all',
       selectedProvider: 'all',
       selectedTargetType: 'all',
     });
@@ -69,36 +68,23 @@ describe('ChecksCatalog ChecksCatalog component', () => {
     await user.click(screen.getByText('All cluster types'));
     await user.click(screen.getByText('ASCS/ERS'));
 
-    await user.click(screen.getByText('All ENSA versions'));
-    await user.click(screen.getByText('ENSA1'));
-
     expect(mockUpdateCatalog).toHaveBeenNthCalledWith(1, {
       selectedClusterType: 'all',
-      selectedEnsaVersion: 'all',
       selectedProvider: 'all',
       selectedTargetType: 'all',
     });
     expect(mockUpdateCatalog).toHaveBeenNthCalledWith(2, {
       selectedClusterType: 'all',
-      selectedEnsaVersion: 'all',
       selectedProvider: 'aws',
       selectedTargetType: 'all',
     });
     expect(mockUpdateCatalog).toHaveBeenNthCalledWith(3, {
       selectedClusterType: 'all',
-      selectedEnsaVersion: 'all',
       selectedProvider: 'aws',
       selectedTargetType: 'cluster',
     });
     expect(mockUpdateCatalog).toHaveBeenNthCalledWith(4, {
       selectedClusterType: 'ascs_ers',
-      selectedEnsaVersion: 'all',
-      selectedProvider: 'aws',
-      selectedTargetType: 'cluster',
-    });
-    expect(mockUpdateCatalog).toHaveBeenNthCalledWith(5, {
-      selectedClusterType: 'ascs_ers',
-      selectedEnsaVersion: 'ensa1',
       selectedProvider: 'aws',
       selectedTargetType: 'cluster',
     });

--- a/assets/js/components/ChecksCatalog/ChecksCatalogPage.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalogPage.jsx
@@ -3,22 +3,15 @@ import { useSelector, useDispatch } from 'react-redux';
 
 import { isValidProvider, isValidTargetType } from '@lib/model';
 import { isValidClusterType } from '@lib/model/clusters';
-import { isValidEnsaVersion } from '@lib/model/sapSystems';
 import { getCatalog } from '@state/selectors/catalog';
 import { updateCatalog } from '@state/actions/catalog';
 import ChecksCatalog from './ChecksCatalog';
 
-const buildUpdateCatalogAction = (
-  provider,
-  targetType,
-  clusterType,
-  ensaVersion
-) => {
+const buildUpdateCatalogAction = (provider, targetType, clusterType) => {
   const payload = {
     ...(isValidProvider(provider) ? { provider } : {}),
     ...(isValidTargetType(targetType) ? { target_type: targetType } : {}),
     ...(isValidClusterType(clusterType) ? { cluster_type: clusterType } : {}),
-    ...(isValidEnsaVersion(ensaVersion) ? { ensa_version: ensaVersion } : {}),
   };
 
   return updateCatalog(payload);
@@ -42,14 +35,12 @@ function ChecksCatalogPage() {
         selectedProvider,
         selectedTargetType,
         selectedClusterType,
-        selectedEnsaVersion,
       }) =>
         dispatch(
           buildUpdateCatalogAction(
             selectedProvider,
             selectedTargetType,
-            selectedClusterType,
-            selectedEnsaVersion
+            selectedClusterType
           )
         )
       }

--- a/assets/js/components/ChecksCatalog/ChecksCatalogPage.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalogPage.jsx
@@ -1,21 +1,16 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
-import { isValidProvider, isValidTargetType } from '@lib/model';
-import { isValidClusterType } from '@lib/model/clusters';
+import { pickBy } from 'lodash';
+
 import { getCatalog } from '@state/selectors/catalog';
 import { updateCatalog } from '@state/actions/catalog';
+import { OPTION_ALL } from '@components/Select';
+
 import ChecksCatalog from './ChecksCatalog';
 
-const buildUpdateCatalogAction = (provider, targetType, clusterType) => {
-  const payload = {
-    ...(isValidProvider(provider) ? { provider } : {}),
-    ...(isValidTargetType(targetType) ? { target_type: targetType } : {}),
-    ...(isValidClusterType(clusterType) ? { cluster_type: clusterType } : {}),
-  };
-
-  return updateCatalog(payload);
-};
+const buildUpdateCatalogAction = (selectedFilters) =>
+  updateCatalog(pickBy(selectedFilters, (value) => value !== OPTION_ALL));
 
 function ChecksCatalogPage() {
   const dispatch = useDispatch();
@@ -37,11 +32,11 @@ function ChecksCatalogPage() {
         selectedClusterType,
       }) =>
         dispatch(
-          buildUpdateCatalogAction(
-            selectedProvider,
-            selectedTargetType,
-            selectedClusterType
-          )
+          buildUpdateCatalogAction({
+            provider: selectedProvider,
+            target_type: selectedTargetType,
+            cluster_type: selectedClusterType,
+          })
         )
       }
     />

--- a/assets/js/components/ChecksCatalog/ChecksCatalogPage.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalogPage.jsx
@@ -1,14 +1,24 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
-import { isValidProvider } from '@lib/model';
+import { isValidProvider, isValidTargetType } from '@lib/model';
+import { isValidClusterType } from '@lib/model/clusters';
+import { isValidEnsaVersion } from '@lib/model/sapSystems';
 import { getCatalog } from '@state/selectors/catalog';
 import { updateCatalog } from '@state/actions/catalog';
 import ChecksCatalog from './ChecksCatalog';
 
-const buildUpdateCatalogAction = (provider) => {
+const buildUpdateCatalogAction = (
+  provider,
+  targetType,
+  clusterType,
+  ensaVersion
+) => {
   const payload = {
-    ...(isValidProvider(provider) ? { provider, target_type: 'cluster' } : {}),
+    ...(isValidProvider(provider) ? { provider } : {}),
+    ...(isValidTargetType(targetType) ? { target_type: targetType } : {}),
+    ...(isValidClusterType(clusterType) ? { cluster_type: clusterType } : {}),
+    ...(isValidEnsaVersion(ensaVersion) ? { ensa_version: ensaVersion } : {}),
   };
 
   return updateCatalog(payload);
@@ -28,8 +38,20 @@ function ChecksCatalogPage() {
       catalogData={catalogData}
       catalogError={catalogError}
       loading={loading}
-      updateCatalog={(selectedProvider) =>
-        dispatch(buildUpdateCatalogAction(selectedProvider))
+      updateCatalog={({
+        selectedProvider,
+        selectedTargetType,
+        selectedClusterType,
+        selectedEnsaVersion,
+      }) =>
+        dispatch(
+          buildUpdateCatalogAction(
+            selectedProvider,
+            selectedTargetType,
+            selectedClusterType,
+            selectedEnsaVersion
+          )
+        )
       }
     />
   );

--- a/assets/js/components/ClusterDetails/AscsErsClusterDetails.jsx
+++ b/assets/js/components/ClusterDetails/AscsErsClusterDetails.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { get } from 'lodash';
 import { EOS_SETTINGS, EOS_CLEAR_ALL, EOS_PLAY_CIRCLE } from 'eos-icons-react';
 
+import { getEnsaVersionLabel } from '@lib/model/sapSystems';
 import { RUNNING_STATES } from '@state/lastExecutions';
 
 import Button from '@components/Button';
@@ -13,7 +14,6 @@ import ProviderLabel from '@components/ProviderLabel';
 import DottedPagination from '@components/DottedPagination';
 import ClusterNodeLink from '@components/ClusterDetails/ClusterNodeLink';
 import SapSystemLink from '@components/SapSystemLink';
-import { renderEnsaVersion } from '@components/SapSystemDetails';
 import Tooltip from '@components/Tooltip';
 
 import CheckResultsOverview from '@components/CheckResultsOverview';
@@ -220,7 +220,7 @@ function AscsErsClusterDetails({
               {
                 title: 'ENSA version',
                 content: currentSapSystem?.ensa_version || '-',
-                render: (content) => renderEnsaVersion(content),
+                render: (content) => getEnsaVersionLabel(content),
               },
               {
                 title: 'Filesystem resource based',

--- a/assets/js/components/ClusterLink.jsx
+++ b/assets/js/components/ClusterLink.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 
-import { CLUSTER_TYPES } from '@lib/model';
+import { clusterTypes } from '@lib/model/clusters';
 
 export const getClusterName = (cluster) => cluster?.name || cluster?.id;
 
@@ -13,7 +13,7 @@ function ClusterLink({ cluster }) {
     'truncate w-32 inline-block align-middle'
   );
 
-  if (CLUSTER_TYPES.includes(cluster?.type)) {
+  if (clusterTypes.includes(cluster?.type)) {
     return (
       <Link
         className="text-jungle-green-500 hover:opacity-75"

--- a/assets/js/components/ClustersList.jsx
+++ b/assets/js/components/ClustersList.jsx
@@ -1,30 +1,21 @@
 import React, { Fragment } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { useSearchParams } from 'react-router-dom';
+
+import { post, del } from '@lib/network';
+import { getClusterTypeLabel } from '@lib/model/clusters';
+
+import { addTagToCluster, removeTagFromCluster } from '@state/clusters';
+import { getAllSAPInstances } from '@state/selectors/sapSystem';
+
 import Table from '@components/Table';
 import Tags from '@components/Tags';
 import PageHeader from '@components/PageHeader';
-import { addTagToCluster, removeTagFromCluster } from '@state/clusters';
 import ClusterLink from '@components/ClusterLink';
 import SapSystemLink from '@components/SapSystemLink';
 import { ExecutionIcon } from '@components/ClusterDetails';
-import { post, del } from '@lib/network';
-import { useSearchParams } from 'react-router-dom';
 import HealthSummary from '@components/HealthSummary/HealthSummary';
 import { getCounters } from '@components/HealthSummary/summarySelection';
-import { getAllSAPInstances } from '@state/selectors/sapSystem';
-
-const getClusterTypeLabel = (type) => {
-  switch (type) {
-    case 'hana_scale_up':
-      return 'HANA Scale Up';
-    case 'hana_scale_out':
-      return 'HANA Scale Out';
-    case 'ascs_ers':
-      return 'ASCS/ERS';
-    default:
-      return 'Unknown';
-  }
-};
 
 const getSapSystemBySID = (instances, sid) =>
   instances.find((instance) => instance.sid === sid);

--- a/assets/js/components/DatabaseDetails/DatabaseDetails.jsx
+++ b/assets/js/components/DatabaseDetails/DatabaseDetails.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
+
+import { DATABASE_TYPE } from '@lib/model/sapSystems';
 import { getEnrichedDatabaseDetails } from '@state/selectors/sapSystem';
 import { deregisterDatabaseInstance } from '@state/databases';
 
 import BackButton from '@components/BackButton';
 import { GenericSystemDetails } from '@components/SapSystemDetails';
-import { DATABASE_TYPE } from '@lib/model';
 
 function DatabaseDetails() {
   const { id } = useParams();

--- a/assets/js/components/DatabaseDetails/DatabaseDetails.stories.jsx
+++ b/assets/js/components/DatabaseDetails/DatabaseDetails.stories.jsx
@@ -7,7 +7,7 @@ import {
   databaseFactory,
   hostFactory,
 } from '@lib/test-utils/factories';
-import { DATABASE_TYPE } from '@lib/model';
+import { DATABASE_TYPE } from '@lib/model/sapSystems';
 
 import { GenericSystemDetails } from '@components/SapSystemDetails';
 

--- a/assets/js/components/DatabasesOverview/DatabaseItemOverview.jsx
+++ b/assets/js/components/DatabasesOverview/DatabaseItemOverview.jsx
@@ -1,7 +1,8 @@
 import { EOS_DATABASE_OUTLINED } from 'eos-icons-react';
 import React from 'react';
+
+import { DATABASE_TYPE } from '@lib/model/sapSystems';
 import InstanceOverview from '@components/InstanceOverview';
-import { DATABASE_TYPE } from '@lib/model';
 
 export function DatabaseInstance({ instance, onCleanUpClick }) {
   return (

--- a/assets/js/components/DatabasesOverview/DatabasesOverview.jsx
+++ b/assets/js/components/DatabasesOverview/DatabasesOverview.jsx
@@ -3,6 +3,8 @@ import React, { useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { filter } from 'lodash';
 
+import { DATABASE_TYPE } from '@lib/model/sapSystems';
+
 import PageHeader from '@components/PageHeader';
 import HealthIcon from '@components/Health';
 import Table from '@components/Table';
@@ -10,8 +12,6 @@ import Tags from '@components/Tags';
 import HealthSummary from '@components/HealthSummary/HealthSummary';
 import DeregistrationModal from '@components/DeregistrationModal';
 import { getCounters } from '@components/HealthSummary/summarySelection';
-
-import { DATABASE_TYPE } from '@lib/model';
 
 import DatabaseItemOverview from './DatabaseItemOverview';
 

--- a/assets/js/components/DeregistrationModal/DeregistrationModal.jsx
+++ b/assets/js/components/DeregistrationModal/DeregistrationModal.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 
 import { EOS_CLEANING_SERVICES } from 'eos-icons-react';
 
+import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model/sapSystems';
+
 import Modal from '@components/Modal';
 import Button from '@components/Button';
-
-import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model';
 
 const getContentByType = (type, data) => {
   switch (type) {

--- a/assets/js/components/DeregistrationModal/DeregistrationModal.stories.jsx
+++ b/assets/js/components/DeregistrationModal/DeregistrationModal.stories.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
+import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model/sapSystems';
 import Button from '@components/Button';
-import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model';
 
 import DeregistrationModal from '.';
 

--- a/assets/js/components/DeregistrationModal/DeregistrationModal.test.jsx
+++ b/assets/js/components/DeregistrationModal/DeregistrationModal.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { faker } from '@faker-js/faker';
 
-import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model';
+import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model/sapSystems';
 
 import DeregistrationModal from '.';
 

--- a/assets/js/components/ExecutionResults/TargetResult.jsx
+++ b/assets/js/components/ExecutionResults/TargetResult.jsx
@@ -20,7 +20,11 @@ function TargetResult({
     >
       <div className="table-cell p-2">
         <div className="flex p-1">
-          <TargetIcon targetType={targetType} />
+          <TargetIcon
+            targetType={targetType}
+            containerClassName="inline-flex bg-jungle-green-500 p-1 rounded-full self-center"
+            iconClassName="fill-white"
+          />
           <span className="ml-3 inline-flex self-center">{targetName}</span>
         </div>
       </div>

--- a/assets/js/components/ExecutionResults/TargetResult.jsx
+++ b/assets/js/components/ExecutionResults/TargetResult.jsx
@@ -23,7 +23,7 @@ function TargetResult({
           <TargetIcon
             targetType={targetType}
             containerClassName="inline-flex bg-jungle-green-500 p-1 rounded-full self-center"
-            iconClassName="fill-white"
+            className="fill-white"
           />
           <span className="ml-3 inline-flex self-center">{targetName}</span>
         </div>

--- a/assets/js/components/InstanceOverview/InstanceOverview.jsx
+++ b/assets/js/components/InstanceOverview/InstanceOverview.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import classNames from 'classnames';
+
+import { DATABASE_TYPE } from '@lib/model/sapSystems';
 import HealthIcon from '@components/Health';
 import { Features } from '@components/SapSystemDetails';
-import { DATABASE_TYPE } from '@lib/model';
 import HostLink from '@components/HostLink';
 import ClusterLink from '@components/ClusterLink';
 import Pill from '@components/Pill';

--- a/assets/js/components/InstanceOverview/InstanceOverview.test.jsx
+++ b/assets/js/components/InstanceOverview/InstanceOverview.test.jsx
@@ -4,8 +4,8 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { databaseInstanceFactory } from '@lib/test-utils/factories';
 import { renderWithRouter } from '@lib/test-utils';
-import { DATABASE_TYPE, APPLICATION_TYPE } from '@lib/model';
 import { faker } from '@faker-js/faker';
+import { DATABASE_TYPE, APPLICATION_TYPE } from '@lib/model/sapSystems';
 import InstanceOverview from './InstanceOverview';
 
 describe('InstanceOverview', () => {

--- a/assets/js/components/SapSystemDetails/GenericSystemDetails.jsx
+++ b/assets/js/components/SapSystemDetails/GenericSystemDetails.jsx
@@ -1,22 +1,21 @@
 import React, { useState } from 'react';
 
+import {
+  EOS_APPLICATION_OUTLINED,
+  EOS_DATABASE_OUTLINED,
+} from 'eos-icons-react';
+
+import { APPLICATION_TYPE, getEnsaVersionLabel } from '@lib/model/sapSystems';
+
 import ListView from '@components/ListView';
 import Table from '@components/Table';
 import PageHeader from '@components/PageHeader';
 import DeregistrationModal from '@components/DeregistrationModal';
 
 import {
-  EOS_APPLICATION_OUTLINED,
-  EOS_DATABASE_OUTLINED,
-} from 'eos-icons-react';
-import { APPLICATION_TYPE } from '@lib/model';
-import {
   systemHostsTableConfiguration,
   getSystemInstancesTableConfiguration,
 } from './tableConfigs';
-
-export const renderEnsaVersion = (ensaVersion) =>
-  ensaVersion === 'no_ensa' ? '-' : ensaVersion.toUpperCase();
 
 const renderType = (t) =>
   t === APPLICATION_TYPE ? 'Application server' : 'HANA Database';
@@ -78,7 +77,7 @@ export function GenericSystemDetails({
                   {
                     title: 'ENSA version',
                     content: system.ensa_version || '-',
-                    render: (content) => renderEnsaVersion(content),
+                    render: (content) => getEnsaVersionLabel(content),
                   },
                 ]
               : []),

--- a/assets/js/components/SapSystemDetails/GenericSystemDetails.test.jsx
+++ b/assets/js/components/SapSystemDetails/GenericSystemDetails.test.jsx
@@ -4,7 +4,7 @@ import { faker } from '@faker-js/faker';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model';
+import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model/sapSystems';
 import { renderWithRouter } from '@lib/test-utils';
 
 import userEvent from '@testing-library/user-event';

--- a/assets/js/components/SapSystemDetails/SapSystemDetails.jsx
+++ b/assets/js/components/SapSystemDetails/SapSystemDetails.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 
+import { APPLICATION_TYPE } from '@lib/model/sapSystems';
 import { getEnrichedSapSystemDetails } from '@state/selectors/sapSystem';
 import { deregisterApplicationInstance } from '@state/sapSystems';
 
 import BackButton from '@components/BackButton';
 import { GenericSystemDetails } from '@components/SapSystemDetails';
-import { APPLICATION_TYPE } from '@lib/model';
 
 function SapSystemDetails() {
   const { id } = useParams();

--- a/assets/js/components/SapSystemDetails/SapSystemDetails.stories.jsx
+++ b/assets/js/components/SapSystemDetails/SapSystemDetails.stories.jsx
@@ -8,7 +8,7 @@ import {
   sapSystemApplicationInstanceFactory,
   sapSystemFactory,
 } from '@lib/test-utils/factories';
-import { APPLICATION_TYPE } from '@lib/model';
+import { APPLICATION_TYPE } from '@lib/model/sapSystems';
 
 import { GenericSystemDetails } from './GenericSystemDetails';
 

--- a/assets/js/components/SapSystemDetails/index.js
+++ b/assets/js/components/SapSystemDetails/index.js
@@ -2,10 +2,7 @@ import SapSystemDetails from './SapSystemDetails';
 import InstanceStatus from './InstanceStatus';
 import Features from './Features';
 
-export {
-  GenericSystemDetails,
-  renderEnsaVersion,
-} from './GenericSystemDetails';
+export { GenericSystemDetails } from './GenericSystemDetails';
 
 export { Features, InstanceStatus };
 

--- a/assets/js/components/SapSystemsOverview/SapSystemItemOverview.jsx
+++ b/assets/js/components/SapSystemsOverview/SapSystemItemOverview.jsx
@@ -1,8 +1,9 @@
 import { EOS_APPLICATION_OUTLINED } from 'eos-icons-react';
 import React from 'react';
+
+import { APPLICATION_TYPE } from '@lib/model/sapSystems';
 import DatabaseItemOverview from '@components/DatabasesOverview/DatabaseItemOverview';
 import InstanceOverview from '@components/InstanceOverview';
-import { APPLICATION_TYPE } from '@lib/model';
 
 function ApplicationInstance({ instance, onCleanUpClick }) {
   return (

--- a/assets/js/components/SapSystemsOverview/SapSystemsOverview.jsx
+++ b/assets/js/components/SapSystemsOverview/SapSystemsOverview.jsx
@@ -3,6 +3,8 @@ import React, { useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { filter } from 'lodash';
 
+import { getEnsaVersionLabel } from '@lib/model/sapSystems';
+
 import PageHeader from '@components/PageHeader';
 import HealthIcon from '@components/Health';
 import Table from '@components/Table';
@@ -11,7 +13,6 @@ import Tags from '@components/Tags';
 import HealthSummary from '@components/HealthSummary/HealthSummary';
 import DeregistrationModal from '@components/DeregistrationModal';
 import { getCounters } from '@components/HealthSummary/summarySelection';
-import { renderEnsaVersion } from '@components/SapSystemDetails';
 
 function SapSystemsOverview({
   sapSystems,
@@ -81,7 +82,7 @@ function SapSystemsOverview({
       {
         title: 'ENSA version',
         key: 'ensaVersion',
-        render: (content) => renderEnsaVersion(content),
+        render: (content) => getEnsaVersionLabel(content),
       },
       {
         title: 'Tags',

--- a/assets/js/components/SapSystemsOverview/SapSystemsOverview.test.jsx
+++ b/assets/js/components/SapSystemsOverview/SapSystemsOverview.test.jsx
@@ -11,7 +11,7 @@ import {
   sapSystemFactory,
 } from '@lib/test-utils/factories';
 import { renderWithRouter } from '@lib/test-utils';
-import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model';
+import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model/sapSystems';
 import { filterTable, clearFilter } from '@components/Table/Table.test';
 
 import SapSystemsOverview from './SapSystemsOverview';

--- a/assets/js/components/SapSystemsOverview/SapSystemsOverviewPage.jsx
+++ b/assets/js/components/SapSystemsOverview/SapSystemsOverviewPage.jsx
@@ -2,6 +2,8 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
+import { post, del } from '@lib/network';
+import { APPLICATION_TYPE } from '@lib/model/sapSystems';
 import {
   getEnrichedApplicationInstances,
   getEnrichedDatabaseInstances,
@@ -12,8 +14,6 @@ import {
   deregisterApplicationInstance,
 } from '@state/sapSystems';
 import { deregisterDatabaseInstance } from '@state/databases';
-import { post, del } from '@lib/network';
-import { APPLICATION_TYPE } from '@lib/model';
 
 import SapSystemsOverview from './SapSystemsOverview';
 

--- a/assets/js/components/Select/Select.jsx
+++ b/assets/js/components/Select/Select.jsx
@@ -29,7 +29,7 @@ function Select({
     ''
   )}-selection-dropdown`;
   return (
-    <div className={classNames('w-64 pb-4', className)}>
+    <div className={classNames('flex-1 w-64 pb-4', className)}>
       <Listbox value={value} onChange={onChange}>
         <div className="relative mt-1">
           <Listbox.Button

--- a/assets/js/components/TargetIcon/TargetIcon.jsx
+++ b/assets/js/components/TargetIcon/TargetIcon.jsx
@@ -1,27 +1,41 @@
 import React from 'react';
 import { EOS_COLLOCATION, EOS_DESKTOP_WINDOWS } from 'eos-icons-react';
 
-import { TARGET_CLUSTER, TARGET_HOST } from '@lib/model';
+import { TARGET_CLUSTER, TARGET_HOST, isValidTargetType } from '@lib/model';
 
 const targetTypeToIcon = {
-  [TARGET_CLUSTER]: <EOS_COLLOCATION className="fill-white" />,
-  [TARGET_HOST]: <EOS_DESKTOP_WINDOWS className="fill-white" />,
+  [TARGET_CLUSTER]: EOS_COLLOCATION,
+  [TARGET_HOST]: EOS_DESKTOP_WINDOWS,
 };
 
-function TargetIcon({ targetType }) {
-  if (!targetType || !targetTypeToIcon[targetType]) {
+const targetTypeToLabel = {
+  [TARGET_CLUSTER]: 'Clusters',
+  [TARGET_HOST]: 'Hosts',
+};
+
+function TargetIcon({
+  targetType,
+  withLabel = false,
+  labelMap = targetTypeToLabel,
+  containerClassName = '',
+  iconClassName = '',
+}) {
+  if (!isValidTargetType(targetType)) {
     return null;
   }
+  const IconComponent = targetTypeToIcon[targetType];
 
   return (
-    <div
-      data-testid="target-icon"
-      className="inline-flex bg-jungle-green-500 p-1 rounded-full self-center"
-    >
-      <span data-testid={`target-icon-${targetType}`}>
-        {targetTypeToIcon[targetType]}
+    <>
+      <span data-testid="target-icon" className={containerClassName}>
+        <span data-testid={`target-icon-${targetType}`}>
+          <IconComponent className={iconClassName} />
+        </span>
       </span>
-    </div>
+      {withLabel && (
+        <span data-testid="target-label">{labelMap[targetType]}</span>
+      )}
+    </>
   );
 }
 

--- a/assets/js/components/TargetIcon/TargetIcon.jsx
+++ b/assets/js/components/TargetIcon/TargetIcon.jsx
@@ -8,17 +8,11 @@ const targetTypeToIcon = {
   [TARGET_HOST]: EOS_DESKTOP_WINDOWS,
 };
 
-const targetTypeToLabel = {
-  [TARGET_CLUSTER]: 'Clusters',
-  [TARGET_HOST]: 'Hosts',
-};
-
 function TargetIcon({
   targetType,
-  withLabel = false,
-  labelMap = targetTypeToLabel,
   containerClassName = '',
-  iconClassName = '',
+  className = '',
+  children,
 }) {
   if (!isValidTargetType(targetType)) {
     return null;
@@ -26,16 +20,12 @@ function TargetIcon({
   const IconComponent = targetTypeToIcon[targetType];
 
   return (
-    <>
-      <span data-testid="target-icon" className={containerClassName}>
-        <span data-testid={`target-icon-${targetType}`}>
-          <IconComponent className={iconClassName} />
-        </span>
+    <span data-testid="target-icon" className={containerClassName}>
+      <span data-testid={`target-icon-${targetType}`}>
+        <IconComponent className={className} />
       </span>
-      {withLabel && (
-        <span data-testid="target-label">{labelMap[targetType]}</span>
-      )}
-    </>
+      <span data-testid="target-label">{children}</span>
+    </span>
   );
 }
 

--- a/assets/js/components/TargetIcon/TargetIcon.stories.jsx
+++ b/assets/js/components/TargetIcon/TargetIcon.stories.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import TargetIcon from './TargetIcon';
 
 export default {
@@ -18,33 +19,14 @@ export const WithCustomStyles = {
     targetType: 'host',
     containerClassName:
       'inline-flex bg-jungle-green-500 p-1 rounded-full self-center',
-    iconClassName: 'fill-white',
+    className: 'fill-white',
   },
 };
 
-export const HostWithLabel = {
+export const WithLabel = {
   args: {
     targetType: 'host',
-    withLabel: true,
-    iconClassName: 'inline mr-2 h-4',
+    className: 'inline mr-2 h-4',
   },
-};
-
-export const ClusterWithLabel = {
-  args: {
-    targetType: 'cluster',
-    withLabel: true,
-    iconClassName: 'inline mr-2 h-4',
-  },
-};
-
-export const WithCustomLabel = {
-  args: {
-    targetType: 'host',
-    withLabel: true,
-    iconClassName: 'inline mr-2 h-4',
-    labelMap: {
-      host: 'Custom host label',
-    },
-  },
+  render: (args) => <TargetIcon {...args}>Hosts</TargetIcon>,
 };

--- a/assets/js/components/TargetIcon/TargetIcon.stories.jsx
+++ b/assets/js/components/TargetIcon/TargetIcon.stories.jsx
@@ -12,3 +12,39 @@ export const Host = {
 export const Cluster = {
   args: { targetType: 'cluster' },
 };
+
+export const WithCustomStyles = {
+  args: {
+    targetType: 'host',
+    containerClassName:
+      'inline-flex bg-jungle-green-500 p-1 rounded-full self-center',
+    iconClassName: 'fill-white',
+  },
+};
+
+export const HostWithLabel = {
+  args: {
+    targetType: 'host',
+    withLabel: true,
+    iconClassName: 'inline mr-2 h-4',
+  },
+};
+
+export const ClusterWithLabel = {
+  args: {
+    targetType: 'cluster',
+    withLabel: true,
+    iconClassName: 'inline mr-2 h-4',
+  },
+};
+
+export const WithCustomLabel = {
+  args: {
+    targetType: 'host',
+    withLabel: true,
+    iconClassName: 'inline mr-2 h-4',
+    labelMap: {
+      host: 'Custom host label',
+    },
+  },
+};

--- a/assets/js/components/TargetIcon/TargetIcon.test.jsx
+++ b/assets/js/components/TargetIcon/TargetIcon.test.jsx
@@ -33,4 +33,51 @@ describe('TargetIcon', () => {
       expect(screen.getByTestId(targetIcon)).toBeVisible();
     }
   );
+
+  const labaledTargetIconsScenarios = [
+    {
+      targetType: 'cluster',
+      label: 'Clusters',
+    },
+    {
+      targetType: 'host',
+      label: 'Hosts',
+    },
+  ];
+
+  it.each(labaledTargetIconsScenarios)(
+    'should render labaled target type $targetType icon',
+    ({ targetType, label }) => {
+      render(<TargetIcon targetType={targetType} withLabel />);
+
+      expect(screen.getByTestId('target-label')).toBeVisible();
+      expect(screen.getByText(label)).toBeVisible();
+    }
+  );
+
+  const customLabelTargetIconsScenarios = [
+    {
+      targetType: 'cluster',
+      labelMap: {
+        cluster: 'Foo Cluster',
+      },
+    },
+    {
+      targetType: 'host',
+      labelMap: {
+        host: 'Foo Host',
+      },
+    },
+  ];
+
+  it.each(customLabelTargetIconsScenarios)(
+    'should render custom label for target type $targetType icon',
+    ({ targetType, labelMap }) => {
+      render(
+        <TargetIcon targetType={targetType} withLabel labelMap={labelMap} />
+      );
+
+      expect(screen.getByText(labelMap[targetType])).toBeVisible();
+    }
+  );
 });

--- a/assets/js/components/TargetIcon/TargetIcon.test.jsx
+++ b/assets/js/components/TargetIcon/TargetIcon.test.jsx
@@ -48,36 +48,10 @@ describe('TargetIcon', () => {
   it.each(labaledTargetIconsScenarios)(
     'should render labaled target type $targetType icon',
     ({ targetType, label }) => {
-      render(<TargetIcon targetType={targetType} withLabel />);
+      render(<TargetIcon targetType={targetType}>{label}</TargetIcon>);
 
       expect(screen.getByTestId('target-label')).toBeVisible();
       expect(screen.getByText(label)).toBeVisible();
-    }
-  );
-
-  const customLabelTargetIconsScenarios = [
-    {
-      targetType: 'cluster',
-      labelMap: {
-        cluster: 'Foo Cluster',
-      },
-    },
-    {
-      targetType: 'host',
-      labelMap: {
-        host: 'Foo Host',
-      },
-    },
-  ];
-
-  it.each(customLabelTargetIconsScenarios)(
-    'should render custom label for target type $targetType icon',
-    ({ targetType, labelMap }) => {
-      render(
-        <TargetIcon targetType={targetType} withLabel labelMap={labelMap} />
-      );
-
-      expect(screen.getByText(labelMap[targetType])).toBeVisible();
     }
   );
 });

--- a/assets/js/lib/model/clusters.js
+++ b/assets/js/lib/model/clusters.js
@@ -1,0 +1,17 @@
+export const HANA_SCALE_UP = 'hana_scale_up';
+export const HANA_SCALE_OUT = 'hana_scale_out';
+export const ASCS_ERS = 'ascs_ers';
+
+export const clusterTypes = [HANA_SCALE_UP, HANA_SCALE_OUT, ASCS_ERS];
+
+export const isValidClusterType = (clusterType) =>
+  clusterTypes.includes(clusterType);
+
+const clusterTypeLabels = {
+  [HANA_SCALE_UP]: 'HANA Scale Up',
+  [HANA_SCALE_OUT]: 'HANA Scale Out',
+  [ASCS_ERS]: 'ASCS/ERS',
+};
+
+export const getClusterTypeLabel = (type) =>
+  clusterTypeLabels[type] || 'Unknown';

--- a/assets/js/lib/model/clusters.test.js
+++ b/assets/js/lib/model/clusters.test.js
@@ -1,0 +1,23 @@
+import { getClusterTypeLabel, isValidClusterType } from './clusters';
+
+describe('clusters', () => {
+  it('should check if a cluster type is valid', () => {
+    ['hana_scale_up', 'hana_scale_out', 'ascs_ers'].forEach((clusterType) => {
+      expect(isValidClusterType(clusterType)).toBe(true);
+    });
+
+    expect(isValidClusterType('other')).toBe(false);
+  });
+
+  it('should provide a label for a cluster type', () => {
+    [
+      { key: 'hana_scale_up', label: 'HANA Scale Up' },
+      { key: 'hana_scale_out', label: 'HANA Scale Out' },
+      { key: 'ascs_ers', label: 'ASCS/ERS' },
+    ].forEach(({ key, label }) => {
+      expect(getClusterTypeLabel(key)).toBe(label);
+    });
+
+    expect(getClusterTypeLabel('other')).toBe('Unknown');
+  });
+});

--- a/assets/js/lib/model/index.js
+++ b/assets/js/lib/model/index.js
@@ -1,14 +1,12 @@
-export const DATABASE_TYPE = 'database';
-export const APPLICATION_TYPE = 'application';
-
 export const EXPECT = 'expect';
 export const EXPECT_SAME = 'expect_same';
 
 export const TARGET_HOST = 'host';
 export const TARGET_CLUSTER = 'cluster';
 
+export const targetTypes = [TARGET_HOST, TARGET_CLUSTER];
 export const isValidTargetType = (targetType) =>
-  [TARGET_HOST, TARGET_CLUSTER].includes(targetType);
+  targetTypes.includes(targetType);
 
 export const AWS_PROVIDER = 'aws';
 export const AZURE_PROVIDER = 'azure';
@@ -27,5 +25,3 @@ export const providers = [
   VMWARE_PROVIDER,
 ];
 export const isValidProvider = (provider) => providers.includes(provider);
-
-export const CLUSTER_TYPES = ['hana_scale_up', 'hana_scale_out', 'ascs_ers'];

--- a/assets/js/lib/model/sapSystems.js
+++ b/assets/js/lib/model/sapSystems.js
@@ -1,0 +1,14 @@
+export const DATABASE_TYPE = 'database';
+export const APPLICATION_TYPE = 'application';
+
+export const ENSA1 = 'ensa1';
+export const ENSA2 = 'ensa2';
+export const NO_ENSA = 'no_ensa';
+
+export const ensaVersions = [ENSA1, ENSA2];
+
+export const isValidEnsaVersion = (ensaVersion) =>
+  ensaVersions.includes(ensaVersion);
+
+export const getEnsaVersionLabel = (ensaVersion) =>
+  ensaVersion === NO_ENSA ? '-' : ensaVersion.toUpperCase();

--- a/assets/js/lib/model/sapSystems.test.js
+++ b/assets/js/lib/model/sapSystems.test.js
@@ -1,0 +1,21 @@
+import { isValidEnsaVersion, getEnsaVersionLabel } from './sapSystems';
+
+describe('sap systems', () => {
+  it('should check if an ensa version is valid', () => {
+    ['ensa1', 'ensa2'].forEach((ensaVersion) => {
+      expect(isValidEnsaVersion(ensaVersion)).toBe(true);
+    });
+
+    expect(isValidEnsaVersion('other')).toBe(false);
+  });
+
+  it('should provide a label for an ensa version', () => {
+    [
+      { key: 'ensa1', label: 'ENSA1' },
+      { key: 'ensa2', label: 'ENSA2' },
+      { key: 'no_ensa', label: '-' },
+    ].forEach(({ key, label }) => {
+      expect(getEnsaVersionLabel(key)).toBe(label);
+    });
+  });
+});

--- a/assets/js/state/selectors/sapSystem.js
+++ b/assets/js/state/selectors/sapSystem.js
@@ -1,7 +1,7 @@
 import { filter } from 'lodash';
 import { createSelector } from '@reduxjs/toolkit';
 
-import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model';
+import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model/sapSystems';
 import { getCluster } from '@state/selectors/cluster';
 import { getHost } from '@state/selectors/host';
 

--- a/test/e2e/cypress/e2e/checks_catalog.cy.js
+++ b/test/e2e/cypress/e2e/checks_catalog.cy.js
@@ -90,19 +90,16 @@ context('Checks catalog', () => {
     });
   });
 
-  describe('Provider selection', () => {
+  describe('Filtering', () => {
     [
       ['aws', 'AWS', 1, 1],
       ['azure', 'Azure', 2, 5],
       ['gcp', 'GCP', 3, 7],
     ].forEach(([provider, label, groupCount, checkCount]) => {
       it(`should query the correct checks data filtered by provider ${label}`, () => {
-        cy.intercept(
-          `${checksCatalogURL}?provider=${provider}&target_type=cluster`,
-          {
-            body: { items: catalog.slice(0, checkCount) },
-          }
-        ).as('request');
+        cy.intercept(`${checksCatalogURL}?provider=${provider}`, {
+          body: { items: catalog.slice(0, checkCount) },
+        }).as('request');
 
         cy.get('.providers-selection-dropdown').click();
         cy.get('.providers-selection-dropdown')


### PR DESCRIPTION
# Description

This PR adds extra filters to the catalog. Besides the already present provider, the following have been added:
- target type
- cluster type
- ~ensa version~

![catalog-filtering-no-ensa](https://github.com/trento-project/web/assets/8167114/8437db1b-371f-4e92-a6a7-999633b15bcc)


Notes:
- first two commits are mainly about making some useful functions/constants/components a bit more reusable
- logic about filter dependencies (ie enable cluster type only if target type was selected) will follow up, with more extensive e2e testing

## How was this tested?

Automated tests and storybook.
https://2009.prenv.trento.suse.com/catalog