### PR TITLE
Add missed CI step name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -768,6 +768,7 @@ jobs:
           osc commit -m "New development version of $NAME released"
 
   obs-commit-rpm:
+    name: Commit to OBS to generate RPM package
     needs: [static-code-analysis, test, test-fe, test-e2e]
     runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/main' || github.event_name == 'release'

--- a/packaging/suse/rpm/systemd/trento-web.service
+++ b/packaging/suse/rpm/systemd/trento-web.service
@@ -4,7 +4,7 @@ Description=Trento Web service
 [Service]
 ExecStart=/usr/lib/trento/bin/trento start
 ExecStartPre=/usr/lib/trento/bin/trento eval 'Trento.Release.init()'
-EnvironmentFile=/etc/trento/trento_web
+EnvironmentFile=/etc/trento/trento-web
 Type=simple
 User=root
 Restart=on-failure


### PR DESCRIPTION
# Description

Add missed name in the RPM step

Edit: I'm slightly hijacking the original goal of this PR to add another one-liner: the EnvironmentFile in systemd better matches the example file name with `-` instead of `_`