### PR TITLE
Hana cluster find sites

### DIFF
--- a/lib/trento/clusters/value_objects/hana_cluster_details.ex
+++ b/lib/trento/clusters/value_objects/hana_cluster_details.ex
@@ -15,6 +15,7 @@ defmodule Trento.Clusters.ValueObjects.HanaClusterDetails do
   alias Trento.Clusters.ValueObjects.{
     ClusterResource,
     HanaClusterNode,
+    HanaClusterSite,
     SbdDevice
   }
 
@@ -22,11 +23,13 @@ defmodule Trento.Clusters.ValueObjects.HanaClusterDetails do
     field :system_replication_mode, :string
     field :system_replication_operation_mode, :string
     field :secondary_sync_state, :string
+    # this attribute is deprecated, moved to the sites entry
     field :sr_health_state, :string
     field :fencing_type, :string
 
     embeds_many :stopped_resources, ClusterResource
     embeds_many :nodes, HanaClusterNode
     embeds_many :sbd_devices, SbdDevice
+    embeds_many :sites, HanaClusterSite
   end
 end

--- a/lib/trento/clusters/value_objects/hana_cluster_details.ex
+++ b/lib/trento/clusters/value_objects/hana_cluster_details.ex
@@ -23,7 +23,7 @@ defmodule Trento.Clusters.ValueObjects.HanaClusterDetails do
     field :system_replication_mode, :string
     field :system_replication_operation_mode, :string
     field :secondary_sync_state, :string
-    # this attribute is deprecated, moved to the sites entry
+    # sr_health_state attribute is deprecated, moved to the sites entry
     field :sr_health_state, :string
     field :fencing_type, :string
 

--- a/lib/trento/clusters/value_objects/hana_cluster_node.ex
+++ b/lib/trento/clusters/value_objects/hana_cluster_node.ex
@@ -5,7 +5,6 @@ defmodule Trento.Clusters.ValueObjects.HanaClusterNode do
 
   @required_fields [
     :name,
-    :site,
     :hana_status,
     :attributes
   ]
@@ -17,6 +16,7 @@ defmodule Trento.Clusters.ValueObjects.HanaClusterNode do
   deftype do
     field :name, :string
     field :site, :string
+    # this attribute is deprecated, moved to the sites entry
     field :hana_status, :string
     field :attributes, {:map, :string}
     field :virtual_ip, :string

--- a/lib/trento/clusters/value_objects/hana_cluster_node.ex
+++ b/lib/trento/clusters/value_objects/hana_cluster_node.ex
@@ -16,7 +16,7 @@ defmodule Trento.Clusters.ValueObjects.HanaClusterNode do
   deftype do
     field :name, :string
     field :site, :string
-    # this attribute is deprecated, moved to the sites entry
+    # hana_status attribute is deprecated, moved to the sites entry
     field :hana_status, :string
     field :attributes, {:map, :string}
     field :virtual_ip, :string

--- a/lib/trento/clusters/value_objects/hana_cluster_site.ex
+++ b/lib/trento/clusters/value_objects/hana_cluster_site.ex
@@ -1,0 +1,19 @@
+defmodule Trento.Clusters.ValueObjects.HanaClusterSite do
+  @moduledoc """
+  Represents the details of a HANA site.
+  """
+
+  @required_fields [
+    :name,
+    :state,
+    :sr_health_state
+  ]
+
+  use Trento.Support.Type
+
+  deftype do
+    field :name, :string
+    field :state, :string
+    field :sr_health_state, :string
+  end
+end

--- a/lib/trento_web/openapi/v2/schema/cluster.ex
+++ b/lib/trento_web/openapi/v2/schema/cluster.ex
@@ -9,6 +9,86 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
 
   alias TrentoWeb.OpenApi.V1.Schema.{Cluster, Provider, ResourceHealth, Tags}
 
+  defmodule HanaClusterNode do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "HanaClusterNode",
+      description: "A HANA Cluster Node",
+      type: :object,
+      properties: %{
+        name: %Schema{type: :string},
+        site: %Schema{type: :string},
+        hana_status: %Schema{type: :string, deprecated: true},
+        attributes: %Schema{
+          type: :object,
+          description: "Node attributes",
+          additionalProperties: %Schema{type: :string}
+        },
+        virtual_ip: %Schema{type: :string},
+        resources: %Schema{
+          description: "A list of Cluster resources",
+          type: :array,
+          items: Cluster.ClusterResource
+        }
+      }
+    })
+  end
+
+  defmodule HanaClusterSite do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "HanaClusterSite",
+      description: "A HANA Cluster Site",
+      type: :object,
+      properties: %{
+        name: %Schema{type: :string, description: "Site name"},
+        state: %Schema{type: :string, description: "Site state"},
+        sr_health_state: %Schema{type: :string, description: "Site SR Health state"}
+      }
+    })
+  end
+
+  defmodule HanaClusterDetails do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "HanaClusterDetails",
+      description: "Details of a HANA Pacemaker Cluster",
+      type: :object,
+      properties: %{
+        system_replication_mode: %Schema{type: :string, description: "System Replication Mode"},
+        system_replication_operation_mode: %Schema{
+          type: :string,
+          description: "System Replication Operation Mode"
+        },
+        secondary_sync_state: %Schema{type: :string, description: "Secondary Sync State"},
+        sr_health_state: %Schema{type: :string, description: "SR health state", deprecated: true},
+        fencing_type: %Schema{type: :string, description: "Fencing Type"},
+        stopped_resources: %Schema{
+          description: "A list of the stopped resources on this HANA Cluster",
+          type: :array,
+          items: Cluster.ClusterResource
+        },
+        nodes: %Schema{
+          type: :array,
+          items: HanaClusterNode
+        },
+        sites: %Schema{
+          description: "A list of HANA sites",
+          type: :array,
+          items: HanaClusterSite
+        },
+        sbd_devices: %Schema{
+          type: :array,
+          items: Cluster.SbdDevice
+        }
+      },
+      required: [:nodes]
+    })
+  end
+
   defmodule AscsErsClusterNode do
     @moduledoc false
 
@@ -117,7 +197,7 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
       nullable: true,
       oneOf: [
         AscsErsClusterDetails,
-        Cluster.HanaClusterDetails
+        HanaClusterDetails
       ]
     })
   end

--- a/lib/trento_web/views/v1/cluster_view.ex
+++ b/lib/trento_web/views/v1/cluster_view.ex
@@ -23,8 +23,16 @@ defmodule TrentoWeb.V1.ClusterView do
     |> Map.put(:id, data.cluster_id)
   end
 
-  defp adapt_v1(%{type: type} = cluster) when type in [:hana_scale_up, :hana_scale_out, :unknown],
-    do: cluster
+  defp adapt_v1(%{type: type, details: nil} = cluster)
+       when type in [:hana_scale_up, :hana_scale_out, :unknown] do
+    cluster
+  end
+
+  defp adapt_v1(%{type: type} = cluster) when type in [:hana_scale_up, :hana_scale_out] do
+    cluster
+    |> pop_in([:details, "sites"])
+    |> elem(1)
+  end
 
   defp adapt_v1(cluster) do
     cluster

--- a/test/fixtures/discovery/ha_cluster_discovery_gcp.json
+++ b/test/fixtures/discovery/ha_cluster_discovery_gcp.json
@@ -547,6 +547,10 @@
                 "Value": "sync"
               },
               {
+                "Name": "hana_prd_sync_state",
+                "Value": "SFAIL"
+              },
+              {
                 "Name": "hana_prd_version",
                 "Value": "2.00.057.00.1629894416"
               },
@@ -581,7 +585,7 @@
               },
               {
                 "Name": "hana_prd_roles",
-                "Value": "4:S:master1:master:worker:master"
+                "Value": "4:P:master1:master:worker:master"
               },
               {
                 "Name": "hana_prd_site",
@@ -590,6 +594,10 @@
               {
                 "Name": "hana_prd_srmode",
                 "Value": "sync"
+              },
+              {
+                "Name": "hana_prd_sync_state",
+                "Value": "PRIM"
               },
               {
                 "Name": "hana_prd_version",

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -15,6 +15,7 @@ defmodule Trento.Factory do
     ClusterResource,
     HanaClusterDetails,
     HanaClusterNode,
+    HanaClusterSite,
     SbdDevice
   }
 
@@ -165,7 +166,7 @@ defmodule Trento.Factory do
       provider: Enum.random(Provider.values()),
       resources_number: 8,
       hosts_number: 2,
-      details: hana_cluster_details_value_object(),
+      details: build(:hana_cluster_details),
       type: ClusterType.hana_scale_up(),
       discovered_health: Health.passing(),
       designated_controller: true
@@ -196,7 +197,7 @@ defmodule Trento.Factory do
       provider: Enum.random(Provider.values()),
       resources_number: 8,
       hosts_number: 2,
-      details: hana_cluster_details_value_object(),
+      details: build(:hana_cluster_details),
       health: Health.passing(),
       type: ClusterType.hana_scale_up()
     }
@@ -423,7 +424,7 @@ defmodule Trento.Factory do
     })
   end
 
-  def hana_cluster_details_value_object do
+  def hana_cluster_details_factory do
     %HanaClusterDetails{
       fencing_type: "external/sbd",
       nodes: [
@@ -441,6 +442,13 @@ defmodule Trento.Factory do
             }
           ],
           site: Faker.StarWars.planet()
+        }
+      ],
+      sites: [
+        %HanaClusterSite{
+          name: Faker.Beer.name(),
+          state: "Primary",
+          sr_health_state: "4"
         }
       ],
       sbd_devices: [

--- a/test/trento/clusters/cluster_test.exs
+++ b/test/trento/clusters/cluster_test.exs
@@ -234,7 +234,7 @@ defmodule Trento.ClusterTest do
         }
       ]
 
-      details = hana_cluster_details_value_object()
+      details = build(:hana_cluster_details)
 
       assert_events_and_state(
         initial_events,

--- a/test/trento/clusters/projections/cluster_projector_test.exs
+++ b/test/trento/clusters/projections/cluster_projector_test.exs
@@ -129,7 +129,7 @@ defmodule Trento.Clusters.Projections.ClusterProjectorTest do
       type: :hana_scale_up,
       resources_number: 8,
       hosts_number: 2,
-      details: hana_cluster_details_value_object()
+      details: build(:hana_cluster_details)
     }
 
     ProjectorTestHelper.project(

--- a/test/trento/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/discovery/policies/cluster_policy_test.exs
@@ -19,6 +19,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
     ClusterResource,
     HanaClusterDetails,
     HanaClusterNode,
+    HanaClusterSite,
     SbdDevice
   }
 
@@ -178,6 +179,18 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       ],
                       site: "SECONDARY_SITE_NAME",
                       virtual_ip: nil
+                    }
+                  ],
+                  sites: [
+                    %HanaClusterSite{
+                      name: "PRIMARY_SITE_NAME",
+                      state: "Primary",
+                      sr_health_state: "4"
+                    },
+                    %HanaClusterSite{
+                      name: "SECONDARY_SITE_NAME",
+                      state: "Secondary",
+                      sr_health_state: "4"
                     }
                   ],
                   sbd_devices: [
@@ -917,6 +930,10 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       virtual_ip: nil
                     }
                   ],
+                  sites: [
+                    %HanaClusterSite{name: "Site1", state: "Primary", sr_health_state: "4"},
+                    %HanaClusterSite{name: "Site2", state: "Secondary", sr_health_state: "4"}
+                  ],
                   sbd_devices: [],
                   secondary_sync_state: "SOK",
                   sr_health_state: "4",
@@ -958,12 +975,13 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                         "hana_prd_roles" => "1:P:master1::worker:",
                         "hana_prd_site" => "Site1",
                         "hana_prd_srmode" => "sync",
+                        "hana_prd_sync_state" => "SFAIL",
                         "hana_prd_version" => "2.00.057.00.1629894416",
                         "hana_prd_vhost" => "vmhana01",
                         "lpa_prd_lpt" => "1650871168",
                         "master-rsc_SAPHana_PRD_HDB00" => "-9000"
                       },
-                      hana_status: "Unknown",
+                      hana_status: "Failed",
                       name: "vmhana01",
                       resources: [
                         %ClusterResource{
@@ -996,15 +1014,16 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                         "hana_prd_clone_state" => "DEMOTED",
                         "hana_prd_op_mode" => "logreplay",
                         "hana_prd_remoteHost" => "vmhana01",
-                        "hana_prd_roles" => "4:S:master1:master:worker:master",
+                        "hana_prd_roles" => "4:P:master1:master:worker:master",
                         "hana_prd_site" => "Site2",
                         "hana_prd_srmode" => "sync",
+                        "hana_prd_sync_state" => "PRIM",
                         "hana_prd_version" => "2.00.057.00.1629894416",
                         "hana_prd_vhost" => "vmhana02",
                         "lpa_prd_lpt" => "30",
                         "master-rsc_SAPHana_PRD_HDB00" => "-INFINITY"
                       },
-                      hana_status: "Unknown",
+                      hana_status: "Primary",
                       name: "vmhana02",
                       resources: [
                         %ClusterResource{
@@ -1026,9 +1045,21 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       virtual_ip: nil
                     }
                   ],
+                  sites: [
+                    %HanaClusterSite{
+                      name: "Site1",
+                      state: "Failed",
+                      sr_health_state: "1"
+                    },
+                    %HanaClusterSite{
+                      name: "Site2",
+                      state: "Primary",
+                      sr_health_state: "4"
+                    }
+                  ],
                   sbd_devices: [],
-                  secondary_sync_state: "Unknown",
-                  sr_health_state: "Unknown",
+                  secondary_sync_state: "SFAIL",
+                  sr_health_state: "1",
                   stopped_resources: [
                     %ClusterResource{
                       fail_count: nil,
@@ -1234,6 +1265,18 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       ],
                       site: "SECONDARY_SITE_NAME",
                       virtual_ip: nil
+                    }
+                  ],
+                  sites: [
+                    %HanaClusterSite{
+                      name: "PRIMARY_SITE_NAME",
+                      state: "Primary",
+                      sr_health_state: "4"
+                    },
+                    %HanaClusterSite{
+                      name: "SECONDARY_SITE_NAME",
+                      state: "Secondary",
+                      sr_health_state: "4"
                     }
                   ],
                   sbd_devices: [
@@ -1511,6 +1554,10 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                         ]
                       }
                     ],
+                    sites: [
+                      %HanaClusterSite{name: "Site1", state: "Primary", sr_health_state: "4"},
+                      %HanaClusterSite{name: "Site2", state: "Secondary", sr_health_state: "4"}
+                    ],
                     sbd_devices: [
                       %SbdDevice{
                         device: "/dev/vdb",
@@ -1698,6 +1745,10 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                           }
                         ]
                       }
+                    ],
+                    sites: [
+                      %HanaClusterSite{name: "Site2", state: "Primary", sr_health_state: "4"},
+                      %HanaClusterSite{name: "Site1", state: "Secondary", sr_health_state: "4"}
                     ],
                     sbd_devices: [
                       %SbdDevice{

--- a/test/trento_web/views/v1/cluster_view_test.exs
+++ b/test/trento_web/views/v1/cluster_view_test.exs
@@ -6,10 +6,25 @@ defmodule TrentoWeb.V1.ClusterViewTest do
 
   alias TrentoWeb.V1.ClusterView
 
-  test "should adapt the cluster view to V1 version" do
-    cluster = build(:cluster, type: :ascs_ers, details: build(:ascs_ers_cluster_details))
+  describe "adapt to V1 version" do
+    test "should remove the ascs/ers cluster type" do
+      cluster = build(:cluster, type: :ascs_ers, details: build(:ascs_ers_cluster_details))
 
-    assert %{type: :unknown, details: nil} =
-             render(ClusterView, "cluster.json", %{cluster: cluster})
+      assert %{type: :unknown, details: nil} =
+               render(ClusterView, "cluster.json", %{cluster: cluster})
+    end
+
+    test "should remove HANA cluster V2 fields" do
+      details =
+        :hana_cluster_details
+        |> build()
+        |> Map.from_struct()
+
+      cluster = build(:cluster, type: :hana_scale_up, details: details)
+
+      %{details: details} = render(ClusterView, "cluster.json", %{cluster: cluster})
+
+      refute Access.get(details, "sites")
+    end
   end
 end


### PR DESCRIPTION
# Description

Backend part related to finding the site name, state and sr health state.
I have done some changes on how we put them, to have a new `sites` field in the details.
I have done this transition, because in reality, these fields are site based, and not host based.
This way, we have the same structure for scale up and scale out (in fact, considering that they are working in a new resource agent that follows this argument, it looks a good idea). And in fact, we can put the sr health state in both sites (until now we only have the secondary site health state).

So the new `sites` entry goes only in `v2` version, and I have set the other values as deprecated, even though the values is there, it is valid, and the user can use, so we don't have non backward compatibles. But marking as deprecated just shows that they will be removed in a potential `v3` version.

![image](https://github.com/trento-project/web/assets/36370954/ceaa26d2-6047-45fe-8280-57c049af3c53)

## How was this tested?

Tests added
