### PR TITLE
Rename node exporter service in compose file for cross docker version compatibility

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ volumes:
   pg_data:
   prometheus_data:
 services:
-  node-exporter:
+  node_exporter:
     image: prom/node-exporter:v1.7.0
     volumes:
       - /proc:/host/proc:ro

--- a/prometheus-dev-config.yml
+++ b/prometheus-dev-config.yml
@@ -9,6 +9,6 @@ scrape_configs:
 
   - job_name: 'node'
     static_configs:
-      - targets: ['web-node-exporter-1:9100']
+      - targets: ['web_node_exporter_1:9100']
         labels:
           agentID: "240f96b1-8d26-53b7-9e99-ffb0f2e735bf"


### PR DESCRIPTION
# Description

Node exporter service is renamed to node_exporter in docker compose file and the dns record is updated in prometheus configuration.

This will prevent issues between the `docker compose` utility and the `docker-compose` utility.

## How was this tested?

Manual and automatic tests
