### PR TITLE
Api key expiration frontend notifications

### DIFF
--- a/assets/js/common/DismissableToast/DismissableToast.jsx
+++ b/assets/js/common/DismissableToast/DismissableToast.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { toast } from 'react-hot-toast';
 
-function DismissableToast({ text, toastInstance }) {
+function DismissableToast({ text, toastID }) {
   return (
     <div className="flex space-x-4">
       <p className="text-sm font-medium text-gray-900">{text}</p>
       <button
         type="button"
         className="text-jungle-green-500"
-        onClick={() => toast.dismiss(toastInstance.id)}
+        onClick={() => toast.dismiss(toastID)}
       >
         Close
       </button>

--- a/assets/js/common/DismissableToast/DismissableToast.jsx
+++ b/assets/js/common/DismissableToast/DismissableToast.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { toast } from 'react-hot-toast';
+
+function DismissableToast({ text, toastInstance }) {
+  return (
+    <div className="flex space-x-4">
+      <p className="text-sm font-medium text-gray-900">{text}</p>
+      <button
+        type="button"
+        className="text-jungle-green-500"
+        onClick={() => toast.dismiss(toastInstance.id)}
+      >
+        Close
+      </button>
+    </div>
+  );
+}
+
+export default DismissableToast;

--- a/assets/js/common/DismissableToast/DismissableToast.test.jsx
+++ b/assets/js/common/DismissableToast/DismissableToast.test.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { toast } from 'react-hot-toast';
+import { screen, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+
+import DismissableToast from '.';
+
+describe('DismissableToast component', () => {
+  afterEach(() => {
+    // restore the spy created with spyOn
+    jest.restoreAllMocks();
+  });
+
+  it('renders the text and forward the onclick event with the provided prop id', async () => {
+    const spy = jest.spyOn(toast, 'dismiss');
+    const toastID = 'toast-1';
+    const user = userEvent.setup();
+
+    render(<DismissableToast text="test" id={toastID} />);
+
+    expect(screen.getByText('test')).toBeVisible();
+    await user.click(screen.getByText('Close'));
+
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/assets/js/common/DismissableToast/index.js
+++ b/assets/js/common/DismissableToast/index.js
@@ -1,0 +1,3 @@
+import DismissableToast from './DismissableToast';
+
+export default DismissableToast;

--- a/assets/js/lib/test-utils/factories/settings.js
+++ b/assets/js/lib/test-utils/factories/settings.js
@@ -1,0 +1,11 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { faker } from '@faker-js/faker';
+import { Factory } from 'fishery';
+import { formatISO } from 'date-fns';
+
+export const apiKeySettingsFactory = Factory.define(() => ({
+  expire_at: formatISO(faker.date.future()),
+  created_at: formatISO(faker.date.past()),
+  generated_api_key:
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0cmVudG9fYXBpX2tleSIsImV4cCI6MTcxMjE1MzE3MCwiaWF0IjoxNzA5NzMzOTcxLCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vdHJlbnRvLXByb2plY3Qvd2ViIiwianRpIjoiYmZmMjA0YjUtMzJmMS00YmVlLThiMGItY2IxZGQwNTlmNGRjIiwibmJmIjoxNzA5NzMzOTcxLCJ0eXAiOiJCZWFyZXIifQ.0Lz0MwZaFpIGbSohnkiJ6AN5FFb5Vg5ZVhqM3fdUf3M',
+}));

--- a/assets/js/state/notifications.js
+++ b/assets/js/state/notifications.js
@@ -1,7 +1,26 @@
 import { createAction } from '@reduxjs/toolkit';
 
 export const NOTIFICATION = 'NOTIFICATION';
+export const DISMISSABLE_NOTIFICATION = 'DISMISSABLE_NOTIFICATION';
+export const DISMISS_NOTIFICATION = 'DISMISS_NOTIFICATION';
 
-export const notify = createAction(NOTIFICATION, ({ text, icon }) => ({
-  payload: { text, icon },
-}));
+export const notify = createAction(
+  NOTIFICATION,
+  ({ text, icon, id, duration }) => ({
+    payload: { text, icon, id, duration },
+  })
+);
+
+export const dismissableNotify = createAction(
+  DISMISSABLE_NOTIFICATION,
+  ({ text, icon, id, duration }) => ({
+    payload: { text, icon, id, duration },
+  })
+);
+
+export const dismissNotification = createAction(
+  DISMISS_NOTIFICATION,
+  ({ notificationID }) => ({
+    payload: { notificationID },
+  })
+);

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -77,6 +77,7 @@ import { watchSoftwareUpdateSettings } from '@state/sagas/softwareUpdatesSetting
 import { initSocketConnection } from '@lib/network/socket';
 import processChannelEvents from '@state/channels';
 import { store } from '@state';
+import { checkApiKeyExpiration } from '@state/sagas/settings';
 
 const RESET_STATE = 'RESET_STATE';
 
@@ -90,6 +91,8 @@ function* loadSapSystemsHealthSummary() {
 
 function* initialDataFetch() {
   yield loadSapSystemsHealthSummary();
+
+  yield fork(checkApiKeyExpiration);
 
   const {
     data: { eula_accepted, premium_subscription },

--- a/assets/js/state/sagas/notifications.jsx
+++ b/assets/js/state/sagas/notifications.jsx
@@ -9,29 +9,31 @@ import {
 } from '@state/notifications';
 import DismissableToast from '@common/DismissableToast';
 
+const DEFAULT_DURATION = 4000;
+
 export function* notification({ payload }) {
-  const { text, icon, id, duration } = payload;
+  const { id, text, icon, duration } = payload;
   toast(<p className="text-sm font-medium text-gray-900">{text}</p>, {
     position: 'top-right',
     icon,
     id,
-    duration: duration || 4000,
+    duration: duration || DEFAULT_DURATION,
   });
 }
 
 export function* dismissableNotification({ payload }) {
-  const { text, icon, id, duration } = payload;
-  toast((t) => <DismissableToast text={text} toastInstance={t} />, {
+  const { id, text, icon, duration } = payload;
+  toast((t) => <DismissableToast text={text} toastID={t.id} />, {
     position: 'top-right',
     icon,
     id,
-    duration: duration || 4000,
+    duration: duration || DEFAULT_DURATION,
   });
 }
 
 export function* dismissNotification({ payload }) {
-  const { notificationID } = payload;
-  toast.dismiss(notificationID);
+  const { id } = payload;
+  toast.dismiss(id);
 }
 
 export function* watchNotifications() {

--- a/assets/js/state/sagas/notifications.jsx
+++ b/assets/js/state/sagas/notifications.jsx
@@ -2,16 +2,40 @@
 import React from 'react';
 import { takeEvery } from 'redux-saga/effects';
 import { toast } from 'react-hot-toast';
-import { NOTIFICATION } from '@state/notifications';
+import {
+  NOTIFICATION,
+  DISMISSABLE_NOTIFICATION,
+  DISMISS_NOTIFICATION,
+} from '@state/notifications';
+import DismissableToast from '@common/DismissableToast';
 
 export function* notification({ payload }) {
-  const { text, icon } = payload;
+  const { text, icon, id, duration } = payload;
   toast(<p className="text-sm font-medium text-gray-900">{text}</p>, {
     position: 'top-right',
     icon,
+    id,
+    duration: duration || 4000,
   });
+}
+
+export function* dismissableNotification({ payload }) {
+  const { text, icon, id, duration } = payload;
+  toast((t) => <DismissableToast text={text} toastInstance={t} />, {
+    position: 'top-right',
+    icon,
+    id,
+    duration: duration || 4000,
+  });
+}
+
+export function* dismissNotification({ payload }) {
+  const { notificationID } = payload;
+  toast.dismiss(notificationID);
 }
 
 export function* watchNotifications() {
   yield takeEvery(NOTIFICATION, notification);
+  yield takeEvery(DISMISSABLE_NOTIFICATION, dismissableNotification);
+  yield takeEvery(DISMISS_NOTIFICATION, dismissNotification);
 }

--- a/assets/js/state/sagas/settings.jsx
+++ b/assets/js/state/sagas/settings.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { get } from '@lib/network';
+import { differenceInDays, parseISO } from 'date-fns';
+import { call, put } from 'redux-saga/effects';
+import HealthIcon from '@common/HealthIcon';
+import { notify, dismissableNotify } from '@state/notifications';
+
+export function* checkApiKeyExpiration() {
+  const {
+    data: { expire_at },
+  } = yield call(get, '/settings/api_key');
+
+  if (!expire_at) return;
+
+  const expireTS = parseISO(expire_at);
+  const expirationDays = differenceInDays(expireTS, new Date());
+
+  if (expirationDays > 30) {
+    return;
+  }
+
+  if (expirationDays < 0) {
+    yield put(
+      notify({
+        text: 'API Key has expired. Go to Settings to issue a new key',
+        icon: <HealthIcon health="critical" />,
+        duration: Infinity,
+        id: 'api-key-expiration-toast',
+      })
+    );
+  } else {
+    yield put(
+      dismissableNotify({
+        text: `API Key expires in ${expirationDays} days`,
+        icon: <HealthIcon health="warning" />,
+        duration: Infinity,
+        id: 'api-key-expiration-toast',
+      })
+    );
+  }
+}

--- a/assets/js/state/sagas/settings.test.jsx
+++ b/assets/js/state/sagas/settings.test.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { recordSaga } from '@lib/test-utils';
+
+import { networkClient } from '@lib/network';
+import MockAdapter from 'axios-mock-adapter';
+
+import { apiKeySettingsFactory } from '@lib/test-utils/factories/settings';
+import { addDays, formatISO, subDays } from 'date-fns';
+import HealthIcon from '@common/HealthIcon';
+import { notify, dismissableNotify } from '@state/notifications';
+import { checkApiKeyExpiration } from './settings';
+
+const axiosMock = new MockAdapter(networkClient);
+
+describe('Settings sagas', () => {
+  beforeEach(() => {
+    axiosMock.reset();
+  });
+
+  describe('checkApiKeyExpiration saga', () => {
+    it('should skip any expiration toast creation when the expire_at of the api key is not defined', async () => {
+      axiosMock
+        .onGet('/api/v1/settings/api_key')
+        .reply(200, apiKeySettingsFactory.build({ expire_at: null }));
+
+      const dispatched = await recordSaga(checkApiKeyExpiration, {});
+
+      expect(dispatched).toEqual([]);
+    });
+
+    it('should dispatch an expired key notification if the expire_at of the api key is in the past', async () => {
+      axiosMock.onGet('/api/v1/settings/api_key').reply(
+        200,
+        apiKeySettingsFactory.build({
+          expire_at: formatISO(subDays(new Date(), 2)),
+        })
+      );
+
+      const dispatched = await recordSaga(checkApiKeyExpiration, {});
+      const expectedAction = notify({
+        text: 'API Key has expired. Go to Settings to issue a new key',
+        icon: <HealthIcon health="critical" />,
+        duration: Infinity,
+        id: 'api-key-expiration-toast',
+      });
+      expect(dispatched).toEqual([expectedAction]);
+    });
+
+    it('should dispatch an expires in dismissable notification if the api key expiration days are less then 30', async () => {
+      axiosMock.onGet('/api/v1/settings/api_key').reply(
+        200,
+        apiKeySettingsFactory.build({
+          expire_at: formatISO(addDays(new Date(), 3)),
+        })
+      );
+
+      const dispatched = await recordSaga(checkApiKeyExpiration, {});
+      const expectedAction = dismissableNotify({
+        text: `API Key expires in 2 days`,
+        icon: <HealthIcon health="warning" />,
+        duration: Infinity,
+        id: 'api-key-expiration-toast',
+      });
+      expect(dispatched).toEqual([expectedAction]);
+    });
+    it('should not dispatch any action if the api key expiration days are more then 30', async () => {
+      axiosMock.onGet('/api/v1/settings/api_key').reply(
+        200,
+        apiKeySettingsFactory.build({
+          expire_at: formatISO(addDays(new Date(), 32)),
+        })
+      );
+
+      const dispatched = await recordSaga(checkApiKeyExpiration, {});
+      expect(dispatched).toEqual([]);
+    });
+  });
+});

--- a/assets/js/state/sagas/settings.test.jsx
+++ b/assets/js/state/sagas/settings.test.jsx
@@ -46,7 +46,7 @@ describe('Settings sagas', () => {
       expect(dispatched).toEqual([expectedAction]);
     });
 
-    it('should dispatch an expires in dismissable notification if the api key expiration days are less then 30', async () => {
+    it('should dispatch a dismissable notification if the api key is to expire in less than 30 days', async () => {
       axiosMock.onGet('/api/v1/settings/api_key').reply(
         200,
         apiKeySettingsFactory.build({
@@ -63,6 +63,7 @@ describe('Settings sagas', () => {
       });
       expect(dispatched).toEqual([expectedAction]);
     });
+
     it('should not dispatch any action if the api key expiration days are more then 30', async () => {
       axiosMock.onGet('/api/v1/settings/api_key').reply(
         200,

--- a/test/e2e/cypress/e2e/settings.cy.js
+++ b/test/e2e/cypress/e2e/settings.cy.js
@@ -9,6 +9,7 @@ context('Settings page', () => {
   after(() => {
     cy.updateApiKeyExpiration(null);
   });
+
   describe('Api key expiration notifications', () => {
     it('should show api key expired notification when first loading the page, when the api key is expired', () => {
       cy.updateApiKeyExpiration(subDays(new Date(), 1));

--- a/test/e2e/cypress/e2e/settings.cy.js
+++ b/test/e2e/cypress/e2e/settings.cy.js
@@ -1,0 +1,34 @@
+/* eslint-disable cypress/no-unnecessary-waiting */
+import { subDays, addDays } from 'date-fns';
+
+context('Settings page', () => {
+  before(() => {
+    cy.visit('/settings');
+  });
+
+  after(() => {
+    cy.updateApiKeyExpiration(null);
+  });
+  describe('Api key expiration notifications', () => {
+    it('should show api key expired notification when first loading the page, when the api key is expired', () => {
+      cy.updateApiKeyExpiration(subDays(new Date(), 1));
+
+      cy.reload();
+
+      cy.wait(3000);
+      cy.get('body').should(
+        'contain',
+        'API Key has expired. Go to Settings to issue a new key'
+      );
+    });
+
+    it('should show api is going to expire notification, when first loadng the page if api key expires in less than 30 days', () => {
+      cy.updateApiKeyExpiration(addDays(new Date(), 10));
+
+      cy.reload();
+
+      cy.wait(3000);
+      cy.get('body').should('contain', 'API Key expires in 9 days');
+    });
+  });
+});

--- a/test/e2e/cypress/support/commands.js
+++ b/test/e2e/cypress/support/commands.js
@@ -75,6 +75,21 @@ Cypress.Commands.add('acceptEula', () => {
   });
 });
 
+Cypress.Commands.add('updateApiKeyExpiration', (apiKeyExpiration) => {
+  apiLogin().then(({ accessToken }) => {
+    cy.request({
+      url: '/api/v1/settings/api_key',
+      method: 'PATCH',
+      auth: {
+        bearer: accessToken,
+      },
+      body: {
+        expire_at: apiKeyExpiration,
+      },
+    });
+  });
+});
+
 Cypress.Commands.add('loadScenario', (scenario) => {
   const [projectRoot, photofinishBinary, webAPIHost, webAPIPort] = [
     Cypress.env('project_root'),

--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.2.0",
       "dependencies": {
         "@cypress/webpack-preprocessor": "^5.16.1",
+        "date-fns": "^3.3.1",
         "lodash": "^4.17.21",
         "npm": "^10.1.0"
       },
@@ -2956,6 +2957,15 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.3.1.tgz",
+      "integrity": "sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/dayjs": {
@@ -10805,6 +10815,11 @@
       "requires": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "date-fns": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.3.1.tgz",
+      "integrity": "sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw=="
     },
     "dayjs": {
       "version": "1.10.7",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@cypress/webpack-preprocessor": "^5.16.1",
+    "date-fns": "^3.3.1",
     "lodash": "^4.17.21",
     "npm": "^10.1.0"
   }


### PR DESCRIPTION
# Description

When the trento frontend application loads, we fetch the api key expiration.

If the api key is expired, the frontend shows a persistent toast.
If the api key will expire in 30 days, the frontend shows a dismissable toast.

This pr also adds a dismissable toast, and a custom notification dispatching with custom duration and dismissable.

![image](https://github.com/trento-project/web/assets/9409502/25f6aa6f-9f50-4f0c-9827-0728a4a6d341)
![image](https://github.com/trento-project/web/assets/9409502/11aeba2d-8006-4296-b159-c8cefc201f5c)

## How was this tested?

Automated tests, e2e tests