### PR TITLE
Fix software updates patching idempotency

### DIFF
--- a/lib/trento/software_updates/settings.ex
+++ b/lib/trento/software_updates/settings.ex
@@ -66,10 +66,13 @@ defmodule Trento.SoftwareUpdates.Settings do
   end
 
   defp maybe_remove_cert_upload_date(changeset, settings_submission) do
-    if Map.has_key?(settings_submission, :ca_cert) && nil == get_change(changeset, :ca_cert) do
+    with true <- Map.has_key?(settings_submission, :ca_cert),
+         true <- changed?(changeset, :ca_cert),
+         nil <- get_change(changeset, :ca_cert) do
       put_change(changeset, :ca_uploaded_at, nil)
     else
-      changeset
+      _ ->
+        changeset
     end
   end
 end


### PR DESCRIPTION
# Description

As per the title: fixing idempotency when requesting software updates patching.

Currently if we send the same change requests for suma creds twice sequentially with the same `ca_cert`, the `ca_uploaded_at` gets nullified.

## How was this tested?

Added a test.
