### PR TITLE
Fix race condition getting software updates settings

### DIFF
--- a/lib/trento/software_updates.ex
+++ b/lib/trento/software_updates.ex
@@ -41,6 +41,8 @@ defmodule Trento.SoftwareUpdates do
   def save_settings(settings_submission, date_service \\ DateService) do
     {:ok, settings} =
       Repo.transaction(fn ->
+        Repo.query!("set transaction isolation level serializable;")
+
         with :ok <- ensure_no_settings_configured() do
           save_new_settings(settings_submission, date_service)
         end

--- a/lib/trento/software_updates.ex
+++ b/lib/trento/software_updates.ex
@@ -39,9 +39,14 @@ defmodule Trento.SoftwareUpdates do
           | {:error, :settings_already_configured}
           | {:error, any()}
   def save_settings(settings_submission, date_service \\ DateService) do
-    with :ok <- ensure_no_settings_configured() do
-      save_new_settings(settings_submission, date_service)
-    end
+    {:ok, settings} =
+      Repo.transaction(fn ->
+        with :ok <- ensure_no_settings_configured() do
+          save_new_settings(settings_submission, date_service)
+        end
+      end)
+
+    settings
   end
 
   @spec change_settings(software_update_settings_change_submission, module()) ::


### PR DESCRIPTION
# Description
Fixes a race condition when getting software updates settings from the database. Putting the read (and the write) inside a transation solves the issue since Postgres is read-committed. By doing this we can avoid enforcing business logic outside of the domain layer.

I also took the chance to replicate the problem using an automatic test.

## How was this tested?
Automatic tests added
