### PR TITLE
Fix typespec for `get software updates` service

### DIFF
--- a/lib/trento/software_updates.ex
+++ b/lib/trento/software_updates.ex
@@ -108,8 +108,9 @@ defmodule Trento.SoftwareUpdates do
 
   @spec get_software_updates(Ecto.UUID.t()) ::
           {:ok, map()}
-          | {:error, :settings_not_configured,
-             :system_id_not_found
+          | {:error,
+             :settings_not_configured
+             | :system_id_not_found
              | :not_found
              | :fqdn_not_found
              | :error_getting_patches


### PR DESCRIPTION
# Description

Small fix arising from https://github.com/trento-project/web/pull/2457. Fix the spec for `Trento.SoftwareUpdates.get_software_updates/1`.

## How was this tested?

Behavior is unaffected.
