### PR TITLE
Add header prop to table

### DIFF
--- a/assets/js/common/Table/Pagination.jsx
+++ b/assets/js/common/Table/Pagination.jsx
@@ -6,7 +6,7 @@ const getPagesArray = (pages) => Array.from({ length: pages }, (_, i) => 1 + i);
 function Pagination({ pages, currentPage, onSelect }) {
   const pagesList = getPagesArray(pages);
   return (
-    <div className="grid py-2 bg-gray-50 rounded-lg">
+    <div className="grid py-2 bg-gray-50">
       <div className="justify-self-end pr-2">
         <div className="flex items-center">
           {pagesList.map((pageNumber) => {

--- a/assets/js/common/Table/Table.jsx
+++ b/assets/js/common/Table/Table.jsx
@@ -62,6 +62,7 @@ function Table({
   setSearchParams,
   emptyStateText = 'No data available',
   withPadding = true,
+  header = null,
   rowKey = defaultRowKey,
 }) {
   const {
@@ -81,6 +82,8 @@ function Table({
   const columnFiltersBoundToParams = columns.filter(
     (c) => c.filter && c.filterFromParams
   );
+
+  const hasFilters = columns.filter(({ filter }) => Boolean(filter)).length > 0;
 
   useEffect(() => {
     if (!searchParamsEnabled) return;
@@ -158,7 +161,13 @@ function Table({
             'pt-4': withPadding,
           })}
         >
-          <div className="min-w-fit shadow rounded-lg">
+          <div
+            className={classNames(
+              'min-w-fit shadow rounded-b-lg overflow-hidden',
+              { 'rounded-t-lg': !hasFilters }
+            )}
+          >
+            {header}
             <table className="min-w-full leading-normal table-fixed">
               <thead>
                 <tr>

--- a/assets/js/common/Table/Table.stories.jsx
+++ b/assets/js/common/Table/Table.stories.jsx
@@ -107,6 +107,17 @@ export function WithFilters(args) {
   return <Table config={filteredConfig} data={data} {...args} />;
 }
 
+export function WithHeader(args) {
+  return (
+    <Table
+      config={config}
+      data={data}
+      header={<h3 className="bg-white px-4 py-4">Header</h3>}
+      {...args}
+    />
+  );
+}
+
 export function Empty() {
   return <Table config={config} data={[]} />;
 }

--- a/assets/js/common/Table/Table.test.jsx
+++ b/assets/js/common/Table/Table.test.jsx
@@ -80,6 +80,22 @@ describe('Table component', () => {
       .forEach((tableRow) => expect(tableRow).toHaveClass(customRowClassName));
   });
 
+  it('should display the header', () => {
+    const data = tableDataFactory.buildList(10);
+    const headerText = faker.person.firstName();
+
+    render(
+      <Table
+        config={tableConfig}
+        data={data}
+        setSearchParams={() => {}}
+        header={<p>{headerText}</p>}
+      />
+    );
+
+    expect(screen.queryByText(headerText)).toBeInTheDocument();
+  });
+
   describe('filtering', () => {
     it('should filter by the chosen filter option with default filter', async () => {
       const data = tableDataFactory.buildList(10);


### PR DESCRIPTION
# Description

Add `header` prop to `Table`. This allows us to include a header to the table using the correct bordering layout.
It will be used in the HanaClusterDetails view, to border properly the site details.

Besides that, the table borders are rounded now on.

## How was this tested?

The styles tested with Storybook
