### PR TITLE
Fix HostDetails story

### DIFF
--- a/assets/js/common/ChartsFeatureWrapper/ChartsFeatureWrapper.jsx
+++ b/assets/js/common/ChartsFeatureWrapper/ChartsFeatureWrapper.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import ChartsDisabledBox from '@common/ChartsDisabledBox';
 
-function ChartsFeatureWrapper({ children }) {
-  // eslint-disable-next-line no-undef
-  if (!config.chartsEnabled) return <ChartsDisabledBox />;
+function ChartsFeatureWrapper({ children, chartsEnabled }) {
+  if (!chartsEnabled) return <ChartsDisabledBox />;
   return children;
 }
 

--- a/assets/js/common/ChartsFeatureWrapper/ChartsFeatureWrapper.test.jsx
+++ b/assets/js/common/ChartsFeatureWrapper/ChartsFeatureWrapper.test.jsx
@@ -4,24 +4,16 @@ import '@testing-library/jest-dom';
 import ChartsFeatureWrapper from './ChartsFeatureWrapper';
 
 describe('ChartFeatureWrapper', () => {
-  afterEach(() => {
-    global.config = { chartsEnabled: false };
-  });
-
   it('should render ChartDisabledBox if the chart feature is disabled', () => {
-    global.config = { chartsEnabled: false };
-
-    render(<ChartsFeatureWrapper />);
+    render(<ChartsFeatureWrapper chartsEnabled={false} />);
     expect(screen.getByTestId('chart-disabled-box')).toHaveTextContent(
       'disabled'
     );
   });
 
   it('should render children if the chart feature is enabled', () => {
-    global.config = { chartsEnabled: true };
-
     render(
-      <ChartsFeatureWrapper>
+      <ChartsFeatureWrapper chartsEnabled>
         {' '}
         <div data-testid="child">child</div>{' '}
       </ChartsFeatureWrapper>

--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -44,6 +44,7 @@ function formatBytes(bytes, decimals = 2) {
 
 function HostDetails({
   agentVersion,
+  chartsEnabled,
   cluster,
   deregisterable,
   deregistering,
@@ -214,7 +215,7 @@ function HostDetails({
             />
           </div>
         </div>
-        <ChartsFeatureWrapper>
+        <ChartsFeatureWrapper chartsEnabled={chartsEnabled}>
           <div>
             <HostChart
               hostId={hostID}

--- a/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
@@ -154,6 +154,7 @@ export default {
 export const Default = {
   args: {
     agentVersion: host.agent_version,
+    chartsEnabled: false,
     cluster,
     deregisterable: false,
     deregistering: false,

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -23,6 +23,9 @@ import {
 import { deregisterHost } from '@state/hosts';
 import HostDetails from './HostDetails';
 
+// eslint-disable-next-line no-undef
+const { chartsEnabled } = config;
+
 function HostDetailsPage() {
   const { hostID } = useParams();
   const dispatch = useDispatch();
@@ -72,6 +75,7 @@ function HostDetailsPage() {
   return (
     <HostDetails
       agentVersion={host.agent_version}
+      chartsEnabled={chartsEnabled}
       cluster={cluster}
       deregisterable={host.deregisterable}
       deregistering={host.deregistering}


### PR DESCRIPTION
# Description

HostDetails storybook is broken. 
The fix is basically to pass `chartsEnabled` param from above to make the components pure.

All the stories are with disabled charts by now, as mocking them is not that simple. If needed, we can do it in the future, but I don't find a big value on that.

It supersedes: 
https://github.com/trento-project/web/pull/2197