### PR TITLE
Refactor to createOptionRenderer helper

### DIFF
--- a/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/components/ChecksCatalog/ChecksCatalog.jsx
@@ -10,20 +10,30 @@ import {
 import { clusterTypes, getClusterTypeLabel } from '@lib/model/clusters';
 import PageHeader from '@components/PageHeader';
 import Accordion from '@components/Accordion';
-import Select, { OPTION_ALL } from '@components/Select';
+import Select, { createOptionRenderer, OPTION_ALL } from '@components/Select';
 import ProviderLabel from '@components/ProviderLabel';
 import TargetIcon from '@components/TargetIcon';
 import CatalogContainer from './CatalogContainer';
 import CheckItem from './CheckItem';
 
-const providerOptionRenderer = (provider) => (
-  <ProviderLabel provider={provider} />
+const providerOptionRenderer = createOptionRenderer(
+  'All providers',
+  (provider) => <ProviderLabel provider={provider} />
 );
-const targetTypeOptionRenderer = (targetType) => (
-  <TargetIcon targetType={targetType} className="inline mr-2 h-4">
-    {targetType === TARGET_CLUSTER && 'Clusters'}
-    {targetType === TARGET_HOST && 'Hosts'}
-  </TargetIcon>
+
+const clusterTypeRenderer = createOptionRenderer(
+  'All cluster types',
+  getClusterTypeLabel
+);
+
+const targetTypeOptionRenderer = createOptionRenderer(
+  'All targets',
+  (targetType) => (
+    <TargetIcon targetType={targetType} className="inline mr-2 h-4">
+      {targetType === TARGET_CLUSTER && 'Clusters'}
+      {targetType === TARGET_HOST && 'Hosts'}
+    </TargetIcon>
+  )
 );
 
 function ChecksCatalog({ catalogData, catalogError, loading, updateCatalog }) {
@@ -49,7 +59,7 @@ function ChecksCatalog({ catalogData, catalogError, loading, updateCatalog }) {
     {
       optionsName: 'cluster types',
       options: clusterTypes,
-      renderOption: getClusterTypeLabel,
+      renderOption: clusterTypeRenderer,
       value: selectedClusterType,
       onChange: setSelectedClusterType,
       disabled: selectedTargetType !== TARGET_CLUSTER,

--- a/assets/js/components/Select/Select.jsx
+++ b/assets/js/components/Select/Select.jsx
@@ -9,12 +9,6 @@ export const OPTION_ALL = 'all';
 
 const defaultOnChange = () => {};
 const defaultRenderOption = (item) => item;
-const doRenderOption = (option, optionsName, renderOption) => {
-  if (option === OPTION_ALL) {
-    return `All ${optionsName}`;
-  }
-  return renderOption(option);
-};
 
 function Select({
   optionsName,
@@ -29,14 +23,18 @@ function Select({
     /\s+/g,
     ''
   )}-selection-dropdown`;
+
   return (
     <div className={classNames('flex-1 w-64 pb-4', className)}>
       <Listbox disabled={disabled} value={value} onChange={onChange}>
         <div className="relative mt-1">
           <Listbox.Button
-            className={`${dropdownSelector} relative w-full py-2 pl-3 pr-10 text-left bg-white rounded-lg cursor-default border border-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-opacity-75 focus-visible:ring-white focus-visible:ring-offset-orange-300 focus-visible:ring-offset-2 focus-visible:border-indigo-500 sm:text-sm disabled:bg-gray-50 disabled:text-gray-400`}
+            className={classNames(
+              dropdownSelector,
+              'relative w-full py-2 pl-3 pr-10 text-left bg-white rounded-lg cursor-default border border-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-opacity-75 focus-visible:ring-white focus-visible:ring-offset-orange-300 focus-visible:ring-offset-2 focus-visible:border-indigo-500 sm:text-sm disabled:bg-gray-50 disabled:text-gray-400'
+            )}
           >
-            {doRenderOption(value, optionsName, renderOption)}
+            {renderOption(value)}
             <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
               <ChevronUpDownIcon
                 className="w-5 h-5 text-gray-400"
@@ -64,11 +62,12 @@ function Select({
                   {({ selected: isSelected }) => (
                     <>
                       <span
-                        className={`block truncate ${
-                          isSelected ? 'font-medium' : 'font-normal'
-                        }`}
+                        className={classNames('block', 'truncate', {
+                          'font-medium': isSelected,
+                          'font-normal': !isSelected,
+                        })}
                       >
-                        {doRenderOption(option, optionsName, renderOption)}
+                        {renderOption(option)}
                       </span>
                       {isSelected ? (
                         <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-green-600">

--- a/assets/js/components/Select/Select.stories.jsx
+++ b/assets/js/components/Select/Select.stories.jsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 
 import { providers } from '@lib/model';
 import ProviderLabel from '@components/ProviderLabel';
-import Select from './Select';
+
+import Select, { createOptionRenderer } from '.';
 
 export default {
   title: 'Components/Select',
@@ -86,8 +87,9 @@ export const Default = {
   },
 };
 
-const providerOptionRenderer = (provider) => (
-  <ProviderLabel provider={provider} />
+const providerOptionRenderer = createOptionRenderer(
+  'All providers',
+  (provider) => <ProviderLabel provider={provider} />
 );
 
 export const WithAllOption = {

--- a/assets/js/components/Select/Select.test.jsx
+++ b/assets/js/components/Select/Select.test.jsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import userEvent from '@testing-library/user-event';
-import Select from './Select';
+import Select, { createOptionRenderer } from '.';
 
 describe('Select Component', () => {
   const scenarios = [
@@ -18,15 +18,15 @@ describe('Select Component', () => {
       optionsName: 'bars',
       options: ['all', 'bar1', 'bar2', 'bar3'],
       value: 'all',
-      selectedValue: 'All bars',
-      allOptions: ['All bars', 'bar1', 'bar2', 'bar3'],
+      selectedValue: 'all',
+      allOptions: ['all', 'bar1', 'bar2', 'bar3'],
     },
     {
       optionsName: 'foobars',
       options: ['all', 'foobar1', 'foobar2', 'foobar3'],
       value: 'foobar1',
       selectedValue: 'foobar1',
-      allOptions: ['All foobars', 'foobar1', 'foobar2', 'foobar3'],
+      allOptions: ['all', 'foobar1', 'foobar2', 'foobar3'],
     },
   ];
 
@@ -69,7 +69,10 @@ describe('Select Component', () => {
     const user = userEvent.setup();
     const options = ['option1', 'option2', 'option3'];
 
-    const optionRenderer = (option) => `custom ${option}`;
+    const optionRenderer = createOptionRenderer(
+      'All foobars',
+      (option) => `custom ${option}`
+    );
 
     render(
       <Select
@@ -97,12 +100,12 @@ describe('Select Component', () => {
       <Select
         optionsName="foobars"
         options={options}
-        value="all"
+        value="option1"
         onChange={mockOnChange}
       />
     );
 
-    await user.click(screen.getByText('All foobars'));
+    await user.click(screen.getByText('option1'));
     await user.click(screen.getByText('option2'));
 
     expect(mockOnChange).toHaveBeenCalledWith('option2');
@@ -114,12 +117,17 @@ describe('Select Component', () => {
     const options = ['option1', 'option2', 'option3'];
 
     render(
-      <Select optionsName="foobars" options={options} value="all" disabled />
+      <Select
+        optionsName="foobars"
+        options={options}
+        value="option1"
+        disabled
+      />
     );
 
     expect(screen.getByRole('button')).toBeDisabled();
 
-    await user.click(screen.getByText('All foobars'));
+    await user.click(screen.getByText('option1'));
     expect(screen.queryByText('option2')).not.toBeInTheDocument();
   });
 });

--- a/assets/js/components/Select/index.js
+++ b/assets/js/components/Select/index.js
@@ -1,5 +1,12 @@
 import Select, { OPTION_ALL } from './Select';
 
+export const createOptionRenderer = (label, renderer) => (option) => {
+  if (option === OPTION_ALL) {
+    return label;
+  }
+  return renderer(option);
+};
+
 export { OPTION_ALL };
 
 export default Select;


### PR DESCRIPTION
# Description
Add a `createOptionRenderer` to the Select component to encapsulate the `all` handling logic

## How was this tested?
Jest tests updated :+1: 