### PR TITLE
Fix ENSA version calculation

### DIFF
--- a/lib/trento/clusters.ex
+++ b/lib/trento/clusters.ex
@@ -8,7 +8,7 @@ defmodule Trento.Clusters do
   require Logger
   require Trento.Clusters.Enums.ClusterType, as: ClusterType
   require Trento.Clusters.Enums.FilesystemType, as: FilesystemType
-  require Trento.Clusters.Enums.EnsaVersion, as: EnsaVersion
+  require Trento.Clusters.Enums.ClusterEnsaVersion, as: ClusterEnsaVersion
 
   alias Trento.Hosts.Projections.HostReadModel
 
@@ -183,7 +183,7 @@ defmodule Trento.Clusters do
       hosts_data
       |> Enum.map(fn %{sap_system_id: sap_system_id} -> sap_system_id end)
       |> Enum.uniq()
-      |> get_aggregated_ensa_version()
+      |> get_cluster_ensa_version()
 
     env = %Checks.ClusterExecutionEnv{
       provider: provider,
@@ -232,8 +232,8 @@ defmodule Trento.Clusters do
 
   defp maybe_request_checks_execution(error), do: error
 
-  @spec get_aggregated_ensa_version([String.t()]) :: EnsaVersion.t()
-  defp get_aggregated_ensa_version(sap_system_ids) do
+  @spec get_cluster_ensa_version([String.t()]) :: ClusterEnsaVersion.t()
+  defp get_cluster_ensa_version(sap_system_ids) do
     ensa_versions =
       Repo.all(
         from(s in SapSystemReadModel,
@@ -245,7 +245,7 @@ defmodule Trento.Clusters do
 
     case ensa_versions do
       [ensa_version] -> ensa_version
-      _ -> EnsaVersion.mixed_versions()
+      _ -> ClusterEnsaVersion.mixed_versions()
     end
   end
 end

--- a/lib/trento/clusters/enums/cluster_ensa_version.ex
+++ b/lib/trento/clusters/enums/cluster_ensa_version.ex
@@ -1,4 +1,4 @@
-defmodule Trento.Clusters.Enums.EnsaVersion do
+defmodule Trento.Clusters.Enums.ClusterEnsaVersion do
   @moduledoc """
   Type that represents the ENSA version info for a cluster.
   """

--- a/lib/trento/infrastructure/checks/cluster_execution_env.ex
+++ b/lib/trento/infrastructure/checks/cluster_execution_env.ex
@@ -9,12 +9,12 @@ defmodule Trento.Infrastructure.Checks.ClusterExecutionEnv do
   require Trento.Enums.Provider, as: Provider
   require Trento.Clusters.Enums.ClusterType, as: ClusterType
   require Trento.Clusters.Enums.FilesystemType, as: FilesystemType
-  require Trento.Clusters.Enums.EnsaVersion, as: EnsaVersion
+  require Trento.Clusters.Enums.ClusterEnsaVersion, as: ClusterEnsaVersion
 
   deftype do
     field :cluster_type, Ecto.Enum, values: ClusterType.values()
     field :provider, Ecto.Enum, values: Provider.values()
     field :filesystem_type, Ecto.Enum, values: FilesystemType.values()
-    field :ensa_version, Ecto.Enum, values: EnsaVersion.values()
+    field :ensa_version, Ecto.Enum, values: ClusterEnsaVersion.values()
   end
 end

--- a/test/trento/clusters_test.exs
+++ b/test/trento/clusters_test.exs
@@ -196,9 +196,13 @@ defmodule Trento.ClustersTest do
 
   describe "ASCS/ERS cluster checks execution" do
     test "should start a checks execution on demand for ascs_ers clusters with a resource managed filesystem type" do
+      %SapSystemReadModel{id: sap_system_id, sid: sid} =
+        insert(:sap_system, ensa_version: EnsaVersion.ensa1())
+
       %{id: cluster_id, provider: provider, type: cluster_type} =
         insert(:cluster,
           type: :ascs_ers,
+          additional_sids: [sid],
           details:
             build(:ascs_ers_cluster_details,
               sap_systems:
@@ -207,7 +211,18 @@ defmodule Trento.ClustersTest do
         )
 
       insert(:host, deregistered_at: DateTime.utc_now(), cluster_id: cluster_id)
-      insert_list(2, :host, cluster_id: cluster_id)
+      hosts = insert_list(2, :host, cluster_id: cluster_id)
+
+      Enum.map(
+        hosts,
+        fn h ->
+          insert(:application_instance_without_host,
+            sap_system_id: sap_system_id,
+            host: h,
+            sid: sid
+          )
+        end
+      )
 
       expect(Trento.Infrastructure.Messaging.Adapter.Mock, :publish, fn "executions", message ->
         assert message.group_id == cluster_id
@@ -218,7 +233,7 @@ defmodule Trento.ClustersTest do
                  "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
                  "filesystem_type" => %{kind: {:string_value, Atom.to_string(:resource_managed)}},
                  "ensa_version" => %{
-                   kind: {:string_value, Atom.to_string(EnsaVersion.mixed_versions())}
+                   kind: {:string_value, Atom.to_string(EnsaVersion.ensa1())}
                  }
                }
 
@@ -231,9 +246,13 @@ defmodule Trento.ClustersTest do
     end
 
     test "should start a checks execution on demand for ascs_ers clusters with a simple mount filesystem type" do
+      %SapSystemReadModel{id: sap_system_id, sid: sid} =
+        insert(:sap_system, ensa_version: EnsaVersion.ensa2())
+
       %{id: cluster_id, provider: provider, type: cluster_type} =
         insert(:cluster,
           type: :ascs_ers,
+          additional_sids: [sid],
           details:
             build(:ascs_ers_cluster_details,
               sap_systems:
@@ -242,7 +261,18 @@ defmodule Trento.ClustersTest do
         )
 
       insert(:host, deregistered_at: DateTime.utc_now(), cluster_id: cluster_id)
-      insert_list(2, :host, cluster_id: cluster_id)
+      hosts = insert_list(2, :host, cluster_id: cluster_id)
+
+      Enum.map(
+        hosts,
+        fn h ->
+          insert(:application_instance_without_host,
+            sap_system_id: sap_system_id,
+            host: h,
+            sid: sid
+          )
+        end
+      )
 
       expect(Trento.Infrastructure.Messaging.Adapter.Mock, :publish, fn "executions", message ->
         assert message.group_id == cluster_id
@@ -253,7 +283,7 @@ defmodule Trento.ClustersTest do
                  "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
                  "filesystem_type" => %{kind: {:string_value, Atom.to_string(:simple_mount)}},
                  "ensa_version" => %{
-                   kind: {:string_value, Atom.to_string(EnsaVersion.mixed_versions())}
+                   kind: {:string_value, Atom.to_string(EnsaVersion.ensa2())}
                  }
                }
 
@@ -266,9 +296,13 @@ defmodule Trento.ClustersTest do
     end
 
     test "should start a checks execution on demand for ascs_ers clusters with a mixed filesystem type" do
+      %SapSystemReadModel{id: sap_system_id, sid: sid} =
+        insert(:sap_system, ensa_version: EnsaVersion.ensa2())
+
       %{id: cluster_id, provider: provider, type: cluster_type} =
         insert(:cluster,
           type: :ascs_ers,
+          additional_sids: [sid],
           details:
             build(:ascs_ers_cluster_details,
               sap_systems: [
@@ -279,7 +313,18 @@ defmodule Trento.ClustersTest do
         )
 
       insert(:host, deregistered_at: DateTime.utc_now(), cluster_id: cluster_id)
-      insert_list(2, :host, cluster_id: cluster_id)
+      hosts = insert_list(2, :host, cluster_id: cluster_id)
+
+      Enum.map(
+        hosts,
+        fn h ->
+          insert(:application_instance_without_host,
+            sap_system_id: sap_system_id,
+            host: h,
+            sid: sid
+          )
+        end
+      )
 
       expect(Trento.Infrastructure.Messaging.Adapter.Mock, :publish, fn "executions", message ->
         assert message.group_id == cluster_id
@@ -290,7 +335,7 @@ defmodule Trento.ClustersTest do
                  "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
                  "filesystem_type" => %{kind: {:string_value, Atom.to_string(:mixed_fs_types)}},
                  "ensa_version" => %{
-                   kind: {:string_value, Atom.to_string(EnsaVersion.mixed_versions())}
+                   kind: {:string_value, Atom.to_string(EnsaVersion.ensa2())}
                  }
                }
 
@@ -322,8 +367,8 @@ defmodule Trento.ClustersTest do
           details:
             build(:ascs_ers_cluster_details,
               sap_systems: [
-                build(:ascs_ers_cluster_sap_system, sid: sid_1, filesystem_resource_based: true),
-                build(:ascs_ers_cluster_sap_system, sid: sid_2, filesystem_resource_based: true)
+                build(:ascs_ers_cluster_sap_system, sid: sid_1, filesystem_resource_based: false),
+                build(:ascs_ers_cluster_sap_system, sid: sid_2, filesystem_resource_based: false)
               ]
             )
         )

--- a/test/trento/clusters_test.exs
+++ b/test/trento/clusters_test.exs
@@ -20,9 +20,11 @@ defmodule Trento.ClustersTest do
     Target
   }
 
-  require Trento.Clusters.Enums.ClusterType
-  require Trento.Clusters.Enums.EnsaVersion, as: EnsaVersion
-  require Trento.SapSystems.Enums.EnsaVersion
+  require Trento.Clusters.Enums.ClusterType, as: ClusterType
+  require Trento.Clusters.Enums.ClusterEnsaVersion, as: ClusterEnsaVersion
+
+  require Trento.SapSystems.Enums.EnsaVersion, as: EnsaVersion
+
   require Logger
 
   setup [:set_mox_from_context, :verify_on_exit!]
@@ -233,7 +235,7 @@ defmodule Trento.ClustersTest do
                  "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
                  "filesystem_type" => %{kind: {:string_value, Atom.to_string(:resource_managed)}},
                  "ensa_version" => %{
-                   kind: {:string_value, Atom.to_string(EnsaVersion.ensa1())}
+                   kind: {:string_value, Atom.to_string(ClusterEnsaVersion.ensa1())}
                  }
                }
 
@@ -283,7 +285,7 @@ defmodule Trento.ClustersTest do
                  "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
                  "filesystem_type" => %{kind: {:string_value, Atom.to_string(:simple_mount)}},
                  "ensa_version" => %{
-                   kind: {:string_value, Atom.to_string(EnsaVersion.ensa2())}
+                   kind: {:string_value, Atom.to_string(ClusterEnsaVersion.ensa2())}
                  }
                }
 
@@ -335,7 +337,7 @@ defmodule Trento.ClustersTest do
                  "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
                  "filesystem_type" => %{kind: {:string_value, Atom.to_string(:mixed_fs_types)}},
                  "ensa_version" => %{
-                   kind: {:string_value, Atom.to_string(EnsaVersion.ensa2())}
+                   kind: {:string_value, Atom.to_string(ClusterEnsaVersion.ensa2())}
                  }
                }
 
@@ -349,20 +351,20 @@ defmodule Trento.ClustersTest do
 
     test "should start a checks execution on demand for ascs_ers clusters with ENSA 1 version" do
       %SapSystemReadModel{id: sap_system_id_1, sid: sid_1} =
-        insert(:sap_system, ensa_version: Trento.SapSystems.Enums.EnsaVersion.ensa1())
+        insert(:sap_system, ensa_version: EnsaVersion.ensa1())
 
       %SapSystemReadModel{id: sap_system_id_2, sid: sid_2} =
-        insert(:sap_system, ensa_version: Trento.SapSystems.Enums.EnsaVersion.ensa1())
+        insert(:sap_system, ensa_version: EnsaVersion.ensa1())
 
       %SapSystemReadModel{id: other_cluster_sap_system_id} =
-        insert(:sap_system, sid: sid_1, ensa_version: Trento.SapSystems.Enums.EnsaVersion.ensa2())
+        insert(:sap_system, sid: sid_1, ensa_version: EnsaVersion.ensa2())
 
       %SapSystemReadModel{sid: other_sid} =
-        insert(:sap_system, ensa_version: Trento.SapSystems.Enums.EnsaVersion.ensa2())
+        insert(:sap_system, ensa_version: EnsaVersion.ensa2())
 
       %ClusterReadModel{id: cluster_id, provider: provider, type: cluster_type} =
         insert(:cluster,
-          type: :ascs_ers,
+          type: ClusterType.ascs_ers(),
           additional_sids: [sid_1, sid_2],
           details:
             build(:ascs_ers_cluster_details,
@@ -413,7 +415,7 @@ defmodule Trento.ClustersTest do
                  "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
                  "filesystem_type" => %{kind: {:string_value, Atom.to_string(:simple_mount)}},
                  "ensa_version" => %{
-                   kind: {:string_value, Atom.to_string(EnsaVersion.ensa1())}
+                   kind: {:string_value, Atom.to_string(ClusterEnsaVersion.ensa1())}
                  }
                }
 
@@ -427,20 +429,20 @@ defmodule Trento.ClustersTest do
 
     test "should start a checks execution on demand for ascs_ers clusters with ENSA 2 version" do
       %SapSystemReadModel{id: sap_system_id_1, sid: sid_1} =
-        insert(:sap_system, ensa_version: Trento.SapSystems.Enums.EnsaVersion.ensa2())
+        insert(:sap_system, ensa_version: EnsaVersion.ensa2())
 
       %SapSystemReadModel{id: sap_system_id_2, sid: sid_2} =
-        insert(:sap_system, ensa_version: Trento.SapSystems.Enums.EnsaVersion.ensa2())
+        insert(:sap_system, ensa_version: EnsaVersion.ensa2())
 
       %SapSystemReadModel{id: other_cluster_sap_system_id} =
-        insert(:sap_system, sid: sid_1, ensa_version: Trento.SapSystems.Enums.EnsaVersion.ensa1())
+        insert(:sap_system, sid: sid_1, ensa_version: EnsaVersion.ensa1())
 
       %SapSystemReadModel{sid: other_sid} =
-        insert(:sap_system, ensa_version: Trento.SapSystems.Enums.EnsaVersion.ensa1())
+        insert(:sap_system, ensa_version: EnsaVersion.ensa1())
 
       %ClusterReadModel{id: cluster_id, provider: provider, type: cluster_type} =
         insert(:cluster,
-          type: :ascs_ers,
+          type: ClusterType.ascs_ers(),
           additional_sids: [sid_1, sid_2],
           details:
             build(:ascs_ers_cluster_details,
@@ -491,7 +493,7 @@ defmodule Trento.ClustersTest do
                  "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
                  "filesystem_type" => %{kind: {:string_value, Atom.to_string(:simple_mount)}},
                  "ensa_version" => %{
-                   kind: {:string_value, Atom.to_string(EnsaVersion.ensa2())}
+                   kind: {:string_value, Atom.to_string(ClusterEnsaVersion.ensa2())}
                  }
                }
 
@@ -505,20 +507,20 @@ defmodule Trento.ClustersTest do
 
     test "should start a checks execution on demand for ascs_ers clusters with mixed ENSA versions" do
       %SapSystemReadModel{id: sap_system_id_1, sid: sid_1} =
-        insert(:sap_system, ensa_version: Trento.SapSystems.Enums.EnsaVersion.ensa1())
+        insert(:sap_system, ensa_version: EnsaVersion.ensa1())
 
       %SapSystemReadModel{id: sap_system_id_2, sid: sid_2} =
-        insert(:sap_system, ensa_version: Trento.SapSystems.Enums.EnsaVersion.ensa2())
+        insert(:sap_system, ensa_version: EnsaVersion.ensa2())
 
       %SapSystemReadModel{id: other_cluster_sap_system_id} =
-        insert(:sap_system, sid: sid_1, ensa_version: Trento.SapSystems.Enums.EnsaVersion.ensa1())
+        insert(:sap_system, sid: sid_1, ensa_version: EnsaVersion.ensa1())
 
       %SapSystemReadModel{sid: other_sid} =
-        insert(:sap_system, ensa_version: Trento.SapSystems.Enums.EnsaVersion.ensa1())
+        insert(:sap_system, ensa_version: EnsaVersion.ensa1())
 
       %ClusterReadModel{id: cluster_id, provider: provider, type: cluster_type} =
         insert(:cluster,
-          type: :ascs_ers,
+          type: ClusterType.ascs_ers(),
           additional_sids: [sid_1, sid_2],
           details:
             build(:ascs_ers_cluster_details,
@@ -569,7 +571,7 @@ defmodule Trento.ClustersTest do
                  "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
                  "filesystem_type" => %{kind: {:string_value, Atom.to_string(:simple_mount)}},
                  "ensa_version" => %{
-                   kind: {:string_value, Atom.to_string(EnsaVersion.mixed_versions())}
+                   kind: {:string_value, Atom.to_string(ClusterEnsaVersion.mixed_versions())}
                  }
                }
 

--- a/test/trento/clusters_test.exs
+++ b/test/trento/clusters_test.exs
@@ -350,17 +350,20 @@ defmodule Trento.ClustersTest do
     end
 
     test "should start a checks execution on demand for ascs_ers clusters with ENSA 1 version" do
-      %SapSystemReadModel{id: sap_system_id_1, sid: sid_1} =
-        insert(:sap_system, ensa_version: EnsaVersion.ensa1())
+      sid_1 = Faker.UUID.v4()
+      sid_2 = Faker.UUID.v4()
+      other_sid = Faker.UUID.v4()
 
-      %SapSystemReadModel{id: sap_system_id_2, sid: sid_2} =
-        insert(:sap_system, ensa_version: EnsaVersion.ensa1())
+      %SapSystemReadModel{id: sap_system_id_1} =
+        insert(:sap_system, sid: sid_1, ensa_version: EnsaVersion.ensa1())
+
+      %SapSystemReadModel{id: sap_system_id_2} =
+        insert(:sap_system, sid: sid_2, ensa_version: EnsaVersion.ensa1())
 
       %SapSystemReadModel{id: other_cluster_sap_system_id} =
         insert(:sap_system, sid: sid_1, ensa_version: EnsaVersion.ensa2())
 
-      %SapSystemReadModel{sid: other_sid} =
-        insert(:sap_system, ensa_version: EnsaVersion.ensa2())
+      insert(:sap_system, sid: other_sid, ensa_version: EnsaVersion.ensa2())
 
       %ClusterReadModel{id: cluster_id, provider: provider, type: cluster_type} =
         insert(:cluster,
@@ -428,17 +431,20 @@ defmodule Trento.ClustersTest do
     end
 
     test "should start a checks execution on demand for ascs_ers clusters with ENSA 2 version" do
-      %SapSystemReadModel{id: sap_system_id_1, sid: sid_1} =
-        insert(:sap_system, ensa_version: EnsaVersion.ensa2())
+      sid_1 = Faker.UUID.v4()
+      sid_2 = Faker.UUID.v4()
+      other_sid = Faker.UUID.v4()
 
-      %SapSystemReadModel{id: sap_system_id_2, sid: sid_2} =
-        insert(:sap_system, ensa_version: EnsaVersion.ensa2())
+      %SapSystemReadModel{id: sap_system_id_1} =
+        insert(:sap_system, sid: sid_1, ensa_version: EnsaVersion.ensa2())
+
+      %SapSystemReadModel{id: sap_system_id_2} =
+        insert(:sap_system, sid: sid_2, ensa_version: EnsaVersion.ensa2())
 
       %SapSystemReadModel{id: other_cluster_sap_system_id} =
         insert(:sap_system, sid: sid_1, ensa_version: EnsaVersion.ensa1())
 
-      %SapSystemReadModel{sid: other_sid} =
-        insert(:sap_system, ensa_version: EnsaVersion.ensa1())
+      insert(:sap_system, sid: other_sid, ensa_version: EnsaVersion.ensa1())
 
       %ClusterReadModel{id: cluster_id, provider: provider, type: cluster_type} =
         insert(:cluster,
@@ -506,17 +512,20 @@ defmodule Trento.ClustersTest do
     end
 
     test "should start a checks execution on demand for ascs_ers clusters with mixed ENSA versions" do
-      %SapSystemReadModel{id: sap_system_id_1, sid: sid_1} =
-        insert(:sap_system, ensa_version: EnsaVersion.ensa1())
+      sid_1 = Faker.UUID.v4()
+      sid_2 = Faker.UUID.v4()
+      other_sid = Faker.UUID.v4()
 
-      %SapSystemReadModel{id: sap_system_id_2, sid: sid_2} =
-        insert(:sap_system, ensa_version: EnsaVersion.ensa2())
+      %SapSystemReadModel{id: sap_system_id_1} =
+        insert(:sap_system, sid: sid_1, ensa_version: EnsaVersion.ensa1())
+
+      %SapSystemReadModel{id: sap_system_id_2} =
+        insert(:sap_system, sid: sid_2, ensa_version: EnsaVersion.ensa2())
 
       %SapSystemReadModel{id: other_cluster_sap_system_id} =
         insert(:sap_system, sid: sid_1, ensa_version: EnsaVersion.ensa1())
 
-      %SapSystemReadModel{sid: other_sid} =
-        insert(:sap_system, ensa_version: EnsaVersion.ensa1())
+      insert(:sap_system, sid: other_sid, ensa_version: EnsaVersion.ensa1())
 
       %ClusterReadModel{id: cluster_id, provider: provider, type: cluster_type} =
         insert(:cluster,


### PR DESCRIPTION
# Description

This PR is a correction to the aggregated ENSA version calculation made in https://github.com/trento-project/web/pull/2177

The way the relevant SAP systems and resulting ENSA version are determined is by:

1. Record all hosts that have the cluster's ID in a list
2. From there, get all application instances that are hosts from the _hosts list_ **and** have an SID managed from the cluster (found in the `additional_sids` field for the cluster)
3. With the list of relevant application instances, their corresponding SAP system IDs can be found, and recorded as a list of distinct SAP system IDs.
4. Lastly, with the relevant SAP systems found, their individual ENSA versions can be recorded, and the aggregated ENSA version can be calculated as previously.

## How was this tested?

Updated unit tests to validate the new logic
