### PR TITLE
Add an error property to inputs for user feedback

### DIFF
--- a/assets/js/common/Input/Input.jsx
+++ b/assets/js/common/Input/Input.jsx
@@ -15,6 +15,7 @@ function Input({
   prefix,
   suffix,
   placeholder,
+  error = false,
   allowClear = false,
   disabled = false,
   onChange = () => {},
@@ -25,8 +26,14 @@ function Input({
   return (
     <RcInput
       className={classNames(
-        'rounded-md w-full block relative placeholder-gray-400 outline-none bg-white border border-gray-200 focus:border-gray-500 focus-visible:border-gray-500 disabled:bg-gray-50',
-        { 'has-prefix': hasPrefix },
+        'rounded-md w-full block relative placeholder-gray-400 outline-none bg-white border disabled:bg-gray-50',
+        {
+          'has-prefix': hasPrefix,
+          'border-gray-200': !error,
+          'focus:border-gray-500': !error,
+          'focus-visible:border-red-500': !error,
+          'border-red-500': error,
+        },
         className
       )}
       id={id}

--- a/assets/js/common/Input/Input.stories.jsx
+++ b/assets/js/common/Input/Input.stories.jsx
@@ -56,6 +56,12 @@ export default {
         type: 'boolean',
       },
     },
+    error: {
+      description: 'Wether the field has an error',
+      control: {
+        type: 'boolean',
+      },
+    },
     disabled: {
       description: 'Whether the input should be disabled or not',
       control: {
@@ -104,6 +110,13 @@ export const ClearableDisabled = {
   args: {
     ...Clearable.args,
     disabled: true,
+  },
+};
+
+export const WithError = {
+  args: {
+    ...WithInitialValue.args,
+    error: true,
   },
 };
 

--- a/assets/js/common/Input/Input.stories.jsx
+++ b/assets/js/common/Input/Input.stories.jsx
@@ -57,7 +57,7 @@ export default {
       },
     },
     error: {
-      description: 'Wether the field has an error',
+      description: 'Whether the field has an error',
       control: {
         type: 'boolean',
       },

--- a/assets/js/common/Input/Password.jsx
+++ b/assets/js/common/Input/Password.jsx
@@ -13,6 +13,7 @@ function Password({
   name,
   value,
   placeholder = 'Password',
+  error = false,
   disabled = false,
   onChange = () => {},
 }) {
@@ -25,6 +26,7 @@ function Password({
       initialValue={value}
       placeholder={placeholder}
       type={inputType}
+      error={error}
       disabled={disabled}
       suffix={
         <button

--- a/assets/js/common/Input/Password.stories.jsx
+++ b/assets/js/common/Input/Password.stories.jsx
@@ -15,7 +15,7 @@ export default {
       },
     },
     error: {
-      description: 'Wether the field has an error',
+      description: 'Whether the field has an error',
       control: {
         type: 'boolean',
       },

--- a/assets/js/common/Input/Password.stories.jsx
+++ b/assets/js/common/Input/Password.stories.jsx
@@ -14,6 +14,12 @@ export default {
         type: { summary: 'string' },
       },
     },
+    error: {
+      description: 'Wether the field has an error',
+      control: {
+        type: 'boolean',
+      },
+    },
     disabled: {
       description: 'Whether the input should be disabled or not',
       control: {
@@ -30,6 +36,13 @@ export const Default = {};
 export const WithValue = {
   args: {
     value: 'somepassword',
+  },
+};
+
+export const WithError = {
+  args: {
+    value: 'someotherpassword',
+    error: true,
   },
 };
 

--- a/assets/js/common/Input/Textarea.jsx
+++ b/assets/js/common/Input/Textarea.jsx
@@ -8,15 +8,23 @@ function Textarea({
   value,
   initialValue,
   placeholder,
+  error = false,
   disabled = false,
   onChange,
 }) {
   const [initialInputValue, setValue] = useState(initialValue);
   const defaultOnChange = (e) => setValue(e.target.value);
+
   return (
     <textarea
       className={classNames(
-        'rc-input outline-none bg-white border border-gray-200 focus:border-gray-500 focus-visible:border-gray-500 px-3 py-2 rounded-md placeholder-gray-400 w-full block disabled:bg-gray-50',
+        'rc-input outline-none bg-white border border-gray-200 px-3 py-2 rounded-md placeholder-gray-400 w-full block disabled:bg-gray-50',
+        {
+          'border-gray-200': !error,
+          'border-red-500': error,
+          'focus:border-gray-500': !error,
+          'focus-visible:border-red-500': !error,
+        },
         className
       )}
       rows={5}

--- a/assets/js/common/Input/Textarea.stories.jsx
+++ b/assets/js/common/Input/Textarea.stories.jsx
@@ -30,6 +30,12 @@ export default {
         type: 'text',
       },
     },
+    error: {
+      description: 'Wether the field has an error',
+      control: {
+        type: 'boolean',
+      },
+    },
     disabled: {
       description: 'Whether the textarea should be disabled or not',
       control: {
@@ -73,6 +79,13 @@ export const WithControlledValue = {
     return (
       <Textarea value={value} onChange={(e) => setValue(e.target.value)} />
     );
+  },
+};
+
+export const WithError = {
+  args: {
+    value: 'This is a wrong value',
+    error: true,
   },
 };
 

--- a/assets/js/common/Input/Textarea.stories.jsx
+++ b/assets/js/common/Input/Textarea.stories.jsx
@@ -31,7 +31,7 @@ export default {
       },
     },
     error: {
-      description: 'Wether the field has an error',
+      description: 'Whether the field has an error',
       control: {
         type: 'boolean',
       },


### PR DESCRIPTION
# Description
Adding an `error` property to input for user feedbacks. The border becomes red when the variable is set to `true`

## How was this tested?
Storybook stories added
