### PR TITLE
Remove API check json output in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -535,7 +535,6 @@ jobs:
             /specs/current-spec.json \
             --fail-on-incompatible \
             --markdown /specs/changes.md \
-            --json /specs/changes.json \
             --text /specs/changes.txt \
             --html /specs/changes.html
       - name: Upload OpenAPI diff report


### PR DESCRIPTION
# Description

The created json file is huge, creating a `java.lang.OutOfMemoryError: Java heap space` in the CI.
For reference: https://github.com/trento-project/web/actions/runs/7971433187/job/21764324589
https://github.com/OpenAPITools/openapi-diff/issues/562

As nobody uses this file, let's remove it.
