### PR TITLE
Deploy to demo env when receives `deploy-demo` action from `wanda`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -658,7 +658,7 @@ jobs:
   deploy-demo-env:
     name: Deploy updated images to the demo environment
     runs-on: self-hosted
-    if: (vars.DEPLOY_DEMO == 'true' || github.event.action == 'deploy-demo') && (github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch')
+    if: (vars.DEPLOY_DEMO == 'true' || github.event.action == 'deploy-demo') || (github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch')
     env:
       IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}
     needs: [build-demo-img, test-e2e]


### PR DESCRIPTION
# Description

The `wanda` repo sends a _GitHub Action_ called `deploy-demo` that _should_ trigger the `web` repo to deploy to the demo environment. However currently, the `web` repo does not do the deployment upon receiving the `deploy-demo` action.

This change fixes in the logic in the CI to trigger deployments to demo.

## How was this tested?

By creating forks of `web` and `wanda` repos, and replicating + verifying the behaviour there.
