### PR TITLE
Add tooltip for non-compliant saptune

### DIFF
--- a/assets/js/pages/SaptuneDetails/SaptuneTuningState.jsx
+++ b/assets/js/pages/SaptuneDetails/SaptuneTuningState.jsx
@@ -10,7 +10,13 @@ function SaptuneTuningState({ state }) {
     case 'not compliant':
       return (
         <div className="flex">
-          <Tooltip content="Run `saptune note verify` in the host for further details">
+          <Tooltip
+            content={
+              <div>
+                Run `saptune note verify` in <br /> the host for further details
+              </div>
+            }
+          >
             <HealthIcon health="critical" />
           </Tooltip>
           <span className="ml-1">Not compliant</span>

--- a/assets/js/pages/SaptuneDetails/SaptuneTuningState.jsx
+++ b/assets/js/pages/SaptuneDetails/SaptuneTuningState.jsx
@@ -1,19 +1,23 @@
 import React from 'react';
 
-import Tooltip from '@common/Tooltip';
 import HealthIcon from '@common/HealthIcon';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import Tooltip from '@common/Tooltip';
 
 function SaptuneTuningState({ state }) {
+  const TooltipContent = () => (
+    <ReactMarkdown className="markdown" remarkPlugins={[remarkGfm]}>
+      Run `saptune note verify` in the host for further details
+    </ReactMarkdown>
+  );
   switch (state) {
     case 'compliant':
       return <span>Compliant</span>;
     case 'not compliant':
       return (
         <div className="flex">
-          <Tooltip
-            content="Run `saptune note verify` in the host for further details"
-            place="bottom"
-          >
+          <Tooltip place="bottom" content={<TooltipContent />}>
             <HealthIcon health="critical" />
           </Tooltip>
           <span className="ml-1">Not compliant</span>

--- a/assets/js/pages/SaptuneDetails/SaptuneTuningState.jsx
+++ b/assets/js/pages/SaptuneDetails/SaptuneTuningState.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import Tooltip from '@common/Tooltip';
 import HealthIcon from '@common/HealthIcon';
 
 function SaptuneTuningState({ state }) {
@@ -9,7 +10,12 @@ function SaptuneTuningState({ state }) {
     case 'not compliant':
       return (
         <div className="flex">
-          <HealthIcon health="critical" />
+          <Tooltip
+            content="Run `saptune note verify` in the host for further details"
+            place="bottom"
+          >
+            <HealthIcon health="critical" />
+          </Tooltip>
           <span className="ml-1">Not compliant</span>
         </div>
       );

--- a/assets/js/pages/SaptuneDetails/SaptuneTuningState.jsx
+++ b/assets/js/pages/SaptuneDetails/SaptuneTuningState.jsx
@@ -17,7 +17,7 @@ function SaptuneTuningState({ state }) {
     case 'not compliant':
       return (
         <div className="flex">
-          <Tooltip place="bottom" content={<TooltipContent />}>
+          <Tooltip content={<TooltipContent />}>
             <HealthIcon health="critical" />
           </Tooltip>
           <span className="ml-1">Not compliant</span>

--- a/assets/js/pages/SaptuneDetails/SaptuneTuningState.jsx
+++ b/assets/js/pages/SaptuneDetails/SaptuneTuningState.jsx
@@ -1,23 +1,16 @@
 import React from 'react';
 
 import HealthIcon from '@common/HealthIcon';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
 import Tooltip from '@common/Tooltip';
 
 function SaptuneTuningState({ state }) {
-  const TooltipContent = () => (
-    <ReactMarkdown className="markdown" remarkPlugins={[remarkGfm]}>
-      Run `saptune note verify` in the host for further details
-    </ReactMarkdown>
-  );
   switch (state) {
     case 'compliant':
       return <span>Compliant</span>;
     case 'not compliant':
       return (
         <div className="flex">
-          <Tooltip content={<TooltipContent />}>
+          <Tooltip content="Run `saptune note verify` in the host for further details">
             <HealthIcon health="critical" />
           </Tooltip>
           <span className="ml-1">Not compliant</span>


### PR DESCRIPTION
# Description

This PR adds a tooltip to add further details when saptune is not compliant

Preview:
![Captura desde 2024-02-15 15-37-12](https://github.com/trento-project/web/assets/2668401/aa62a985-152e-489a-a188-56f345c9cb51)

