### PR TITLE
Add the ability to get relevant patches given a SUMA system ID

### DIFF
--- a/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
+++ b/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
@@ -14,25 +14,27 @@ defmodule Trento.Infrastructure.SoftwareUpdates.MockSuma do
        |> Enum.sum()}
 
   @impl true
-  def get_relevant_patches(system_id),
-    do: [
-      %{
-        date: "2024-02-27",
-        advisory_name: "SUSE-15-SP4-2024-630",
-        advisory_type: "Bug Fix Advisory",
-        advisory_status: "stable",
-        id: 4182,
-        advisory_synopsis: "Recommended update for cloud-netconfig",
-        update_date: "2024-02-27"
-      },
-      %{
-        date: "2024-02-26",
-        advisory_name: "SUSE-15-SP4-2024-619",
-        advisory_type: "Security Advisory",
-        advisory_status: "stable",
-        id: 4174,
-        advisory_synopsis: "important: Security update for java-1_8_0-ibm",
-        update_date: "2024-02-26"
-      }
-    ]
+  def get_relevant_patches(_system_id),
+    do:
+      {:ok,
+       [
+         %{
+           date: "2024-02-27",
+           advisory_name: "SUSE-15-SP4-2024-630",
+           advisory_type: "Bug Fix Advisory",
+           advisory_status: "stable",
+           id: 4182,
+           advisory_synopsis: "Recommended update for cloud-netconfig",
+           update_date: "2024-02-27"
+         },
+         %{
+           date: "2024-02-26",
+           advisory_name: "SUSE-15-SP4-2024-619",
+           advisory_type: "Security Advisory",
+           advisory_status: "stable",
+           id: 4174,
+           advisory_synopsis: "important: Security update for java-1_8_0-ibm",
+           update_date: "2024-02-26"
+         }
+       ]}
 end

--- a/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
+++ b/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
@@ -12,4 +12,27 @@ defmodule Trento.Infrastructure.SoftwareUpdates.MockSuma do
        fully_qualified_domain_name
        |> String.to_charlist()
        |> Enum.sum()}
+
+  @impl true
+  def get_relevant_patches(system_id),
+    do: [
+      %{
+        date: "2024-02-27",
+        advisory_name: "SUSE-15-SP4-2024-630",
+        advisory_type: "Bug Fix Advisory",
+        advisory_status: "stable",
+        id: 4182,
+        advisory_synopsis: "Recommended update for cloud-netconfig",
+        update_date: "2024-02-27"
+      },
+      %{
+        date: "2024-02-26",
+        advisory_name: "SUSE-15-SP4-2024-619",
+        advisory_type: "Security Advisory",
+        advisory_status: "stable",
+        id: 4174,
+        advisory_synopsis: "important: Security update for java-1_8_0-ibm",
+        update_date: "2024-02-26"
+      }
+    ]
 end

--- a/lib/trento/infrastructure/software_updates/adapter/suma_http_executor.ex
+++ b/lib/trento/infrastructure/software_updates/adapter/suma_http_executor.ex
@@ -13,6 +13,13 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor do
             ) ::
               {:ok, HTTPoison.Response.t()} | {:error, HTTPoison.Error.t()}
 
+  @callback get_relevant_patches(
+              base_url :: String.t(),
+              auth :: String.t(),
+              system_id :: pos_integer()
+            ) ::
+              {:ok, HTTPoison.Response.t()} | {:error, HTTPoison.Error.t()}
+
   @behaviour Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor
 
   @impl true
@@ -35,6 +42,16 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor do
   def get_system_id(base_url, auth, fully_qualified_domain_name) do
     HTTPoison.get(
       "#{base_url}/system/getId?name=#{fully_qualified_domain_name}",
+      [{"Content-type", "application/json"}],
+      hackney: [cookie: [auth]],
+      ssl: [verify: :verify_none]
+    )
+  end
+
+  @impl true
+  def get_relevant_patches(base_url, auth, system_id) do
+    HTTPoison.get(
+      "#{base_url}/system/getRelevantErrata?sid=#{system_id}",
       [{"Content-type", "application/json"}],
       hackney: [cookie: [auth]],
       ssl: [verify: :verify_none]

--- a/lib/trento/infrastructure/software_updates/suma.ex
+++ b/lib/trento/infrastructure/software_updates/suma.ex
@@ -42,6 +42,10 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma do
       |> GenServer.call({:get_system_id, fully_qualified_domain_name})
 
   @impl true
+  def get_relevant_patches(system_id) do
+  end
+
+  @impl true
   def handle_call(:setup, _from, %State{} = state) do
     case setup_auth(state) do
       {:ok, new_state} ->

--- a/lib/trento/infrastructure/software_updates/suma_api.ex
+++ b/lib/trento/infrastructure/software_updates/suma_api.ex
@@ -33,6 +33,20 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
     end
   end
 
+  def get_relevant_patches(url, auth, system_id) do
+    response = http_executor().get_relevant_patches(url, auth, system_id)
+
+    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- response,
+         {:ok, %{success: true, result: result}} <- Jason.decode(body, keys: :atoms) do
+      {:ok, result}
+    else
+      error ->
+        Logger.error("Failed to get errata for system ID #{system_id}. Error: #{inspect(error)}")
+
+        {:error, :error_getting_patches}
+    end
+  end
+
   defp get_suma_api_url(base_url),
     do: String.trim_trailing(base_url, "/") <> "/rhn/manager/api"
 

--- a/lib/trento/software_updates/discovery.ex
+++ b/lib/trento/software_updates/discovery.ex
@@ -9,5 +9,9 @@ defmodule Trento.SoftwareUpdates.Discovery do
   def get_system_id(fully_qualified_domain_name),
     do: adapter().get_system_id(fully_qualified_domain_name)
 
+  @impl true
+  def get_relevant_patches(system_id),
+    do: adapter().get_relevant_patches(system_id)
+
   defp adapter, do: Application.fetch_env!(:trento, __MODULE__)[:adapter]
 end

--- a/lib/trento/software_updates/discovery/gen.ex
+++ b/lib/trento/software_updates/discovery/gen.ex
@@ -5,4 +5,7 @@ defmodule Trento.SoftwareUpdates.Discovery.Gen do
 
   @callback get_system_id(fully_qualified_domain_name :: String.t()) ::
               {:ok, pos_integer()} | {:error, any}
+
+  @callback get_relevant_patches(system_id :: pos_integer()) ::
+              {:ok, [map]} | {:error, any}
 end


### PR DESCRIPTION
# Description

Adds the ability to retrieve relevant patches for a given SUMA system ID.

## How was this tested?

Added unit test for GenServer HTTP service
