### PR TITLE
Move database projections

### DIFF
--- a/lib/trento/databases.ex
+++ b/lib/trento/databases.ex
@@ -5,7 +5,7 @@ defmodule Trento.Databases do
 
   import Ecto.Query
 
-  alias Trento.SapSystems.Projections.{
+  alias Trento.Databases.Projections.{
     DatabaseInstanceReadModel,
     DatabaseReadModel
   }
@@ -44,7 +44,7 @@ defmodule Trento.Databases do
         date_service \\ DateService
       ) do
     case Repo.get_by(DatabaseInstanceReadModel,
-           sap_system_id: database_id,
+           database_id: database_id,
            host_id: host_id,
            instance_number: instance_number
          ) do

--- a/lib/trento/databases/projections/database_instance_read_model.ex
+++ b/lib/trento/databases/projections/database_instance_read_model.ex
@@ -1,4 +1,4 @@
-defmodule Trento.SapSystems.Projections.DatabaseInstanceReadModel do
+defmodule Trento.Databases.Projections.DatabaseInstanceReadModel do
   @moduledoc """
   Database instance read model
   """
@@ -16,7 +16,7 @@ defmodule Trento.SapSystems.Projections.DatabaseInstanceReadModel do
   @derive {Jason.Encoder, except: [:__meta__, :__struct__]}
   @primary_key false
   schema "database_instances" do
-    field :sap_system_id, Ecto.UUID, primary_key: true
+    field :database_id, Ecto.UUID, primary_key: true
     field :sid, :string
     field :tenant, :string
     field :instance_number, :string, primary_key: true

--- a/lib/trento/databases/projections/database_projector.ex
+++ b/lib/trento/databases/projections/database_projector.ex
@@ -1,4 +1,4 @@
-defmodule Trento.SapSystems.Projections.DatabaseProjector do
+defmodule Trento.Databases.Projections.DatabaseProjector do
   @moduledoc """
   Database projector
   """
@@ -8,7 +8,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
     repo: Trento.Repo,
     name: "database_projector"
 
-  alias Trento.SapSystems.Projections.{
+  alias Trento.Databases.Projections.{
     DatabaseInstanceReadModel,
     DatabaseReadModel
   }
@@ -33,11 +33,11 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
   @databases_topic "monitoring:databases"
 
   project(
-    %DatabaseRegistered{database_id: sap_system_id, sid: sid, health: health},
+    %DatabaseRegistered{database_id: database_id, sid: sid, health: health},
     fn multi ->
       changeset =
         DatabaseReadModel.changeset(%DatabaseReadModel{}, %{
-          id: sap_system_id,
+          id: database_id,
           sid: sid,
           health: health
         })
@@ -48,13 +48,13 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
 
   project(
     %DatabaseHealthChanged{
-      database_id: sap_system_id,
+      database_id: database_id,
       health: health
     },
     fn multi ->
       changeset =
         DatabaseReadModel
-        |> Repo.get!(sap_system_id)
+        |> Repo.get!(database_id)
         |> DatabaseReadModel.changeset(%{health: health})
 
       Ecto.Multi.update(multi, :database, changeset)
@@ -63,7 +63,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
 
   project(
     %DatabaseInstanceRegistered{
-      database_id: sap_system_id,
+      database_id: database_id,
       sid: sid,
       instance_number: instance_number,
       instance_hostname: instance_hostname,
@@ -80,7 +80,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
     fn multi ->
       database_instance_changeset =
         DatabaseInstanceReadModel.changeset(%DatabaseInstanceReadModel{}, %{
-          sap_system_id: sap_system_id,
+          database_id: database_id,
           sid: sid,
           instance_number: instance_number,
           instance_hostname: instance_hostname,
@@ -101,7 +101,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
 
   project(
     %DatabaseInstanceHealthChanged{
-      database_id: sap_system_id,
+      database_id: database_id,
       host_id: host_id,
       instance_number: instance_number,
       health: health
@@ -110,7 +110,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
       changeset =
         DatabaseInstanceReadModel
         |> Repo.get_by(
-          sap_system_id: sap_system_id,
+          database_id: database_id,
           instance_number: instance_number,
           host_id: host_id
         )
@@ -122,7 +122,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
 
   project(
     %DatabaseInstanceSystemReplicationChanged{
-      database_id: sap_system_id,
+      database_id: database_id,
       host_id: host_id,
       instance_number: instance_number,
       system_replication: system_replication,
@@ -132,7 +132,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
       changeset =
         DatabaseInstanceReadModel
         |> Repo.get_by(
-          sap_system_id: sap_system_id,
+          database_id: database_id,
           instance_number: instance_number,
           host_id: host_id
         )
@@ -149,14 +149,14 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
     %DatabaseInstanceMarkedAbsent{
       instance_number: instance_number,
       host_id: host_id,
-      database_id: sap_system_id,
+      database_id: database_id,
       absent_at: absent_at
     },
     fn multi ->
       changeset =
         DatabaseInstanceReadModel
         |> Repo.get_by(
-          sap_system_id: sap_system_id,
+          database_id: database_id,
           instance_number: instance_number,
           host_id: host_id
         )
@@ -172,13 +172,13 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
     %DatabaseInstanceMarkedPresent{
       instance_number: instance_number,
       host_id: host_id,
-      database_id: sap_system_id
+      database_id: database_id
     },
     fn multi ->
       changeset =
         DatabaseInstanceReadModel
         |> Repo.get_by(
-          sap_system_id: sap_system_id,
+          database_id: database_id,
           instance_number: instance_number,
           host_id: host_id
         )
@@ -192,13 +192,13 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
 
   project(
     %DatabaseDeregistered{
-      database_id: sap_system_id,
+      database_id: database_id,
       deregistered_at: deregistered_at
     },
     fn multi ->
       changeset =
         DatabaseReadModel
-        |> Repo.get!(sap_system_id)
+        |> Repo.get!(database_id)
         |> DatabaseReadModel.changeset(%{deregistered_at: deregistered_at})
 
       Ecto.Multi.update(multi, :database, changeset)
@@ -207,13 +207,13 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
 
   project(
     %DatabaseRestored{
-      database_id: sap_system_id,
+      database_id: database_id,
       health: health
     },
     fn multi ->
       changeset =
         DatabaseReadModel
-        |> Repo.get!(sap_system_id)
+        |> Repo.get!(database_id)
         |> DatabaseReadModel.changeset(%{deregistered_at: nil, health: health})
 
       Ecto.Multi.update(multi, :database, changeset)
@@ -224,12 +224,12 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
     %DatabaseInstanceDeregistered{
       instance_number: instance_number,
       host_id: host_id,
-      database_id: sap_system_id
+      database_id: database_id
     },
     fn multi ->
       deregistered_instance =
         Repo.get_by(DatabaseInstanceReadModel,
-          sap_system_id: sap_system_id,
+          database_id: database_id,
           instance_number: instance_number,
           host_id: host_id
         )
@@ -273,12 +273,12 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
   def after_update(
         %DatabaseInstanceRegistered{},
         _,
-        %{database_instance: %DatabaseInstanceReadModel{sap_system_id: sap_system_id} = instance}
+        %{database_instance: %DatabaseInstanceReadModel{database_id: database_id} = instance}
       ) do
     # All database instances are required to compute the system replication status in the current instance
     database_instances =
       DatabaseInstanceReadModel
-      |> where([i], i.sap_system_id == ^sap_system_id)
+      |> where([i], i.database_id == ^database_id)
       |> Repo.all()
 
     TrentoWeb.Endpoint.broadcast(
@@ -300,7 +300,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
         _,
         %{
           database_instance: %DatabaseInstanceReadModel{
-            sap_system_id: sap_system_id,
+            database_id: database_id,
             host_id: host_id,
             instance_number: instance_number,
             health: health
@@ -312,7 +312,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
       "database_instance_health_changed",
       SapSystemView.render("database_instance_health_changed.json",
         instance: %{
-          sap_system_id: sap_system_id,
+          sap_system_id: database_id,
           host_id: host_id,
           instance_number: instance_number,
           health: health
@@ -327,7 +327,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
         _,
         %{
           database_instance: %DatabaseInstanceReadModel{
-            sap_system_id: sap_system_id,
+            database_id: database_id,
             host_id: host_id,
             instance_number: instance_number,
             system_replication: system_replication,
@@ -340,7 +340,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
       "database_instance_system_replication_changed",
       SapSystemView.render("database_instance_system_replication_changed.json",
         instance: %{
-          sap_system_id: sap_system_id,
+          sap_system_id: database_id,
           host_id: host_id,
           instance_number: instance_number,
           system_replication: system_replication,
@@ -355,7 +355,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
         %DatabaseInstanceMarkedAbsent{
           instance_number: instance_number,
           host_id: host_id,
-          database_id: sap_system_id,
+          database_id: database_id,
           absent_at: absent_at
         },
         _,
@@ -368,7 +368,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
         instance: %{
           instance_number: instance_number,
           host_id: host_id,
-          sap_system_id: sap_system_id,
+          sap_system_id: database_id,
           sid: sid,
           absent_at: absent_at
         }
@@ -381,7 +381,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
         %DatabaseInstanceMarkedPresent{
           instance_number: instance_number,
           host_id: host_id,
-          database_id: sap_system_id
+          database_id: database_id
         },
         _,
         %{database_instance: %DatabaseInstanceReadModel{sid: sid}}
@@ -393,7 +393,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
         instance: %{
           instance_number: instance_number,
           host_id: host_id,
-          sap_system_id: sap_system_id,
+          sap_system_id: database_id,
           sid: sid,
           absent_at: nil
         }
@@ -403,13 +403,13 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
 
   @impl true
   def after_update(
-        %DatabaseRestored{database_id: sap_system_id},
+        %DatabaseRestored{database_id: database_id},
         _,
         _
       ) do
     database =
       DatabaseReadModel
-      |> Repo.get!(sap_system_id)
+      |> Repo.get!(database_id)
       |> Repo.preload([:tags, :database_instances])
 
     TrentoWeb.Endpoint.broadcast(
@@ -422,7 +422,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
   @impl true
   def after_update(
         %DatabaseDeregistered{
-          database_id: sap_system_id
+          database_id: database_id
         },
         _,
         %{
@@ -435,7 +435,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
       @databases_topic,
       "database_deregistered",
       SapSystemView.render("database_deregistered.json",
-        id: sap_system_id,
+        id: database_id,
         sid: sid
       )
     )
@@ -446,7 +446,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
         %DatabaseInstanceDeregistered{
           instance_number: instance_number,
           host_id: host_id,
-          database_id: sap_system_id
+          database_id: database_id
         },
         _,
         %{
@@ -459,7 +459,7 @@ defmodule Trento.SapSystems.Projections.DatabaseProjector do
       @databases_topic,
       "database_instance_deregistered",
       SapSystemView.render("instance_deregistered.json",
-        sap_system_id: sap_system_id,
+        sap_system_id: database_id,
         instance_number: instance_number,
         host_id: host_id,
         sid: sid

--- a/lib/trento/databases/projections/database_read_model.ex
+++ b/lib/trento/databases/projections/database_read_model.ex
@@ -1,4 +1,4 @@
-defmodule Trento.SapSystems.Projections.DatabaseReadModel do
+defmodule Trento.Databases.Projections.DatabaseReadModel do
   @moduledoc """
   Database read model
   """
@@ -9,10 +9,8 @@ defmodule Trento.SapSystems.Projections.DatabaseReadModel do
 
   require Trento.Enums.Health, as: Health
 
-  alias Trento.SapSystems.Projections.{
-    DatabaseInstanceReadModel,
-    SapSystemReadModel
-  }
+  alias Trento.Databases.Projections.DatabaseInstanceReadModel
+  alias Trento.SapSystems.Projections.SapSystemReadModel
 
   alias Trento.Tags.Tag
 
@@ -30,7 +28,7 @@ defmodule Trento.SapSystems.Projections.DatabaseReadModel do
 
     has_many :database_instances, DatabaseInstanceReadModel,
       references: :id,
-      foreign_key: :sap_system_id,
+      foreign_key: :database_id,
       preload_order: [asc: :instance_number, asc: :host_id]
 
     field :deregistered_at, :utc_datetime_usec

--- a/lib/trento/discovery/policies/sap_system_policy.ex
+++ b/lib/trento/discovery/policies/sap_system_policy.ex
@@ -15,7 +15,9 @@ defmodule Trento.Discovery.Policies.SapSystemPolicy do
     RegisterApplicationInstance
   }
 
-  alias Trento.SapSystems.Projections.{ApplicationInstanceReadModel, DatabaseInstanceReadModel}
+  alias Trento.Databases.Projections.DatabaseInstanceReadModel
+
+  alias Trento.SapSystems.Projections.ApplicationInstanceReadModel
 
   alias Trento.Discovery.Payloads.SapSystemDiscoveryPayload
 
@@ -170,7 +172,7 @@ defmodule Trento.Discovery.Policies.SapSystemPolicy do
         MarkDatabaseInstanceAbsent.new!(%{
           host_id: instance.host_id,
           instance_number: instance.instance_number,
-          database_id: instance.sap_system_id,
+          database_id: instance.database_id,
           absent_at: DateTime.utc_now()
         })
     end)

--- a/lib/trento/infrastructure/alerting/alerting.ex
+++ b/lib/trento/infrastructure/alerting/alerting.ex
@@ -6,10 +6,8 @@ defmodule Trento.Infrastructure.Alerting.Alerting do
   alias Trento.Clusters.Projections.ClusterReadModel
   alias Trento.Hosts.Projections.HostReadModel
 
-  alias Trento.SapSystems.Projections.{
-    DatabaseReadModel,
-    SapSystemReadModel
-  }
+  alias Trento.Databases.Projections.DatabaseReadModel
+  alias Trento.SapSystems.Projections.SapSystemReadModel
 
   alias Trento.Infrastructure.Alerting.Emails.EmailAlert
   alias Trento.Mailer

--- a/lib/trento/infrastructure/commanded/event_handlers/database_deregistration_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/database_deregistration_event_handler.ex
@@ -9,9 +9,9 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.DatabaseDeregistrationEv
     name: "database_deregistration_event_handler"
 
   alias Trento.Databases.Events.DatabaseDeregistered
+  alias Trento.Databases.Projections.DatabaseReadModel
   alias Trento.Repo
   alias Trento.SapSystems.Commands.DeregisterSapSystem
-  alias Trento.SapSystems.Projections.DatabaseReadModel
 
   import Ecto.Query, only: [from: 2]
 

--- a/lib/trento/infrastructure/commanded/event_handlers/database_restore_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/database_restore_event_handler.ex
@@ -9,9 +9,9 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.DatabaseRestoreEventHand
     name: "database_restore_event_handler"
 
   alias Trento.Databases.Events.DatabaseRestored
+  alias Trento.Databases.Projections.DatabaseReadModel
   alias Trento.Repo
   alias Trento.SapSystems.Commands.RestoreSapSystem
-  alias Trento.SapSystems.Projections.DatabaseReadModel
 
   import Ecto.Query, only: [from: 2]
 

--- a/lib/trento/infrastructure/commanded/middleware/enrich_register_application_instance.ex
+++ b/lib/trento/infrastructure/commanded/middleware/enrich_register_application_instance.ex
@@ -3,7 +3,7 @@ defimpl Trento.Infrastructure.Commanded.Middleware.Enrichable,
   alias Trento.SapSystems.Commands.RegisterApplicationInstance
 
   alias Trento.Hosts.Projections.HostReadModel
-  alias Trento.SapSystems.Projections.DatabaseInstanceReadModel
+  alias Trento.Databases.Projections.DatabaseInstanceReadModel
 
   alias Trento.Repo
   import Ecto.Query
@@ -17,12 +17,12 @@ defimpl Trento.Infrastructure.Commanded.Middleware.Enrichable,
         where: ^db_host in h.ip_addresses and ^tenant == d.tenant and is_nil(h.deregistered_at)
 
     case Repo.one(query) do
-      %DatabaseInstanceReadModel{sap_system_id: sap_system_id} ->
+      %DatabaseInstanceReadModel{database_id: database_id} ->
         {:ok,
          %RegisterApplicationInstance{
            command
-           | sap_system_id: UUID.uuid5(sap_system_id, tenant),
-             database_id: sap_system_id
+           | sap_system_id: UUID.uuid5(database_id, tenant),
+             database_id: database_id
          }}
 
       nil ->

--- a/lib/trento/infrastructure/commanded/process_managers/deregistration_process_manager.ex
+++ b/lib/trento/infrastructure/commanded/process_managers/deregistration_process_manager.ex
@@ -158,11 +158,11 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
       ) do
     database_instances_deregister_commands =
       Enum.map(database_instances, fn %Instance{
-                                        sap_system_id: sap_system_id,
+                                        sap_system_id: database_id,
                                         instance_number: instance_number
                                       } ->
         %DeregisterDatabaseInstance{
-          database_id: sap_system_id,
+          database_id: database_id,
           instance_number: instance_number,
           host_id: host_id,
           deregistered_at: requested_at

--- a/lib/trento/projectors_supervisor.ex
+++ b/lib/trento/projectors_supervisor.ex
@@ -11,10 +11,9 @@ defmodule Trento.ProjectorsSupervisor do
     TelemetryProjector
   }
 
-  alias Trento.SapSystems.Projections.{
-    DatabaseProjector,
-    SapSystemProjector
-  }
+  alias Trento.Databases.Projections.DatabaseProjector
+
+  alias Trento.SapSystems.Projections.SapSystemProjector
 
   def start_link(init_arg) do
     Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)

--- a/lib/trento/sap_systems/projections/sap_system_read_model.ex
+++ b/lib/trento/sap_systems/projections/sap_system_read_model.ex
@@ -10,11 +10,12 @@ defmodule Trento.SapSystems.Projections.SapSystemReadModel do
   require Trento.SapSystems.Enums.EnsaVersion, as: EnsaVersion
   require Trento.Enums.Health, as: Health
 
-  alias Trento.SapSystems.Projections.{
-    ApplicationInstanceReadModel,
+  alias Trento.Databases.Projections.{
     DatabaseInstanceReadModel,
     DatabaseReadModel
   }
+
+  alias Trento.SapSystems.Projections.ApplicationInstanceReadModel
 
   alias Trento.Tags.Tag
 
@@ -33,7 +34,7 @@ defmodule Trento.SapSystems.Projections.SapSystemReadModel do
 
     has_many :database_instances, DatabaseInstanceReadModel,
       references: :database_id,
-      foreign_key: :sap_system_id,
+      foreign_key: :database_id,
       preload_order: [asc: :instance_number, asc: :host_id]
 
     has_many :application_instances, ApplicationInstanceReadModel,

--- a/lib/trento/sap_systems/services/health_summary_service.ex
+++ b/lib/trento/sap_systems/services/health_summary_service.ex
@@ -7,9 +7,10 @@ defmodule Trento.SapSystems.Services.HealthSummaryService do
 
   require Trento.Enums.Health, as: HealthEnum
 
+  alias Trento.Databases.Projections.DatabaseInstanceReadModel
+
   alias Trento.SapSystems.Projections.{
     ApplicationInstanceReadModel,
-    DatabaseInstanceReadModel,
     SapSystemReadModel
   }
 

--- a/lib/trento_web/views/v1/health_overview_view.ex
+++ b/lib/trento_web/views/v1/health_overview_view.ex
@@ -1,10 +1,8 @@
 defmodule TrentoWeb.V1.HealthOverviewView do
   use TrentoWeb, :view
 
-  alias Trento.SapSystems.Projections.{
-    ApplicationInstanceReadModel,
-    DatabaseInstanceReadModel
-  }
+  alias Trento.Databases.Projections.DatabaseInstanceReadModel
+  alias Trento.SapSystems.Projections.ApplicationInstanceReadModel
 
   def render("overview.json", %{health_infos: health_infos}) do
     render_many(health_infos, __MODULE__, "health_summary.json", as: :summary)
@@ -45,8 +43,8 @@ defmodule TrentoWeb.V1.HealthOverviewView do
   @spec extract_database_id([DatabaseInstanceReadModel.t()]) :: String.t() | nil
   defp extract_database_id([]), do: nil
 
-  defp extract_database_id([%DatabaseInstanceReadModel{sap_system_id: sap_system_id} | _]),
-    do: sap_system_id
+  defp extract_database_id([%DatabaseInstanceReadModel{database_id: database_id} | _]),
+    do: database_id
 
   @spec extract_cluster_id([ApplicationInstanceReadModel.t()] | [DatabaseInstanceReadModel.t()]) ::
           String.t() | nil

--- a/lib/trento_web/views/v1/sap_system_view.ex
+++ b/lib/trento_web/views/v1/sap_system_view.ex
@@ -23,11 +23,14 @@ defmodule TrentoWeb.V1.SapSystemView do
     |> add_system_replication_status_to_secondary_instance
   end
 
-  def render("database_instance.json", %{instance: instance}) do
+  def render("database_instance.json", %{instance: %{database_id: database_id} = instance}) do
     instance
     |> Map.from_struct()
     |> Map.delete(:__meta__)
     |> Map.delete(:host)
+    # Temporary solution to avoid changing frontend code in the same PR
+    |> Map.drop([:database_id])
+    |> Map.put(:sap_system_id, database_id)
   end
 
   def render("database_instance_with_sr_status.json", %{

--- a/priv/repo/migrations/20240320152419_rename_database_instance_read_model_id_field.exs
+++ b/priv/repo/migrations/20240320152419_rename_database_instance_read_model_id_field.exs
@@ -1,0 +1,7 @@
+defmodule Trento.Repo.Migrations.RenameDatabaseInstanceReadModelIdField do
+  use Ecto.Migration
+
+  def change do
+    rename table("database_instances"), :sap_system_id, to: :database_id
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -90,10 +90,13 @@ defmodule Trento.Factory do
     SlesSubscriptionReadModel
   }
 
+  alias Trento.Databases.Projections.{
+    DatabaseInstanceReadModel,
+    DatabaseReadModel
+  }
+
   alias Trento.SapSystems.Projections.{
     ApplicationInstanceReadModel,
-    DatabaseInstanceReadModel,
-    DatabaseReadModel,
     SapSystemReadModel
   }
 
@@ -564,7 +567,7 @@ defmodule Trento.Factory do
 
   def database_instance_without_host_factory do
     %DatabaseInstanceReadModel{
-      sap_system_id: Faker.UUID.v4(),
+      database_id: Faker.UUID.v4(),
       sid: Faker.UUID.v4(),
       tenant: Faker.UUID.v4(),
       instance_number: "00",

--- a/test/trento/databases_test.exs
+++ b/test/trento/databases_test.exs
@@ -7,7 +7,7 @@ defmodule Trento.DatabasesTest do
 
   alias Trento.Databases
 
-  alias Trento.SapSystems.Projections.DatabaseReadModel
+  alias Trento.Databases.Projections.DatabaseReadModel
 
   alias Trento.Databases.Commands.DeregisterDatabaseInstance
 
@@ -24,7 +24,7 @@ defmodule Trento.DatabasesTest do
 
       database_instances =
         Enum.sort_by(
-          insert_list(5, :database_instance_without_host, sap_system_id: database_id),
+          insert_list(5, :database_instance_without_host, database_id: database_id),
           & &1.host_id
         )
 
@@ -91,7 +91,7 @@ defmodule Trento.DatabasesTest do
     end
 
     test "should not delete a present database instance" do
-      %{sap_system_id: database_id, host_id: host_id, instance_number: instance_number} =
+      %{database_id: database_id, host_id: host_id, instance_number: instance_number} =
         insert(:database_instance_without_host, absent_at: nil)
 
       assert {:error, :instance_present} =

--- a/test/trento/discovery/policies/sap_system_policy_test.exs
+++ b/test/trento/discovery/policies/sap_system_policy_test.exs
@@ -211,7 +211,7 @@ defmodule Trento.Discovery.Policies.SapSystemPolicyTest do
         build_list(
           2,
           :database_instance_without_host,
-          sap_system_id: database_sap_system_id
+          database_id: database_sap_system_id
         )
 
       [

--- a/test/trento/infrastructure/commanded/middleware/enrich_register_application_instance_test.exs
+++ b/test/trento/infrastructure/commanded/middleware/enrich_register_application_instance_test.exs
@@ -9,7 +9,7 @@ defmodule Trento.Infrastructure.Commanded.Middleware.EnrichRegisterApplicationIn
 
   test "should return an enriched command if the database was found by the ip and tenant" do
     %{
-      sap_system_id: sap_system_id,
+      database_id: database_id,
       tenant: tenant,
       host: %{ip_addresses: [ip]}
     } = insert(:database_instance)
@@ -27,7 +27,7 @@ defmodule Trento.Infrastructure.Commanded.Middleware.EnrichRegisterApplicationIn
         health: :passing
       )
 
-    expected_sap_system_id = UUID.uuid5(sap_system_id, tenant)
+    expected_sap_system_id = UUID.uuid5(database_id, tenant)
 
     assert {:ok,
             %RegisterApplicationInstance{

--- a/test/trento/infrastructure/commanded/middleware/enrich_register_application_instance_test.exs
+++ b/test/trento/infrastructure/commanded/middleware/enrich_register_application_instance_test.exs
@@ -32,7 +32,7 @@ defmodule Trento.Infrastructure.Commanded.Middleware.EnrichRegisterApplicationIn
     assert {:ok,
             %RegisterApplicationInstance{
               sap_system_id: ^expected_sap_system_id,
-              database_id: ^sap_system_id
+              database_id: ^database_id
             }} =
              Enrichable.enrich(command, %{})
   end

--- a/test/trento/infrastructure/commanded/process_managers/deregistration_process_manager_test.exs
+++ b/test/trento/infrastructure/commanded/process_managers/deregistration_process_manager_test.exs
@@ -375,6 +375,7 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
     test "should dispatch commands when HostDeregistrationRequested is emitted and the host does not belong to a cluster and has instances associated" do
       host_id = UUID.uuid4()
       sap_system_id = UUID.uuid4()
+      database_id = UUID.uuid4()
       db_instance_number = "00"
       app_instance_number = "01"
       requested_at = DateTime.utc_now()
@@ -382,7 +383,7 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
       initial_state = %DeregistrationProcessManager{
         cluster_id: nil,
         database_instances: [
-          %Instance{sap_system_id: sap_system_id, instance_number: db_instance_number}
+          %Instance{sap_system_id: database_id, instance_number: db_instance_number}
         ],
         application_instances: [
           %Instance{sap_system_id: sap_system_id, instance_number: app_instance_number}
@@ -397,7 +398,7 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
 
       assert [
                %DeregisterDatabaseInstance{
-                 database_id: ^sap_system_id,
+                 database_id: ^database_id,
                  instance_number: ^db_instance_number,
                  host_id: ^host_id,
                  deregistered_at: ^requested_at
@@ -443,6 +444,7 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
       host_id = UUID.uuid4()
       cluster_id = UUID.uuid4()
       sap_system_id = UUID.uuid4()
+      database_id = UUID.uuid4()
       db_instance_number = "00"
       app_instance_number = "01"
       requested_at = DateTime.utc_now()
@@ -450,7 +452,7 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
       initial_state = %DeregistrationProcessManager{
         cluster_id: cluster_id,
         database_instances: [
-          %Instance{sap_system_id: sap_system_id, instance_number: db_instance_number}
+          %Instance{sap_system_id: database_id, instance_number: db_instance_number}
         ],
         application_instances: [
           %Instance{sap_system_id: sap_system_id, instance_number: app_instance_number}
@@ -465,7 +467,7 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
 
       assert [
                %DeregisterDatabaseInstance{
-                 database_id: ^sap_system_id,
+                 database_id: ^database_id,
                  instance_number: ^db_instance_number,
                  host_id: ^host_id,
                  deregistered_at: ^requested_at

--- a/test/trento/sap_systems/projections/sap_system_projector_test.exs
+++ b/test/trento/sap_systems/projections/sap_system_projector_test.exs
@@ -306,7 +306,7 @@ defmodule Trento.SapSystems.Projections.SapSystemProjectorTest do
       insert(:sap_system, deregistered_at: DateTime.utc_now(), database_id: database_id)
 
     database_instance =
-      insert(:database_instance_without_host, sap_system_id: database_id)
+      insert(:database_instance_without_host, database_id: database_id)
       |> Map.from_struct()
       |> Map.delete(:__meta__)
       |> Map.delete(:host)
@@ -337,6 +337,12 @@ defmodule Trento.SapSystems.Projections.SapSystemProjectorTest do
       |> Repo.get(sap_system_id)
       |> Repo.preload([:tags])
 
+    # Temporary solution to avoid changing frontend code in the same PR
+    adapted_database_instance =
+      database_instance
+      |> Map.drop([:database_id])
+      |> Map.put(:sap_system_id, sap_system_id)
+
     assert_broadcast(
       "sap_system_restored",
       %{
@@ -345,7 +351,7 @@ defmodule Trento.SapSystems.Projections.SapSystemProjectorTest do
         id: ^sap_system_id,
         sid: ^sid,
         tenant: ^tenant,
-        database_instances: [^database_instance],
+        database_instances: [^adapted_database_instance],
         application_instances: [^application_instance],
         tags: ^tags
       },

--- a/test/trento/sap_systems/projections/sap_system_projector_test.exs
+++ b/test/trento/sap_systems/projections/sap_system_projector_test.exs
@@ -341,7 +341,7 @@ defmodule Trento.SapSystems.Projections.SapSystemProjectorTest do
     adapted_database_instance =
       database_instance
       |> Map.drop([:database_id])
-      |> Map.put(:sap_system_id, sap_system_id)
+      |> Map.put(:sap_system_id, database_id)
 
     assert_broadcast(
       "sap_system_restored",

--- a/test/trento/sap_systems/sap_system_test.exs
+++ b/test/trento/sap_systems/sap_system_test.exs
@@ -865,6 +865,7 @@ defmodule Trento.SapSystems.SapSystemTest do
   describe "SAP System health" do
     test "should change the health of a SAP System when a new Application instance is registered" do
       sap_system_id = Faker.UUID.v4()
+      database_id = Faker.UUID.v4()
       sid = Faker.StarWars.planet()
       tenant = Faker.Beer.style()
       db_host = Faker.Internet.ip_v4_address()
@@ -894,7 +895,7 @@ defmodule Trento.SapSystems.SapSystemTest do
           features: features,
           host_id: host_id,
           health: :critical,
-          database_id: sap_system_id
+          database_id: database_id
         ),
         [
           build(
@@ -913,7 +914,7 @@ defmodule Trento.SapSystems.SapSystemTest do
             tenant: tenant,
             health: :critical,
             ensa_version: ensa_version,
-            database_id: sap_system_id
+            database_id: database_id
           }
         ],
         fn state ->

--- a/test/trento/sap_systems/services/health_summary_service_test.exs
+++ b/test/trento/sap_systems/services/health_summary_service_test.exs
@@ -30,7 +30,7 @@ defmodule Trento.SapSystems.Services.HealthSummaryServiceTest do
 
       insert(
         :database_instance_without_host,
-        sap_system_id: database_id,
+        database_id: database_id,
         host_id: a_host_id
       )
 
@@ -78,7 +78,7 @@ defmodule Trento.SapSystems.Services.HealthSummaryServiceTest do
       database_instances = [
         insert(
           :database_instance,
-          sap_system_id: database_id,
+          database_id: database_id,
           instance_number: "00",
           host_id: db_host_id,
           health: Health.warning(),
@@ -86,7 +86,7 @@ defmodule Trento.SapSystems.Services.HealthSummaryServiceTest do
         ),
         insert(
           :database_instance,
-          sap_system_id: database_id,
+          database_id: database_id,
           instance_number: "01",
           host_id: db_host_id_2,
           health: Health.passing(),
@@ -150,7 +150,7 @@ defmodule Trento.SapSystems.Services.HealthSummaryServiceTest do
         insert_list(
           1,
           :database_instance,
-          sap_system_id: database_id,
+          database_id: database_id,
           instance_number: "00",
           host_id: db_host_id,
           health: Health.warning(),

--- a/test/trento/sap_systems_test.exs
+++ b/test/trento/sap_systems_test.exs
@@ -35,7 +35,7 @@ defmodule Trento.SapSystemsTest do
 
       database_instances =
         Enum.sort_by(
-          insert_list(5, :database_instance_without_host, sap_system_id: database_id),
+          insert_list(5, :database_instance_without_host, database_id: database_id),
           &{&1.instance_number, &1.host_id}
         )
 

--- a/test/trento_web/controllers/v1/health_overview_controller_test.exs
+++ b/test/trento_web/controllers/v1/health_overview_controller_test.exs
@@ -28,7 +28,7 @@ defmodule TrentoWeb.V1.HealthOverviewControllerTest do
 
     insert(
       :database_instance_without_host,
-      sap_system_id: database_id,
+      database_id: database_id,
       sid: "HDD",
       host_id: host_1_id,
       health: Health.warning()

--- a/test/trento_web/controllers/v1/sap_system_controller_test.exs
+++ b/test/trento_web/controllers/v1/sap_system_controller_test.exs
@@ -16,10 +16,8 @@ defmodule TrentoWeb.V1.SapSystemControllerTest do
 
   describe "list" do
     test "should list all sap_systems", %{conn: conn} do
-      sap_system_id = UUID.uuid4()
-
-      insert(:sap_system, id: sap_system_id)
-      insert_list(2, :database_instance, sap_system_id: sap_system_id)
+      %{id: sap_system_id} = build(:sap_system)
+      insert_list(2, :database_instance, database_id: sap_system_id)
       insert_list(2, :application_instance, sap_system_id: sap_system_id)
 
       api_spec = ApiSpec.spec()
@@ -35,7 +33,7 @@ defmodule TrentoWeb.V1.SapSystemControllerTest do
       database_id = UUID.uuid4()
 
       insert(:database, id: database_id)
-      insert_list(2, :database_instance, sap_system_id: database_id)
+      insert_list(2, :database_instance, database_id: database_id)
 
       api_spec = ApiSpec.spec()
 
@@ -134,16 +132,16 @@ defmodule TrentoWeb.V1.SapSystemControllerTest do
     end
 
     test "should send 204 response on successful database instance deletion", %{conn: conn} do
-      %{id: sap_system_id} = build(:sap_system)
+      %{id: database_id} = build(:database)
 
       %{host_id: host_id, instance_number: instance_number} =
-        build(:database_instance, sap_system_id: sap_system_id)
+        build(:database_instance, database_id: database_id)
 
       expect(
         Trento.Commanded.Mock,
         :dispatch,
         fn %DeregisterDatabaseInstance{
-             database_id: ^sap_system_id,
+             database_id: ^database_id,
              host_id: ^host_id,
              instance_number: ^instance_number
            } ->
@@ -152,25 +150,23 @@ defmodule TrentoWeb.V1.SapSystemControllerTest do
       )
 
       conn
-      |> delete(
-        "/api/v1/databases/#{sap_system_id}/hosts/#{host_id}/instances/#{instance_number}"
-      )
+      |> delete("/api/v1/databases/#{database_id}/hosts/#{host_id}/instances/#{instance_number}")
       |> response(204)
     end
 
     test "should send 422 response if the database instance is still present", %{
       conn: conn
     } do
-      %{id: sap_system_id} = build(:sap_system)
+      %{id: database_id} = build(:database)
 
       %{host_id: host_id, instance_number: instance_number} =
-        build(:database_instance, sap_system_id: sap_system_id)
+        build(:database_instance, database_id: database_id)
 
       expect(
         Trento.Commanded.Mock,
         :dispatch,
         fn %DeregisterDatabaseInstance{
-             database_id: ^sap_system_id,
+             database_id: ^database_id,
              host_id: ^host_id,
              instance_number: ^instance_number
            } ->
@@ -181,9 +177,7 @@ defmodule TrentoWeb.V1.SapSystemControllerTest do
       api_spec = ApiSpec.spec()
 
       conn
-      |> delete(
-        "/api/v1/databases/#{sap_system_id}/hosts/#{host_id}/instances/#{instance_number}"
-      )
+      |> delete("/api/v1/databases/#{database_id}/hosts/#{host_id}/instances/#{instance_number}")
       |> json_response(422)
       |> assert_schema("UnprocessableEntity", api_spec)
     end
@@ -191,16 +185,16 @@ defmodule TrentoWeb.V1.SapSystemControllerTest do
     test "should send 404 response if the database instance is not found", %{
       conn: conn
     } do
-      %{id: sap_system_id} = build(:sap_system)
+      %{id: database_id} = build(:database)
 
       %{host_id: host_id, instance_number: instance_number} =
-        build(:database_instance, sap_system_id: sap_system_id)
+        build(:database_instance, database_id: database_id)
 
       expect(
         Trento.Commanded.Mock,
         :dispatch,
         fn %DeregisterDatabaseInstance{
-             database_id: ^sap_system_id,
+             database_id: ^database_id,
              host_id: ^host_id,
              instance_number: ^instance_number
            } ->
@@ -211,9 +205,7 @@ defmodule TrentoWeb.V1.SapSystemControllerTest do
       api_spec = ApiSpec.spec()
 
       conn
-      |> delete(
-        "/api/v1/databases/#{sap_system_id}/hosts/#{host_id}/instances/#{instance_number}"
-      )
+      |> delete("/api/v1/databases/#{database_id}/hosts/#{host_id}/instances/#{instance_number}")
       |> json_response(404)
       |> assert_schema("NotFound", api_spec)
     end

--- a/test/trento_web/controllers/v1/sap_system_controller_test.exs
+++ b/test/trento_web/controllers/v1/sap_system_controller_test.exs
@@ -16,8 +16,8 @@ defmodule TrentoWeb.V1.SapSystemControllerTest do
 
   describe "list" do
     test "should list all sap_systems", %{conn: conn} do
-      %{id: sap_system_id} = build(:sap_system)
-      insert_list(2, :database_instance, database_id: sap_system_id)
+      %{id: sap_system_id, database_id: database_id} = build(:sap_system)
+      insert_list(2, :database_instance, database_id: database_id)
       insert_list(2, :application_instance, sap_system_id: sap_system_id)
 
       api_spec = ApiSpec.spec()

--- a/test/trento_web/views/v1/health_overview_view_test.exs
+++ b/test/trento_web/views/v1/health_overview_view_test.exs
@@ -10,6 +10,7 @@ defmodule TrentoWeb.V1.HealthOverviewViewTest do
   describe "renders overview.json" do
     test "should render all the fields" do
       sap_system_id = UUID.uuid4()
+      database_id = UUID.uuid4()
       sid = UUID.uuid4()
       tenant = UUID.uuid4()
       app_cluster_id = UUID.uuid4()
@@ -31,7 +32,7 @@ defmodule TrentoWeb.V1.HealthOverviewViewTest do
         build_list(
           2,
           :database_instance_without_host,
-          sap_system_id: sap_system_id,
+          database_id: database_id,
           host: build(:host, cluster_id: db_cluster_id),
           tenant: tenant
         )
@@ -45,7 +46,7 @@ defmodule TrentoWeb.V1.HealthOverviewViewTest do
                  application_cluster_health: Health.critical(),
                  database_cluster_health: Health.warning(),
                  database_health: Health.passing(),
-                 database_id: sap_system_id,
+                 database_id: database_id,
                  hosts_health: Health.warning(),
                  id: sap_system_id,
                  sapsystem_health: Health.passing(),
@@ -72,6 +73,7 @@ defmodule TrentoWeb.V1.HealthOverviewViewTest do
 
     test "should send empty cluster ids" do
       sap_system_id = UUID.uuid4()
+      database_id = UUID.uuid4()
 
       application_instances =
         build_list(
@@ -85,7 +87,7 @@ defmodule TrentoWeb.V1.HealthOverviewViewTest do
         build_list(
           2,
           :database_instance_without_host,
-          sap_system_id: sap_system_id,
+          database_id: database_id,
           host: build(:host, cluster_id: nil),
           tenant: UUID.uuid4()
         )

--- a/test/trento_web/views/v1/sap_system_view_test.exs
+++ b/test/trento_web/views/v1/sap_system_view_test.exs
@@ -3,10 +3,8 @@ defmodule TrentoWeb.V1.SapSystemViewTest do
 
   import Phoenix.View
 
-  alias Trento.SapSystems.Projections.{
-    DatabaseInstanceReadModel,
-    SapSystemReadModel
-  }
+  alias Trento.Databases.Projections.DatabaseInstanceReadModel
+  alias Trento.SapSystems.Projections.SapSystemReadModel
 
   test "should add the system replication status to the secondary instance and should remove it from the primary one" do
     [%{database_instances: database_instances}] =


### PR DESCRIPTION
# Description

Following the database/sap system split. Split the projections and read models code to the database aggregate.

The unique new piece of code that this adds is the migration to rename `sap_system_id` field to `database_id` in the database instance read model.

You might still see some `sap_system_id` usages in the database projector, but they are part of the views, which I will change in the next PR.

Still pending:
- Controllers/views/frontend

## How was this tested?

Previous tests passing
