### PR TITLE
PoC SUMA integration

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -180,6 +180,11 @@ config :trento, Trento.Vault,
       iv_length: 12
     }
   ]
+  
+config :trento, :suma,
+  user: "",
+  password: "",
+  base_url: ""
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/lib/trento/application.ex
+++ b/lib/trento/application.ex
@@ -25,6 +25,7 @@ defmodule Trento.Application do
         Trento.Infrastructure.Messaging.Adapter.AMQP.Publisher,
         Trento.Infrastructure.Checks.AMQP.Consumer,
         Trento.Vault
+        {Trento.Infrastructure.SUMA, nil}
         # Start a worker by calling: Trento.Worker.start_link(arg)
         # {Trento.Worker, arg}
       ] ++

--- a/lib/trento/infrastructure/software_updates/suma.ex
+++ b/lib/trento/infrastructure/software_updates/suma.ex
@@ -1,0 +1,85 @@
+defmodule Trento.Infrastructure.SUMA do
+  @moduledoc """
+  SUSE Manager integration service
+  """
+
+  use Agent
+
+  require Logger
+
+  @suma_url Application.compile_env!(:trento, :suma)[:base_url]
+
+  def start_link(initial_value) do
+    Agent.start_link(fn -> initial_value end, name: __MODULE__)
+  end
+
+  def login do
+    suma_user = Application.fetch_env!(:trento, :suma)[:user]
+    suma_password = Application.fetch_env!(:trento, :suma)[:password]
+
+    payload =
+      Jason.encode!(%{
+        "login" => suma_user,
+        "password" => suma_password
+      })
+
+    case HTTPoison.post(
+           "#{@suma_url}/auth/login",
+           payload,
+           [{"Content-type", "application/json"}],
+           ssl: [verify: :verify_none]
+         ) do
+      {:ok, %HTTPoison.Response{headers: headers} = response} ->
+        Agent.update(__MODULE__, fn _ ->
+          get_session_cookies(headers)
+        end)
+
+        Logger.debug("Successfully logged into suma #{inspect(response)}")
+        {:ok, :logged_in}
+
+      {:error, reason} ->
+        Logger.error("Failed to login to SUSE Manager. Error: #{inspect(reason)}")
+        {:error, :unable_to_login}
+    end
+  end
+
+  def list_affected_systems() do
+    case get_auth_cookies() do
+      nil ->
+        Logger.error("Unable to get auth cookies")
+        {:error, :unable_to_get_auth_cookies}
+
+      cookies ->
+        response =
+          HTTPoison.get(
+            "#{@suma_url}/errata/listAffectedSystems?advisoryName=SUSE-15-SP4-2023-4615",
+            [{"Content-type", "application/json"}],
+            hackney: [cookie: [cookies]],
+            ssl: [verify: :verify_none]
+          )
+
+        Logger.debug("Response from list_affected_systems #{inspect(response)}")
+
+        {:ok, :list_affected_systems}
+    end
+  end
+
+  def get_auth_cookies() do
+    Agent.get(__MODULE__, & &1)
+  end
+
+  defp get_session_cookies(login_response_headers) do
+    Enum.filter(login_response_headers, fn {key, value} ->
+      String.match?(key, ~r/\Aset-cookie\z/i) &&
+        String.starts_with?(value, "pxt-session-cookie=")
+    end)
+    |> Enum.map(fn {_, value} ->
+      parts = String.split(value, ";")
+
+      Enum.find(parts, fn part ->
+        String.starts_with?(part, "pxt-session-cookie=")
+      end)
+    end)
+    |> List.last()
+  end
+end


### PR DESCRIPTION
# Description

Tiny PoC for SUMA integration supporting exploration. Not meant to be production ready.

How to play with it:
edit `./config/dev.local.exs` by adding
```elixir
config :trento, :suma,
  user: "<the username>",
  password: "<the password>",
  base_url: "<the base suma url>/rhn/manager/api"
```
start the system `iex -S mix phx.server` and the following functions can be called
```
iex(109)> Trento.Infrastructure.SUMA.login # to make a login
iex(110)> Trento.Infrastructure.SUMA.get_auth_cookies # to see the auth cookie
iex(111)> Trento.Infrastructure.SUMA.list_affected_systems # to trigger a listAffectedSystems API call
```