### PR TITLE
Change KVM label to "On-premises / KVM"

### DIFF
--- a/assets/js/common/ClusterInfoBox/ClusterInfoBox.test.jsx
+++ b/assets/js/common/ClusterInfoBox/ClusterInfoBox.test.jsx
@@ -39,7 +39,7 @@ describe('Cluster Info Box', () => {
       haScenario: 'unknown',
       haScenarioText: 'Unknown',
       provider: 'kvm',
-      providerText: 'On-premise / KVM',
+      providerText: 'On-premises / KVM',
     },
     {
       haScenario: 'unknown',

--- a/assets/js/common/HostInfoBox/HostInfoBox.test.jsx
+++ b/assets/js/common/HostInfoBox/HostInfoBox.test.jsx
@@ -28,7 +28,7 @@ describe('Host Info Box', () => {
     {
       agentVersion: '1.2.0',
       provider: 'kvm',
-      providerText: 'On-premise / KVM',
+      providerText: 'On-premises / KVM',
     },
     {
       agentVersion: '2.0.0',

--- a/assets/js/common/ProviderLabel/ProviderLabel.jsx
+++ b/assets/js/common/ProviderLabel/ProviderLabel.jsx
@@ -36,7 +36,7 @@ export const providerData = {
   },
   [KVM_PROVIDER]: {
     logo: KvmLogo,
-    label: 'On-premise / KVM',
+    label: 'On-premises / KVM',
   },
   [VMWARE_PROVIDER]: {
     logo: VmwareLogo,

--- a/assets/js/pages/HostDetailsPage/ProviderDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/ProviderDetails.test.jsx
@@ -19,7 +19,7 @@ describe('Provider Details', () => {
     },
     {
       provider: 'kvm',
-      providerText: 'On-premise / KVM',
+      providerText: 'On-premises / KVM',
     },
     {
       provider: 'vmware',


### PR DESCRIPTION
# Description

Related to https://github.com/trento-project/web/pull/2358.

_Technically_ the spelling should be "On-premises".

## How was this tested?

Updated unit tests
