### PR TITLE
Make `Software Updates` service handle no SUMA settings saved

### DIFF
--- a/lib/trento/software_updates.ex
+++ b/lib/trento/software_updates.ex
@@ -108,9 +108,8 @@ defmodule Trento.SoftwareUpdates do
 
   @spec get_software_updates(Ecto.UUID.t()) ::
           {:ok, map()}
-          | {:error, :unable_to_get_software_updates,
-             :settings_not_configured
-             | :system_id_not_found
+          | {:error, :settings_not_configured,
+             :system_id_not_found
              | :not_found
              | :fqdn_not_found
              | :error_getting_patches
@@ -123,8 +122,6 @@ defmodule Trento.SoftwareUpdates do
          {:ok, upgradable_packages} <-
            Discovery.get_upgradable_packages(system_id) do
       {:ok, %{relevant_patches: relevant_patches, upgradable_packages: upgradable_packages}}
-    else
-      {:error, reason} -> {:error, :unable_to_get_software_updates, reason}
     end
   end
 

--- a/lib/trento/software_updates.ex
+++ b/lib/trento/software_updates.ex
@@ -108,19 +108,23 @@ defmodule Trento.SoftwareUpdates do
 
   @spec get_software_updates(Ecto.UUID.t()) ::
           {:ok, map()}
-          | {:error,
-             :system_id_not_found
+          | {:error, :unable_to_get_software_updates,
+             :settings_not_configured
+             | :system_id_not_found
              | :not_found
              | :fqdn_not_found
              | :error_getting_patches
              | :error_getting_packages}
   def get_software_updates(host_id) do
-    with {:ok, fqdn} <- get_host_fqdn(host_id),
+    with {:ok, _} <- get_settings(),
+         {:ok, fqdn} <- get_host_fqdn(host_id),
          {:ok, system_id} <- Discovery.get_system_id(fqdn),
          {:ok, relevant_patches} <- Discovery.get_relevant_patches(system_id),
          {:ok, upgradable_packages} <-
            Discovery.get_upgradable_packages(system_id) do
       {:ok, %{relevant_patches: relevant_patches, upgradable_packages: upgradable_packages}}
+    else
+      {:error, reason} -> {:error, :unable_to_get_software_updates, reason}
     end
   end
 

--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -17,6 +17,16 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"401", reason: "Invalid refresh token.")
   end
 
+  def call(conn, {:error, :unable_to_get_software_updates, :not_found}),
+    do: call(conn, {:error, :not_found})
+
+  def call(conn, {:error, :unable_to_get_software_updates, reason}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(ErrorView)
+    |> render(:"422", reason: get_failure_message(reason))
+  end
+
   def call(conn, {:error, :not_found}) do
     conn
     |> put_status(:not_found)
@@ -90,34 +100,6 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"422", reason: "No checks were selected for the target.")
   end
 
-  def call(conn, {:error, :fqdn_not_found}) do
-    conn
-    |> put_status(:unprocessable_entity)
-    |> put_view(ErrorView)
-    |> render(:"422", reason: "No FQDN was found for the target host.")
-  end
-
-  def call(conn, {:error, :system_id_not_found}) do
-    conn
-    |> put_status(:unprocessable_entity)
-    |> put_view(ErrorView)
-    |> render(:"422", reason: "No system ID was found on SUSE Manager for this host.")
-  end
-
-  def call(conn, {:error, :error_getting_patches}) do
-    conn
-    |> put_status(:unprocessable_entity)
-    |> put_view(ErrorView)
-    |> render(:"422", reason: "Unable to retrieve relevant patches for this host.")
-  end
-
-  def call(conn, {:error, :error_getting_packages}) do
-    conn
-    |> put_status(:unprocessable_entity)
-    |> put_view(ErrorView)
-    |> render(:"422", reason: "Unable to retrieve upgradable packages for this host.")
-  end
-
   def call(conn, {:error, :connection_test_failed}) do
     conn
     |> put_status(:unprocessable_entity)
@@ -133,4 +115,18 @@ defmodule TrentoWeb.FallbackController do
     |> put_view(ErrorView)
     |> render(:"500")
   end
+
+  defp get_failure_message(:settings_not_configured), do: "SUSE Manager settings not configured."
+  defp get_failure_message(:fqdn_not_found), do: "No FQDN was found for the target host."
+
+  defp get_failure_message(:system_id_not_found),
+    do: "No system ID was found on SUSE Manager for this host."
+
+  defp get_failure_message(:error_getting_patches),
+    do: "Unable to retrieve relevant patches for this host."
+
+  defp get_failure_message(:error_getting_packages),
+    do: "Unable to retrieve upgradable packages for this host."
+
+  defp get_failure_message(_), do: "Unknown error encountered getting software updates."
 end

--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -10,21 +10,18 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"401", reason: "Invalid credentials.")
   end
 
+  def call(conn, {:error, :settings_not_configured}) do
+    conn
+    |> put_status(:unauthorized)
+    |> put_view(ErrorView)
+    |> render(:"401", reason: "SUSE Manager settings not configured.")
+  end
+
   def call(conn, {:error, :invalid_refresh_token}) do
     conn
     |> put_status(:unauthorized)
     |> put_view(ErrorView)
     |> render(:"401", reason: "Invalid refresh token.")
-  end
-
-  def call(conn, {:error, :unable_to_get_software_updates, :not_found}),
-    do: call(conn, {:error, :not_found})
-
-  def call(conn, {:error, :unable_to_get_software_updates, reason}) do
-    conn
-    |> put_status(:unprocessable_entity)
-    |> put_view(ErrorView)
-    |> render(:"422", reason: get_failure_message(reason))
   end
 
   def call(conn, {:error, :not_found}) do
@@ -42,7 +39,6 @@ defmodule TrentoWeb.FallbackController do
              :database_not_registered,
              :application_instance_not_registered,
              :database_instance_not_registered,
-             :settings_not_configured,
              :api_key_settings_missing
            ] do
     conn
@@ -100,6 +96,34 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"422", reason: "No checks were selected for the target.")
   end
 
+  def call(conn, {:error, :fqdn_not_found}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(ErrorView)
+    |> render(:"422", reason: "No FQDN was found for the target host.")
+  end
+
+  def call(conn, {:error, :system_id_not_found}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(ErrorView)
+    |> render(:"422", reason: "No system ID was found on SUSE Manager for this host.")
+  end
+
+  def call(conn, {:error, :error_getting_patches}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(ErrorView)
+    |> render(:"422", reason: "Unable to retrieve relevant patches for this host.")
+  end
+
+  def call(conn, {:error, :error_getting_packages}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(ErrorView)
+    |> render(:"422", reason: "Unable to retrieve upgradable packages for this host.")
+  end
+
   def call(conn, {:error, :connection_test_failed}) do
     conn
     |> put_status(:unprocessable_entity)
@@ -115,18 +139,4 @@ defmodule TrentoWeb.FallbackController do
     |> put_view(ErrorView)
     |> render(:"500")
   end
-
-  defp get_failure_message(:settings_not_configured), do: "SUSE Manager settings not configured."
-  defp get_failure_message(:fqdn_not_found), do: "No FQDN was found for the target host."
-
-  defp get_failure_message(:system_id_not_found),
-    do: "No system ID was found on SUSE Manager for this host."
-
-  defp get_failure_message(:error_getting_patches),
-    do: "Unable to retrieve relevant patches for this host."
-
-  defp get_failure_message(:error_getting_packages),
-    do: "Unable to retrieve upgradable packages for this host."
-
-  defp get_failure_message(_), do: "Unknown error encountered getting software updates."
 end

--- a/test/trento/software_updates_test.exs
+++ b/test/trento/software_updates_test.exs
@@ -456,6 +456,7 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
 
   describe "getting software updates" do
     test "successfully returns software updates" do
+      insert_software_updates_settings()
       %{id: host_id} = insert(:host)
 
       assert {:ok, %{relevant_patches: [_, _], upgradable_packages: [_, _]}} =
@@ -463,36 +464,43 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
     end
 
     test "handles non existing hosts" do
+      insert_software_updates_settings()
       host_id = Faker.UUID.v4()
 
-      assert {:error, :not_found} =
+      assert {:error, :unable_to_get_software_updates, :not_found} =
                SoftwareUpdates.get_software_updates(host_id)
     end
 
     test "returns errors when fetching upgradable packages" do
+      insert_software_updates_settings()
       %{id: host_id} = insert(:host)
 
       expect(Trento.SoftwareUpdates.Discovery.Mock, :get_upgradable_packages, 1, fn _ ->
         {:error, :error_getting_packages}
       end)
 
-      assert {:error, :error_getting_packages} = SoftwareUpdates.get_software_updates(host_id)
+      assert {:error, :unable_to_get_software_updates, :error_getting_packages} =
+               SoftwareUpdates.get_software_updates(host_id)
     end
 
     test "returns errors when fetching relevant_patches" do
+      insert_software_updates_settings()
       %{id: host_id} = insert(:host)
 
       expect(Trento.SoftwareUpdates.Discovery.Mock, :get_relevant_patches, 1, fn _ ->
         {:error, :error_getting_patches}
       end)
 
-      assert {:error, :error_getting_patches} = SoftwareUpdates.get_software_updates(host_id)
+      assert {:error, :unable_to_get_software_updates, :error_getting_patches} =
+               SoftwareUpdates.get_software_updates(host_id)
     end
 
     test "errors when non existing fqdns are attempted" do
+      insert_software_updates_settings()
       %{id: host_id} = insert(:host, fully_qualified_domain_name: nil)
 
-      assert {:error, :fqdn_not_found} = SoftwareUpdates.get_software_updates(host_id)
+      assert {:error, :unable_to_get_software_updates, :fqdn_not_found} =
+               SoftwareUpdates.get_software_updates(host_id)
     end
   end
 

--- a/test/trento/software_updates_test.exs
+++ b/test/trento/software_updates_test.exs
@@ -467,8 +467,7 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
       insert_software_updates_settings()
       host_id = Faker.UUID.v4()
 
-      assert {:error, :unable_to_get_software_updates, :not_found} =
-               SoftwareUpdates.get_software_updates(host_id)
+      assert {:error, :not_found} = SoftwareUpdates.get_software_updates(host_id)
     end
 
     test "returns errors when fetching upgradable packages" do
@@ -479,8 +478,7 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
         {:error, :error_getting_packages}
       end)
 
-      assert {:error, :unable_to_get_software_updates, :error_getting_packages} =
-               SoftwareUpdates.get_software_updates(host_id)
+      assert {:error, :error_getting_packages} = SoftwareUpdates.get_software_updates(host_id)
     end
 
     test "returns errors when fetching relevant_patches" do
@@ -491,16 +489,14 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
         {:error, :error_getting_patches}
       end)
 
-      assert {:error, :unable_to_get_software_updates, :error_getting_patches} =
-               SoftwareUpdates.get_software_updates(host_id)
+      assert {:error, :error_getting_patches} = SoftwareUpdates.get_software_updates(host_id)
     end
 
     test "errors when non existing fqdns are attempted" do
       insert_software_updates_settings()
       %{id: host_id} = insert(:host, fully_qualified_domain_name: nil)
 
-      assert {:error, :unable_to_get_software_updates, :fqdn_not_found} =
-               SoftwareUpdates.get_software_updates(host_id)
+      assert {:error, :fqdn_not_found} = SoftwareUpdates.get_software_updates(host_id)
     end
   end
 

--- a/test/trento_web/controllers/v1/suma_credentials_controller_test.exs
+++ b/test/trento_web/controllers/v1/suma_credentials_controller_test.exs
@@ -28,12 +28,12 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
       |> assert_schema("SUMACredentials", api_spec)
     end
 
-    test "should return 404 if no user settings have been saved", %{conn: conn} do
+    test "should return 401 if no user settings have been saved", %{conn: conn} do
       api_spec = ApiSpec.spec()
 
       conn
       |> get("/api/v1/settings/suma_credentials")
-      |> json_response(:not_found)
+      |> json_response(:unauthorized)
       |> assert_schema("NotFound", api_spec)
     end
   end
@@ -177,11 +177,11 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
         conn
         |> put_req_header("content-type", "application/json")
         |> patch("/api/v1/settings/suma_credentials", submission)
-        |> json_response(:not_found)
+        |> json_response(:unauthorized)
 
       assert %{
                "errors" => [
-                 %{"detail" => "The requested resource cannot be found.", "title" => "Not Found"}
+                 %{"detail" => "SUSE Manager settings not configured.", "title" => "Unauthorized"}
                ]
              } == resp
     end

--- a/test/trento_web/controllers/v1/suse_manager_controller_test.exs
+++ b/test/trento_web/controllers/v1/suse_manager_controller_test.exs
@@ -49,16 +49,19 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
         |> assert_schema("AvailableSoftwareUpdatesResponse", api_spec)
     end
 
-    test "should return 422 when no settings have been saved", %{
-      conn: conn,
-      api_spec: api_spec
-    } do
+    test "should return 401 when no settings have been saved", %{conn: conn} do
       %{id: host_id} = insert(:host)
 
-      conn
-      |> get("/api/v1/hosts/#{host_id}/software_updates")
-      |> json_response(:unprocessable_entity)
-      |> assert_schema("UnprocessableEntity", api_spec)
+      resp =
+        conn
+        |> get("/api/v1/hosts/#{host_id}/software_updates")
+        |> json_response(:unauthorized)
+
+      assert %{
+               "errors" => [
+                 %{"detail" => "SUSE Manager settings not configured.", "title" => "Unauthorized"}
+               ]
+             } == resp
     end
 
     test "should return 404 when a host is not found", %{

--- a/test/trento_web/controllers/v1/suse_manager_controller_test.exs
+++ b/test/trento_web/controllers/v1/suse_manager_controller_test.exs
@@ -22,6 +22,7 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
       conn: conn,
       api_spec: api_spec
     } do
+      insert_software_updates_settings()
       %{id: host_id} = insert(:host)
 
       %AvailableSoftwareUpdatesResponse{
@@ -48,10 +49,23 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
         |> assert_schema("AvailableSoftwareUpdatesResponse", api_spec)
     end
 
+    test "should return 422 when no settings have been saved", %{
+      conn: conn,
+      api_spec: api_spec
+    } do
+      %{id: host_id} = insert(:host)
+
+      conn
+      |> get("/api/v1/hosts/#{host_id}/software_updates")
+      |> json_response(:unprocessable_entity)
+      |> assert_schema("UnprocessableEntity", api_spec)
+    end
+
     test "should return 404 when a host is not found", %{
       conn: conn,
       api_spec: api_spec
     } do
+      insert_software_updates_settings()
       host_id = Faker.UUID.v4()
 
       conn
@@ -64,6 +78,7 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
       conn: conn,
       api_spec: api_spec
     } do
+      insert_software_updates_settings()
       %{id: host_id} = insert(:host, fully_qualified_domain_name: nil)
 
       conn


### PR DESCRIPTION
# Description

This changes allows the `Software Updates` service to return an error with a response status of `422` and provides the message _"SUSE Manager settings not configured."_.

## How was this tested?

Updated existing unit tests to validate new behaviour.
