### PR TITLE
Add exporter_name to prometheus dev config file

### DIFF
--- a/prometheus-dev-config.yml
+++ b/prometheus-dev-config.yml
@@ -12,3 +12,4 @@ scrape_configs:
       - targets: ['web-node_exporter-1:9100']
         labels:
           agentID: "240f96b1-8d26-53b7-9e99-ffb0f2e735bf"
+          exporter_name: "Node Exporter"


### PR DESCRIPTION
# Description

Add missing `exporter_name` label to the dev prometheus configuraiton file
