### PR TITLE
Add missed local-npm-registry dep

### DIFF
--- a/packaging/suse/rpm/trento-web.spec
+++ b/packaging/suse/rpm/trento-web.spec
@@ -28,7 +28,7 @@ Source2:        package-lock.json
 Source3:        node_modules.spec.inc
 %include        %{_sourcedir}/node_modules.spec.inc
 Group:          System/Monitoring
-BuildRequires:  elixir, elixir-hex, npm16, erlang-rebar3, git-core
+BuildRequires:  elixir, elixir-hex, npm16, erlang-rebar3, git-core, local-npm-registry
 
 %description
 Trento is an open cloud-native web application for SAP Applications administrators.


### PR DESCRIPTION
# Description

This PR adds a missing BuildRequire in the RPM spec. Without it, OBS is not able to pull the node modules from the local npm registry that we use to build the RPM.