### PR TITLE
Add saptune discovery payloads to the healthy clusters scenario

### DIFF
--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -145,13 +145,14 @@ context('Hosts Overview', () => {
       it('should show health status of the entire cluster of 27 hosts with partial pagination', () => {
         cy.get('.tn-health-container .tn-health-passing', {
           timeout: 15000,
-        }).should('contain', 27);
-        cy.get('.tn-health-container .tn-health-warning').should('contain', 0);
-        cy.get('.tn-health-container .tn-health-critical').should('contain', 0);
+        }).should('contain', 11);
+        cy.get('.tn-health-container .tn-health-warning').should('contain', 12);
+        cy.get('.tn-health-container .tn-health-critical').should('contain', 4);
       });
 
-      it('should show a passing health on the hosts when the agents are sending the heartbeat', () => {
-        cy.get('svg.fill-jungle-green-500').its('length').should('eq', 10);
+      it('should show the correct health on the hosts when the agents are sending the heartbeat', () => {
+        cy.get('svg.fill-jungle-green-500').its('length').should('eq', 8);
+        cy.get('svg.fill-yellow-500').its('length').should('eq', 2);
       });
     });
     describe('Health is changed based on saptune status', () => {

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/098fc159-3ed6-58e7-91be-38fda8a833ea_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/098fc159-3ed6-58e7-91be-38fda8a833ea_saptune_discovery.json
@@ -1,0 +1,9 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "098fc159-3ed6-58e7-91be-38fda8a833ea",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.0.0",
+    "status": null
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_saptune_discovery.json
@@ -1,0 +1,9 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4",
+  "payload": {
+    "saptune_installed": false,
+    "package_version": "",
+    "status": null
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0fc07435-7ee2-54ca-b0de-fb27ffdc5deb_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0fc07435-7ee2-54ca-b0de-fb27ffdc5deb_saptune_discovery.json
@@ -1,0 +1,107 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "0fc07435-7ee2-54ca-b0de-fb27ffdc5deb",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.1.0",
+    "status": {
+      "$schema": "file:///usr/share/saptune/schemas/1.0/saptune_status.schema.json",
+      "publish time": "2023-04-24 12:41:56.612",
+      "argv": "saptune --format json status",
+      "pid": 24623,
+      "command": "status",
+      "exit code": 4,
+      "result": {
+        "services": {
+          "saptune": [
+            "enabled",
+            "active"
+          ],
+          "sapconf": [],
+          "tuned": []
+        },
+        "systemd system state": "running",
+        "tuning state": "not compliant",
+        "virtualization": "oracle",
+        "configured version": "3",
+        "package version": "3.1.0",
+        "Solution enabled": [
+          "NETWEAVER"
+        ],
+        "Notes enabled by Solution": [
+          {
+            "Solution ID": "NETWEAVER",
+            "Note list": [
+              "941735",
+              "1771258",
+              "2578899",
+              "2993054",
+              "1656250",
+              "900929"
+            ]
+          }
+        ],
+        "Solution applied": [
+          {
+            "Solution ID": "NETWEAVER",
+            "applied partially": false
+          }
+        ],
+        "Notes applied by Solution": [
+          {
+            "Solution ID": "NETWEAVER",
+            "Note list": [
+              "941735",
+              "1771258",
+              "2578899",
+              "2993054",
+              "1656250",
+              "900929"
+            ]
+          }
+        ],
+        "Notes enabled additionally": [],
+        "Notes enabled": [
+          "941735",
+          "1771258",
+          "2578899",
+          "2993054",
+          "1656250",
+          "900929"
+        ],
+        "Notes applied": [
+          "941735",
+          "1771258",
+          "2578899",
+          "2993054",
+          "1656250",
+          "900929"
+        ],
+        "staging": {
+          "staging enabled": false,
+          "Notes staged": [],
+          "Solutions staged": []
+        },
+        "remember message": "\nRegarding the tuning state of the system please use 'saptune note verify' for detailed information.\n\n"
+      },
+      "messages": [
+        {
+          "priority": "NOTICE",
+          "message": "actions.go:85: ATTENTION: You are running a test version (3.1.0 from 2022/11/28) of saptune which is not supported for production use\n"
+        },
+        {
+          "priority": "WARNING",
+          "message": "sysctl.go:73: Parameter 'kernel.shmmax' additional defined in the following sysctl config file /boot/sysctl.conf-5.3.18-150300.59.90-default(0xffffffffffffffff), /boot/sysctl.conf-5.3.18-150300.59.93-default(0xffffffffffffffff).\n"
+        },
+        {
+          "priority": "WARNING",
+          "message": "sysctl.go:73: Parameter 'kernel.shmall' additional defined in the following sysctl config file /boot/sysctl.conf-5.3.18-150300.59.90-default(0x0fffffffffffff00), /boot/sysctl.conf-5.3.18-150300.59.93-default(0x0fffffffffffff00).\n"
+        },
+        {
+          "priority": "NOTICE",
+          "message": "ini.go:308: block device related section settings detected: Traversing all block devices can take a considerable amount of time.\n"
+        }
+      ]
+    } 
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/116d49bd-85e1-5e59-b820-83f66db8800c_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/116d49bd-85e1-5e59-b820-83f66db8800c_saptune_discovery.json
@@ -1,0 +1,107 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "116d49bd-85e1-5e59-b820-83f66db8800c",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.1.0",
+    "status": {
+      "$schema": "file:///usr/share/saptune/schemas/1.0/saptune_status.schema.json",
+      "publish time": "2023-04-24 12:41:56.612",
+      "argv": "saptune --format json status",
+      "pid": 24623,
+      "command": "status",
+      "exit code": 4,
+      "result": {
+        "services": {
+          "saptune": [
+            "enabled",
+            "active"
+          ],
+          "sapconf": [],
+          "tuned": []
+        },
+        "systemd system state": "running",
+        "tuning state": "not compliant",
+        "virtualization": "oracle",
+        "configured version": "3",
+        "package version": "3.1.0",
+        "Solution enabled": [
+          "NETWEAVER"
+        ],
+        "Notes enabled by Solution": [
+          {
+            "Solution ID": "NETWEAVER",
+            "Note list": [
+              "941735",
+              "1771258",
+              "2578899",
+              "2993054",
+              "1656250",
+              "900929"
+            ]
+          }
+        ],
+        "Solution applied": [
+          {
+            "Solution ID": "NETWEAVER",
+            "applied partially": false
+          }
+        ],
+        "Notes applied by Solution": [
+          {
+            "Solution ID": "NETWEAVER",
+            "Note list": [
+              "941735",
+              "1771258",
+              "2578899",
+              "2993054",
+              "1656250",
+              "900929"
+            ]
+          }
+        ],
+        "Notes enabled additionally": [],
+        "Notes enabled": [
+          "941735",
+          "1771258",
+          "2578899",
+          "2993054",
+          "1656250",
+          "900929"
+        ],
+        "Notes applied": [
+          "941735",
+          "1771258",
+          "2578899",
+          "2993054",
+          "1656250",
+          "900929"
+        ],
+        "staging": {
+          "staging enabled": false,
+          "Notes staged": [],
+          "Solutions staged": []
+        },
+        "remember message": "\nRegarding the tuning state of the system please use 'saptune note verify' for detailed information.\n\n"
+      },
+      "messages": [
+        {
+          "priority": "NOTICE",
+          "message": "actions.go:85: ATTENTION: You are running a test version (3.1.0 from 2022/11/28) of saptune which is not supported for production use\n"
+        },
+        {
+          "priority": "WARNING",
+          "message": "sysctl.go:73: Parameter 'kernel.shmmax' additional defined in the following sysctl config file /boot/sysctl.conf-5.3.18-150300.59.90-default(0xffffffffffffffff), /boot/sysctl.conf-5.3.18-150300.59.93-default(0xffffffffffffffff).\n"
+        },
+        {
+          "priority": "WARNING",
+          "message": "sysctl.go:73: Parameter 'kernel.shmall' additional defined in the following sysctl config file /boot/sysctl.conf-5.3.18-150300.59.90-default(0x0fffffffffffff00), /boot/sysctl.conf-5.3.18-150300.59.93-default(0x0fffffffffffff00).\n"
+        },
+        {
+          "priority": "NOTICE",
+          "message": "ini.go:308: block device related section settings detected: Traversing all block devices can take a considerable amount of time.\n"
+        }
+      ]
+    } 
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_saptune_discovery.json
@@ -1,0 +1,9 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "13e8c25c-3180-5a9a-95c8-51ec38e50cfc",
+  "payload": {
+    "saptune_installed": false,
+    "package_version": "",
+    "status": null
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/1b0e9297-97dd-55d6-9874-8efde4d84c90_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/1b0e9297-97dd-55d6-9874-8efde4d84c90_saptune_discovery.json
@@ -1,0 +1,9 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "1b0e9297-97dd-55d6-9874-8efde4d84c90",
+  "payload": {
+    "saptune_installed": false,
+    "package_version": "",
+    "status": null
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/21de186a-e38f-5804-b643-7f4ef22fecfd_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/21de186a-e38f-5804-b643-7f4ef22fecfd_saptune_discovery.json
@@ -1,0 +1,9 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "21de186a-e38f-5804-b643-7f4ef22fecfd",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.0.0",
+    "status": null
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_saptune_discovery.json
@@ -1,0 +1,9 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "240f96b1-8d26-53b7-9e99-ffb0f2e735bf",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.0.0",
+    "status": null
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/25677e37-fd33-5005-896c-9275b1284534_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/25677e37-fd33-5005-896c-9275b1284534_saptune_discovery.json
@@ -1,0 +1,9 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "25677e37-fd33-5005-896c-9275b1284534",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.0.0",
+    "status": null
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/3711ea88-9ccc-5b07-8f9d-042be449d72b_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/3711ea88-9ccc-5b07-8f9d-042be449d72b_saptune_discovery.json
@@ -1,0 +1,9 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "3711ea88-9ccc-5b07-8f9d-042be449d72b",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.0.0",
+    "status": null
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/422686d6-b2d1-5092-93e8-a744854f5085_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/422686d6-b2d1-5092-93e8-a744854f5085_saptune_discovery.json
@@ -1,0 +1,9 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "422686d6-b2d1-5092-93e8-a744854f5085",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.0.0",
+    "status": null
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/4b30a6af-4b52-5bda-bccb-f2248a12c992_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/4b30a6af-4b52-5bda-bccb-f2248a12c992_saptune_discovery.json
@@ -1,0 +1,107 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "4b30a6af-4b52-5bda-bccb-f2248a12c992",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.1.0",
+    "status": {
+      "$schema": "file:///usr/share/saptune/schemas/1.0/saptune_status.schema.json",
+      "publish time": "2023-04-24 12:41:56.612",
+      "argv": "saptune --format json status",
+      "pid": 24623,
+      "command": "status",
+      "exit code": 4,
+      "result": {
+        "services": {
+          "saptune": [
+            "enabled",
+            "active"
+          ],
+          "sapconf": [],
+          "tuned": []
+        },
+        "systemd system state": "running",
+        "tuning state": "not compliant",
+        "virtualization": "oracle",
+        "configured version": "3",
+        "package version": "3.1.0",
+        "Solution enabled": [
+          "NETWEAVER"
+        ],
+        "Notes enabled by Solution": [
+          {
+            "Solution ID": "NETWEAVER",
+            "Note list": [
+              "941735",
+              "1771258",
+              "2578899",
+              "2993054",
+              "1656250",
+              "900929"
+            ]
+          }
+        ],
+        "Solution applied": [
+          {
+            "Solution ID": "NETWEAVER",
+            "applied partially": false
+          }
+        ],
+        "Notes applied by Solution": [
+          {
+            "Solution ID": "NETWEAVER",
+            "Note list": [
+              "941735",
+              "1771258",
+              "2578899",
+              "2993054",
+              "1656250",
+              "900929"
+            ]
+          }
+        ],
+        "Notes enabled additionally": [],
+        "Notes enabled": [
+          "941735",
+          "1771258",
+          "2578899",
+          "2993054",
+          "1656250",
+          "900929"
+        ],
+        "Notes applied": [
+          "941735",
+          "1771258",
+          "2578899",
+          "2993054",
+          "1656250",
+          "900929"
+        ],
+        "staging": {
+          "staging enabled": false,
+          "Notes staged": [],
+          "Solutions staged": []
+        },
+        "remember message": "\nRegarding the tuning state of the system please use 'saptune note verify' for detailed information.\n\n"
+      },
+      "messages": [
+        {
+          "priority": "NOTICE",
+          "message": "actions.go:85: ATTENTION: You are running a test version (3.1.0 from 2022/11/28) of saptune which is not supported for production use\n"
+        },
+        {
+          "priority": "WARNING",
+          "message": "sysctl.go:73: Parameter 'kernel.shmmax' additional defined in the following sysctl config file /boot/sysctl.conf-5.3.18-150300.59.90-default(0xffffffffffffffff), /boot/sysctl.conf-5.3.18-150300.59.93-default(0xffffffffffffffff).\n"
+        },
+        {
+          "priority": "WARNING",
+          "message": "sysctl.go:73: Parameter 'kernel.shmall' additional defined in the following sysctl config file /boot/sysctl.conf-5.3.18-150300.59.90-default(0x0fffffffffffff00), /boot/sysctl.conf-5.3.18-150300.59.93-default(0x0fffffffffffff00).\n"
+        },
+        {
+          "priority": "NOTICE",
+          "message": "ini.go:308: block device related section settings detected: Traversing all block devices can take a considerable amount of time.\n"
+        }
+      ]
+    } 
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/69f4dcbb-efa2-5a16-8bc8-01df7dbb7384_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/69f4dcbb-efa2-5a16-8bc8-01df7dbb7384_saptune_discovery.json
@@ -1,0 +1,9 @@
+{
+  "agent_id": "69f4dcbb-efa2-5a16-8bc8-01df7dbb7384",
+  "discovery_type": "saptune_discovery",
+  "payload": {
+    "saptune_installed": false,
+    "package_version": "",
+    "status": null
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_saptune_discovery.json
@@ -1,0 +1,9 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "7269ee51-5007-5849-aaa7-7c4a98b0c9ce",
+  "payload": {
+    "saptune_installed": false,
+    "package_version": "",
+    "status": null
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/81e9b629-c1e7-538f-bff1-47d3a6580522_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/81e9b629-c1e7-538f-bff1-47d3a6580522_saptune_discovery.json
@@ -1,0 +1,9 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "81e9b629-c1e7-538f-bff1-47d3a6580522",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.0.0",
+    "status": null
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/927901fa-2c87-524e-b18c-3ef5187f504f_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/927901fa-2c87-524e-b18c-3ef5187f504f_saptune_discovery.json
@@ -1,0 +1,45 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "927901fa-2c87-524e-b18c-3ef5187f504f",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.1.0",
+    "status": {
+      "$schema": "file:///usr/share/saptune/schemas/1.0/saptune_status.schema.json",
+      "publish time": "2023-04-24 12:41:56.612",
+      "argv": "saptune --format json status",
+      "pid": 24623,
+      "command": "status",
+      "exit code": 4,
+      "result": {
+        "services": {
+          "saptune": [
+            "enabled",
+            "inactive"
+          ],
+          "sapconf": [],
+          "tuned": []
+        },
+        "systemd system state": "running",
+        "tuning state": "not tuned",
+        "virtualization": "oracle",
+        "configured version": "3",
+        "package version": "3.1.0",
+        "Solution enabled": [],
+        "Notes enabled by Solution": [],
+        "Solution applied": [],
+        "Notes applied by Solution": [],
+        "Notes enabled additionally": [],
+        "Notes enabled": [],
+        "Notes applied": [],
+        "staging": {
+          "staging enabled": false,
+          "Notes staged": [],
+          "Solutions staged": []
+        },
+        "remember message": "\nRegarding the tuning state of the system please use 'saptune note verify' for detailed information.\n\n"
+      },
+      "messages": []
+    } 
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/99cf8a3a-48d6-57a4-b302-6e4482227ab6_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/99cf8a3a-48d6-57a4-b302-6e4482227ab6_saptune_discovery.json
@@ -1,0 +1,9 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "99cf8a3a-48d6-57a4-b302-6e4482227ab6",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.0.0",
+    "status": null
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a26b6d0-6e72-597c-9fe5-152a6875f214_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a26b6d0-6e72-597c-9fe5-152a6875f214_saptune_discovery.json
@@ -1,0 +1,9 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "9a26b6d0-6e72-597c-9fe5-152a6875f214",
+  "payload": {
+    "saptune_installed": false,
+    "package_version": "",
+    "status": null
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_saptune_discovery.json
@@ -1,0 +1,9 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f",
+  "payload": {
+    "saptune_installed": false,
+    "package_version": "",
+    "status": null
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9cd46919-5f19-59aa-993e-cf3736c71053_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9cd46919-5f19-59aa-993e-cf3736c71053_saptune_discovery.json
@@ -26,37 +26,45 @@
         "configured version": "3",
         "package version": "3.1.0",
         "Solution enabled": [
-          "NETWEAVER"
+          "HANA"
         ],
         "Notes enabled by Solution": [
           {
-            "Solution ID": "NETWEAVER",
+            "Solution ID": "HANA",
             "Note list": [
               "941735",
               "1771258",
+              "1868829",
+              "1980196",
               "2578899",
+              "2684254",
+              "2382421",
+              "2534844",
               "2993054",
-              "1656250",
-              "900929"
+              "1656250"
             ]
           }
         ],
         "Solution applied": [
           {
-            "Solution ID": "NETWEAVER",
+            "Solution ID": "HANA",
             "applied partially": false
           }
         ],
         "Notes applied by Solution": [
           {
-            "Solution ID": "NETWEAVER",
+            "Solution ID": "HANA",
             "Note list": [
               "941735",
               "1771258",
+              "1868829",
+              "1980196",
               "2578899",
+              "2684254",
+              "2382421",
+              "2534844",
               "2993054",
-              "1656250",
-              "900929"
+              "1656250"
             ]
           }
         ],
@@ -64,18 +72,26 @@
         "Notes enabled": [
           "941735",
           "1771258",
+          "1868829",
+          "1980196",
           "2578899",
+          "2684254",
+          "2382421",
+          "2534844",
           "2993054",
-          "1656250",
-          "900929"
+          "1656250"
         ],
         "Notes applied": [
           "941735",
           "1771258",
+          "1868829",
+          "1980196",
           "2578899",
+          "2684254",
+          "2382421",
+          "2534844",
           "2993054",
-          "1656250",
-          "900929"
+          "1656250"
         ],
         "staging": {
           "staging enabled": false,

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9cd46919-5f19-59aa-993e-cf3736c71053_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9cd46919-5f19-59aa-993e-cf3736c71053_saptune_discovery.json
@@ -1,0 +1,107 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "9cd46919-5f19-59aa-993e-cf3736c71053",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.1.0",
+    "status": {
+      "$schema": "file:///usr/share/saptune/schemas/1.0/saptune_status.schema.json",
+      "publish time": "2023-04-24 12:41:56.612",
+      "argv": "saptune --format json status",
+      "pid": 24623,
+      "command": "status",
+      "exit code": 4,
+      "result": {
+        "services": {
+          "saptune": [
+            "enabled",
+            "active"
+          ],
+          "sapconf": [],
+          "tuned": []
+        },
+        "systemd system state": "running",
+        "tuning state": "compliant",
+        "virtualization": "oracle",
+        "configured version": "3",
+        "package version": "3.1.0",
+        "Solution enabled": [
+          "NETWEAVER"
+        ],
+        "Notes enabled by Solution": [
+          {
+            "Solution ID": "NETWEAVER",
+            "Note list": [
+              "941735",
+              "1771258",
+              "2578899",
+              "2993054",
+              "1656250",
+              "900929"
+            ]
+          }
+        ],
+        "Solution applied": [
+          {
+            "Solution ID": "NETWEAVER",
+            "applied partially": false
+          }
+        ],
+        "Notes applied by Solution": [
+          {
+            "Solution ID": "NETWEAVER",
+            "Note list": [
+              "941735",
+              "1771258",
+              "2578899",
+              "2993054",
+              "1656250",
+              "900929"
+            ]
+          }
+        ],
+        "Notes enabled additionally": [],
+        "Notes enabled": [
+          "941735",
+          "1771258",
+          "2578899",
+          "2993054",
+          "1656250",
+          "900929"
+        ],
+        "Notes applied": [
+          "941735",
+          "1771258",
+          "2578899",
+          "2993054",
+          "1656250",
+          "900929"
+        ],
+        "staging": {
+          "staging enabled": false,
+          "Notes staged": [],
+          "Solutions staged": []
+        },
+        "remember message": "\nRegarding the tuning state of the system please use 'saptune note verify' for detailed information.\n\n"
+      },
+      "messages": [
+        {
+          "priority": "NOTICE",
+          "message": "actions.go:85: ATTENTION: You are running a test version (3.1.0 from 2022/11/28) of saptune which is not supported for production use\n"
+        },
+        {
+          "priority": "WARNING",
+          "message": "sysctl.go:73: Parameter 'kernel.shmmax' additional defined in the following sysctl config file /boot/sysctl.conf-5.3.18-150300.59.90-default(0xffffffffffffffff), /boot/sysctl.conf-5.3.18-150300.59.93-default(0xffffffffffffffff).\n"
+        },
+        {
+          "priority": "WARNING",
+          "message": "sysctl.go:73: Parameter 'kernel.shmall' additional defined in the following sysctl config file /boot/sysctl.conf-5.3.18-150300.59.90-default(0x0fffffffffffff00), /boot/sysctl.conf-5.3.18-150300.59.93-default(0x0fffffffffffff00).\n"
+        },
+        {
+          "priority": "NOTICE",
+          "message": "ini.go:308: block device related section settings detected: Traversing all block devices can take a considerable amount of time.\n"
+        }
+      ]
+    } 
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a09d9cf3-46c1-505c-8fb8-4b0a71a9114e_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a09d9cf3-46c1-505c-8fb8-4b0a71a9114e_saptune_discovery.json
@@ -1,0 +1,45 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "a09d9cf3-46c1-505c-8fb8-4b0a71a9114e",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.1.0",
+    "status": {
+      "$schema": "file:///usr/share/saptune/schemas/1.0/saptune_status.schema.json",
+      "publish time": "2023-04-24 12:41:56.612",
+      "argv": "saptune --format json status",
+      "pid": 24623,
+      "command": "status",
+      "exit code": 4,
+      "result": {
+        "services": {
+          "saptune": [
+            "enabled",
+            "inactive"
+          ],
+          "sapconf": [],
+          "tuned": []
+        },
+        "systemd system state": "running",
+        "tuning state": "not tuned",
+        "virtualization": "oracle",
+        "configured version": "3",
+        "package version": "3.1.0",
+        "Solution enabled": [],
+        "Notes enabled by Solution": [],
+        "Solution applied": [],
+        "Notes applied by Solution": [],
+        "Notes enabled additionally": [],
+        "Notes enabled": [],
+        "Notes applied": [],
+        "staging": {
+          "staging enabled": false,
+          "Notes staged": [],
+          "Solutions staged": []
+        },
+        "remember message": "\nRegarding the tuning state of the system please use 'saptune note verify' for detailed information.\n\n"
+      },
+      "messages": []
+    } 
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a3297d85-5e8b-5ac5-b8a3-55eebc2b8d12_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a3297d85-5e8b-5ac5-b8a3-55eebc2b8d12_saptune_discovery.json
@@ -1,0 +1,107 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "a3297d85-5e8b-5ac5-b8a3-55eebc2b8d12",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.1.0",
+    "status": {
+      "$schema": "file:///usr/share/saptune/schemas/1.0/saptune_status.schema.json",
+      "publish time": "2023-04-24 12:41:56.612",
+      "argv": "saptune --format json status",
+      "pid": 24623,
+      "command": "status",
+      "exit code": 4,
+      "result": {
+        "services": {
+          "saptune": [
+            "enabled",
+            "active"
+          ],
+          "sapconf": [],
+          "tuned": []
+        },
+        "systemd system state": "running",
+        "tuning state": "not compliant",
+        "virtualization": "oracle",
+        "configured version": "3",
+        "package version": "3.1.0",
+        "Solution enabled": [
+          "NETWEAVER"
+        ],
+        "Notes enabled by Solution": [
+          {
+            "Solution ID": "NETWEAVER",
+            "Note list": [
+              "941735",
+              "1771258",
+              "2578899",
+              "2993054",
+              "1656250",
+              "900929"
+            ]
+          }
+        ],
+        "Solution applied": [
+          {
+            "Solution ID": "NETWEAVER",
+            "applied partially": false
+          }
+        ],
+        "Notes applied by Solution": [
+          {
+            "Solution ID": "NETWEAVER",
+            "Note list": [
+              "941735",
+              "1771258",
+              "2578899",
+              "2993054",
+              "1656250",
+              "900929"
+            ]
+          }
+        ],
+        "Notes enabled additionally": [],
+        "Notes enabled": [
+          "941735",
+          "1771258",
+          "2578899",
+          "2993054",
+          "1656250",
+          "900929"
+        ],
+        "Notes applied": [
+          "941735",
+          "1771258",
+          "2578899",
+          "2993054",
+          "1656250",
+          "900929"
+        ],
+        "staging": {
+          "staging enabled": false,
+          "Notes staged": [],
+          "Solutions staged": []
+        },
+        "remember message": "\nRegarding the tuning state of the system please use 'saptune note verify' for detailed information.\n\n"
+      },
+      "messages": [
+        {
+          "priority": "NOTICE",
+          "message": "actions.go:85: ATTENTION: You are running a test version (3.1.0 from 2022/11/28) of saptune which is not supported for production use\n"
+        },
+        {
+          "priority": "WARNING",
+          "message": "sysctl.go:73: Parameter 'kernel.shmmax' additional defined in the following sysctl config file /boot/sysctl.conf-5.3.18-150300.59.90-default(0xffffffffffffffff), /boot/sysctl.conf-5.3.18-150300.59.93-default(0xffffffffffffffff).\n"
+        },
+        {
+          "priority": "WARNING",
+          "message": "sysctl.go:73: Parameter 'kernel.shmall' additional defined in the following sysctl config file /boot/sysctl.conf-5.3.18-150300.59.90-default(0x0fffffffffffff00), /boot/sysctl.conf-5.3.18-150300.59.93-default(0x0fffffffffffff00).\n"
+        },
+        {
+          "priority": "NOTICE",
+          "message": "ini.go:308: block device related section settings detected: Traversing all block devices can take a considerable amount of time.\n"
+        }
+      ]
+    } 
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_saptune_discovery.json
@@ -1,0 +1,107 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "b767b3e9-e802-587e-a442-541d093b86b9",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.1.0",
+    "status": {
+      "$schema": "file:///usr/share/saptune/schemas/1.0/saptune_status.schema.json",
+      "publish time": "2023-04-24 12:41:56.612",
+      "argv": "saptune --format json status",
+      "pid": 24623,
+      "command": "status",
+      "exit code": 4,
+      "result": {
+        "services": {
+          "saptune": [
+            "enabled",
+            "active"
+          ],
+          "sapconf": [],
+          "tuned": []
+        },
+        "systemd system state": "running",
+        "tuning state": "compliant",
+        "virtualization": "oracle",
+        "configured version": "3",
+        "package version": "3.1.0",
+        "Solution enabled": [
+          "NETWEAVER"
+        ],
+        "Notes enabled by Solution": [
+          {
+            "Solution ID": "NETWEAVER",
+            "Note list": [
+              "941735",
+              "1771258",
+              "2578899",
+              "2993054",
+              "1656250",
+              "900929"
+            ]
+          }
+        ],
+        "Solution applied": [
+          {
+            "Solution ID": "NETWEAVER",
+            "applied partially": false
+          }
+        ],
+        "Notes applied by Solution": [
+          {
+            "Solution ID": "NETWEAVER",
+            "Note list": [
+              "941735",
+              "1771258",
+              "2578899",
+              "2993054",
+              "1656250",
+              "900929"
+            ]
+          }
+        ],
+        "Notes enabled additionally": [],
+        "Notes enabled": [
+          "941735",
+          "1771258",
+          "2578899",
+          "2993054",
+          "1656250",
+          "900929"
+        ],
+        "Notes applied": [
+          "941735",
+          "1771258",
+          "2578899",
+          "2993054",
+          "1656250",
+          "900929"
+        ],
+        "staging": {
+          "staging enabled": false,
+          "Notes staged": [],
+          "Solutions staged": []
+        },
+        "remember message": "\nRegarding the tuning state of the system please use 'saptune note verify' for detailed information.\n\n"
+      },
+      "messages": [
+        {
+          "priority": "NOTICE",
+          "message": "actions.go:85: ATTENTION: You are running a test version (3.1.0 from 2022/11/28) of saptune which is not supported for production use\n"
+        },
+        {
+          "priority": "WARNING",
+          "message": "sysctl.go:73: Parameter 'kernel.shmmax' additional defined in the following sysctl config file /boot/sysctl.conf-5.3.18-150300.59.90-default(0xffffffffffffffff), /boot/sysctl.conf-5.3.18-150300.59.93-default(0xffffffffffffffff).\n"
+        },
+        {
+          "priority": "WARNING",
+          "message": "sysctl.go:73: Parameter 'kernel.shmall' additional defined in the following sysctl config file /boot/sysctl.conf-5.3.18-150300.59.90-default(0x0fffffffffffff00), /boot/sysctl.conf-5.3.18-150300.59.93-default(0x0fffffffffffff00).\n"
+        },
+        {
+          "priority": "NOTICE",
+          "message": "ini.go:308: block device related section settings detected: Traversing all block devices can take a considerable amount of time.\n"
+        }
+      ]
+    } 
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_saptune_discovery.json
@@ -26,37 +26,45 @@
         "configured version": "3",
         "package version": "3.1.0",
         "Solution enabled": [
-          "NETWEAVER"
+          "HANA"
         ],
         "Notes enabled by Solution": [
           {
-            "Solution ID": "NETWEAVER",
+            "Solution ID": "HANA",
             "Note list": [
               "941735",
               "1771258",
+              "1868829",
+              "1980196",
               "2578899",
+              "2684254",
+              "2382421",
+              "2534844",
               "2993054",
-              "1656250",
-              "900929"
+              "1656250"
             ]
           }
         ],
         "Solution applied": [
           {
-            "Solution ID": "NETWEAVER",
+            "Solution ID": "HANA",
             "applied partially": false
           }
         ],
         "Notes applied by Solution": [
           {
-            "Solution ID": "NETWEAVER",
+            "Solution ID": "HANA",
             "Note list": [
               "941735",
               "1771258",
+              "1868829",
+              "1980196",
               "2578899",
+              "2684254",
+              "2382421",
+              "2534844",
               "2993054",
-              "1656250",
-              "900929"
+              "1656250"
             ]
           }
         ],
@@ -64,18 +72,26 @@
         "Notes enabled": [
           "941735",
           "1771258",
+          "1868829",
+          "1980196",
           "2578899",
+          "2684254",
+          "2382421",
+          "2534844",
           "2993054",
-          "1656250",
-          "900929"
+          "1656250"
         ],
         "Notes applied": [
           "941735",
           "1771258",
+          "1868829",
+          "1980196",
           "2578899",
+          "2684254",
+          "2382421",
+          "2534844",
           "2993054",
-          "1656250",
-          "900929"
+          "1656250"
         ],
         "staging": {
           "staging enabled": false,

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/ddcb7992-2ffb-5c10-8b39-80685f6eaaba_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/ddcb7992-2ffb-5c10-8b39-80685f6eaaba_saptune_discovery.json
@@ -1,0 +1,9 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "ddcb7992-2ffb-5c10-8b39-80685f6eaaba",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.0.0",
+    "status": null
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/e0c182db-32ff-55c6-a9eb-2b82dd21bc8b_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/e0c182db-32ff-55c6-a9eb-2b82dd21bc8b_saptune_discovery.json
@@ -1,0 +1,9 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "e0c182db-32ff-55c6-a9eb-2b82dd21bc8b",
+  "payload": {
+    "saptune_installed": true,
+    "package_version": "3.0.0",
+    "status": null
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/f0c808b3-d869-5192-a944-20f66a6a8449_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/f0c808b3-d869-5192-a944-20f66a6a8449_saptune_discovery.json
@@ -1,0 +1,9 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "f0c808b3-d869-5192-a944-20f66a6a8449",
+  "payload": {
+    "saptune_installed": false,
+    "package_version": "",
+    "status": null
+  } 
+}

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_saptune_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_saptune_discovery.json
@@ -1,0 +1,9 @@
+{
+  "discovery_type": "saptune_discovery",
+  "agent_id": "fb2c6b8a-9915-5969-a6b7-8b5a42de1971",
+  "payload": {
+    "saptune_installed": false,
+    "package_version": "",
+    "status": null
+  } 
+}


### PR DESCRIPTION
# Description
Add saptune discovery payloads to the 27 nodes cluster scenario, so we have the data in the demo environment.

The types are saptune payloads are based on:
 * saptune not installed / without sap workload
  three vmiscsi hosts
 * saptune not installed / with sap workload
  vmhdbdev* and vmnwdev* hosts
 * saptune < 3.1.0 installed / wihtout sap workload
  vmdrbddev* and vmdrbdqas* hosts
 * saptune < 3.1.0 installed / with sap workload
  vmhdbqas* and vmnwqas* hosts 
 * saptune >= 3.1.0 installed / without sap worload
  vmdrbdprd* hosts
 * saptune >= 3.1.0 installed / with sap workload / tuning compliant
  vmhdbprd* hosts
 * saptune >= 3.1.0 installed / with sap workload / not tuning compliant
  vmnwprd* hosts

@abravosuse I'm afraid that the PR env is not the best way to test this, as it doesn't have the heartbeat, so the agent health status is not changed, so either you go host by host to see the saptune summary, or you trust my local tests
https://2265.prenv.trento.suse.com/

