### PR TITLE
Clean tgzs after `service manualrun`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -819,9 +819,9 @@ jobs:
           cp $FOLDER/_service $OSC_CHECKOUT_DIR
           cp $FOLDER/trento-web.spec $OSC_CHECKOUT_DIR
           rm -vf $OSC_CHECKOUT_DIR/*.tar.gz
-          rm -vf $OSC_CHECKOUT_DIR/*.tgz
           pushd $OSC_CHECKOUT_DIR 
           osc service manualrun
+          rm -vf $OSC_CHECKOUT_DIR/*.tgz
           cp  /__w/web/web/deps.tar.gz .
       - name: Prepare trento-web.changes file
         # The .changes file is updated only in release creation. This current task should be improved


### PR DESCRIPTION
# Description

This PR fixes the issue discussed in today's review meeting where some of the node_modules tgz's where left in the OBS project. This is due to the fact that we clean them up too early and `osc service manualrun` will recreate the node_modules from the obscpio that where updated since the last build.

By cleaning up after `osc service manualrun` we make sure no tgz are left in the working copy and send to OBS.