### PR TITLE
Move database events

### DIFF
--- a/lib/trento/databases.ex
+++ b/lib/trento/databases.ex
@@ -1,0 +1,68 @@
+defmodule Trento.Databases do
+  @moduledoc """
+  Provides a set of functions to interact with databases.
+  """
+
+  import Ecto.Query
+
+  alias Trento.SapSystems.Projections.{
+    DatabaseInstanceReadModel,
+    DatabaseReadModel
+  }
+
+  alias Trento.Support.DateService
+
+  alias Trento.Databases.Commands.DeregisterDatabaseInstance
+
+  alias Trento.Repo
+
+  @spec get_all_databases :: [DatabaseReadModel.t()]
+  def get_all_databases do
+    DatabaseReadModel
+    |> where([d], is_nil(d.deregistered_at))
+    |> order_by(asc: :sid)
+    |> Repo.all()
+    |> Repo.preload([
+      :database_instances,
+      :tags
+    ])
+  end
+
+  @spec get_database_instances_by_host_id(String.t()) :: [DatabaseInstanceReadModel.t()]
+  def get_database_instances_by_host_id(host_id) do
+    DatabaseInstanceReadModel
+    |> where([d], d.host_id == ^host_id)
+    |> Repo.all()
+  end
+
+  @spec deregister_database_instance(Ecto.UUID.t(), Ecto.UUID.t(), String.t(), DateService) ::
+          :ok | {:error, :instance_present} | {:error, :database_instance_not_registered}
+  def deregister_database_instance(
+        database_id,
+        host_id,
+        instance_number,
+        date_service \\ DateService
+      ) do
+    case Repo.get_by(DatabaseInstanceReadModel,
+           sap_system_id: database_id,
+           host_id: host_id,
+           instance_number: instance_number
+         ) do
+      %DatabaseInstanceReadModel{absent_at: nil} ->
+        {:error, :instance_present}
+
+      _ ->
+        commanded().dispatch(
+          DeregisterDatabaseInstance.new!(%{
+            database_id: database_id,
+            host_id: host_id,
+            instance_number: instance_number,
+            deregistered_at: date_service.utc_now()
+          })
+        )
+    end
+  end
+
+  defp commanded,
+    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
+end

--- a/lib/trento/databases/database.ex
+++ b/lib/trento/databases/database.ex
@@ -25,7 +25,7 @@ defmodule Trento.Databases.Database do
     RegisterDatabaseInstance
   }
 
-  alias Trento.SapSystems.Events.{
+  alias Trento.Databases.Events.{
     DatabaseDeregistered,
     DatabaseHealthChanged,
     DatabaseInstanceDeregistered,
@@ -84,12 +84,12 @@ defmodule Trento.Databases.Database do
       ) do
     [
       %DatabaseRegistered{
-        sap_system_id: database_id,
+        database_id: database_id,
         sid: sid,
         health: health
       },
       %DatabaseInstanceRegistered{
-        sap_system_id: database_id,
+        database_id: database_id,
         sid: sid,
         tenant: tenant,
         instance_number: instance_number,
@@ -139,7 +139,7 @@ defmodule Trento.Databases.Database do
       when not is_nil(deregistered_at) do
     [
       %DatabaseInstanceRegistered{
-        sap_system_id: database_id,
+        database_id: database_id,
         sid: sid,
         tenant: tenant,
         instance_number: instance_number,
@@ -154,7 +154,7 @@ defmodule Trento.Databases.Database do
         health: health
       },
       %DatabaseRestored{
-        sap_system_id: database_id,
+        database_id: database_id,
         health: health
       }
     ]
@@ -206,7 +206,7 @@ defmodule Trento.Databases.Database do
         %DatabaseInstanceMarkedAbsent{
           instance_number: instance_number,
           host_id: host_id,
-          sap_system_id: database_id,
+          database_id: database_id,
           absent_at: absent_at
         }
 
@@ -245,7 +245,7 @@ defmodule Trento.Databases.Database do
   def apply(
         %Database{database_id: nil},
         %DatabaseRegistered{
-          sap_system_id: database_id,
+          database_id: database_id,
           sid: sid,
           health: health
         }
@@ -426,7 +426,7 @@ defmodule Trento.Databases.Database do
          }
        ) do
     %DatabaseInstanceRegistered{
-      sap_system_id: database_id,
+      database_id: database_id,
       sid: sid,
       tenant: tenant,
       instance_number: instance_number,
@@ -460,7 +460,7 @@ defmodule Trento.Databases.Database do
     %DatabaseInstanceMarkedPresent{
       instance_number: instance_number,
       host_id: host_id,
-      sap_system_id: database_id
+      database_id: database_id
     }
   end
 
@@ -482,7 +482,7 @@ defmodule Trento.Databases.Database do
        when system_replication != new_system_replication or
               system_replication_status != new_system_replication_status do
     %DatabaseInstanceSystemReplicationChanged{
-      sap_system_id: database_id,
+      database_id: database_id,
       host_id: host_id,
       instance_number: instance_number,
       system_replication: new_system_replication,
@@ -505,7 +505,7 @@ defmodule Trento.Databases.Database do
        )
        when health != new_health do
     %DatabaseInstanceHealthChanged{
-      sap_system_id: database_id,
+      database_id: database_id,
       host_id: host_id,
       instance_number: instance_number,
       health: new_health
@@ -528,7 +528,7 @@ defmodule Trento.Databases.Database do
 
     if new_health != health do
       %DatabaseHealthChanged{
-        sap_system_id: database_id,
+        database_id: database_id,
         health: new_health
       }
     end
@@ -555,7 +555,7 @@ defmodule Trento.Databases.Database do
 
       _ ->
         %DatabaseInstanceDeregistered{
-          sap_system_id: database_id,
+          database_id: database_id,
           instance_number: instance_number,
           host_id: host_id,
           deregistered_at: deregistered_at
@@ -571,7 +571,7 @@ defmodule Trento.Databases.Database do
          },
          deregistered_at
        ) do
-    %DatabaseDeregistered{sap_system_id: database_id, deregistered_at: deregistered_at}
+    %DatabaseDeregistered{database_id: database_id, deregistered_at: deregistered_at}
   end
 
   defp maybe_emit_database_deregistered_event(
@@ -594,7 +594,7 @@ defmodule Trento.Databases.Database do
 
     if has_secondary? and !has_primary? do
       %DatabaseDeregistered{
-        sap_system_id: database_id,
+        database_id: database_id,
         deregistered_at: deregistered_at
       }
     end

--- a/lib/trento/databases/events/database_deregistered.ex
+++ b/lib/trento/databases/events/database_deregistered.ex
@@ -1,0 +1,12 @@
+defmodule Trento.Databases.Events.DatabaseDeregistered do
+  @moduledoc """
+  This event is emitted once all database instances belonging to a HANA database have been deregistered (decommissioned).
+  """
+
+  use Trento.Support.Event
+
+  defevent do
+    field :database_id, Ecto.UUID
+    field :deregistered_at, :utc_datetime_usec
+  end
+end

--- a/lib/trento/databases/events/database_health_changed.ex
+++ b/lib/trento/databases/events/database_health_changed.ex
@@ -1,0 +1,14 @@
+defmodule Trento.Databases.Events.DatabaseHealthChanged do
+  @moduledoc """
+  This event is emitted when a database health has changed.
+  """
+
+  use Trento.Support.Event
+
+  require Trento.Enums.Health, as: Health
+
+  defevent do
+    field :database_id, Ecto.UUID
+    field :health, Ecto.Enum, values: Health.values()
+  end
+end

--- a/lib/trento/databases/events/database_instance_deregistered.ex
+++ b/lib/trento/databases/events/database_instance_deregistered.ex
@@ -1,0 +1,14 @@
+defmodule Trento.Databases.Events.DatabaseInstanceDeregistered do
+  @moduledoc """
+  This event is emitted when a database instance is deregistered (decommissioned).
+  """
+
+  use Trento.Support.Event
+
+  defevent do
+    field :instance_number, :string
+    field :host_id, Ecto.UUID
+    field :database_id, Ecto.UUID
+    field :deregistered_at, :utc_datetime_usec
+  end
+end

--- a/lib/trento/databases/events/database_instance_health_changed.ex
+++ b/lib/trento/databases/events/database_instance_health_changed.ex
@@ -1,4 +1,4 @@
-defmodule Trento.SapSystems.Events.DatabaseInstanceHealthChanged do
+defmodule Trento.Databases.Events.DatabaseInstanceHealthChanged do
   @moduledoc """
   This event is emitted when a database instance health has changed.
   """
@@ -8,7 +8,7 @@ defmodule Trento.SapSystems.Events.DatabaseInstanceHealthChanged do
   require Trento.Enums.Health, as: Health
 
   defevent do
-    field :sap_system_id, Ecto.UUID
+    field :database_id, Ecto.UUID
     field :host_id, Ecto.UUID
     field :instance_number, :string
     field :health, Ecto.Enum, values: Health.values()

--- a/lib/trento/databases/events/database_instance_marked_absent.ex
+++ b/lib/trento/databases/events/database_instance_marked_absent.ex
@@ -1,0 +1,14 @@
+defmodule Trento.Databases.Events.DatabaseInstanceMarkedAbsent do
+  @moduledoc """
+  This event is emitted when a database instance is marked as absent.
+  """
+
+  use Trento.Support.Event
+
+  defevent do
+    field :instance_number, :string
+    field :host_id, Ecto.UUID
+    field :database_id, Ecto.UUID
+    field :absent_at, :utc_datetime_usec
+  end
+end

--- a/lib/trento/databases/events/database_instance_marked_present.ex
+++ b/lib/trento/databases/events/database_instance_marked_present.ex
@@ -1,0 +1,13 @@
+defmodule Trento.Databases.Events.DatabaseInstanceMarkedPresent do
+  @moduledoc """
+  This event is emitted when a database instance is marked as present.
+  """
+
+  use Trento.Support.Event
+
+  defevent do
+    field :instance_number, :string
+    field :host_id, Ecto.UUID
+    field :database_id, Ecto.UUID
+  end
+end

--- a/lib/trento/databases/events/database_instance_registered.ex
+++ b/lib/trento/databases/events/database_instance_registered.ex
@@ -1,0 +1,25 @@
+defmodule Trento.Databases.Events.DatabaseInstanceRegistered do
+  @moduledoc """
+  This event is emitted when a database instance is registered.
+  """
+
+  use Trento.Support.Event
+
+  require Trento.Enums.Health, as: Health
+
+  defevent do
+    field :database_id, Ecto.UUID
+    field :sid, :string
+    field :tenant, :string
+    field :host_id, Ecto.UUID
+    field :instance_number, :string
+    field :instance_hostname, :string
+    field :features, :string
+    field :http_port, :integer
+    field :https_port, :integer
+    field :start_priority, :string
+    field :system_replication, :string
+    field :system_replication_status, :string
+    field :health, Ecto.Enum, values: Health.values()
+  end
+end

--- a/lib/trento/databases/events/database_instance_system_replication_changed.ex
+++ b/lib/trento/databases/events/database_instance_system_replication_changed.ex
@@ -1,0 +1,15 @@
+defmodule Trento.Databases.Events.DatabaseInstanceSystemReplicationChanged do
+  @moduledoc """
+  This event is emitted when a database instance system replication has changed.
+  """
+
+  use Trento.Support.Event
+
+  defevent do
+    field :database_id, Ecto.UUID
+    field :host_id, Ecto.UUID
+    field :instance_number, :string
+    field :system_replication, :string
+    field :system_replication_status, :string
+  end
+end

--- a/lib/trento/databases/events/database_registered.ex
+++ b/lib/trento/databases/events/database_registered.ex
@@ -1,6 +1,6 @@
-defmodule Trento.SapSystems.Events.DatabaseRestored do
+defmodule Trento.Databases.Events.DatabaseRegistered do
   @moduledoc """
-  This event is emitted when a database is restored.
+  This event is emitted when a database is registered.
   """
 
   use Trento.Support.Event
@@ -8,7 +8,8 @@ defmodule Trento.SapSystems.Events.DatabaseRestored do
   require Trento.Enums.Health, as: Health
 
   defevent do
-    field :sap_system_id, Ecto.UUID
+    field :database_id, Ecto.UUID
+    field :sid, :string
     field :health, Ecto.Enum, values: Health.values()
   end
 end

--- a/lib/trento/databases/events/database_restored.ex
+++ b/lib/trento/databases/events/database_restored.ex
@@ -1,6 +1,6 @@
-defmodule Trento.SapSystems.Events.DatabaseHealthChanged do
+defmodule Trento.Databases.Events.DatabaseRestored do
   @moduledoc """
-  This event is emitted when a database health has changed.
+  This event is emitted when a database is restored.
   """
 
   use Trento.Support.Event
@@ -8,7 +8,7 @@ defmodule Trento.SapSystems.Events.DatabaseHealthChanged do
   require Trento.Enums.Health, as: Health
 
   defevent do
-    field :sap_system_id, Ecto.UUID
+    field :database_id, Ecto.UUID
     field :health, Ecto.Enum, values: Health.values()
   end
 end

--- a/lib/trento/databases/events/legacy/database_deregistered.ex
+++ b/lib/trento/databases/events/legacy/database_deregistered.ex
@@ -5,7 +5,7 @@ defmodule Trento.SapSystems.Events.DatabaseDeregistered do
 
   use Trento.Support.Event
 
-  defevent do
+  defevent superseded_by: Trento.Databases.Events.DatabaseDeregistered do
     field :sap_system_id, Ecto.UUID
     field :deregistered_at, :utc_datetime_usec
   end

--- a/lib/trento/databases/events/legacy/database_health_changed.ex
+++ b/lib/trento/databases/events/legacy/database_health_changed.ex
@@ -1,15 +1,14 @@
-defmodule Trento.SapSystems.Events.DatabaseRegistered do
+defmodule Trento.SapSystems.Events.DatabaseHealthChanged do
   @moduledoc """
-  This event is emitted when a database is registered.
+  This event is emitted when a database health has changed.
   """
 
   use Trento.Support.Event
 
   require Trento.Enums.Health, as: Health
 
-  defevent do
+  defevent superseded_by: Trento.Databases.Events.DatabaseHealthChanged do
     field :sap_system_id, Ecto.UUID
-    field :sid, :string
     field :health, Ecto.Enum, values: Health.values()
   end
 end

--- a/lib/trento/databases/events/legacy/database_instance_deregistered.ex
+++ b/lib/trento/databases/events/legacy/database_instance_deregistered.ex
@@ -5,7 +5,7 @@ defmodule Trento.SapSystems.Events.DatabaseInstanceDeregistered do
 
   use Trento.Support.Event
 
-  defevent do
+  defevent superseded_by: Trento.Databases.Events.DatabaseInstanceDeregistered do
     field :instance_number, :string
     field :host_id, Ecto.UUID
     field :sap_system_id, Ecto.UUID

--- a/lib/trento/databases/events/legacy/database_instance_health_changed.ex
+++ b/lib/trento/databases/events/legacy/database_instance_health_changed.ex
@@ -1,0 +1,16 @@
+defmodule Trento.SapSystems.Events.DatabaseInstanceHealthChanged do
+  @moduledoc """
+  This event is emitted when a database instance health has changed.
+  """
+
+  use Trento.Support.Event
+
+  require Trento.Enums.Health, as: Health
+
+  defevent superseded_by: Trento.Databases.Events.DatabaseInstanceHealthChanged do
+    field :sap_system_id, Ecto.UUID
+    field :host_id, Ecto.UUID
+    field :instance_number, :string
+    field :health, Ecto.Enum, values: Health.values()
+  end
+end

--- a/lib/trento/databases/events/legacy/database_instance_marked_absent.ex
+++ b/lib/trento/databases/events/legacy/database_instance_marked_absent.ex
@@ -5,7 +5,7 @@ defmodule Trento.SapSystems.Events.DatabaseInstanceMarkedAbsent do
 
   use Trento.Support.Event
 
-  defevent do
+  defevent superseded_by: Trento.Databases.Events.DatabaseInstanceMarkedAbsent do
     field :instance_number, :string
     field :host_id, Ecto.UUID
     field :sap_system_id, Ecto.UUID

--- a/lib/trento/databases/events/legacy/database_instance_marked_present.ex
+++ b/lib/trento/databases/events/legacy/database_instance_marked_present.ex
@@ -5,7 +5,7 @@ defmodule Trento.SapSystems.Events.DatabaseInstanceMarkedPresent do
 
   use Trento.Support.Event
 
-  defevent do
+  defevent superseded_by: Trento.Databases.Events.DatabaseInstanceMarkedPresent do
     field :instance_number, :string
     field :host_id, Ecto.UUID
     field :sap_system_id, Ecto.UUID

--- a/lib/trento/databases/events/legacy/database_instance_registered.ex
+++ b/lib/trento/databases/events/legacy/database_instance_registered.ex
@@ -7,7 +7,7 @@ defmodule Trento.SapSystems.Events.DatabaseInstanceRegistered do
 
   require Trento.Enums.Health, as: Health
 
-  defevent do
+  defevent superseded_by: Trento.Databases.Events.DatabaseInstanceRegistered do
     field :sap_system_id, Ecto.UUID
     field :sid, :string
     field :tenant, :string

--- a/lib/trento/databases/events/legacy/database_instance_system_replication_changed.ex
+++ b/lib/trento/databases/events/legacy/database_instance_system_replication_changed.ex
@@ -5,7 +5,7 @@ defmodule Trento.SapSystems.Events.DatabaseInstanceSystemReplicationChanged do
 
   use Trento.Support.Event
 
-  defevent do
+  defevent superseded_by: Trento.Databases.Events.DatabaseInstanceSystemReplicationChanged do
     field :sap_system_id, Ecto.UUID
     field :host_id, Ecto.UUID
     field :instance_number, :string

--- a/lib/trento/databases/events/legacy/database_registered.ex
+++ b/lib/trento/databases/events/legacy/database_registered.ex
@@ -1,0 +1,15 @@
+defmodule Trento.SapSystems.Events.DatabaseRegistered do
+  @moduledoc """
+  This event is emitted when a database is registered.
+  """
+
+  use Trento.Support.Event
+
+  require Trento.Enums.Health, as: Health
+
+  defevent superseded_by: Trento.Databases.Events.DatabaseRegistered do
+    field :sap_system_id, Ecto.UUID
+    field :sid, :string
+    field :health, Ecto.Enum, values: Health.values()
+  end
+end

--- a/lib/trento/databases/events/legacy/database_restored.ex
+++ b/lib/trento/databases/events/legacy/database_restored.ex
@@ -1,0 +1,14 @@
+defmodule Trento.SapSystems.Events.DatabaseRestored do
+  @moduledoc """
+  This event is emitted when a database is restored.
+  """
+
+  use Trento.Support.Event
+
+  require Trento.Enums.Health, as: Health
+
+  defevent superseded_by: Trento.Databases.Events.DatabaseRestored do
+    field :sap_system_id, Ecto.UUID
+    field :health, Ecto.Enum, values: Health.values()
+  end
+end

--- a/lib/trento/discovery.ex
+++ b/lib/trento/discovery.ex
@@ -20,7 +20,7 @@ defmodule Trento.Discovery do
     SapSystemPolicy
   }
 
-  alias Trento.{Clusters, SapSystems}
+  alias Trento.{Clusters, Databases, SapSystems}
 
   @type command :: struct
 
@@ -142,7 +142,7 @@ defmodule Trento.Discovery do
 
   defp do_handle(%{"discovery_type" => "saptune_discovery", "agent_id" => agent_id} = event) do
     current_application_instances = SapSystems.get_application_instances_by_host_id(agent_id)
-    current_database_instances = SapSystems.get_database_instances_by_host_id(agent_id)
+    current_database_instances = Databases.get_database_instances_by_host_id(agent_id)
     sap_running = length(current_application_instances) + length(current_database_instances) > 0
 
     HostPolicy.handle(event, sap_running)
@@ -150,7 +150,7 @@ defmodule Trento.Discovery do
 
   defp do_handle(%{"discovery_type" => "sap_system_discovery", "agent_id" => agent_id} = event) do
     current_application_instances = SapSystems.get_application_instances_by_host_id(agent_id)
-    current_database_instances = SapSystems.get_database_instances_by_host_id(agent_id)
+    current_database_instances = Databases.get_database_instances_by_host_id(agent_id)
     cluster_id = Trento.Clusters.get_cluster_id_by_host_id(agent_id)
 
     SapSystemPolicy.handle(

--- a/lib/trento/infrastructure/commanded/event_handlers/alerts_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/alerts_event_handler.ex
@@ -11,10 +11,9 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.AlertsEventHandler do
 
   alias Trento.Hosts.Events.HostHealthChanged
 
-  alias Trento.SapSystems.Events.{
-    DatabaseHealthChanged,
-    SapSystemHealthChanged
-  }
+  alias Trento.Databases.Events.DatabaseHealthChanged
+
+  alias Trento.SapSystems.Events.SapSystemHealthChanged
 
   alias Trento.Infrastructure.Alerting.Alerting
 
@@ -35,11 +34,11 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.AlertsEventHandler do
   end
 
   def handle(
-        %DatabaseHealthChanged{sap_system_id: sap_system_id, health: health},
+        %DatabaseHealthChanged{database_id: database_id, health: health},
         _metadata
       )
       when health == :critical do
-    Alerting.notify_critical_database_health(sap_system_id)
+    Alerting.notify_critical_database_health(database_id)
   end
 
   def handle(

--- a/lib/trento/infrastructure/commanded/process_managers/deregistration_process_manager.ex
+++ b/lib/trento/infrastructure/commanded/process_managers/deregistration_process_manager.ex
@@ -44,11 +44,14 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
     HostRolledUp
   }
 
+  alias Trento.Databases.Events.{
+    DatabaseInstanceDeregistered,
+    DatabaseInstanceRegistered
+  }
+
   alias Trento.SapSystems.Events.{
     ApplicationInstanceDeregistered,
     ApplicationInstanceRegistered,
-    DatabaseInstanceDeregistered,
-    DatabaseInstanceRegistered,
     SapSystemRolledUp
   }
 
@@ -190,7 +193,7 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
   def apply(
         %DeregistrationProcessManager{database_instances: database_instances} = state,
         %DatabaseInstanceRegistered{
-          sap_system_id: sap_system_id,
+          database_id: database_id,
           instance_number: instance_number
         }
       ) do
@@ -198,7 +201,7 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
       state
       | database_instances: [
           %Instance{
-            sap_system_id: sap_system_id,
+            sap_system_id: database_id,
             instance_number: instance_number
           }
           | database_instances

--- a/lib/trento/sap_systems/projections/database_projector.ex
+++ b/lib/trento/sap_systems/projections/database_projector.ex
@@ -15,7 +15,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
 
   alias TrentoWeb.V1.SapSystemView
 
-  alias Trento.SapSystems.Events.{
+  alias Trento.Databases.Events.{
     DatabaseDeregistered,
     DatabaseHealthChanged,
     DatabaseInstanceDeregistered,
@@ -33,7 +33,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
   @databases_topic "monitoring:databases"
 
   project(
-    %DatabaseRegistered{sap_system_id: sap_system_id, sid: sid, health: health},
+    %DatabaseRegistered{database_id: sap_system_id, sid: sid, health: health},
     fn multi ->
       changeset =
         DatabaseReadModel.changeset(%DatabaseReadModel{}, %{
@@ -48,7 +48,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
 
   project(
     %DatabaseHealthChanged{
-      sap_system_id: sap_system_id,
+      database_id: sap_system_id,
       health: health
     },
     fn multi ->
@@ -63,7 +63,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
 
   project(
     %DatabaseInstanceRegistered{
-      sap_system_id: sap_system_id,
+      database_id: sap_system_id,
       sid: sid,
       instance_number: instance_number,
       instance_hostname: instance_hostname,
@@ -101,7 +101,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
 
   project(
     %DatabaseInstanceHealthChanged{
-      sap_system_id: sap_system_id,
+      database_id: sap_system_id,
       host_id: host_id,
       instance_number: instance_number,
       health: health
@@ -122,7 +122,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
 
   project(
     %DatabaseInstanceSystemReplicationChanged{
-      sap_system_id: sap_system_id,
+      database_id: sap_system_id,
       host_id: host_id,
       instance_number: instance_number,
       system_replication: system_replication,
@@ -149,7 +149,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
     %DatabaseInstanceMarkedAbsent{
       instance_number: instance_number,
       host_id: host_id,
-      sap_system_id: sap_system_id,
+      database_id: sap_system_id,
       absent_at: absent_at
     },
     fn multi ->
@@ -172,7 +172,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
     %DatabaseInstanceMarkedPresent{
       instance_number: instance_number,
       host_id: host_id,
-      sap_system_id: sap_system_id
+      database_id: sap_system_id
     },
     fn multi ->
       changeset =
@@ -192,7 +192,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
 
   project(
     %DatabaseDeregistered{
-      sap_system_id: sap_system_id,
+      database_id: sap_system_id,
       deregistered_at: deregistered_at
     },
     fn multi ->
@@ -207,7 +207,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
 
   project(
     %DatabaseRestored{
-      sap_system_id: sap_system_id,
+      database_id: sap_system_id,
       health: health
     },
     fn multi ->
@@ -224,7 +224,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
     %DatabaseInstanceDeregistered{
       instance_number: instance_number,
       host_id: host_id,
-      sap_system_id: sap_system_id
+      database_id: sap_system_id
     },
     fn multi ->
       deregistered_instance =
@@ -355,7 +355,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
         %DatabaseInstanceMarkedAbsent{
           instance_number: instance_number,
           host_id: host_id,
-          sap_system_id: sap_system_id,
+          database_id: sap_system_id,
           absent_at: absent_at
         },
         _,
@@ -381,7 +381,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
         %DatabaseInstanceMarkedPresent{
           instance_number: instance_number,
           host_id: host_id,
-          sap_system_id: sap_system_id
+          database_id: sap_system_id
         },
         _,
         %{database_instance: %DatabaseInstanceReadModel{sid: sid}}
@@ -403,7 +403,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
 
   @impl true
   def after_update(
-        %DatabaseRestored{sap_system_id: sap_system_id},
+        %DatabaseRestored{database_id: sap_system_id},
         _,
         _
       ) do
@@ -422,7 +422,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
   @impl true
   def after_update(
         %DatabaseDeregistered{
-          sap_system_id: sap_system_id
+          database_id: sap_system_id
         },
         _,
         %{
@@ -446,7 +446,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
         %DatabaseInstanceDeregistered{
           instance_number: instance_number,
           host_id: host_id,
-          sap_system_id: sap_system_id
+          database_id: sap_system_id
         },
         _,
         %{

--- a/lib/trento_web/controllers/v1/sap_system_controller.ex
+++ b/lib/trento_web/controllers/v1/sap_system_controller.ex
@@ -2,7 +2,10 @@ defmodule TrentoWeb.V1.SapSystemController do
   use TrentoWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
-  alias Trento.SapSystems
+  alias Trento.{
+    Databases,
+    SapSystems
+  }
 
   alias TrentoWeb.OpenApi.V1.Schema
 
@@ -41,7 +44,7 @@ defmodule TrentoWeb.V1.SapSystemController do
     ]
 
   def list_databases(conn, _) do
-    databases = SapSystems.get_all_databases()
+    databases = Databases.get_all_databases()
 
     render(conn, "databases.json", databases: databases)
   end
@@ -117,7 +120,7 @@ defmodule TrentoWeb.V1.SapSystemController do
         host_id: host_id,
         instance_number: instance_number
       }) do
-    with :ok <- SapSystems.deregister_database_instance(sap_system_id, host_id, instance_number) do
+    with :ok <- Databases.deregister_database_instance(sap_system_id, host_id, instance_number) do
       send_resp(conn, 204, "")
     end
   end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -42,16 +42,19 @@ defmodule Trento.Factory do
     SoftwareUpdatesDiscoveryCompleted
   }
 
-  alias Trento.SapSystems.Events.{
-    ApplicationInstanceDeregistered,
-    ApplicationInstanceMarkedAbsent,
-    ApplicationInstanceRegistered,
+  alias Trento.Databases.Events.{
     DatabaseDeregistered,
     DatabaseInstanceDeregistered,
     DatabaseInstanceMarkedAbsent,
     DatabaseInstanceRegistered,
     DatabaseRegistered,
-    DatabaseRestored,
+    DatabaseRestored
+  }
+
+  alias Trento.SapSystems.Events.{
+    ApplicationInstanceDeregistered,
+    ApplicationInstanceMarkedAbsent,
+    ApplicationInstanceRegistered,
     SapSystemDeregistered,
     SapSystemRegistered,
     SapSystemTombstoned
@@ -305,7 +308,7 @@ defmodule Trento.Factory do
 
   def database_instance_registered_event_factory do
     %DatabaseInstanceRegistered{
-      sap_system_id: Faker.UUID.v4(),
+      database_id: Faker.UUID.v4(),
       sid: Faker.UUID.v4(),
       tenant: Faker.UUID.v4(),
       instance_number: "00",
@@ -325,7 +328,7 @@ defmodule Trento.Factory do
     DatabaseInstanceMarkedAbsent.new!(%{
       instance_number: "00",
       host_id: Faker.UUID.v4(),
-      sap_system_id: Faker.UUID.v4(),
+      database_id: Faker.UUID.v4(),
       absent_at: DateTime.utc_now()
     })
   end
@@ -334,14 +337,14 @@ defmodule Trento.Factory do
     DatabaseInstanceDeregistered.new!(%{
       instance_number: "00",
       host_id: Faker.UUID.v4(),
-      sap_system_id: Faker.UUID.v4(),
+      database_id: Faker.UUID.v4(),
       deregistered_at: DateTime.utc_now()
     })
   end
 
   def database_restored_event_factory do
     DatabaseRestored.new!(%{
-      sap_system_id: Faker.UUID.v4(),
+      database_id: Faker.UUID.v4(),
       health: Health.passing()
     })
   end
@@ -357,7 +360,7 @@ defmodule Trento.Factory do
 
   def database_deregistered_event_factory do
     DatabaseDeregistered.new!(%{
-      sap_system_id: Faker.UUID.v4(),
+      database_id: Faker.UUID.v4(),
       deregistered_at: DateTime.utc_now()
     })
   end
@@ -406,7 +409,7 @@ defmodule Trento.Factory do
 
   def database_registered_event_factory do
     %DatabaseRegistered{
-      sap_system_id: Faker.UUID.v4(),
+      database_id: Faker.UUID.v4(),
       sid: Faker.UUID.v4(),
       health: Health.passing()
     }

--- a/test/trento/databases/database_test.exs
+++ b/test/trento/databases/database_test.exs
@@ -9,7 +9,7 @@ defmodule Trento.Databases.DatabaseTest do
     RegisterDatabaseInstance
   }
 
-  alias Trento.SapSystems.Events.{
+  alias Trento.Databases.Events.{
     DatabaseDeregistered,
     DatabaseHealthChanged,
     DatabaseInstanceDeregistered,
@@ -68,12 +68,12 @@ defmodule Trento.Databases.DatabaseTest do
         }),
         [
           %DatabaseRegistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             sid: sid,
             health: :passing
           },
           %DatabaseInstanceRegistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             sid: sid,
             tenant: tenant,
             instance_number: instance_number,
@@ -139,12 +139,12 @@ defmodule Trento.Databases.DatabaseTest do
         }),
         [
           %DatabaseRegistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             sid: sid,
             health: :passing
           },
           %DatabaseInstanceRegistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             sid: sid,
             tenant: tenant,
             instance_number: instance_number,
@@ -189,12 +189,12 @@ defmodule Trento.Databases.DatabaseTest do
       initial_events = [
         build(
           :database_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           sid: sid
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           sid: sid,
           tenant: tenant,
           instance_number: "10"
@@ -215,7 +215,7 @@ defmodule Trento.Databases.DatabaseTest do
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           sid: sid,
           tenant: tenant,
           instance_number: instance_number,
@@ -246,7 +246,7 @@ defmodule Trento.Databases.DatabaseTest do
       database_instance_registered_event =
         build(
           :database_instance_registered_event,
-          sap_system_id: database_registered_event.sap_system_id
+          database_id: database_registered_event.database_id
         )
 
       initial_events = [
@@ -258,7 +258,7 @@ defmodule Trento.Databases.DatabaseTest do
         initial_events,
         build(
           :register_database_instance_command,
-          database_id: database_registered_event.sap_system_id,
+          database_id: database_registered_event.database_id,
           sid: database_instance_registered_event.sid,
           tenant: database_instance_registered_event.tenant,
           instance_number: database_instance_registered_event.instance_number,
@@ -278,7 +278,7 @@ defmodule Trento.Databases.DatabaseTest do
       database_instance_registered_event =
         build(
           :database_instance_registered_event,
-          sap_system_id: database_registered_event.sap_system_id,
+          database_id: database_registered_event.database_id,
           system_replication: "Secondary",
           system_replication_status: ""
         )
@@ -292,7 +292,7 @@ defmodule Trento.Databases.DatabaseTest do
         initial_events,
         build(
           :register_database_instance_command,
-          database_id: database_registered_event.sap_system_id,
+          database_id: database_registered_event.database_id,
           sid: database_instance_registered_event.sid,
           tenant: database_instance_registered_event.tenant,
           instance_number: database_instance_registered_event.instance_number,
@@ -303,7 +303,7 @@ defmodule Trento.Databases.DatabaseTest do
           health: :passing
         ),
         %DatabaseInstanceSystemReplicationChanged{
-          sap_system_id: database_registered_event.sap_system_id,
+          database_id: database_registered_event.database_id,
           host_id: database_instance_registered_event.host_id,
           instance_number: database_instance_registered_event.instance_number,
           system_replication: "Primary",
@@ -323,8 +323,8 @@ defmodule Trento.Databases.DatabaseTest do
       host_id = Faker.UUID.v4()
 
       initial_events = [
-        build(:database_registered_event, sap_system_id: database_id),
-        build(:database_instance_registered_event, sap_system_id: database_id)
+        build(:database_registered_event, database_id: database_id),
+        build(:database_instance_registered_event, database_id: database_id)
       ]
 
       assert_events_and_state(
@@ -342,7 +342,7 @@ defmodule Trento.Databases.DatabaseTest do
         [
           build(
             :database_instance_registered_event,
-            sap_system_id: database_id,
+            database_id: database_id,
             sid: sid,
             tenant: tenant,
             instance_number: instance_number,
@@ -351,7 +351,7 @@ defmodule Trento.Databases.DatabaseTest do
             health: :critical
           ),
           %DatabaseHealthChanged{
-            sap_system_id: database_id,
+            database_id: database_id,
             health: :critical
           }
         ],
@@ -379,13 +379,13 @@ defmodule Trento.Databases.DatabaseTest do
       database_instance_registered_event =
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: host_id,
           instance_number: instance_number
         )
 
       initial_events = [
-        build(:database_registered_event, sap_system_id: database_id),
+        build(:database_registered_event, database_id: database_id),
         database_instance_registered_event
       ]
 
@@ -403,13 +403,13 @@ defmodule Trento.Databases.DatabaseTest do
         ),
         [
           %DatabaseInstanceHealthChanged{
-            sap_system_id: database_id,
+            database_id: database_id,
             instance_number: instance_number,
             host_id: host_id,
             health: :critical
           },
           %DatabaseHealthChanged{
-            sap_system_id: database_id,
+            database_id: database_id,
             health: :critical
           }
         ],
@@ -438,12 +438,12 @@ defmodule Trento.Databases.DatabaseTest do
       database_instance_registered_event =
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           health: :warning
         )
 
       initial_events = [
-        build(:database_registered_event, sap_system_id: database_id, health: :warning),
+        build(:database_registered_event, database_id: database_id, health: :warning),
         database_instance_registered_event
       ]
 
@@ -474,7 +474,7 @@ defmodule Trento.Databases.DatabaseTest do
         [
           build(
             :database_instance_registered_event,
-            sap_system_id: database_id,
+            database_id: database_id,
             sid: database_instance_registered_event.sid,
             tenant: database_instance_registered_event.tenant,
             instance_number: new_instance_number,
@@ -517,12 +517,12 @@ defmodule Trento.Databases.DatabaseTest do
       initial_events = [
         build(
           :database_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           sid: db_sid
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: primary_database_host_id,
           sid: db_sid,
           instance_number: db_instance_number_1,
@@ -530,20 +530,20 @@ defmodule Trento.Databases.DatabaseTest do
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: secondary_database_host_id,
           instance_number: db_instance_number_2,
           system_replication: "Secondary",
           sid: db_sid
         ),
         build(:database_instance_deregistered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: primary_database_host_id,
           instance_number: db_instance_number_1,
           deregistered_at: deregistered_at
         ),
         build(:database_deregistered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           deregistered_at: deregistered_at
         )
       ]
@@ -578,12 +578,12 @@ defmodule Trento.Databases.DatabaseTest do
       initial_events = [
         build(
           :database_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           sid: db_sid
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: primary_database_host_id,
           sid: db_sid,
           instance_number: db_instance_number_1,
@@ -591,20 +591,20 @@ defmodule Trento.Databases.DatabaseTest do
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: secondary_database_host_id,
           instance_number: db_instance_number_2,
           system_replication: "Secondary",
           sid: db_sid
         ),
         build(:database_instance_deregistered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: primary_database_host_id,
           instance_number: db_instance_number_1,
           deregistered_at: deregistered_at
         ),
         build(:database_deregistered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           deregistered_at: deregistered_at
         )
       ]
@@ -622,7 +622,7 @@ defmodule Trento.Databases.DatabaseTest do
         command,
         [
           %DatabaseInstanceRegistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             sid: db_sid,
             tenant: command.tenant,
             instance_number: command.instance_number,
@@ -637,7 +637,7 @@ defmodule Trento.Databases.DatabaseTest do
             health: command.health
           },
           %DatabaseRestored{
-            sap_system_id: database_id,
+            database_id: database_id,
             health: command.health
           }
         ],
@@ -675,12 +675,12 @@ defmodule Trento.Databases.DatabaseTest do
       initial_events = [
         build(
           :database_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           sid: db_sid
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: primary_database_host_id,
           sid: db_sid,
           instance_number: db_instance_number_1,
@@ -688,26 +688,26 @@ defmodule Trento.Databases.DatabaseTest do
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: secondary_database_host_id,
           instance_number: db_instance_number_2,
           system_replication: "Secondary",
           sid: db_sid
         ),
         build(:database_instance_deregistered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: primary_database_host_id,
           instance_number: db_instance_number_1,
           deregistered_at: deregistered_at
         ),
         build(:database_instance_deregistered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: secondary_database_host_id,
           instance_number: db_instance_number_2,
           deregistered_at: deregistered_at
         ),
         build(:database_deregistered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           deregistered_at: deregistered_at
         )
       ]
@@ -725,7 +725,7 @@ defmodule Trento.Databases.DatabaseTest do
         command,
         [
           %DatabaseInstanceRegistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             sid: db_sid,
             tenant: command.tenant,
             instance_number: command.instance_number,
@@ -740,7 +740,7 @@ defmodule Trento.Databases.DatabaseTest do
             health: command.health
           },
           %DatabaseRestored{
-            sap_system_id: database_id,
+            database_id: database_id,
             health: command.health
           }
         ],
@@ -780,12 +780,12 @@ defmodule Trento.Databases.DatabaseTest do
       initial_events = [
         build(
           :database_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           sid: db_sid
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: primary_database_host_id,
           sid: db_sid,
           instance_number: db_instance_number_1,
@@ -793,26 +793,26 @@ defmodule Trento.Databases.DatabaseTest do
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: secondary_database_host_id,
           instance_number: db_instance_number_2,
           system_replication: "Secondary",
           sid: db_sid
         ),
         build(:database_instance_deregistered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: primary_database_host_id,
           instance_number: db_instance_number_1,
           deregistered_at: deregistered_at
         ),
         build(:database_instance_deregistered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: secondary_database_host_id,
           instance_number: db_instance_number_2,
           deregistered_at: deregistered_at
         ),
         build(:database_deregistered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           deregistered_at: deregistered_at
         )
       ]
@@ -830,7 +830,7 @@ defmodule Trento.Databases.DatabaseTest do
         command,
         [
           %DatabaseInstanceRegistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             sid: db_sid,
             tenant: command.tenant,
             instance_number: command.instance_number,
@@ -845,7 +845,7 @@ defmodule Trento.Databases.DatabaseTest do
             health: command.health
           },
           %DatabaseRestored{
-            sap_system_id: database_id,
+            database_id: database_id,
             health: command.health
           }
         ],
@@ -885,12 +885,12 @@ defmodule Trento.Databases.DatabaseTest do
       initial_events = [
         build(
           :database_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           sid: db_sid
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: primary_database_host_id,
           sid: db_sid,
           instance_number: db_instance_number_1,
@@ -898,20 +898,20 @@ defmodule Trento.Databases.DatabaseTest do
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: secondary_database_host_id,
           instance_number: db_instance_number_2,
           system_replication: "Secondary",
           sid: db_sid
         ),
         build(:database_instance_deregistered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: primary_database_host_id,
           instance_number: db_instance_number_1,
           deregistered_at: deregistered_at
         ),
         build(:database_deregistered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           deregistered_at: deregistered_at
         )
       ]
@@ -929,7 +929,7 @@ defmodule Trento.Databases.DatabaseTest do
         command,
         [
           %DatabaseInstanceRegistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             sid: db_sid,
             tenant: command.tenant,
             instance_number: command.instance_number,
@@ -944,7 +944,7 @@ defmodule Trento.Databases.DatabaseTest do
             health: command.health
           },
           %DatabaseRestored{
-            sap_system_id: database_id,
+            database_id: database_id,
             health: command.health
           }
         ],
@@ -985,12 +985,12 @@ defmodule Trento.Databases.DatabaseTest do
       initial_events = [
         build(
           :database_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           sid: db_sid
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: primary_database_host_id,
           sid: db_sid,
           instance_number: db_instance_number_1,
@@ -998,20 +998,20 @@ defmodule Trento.Databases.DatabaseTest do
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: secondary_database_host_id,
           instance_number: db_instance_number_2,
           system_replication: "Secondary",
           sid: db_sid
         ),
         build(:database_instance_deregistered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: primary_database_host_id,
           instance_number: db_instance_number_1,
           deregistered_at: deregistered_at
         ),
         build(:database_deregistered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           deregistered_at: deregistered_at
         )
       ]
@@ -1043,12 +1043,12 @@ defmodule Trento.Databases.DatabaseTest do
         [
           build(
             :database_registered_event,
-            sap_system_id: database_id,
+            database_id: database_id,
             sid: db_sid
           ),
           build(
             :database_instance_registered_event,
-            sap_system_id: database_id,
+            database_id: database_id,
             host_id: primary_database_host_id,
             sid: db_sid,
             instance_number: db_instance_number_1,
@@ -1056,7 +1056,7 @@ defmodule Trento.Databases.DatabaseTest do
           ),
           build(
             :database_instance_registered_event,
-            sap_system_id: database_id,
+            database_id: database_id,
             host_id: secondary_database_host_id,
             instance_number: db_instance_number_2,
             system_replication: "Secondary",
@@ -1071,13 +1071,13 @@ defmodule Trento.Databases.DatabaseTest do
         },
         [
           %DatabaseInstanceDeregistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             host_id: primary_database_host_id,
             instance_number: db_instance_number_1,
             deregistered_at: deregistered_at
           },
           %DatabaseDeregistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             deregistered_at: deregistered_at
           }
         ],
@@ -1114,12 +1114,12 @@ defmodule Trento.Databases.DatabaseTest do
         [
           build(
             :database_registered_event,
-            sap_system_id: database_id,
+            database_id: database_id,
             sid: db_sid
           ),
           build(
             :database_instance_registered_event,
-            sap_system_id: database_id,
+            database_id: database_id,
             system_replication: "Primary",
             sid: db_sid,
             instance_number: instance_number_1,
@@ -1127,7 +1127,7 @@ defmodule Trento.Databases.DatabaseTest do
           ),
           build(
             :database_instance_registered_event,
-            sap_system_id: database_id,
+            database_id: database_id,
             system_replication: "Secondary",
             sid: db_sid,
             host_id: secondary_db_host_id,
@@ -1141,7 +1141,7 @@ defmodule Trento.Databases.DatabaseTest do
           deregistered_at: deregistered_at
         },
         %DatabaseInstanceDeregistered{
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: secondary_db_host_id,
           instance_number: instance_number_2,
           deregistered_at: deregistered_at
@@ -1167,12 +1167,12 @@ defmodule Trento.Databases.DatabaseTest do
         [
           build(
             :database_registered_event,
-            sap_system_id: database_id,
+            database_id: database_id,
             sid: db_sid
           ),
           build(
             :database_instance_registered_event,
-            sap_system_id: database_id,
+            database_id: database_id,
             host_id: database_host_id,
             instance_number: db_instance_number_1,
             system_replication: nil,
@@ -1187,13 +1187,13 @@ defmodule Trento.Databases.DatabaseTest do
         },
         [
           %DatabaseInstanceDeregistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             host_id: database_host_id,
             instance_number: db_instance_number_1,
             deregistered_at: deregistered_at
           },
           %DatabaseDeregistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             deregistered_at: deregistered_at
           }
         ],
@@ -1222,12 +1222,12 @@ defmodule Trento.Databases.DatabaseTest do
         [
           build(
             :database_registered_event,
-            sap_system_id: database_id,
+            database_id: database_id,
             sid: db_sid
           ),
           build(
             :database_instance_registered_event,
-            sap_system_id: database_id,
+            database_id: database_id,
             host_id: database_host_id,
             instance_number: db_instance_number_1,
             system_replication: nil,
@@ -1235,7 +1235,7 @@ defmodule Trento.Databases.DatabaseTest do
           ),
           build(
             :database_instance_registered_event,
-            sap_system_id: database_id,
+            database_id: database_id,
             host_id: second_database_host_id,
             instance_number: db_instance_number_2,
             system_replication: nil,
@@ -1249,7 +1249,7 @@ defmodule Trento.Databases.DatabaseTest do
           deregistered_at: deregistered_at
         },
         %DatabaseInstanceDeregistered{
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: database_host_id,
           instance_number: db_instance_number_1,
           deregistered_at: deregistered_at
@@ -1277,12 +1277,12 @@ defmodule Trento.Databases.DatabaseTest do
       initial_events = [
         build(
           :database_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           sid: db_sid
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: primary_database_host_id,
           sid: db_sid,
           instance_number: db_instance_number_1,
@@ -1290,7 +1290,7 @@ defmodule Trento.Databases.DatabaseTest do
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: secondary_database_host_id,
           instance_number: db_instance_number_2,
           system_replication: "Secondary"
@@ -1315,17 +1315,17 @@ defmodule Trento.Databases.DatabaseTest do
         ],
         [
           %DatabaseInstanceDeregistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             host_id: primary_database_host_id,
             instance_number: db_instance_number_1,
             deregistered_at: deregistered_at
           },
           %DatabaseDeregistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             deregistered_at: deregistered_at
           },
           %DatabaseInstanceDeregistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             host_id: secondary_database_host_id,
             instance_number: db_instance_number_2,
             deregistered_at: deregistered_at
@@ -1354,12 +1354,12 @@ defmodule Trento.Databases.DatabaseTest do
       initial_events = [
         build(
           :database_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           sid: db_sid
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: first_primary_database_host_id,
           sid: db_sid,
           instance_number: db_instance_number_1,
@@ -1367,7 +1367,7 @@ defmodule Trento.Databases.DatabaseTest do
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: other_primary_database_host_id,
           sid: db_sid,
           instance_number: db_instance_number_2,
@@ -1375,14 +1375,14 @@ defmodule Trento.Databases.DatabaseTest do
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: secondary_database_host_id,
           instance_number: db_instance_number_3,
           system_replication: "Secondary"
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: other_secondary_database_host_id,
           instance_number: db_instance_number_4,
           system_replication: "Secondary"
@@ -1419,29 +1419,29 @@ defmodule Trento.Databases.DatabaseTest do
         ],
         [
           %DatabaseInstanceDeregistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             host_id: first_primary_database_host_id,
             instance_number: db_instance_number_1,
             deregistered_at: deregistered_at
           },
           %DatabaseInstanceDeregistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             host_id: other_primary_database_host_id,
             instance_number: db_instance_number_2,
             deregistered_at: deregistered_at
           },
           %DatabaseDeregistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             deregistered_at: deregistered_at
           },
           %DatabaseInstanceDeregistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             host_id: secondary_database_host_id,
             instance_number: db_instance_number_3,
             deregistered_at: deregistered_at
           },
           %DatabaseInstanceDeregistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             host_id: other_secondary_database_host_id,
             instance_number: db_instance_number_4,
             deregistered_at: deregistered_at
@@ -1465,12 +1465,12 @@ defmodule Trento.Databases.DatabaseTest do
       initial_events = [
         build(
           :database_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           sid: db_sid
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: primary_database_host_id,
           sid: db_sid,
           instance_number: database_instance_number_1,
@@ -1478,7 +1478,7 @@ defmodule Trento.Databases.DatabaseTest do
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: secondary_database_host_id,
           instance_number: database_instance_number_2,
           system_replication: "Secondary"
@@ -1497,13 +1497,13 @@ defmodule Trento.Databases.DatabaseTest do
         ],
         [
           %DatabaseInstanceDeregistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             host_id: primary_database_host_id,
             instance_number: database_instance_number_1,
             deregistered_at: deregistered_at
           },
           %DatabaseDeregistered{
-            sap_system_id: database_id,
+            database_id: database_id,
             deregistered_at: deregistered_at
           }
         ]
@@ -1518,12 +1518,12 @@ defmodule Trento.Databases.DatabaseTest do
         [
           build(
             :database_registered_event,
-            sap_system_id: database_id,
+            database_id: database_id,
             sid: db_sid
           ),
           build(
             :database_instance_registered_event,
-            sap_system_id: database_id,
+            database_id: database_id,
             sid: db_sid,
             host_id: UUID.uuid4(),
             instance_number: "00",
@@ -1552,12 +1552,12 @@ defmodule Trento.Databases.DatabaseTest do
         [
           build(
             :database_registered_event,
-            sap_system_id: database_id,
+            database_id: database_id,
             sid: db_sid
           ),
           build(
             :database_instance_registered_event,
-            sap_system_id: database_id,
+            database_id: database_id,
             sid: db_sid,
             host_id: deregistered_host_id,
             instance_number: deregistered_instance_number,
@@ -1565,7 +1565,7 @@ defmodule Trento.Databases.DatabaseTest do
           ),
           build(
             :database_instance_deregistered_event,
-            sap_system_id: database_id,
+            database_id: database_id,
             host_id: deregistered_host_id,
             instance_number: deregistered_instance_number,
             deregistered_at: DateTime.utc_now()
@@ -1596,12 +1596,12 @@ defmodule Trento.Databases.DatabaseTest do
       initial_events = [
         build(
           :database_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           sid: sid
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           sid: sid,
           host_id: host_id,
           instance_number: absent_db_instance_number,
@@ -1610,14 +1610,14 @@ defmodule Trento.Databases.DatabaseTest do
         ),
         build(
           :database_instance_marked_absent_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: host_id,
           instance_number: absent_db_instance_number,
           absent_at: absent_db_absent_at
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           sid: sid,
           host_id: host_id,
           instance_number: present_db_instance_number,
@@ -1648,7 +1648,7 @@ defmodule Trento.Databases.DatabaseTest do
           %DatabaseInstanceMarkedAbsent{
             instance_number: present_db_instance_number,
             host_id: host_id,
-            sap_system_id: database_id,
+            database_id: database_id,
             absent_at: absent_at
           }
         ],
@@ -1680,12 +1680,12 @@ defmodule Trento.Databases.DatabaseTest do
       initial_events = [
         build(
           :database_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           sid: sid
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           sid: sid,
           host_id: host_id,
           instance_number: absent_db_instance_number,
@@ -1694,14 +1694,14 @@ defmodule Trento.Databases.DatabaseTest do
         ),
         build(
           :database_instance_marked_absent_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           host_id: host_id,
           instance_number: absent_db_instance_number,
           absent_at: DateTime.utc_now()
         ),
         build(
           :database_instance_registered_event,
-          sap_system_id: database_id,
+          database_id: database_id,
           sid: sid,
           host_id: host_id,
           instance_number: present_db_instance_number,
@@ -1730,7 +1730,7 @@ defmodule Trento.Databases.DatabaseTest do
           %DatabaseInstanceMarkedPresent{
             instance_number: absent_db_instance_number,
             host_id: host_id,
-            sap_system_id: database_id
+            database_id: database_id
           }
         ],
         fn state ->

--- a/test/trento/databases_test.exs
+++ b/test/trento/databases_test.exs
@@ -1,0 +1,106 @@
+defmodule Trento.DatabasesTest do
+  use ExUnit.Case
+  use Trento.DataCase
+
+  import Trento.Factory
+  import Mox
+
+  alias Trento.Databases
+
+  alias Trento.SapSystems.Projections.DatabaseReadModel
+
+  alias Trento.Databases.Commands.DeregisterDatabaseInstance
+
+  @moduletag :integration
+
+  describe "databases" do
+    test "should retrieve all the currently registered existing databases and the related instances" do
+      %DatabaseReadModel{
+        id: database_id,
+        sid: sid
+      } = insert(:database)
+
+      insert(:database, deregistered_at: DateTime.utc_now())
+
+      database_instances =
+        Enum.sort_by(
+          insert_list(5, :database_instance_without_host, sap_system_id: database_id),
+          & &1.host_id
+        )
+
+      assert [
+               %DatabaseReadModel{
+                 sid: ^sid,
+                 database_instances: ^database_instances
+               }
+             ] = Databases.get_all_databases()
+    end
+  end
+
+  describe "get_database_instances_by_host_id/1" do
+    test "should return empty if no database instances were found" do
+      assert [] == Databases.get_database_instances_by_host_id(UUID.uuid4())
+    end
+
+    test "should return all the instances with the matching host_id" do
+      host_id = UUID.uuid4()
+      insert_list(10, :database_instance_without_host, host_id: host_id)
+      insert_list(10, :database_instance_without_host)
+
+      database_instances = Databases.get_database_instances_by_host_id(host_id)
+
+      assert 10 == length(database_instances)
+      assert Enum.all?(database_instances, &(&1.host_id == host_id))
+    end
+  end
+
+  describe "deregister_database_instance/4" do
+    test "should dispatch an database deregistration command" do
+      database_id = Faker.UUID.v4()
+      host_id = Faker.UUID.v4()
+      instance_number = "00"
+
+      deregistered_at = DateTime.utc_now()
+
+      expect(
+        Trento.Support.DateService.Mock,
+        :utc_now,
+        fn -> deregistered_at end
+      )
+
+      expect(
+        Trento.Commanded.Mock,
+        :dispatch,
+        fn %DeregisterDatabaseInstance{
+             database_id: ^database_id,
+             host_id: ^host_id,
+             instance_number: ^instance_number,
+             deregistered_at: ^deregistered_at
+           } ->
+          :ok
+        end
+      )
+
+      assert :ok =
+               Databases.deregister_database_instance(
+                 database_id,
+                 host_id,
+                 instance_number,
+                 Trento.Support.DateService.Mock
+               )
+    end
+
+    test "should not delete a present database instance" do
+      %{sap_system_id: database_id, host_id: host_id, instance_number: instance_number} =
+        insert(:database_instance_without_host, absent_at: nil)
+
+      assert {:error, :instance_present} =
+               Databases.deregister_database_instance(
+                 database_id,
+                 host_id,
+                 instance_number,
+                 Trento.Support.DateService.Mock
+               )
+    end
+  end
+end

--- a/test/trento/infrastructure/commanded/event_handlers/stream_roll_up_event_handler_test.exs
+++ b/test/trento/infrastructure/commanded/event_handlers/stream_roll_up_event_handler_test.exs
@@ -100,7 +100,7 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.StreamRollUpEventHandler
         end)
       )
 
-    event = build(:database_instance_registered_event, sap_system_id: sap_system_id)
+    event = build(:application_instance_registered_event, sap_system_id: sap_system_id)
 
     expect(Trento.Commanded.Mock, :dispatch, fn %RollUpSapSystem{
                                                   sap_system_id: ^sap_system_id

--- a/test/trento/infrastructure/commanded/process_managers/deregistration_process_manager_test.exs
+++ b/test/trento/infrastructure/commanded/process_managers/deregistration_process_manager_test.exs
@@ -16,11 +16,14 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
     HostRolledUp
   }
 
+  alias Trento.Databases.Events.{
+    DatabaseInstanceDeregistered,
+    DatabaseInstanceRegistered
+  }
+
   alias Trento.SapSystems.Events.{
     ApplicationInstanceDeregistered,
     ApplicationInstanceRegistered,
-    DatabaseInstanceDeregistered,
-    DatabaseInstanceRegistered,
     SapSystemRolledUp
   }
 
@@ -164,13 +167,13 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
       }
 
       host_id = UUID.uuid4()
-      sap_system_id = UUID.uuid4()
+      database_id = UUID.uuid4()
       instance_number = "01"
 
       events = [
         %DatabaseInstanceRegistered{
           host_id: host_id,
-          sap_system_id: sap_system_id,
+          database_id: database_id,
           instance_number: instance_number
         }
       ]
@@ -182,7 +185,7 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
       assert %DeregistrationProcessManager{
                database_instances: [
                  %Instance{
-                   sap_system_id: ^sap_system_id,
+                   sap_system_id: ^database_id,
                    instance_number: ^instance_number
                  }
                ],
@@ -441,6 +444,7 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
 
     test "should remove instance from state when DatabaseInstanceDeregistered event received" do
       sap_system_id = UUID.uuid4()
+      database_id = UUID.uuid4()
       instance_number = "00"
 
       initial_state = %DeregistrationProcessManager{
@@ -460,7 +464,7 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
         %DatabaseInstanceDeregistered{
           instance_number: instance_number,
           host_id: host_id,
-          sap_system_id: sap_system_id,
+          database_id: database_id,
           deregistered_at: deregistered_at
         }
       ]

--- a/test/trento/sap_systems_test.exs
+++ b/test/trento/sap_systems_test.exs
@@ -7,12 +7,8 @@ defmodule Trento.SapSystemsTest do
 
   alias Trento.SapSystems
 
-  alias Trento.SapSystems.Projections.{
-    DatabaseReadModel,
-    SapSystemReadModel
-  }
+  alias Trento.SapSystems.Projections.SapSystemReadModel
 
-  alias Trento.Databases.Commands.DeregisterDatabaseInstance
   alias Trento.SapSystems.Commands.DeregisterApplicationInstance
 
   @moduletag :integration
@@ -51,28 +47,6 @@ defmodule Trento.SapSystemsTest do
                }
              ] = SapSystems.get_all_sap_systems()
     end
-
-    test "should retrieve all the currently registered existing databases and the related instances" do
-      %DatabaseReadModel{
-        id: sap_system_id,
-        sid: sid
-      } = insert(:database)
-
-      insert(:database, deregistered_at: DateTime.utc_now())
-
-      database_instances =
-        Enum.sort_by(
-          insert_list(5, :database_instance_without_host, sap_system_id: sap_system_id),
-          & &1.host_id
-        )
-
-      assert [
-               %DatabaseReadModel{
-                 sid: ^sid,
-                 database_instances: ^database_instances
-               }
-             ] = SapSystems.get_all_databases()
-    end
   end
 
   describe "get_application_instances_by_host_id/1" do
@@ -89,23 +63,6 @@ defmodule Trento.SapSystemsTest do
 
       assert 10 == length(application_instances)
       assert Enum.all?(application_instances, &(&1.host_id == host_id))
-    end
-  end
-
-  describe "get_database_instances_by_host_id/1" do
-    test "should return empty if no database instances were found" do
-      assert [] == SapSystems.get_application_instances_by_host_id(UUID.uuid4())
-    end
-
-    test "should return all the instances with the matching host_id" do
-      host_id = UUID.uuid4()
-      insert_list(10, :database_instance_without_host, host_id: host_id)
-      insert_list(10, :database_instance_without_host)
-
-      database_instances = SapSystems.get_database_instances_by_host_id(host_id)
-
-      assert 10 == length(database_instances)
-      assert Enum.all?(database_instances, &(&1.host_id == host_id))
     end
   end
 
@@ -151,56 +108,6 @@ defmodule Trento.SapSystemsTest do
 
       assert {:error, :instance_present} =
                SapSystems.deregister_application_instance(
-                 sap_system_id,
-                 host_id,
-                 instance_number,
-                 Trento.Support.DateService.Mock
-               )
-    end
-  end
-
-  describe "deregister_database_instance/4" do
-    test "should dispatch an database deregistration command" do
-      sap_system_id = Faker.UUID.v4()
-      host_id = Faker.UUID.v4()
-      instance_number = "00"
-
-      deregistered_at = DateTime.utc_now()
-
-      expect(
-        Trento.Support.DateService.Mock,
-        :utc_now,
-        fn -> deregistered_at end
-      )
-
-      expect(
-        Trento.Commanded.Mock,
-        :dispatch,
-        fn %DeregisterDatabaseInstance{
-             database_id: ^sap_system_id,
-             host_id: ^host_id,
-             instance_number: ^instance_number,
-             deregistered_at: ^deregistered_at
-           } ->
-          :ok
-        end
-      )
-
-      assert :ok =
-               SapSystems.deregister_database_instance(
-                 sap_system_id,
-                 host_id,
-                 instance_number,
-                 Trento.Support.DateService.Mock
-               )
-    end
-
-    test "should not delete a present database instance" do
-      %{sap_system_id: sap_system_id, host_id: host_id, instance_number: instance_number} =
-        insert(:database_instance_without_host, absent_at: nil)
-
-      assert {:error, :instance_present} =
-               SapSystems.deregister_database_instance(
                  sap_system_id,
                  host_id,
                  instance_number,


### PR DESCRIPTION
# Description

Move the `database` events to its own folder, and create the `databases` context file.
Simple easy file movements.

I don't take care of `upcasting` the events to change `sap_system_id` to `database_id`. We will take care of this when we handle the old events, as we might even ditch them.
I have included the `legacy` events by now, because we need them. Again, we might remove them when we take care of old events.

If you still see some `sap_system_id` fields in the database code, don't worry. I will remove them when I modify the projections code.

Next to come:
- Projectors
- Controllers/views/frontend

## How was this tested?

Tests passing as before
