### PR TITLE
Cluster details updates

### DIFF
--- a/assets/js/pages/ClusterDetails/AscsErsClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/AscsErsClusterDetails.jsx
@@ -260,13 +260,11 @@ function AscsErsClusterDetails({
         </div>
       </div>
 
-      {details && details.stopped_resources.length > 0 && (
-        <StoppedResources resources={details.stopped_resources} />
-      )}
-
       <div className="mt-2">
         <Table config={nodeDetailsConfig} data={currentSapSystem?.nodes} />
       </div>
+
+      <StoppedResources resources={details.stopped_resources} />
 
       <SBDDetails sbdDevices={details.sbd_devices} />
     </div>

--- a/assets/js/pages/ClusterDetails/AttributesDetails.jsx
+++ b/assets/js/pages/ClusterDetails/AttributesDetails.jsx
@@ -28,9 +28,11 @@ function AttributesDetails({ attributes, resources, title }) {
 
   return (
     <>
-      <Button type="primary" size="small" onClick={() => setModalOpen(true)}>
+    <span className="text-jungle-green-500 hover:opacity-75">
+      <a href="#" onClick={() => setModalOpen(true)}>
         Details
-      </Button>
+      </a>
+      </span>
       <Modal title={title} open={modalOpen} onClose={() => setModalOpen(false)}>
         <h3 className="font-medium">Attributes</h3>
         <Table

--- a/assets/js/pages/ClusterDetails/AttributesDetails.jsx
+++ b/assets/js/pages/ClusterDetails/AttributesDetails.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 
-import Button from '@common/Button';
 import Modal from '@common/Modal';
 import Table from '@common/Table';
 
@@ -34,7 +33,7 @@ function AttributesDetails({ attributes, resources, title }) {
       </a>
       </span>
       <Modal title={title} open={modalOpen} onClose={() => setModalOpen(false)}>
-        <h3 className="font-medium">Attributes</h3>
+        <h3 className="font-medium mt-6">Attributes</h3>
         <Table
           config={attributesTableConfig}
           data={Object.keys(attributes).map((key) => ({
@@ -43,7 +42,7 @@ function AttributesDetails({ attributes, resources, title }) {
           }))}
         />
 
-        <h3 className="font-medium">Resources</h3>
+        <h3 className="font-medium mt-6">Resources</h3>
         <Table config={resourcesTableConfig} data={resources} />
       </Modal>
     </>

--- a/assets/js/pages/ClusterDetails/AttributesDetails.jsx
+++ b/assets/js/pages/ClusterDetails/AttributesDetails.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 
+import Button from '@common/Button';
 import Modal from '@common/Modal';
 import Table from '@common/Table';
 
@@ -27,11 +28,14 @@ function AttributesDetails({ attributes, resources, title }) {
 
   return (
     <>
-    <span className="text-jungle-green-500 hover:opacity-75">
-      <a href="#" onClick={() => setModalOpen(true)}>
+      <Button
+        type="transparent"
+        className="text-jungle-green-500"
+        size="fit"
+        onClick={() => setModalOpen(true)}
+      >
         Details
-      </a>
-      </span>
+      </Button>
       <Modal title={title} open={modalOpen} onClose={() => setModalOpen(false)}>
         <h3 className="font-medium mt-6">Attributes</h3>
         <Table

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
@@ -194,10 +194,6 @@ function HanaClusterDetails({
         </div>
       </div>
 
-      {details && details.stopped_resources.length > 0 && (
-        <StoppedResources resources={details.stopped_resources} />
-      )}
-
       <h2 className="mt-8 text-2xl font-bold">Site details</h2>
       <div className="mt-2 tn-site-details">
         {sortBy(details.sites, 'name').map(
@@ -216,6 +212,8 @@ function HanaClusterDetails({
       {unsitedNodes.length > 0 && (
         <HanaClusterSite name="Other" nodes={unsitedNodes} />
       )}
+
+      <StoppedResources resources={details.stopped_resources} />
 
       <SBDDetails sbdDevices={details.sbd_devices} />
     </div>

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.test.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.test.jsx
@@ -381,7 +381,7 @@ describe('HanaClusterDetails component', () => {
 
     await userEvent.click(screen.getAllByText('Details')[0]);
 
-    expect(screen.getByText('Site Details')).toBeInTheDocument();
+    expect(screen.getByText('Node Details')).toBeInTheDocument();
     expect(screen.getByText('Attributes')).toBeInTheDocument();
     expect(screen.getByText('Resources')).toBeInTheDocument();
 

--- a/assets/js/pages/ClusterDetails/HanaClusterSite.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterSite.jsx
@@ -62,7 +62,7 @@ const siteDetailsConfig = {
         const { attributes, resources } = item;
         return (
           <AttributesDetails
-            title="Site Details"
+            title="Node Details"
             attributes={attributes}
             resources={resources}
           />

--- a/assets/js/pages/ClusterDetails/HanaClusterSite.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterSite.jsx
@@ -78,19 +78,22 @@ function HanaClusterSite({ name, nodes, state = null, srHealthState = null }) {
       key={name}
       className={`tn-site-details-${name} mt-4 bg-white rounded-lg`}
     >
-      <div className="flex space-x-2 px-4 pt-4">
-        {state && (
-          <span className="text-left">
-            <HealthIcon health={getSiteHealth(srHealthState)} centered />
-          </span>
-        )}
-        <h3 className="text-l font-bold tn-site-name">{name}</h3>
-        {srHealthState && <ReplicationStatusPill status={state} />}
-      </div>
       <Table
         className="tn-site-table"
         config={siteDetailsConfig}
         data={nodes}
+        withPadding={false}
+        header={
+          <div className="flex space-x-2 p-4">
+            {state && (
+              <span className="text-left">
+                <HealthIcon health={getSiteHealth(srHealthState)} centered />
+              </span>
+            )}
+            <h3 className="text-l font-bold tn-site-name">{name}</h3>
+            {srHealthState && <ReplicationStatusPill status={state} />}
+          </div>
+        }
       />
     </div>
   );

--- a/assets/js/pages/ClusterDetails/StoppedResources.jsx
+++ b/assets/js/pages/ClusterDetails/StoppedResources.jsx
@@ -4,16 +4,20 @@ import Pill from '@common/Pill';
 
 function StoppedResources({ resources }) {
   return (
-    <div className="mt-16">
+    <div className="mt-8">
       <div className="flex flex-direction-row">
         <h2 className="text-2xl font-bold self-center">Stopped resources</h2>
       </div>
       <div className="mt-2 space-x-2">
-        {resources.map(({ id }) => (
-          <Pill className="bg-gray-200 text-gray-800" key={id}>
-            {id}
-          </Pill>
-        ))}
+        {resources.length === 0 ? (
+          <p>No resources to display.</p>
+        ) : (
+          resources.map(({ id }) => (
+            <Pill className="bg-gray-200 text-gray-800" key={id}>
+              {id}
+            </Pill>
+          ))
+        )}
       </div>
     </div>
   );

--- a/assets/js/pages/ClusterDetails/StoppedResources.test.jsx
+++ b/assets/js/pages/ClusterDetails/StoppedResources.test.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { renderWithRouter } from '@lib/test-utils';
+
+import StoppedResources from './StoppedResources';
+
+it('should display a "No resources to display." message when there are no resources', async () => {
+  renderWithRouter(<StoppedResources resources={[]} />);
+
+  expect(screen.getByText('No resources to display.')).toBeInTheDocument();
+});

--- a/assets/js/pages/ClusterDetails/StoppedResources.test.jsx
+++ b/assets/js/pages/ClusterDetails/StoppedResources.test.jsx
@@ -1,13 +1,11 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
-
-import { renderWithRouter } from '@lib/test-utils';
 
 import StoppedResources from './StoppedResources';
 
 it('should display a "No resources to display." message when there are no resources', async () => {
-  renderWithRouter(<StoppedResources resources={[]} />);
+  render(<StoppedResources resources={[]} />);
 
   expect(screen.getByText('No resources to display.')).toBeInTheDocument();
 });


### PR DESCRIPTION
# Description

This PR adds some of the UI changes proposed by @jagabomb:

 - details button becomes a link
 - details content header changes from "Site details" to "Node details"
 - rounded bottom of tables 
 - top margins in the resources in the node details view
 - stop resources section should go under the site details section
 - stop resources section becomes a fixed section and when there are no stopped resources it shows a text saying "No resources to display"


See attached screenshots for more details:
![Captura desde 2024-02-16 13-49-53](https://github.com/trento-project/web/assets/2668401/a90ab341-0b62-4fb7-af9f-4fe3934d4c62)
![Captura desde 2024-02-16 13-49-32](https://github.com/trento-project/web/assets/2668401/9f4d76d0-ca50-46cd-8b5e-ac37e239f923)
![Captura desde 2024-02-16 13-49-46](https://github.com/trento-project/web/assets/2668401/1dc8a5c3-6b72-419a-99ff-ca0fb8ea26bb)
