### PR TITLE
Fix broken HostDetails story

### DIFF
--- a/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
@@ -13,6 +13,9 @@ import HostDetails from './HostDetails';
 const host = hostFactory.build({ provider: 'azure', agent_version: '2.0.0' });
 const cluster = clusterFactory.build({ id: host.cluster_id });
 const sapInstances = sapSystemApplicationInstanceFactory.buildList(2);
+const mockGlobalConfig = {
+  chartsEnabled: false,
+};
 
 function ContainerWrapper({ children }) {
   return (
@@ -138,11 +141,14 @@ export default {
     },
   },
   decorators: [
-    (Story) => (
-      <MemoryRouter>
-        <Story />
-      </MemoryRouter>
-    ),
+    (Story) => {
+      global.config = mockGlobalConfig;
+      return (
+        <MemoryRouter>
+          <Story />
+        </MemoryRouter>
+      );
+    },
   ],
   render: (args) => (
     <ContainerWrapper>


### PR DESCRIPTION
# Description

This pr will add a little fix for the HostDetails story. The introduction of the new charts for the HostDetails view made a global config required in order to render the story correct.
By providing a mocked config in the decorator, the charts are disabled.

Preview: 
![image](https://github.com/trento-project/web/assets/54111255/6e16c97e-5761-4026-8d65-258437f8403e)


## How was this tested?
No test needed, check storybook HostDetails.stories.jsx
