### PR TITLE
Fix Start Execution button size in cluster details

### DIFF
--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
@@ -144,7 +144,8 @@ function HanaClusterDetails({
             >
               <Button
                 type="primary"
-                className="mx-1"
+                className="mx-0.5 border border-green-500"
+                size="small"
                 onClick={() => {
                   onStartExecution(clusterID, hosts, selectedChecks, navigate);
                 }}


### PR DESCRIPTION
# Description

Fix the size (and the margin) for the Start Execution button in the cluster details.

## How was this tested?

Existing jest tests and stories cover it
