### PR TITLE
Clear suma discoveries

### DIFF
--- a/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
+++ b/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
@@ -21,7 +21,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.MockSuma do
          %{
            date: "2024-02-27",
            advisory_name: "SUSE-15-SP4-2024-630",
-           advisory_type: "Bug Fix Advisory",
+           advisory_type: :bugfix,
            advisory_status: "stable",
            id: 4182,
            advisory_synopsis: "Recommended update for cloud-netconfig",
@@ -30,7 +30,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.MockSuma do
          %{
            date: "2024-02-26",
            advisory_name: "SUSE-15-SP4-2024-619",
-           advisory_type: "Security Advisory",
+           advisory_type: :security_advisory,
            advisory_status: "stable",
            id: 4174,
            advisory_synopsis: "important: Security update for java-1_8_0-ibm",
@@ -38,5 +38,6 @@ defmodule Trento.Infrastructure.SoftwareUpdates.MockSuma do
          }
        ]}
 
+  @impl true
   def clear, do: :ok
 end

--- a/lib/trento/infrastructure/software_updates/suma.ex
+++ b/lib/trento/infrastructure/software_updates/suma.ex
@@ -35,27 +35,28 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma do
       |> process_identifier
       |> GenServer.call(:setup)
 
+  @impl Trento.SoftwareUpdates.Discovery.Gen
   def clear(server_name \\ @default_name),
     do:
       server_name
       |> process_identifier
       |> GenServer.call(:clear)
 
-  @impl true
+  @impl Trento.SoftwareUpdates.Discovery.Gen
   def get_system_id(fully_qualified_domain_name, server_name \\ @default_name),
     do:
       server_name
       |> process_identifier
       |> GenServer.call({:get_system_id, fully_qualified_domain_name})
 
-  @impl true
+  @impl Trento.SoftwareUpdates.Discovery.Gen
   def get_relevant_patches(system_id, server_name \\ @default_name),
     do:
       server_name
       |> process_identifier
       |> GenServer.call({:get_relevant_patches, system_id})
 
-  @impl true
+  @impl GenServer
   def handle_call(:setup, _from, %State{} = state) do
     case setup_auth(state) do
       {:ok, new_state} ->
@@ -66,14 +67,14 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma do
     end
   end
 
-  @impl true
+  @impl GenServer
   def handle_call(:clear, _, _), do: {:reply, :ok, %State{}}
 
-  @impl true
+  @impl GenServer
   def handle_call(request, _, %State{auth: nil} = state),
     do: authenticate_and_handle(request, state)
 
-  @impl true
+  @impl GenServer
   def handle_call(request, _, %State{} = state) do
     case handle_result = do_handle(request, state) do
       {:error, :authentication_error} ->

--- a/lib/trento/software_updates.ex
+++ b/lib/trento/software_updates.ex
@@ -57,18 +57,23 @@ defmodule Trento.SoftwareUpdates do
 
   @spec clear_settings :: :ok
   def clear_settings do
-    Repo.update_all(Settings,
-      set: [
-        url: nil,
-        username: nil,
-        password: nil,
-        ca_cert: nil,
-        ca_uploaded_at: nil,
-        updated_at: DateTime.utc_now()
-      ]
-    )
+    clear_result =
+      Repo.update_all(Settings,
+        set: [
+          url: nil,
+          username: nil,
+          password: nil,
+          ca_cert: nil,
+          ca_uploaded_at: nil,
+          updated_at: DateTime.utc_now()
+        ]
+      )
 
-    :ok
+    with {1, _} <- clear_result do
+      Discovery.clear_software_updates_discoveries()
+
+      :ok
+    end
   end
 
   @spec run_discovery :: :ok | {:error, :settings_not_configured}

--- a/lib/trento/software_updates.ex
+++ b/lib/trento/software_updates.ex
@@ -57,7 +57,7 @@ defmodule Trento.SoftwareUpdates do
 
   @spec clear_settings :: :ok
   def clear_settings do
-    clear_result =
+    {1, _} =
       Repo.update_all(Settings,
         set: [
           url: nil,
@@ -69,11 +69,9 @@ defmodule Trento.SoftwareUpdates do
         ]
       )
 
-    with {1, _} <- clear_result do
-      Discovery.clear_software_updates_discoveries()
+    Discovery.clear_software_updates_discoveries()
 
-      :ok
-    end
+    :ok
   end
 
   @spec run_discovery :: :ok | {:error, :settings_not_configured}

--- a/lib/trento/software_updates/discovery.ex
+++ b/lib/trento/software_updates/discovery.ex
@@ -44,13 +44,15 @@ defmodule Trento.SoftwareUpdates.Discovery do
   def clear_software_updates_discoveries do
     hosts = Hosts.get_all_hosts()
 
-    if !Enum.empty?(hosts) do
-      Enum.each(hosts, fn %HostReadModel{id: host_id} ->
-        %{host_id: host_id}
-        |> ClearSoftwareUpdatesDiscovery.new!()
-        |> commanded().dispatch()
-      end)
+    hosts
+    |> Enum.map(fn %HostReadModel{id: host_id} -> %{host_id: host_id} end)
+    |> Enum.each(fn command_payload ->
+      command_payload
+      |> ClearSoftwareUpdatesDiscovery.new!()
+      |> commanded().dispatch()
+    end)
 
+    if !Enum.empty?(hosts) do
       clear()
     end
 

--- a/lib/trento/software_updates/discovery/gen.ex
+++ b/lib/trento/software_updates/discovery/gen.ex
@@ -8,4 +8,6 @@ defmodule Trento.SoftwareUpdates.Discovery.Gen do
 
   @callback get_relevant_patches(system_id :: pos_integer()) ::
               {:ok, [map]} | {:error, any}
+
+  @callback clear() :: :ok | {:error, any}
 end

--- a/lib/trento/software_updates/discovery/gen.ex
+++ b/lib/trento/software_updates/discovery/gen.ex
@@ -9,5 +9,5 @@ defmodule Trento.SoftwareUpdates.Discovery.Gen do
   @callback get_relevant_patches(system_id :: pos_integer()) ::
               {:ok, [map]} | {:error, any}
 
-  @callback clear() :: :ok | {:error, any}
+  @callback clear() :: :ok
 end

--- a/test/support/commanded/commanded_case.ex
+++ b/test/support/commanded/commanded_case.ex
@@ -1,0 +1,11 @@
+defmodule Trento.CommandedCase do
+  @moduledoc false
+
+  use ExUnit.CaseTemplate
+
+  setup _ do
+    Mox.stub(Trento.Commanded.Mock, :dispatch, fn _ -> :ok end)
+
+    :ok
+  end
+end

--- a/test/support/software_updates/discovery_case.ex
+++ b/test/support/software_updates/discovery_case.ex
@@ -1,0 +1,14 @@
+defmodule Trento.SoftwareUpdates.DiscoveryCase do
+  @moduledoc false
+
+  use ExUnit.CaseTemplate
+
+  setup _ do
+    Mox.stub_with(
+      Trento.SoftwareUpdates.Discovery.Mock,
+      Trento.Infrastructure.SoftwareUpdates.MockSuma
+    )
+
+    :ok
+  end
+end

--- a/test/trento/software_updates_test.exs
+++ b/test/trento/software_updates_test.exs
@@ -11,6 +11,8 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
   alias Trento.SoftwareUpdates
   alias Trento.SoftwareUpdates.Settings
 
+  setup :verify_on_exit!
+
   describe "retrieving software updates settings" do
     test "should return an error when settings are not available" do
       assert {:error, :settings_not_configured} == SoftwareUpdates.get_settings()
@@ -437,6 +439,17 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
       insert_list(4, :host)
 
       assert :ok == SoftwareUpdates.run_discovery()
+    end
+
+    test "should trigger clearing of software updates discoveries when clearing settings" do
+      insert_software_updates_settings()
+
+      expect(Trento.SoftwareUpdates.Discovery.Mock, :clear, 3, fn -> :ok end)
+
+      Enum.each(1..3, fn _ ->
+        assert :ok == SoftwareUpdates.clear_settings()
+        assert {:error, :settings_not_configured} == SoftwareUpdates.get_settings()
+      end)
     end
   end
 end

--- a/test/trento/software_updates_test.exs
+++ b/test/trento/software_updates_test.exs
@@ -443,6 +443,7 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
 
     test "should trigger clearing of software updates discoveries when clearing settings" do
       insert_software_updates_settings()
+      insert_list(4, :host)
 
       expect(Trento.SoftwareUpdates.Discovery.Mock, :clear, 3, fn -> :ok end)
 

--- a/test/trento/software_updates_test.exs
+++ b/test/trento/software_updates_test.exs
@@ -1,6 +1,8 @@
 defmodule Trento.SoftwareUpdates.SettingsTest do
   use ExUnit.Case
+  use Trento.CommandedCase
   use Trento.DataCase
+  use Trento.SoftwareUpdates.DiscoveryCase
 
   import Mox
 
@@ -432,6 +434,7 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
 
     test "should start discovery if settings are configured" do
       insert_software_updates_settings()
+      insert_list(4, :host)
 
       assert :ok == SoftwareUpdates.run_discovery()
     end

--- a/test/trento_web/controllers/v1/suma_credentials_controller_test.exs
+++ b/test/trento_web/controllers/v1/suma_credentials_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
   use TrentoWeb.ConnCase, async: true
+  use Trento.SoftwareUpdates.DiscoveryCase
 
   import OpenApiSpex.TestAssertions
 


### PR DESCRIPTION
# Description

This PR introduces the ability to clear up previously discovered software updates information when software updates settings get cleared themselves.

Mechanism is pretty simple: 
1. attempt to clear software updates settings
2. for each _registered_* host issue a `ClearSoftwareUpdatesDiscovery`** -> host ignores previously discovered info
3. the state of the integration service is cleared up as well

 **\*** wondering whether it is enough and if we should do anything on host deregistration to wipe out software updates discovery. Deferring.

**\*\*** current implementation works in a best effort fashion, meaning that failures when dispatching `ClearSoftwareUpdatesDiscovery` do not block the overall clear up process.

## How was this tested?

Automated tests.

Note that a couple of test cases have been added:
- `Trento.CommandedCase`
- `Trento.SoftwareUpdates.DiscoveryCase`

These provide respectively a default stub for commanded dispatching and for the software updates discovery.
They come handy when a default behaviour is enough in tests and no specific expectation is needed for respective behaviours.