### PR TITLE
Add endpoint to retrieve software update settings

### DIFF
--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -31,7 +31,8 @@ defmodule TrentoWeb.FallbackController do
              :sap_system_not_registered,
              :database_not_registered,
              :application_instance_not_registered,
-             :database_instance_not_registered
+             :database_instance_not_registered,
+             :settings_not_configured
            ] do
     conn
     |> put_status(:not_found)

--- a/lib/trento_web/controllers/v1/software_updates_controller.ex
+++ b/lib/trento_web/controllers/v1/software_updates_controller.ex
@@ -1,0 +1,29 @@
+defmodule TrentoWeb.V1.SoftwareUpdatesController do
+  use TrentoWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Trento.SoftwareUpdates
+
+  alias TrentoWeb.OpenApi.V1.Schema
+
+  plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
+  action_fallback TrentoWeb.FallbackController
+
+  operation :get_user_settings,
+    summary: "Gets the user settings",
+    tags: ["Platform"],
+    description: "Gets the saved user settings for SUSE Manager",
+    responses: [
+      ok: {"The user settings", "application/json", Schema.SoftwareUpdates.UserSettings},
+      not_found: Schema.NotFound.response()
+    ]
+
+  @spec get_user_settings(Plug.Conn.t(), any) :: Plug.Conn.t()
+  def get_user_settings(conn, _) do
+    with {:ok, settings} <- SoftwareUpdates.get_settings() do
+      conn
+      |> put_status(:ok)
+      |> render("user_settings.json", settings)
+    end
+  end
+end

--- a/lib/trento_web/controllers/v1/software_updates_controller.ex
+++ b/lib/trento_web/controllers/v1/software_updates_controller.ex
@@ -23,7 +23,7 @@ defmodule TrentoWeb.V1.SoftwareUpdatesController do
     with {:ok, settings} <- SoftwareUpdates.get_settings() do
       conn
       |> put_status(:ok)
-      |> render("user_settings.json", settings)
+      |> render("user_settings.json", %{settings: settings})
     end
   end
 end

--- a/lib/trento_web/controllers/v1/software_updates_controller.ex
+++ b/lib/trento_web/controllers/v1/software_updates_controller.ex
@@ -14,7 +14,9 @@ defmodule TrentoWeb.V1.SoftwareUpdatesController do
     tags: ["Platform"],
     description: "Gets the saved user settings for SUSE Manager",
     responses: [
-      ok: {"The software updates user settings", "application/json", Schema.SoftwareUpdates.Settings},
+      ok:
+        {"The software updates user settings", "application/json",
+         Schema.SoftwareUpdates.Settings},
       not_found: Schema.NotFound.response()
     ]
 

--- a/lib/trento_web/controllers/v1/software_updates_controller.ex
+++ b/lib/trento_web/controllers/v1/software_updates_controller.ex
@@ -9,21 +9,21 @@ defmodule TrentoWeb.V1.SoftwareUpdatesController do
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
   action_fallback TrentoWeb.FallbackController
 
-  operation :get_user_settings,
+  operation :get_software_updates_settings,
     summary: "Gets the user settings",
     tags: ["Platform"],
     description: "Gets the saved user settings for SUSE Manager",
     responses: [
-      ok: {"The user settings", "application/json", Schema.SoftwareUpdates.UserSettings},
+      ok: {"The software updates user settings", "application/json", Schema.SoftwareUpdates.Settings},
       not_found: Schema.NotFound.response()
     ]
 
-  @spec get_user_settings(Plug.Conn.t(), any) :: Plug.Conn.t()
-  def get_user_settings(conn, _) do
+  @spec get_software_updates_settings(Plug.Conn.t(), any) :: Plug.Conn.t()
+  def get_software_updates_settings(conn, _) do
     with {:ok, settings} <- SoftwareUpdates.get_settings() do
       conn
       |> put_status(:ok)
-      |> render("user_settings.json", %{settings: settings})
+      |> render("software_updates_settings.json", %{settings: settings})
     end
   end
 end

--- a/lib/trento_web/openapi/v1/schema/software_updates.ex
+++ b/lib/trento_web/openapi/v1/schema/software_updates.ex
@@ -1,0 +1,32 @@
+defmodule TrentoWeb.OpenApi.V1.Schema.SoftwareUpdates do
+  @moduledoc false
+
+  require OpenApiSpex
+  alias OpenApiSpex.Schema
+
+  defmodule UserSettings do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "UserSettings",
+      description: "User settings for SUSE Manager",
+      type: :object,
+      properties: %{
+        url: %Schema{
+          type: :string,
+          description: "URL of SUSE Manager"
+        },
+        username: %Schema{
+          type: :string,
+          description: "Username"
+        },
+        ca_uploaded_at: %Schema{
+          type: :string,
+          format: :datetime,
+          nullable: true,
+          description: "Time that SSL certificate was uploaded."
+        }
+      }
+    })
+  end
+end

--- a/lib/trento_web/openapi/v1/schema/software_updates.ex
+++ b/lib/trento_web/openapi/v1/schema/software_updates.ex
@@ -4,11 +4,11 @@ defmodule TrentoWeb.OpenApi.V1.Schema.SoftwareUpdates do
   require OpenApiSpex
   alias OpenApiSpex.Schema
 
-  defmodule UserSettings do
+  defmodule Settings do
     @moduledoc false
 
     OpenApiSpex.schema(%{
-      title: "UserSettings",
+      title: "Settings",
       description: "User settings for SUSE Manager",
       type: :object,
       properties: %{

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -146,7 +146,7 @@ defmodule TrentoWeb.Router do
 
       get "/hosts/:id/exporters_status", PrometheusController, :exporters_status
 
-      get "/user_settings", SoftwareUpdatesController, :get_user_settings
+      get "/software_updates/settings", SoftwareUpdatesController, :get_user_settings
 
       scope "/charts" do
         pipe_through :charts_feature

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -146,7 +146,7 @@ defmodule TrentoWeb.Router do
 
       get "/hosts/:id/exporters_status", PrometheusController, :exporters_status
 
-      get "/software_updates/settings", SoftwareUpdatesController, :get_user_settings
+      get "/software_updates/settings", SoftwareUpdatesController, :get_software_updates_settings
 
       scope "/charts" do
         pipe_through :charts_feature

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -146,6 +146,8 @@ defmodule TrentoWeb.Router do
 
       get "/hosts/:id/exporters_status", PrometheusController, :exporters_status
 
+      get "/user_settings", SoftwareUpdatesController, :get_user_settings
+
       scope "/charts" do
         pipe_through :charts_feature
 

--- a/lib/trento_web/views/v1/software_updates_view.ex
+++ b/lib/trento_web/views/v1/software_updates_view.ex
@@ -1,0 +1,15 @@
+defmodule TrentoWeb.V1.SoftwareUpdatesView do
+  use TrentoWeb, :view
+
+  def render("user_settings.json", %{
+        url: url,
+        username: username,
+        ca_uploaded_at: ca_uploaded_at
+      }) do
+    %{
+      url: url,
+      username: username,
+      ca_uploaded_at: ca_uploaded_at
+    }
+  end
+end

--- a/lib/trento_web/views/v1/software_updates_view.ex
+++ b/lib/trento_web/views/v1/software_updates_view.ex
@@ -2,9 +2,11 @@ defmodule TrentoWeb.V1.SoftwareUpdatesView do
   use TrentoWeb, :view
 
   def render("user_settings.json", %{
-        url: url,
-        username: username,
-        ca_uploaded_at: ca_uploaded_at
+        settings: %{
+          url: url,
+          username: username,
+          ca_uploaded_at: ca_uploaded_at
+        }
       }) do
     %{
       url: url,

--- a/lib/trento_web/views/v1/software_updates_view.ex
+++ b/lib/trento_web/views/v1/software_updates_view.ex
@@ -1,7 +1,7 @@
 defmodule TrentoWeb.V1.SoftwareUpdatesView do
   use TrentoWeb, :view
 
-  def render("user_settings.json", %{
+  def render("software_updates_settings.json", %{
         settings: %{
           url: url,
           username: username,

--- a/test/trento_web/controllers/v1/software_updates_controller_test.exs
+++ b/test/trento_web/controllers/v1/software_updates_controller_test.exs
@@ -28,7 +28,7 @@ defmodule TrentoWeb.V1.SoftwareUpdatesControllerTest do
       conn
       |> get("/api/v1/software_updates/settings")
       |> json_response(:ok)
-      |> assert_schema("UserSettings", api_spec)
+      |> assert_schema("Settings", api_spec)
     end
 
     test "should return 404 if no user settings have been saved", %{conn: conn} do

--- a/test/trento_web/controllers/v1/software_updates_controller_test.exs
+++ b/test/trento_web/controllers/v1/software_updates_controller_test.exs
@@ -1,0 +1,43 @@
+defmodule TrentoWeb.V1.SoftwareUpdatesControllerTest do
+  use TrentoWeb.ConnCase, async: true
+
+  import Mox
+  import OpenApiSpex.TestAssertions
+
+  import Trento.Factory
+
+  alias TrentoWeb.OpenApi.V1.ApiSpec
+
+  setup [:set_mox_from_context, :verify_on_exit!]
+
+  setup do
+    %{api_spec: ApiSpec.spec()}
+  end
+
+  describe "user settings" do
+    test "should return user settings", %{conn: conn} do
+      insert(
+        :software_updates_settings,
+        [ca_cert: Faker.Lorem.sentence(), ca_uploaded_at: DateTime.utc_now()],
+        conflict_target: :id,
+        on_conflict: :replace_all
+      )
+
+      api_spec = ApiSpec.spec()
+
+      conn
+      |> get("/api/v1/user_settings")
+      |> json_response(:ok)
+      |> assert_schema("UserSettings", api_spec)
+    end
+
+    test "should return 404 if no user settings have been saved", %{conn: conn} do
+      api_spec = ApiSpec.spec()
+
+      conn
+      |> get("/api/v1/user_settings")
+      |> json_response(:not_found)
+      |> assert_schema("NotFound", api_spec)
+    end
+  end
+end

--- a/test/trento_web/controllers/v1/software_updates_controller_test.exs
+++ b/test/trento_web/controllers/v1/software_updates_controller_test.exs
@@ -1,14 +1,11 @@
 defmodule TrentoWeb.V1.SoftwareUpdatesControllerTest do
   use TrentoWeb.ConnCase, async: true
 
-  import Mox
   import OpenApiSpex.TestAssertions
 
   import Trento.Factory
 
   alias TrentoWeb.OpenApi.V1.ApiSpec
-
-  setup [:set_mox_from_context, :verify_on_exit!]
 
   setup do
     %{api_spec: ApiSpec.spec()}

--- a/test/trento_web/controllers/v1/software_updates_controller_test.exs
+++ b/test/trento_web/controllers/v1/software_updates_controller_test.exs
@@ -26,7 +26,7 @@ defmodule TrentoWeb.V1.SoftwareUpdatesControllerTest do
       api_spec = ApiSpec.spec()
 
       conn
-      |> get("/api/v1/user_settings")
+      |> get("/api/v1/software_updates/settings")
       |> json_response(:ok)
       |> assert_schema("UserSettings", api_spec)
     end
@@ -35,7 +35,7 @@ defmodule TrentoWeb.V1.SoftwareUpdatesControllerTest do
       api_spec = ApiSpec.spec()
 
       conn
-      |> get("/api/v1/user_settings")
+      |> get("/api/v1/software_updates/settings")
       |> json_response(:not_found)
       |> assert_schema("NotFound", api_spec)
     end

--- a/test/trento_web/views/v1/software_updates_view_test.exs
+++ b/test/trento_web/views/v1/software_updates_view_test.exs
@@ -1,0 +1,28 @@
+defmodule TrentoWeb.V1.UserSettingsViewTest do
+  use TrentoWeb.ConnCase, async: true
+
+  import Phoenix.View
+  import Trento.Factory
+
+  alias Trento.SoftwareUpdates.Settings
+  alias TrentoWeb.V1.SoftwareUpdatesView
+
+  describe "renders user_settings.json" do
+    test "should render all the fields" do
+      %Settings{url: url, username: username, ca_uploaded_at: ca_uploaded_at} =
+        insert(
+          :software_updates_settings,
+          [ca_cert: Faker.Lorem.sentence(), ca_uploaded_at: DateTime.utc_now()],
+          conflict_target: :id,
+          on_conflict: :replace_all
+        )
+
+      assert %{url: url, username: username, ca_uploaded_at: ca_uploaded_at} ==
+               render(SoftwareUpdatesView, "user_settings.json", %{
+                 url: url,
+                 username: username,
+                 ca_uploaded_at: ca_uploaded_at
+               })
+    end
+  end
+end

--- a/test/trento_web/views/v1/software_updates_view_test.exs
+++ b/test/trento_web/views/v1/software_updates_view_test.exs
@@ -1,4 +1,4 @@
-defmodule TrentoWeb.V1.UserSettingsViewTest do
+defmodule TrentoWeb.V1.SettingsViewTest do
   use TrentoWeb.ConnCase, async: true
 
   import Phoenix.View
@@ -7,13 +7,13 @@ defmodule TrentoWeb.V1.UserSettingsViewTest do
   alias Trento.SoftwareUpdates.Settings
   alias TrentoWeb.V1.SoftwareUpdatesView
 
-  describe "renders user_settings.json" do
+  describe "renders software_updates_settings.json" do
     test "should render relevant fields" do
       %Settings{url: url, username: username, ca_uploaded_at: ca_uploaded_at} =
         settings = build(:software_updates_settings)
 
-      assert %{url: url, username: username, ca_uploaded_at: ca_uploaded_at} ==
-               render(SoftwareUpdatesView, "user_settings.json", %{settings: settings})
+      assert %{url: ^url, username: ^username, ca_uploaded_at: ^ca_uploaded_at} =
+               render(SoftwareUpdatesView, "software_updates_settings.json", %{settings: settings})
     end
   end
 end

--- a/test/trento_web/views/v1/software_updates_view_test.exs
+++ b/test/trento_web/views/v1/software_updates_view_test.exs
@@ -10,14 +10,10 @@ defmodule TrentoWeb.V1.UserSettingsViewTest do
   describe "renders user_settings.json" do
     test "should render relevant fields" do
       %Settings{url: url, username: username, ca_uploaded_at: ca_uploaded_at} =
-        build(:software_updates_settings)
+        settings = build(:software_updates_settings)
 
       assert %{url: url, username: username, ca_uploaded_at: ca_uploaded_at} ==
-               render(SoftwareUpdatesView, "user_settings.json", %{
-                 url: url,
-                 username: username,
-                 ca_uploaded_at: ca_uploaded_at
-               })
+               render(SoftwareUpdatesView, "user_settings.json", %{settings: settings})
     end
   end
 end

--- a/test/trento_web/views/v1/software_updates_view_test.exs
+++ b/test/trento_web/views/v1/software_updates_view_test.exs
@@ -8,14 +8,9 @@ defmodule TrentoWeb.V1.UserSettingsViewTest do
   alias TrentoWeb.V1.SoftwareUpdatesView
 
   describe "renders user_settings.json" do
-    test "should render all the fields" do
+    test "should render relevant fields" do
       %Settings{url: url, username: username, ca_uploaded_at: ca_uploaded_at} =
-        insert(
-          :software_updates_settings,
-          [ca_cert: Faker.Lorem.sentence(), ca_uploaded_at: DateTime.utc_now()],
-          conflict_target: :id,
-          on_conflict: :replace_all
-        )
+        build(:software_updates_settings)
 
       assert %{url: url, username: username, ca_uploaded_at: ca_uploaded_at} ==
                render(SoftwareUpdatesView, "user_settings.json", %{

--- a/test/trento_web/views/v1/software_updates_view_test.exs
+++ b/test/trento_web/views/v1/software_updates_view_test.exs
@@ -2,17 +2,21 @@ defmodule TrentoWeb.V1.SettingsViewTest do
   use TrentoWeb.ConnCase, async: true
 
   import Phoenix.View
-  import Trento.Factory
 
-  alias Trento.SoftwareUpdates.Settings
   alias TrentoWeb.V1.SoftwareUpdatesView
 
   describe "renders software_updates_settings.json" do
     test "should render relevant fields" do
-      %Settings{url: url, username: username, ca_uploaded_at: ca_uploaded_at} =
-        settings = build(:software_updates_settings)
+      %{url: url, username: username, ca_uploaded_at: ca_uploaded_at} =
+        settings = %{
+          url: Faker.Internet.url(),
+          username: Faker.Internet.user_name(),
+          password: Faker.Lorem.word(),
+          ca_cert: Faker.Lorem.sentence(),
+          ca_uploaded_at: DateTime.utc_now()
+        }
 
-      assert %{url: ^url, username: ^username, ca_uploaded_at: ^ca_uploaded_at} =
+      assert %{url: url, username: username, ca_uploaded_at: ca_uploaded_at} ==
                render(SoftwareUpdatesView, "software_updates_settings.json", %{settings: settings})
     end
   end


### PR DESCRIPTION
# Description

This change adds a HTTP endpoint `GET /api/v1/user_settings` to allow reading of user credentials to the SAP software update system (i.e. at time of writing, SUSE Manager).

## How was this tested?

Added unit tests for new functions.
