### PR TITLE
Cleanup .tgz(s) from previous runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -815,7 +815,8 @@ jobs:
           osc checkout $OBS_PROJECT trento-web -o $OSC_CHECKOUT_DIR
           cp $FOLDER/_service $OSC_CHECKOUT_DIR
           cp $FOLDER/trento-web.spec $OSC_CHECKOUT_DIR
-          rm -v $OSC_CHECKOUT_DIR/*.tar.gz
+          rm -vf $OSC_CHECKOUT_DIR/*.tar.gz
+          rm -vf $OSC_CHECKOUT_DIR/*.tgz
           pushd $OSC_CHECKOUT_DIR 
           osc service manualrun
           cp  /__w/web/web/deps.tar.gz .


### PR DESCRIPTION
# Description

The node_modules obs service downloads the modules as .tgz in the package. Nothing wrong with this, but we should cleanup before each run to avoid having leftover files in the package.

The -f was added as it allows to move forward even when nothing was found (useful if the files have been manually removed or if it's the first run)