### PR TITLE
Hana scale out discovery

### DIFF
--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { get, groupBy } from 'lodash';
 import classNames from 'classnames';
 
+import { getClusterTypeLabel } from '@lib/model/clusters';
 import { RUNNING_STATES } from '@state/lastExecutions';
 
 import BackButton from '@common/BackButton';
@@ -194,8 +195,7 @@ function HanaClusterDetails({
               },
               {
                 title: 'Cluster type',
-                content:
-                  clusterType === 'hana_scale_up' ? 'HANA Scale Up' : 'Unknown',
+                content: getClusterTypeLabel(clusterType),
               },
               {
                 title: 'SAPHanaSR health state',

--- a/test/fixtures/discovery/ha_cluster_discovery_hana_scale_out.json
+++ b/test/fixtures/discovery/ha_cluster_discovery_hana_scale_out.json
@@ -109,6 +109,16 @@
               "Id": "SAPHanaSR-hana_prd_site_lpt_Site2",
               "Name": "hana_prd_site_lpt_Site2",
               "Value": "30"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_glob_srmode",
+              "Name": "hana_prd_glob_srmode",
+              "Value": "syncmem"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_glob_op_mode",
+              "Name": "hana_prd_glob_op_mode",
+              "Value": "delta_datashipping"
             }
           ]
         },

--- a/test/fixtures/discovery/ha_cluster_discovery_hana_scale_out.json
+++ b/test/fixtures/discovery/ha_cluster_discovery_hana_scale_out.json
@@ -1,0 +1,1187 @@
+ 
+{
+  "agent_id": "286808a7-01bf-420d-af50-10846a7d7868",
+  "discovery_type": "ha_cluster_discovery",
+  "payload": {
+    "Cib": {
+      "Configuration": {
+        "Constraints": {
+          "RscLocations": null
+        },
+        "CrmConfig": {
+          "ClusterProperties": [
+            {
+              "Id": "cib-bootstrap-options-have-watchdog",
+              "Name": "have-watchdog",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-dc-version",
+              "Name": "dc-version",
+              "Value": "2.0.4+20200616.2deceaa3a-150200.3.24.2-2.0.4+20200616.2deceaa3a"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-infrastructure",
+              "Name": "cluster-infrastructure",
+              "Value": "corosync"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-name",
+              "Name": "cluster-name",
+              "Value": "hana_cluster"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-enabled",
+              "Name": "stonith-enabled",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-concurrent-fencing",
+              "Name": "concurrent-fencing",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-no-quorum-policy",
+              "Name": "no-quorum-policy",
+              "Value": "freeze"
+            },
+            {
+              "Id": "cib-bootstrap-options-last-lrm-refresh",
+              "Name": "last-lrm-refresh",
+              "Value": "1677162267"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_site_lss_Site1",
+              "Name": "hana_prd_site_lss_Site1",
+              "Value": "4"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_site_srr_Site1",
+              "Name": "hana_prd_site_srr_Site1",
+              "Value": "P"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_glob_upd",
+              "Name": "hana_prd_glob_upd",
+              "Value": "ok"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_site_mns_Site1",
+              "Name": "hana_prd_site_mns_Site1",
+              "Value": "vmhana01"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_site_lpt_Site1",
+              "Name": "hana_prd_site_lpt_Site1",
+              "Value": "1677164396"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_glob_prim",
+              "Name": "hana_prd_glob_prim",
+              "Value": "Site1"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_glob_srHook",
+              "Name": "hana_prd_glob_srHook",
+              "Value": "SOK"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_glob_sync_state",
+              "Name": "hana_prd_glob_sync_state",
+              "Value": "SOK"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_site_lss_Site2",
+              "Name": "hana_prd_site_lss_Site2",
+              "Value": "4"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_site_srr_Site2",
+              "Name": "hana_prd_site_srr_Site2",
+              "Value": "S"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_site_mns_Site2",
+              "Name": "hana_prd_site_mns_Site2",
+              "Value": "vmhana02"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_site_lpt_Site2",
+              "Name": "hana_prd_site_lpt_Site2",
+              "Value": "30"
+            }
+          ]
+        },
+        "Nodes": [
+          {
+            "Id": "1",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-1-hana_prd_site",
+                "Name": "hana_prd_site",
+                "Value": "Site1"
+              },
+              {
+                "Id": "nodes-1-hana_prd_gra",
+                "Name": "hana_prd_gra",
+                "Value": "2.0"
+              }
+            ],
+            "Uname": "vmhana01"
+          },
+          {
+            "Id": "2",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-2-hana_prd_site",
+                "Name": "hana_prd_site",
+                "Value": "Site2"
+              },
+              {
+                "Id": "nodes-2-hana_prd_gra",
+                "Name": "hana_prd_gra",
+                "Value": "2.0"
+              }
+            ],
+            "Uname": "vmhana02"
+          },
+          {
+            "Id": "3",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-3-hana_prd_site",
+                "Name": "hana_prd_site",
+                "Value": "Site1"
+              },
+              {
+                "Id": "nodes-3-hana_prd_gra",
+                "Name": "hana_prd_gra",
+                "Value": "2.0"
+              }
+            ],
+            "Uname": "vmhana03"
+          },
+          {
+            "Id": "4",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-4-hana_prd_site",
+                "Name": "hana_prd_site",
+                "Value": "Site2"
+              },
+              {
+                "Id": "nodes-4-hana_prd_gra",
+                "Name": "hana_prd_gra",
+                "Value": "2.0"
+              }
+            ],
+            "Uname": "vmhana04"
+          },
+          {
+            "Id": "5",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-5-hana_prd_site",
+                "Name": "hana_prd_site",
+                "Value": "Site1"
+              },
+              {
+                "Id": "nodes-5-hana_prd_gra",
+                "Name": "hana_prd_gra",
+                "Value": "2.0"
+              }
+            ],
+            "Uname": "vmhana05"
+          },
+          {
+            "Id": "6",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-6-hana_prd_site",
+                "Name": "hana_prd_site",
+                "Value": "Site2"
+              },
+              {
+                "Id": "nodes-6-hana_prd_gra",
+                "Name": "hana_prd_gra",
+                "Value": "2.0"
+              }
+            ],
+            "Uname": "vmhana06"
+          }
+        ],
+        "Resources": {
+          "Clones": [
+            {
+              "Id": "cln_SAPHanaTopology_PRD_HDB00",
+              "MetaAttributes": [
+                {
+                  "Id": "cln_SAPHanaTopology_PRD_HDB00-meta_attributes-is-managed",
+                  "Name": "is-managed",
+                  "Value": "true"
+                },
+                {
+                  "Id": "cln_SAPHanaTopology_PRD_HDB00-meta_attributes-clone-node-max",
+                  "Name": "clone-node-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "cln_SAPHanaTopology_PRD_HDB00-meta_attributes-interleave",
+                  "Name": "interleave",
+                  "Value": "true"
+                }
+              ],
+              "Primitive": {
+                "Class": "ocf",
+                "Id": "rsc_SAPHanaTopology_PRD_HDB00",
+                "InstanceAttributes": [
+                  {
+                    "Id": "rsc_SAPHanaTopology_PRD_HDB00-instance_attributes-SID",
+                    "Name": "SID",
+                    "Value": "PRD"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_PRD_HDB00-instance_attributes-InstanceNumber",
+                    "Name": "InstanceNumber",
+                    "Value": "00"
+                  }
+                ],
+                "MetaAttributes": null,
+                "Operations": [
+                  {
+                    "Id": "rsc_SAPHanaTopology_PRD_HDB00-monitor-10",
+                    "Interval": "10",
+                    "Name": "monitor",
+                    "Role": "",
+                    "Timeout": "600"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_PRD_HDB00-start-0",
+                    "Interval": "0",
+                    "Name": "start",
+                    "Role": "",
+                    "Timeout": "600"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_PRD_HDB00-stop-0",
+                    "Interval": "0",
+                    "Name": "stop",
+                    "Role": "",
+                    "Timeout": "300"
+                  }
+                ],
+                "Provider": "suse",
+                "Type": "SAPHanaTopology"
+              }
+            }
+          ],
+          "Groups": null,
+          "Masters": [
+            {
+              "Id": "msl_SAPHanaController_PRD_HDB00",
+              "MetaAttributes": [
+                {
+                  "Id": "msl_SAPHanaController_PRD_HDB00-meta_attributes-master-max",
+                  "Name": "master-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "msl_SAPHanaController_PRD_HDB00-meta_attributes-clone-node-max",
+                  "Name": "clone-node-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "msl_SAPHanaController_PRD_HDB00-meta_attributes-interleave",
+                  "Name": "interleave",
+                  "Value": "true"
+                }
+              ],
+              "Primitive": {
+                "Class": "ocf",
+                "Id": "rsc_SAPHanaController_PRD_HDB00",
+                "InstanceAttributes": [
+                  {
+                    "Id": "rsc_SAPHanaController_PRD_HDB00-instance_attributes-SID",
+                    "Name": "SID",
+                    "Value": "PRD"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaController_PRD_HDB00-instance_attributes-InstanceNumber",
+                    "Name": "InstanceNumber",
+                    "Value": "00"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaController_PRD_HDB00-instance_attributes-PREFER_SITE_TAKEOVER",
+                    "Name": "PREFER_SITE_TAKEOVER",
+                    "Value": "True"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaController_PRD_HDB00-instance_attributes-AUTOMATED_REGISTER",
+                    "Name": "AUTOMATED_REGISTER",
+                    "Value": "False"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaController_PRD_HDB00-instance_attributes-DUPLICATE_PRIMARY_TIMEOUT",
+                    "Name": "DUPLICATE_PRIMARY_TIMEOUT",
+                    "Value": "7200"
+                  }
+                ],
+                "MetaAttributes": null,
+                "Operations": [
+                  {
+                    "Id": "rsc_SAPHanaController_PRD_HDB00-start-0",
+                    "Interval": "0",
+                    "Name": "start",
+                    "Role": "",
+                    "Timeout": "3600"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaController_PRD_HDB00-stop-0",
+                    "Interval": "0",
+                    "Name": "stop",
+                    "Role": "",
+                    "Timeout": "3600"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaController_PRD_HDB00-promote-0",
+                    "Interval": "0",
+                    "Name": "promote",
+                    "Role": "",
+                    "Timeout": "3600"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaController_PRD_HDB00-monitor-60",
+                    "Interval": "60",
+                    "Name": "monitor",
+                    "Role": "Master",
+                    "Timeout": "700"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaController_PRD_HDB00-monitor-61",
+                    "Interval": "61",
+                    "Name": "monitor",
+                    "Role": "Slave",
+                    "Timeout": "700"
+                  }
+                ],
+                "Provider": "suse",
+                "Type": "SAPHanaController"
+              }
+            }
+          ],
+          "Primitives": [
+            {
+              "Class": "stonith",
+              "Id": "stonith-sbd",
+              "InstanceAttributes": [
+                {
+                  "Id": "stonith-sbd-instance_attributes-pcmk_action_limit",
+                  "Name": "pcmk_action_limit",
+                  "Value": "-1"
+                }
+              ],
+              "MetaAttributes": null,
+              "Operations": null,
+              "Provider": "",
+              "Type": "external/sbd"
+            },
+            {
+              "Class": "ocf",
+              "Id": "rsc_ip_PRD_HDB00",
+              "InstanceAttributes": [
+                {
+                  "Id": "rsc_ip_PRD_HDB00-instance_attributes-ip",
+                  "Name": "ip",
+                  "Value": "192.168.152.16"
+                },
+                {
+                  "Id": "rsc_ip_PRD_HDB00-instance_attributes-cidr_netmask",
+                  "Name": "cidr_netmask",
+                  "Value": "24"
+                },
+                {
+                  "Id": "rsc_ip_PRD_HDB00-instance_attributes-nic",
+                  "Name": "nic",
+                  "Value": "eth1"
+                }
+              ],
+              "MetaAttributes": null,
+              "Operations": [
+                {
+                  "Id": "rsc_ip_PRD_HDB00-monitor-10s",
+                  "Interval": "10s",
+                  "Name": "monitor",
+                  "Role": "",
+                  "Timeout": "20s"
+                }
+              ],
+              "Provider": "heartbeat",
+              "Type": "IPaddr2"
+            },
+            {
+              "Class": "systemd",
+              "Id": "rsc_exporter_PRD_HDB00",
+              "InstanceAttributes": null,
+              "MetaAttributes": [
+                {
+                  "Id": "rsc_exporter_PRD_HDB00-meta_attributes-resource-stickiness",
+                  "Name": "resource-stickiness",
+                  "Value": "0"
+                },
+                {
+                  "Id": "rsc_exporter_PRD_HDB00-meta_attributes-0-target-role",
+                  "Name": "target-role",
+                  "Value": "Started"
+                }
+              ],
+              "Operations": [
+                {
+                  "Id": "rsc_exporter_PRD_HDB00-start-0",
+                  "Interval": "0",
+                  "Name": "start",
+                  "Role": "",
+                  "Timeout": "100"
+                },
+                {
+                  "Id": "rsc_exporter_PRD_HDB00-stop-0",
+                  "Interval": "0",
+                  "Name": "stop",
+                  "Role": "",
+                  "Timeout": "100"
+                },
+                {
+                  "Id": "rsc_exporter_PRD_HDB00-monitor-10",
+                  "Interval": "10",
+                  "Name": "monitor",
+                  "Role": "",
+                  "Timeout": ""
+                }
+              ],
+              "Provider": "",
+              "Type": "prometheus-hanadb_exporter@PRD_HDB00"
+            }
+          ]
+        }
+      }
+    },
+    "Crmmon": {
+      "Clones": [
+        {
+          "Failed": false,
+          "FailureIgnored": false,
+          "Id": "msl_SAPHanaController_PRD_HDB00",
+          "Managed": true,
+          "MultiState": true,
+          "Resources": [
+            {
+              "Active": true,
+              "Agent": "ocf::suse:SAPHanaController",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaController_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "1",
+                "Name": "vmhana01"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Master"
+            },
+            {
+              "Active": true,
+              "Agent": "ocf::suse:SAPHanaController",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaController_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "2",
+                "Name": "vmhana02"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Slave"
+            },
+            {
+              "Active": true,
+              "Agent": "ocf::suse:SAPHanaController",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaController_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "3",
+                "Name": "vmhana03"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Slave"
+            },
+            {
+              "Active": true,
+              "Agent": "ocf::suse:SAPHanaController",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaController_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "4",
+                "Name": "vmhana04"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Slave"
+            },
+            {
+              "Active": true,
+              "Agent": "ocf::suse:SAPHanaController",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaController_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "5",
+                "Name": "vmhana05"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Slave"
+            },
+            {
+              "Active": true,
+              "Agent": "ocf::suse:SAPHanaController",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaController_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "6",
+                "Name": "vmhana06"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Slave"
+            }
+          ],
+          "Unique": false
+        },
+        {
+          "Failed": false,
+          "FailureIgnored": false,
+          "Id": "cln_SAPHanaTopology_PRD_HDB00",
+          "Managed": true,
+          "MultiState": false,
+          "Resources": [
+            {
+              "Active": true,
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaTopology_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "1",
+                "Name": "vmhana01"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Started"
+            },
+            {
+              "Active": true,
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaTopology_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "2",
+                "Name": "vmhana02"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Started"
+            },
+            {
+              "Active": true,
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaTopology_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "3",
+                "Name": "vmhana03"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Started"
+            },
+            {
+              "Active": true,
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaTopology_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "4",
+                "Name": "vmhana04"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Started"
+            },
+            {
+              "Active": true,
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaTopology_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "5",
+                "Name": "vmhana05"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Started"
+            },
+            {
+              "Active": true,
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaTopology_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "6",
+                "Name": "vmhana06"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Started"
+            }
+          ],
+          "Unique": false
+        }
+      ],
+      "Groups": null,
+      "NodeAttributes": {
+        "Nodes": [
+          {
+            "Attributes": [
+              {
+                "Name": "hana_prd_clone_state",
+                "Value": "PROMOTED"
+              },
+              {
+                "Name": "hana_prd_gra",
+                "Value": "2.0"
+              },
+              {
+                "Name": "hana_prd_roles",
+                "Value": "master1:master:worker:master"
+              },
+              {
+                "Name": "hana_prd_site",
+                "Value": "Site1"
+              },
+              {
+                "Name": "master-rsc_SAPHanaController_PRD_HDB00",
+                "Value": "150"
+              }
+            ],
+            "Name": "vmhana01"
+          },
+          {
+            "Attributes": [
+              {
+                "Name": "hana_prd_clone_state",
+                "Value": "DEMOTED"
+              },
+              {
+                "Name": "hana_prd_gra",
+                "Value": "2.0"
+              },
+              {
+                "Name": "hana_prd_roles",
+                "Value": "master1:master:worker:master"
+              },
+              {
+                "Name": "hana_prd_site",
+                "Value": "Site2"
+              },
+              {
+                "Name": "master-rsc_SAPHanaController_PRD_HDB00",
+                "Value": "100"
+              }
+            ],
+            "Name": "vmhana02"
+          },
+          {
+            "Attributes": [
+              {
+                "Name": "hana_prd_clone_state",
+                "Value": "DEMOTED"
+              },
+              {
+                "Name": "hana_prd_gra",
+                "Value": "2.0"
+              },
+              {
+                "Name": "hana_prd_roles",
+                "Value": "master3:slave:standby:standby"
+              },
+              {
+                "Name": "hana_prd_site",
+                "Value": "Site1"
+              },
+              {
+                "Name": "master-rsc_SAPHanaController_PRD_HDB00",
+                "Value": "140"
+              }
+            ],
+            "Name": "vmhana03"
+          },
+          {
+            "Attributes": [
+              {
+                "Name": "hana_prd_clone_state",
+                "Value": "DEMOTED"
+              },
+              {
+                "Name": "hana_prd_gra",
+                "Value": "2.0"
+              },
+              {
+                "Name": "hana_prd_roles",
+                "Value": "master2:slave:standby:standby"
+              },
+              {
+                "Name": "hana_prd_site",
+                "Value": "Site2"
+              },
+              {
+                "Name": "master-rsc_SAPHanaController_PRD_HDB00",
+                "Value": "80"
+              }
+            ],
+            "Name": "vmhana04"
+          },
+          {
+            "Attributes": [
+              {
+                "Name": "hana_prd_clone_state",
+                "Value": "DEMOTED"
+              },
+              {
+                "Name": "hana_prd_gra",
+                "Value": "2.0"
+              },
+              {
+                "Name": "hana_prd_roles",
+                "Value": "master2:slave:worker:slave"
+              },
+              {
+                "Name": "hana_prd_site",
+                "Value": "Site1"
+              },
+              {
+                "Name": "master-rsc_SAPHanaController_PRD_HDB00",
+                "Value": "140"
+              }
+            ],
+            "Name": "vmhana05"
+          },
+          {
+            "Attributes": [
+              {
+                "Name": "hana_prd_clone_state",
+                "Value": "DEMOTED"
+              },
+              {
+                "Name": "hana_prd_gra",
+                "Value": "2.0"
+              },
+              {
+                "Name": "hana_prd_roles",
+                "Value": "master3:slave:worker:slave"
+              },
+              {
+                "Name": "hana_prd_site",
+                "Value": "Site2"
+              },
+              {
+                "Name": "master-rsc_SAPHanaController_PRD_HDB00",
+                "Value": "80"
+              }
+            ],
+            "Name": "vmhana06"
+          }
+        ]
+      },
+      "NodeHistory": {
+        "Nodes": [
+          {
+            "Name": "vmhana01",
+            "ResourceHistory": [
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "stonith-sbd"
+              },
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_exporter_PRD_HDB00"
+              },
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_SAPHanaTopology_PRD_HDB00"
+              },
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_ip_PRD_HDB00"
+              },
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_SAPHanaController_PRD_HDB00"
+              }
+            ]
+          },
+          {
+            "Name": "vmhana02",
+            "ResourceHistory": [
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_SAPHanaController_PRD_HDB00"
+              },
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_SAPHanaTopology_PRD_HDB00"
+              }
+            ]
+          },
+          {
+            "Name": "vmhana03",
+            "ResourceHistory": [
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_SAPHanaController_PRD_HDB00"
+              },
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_SAPHanaTopology_PRD_HDB00"
+              }
+            ]
+          },
+          {
+            "Name": "vmhana04",
+            "ResourceHistory": [
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_SAPHanaController_PRD_HDB00"
+              },
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_SAPHanaTopology_PRD_HDB00"
+              }
+            ]
+          },
+          {
+            "Name": "vmhana05",
+            "ResourceHistory": [
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_SAPHanaController_PRD_HDB00"
+              },
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_SAPHanaTopology_PRD_HDB00"
+              }
+            ]
+          },
+          {
+            "Name": "vmhana06",
+            "ResourceHistory": [
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_SAPHanaController_PRD_HDB00"
+              },
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_SAPHanaTopology_PRD_HDB00"
+              }
+            ]
+          }
+        ]
+      },
+      "Nodes": [
+        {
+          "DC": true,
+          "ExpectedUp": true,
+          "Id": "1",
+          "Maintenance": false,
+          "Name": "vmhana01",
+          "Online": true,
+          "Pending": false,
+          "ResourcesRunning": 5,
+          "Shutdown": false,
+          "Standby": false,
+          "StandbyOnFail": false,
+          "Type": "member",
+          "Unclean": false
+        },
+        {
+          "DC": false,
+          "ExpectedUp": true,
+          "Id": "2",
+          "Maintenance": false,
+          "Name": "vmhana02",
+          "Online": true,
+          "Pending": false,
+          "ResourcesRunning": 2,
+          "Shutdown": false,
+          "Standby": false,
+          "StandbyOnFail": false,
+          "Type": "member",
+          "Unclean": false
+        },
+        {
+          "DC": false,
+          "ExpectedUp": true,
+          "Id": "3",
+          "Maintenance": false,
+          "Name": "vmhana03",
+          "Online": true,
+          "Pending": false,
+          "ResourcesRunning": 2,
+          "Shutdown": false,
+          "Standby": false,
+          "StandbyOnFail": false,
+          "Type": "member",
+          "Unclean": false
+        },
+        {
+          "DC": false,
+          "ExpectedUp": true,
+          "Id": "4",
+          "Maintenance": false,
+          "Name": "vmhana04",
+          "Online": true,
+          "Pending": false,
+          "ResourcesRunning": 2,
+          "Shutdown": false,
+          "Standby": false,
+          "StandbyOnFail": false,
+          "Type": "member",
+          "Unclean": false
+        },
+        {
+          "DC": false,
+          "ExpectedUp": true,
+          "Id": "5",
+          "Maintenance": false,
+          "Name": "vmhana05",
+          "Online": true,
+          "Pending": false,
+          "ResourcesRunning": 2,
+          "Shutdown": false,
+          "Standby": false,
+          "StandbyOnFail": false,
+          "Type": "member",
+          "Unclean": false
+        },
+        {
+          "DC": false,
+          "ExpectedUp": true,
+          "Id": "6",
+          "Maintenance": false,
+          "Name": "vmhana06",
+          "Online": true,
+          "Pending": false,
+          "ResourcesRunning": 2,
+          "Shutdown": false,
+          "Standby": false,
+          "StandbyOnFail": false,
+          "Type": "member",
+          "Unclean": false
+        }
+      ],
+      "Resources": [
+        {
+          "Active": true,
+          "Agent": "stonith:external/sbd",
+          "Blocked": false,
+          "Failed": false,
+          "FailureIgnored": false,
+          "Id": "stonith-sbd",
+          "Managed": true,
+          "Node": {
+            "Cached": true,
+            "Id": "1",
+            "Name": "vmhana01"
+          },
+          "NodesRunningOn": 1,
+          "Orphaned": false,
+          "Role": "Started"
+        },
+        {
+          "Active": true,
+          "Agent": "ocf::heartbeat:IPaddr2",
+          "Blocked": false,
+          "Failed": false,
+          "FailureIgnored": false,
+          "Id": "rsc_ip_PRD_HDB00",
+          "Managed": true,
+          "Node": {
+            "Cached": true,
+            "Id": "1",
+            "Name": "vmhana01"
+          },
+          "NodesRunningOn": 1,
+          "Orphaned": false,
+          "Role": "Started"
+        },
+        {
+          "Active": true,
+          "Agent": "systemd:prometheus-hanadb_exporter@PRD_HDB00",
+          "Blocked": false,
+          "Failed": false,
+          "FailureIgnored": false,
+          "Id": "rsc_exporter_PRD_HDB00",
+          "Managed": true,
+          "Node": {
+            "Cached": true,
+            "Id": "1",
+            "Name": "vmhana01"
+          },
+          "NodesRunningOn": 1,
+          "Orphaned": false,
+          "Role": "Started"
+        }
+      ],
+      "Summary": {
+        "ClusterOptions": {
+          "StonithEnabled": true
+        },
+        "LastChange": {
+          "Time": "Thu Feb 23 15:59:56 2023"
+        },
+        "Nodes": {
+          "Number": 6
+        },
+        "Resources": {
+          "Blocked": 0,
+          "Disabled": 0,
+          "Number": 15
+        }
+      },
+      "Version": "2.0.4"
+    },
+    "DC": true,
+    "Id": "d0a0d4caff6a5f4cba70d47e9cd12889",
+    "Name": "hana_cluster",
+    "Provider": "kvm",
+    "SBD": {
+      "Config": {
+        "SBD_DELAY_START": "yes",
+        "SBD_DEVICE": "/dev/vdb",
+        "SBD_MOVE_TO_ROOT_CGROUP": "auto",
+        "SBD_OPTS": "",
+        "SBD_PACEMAKER": "yes",
+        "SBD_STARTMODE": "always",
+        "SBD_TIMEOUT_ACTION": "flush,reboot",
+        "SBD_WATCHDOG_DEV": "/dev/watchdog",
+        "SBD_WATCHDOG_TIMEOUT": "5"
+      },
+      "Devices": [
+        {
+          "Device": "/dev/vdb",
+          "Dump": {
+            "Header": "2.1",
+            "SectorSize": 512,
+            "Slots": 255,
+            "TimeoutAllocate": 2,
+            "TimeoutLoop": 1,
+            "TimeoutMsgwait": 10,
+            "TimeoutWatchdog": 5,
+            "Uuid": "b4a33745-96ca-4107-ac90-85febd41c42f"
+          },
+          "List": [
+            {
+              "Id": 0,
+              "Name": "vmhana01",
+              "Status": "clear"
+            },
+            {
+              "Id": 1,
+              "Name": "vmhana02",
+              "Status": "clear"
+            },
+            {
+              "Id": 2,
+              "Name": "vmhana03",
+              "Status": "clear"
+            },
+            {
+              "Id": 3,
+              "Name": "vmhana04",
+              "Status": "clear"
+            },
+            {
+              "Id": 4,
+              "Name": "vmhana05",
+              "Status": "clear"
+            },
+            {
+              "Id": 5,
+              "Name": "vmhana06",
+              "Status": "clear"
+            }
+          ],
+          "Status": "healthy"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/discovery/ha_cluster_discovery_hana_scale_out_multitarget.json
+++ b/test/fixtures/discovery/ha_cluster_discovery_hana_scale_out_multitarget.json
@@ -1,0 +1,1161 @@
+ 
+{
+  "agent_id": "9abb22d6-716a-4321-bb1e-175f179e7bb6",
+  "discovery_type": "ha_cluster_discovery",
+  "payload": {
+    "Cib": {
+      "Configuration": {
+        "Constraints": {
+          "RscLocations": [
+            {
+              "Id": "SAPHanaCon_not_on_majority_maker",
+              "Node": "vmhanamm",
+              "Resource": "msl_SAPHanaCon_PRD_HDB00",
+              "Role": "",
+              "Score": "-INFINITY"
+            },
+            {
+              "Id": "SAPHanaTop_not_on_majority_maker",
+              "Node": "vmhanamm",
+              "Resource": "cln_SAPHanaTop_PRD_HDB00",
+              "Role": "",
+              "Score": "-INFINITY"
+            }
+          ]
+        },
+        "CrmConfig": {
+          "ClusterProperties": [
+            {
+              "Id": "cib-bootstrap-options-have-watchdog",
+              "Name": "have-watchdog",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-dc-version",
+              "Name": "dc-version",
+              "Value": "2.1.5+20221208.a3f44794f-150500.6.5.8-2.1.5+20221208.a3f44794f"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-infrastructure",
+              "Name": "cluster-infrastructure",
+              "Value": "corosync"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-name",
+              "Name": "cluster-name",
+              "Value": "hana_cluster"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-enabled",
+              "Name": "stonith-enabled",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-timeout",
+              "Name": "stonith-timeout",
+              "Value": "150"
+            },
+            {
+              "Id": "cib-bootstrap-options-priority-fencing-delay",
+              "Name": "priority-fencing-delay",
+              "Value": "0"
+            },
+            {
+              "Id": "cib-bootstrap-options-maintenance-mode",
+              "Name": "maintenance-mode",
+              "Value": "false"
+            },
+            {
+              "Id": "cib-bootstrap-options-placement-strategy",
+              "Name": "placement-strategy",
+              "Value": "balanced"
+            },
+            {
+              "Id": "cib-bootstrap-options-no-quorum-policy",
+              "Name": "no-quorum-policy",
+              "Value": "freeze"
+            },
+            {
+              "Id": "cib-bootstrap-options-concurrent-fencing",
+              "Name": "concurrent-fencing",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-action",
+              "Name": "stonith-action",
+              "Value": "reboot"
+            },
+            {
+              "Id": "cib-bootstrap-options-last-lrm-refresh",
+              "Name": "last-lrm-refresh",
+              "Value": "1706008908"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_site_lss_Site2",
+              "Name": "hana_prd_site_lss_Site2",
+              "Value": "4"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_site_lss_Site1",
+              "Name": "hana_prd_site_lss_Site1",
+              "Value": "4"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_site_srr_Site2",
+              "Name": "hana_prd_site_srr_Site2",
+              "Value": "P"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_site_srr_Site1",
+              "Name": "hana_prd_site_srr_Site1",
+              "Value": "S"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_glob_upd",
+              "Name": "hana_prd_glob_upd",
+              "Value": "ok"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_site_mns_Site2",
+              "Name": "hana_prd_site_mns_Site2",
+              "Value": "vmhana21"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_site_mns_Site1",
+              "Name": "hana_prd_site_mns_Site1",
+              "Value": "vmhana11"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_site_lpt_Site2",
+              "Name": "hana_prd_site_lpt_Site2",
+              "Value": "1706014147"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_site_lpt_Site1",
+              "Name": "hana_prd_site_lpt_Site1",
+              "Value": "30"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_glob_sync_state",
+              "Name": "hana_prd_glob_sync_state",
+              "Value": "SOK"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_glob_prim",
+              "Name": "hana_prd_glob_prim",
+              "Value": "Site2"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_glob_sec",
+              "Name": "hana_prd_glob_sec",
+              "Value": "Site1"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_site_srHook_Site2",
+              "Name": "hana_prd_site_srHook_Site2",
+              "Value": "PRIM"
+            },
+            {
+              "Id": "SAPHanaSR-hana_prd_site_srHook_Site1",
+              "Name": "hana_prd_site_srHook_Site1",
+              "Value": "SOK"
+            }
+          ]
+        },
+        "Nodes": [
+          {
+            "Id": "1",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-1-hana_prd_site",
+                "Name": "hana_prd_site",
+                "Value": "Site1"
+              },
+              {
+                "Id": "nodes-1-hana_prd_gra",
+                "Name": "hana_prd_gra",
+                "Value": "2.0"
+              }
+            ],
+            "Uname": "vmhana11"
+          },
+          {
+            "Id": "2",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-2-hana_prd_site",
+                "Name": "hana_prd_site",
+                "Value": "Site1"
+              },
+              {
+                "Id": "nodes-2-hana_prd_gra",
+                "Name": "hana_prd_gra",
+                "Value": "2.0"
+              }
+            ],
+            "Uname": "vmhana12"
+          },
+          {
+            "Id": "3",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-3-hana_prd_site",
+                "Name": "hana_prd_site",
+                "Value": "Site2"
+              },
+              {
+                "Id": "nodes-3-hana_prd_gra",
+                "Name": "hana_prd_gra",
+                "Value": "2.0"
+              }
+            ],
+            "Uname": "vmhana21"
+          },
+          {
+            "Id": "4",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-4-hana_prd_site",
+                "Name": "hana_prd_site",
+                "Value": "Site2"
+              },
+              {
+                "Id": "nodes-4-hana_prd_gra",
+                "Name": "hana_prd_gra",
+                "Value": "2.0"
+              }
+            ],
+            "Uname": "vmhana22"
+          },
+          {
+            "Id": "5",
+            "InstanceAttributes": null,
+            "Uname": "vmhanamm"
+          }
+        ],
+        "Resources": {
+          "Clones": [
+            {
+              "Id": "cln_SAPHanaTop_PRD_HDB00",
+              "MetaAttributes": [
+                {
+                  "Id": "cln_SAPHanaTop_PRD_HDB00-meta_attributes-clone-node-max",
+                  "Name": "clone-node-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "cln_SAPHanaTop_PRD_HDB00-meta_attributes-interleave",
+                  "Name": "interleave",
+                  "Value": "true"
+                }
+              ],
+              "Primitive": {
+                "Class": "ocf",
+                "Id": "rsc_SAPHanaTop_PRD_HDB00",
+                "InstanceAttributes": [
+                  {
+                    "Id": "rsc_SAPHanaTop_PRD_HDB00-instance_attributes-SID",
+                    "Name": "SID",
+                    "Value": "PRD"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTop_PRD_HDB00-instance_attributes-InstanceNumber",
+                    "Name": "InstanceNumber",
+                    "Value": "00"
+                  }
+                ],
+                "MetaAttributes": null,
+                "Operations": [
+                  {
+                    "Id": "rsc_SAPHanaTop_PRD_HDB00-monitor-10",
+                    "Interval": "10",
+                    "Name": "monitor",
+                    "Role": "",
+                    "Timeout": "600"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTop_PRD_HDB00-start-0",
+                    "Interval": "0",
+                    "Name": "start",
+                    "Role": "",
+                    "Timeout": "600"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTop_PRD_HDB00-stop-0",
+                    "Interval": "0",
+                    "Name": "stop",
+                    "Role": "",
+                    "Timeout": "300"
+                  }
+                ],
+                "Provider": "suse",
+                "Type": "SAPHanaTopology"
+              }
+            }
+          ],
+          "Groups": [
+            {
+              "Id": "g_ip_PRD_HDB00",
+              "Primitives": [
+                {
+                  "Class": "ocf",
+                  "Id": "rsc_ip_PRD_HDB00",
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_ip_PRD_HDB00-instance_attributes-ip",
+                      "Name": "ip",
+                      "Value": "10.0.0.10"
+                    }
+                  ],
+                  "MetaAttributes": [
+                    {
+                      "Id": "rsc_ip_PRD_HDB00-meta_attributes-target-role",
+                      "Name": "target-role",
+                      "Value": "Started"
+                    }
+                  ],
+                  "Operations": [
+                    {
+                      "Id": "rsc_ip_PRD_HDB00-operations-monitor-10s",
+                      "Interval": "10s",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "20s"
+                    },
+                    {
+                      "Id": "rsc_ip_PRD_HDB00-operations-start-0s",
+                      "Interval": "0s",
+                      "Name": "start",
+                      "Role": "",
+                      "Timeout": "20s"
+                    },
+                    {
+                      "Id": "rsc_ip_PRD_HDB00-operations-stop-0s",
+                      "Interval": "0s",
+                      "Name": "stop",
+                      "Role": "",
+                      "Timeout": "20s"
+                    }
+                  ],
+                  "Provider": "heartbeat",
+                  "Type": "IPaddr2"
+                },
+                {
+                  "Class": "ocf",
+                  "Id": "rsc_nc_PRD_HDB00",
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_nc_PRD_HDB00-instance_attributes-port",
+                      "Name": "port",
+                      "Value": "62500"
+                    }
+                  ],
+                  "MetaAttributes": [
+                    {
+                      "Id": "rsc_nc_PRD_HDB00-meta_attributes-resource-stickiness",
+                      "Name": "resource-stickiness",
+                      "Value": "0"
+                    }
+                  ],
+                  "Operations": [
+                    {
+                      "Id": "rsc_nc_PRD_HDB00-monitor-10",
+                      "Interval": "10",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "20s"
+                    },
+                    {
+                      "Id": "rsc_nc_PRD_HDB00-start-0s",
+                      "Interval": "0s",
+                      "Name": "start",
+                      "Role": "",
+                      "Timeout": "20s"
+                    },
+                    {
+                      "Id": "rsc_nc_PRD_HDB00-stop-0s",
+                      "Interval": "0s",
+                      "Name": "stop",
+                      "Role": "",
+                      "Timeout": "20s"
+                    }
+                  ],
+                  "Provider": "heartbeat",
+                  "Type": "azure-lb"
+                }
+              ]
+            }
+          ],
+          "Masters": [
+            {
+              "Id": "msl_SAPHanaCon_PRD_HDB00",
+              "MetaAttributes": [
+                {
+                  "Id": "msl_SAPHanaCon_PRD_HDB00-meta_attributes-master-node-max",
+                  "Name": "master-node-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "msl_SAPHanaCon_PRD_HDB00-meta_attributes-master-max",
+                  "Name": "master-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "msl_SAPHanaCon_PRD_HDB00-meta_attributes-clone-node-max",
+                  "Name": "clone-node-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "msl_SAPHanaCon_PRD_HDB00-meta_attributes-interleave",
+                  "Name": "interleave",
+                  "Value": "true"
+                },
+                {
+                  "Id": "msl_SAPHanaCon_PRD_HDB00-meta_attributes-maintenance",
+                  "Name": "maintenance",
+                  "Value": "false"
+                }
+              ],
+              "Primitive": {
+                "Class": "ocf",
+                "Id": "rsc_SAPHanaCon_PRD_HDB00",
+                "InstanceAttributes": [
+                  {
+                    "Id": "rsc_SAPHanaCon_PRD_HDB00-instance_attributes-SID",
+                    "Name": "SID",
+                    "Value": "PRD"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaCon_PRD_HDB00-instance_attributes-InstanceNumber",
+                    "Name": "InstanceNumber",
+                    "Value": "00"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaCon_PRD_HDB00-instance_attributes-PREFER_SITE_TAKEOVER",
+                    "Name": "PREFER_SITE_TAKEOVER",
+                    "Value": "true"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaCon_PRD_HDB00-instance_attributes-DUPLICATE_PRIMARY_TIMEOUT",
+                    "Name": "DUPLICATE_PRIMARY_TIMEOUT",
+                    "Value": "7200"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaCon_PRD_HDB00-instance_attributes-AUTOMATED_REGISTER",
+                    "Name": "AUTOMATED_REGISTER",
+                    "Value": "false"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaCon_PRD_HDB00-instance_attributes-HANA_CALL_TIMEOUT",
+                    "Name": "HANA_CALL_TIMEOUT",
+                    "Value": "120"
+                  }
+                ],
+                "MetaAttributes": null,
+                "Operations": [
+                  {
+                    "Id": "rsc_SAPHanaCon_PRD_HDB00-start-0",
+                    "Interval": "0",
+                    "Name": "start",
+                    "Role": "",
+                    "Timeout": "3600"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaCon_PRD_HDB00-stop-0",
+                    "Interval": "0",
+                    "Name": "stop",
+                    "Role": "",
+                    "Timeout": "3600"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaCon_PRD_HDB00-promote-0",
+                    "Interval": "0",
+                    "Name": "promote",
+                    "Role": "",
+                    "Timeout": "900"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaCon_PRD_HDB00-demote-0",
+                    "Interval": "0",
+                    "Name": "demote",
+                    "Role": "",
+                    "Timeout": "320"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaCon_PRD_HDB00-monitor-60",
+                    "Interval": "60",
+                    "Name": "monitor",
+                    "Role": "Master",
+                    "Timeout": "700"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaCon_PRD_HDB00-monitor-61",
+                    "Interval": "61",
+                    "Name": "monitor",
+                    "Role": "Slave",
+                    "Timeout": "700"
+                  }
+                ],
+                "Provider": "suse",
+                "Type": "SAPHanaController"
+              }
+            }
+          ],
+          "Primitives": [
+            {
+              "Class": "stonith",
+              "Id": "stonith-sbd",
+              "InstanceAttributes": null,
+              "MetaAttributes": null,
+              "Operations": [
+                {
+                  "Id": "stonith-sbd-monitor-3600",
+                  "Interval": "3600",
+                  "Name": "monitor",
+                  "Role": "",
+                  "Timeout": "20"
+                },
+                {
+                  "Id": "stonith-sbd-start-0s",
+                  "Interval": "0s",
+                  "Name": "start",
+                  "Role": "",
+                  "Timeout": "20"
+                },
+                {
+                  "Id": "stonith-sbd-stop-0s",
+                  "Interval": "0s",
+                  "Name": "stop",
+                  "Role": "",
+                  "Timeout": "15"
+                }
+              ],
+              "Provider": "",
+              "Type": "external/sbd"
+            }
+          ]
+        }
+      }
+    },
+    "Crmmon": {
+      "Clones": [
+        {
+          "Failed": false,
+          "FailureIgnored": false,
+          "Id": "cln_SAPHanaTop_PRD_HDB00",
+          "Managed": true,
+          "MultiState": false,
+          "Resources": [
+            {
+              "Active": true,
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaTop_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "1",
+                "Name": "vmhana11"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Started"
+            },
+            {
+              "Active": true,
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaTop_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "2",
+                "Name": "vmhana12"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Started"
+            },
+            {
+              "Active": true,
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaTop_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "4",
+                "Name": "vmhana22"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Started"
+            },
+            {
+              "Active": true,
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaTop_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "3",
+                "Name": "vmhana21"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Started"
+            },
+            {
+              "Active": false,
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaTop_PRD_HDB00",
+              "Managed": true,
+              "Node": null,
+              "NodesRunningOn": 0,
+              "Orphaned": false,
+              "Role": "Stopped"
+            }
+          ],
+          "Unique": false
+        },
+        {
+          "Failed": false,
+          "FailureIgnored": false,
+          "Id": "msl_SAPHanaCon_PRD_HDB00",
+          "Managed": true,
+          "MultiState": true,
+          "Resources": [
+            {
+              "Active": true,
+              "Agent": "ocf::suse:SAPHanaController",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaCon_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "1",
+                "Name": "vmhana11"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Slave"
+            },
+            {
+              "Active": true,
+              "Agent": "ocf::suse:SAPHanaController",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaCon_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "2",
+                "Name": "vmhana12"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Slave"
+            },
+            {
+              "Active": true,
+              "Agent": "ocf::suse:SAPHanaController",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaCon_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "4",
+                "Name": "vmhana22"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Slave"
+            },
+            {
+              "Active": true,
+              "Agent": "ocf::suse:SAPHanaController",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaCon_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "3",
+                "Name": "vmhana21"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Master"
+            },
+            {
+              "Active": false,
+              "Agent": "ocf::suse:SAPHanaController",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_SAPHanaCon_PRD_HDB00",
+              "Managed": true,
+              "Node": null,
+              "NodesRunningOn": 0,
+              "Orphaned": false,
+              "Role": "Stopped"
+            }
+          ],
+          "Unique": false
+        }
+      ],
+      "Groups": [
+        {
+          "Id": "g_ip_PRD_HDB00",
+          "Resources": [
+            {
+              "Active": true,
+              "Agent": "ocf::heartbeat:IPaddr2",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_ip_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "3",
+                "Name": "vmhana21"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Started"
+            },
+            {
+              "Active": true,
+              "Agent": "ocf::heartbeat:azure-lb",
+              "Blocked": false,
+              "Failed": false,
+              "FailureIgnored": false,
+              "Id": "rsc_nc_PRD_HDB00",
+              "Managed": true,
+              "Node": {
+                "Cached": true,
+                "Id": "3",
+                "Name": "vmhana21"
+              },
+              "NodesRunningOn": 1,
+              "Orphaned": false,
+              "Role": "Started"
+            }
+          ]
+        }
+      ],
+      "NodeAttributes": {
+        "Nodes": [
+          {
+            "Attributes": [
+              {
+                "Name": "hana_prd_clone_state",
+                "Value": "DEMOTED"
+              },
+              {
+                "Name": "hana_prd_gra",
+                "Value": "2.0"
+              },
+              {
+                "Name": "hana_prd_gsh",
+                "Value": "2.2"
+              },
+              {
+                "Name": "hana_prd_roles",
+                "Value": "master1:master:worker:master"
+              },
+              {
+                "Name": "hana_prd_site",
+                "Value": "Site1"
+              },
+              {
+                "Name": "master-rsc_SAPHanaCon_PRD_HDB00",
+                "Value": "100"
+              }
+            ],
+            "Name": "vmhana11"
+          },
+          {
+            "Attributes": [
+              {
+                "Name": "hana_prd_clone_state",
+                "Value": "DEMOTED"
+              },
+              {
+                "Name": "hana_prd_gra",
+                "Value": "2.0"
+              },
+              {
+                "Name": "hana_prd_gsh",
+                "Value": "2.2"
+              },
+              {
+                "Name": "hana_prd_roles",
+                "Value": "slave:slave:worker:slave"
+              },
+              {
+                "Name": "hana_prd_site",
+                "Value": "Site1"
+              },
+              {
+                "Name": "master-rsc_SAPHanaCon_PRD_HDB00",
+                "Value": "-12200"
+              }
+            ],
+            "Name": "vmhana12"
+          },
+          {
+            "Attributes": [
+              {
+                "Name": "hana_prd_clone_state",
+                "Value": "PROMOTED"
+              },
+              {
+                "Name": "hana_prd_gra",
+                "Value": "2.0"
+              },
+              {
+                "Name": "hana_prd_gsh",
+                "Value": "2.2"
+              },
+              {
+                "Name": "hana_prd_roles",
+                "Value": "master1:master:worker:master"
+              },
+              {
+                "Name": "hana_prd_site",
+                "Value": "Site2"
+              },
+              {
+                "Name": "master-rsc_SAPHanaCon_PRD_HDB00",
+                "Value": "150"
+              }
+            ],
+            "Name": "vmhana21"
+          },
+          {
+            "Attributes": [
+              {
+                "Name": "hana_prd_clone_state",
+                "Value": "DEMOTED"
+              },
+              {
+                "Name": "hana_prd_gra",
+                "Value": "2.0"
+              },
+              {
+                "Name": "hana_prd_gsh",
+                "Value": "2.2"
+              },
+              {
+                "Name": "hana_prd_roles",
+                "Value": "slave:slave:worker:slave"
+              },
+              {
+                "Name": "hana_prd_site",
+                "Value": "Site2"
+              },
+              {
+                "Name": "master-rsc_SAPHanaCon_PRD_HDB00",
+                "Value": "-10000"
+              }
+            ],
+            "Name": "vmhana22"
+          }
+        ]
+      },
+      "NodeHistory": {
+        "Nodes": [
+          {
+            "Name": "vmhana11",
+            "ResourceHistory": [
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_SAPHanaTop_PRD_HDB00"
+              },
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_SAPHanaCon_PRD_HDB00"
+              }
+            ]
+          },
+          {
+            "Name": "vmhana12",
+            "ResourceHistory": [
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_SAPHanaTop_PRD_HDB00"
+              },
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_SAPHanaCon_PRD_HDB00"
+              }
+            ]
+          },
+          {
+            "Name": "vmhana22",
+            "ResourceHistory": [
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_SAPHanaTop_PRD_HDB00"
+              },
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_SAPHanaCon_PRD_HDB00"
+              }
+            ]
+          },
+          {
+            "Name": "vmhana21",
+            "ResourceHistory": [
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_ip_PRD_HDB00"
+              },
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_nc_PRD_HDB00"
+              },
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_SAPHanaTop_PRD_HDB00"
+              },
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_SAPHanaCon_PRD_HDB00"
+              }
+            ]
+          },
+          {
+            "Name": "vmhanamm",
+            "ResourceHistory": [
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "stonith-sbd"
+              },
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_nc_PRD_HDB00"
+              },
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_ip_PRD_HDB00"
+              },
+              {
+                "FailCount": 0,
+                "MigrationThreshold": 50,
+                "Name": "rsc_SAPHanaCon_PRD_HDB00"
+              }
+            ]
+          }
+        ]
+      },
+      "Nodes": [
+        {
+          "DC": true,
+          "ExpectedUp": true,
+          "Id": "1",
+          "Maintenance": false,
+          "Name": "vmhana11",
+          "Online": true,
+          "Pending": false,
+          "ResourcesRunning": 2,
+          "Shutdown": false,
+          "Standby": false,
+          "StandbyOnFail": false,
+          "Type": "member",
+          "Unclean": false
+        },
+        {
+          "DC": false,
+          "ExpectedUp": true,
+          "Id": "2",
+          "Maintenance": false,
+          "Name": "vmhana12",
+          "Online": true,
+          "Pending": false,
+          "ResourcesRunning": 2,
+          "Shutdown": false,
+          "Standby": false,
+          "StandbyOnFail": false,
+          "Type": "member",
+          "Unclean": false
+        },
+        {
+          "DC": false,
+          "ExpectedUp": true,
+          "Id": "3",
+          "Maintenance": false,
+          "Name": "vmhana21",
+          "Online": true,
+          "Pending": false,
+          "ResourcesRunning": 4,
+          "Shutdown": false,
+          "Standby": false,
+          "StandbyOnFail": false,
+          "Type": "member",
+          "Unclean": false
+        },
+        {
+          "DC": false,
+          "ExpectedUp": true,
+          "Id": "4",
+          "Maintenance": false,
+          "Name": "vmhana22",
+          "Online": true,
+          "Pending": false,
+          "ResourcesRunning": 2,
+          "Shutdown": false,
+          "Standby": false,
+          "StandbyOnFail": false,
+          "Type": "member",
+          "Unclean": false
+        },
+        {
+          "DC": false,
+          "ExpectedUp": true,
+          "Id": "5",
+          "Maintenance": false,
+          "Name": "vmhanamm",
+          "Online": true,
+          "Pending": false,
+          "ResourcesRunning": 1,
+          "Shutdown": false,
+          "Standby": false,
+          "StandbyOnFail": false,
+          "Type": "member",
+          "Unclean": false
+        }
+      ],
+      "Resources": [
+        {
+          "Active": true,
+          "Agent": "stonith:external/sbd",
+          "Blocked": false,
+          "Failed": false,
+          "FailureIgnored": false,
+          "Id": "stonith-sbd",
+          "Managed": true,
+          "Node": {
+            "Cached": true,
+            "Id": "5",
+            "Name": "vmhanamm"
+          },
+          "NodesRunningOn": 1,
+          "Orphaned": false,
+          "Role": "Started"
+        }
+      ],
+      "Summary": {
+        "ClusterOptions": {
+          "StonithEnabled": true
+        },
+        "LastChange": {
+          "Time": "Tue Jan 23 12:49:07 2024"
+        },
+        "Nodes": {
+          "Number": 5
+        },
+        "Resources": {
+          "Blocked": 0,
+          "Disabled": 0,
+          "Number": 13
+        }
+      },
+      "Version": "2.1.5+20221208.a3f44794f-150500.6.5.8"
+    },
+    "DC": false,
+    "Id": "72624160ba9290ae3768c52d8ea485e3",
+    "Name": "hana_cluster",
+    "Provider": "azure",
+    "SBD": {
+      "Config": {
+        "SBD_DELAY_START": "216",
+        "SBD_DEVICE": "/dev/disk/by-id/scsi-1LIO-ORG_sbdnfs:01144514-24f0-4386-83c2-321e6b1af8b0",
+        "SBD_MOVE_TO_ROOT_CGROUP": "auto",
+        "SBD_OPTS": "",
+        "SBD_PACEMAKER": "yes",
+        "SBD_STARTMODE": "always",
+        "SBD_SYNC_RESOURCE_STARTUP": "yes",
+        "SBD_TIMEOUT_ACTION": "flush,reboot",
+        "SBD_WATCHDOG_DEV": "/dev/watchdog",
+        "SBD_WATCHDOG_TIMEOUT": "60"
+      },
+      "Devices": [
+        {
+          "Device": "/dev/disk/by-id/scsi-1LIO-ORG_sbdnfs:01144514-24f0-4386-83c2-321e6b1af8b0",
+          "Dump": {
+            "Header": "2.1",
+            "SectorSize": 512,
+            "Slots": 255,
+            "TimeoutAllocate": 2,
+            "TimeoutLoop": 1,
+            "TimeoutMsgwait": 120,
+            "TimeoutWatchdog": 60,
+            "Uuid": "6dff0805-9e2d-484c-9f18-06f017cb81e5"
+          },
+          "List": [
+            {
+              "Id": 0,
+              "Name": "vmhana11",
+              "Status": "clear"
+            },
+            {
+              "Id": 1,
+              "Name": "vmhana12",
+              "Status": "clear"
+            },
+            {
+              "Id": 2,
+              "Name": "vmhana21",
+              "Status": "clear"
+            },
+            {
+              "Id": 3,
+              "Name": "vmhana22",
+              "Status": "clear"
+            },
+            {
+              "Id": 4,
+              "Name": "vmhanamm",
+              "Status": "clear"
+            }
+          ],
+          "Status": "healthy"
+        }
+      ]
+    }
+  }
+}

--- a/test/trento/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/discovery/policies/cluster_policy_test.exs
@@ -1308,8 +1308,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   discovered_health: :passing,
                   cib_last_written: "Thu Feb 23 15:59:56 2023",
                   details: %HanaClusterDetails{
-                    system_replication_mode: "Unknown",
-                    system_replication_operation_mode: "Unknown",
+                    system_replication_mode: "syncmem",
+                    system_replication_operation_mode: "delta_datashipping",
                     secondary_sync_state: "SOK",
                     sr_health_state: "4",
                     fencing_type: "external/sbd",
@@ -1542,8 +1542,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   discovered_health: :passing,
                   cib_last_written: "Tue Jan 23 12:49:07 2024",
                   details: %HanaClusterDetails{
-                    system_replication_mode: "Unknown",
-                    system_replication_operation_mode: "Unknown",
+                    system_replication_mode: "sync",
+                    system_replication_operation_mode: "logreplay",
                     secondary_sync_state: "SOK",
                     sr_health_state: "4",
                     fencing_type: "external/sbd",

--- a/test/trento/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/discovery/policies/cluster_policy_test.exs
@@ -1290,6 +1290,431 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
              |> ClusterPolicy.handle(nil)
   end
 
+  describe "HANA scale out" do
+    test "should return the expected commands when a ha_cluster_discovery payload with hana scale out is handled" do
+      assert {:ok,
+              [
+                %RegisterClusterHost{
+                  cluster_id: "751fb16d-62e3-5411-aa33-0100012453c7",
+                  host_id: "286808a7-01bf-420d-af50-10846a7d7868",
+                  name: "hana_cluster",
+                  type: :hana_scale_out,
+                  sid: "PRD",
+                  additional_sids: [],
+                  provider: :kvm,
+                  designated_controller: true,
+                  resources_number: 15,
+                  hosts_number: 6,
+                  discovered_health: :passing,
+                  cib_last_written: "Thu Feb 23 15:59:56 2023",
+                  details: %HanaClusterDetails{
+                    system_replication_mode: "Unknown",
+                    system_replication_operation_mode: "Unknown",
+                    secondary_sync_state: "SOK",
+                    sr_health_state: "4",
+                    fencing_type: "external/sbd",
+                    stopped_resources: [],
+                    nodes: [
+                      %HanaClusterNode{
+                        name: "vmhana01",
+                        site: "Site1",
+                        hana_status: "Primary",
+                        attributes: %{
+                          "hana_prd_clone_state" => "PROMOTED",
+                          "hana_prd_gra" => "2.0",
+                          "hana_prd_roles" => "master1:master:worker:master",
+                          "hana_prd_site" => "Site1",
+                          "master-rsc_SAPHanaController_PRD_HDB00" => "150"
+                        },
+                        virtual_ip: "192.168.152.16",
+                        resources: [
+                          %ClusterResource{
+                            id: "stonith-sbd",
+                            type: "stonith:external/sbd",
+                            role: "Started",
+                            status: "Active",
+                            fail_count: 0
+                          },
+                          %ClusterResource{
+                            id: "rsc_ip_PRD_HDB00",
+                            type: "ocf::heartbeat:IPaddr2",
+                            role: "Started",
+                            status: "Active",
+                            fail_count: 0
+                          },
+                          %ClusterResource{
+                            id: "rsc_exporter_PRD_HDB00",
+                            type: "systemd:prometheus-hanadb_exporter@PRD_HDB00",
+                            role: "Started",
+                            status: "Active",
+                            fail_count: 0
+                          },
+                          %ClusterResource{
+                            id: "rsc_SAPHanaController_PRD_HDB00",
+                            type: "ocf::suse:SAPHanaController",
+                            role: "Master",
+                            status: "Active",
+                            fail_count: 0
+                          },
+                          %ClusterResource{
+                            id: "rsc_SAPHanaTopology_PRD_HDB00",
+                            type: "ocf::suse:SAPHanaTopology",
+                            role: "Started",
+                            status: "Active",
+                            fail_count: 0
+                          }
+                        ]
+                      },
+                      %HanaClusterNode{
+                        name: "vmhana02",
+                        site: "Site2",
+                        hana_status: "Secondary",
+                        attributes: %{
+                          "hana_prd_clone_state" => "DEMOTED",
+                          "hana_prd_gra" => "2.0",
+                          "hana_prd_roles" => "master1:master:worker:master",
+                          "hana_prd_site" => "Site2",
+                          "master-rsc_SAPHanaController_PRD_HDB00" => "100"
+                        },
+                        virtual_ip: nil,
+                        resources: [
+                          %ClusterResource{
+                            id: "rsc_SAPHanaController_PRD_HDB00",
+                            type: "ocf::suse:SAPHanaController",
+                            role: "Slave",
+                            status: "Active",
+                            fail_count: 0
+                          },
+                          %ClusterResource{
+                            id: "rsc_SAPHanaTopology_PRD_HDB00",
+                            type: "ocf::suse:SAPHanaTopology",
+                            role: "Started",
+                            status: "Active",
+                            fail_count: 0
+                          }
+                        ]
+                      },
+                      %HanaClusterNode{
+                        name: "vmhana03",
+                        site: "Site1",
+                        hana_status: "Primary",
+                        attributes: %{
+                          "hana_prd_clone_state" => "DEMOTED",
+                          "hana_prd_gra" => "2.0",
+                          "hana_prd_roles" => "master3:slave:standby:standby",
+                          "hana_prd_site" => "Site1",
+                          "master-rsc_SAPHanaController_PRD_HDB00" => "140"
+                        },
+                        virtual_ip: nil,
+                        resources: [
+                          %ClusterResource{
+                            id: "rsc_SAPHanaController_PRD_HDB00",
+                            type: "ocf::suse:SAPHanaController",
+                            role: "Slave",
+                            status: "Active",
+                            fail_count: 0
+                          },
+                          %ClusterResource{
+                            id: "rsc_SAPHanaTopology_PRD_HDB00",
+                            type: "ocf::suse:SAPHanaTopology",
+                            role: "Started",
+                            status: "Active",
+                            fail_count: 0
+                          }
+                        ]
+                      },
+                      %HanaClusterNode{
+                        name: "vmhana04",
+                        site: "Site2",
+                        hana_status: "Secondary",
+                        attributes: %{
+                          "hana_prd_clone_state" => "DEMOTED",
+                          "hana_prd_gra" => "2.0",
+                          "hana_prd_roles" => "master2:slave:standby:standby",
+                          "hana_prd_site" => "Site2",
+                          "master-rsc_SAPHanaController_PRD_HDB00" => "80"
+                        },
+                        virtual_ip: nil,
+                        resources: [
+                          %ClusterResource{
+                            id: "rsc_SAPHanaController_PRD_HDB00",
+                            type: "ocf::suse:SAPHanaController",
+                            role: "Slave",
+                            status: "Active",
+                            fail_count: 0
+                          },
+                          %ClusterResource{
+                            id: "rsc_SAPHanaTopology_PRD_HDB00",
+                            type: "ocf::suse:SAPHanaTopology",
+                            role: "Started",
+                            status: "Active",
+                            fail_count: 0
+                          }
+                        ]
+                      },
+                      %HanaClusterNode{
+                        name: "vmhana05",
+                        site: "Site1",
+                        hana_status: "Primary",
+                        attributes: %{
+                          "hana_prd_clone_state" => "DEMOTED",
+                          "hana_prd_gra" => "2.0",
+                          "hana_prd_roles" => "master2:slave:worker:slave",
+                          "hana_prd_site" => "Site1",
+                          "master-rsc_SAPHanaController_PRD_HDB00" => "140"
+                        },
+                        virtual_ip: nil,
+                        resources: [
+                          %ClusterResource{
+                            id: "rsc_SAPHanaController_PRD_HDB00",
+                            type: "ocf::suse:SAPHanaController",
+                            role: "Slave",
+                            status: "Active",
+                            fail_count: 0
+                          },
+                          %ClusterResource{
+                            id: "rsc_SAPHanaTopology_PRD_HDB00",
+                            type: "ocf::suse:SAPHanaTopology",
+                            role: "Started",
+                            status: "Active",
+                            fail_count: 0
+                          }
+                        ]
+                      },
+                      %HanaClusterNode{
+                        name: "vmhana06",
+                        site: "Site2",
+                        hana_status: "Secondary",
+                        attributes: %{
+                          "hana_prd_clone_state" => "DEMOTED",
+                          "hana_prd_gra" => "2.0",
+                          "hana_prd_roles" => "master3:slave:worker:slave",
+                          "hana_prd_site" => "Site2",
+                          "master-rsc_SAPHanaController_PRD_HDB00" => "80"
+                        },
+                        virtual_ip: nil,
+                        resources: [
+                          %ClusterResource{
+                            id: "rsc_SAPHanaController_PRD_HDB00",
+                            type: "ocf::suse:SAPHanaController",
+                            role: "Slave",
+                            status: "Active",
+                            fail_count: 0
+                          },
+                          %ClusterResource{
+                            id: "rsc_SAPHanaTopology_PRD_HDB00",
+                            type: "ocf::suse:SAPHanaTopology",
+                            role: "Started",
+                            status: "Active",
+                            fail_count: 0
+                          }
+                        ]
+                      }
+                    ],
+                    sbd_devices: [
+                      %SbdDevice{
+                        device: "/dev/vdb",
+                        status: "healthy"
+                      }
+                    ]
+                  }
+                }
+              ]} ==
+               "ha_cluster_discovery_hana_scale_out"
+               |> load_discovery_event_fixture()
+               |> ClusterPolicy.handle(nil)
+    end
+
+    test "should return the expected commands when a ha_cluster_discovery payload with hana scale out with multi target hook is handled" do
+      assert {:ok,
+              [
+                %RegisterClusterHost{
+                  cluster_id: "f343beb7-f474-57d9-bec6-60215e5a4fbc",
+                  host_id: "9abb22d6-716a-4321-bb1e-175f179e7bb6",
+                  name: "hana_cluster",
+                  type: :hana_scale_out,
+                  sid: "PRD",
+                  additional_sids: [],
+                  provider: :azure,
+                  designated_controller: false,
+                  resources_number: 13,
+                  hosts_number: 5,
+                  discovered_health: :passing,
+                  cib_last_written: "Tue Jan 23 12:49:07 2024",
+                  details: %HanaClusterDetails{
+                    system_replication_mode: "Unknown",
+                    system_replication_operation_mode: "Unknown",
+                    secondary_sync_state: "SOK",
+                    sr_health_state: "4",
+                    fencing_type: "external/sbd",
+                    stopped_resources: [
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTop_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Stopped",
+                        status: nil,
+                        fail_count: nil
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaCon_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Stopped",
+                        status: nil,
+                        fail_count: nil
+                      }
+                    ],
+                    nodes: [
+                      %HanaClusterNode{
+                        name: "vmhana11",
+                        site: "Site1",
+                        hana_status: "Secondary",
+                        attributes: %{
+                          "hana_prd_clone_state" => "DEMOTED",
+                          "hana_prd_gra" => "2.0",
+                          "hana_prd_gsh" => "2.2",
+                          "hana_prd_roles" => "master1:master:worker:master",
+                          "hana_prd_site" => "Site1",
+                          "master-rsc_SAPHanaCon_PRD_HDB00" => "100"
+                        },
+                        virtual_ip: nil,
+                        resources: [
+                          %ClusterResource{
+                            id: "rsc_SAPHanaTop_PRD_HDB00",
+                            type: "ocf::suse:SAPHanaTopology",
+                            role: "Started",
+                            status: "Active",
+                            fail_count: 0
+                          },
+                          %ClusterResource{
+                            id: "rsc_SAPHanaCon_PRD_HDB00",
+                            type: "ocf::suse:SAPHanaController",
+                            role: "Slave",
+                            status: "Active",
+                            fail_count: 0
+                          }
+                        ]
+                      },
+                      %HanaClusterNode{
+                        name: "vmhana12",
+                        site: "Site1",
+                        hana_status: "Secondary",
+                        attributes: %{
+                          "hana_prd_clone_state" => "DEMOTED",
+                          "hana_prd_gra" => "2.0",
+                          "hana_prd_gsh" => "2.2",
+                          "hana_prd_roles" => "slave:slave:worker:slave",
+                          "hana_prd_site" => "Site1",
+                          "master-rsc_SAPHanaCon_PRD_HDB00" => "-12200"
+                        },
+                        virtual_ip: nil,
+                        resources: [
+                          %ClusterResource{
+                            id: "rsc_SAPHanaTop_PRD_HDB00",
+                            type: "ocf::suse:SAPHanaTopology",
+                            role: "Started",
+                            status: "Active",
+                            fail_count: 0
+                          },
+                          %ClusterResource{
+                            id: "rsc_SAPHanaCon_PRD_HDB00",
+                            type: "ocf::suse:SAPHanaController",
+                            role: "Slave",
+                            status: "Active",
+                            fail_count: 0
+                          }
+                        ]
+                      },
+                      %HanaClusterNode{
+                        name: "vmhana21",
+                        site: "Site2",
+                        hana_status: "Primary",
+                        attributes: %{
+                          "hana_prd_clone_state" => "PROMOTED",
+                          "hana_prd_gra" => "2.0",
+                          "hana_prd_gsh" => "2.2",
+                          "hana_prd_roles" => "master1:master:worker:master",
+                          "hana_prd_site" => "Site2",
+                          "master-rsc_SAPHanaCon_PRD_HDB00" => "150"
+                        },
+                        virtual_ip: "10.0.0.10",
+                        resources: [
+                          %ClusterResource{
+                            id: "rsc_SAPHanaTop_PRD_HDB00",
+                            type: "ocf::suse:SAPHanaTopology",
+                            role: "Started",
+                            status: "Active",
+                            fail_count: 0
+                          },
+                          %ClusterResource{
+                            id: "rsc_SAPHanaCon_PRD_HDB00",
+                            type: "ocf::suse:SAPHanaController",
+                            role: "Master",
+                            status: "Active",
+                            fail_count: 0
+                          },
+                          %ClusterResource{
+                            id: "rsc_ip_PRD_HDB00",
+                            type: "ocf::heartbeat:IPaddr2",
+                            role: "Started",
+                            status: "Active",
+                            fail_count: 0
+                          },
+                          %ClusterResource{
+                            id: "rsc_nc_PRD_HDB00",
+                            type: "ocf::heartbeat:azure-lb",
+                            role: "Started",
+                            status: "Active",
+                            fail_count: 0
+                          }
+                        ]
+                      },
+                      %HanaClusterNode{
+                        name: "vmhana22",
+                        site: "Site2",
+                        hana_status: "Primary",
+                        attributes: %{
+                          "hana_prd_clone_state" => "DEMOTED",
+                          "hana_prd_gra" => "2.0",
+                          "hana_prd_gsh" => "2.2",
+                          "hana_prd_roles" => "slave:slave:worker:slave",
+                          "hana_prd_site" => "Site2",
+                          "master-rsc_SAPHanaCon_PRD_HDB00" => "-10000"
+                        },
+                        virtual_ip: nil,
+                        resources: [
+                          %ClusterResource{
+                            id: "rsc_SAPHanaTop_PRD_HDB00",
+                            type: "ocf::suse:SAPHanaTopology",
+                            role: "Started",
+                            status: "Active",
+                            fail_count: 0
+                          },
+                          %ClusterResource{
+                            id: "rsc_SAPHanaCon_PRD_HDB00",
+                            type: "ocf::suse:SAPHanaController",
+                            role: "Slave",
+                            status: "Active",
+                            fail_count: 0
+                          }
+                        ]
+                      }
+                    ],
+                    sbd_devices: [
+                      %SbdDevice{
+                        device:
+                          "/dev/disk/by-id/scsi-1LIO-ORG_sbdnfs:01144514-24f0-4386-83c2-321e6b1af8b0",
+                        status: "healthy"
+                      }
+                    ]
+                  }
+                }
+              ]} ==
+               "ha_cluster_discovery_hana_scale_out_multitarget"
+               |> load_discovery_event_fixture()
+               |> ClusterPolicy.handle(nil)
+    end
+  end
+
   describe "delta deregistration" do
     test "should deregister the host from the current cluster and register to the new one" do
       current_cluster_id = UUID.uuid4()


### PR DESCRIPTION
# Description
HANA scale out discovery.
We only need to change the policy.
In a scale out cluster how we identify different fields is different.
We need to find them in the `cluser_properties` field. Check the test fixtures to see them.
The major difficulty comes when these attributes are not always present...
This depends on if some resource agents hooks are used or not...
As far as I discovered there are 3 ways:
- No hooks. So the fields might not be there, so some fields will be populated with `unknown` value (**I have not been able to get any fixture for this, so it is just a "I hope it works" effort**)
- `SAPHanaSR.py` hook. This is old hook. In this case we don't have the `hana_<sid>_site_srHook_<site>` attributes
- `SAPHanaSrMultiTarget.py` hook, which provides the latest fields.

Now...
- The value in nodes `role` column needs to be redefined. This value is `site` based instead of host based. In scale up it doesn't really matter to show it wrong, but we need a new design most probably
- The `SAPHanaSR health state` field is as well site based. Right now, we only show the secondary value, but we could show both sites in fact
- The majority maker nodes is not visualized

@abravosuse the topics above must be discussed (we already started some days ago in fact).

In a next PR I want to add some storybook story, add some E2E test just in case and upload a real scale out fixtures set.

This is how it looks like:
![scale_out](https://github.com/trento-project/web/assets/36370954/1a77919a-aaec-420b-aaf9-2f5a75acf2b1)


## How was this tested?

Tested in the backend
