### PR TITLE
Set docker as install method in `env` CI job

### DIFF
--- a/.github/workflows/pr_env.yaml
+++ b/.github/workflows/pr_env.yaml
@@ -132,7 +132,8 @@ jobs:
             nginx_ssl_cert_as_base64='true' \
             nginx_ssl_key_as_base64='true' \
             nginx_ssl_cert='${{ secrets.PR_ENV_SSL_CERT }}' \
-            nginx_ssl_key='${{ secrets.PR_ENV_SSL_CERT_KEY }}'"
+            nginx_ssl_key='${{ secrets.PR_ENV_SSL_CERT_KEY }}' \
+            install_method='docker'"
 
   run-photofinish-demo-env:
     name: Use photofinish to push mock data to the pr environment

--- a/.github/workflows/pr_env_close.yaml
+++ b/.github/workflows/pr_env_close.yaml
@@ -108,4 +108,5 @@ jobs:
             rabbitmq_vhost='${{ env.PR_NUMBER }}' \
             rabbitmq_password='trento' \
             rabbitmq_username='${{ env.PR_NUMBER }}rabbitusr' \
-            remove_wanda_container_image='false'"
+            remove_wanda_container_image='false' \
+            install_method='docker'"


### PR DESCRIPTION
# Description

Set `install_method: docker` explicitily, as `rpm` is the default option and e2e depends on docker containers.
Related to: https://github.com/trento-project/ansible/pull/30