### PR TITLE
Add wrap prop to tooltip

### DIFF
--- a/assets/js/common/Tooltip/Tooltip.jsx
+++ b/assets/js/common/Tooltip/Tooltip.jsx
@@ -25,6 +25,7 @@ function Tooltip({
   children,
   place = 'top',
   isEnabled = true,
+  wrap = true,
   ...rest
 }) {
   if (!isEnabled) {
@@ -41,7 +42,7 @@ function Tooltip({
       placement={getPlacement(place)}
       {...rest}
     >
-      <span className="inline-flex">{children}</span>
+      {wrap ? <span>{children}</span> : children}
     </RcTooltip>
   );
 }

--- a/assets/js/common/Tooltip/Tooltip.stories.jsx
+++ b/assets/js/common/Tooltip/Tooltip.stories.jsx
@@ -24,6 +24,10 @@ export default {
       description: 'Whether the tooltip is enabled',
       control: { type: 'boolean' },
     },
+    wrap: {
+      type: 'boolean',
+      description: 'Whether to wrap children in a span or not.',
+    },
   },
   render: (args) => (
     <div className="p-12 flex items-center justify-center">

--- a/assets/js/common/Tooltip/Tooltip.test.jsx
+++ b/assets/js/common/Tooltip/Tooltip.test.jsx
@@ -24,4 +24,24 @@ describe('Tooltip', () => {
       expect(screen.queryByText('This is my tooltip text')).toBeVisible()
     );
   });
+
+  it('should show a text when mouse is hovering and wrap is false', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <div>
+        <Tooltip content="This is my tooltip text" wrap={false}>
+          <div>This is my anchor</div>
+        </Tooltip>
+      </div>
+    );
+
+    expect(screen.queryByText('This is my tooltip text')).toBeNull();
+
+    await act(async () => user.hover(screen.queryByText('This is my anchor')));
+
+    await waitFor(() =>
+      expect(screen.queryByText('This is my tooltip text')).toBeVisible()
+    );
+  });
 });


### PR DESCRIPTION
# Description
Our tooltip component wraps elements in a span by default. In order not to mess up with CSS styles in some flexbox/grid context this behavior needs to be turned off on demand.

## How was this tested?
Jest tests added
