### PR TITLE
Fix classNames usage in HanaClusterDetails

### DIFF
--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { get, groupBy } from 'lodash';
+import classNames from 'classnames';
 
 import { RUNNING_STATES } from '@state/lastExecutions';
 
@@ -152,9 +153,10 @@ function HanaClusterDetails({
                 disabled={startExecutionDisabled}
               >
                 <EOS_PLAY_CIRCLE
-                  className={`${
-                    !startExecutionDisabled ? 'fill-white' : 'fill-gray-200'
-                  } inline-block align-sub`}
+                  className={classNames('inline-block align-sub', {
+                    'fill-white': !startExecutionDisabled,
+                    'fill-gray-200': startExecutionDisabled,
+                  })}
                 />{' '}
                 Start Execution
               </Button>

--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -145,7 +145,7 @@ function HostDetails({
                   disabled={!canStartExecution(selectedChecks, savingChecks)}
                 >
                   <EOS_PLAY_CIRCLE
-                    className={classNames('inline-block, align-sub', {
+                    className={classNames('inline-block align-sub', {
                       'fill-white': canStartExecution(
                         selectedChecks,
                         savingChecks


### PR DESCRIPTION
# Description

Fixing classNames usage instead of string interpolation in HanaClusterDetails

## How was this tested?

Existing jest tests
