### PR TITLE
Add flag for "SUSE Manager config enabled"

### DIFF
--- a/assets/jest.config.js
+++ b/assets/jest.config.js
@@ -66,6 +66,8 @@ module.exports = {
   globals: {
     config: {
       checksServiceBaseUrl: '',
+      suseManagerEnabled: true,
+      aTestVariable: 123,
     },
   },
 

--- a/assets/js/lib/config/config.js
+++ b/assets/js/lib/config/config.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-undef
+export const getFromConfig = (key) => config[key];

--- a/assets/js/lib/config/config.test.js
+++ b/assets/js/lib/config/config.test.js
@@ -1,0 +1,16 @@
+import { getFromConfig } from '.';
+
+describe('getFromConfig', () => {
+  it('should retrieve variable from the config', () => {
+    // See jest.config.js for global config used in testing
+    const fetchedConfigVariable = getFromConfig('aTestVariable');
+
+    expect(fetchedConfigVariable).toEqual(123);
+  });
+
+  it('should return undefined when variable is not available the config', () => {
+    const fetchedConfigVariable = getFromConfig('variableThatDoesntExist');
+
+    expect(fetchedConfigVariable).toBeUndefined();
+  });
+});

--- a/assets/js/lib/config/index.js
+++ b/assets/js/lib/config/index.js
@@ -1,0 +1,3 @@
+import { getFromConfig } from './config';
+
+export { getFromConfig };

--- a/assets/js/pages/SettingsPage/SettingsPage.jsx
+++ b/assets/js/pages/SettingsPage/SettingsPage.jsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 
 import { logError } from '@lib/log';
 import { get } from '@lib/network';
+import { getFromConfig } from '@lib/config';
 
 import LoadingBox from '@common/LoadingBox';
 import PageHeader from '@common/PageHeader';
@@ -182,47 +183,53 @@ function SettingsPage() {
           </div>
         </div>
       </div>
-      <div className="py-4">
-        {softwareUpdatesSettingsLoading ? (
-          <LoadingBox
-            className="shadow-none rounded-lg"
-            text="Loading Settings..."
-          />
-        ) : (
-          <SuseManagerConfig
-            url={settings.url}
-            username={settings.username}
+      {getFromConfig('suseManagerEnabled') && (
+        <div className="py-4">
+          {softwareUpdatesSettingsLoading ? (
+            <LoadingBox
+              className="shadow-none rounded-lg"
+              text="Loading Settings..."
+            />
+          ) : (
+            <SuseManagerConfig
+              url={settings.url}
+              username={settings.username}
+              certUploadDate={settings.ca_uploaded_at}
+              onEditClick={() =>
+                dispatch(setEditingSoftwareUpdatesSettings(true))
+              }
+              clearSettingsDialogOpen={clearingSoftwareUpdatesSettings}
+              onClearClick={() => setClearingSoftwareUpdatesSettings(true)}
+              onClearSettings={() => {
+                setClearingSoftwareUpdatesSettings(false);
+                dispatch(clearSoftwareUpdatesSettings());
+              }}
+              onCancel={() => setClearingSoftwareUpdatesSettings(false)}
+            />
+          )}
+          <SuseManagerSettingsModal
+            key={`${settings.url}-${settings.username}-${settings.ca_uploaded_at}-${editingSoftwareUpdatesSettings}`}
+            open={editingSoftwareUpdatesSettings}
+            errors={suseManagerValidationErrors}
+            loading={softwareUpdatesSettingsLoading}
+            initialUsername={settings.username}
+            initialUrl={settings.url}
             certUploadDate={settings.ca_uploaded_at}
-            onEditClick={() =>
-              dispatch(setEditingSoftwareUpdatesSettings(true))
-            }
-            clearSettingsDialogOpen={clearingSoftwareUpdatesSettings}
-            onClearClick={() => setClearingSoftwareUpdatesSettings(true)}
-            onClearSettings={() => {
-              setClearingSoftwareUpdatesSettings(false);
-              dispatch(clearSoftwareUpdatesSettings());
+            onSave={(payload) => {
+              if (
+                settings.username ||
+                settings.url ||
+                settings.ca_uploaded_at
+              ) {
+                dispatch(updateSoftwareUpdatesSettings(payload));
+              } else {
+                dispatch(saveSoftwareUpdatesSettings(payload));
+              }
             }}
-            onCancel={() => setClearingSoftwareUpdatesSettings(false)}
+            onCancel={() => dispatch(setEditingSoftwareUpdatesSettings(false))}
           />
-        )}
-        <SuseManagerSettingsModal
-          key={`${settings.url}-${settings.username}-${settings.ca_uploaded_at}-${editingSoftwareUpdatesSettings}`}
-          open={editingSoftwareUpdatesSettings}
-          errors={suseManagerValidationErrors}
-          loading={softwareUpdatesSettingsLoading}
-          initialUsername={settings.username}
-          initialUrl={settings.url}
-          certUploadDate={settings.ca_uploaded_at}
-          onSave={(payload) => {
-            if (settings.username || settings.url || settings.ca_uploaded_at) {
-              dispatch(updateSoftwareUpdatesSettings(payload));
-            } else {
-              dispatch(saveSoftwareUpdatesSettings(payload));
-            }
-          }}
-          onCancel={() => dispatch(setEditingSoftwareUpdatesSettings(false))}
-        />
-      </div>
+        </div>
+      )}
     </section>
   );
 }

--- a/config/demo.exs
+++ b/config/demo.exs
@@ -31,3 +31,5 @@ config :trento, Trento.Infrastructure.Prometheus,
 
 config :trento, Trento.Charts,
   host_data_fetcher: Trento.Infrastructure.Prometheus.MockPrometheusApi
+
+config :trento, suse_manager_enabled: true

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -121,7 +121,8 @@ config :phoenix, :stacktrace_depth, 20
 config :phoenix, :plug_init_mode, :runtime
 
 config :trento,
-  api_key_authentication_enabled: false
+  api_key_authentication_enabled: false,
+  suse_manager_enabled: true
 
 config :joken,
   access_token_signer: "s2ZdE+3+ke1USHEJ5O45KT364KiXPYaB9cJPdH3p60t8yT0nkLexLBNw8TFSzC7k",

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -7,5 +7,7 @@ config :trento, TrentoWeb.Endpoint,
 
 config :swoosh, local: false
 
+config :trento, suse_manager_enabled: false
+
 # Do not print debug messages in production
 # config :logger, level: :info

--- a/config/test.exs
+++ b/config/test.exs
@@ -50,7 +50,8 @@ config :trento, deregistration_debounce: :timer.seconds(5)
 
 config :trento,
   api_key_authentication_enabled: false,
-  jwt_authentication_enabled: false
+  jwt_authentication_enabled: false,
+  suse_manager_enabled: true
 
 config :trento, Trento.Infrastructure.Checks.AMQP.Consumer,
   processor: GenRMQ.Processor.Mock,

--- a/lib/trento_web/controllers/page_controller.ex
+++ b/lib/trento_web/controllers/page_controller.ex
@@ -5,11 +5,13 @@ defmodule TrentoWeb.PageController do
     check_service_base_url = Application.fetch_env!(:trento, :checks_service)[:base_url]
     charts_enabled = Application.fetch_env!(:trento, Trento.Charts)[:enabled]
     deregistration_debounce = Application.fetch_env!(:trento, :deregistration_debounce)
+    suse_manager_enabled = Application.fetch_env!(:trento, :suse_manager_enabled)
 
     render(conn, "index.html",
       check_service_base_url: check_service_base_url,
       charts_enabled: charts_enabled,
-      deregistration_debounce: deregistration_debounce
+      deregistration_debounce: deregistration_debounce,
+      suse_manager_enabled: suse_manager_enabled
     )
   end
 end

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -146,9 +146,11 @@ defmodule TrentoWeb.Router do
 
       get "/hosts/:id/exporters_status", PrometheusController, :exporters_status
 
-      resources "/settings/suma_credentials", SUMACredentialsController,
-        only: [:show, :create, :update, :delete],
-        singleton: true
+      if Application.compile_env!(:trento, :suse_manager_enabled) do
+        resources "/settings/suma_credentials", SUMACredentialsController,
+          only: [:show, :create, :update, :delete],
+          singleton: true
+      end
 
       scope "/charts" do
         pipe_through :charts_feature

--- a/lib/trento_web/templates/page/index.html.heex
+++ b/lib/trento_web/templates/page/index.html.heex
@@ -5,6 +5,7 @@ const config = {
     checksServiceBaseUrl: '<%= @check_service_base_url %>',
     deregistrationDebounce: <%= @deregistration_debounce %>,
     chartsEnabled: <%= @charts_enabled %>,
+    suseManagerEnabled: <%= @suse_manager_enabled %>,
 };
 </script>
 


### PR DESCRIPTION
# Description

This PR adds a flag to enable the SUSE Manager config. When the flag is enabled:
- The API endpoints for SUSE Manager credentials are enabled
- The SUSE Manager config is available in the Settings page

Also added a helper library `getFromConfig()` that retrieves a variable from the global `config` object. This way we don't need to add the line `// eslint-disable-next-line no-undef` everywhere when we need to read values from the global `config`.

## How was this tested?

Add unit tests for the `getFromConfig()` library.
