### PR TITLE
Provide ENSA version info to Wanda

### DIFF
--- a/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
@@ -7,6 +7,7 @@ import {
   getCluster,
   getClusterHosts,
   getClusterSapSystems,
+  getEnsaVersion,
 } from '@state/selectors/cluster';
 import { getCatalog } from '@state/selectors/catalog';
 import { getLastExecution } from '@state/selectors/lastExecutions';
@@ -32,6 +33,8 @@ export function ClusterDetailsPage() {
 
   const lastExecution = useSelector(getLastExecution(clusterID));
 
+  const ensaVersion = useSelector((state) => getEnsaVersion(state, clusterID));
+
   useEffect(() => {
     if (provider && type) {
       dispatch(
@@ -39,11 +42,12 @@ export function ClusterDetailsPage() {
           provider,
           target_type: TARGET_CLUSTER,
           cluster_type: type,
+          ensa_version: ensaVersion,
         })
       );
       dispatch(updateLastExecution(clusterID));
     }
-  }, [dispatch, provider, type]);
+  }, [dispatch, provider, type, ensaVersion]);
 
   const clusterHosts = useSelector((state) =>
     getClusterHosts(state, clusterID)

--- a/assets/js/state/selectors/cluster.js
+++ b/assets/js/state/selectors/cluster.js
@@ -63,7 +63,7 @@ export const getClusterSapSystems = createSelector(
 );
 
 export const getEnsaVersion = createSelector(
-  [(state, clusterID) => getClusterSapSystems(state, clusterID)],
+  [getClusterSapSystems],
   (sapSystems) => {
     const ensaVersions = new Set();
     sapSystems.forEach(({ ensa_version }) => ensaVersions.add(ensa_version));
@@ -72,7 +72,7 @@ export const getEnsaVersion = createSelector(
 
     return firstEnsaVersion && ensaVersions.size === 1
       ? firstEnsaVersion
-      : 'mixed_versions';
+      : 'MIXED_VERSIONS';
   }
 );
 

--- a/assets/js/state/selectors/cluster.js
+++ b/assets/js/state/selectors/cluster.js
@@ -62,6 +62,20 @@ export const getClusterSapSystems = createSelector(
   }
 );
 
+export const getEnsaVersion = createSelector(
+  [(state, clusterID) => getClusterSapSystems(state, clusterID)],
+  (sapSystems) => {
+    const ensaVersions = new Set();
+    sapSystems.forEach(({ ensa_version }) => ensaVersions.add(ensa_version));
+
+    const firstEnsaVersion = [...ensaVersions.values()][0];
+
+    return firstEnsaVersion && ensaVersions.size === 1
+      ? firstEnsaVersion
+      : 'mixed_versions';
+  }
+);
+
 export const getClusterSelectedChecks = createSelector(
   [(state, clusterID) => getCluster(clusterID)(state)],
   (cluster) => get(cluster, 'selected_checks', [])

--- a/assets/js/state/selectors/cluster.js
+++ b/assets/js/state/selectors/cluster.js
@@ -62,7 +62,7 @@ export const getClusterSapSystems = createSelector(
   }
 );
 
-export const MIXED_VERSIONS = 'MIXED_VERSIONS';
+export const MIXED_VERSIONS = 'mixed_versions';
 
 export const getEnsaVersion = createSelector(
   [getClusterSapSystems],

--- a/assets/js/state/selectors/cluster.js
+++ b/assets/js/state/selectors/cluster.js
@@ -62,6 +62,8 @@ export const getClusterSapSystems = createSelector(
   }
 );
 
+export const MIXED_VERSIONS = 'MIXED_VERSIONS';
+
 export const getEnsaVersion = createSelector(
   [getClusterSapSystems],
   (sapSystems) => {
@@ -72,7 +74,7 @@ export const getEnsaVersion = createSelector(
 
     return firstEnsaVersion && ensaVersions.size === 1
       ? firstEnsaVersion
-      : 'MIXED_VERSIONS';
+      : MIXED_VERSIONS;
   }
 );
 

--- a/assets/js/state/selectors/cluster.test.js
+++ b/assets/js/state/selectors/cluster.test.js
@@ -14,6 +14,7 @@ import {
   getClusterSapSystems,
   getClusterSelectedChecks,
   getClusterIDs,
+  getEnsaVersion,
 } from './cluster';
 
 describe('Cluster selector', () => {
@@ -204,5 +205,180 @@ describe('Cluster selector', () => {
     };
 
     expect(getClusterIDs(state)).toEqual([clusterID1, clusterID2]);
+  });
+
+  it('should return ENSA version', () => {
+    const clusterID = faker.string.uuid();
+    const cluster = clusterFactory.build({ id: clusterID });
+
+    const sapSystems = sapSystemFactory.buildList(2, { ensa_version: 'ensa1' });
+    const [{ id: sapSystem1 }, { id: sapSystem2 }] = sapSystems;
+
+    const hosts = hostFactory
+      .buildList(4, { cluster_id: clusterID })
+      .concat(hostFactory.buildList(2));
+    const [{ id: host1 }, { id: host2 }, { id: host3 }, { id: host4 }] = hosts;
+
+    const applicationInstances = [
+      sapSystemApplicationInstanceFactory.build({
+        sap_system_id: sapSystem1,
+        host_id: host1,
+      }),
+      sapSystemApplicationInstanceFactory.build({
+        sap_system_id: sapSystem2,
+        host_id: host2,
+      }),
+    ];
+
+    const databases = databaseFactory.buildList(4);
+
+    const databaseInstances = [
+      databaseInstanceFactory.build({
+        sap_system_id: sapSystem1,
+        host_id: host3,
+      }),
+      databaseInstanceFactory.build({
+        sap_system_id: sapSystem2,
+        host_id: host4,
+      }),
+    ];
+
+    const state = {
+      hostsList: {
+        hosts,
+      },
+      databasesList: {
+        databases,
+        databaseInstances,
+      },
+      sapSystemsList: {
+        sapSystems,
+        applicationInstances,
+        databaseInstances,
+      },
+      clustersList: {
+        clusters: [cluster],
+      },
+    };
+
+    expect(getEnsaVersion(state, clusterID)).toEqual('ensa1');
+  });
+
+  it('should return mixed ENSA versions', () => {
+    const clusterID = faker.string.uuid();
+    const cluster = clusterFactory.build({ id: clusterID });
+
+    const sapSystems = [
+      sapSystemFactory.build({ ensa_version: 'ensa1' }),
+      sapSystemFactory.build({ ensa_version: 'ensa2' }),
+    ];
+    const [{ id: sapSystem1 }, { id: sapSystem2 }] = sapSystems;
+
+    const hosts = hostFactory
+      .buildList(4, { cluster_id: clusterID })
+      .concat(hostFactory.buildList(2));
+    const [{ id: host1 }, { id: host2 }, { id: host3 }, { id: host4 }] = hosts;
+
+    const applicationInstances = [
+      sapSystemApplicationInstanceFactory.build({
+        sap_system_id: sapSystem1,
+        host_id: host1,
+      }),
+      sapSystemApplicationInstanceFactory.build({
+        sap_system_id: sapSystem2,
+        host_id: host2,
+      }),
+    ];
+
+    const databases = databaseFactory.buildList(4);
+
+    const databaseInstances = [
+      databaseInstanceFactory.build({
+        sap_system_id: sapSystem1,
+        host_id: host3,
+      }),
+      databaseInstanceFactory.build({
+        sap_system_id: sapSystem2,
+        host_id: host4,
+      }),
+    ];
+
+    const state = {
+      hostsList: {
+        hosts,
+      },
+      databasesList: {
+        databases,
+        databaseInstances,
+      },
+      sapSystemsList: {
+        sapSystems,
+        applicationInstances,
+        databaseInstances,
+      },
+      clustersList: {
+        clusters: [cluster],
+      },
+    };
+
+    expect(getEnsaVersion(state, clusterID)).toEqual('mixed_versions');
+  });
+
+  it('should return mixed ENSA versions if SAP system does not have ENSA version info', () => {
+    const clusterID = faker.string.uuid();
+    const cluster = clusterFactory.build({ id: clusterID });
+
+    const sapSystems = sapSystemFactory.buildList(2, { ensa_version: 'ensa1' });
+    const [{ id: sapSystem1 }, { id: sapSystem2 }] = sapSystems;
+
+    const hosts = hostFactory
+      .buildList(4, { cluster_id: clusterID })
+      .concat(hostFactory.buildList(2));
+    const [{ id: host1 }, { id: host2 }, { id: host3 }, { id: host4 }] = hosts;
+
+    const applicationInstances = [
+      sapSystemApplicationInstanceFactory.build({
+        sap_system_id: sapSystem1,
+        host_id: host1,
+      }),
+      sapSystemApplicationInstanceFactory.build({
+        sap_system_id: sapSystem2,
+        host_id: host2,
+      }),
+    ];
+
+    const databases = databaseFactory.buildList(4);
+    const [{ id: database1 }, { id: database2 }] = databases;
+
+    const databaseInstances = [
+      databaseInstanceFactory.build({
+        sap_system_id: database1,
+        host_id: host3,
+      }),
+      databaseInstanceFactory.build({
+        sap_system_id: database2,
+        host_id: host4,
+      }),
+    ];
+
+    const state = {
+      hostsList: {
+        hosts,
+      },
+      databasesList: {
+        databases,
+        databaseInstances,
+      },
+      sapSystemsList: {
+        sapSystems,
+        applicationInstances,
+        databaseInstances,
+      },
+      clustersList: {
+        clusters: [cluster],
+      },
+    };
+
+    expect(getEnsaVersion(state, clusterID)).toEqual('mixed_versions');
   });
 });

--- a/assets/js/state/selectors/cluster.test.js
+++ b/assets/js/state/selectors/cluster.test.js
@@ -14,6 +14,7 @@ import {
   getClusterSapSystems,
   getClusterSelectedChecks,
   getClusterIDs,
+  MIXED_VERSIONS,
   getEnsaVersion,
 } from './cluster';
 
@@ -321,7 +322,7 @@ describe('Cluster selector', () => {
       },
     };
 
-    expect(getEnsaVersion(state, clusterID)).toEqual('MIXED_VERSIONS');
+    expect(getEnsaVersion(state, clusterID)).toEqual(MIXED_VERSIONS);
   });
 
   it('should return mixed ENSA versions if SAP system does not have ENSA version info', () => {
@@ -379,6 +380,6 @@ describe('Cluster selector', () => {
       },
     };
 
-    expect(getEnsaVersion(state, clusterID)).toEqual('MIXED_VERSIONS');
+    expect(getEnsaVersion(state, clusterID)).toEqual(MIXED_VERSIONS);
   });
 });

--- a/assets/js/state/selectors/cluster.test.js
+++ b/assets/js/state/selectors/cluster.test.js
@@ -321,7 +321,7 @@ describe('Cluster selector', () => {
       },
     };
 
-    expect(getEnsaVersion(state, clusterID)).toEqual('mixed_versions');
+    expect(getEnsaVersion(state, clusterID)).toEqual('MIXED_VERSIONS');
   });
 
   it('should return mixed ENSA versions if SAP system does not have ENSA version info', () => {
@@ -379,6 +379,6 @@ describe('Cluster selector', () => {
       },
     };
 
-    expect(getEnsaVersion(state, clusterID)).toEqual('mixed_versions');
+    expect(getEnsaVersion(state, clusterID)).toEqual('MIXED_VERSIONS');
   });
 });


### PR DESCRIPTION
# Description

This change enables the frontend to send ENSA version information about the SAP systems belonging to a certain cluster.

## Business Logic

Note that the ENSA version value sent is an aggregated value of the ENSA versions present in the SAP systems for a given cluster.

- If a scenario where the ENSA versions are not _completely_ in agreement, then the value `'mixed_versions'` is sent.

- If the ENSA version info is not present for a SAP system, then `'mixed_versions'` is sent.

Some example scenarios are below:

| SAP Systems' ENSA versions |       Result       |
|:---------------------------|:------------------:|
| `['ensa1']`                |     `'ensa1'`      |
| `['ensa2', 'ensa2']`       |     `'ensa2'`      |
| `['ensa1', 'ensa2']`       | `'mixed_versions'` |
| `['ensa1', undefined]`     | `'mixed_versions'` |
| `[undefined]`              | `'mixed_versions'` | 

## How was this tested?

Added unit tests
