### PR TITLE
Add extra concurrency tests on saving software updates

### DIFF
--- a/lib/trento/software_updates.ex
+++ b/lib/trento/software_updates.ex
@@ -39,9 +39,14 @@ defmodule Trento.SoftwareUpdates do
           | {:error, :settings_already_configured}
           | {:error, any()}
   def save_settings(settings_submission, date_service \\ DateService) do
-    with {:ok, :settings_not_configured, settings} <- ensure_no_settings_configured() do
-      save_new_settings(settings, settings_submission, date_service)
-    end
+    {:ok, transacion_result} =
+      Repo.transaction(fn ->
+        with {:ok, :settings_not_configured, settings} <- ensure_no_settings_configured() do
+          save_new_settings(settings, settings_submission, date_service)
+        end
+      end)
+
+    transacion_result
   end
 
   @spec change_settings(software_update_settings_change_submission, module()) ::


### PR DESCRIPTION
# Description

Taking inspiration from this tentative https://github.com/trento-project/web/pull/2327

Tests seem to be good, however on a real scenario (ie a browser sending concurrent saving requests) we might still get more than one request succeed (with a 201) with the last that completed to have its data written.

Seems that in tests always the same connection is used, that knows about ongoing transactions.

The endpoint does not go 500.

Concurrency... :trollface: might need extra investigation to learn more.