### PR TITLE
Add a clear operation to suma service

### DIFF
--- a/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
+++ b/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
@@ -37,4 +37,6 @@ defmodule Trento.Infrastructure.SoftwareUpdates.MockSuma do
            update_date: "2024-02-26"
          }
        ]}
+
+  def clear, do: :ok
 end

--- a/lib/trento/infrastructure/software_updates/suma.ex
+++ b/lib/trento/infrastructure/software_updates/suma.ex
@@ -34,6 +34,12 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma do
       |> process_identifier
       |> GenServer.call(:setup)
 
+  def clear(server_name \\ @default_name),
+    do:
+      server_name
+      |> process_identifier
+      |> GenServer.call(:clear)
+
   @impl true
   def get_system_id(fully_qualified_domain_name, server_name \\ @default_name),
     do:
@@ -58,6 +64,9 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma do
         {:reply, error, state}
     end
   end
+
+  @impl true
+  def handle_call(:clear, _, _), do: {:reply, :ok, %State{}}
 
   @impl true
   def handle_call(request, _, %State{auth: nil} = state),


### PR DESCRIPTION
# Description

Adding a clear feature to the suma integration service that wipes out its internal state.

We might end up in adding the `clear` function in the discovery behaviour, but I'll add that later if actually needed (I guess so :smile: )

## How was this tested?

Automated tests.