### PR TITLE
Fetch credentials and feed SUMA Config

### DIFF
--- a/assets/js/pages/Settings/index.js
+++ b/assets/js/pages/Settings/index.js
@@ -1,3 +1,0 @@
-import Settings from './Settings';
-
-export default Settings;

--- a/assets/js/pages/SettingsPage/SettingsPage.jsx
+++ b/assets/js/pages/SettingsPage/SettingsPage.jsx
@@ -1,14 +1,23 @@
 import React, { useState, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { Transition } from '@headlessui/react';
 import classNames from 'classnames';
 
 import { logError } from '@lib/log';
 import { get } from '@lib/network';
 
+import LoadingBox from '@common/LoadingBox';
 import PageHeader from '@common/PageHeader';
 import Button from '@common/Button';
 
+import { fetchSoftwareUpdatesSettings } from '@state/softwareUpdatesSettings';
+import { getSoftwareUpdatesSettings } from '@state/selectors/softwareUpdatesSettings';
+
+import SuseManagerConfig from '@common/SuseManagerConfig';
+
 function SettingsPage() {
+  const dispatch = useDispatch();
+
   const [loading, setLoading] = useState(false);
   const [apiKey, setApiKey] = useState(null);
   const [showApiKey, setShowApiKey] = useState(false);
@@ -24,7 +33,12 @@ function SettingsPage() {
         logError(error);
         setLoading(false);
       });
+    dispatch(fetchSoftwareUpdatesSettings());
   }, []);
+
+  const { settings, loading: softwareUpdatesSettingsLoading } = useSelector(
+    getSoftwareUpdatesSettings()
+  );
 
   const hasApiKey = Boolean(apiKey);
 
@@ -149,6 +163,20 @@ function SettingsPage() {
             </ul>
           </div>
         </div>
+      </div>
+      <div className="py-4">
+        {softwareUpdatesSettingsLoading ? (
+          <LoadingBox
+            className="shadow-none rounded-lg"
+            text="Loading Settings..."
+          />
+        ) : (
+          <SuseManagerConfig
+            url={settings.url}
+            username={settings.username}
+            certUploadDate={settings.ca_uploaded_at}
+          />
+        )}
       </div>
     </section>
   );

--- a/assets/js/pages/SettingsPage/SettingsPage.jsx
+++ b/assets/js/pages/SettingsPage/SettingsPage.jsx
@@ -2,12 +2,13 @@ import React, { useState, useEffect } from 'react';
 import { Transition } from '@headlessui/react';
 import classNames from 'classnames';
 
-import PageHeader from '@common/PageHeader';
-import Button from '@common/Button';
 import { logError } from '@lib/log';
 import { get } from '@lib/network';
 
-function Settings() {
+import PageHeader from '@common/PageHeader';
+import Button from '@common/Button';
+
+function SettingsPage() {
   const [loading, setLoading] = useState(false);
   const [apiKey, setApiKey] = useState(null);
   const [showApiKey, setShowApiKey] = useState(false);
@@ -153,4 +154,4 @@ function Settings() {
   );
 }
 
-export default Settings;
+export default SettingsPage;

--- a/assets/js/pages/SettingsPage/SettingsPage.test.jsx
+++ b/assets/js/pages/SettingsPage/SettingsPage.test.jsx
@@ -1,0 +1,5 @@
+import '@testing-library/jest-dom';
+
+describe('Settings Page', () => {
+  
+});

--- a/assets/js/pages/SettingsPage/SettingsPage.test.jsx
+++ b/assets/js/pages/SettingsPage/SettingsPage.test.jsx
@@ -1,5 +1,89 @@
+import React from 'react';
+
+import { format } from 'date-fns';
+import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
+import {
+  withState,
+  defaultInitialState,
+  renderWithRouter,
+} from '@lib/test-utils';
+import { softwareUpdatesSettingsFactory } from '@lib/test-utils/factories/softwareUpdatesSettings';
+
+import SettingsPage from './SettingsPage';
+
 describe('Settings Page', () => {
-  
+  it('should render a loading box while fetching settings', async () => {
+    const [StatefulSettings] = withState(<SettingsPage />, {
+      ...defaultInitialState,
+      softwareUpdatesSettings: {
+        loading: true,
+      },
+    });
+
+    renderWithRouter(StatefulSettings);
+
+    expect(screen.getByText('Loading Settings...')).toBeVisible();
+  });
+
+  it('should render an empty SUSE Manager Config Section', async () => {
+    const [StatefulSettings] = withState(<SettingsPage />, {
+      ...defaultInitialState,
+      softwareUpdatesSettings: {
+        loading: false,
+        settings: {
+          url: undefined,
+          username: undefined,
+          ca_uploaded_at: undefined,
+        },
+        error: null,
+      },
+    });
+
+    renderWithRouter(StatefulSettings);
+
+    expect(screen.getByText('SUSE Manager URL')).toBeVisible();
+    expect(screen.getByText('https://')).toBeVisible();
+
+    expect(screen.getByText('CA Certificate')).toBeVisible();
+    expect(screen.getByText('-')).toBeVisible();
+
+    expect(screen.getByText('Username')).toBeVisible();
+    expect(screen.getByText('Password')).toBeVisible();
+
+    expect(screen.queryAllByText('.....')).toHaveLength(2);
+  });
+
+  it('should render SUSE Manager Config Section with configured settings', async () => {
+    const settings = softwareUpdatesSettingsFactory.build();
+
+    const [StatefulSettings] = withState(<SettingsPage />, {
+      ...defaultInitialState,
+      softwareUpdatesSettings: {
+        loading: false,
+        settings,
+        error: null,
+      },
+    });
+
+    const { url, username, ca_uploaded_at } = settings;
+
+    renderWithRouter(StatefulSettings);
+
+    expect(screen.getByText('SUSE Manager URL')).toBeVisible();
+    expect(screen.getByText(url)).toBeVisible();
+
+    expect(screen.getByText('CA Certificate')).toBeVisible();
+    expect(screen.getByText('Certificate Uploaded')).toBeVisible();
+    expect(
+      screen.getByText(format(ca_uploaded_at, "'Uploaded:' dd MMM y"))
+    ).toBeVisible();
+
+    expect(screen.getByText('Username')).toBeVisible();
+    expect(screen.getByText(username)).toBeVisible();
+
+    expect(screen.getByText('Password')).toBeVisible();
+    expect(screen.getByText('•••••')).toBeVisible();
+  });
 });

--- a/assets/js/pages/SettingsPage/index.js
+++ b/assets/js/pages/SettingsPage/index.js
@@ -1,0 +1,3 @@
+import SettingsPage from './SettingsPage';
+
+export default SettingsPage;

--- a/assets/js/state/softwareUpdatesSettings.js
+++ b/assets/js/state/softwareUpdatesSettings.js
@@ -22,7 +22,7 @@ export const softwareUpdatesSettingsSlice = createSlice({
     startLoadingSoftwareUpdatesSettings: (state) => {
       state.loading = true;
     },
-    setSoftwareUpdatesSettings: (state, { payload: { settings } }) => {
+    setSoftwareUpdatesSettings: (state, { payload: settings }) => {
       state.loading = false;
       state.error = null;
       state.settings = settings;

--- a/assets/js/state/softwareUpdatesSettings.test.js
+++ b/assets/js/state/softwareUpdatesSettings.test.js
@@ -38,7 +38,7 @@ describe('SoftwareUpdateSettings reducer', () => {
       ca_uploaded_at: '2021-01-01T00:00:00Z',
     };
 
-    const action = setSoftwareUpdatesSettings({ settings });
+    const action = setSoftwareUpdatesSettings(settings);
 
     const actual = softwareUpdatesSettingsReducer(initialState, action);
 

--- a/assets/js/trento.jsx
+++ b/assets/js/trento.jsx
@@ -29,7 +29,7 @@ import NotFound from '@pages/NotFound';
 import SapSystemDetails from '@pages//SapSystemDetails/SapSystemDetails';
 import SapSystemsOverviewPage from '@pages/SapSystemsOverviewPage';
 import SaptuneDetailsPage from '@pages/SaptuneDetails';
-import Settings from '@pages/Settings';
+import SettingsPage from '@pages/SettingsPage';
 import SomethingWentWrong from '@pages/SomethingWentWrong';
 
 import { me } from '@lib/auth';
@@ -78,7 +78,7 @@ function App() {
                   />
                   <Route path="databases" element={<DatabasesOverviewPage />} />
                   <Route path="catalog" element={<ChecksCatalogPage />} />
-                  <Route path="settings" element={<Settings />} />
+                  <Route path="settings" element={<SettingsPage />} />
                   <Route path="about" element={<AboutPage />} />
                   <Route path="hosts/:hostID" element={<HostDetailsPage />} />
                   <Route


### PR DESCRIPTION
# Description

This PR adds fetching of the software updates settings when landing on `/settings` page and renders the SUMA config component.

Finer error handling to be addressed when the ux is defined.

## How was this tested?

Automated tests.
