### PR TITLE
Differentiate env build between HANA and ASCS/ERS cluster details

### DIFF
--- a/assets/js/lib/checks/env.js
+++ b/assets/js/lib/checks/env.js
@@ -1,0 +1,28 @@
+import { ASCS_ERS } from '@lib/model/clusters';
+
+export const buildEnv = ({
+  provider,
+  target_type,
+  cluster_type,
+  ensa_version,
+  filesystem_type,
+}) => {
+  switch (cluster_type) {
+    case ASCS_ERS: {
+      return {
+        provider,
+        target_type,
+        cluster_type,
+        ensa_version,
+        filesystem_type,
+      };
+    }
+    default: {
+      return {
+        provider,
+        target_type,
+        cluster_type,
+      };
+    }
+  }
+};

--- a/assets/js/lib/checks/env.test.js
+++ b/assets/js/lib/checks/env.test.js
@@ -1,0 +1,37 @@
+import { faker } from '@faker-js/faker';
+import { has } from 'lodash';
+
+import { ASCS_ERS, HANA_SCALE_UP } from '@lib/model/clusters';
+
+import { buildEnv } from '.';
+
+describe('buildEnv', () => {
+  it('should build and env with filesystem type and ensa version for ASCS/ERS clusters', () => {
+    const payload = {
+      cluster_type: ASCS_ERS,
+      provider: faker.color.rgb(),
+      target_type: faker.hacker.noun(),
+      ensa_version: faker.number.int(),
+      filesystem_type: faker.animal.dog(),
+    };
+
+    const env = buildEnv(payload);
+
+    expect(env).toEqual(payload);
+  });
+
+  it('should build and env without filesystem type and ensa version for other clusters', () => {
+    const payload = {
+      cluster_type: HANA_SCALE_UP,
+      provider: faker.color.rgb(),
+      target_type: faker.hacker.noun(),
+      ensa_version: faker.number.int(),
+      filesystem_type: faker.animal.dog(),
+    };
+
+    const env = buildEnv(payload);
+
+    expect(has(env, 'ensa_version')).toBe(false);
+    expect(has(env, 'filesystem_type')).toBe(false);
+  });
+});

--- a/assets/js/lib/checks/index.js
+++ b/assets/js/lib/checks/index.js
@@ -1,0 +1,3 @@
+import { buildEnv } from './env';
+
+export { buildEnv };

--- a/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
@@ -14,7 +14,9 @@ import { getCatalog } from '@state/selectors/catalog';
 import { getLastExecution } from '@state/selectors/lastExecutions';
 import { updateCatalog } from '@state/catalog';
 import { executionRequested, updateLastExecution } from '@state/lastExecutions';
+import { buildEnv } from '@lib/checks';
 import { TARGET_CLUSTER } from '@lib/model';
+
 import AscsErsClusterDetails from './AscsErsClusterDetails';
 import HanaClusterDetails from './HanaClusterDetails';
 import { getClusterName } from './ClusterLink';
@@ -40,16 +42,16 @@ export function ClusterDetailsPage() {
   );
 
   useEffect(() => {
+    const env = buildEnv({
+      provider,
+      target_type: TARGET_CLUSTER,
+      cluster_type: type,
+      ensa_version: ensaVersion,
+      filesystem_type: filesystemType,
+    });
+
     if (provider && type) {
-      dispatch(
-        updateCatalog({
-          provider,
-          target_type: TARGET_CLUSTER,
-          cluster_type: type,
-          ensa_version: ensaVersion,
-          filesystem_type: filesystemType,
-        })
-      );
+      dispatch(updateCatalog(env));
       dispatch(updateLastExecution(clusterID));
     }
   }, [dispatch, provider, type, ensaVersion, filesystemType]);

--- a/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
+++ b/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
@@ -10,12 +10,14 @@ import {
   getClusterSelectedChecks,
   getClusterHosts,
   getFilesystemType,
+  getEnsaVersion,
 } from '@state/selectors/cluster';
 import { updateCatalog } from '@state/catalog';
 import { getCatalog } from '@state/selectors/catalog';
 import { isSaving } from '@state/selectors/checksSelection';
 import { executionRequested } from '@state/lastExecutions';
 
+import { buildEnv } from '@lib/checks';
 import { UNKNOWN_PROVIDER, VMWARE_PROVIDER, TARGET_CLUSTER } from '@lib/model';
 
 import BackButton from '@common/BackButton';
@@ -58,6 +60,7 @@ function ClusterSettingsPage() {
     getClusterSelectedChecks(state, clusterID)
   );
   const clusterName = useSelector(getClusterName(clusterID));
+  const ensaVersion = useSelector((state) => getEnsaVersion(state, clusterID));
   const filesystemType = useSelector((state) =>
     getFilesystemType(state, clusterID)
   );
@@ -81,15 +84,17 @@ function ClusterSettingsPage() {
   const provider = get(cluster, 'provider');
   const type = get(cluster, 'type');
 
-  const refreshCatalog = () =>
-    dispatch(
-      updateCatalog({
-        provider,
-        target_type: TARGET_CLUSTER,
-        cluster_type: type,
-        filesystem_type: filesystemType,
-      })
-    );
+  const refreshCatalog = () => {
+    const env = buildEnv({
+      provider,
+      target_type: TARGET_CLUSTER,
+      cluster_type: type,
+      ensa_version: ensaVersion,
+      filesystem_type: filesystemType,
+    });
+
+    dispatch(updateCatalog(env));
+  };
 
   const saveSelection = (newSelection, targetID, targetName) =>
     dispatch(


### PR DESCRIPTION
# Description
In a previous PR it was outlined that we are not differentiating the building of the env sent to Wanda based on the cluster type.

This PR implements such a thing.

## How was this tested?
Existing jest tests passing
