### PR TITLE
Add endpoint to update SUSE Manager credentials

### DIFF
--- a/lib/trento/software_updates/settings.ex
+++ b/lib/trento/software_updates/settings.ex
@@ -34,7 +34,7 @@ defmodule Trento.SoftwareUpdates.Settings do
   end
 
   defp validate_url(_url_atom, url) do
-    case url |> String.trim() |> URI.parse() do
+    case URI.parse(url) do
       %URI{scheme: "https"} ->
         []
 

--- a/lib/trento/software_updates/settings.ex
+++ b/lib/trento/software_updates/settings.ex
@@ -34,7 +34,7 @@ defmodule Trento.SoftwareUpdates.Settings do
   end
 
   defp validate_url(_url_atom, url) do
-    case URI.parse(url) do
+    case url |> String.trim() |> URI.parse() do
       %URI{scheme: "https"} ->
         []
 

--- a/lib/trento_web/controllers/v1/suma_credentials_controller.ex
+++ b/lib/trento_web/controllers/v1/suma_credentials_controller.ex
@@ -32,7 +32,8 @@ defmodule TrentoWeb.V1.SUMACredentialsController do
     tags: ["Platform"],
     description: "Saves credentials for SUSE Manager",
     request_body:
-      {"SUMACredentialsRequest", "application/json", SUMACredentials.SUMACredentialsRequest},
+      {"SaveSUMACredentialsRequest", "application/json",
+       SUMACredentials.SaveSUMACredentialsRequest},
     responses: [
       created: {"Settings saved successfully", "application/json", SUMACredentials.Settings},
       unprocessable_entity: UnprocessableEntity.response()
@@ -45,6 +46,29 @@ defmodule TrentoWeb.V1.SUMACredentialsController do
     with {:ok, saved_settings} <- SoftwareUpdates.save_settings(attrs) do
       conn
       |> put_status(:created)
+      |> render("suma_credentials.json", %{settings: saved_settings})
+    end
+  end
+
+  operation :update,
+    summary: "Updates the SUMA credentials",
+    tags: ["Platform"],
+    description: "Updates credentials for SUSE Manager",
+    request_body:
+      {"UpdateSUMACredentialsRequest", "application/json",
+       SUMACredentials.UpdateSUMACredentialsRequest},
+    responses: [
+      ok: {"Settings saved successfully", "application/json", SUMACredentials.Settings},
+      unprocessable_entity: UnprocessableEntity.response()
+    ]
+
+  @spec update(Plug.Conn.t(), any) :: Plug.Conn.t()
+  def update(%{body_params: body_params} = conn, _) do
+    attrs = decode_body(body_params)
+
+    with {:ok, saved_settings} <- SoftwareUpdates.change_settings(attrs) do
+      conn
+      |> put_status(:ok)
       |> render("suma_credentials.json", %{settings: saved_settings})
     end
   end

--- a/lib/trento_web/openapi/v1/schema/suma_credentials.ex
+++ b/lib/trento_web/openapi/v1/schema/suma_credentials.ex
@@ -38,6 +38,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.SUMACredentials do
         description:
           "Request body for updating SUMA credentials.\nOnly provide fields to be updated",
         type: :object,
+        minProperties: 1,
         properties: %{
           url: %Schema{
             type: :string

--- a/lib/trento_web/openapi/v1/schema/suma_credentials.ex
+++ b/lib/trento_web/openapi/v1/schema/suma_credentials.ex
@@ -4,11 +4,11 @@ defmodule TrentoWeb.OpenApi.V1.Schema.SUMACredentials do
   require OpenApiSpex
   alias OpenApiSpex.Schema
 
-  defmodule SUMACredentialsRequest do
+  defmodule SaveSUMACredentialsRequest do
     @moduledoc false
 
     OpenApiSpex.schema(%{
-      title: "SUMACredentialsRequest",
+      title: "SaveSUMACredentialsRequest",
       description: "Request body for saving SUMA credentials",
       type: :object,
       properties: %{
@@ -27,6 +27,35 @@ defmodule TrentoWeb.OpenApi.V1.Schema.SUMACredentials do
       },
       required: [:url, :username, :password]
     })
+  end
+
+  defmodule UpdateSUMACredentialsRequest do
+    @moduledoc false
+
+    OpenApiSpex.schema(
+      %{
+        title: "UpdateSUMACredentialsRequest",
+        description:
+          "Request body for updating SUMA credentials.\nOnly provide fields to be updated",
+        type: :object,
+        properties: %{
+          url: %Schema{
+            type: :string
+          },
+          username: %Schema{
+            type: :string
+          },
+          password: %Schema{
+            type: :string
+          },
+          ca_cert: %Schema{
+            type: :string,
+            nullable: true
+          }
+        }
+      },
+      struct?: false
+    )
   end
 
   defmodule Settings do

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -147,7 +147,7 @@ defmodule TrentoWeb.Router do
       get "/hosts/:id/exporters_status", PrometheusController, :exporters_status
 
       resources "/settings/suma_credentials", SUMACredentialsController,
-        only: [:show, :create, :delete],
+        only: [:show, :create, :update, :delete],
         singleton: true
 
       scope "/charts" do

--- a/test/trento_web/controllers/v1/suma_credentials_controller_test.exs
+++ b/test/trento_web/controllers/v1/suma_credentials_controller_test.exs
@@ -185,6 +185,30 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
              } == resp
     end
 
+    test "should not process empty request body", %{
+      conn: conn
+    } do
+      insert(:software_updates_settings)
+
+      submission = %{}
+
+      resp =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> patch("/api/v1/settings/suma_credentials", submission)
+        |> json_response(:unprocessable_entity)
+
+      assert %{
+               "errors" => [
+                 %{
+                   "detail" => "Object property count 0 is less than minProperties: 1",
+                   "title" => "Invalid value",
+                   "source" => %{"pointer" => "/"}
+                 }
+               ]
+             } == resp
+    end
+
     test "should validate partial changes to software updates settings", %{conn: conn} do
       insert(:software_updates_settings)
 

--- a/test/trento_web/controllers/v1/suma_credentials_controller_test.exs
+++ b/test/trento_web/controllers/v1/suma_credentials_controller_test.exs
@@ -161,6 +161,247 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
     end
   end
 
+  describe "changing software updates settings" do
+    test "should not be able to change software updates settings if none previously saved", %{
+      conn: conn
+    } do
+      submission = %{
+        url: "https://validurl.com",
+        username: Faker.Internet.user_name(),
+        password: Faker.Lorem.word(),
+        ca_cert: nil
+      }
+
+      resp =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> patch("/api/v1/settings/suma_credentials", submission)
+        |> json_response(:not_found)
+
+      assert %{
+               "errors" => [
+                 %{"detail" => "The requested resource cannot be found.", "title" => "Not Found"}
+               ]
+             } == resp
+    end
+
+    test "should validate partial changes to software updates settings", %{conn: conn} do
+      insert(:software_updates_settings)
+
+      change_settings_scenarios = [
+        %{
+          change_submissions: %{url: nil},
+          errors: [
+            %{
+              "detail" => "null value where string expected",
+              "source" => %{"pointer" => "/url"},
+              "title" => "Invalid value"
+            }
+          ]
+        },
+        %{
+          change_submissions: [%{url: ""}, %{url: "   "}],
+          errors: [
+            %{
+              "detail" => "can't be blank",
+              "source" => %{"pointer" => "/url"},
+              "title" => "Invalid value"
+            }
+          ]
+        },
+        %{
+          change_submissions: %{url: "http://not-secure.com"},
+          errors: [
+            %{
+              "detail" => "can only be an https url",
+              "source" => %{"pointer" => "/url"},
+              "title" => "Invalid value"
+            }
+          ]
+        },
+        %{
+          change_submissions: %{username: nil},
+          errors: [
+            %{
+              "detail" => "null value where string expected",
+              "source" => %{"pointer" => "/username"},
+              "title" => "Invalid value"
+            }
+          ]
+        },
+        %{
+          change_submissions: [%{username: ""}, %{username: "   "}],
+          errors: [
+            %{
+              "detail" => "can't be blank",
+              "source" => %{"pointer" => "/username"},
+              "title" => "Invalid value"
+            }
+          ]
+        },
+        %{
+          change_submissions: %{password: nil},
+          errors: [
+            %{
+              "detail" => "null value where string expected",
+              "source" => %{"pointer" => "/password"},
+              "title" => "Invalid value"
+            }
+          ]
+        },
+        %{
+          change_submissions: [
+            %{password: ""},
+            %{password: "   "}
+          ],
+          errors: [
+            %{
+              "detail" => "can't be blank",
+              "source" => %{"pointer" => "/password"},
+              "title" => "Invalid value"
+            }
+          ]
+        },
+        %{
+          change_submissions: [
+            %{ca_cert: ""},
+            %{ca_cert: "   "}
+          ],
+          errors: [
+            %{
+              "detail" => "can't be blank",
+              "source" => %{"pointer" => "/ca_cert"},
+              "title" => "Invalid value"
+            }
+          ]
+        },
+        %{
+          change_submissions: %{
+            url: nil,
+            username: "",
+            password: "   ",
+            ca_cert: nil
+          },
+          errors: [
+            %{
+              "detail" => "null value where string expected",
+              "source" => %{"pointer" => "/url"},
+              "title" => "Invalid value"
+            }
+          ]
+        }
+      ]
+
+      for %{change_submissions: change_submissions, errors: errors} <- change_settings_scenarios do
+        change_submissions
+        |> List.wrap()
+        |> Enum.each(fn change_submission ->
+          resp =
+            conn
+            |> put_req_header("content-type", "application/json")
+            |> patch("/api/v1/settings/suma_credentials", change_submission)
+            |> json_response(:unprocessable_entity)
+
+          assert %{"errors" => errors} == resp
+        end)
+      end
+    end
+
+    test "should support partial change of software updates settings", %{conn: conn} do
+      %{
+        url: initial_url,
+        username: _initial_username,
+        password: _initial_password,
+        ca_cert: _initial_ca_cert,
+        ca_uploaded_at: initial_ca_uploaded_at
+      } =
+        insert(
+          :software_updates_settings,
+          ca_cert: Faker.Lorem.sentence(),
+          ca_uploaded_at: DateTime.utc_now()
+        )
+
+      change_submission = %{
+        username: new_username = "new_username",
+        password: "new_password"
+      }
+
+      resp =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> patch("/api/v1/settings/suma_credentials", change_submission)
+        |> json_response(:ok)
+
+      assert %{
+               "url" => initial_url,
+               "username" => new_username,
+               "ca_uploaded_at" => DateTime.to_iso8601(initial_ca_uploaded_at)
+             } == resp
+    end
+
+    test "should properly update ca_cert and its upload date when a new cert is provided", %{
+      conn: conn
+    } do
+      %{
+        url: _initial_url,
+        username: initial_username,
+        password: _initial_password,
+        ca_cert: _initial_ca_cert,
+        ca_uploaded_at: initial_ca_uploaded_at
+      } =
+        insert(
+          :software_updates_settings,
+          ca_cert: Faker.Lorem.sentence(),
+          ca_uploaded_at: DateTime.utc_now()
+        )
+
+      change_submission = %{url: new_url = "https://new.com", ca_cert: "new_ca_cert"}
+
+      resp =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> patch("/api/v1/settings/suma_credentials", change_submission)
+        |> json_response(:ok)
+
+      assert %{"url" => ^new_url, "username" => ^initial_username} = resp
+
+      %{"ca_uploaded_at" => new_upload_time} = resp
+
+      refute new_upload_time == initial_ca_uploaded_at
+    end
+
+    test "should properly remove ca_cert and its upload date", %{conn: conn} do
+      %{
+        url: initial_url,
+        username: initial_username,
+        password: _initial_password,
+        ca_cert: _initial_ca_cert,
+        ca_uploaded_at: _initial_ca_uploaded_at
+      } =
+        insert(
+          :software_updates_settings,
+          ca_cert: Faker.Lorem.sentence(),
+          ca_uploaded_at: DateTime.utc_now()
+        )
+
+      change_submission = %{
+        ca_cert: nil
+      }
+
+      resp =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> patch("/api/v1/settings/suma_credentials", change_submission)
+        |> json_response(:ok)
+
+      assert %{
+               "url" => initial_url,
+               "username" => initial_username,
+               "ca_uploaded_at" => nil
+             } == resp
+    end
+  end
+
   describe "Clear user settings" do
     test "should return 204 if no user settings have previously been saved", %{conn: conn} do
       conn = delete(conn, "/api/v1/settings/suma_credentials")


### PR DESCRIPTION
# Description

This change adds an endpoint to allow users to update their SUSE Manager credentials in Trento.

## How was this tested?

Added unit tests.
