### PR TITLE
Add ability to read software update settings

### DIFF
--- a/lib/trento/software_updates.ex
+++ b/lib/trento/software_updates.ex
@@ -1,0 +1,45 @@
+defmodule Trento.SoftwareUpdates do
+  @moduledoc """
+  Entry point for the software updates feature.
+  """
+
+  alias Trento.Repo
+  alias Trento.SoftwareUpdates.Settings
+
+  @type software_update_settings :: %{
+          url: String.t(),
+          username: String.t(),
+          password: String.t(),
+          ca_cert: String.t() | nil,
+          ca_uploaded_at: DateTime.t() | nil
+        }
+
+  @spec get_settings :: {:ok, software_update_settings} | {:error, :settings_not_configured}
+  def get_settings do
+    %Settings{
+      url: url,
+      username: username,
+      password: password,
+      ca_cert: ca_cert,
+      ca_uploaded_at: ca_uploaded_at
+    } = settings = Repo.one!(Settings)
+
+    if has_valid_settings?(settings) do
+      {
+        :ok,
+        %{
+          url: url,
+          username: username,
+          password: password,
+          ca_cert: ca_cert,
+          ca_uploaded_at: ca_uploaded_at
+        }
+      }
+    else
+      {:error, :settings_not_configured}
+    end
+  end
+
+  defp has_valid_settings?(%Settings{url: url, username: username, password: password}),
+    do: url != nil and username != nil and password != nil
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -96,6 +96,8 @@ defmodule Trento.Factory do
     DiscoveryEvent
   }
 
+  alias Trento.SoftwareUpdates.Settings
+
   use ExMachina.Ecto, repo: Trento.Repo
 
   def host_registered_event_factory do
@@ -746,5 +748,23 @@ defmodule Trento.Factory do
       host_id: Faker.UUID.v4(),
       health: Health.passing()
     })
+  end
+
+  def software_updates_settings_factory(attrs) do
+    url = Map.get(attrs, :url, Faker.Internet.url())
+    username = Map.get(attrs, :username, Faker.Internet.user_name())
+    password = Map.get(attrs, :password, Faker.Lorem.word())
+    ca_cert = Map.get(attrs, :ca_cert, Faker.Lorem.sentence())
+    ca_uploaded_at = Map.get(attrs, :ca_uploaded_at, DateTime.utc_now())
+
+    %Settings{}
+    |> Settings.changeset(%{
+      url: url,
+      username: username,
+      password: password,
+      ca_cert: ca_cert,
+      ca_uploaded_at: ca_uploaded_at
+    })
+    |> Ecto.Changeset.apply_changes()
   end
 end

--- a/test/trento/software_updates_test.exs
+++ b/test/trento/software_updates_test.exs
@@ -1,0 +1,58 @@
+defmodule Trento.SoftwareUpdates.SettingsTest do
+  use ExUnit.Case
+  use Trento.DataCase
+
+  import Trento.Factory
+
+  alias Trento.SoftwareUpdates
+
+  test "should return an error when settings are not available" do
+    assert {:error, :settings_not_configured} == SoftwareUpdates.get_settings()
+  end
+
+  test "should return settings without ca certificate" do
+    %{
+      url: url,
+      username: username,
+      password: password
+    } =
+      insert(:software_updates_settings, [ca_cert: nil, ca_uploaded_at: nil],
+        conflict_target: :id,
+        on_conflict: :replace_all
+      )
+
+    assert {:ok,
+            %{
+              url: ^url,
+              username: ^username,
+              password: ^password,
+              ca_cert: nil,
+              ca_uploaded_at: nil
+            }} = SoftwareUpdates.get_settings()
+  end
+
+  test "should return settings with ca certificate" do
+    %{
+      url: url,
+      username: username,
+      password: password,
+      ca_cert: ca_cert,
+      ca_uploaded_at: ca_uploaded_at
+    } =
+      insert(
+        :software_updates_settings,
+        [ca_cert: Faker.Lorem.sentence(), ca_uploaded_at: DateTime.utc_now()],
+        conflict_target: :id,
+        on_conflict: :replace_all
+      )
+
+    assert {:ok,
+            %{
+              url: ^url,
+              username: ^username,
+              password: ^password,
+              ca_cert: ^ca_cert,
+              ca_uploaded_at: ^ca_uploaded_at
+            }} = SoftwareUpdates.get_settings()
+  end
+end


### PR DESCRIPTION
# Description

Adding a `Trento.SoftwareUpdates` context allowing, for now, to load software updates settings.

## How was this tested?

Automated tests
