### PR TITLE
Elixir upgrade dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,13 @@
-FROM opensuse/leap AS elixir-build
+FROM opensuse/tumbleweed AS elixir-build
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
-RUN zypper -n addrepo https://download.opensuse.org/repositories/devel:/languages:/erlang/SLE_15_SP3/devel:languages:erlang.repo
-RUN zypper -n --gpg-auto-import-keys ref -s
-RUN zypper -n in elixir
+RUN zypper -n in git-core elixir elixir-hex erlang-rebar3
 COPY . /build
 WORKDIR /build
 ARG MIX_ENV=prod
 ENV MIX_ENV=$MIX_ENV
-RUN mix local.rebar --force \
-    && mix local.hex --force \
-    && mix deps.get
+RUN mix deps.get
 
 FROM registry.suse.com/bci/nodejs:16 AS assets-build
 COPY --from=elixir-build /build /build
@@ -23,12 +19,15 @@ RUN npm run build
 FROM elixir-build AS release
 COPY --from=assets-build /build /build
 WORKDIR /build
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 ARG MIX_ENV=prod
 ENV MIX_ENV=$MIX_ENV
 RUN mix phx.digest
 RUN mix release
 
-FROM registry.suse.com/bci/bci-base:15.4 AS trento
+FROM opensuse/tumbleweed AS trento
 LABEL org.opencontainers.image.source="https://github.com/trento-project/web"
 ARG MIX_ENV=prod
 ENV LANG en_US.UTF-8

--- a/packaging/suse/Dockerfile
+++ b/packaging/suse/Dockerfile
@@ -14,7 +14,7 @@ RUN npm run build
 FROM bci/bci-base:15.4 AS release
 # Workaround for https://github.com/openSUSE/obs-build/issues/487
 RUN zypper --non-interactive in sles-release
-RUN zypper -n in elixir elixir-hex erlang-rebar3
+RUN zypper -n in git-core elixir elixir-hex erlang-rebar3
 COPY --from=assets-build /build /build
 WORKDIR /build/web/
 ENV LANG en_US.UTF-8
@@ -22,6 +22,8 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 ENV MIX_ENV=prod
 ENV MIX_HOME=/usr/bin
+ENV MIX_REBAR3=/usr/bin/rebar3
+ENV MIX_PATH=/usr/lib/elixir/lib/hex/ebin
 ENV FLAVOR="Premium"
 ENV VERSION=%%VERSION%%
 RUN mix phx.digest


### PR DESCRIPTION
# Description

Update dockerfiles to work with elixir 1.15.7.
- The community goes with tumbleweed, as it is the unique version which includes the needed elixir/erlang versions
- The sles one needs those additional mix values to identify the needed utilities properly

## How was this tested?

Manually
