### PR TITLE
Change KVM provider label to "on-premise / KVM"

### DIFF
--- a/assets/js/common/ClusterInfoBox/ClusterInfoBox.test.jsx
+++ b/assets/js/common/ClusterInfoBox/ClusterInfoBox.test.jsx
@@ -39,7 +39,7 @@ describe('Cluster Info Box', () => {
       haScenario: 'unknown',
       haScenarioText: 'Unknown',
       provider: 'kvm',
-      providerText: 'KVM',
+      providerText: 'on-premise / KVM',
     },
     {
       haScenario: 'unknown',

--- a/assets/js/common/ClusterInfoBox/ClusterInfoBox.test.jsx
+++ b/assets/js/common/ClusterInfoBox/ClusterInfoBox.test.jsx
@@ -39,7 +39,7 @@ describe('Cluster Info Box', () => {
       haScenario: 'unknown',
       haScenarioText: 'Unknown',
       provider: 'kvm',
-      providerText: 'on-premise / KVM',
+      providerText: 'On-premise / KVM',
     },
     {
       haScenario: 'unknown',

--- a/assets/js/common/HostInfoBox/HostInfoBox.test.jsx
+++ b/assets/js/common/HostInfoBox/HostInfoBox.test.jsx
@@ -28,7 +28,7 @@ describe('Host Info Box', () => {
     {
       agentVersion: '1.2.0',
       provider: 'kvm',
-      providerText: 'on-premise / KVM',
+      providerText: 'On-premise / KVM',
     },
     {
       agentVersion: '2.0.0',

--- a/assets/js/common/HostInfoBox/HostInfoBox.test.jsx
+++ b/assets/js/common/HostInfoBox/HostInfoBox.test.jsx
@@ -28,7 +28,7 @@ describe('Host Info Box', () => {
     {
       agentVersion: '1.2.0',
       provider: 'kvm',
-      providerText: 'KVM',
+      providerText: 'on-premise / KVM',
     },
     {
       agentVersion: '2.0.0',

--- a/assets/js/common/ProviderLabel/ProviderLabel.jsx
+++ b/assets/js/common/ProviderLabel/ProviderLabel.jsx
@@ -36,7 +36,7 @@ export const providerData = {
   },
   [KVM_PROVIDER]: {
     logo: KvmLogo,
-    label: 'on-premise / KVM',
+    label: 'On-premise / KVM',
   },
   [VMWARE_PROVIDER]: {
     logo: VmwareLogo,

--- a/assets/js/common/ProviderLabel/ProviderLabel.jsx
+++ b/assets/js/common/ProviderLabel/ProviderLabel.jsx
@@ -36,7 +36,7 @@ export const providerData = {
   },
   [KVM_PROVIDER]: {
     logo: KvmLogo,
-    label: 'KVM',
+    label: 'on-premise / KVM',
   },
   [VMWARE_PROVIDER]: {
     logo: VmwareLogo,

--- a/assets/js/pages/HostDetailsPage/ProviderDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/ProviderDetails.test.jsx
@@ -19,7 +19,7 @@ describe('Provider Details', () => {
     },
     {
       provider: 'kvm',
-      providerText: 'KVM',
+      providerText: 'on-premise / KVM',
     },
     {
       provider: 'vmware',

--- a/assets/js/pages/HostDetailsPage/ProviderDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/ProviderDetails.test.jsx
@@ -19,7 +19,7 @@ describe('Provider Details', () => {
     },
     {
       provider: 'kvm',
-      providerText: 'on-premise / KVM',
+      providerText: 'On-premise / KVM',
     },
     {
       provider: 'vmware',


### PR DESCRIPTION
# Description

This PR changes the use of the KVM _provider_ label to say "_on-premise / KVM_".

This change applies in three places:

## Checks Catalog page - provider filter

![image](https://github.com/trento-project/web/assets/113615552/57d300c0-47a5-485b-9831-a26cdc1830b7)

## Host Details page - info box

![image](https://github.com/trento-project/web/assets/113615552/68f27064-d770-48c0-b717-ef6ff7dd12be)

## Cluster Details page - info box

![image](https://github.com/trento-project/web/assets/113615552/c0acb48d-64d9-4373-841b-2b89a65c23ae)

## How was this tested?

Updated unit tests
