### PR TITLE
Fix sequence usage in sles subscription factory

### DIFF
--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -207,10 +207,11 @@ defmodule Trento.Factory do
 
   def sles_subscription_factory do
     host = build(:host)
+    identifier = sequence(:identifier, &"#{Faker.StarWars.planet()}#{&1}")
 
     %SlesSubscriptionReadModel{
       host_id: host.id,
-      identifier: Faker.StarWars.planet(),
+      identifier: identifier,
       version: Faker.App.semver(),
       expires_at: DateTime.to_iso8601(Faker.DateTime.forward(2)),
       starts_at: DateTime.to_iso8601(Faker.DateTime.backward(2)),


### PR DESCRIPTION
# Description
Sometimes we build lists of SLES subscriptions using the factory we have, that doesn't use sequences to assign different numbers to the identifier field which is actually a part of a primary key.

Given this, the problem we're incurring into is that our unit tests pipeline runs into collisions. This change should fix that.

## How was this tested?
Existing tests passing
