### PR TITLE
Remove Reset Filters button in Checks selection

### DIFF
--- a/assets/js/pages/ChecksCatalog/CatalogContainer.jsx
+++ b/assets/js/pages/ChecksCatalog/CatalogContainer.jsx
@@ -9,6 +9,7 @@ import LoadingBox from '@common/LoadingBox';
 function CatalogContainer({
   onClear = () => {},
   onRefresh = () => {},
+  withResetFilters = false,
   empty = false,
   catalogError = null,
   loading = false,
@@ -48,7 +49,7 @@ function CatalogContainer({
         }
         title="No Checks Found"
         text="Checks Catalog is empty."
-        buttonText="Reset filters"
+        buttonText={withResetFilters ? 'Reset filters' : null}
         buttonOnClick={onClear}
       />
     );

--- a/assets/js/pages/ChecksCatalog/CatalogContainer.test.jsx
+++ b/assets/js/pages/ChecksCatalog/CatalogContainer.test.jsx
@@ -24,11 +24,13 @@ describe('ChecksCatalog CatalogContainer component', () => {
     expect(screen.getByText('Loading checks catalog...')).toBeVisible();
   });
 
-  it('should render an error message if the checks catalog is empty', async () => {
+  it('should render an error message if the checks catalog is empty and allow filter reset', async () => {
     const user = userEvent.setup();
     const onClear = jest.fn();
 
-    renderWithRouter(<CatalogContainer empty onClear={onClear} />);
+    renderWithRouter(
+      <CatalogContainer withResetFilters empty onClear={onClear} />
+    );
 
     expect(screen.getByText('Checks Catalog is empty.')).toBeVisible();
     expect(screen.getByRole('button')).toHaveTextContent('Reset filters');
@@ -36,5 +38,12 @@ describe('ChecksCatalog CatalogContainer component', () => {
     const button = screen.getByText('Reset filters');
     await act(async () => user.click(button));
     expect(onClear).toHaveBeenCalled();
+  });
+
+  it('should not render a reset filters button when not needed', () => {
+    renderWithRouter(<CatalogContainer empty />);
+
+    expect(screen.getByText('Checks Catalog is empty.')).toBeVisible();
+    expect(screen.queryByText('Reset filters')).toBeNull();
   });
 });

--- a/assets/js/pages/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/pages/ChecksCatalog/ChecksCatalog.jsx
@@ -143,6 +143,7 @@ function ChecksCatalog({ catalogData, catalogError, loading, updateCatalog }) {
       <CatalogContainer
         onClear={clearFilters}
         onRefresh={() => updateCatalog(selectedProvider)}
+        withResetFilters
         empty={catalogData.length === 0}
         catalogError={catalogError}
         loading={loading}

--- a/assets/js/pages/ChecksSelection/ChecksSelection.stories.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelection.stories.jsx
@@ -1,5 +1,3 @@
-import { faker } from '@faker-js/faker';
-
 import { catalogCheckFactory } from '@lib/test-utils/factories';
 
 import ChecksSelection from './ChecksSelection';
@@ -23,19 +21,10 @@ const selectedChecks = [
   catalog[6].id,
 ];
 
-const targetID = faker.string.uuid();
-
 export default {
   title: 'Patterns/ChecksSelection',
   component: ChecksSelection,
   argTypes: {
-    className: {
-      control: 'text',
-      description: 'CSS classes',
-      table: {
-        type: { summary: 'string' },
-      },
-    },
     catalog: {
       control: 'object',
       description: 'Catalog data',
@@ -43,11 +32,11 @@ export default {
         type: { summary: 'object' },
       },
     },
-    targetID: {
-      control: 'text',
-      description: 'Target ID',
+    selectedChecks: {
+      control: 'array',
+      description: 'Currently selected checks',
       table: {
-        type: { summary: 'string' },
+        type: { summary: 'array' },
       },
     },
     loading: {
@@ -58,36 +47,21 @@ export default {
         defaultValue: { summary: false },
       },
     },
-    saving: {
-      control: { type: 'boolean' },
-      description: 'Saving state',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: false },
-      },
-    },
-    error: {
+    catalogError: {
       control: { type: 'string' },
-      description: 'Saving error',
+      description: 'Error occurred while loading the catalog',
       table: {
         type: { summary: 'string' },
       },
     },
-    success: {
-      control: { type: 'boolean' },
-      description: 'Was the saving successful?',
-      table: {
-        type: { summary: 'string' },
-        defaultValue: { summary: false },
-      },
+    onUpdateCatalog: {
+      action: 'Update catalog',
+      description: 'Gets called to refresh the catalog.',
     },
-    onUpdateCatalog: { action: 'Update catalog' },
-    onStartExecution: { action: 'Start execution' },
-    onSave: { action: 'Save' },
-    onClear: {
-      action: 'Clear',
+    onChange: {
+      action: 'Change',
       description:
-        'Gets called on mount and when checks are selected. It can be used to clear any external state.',
+        'Gets called when the selection changes. Used to propagate the new selected checks by the user.',
     },
   },
 };
@@ -95,7 +69,6 @@ export default {
 export const Default = {
   args: {
     catalog,
-    targetID,
   },
 };
 
@@ -116,20 +89,13 @@ export const Loading = {
 export const WithSelection = {
   args: {
     ...Default.args,
-    selected: selectedChecks,
+    selectedChecks,
   },
 };
 
 export const WithError = {
   args: {
     ...WithSelection.args,
-    error: 'Error saving checks selection',
-  },
-};
-
-export const Saving = {
-  args: {
-    ...WithSelection.args,
-    saving: true,
+    catalogError: 'An error occurred while fetching the catalog.',
   },
 };


### PR DESCRIPTION
# Description

This PR allows to decide whether the `CatalogContainer` component should also show a `Reset Filters` button when an empty catalog is detected.

Needed to be able to have that reset filter in the catalog page, but not in the checks selection.

## How was this tested?

Test added. Outdated storybooks fixed.

https://2154.prenv.trento.suse.com/clusters/0eac831a-aa66-5f45-89a4-007fbd2c5714/settings

Stories
https://643fc66e9747e47344899b8c-dbrfuwanza.chromatic.com/?path=/story/layouts-checkscatalog--empty
https://643fc66e9747e47344899b8c-dbrfuwanza.chromatic.com/?path=/story/patterns-checksselection--empty
