### PR TITLE
Ensure event modules are loaded during deserialization

### DIFF
--- a/lib/trento/support/jsonb_serializer.ex
+++ b/lib/trento/support/jsonb_serializer.ex
@@ -33,6 +33,7 @@ defmodule Trento.JsonbSerializer do
 
       type ->
         module = String.to_existing_atom(type)
+        Code.ensure_loaded?(module)
 
         if Kernel.function_exported?(module, :upcast, 2) do
           %IntermediateEvent{module: module, term: term}


### PR DESCRIPTION
# Description

Ensure the event module is loaded during deserialization, otherwise `function_exported?` doesn't return the expected response, as this function doesn't load the modules.
Without, this the upcasting and superseding of the modules wasn't happening with legacy events, which were not being loaded in some cases, I guess because they are not used anywhere during compilation (my guess).

Some refs:
https://github.com/elixir-lang/elixir/issues/11524
https://hexdocs.pm/elixir/Kernel.html#function_exported?/3
https://hexdocs.pm/elixir/Code.html#ensure_loaded?/1

## How was this tested?

Tested manually. As discussed with @CDimonaco , we need some integration test to check if the migration doesn't fail.
