### PR TITLE
Handle concurrent settings saving operations

### DIFF
--- a/lib/trento/software_updates/settings.ex
+++ b/lib/trento/software_updates/settings.ex
@@ -11,7 +11,7 @@ defmodule Trento.SoftwareUpdates.Settings do
 
   @type t :: %__MODULE__{}
 
-  @primary_key {:id, :binary_id, autogenerate: true}
+  @primary_key {:id, :binary_id, autogenerate: false}
   schema "software_update_settings" do
     field :url, :string
     field :username, :string

--- a/priv/repo/migrations/20240214153742_add_uniqueness_to_software_updates_settings.exs
+++ b/priv/repo/migrations/20240214153742_add_uniqueness_to_software_updates_settings.exs
@@ -1,0 +1,28 @@
+defmodule Trento.Repo.Migrations.AddUniquenessToSoftwareUpdatesSettings do
+  use Ecto.Migration
+
+  def change do
+    %Postgrex.Result{rows: rows} =
+      repo().query!("SELECT id FROM software_update_settings;", [], log: false)
+
+    settings_identifier =
+      case rows do
+        [] -> UUID.uuid4()
+        [[binary_uuid | _] | _] -> UUID.binary_to_string!(binary_uuid)
+      end
+
+    alter table(:software_update_settings) do
+      modify :id, :uuid, default: settings_identifier
+    end
+
+    create constraint("software_update_settings", :only_one_record,
+             check: "id ='#{settings_identifier}'"
+           )
+
+    execute "INSERT INTO software_update_settings(id, inserted_at, updated_at) VALUES('#{settings_identifier}', NOW(), NOW()) ON CONFLICT DO NOTHING;"
+  end
+
+  def down do
+    drop constraint("software_update_settings", :only_one_record)
+  end
+end

--- a/test/trento/software_updates_test.exs
+++ b/test/trento/software_updates_test.exs
@@ -20,7 +20,10 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
         username: username,
         password: password
       } =
-        insert(:software_updates_settings, ca_cert: nil, ca_uploaded_at: nil)
+        insert(:software_updates_settings, [ca_cert: nil, ca_uploaded_at: nil],
+          conflict_target: :id,
+          on_conflict: :replace_all
+        )
 
       assert {:ok,
               %Settings{
@@ -42,8 +45,9 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
       } =
         insert(
           :software_updates_settings,
-          ca_cert: Faker.Lorem.sentence(),
-          ca_uploaded_at: DateTime.utc_now()
+          [ca_cert: Faker.Lorem.sentence(), ca_uploaded_at: DateTime.utc_now()],
+          conflict_target: :id,
+          on_conflict: :replace_all
         )
 
       assert {:ok,
@@ -204,7 +208,10 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
     end
 
     test "should validate partial changes to software updates settings" do
-      insert(:software_updates_settings)
+      insert(:software_updates_settings, [],
+        conflict_target: :id,
+        on_conflict: :replace_all
+      )
 
       change_settings_scenarios = [
         %{
@@ -277,8 +284,9 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
       } =
         insert(
           :software_updates_settings,
-          ca_cert: Faker.Lorem.sentence(),
-          ca_uploaded_at: DateTime.utc_now()
+          [ca_cert: Faker.Lorem.sentence(), ca_uploaded_at: DateTime.utc_now()],
+          conflict_target: :id,
+          on_conflict: :replace_all
         )
 
       change_submission = %{
@@ -314,8 +322,9 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
       } =
         insert(
           :software_updates_settings,
-          ca_cert: Faker.Lorem.sentence(),
-          ca_uploaded_at: DateTime.utc_now()
+          [ca_cert: Faker.Lorem.sentence(), ca_uploaded_at: DateTime.utc_now()],
+          conflict_target: :id,
+          on_conflict: :replace_all
         )
 
       change_submission = %{
@@ -344,8 +353,9 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
       } =
         insert(
           :software_updates_settings,
-          ca_cert: Faker.Lorem.sentence(),
-          ca_uploaded_at: DateTime.utc_now()
+          [ca_cert: Faker.Lorem.sentence(), ca_uploaded_at: DateTime.utc_now()],
+          conflict_target: :id,
+          on_conflict: :replace_all
         )
 
       change_submission = %{
@@ -367,8 +377,9 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
     test "should support idempotent sequential clear settings" do
       insert(
         :software_updates_settings,
-        ca_cert: Faker.Lorem.sentence(),
-        ca_uploaded_at: DateTime.utc_now()
+        [ca_cert: Faker.Lorem.sentence(), ca_uploaded_at: DateTime.utc_now()],
+        conflict_target: :id,
+        on_conflict: :replace_all
       )
 
       assert {:ok, _} = SoftwareUpdates.get_settings()

--- a/test/trento_web/controllers/v1/suma_credentials_controller_test.exs
+++ b/test/trento_web/controllers/v1/suma_credentials_controller_test.exs
@@ -15,8 +15,9 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
     test "should return user settings", %{conn: conn} do
       insert(
         :software_updates_settings,
-        ca_cert: Faker.Lorem.sentence(),
-        ca_uploaded_at: DateTime.utc_now()
+        [ca_cert: Faker.Lorem.sentence(), ca_uploaded_at: DateTime.utc_now()],
+        conflict_target: :id,
+        on_conflict: :replace_all
       )
 
       api_spec = ApiSpec.spec()
@@ -112,7 +113,10 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
     end
 
     test "should not save valid settings when previously settings have been saved", %{conn: conn} do
-      insert(:software_updates_settings, ca_cert: nil, ca_uploaded_at: nil)
+      insert(:software_updates_settings, [ca_cert: nil, ca_uploaded_at: nil],
+        conflict_target: :id,
+        on_conflict: :replace_all
+      )
 
       new_settings = %{
         url: Faker.Internet.image_url(),
@@ -188,7 +192,10 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
     test "should not process empty request body", %{
       conn: conn
     } do
-      insert(:software_updates_settings)
+      insert(:software_updates_settings, [],
+        conflict_target: :id,
+        on_conflict: :replace_all
+      )
 
       submission = %{}
 
@@ -210,7 +217,10 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
     end
 
     test "should validate partial changes to software updates settings", %{conn: conn} do
-      insert(:software_updates_settings)
+      insert(:software_updates_settings, [],
+        conflict_target: :id,
+        on_conflict: :replace_all
+      )
 
       change_settings_scenarios = [
         %{
@@ -341,8 +351,9 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
       } =
         insert(
           :software_updates_settings,
-          ca_cert: Faker.Lorem.sentence(),
-          ca_uploaded_at: DateTime.utc_now()
+          [ca_cert: Faker.Lorem.sentence(), ca_uploaded_at: DateTime.utc_now()],
+          conflict_target: :id,
+          on_conflict: :replace_all
         )
 
       change_submission = %{
@@ -375,8 +386,9 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
       } =
         insert(
           :software_updates_settings,
-          ca_cert: Faker.Lorem.sentence(),
-          ca_uploaded_at: DateTime.utc_now()
+          [ca_cert: Faker.Lorem.sentence(), ca_uploaded_at: DateTime.utc_now()],
+          conflict_target: :id,
+          on_conflict: :replace_all
         )
 
       change_submission = %{url: new_url = "https://new.com", ca_cert: "new_ca_cert"}
@@ -404,8 +416,9 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
       } =
         insert(
           :software_updates_settings,
-          ca_cert: Faker.Lorem.sentence(),
-          ca_uploaded_at: DateTime.utc_now()
+          [ca_cert: Faker.Lorem.sentence(), ca_uploaded_at: DateTime.utc_now()],
+          conflict_target: :id,
+          on_conflict: :replace_all
         )
 
       change_submission = %{
@@ -434,7 +447,10 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
     end
 
     test "should return 204 when user settings have previously been saved", %{conn: conn} do
-      insert(:software_updates_settings)
+      insert(:software_updates_settings, [],
+        conflict_target: :id,
+        on_conflict: :replace_all
+      )
 
       conn = delete(conn, "/api/v1/settings/suma_credentials")
 


### PR DESCRIPTION
# Description

Fix for concurrent calls to save settings operation.

Currently if two, or more, concurrent requests come to save settings, the database says: _ok, I have nothing, you can proceed with insertion_ to both, or all, requests resulting in multiple records being inserted which later breaks logic relying on the fact we do want only one record there.

The new migration adds a uniqueness constraint and sets a default value for the id, so we don't need to really pass it around in the code and takes care of reusing a previously inserted id, if any.

## How was this tested?
Current tests cover desired behavior. Concurrency tested manually.

Reopened as we're trying to figure out what way to go https://github.com/trento-project/web/pull/2327