### PR TITLE
Integrate suma get system id

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -181,6 +181,12 @@ config :trento, Trento.Vault,
     }
   ]
 
+config :trento, Trento.SoftwareUpdates.Discovery,
+  adapter: Trento.Infrastructure.SoftwareUpdates.MockSuma
+
+config :trento, Trento.Infrastructure.SoftwareUpdates.SumaApi,
+  executor: Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -9,5 +9,8 @@ config :swoosh, local: false
 
 config :trento, suse_manager_enabled: false
 
+config :trento, Trento.SoftwareUpdates.Discovery,
+  adapter: Trento.Infrastructure.SoftwareUpdates.Suma
+
 # Do not print debug messages in production
 # config :logger, level: :info

--- a/lib/trento/application.ex
+++ b/lib/trento/application.ex
@@ -24,7 +24,8 @@ defmodule Trento.Application do
         Trento.ProcessManagersSupervisor,
         Trento.Infrastructure.Messaging.Adapter.AMQP.Publisher,
         Trento.Infrastructure.Checks.AMQP.Consumer,
-        Trento.Vault
+        Trento.Vault,
+        Trento.Infrastructure.SoftwareUpdates.Suma
         # Start a worker by calling: Trento.Worker.start_link(arg)
         # {Trento.Worker, arg}
       ] ++

--- a/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
+++ b/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
@@ -1,0 +1,15 @@
+defmodule Trento.Infrastructure.SoftwareUpdates.MockSuma do
+  @moduledoc """
+  Mocked SUMA Software updates discovery adapter
+  """
+
+  @behaviour Trento.SoftwareUpdates.Discovery.Gen
+
+  @impl true
+  def get_system_id(fully_qualified_domain_name),
+    do:
+      {:ok,
+       fully_qualified_domain_name
+       |> String.to_charlist()
+       |> Enum.sum()}
+end

--- a/lib/trento/infrastructure/software_updates/adapter/suma_http_executor.ex
+++ b/lib/trento/infrastructure/software_updates/adapter/suma_http_executor.ex
@@ -1,0 +1,43 @@
+defmodule Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor do
+  @moduledoc """
+  SUMA Http requests executor
+  """
+
+  @callback login(base_url :: String.t(), username :: String.t(), password :: String.t()) ::
+              {:ok, HTTPoison.Response.t()} | {:error, HTTPoison.Error.t()}
+
+  @callback get_system_id(
+              base_url :: String.t(),
+              auth :: String.t(),
+              fully_qualified_domain_name :: String.t()
+            ) ::
+              {:ok, HTTPoison.Response.t()} | {:error, HTTPoison.Error.t()}
+
+  @behaviour Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor
+
+  @impl true
+  def login(base_url, username, password) do
+    payload =
+      Jason.encode!(%{
+        "login" => username,
+        "password" => password
+      })
+
+    HTTPoison.post(
+      "#{base_url}/auth/login",
+      payload,
+      [{"Content-type", "application/json"}],
+      ssl: [verify: :verify_none]
+    )
+  end
+
+  @impl true
+  def get_system_id(base_url, auth, fully_qualified_domain_name) do
+    HTTPoison.get(
+      "#{base_url}/system/getId?name=#{fully_qualified_domain_name}",
+      [{"Content-type", "application/json"}],
+      hackney: [cookie: [auth]],
+      ssl: [verify: :verify_none]
+    )
+  end
+end

--- a/lib/trento/infrastructure/software_updates/state.ex
+++ b/lib/trento/infrastructure/software_updates/state.ex
@@ -1,0 +1,21 @@
+defmodule Trento.Infrastructure.SoftwareUpdates.Suma.State do
+  @moduledoc """
+  State for the SUMA Software Updates discovery adapter
+  """
+
+  defstruct [
+    :url,
+    :username,
+    :password,
+    :ca_cert,
+    :auth
+  ]
+
+  @type t :: %{
+          url: String.t() | nil,
+          username: String.t() | nil,
+          password: String.t() | nil,
+          ca_cert: String.t() | nil,
+          auth: String.t() | nil
+        }
+end

--- a/lib/trento/infrastructure/software_updates/suma.ex
+++ b/lib/trento/infrastructure/software_updates/suma.ex
@@ -1,0 +1,115 @@
+defmodule Trento.Infrastructure.SoftwareUpdates.Suma do
+  @moduledoc """
+  SUMA Software updates discovery adapter
+  """
+
+  @behaviour Trento.SoftwareUpdates.Discovery.Gen
+
+  use GenServer, restart: :transient
+
+  alias Trento.Infrastructure.SoftwareUpdates.{Suma.State, SumaApi}
+  alias Trento.SoftwareUpdates
+
+  require Logger
+
+  @default_name "suma"
+
+  def start_link([]), do: start_link(@default_name)
+
+  def start_link(server_name),
+    do: GenServer.start_link(__MODULE__, %State{}, name: process_identifier(server_name))
+
+  @impl true
+  def init(%State{} = state), do: {:ok, state}
+
+  def identify(server_name \\ @default_name),
+    do:
+      server_name
+      |> identificaton_tuple
+      |> :global.whereis_name()
+
+  def setup(server_name \\ @default_name),
+    do:
+      server_name
+      |> process_identifier
+      |> GenServer.call(:setup)
+
+  @impl true
+  def get_system_id(fully_qualified_domain_name, server_name \\ @default_name),
+    do:
+      server_name
+      |> process_identifier
+      |> GenServer.call({:get_system_id, fully_qualified_domain_name})
+
+  @impl true
+  def handle_call(:setup, _from, %State{} = state) do
+    case setup_auth(state) do
+      {:ok, new_state} ->
+        {:reply, :ok, new_state}
+
+      {:error, _} = error ->
+        {:reply, error, state}
+    end
+  end
+
+  @impl true
+  def handle_call(request, from, %State{auth: nil} = state),
+    do: {:noreply, state, {:continue, {:setup, from, request}}}
+
+  @impl true
+  def handle_call(
+        {:get_system_id, fully_qualified_domain_name},
+        _from,
+        %{
+          url: url,
+          auth: auth_cookie
+        } = state
+      ) do
+    {:reply, SumaApi.get_system_id(url, auth_cookie, fully_qualified_domain_name), state}
+  end
+
+  @impl true
+  def handle_continue({:setup, from, previous_message}, %State{} = state) do
+    case setup_auth(state) do
+      {:ok, new_state} ->
+        Process.send(self(), {previous_message, reply_to: from}, [:nosuspend, :noconnect])
+        {:noreply, new_state}
+
+      {:error, reason} ->
+        {:stop, reason}
+    end
+  end
+
+  @impl true
+  def handle_info(
+        {{:get_system_id, fully_qualified_domain_name}, reply_to: from},
+        %State{
+          url: url,
+          auth: auth_cookie
+        } = state
+      ) do
+    GenServer.reply(from, SumaApi.get_system_id(url, auth_cookie, fully_qualified_domain_name))
+
+    {:noreply, state}
+  end
+
+  defp process_identifier(server_name), do: {:global, identificaton_tuple(server_name)}
+
+  defp identificaton_tuple(server_name), do: {__MODULE__, server_name}
+
+  defp setup_auth(%State{} = state) do
+    with {:ok, %{url: url, username: username, password: password, ca_cert: ca_cert}} <-
+           SoftwareUpdates.get_settings(),
+         {:ok, auth_cookie} <- SumaApi.login(url, username, password) do
+      {:ok,
+       %State{
+         state
+         | url: url,
+           username: username,
+           password: password,
+           ca_cert: ca_cert,
+           auth: auth_cookie
+       }}
+    end
+  end
+end

--- a/lib/trento/infrastructure/software_updates/suma_api.ex
+++ b/lib/trento/infrastructure/software_updates/suma_api.ex
@@ -1,0 +1,110 @@
+defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
+  @moduledoc """
+  SUMA API client supporting software updates discovery.
+  """
+
+  require Logger
+
+  @login_retries 5
+
+  def login(url, username, password),
+    do:
+      url
+      |> get_suma_api_url()
+      |> try_login(username, password, @login_retries)
+
+  def get_system_id(url, auth, fully_qualified_domain_name) do
+    response =
+      url
+      |> get_suma_api_url()
+      |> http_executor().get_system_id(auth, fully_qualified_domain_name)
+
+    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- response,
+         {:ok, %{"success" => true, "result" => result}} <- Jason.decode(body),
+         {:ok, system_id} <- extract_system_id(result) do
+      {:ok, system_id}
+    else
+      error ->
+        Logger.error(
+          "Failed to get system id for host #{fully_qualified_domain_name}. Error: #{inspect(error)}"
+        )
+
+        {:error, :system_id_not_found}
+    end
+  end
+
+  defp get_suma_api_url(base_url),
+    do: String.trim_trailing(base_url, "/") <> "/rhn/manager/api"
+
+  defp try_login(_, _, _, 0) do
+    Logger.error("Failed to Log into SUSE Manager. Max retries reached.")
+    {:error, :max_login_retries_reached}
+  end
+
+  defp try_login(url, username, password, retry) do
+    case do_login(url, username, password) do
+      {:ok, _} = successful_login ->
+        successful_login
+
+      {:error, reason} ->
+        Logger.error("Failed to Log into SUSE Manager, retrying...", error: inspect(reason))
+        try_login(url, username, password, retry - 1)
+    end
+  end
+
+  defp do_login(url, username, password) do
+    case http_executor().login(url, username, password) do
+      {:ok, %HTTPoison.Response{headers: headers, status_code: 200} = response} ->
+        Logger.debug("Successfully logged into suma #{inspect(response)}")
+        {:ok, get_session_cookies(headers)}
+
+      {:ok, %HTTPoison.Response{status_code: _} = response} ->
+        Logger.error(
+          "Failed to login to SUSE Manager due to unsuccessful response. Response: #{inspect(response)}"
+        )
+
+        {:error, :login_error}
+
+      {:error, reason} ->
+        Logger.error("Failed to login to SUSE Manager due to an error. Error: #{inspect(reason)}")
+        {:error, :login_error}
+    end
+  end
+
+  def get_session_cookies(login_response_headers),
+    do:
+      login_response_headers
+      |> Enum.filter(&suma_session_cookie?(& 1))
+      |> Enum.map(fn {_, value} -> get_suma_session_cookie(value) end)
+      |> List.last()
+
+  defp suma_session_cookie?({header_name, header_value}),
+    do:
+      String.match?(header_name, ~r/\Aset-cookie\z/i) &&
+        match_suma_session_cookie(header_value)
+
+  defp match_suma_session_cookie(cookies),
+    do: String.starts_with?(cookies, "pxt-session-cookie=")
+
+  defp get_suma_session_cookie(cookies),
+    do:
+      cookies
+      |> String.split(";")
+      |> Enum.find(&match_suma_session_cookie(&1))
+
+  defp extract_system_id(result) do
+    with false <- Enum.empty?(result),
+         %{"id" => system_id} <- Enum.at(result, 0) do
+      {:ok, system_id}
+    else
+      _ ->
+        Logger.error(
+          "Could not get system id for host from suma result. Result: #{inspect(result)}"
+        )
+
+        {:error, :system_id_not_found}
+    end
+  end
+
+  defp http_executor, do: Application.fetch_env!(:trento, __MODULE__)[:executor]
+end

--- a/lib/trento/software_updates/discovery.ex
+++ b/lib/trento/software_updates/discovery.ex
@@ -1,0 +1,13 @@
+defmodule Trento.SoftwareUpdates.Discovery do
+  @moduledoc """
+  Software updates integration service
+  """
+
+  @behaviour Trento.SoftwareUpdates.Discovery.Gen
+
+  @impl true
+  def get_system_id(fully_qualified_domain_name),
+    do: adapter().get_system_id(fully_qualified_domain_name)
+
+  defp adapter, do: Application.fetch_env!(:trento, __MODULE__)[:adapter]
+end

--- a/lib/trento/software_updates/discovery/gen.ex
+++ b/lib/trento/software_updates/discovery/gen.ex
@@ -1,0 +1,8 @@
+defmodule Trento.SoftwareUpdates.Discovery.Gen do
+  @moduledoc """
+  Behaviour of the software updates discovery process.
+  """
+
+  @callback get_system_id(fully_qualified_domain_name :: String.t()) ::
+              {:ok, pos_integer()} | {:error, any}
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -14,6 +14,14 @@ Application.put_env(:trento, Trento.Infrastructure.Prometheus,
   adapter: Trento.Infrastructure.Prometheus.Mock
 )
 
+Mox.defmock(Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor.Mock,
+  for: Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor
+)
+
+Application.put_env(:trento, Trento.Infrastructure.SoftwareUpdates.SumaApi,
+  executor: Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor.Mock
+)
+
 Mox.defmock(Trento.Infrastructure.Messaging.Adapter.Mock,
   for: Trento.Infrastructure.Messaging.Adapter.Gen
 )

--- a/test/trento/infrastructure/software_updates/suma_test.exs
+++ b/test/trento/infrastructure/software_updates/suma_test.exs
@@ -1,0 +1,228 @@
+defmodule Trento.Infrastructure.SoftwareUpdates.SumaTest do
+  use Trento.DataCase
+
+  import Mox
+
+  import Trento.Factory
+
+  alias Trento.Infrastructure.SoftwareUpdates.Suma
+  alias Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor.Mock, as: SumaApiMock
+  alias Trento.Infrastructure.SoftwareUpdates.Suma.State
+  alias Trento.SoftwareUpdates.Settings
+
+  setup [:set_mox_from_context, :verify_on_exit!]
+
+  @test_integration_name "test_integration"
+
+  setup do
+    %Settings{} =
+      software_updates_settings =
+      insert(:software_updates_settings, [],
+        conflict_target: :id,
+        on_conflict: :replace_all
+      )
+
+    {:ok, %{settings: software_updates_settings}}
+  end
+
+  describe "Process start up and identification" do
+    test "should find an already started SUMA process" do
+      assert {_, {:already_started, pid}} = start_supervised(Suma)
+
+      assert pid == Suma.identify()
+    end
+
+    test "should start a new identifiable process" do
+      assert {:ok, pid} = start_supervised({Suma, @test_integration_name})
+
+      assert pid == Suma.identify(@test_integration_name)
+    end
+
+    test "should have expected initial state" do
+      {_, {:already_started, _}} = start_supervised(Suma)
+      {:ok, _} = start_supervised({Suma, @test_integration_name})
+
+      expected_state = %State{
+        url: nil,
+        username: nil,
+        password: nil,
+        ca_cert: nil,
+        auth: nil
+      }
+
+      assert :sys.get_state(Suma.identify()) == expected_state
+      assert :sys.get_state(Suma.identify(@test_integration_name)) == expected_state
+    end
+  end
+
+  describe "Setting up SUMA integration service" do
+    test "should setup SUMA state", %{
+      settings: %Settings{url: url, username: username, password: password, ca_cert: ca_cert}
+    } do
+      {:ok, _} = start_supervised({Suma, @test_integration_name})
+
+      base_api_url = "#{url}/rhn/manager/api"
+      ignored_cookie = "pxt-session-cookie=1234"
+      auth_cookie = "pxt-session-cookie=4321"
+
+      expect(SumaApiMock, :login, fn ^base_api_url, ^username, ^password ->
+        {:ok,
+         %HTTPoison.Response{
+           status_code: 200,
+           headers: [
+             {"Set-Cookie",
+              "JSESSIONID=FOOBAR; Path=/; Secure; HttpOnly; HttpOnly;HttpOnly;Secure"},
+             {"Set-Cookie",
+              "#{ignored_cookie}; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:10 GMT; Path=/; Secure; HttpOnly;HttpOnly;Secure"},
+             {"Set-Cookie",
+              "#{auth_cookie}; Max-Age=3600; Expires=Mon, 26 Feb 2024 10:53:57 GMT; Path=/; Secure; HttpOnly;HttpOnly;Secure"}
+           ]
+         }}
+      end)
+
+      assert :ok = Suma.setup(@test_integration_name)
+
+      expected_state = %State{
+        url: url,
+        username: username,
+        password: password,
+        ca_cert: ca_cert,
+        auth: auth_cookie
+      }
+
+      assert @test_integration_name
+             |> Suma.identify()
+             |> :sys.get_state() == expected_state
+    end
+
+    test "should handle error when reaching maximum login retries" do
+      {:ok, _} = start_supervised({Suma, @test_integration_name})
+
+      error_causes = [
+        {:ok, %HTTPoison.Response{status_code: 401}},
+        {:ok, %HTTPoison.Response{status_code: 503}},
+        {:error, %HTTPoison.Error{reason: "kaboom"}}
+      ]
+
+      for error_cause <- error_causes do
+        expect(SumaApiMock, :login, 5, fn _, _, _ -> error_cause end)
+
+        assert {:error, :max_login_retries_reached} = Suma.setup(@test_integration_name)
+
+        expected_state = %State{
+          url: nil,
+          username: nil,
+          password: nil,
+          ca_cert: nil,
+          auth: nil
+        }
+
+        assert @test_integration_name
+               |> Suma.identify()
+               |> :sys.get_state() == expected_state
+      end
+    end
+
+    test "should successfully login after retrying" do
+      {:ok, _} = start_supervised({Suma, @test_integration_name})
+
+      ignored_cookie = "pxt-session-cookie=1234"
+      auth_cookie = "pxt-session-cookie=4321"
+
+      responses = [
+        {:ok, %HTTPoison.Response{status_code: 401}},
+        {:error, %HTTPoison.Error{reason: "kaboom"}},
+        {:ok,
+         %HTTPoison.Response{
+           status_code: 200,
+           headers: [
+             {"Set-Cookie",
+              "JSESSIONID=FOOBAR; Path=/; Secure; HttpOnly; HttpOnly;HttpOnly;Secure"},
+             {"Set-Cookie",
+              "#{ignored_cookie}; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:10 GMT; Path=/; Secure; HttpOnly;HttpOnly;Secure"},
+             {"Set-Cookie",
+              "#{auth_cookie}; Max-Age=3600; Expires=Mon, 26 Feb 2024 10:53:57 GMT; Path=/; Secure; HttpOnly;HttpOnly;Secure"}
+           ]
+         }}
+      ]
+
+      {:ok, _} = Agent.start_link(fn -> 0 end, name: :login_call_iteration)
+
+      expect(SumaApiMock, :login, 3, fn _, _, _ ->
+        iteration = Agent.get(:login_call_iteration, & &1)
+
+        iteration_response = Enum.at(responses, iteration)
+        Agent.update(:login_call_iteration, &(&1 + 1))
+
+        iteration_response
+      end)
+
+      assert :ok = Suma.setup(@test_integration_name)
+
+      assert %State{
+               auth: ^auth_cookie
+             } =
+               @test_integration_name
+               |> Suma.identify()
+               |> :sys.get_state()
+    end
+  end
+
+  describe "Integration service" do
+    test "should return an error when a system id was not found for a given fqdn" do
+      {:ok, _} = start_supervised({Suma, @test_integration_name})
+
+      fqdn = "machine.fqdn.internal"
+
+      expect(SumaApiMock, :login, 1, fn _, _, _ -> successful_login_response() end)
+
+      error_causes = [
+        {:ok, %HTTPoison.Response{status_code: 200, body: ~s({"success":true,"result":[]})}},
+        {:ok, %HTTPoison.Response{status_code: 404}},
+        {:ok, %HTTPoison.Response{status_code: 503}},
+        {:error, %HTTPoison.Error{reason: "kaboom"}}
+      ]
+
+      for error_cause <- error_causes do
+        expect(SumaApiMock, :get_system_id, 1, fn _, _, ^fqdn -> error_cause end)
+
+        assert {:error, :system_id_not_found} = Suma.get_system_id(fqdn, @test_integration_name)
+      end
+    end
+
+    test "should get a system for a given fqdn" do
+      {:ok, _} = start_supervised({Suma, @test_integration_name})
+
+      fqdn = "machine.fqdn.internal"
+
+      expect(SumaApiMock, :login, 1, fn _, _, _ -> successful_login_response() end)
+
+      expect(SumaApiMock, :get_system_id, 1, fn _, _, ^fqdn ->
+        {:ok,
+         %HTTPoison.Response{
+           status_code: 200,
+           body: ~s({"success": true,"result": [{"id":1000010001}]})
+         }}
+      end)
+
+      assert {:ok, 1_000_010_001} = Suma.get_system_id(fqdn, @test_integration_name)
+    end
+  end
+
+  defp successful_login_response(
+         auth_cookie \\ "pxt-session-cookie=4321",
+         ignored_cookie \\ "pxt-session-cookie=1234"
+       ) do
+    {:ok,
+     %HTTPoison.Response{
+       status_code: 200,
+       headers: [
+         {"Set-Cookie", "JSESSIONID=FOOBAR; Path=/; Secure; HttpOnly; HttpOnly;HttpOnly;Secure"},
+         {"Set-Cookie",
+          "#{ignored_cookie}; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:10 GMT; Path=/; Secure; HttpOnly;HttpOnly;Secure"},
+         {"Set-Cookie",
+          "#{auth_cookie}; Max-Age=3600; Expires=Mon, 26 Feb 2024 10:53:57 GMT; Path=/; Secure; HttpOnly;HttpOnly;Secure"}
+       ]
+     }}
+  end
+end


### PR DESCRIPTION
# Description

This PR adds an integration service for SUMA software updates discovery, as a GenServer.
This service mainly keeps track of settings/credentials and authentication against suma.
Available features/interactions:
- `setup`: sets up the state of the process by loading stored credentials and attempting a login (login is retried 5 times before giving up)
- `get_system_id`: gets the system id for a given fqdn. if the process was never setup and no authentication is available, the setup step is invoked before querying suma for the system id
- process is globally registered as [indicated here](https://hexdocs.pm/elixir/1.15.7/GenServer.html#module-name-registration)
- for demo purposes a mock of the integration is provided as `MockSuma`

Notes: 
- setup comes handy when we change settings/creds for instance and we want to re-set service state with new info
- the name to be passed to the service is mainly for testing purposes, here's [Valim's take on that](https://elixirforum.com/t/exunit-start-supervisor-2-is-persisting-process-state-between-tests/15421/3)

TODO:
- intercept cookie expiration, ie when we get a 401 from an api we try logging in first
- hide sensitive info in process state (password, ca_cert, auth cookie) from inspection. Thanks @dottorblaster for [raising this up](https://gabrielpereira.dev/en/posts/protecting-sensitive-data-in-elixir-gen-servers/)
- handle ca_cert 

## How was this tested?

Automated tests added plus manual testing against a real suma instance.