### PR TITLE
Docker compose utility adapt

### DIFF
--- a/prometheus-dev-config.yml
+++ b/prometheus-dev-config.yml
@@ -9,6 +9,6 @@ scrape_configs:
 
   - job_name: 'node'
     static_configs:
-      - targets: ['web_node_exporter_1:9100']
+      - targets: ['web-node_exporter-1:9100']
         labels:
           agentID: "240f96b1-8d26-53b7-9e99-ffb0f2e735bf"


### PR DESCRIPTION
# Description

Adapt the new `docker compose` utility dns naming, we use it only in the prometheus config.

From this PR, the `docker-compose` version 1 utility is **NOT SUPPORTED**.

## How was this tested?

Automated tests
