### PR TITLE
Fix ascs ers detection in checks selection

### DIFF
--- a/assets/js/common/ClusterInfoBox/ClusterInfoBox.jsx
+++ b/assets/js/common/ClusterInfoBox/ClusterInfoBox.jsx
@@ -1,12 +1,9 @@
 import React from 'react';
 
+import { getClusterTypeLabel } from '@lib/model/clusters';
+
 import ListView from '@common/ListView';
 import ProviderLabel from '@common/ProviderLabel';
-
-const haScenarioToString = {
-  hana_scale_up: 'HANA scale-up',
-  hana_scale_out: 'HANA scale-out',
-};
 
 // eslint-disable-next-line import/prefer-default-export
 function ClusterInfoBox({ haScenario, provider }) {
@@ -19,7 +16,7 @@ function ClusterInfoBox({ haScenario, provider }) {
         data={[
           {
             title: 'HA Scenario',
-            content: haScenarioToString[haScenario] ?? 'Unknown',
+            content: getClusterTypeLabel(haScenario),
           },
           {
             title: 'Provider',

--- a/assets/js/common/ClusterInfoBox/ClusterInfoBox.test.jsx
+++ b/assets/js/common/ClusterInfoBox/ClusterInfoBox.test.jsx
@@ -7,19 +7,25 @@ describe('Cluster Info Box', () => {
   [
     {
       haScenario: 'hana_scale_up',
-      haScenarioText: 'HANA scale-up',
+      haScenarioText: 'HANA Scale Up',
       provider: 'aws',
       providerText: 'AWS',
     },
     {
       haScenario: 'hana_scale_out',
-      haScenarioText: 'HANA scale-out',
+      haScenarioText: 'HANA Scale Out',
       provider: 'aws',
       providerText: 'AWS',
     },
     {
       haScenario: 'hana_scale_up',
-      haScenarioText: 'HANA scale-up',
+      haScenarioText: 'HANA Scale Up',
+      provider: 'azure',
+      providerText: 'Azure',
+    },
+    {
+      haScenario: 'ascs_ers',
+      haScenarioText: 'ASCS/ERS',
       provider: 'azure',
       providerText: 'Azure',
     },
@@ -43,7 +49,7 @@ describe('Cluster Info Box', () => {
     },
     {
       haScenario: 'hana_scale_up',
-      haScenarioText: 'HANA scale-up',
+      haScenarioText: 'HANA Scale Up',
       provider: 'nutanix',
       providerText: 'Nutanix',
     },

--- a/assets/js/pages/ClusterDetails/ClusterDetailsPage.test.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetailsPage.test.jsx
@@ -10,7 +10,7 @@ import { ClusterDetailsPage } from './ClusterDetailsPage';
 
 describe('ClusterDetails ClusterDetailsPage component', () => {
   it.each([
-    { type: 'hana_scale_up', label: 'HANA scale-up' },
+    { type: 'hana_scale_up', label: 'HANA Scale Up' },
     { type: 'ascs_ers', label: 'ASCS/ERS' },
     { type: 'unknwon', label: 'Unknown cluster type' },
   ])(

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
@@ -195,7 +195,7 @@ function HanaClusterDetails({
               {
                 title: 'Cluster type',
                 content:
-                  clusterType === 'hana_scale_up' ? 'HANA scale-up' : 'Unknown',
+                  clusterType === 'hana_scale_up' ? 'HANA Scale Up' : 'Unknown',
               },
               {
                 title: 'SAPHanaSR health state',

--- a/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
+++ b/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
@@ -37,7 +37,7 @@ const catalogWarningBanner = {
   ),
   [VMWARE_PROVIDER]: (
     <WarningBanner>
-      Configuration checks for HANA scale-up performance optimized clusters on
+      Configuration checks for HANA Scale Up performance optimized clusters on
       VMware are still in experimental phase. Please use results with caution.
     </WarningBanner>
   ),

--- a/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.test.jsx
+++ b/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.test.jsx
@@ -67,7 +67,7 @@ describe('ClusterDetails ClusterSettings component', () => {
     expect(screen.getByText(group)).toBeVisible();
     expect(
       screen.getByText(
-        'Configuration checks for HANA scale-up performance optimized clusters on VMware are still in experimental phase. Please use results with caution.'
+        'Configuration checks for HANA Scale Up performance optimized clusters on VMware are still in experimental phase. Please use results with caution.'
       )
     ).toBeVisible();
   });

--- a/assets/js/pages/ExecutionResults/ExecutionHeader.jsx
+++ b/assets/js/pages/ExecutionResults/ExecutionHeader.jsx
@@ -21,7 +21,7 @@ export const clusterWarningBanner = {
   ),
   [VMWARE_PROVIDER]: (
     <WarningBanner>
-      Configuration checks for HANA scale-up performance optimized clusters on
+      Configuration checks for HANA Scale Up performance optimized clusters on
       VMware are still in experimental phase. Please use results with caution.
     </WarningBanner>
   ),

--- a/assets/js/pages/ExecutionResults/ExecutionHeader.test.jsx
+++ b/assets/js/pages/ExecutionResults/ExecutionHeader.test.jsx
@@ -34,7 +34,7 @@ describe('Checks results ExecutionHeader Component', () => {
 
       expect(screen.getByText('Back to Cluster Details')).toBeTruthy();
       expect(screen.getByText('Azure')).toBeTruthy();
-      expect(screen.getByText('HANA scale-up')).toBeTruthy();
+      expect(screen.getByText('HANA Scale Up')).toBeTruthy();
       expect(screen.getByText('Checks Results for cluster')).toBeTruthy();
       expect(screen.getByText(clusterName)).toBeTruthy();
     });
@@ -62,7 +62,7 @@ describe('Checks results ExecutionHeader Component', () => {
       );
 
       expect(screen.getByText('Provider not recognized')).toBeTruthy();
-      expect(screen.getByText('HANA scale-up')).toBeTruthy();
+      expect(screen.getByText('HANA Scale Up')).toBeTruthy();
       expect(screen.getByText('Checks Results for cluster')).toBeTruthy();
       expect(
         screen.getByText(

--- a/assets/js/pages/ExecutionResults/ExecutionResults.test.jsx
+++ b/assets/js/pages/ExecutionResults/ExecutionResults.test.jsx
@@ -328,7 +328,7 @@ describe('ExecutionResults', () => {
     );
 
     expect(screen.getAllByText('test-cluster')).toHaveLength(2);
-    expect(screen.getByText('HANA scale-up')).toBeTruthy();
+    expect(screen.getByText('HANA Scale Up')).toBeTruthy();
     expect(screen.getByText('Azure')).toBeTruthy();
     expect(screen.getByText(clusterHosts[0].hostname)).toBeTruthy();
     expect(screen.getByText(clusterHosts[1].hostname)).toBeTruthy();
@@ -372,7 +372,7 @@ describe('ExecutionResults', () => {
     );
 
     expect(screen.getAllByText('test-cluster')).toHaveLength(2);
-    expect(screen.getByText('HANA scale-up')).toBeTruthy();
+    expect(screen.getByText('HANA Scale Up')).toBeTruthy();
     expect(screen.getByText('Azure')).toBeTruthy();
     expect(screen.getByText(clusterHosts[0].hostname)).toBeTruthy();
     expect(screen.getByText(clusterHosts[1].hostname)).toBeTruthy();
@@ -419,7 +419,7 @@ describe('ExecutionResults', () => {
     );
 
     expect(screen.getAllByText('test-cluster')).toHaveLength(2);
-    expect(screen.getByText('HANA scale-up')).toBeTruthy();
+    expect(screen.getByText('HANA Scale Up')).toBeTruthy();
     expect(screen.getByText('Azure')).toBeTruthy();
     expect(screen.getAllByText(clusterHosts[0].hostname)).toHaveLength(2);
     expect(screen.getAllByText(clusterHosts[1].hostname)).toHaveLength(2);
@@ -464,7 +464,7 @@ describe('ExecutionResults', () => {
     expect(screen.getByText('VMware')).toBeTruthy();
     expect(
       screen.getByText(
-        'Configuration checks for HANA scale-up performance optimized clusters on VMware are still in experimental phase. Please use results with caution.'
+        'Configuration checks for HANA Scale Up performance optimized clusters on VMware are still in experimental phase. Please use results with caution.'
       )
     ).toBeTruthy();
   });

--- a/test/e2e/cypress/fixtures/hana-cluster-details/available_hana_cluster.js
+++ b/test/e2e/cypress/fixtures/hana-cluster-details/available_hana_cluster.js
@@ -2,7 +2,7 @@ export const availableHanaCluster = {
   id: '469e7be5-4e20-5007-b044-c6f540a87493',
   name: 'hana_cluster_3',
   sid: 'HDP',
-  clusterType: 'HANA scale-up',
+  clusterType: 'HANA Scale Up',
   provider: 'Azure',
   hanaSystemReplicationMode: 'sync',
   fencingType: 'external/sbd',


### PR DESCRIPTION
# Description

Makes sure that also ASCS/ERS correct cluster type is detected

![image](https://github.com/trento-project/web/assets/8167114/5eea1939-3064-4144-b71b-ba00ec2fe54c)

Also takes care of uniforming `HANA scale-up` to `HANA Scale Up`

## How was this tested?

Tests updated/added

https://2144.prenv.trento.suse.com/clusters/0eac831a-aa66-5f45-89a4-007fbd2c5714/settings