### PR TITLE
Run `run-photofinish-demo-env` job when receiving `demo-deploy` action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -658,7 +658,14 @@ jobs:
   deploy-demo-env:
     name: Deploy updated images to the demo environment
     runs-on: self-hosted
-    if: (vars.DEPLOY_DEMO == 'true' || github.event.action == 'deploy-demo') || (github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch')
+    if: |
+      vars.DEPLOY_DEMO == 'true' &&
+        (
+          github.event_name == 'release' ||
+          github.event.action == 'deploy-demo' ||
+          (github.event_name == 'push' && github.ref_name == 'main') ||
+          github.event_name == 'workflow_dispatch'
+        )
     env:
       IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}
     needs: [build-demo-img, test-e2e]
@@ -693,7 +700,14 @@ jobs:
   run-photofinish-demo-env:
     name: Use photofinish to push mock data to the demo environment
     runs-on: ubuntu-20.04
-    if: vars.DEPLOY_DEMO == 'true' && (github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch')
+    if: |
+      vars.DEPLOY_DEMO == 'true' &&
+        (
+          github.event_name == 'release' ||
+          github.event.action == 'deploy-demo' ||
+          (github.event_name == 'push' && github.ref_name == 'main') ||
+          github.event_name == 'workflow_dispatch'
+        )
     needs: deploy-demo-env
     env:
       TRENTO_DEMO_IP: ${{ secrets.TRENTO_DEMO_IP }}


### PR DESCRIPTION
# Description

Related to https://github.com/trento-project/web/pull/2025

Triggers the CI job `Use photofinish to push mock data to the demo environment` when `web` repo receives the `deploy-demo` action.

## How was this tested?

By creating forks of `web` and `wanda` repos, and replicating + verifying the behaviour there.
