### PR TITLE
Add ability to provide a CA cert when making requests to SUMA

### DIFF
--- a/lib/trento/infrastructure/software_updates/adapter/suma_http_executor.ex
+++ b/lib/trento/infrastructure/software_updates/adapter/suma_http_executor.ex
@@ -43,7 +43,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor do
       "#{base_url}/auth/login",
       payload,
       [{"Content-type", "application/json"}],
-      maybe_provide_ssl_options(use_ca_cert)
+      ssl_options(use_ca_cert)
     )
   end
 
@@ -52,7 +52,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor do
     HTTPoison.get(
       "#{base_url}/system/getId?name=#{fully_qualified_domain_name}",
       [{"Content-type", "application/json"}],
-      hackney: [cookie: [auth]] ++ maybe_provide_ssl_options(use_ca_cert)
+      hackney: [cookie: [auth]] ++ ssl_options(use_ca_cert)
     )
   end
 
@@ -61,12 +61,12 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor do
     HTTPoison.get(
       "#{base_url}/system/getRelevantErrata?sid=#{system_id}",
       [{"Content-type", "application/json"}],
-      hackney: [cookie: [auth]] ++ maybe_provide_ssl_options(use_ca_cert)
+      hackney: [cookie: [auth]] ++ ssl_options(use_ca_cert)
     )
   end
 
-  defp maybe_provide_ssl_options(true),
+  defp ssl_options(true),
     do: [ssl: [verify: :verify_peer, certfile: SumaApi.ca_cert_path()]]
 
-  defp maybe_provide_ssl_options(_), do: []
+  defp ssl_options(_), do: []
 end

--- a/lib/trento/infrastructure/software_updates/suma.ex
+++ b/lib/trento/infrastructure/software_updates/suma.ex
@@ -115,7 +115,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma do
   defp setup_auth(%State{} = state) do
     with {:ok, %{url: url, username: username, password: password, ca_cert: ca_cert}} <-
            SoftwareUpdates.get_settings(),
-         :ok <- maybe_write_ca_cert_file(ca_cert),
+         :ok <- write_ca_cert_file(ca_cert),
          {:ok, auth_cookie} <- SumaApi.login(url, username, password, ca_cert != nil) do
       {:ok,
        %State{
@@ -129,9 +129,9 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma do
     end
   end
 
-  defp maybe_write_ca_cert_file(nil), do: File.rm(SumaApi.ca_cert_path())
+  defp write_ca_cert_file(nil), do: File.rm(SumaApi.ca_cert_path())
 
-  defp maybe_write_ca_cert_file(ca_cert) do
+  defp write_ca_cert_file(ca_cert) do
     SumaApi.ca_cert_path()
     |> Path.dirname()
     |> File.mkdir_p!()

--- a/lib/trento/infrastructure/software_updates/suma.ex
+++ b/lib/trento/infrastructure/software_updates/suma.ex
@@ -99,14 +99,14 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma do
          auth: auth_cookie,
          ca_cert: ca_cert
        }),
-       do: SumaApi.get_system_id(url, auth_cookie, fully_qualified_domain_name, ca_cert)
+       do: SumaApi.get_system_id(url, auth_cookie, fully_qualified_domain_name, ca_cert != nil)
 
   defp do_handle({:get_relevant_patches, system_id}, %State{
          url: url,
          auth: auth_cookie,
          ca_cert: ca_cert
        }),
-       do: SumaApi.get_relevant_patches(url, auth_cookie, system_id, ca_cert)
+       do: SumaApi.get_relevant_patches(url, auth_cookie, system_id, ca_cert != nil)
 
   defp process_identifier(server_name), do: {:global, identification_tuple(server_name)}
 
@@ -116,7 +116,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma do
     with {:ok, %{url: url, username: username, password: password, ca_cert: ca_cert}} <-
            SoftwareUpdates.get_settings(),
          :ok <- maybe_write_ca_cert_file(ca_cert),
-         {:ok, auth_cookie} <- SumaApi.login(url, username, password, ca_cert) do
+         {:ok, auth_cookie} <- SumaApi.login(url, username, password, ca_cert != nil) do
       {:ok,
        %State{
          state

--- a/lib/trento/infrastructure/software_updates/suma_api.ex
+++ b/lib/trento/infrastructure/software_updates/suma_api.ex
@@ -8,21 +8,35 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
 
   @login_retries 5
 
-  @spec login(url :: String.t(), username :: String.t(), password :: String.t()) ::
+  @ca_cert_path "/tmp/suma_ca_cert.crt"
+
+  def ca_cert_path, do: @ca_cert_path
+
+  @spec login(
+          url :: String.t(),
+          username :: String.t(),
+          password :: String.t(),
+          ca_cert :: String.t() | nil
+        ) ::
           {:ok, any()} | {:error, :max_login_retries_reached | any()}
-  def login(url, username, password),
+  def login(url, username, password, ca_cert),
     do:
       url
       |> get_suma_api_url()
-      |> try_login(username, password, @login_retries)
+      |> try_login(username, password, ca_cert, @login_retries)
 
-  @spec get_system_id(url :: String.t(), auth :: any(), fully_qualified_domain_name :: String.t()) ::
+  @spec get_system_id(
+          url :: String.t(),
+          auth :: any(),
+          fully_qualified_domain_name :: String.t(),
+          ca_cert :: String.t() | nil
+        ) ::
           {:ok, pos_integer()} | {:error, :system_id_not_found | :authentication_error}
-  def get_system_id(url, auth, fully_qualified_domain_name) do
+  def get_system_id(url, auth, fully_qualified_domain_name, ca_cert) do
     response =
       url
       |> get_suma_api_url()
-      |> http_executor().get_system_id(auth, fully_qualified_domain_name)
+      |> http_executor().get_system_id(auth, fully_qualified_domain_name, ca_cert != nil)
 
     with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- response,
          {:ok, %{success: true, result: result}} <- Jason.decode(body, keys: :atoms),
@@ -41,14 +55,19 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
     end
   end
 
-  @spec get_relevant_patches(url :: String.t(), auth :: any(), system_id :: pos_integer()) ::
+  @spec get_relevant_patches(
+          url :: String.t(),
+          auth :: any(),
+          system_id :: pos_integer(),
+          ca_cert :: String.t() | nil
+        ) ::
           {:ok, [map()]}
           | {:error, :error_getting_patches | :authentication_error}
-  def get_relevant_patches(url, auth, system_id) do
+  def get_relevant_patches(url, auth, system_id, ca_cert) do
     response =
       url
       |> get_suma_api_url()
-      |> http_executor().get_relevant_patches(auth, system_id)
+      |> http_executor().get_relevant_patches(auth, system_id, ca_cert != nil)
 
     with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- response,
          {:ok, %{success: true, result: result}} <- Jason.decode(body, keys: :atoms) do
@@ -70,24 +89,24 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
   defp get_suma_api_url(base_url),
     do: String.trim_trailing(base_url, "/") <> "/rhn/manager/api"
 
-  defp try_login(_, _, _, 0) do
+  defp try_login(_, _, _, _, 0) do
     Logger.error("Failed to Log into SUSE Manager. Max retries reached.")
     {:error, :max_login_retries_reached}
   end
 
-  defp try_login(url, username, password, retry) do
-    case do_login(url, username, password) do
+  defp try_login(url, username, password, ca_cert, retry) do
+    case do_login(url, username, password, ca_cert) do
       {:ok, _} = successful_login ->
         successful_login
 
       {:error, reason} ->
         Logger.error("Failed to Log into SUSE Manager, retrying...", error: inspect(reason))
-        try_login(url, username, password, retry - 1)
+        try_login(url, username, password, ca_cert, retry - 1)
     end
   end
 
-  defp do_login(url, username, password) do
-    case http_executor().login(url, username, password) do
+  defp do_login(url, username, password, ca_cert) do
+    case http_executor().login(url, username, password, ca_cert != nil) do
       {:ok, %HTTPoison.Response{headers: headers, status_code: 200} = response} ->
         Logger.debug("Successfully logged into suma #{inspect(response)}")
         {:ok, get_session_cookies(headers)}

--- a/test/trento/infrastructure/software_updates/suma_test.exs
+++ b/test/trento/infrastructure/software_updates/suma_test.exs
@@ -54,9 +54,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaTest do
 
       base_api_url = "#{url}/rhn/manager/api"
 
-      expect(SumaApiMock, :login, fn ^base_api_url, ^username, ^password, true ->
-        successful_login_response()
-      end)
+      expect(SumaApiMock, :login, fn _, _, _, true -> successful_login_response() end)
 
       assert :ok = Suma.setup(@test_integration_name)
 
@@ -74,9 +72,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaTest do
 
       base_api_url = "#{url}/rhn/manager/api"
 
-      expect(SumaApiMock, :login, fn ^base_api_url, ^username, ^password, false ->
-        successful_login_response()
-      end)
+      expect(SumaApiMock, :login, fn ^_, _, _, false -> successful_login_response() end)
 
       assert :ok = Suma.setup(@test_integration_name)
 
@@ -90,7 +86,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaTest do
 
       base_api_url = "#{url}/rhn/manager/api"
 
-      expect(SumaApiMock, :login, fn ^base_api_url, ^username, ^password, true ->
+      expect(SumaApiMock, :login, fn ^base_api_url, ^username, ^password, _ ->
         successful_login_response()
       end)
 
@@ -124,7 +120,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaTest do
       base_api_url = "#{url}/rhn/manager/api"
       auth_cookie = "pxt-session-cookie=4321"
 
-      expect(SumaApiMock, :login, fn ^base_api_url, ^username, ^password, true ->
+      expect(SumaApiMock, :login, fn ^base_api_url, ^username, ^password, _ ->
         successful_login_response()
       end)
 

--- a/test/trento/infrastructure/software_updates/suma_test.exs
+++ b/test/trento/infrastructure/software_updates/suma_test.exs
@@ -201,7 +201,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaTest do
     } do
       {:ok, _} = start_supervised({Suma, @test_integration_name})
 
-      expect(SumaApiMock, :login, fn _, _, _ -> successful_login_response() end)
+      expect(SumaApiMock, :login, fn _, _, _, _ -> successful_login_response() end)
 
       assert :ok = Suma.setup(@test_integration_name)
 

--- a/test/trento/infrastructure/software_updates/suma_test.exs
+++ b/test/trento/infrastructure/software_updates/suma_test.exs
@@ -48,11 +48,9 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaTest do
     end
 
     test "should save existing CA certificate to local file", %{
-      settings: %Settings{url: url, username: username, password: password, ca_cert: ca_cert}
+      settings: %Settings{ca_cert: ca_cert}
     } do
       assert {:ok, _} = start_supervised({Suma, @test_integration_name})
-
-      base_api_url = "#{url}/rhn/manager/api"
 
       expect(SumaApiMock, :login, fn _, _, _, true -> successful_login_response() end)
 
@@ -65,14 +63,11 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaTest do
     end
 
     test "should not save CA certificate file if no cert is provided" do
-      %Settings{url: url, username: username, password: password} =
-        insert_software_updates_settings(ca_cert: nil, ca_uploaded_at: nil)
+      insert_software_updates_settings(ca_cert: nil, ca_uploaded_at: nil)
 
       assert {:ok, _} = start_supervised({Suma, @test_integration_name})
 
-      base_api_url = "#{url}/rhn/manager/api"
-
-      expect(SumaApiMock, :login, fn ^_, _, _, false -> successful_login_response() end)
+      expect(SumaApiMock, :login, fn _, _, _, false -> successful_login_response() end)
 
       assert :ok = Suma.setup(@test_integration_name)
 


### PR DESCRIPTION
# Description

This change adds ability to provide a CA cert when making requests to SUMA.

Because the [HTTPoison](https://github.com/edgurgel/httpoison) library uses Erlang library [hackney](https://github.com/benoitc/hackney) underneath, whose API demands that we provide a path to a file containing the certificate; we need to save a certificate file on the filesystem somewhere. Note that if we save some new credentials that _don't_ contain a certificate (i.e. the user _clears_ the certificate), then the old certificate file is removed.

## How was this tested?

Added unit tests for this new functionality.
