### PR TITLE
Indexserver & nameserver roles in cluster sites

### DIFF
--- a/assets/js/lib/test-utils/factories/clusters.js
+++ b/assets/js/lib/test-utils/factories/clusters.js
@@ -40,6 +40,8 @@ export const hanaClusterDetailsNodesFactory = Factory.define(() => ({
   name: faker.animal.dog(),
   site: faker.location.city(),
   virtual_ip: faker.internet.ip(),
+  indexserver_actual_role: 'master',
+  nameserver_actual_role: 'slave',
   hana_status: hanaStatus(),
   attributes: Array.from({ length: 5 }).reduce(
     (acc, _) => ({

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.stories.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.stories.jsx
@@ -31,11 +31,31 @@ const scaleOutSites = hanaClusterSiteFactory.buildList(2);
 const scaleOutDetails = hanaClusterDetailsFactory.build({
   sites: scaleOutSites,
   nodes: [
-    hanaClusterDetailsNodesFactory.build({ site: scaleOutSites[0].name }),
-    hanaClusterDetailsNodesFactory.build({ site: scaleOutSites[1].name }),
-    hanaClusterDetailsNodesFactory.build({ site: scaleOutSites[0].name }),
-    hanaClusterDetailsNodesFactory.build({ site: scaleOutSites[1].name }),
-    hanaClusterDetailsNodesFactory.build({ site: null, hana_status: '' }),
+    hanaClusterDetailsNodesFactory.build({
+      site: scaleOutSites[0].name,
+      nameserver_actual_role: 'master',
+      indexserver_actual_role: 'master',
+    }),
+    hanaClusterDetailsNodesFactory.build({
+      site: scaleOutSites[1].name,
+      nameserver_actual_role: 'slave',
+      indexserver_actual_role: 'slave',
+    }),
+    hanaClusterDetailsNodesFactory.build({
+      site: scaleOutSites[0].name,
+      nameserver_actual_role: 'master',
+      indexserver_actual_role: 'master',
+    }),
+    hanaClusterDetailsNodesFactory.build({
+      site: scaleOutSites[1].name,
+      nameserver_actual_role: 'slave',
+      indexserver_actual_role: 'slave',
+    }),
+    hanaClusterDetailsNodesFactory.build({
+      site: null,
+      nameserver_actual_role: '',
+      indexserver_actual_role: '',
+    }),
   ],
 });
 

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.stories.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.stories.jsx
@@ -38,13 +38,13 @@ const scaleOutDetails = hanaClusterDetailsFactory.build({
     }),
     hanaClusterDetailsNodesFactory.build({
       site: scaleOutSites[1].name,
-      nameserver_actual_role: 'slave',
-      indexserver_actual_role: 'slave',
+      nameserver_actual_role: 'master',
+      indexserver_actual_role: 'master',
     }),
     hanaClusterDetailsNodesFactory.build({
       site: scaleOutSites[0].name,
-      nameserver_actual_role: 'master',
-      indexserver_actual_role: 'master',
+      nameserver_actual_role: 'slave',
+      indexserver_actual_role: 'slave',
     }),
     hanaClusterDetailsNodesFactory.build({
       site: scaleOutSites[1].name,
@@ -58,7 +58,6 @@ const scaleOutDetails = hanaClusterDetailsFactory.build({
     }),
   ],
 });
-
 const lastExecution = {
   data: checksExecutionCompletedFactory.build({
     result: 'passing',

--- a/assets/js/pages/ClusterDetails/HanaClusterSite.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterSite.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { capitalize } from 'lodash';
 
 import HealthIcon from '@common/HealthIcon';
 import Table from '@common/Table';
@@ -25,11 +26,23 @@ const siteDetailsConfig = {
     {
       title: 'Hostname',
       key: '',
+      className: 'table-col-m',
       render: (_, hostData) => (
         <ClusterNodeLink hostId={hostData.id}>{hostData.name}</ClusterNodeLink>
       ),
     },
-    { title: 'Role', key: 'hana_status' },
+    {
+      title: 'Nameserver',
+      key: 'nameserver_actual_role',
+      className: 'table-col-m',
+      render: (content) => capitalize(content),
+    },
+    {
+      title: 'Indexserver',
+      key: 'indexserver_actual_role',
+      className: 'table-col-m',
+      render: (content) => capitalize(content),
+    },
     {
       title: 'IP',
       key: 'ip_addresses',

--- a/assets/js/pages/ClusterDetails/HanaClusterSite.test.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterSite.test.jsx
@@ -66,4 +66,37 @@ describe('HanaClusterSite', () => {
       screen.getByRole('table').querySelectorAll('tbody > tr')
     ).toHaveLength(3);
   });
+
+  it('should show nameserver and indexserver roles', () => {
+    const {
+      name,
+      state,
+      sr_healt_state: srHealthState,
+    } = hanaClusterSiteFactory.build();
+    const nodes = hanaClusterDetailsNodesFactory.buildList(1);
+    render(
+      <HanaClusterSite
+        name={name}
+        nodes={nodes}
+        state={state}
+        srHealthState={srHealthState}
+      />
+    );
+
+    expect(
+      screen.getByRole('table').querySelectorAll('thead > tr > th').item(1)
+    ).toHaveTextContent('Nameserver');
+
+    expect(
+      screen.getByRole('table').querySelectorAll('thead > tr > th').item(2)
+    ).toHaveTextContent('Indexserver');
+
+    expect(
+      screen.getByRole('table').querySelectorAll('tbody > tr > td').item(1)
+    ).toHaveTextContent('Slave');
+
+    expect(
+      screen.getByRole('table').querySelectorAll('tbody > tr > td').item(2)
+    ).toHaveTextContent('Master');
+  });
 });

--- a/lib/trento/clusters/value_objects/hana_cluster_node.ex
+++ b/lib/trento/clusters/value_objects/hana_cluster_node.ex
@@ -20,6 +20,8 @@ defmodule Trento.Clusters.ValueObjects.HanaClusterNode do
     field :hana_status, :string
     field :attributes, {:map, :string}
     field :virtual_ip, :string
+    field :nameserver_actual_role, :string
+    field :indexserver_actual_role, :string
 
     embeds_many :resources, ClusterResource
   end

--- a/lib/trento/discovery/policies/cluster_policy.ex
+++ b/lib/trento/discovery/policies/cluster_policy.ex
@@ -233,13 +233,26 @@ defmodule Trento.Discovery.Policies.ClusterPolicy do
 
       site = Map.get(attributes, "hana_#{String.downcase(sid)}_site", "")
 
+      hana_roles =
+        attributes
+        |> Map.get("hana_#{String.downcase(sid)}_roles", "")
+        |> String.split(":")
+
+      %{
+        indexserver_actual_role: indexserver_actual_role,
+        nameserver_actual_role: nameserver_actual_role
+      } =
+        parse_nodes_actual_roles(hana_roles, cluster_type)
+
       node = %{
         name: name,
         attributes: attributes,
         resources: node_resources,
         site: site,
         hana_status: "Unknown",
-        virtual_ip: virtual_ip
+        virtual_ip: virtual_ip,
+        nameserver_actual_role: nameserver_actual_role,
+        indexserver_actual_role: indexserver_actual_role
       }
 
       hana_status =
@@ -253,6 +266,30 @@ defmodule Trento.Discovery.Policies.ClusterPolicy do
 
       %{node | hana_status: hana_status}
     end)
+  end
+
+  defp parse_nodes_actual_roles(
+         [_, _, _, nameserver_actual_role, _, indexserver_actual_role],
+         ClusterType.hana_scale_up()
+       ) do
+    %{
+      indexserver_actual_role: indexserver_actual_role,
+      nameserver_actual_role: nameserver_actual_role
+    }
+  end
+
+  defp parse_nodes_actual_roles(
+         [_, nameserver_actual_role, _, indexserver_actual_role],
+         ClusterType.hana_scale_out()
+       ) do
+    %{
+      indexserver_actual_role: indexserver_actual_role,
+      nameserver_actual_role: nameserver_actual_role
+    }
+  end
+
+  defp parse_nodes_actual_roles(_, _) do
+    %{indexserver_actual_role: "", nameserver_actual_role: ""}
   end
 
   defp parse_hana_scale_up_system_replication_mode([%{attributes: attributes} | _], sid) do

--- a/lib/trento/discovery/policies/cluster_policy.ex
+++ b/lib/trento/discovery/policies/cluster_policy.ex
@@ -233,16 +233,14 @@ defmodule Trento.Discovery.Policies.ClusterPolicy do
 
       site = Map.get(attributes, "hana_#{String.downcase(sid)}_site", "")
 
-      hana_roles =
-        attributes
-        |> Map.get("hana_#{String.downcase(sid)}_roles", "")
-        |> String.split(":")
-
       %{
         indexserver_actual_role: indexserver_actual_role,
         nameserver_actual_role: nameserver_actual_role
       } =
-        parse_nodes_actual_roles(hana_roles, cluster_type)
+        attributes
+        |> Map.get("hana_#{String.downcase(sid)}_roles", "")
+        |> String.split(":")
+        |> parse_nodes_actual_roles(cluster_type)
 
       node = %{
         name: name,

--- a/lib/trento_web/openapi/v2/schema/cluster.ex
+++ b/lib/trento_web/openapi/v2/schema/cluster.ex
@@ -19,6 +19,8 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
       properties: %{
         name: %Schema{type: :string},
         site: %Schema{type: :string},
+        indexserver_actual_role: %Schema{type: :string, nullable: true},
+        nameserver_actual_role: %Schema{type: :string, nullable: true},
         hana_status: %Schema{type: :string, deprecated: true},
         attributes: %Schema{
           type: :object,

--- a/lib/trento_web/views/v1/cluster_view.ex
+++ b/lib/trento_web/views/v1/cluster_view.ex
@@ -28,9 +28,15 @@ defmodule TrentoWeb.V1.ClusterView do
     cluster
   end
 
-  defp adapt_v1(%{type: type, details: details} = cluster)
+  defp adapt_v1(%{type: type, details: %{nodes: nodes} = details} = cluster)
        when type in [:hana_scale_up, :hana_scale_out] do
-    adapted_details = Map.drop(details, ["sites", "maintenance_mode"])
+    adapted_nodes =
+      Enum.map(nodes, &Map.drop(&1, [:indexserver_actual_role, :nameserver_actual_role]))
+
+    adapted_details =
+      details
+      |> Map.drop([:sites, :maintenance_mode])
+      |> Map.put(:nodes, adapted_nodes)
 
     %{cluster | details: adapted_details}
   end

--- a/test/e2e/cypress/e2e/hana_cluster_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_cluster_details.cy.js
@@ -2,7 +2,7 @@ import {
   checksExecutionCompletedFactory,
   catalogFactory,
 } from '@lib/test-utils/factories';
-
+import { capitalize } from 'lodash';
 import { availableHanaCluster } from '../fixtures/hana-cluster-details/available_hana_cluster';
 
 context('HANA cluster details', () => {
@@ -174,8 +174,16 @@ context('HANA cluster details', () => {
           });
         });
 
-        it(`${host.hostname} should have the expected role`, () => {
-          cy.get(`.tn-site-details-${site.name}`).contains(host.role);
+        it(`${host.hostname} should have the expected indexserver role`, () => {
+          cy.get(`.tn-site-details-${site.name}`).contains(
+            capitalize(host.indexserver_actual_role)
+          );
+        });
+
+        it(`${host.hostname} should have the expected nameserver role`, () => {
+          cy.get(`.tn-site-details-${site.name}`).contains(
+            capitalize(host.nameserver_actual_role)
+          );
         });
       });
     });

--- a/test/e2e/cypress/fixtures/hana-cluster-details/available_hana_cluster.js
+++ b/test/e2e/cypress/fixtures/hana-cluster-details/available_hana_cluster.js
@@ -22,6 +22,8 @@ export const availableHanaCluster = {
           ips: ['10.80.1.11', '10.80.1.13'],
           virtualIps: ['10.80.1.13'],
           role: 'Primary',
+          indexserver_actual_role: 'master',
+          nameserver_actual_role: 'master',
           attributes: [
             {
               attribute: 'hana_hdp_clone_state',
@@ -118,6 +120,8 @@ export const availableHanaCluster = {
           ips: ['10.80.1.12'],
           virtualIps: [],
           role: 'Secondary',
+          indexserver_actual_role: 'master',
+          nameserver_actual_role: 'master',
           attributes: [
             {
               attribute: 'hana_hdp_clone_state',

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -464,8 +464,8 @@ defmodule Trento.Factory do
       hana_status: "Secondary",
       virtual_ip: Faker.Internet.ip_v4_address(),
       name: Faker.StarWars.character(),
-      indexserver_actual_role: nil,
-      nameserver_actual_role: nil,
+      indexserver_actual_role: "master",
+      nameserver_actual_role: "master",
       resources: [
         %ClusterResource{
           fail_count: Enum.random(0..100),

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -428,24 +428,7 @@ defmodule Trento.Factory do
     %HanaClusterDetails{
       fencing_type: "external/sbd",
       maintenance_mode: false,
-      nodes: [
-        %HanaClusterNode{
-          attributes: %{"attribute" => Faker.Beer.name()},
-          hana_status: "Secondary",
-          virtual_ip: Faker.Internet.ip_v4_address(),
-          name: Faker.StarWars.character(),
-          resources: [
-            %ClusterResource{
-              fail_count: Enum.random(0..100),
-              id: Faker.Pokemon.name(),
-              role: "Started",
-              status: "Active",
-              type: "ocf::heartbeat:Dummy"
-            }
-          ],
-          site: Faker.StarWars.planet()
-        }
-      ],
+      nodes: build_list(1, :hana_cluster_node),
       sites: [
         %HanaClusterSite{
           name: Faker.Beer.name(),
@@ -472,6 +455,27 @@ defmodule Trento.Factory do
       ],
       system_replication_mode: "sync",
       system_replication_operation_mode: "logreplay"
+    }
+  end
+
+  def hana_cluster_node_factory do
+    %HanaClusterNode{
+      attributes: %{"attribute" => Faker.Beer.name()},
+      hana_status: "Secondary",
+      virtual_ip: Faker.Internet.ip_v4_address(),
+      name: Faker.StarWars.character(),
+      indexserver_actual_role: nil,
+      nameserver_actual_role: nil,
+      resources: [
+        %ClusterResource{
+          fail_count: Enum.random(0..100),
+          id: Faker.Pokemon.name(),
+          role: "Started",
+          status: "Active",
+          type: "ocf::heartbeat:Dummy"
+        }
+      ],
+      site: Faker.StarWars.planet()
     }
   end
 

--- a/test/trento/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/discovery/policies/cluster_policy_test.exs
@@ -50,6 +50,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       },
                       hana_status: "Primary",
                       name: "node01",
+                      indexserver_actual_role: "master",
+                      nameserver_actual_role: "master",
                       resources: [
                         %ClusterResource{
                           fail_count: 0,
@@ -127,6 +129,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       },
                       hana_status: "Secondary",
                       name: "node02",
+                      indexserver_actual_role: "master",
+                      nameserver_actual_role: "master",
                       resources: [
                         %ClusterResource{
                           fail_count: 0,
@@ -275,6 +279,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       },
                       hana_status: "Primary",
                       name: "node01",
+                      nameserver_actual_role: "master",
+                      indexserver_actual_role: "master",
                       resources: [
                         %ClusterResource{
                           fail_count: 0,
@@ -352,6 +358,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       },
                       hana_status: "Secondary",
                       name: "node02",
+                      indexserver_actual_role: "master",
+                      nameserver_actual_role: "master",
                       resources: [
                         %ClusterResource{
                           fail_count: 0,
@@ -1203,6 +1211,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       },
                       hana_status: "Primary",
                       name: "vmhana01",
+                      indexserver_actual_role: "master",
+                      nameserver_actual_role: "master",
                       resources: [
                         %ClusterResource{
                           fail_count: 0,
@@ -1259,6 +1269,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       },
                       hana_status: "Secondary",
                       name: "vmhana02",
+                      indexserver_actual_role: "master",
+                      nameserver_actual_role: "master",
                       resources: [
                         %ClusterResource{
                           fail_count: 0,
@@ -1333,6 +1345,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       },
                       hana_status: "Failed",
                       name: "vmhana01",
+                      indexserver_actual_role: nil,
+                      nameserver_actual_role: nil,
                       resources: [
                         %ClusterResource{
                           fail_count: 0,
@@ -1375,6 +1389,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       },
                       hana_status: "Primary",
                       name: "vmhana02",
+                      indexserver_actual_role: "master",
+                      nameserver_actual_role: "master",
                       resources: [
                         %ClusterResource{
                           fail_count: 0,
@@ -1485,6 +1501,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                         "master-rsc_SAPHana_PRD_HDB00" => "150"
                       },
                       hana_status: "Primary",
+                      indexserver_actual_role: "master",
+                      nameserver_actual_role: "master",
                       name: "node01",
                       resources: [
                         %ClusterResource{
@@ -1561,6 +1579,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                         "lpa_prd_lpt" => "30",
                         "master-rsc_SAPHana_PRD_HDB00" => "100"
                       },
+                      indexserver_actual_role: "master",
+                      nameserver_actual_role: "master",
                       hana_status: "Secondary",
                       name: "node02",
                       resources: [
@@ -1845,6 +1865,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                           "hana_prd_site" => "Site1",
                           "master-rsc_SAPHanaController_PRD_HDB00" => "150"
                         },
+                        indexserver_actual_role: "master",
+                        nameserver_actual_role: "master",
                         virtual_ip: "192.168.152.16",
                         resources: [
                           %ClusterResource{
@@ -1895,6 +1917,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                           "hana_prd_site" => "Site2",
                           "master-rsc_SAPHanaController_PRD_HDB00" => "100"
                         },
+                        indexserver_actual_role: "master",
+                        nameserver_actual_role: "master",
                         virtual_ip: nil,
                         resources: [
                           %ClusterResource{
@@ -1924,6 +1948,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                           "hana_prd_site" => "Site1",
                           "master-rsc_SAPHanaController_PRD_HDB00" => "140"
                         },
+                        indexserver_actual_role: "standby",
+                        nameserver_actual_role: "slave",
                         virtual_ip: nil,
                         resources: [
                           %ClusterResource{
@@ -1953,6 +1979,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                           "hana_prd_site" => "Site2",
                           "master-rsc_SAPHanaController_PRD_HDB00" => "80"
                         },
+                        indexserver_actual_role: "standby",
+                        nameserver_actual_role: "slave",
                         virtual_ip: nil,
                         resources: [
                           %ClusterResource{
@@ -1982,6 +2010,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                           "hana_prd_site" => "Site1",
                           "master-rsc_SAPHanaController_PRD_HDB00" => "140"
                         },
+                        indexserver_actual_role: "slave",
+                        nameserver_actual_role: "slave",
                         virtual_ip: nil,
                         resources: [
                           %ClusterResource{
@@ -2011,6 +2041,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                           "hana_prd_site" => "Site2",
                           "master-rsc_SAPHanaController_PRD_HDB00" => "80"
                         },
+                        indexserver_actual_role: "slave",
+                        nameserver_actual_role: "slave",
                         virtual_ip: nil,
                         resources: [
                           %ClusterResource{
@@ -2100,6 +2132,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                           "hana_prd_site" => "Site1",
                           "master-rsc_SAPHanaCon_PRD_HDB00" => "100"
                         },
+                        indexserver_actual_role: "master",
+                        nameserver_actual_role: "master",
                         virtual_ip: nil,
                         resources: [
                           %ClusterResource{
@@ -2131,6 +2165,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                           "master-rsc_SAPHanaCon_PRD_HDB00" => "-12200"
                         },
                         virtual_ip: nil,
+                        indexserver_actual_role: "slave",
+                        nameserver_actual_role: "slave",
                         resources: [
                           %ClusterResource{
                             id: "rsc_SAPHanaTop_PRD_HDB00",
@@ -2160,6 +2196,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                           "hana_prd_site" => "Site2",
                           "master-rsc_SAPHanaCon_PRD_HDB00" => "150"
                         },
+                        indexserver_actual_role: "master",
+                        nameserver_actual_role: "master",
                         virtual_ip: "10.0.0.10",
                         resources: [
                           %ClusterResource{
@@ -2204,6 +2242,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                           "hana_prd_site" => "Site2",
                           "master-rsc_SAPHanaCon_PRD_HDB00" => "-10000"
                         },
+                        indexserver_actual_role: "slave",
+                        nameserver_actual_role: "slave",
                         virtual_ip: nil,
                         resources: [
                           %ClusterResource{
@@ -2294,6 +2334,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                           "hana_prd_site" => "Site1",
                           "master-rsc_SAPHanaController_PRD_HDB00" => "150"
                         },
+                        indexserver_actual_role: "master",
+                        nameserver_actual_role: "master",
                         virtual_ip: "192.168.152.16",
                         resources: [
                           %ClusterResource{
@@ -2344,6 +2386,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                           "hana_prd_site" => "Site2",
                           "master-rsc_SAPHanaController_PRD_HDB00" => "100"
                         },
+                        indexserver_actual_role: "master",
+                        nameserver_actual_role: "master",
                         virtual_ip: nil,
                         resources: [
                           %ClusterResource{
@@ -2373,6 +2417,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                           "hana_prd_site" => "Site1",
                           "master-rsc_SAPHanaController_PRD_HDB00" => "140"
                         },
+                        indexserver_actual_role: "standby",
+                        nameserver_actual_role: "slave",
                         virtual_ip: nil,
                         resources: [
                           %ClusterResource{
@@ -2402,6 +2448,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                           "hana_prd_site" => "Site2",
                           "master-rsc_SAPHanaController_PRD_HDB00" => "80"
                         },
+                        indexserver_actual_role: "standby",
+                        nameserver_actual_role: "slave",
                         virtual_ip: nil,
                         resources: [
                           %ClusterResource{
@@ -2431,6 +2479,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                           "hana_prd_site" => "Site1",
                           "master-rsc_SAPHanaController_PRD_HDB00" => "140"
                         },
+                        indexserver_actual_role: "slave",
+                        nameserver_actual_role: "slave",
                         virtual_ip: nil,
                         resources: [
                           %ClusterResource{
@@ -2460,6 +2510,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                           "hana_prd_site" => "Site2",
                           "master-rsc_SAPHanaController_PRD_HDB00" => "80"
                         },
+                        indexserver_actual_role: "slave",
+                        nameserver_actual_role: "slave",
                         virtual_ip: nil,
                         resources: [
                           %ClusterResource{

--- a/test/trento/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/discovery/policies/cluster_policy_test.exs
@@ -1730,7 +1730,9 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                         "master-rsc_SAPHana_PRD_HDB00" => "150"
                       },
                       hana_status: "Primary",
+                      indexserver_actual_role: "master",
                       name: "node01",
+                      nameserver_actual_role: "master",
                       resources: [
                         %ClusterResource{
                           fail_count: 2,
@@ -1772,7 +1774,9 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                         "master-rsc_SAPHana_PRD_HDB00" => "100"
                       },
                       hana_status: "Secondary",
+                      indexserver_actual_role: "master",
                       name: "node02",
+                      nameserver_actual_role: "master",
                       resources: [
                         %ClusterResource{
                           fail_count: 300,

--- a/test/trento/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/discovery/policies/cluster_policy_test.exs
@@ -1345,8 +1345,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       },
                       hana_status: "Failed",
                       name: "vmhana01",
-                      indexserver_actual_role: "master",
-                      nameserver_actual_role: "master",
+                      indexserver_actual_role: nil,
+                      nameserver_actual_role: nil,
                       resources: [
                         %ClusterResource{
                           fail_count: 0,

--- a/test/trento/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/discovery/policies/cluster_policy_test.exs
@@ -1345,8 +1345,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       },
                       hana_status: "Failed",
                       name: "vmhana01",
-                      indexserver_actual_role: nil,
-                      nameserver_actual_role: nil,
+                      indexserver_actual_role: "master",
+                      nameserver_actual_role: "master",
                       resources: [
                         %ClusterResource{
                           fail_count: 0,

--- a/test/trento_web/controllers/v2/cluster_controller_test.exs
+++ b/test/trento_web/controllers/v2/cluster_controller_test.exs
@@ -22,7 +22,16 @@ defmodule TrentoWeb.V2.ClusterControllerTest do
     end
 
     test "should be compliant with Hana Cluster details schema", %{conn: conn} do
-      insert(:cluster, details: build(:hana_cluster_details))
+      insert(:cluster,
+        details:
+          build(:hana_cluster_details,
+            nodes:
+              build_list(1, :hana_cluster_node, %{
+                indexserver_actual_role: "master",
+                nameserver_actual_role: "slave"
+              })
+          )
+      )
 
       api_spec = ApiSpec.spec()
 

--- a/test/trento_web/controllers/v2/cluster_controller_test.exs
+++ b/test/trento_web/controllers/v2/cluster_controller_test.exs
@@ -25,11 +25,7 @@ defmodule TrentoWeb.V2.ClusterControllerTest do
       insert(:cluster,
         details:
           build(:hana_cluster_details,
-            nodes:
-              build_list(1, :hana_cluster_node, %{
-                indexserver_actual_role: "master",
-                nameserver_actual_role: "slave"
-              })
+            nodes: build_list(1, :hana_cluster_node)
           )
       )
 

--- a/test/trento_web/views/v1/cluster_view_test.exs
+++ b/test/trento_web/views/v1/cluster_view_test.exs
@@ -15,17 +15,29 @@ defmodule TrentoWeb.V1.ClusterViewTest do
     end
 
     test "should remove HANA cluster V2 fields" do
+      nodes =
+        Enum.map(
+          build_list(1, :hana_cluster_node, %{
+            nameserver_actual_role: "master",
+            indexserver_actual_role: "master"
+          }),
+          &Map.from_struct(&1)
+        )
+
       details =
         :hana_cluster_details
-        |> build()
+        |> build(nodes: nodes)
         |> Map.from_struct()
 
       cluster = build(:cluster, type: :hana_scale_up, details: details)
 
-      %{details: details} = render(ClusterView, "cluster.json", %{cluster: cluster})
+      %{details: %{nodes: [node]} = details} =
+        render(ClusterView, "cluster.json", %{cluster: cluster})
 
-      refute Access.get(details, "sites")
-      refute Access.get(details, "maintenance_mode")
+      refute Access.get(details, :sites)
+      refute Access.get(details, :maintenance_mode)
+      refute Access.get(node, :nameserver_actual_role)
+      refute Access.get(node, :indexserver_actual_role)
     end
   end
 end


### PR DESCRIPTION
# Description

This PR adds the support to nameserver and indexserver roles in cluster nodes.

![image](https://github.com/trento-project/web/assets/9409502/fb86ef14-696d-4ae2-8c02-32b0dde7c3d4)

The roles are extracted from node attributes.
The roles are separated by ":", the role string is splitted on the ":" character.

In scale up

`4:P:master1:master:worker:master`

Nameserver is at index 3, and Indexserver at index 5

In scale out

`master1:master:worker:master`

Nameserver is at index 1 and Indexserver at index 3

## How was this tested?

Automated tests, frontend, backend and e2e
