### PR TITLE
Add endpoint to clear SUMA credentials

### DIFF
--- a/lib/trento_web/controllers/v1/suma_credentials_controller.ex
+++ b/lib/trento_web/controllers/v1/suma_credentials_controller.ex
@@ -35,8 +35,7 @@ defmodule TrentoWeb.V1.SUMACredentialsController do
 
   @spec delete(Plug.Conn.t(), any) :: Plug.Conn.t()
   def delete(conn, _) do
-    with :ok <- SoftwareUpdates.clear_settings() do
-      send_resp(conn, :no_content, "")
-    end
+    :ok = SoftwareUpdates.clear_settings()
+    send_resp(conn, :no_content, "")
   end
 end

--- a/lib/trento_web/controllers/v1/suma_credentials_controller.ex
+++ b/lib/trento_web/controllers/v1/suma_credentials_controller.ex
@@ -24,4 +24,19 @@ defmodule TrentoWeb.V1.SUMACredentialsController do
       render(conn, "suma_credentials.json", %{settings: settings})
     end
   end
+
+  operation :delete,
+    summary: "Clears the SUMA credentials",
+    tags: ["Platform"],
+    description: "Clears the saved credentials for SUSE Manager",
+    responses: [
+      no_content: "Settings cleared successfully"
+    ]
+
+  @spec delete(Plug.Conn.t(), any) :: Plug.Conn.t()
+  def delete(conn, _) do
+    with :ok <- SoftwareUpdates.clear_settings() do
+      send_resp(conn, :no_content, "")
+    end
+  end
 end

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -147,7 +147,7 @@ defmodule TrentoWeb.Router do
       get "/hosts/:id/exporters_status", PrometheusController, :exporters_status
 
       resources "/settings/suma_credentials", SUMACredentialsController,
-        only: [:show],
+        only: [:show, :delete],
         singleton: true
 
       scope "/charts" do

--- a/test/trento_web/controllers/v1/suma_credentials_controller_test.exs
+++ b/test/trento_web/controllers/v1/suma_credentials_controller_test.exs
@@ -37,4 +37,20 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
       |> assert_schema("NotFound", api_spec)
     end
   end
+
+  describe "Clear user settings" do
+    test "should return 204 if no user settings have previously been saved", %{conn: conn} do
+      conn = delete(conn, "/api/v1/settings/suma_credentials")
+
+      assert response(conn, 204) == ""
+    end
+
+    test "should return 204 when user settings have previously been saved", %{conn: conn} do
+      insert(:software_updates_settings)
+
+      conn = delete(conn, "/api/v1/settings/suma_credentials")
+
+      assert response(conn, 204) == ""
+    end
+  end
 end


### PR DESCRIPTION
# Description

Adds an endpoint to clear user settings for SUSE Manager.

Endpoint is idempotent - server returns `204` status regardless if user settings have been previously saved or not.

## How was this tested?

Added unit tests.
