### PR TITLE
Don't return error when deleting non-existent CA cert file

### DIFF
--- a/lib/trento/infrastructure/software_updates/suma.ex
+++ b/lib/trento/infrastructure/software_updates/suma.ex
@@ -129,7 +129,12 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma do
     end
   end
 
-  defp write_ca_cert_file(nil), do: File.rm(SumaApi.ca_cert_path())
+  defp write_ca_cert_file(nil) do
+    case File.rm_rf(SumaApi.ca_cert_path()) do
+      {:ok, _} -> :ok
+      _ -> :error
+    end
+  end
 
   defp write_ca_cert_file(ca_cert) do
     SumaApi.ca_cert_path()


### PR DESCRIPTION
# Description

Relates to https://github.com/trento-project/web/pull/2391

If the SUMA GenServer attempts to delete a certificate file that doesn't exist, it will return an error status. This should not be considered an error case for our use-case and so we should use `File.rm_rf/1` instead, which specifically ignores this.

This behaviour/symptom also surfaced with some flakiness in the test `"should not save CA certificate file if no cert is provided"`, where _sometimes_ `Suma.setup(@test_integration_name)` returned the aforementioned `{:error, :enoent}`, due to the nondeterministic nature of the order of operations.

## How was this tested?

Flakiness of unit test `"should not save CA certificate file if no cert is provided"` should be fixed.
