### PR TITLE
Remove duplicated redux state `database_instances` field from the SAP system reducer

### DIFF
--- a/assets/js/state/sagas/databases.js
+++ b/assets/js/state/sagas/databases.js
@@ -24,16 +24,6 @@ import {
   unsetDatabaseInstanceDeregistering,
 } from '@state/databases';
 
-import {
-  upsertDatabaseInstancesToSapSystem,
-  removeDatabaseInstanceFromSapSystem,
-  updateSAPSystemDatabaseInstanceHealth,
-  updateSAPSystemDatabaseInstanceSystemReplication,
-  setDatabaseInstanceDeregisteringToSAPSystem,
-  unsetDatabaseInstanceDeregisteringToSAPSystem,
-  updateDatabaseInstanceAbsentToSAPSystem,
-} from '@state/sapSystems';
-
 import { getDatabase } from '@state/selectors/sapSystem';
 import { notify } from '@state/notifications';
 
@@ -62,7 +52,6 @@ function* databaseHealthChanged({ payload }) {
 
 function* databaseInstanceRegistered({ payload }) {
   yield put(upsertDatabaseInstances([payload]));
-  yield put(upsertDatabaseInstancesToSapSystem([payload]));
   yield put(
     notify({
       text: `A new Database instance, ${payload.sid}, has been discovered.`,
@@ -84,7 +73,6 @@ export function* databaseDeregistered({ payload }) {
 export function* databaseRestored({ payload }) {
   yield put(appendDatabase(payload));
   yield put(upsertDatabaseInstances(payload.database_instances));
-  yield put(upsertDatabaseInstancesToSapSystem(payload.database_instances));
   yield put(
     notify({
       text: `The database ${payload.sid} has been restored.`,
@@ -95,7 +83,6 @@ export function* databaseRestored({ payload }) {
 
 export function* databaseInstanceDeregistered({ payload }) {
   yield put(removeDatabaseInstance(payload));
-  yield put(removeDatabaseInstanceFromSapSystem(payload));
   yield put(
     notify({
       text: `The database instance ${payload.instance_number} has been deregistered from ${payload.sid}.`,
@@ -106,17 +93,14 @@ export function* databaseInstanceDeregistered({ payload }) {
 
 function* databaseInstanceHealthChanged({ payload }) {
   yield put(updateDatabaseInstanceHealth(payload));
-  yield put(updateSAPSystemDatabaseInstanceHealth(payload));
 }
 
 function* databaseInstanceSystemReplicationChanged({ payload }) {
   yield put(updateDatabaseInstanceSystemReplication(payload));
-  yield put(updateSAPSystemDatabaseInstanceSystemReplication(payload));
 }
 
 export function* databaseInstanceAbsentAtChanged({ payload }) {
   yield put(updateDatabaseInstanceAbsentAt(payload));
-  yield put(updateDatabaseInstanceAbsentToSAPSystem(payload));
   const { sid, absent_at, instance_number } = payload;
   yield put(
     notify({
@@ -133,7 +117,6 @@ export function* deregisterDatabaseInstance({
   payload: { sid, sap_system_id, host_id, instance_number },
 }) {
   yield put(setDatabaseInstanceDeregistering(payload));
-  yield put(setDatabaseInstanceDeregisteringToSAPSystem(payload));
   try {
     yield call(
       del,
@@ -148,7 +131,6 @@ export function* deregisterDatabaseInstance({
     );
   } finally {
     yield put(unsetDatabaseInstanceDeregistering(payload));
-    yield put(unsetDatabaseInstanceDeregisteringToSAPSystem(payload));
   }
 }
 

--- a/assets/js/state/sagas/databases.test.js
+++ b/assets/js/state/sagas/databases.test.js
@@ -18,13 +18,6 @@ import {
   unsetDatabaseInstanceDeregistering,
 } from '@state/databases';
 import {
-  removeDatabaseInstanceFromSapSystem,
-  upsertDatabaseInstancesToSapSystem,
-  setDatabaseInstanceDeregisteringToSAPSystem,
-  unsetDatabaseInstanceDeregisteringToSAPSystem,
-  updateDatabaseInstanceAbsentToSAPSystem,
-} from '@state/sapSystems';
-import {
   databaseFactory,
   databaseInstanceFactory,
 } from '@lib/test-utils/factories';
@@ -52,14 +45,6 @@ describe('SAP Systems sagas', () => {
       payload: { sap_system_id, host_id, instance_number, sid },
     });
 
-    expect(dispatched).toContainEqual(
-      removeDatabaseInstanceFromSapSystem({
-        sap_system_id,
-        host_id,
-        instance_number,
-        sid,
-      })
-    );
     expect(dispatched).toContainEqual(
       removeDatabaseInstance({ sap_system_id, host_id, instance_number, sid })
     );
@@ -98,7 +83,6 @@ describe('SAP Systems sagas', () => {
     expect(dispatched).toEqual([
       appendDatabase(database),
       upsertDatabaseInstances(database.database_instances),
-      upsertDatabaseInstancesToSapSystem(database.database_instances),
       notify({
         text: `The database ${database.sid} has been restored.`,
         icon: 'ℹ️',
@@ -122,9 +106,7 @@ describe('SAP Systems sagas', () => {
 
     expect(dispatched).toEqual([
       setDatabaseInstanceDeregistering(instance),
-      setDatabaseInstanceDeregisteringToSAPSystem(instance),
       unsetDatabaseInstanceDeregistering(instance),
-      unsetDatabaseInstanceDeregisteringToSAPSystem(instance),
     ]);
   });
 
@@ -144,13 +126,11 @@ describe('SAP Systems sagas', () => {
 
     expect(dispatched).toEqual([
       setDatabaseInstanceDeregistering(instance),
-      setDatabaseInstanceDeregisteringToSAPSystem(instance),
       notify({
         text: `Error deregistering instance ${instance_number} from ${sid}.`,
         icon: '❌',
       }),
       unsetDatabaseInstanceDeregistering(instance),
-      unsetDatabaseInstanceDeregisteringToSAPSystem(instance),
     ]);
   });
 
@@ -164,13 +144,6 @@ describe('SAP Systems sagas', () => {
 
     expect(dispatched).toEqual([
       updateDatabaseInstanceAbsentAt({
-        sap_system_id,
-        instance_number,
-        host_id,
-        sid,
-        absent_at,
-      }),
-      updateDatabaseInstanceAbsentToSAPSystem({
         sap_system_id,
         instance_number,
         host_id,
@@ -194,13 +167,6 @@ describe('SAP Systems sagas', () => {
 
     expect(dispatched).toEqual([
       updateDatabaseInstanceAbsentAt({
-        sap_system_id,
-        instance_number,
-        host_id,
-        sid,
-        absent_at,
-      }),
-      updateDatabaseInstanceAbsentToSAPSystem({
         sap_system_id,
         instance_number,
         host_id,

--- a/assets/js/state/sagas/sapSystems.js
+++ b/assets/js/state/sagas/sapSystems.js
@@ -15,7 +15,6 @@ import {
   DEREGISTER_APPLICATION_INSTANCE,
   appendSapsystem,
   updateSapSystemHealth,
-  upsertDatabaseInstancesToSapSystem,
   upsertApplicationInstances,
   removeApplicationInstance,
   updateApplicationInstanceHost,
@@ -107,12 +106,8 @@ export function* sapSystemDeregistered({ payload: { id, sid } }) {
 export function* sapSystemRestored({ payload }) {
   yield put(appendSapsystem(payload));
 
-  const {
-    database_instances: databaseInstances,
-    application_instances: applicationInstances,
-  } = payload;
+  const { application_instances: applicationInstances } = payload;
 
-  yield put(upsertDatabaseInstancesToSapSystem(databaseInstances));
   yield put(upsertApplicationInstances(applicationInstances));
 
   yield put(

--- a/assets/js/state/sagas/sapSystems.test.js
+++ b/assets/js/state/sagas/sapSystems.test.js
@@ -13,7 +13,6 @@ import {
 import {
   appendSapsystem,
   removeSAPSystem,
-  upsertDatabaseInstancesToSapSystem,
   updateApplicationInstanceHost,
   upsertApplicationInstances,
   updateApplicationInstanceAbsentAt,
@@ -62,7 +61,6 @@ describe('SAP Systems sagas', () => {
 
     expect(dispatched).toEqual([
       appendSapsystem(sapSystem),
-      upsertDatabaseInstancesToSapSystem(sapSystem.database_instances),
       upsertApplicationInstances(sapSystem.application_instances),
       notify({
         text: `SAP System ${sapSystem.sid} has been restored.`,

--- a/assets/js/state/sapSystems.js
+++ b/assets/js/state/sapSystems.js
@@ -5,8 +5,7 @@ const initialState = {
   loading: false,
   sapSystems: [],
   // eslint-disable-next-line
-  applicationInstances: [], // TODO: is this separation needed? Can it be just encapsulated into previous sapSystems?
-  databaseInstances: [],
+  applicationInstances: [],
 };
 
 export const sapSystemsListSlice = createSlice({
@@ -14,16 +13,12 @@ export const sapSystemsListSlice = createSlice({
   initialState,
   reducers: {
     // Here the payload comes from /api/sap_systems API when the application loads
-    // Note that each sap system item has an application_instances and
-    // a database_instances properties
+    // Note that each sap system item has an application_instances
     setSapSystems: (state, { payload: sapSystems }) => {
       state.sapSystems = sapSystems;
 
       state.applicationInstances = sapSystems.flatMap(
         (sapSystem) => sapSystem.application_instances
-      );
-      state.databaseInstances = sapSystems.flatMap(
-        (sapSystem) => sapSystem.database_instances
       );
     },
     startSapSystemsLoading: (state) => {
@@ -33,7 +28,7 @@ export const sapSystemsListSlice = createSlice({
       state.loading = false;
     },
     // When a new SapSystemRegistered comes in, it gets appended to the list
-    // Note that the item does not have any application_instances nor database_instances properties
+    // Note that the item does not have any application_instances properties
     appendSapsystem: (state, { payload: newSapSystem }) => {
       state.sapSystems = [...state.sapSystems, newSapSystem];
     },
@@ -43,9 +38,6 @@ export const sapSystemsListSlice = createSlice({
       );
       state.applicationInstances = state.applicationInstances.filter(
         (applicationInstance) => applicationInstance.sap_system_id !== id
-      );
-      state.databaseInstances = state.databaseInstances.filter(
-        (databaseInstance) => databaseInstance.sap_system_id !== id
       );
     },
     updateSAPSystem: (state, { payload: sapSystemToUpdate }) => {
@@ -90,22 +82,9 @@ export const sapSystemsListSlice = createSlice({
         instances
       );
     },
-    // When a new DatabaseInstanceRegistered comes in,
-    // it need to be appended to the list of the database instances of the relative sap system
-    upsertDatabaseInstancesToSapSystem: (state, { payload: instances }) => {
-      state.databaseInstances = upsertInstances(
-        state.databaseInstances,
-        instances
-      );
-    },
     removeApplicationInstance: (state, { payload: instance }) => {
       state.applicationInstances = state.applicationInstances.filter(
         (applicationInstance) => !instancesMatch(applicationInstance, instance)
-      );
-    },
-    removeDatabaseInstanceFromSapSystem: (state, { payload: instance }) => {
-      state.databaseInstances = state.databaseInstances.filter(
-        (databaseInstance) => !instancesMatch(databaseInstance, instance)
       );
     },
     updateApplicationInstanceHost: (
@@ -129,36 +108,9 @@ export const sapSystemsListSlice = createSlice({
         { health: instance.health }
       );
     },
-    updateSAPSystemDatabaseInstanceHealth: (state, { payload: instance }) => {
-      state.databaseInstances = updateInstance(
-        state.databaseInstances,
-        instance,
-        { health: instance.health }
-      );
-    },
-    updateSAPSystemDatabaseInstanceSystemReplication: (
-      state,
-      { payload: instance }
-    ) => {
-      state.databaseInstances = updateInstance(
-        state.databaseInstances,
-        instance,
-        {
-          system_replication: instance.system_replication,
-          system_replication_status: instance.system_replication_status,
-        }
-      );
-    },
     updateApplicationInstanceAbsentAt: (state, { payload: instance }) => {
       state.applicationInstances = updateInstance(
         state.applicationInstances,
-        instance,
-        { absent_at: instance.absent_at }
-      );
-    },
-    updateDatabaseInstanceAbsentToSAPSystem: (state, { payload: instance }) => {
-      state.databaseInstances = updateInstance(
-        state.databaseInstances,
         instance,
         { absent_at: instance.absent_at }
       );
@@ -173,26 +125,6 @@ export const sapSystemsListSlice = createSlice({
     unsetApplicationInstanceDeregistering: (state, { payload: instance }) => {
       state.applicationInstances = updateInstance(
         state.applicationInstances,
-        instance,
-        { deregistering: false }
-      );
-    },
-    setDatabaseInstanceDeregisteringToSAPSystem: (
-      state,
-      { payload: instance }
-    ) => {
-      state.databaseInstances = updateInstance(
-        state.databaseInstances,
-        instance,
-        { deregistering: true }
-      );
-    },
-    unsetDatabaseInstanceDeregisteringToSAPSystem: (
-      state,
-      { payload: instance }
-    ) => {
-      state.databaseInstances = updateInstance(
-        state.databaseInstances,
         instance,
         { deregistering: false }
       );
@@ -228,13 +160,9 @@ export const {
   appendSapsystem,
   upsertApplicationInstances,
   removeApplicationInstance,
-  upsertDatabaseInstancesToSapSystem,
-  removeDatabaseInstanceFromSapSystem,
   updateSapSystemHealth,
   updateApplicationInstanceHost,
   updateApplicationInstanceHealth,
-  updateSAPSystemDatabaseInstanceHealth,
-  updateSAPSystemDatabaseInstanceSystemReplication,
   addTagToSAPSystem,
   removeTagFromSAPSystem,
   removeSAPSystem,
@@ -242,9 +170,6 @@ export const {
   updateApplicationInstanceAbsentAt,
   setApplicationInstanceDeregistering,
   unsetApplicationInstanceDeregistering,
-  setDatabaseInstanceDeregisteringToSAPSystem,
-  updateDatabaseInstanceAbsentToSAPSystem,
-  unsetDatabaseInstanceDeregisteringToSAPSystem,
 } = sapSystemsListSlice.actions;
 
 export default sapSystemsListSlice.reducer;

--- a/assets/js/state/sapSystems.test.js
+++ b/assets/js/state/sapSystems.test.js
@@ -1,20 +1,13 @@
 import sapSystemsReducer, {
   removeSAPSystem,
-  upsertDatabaseInstancesToSapSystem,
   upsertApplicationInstances,
   updateApplicationInstanceHost,
   updateApplicationInstanceHealth,
-  updateSAPSystemDatabaseInstanceHealth,
-  updateSAPSystemDatabaseInstanceSystemReplication,
   updateApplicationInstanceAbsentAt,
   removeApplicationInstance,
-  removeDatabaseInstanceFromSapSystem,
   updateSAPSystem,
   setApplicationInstanceDeregistering,
   unsetApplicationInstanceDeregistering,
-  setDatabaseInstanceDeregisteringToSAPSystem,
-  unsetDatabaseInstanceDeregisteringToSAPSystem,
-  updateDatabaseInstanceAbsentToSAPSystem,
 } from '@state/sapSystems';
 import {
   sapSystemFactory,
@@ -132,60 +125,6 @@ describe('SAP Systems reducer', () => {
     expect(sapSystemsReducer(initialState, action)).toEqual(expectedState);
   });
 
-  it('should update the health of a database instance', () => {
-    const instance = databaseInstanceFactory.build();
-    const newHealth = 'newHealth';
-
-    const initialState = {
-      databaseInstances: [instance],
-    };
-
-    const instanceToUpdate = {
-      sap_system_id: instance.sap_system_id,
-      instance_number: instance.instance_number,
-      host_id: instance.host_id,
-      health: newHealth,
-    };
-    const action = updateSAPSystemDatabaseInstanceHealth(instanceToUpdate);
-
-    const expectedState = {
-      databaseInstances: [{ ...instance, health: newHealth }],
-    };
-
-    expect(sapSystemsReducer(initialState, action)).toEqual(expectedState);
-  });
-
-  it('should update the system replication data of a database instance', () => {
-    const instance = databaseInstanceFactory.build();
-    const newSystemReplication = 'newSR';
-    const newStatus = 'newStatus';
-
-    const initialState = {
-      databaseInstances: [instance],
-    };
-
-    const instanceToUpdate = {
-      ...instance,
-      system_replication: newSystemReplication,
-      system_replication_status: newStatus,
-    };
-
-    const action =
-      updateSAPSystemDatabaseInstanceSystemReplication(instanceToUpdate);
-
-    const expectedState = {
-      databaseInstances: [
-        {
-          ...instance,
-          system_replication: newSystemReplication,
-          system_replication_status: newStatus,
-        },
-      ],
-    };
-
-    expect(sapSystemsReducer(initialState, action)).toEqual(expectedState);
-  });
-
   it('should update the absent_at field of an application instance', () => {
     const instance = sapSystemApplicationInstanceFactory.build();
     const absentAt = Date.now();
@@ -225,45 +164,6 @@ describe('SAP Systems reducer', () => {
 
     const expectedState = {
       applicationInstances: [instance2],
-    };
-
-    expect(sapSystemsReducer(initialState, action)).toEqual(expectedState);
-  });
-
-  it('should remove an database instance from state', () => {
-    const [instance1, instance2] = databaseInstanceFactory.buildList(2);
-
-    const initialState = {
-      databaseInstances: [instance1, instance2],
-    };
-
-    const action = removeDatabaseInstanceFromSapSystem(instance1);
-
-    const expectedState = {
-      databaseInstances: [instance2],
-    };
-
-    expect(sapSystemsReducer(initialState, action)).toEqual(expectedState);
-  });
-
-  it('should upsert database instances', () => {
-    const initialInstances = databaseInstanceFactory.buildList(2);
-
-    const initialState = {
-      databaseInstances: initialInstances,
-    };
-
-    const updatedInstance = {
-      ...initialState.databaseInstances[0],
-      instance_hostname: 'my_name_has_changed',
-    };
-    const newInstance = databaseInstanceFactory.build();
-    const newInstances = [updatedInstance, newInstance];
-
-    const action = upsertDatabaseInstancesToSapSystem(newInstances);
-
-    const expectedState = {
-      databaseInstances: [initialInstances[1], ...newInstances],
     };
 
     expect(sapSystemsReducer(initialState, action)).toEqual(expectedState);
@@ -331,73 +231,6 @@ describe('SAP Systems reducer', () => {
       ],
     };
 
-    expect(sapSystemsReducer(initialState, action)).toEqual(expectedState);
-  });
-
-  it('should set database instance in deregistering state', () => {
-    const instance = databaseInstanceFactory.build();
-
-    const initialState = {
-      databaseInstances: [instance],
-    };
-
-    const action = setDatabaseInstanceDeregisteringToSAPSystem(instance);
-
-    const expectedState = {
-      databaseInstances: [
-        {
-          ...instance,
-          deregistering: true,
-        },
-      ],
-    };
-
-    expect(sapSystemsReducer(initialState, action)).toEqual(expectedState);
-  });
-
-  it('should remove deregistering state from database instance', () => {
-    const instance = databaseInstanceFactory.build();
-
-    const initialState = {
-      databaseInstances: [instance],
-    };
-
-    const action = unsetDatabaseInstanceDeregisteringToSAPSystem(instance);
-
-    const expectedState = {
-      databaseInstances: [
-        {
-          ...instance,
-          deregistering: false,
-        },
-      ],
-    };
-
-    expect(sapSystemsReducer(initialState, action)).toEqual(expectedState);
-  });
-
-  it('should update absent state from database instance', () => {
-    const instance = databaseInstanceFactory.build({
-      absent_at: new Date().toISOString(),
-    });
-
-    const initialState = {
-      databaseInstances: [instance],
-    };
-
-    const action = updateDatabaseInstanceAbsentToSAPSystem({
-      ...instance,
-      absent_at: null,
-    });
-
-    const expectedState = {
-      databaseInstances: [
-        {
-          ...instance,
-          absent_at: null,
-        },
-      ],
-    };
     expect(sapSystemsReducer(initialState, action)).toEqual(expectedState);
   });
 });

--- a/assets/js/state/selectors/sapSystem.js
+++ b/assets/js/state/selectors/sapSystem.js
@@ -86,16 +86,12 @@ export const getEnrichedDatabaseDetails = createSelector(
 
 export const getInstancesOnHost = createSelector(
   [
-    (state) => state.sapSystemsList.databaseInstances,
     (state) => state.sapSystemsList.applicationInstances,
     (state) => state.databasesList.databaseInstances,
     (_, hostID) => hostID,
   ],
-  (databaseInstances, applicationInstances, databasesListInstances, hostID) => {
-    const availableDatabaseInstances =
-      databaseInstances.length > 0 ? databaseInstances : databasesListInstances;
-
-    const foundDatabaseInstances = filter(availableDatabaseInstances, {
+  (applicationInstances, databaseInstances, hostID) => {
+    const foundDatabaseInstances = filter(databaseInstances, {
       host_id: hostID,
     }).map((instance) => ({ ...instance, type: DATABASE_TYPE }));
 


### PR DESCRIPTION
# Description

This PRs remove a lot of duplicated code in the redux state usage.
Having the `database_instances` information the sap system reducer is not needed, as we are not using this field information anywhere. 
When we need to merge get a SAP system database instances, we just get them in a selector code, matching the `sap_system_id`.

I have checked all the options, and we should be fine.
In the other hand, I have left that information in the backend. Even though we don't use it in the frontend, I find it useful for any other usecase (to know the database instances belonging to a SAP system).

## How was this tested?

Current tests are enough to see that anything breaks
