### PR TITLE
Clear suma discovery domain

### DIFF
--- a/lib/trento/hosts/commands/clear_software_updates_discovery.ex
+++ b/lib/trento/hosts/commands/clear_software_updates_discovery.ex
@@ -1,0 +1,13 @@
+defmodule Trento.Hosts.Commands.ClearSoftwareUpdatesDiscovery do
+  @moduledoc """
+  Clears the software updates discovery when its output is not needed anymore
+  """
+
+  @required_fields :all
+
+  use Trento.Support.Command
+
+  defcommand do
+    field :host_id, Ecto.UUID
+  end
+end

--- a/lib/trento/hosts/events/software_updates_discovery_cleared.ex
+++ b/lib/trento/hosts/events/software_updates_discovery_cleared.ex
@@ -1,0 +1,11 @@
+defmodule Trento.Hosts.Events.SoftwareUpdatesDiscoveryCleared do
+  @moduledoc """
+  This event is emitted when a host's software updates discovery is cleared
+  """
+
+  use Trento.Support.Event
+
+  defevent do
+    field :host_id, Ecto.UUID
+  end
+end

--- a/lib/trento/router.ex
+++ b/lib/trento/router.ex
@@ -12,6 +12,7 @@ defmodule Trento.Router do
   }
 
   alias Trento.Hosts.Commands.{
+    ClearSoftwareUpdatesDiscovery,
     CompleteHostChecksExecution,
     CompleteSoftwareUpdatesDiscovery,
     DeregisterHost,
@@ -54,7 +55,8 @@ defmodule Trento.Router do
              RequestHostDeregistration,
              DeregisterHost,
              CompleteHostChecksExecution,
-             CompleteSoftwareUpdatesDiscovery
+             CompleteSoftwareUpdatesDiscovery,
+             ClearSoftwareUpdatesDiscovery
            ],
            to: Hosts.Host,
            lifespan: Hosts.Lifespan

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -36,7 +36,8 @@ defmodule Trento.Factory do
     HostSaptuneHealthChanged,
     HostTombstoned,
     SaptuneStatusUpdated,
-    SlesSubscriptionsUpdated
+    SlesSubscriptionsUpdated,
+    SoftwareUpdatesDiscoveryCompleted
   }
 
   alias Trento.SapSystems.Events.{
@@ -760,6 +761,13 @@ defmodule Trento.Factory do
       host_id: Faker.UUID.v4(),
       saptune_health: Health.passing()
     }
+  end
+
+  def software_updates_discovery_completed_event_factory do
+    SoftwareUpdatesDiscoveryCompleted.new!(%{
+      host_id: Faker.UUID.v4(),
+      relevant_patches: %{}
+    })
   end
 
   def host_health_changed_event_factory do


### PR DESCRIPTION
# Description

This PR introduces domain logic to handle clearing up of software updates discovery results.
Basically when a user clears up suma credentials, whatever has been previously discovered, gets ignored.
Specifically the health of the software updates discovery gets ignored from the host's aggregated health.

This is going to happen in a loop for all the hosts meaning that a bunch of `HostHealthChanged` could be emitted upon creds clear up, with related ui notifications.

## How was this tested?

Automated tests