### PR TITLE
Clear software updates discovered health on host deregistration

### DIFF
--- a/lib/trento/hosts/host.ex
+++ b/lib/trento/hosts/host.ex
@@ -410,6 +410,9 @@ defmodule Trento.Hosts.Host do
         %DeregisterHost{deregistered_at: deregistered_at}
       ) do
     [
+      %SoftwareUpdatesDiscoveryCleared{
+        host_id: host_id
+      },
       %HostDeregistered{
         host_id: host_id,
         deregistered_at: deregistered_at


### PR DESCRIPTION
# Description

This PR makes sure a `SoftwareUpdatesDiscoveryCleared` event is emitted when deregistering a host.

I also considered the alternative to hook in the deregistration process manager by dispatching a `ClearSoftwareUpdatesDiscovery` command when appropriate, but that would have meant possibily emitting also a `HostHealthChanged` event which is irrelevant for the usecase.

Gotta double check if rollup needs also any intervention.

## How was this tested?

Automated tests.

@arbulu89 you might have good points here, that's why I am asking your review as well. 