### PR TITLE
Change host's health based on software updates discovery result

### DIFF
--- a/lib/trento/hosts/commands/complete_software_updates_discovery.ex
+++ b/lib/trento/hosts/commands/complete_software_updates_discovery.ex
@@ -1,0 +1,16 @@
+defmodule Trento.Hosts.Commands.CompleteSoftwareUpdatesDiscovery do
+  @moduledoc """
+  Complete the software updates discovery with the detected info
+  """
+
+  alias Trento.Hosts.ValueObjects.RelevantPatches
+
+  @required_fields :all
+
+  use Trento.Support.Command
+
+  defcommand do
+    field :host_id, Ecto.UUID
+    embeds_one :relevant_patches, RelevantPatches
+  end
+end

--- a/lib/trento/hosts/events/software_updates_discovery_completed.ex
+++ b/lib/trento/hosts/events/software_updates_discovery_completed.ex
@@ -1,0 +1,14 @@
+defmodule Trento.Hosts.Events.SoftwareUpdatesDiscoveryCompleted do
+  @moduledoc """
+  This event is emitted when a host's software updates discovery process complete
+  """
+
+  alias Trento.Hosts.ValueObjects.RelevantPatches
+
+  use Trento.Support.Event
+
+  defevent do
+    field :host_id, Ecto.UUID
+    embeds_one :relevant_patches, RelevantPatches
+  end
+end

--- a/lib/trento/hosts/value_objects/relevant_patches.ex
+++ b/lib/trento/hosts/value_objects/relevant_patches.ex
@@ -8,7 +8,6 @@ defmodule Trento.Hosts.ValueObjects.RelevantPatches do
   use Trento.Support.Type
 
   deftype do
-    field :total, :integer, default: 0
     field :security_advisories, :integer, default: 0
     field :bug_fixes, :integer, default: 0
     field :software_enhancements, :integer, default: 0

--- a/lib/trento/hosts/value_objects/relevant_patches.ex
+++ b/lib/trento/hosts/value_objects/relevant_patches.ex
@@ -1,0 +1,16 @@
+defmodule Trento.Hosts.ValueObjects.RelevantPatches do
+  @moduledoc """
+  Represents a host's relevant patches counts
+  """
+
+  @required_fields nil
+
+  use Trento.Support.Type
+
+  deftype do
+    field :total, :integer, default: 0
+    field :security_advisories, :integer, default: 0
+    field :bug_fixes, :integer, default: 0
+    field :software_enhancements, :integer, default: 0
+  end
+end

--- a/lib/trento/router.ex
+++ b/lib/trento/router.ex
@@ -13,6 +13,7 @@ defmodule Trento.Router do
 
   alias Trento.Hosts.Commands.{
     CompleteHostChecksExecution,
+    CompleteSoftwareUpdatesDiscovery,
     DeregisterHost,
     RegisterHost,
     RequestHostDeregistration,
@@ -52,7 +53,8 @@ defmodule Trento.Router do
              RollUpHost,
              RequestHostDeregistration,
              DeregisterHost,
-             CompleteHostChecksExecution
+             CompleteHostChecksExecution,
+             CompleteSoftwareUpdatesDiscovery
            ],
            to: Hosts.Host,
            lifespan: Hosts.Lifespan

--- a/test/trento/hosts/host_test.exs
+++ b/test/trento/hosts/host_test.exs
@@ -1411,36 +1411,6 @@ defmodule Trento.Hosts.HostTest do
       )
     end
 
-    test "should not accept inconsistent software updates discovery" do
-      host_id = Faker.UUID.v4()
-
-      inconsistent_scenarios = [
-        %{
-          total: 5,
-          security_advisories: 5,
-          bug_fixes: 2,
-          software_enhancements: 0
-        },
-        %{
-          total: 0,
-          security_advisories: 5,
-          bug_fixes: 2,
-          software_enhancements: 0
-        }
-      ]
-
-      for inconsistent_patches <- inconsistent_scenarios do
-        assert_error(
-          build(:host_registered_event, host_id: host_id),
-          CompleteSoftwareUpdatesDiscovery.new!(%{
-            host_id: host_id,
-            relevant_patches: inconsistent_patches
-          }),
-          {:error, :inconsistent_software_updates_discovery}
-        )
-      end
-    end
-
     test "should handle host's health change based on software updates discovery" do
       host_id = Faker.UUID.v4()
 
@@ -1448,7 +1418,6 @@ defmodule Trento.Hosts.HostTest do
         %{
           initial_host_health: Health.passing(),
           relevant_patches: %{
-            total: 5,
             security_advisories: 5,
             bug_fixes: 0,
             software_enhancements: 0
@@ -1459,7 +1428,6 @@ defmodule Trento.Hosts.HostTest do
         %{
           initial_host_health: Health.passing(),
           relevant_patches: %{
-            total: 7,
             security_advisories: 0,
             bug_fixes: 4,
             software_enhancements: 3
@@ -1470,7 +1438,6 @@ defmodule Trento.Hosts.HostTest do
         %{
           initial_host_health: Health.passing(),
           relevant_patches: %{
-            total: 0,
             security_advisories: 0,
             bug_fixes: 0,
             software_enhancements: 0
@@ -1482,7 +1449,6 @@ defmodule Trento.Hosts.HostTest do
         %{
           initial_host_health: Health.warning(),
           relevant_patches: %{
-            total: 50,
             security_advisories: 5,
             bug_fixes: 3,
             software_enhancements: 42
@@ -1493,7 +1459,6 @@ defmodule Trento.Hosts.HostTest do
         %{
           initial_host_health: Health.warning(),
           relevant_patches: %{
-            total: 0,
             security_advisories: 0,
             bug_fixes: 0,
             software_enhancements: 0
@@ -1504,7 +1469,6 @@ defmodule Trento.Hosts.HostTest do
         %{
           initial_host_health: Health.warning(),
           relevant_patches: %{
-            total: 45,
             security_advisories: 0,
             bug_fixes: 3,
             software_enhancements: 42
@@ -1517,7 +1481,6 @@ defmodule Trento.Hosts.HostTest do
           initial_host_health: Health.critical(),
           initial_heartbeat: :heartbeat_failed,
           relevant_patches: %{
-            total: 5,
             security_advisories: 0,
             bug_fixes: 0,
             software_enhancements: 5
@@ -1529,7 +1492,6 @@ defmodule Trento.Hosts.HostTest do
         %{
           initial_host_health: Health.critical(),
           relevant_patches: %{
-            total: 5,
             security_advisories: 5,
             bug_fixes: 0,
             software_enhancements: 0
@@ -1541,7 +1503,6 @@ defmodule Trento.Hosts.HostTest do
         %{
           initial_host_health: Health.critical(),
           relevant_patches: %{
-            total: 5,
             security_advisories: 0,
             bug_fixes: 5,
             software_enhancements: 0
@@ -1552,7 +1513,6 @@ defmodule Trento.Hosts.HostTest do
         %{
           initial_host_health: Health.critical(),
           relevant_patches: %{
-            total: 0,
             security_advisories: 0,
             bug_fixes: 0,
             software_enhancements: 0
@@ -1609,8 +1569,7 @@ defmodule Trento.Hosts.HostTest do
             assert %Host{
                      health: ^expected_host_health,
                      software_updates_discovery_health:
-                       ^expected_software_updates_discovery_health,
-                     relevant_patches: ^relevant_patches
+                       ^expected_software_updates_discovery_health
                    } = host
           end
         )


### PR DESCRIPTION
# Description

This PR adds the domain logic to handle software updates discovery.
- a new event `SoftwareUpdatesDiscoveryCompleted` is emitted containing the discovered relevant patches counts. Needed to properly update aggregate state and opens the possibility to project such data if needed and to possibly broadcast via websockets interesting information that might be useful for the UX.
-  based on what has been discovered also a `HostHealthChanged` event might be emitted

I think we might need extra domain interactions related to software updates discovery business process that would allow us to answer the following:
- what happens when a user clears up suma settings? should we invalidate latest discovery data and ignore it in host's aggregated health?
- if we don't do anything when clearing up settings, we might wait for _the watch process_ :tm: next tick, however also in that case we need to decide what to do if a discovery had previously ran, but now we do not have settings anymore.

## How was this tested?

Automated tests added.