### PR TITLE
Saptune summary warning icon

### DIFF
--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -69,7 +69,7 @@ function HostDetails({
 
   const versionWarningMessage = agentVersionWarning(agentVersion);
 
-  const isSapPresent = sapInstances?.length > 0;
+  const sapPresent = sapInstances?.length > 0;
 
   const saptuneVersion = get(saptuneStatus, 'package_version');
   const saptuneConfiguredVersion = get(saptuneStatus, 'configured_version');
@@ -195,7 +195,7 @@ function HostDetails({
           />
           <div className="flex flex-col mt-4 bg-white shadow rounded-lg pt-8 px-8 xl:w-2/5 mr-4">
             <SaptuneSummary
-              isSapPresent={isSapPresent}
+              sapPresent={sapPresent}
               saptuneVersion={saptuneVersion}
               saptuneConfiguredVersion={saptuneConfiguredVersion}
               saptuneTuning={saptuneTuning}

--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -69,6 +69,8 @@ function HostDetails({
 
   const versionWarningMessage = agentVersionWarning(agentVersion);
 
+  const isSapPresent = sapInstances.length > 0;
+
   const saptuneVersion = get(saptuneStatus, 'package_version');
   const saptuneConfiguredVersion = get(saptuneStatus, 'configured_version');
   const saptuneTuning = get(saptuneStatus, 'tuning_state');
@@ -193,6 +195,7 @@ function HostDetails({
           />
           <div className="flex flex-col mt-4 bg-white shadow rounded-lg pt-8 px-8 xl:w-2/5 mr-4">
             <SaptuneSummary
+              isSapPresent={isSapPresent}
               saptuneVersion={saptuneVersion}
               saptuneConfiguredVersion={saptuneConfiguredVersion}
               saptuneTuning={saptuneTuning}

--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -69,7 +69,7 @@ function HostDetails({
 
   const versionWarningMessage = agentVersionWarning(agentVersion);
 
-  const isSapPresent = sapInstances.length > 0;
+  const isSapPresent = sapInstances?.length > 0;
 
   const saptuneVersion = get(saptuneStatus, 'package_version');
   const saptuneConfiguredVersion = get(saptuneStatus, 'configured_version');

--- a/assets/js/pages/HostDetailsPage/SaptuneSummary.jsx
+++ b/assets/js/pages/HostDetailsPage/SaptuneSummary.jsx
@@ -7,7 +7,7 @@ import ListView from '@common/ListView';
 import { SaptuneVersion, SaptuneTuningState } from '@pages/SaptuneDetails';
 
 function SaptuneSummary({
-  isSapPresent,
+  sapPresent,
   onViewDetails,
   saptuneVersion,
   saptuneConfiguredVersion,
@@ -35,7 +35,7 @@ function SaptuneSummary({
             title: 'Package',
             content: (
               <SaptuneVersion
-                isSapPresent={isSapPresent}
+                sapPresent={sapPresent}
                 version={saptuneVersion}
               />
             ),

--- a/assets/js/pages/HostDetailsPage/SaptuneSummary.jsx
+++ b/assets/js/pages/HostDetailsPage/SaptuneSummary.jsx
@@ -7,6 +7,7 @@ import ListView from '@common/ListView';
 import { SaptuneVersion, SaptuneTuningState } from '@pages/SaptuneDetails';
 
 function SaptuneSummary({
+  isSapPresent,
   saptuneVersion,
   saptuneConfiguredVersion,
   saptuneTuning,
@@ -32,7 +33,12 @@ function SaptuneSummary({
         data={[
           {
             title: 'Package',
-            content: <SaptuneVersion version={saptuneVersion} />,
+            content: (
+              <SaptuneVersion
+                isSapPresent={isSapPresent}
+                version={saptuneVersion}
+              />
+            ),
           },
           {
             title: 'Tuning',

--- a/assets/js/pages/HostDetailsPage/SaptuneSummary.jsx
+++ b/assets/js/pages/HostDetailsPage/SaptuneSummary.jsx
@@ -8,10 +8,10 @@ import { SaptuneVersion, SaptuneTuningState } from '@pages/SaptuneDetails';
 
 function SaptuneSummary({
   isSapPresent,
+  onViewDetails,
   saptuneVersion,
   saptuneConfiguredVersion,
   saptuneTuning,
-  onViewDetails,
 }) {
   return (
     <>

--- a/assets/js/pages/SaptuneDetails/SaptuneVersion.jsx
+++ b/assets/js/pages/SaptuneDetails/SaptuneVersion.jsx
@@ -7,11 +7,13 @@ import HealthIcon from '@common/HealthIcon';
 
 function SaptuneVersion({ isSapPresent = true, version }) {
   if (!version) {
-    return (
+    return isSapPresent ? (
       <div className="flex">
-        {isSapPresent ? <HealthIcon health="warning" /> : null}
+        <HealthIcon health="warning" />
         <span className="ml-1">Not installed</span>
       </div>
+    ) : (
+      <span>Not installed</span>
     );
   }
 

--- a/assets/js/pages/SaptuneDetails/SaptuneVersion.jsx
+++ b/assets/js/pages/SaptuneDetails/SaptuneVersion.jsx
@@ -5,9 +5,9 @@ import { isVersionSupported, SUPPORTED_VERSION } from '@lib/saptune';
 import Tooltip from '@common/Tooltip';
 import HealthIcon from '@common/HealthIcon';
 
-function SaptuneVersion({ isSapPresent = true, version }) {
+function SaptuneVersion({ sapPresent = true, version }) {
   if (!version) {
-    return isSapPresent ? (
+    return sapPresent ? (
       <div className="flex">
         <HealthIcon health="warning" />
         <span className="ml-1">Not installed</span>

--- a/assets/js/pages/SaptuneDetails/SaptuneVersion.jsx
+++ b/assets/js/pages/SaptuneDetails/SaptuneVersion.jsx
@@ -7,7 +7,12 @@ import HealthIcon from '@common/HealthIcon';
 
 function SaptuneVersion({ version }) {
   if (!version) {
-    return <span>Not installed</span>;
+    return (
+      <div className="flex">
+        <HealthIcon health="warning" />
+        <span className="ml-1">Not installed</span>
+      </div>
+    );
   }
 
   if (isVersionSupported(version)) {

--- a/assets/js/pages/SaptuneDetails/SaptuneVersion.jsx
+++ b/assets/js/pages/SaptuneDetails/SaptuneVersion.jsx
@@ -5,7 +5,7 @@ import { isVersionSupported, SUPPORTED_VERSION } from '@lib/saptune';
 import Tooltip from '@common/Tooltip';
 import HealthIcon from '@common/HealthIcon';
 
-function SaptuneVersion({ version, isSapPresent = true }) {
+function SaptuneVersion({ isSapPresent = true, version }) {
   if (!version) {
     return (
       <div className="flex">

--- a/assets/js/pages/SaptuneDetails/SaptuneVersion.jsx
+++ b/assets/js/pages/SaptuneDetails/SaptuneVersion.jsx
@@ -5,11 +5,11 @@ import { isVersionSupported, SUPPORTED_VERSION } from '@lib/saptune';
 import Tooltip from '@common/Tooltip';
 import HealthIcon from '@common/HealthIcon';
 
-function SaptuneVersion({ version }) {
+function SaptuneVersion({ version, isSapPresent = true }) {
   if (!version) {
     return (
       <div className="flex">
-        <HealthIcon health="warning" />
+        {isSapPresent ? <HealthIcon health="warning" /> : null}
         <span className="ml-1">Not installed</span>
       </div>
     );

--- a/assets/js/pages/SaptuneDetails/SaptuneVersion.test.jsx
+++ b/assets/js/pages/SaptuneDetails/SaptuneVersion.test.jsx
@@ -6,7 +6,7 @@ import SaptuneVersion from './SaptuneVersion';
 
 describe('SaptuneVersion', () => {
   it.each([
-    { version: null, text: 'Not installed', iconCss: null },
+    { version: null, text: 'Not installed', iconCss: 'fill-yellow-500' },
     { version: '3.0.0', text: '3.0.0', iconCss: 'fill-yellow-500' },
     { version: '3.1.0', text: '3.1.0', iconCss: null },
   ])(

--- a/assets/js/pages/SaptuneDetails/SaptuneVersion.test.jsx
+++ b/assets/js/pages/SaptuneDetails/SaptuneVersion.test.jsx
@@ -6,13 +6,29 @@ import SaptuneVersion from './SaptuneVersion';
 
 describe('SaptuneVersion', () => {
   it.each([
-    { version: null, text: 'Not installed', iconCss: 'fill-yellow-500' },
-    { version: '3.0.0', text: '3.0.0', iconCss: 'fill-yellow-500' },
-    { version: '3.1.0', text: '3.1.0', iconCss: null },
+    {
+      version: null,
+      text: 'Not installed',
+      iconCss: 'fill-yellow-500',
+      isSapPresent: true,
+    },
+    {
+      version: null,
+      text: 'Not installed',
+      iconCss: null,
+      isSapPresent: false,
+    },
+    {
+      version: '3.0.0',
+      text: '3.0.0',
+      iconCss: 'fill-yellow-500',
+      isSapPresent: true,
+    },
+    { version: '3.1.0', text: '3.1.0', iconCss: null, isSapPresent: true },
   ])(
     'should render correctly the $version version',
-    ({ version, text, iconClass }) => {
-      render(<SaptuneVersion version={version} />);
+    ({ version, text, iconClass, isSapPresent }) => {
+      render(<SaptuneVersion isSapPresent={isSapPresent} version={version} />);
 
       expect(screen.getByText(text)).toBeTruthy();
 

--- a/assets/js/pages/SaptuneDetails/SaptuneVersion.test.jsx
+++ b/assets/js/pages/SaptuneDetails/SaptuneVersion.test.jsx
@@ -10,25 +10,25 @@ describe('SaptuneVersion', () => {
       version: null,
       text: 'Not installed',
       iconCss: 'fill-yellow-500',
-      isSapPresent: true,
+      sapPresent: true,
     },
     {
       version: null,
       text: 'Not installed',
       iconCss: null,
-      isSapPresent: false,
+      sapPresent: false,
     },
     {
       version: '3.0.0',
       text: '3.0.0',
       iconCss: 'fill-yellow-500',
-      isSapPresent: true,
+      sapPresent: true,
     },
-    { version: '3.1.0', text: '3.1.0', iconCss: null, isSapPresent: true },
+    { version: '3.1.0', text: '3.1.0', iconCss: null, sapPresent: true },
   ])(
     'should render correctly the $version version',
-    ({ version, text, iconClass, isSapPresent }) => {
-      render(<SaptuneVersion isSapPresent={isSapPresent} version={version} />);
+    ({ version, text, iconClass, sapPresent }) => {
+      render(<SaptuneVersion sapPresent={sapPresent} version={version} />);
 
       expect(screen.getByText(text)).toBeTruthy();
 


### PR DESCRIPTION
# Description
Add a warning state icon to the saptune overview when no saptune version is provided and sap workload is happening on the host

Left on host with sap workload and right without.
Preview: 
![image](https://github.com/trento-project/web/assets/54111255/f4921b55-cf68-48e4-8eda-6460b151e2dc)


## How was this tested?
Updated existing good test to check if the icon was rendered.
