### PR TITLE
Interdependent catalog filters

### DIFF
--- a/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
@@ -31,6 +31,38 @@ function ChecksCatalog({ catalogData, catalogError, loading, updateCatalog }) {
   const [selectedTargetType, setSelectedTargetType] = useState(OPTION_ALL);
   const [selectedClusterType, setSelectedClusterType] = useState(OPTION_ALL);
 
+  const onTargetTypeChange = (targetType) => {
+    if (targetType !== TARGET_CLUSTER) {
+      setSelectedClusterType(OPTION_ALL);
+    }
+    setSelectedTargetType(targetType);
+  };
+
+  const filters = [
+    {
+      optionsName: 'targets',
+      options: targetTypes,
+      renderOption: targetTypeOptionRenderer,
+      value: selectedTargetType,
+      onChange: onTargetTypeChange,
+    },
+    {
+      optionsName: 'cluster types',
+      options: clusterTypes,
+      renderOption: getClusterTypeLabel,
+      value: selectedClusterType,
+      onChange: setSelectedClusterType,
+      disabled: selectedTargetType !== TARGET_CLUSTER,
+    },
+    {
+      optionsName: 'providers',
+      options: providers,
+      renderOption: providerOptionRenderer,
+      value: selectedProvider,
+      onChange: setProviderSelected,
+    },
+  ];
+
   useEffect(() => {
     updateCatalog({
       selectedProvider,
@@ -45,30 +77,14 @@ function ChecksCatalog({ catalogData, catalogError, loading, updateCatalog }) {
         <PageHeader className="font-bold flex-1 w-64 pb-4">
           Checks catalog
         </PageHeader>
-        <Select
-          optionsName="targets"
-          className="ml-auto"
-          options={[OPTION_ALL, ...targetTypes]}
-          renderOption={targetTypeOptionRenderer}
-          value={selectedTargetType}
-          onChange={setSelectedTargetType}
-        />
-        <Select
-          optionsName="cluster types"
-          className="ml-auto"
-          options={[OPTION_ALL, ...clusterTypes]}
-          renderOption={getClusterTypeLabel}
-          value={selectedClusterType}
-          onChange={setSelectedClusterType}
-        />
-        <Select
-          optionsName="providers"
-          className="ml-auto"
-          options={[OPTION_ALL, ...providers]}
-          renderOption={providerOptionRenderer}
-          value={selectedProvider}
-          onChange={setProviderSelected}
-        />
+        {filters.map((filterProps) => (
+          <Select
+            key={filterProps.optionsName}
+            className="ml-auto"
+            {...filterProps}
+            options={[OPTION_ALL, ...filterProps.options]}
+          />
+        ))}
       </div>
       <CatalogContainer
         onRefresh={() => updateCatalog(selectedProvider)}

--- a/assets/js/components/Select/Select.jsx
+++ b/assets/js/components/Select/Select.jsx
@@ -23,6 +23,7 @@ function Select({
   renderOption = defaultRenderOption,
   onChange = defaultOnChange,
   className,
+  disabled = false,
 }) {
   const dropdownSelector = `${optionsName.replace(
     /\s+/g,
@@ -30,10 +31,10 @@ function Select({
   )}-selection-dropdown`;
   return (
     <div className={classNames('flex-1 w-64 pb-4', className)}>
-      <Listbox value={value} onChange={onChange}>
+      <Listbox disabled={disabled} value={value} onChange={onChange}>
         <div className="relative mt-1">
           <Listbox.Button
-            className={`${dropdownSelector} relative w-full py-2 pl-3 pr-10 text-left bg-white rounded-lg cursor-default border border-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-opacity-75 focus-visible:ring-white focus-visible:ring-offset-orange-300 focus-visible:ring-offset-2 focus-visible:border-indigo-500 sm:text-sm`}
+            className={`${dropdownSelector} relative w-full py-2 pl-3 pr-10 text-left bg-white rounded-lg cursor-default border border-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-opacity-75 focus-visible:ring-white focus-visible:ring-offset-orange-300 focus-visible:ring-offset-2 focus-visible:border-indigo-500 sm:text-sm disabled:bg-gray-50 disabled:text-gray-400`}
           >
             {doRenderOption(value, optionsName, renderOption)}
             <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">

--- a/assets/js/components/Select/Select.stories.jsx
+++ b/assets/js/components/Select/Select.stories.jsx
@@ -49,6 +49,16 @@ export default {
         type: 'text',
       },
     },
+    disabled: {
+      type: 'boolean',
+      description: 'Whether the Select is disabled or not',
+      control: {
+        type: 'boolean',
+      },
+    },
+    args: {
+      disabled: false,
+    },
   },
   render: (args) => {
     const [value, setValue] = useState(args.value);
@@ -86,5 +96,12 @@ export const WithAllOption = {
     options: ['all', ...providers],
     value: 'all',
     renderOption: providerOptionRenderer,
+  },
+};
+
+export const Disabled = {
+  args: {
+    ...Default.args,
+    disabled: true,
   },
 };

--- a/assets/js/components/Select/Select.test.jsx
+++ b/assets/js/components/Select/Select.test.jsx
@@ -107,4 +107,19 @@ describe('Select Component', () => {
 
     expect(mockOnChange).toHaveBeenCalledWith('option2');
   });
+
+  it('should render a disabled select', async () => {
+    const user = userEvent.setup();
+
+    const options = ['option1', 'option2', 'option3'];
+
+    render(
+      <Select optionsName="foobars" options={options} value="all" disabled />
+    );
+
+    expect(screen.getByRole('button')).toBeDisabled();
+
+    await user.click(screen.getByText('All foobars'));
+    expect(screen.queryByText('option2')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
# Description

This PR makes sure that in the catalog page cluster type filter is enabled only when selected target type filter is `cluster`

## How was this tested?

Automated tests

https://2028.prenv.trento.suse.com/catalog
