### PR TITLE
Remove unnecessary tar arguments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -808,7 +808,7 @@ jobs:
       - name: Get mix deps & prepare tarball
         run: |
          mix local.hex --force && mix deps.clean --all && mix deps.get
-         tar --sort=name --owner=root:0 --group=root:0 --mtime='UTC 1970-01-01' -c deps | gzip -n > deps.tar.gz
+         tar -c deps | gzip -n > deps.tar.gz
       - name: Checkout and prepare OBS package
         run: |
           osc checkout $OBS_PROJECT trento-web -o $OSC_CHECKOUT_DIR


### PR DESCRIPTION
# Description
This PR should fix the current build issue
```
[  120s] ** (UndefinedFunctionError) function :expo_plural_forms_parser.parse/1 is undefined (module :expo_plural_forms_parser is not available)
[  120s]     :expo_plural_forms_parser.parse([{:nplurals, 1}, {:=, 1}, {:int, 1, 2}, {:";", 1}, {:plural, 1}, {:=, 1}, {:"(", 1}, {:n, 1}, {:>, 1}, {:int, 1, 1}, {:")", 1}, {:";", 1}, {:"$end", 1}])
[  120s]     lib/expo/plural_forms.ex:56: Expo.PluralForms.parse/1
[  120s]     lib/expo/plural_forms/known.ex:158: anonymous fn/1 in :elixir_compiler_7._MODULE_/1
[  120s]     (elixir 1.15.7) lib/enum.ex:1693: Enum."-map/2-lists^map/1-1-"/2
[  120s]     (elixir 1.15.7) lib/map.ex:262: Map.new_from_enum/2
[  120s]     lib/expo/plural_forms/known.ex:156: (module)
[  120s] could not compile dependency :expo, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile expo --force", update it with "mix deps.update expo" or clean it with "mix deps.clean expo"
[5:40 PM](https://suse.slack.com/archives/D02CMRD2FGF/p1707414050789019)
```
that we are having in OBS while building the package. After doing some manual tests it would seem that using this arguments leads to an unusable deps.tar.gz, while removing them seems to work.

After that, I confirmed with my fork that removing these arguments leads to OBS building the package correctly.
