### PR TITLE
Use derived state `use_ca_cert` in SUMA GenServer

### DIFF
--- a/lib/trento/infrastructure/software_updates/state.ex
+++ b/lib/trento/infrastructure/software_updates/state.ex
@@ -9,7 +9,8 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma.State do
     :username,
     :password,
     :ca_cert,
-    :auth
+    :auth,
+    use_ca_cert: false,
   ]
 
   @type t :: %{
@@ -17,15 +18,17 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma.State do
           username: String.t() | nil,
           password: String.t() | nil,
           ca_cert: String.t() | nil,
+          use_ca_cert: boolean(),
           auth: String.t() | nil
         }
 
   defimpl Inspect, for: State do
-    def inspect(%State{url: url, username: username}, opts) do
+    def inspect(%State{url: url, username: username, use_ca_cert: use_ca_cert}, opts) do
       Inspect.Map.inspect(
         %{
           url: url,
           username: username,
+          use_ca_cert: use_ca_cert,
           password: "<REDACTED>",
           auth: "<REDACTED>",
           ca_cert: "<REDACTED>"

--- a/lib/trento/infrastructure/software_updates/state.ex
+++ b/lib/trento/infrastructure/software_updates/state.ex
@@ -10,7 +10,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma.State do
     :password,
     :ca_cert,
     :auth,
-    use_ca_cert: false,
+    use_ca_cert: false
   ]
 
   @type t :: %{

--- a/lib/trento/infrastructure/software_updates/suma.ex
+++ b/lib/trento/infrastructure/software_updates/suma.ex
@@ -97,16 +97,16 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma do
   defp do_handle({:get_system_id, fully_qualified_domain_name}, %State{
          url: url,
          auth: auth_cookie,
-         ca_cert: ca_cert
+         use_ca_cert: use_ca_cert
        }),
-       do: SumaApi.get_system_id(url, auth_cookie, fully_qualified_domain_name, ca_cert != nil)
+       do: SumaApi.get_system_id(url, auth_cookie, fully_qualified_domain_name, use_ca_cert)
 
   defp do_handle({:get_relevant_patches, system_id}, %State{
          url: url,
          auth: auth_cookie,
-         ca_cert: ca_cert
+         use_ca_cert: use_ca_cert
        }),
-       do: SumaApi.get_relevant_patches(url, auth_cookie, system_id, ca_cert != nil)
+       do: SumaApi.get_relevant_patches(url, auth_cookie, system_id, use_ca_cert)
 
   defp process_identifier(server_name), do: {:global, identification_tuple(server_name)}
 
@@ -124,7 +124,8 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma do
            username: username,
            password: password,
            ca_cert: ca_cert,
-           auth: auth_cookie
+           auth: auth_cookie,
+           use_ca_cert: ca_cert != nil
        }}
     end
   end

--- a/test/trento/infrastructure/software_updates/suma_test.exs
+++ b/test/trento/infrastructure/software_updates/suma_test.exs
@@ -40,6 +40,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaTest do
         username: nil,
         password: nil,
         ca_cert: nil,
+        use_ca_cert: false,
         auth: nil
       }
 
@@ -92,6 +93,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaTest do
         username: username,
         password: "<REDACTED>",
         ca_cert: "<REDACTED>",
+        use_ca_cert: true,
         auth: "<REDACTED>"
       }
 
@@ -126,6 +128,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaTest do
         username: username,
         password: password,
         ca_cert: ca_cert,
+        use_ca_cert: true,
         auth: auth_cookie
       }
 
@@ -153,6 +156,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaTest do
           username: nil,
           password: nil,
           ca_cert: nil,
+          use_ca_cert: false,
           auth: nil
         }
 
@@ -210,6 +214,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaTest do
         username: username,
         password: password,
         ca_cert: ca_cert,
+        use_ca_cert: true,
         auth: "pxt-session-cookie=4321"
       }
 
@@ -232,6 +237,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaTest do
         username: nil,
         password: nil,
         ca_cert: nil,
+        use_ca_cert: false,
         auth: nil
       }
 


### PR DESCRIPTION
# Description

Arises from [comment](https://github.com/trento-project/web/pull/2391#discussion_r1515712747) in https://github.com/trento-project/web/pull/2391

> If we decide to have `SumaApi` functions accept a `use_ca_cert` as mentioned [here](https://github.com/trento-project/web/pull/2391/files#r1515701175) we could also think of centralizing that `ca_cert =! nil` in the genserver state that we set in this function 👀

This change adds some derived state `use_ca_cert` into the SUMA GenServer, to abstract away the logic of checking `ca_cert =! nil` when the GenServer calls the SUMA API functions.

## How was this tested?

Updated existing unit tests.
