### PR TITLE
Send filesystem type to Wanda

### DIFF
--- a/assets/js/lib/model/clusters.js
+++ b/assets/js/lib/model/clusters.js
@@ -15,3 +15,7 @@ const clusterTypeLabels = {
 
 export const getClusterTypeLabel = (type) =>
   clusterTypeLabels[type] || 'Unknown';
+
+export const FS_TYPE_RESOURCE_MANAGED = 'resource_managed';
+export const FS_TYPE_SIMPLE_MOUNT = 'simple_mount';
+export const FS_TYPE_MIXED = 'mixed_fs_types';

--- a/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
@@ -8,6 +8,7 @@ import {
   getClusterHosts,
   getClusterSapSystems,
   getEnsaVersion,
+  getFilesystemType,
 } from '@state/selectors/cluster';
 import { getCatalog } from '@state/selectors/catalog';
 import { getLastExecution } from '@state/selectors/lastExecutions';
@@ -34,6 +35,9 @@ export function ClusterDetailsPage() {
   const lastExecution = useSelector(getLastExecution(clusterID));
 
   const ensaVersion = useSelector((state) => getEnsaVersion(state, clusterID));
+  const filesystemType = useSelector((state) =>
+    getFilesystemType(state, clusterID)
+  );
 
   useEffect(() => {
     if (provider && type) {
@@ -43,11 +47,12 @@ export function ClusterDetailsPage() {
           target_type: TARGET_CLUSTER,
           cluster_type: type,
           ensa_version: ensaVersion,
+          filesystem_type: filesystemType,
         })
       );
       dispatch(updateLastExecution(clusterID));
     }
-  }, [dispatch, provider, type, ensaVersion]);
+  }, [dispatch, provider, type, ensaVersion, filesystemType]);
 
   const clusterHosts = useSelector((state) =>
     getClusterHosts(state, clusterID)

--- a/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
+++ b/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
@@ -9,6 +9,7 @@ import {
   getClusterName,
   getClusterSelectedChecks,
   getClusterHosts,
+  getFilesystemType,
 } from '@state/selectors/cluster';
 import { updateCatalog } from '@state/catalog';
 import { getCatalog } from '@state/selectors/catalog';
@@ -57,6 +58,9 @@ function ClusterSettingsPage() {
     getClusterSelectedChecks(state, clusterID)
   );
   const clusterName = useSelector(getClusterName(clusterID));
+  const filesystemType = useSelector((state) =>
+    getFilesystemType(state, clusterID)
+  );
 
   const {
     data: catalog,
@@ -83,6 +87,7 @@ function ClusterSettingsPage() {
         provider,
         target_type: TARGET_CLUSTER,
         cluster_type: type,
+        filesystem_type: filesystemType,
       })
     );
 

--- a/assets/js/state/selectors/cluster.test.js
+++ b/assets/js/state/selectors/cluster.test.js
@@ -394,64 +394,6 @@ describe('Cluster selector', () => {
     expect(getEnsaVersion(state, clusterID)).toEqual(MIXED_VERSIONS);
   });
 
-  it('should return filesystem type', () => {
-    const clusterID = faker.string.uuid();
-    const cluster = clusterFactory.build({ id: clusterID });
-
-    const sapSystems = sapSystemFactory.buildList(2, { ensa_version: 'ensa1' });
-    const [{ id: sapSystem1 }, { id: sapSystem2 }] = sapSystems;
-
-    const hosts = hostFactory
-      .buildList(4, { cluster_id: clusterID })
-      .concat(hostFactory.buildList(2));
-    const [{ id: host1 }, { id: host2 }, { id: host3 }, { id: host4 }] = hosts;
-
-    const applicationInstances = [
-      sapSystemApplicationInstanceFactory.build({
-        sap_system_id: sapSystem1,
-        host_id: host1,
-      }),
-      sapSystemApplicationInstanceFactory.build({
-        sap_system_id: sapSystem2,
-        host_id: host2,
-      }),
-    ];
-
-    const databases = databaseFactory.buildList(4);
-    const [{ id: database1 }, { id: database2 }] = databases;
-
-    const databaseInstances = [
-      databaseInstanceFactory.build({
-        sap_system_id: database1,
-        host_id: host3,
-      }),
-      databaseInstanceFactory.build({
-        sap_system_id: database2,
-        host_id: host4,
-      }),
-    ];
-
-    const state = {
-      hostsList: {
-        hosts,
-      },
-      databasesList: {
-        databases,
-        databaseInstances,
-      },
-      sapSystemsList: {
-        sapSystems,
-        applicationInstances,
-        databaseInstances,
-      },
-      clustersList: {
-        clusters: [cluster],
-      },
-    };
-
-    expect(getEnsaVersion(state, clusterID)).toEqual(MIXED_VERSIONS);
-  });
-
   it('should return resource_managed filesystem type if every SAP system has resource based filesystem', () => {
     const clusterID = faker.string.uuid();
     const cluster = clusterFactory.build({

--- a/lib/trento/clusters/enums/filesystem_type.ex
+++ b/lib/trento/clusters/enums/filesystem_type.ex
@@ -1,0 +1,7 @@
+defmodule Trento.Clusters.Enums.FilesystemType do
+  @moduledoc """
+  Type that represents the filesystem types used by an ASCS/ERS cluster.
+  """
+
+  use Trento.Support.Enum, values: [:resource_managed, :simple_mount, :mixed_fs_types]
+end

--- a/lib/trento/infrastructure/checks/checks.ex
+++ b/lib/trento/infrastructure/checks/checks.ex
@@ -20,6 +20,7 @@ defmodule Trento.Infrastructure.Checks do
   }
 
   require Logger
+  require Trento.Clusters.Enums.ClusterType, as: ClusterType
   require Trento.Infrastructure.Checks.TargetType, as: TargetType
 
   @type target_type :: TargetType.t()
@@ -91,6 +92,18 @@ defmodule Trento.Infrastructure.Checks do
 
   defp dispatch_completion_command(execution_id, command) do
     commanded().dispatch(command, correlation_id: execution_id)
+  end
+
+  defp build_env(%ClusterExecutionEnv{
+         cluster_type: :ascs_ers,
+         provider: provider,
+         filesystem_type: filesystem_type
+       }) do
+    %{
+      "cluster_type" => %{kind: {:string_value, Atom.to_string(ClusterType.ascs_ers())}},
+      "provider" => %{kind: {:string_value, Atom.to_string(provider)}},
+      "filesystem_type" => %{kind: {:string_value, Atom.to_string(filesystem_type)}}
+    }
   end
 
   defp build_env(%ClusterExecutionEnv{cluster_type: cluster_type, provider: provider}) do

--- a/lib/trento/infrastructure/checks/cluster_execution_env.ex
+++ b/lib/trento/infrastructure/checks/cluster_execution_env.ex
@@ -3,14 +3,16 @@ defmodule Trento.Infrastructure.Checks.ClusterExecutionEnv do
   Cluster checks execution env map
   """
 
-  @required_fields :all
+  @required_fields [:cluster_type, :provider]
   use Trento.Support.Type
 
   require Trento.Enums.Provider, as: Provider
   require Trento.Clusters.Enums.ClusterType, as: ClusterType
+  require Trento.Clusters.Enums.FilesystemType, as: FilesystemType
 
   deftype do
     field :cluster_type, Ecto.Enum, values: ClusterType.values()
     field :provider, Ecto.Enum, values: Provider.values()
+    field :filesystem_type, Ecto.Enum, values: FilesystemType.values()
   end
 end

--- a/test/trento/clusters_test.exs
+++ b/test/trento/clusters_test.exs
@@ -189,4 +189,104 @@ defmodule Trento.ClustersTest do
         Clusters.update_cib_last_written(cluster.id, cib_last_written)
     end
   end
+
+  describe "ASCS/ERS cluster checks execution" do
+    test "should start a checks execution on demand for ascs_ers clusters with a resource managed filesystem type" do
+      %{id: cluster_id, provider: provider, type: cluster_type} =
+        insert(:cluster,
+          type: :ascs_ers,
+          details:
+            build(:ascs_ers_cluster_details,
+              sap_systems:
+                build_list(2, :ascs_ers_cluster_sap_system, filesystem_resource_based: true)
+            )
+        )
+
+      insert(:host, deregistered_at: DateTime.utc_now(), cluster_id: cluster_id)
+      insert_list(2, :host, cluster_id: cluster_id)
+
+      expect(Trento.Infrastructure.Messaging.Adapter.Mock, :publish, fn "executions", message ->
+        assert message.group_id == cluster_id
+        assert length(message.targets) == 2
+
+        assert message.env == %{
+                 "provider" => %{kind: {:string_value, Atom.to_string(provider)}},
+                 "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
+                 "filesystem_type" => %{kind: {:string_value, Atom.to_string(:resource_managed)}}
+               }
+
+        assert message.target_type == "cluster"
+
+        :ok
+      end)
+
+      assert :ok = Clusters.request_checks_execution(cluster_id)
+    end
+
+    test "should start a checks execution on demand for ascs_ers clusters with a simple mount filesystem type" do
+      %{id: cluster_id, provider: provider, type: cluster_type} =
+        insert(:cluster,
+          type: :ascs_ers,
+          details:
+            build(:ascs_ers_cluster_details,
+              sap_systems:
+                build_list(2, :ascs_ers_cluster_sap_system, filesystem_resource_based: false)
+            )
+        )
+
+      insert(:host, deregistered_at: DateTime.utc_now(), cluster_id: cluster_id)
+      insert_list(2, :host, cluster_id: cluster_id)
+
+      expect(Trento.Infrastructure.Messaging.Adapter.Mock, :publish, fn "executions", message ->
+        assert message.group_id == cluster_id
+        assert length(message.targets) == 2
+
+        assert message.env == %{
+                 "provider" => %{kind: {:string_value, Atom.to_string(provider)}},
+                 "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
+                 "filesystem_type" => %{kind: {:string_value, Atom.to_string(:simple_mount)}}
+               }
+
+        assert message.target_type == "cluster"
+
+        :ok
+      end)
+
+      assert :ok = Clusters.request_checks_execution(cluster_id)
+    end
+
+    test "should start a checks execution on demand for ascs_ers clusters with a mixed filesystem type" do
+      %{id: cluster_id, provider: provider, type: cluster_type} =
+        insert(:cluster,
+          type: :ascs_ers,
+          details:
+            build(:ascs_ers_cluster_details,
+              sap_systems: [
+                build(:ascs_ers_cluster_sap_system, filesystem_resource_based: false),
+                build(:ascs_ers_cluster_sap_system, filesystem_resource_based: true)
+              ]
+            )
+        )
+
+      insert(:host, deregistered_at: DateTime.utc_now(), cluster_id: cluster_id)
+      insert_list(2, :host, cluster_id: cluster_id)
+
+      expect(Trento.Infrastructure.Messaging.Adapter.Mock, :publish, fn "executions", message ->
+        assert message.group_id == cluster_id
+        assert length(message.targets) == 2
+
+        assert message.env == %{
+                 "provider" => %{kind: {:string_value, Atom.to_string(provider)}},
+                 "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
+                 "filesystem_type" => %{kind: {:string_value, Atom.to_string(:mixed_fs_types)}}
+               }
+
+        assert message.target_type == "cluster"
+
+        :ok
+      end)
+
+      assert :ok = Clusters.request_checks_execution(cluster_id)
+    end
+  end
 end


### PR DESCRIPTION
# Description
Sending filesystem type to Wanda when selecting checks for a cluster, and during an execution request.

## How was this tested?
Jest tests added, Elixir tests added
