### PR TITLE
Add endpoint to save SUMA credentials

### DIFF
--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -75,6 +75,13 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"422", reason: "Requested operation not allowed for present SAP instances.")
   end
 
+  def call(conn, {:error, :settings_already_configured}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(ErrorView)
+    |> render(:"422", reason: "Credentials have already been set.")
+  end
+
   def call(conn, {:error, :no_checks_selected}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/lib/trento_web/controllers/v1/suma_credentials_controller.ex
+++ b/lib/trento_web/controllers/v1/suma_credentials_controller.ex
@@ -40,8 +40,9 @@ defmodule TrentoWeb.V1.SUMACredentialsController do
 
   @spec create(Plug.Conn.t(), any) :: Plug.Conn.t()
   def create(%{body_params: body_params} = conn, _) do
-    with {:ok, saved_settings} <-
-           body_params |> decode_body() |> SoftwareUpdates.save_settings() do
+    attrs = decode_body(body_params)
+
+    with {:ok, saved_settings} <- SoftwareUpdates.save_settings(attrs) do
       conn
       |> put_status(:created)
       |> render("suma_credentials.json", %{settings: saved_settings})

--- a/lib/trento_web/controllers/v1/suma_credentials_controller.ex
+++ b/lib/trento_web/controllers/v1/suma_credentials_controller.ex
@@ -12,11 +12,11 @@ defmodule TrentoWeb.V1.SUMACredentialsController do
   action_fallback TrentoWeb.FallbackController
 
   operation :show,
-    summary: "Gets the user settings",
+    summary: "Gets the SUMA credentials",
     tags: ["Platform"],
-    description: "Gets the saved user settings for SUSE Manager",
+    description: "Gets the saved credentials for SUSE Manager",
     responses: [
-      ok: {"The SUSE Manager user settings", "application/json", SUMACredentials.Settings},
+      ok: {"The SUSE Manager credentials", "application/json", SUMACredentials.Settings},
       not_found: Schema.NotFound.response()
     ]
 
@@ -28,9 +28,9 @@ defmodule TrentoWeb.V1.SUMACredentialsController do
   end
 
   operation :create,
-    summary: "Saves the user settings",
+    summary: "Saves the SUMA credentials",
     tags: ["Platform"],
-    description: "Saves user settings for SUSE Manager",
+    description: "Saves credentials for SUSE Manager",
     request_body:
       {"SUMACredentialsRequest", "application/json", SUMACredentials.SUMACredentialsRequest},
     responses: [

--- a/lib/trento_web/controllers/v1/suma_credentials_controller.ex
+++ b/lib/trento_web/controllers/v1/suma_credentials_controller.ex
@@ -5,6 +5,8 @@ defmodule TrentoWeb.V1.SUMACredentialsController do
   alias Trento.SoftwareUpdates
 
   alias TrentoWeb.OpenApi.V1.Schema
+  alias TrentoWeb.OpenApi.V1.Schema.SUMACredentials
+  alias TrentoWeb.OpenApi.V1.Schema.UnprocessableEntity
 
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
   action_fallback TrentoWeb.FallbackController
@@ -14,7 +16,7 @@ defmodule TrentoWeb.V1.SUMACredentialsController do
     tags: ["Platform"],
     description: "Gets the saved user settings for SUSE Manager",
     responses: [
-      ok: {"The SUSE Manager user settings", "application/json", Schema.SUMACredentials.Settings},
+      ok: {"The SUSE Manager user settings", "application/json", SUMACredentials.Settings},
       not_found: Schema.NotFound.response()
     ]
 
@@ -22,6 +24,33 @@ defmodule TrentoWeb.V1.SUMACredentialsController do
   def show(conn, _) do
     with {:ok, settings} <- SoftwareUpdates.get_settings() do
       render(conn, "suma_credentials.json", %{settings: settings})
+    end
+  end
+
+  operation :create,
+    summary: "Saves the user settings",
+    tags: ["Platform"],
+    description: "Saves user settings for SUSE Manager",
+    request_body:
+      {"SUMACredentialsRequest", "application/json", SUMACredentials.SUMACredentialsRequest},
+    responses: [
+      created: {"Settings saved successfully", "application/json", SUMACredentials.Settings},
+      unprocessable_entity: UnprocessableEntity.response()
+    ]
+
+  @spec create(Plug.Conn.t(), any) :: Plug.Conn.t()
+  def create(%{body_params: body_params} = conn, _) do
+    with {:ok, saved_settings} <-
+           body_params |> Map.from_struct() |> SoftwareUpdates.save_settings() do
+      %{url: url, username: username, ca_uploaded_at: ca_uploaded_at} = saved_settings
+
+      conn
+      |> put_status(:created)
+      |> json(%SUMACredentials.Settings{
+        url: url,
+        username: username,
+        ca_uploaded_at: ca_uploaded_at
+      })
     end
   end
 

--- a/lib/trento_web/controllers/v1/suma_credentials_controller.ex
+++ b/lib/trento_web/controllers/v1/suma_credentials_controller.ex
@@ -41,16 +41,10 @@ defmodule TrentoWeb.V1.SUMACredentialsController do
   @spec create(Plug.Conn.t(), any) :: Plug.Conn.t()
   def create(%{body_params: body_params} = conn, _) do
     with {:ok, saved_settings} <-
-           body_params |> Map.from_struct() |> SoftwareUpdates.save_settings() do
-      %{url: url, username: username, ca_uploaded_at: ca_uploaded_at} = saved_settings
-
+           body_params |> decode_body() |> SoftwareUpdates.save_settings() do
       conn
       |> put_status(:created)
-      |> json(%SUMACredentials.Settings{
-        url: url,
-        username: username,
-        ca_uploaded_at: ca_uploaded_at
-      })
+      |> render("suma_credentials.json", %{settings: saved_settings})
     end
   end
 
@@ -67,4 +61,7 @@ defmodule TrentoWeb.V1.SUMACredentialsController do
     :ok = SoftwareUpdates.clear_settings()
     send_resp(conn, :no_content, "")
   end
+
+  defp decode_body(body) when is_struct(body), do: Map.from_struct(body)
+  defp decode_body(body), do: body
 end

--- a/lib/trento_web/openapi/v1/schema/suma_credentials.ex
+++ b/lib/trento_web/openapi/v1/schema/suma_credentials.ex
@@ -4,6 +4,31 @@ defmodule TrentoWeb.OpenApi.V1.Schema.SUMACredentials do
   require OpenApiSpex
   alias OpenApiSpex.Schema
 
+  defmodule SUMACredentialsRequest do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "SUMACredentialsRequest",
+      description: "Request body for saving SUMA credentials",
+      type: :object,
+      properties: %{
+        url: %Schema{
+          type: :string
+        },
+        username: %Schema{
+          type: :string
+        },
+        password: %Schema{
+          type: :string
+        },
+        ca_cert: %Schema{
+          type: :string
+        }
+      },
+      required: [:url, :username, :password]
+    })
+  end
+
   defmodule Settings do
     @moduledoc false
 

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -147,7 +147,7 @@ defmodule TrentoWeb.Router do
       get "/hosts/:id/exporters_status", PrometheusController, :exporters_status
 
       resources "/settings/suma_credentials", SUMACredentialsController,
-        only: [:show, :delete],
+        only: [:show, :create, :delete],
         singleton: true
 
       scope "/charts" do

--- a/test/trento_web/controllers/v1/suma_credentials_controller_test.exs
+++ b/test/trento_web/controllers/v1/suma_credentials_controller_test.exs
@@ -15,9 +15,8 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
     test "should return user settings", %{conn: conn} do
       insert(
         :software_updates_settings,
-        [ca_cert: Faker.Lorem.sentence(), ca_uploaded_at: DateTime.utc_now()],
-        conflict_target: :id,
-        on_conflict: :replace_all
+        ca_cert: Faker.Lorem.sentence(),
+        ca_uploaded_at: DateTime.utc_now()
       )
 
       api_spec = ApiSpec.spec()
@@ -113,10 +112,7 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
     end
 
     test "should not save valid settings when previously settings have been saved", %{conn: conn} do
-      insert(:software_updates_settings, [ca_cert: nil, ca_uploaded_at: nil],
-        conflict_target: :id,
-        on_conflict: :replace_all
-      )
+      insert(:software_updates_settings, ca_cert: nil, ca_uploaded_at: nil)
 
       new_settings = %{
         url: Faker.Internet.image_url(),


### PR DESCRIPTION
# Description

Adds endpoint to save SUMA credentials.

Using this endpoint, (new) credentials can only be saved if there currently aren't existing saved credentials.

## How was this tested?

Added unit tests
