### PR TITLE
Add missing timestamps to ecto schemas

### DIFF
--- a/lib/trento/clusters/cluster_enrichment_data.ex
+++ b/lib/trento/clusters/cluster_enrichment_data.ex
@@ -13,6 +13,8 @@ defmodule Trento.Clusters.ClusterEnrichmentData do
   @primary_key {:cluster_id, :binary_id, autogenerate: false}
   schema "clusters_enrichment_data" do
     field :cib_last_written, :string
+
+    timestamps(type: :utc_datetime_usec)
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()

--- a/lib/trento/clusters/projections/cluster_read_model.ex
+++ b/lib/trento/clusters/projections/cluster_read_model.ex
@@ -35,6 +35,8 @@ defmodule Trento.Clusters.Projections.ClusterReadModel do
     field :cib_last_written, :string, virtual: true
 
     field :deregistered_at, :utc_datetime_usec
+
+    timestamps(type: :utc_datetime_usec)
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()

--- a/lib/trento/heartbeats/heartbeat.ex
+++ b/lib/trento/heartbeats/heartbeat.ex
@@ -10,6 +10,8 @@ defmodule Trento.Heartbeats.Heartbeat do
   @primary_key {:agent_id, :string, autogenerate: false}
   schema "heartbeats" do
     field :timestamp, :utc_datetime_usec
+
+    timestamps(type: :utc_datetime_usec)
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()

--- a/lib/trento/hosts/projections/host_read_model.ex
+++ b/lib/trento/hosts/projections/host_read_model.ex
@@ -40,6 +40,7 @@ defmodule Trento.Hosts.Projections.HostReadModel do
     field :last_heartbeat_timestamp, :utc_datetime_usec, virtual: true
 
     field :deregistered_at, :utc_datetime_usec
+    timestamps(type: :utc_datetime_usec)
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()

--- a/lib/trento/hosts/projections/host_telemetry_read_model.ex
+++ b/lib/trento/hosts/projections/host_telemetry_read_model.ex
@@ -27,7 +27,7 @@ defmodule Trento.Hosts.Projections.HostTelemetryReadModel do
 
     field :provider, Ecto.Enum, values: Provider.values()
 
-    timestamps()
+    timestamps(type: :utc_datetime_usec)
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()

--- a/lib/trento/hosts/projections/sles_subscription_read_model.ex
+++ b/lib/trento/hosts/projections/sles_subscription_read_model.ex
@@ -22,7 +22,7 @@ defmodule Trento.Hosts.Projections.SlesSubscriptionReadModel do
     field :starts_at, :string
     field :expires_at, :string
 
-    timestamps()
+    timestamps(type: :utc_datetime_usec)
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()

--- a/lib/trento/sap_systems/projections/application_instance_read_model.ex
+++ b/lib/trento/sap_systems/projections/application_instance_read_model.ex
@@ -32,6 +32,8 @@ defmodule Trento.SapSystems.Projections.ApplicationInstanceReadModel do
       references: :host_id,
       foreign_key: :id,
       where: [deregistered_at: nil]
+
+    timestamps(type: :utc_datetime_usec)
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()

--- a/lib/trento/sap_systems/projections/database_instance_read_model.ex
+++ b/lib/trento/sap_systems/projections/database_instance_read_model.ex
@@ -35,6 +35,8 @@ defmodule Trento.SapSystems.Projections.DatabaseInstanceReadModel do
       references: :host_id,
       foreign_key: :id,
       where: [deregistered_at: nil]
+
+    timestamps(type: :utc_datetime_usec)
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()

--- a/lib/trento/sap_systems/projections/database_read_model.ex
+++ b/lib/trento/sap_systems/projections/database_read_model.ex
@@ -28,6 +28,8 @@ defmodule Trento.SapSystems.Projections.DatabaseReadModel do
       preload_order: [asc: :instance_number, asc: :host_id]
 
     field :deregistered_at, :utc_datetime_usec
+
+    timestamps(type: :utc_datetime_usec)
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()

--- a/lib/trento/sap_systems/projections/sap_system_read_model.ex
+++ b/lib/trento/sap_systems/projections/sap_system_read_model.ex
@@ -41,6 +41,8 @@ defmodule Trento.SapSystems.Projections.SapSystemReadModel do
     has_many :tags, Tag, foreign_key: :resource_id
 
     field :deregistered_at, :utc_datetime_usec
+
+    timestamps(type: :utc_datetime_usec)
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()

--- a/lib/trento/settings/settings.ex
+++ b/lib/trento/settings/settings.ex
@@ -11,6 +11,8 @@ defmodule Trento.Settings.Settings do
   @primary_key {:installation_id, :binary_id, autogenerate: false}
   schema "settings" do
     field :eula_accepted, :boolean
+
+    timestamps(type: :utc_datetime_usec)
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()

--- a/lib/trento/tags/tag.ex
+++ b/lib/trento/tags/tag.ex
@@ -14,6 +14,8 @@ defmodule Trento.Tags.Tag do
     field :value, :string
     field :resource_id, Ecto.UUID
     field :resource_type, Ecto.Enum, values: [:host, :cluster, :sap_system, :database]
+
+    timestamps(type: :utc_datetime_usec)
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()

--- a/lib/trento/users/user.ex
+++ b/lib/trento/users/user.ex
@@ -12,7 +12,7 @@ defmodule Trento.Users.User do
   schema "users" do
     pow_user_fields()
 
-    timestamps()
+    timestamps(type: :utc_datetime_usec)
   end
 
   def changeset(user, attrs) do

--- a/lib/trento_web/openapi/v1/schema/cluster.ex
+++ b/lib/trento_web/openapi/v1/schema/cluster.ex
@@ -153,7 +153,9 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Cluster do
           nullable: true
         },
         details: Details,
-        tags: Tags
+        tags: Tags,
+        inserted_at: %Schema{type: :string, format: :datetime},
+        updated_at: %Schema{type: :string, format: :datetime, nullable: true}
       }
     })
   end

--- a/lib/trento_web/openapi/v1/schema/database.ex
+++ b/lib/trento_web/openapi/v1/schema/database.ex
@@ -48,7 +48,9 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Database do
           type: :string,
           description: "System Replication Status"
         },
-        health: ResourceHealth
+        health: ResourceHealth,
+        inserted_at: %Schema{type: :string, format: :datetime},
+        updated_at: %Schema{type: :string, format: :datetime, nullable: true}
       }
     })
   end
@@ -78,7 +80,9 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Database do
         sid: %Schema{type: :string, description: "SID"},
         health: ResourceHealth,
         database_instances: DatabaseInstances,
-        tags: Tags
+        tags: Tags,
+        inserted_at: %Schema{type: :string, format: :datetime},
+        updated_at: %Schema{type: :string, format: :datetime, nullable: true}
       }
     })
   end

--- a/lib/trento_web/openapi/v1/schema/host.ex
+++ b/lib/trento_web/openapi/v1/schema/host.ex
@@ -98,7 +98,9 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Host do
           type: :string,
           nullable: true,
           format: :"date-time"
-        }
+        },
+        inserted_at: %Schema{type: :string, format: :datetime},
+        updated_at: %Schema{type: :string, format: :datetime, nullable: true}
       }
     })
   end

--- a/lib/trento_web/openapi/v1/schema/sap_system.ex
+++ b/lib/trento_web/openapi/v1/schema/sap_system.ex
@@ -44,7 +44,9 @@ defmodule TrentoWeb.OpenApi.V1.Schema.SAPSystem do
           description: "Identifier of the host where current instance is running",
           format: :uuid
         },
-        health: ResourceHealth
+        health: ResourceHealth,
+        inserted_at: %Schema{type: :string, format: :datetime},
+        updated_at: %Schema{type: :string, format: :datetime, nullable: true}
       }
     })
   end
@@ -75,7 +77,9 @@ defmodule TrentoWeb.OpenApi.V1.Schema.SAPSystem do
           items: ApplicationInstance
         },
         database_instances: Database.DatabaseInstances,
-        tags: Tags
+        tags: Tags,
+        inserted_at: %Schema{type: :string, format: :datetime},
+        updated_at: %Schema{type: :string, format: :datetime, nullable: true}
       }
     })
   end

--- a/lib/trento_web/openapi/v1/schema/tag.ex
+++ b/lib/trento_web/openapi/v1/schema/tag.ex
@@ -18,7 +18,9 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Tags do
         id: %Schema{type: :integer},
         resource_id: %Schema{type: :string, format: :uuid},
         resource_type: %Schema{type: :string, enum: [:host, :cluster, :sap_system, :database]},
-        value: %Schema{type: :string}
+        value: %Schema{type: :string},
+        inserted_at: %Schema{type: :string, format: :datetime},
+        updated_at: %Schema{type: :string, format: :datetime, nullable: true}
       }
     })
   end

--- a/lib/trento_web/openapi/v2/schema/cluster.ex
+++ b/lib/trento_web/openapi/v2/schema/cluster.ex
@@ -263,7 +263,9 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
           nullable: true
         },
         details: Details,
-        tags: Tags
+        tags: Tags,
+        inserted_at: %Schema{type: :string, format: :datetime},
+        updated_at: %Schema{type: :string, format: :datetime, nullable: true}
       }
     })
   end

--- a/priv/repo/migrations/20240221134250_add_missing_timestamps.exs
+++ b/priv/repo/migrations/20240221134250_add_missing_timestamps.exs
@@ -1,0 +1,39 @@
+defmodule Trento.Repo.Migrations.AddMissingTimestamps do
+  use Ecto.Migration
+
+  def change do
+    [
+      :heartbeats,
+      :hosts,
+      :clusters,
+      :database_instances,
+      :sap_systems,
+      :application_instances,
+      :databases,
+      :tags,
+      :settings,
+      :clusters_enrichment_data
+    ]
+    |> Enum.each(fn table ->
+      alter table(table) do
+        # We add the default value to deal with already existing records, otherwise the not-null constraint of timestamps is triggered
+        timestamps(default: "NOW()", type: :utc_datetime_usec)
+      end
+    end)
+
+    [
+      :users,
+      :projection_versions,
+      :sles_subscriptions,
+      :discovery_events,
+      :hosts_telemetry,
+      :discarded_discovery_events
+    ]
+    |> Enum.each(fn table ->
+      alter table(table) do
+        modify :inserted_at, :utc_datetime_usec, default: "NOW()"
+        modify :updated_at, :utc_datetime_usec, default: "NOW()"
+      end
+    end)
+  end
+end


### PR DESCRIPTION
# Description

This pr adds the missing timestamps fields to all ecto schemas for minimal auditability.

## How was this tested?

Automated tests, manual rollback and migration checking.