### PR TITLE
Apply software updates settings

### DIFF
--- a/lib/trento/software_updates.ex
+++ b/lib/trento/software_updates.ex
@@ -2,6 +2,11 @@ defmodule Trento.SoftwareUpdates do
   @moduledoc """
   Entry point for the software updates feature.
   """
+  require Logger
+
+  alias Ecto.Changeset
+
+  alias Trento.Support.DateService
 
   alias Trento.Repo
   alias Trento.SoftwareUpdates.Settings
@@ -14,32 +19,71 @@ defmodule Trento.SoftwareUpdates do
           ca_uploaded_at: DateTime.t() | nil
         }
 
+  @type software_update_settings_submission :: %{
+          url: String.t(),
+          username: String.t(),
+          password: String.t(),
+          ca_cert: String.t() | nil
+        }
+
   @spec get_settings :: {:ok, software_update_settings} | {:error, :settings_not_configured}
   def get_settings do
-    %Settings{
-      url: url,
-      username: username,
-      password: password,
-      ca_cert: ca_cert,
-      ca_uploaded_at: ca_uploaded_at
-    } = settings = Repo.one!(Settings)
+    settings = Repo.one!(Settings)
 
     if has_valid_settings?(settings) do
-      {
-        :ok,
-        %{
-          url: url,
-          username: username,
-          password: password,
-          ca_cert: ca_cert,
-          ca_uploaded_at: ca_uploaded_at
-        }
-      }
+      {:ok, map_to_settings_result(settings)}
     else
       {:error, :settings_not_configured}
     end
   end
 
+  @spec save_settings(software_update_settings_submission, module()) ::
+          {:ok, software_update_settings} | {:error, any()}
+  def save_settings(settings_submission, date_service \\ DateService) do
+    changeset =
+      Settings
+      |> Repo.one!()
+      |> Settings.changeset(settings_submission)
+      |> Changeset.validate_required([:url, :username, :password])
+      |> Changeset.validate_change(:url, &validate_url/2)
+      |> Changeset.prepare_changes(maybe_add_cert_upload_date(date_service))
+
+    case Repo.update(changeset) do
+      {:ok, saved_settings} ->
+        {:ok, map_to_settings_result(saved_settings)}
+
+      {:error, reason} = error ->
+        Logger.error("Error while saving software updates settings: #{inspect(reason)}")
+
+        error
+    end
+  end
+
   defp has_valid_settings?(%Settings{url: url, username: username, password: password}),
     do: url != nil and username != nil and password != nil
+
+  defp map_to_settings_result(%Settings{} = settings),
+    do: Map.take(settings, [:url, :username, :password, :ca_cert, :ca_uploaded_at])
+
+  defp validate_url(_url_atom, url) do
+    %URI{scheme: scheme} = URI.parse(url)
+
+    case scheme do
+      "https" ->
+        []
+
+      _ ->
+        [url: {"can only be an https url", validation: :https_url_only}]
+    end
+  end
+
+  defp maybe_add_cert_upload_date(date_service) do
+    fn changeset ->
+      if Changeset.get_change(changeset, :ca_cert) do
+        Changeset.put_change(changeset, :ca_uploaded_at, date_service.utc_now())
+      else
+        changeset
+      end
+    end
+  end
 end

--- a/lib/trento/software_updates.ex
+++ b/lib/trento/software_updates.ex
@@ -32,23 +32,21 @@ defmodule Trento.SoftwareUpdates do
           | {:error, :settings_already_configured}
           | {:error, any()}
   def save_settings(settings_submission, date_service \\ DateService) do
-    case Repo.one(Settings) do
-      nil ->
-        result =
-          %Settings{} |> Settings.changeset(settings_submission, date_service) |> Repo.insert()
+    if Repo.one(Settings) do
+      {:error, :settings_already_configured}
+    else
+      result =
+        %Settings{} |> Settings.changeset(settings_submission, date_service) |> Repo.insert()
 
-        case result do
-          {:ok, saved_settings} ->
-            {:ok, saved_settings}
+      case result do
+        {:ok, saved_settings} ->
+          {:ok, saved_settings}
 
-          {:error, reason} = error ->
-            Logger.error("Error while saving software updates settings: #{inspect(reason)}")
+        {:error, reason} = error ->
+          Logger.error("Error while saving software updates settings: #{inspect(reason)}")
 
-            error
-        end
-
-      _ ->
-        {:error, :settings_already_configured}
+          error
+      end
     end
   end
 end

--- a/lib/trento/software_updates.ex
+++ b/lib/trento/software_updates.ex
@@ -9,14 +9,6 @@ defmodule Trento.SoftwareUpdates do
   alias Trento.Repo
   alias Trento.SoftwareUpdates.Settings
 
-  @type software_update_settings :: %{
-          url: String.t(),
-          username: String.t(),
-          password: String.t(),
-          ca_cert: String.t() | nil,
-          ca_uploaded_at: DateTime.t() | nil
-        }
-
   @type software_update_settings_submission :: %{
           url: String.t(),
           username: String.t(),
@@ -24,43 +16,39 @@ defmodule Trento.SoftwareUpdates do
           ca_cert: String.t() | nil
         }
 
-  @spec get_settings :: {:ok, software_update_settings} | {:error, :settings_not_configured}
+  @spec get_settings :: {:ok, Settings.t()} | {:error, :settings_not_configured}
   def get_settings do
-    settings = Repo.one!(Settings)
+    case Repo.one(Settings) do
+      nil ->
+        {:error, :settings_not_configured}
 
-    if has_valid_settings?(settings) do
-      {:ok, map_to_settings_result(settings)}
-    else
-      {:error, :settings_not_configured}
+      settings ->
+        {:ok, settings}
     end
   end
 
   @spec save_settings(software_update_settings_submission, module()) ::
-          {:ok, software_update_settings}
+          {:ok, Settings.t()}
           | {:error, :settings_already_configured}
           | {:error, any()}
   def save_settings(settings_submission, date_service \\ DateService) do
-    with settings <- Repo.one!(Settings),
-         false <- has_valid_settings?(settings),
-         {:ok, saved_settings} <-
-           settings
-           |> Settings.apply_saving_changeset(settings_submission, date_service)
-           |> Repo.update() do
-      {:ok, map_to_settings_result(saved_settings)}
-    else
-      true ->
+    case Repo.one(Settings) do
+      nil ->
+        result =
+          %Settings{} |> Settings.changeset(settings_submission, date_service) |> Repo.insert()
+
+        case result do
+          {:ok, saved_settings} ->
+            {:ok, saved_settings}
+
+          {:error, reason} = error ->
+            Logger.error("Error while saving software updates settings: #{inspect(reason)}")
+
+            error
+        end
+
+      _ ->
         {:error, :settings_already_configured}
-
-      {:error, reason} = error ->
-        Logger.error("Error while saving software updates settings: #{inspect(reason)}")
-
-        error
     end
   end
-
-  defp has_valid_settings?(%Settings{url: url, username: username, password: password}),
-    do: url != nil and username != nil and password != nil
-
-  defp map_to_settings_result(%Settings{} = settings),
-    do: Map.take(settings, [:url, :username, :password, :ca_cert, :ca_uploaded_at])
 end

--- a/lib/trento/software_updates.ex
+++ b/lib/trento/software_updates.ex
@@ -4,8 +4,6 @@ defmodule Trento.SoftwareUpdates do
   """
   require Logger
 
-  alias Ecto.Changeset
-
   alias Trento.Support.DateService
 
   alias Trento.Repo
@@ -46,7 +44,7 @@ defmodule Trento.SoftwareUpdates do
          false <- has_valid_settings?(settings),
          {:ok, saved_settings} <-
            settings
-           |> apply_saving_changeset(settings_submission, date_service)
+           |> Settings.apply_saving_changeset(settings_submission, date_service)
            |> Repo.update() do
       {:ok, map_to_settings_result(saved_settings)}
     else
@@ -65,34 +63,4 @@ defmodule Trento.SoftwareUpdates do
 
   defp map_to_settings_result(%Settings{} = settings),
     do: Map.take(settings, [:url, :username, :password, :ca_cert, :ca_uploaded_at])
-
-  defp apply_saving_changeset(settings, settings_submission, date_service) do
-    settings
-    |> Settings.changeset(settings_submission)
-    |> Changeset.validate_required([:url, :username, :password])
-    |> Changeset.validate_change(:url, &validate_url/2)
-    |> Changeset.prepare_changes(maybe_add_cert_upload_date(date_service))
-  end
-
-  defp validate_url(_url_atom, url) do
-    %URI{scheme: scheme} = URI.parse(url)
-
-    case scheme do
-      "https" ->
-        []
-
-      _ ->
-        [url: {"can only be an https url", validation: :https_url_only}]
-    end
-  end
-
-  defp maybe_add_cert_upload_date(date_service) do
-    fn changeset ->
-      if Changeset.get_change(changeset, :ca_cert) do
-        Changeset.put_change(changeset, :ca_uploaded_at, date_service.utc_now())
-      else
-        changeset
-      end
-    end
-  end
 end

--- a/lib/trento/software_updates/settings.ex
+++ b/lib/trento/software_updates/settings.ex
@@ -21,10 +21,9 @@ defmodule Trento.SoftwareUpdates.Settings do
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()
-  def changeset(software_update_settings, attrs) do
-    software_update_settings
+  def changeset(software_updates_settings, attrs) do
+    software_updates_settings
     |> cast(attrs, __MODULE__.__schema__(:fields))
-    |> validate_required([:url, :username, :password])
     |> unique_constraint(:id, name: :software_update_settings_pkey)
   end
 end

--- a/priv/repo/migrations/20240130130617_create_software_update_settings.exs
+++ b/priv/repo/migrations/20240130130617_create_software_update_settings.exs
@@ -3,9 +3,7 @@ defmodule Trento.Repo.Migrations.CreateSoftwareUpdateSettings do
 
   def change do
     create table(:software_update_settings, primary_key: false) do
-      settings_identifier = UUID.uuid4()
-
-      add :id, :uuid, primary_key: true, default: settings_identifier
+      add :id, :uuid, primary_key: true
       add :url, :string, default: nil
       add :username, :string, default: nil
       add :password, :binary, default: nil
@@ -14,15 +12,5 @@ defmodule Trento.Repo.Migrations.CreateSoftwareUpdateSettings do
 
       timestamps()
     end
-
-    create constraint("software_update_settings", :only_one_record,
-             check: "id ='#{settings_identifier}'"
-           )
-
-    execute "INSERT INTO software_update_settings(id, inserted_at, updated_at) VALUES('#{settings_identifier}', NOW(), NOW());"
-  end
-
-  def down do
-    drop table(:software_update_settings)
   end
 end

--- a/test/trento/software_updates_test.exs
+++ b/test/trento/software_updates_test.exs
@@ -7,6 +7,7 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
   import Trento.Factory
 
   alias Trento.SoftwareUpdates
+  alias Trento.SoftwareUpdates.Settings
 
   test "should return an error when settings are not available" do
     assert {:error, :settings_not_configured} == SoftwareUpdates.get_settings()
@@ -24,13 +25,13 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
       )
 
     assert {:ok,
-            %{
-              url: url,
-              username: username,
-              password: password,
+            %Settings{
+              url: ^url,
+              username: ^username,
+              password: ^password,
               ca_cert: nil,
               ca_uploaded_at: nil
-            }} == SoftwareUpdates.get_settings()
+            }} = SoftwareUpdates.get_settings()
   end
 
   test "should return settings with ca certificate" do
@@ -49,13 +50,13 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
       )
 
     assert {:ok,
-            %{
-              url: url,
-              username: username,
-              password: password,
-              ca_cert: ca_cert,
-              ca_uploaded_at: ca_uploaded_at
-            }} == SoftwareUpdates.get_settings()
+            %Settings{
+              url: ^url,
+              username: ^username,
+              password: ^password,
+              ca_cert: ^ca_cert,
+              ca_uploaded_at: ^ca_uploaded_at
+            }} = SoftwareUpdates.get_settings()
   end
 
   test "should not save invalid software updates settings" do
@@ -117,13 +118,13 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
     }
 
     assert {:ok,
-            %{
-              url: url,
-              username: username,
-              password: password,
+            %Settings{
+              url: ^url,
+              username: ^username,
+              password: ^password,
               ca_cert: nil,
               ca_uploaded_at: nil
-            }} == SoftwareUpdates.save_settings(settings)
+            }} = SoftwareUpdates.save_settings(settings)
   end
 
   test "should save software updates settings with a nil ca cert" do
@@ -135,13 +136,13 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
     }
 
     assert {:ok,
-            %{
-              url: url,
-              username: username,
-              password: password,
+            %Settings{
+              url: ^url,
+              username: ^username,
+              password: ^password,
               ca_cert: nil,
               ca_uploaded_at: nil
-            }} == SoftwareUpdates.save_settings(settings)
+            }} = SoftwareUpdates.save_settings(settings)
   end
 
   test "should save software updates settings with ca cert" do
@@ -161,13 +162,13 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
     }
 
     assert {:ok,
-            %{
-              url: url,
-              username: username,
-              password: password,
-              ca_cert: ca_cert,
-              ca_uploaded_at: now
-            }} == SoftwareUpdates.save_settings(settings, Trento.Support.DateService.Mock)
+            %Settings{
+              url: ^url,
+              username: ^username,
+              password: ^password,
+              ca_cert: ^ca_cert,
+              ca_uploaded_at: ^now
+            }} = SoftwareUpdates.save_settings(settings, Trento.Support.DateService.Mock)
   end
 
   test "should not save software updates settings if already saved" do

--- a/test/trento/software_updates_test.exs
+++ b/test/trento/software_updates_test.exs
@@ -25,12 +25,12 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
 
     assert {:ok,
             %{
-              url: ^url,
-              username: ^username,
-              password: ^password,
+              url: url,
+              username: username,
+              password: password,
               ca_cert: nil,
               ca_uploaded_at: nil
-            }} = SoftwareUpdates.get_settings()
+            }} == SoftwareUpdates.get_settings()
   end
 
   test "should return settings with ca certificate" do
@@ -50,12 +50,12 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
 
     assert {:ok,
             %{
-              url: ^url,
-              username: ^username,
-              password: ^password,
-              ca_cert: ^ca_cert,
-              ca_uploaded_at: ^ca_uploaded_at
-            }} = SoftwareUpdates.get_settings()
+              url: url,
+              username: username,
+              password: password,
+              ca_cert: ca_cert,
+              ca_uploaded_at: ca_uploaded_at
+            }} == SoftwareUpdates.get_settings()
   end
 
   test "should not save invalid software updates settings" do
@@ -122,12 +122,12 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
     Enum.each([settings_with_nil_ca_cert, settings_without_ca_cert], fn settings ->
       assert {:ok,
               %{
-                url: ^url,
-                username: ^username,
-                password: ^password,
+                url: url,
+                username: username,
+                password: password,
                 ca_cert: nil,
                 ca_uploaded_at: nil
-              }} = SoftwareUpdates.save_settings(settings)
+              }} == SoftwareUpdates.save_settings(settings)
     end)
   end
 
@@ -149,11 +149,11 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
 
     assert {:ok,
             %{
-              url: ^url,
-              username: ^username,
-              password: ^password,
-              ca_cert: ^ca_cert,
-              ca_uploaded_at: ^now
-            }} = SoftwareUpdates.save_settings(settings, Trento.Support.DateService.Mock)
+              url: url,
+              username: username,
+              password: password,
+              ca_cert: ca_cert,
+              ca_uploaded_at: now
+            }} == SoftwareUpdates.save_settings(settings, Trento.Support.DateService.Mock)
   end
 end

--- a/test/trento/software_updates_test.exs
+++ b/test/trento/software_updates_test.exs
@@ -110,25 +110,38 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
   end
 
   test "should save software updates settings without ca cert" do
-    settings_with_nil_ca_cert = %{
+    settings = %{
+      url: url = "https://valid.com",
+      username: username = Faker.Internet.user_name(),
+      password: password = Faker.Lorem.word()
+    }
+
+    assert {:ok,
+            %{
+              url: url,
+              username: username,
+              password: password,
+              ca_cert: nil,
+              ca_uploaded_at: nil
+            }} == SoftwareUpdates.save_settings(settings)
+  end
+
+  test "should save software updates settings with a nil ca cert" do
+    settings = %{
       url: url = "https://valid.com",
       username: username = Faker.Internet.user_name(),
       password: password = Faker.Lorem.word(),
       ca_cert: nil
     }
 
-    settings_without_ca_cert = Map.delete(settings_with_nil_ca_cert, :ca_cert)
-
-    Enum.each([settings_with_nil_ca_cert, settings_without_ca_cert], fn settings ->
-      assert {:ok,
-              %{
-                url: url,
-                username: username,
-                password: password,
-                ca_cert: nil,
-                ca_uploaded_at: nil
-              }} == SoftwareUpdates.save_settings(settings)
-    end)
+    assert {:ok,
+            %{
+              url: url,
+              username: username,
+              password: password,
+              ca_cert: nil,
+              ca_uploaded_at: nil
+            }} == SoftwareUpdates.save_settings(settings)
   end
 
   test "should save software updates settings with ca cert" do
@@ -155,5 +168,18 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
               ca_cert: ca_cert,
               ca_uploaded_at: now
             }} == SoftwareUpdates.save_settings(settings, Trento.Support.DateService.Mock)
+  end
+
+  test "should not save software updates settings if already saved" do
+    settings = %{
+      url: "https://valid.com",
+      username: Faker.Internet.user_name(),
+      password: Faker.Lorem.word(),
+      ca_cert: nil
+    }
+
+    assert {:ok, _} = SoftwareUpdates.save_settings(settings)
+
+    assert {:error, :settings_already_configured} = SoftwareUpdates.save_settings(settings)
   end
 end


### PR DESCRIPTION
# Description

Enables saving software updates settings.

Consider that when saving software updates settings for the first time:
- `url` is required, cannot be blank and it has to be `https`
- `username` is required and cannot be blank
- `password` is required and cannot be blank
- when a `ca_cert` is provided, also its upload time `ca_uploaded_at` is tracked

## How was this tested?

Automated tests.