### PR TITLE
Fix start execution button size for host details

### DIFF
--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -138,7 +138,8 @@ function HostDetails({
               >
                 <Button
                   type="primary"
-                  className="mx-1"
+                  className="mx-0.5"
+                  size="small"
                   onClick={requestHostChecksExecution}
                   disabled={!canStartExecution(selectedChecks, savingChecks)}
                 >


### PR DESCRIPTION
# Description

Fix start execution button size for host details (and margin as well)

## How was this tested?

Existing jest tests and stories already in place
