### PR TITLE
Validate ca_cert when it was provided different than null

### DIFF
--- a/lib/trento/software_updates/settings.ex
+++ b/lib/trento/software_updates/settings.ex
@@ -28,6 +28,7 @@ defmodule Trento.SoftwareUpdates.Settings do
     |> cast(attrs, __MODULE__.__schema__(:fields))
     |> validate_required([:url, :username, :password])
     |> validate_change(:url, &validate_url/2)
+    |> maybe_validate_ca_cert(attrs)
     |> maybe_change_cert_upload_date(attrs, date_service)
     |> unique_constraint(:id, name: :software_update_settings_pkey)
   end
@@ -39,6 +40,14 @@ defmodule Trento.SoftwareUpdates.Settings do
 
       _ ->
         [url: {"can only be an https url", validation: :https_url_only}]
+    end
+  end
+
+  defp maybe_validate_ca_cert(changeset, settings_submission) do
+    if nil != Map.get(settings_submission, :ca_cert) do
+      validate_required(changeset, :ca_cert)
+    else
+      changeset
     end
   end
 

--- a/test/trento/software_updates_test.exs
+++ b/test/trento/software_updates_test.exs
@@ -97,6 +97,13 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
             Map.put(submission, :password, "   ")
           ],
           errors: [password: {"can't be blank", [validation: :required]}]
+        },
+        %{
+          submission: [
+            Map.put(submission, :ca_cert, ""),
+            Map.put(submission, :ca_cert, "   ")
+          ],
+          errors: [ca_cert: {"can't be blank", [validation: :required]}]
         }
       ]
 
@@ -240,6 +247,13 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
             {:username, {"can't be blank", [validation: :required]}},
             {:password, {"can't be blank", [validation: :required]}}
           ]
+        },
+        %{
+          change_submissions: [
+            %{ca_cert: ""},
+            %{ca_cert: "   "}
+          ],
+          errors: [ca_cert: {"can't be blank", [validation: :required]}]
         }
       ]
 


### PR DESCRIPTION
# Description

A tiny improvement to the validation of `ca_cert`.
It gets validated when its provided value is different than `null`, meaning that cases like empty strings `""`, `"    "` trigger validation error both when saving or updating settings.

## How was this tested?

Automated tests
