### PR TITLE
Hana details other site nodes

### DIFF
--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
@@ -49,6 +49,7 @@ function HanaClusterDetails({
     sid,
     ...sapSystems.find(({ sid: currentSid }) => currentSid === sid),
   };
+  const unsitedNodes = enrichedNodes.filter(({ site }) => site === null);
 
   const {
     data: executionData,
@@ -211,6 +212,10 @@ function HanaClusterDetails({
           )
         )}
       </div>
+
+      {unsitedNodes.length > 0 && (
+        <HanaClusterSite name="Other" nodes={unsitedNodes} />
+      )}
 
       <SBDDetails sbdDevices={details.sbd_devices} />
     </div>

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.stories.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.stories.jsx
@@ -35,6 +35,7 @@ const scaleOutDetails = hanaClusterDetailsFactory.build({
     hanaClusterDetailsNodesFactory.build({ site: scaleOutSites[1].name }),
     hanaClusterDetailsNodesFactory.build({ site: scaleOutSites[0].name }),
     hanaClusterDetailsNodesFactory.build({ site: scaleOutSites[1].name }),
+    hanaClusterDetailsNodesFactory.build({ site: null, hana_status: '' }),
   ],
 });
 

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.test.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.test.jsx
@@ -7,6 +7,7 @@ import '@testing-library/jest-dom';
 import { renderWithRouter } from '@lib/test-utils';
 import {
   clusterFactory,
+  hanaClusterDetailsNodesFactory,
   hostFactory,
   checksExecutionCompletedFactory,
   checksExecutionRunningFactory,
@@ -262,6 +263,50 @@ describe('HanaClusterDetails component', () => {
 
     expect(screen.getByText(siteName1)).toBeInTheDocument();
     expect(screen.getByText(siteName2)).toBeInTheDocument();
+    expect(screen.queryByText('Other')).not.toBeInTheDocument();
+  });
+
+  it('should display not sited nodes in the Other table', () => {
+    const {
+      clusterID,
+      clusterName,
+      cib_last_written: cibLastWritten,
+      type: clusterType,
+      sid,
+      provider,
+      details,
+    } = clusterFactory.build();
+
+    const hosts = hostFactory.buildList(3, { cluster_id: clusterID });
+
+    const updatedNodes = details.nodes.concat(
+      hanaClusterDetailsNodesFactory.build({ site: null })
+    );
+
+    const updatedDetails = { ...details, ...{ nodes: updatedNodes } };
+
+    renderWithRouter(
+      <HanaClusterDetails
+        clusterID={clusterID}
+        clusterName={clusterName}
+        selectedChecks={[]}
+        hasSelectedChecks={false}
+        hosts={hosts}
+        clusterType={clusterType}
+        cibLastWritten={cibLastWritten}
+        sid={sid}
+        provider={provider}
+        sapSystems={[]}
+        details={updatedDetails}
+        lastExecution={null}
+      />
+    );
+
+    expect(screen.queryByText('Other')).toBeInTheDocument();
+    const tables = screen.getAllByRole('table');
+    expect(tables.length).toBe(3);
+
+    expect(tables[2].querySelectorAll('tbody > tr')).toHaveLength(1);
   });
 
   it('should display infos about node details', async () => {

--- a/lib/trento/discovery/policies/cluster_policy.ex
+++ b/lib/trento/discovery/policies/cluster_policy.ex
@@ -197,16 +197,22 @@ defmodule Trento.Discovery.Policies.ClusterPolicy do
            },
            crmmon:
              %{
+               nodes: nodes,
                node_attributes: %{
-                 nodes: nodes
+                 nodes: nodes_with_attributes
                }
              } = crmmon
          },
          sid
        ) do
-    Enum.map(nodes, fn %{name: name, attributes: attributes} ->
+    Enum.map(nodes, fn %{name: name} ->
       attributes =
-        Enum.into(attributes, %{}, fn %{name: name, value: value} ->
+        nodes_with_attributes
+        |> Enum.find_value([], fn
+          %{name: ^name, attributes: attributes} -> attributes
+          _ -> nil
+        end)
+        |> Enum.into(%{}, fn %{name: name, value: value} ->
           {name, value}
         end)
 

--- a/test/trento/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/discovery/policies/cluster_policy_test.exs
@@ -1744,6 +1744,22 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                             fail_count: 0
                           }
                         ]
+                      },
+                      %HanaClusterNode{
+                        name: "vmhanamm",
+                        site: nil,
+                        hana_status: "Unknown",
+                        attributes: %{},
+                        virtual_ip: nil,
+                        resources: [
+                          %ClusterResource{
+                            id: "stonith-sbd",
+                            type: "stonith:external/sbd",
+                            role: "Started",
+                            status: "Active",
+                            fail_count: 0
+                          }
+                        ]
                       }
                     ],
                     sites: [


### PR DESCRIPTION
# Description

**Pending to rebase**: https://github.com/trento-project/web/pull/2278

Display unsited nodes in the HANA details view.

![image](https://github.com/trento-project/web/assets/36370954/d5345645-66cc-4d1c-ac70-3e47c72bd335)

## How was this tested?

Tests added
