### PR TITLE
Fix typo in software updates settings schema

### DIFF
--- a/lib/trento/software_updates/settings.ex
+++ b/lib/trento/software_updates/settings.ex
@@ -15,7 +15,7 @@ defmodule Trento.SoftwareUpdates.Settings do
     field :username, :string
     field :password, Trento.Support.Ecto.EncryptedBinary
     field :ca_cert, Trento.Support.Ecto.EncryptedBinary
-    field :ca_updloaded_at, :utc_datetime_usec
+    field :ca_uploaded_at, :utc_datetime_usec
 
     timestamps(type: :utc_datetime_usec)
   end

--- a/priv/repo/migrations/20240130130617_create_software_update_settings.exs
+++ b/priv/repo/migrations/20240130130617_create_software_update_settings.exs
@@ -10,7 +10,7 @@ defmodule Trento.Repo.Migrations.CreateSoftwareUpdateSettings do
       add :username, :string, default: nil
       add :password, :binary, default: nil
       add :ca_cert, :binary, default: nil
-      add :ca_updloaded_at, :utc_datetime_usec, default: nil
+      add :ca_uploaded_at, :utc_datetime_usec, default: nil
 
       timestamps()
     end


### PR DESCRIPTION
# Description

a tiny typo fix. Local database reset is needed `mix ecto.reset` and `MIX_ENV=test mix ecto.reset` :see_no_evil: 
