### PR TITLE
Hotfix MockPrometheusApi as host data fetcher in demo env

### DIFF
--- a/config/demo.exs
+++ b/config/demo.exs
@@ -29,4 +29,5 @@ config :trento, Trento.Scheduler,
 config :trento, Trento.Infrastructure.Prometheus,
   adapter: Trento.Infrastructure.Prometheus.MockPrometheusApi
 
-config :trento, Trento.Charts, host_data_fetcher: Trento.Infrastructure.Prometheus.PrometheusApi
+config :trento, Trento.Charts,
+  host_data_fetcher: Trento.Infrastructure.Prometheus.MockPrometheusApi


### PR DESCRIPTION
# Description

This is a subsequent hotfix for the pr #2155, which enable the mock prometheus api in demo env.

## How was this tested?

Manual and automatic testing
