### PR TITLE
Initial software updates settings state and saga

### DIFF
--- a/assets/js/lib/test-utils/factories/softwareUpdatesSettings.js
+++ b/assets/js/lib/test-utils/factories/softwareUpdatesSettings.js
@@ -1,0 +1,10 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { faker } from '@faker-js/faker';
+import { formatISO } from 'date-fns';
+import { Factory } from 'fishery';
+
+export const softwareUpdatesSettingsFactory = Factory.define(() => ({
+  url: faker.internet.url(),
+  username: faker.internet.userName(),
+  ca_uploaded_at: formatISO(faker.date.recent()),
+}));

--- a/assets/js/state/index.js
+++ b/assets/js/state/index.js
@@ -12,6 +12,7 @@ import catalogReducer from './catalog';
 import lastExecutionsReducer from './lastExecutions';
 import settingsReducer from './settings';
 import userReducer from './user';
+import softwareUpdatesSettingsReducer from './softwareUpdatesSettings';
 import rootSaga from './sagas';
 
 const sagaMiddleware = createSagaMiddleware();
@@ -29,6 +30,7 @@ export const store = configureStore({
     lastExecutions: lastExecutionsReducer,
     settings: settingsReducer,
     user: userReducer,
+    softwareUpdatesSettings: softwareUpdatesSettingsReducer,
   },
   middleware: [sagaMiddleware],
 });

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -59,7 +59,6 @@ import {
 import { SET_USER_AS_LOGGED } from '@state/user';
 
 import { setEulaVisible, setIsPremium } from '@state/settings';
-import { fetchSoftwareUpdatesSettings } from '@state/softwareUpdatesSettings';
 
 import { watchNotifications } from '@state/sagas/notifications';
 import { watchAcceptEula } from '@state/sagas/eula';
@@ -126,8 +125,6 @@ function* initialDataFetch() {
   const { data: databases } = yield call(get, '/databases');
   yield put(setDatabases(databases));
   yield put(stopDatabasesLoading());
-
-  yield put(fetchSoftwareUpdatesSettings());
 }
 
 function* setupSocketEvents() {

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -59,6 +59,7 @@ import {
 import { SET_USER_AS_LOGGED } from '@state/user';
 
 import { setEulaVisible, setIsPremium } from '@state/settings';
+import { fetchSoftwareUpdatesSettings } from '@state/softwareUpdatesSettings';
 
 import { watchNotifications } from '@state/sagas/notifications';
 import { watchAcceptEula } from '@state/sagas/eula';
@@ -72,6 +73,7 @@ import { watchSapSystemEvents } from '@state/sagas/sapSystems';
 
 import { watchPerformLogin } from '@state/sagas/user';
 import { watchChecksSelectionEvents } from '@state/sagas/checksSelection';
+import { watchSoftwareUpdateSettings } from '@state/sagas/softwareUpdatesSettings';
 
 import { initSocketConnection } from '@lib/network/socket';
 import processChannelEvents from '@state/channels';
@@ -124,6 +126,8 @@ function* initialDataFetch() {
   const { data: databases } = yield call(get, '/databases');
   yield put(setDatabases(databases));
   yield put(stopDatabasesLoading());
+
+  yield put(fetchSoftwareUpdatesSettings());
 }
 
 function* setupSocketEvents() {
@@ -243,5 +247,6 @@ export default function* rootSaga() {
     watchResetState(),
     watchSapSystemEvents(),
     watchUserLoggedIn(),
+    watchSoftwareUpdateSettings(),
   ]);
 }

--- a/assets/js/state/sagas/softwareUpdatesSettings.js
+++ b/assets/js/state/sagas/softwareUpdatesSettings.js
@@ -1,0 +1,27 @@
+import { put, call, takeEvery } from 'redux-saga/effects';
+import { getSettings } from '@lib/api/softwareUpdatesSettings';
+
+import {
+  FETCH_SOFTWARE_UPDATES_SETTINGS,
+  startLoadingSoftwareUpdatesSettings,
+  setSoftwareUpdatesSettings,
+  setEmptySoftwareUpdatesSettings,
+} from '@state/softwareUpdatesSettings';
+
+export function* fetchSoftwareUpdatesSettings() {
+  yield put(startLoadingSoftwareUpdatesSettings());
+
+  try {
+    const response = yield call(getSettings);
+    yield put(setSoftwareUpdatesSettings(response.data));
+  } catch (error) {
+    yield put(setEmptySoftwareUpdatesSettings());
+  }
+}
+
+export function* watchSoftwareUpdateSettings() {
+  yield takeEvery(
+    FETCH_SOFTWARE_UPDATES_SETTINGS,
+    fetchSoftwareUpdatesSettings
+  );
+}

--- a/assets/js/state/sagas/softwareUpdatesSettings.test.js
+++ b/assets/js/state/sagas/softwareUpdatesSettings.test.js
@@ -1,0 +1,47 @@
+import { recordSaga } from '@lib/test-utils';
+
+import { networkClient } from '@lib/network';
+import MockAdapter from 'axios-mock-adapter';
+
+import { softwareUpdatesSettingsFactory } from '@lib/test-utils/factories/softwareUpdatesSettings';
+import {
+  startLoadingSoftwareUpdatesSettings,
+  setSoftwareUpdatesSettings,
+  setEmptySoftwareUpdatesSettings,
+} from '@state/softwareUpdatesSettings';
+
+import { fetchSoftwareUpdatesSettings } from './softwareUpdatesSettings';
+
+const axiosMock = new MockAdapter(networkClient);
+
+describe('Software Updates Settings saga', () => {
+  describe('Fetching Software Updates Settings', () => {
+    it('should successfully fetch software updates settings', async () => {
+      const successfulResponse = softwareUpdatesSettingsFactory.build();
+
+      axiosMock
+        .onGet('/settings/suma_credentials')
+        .reply(200, successfulResponse);
+
+      const dispatched = await recordSaga(fetchSoftwareUpdatesSettings);
+
+      expect(dispatched).toEqual([
+        startLoadingSoftwareUpdatesSettings(),
+        setSoftwareUpdatesSettings(successfulResponse),
+      ]);
+    });
+
+    it('should empty software updates settings on failed fetching', async () => {
+      [404, 500].forEach(async (errorStatus) => {
+        axiosMock.onGet('/settings/suma_credentials').reply(errorStatus);
+
+        const dispatched = await recordSaga(fetchSoftwareUpdatesSettings);
+
+        expect(dispatched).toEqual([
+          startLoadingSoftwareUpdatesSettings(),
+          setEmptySoftwareUpdatesSettings(),
+        ]);
+      });
+    });
+  });
+});

--- a/assets/js/state/selectors/softwareUpdatesSettings.js
+++ b/assets/js/state/selectors/softwareUpdatesSettings.js
@@ -1,0 +1,11 @@
+import { createSelector } from '@reduxjs/toolkit';
+
+export const getSoftwareUpdatesSettings = () =>
+  createSelector(
+    [({ softwareUpdatesSettings }) => softwareUpdatesSettings],
+    ({ settings, error, loading }) => ({
+      settings,
+      error,
+      loading,
+    })
+  );

--- a/assets/js/state/selectors/softwareUpdatesSettings.test.js
+++ b/assets/js/state/selectors/softwareUpdatesSettings.test.js
@@ -1,0 +1,33 @@
+import { getSoftwareUpdatesSettings } from './softwareUpdatesSettings';
+
+describe('Software Updates Settings selector', () => {
+  const stateScenarios = [
+    {
+      loading: false,
+      settings: {
+        url: 'https://valid.url',
+        username: 'username',
+        ca_uploaded_at: '2021-01-01T00:00:00Z',
+      },
+      error: null,
+    },
+    {
+      loading: true,
+      settings: {
+        url: undefined,
+        username: undefined,
+        ca_uploaded_at: undefined,
+      },
+      error: null,
+    },
+  ];
+
+  it.each(stateScenarios)(
+    'should return the correct catalog state',
+    (softwareUpdatesSettings) => {
+      expect(getSoftwareUpdatesSettings()({ softwareUpdatesSettings })).toEqual(
+        softwareUpdatesSettings
+      );
+    }
+  );
+});

--- a/assets/js/state/softwareUpdatesSettings.js
+++ b/assets/js/state/softwareUpdatesSettings.js
@@ -1,0 +1,50 @@
+import { createAction, createSlice } from '@reduxjs/toolkit';
+
+export const UPDATE_CATALOG = 'UPDATE_CATALOG';
+export const updateCatalog = createAction(UPDATE_CATALOG);
+
+const emptySettings = {
+  url: undefined,
+  username: undefined,
+  ca_uploaded_at: undefined,
+};
+
+const initialState = {
+  loading: false,
+  settings: emptySettings,
+  error: null,
+};
+
+export const softwareUpdatesSettingsSlice = createSlice({
+  name: 'softwareUpdatesSettings',
+  initialState,
+  reducers: {
+    startLoadingSoftwareUpdatesSettings: (state) => {
+      state.loading = true;
+    },
+    setSoftwareUpdatesSettings: (state, { payload: { settings } }) => {
+      state.loading = false;
+      state.error = null;
+      state.settings = settings;
+    },
+    setEmptySoftwareUpdatesSettings: (state) => {
+      state.loading = false;
+      state.error = null;
+      state.settings = emptySettings;
+    },
+  },
+});
+
+export const FETCH_SOFTWARE_UPDATES_SETTINGS =
+  'FETCH_SOFTWARE_UPDATES_SETTINGS';
+export const fetchSoftwareUpdatesSettings = createAction(
+  FETCH_SOFTWARE_UPDATES_SETTINGS
+);
+
+export const {
+  startLoadingSoftwareUpdatesSettings,
+  setSoftwareUpdatesSettings,
+  setEmptySoftwareUpdatesSettings,
+} = softwareUpdatesSettingsSlice.actions;
+
+export default softwareUpdatesSettingsSlice.reducer;

--- a/assets/js/state/softwareUpdatesSettings.test.js
+++ b/assets/js/state/softwareUpdatesSettings.test.js
@@ -1,0 +1,77 @@
+import softwareUpdatesSettingsReducer, {
+  startLoadingSoftwareUpdatesSettings,
+  setSoftwareUpdatesSettings,
+  setEmptySoftwareUpdatesSettings,
+} from './softwareUpdatesSettings';
+
+describe('SoftwareUpdateSettings reducer', () => {
+  it('should mark software updates settings on loading state', () => {
+    const initialState = {
+      loading: false,
+    };
+
+    const action = startLoadingSoftwareUpdatesSettings();
+
+    const expectedState = {
+      loading: true,
+    };
+
+    expect(softwareUpdatesSettingsReducer(initialState, action)).toEqual(
+      expectedState
+    );
+  });
+
+  it('should set software updates settings', () => {
+    const initialState = {
+      loading: true,
+      settings: {
+        url: undefined,
+        username: undefined,
+        ca_uploaded_at: undefined,
+      },
+      error: null,
+    };
+
+    const settings = {
+      url: 'https://valid.url',
+      username: 'username',
+      ca_uploaded_at: '2021-01-01T00:00:00Z',
+    };
+
+    const action = setSoftwareUpdatesSettings({ settings });
+
+    const actual = softwareUpdatesSettingsReducer(initialState, action);
+
+    expect(actual).toEqual({
+      loading: false,
+      settings,
+      error: null,
+    });
+  });
+
+  it('should empty software updates settings', () => {
+    const initialState = {
+      loading: true,
+      settings: {
+        url: 'https://valid.url',
+        username: 'username',
+        ca_uploaded_at: '2021-01-01T00:00:00Z',
+      },
+      error: null,
+    };
+
+    const action = setEmptySoftwareUpdatesSettings();
+
+    const actual = softwareUpdatesSettingsReducer(initialState, action);
+
+    expect(actual).toEqual({
+      loading: false,
+      settings: {
+        url: undefined,
+        username: undefined,
+        ca_uploaded_at: undefined,
+      },
+      error: null,
+    });
+  });
+});


### PR DESCRIPTION
# Description

Adding initial state/selector/saga for software updates settings.
It should be enough to build initial loading of the settings.

```js
  const {
    settings,
    error,
    loading,
  } = useSelector(getSoftwareUpdatesSettings());
```

Note: at the moment no distinction is made on errors.
We might want to iterate over the case we get something different from 404, which has the specific meaning of _no settings are available, yet_

## How was this tested?
Automated tests
