### PR TITLE
Redact sensitive data in SUMA GenServer state

### DIFF
--- a/lib/trento/infrastructure/software_updates/state.ex
+++ b/lib/trento/infrastructure/software_updates/state.ex
@@ -2,6 +2,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma.State do
   @moduledoc """
   State for the SUMA Software Updates discovery adapter
   """
+  alias __MODULE__
 
   defstruct [
     :url,
@@ -18,4 +19,19 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma.State do
           ca_cert: String.t() | nil,
           auth: String.t() | nil
         }
+
+  defimpl Inspect, for: State do
+    def inspect(%State{url: url, username: username}, opts) do
+      Inspect.Map.inspect(
+        %{
+          url: url,
+          username: username,
+          password: "<REDACTED>",
+          auth: "<REDACTED>",
+          ca_cert: "<REDACTED>"
+        },
+        opts
+      )
+    end
+  end
 end


### PR DESCRIPTION
# Description

This PR redacts sensitive data (`password`, `auth`, `ca_cert`) in the SUMA GenServer state when the GenServer is inspected or logged. More concretely, a custom `Inspect` protocol is implemented for the GenServer's `State` struct, thereby redacting said fields when inspections such as `:sys.get_state/1` or `:sys.get_status/1` are called.

## How was this tested?

Added unit test
