### PR TITLE
Display SUMA updates in Host Details page

### DIFF
--- a/assets/js/lib/api/softwareUpdates.js
+++ b/assets/js/lib/api/softwareUpdates.js
@@ -1,4 +1,4 @@
 import { networkClient } from '@lib/network';
 
 export const getSoftwareUpdates = (hostId) =>
-  networkClient.get(`/api/v1/hosts/${hostId}/software_updates`);
+  networkClient.get(`/hosts/${hostId}/software_updates`);

--- a/assets/js/lib/api/softwareUpdates.js
+++ b/assets/js/lib/api/softwareUpdates.js
@@ -1,4 +1,4 @@
 import { networkClient } from '@lib/network';
 
-export const getSoftwareUpdates = (hostId) =>
-  networkClient.get(`/hosts/${hostId}/software_updates`);
+export const getSoftwareUpdates = (hostID) =>
+  networkClient.get(`/hosts/${hostID}/software_updates`);

--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -66,6 +66,7 @@ function HostDetails({
   relevantPatches,
   upgradablePackages,
   softwareUpdatesLoading,
+  softwareUpdatesTooltip,
   cleanUpHost,
   requestHostChecksExecution,
   navigate,
@@ -223,11 +224,7 @@ function HostDetails({
           className="mx-0 my-4"
           relevantPatches={relevantPatches}
           upgradablePackages={upgradablePackages}
-          tooltip={
-            relevantPatches === undefined && upgradablePackages === undefined
-              ? 'SUSE Manager is not available'
-              : undefined
-          }
+          tooltip={softwareUpdatesTooltip}
           loading={softwareUpdatesLoading}
         />
         <ChartsFeatureWrapper chartsEnabled={chartsEnabled}>

--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { EOS_CLEAR_ALL, EOS_PLAY_CIRCLE, EOS_SETTINGS } from 'eos-icons-react';
 
 import { agentVersionWarning } from '@lib/agent';
+import { getFromConfig } from '@lib/config';
 
 import BackButton from '@common/BackButton';
 import Button from '@common/Button';
@@ -220,13 +221,16 @@ function HostDetails({
             />
           </div>
         </div>
-        <AvailableSoftwareUpdates
-          className="mx-0 my-4"
-          relevantPatches={relevantPatches}
-          upgradablePackages={upgradablePackages}
-          tooltip={softwareUpdatesTooltip}
-          loading={softwareUpdatesLoading}
-        />
+
+        {getFromConfig('suseManagerEnabled') && (
+          <AvailableSoftwareUpdates
+            className="mx-0 my-4"
+            relevantPatches={relevantPatches}
+            upgradablePackages={upgradablePackages}
+            tooltip={softwareUpdatesTooltip}
+            loading={softwareUpdatesLoading}
+          />
+        )}
         <ChartsFeatureWrapper chartsEnabled={chartsEnabled}>
           <div>
             <HostChart

--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -13,6 +13,7 @@ import Table from '@common/Table';
 import Tooltip from '@common/Tooltip';
 import Banner from '@common/Banners/Banner';
 import ChartsFeatureWrapper from '@common/ChartsFeatureWrapper';
+import AvailableSoftwareUpdates from '@common/AvailableSoftwareUpdates';
 
 import { subHours } from 'date-fns';
 
@@ -62,6 +63,9 @@ function HostDetails({
   slesSubscriptions,
   catalog,
   lastExecution,
+  relevantPatches,
+  upgradablePackages,
+  softwareUpdatesLoading,
   cleanUpHost,
   requestHostChecksExecution,
   navigate,
@@ -215,6 +219,17 @@ function HostDetails({
             />
           </div>
         </div>
+        <AvailableSoftwareUpdates
+          className="mx-0 my-4"
+          relevantPatches={relevantPatches}
+          upgradablePackages={upgradablePackages}
+          tooltip={
+            relevantPatches === undefined && upgradablePackages === undefined
+              ? 'SUSE Manager is not available'
+              : undefined
+          }
+          loading={softwareUpdatesLoading}
+        />
         <ChartsFeatureWrapper chartsEnabled={chartsEnabled}>
           <div>
             <HostChart

--- a/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
@@ -176,6 +176,58 @@ describe('HostDetails component', () => {
     });
   });
 
+  describe('SUMA', () => {
+    it('should show the summary of SUMA software updates', () => {
+      const relevantPatches = faker.number.int(100);
+      const upgradablePackages = faker.number.int(100);
+
+      renderWithRouter(
+        <HostDetails
+          agentVersion="2.0.0"
+          relevantPatches={relevantPatches}
+          upgradablePackages={upgradablePackages}
+        />
+      );
+
+      const relevantPatchesElement = screen
+        .getByText(/Relevant Patches/)
+        .closest('div');
+      const upgradablePackagesElement = screen
+        .getByText(/Upgradable Packages/)
+        .closest('div');
+
+      expect(relevantPatchesElement).toHaveTextContent(
+        relevantPatches.toString()
+      );
+      expect(upgradablePackagesElement).toHaveTextContent(
+        upgradablePackages.toString()
+      );
+    });
+
+    it("should display software updates as 'Unknown' when no SUMA updates data is available", () => {
+      const relevantPatches = undefined;
+      const upgradablePackages = undefined;
+
+      renderWithRouter(
+        <HostDetails
+          agentVersion="2.0.0"
+          relevantPatches={relevantPatches}
+          upgradablePackages={upgradablePackages}
+        />
+      );
+
+      const relevantPatchesElement = screen
+        .getByText(/Relevant Patches/)
+        .closest('div');
+      const upgradablePackagesElement = screen
+        .getByText(/Upgradable Packages/)
+        .closest('div');
+
+      expect(relevantPatchesElement).toHaveTextContent('Unknown');
+      expect(upgradablePackagesElement).toHaveTextContent('Unknown');
+    });
+  });
+
   describe('last execution overview', () => {
     it('should be displayed when lastExecution has data inside', () => {
       const passingCount = faker.number.int(100);

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -11,6 +11,10 @@ import { getClusterByHost } from '@state/selectors/cluster';
 import { getInstancesOnHost } from '@state/selectors/sapSystem';
 import { getCatalog } from '@state/selectors/catalog';
 import { getLastExecution } from '@state/selectors/lastExecutions';
+import {
+  getSoftwareUpdates,
+  getSoftwareUpdatesStats,
+} from '@state/selectors/softwareUpdates';
 
 import { getHost, getHostSelectedChecks } from '@state/selectors/host';
 import { isSaving } from '@state/selectors/checksSelection';
@@ -46,6 +50,13 @@ function HostDetailsPage() {
   const saving = useSelector(isSaving(TARGET_HOST, hostID));
 
   const [exportersStatus, setExportersStatus] = useState([]);
+
+  const { loading: softwareUpdatesLoading } = useSelector((state) =>
+    getSoftwareUpdates(state)
+  );
+  const { numRelevantPatches, numUpgradablePackages } = useSelector((state) =>
+    getSoftwareUpdatesStats(state, hostID)
+  );
 
   const getExportersStatus = async () => {
     const { data } = await networkClient.get(
@@ -92,6 +103,9 @@ function HostDetailsPage() {
       selectedChecks={hostSelectedChecks}
       slesSubscriptions={host.sles_subscriptions}
       catalog={catalog}
+      relevantPatches={numRelevantPatches}
+      upgradablePackages={numUpgradablePackages}
+      softwareUpdatesLoading={softwareUpdatesLoading}
       lastExecution={lastExecution}
       cleanUpHost={() => {
         dispatch(

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -25,7 +25,7 @@ import {
 } from '@state/lastExecutions';
 
 import { deregisterHost } from '@state/hosts';
-import { fetchSoftwareUpdates } from '@state/sagas/softwareUpdates';
+import { fetchSoftwareUpdates } from '@state/softwareUpdates';
 import HostDetails from './HostDetails';
 
 // eslint-disable-next-line no-undef

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -25,6 +25,7 @@ import {
 } from '@state/lastExecutions';
 
 import { deregisterHost } from '@state/hosts';
+import { fetchSoftwareUpdates } from '@state/sagas/softwareUpdates';
 import HostDetails from './HostDetails';
 
 // eslint-disable-next-line no-undef
@@ -77,6 +78,7 @@ function HostDetailsPage() {
     getExportersStatus();
     refreshCatalog();
     dispatch(updateLastExecution(hostID));
+    dispatch(fetchSoftwareUpdates(hostID));
   }, []);
 
   if (!host) {

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -108,6 +108,11 @@ function HostDetailsPage() {
       relevantPatches={numRelevantPatches}
       upgradablePackages={numUpgradablePackages}
       softwareUpdatesLoading={softwareUpdatesLoading}
+      softwareUpdatesTooltip={
+        numRelevantPatches === undefined && numUpgradablePackages === undefined
+          ? 'SUSE Manager is not available'
+          : undefined
+      }
       lastExecution={lastExecution}
       cleanUpHost={() => {
         dispatch(

--- a/assets/js/state/sagas/softwareUpdates.js
+++ b/assets/js/state/sagas/softwareUpdates.js
@@ -10,7 +10,7 @@ import {
   setSoftwareUpdatesErrors,
 } from '@state/softwareUpdates';
 
-export function* fetchSoftwareUpdates({ payload: { hostID } }) {
+export function* fetchSoftwareUpdates(hostID) {
   yield put(startLoadingSoftwareUpdates());
 
   try {

--- a/assets/js/state/sagas/softwareUpdates.js
+++ b/assets/js/state/sagas/softwareUpdates.js
@@ -10,14 +10,14 @@ import {
   setSoftwareUpdatesErrors,
 } from '@state/softwareUpdates';
 
-export function* fetchSoftwareUpdates({ payload: { hostId } }) {
+export function* fetchSoftwareUpdates({ payload: { hostID } }) {
   yield put(startLoadingSoftwareUpdates());
 
   try {
-    const response = yield call(getSoftwareUpdates, hostId);
-    yield put(setSoftwareUpdates({ hostId, ...response.data }));
+    const response = yield call(getSoftwareUpdates, hostID);
+    yield put(setSoftwareUpdates({ hostID, ...response.data }));
   } catch (error) {
-    yield put(setEmptySoftwareUpdates({ hostId }));
+    yield put(setEmptySoftwareUpdates({ hostID }));
     const errors = get(error, ['response', 'data'], []);
     yield put(setSoftwareUpdatesErrors(errors));
   }

--- a/assets/js/state/sagas/softwareUpdates.js
+++ b/assets/js/state/sagas/softwareUpdates.js
@@ -10,7 +10,7 @@ import {
   setSoftwareUpdatesErrors,
 } from '@state/softwareUpdates';
 
-export function* fetchSoftwareUpdates(hostID) {
+export function* fetchSoftwareUpdates({ payload: hostID }) {
   yield put(startLoadingSoftwareUpdates());
 
   try {

--- a/assets/js/state/sagas/softwareUpdates.test.js
+++ b/assets/js/state/sagas/softwareUpdates.test.js
@@ -52,9 +52,7 @@ describe('Software Updates saga', () => {
         .onGet(`/api/v1/hosts/${hostID}/software_updates`)
         .reply(200, response);
 
-      const dispatched = await recordSaga(fetchSoftwareUpdates, {
-        payload: { hostID, ...response },
-      });
+      const dispatched = await recordSaga(fetchSoftwareUpdates, hostID);
 
       expect(dispatched).toEqual([
         startLoadingSoftwareUpdates(),
@@ -75,9 +73,7 @@ describe('Software Updates saga', () => {
           .onGet(`/api/v1/hosts/${hostID}/software_updates`)
           .reply(status, body);
 
-        const dispatched = await recordSaga(fetchSoftwareUpdates, {
-          payload: { hostID },
-        });
+        const dispatched = await recordSaga(fetchSoftwareUpdates, hostID);
 
         expect(dispatched).toEqual([
           startLoadingSoftwareUpdates(),

--- a/assets/js/state/sagas/softwareUpdates.test.js
+++ b/assets/js/state/sagas/softwareUpdates.test.js
@@ -18,7 +18,7 @@ describe('Software Updates saga', () => {
   describe('Fetching Software Updates', () => {
     it('should successfully fetch software updates', async () => {
       const axiosMock = new MockAdapter(networkClient);
-      const hostId = faker.string.uuid();
+      const hostID = faker.string.uuid();
       const response = {
         relevant_patches: [
           {
@@ -49,16 +49,16 @@ describe('Software Updates saga', () => {
       };
 
       axiosMock
-        .onGet(`/api/v1/hosts/${hostId}/software_updates`)
+        .onGet(`/api/v1/hosts/${hostID}/software_updates`)
         .reply(200, response);
 
       const dispatched = await recordSaga(fetchSoftwareUpdates, {
-        payload: { hostId, ...response },
+        payload: { hostID, ...response },
       });
 
       expect(dispatched).toEqual([
         startLoadingSoftwareUpdates(),
-        setSoftwareUpdates({ hostId, ...response }),
+        setSoftwareUpdates({ hostID, ...response }),
       ]);
     });
 
@@ -69,19 +69,19 @@ describe('Software Updates saga', () => {
       'should empty software updates settings on failed fetching',
       async ({ status, body }) => {
         const axiosMock = new MockAdapter(networkClient);
-        const hostId = faker.string.uuid();
+        const hostID = faker.string.uuid();
 
         axiosMock
-          .onGet(`/api/v1/hosts/${hostId}/software_updates`)
+          .onGet(`/api/v1/hosts/${hostID}/software_updates`)
           .reply(status, body);
 
         const dispatched = await recordSaga(fetchSoftwareUpdates, {
-          payload: { hostId },
+          payload: { hostID },
         });
 
         expect(dispatched).toEqual([
           startLoadingSoftwareUpdates(),
-          setEmptySoftwareUpdates({ hostId }),
+          setEmptySoftwareUpdates({ hostID }),
           setSoftwareUpdatesErrors(body),
         ]);
       }

--- a/assets/js/state/sagas/softwareUpdates.test.js
+++ b/assets/js/state/sagas/softwareUpdates.test.js
@@ -52,7 +52,9 @@ describe('Software Updates saga', () => {
         .onGet(`/api/v1/hosts/${hostID}/software_updates`)
         .reply(200, response);
 
-      const dispatched = await recordSaga(fetchSoftwareUpdates, { payload: hostID });
+      const dispatched = await recordSaga(fetchSoftwareUpdates, {
+        payload: hostID,
+      });
 
       expect(dispatched).toEqual([
         startLoadingSoftwareUpdates(),
@@ -73,7 +75,9 @@ describe('Software Updates saga', () => {
           .onGet(`/api/v1/hosts/${hostID}/software_updates`)
           .reply(status, body);
 
-        const dispatched = await recordSaga(fetchSoftwareUpdates, { payload: hostID });
+        const dispatched = await recordSaga(fetchSoftwareUpdates, {
+          payload: hostID,
+        });
 
         expect(dispatched).toEqual([
           startLoadingSoftwareUpdates(),

--- a/assets/js/state/sagas/softwareUpdates.test.js
+++ b/assets/js/state/sagas/softwareUpdates.test.js
@@ -52,7 +52,7 @@ describe('Software Updates saga', () => {
         .onGet(`/api/v1/hosts/${hostID}/software_updates`)
         .reply(200, response);
 
-      const dispatched = await recordSaga(fetchSoftwareUpdates, hostID);
+      const dispatched = await recordSaga(fetchSoftwareUpdates, { payload: hostID });
 
       expect(dispatched).toEqual([
         startLoadingSoftwareUpdates(),
@@ -73,7 +73,7 @@ describe('Software Updates saga', () => {
           .onGet(`/api/v1/hosts/${hostID}/software_updates`)
           .reply(status, body);
 
-        const dispatched = await recordSaga(fetchSoftwareUpdates, hostID);
+        const dispatched = await recordSaga(fetchSoftwareUpdates, { payload: hostID });
 
         expect(dispatched).toEqual([
           startLoadingSoftwareUpdates(),

--- a/assets/js/state/selectors/softwareUpdates.test.js
+++ b/assets/js/state/selectors/softwareUpdates.test.js
@@ -2,9 +2,9 @@ import { faker } from '@faker-js/faker';
 import { getSoftwareUpdates, getSoftwareUpdatesStats } from './softwareUpdates';
 
 describe('Software Updates selector', () => {
-  const hostId = faker.string.uuid();
+  const hostID = faker.string.uuid();
   const softwareUpdates = {
-    [hostId]: {
+    [hostID]: {
       relevant_patches: [
         {
           date: '2024-03-13',
@@ -103,7 +103,7 @@ describe('Software Updates selector', () => {
   });
 
   it('should return the correct software updates statistics', () => {
-    expect(getSoftwareUpdatesStats(state, hostId)).toEqual({
+    expect(getSoftwareUpdatesStats(state, hostID)).toEqual({
       numRelevantPatches: 4,
       numUpgradablePackages: 3,
     });

--- a/assets/js/state/softwareUpdates.js
+++ b/assets/js/state/softwareUpdates.js
@@ -15,21 +15,21 @@ export const softwareUpdatesSlice = createSlice({
     },
     setSoftwareUpdates: (
       state,
-      { payload: { hostId, relevant_patches, upgradable_packages } }
+      { payload: { hostID, relevant_patches, upgradable_packages } }
     ) => {
       state.loading = false;
 
       state.softwareUpdates = {
         ...state.softwareUpdates,
-        [hostId]: {
+        [hostID]: {
           relevant_patches,
           upgradable_packages,
         },
       };
     },
-    setEmptySoftwareUpdates: (state, { payload: { hostId } }) => {
+    setEmptySoftwareUpdates: (state, { payload: { hostID } }) => {
       state.loading = false;
-      state.softwareUpdates = { ...state.softwareUpdates, [hostId]: {} };
+      state.softwareUpdates = { ...state.softwareUpdates, [hostID]: {} };
     },
     setSoftwareUpdatesErrors: (state, { payload: errors }) => {
       state.loading = false;

--- a/assets/js/state/softwareUpdates.test.js
+++ b/assets/js/state/softwareUpdates.test.js
@@ -92,7 +92,7 @@ describe('SoftwareUpdates reducer', () => {
     };
 
     const action = setSoftwareUpdates({
-      hostId: host2,
+      hostID: host2,
       relevant_patches: newRelevantPatches,
       upgradable_packages: newUpgradablePackages,
     });
@@ -135,7 +135,7 @@ describe('SoftwareUpdates reducer', () => {
       errors: [],
     };
 
-    const action = setEmptySoftwareUpdates({ hostId: host2 });
+    const action = setEmptySoftwareUpdates({ hostID: host2 });
 
     const actual = softwareUpdatesReducer(initialState, action);
 


### PR DESCRIPTION
# Description

This change mounts the `AvailableSoftwareUpdates` component in the _Host Details_ page, allowing users to see the available updates and patches for a host, as instructed by SUMA.

## How was this tested?

Added React component tests to validate that the _Available Software Updates_ component is correctly being displayed in the _Host Details_ page.
