### PR TITLE
Fix required fields usage

### DIFF
--- a/lib/trento/discovery/payloads/cluster/cib_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/cluster/cib_discovery_payload.ex
@@ -56,13 +56,13 @@ defmodule Trento.Discovery.Payloads.Cluster.CibDiscoveryPayload do
     defp operations_changeset(operations, attrs) do
       operations
       |> cast(attrs, [:id, :name, :role, :timeout, :interval])
-      |> validate_required([:id, :name, :role])
+      |> validate_required([:id, :name])
     end
 
     defp instance_attributes_changeset(instance_attributes, attrs) do
       instance_attributes
       |> cast(attrs, [:id, :name, :value])
-      |> validate_required([:id, :name, :value])
+      |> validate_required([:id, :name])
     end
   end
 
@@ -168,6 +168,6 @@ defmodule Trento.Discovery.Payloads.Cluster.CibDiscoveryPayload do
   def cluster_properties_changeset(cluster_properties, attrs) do
     cluster_properties
     |> cast(attrs, [:id, :name, :value])
-    |> validate_required([:id, :name, :value])
+    |> validate_required([:id, :name])
   end
 end

--- a/lib/trento/discovery/payloads/cluster/cib_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/cluster/cib_discovery_payload.ex
@@ -9,7 +9,7 @@ defmodule Trento.Discovery.Payloads.Cluster.CibDiscoveryPayload do
     Primitive field payload
     """
 
-    @required_fields [:id, :type, :class, :operations, :instance_attributes]
+    @required_fields [:id, :type, :class]
     use Trento.Support.Type
 
     deftype do
@@ -56,13 +56,13 @@ defmodule Trento.Discovery.Payloads.Cluster.CibDiscoveryPayload do
     defp operations_changeset(operations, attrs) do
       operations
       |> cast(attrs, [:id, :name, :role, :timeout, :interval])
-      |> validate_required_fields([:id, :name, :role])
+      |> validate_required([:id, :name, :role])
     end
 
     defp instance_attributes_changeset(instance_attributes, attrs) do
       instance_attributes
       |> cast(attrs, [:id, :name, :value])
-      |> validate_required_fields([:id, :name, :value])
+      |> validate_required([:id, :name, :value])
     end
   end
 
@@ -71,7 +71,7 @@ defmodule Trento.Discovery.Payloads.Cluster.CibDiscoveryPayload do
     Resources field payload
     """
 
-    @required_fields [:primitives, :clones, :groups]
+    @required_fields []
     use Trento.Support.Type
 
     deftype do
@@ -105,14 +105,14 @@ defmodule Trento.Discovery.Payloads.Cluster.CibDiscoveryPayload do
       clones
       |> cast(attrs, [:id])
       |> cast_embed(:primitive)
-      |> validate_required_fields([:id])
+      |> validate_required([:id])
     end
 
     defp groups_changeset(groups, attrs) do
       groups
       |> cast(attrs, [:id])
       |> cast_embed(:primitives)
-      |> validate_required_fields([:id])
+      |> validate_required([:id])
     end
 
     defp transform_nil_lists(
@@ -127,7 +127,7 @@ defmodule Trento.Discovery.Payloads.Cluster.CibDiscoveryPayload do
     defp transform_nil_lists(attrs), do: attrs
   end
 
-  @required_fields [:configuration]
+  @required_fields []
 
   use Trento.Support.Type
 
@@ -148,28 +148,26 @@ defmodule Trento.Discovery.Payloads.Cluster.CibDiscoveryPayload do
   def changeset(cib, attrs) do
     cib
     |> cast(attrs, [])
-    |> cast_embed(:configuration, with: &configuration_changeset/2)
+    |> cast_embed(:configuration, with: &configuration_changeset/2, required: true)
     |> validate_required_fields(@required_fields)
   end
 
   def configuration_changeset(configuration, attrs) do
     configuration
     |> cast(attrs, [])
-    |> cast_embed(:resources)
-    |> cast_embed(:crm_config, with: &crm_config_changeset/2)
-    |> validate_required_fields([:resources])
+    |> cast_embed(:resources, required: true)
+    |> cast_embed(:crm_config, with: &crm_config_changeset/2, required: true)
   end
 
   def crm_config_changeset(crm_config, attrs) do
     crm_config
     |> cast(attrs, [])
-    |> cast_embed(:cluster_properties, with: &cluster_properties_changeset/2)
-    |> validate_required_fields([:cluster_properties])
+    |> cast_embed(:cluster_properties, with: &cluster_properties_changeset/2, required: true)
   end
 
   def cluster_properties_changeset(cluster_properties, attrs) do
     cluster_properties
     |> cast(attrs, [:id, :name, :value])
-    |> validate_required_fields([:id, :name, :value])
+    |> validate_required([:id, :name, :value])
   end
 end

--- a/lib/trento/discovery/payloads/cluster/cluster_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/cluster/cluster_discovery_payload.ex
@@ -3,7 +3,7 @@ defmodule Trento.Discovery.Payloads.Cluster.ClusterDiscoveryPayload do
   Cluster discovery integration event payload
   """
 
-  @required_fields [:dc, :provider, :id, :cluster_type, :cib, :sbd, :crmmon]
+  @required_fields [:dc, :provider, :id, :cluster_type]
   @required_fields_hana [:sid]
   @required_fields_ascs_ers [:additional_sids]
 
@@ -44,9 +44,9 @@ defmodule Trento.Discovery.Payloads.Cluster.ClusterDiscoveryPayload do
 
     cluster
     |> cast(enriched_attributes, fields())
-    |> cast_embed(:cib)
+    |> cast_embed(:cib, required: true)
     |> cast_embed(:sbd)
-    |> cast_embed(:crmmon)
+    |> cast_embed(:crmmon, required: true)
     |> validate_required_fields(@required_fields)
     |> maybe_validate_required_fields(enriched_attributes)
   end

--- a/lib/trento/discovery/payloads/cluster/crmmon_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/cluster/crmmon_discovery_payload.ex
@@ -41,7 +41,7 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
     def resource_history_changeset(resource_history, attrs) do
       resource_history
       |> cast(attrs, [:name, :fail_count, :migration_threshold])
-      |> validate_required([:name, :fail_count, :migration_threshold])
+      |> validate_required([:name, :fail_count])
     end
   end
 
@@ -57,7 +57,6 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
       :active,
       :failed,
       :blocked,
-      :managed,
       :orphaned,
       :failure_ignored,
       :nodes_running_on
@@ -93,7 +92,7 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
     defp resource_node_changeset(resource_node, attrs) do
       resource_node
       |> cast(attrs, [:id, :name, :cached])
-      |> validate_required([:id, :name, :cached])
+      |> validate_required([:id, :name])
     end
   end
 
@@ -139,7 +138,7 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
     def resources_changeset(resources, attrs) do
       resources
       |> cast(attrs, [:number, :blocked, :disabled])
-      |> validate_required([:number, :blocked, :disabled])
+      |> validate_required([:number])
     end
 
     def last_change_changeset(last_change, attrs) do
@@ -149,12 +148,8 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
     end
   end
 
-  @required_fields [
-    :version,
-    :summary,
-    :node_history,
-    :node_attributes
-  ]
+  @required_fields [:version]
+
   use Trento.Support.Type
 
   deftype do
@@ -208,7 +203,7 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
 
     crmmon
     |> cast(transformed_attrs, [:version])
-    |> cast_embed(:summary)
+    |> cast_embed(:summary, required: true)
     |> cast_embed(:nodes, with: &nodes_changeset/2, required: true)
     |> cast_embed(:resources)
     |> cast_embed(:groups, with: &groups_changeset/2)
@@ -240,8 +235,6 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
       :id,
       :failed,
       :unique,
-      :managed,
-      :multi_state,
       :failure_ignored
     ])
   end

--- a/lib/trento/discovery/payloads/cluster/crmmon_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/cluster/crmmon_discovery_payload.ex
@@ -86,14 +86,14 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
     def changeset(crmmon_resource, attrs) do
       crmmon_resource
       |> cast(attrs, fields())
-      |> cast_embed(:node, with: &resource_node_changeset/2, required: true)
+      |> cast_embed(:node, with: &resource_node_changeset/2)
       |> validate_required_fields(@required_fields)
     end
 
     defp resource_node_changeset(resource_node, attrs) do
       resource_node
       |> cast(attrs, [:id, :name, :cached])
-      |> validate_required([])
+      |> validate_required([:id, :name, :cached])
     end
   end
 

--- a/lib/trento/discovery/payloads/cluster/crmmon_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/cluster/crmmon_discovery_payload.ex
@@ -9,7 +9,7 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
     NodeHistory field payload
     """
 
-    @required_fields [:nodes]
+    @required_fields []
     use Trento.Support.Type
 
     deftype do
@@ -27,7 +27,7 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
     def changeset(node_history, attrs) do
       node_history
       |> cast(attrs, [])
-      |> cast_embed(:nodes, with: &nodes_changeset/2)
+      |> cast_embed(:nodes, with: &nodes_changeset/2, required: true)
       |> validate_required_fields(@required_fields)
     end
 
@@ -35,13 +35,13 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
       nodes
       |> cast(attrs, [:name])
       |> cast_embed(:resource_history, with: &resource_history_changeset/2)
-      |> validate_required_fields([:name, :resource_history])
+      |> validate_required_fields([:name])
     end
 
     def resource_history_changeset(resource_history, attrs) do
       resource_history
       |> cast(attrs, [:name, :fail_count, :migration_threshold])
-      |> validate_required_fields([:name, :fail_count, :migration_threshold])
+      |> validate_required([:name, :fail_count, :migration_threshold])
     end
   end
 
@@ -60,8 +60,7 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
       :managed,
       :orphaned,
       :failure_ignored,
-      :nodes_running_on,
-      :node
+      :nodes_running_on
     ]
     use Trento.Support.Type
 
@@ -87,14 +86,14 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
     def changeset(crmmon_resource, attrs) do
       crmmon_resource
       |> cast(attrs, fields())
-      |> cast_embed(:node, with: &resource_node_changeset/2)
+      |> cast_embed(:node, with: &resource_node_changeset/2, required: true)
       |> validate_required_fields(@required_fields)
     end
 
     defp resource_node_changeset(resource_node, attrs) do
       resource_node
       |> cast(attrs, [:id, :name, :cached])
-      |> validate_required_fields([])
+      |> validate_required([])
     end
   end
 
@@ -103,7 +102,7 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
     Summary field payload
     """
 
-    @required_fields [:nodes, :resources, :last_change]
+    @required_fields []
     use Trento.Support.Type
 
     deftype do
@@ -125,36 +124,34 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
     def changeset(summary, attrs) do
       summary
       |> cast(attrs, [])
-      |> cast_embed(:nodes, with: &nodes_changeset/2)
-      |> cast_embed(:resources, with: &resources_changeset/2)
-      |> cast_embed(:last_change, with: &last_change_changeset/2)
+      |> cast_embed(:nodes, with: &nodes_changeset/2, required: true)
+      |> cast_embed(:resources, with: &resources_changeset/2, required: true)
+      |> cast_embed(:last_change, with: &last_change_changeset/2, required: true)
       |> validate_required_fields(@required_fields)
     end
 
     def nodes_changeset(nodes, attrs) do
       nodes
       |> cast(attrs, [:number])
-      |> validate_required_fields([:number])
+      |> validate_required([:number])
     end
 
     def resources_changeset(resources, attrs) do
       resources
       |> cast(attrs, [:number, :blocked, :disabled])
-      |> validate_required_fields([:number, :blocked, :disabled])
+      |> validate_required([:number, :blocked, :disabled])
     end
 
     def last_change_changeset(last_change, attrs) do
       last_change
       |> cast(attrs, [:time])
-      |> validate_required_fields([:time])
+      |> validate_required([:time])
     end
   end
 
   @required_fields [
     :version,
     :summary,
-    :resources,
-    :clones,
     :node_history,
     :node_attributes
   ]
@@ -212,12 +209,12 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
     crmmon
     |> cast(transformed_attrs, [:version])
     |> cast_embed(:summary)
-    |> cast_embed(:nodes, with: &nodes_changeset/2)
+    |> cast_embed(:nodes, with: &nodes_changeset/2, required: true)
     |> cast_embed(:resources)
     |> cast_embed(:groups, with: &groups_changeset/2)
     |> cast_embed(:clones, with: &clones_changeset/2)
-    |> cast_embed(:node_history)
-    |> cast_embed(:node_attributes, with: &node_attributes_changeset/2)
+    |> cast_embed(:node_history, required: true)
+    |> cast_embed(:node_attributes, with: &node_attributes_changeset/2, required: true)
     |> validate_required_fields(@required_fields)
   end
 
@@ -232,21 +229,20 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
     |> cast(attrs, [:id])
     |> cast_embed(:resources)
     |> cast_embed(:primitives)
-    |> validate_required_fields([:id, :resources, :primitives])
+    |> validate_required([:id])
   end
 
   defp clones_changeset(clones, attrs) do
     clones
     |> cast(attrs, [:id, :failed, :unique, :managed, :multi_state, :failure_ignored])
     |> cast_embed(:resources)
-    |> validate_required_fields([
+    |> validate_required([
       :id,
       :failed,
       :unique,
       :managed,
       :multi_state,
-      :failure_ignored,
-      :resources
+      :failure_ignored
     ])
   end
 
@@ -261,13 +257,13 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
     nodes
     |> cast(attrs, [:name])
     |> cast_embed(:attributes, with: &attributes_changeset/2)
-    |> validate_required_fields([:name, :attributes])
+    |> validate_required([:name])
   end
 
   defp attributes_changeset(attributes, attrs) do
     attributes
     |> cast(attrs, [:name, :value])
-    |> validate_required_fields([:name, :value])
+    |> validate_required([:name, :value])
   end
 
   defp transform_nil_lists(

--- a/lib/trento/discovery/payloads/cluster/crmmon_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/cluster/crmmon_discovery_payload.ex
@@ -35,7 +35,7 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
       nodes
       |> cast(attrs, [:name])
       |> cast_embed(:resource_history, with: &resource_history_changeset/2)
-      |> validate_required_fields([:name])
+      |> validate_required([:name])
     end
 
     def resource_history_changeset(resource_history, attrs) do
@@ -250,7 +250,6 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
     node_attributes
     |> cast(attrs, [])
     |> cast_embed(:nodes, with: &node_attributes_nodes_changeset/2)
-    |> validate_required_fields([:nodes])
   end
 
   defp node_attributes_nodes_changeset(nodes, attrs) do

--- a/lib/trento/discovery/payloads/cluster/sbd_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/cluster/sbd_discovery_payload.ex
@@ -28,7 +28,7 @@ defmodule Trento.Discovery.Payloads.Cluster.SbdDiscoveryPayload do
   defp devices_changeset(devices, attrs) do
     devices
     |> cast(attrs, [:device, :status])
-    |> validate_required_fields([:device, :status])
+    |> validate_required([:device, :status])
   end
 
   defp transform_nil_lists(%{"devices" => devices} = attrs) do

--- a/lib/trento/discovery/payloads/sap_system_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/sap_system_discovery_payload.ex
@@ -36,10 +36,11 @@ defmodule Trento.Discovery.Payloads.SapSystemDiscoveryPayload do
     sap_system
     |> cast(modified_attrs, fields())
     |> cast_embed(:Profile,
-      with: fn profile, attrs -> Profile.changeset(profile, attrs, parse_system_type(attrs)) end
+      with: fn profile, attrs -> Profile.changeset(profile, attrs, parse_system_type(attrs)) end,
+      required: true
     )
     |> cast_embed(:Databases)
-    |> cast_embed(:Instances)
+    |> cast_embed(:Instances, required: true)
     |> validate_required_fields(@required_fields)
     |> validate_inclusion(:Type, @system_types)
   end
@@ -122,7 +123,7 @@ defmodule Trento.Discovery.Payloads.SapSystemDiscoveryPayload do
       SystemReplication
     }
 
-    @required_fields [:Host, :Name, :Type, :SAPControl, :SystemReplication]
+    @required_fields [:Host, :Name, :Type]
 
     use Trento.Support.Type
 
@@ -138,7 +139,7 @@ defmodule Trento.Discovery.Payloads.SapSystemDiscoveryPayload do
     def changeset(instance, attrs) do
       instance
       |> cast(attrs, fields())
-      |> cast_embed(:SAPControl)
+      |> cast_embed(:SAPControl, required: true)
       |> cast_embed(:SystemReplication)
       |> validate_required_fields(@required_fields)
     end
@@ -155,7 +156,7 @@ defmodule Trento.Discovery.Payloads.SapSystemDiscoveryPayload do
       SapControlProperty
     }
 
-    @required_fields [:Properties, :Instances, :Processes]
+    @required_fields []
 
     use Trento.Support.Type
 
@@ -176,13 +177,14 @@ defmodule Trento.Discovery.Payloads.SapSystemDiscoveryPayload do
 
       sap_control
       |> cast(attrs, fields())
-      |> cast_embed(:Properties)
+      |> cast_embed(:Properties, required: true)
       |> cast_embed(:Instances,
         with: fn instances, attrs ->
           SapControlInstance.changeset(instances, attrs, hostname, instance_number)
-        end
+        end,
+        required: true
       )
-      |> cast_embed(:Processes)
+      |> cast_embed(:Processes, required: true)
       |> validate_required_fields(@required_fields)
     end
 

--- a/lib/trento/discovery/policies/cluster_policy.ex
+++ b/lib/trento/discovery/policies/cluster_policy.ex
@@ -278,6 +278,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicy do
     end)
   end
 
+  defp parse_sbd_devices(_), do: []
+
   defp parse_node_resources(node_name, crmmon) do
     crmmon
     |> extract_cluster_resources()

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -653,11 +653,7 @@ defmodule Trento.Factory do
   def crm_resource_factory do
     %{
       "Id" => Faker.UUID.v4(),
-      "Node" => %{
-        "Id" => "1",
-        "Name" => Faker.StarWars.planet(),
-        "Cached" => true
-      },
+      "Node" => build(:crm_resource_node),
       "Role" => "Started",
       "Agent" => Faker.Pokemon.name(),
       "Active" => true,
@@ -667,6 +663,14 @@ defmodule Trento.Factory do
       "Orphaned" => false,
       "FailureIgnored" => false,
       "NodesRunningOn" => 1
+    }
+  end
+
+  def crm_resource_node_factory do
+    %{
+      "Id" => "1",
+      "Name" => Faker.StarWars.planet(),
+      "Cached" => true
     }
   end
 

--- a/test/trento/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/discovery/policies/cluster_policy_test.exs
@@ -702,7 +702,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
           "Id" => "rsc_sap_NWP_ASCS00",
           "Agent" => "ocf::heartbeat:SAPInstance",
           "Role" => "Started",
-          "Node" => %{"Name" => "vmnwpd01"}
+          "Node" => build(:crm_resource_node, %{"Name" => "vmnwpd01"})
         })
 
       group_2_resources =
@@ -710,7 +710,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
           "Id" => "rsc_sap_NWP_ERS10",
           "Agent" => "ocf::heartbeat:SAPInstance",
           "Role" => "Stopped",
-          "Node" => %{"Name" => "vmnwpd02"}
+          "Node" => build(:crm_resource_node, %{"Name" => "vmnwpd02"})
         })
 
       assert {:ok,
@@ -730,8 +730,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                "ha_cluster_discovery_ascs_ers"
                |> load_discovery_event_fixture()
                |> put_in(["payload", "Crmmon", "Groups"], [
-                 %{"Resources" => group_1_resources},
-                 %{"Resources" => group_2_resources}
+                 %{"Id" => UUID.uuid4(), "Resources" => group_1_resources},
+                 %{"Id" => UUID.uuid4(), "Resources" => group_2_resources}
                ])
                |> ClusterPolicy.handle(nil)
     end
@@ -741,14 +741,14 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
         build_list(1, :crm_resource, %{
           "Id" => "rsc_sap_NWP_ASCS00",
           "Agent" => "ocf::heartbeat:SAPInstance",
-          "Node" => %{"Name" => "vmnwpd01"}
+          "Node" => build(:crm_resource_node, %{"Name" => "vmnwpd01"})
         })
 
       group_2_resources =
         build_list(1, :crm_resource, %{
           "Id" => "rsc_sap_NWP_ERS10",
           "Agent" => "ocf::heartbeat:SAPInstance",
-          "Node" => %{"Name" => "vmnwpd01"}
+          "Node" => build(:crm_resource_node, %{"Name" => "vmnwpd01"})
         })
 
       assert {:ok,
@@ -768,8 +768,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                "ha_cluster_discovery_ascs_ers"
                |> load_discovery_event_fixture()
                |> put_in(["payload", "Crmmon", "Groups"], [
-                 %{"Resources" => group_1_resources},
-                 %{"Resources" => group_2_resources}
+                 %{"Id" => UUID.uuid4(), "Resources" => group_1_resources},
+                 %{"Id" => UUID.uuid4(), "Resources" => group_2_resources}
                ])
                |> ClusterPolicy.handle(nil)
     end
@@ -780,7 +780,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
           "Id" => "rsc_sap_NWP_ASCS00",
           "Agent" => "ocf::heartbeat:SAPInstance",
           "Failed" => true,
-          "Node" => %{"Name" => "vmnwpd01"}
+          "Node" => build(:crm_resource_node, %{"Name" => "vmnwpd01"})
         })
 
       group_2_resources =
@@ -788,7 +788,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
           "Id" => "rsc_sap_NWP_ERS10",
           "Agent" => "ocf::heartbeat:SAPInstance",
           "Failed" => false,
-          "Node" => %{"Name" => "vmnwpd01"}
+          "Node" => build(:crm_resource_node, %{"Name" => "vmnwpd01"})
         })
 
       assert {:ok,
@@ -808,8 +808,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                "ha_cluster_discovery_ascs_ers"
                |> load_discovery_event_fixture()
                |> put_in(["payload", "Crmmon", "Groups"], [
-                 %{"Resources" => group_1_resources},
-                 %{"Resources" => group_2_resources}
+                 %{"Id" => UUID.uuid4(), "Resources" => group_1_resources},
+                 %{"Id" => UUID.uuid4(), "Resources" => group_2_resources}
                ])
                |> ClusterPolicy.handle(nil)
     end


### PR DESCRIPTION
# Description
Fix `validate_required_fields` usage. We were using this function incorrectly in many places.
When we have an explicit `changeset` implemented for the `Type`, the `validate_required_fields` only works for the type itself. If there are other inline types with their own `changeset` functions, we cannot use it, as it would expand the `fields` of the main module, and not run the proper validation.
Together with this, in other to check if embedded fields are required or not, we cannot use `validate_required_fields`, we need to set the `required: true` in the `embed_cast` itself.

Using the macro `changeset` all of this is done there.

**PD: I have tried to put the required values in the places where it makes sense. Until now, any of them on the `embeds_*` was working, so it was like there were not required. Many of them actually shouldn't be required...**

As a bonus, I have removed the `sbd` from the required list (even though it was not really working) to avoid an error we were having when the cluster doesn't have sbd configured. FYI @abravosuse 

Ref: https://github.com/trento-project/web/pull/1422/files#r1196297634

## How was this tested?
Current tests passing
