### PR TITLE
Fix charts tests increasing prometheus retention time in dev docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,6 +25,8 @@ services:
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=5y'
+      - '--storage.tsdb.retention.size=1GB'
       - '--web.console.libraries=/etc/prometheus/console_libraries'
       - '--web.console.templates=/etc/prometheus/consoles'
       - '--web.enable-lifecycle'


### PR DESCRIPTION
# Description

Fix charts tests increasing prometheus retention time in dev docker compose.
Without this, the default retention time of 15 days was removing the samples coming in the snapshot.
Unfortunately, this is not 100% fix, as after 5 years, the tests might start failling again, but I didn't find anything better without changing completely how the tests are done.

Mocking the prometheus server could an option, but this would remove the real integration test that we do now with the current tests.


## How was this tested?

Tested manually over some days
