### PR TITLE
Apply database health to sap system

### DIFF
--- a/lib/trento/event_handlers_supervisor.ex
+++ b/lib/trento/event_handlers_supervisor.ex
@@ -8,6 +8,7 @@ defmodule Trento.EventHandlersSupervisor do
     DatabaseDeregistrationEventHandler,
     DatabaseRestoreEventHandler,
     RollUpEventHandler,
+    SapSystemDatabaseHealthEventHandler,
     StreamRollUpEventHandler
   }
 
@@ -22,7 +23,8 @@ defmodule Trento.EventHandlersSupervisor do
       RollUpEventHandler,
       StreamRollUpEventHandler,
       DatabaseDeregistrationEventHandler,
-      DatabaseRestoreEventHandler
+      DatabaseRestoreEventHandler,
+      SapSystemDatabaseHealthEventHandler
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/trento/infrastructure/commanded/event_handlers/database_restore_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/database_restore_event_handler.ex
@@ -18,7 +18,7 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.DatabaseRestoreEventHand
   require Logger
 
   def handle(
-        %DatabaseRestored{database_id: database_id},
+        %DatabaseRestored{database_id: database_id, health: database_health},
         _metadata
       ) do
     %{sap_systems: sap_systems} =
@@ -34,7 +34,12 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.DatabaseRestoreEventHand
       Logger.info("Restoring sap system #{sid} attached to database #{database_id}")
 
       commanded().dispatch(
-        %RestoreSapSystem{sap_system_id: sap_system_id, db_host: db_host, tenant: tenant},
+        %RestoreSapSystem{
+          sap_system_id: sap_system_id,
+          db_host: db_host,
+          tenant: tenant,
+          database_health: database_health
+        },
         consistency: :strong
       )
     end

--- a/lib/trento/infrastructure/commanded/event_handlers/sap_system_database_health_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/sap_system_database_health_event_handler.ex
@@ -1,0 +1,49 @@
+defmodule Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseHealthEventHandler do
+  @moduledoc """
+  This event handler is responsible to forward update database health commands to the SAP systems
+  related to a database that has a new health state
+  """
+
+  use Commanded.Event.Handler,
+    application: Trento.Commanded,
+    name: "sap_system_database_health_event_handler"
+
+  alias Trento.Databases.Events.DatabaseHealthChanged
+  alias Trento.Databases.Projections.DatabaseReadModel
+  alias Trento.Repo
+  alias Trento.SapSystems.Commands.UpdateDatabaseHealth
+
+  import Ecto.Query, only: [from: 2]
+
+  require Logger
+
+  def handle(
+        %DatabaseHealthChanged{database_id: database_id, health: health},
+        _metadata
+      ) do
+    %{sap_systems: sap_systems} =
+      Repo.one!(
+        from(d in DatabaseReadModel,
+          where: d.id == ^database_id,
+          preload: [:sap_systems],
+          select: [:id]
+        )
+      )
+
+    for %{id: sap_system_id, sid: sid} <- sap_systems do
+      Logger.info(
+        "Updating database health of #{sid} SAP system to #{health}"
+      )
+
+      commanded().dispatch(
+        %UpdateDatabaseHealth{sap_system_id: sap_system_id, database_health: health},
+        consistency: :strong
+      )
+    end
+
+    :ok
+  end
+
+  defp commanded,
+    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
+end

--- a/lib/trento/infrastructure/commanded/event_handlers/sap_system_database_health_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/sap_system_database_health_event_handler.ex
@@ -31,9 +31,7 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseHealthE
       )
 
     for %{id: sap_system_id, sid: sid} <- sap_systems do
-      Logger.info(
-        "Updating database health of #{sid} SAP system to #{health}"
-      )
+      Logger.info("Updating database health of #{sid} SAP system to #{health}")
 
       commanded().dispatch(
         %UpdateDatabaseHealth{sap_system_id: sap_system_id, database_health: health},

--- a/lib/trento/infrastructure/commanded/middleware/enrich_register_application_instance.ex
+++ b/lib/trento/infrastructure/commanded/middleware/enrich_register_application_instance.ex
@@ -3,7 +3,11 @@ defimpl Trento.Infrastructure.Commanded.Middleware.Enrichable,
   alias Trento.SapSystems.Commands.RegisterApplicationInstance
 
   alias Trento.Hosts.Projections.HostReadModel
-  alias Trento.Databases.Projections.DatabaseInstanceReadModel
+
+  alias Trento.Databases.Projections.{
+    DatabaseReadModel,
+    DatabaseInstanceReadModel
+  }
 
   alias Trento.Repo
   import Ecto.Query
@@ -11,18 +15,23 @@ defimpl Trento.Infrastructure.Commanded.Middleware.Enrichable,
   @spec enrich(RegisterApplicationInstance.t(), map) :: {:ok, map} | {:error, any}
   def enrich(%RegisterApplicationInstance{db_host: db_host, tenant: tenant} = command, _) do
     query =
-      from d in DatabaseInstanceReadModel,
+      from d in DatabaseReadModel,
+        join: di in DatabaseInstanceReadModel,
+        on: d.id == di.database_id,
         join: h in HostReadModel,
-        on: d.host_id == h.id,
-        where: ^db_host in h.ip_addresses and ^tenant == d.tenant and is_nil(h.deregistered_at)
+        on: di.host_id == h.id,
+        where:
+          ^db_host in h.ip_addresses and ^tenant == di.tenant and is_nil(h.deregistered_at) and
+            is_nil(d.deregistered_at)
 
     case Repo.one(query) do
-      %DatabaseInstanceReadModel{database_id: database_id} ->
+      %DatabaseReadModel{id: database_id, health: database_health} ->
         {:ok,
          %RegisterApplicationInstance{
            command
            | sap_system_id: UUID.uuid5(database_id, tenant),
-             database_id: database_id
+             database_id: database_id,
+             database_health: database_health
          }}
 
       nil ->

--- a/lib/trento/router.ex
+++ b/lib/trento/router.ex
@@ -39,7 +39,8 @@ defmodule Trento.Router do
     MarkApplicationInstanceAbsent,
     RegisterApplicationInstance,
     RestoreSapSystem,
-    RollUpSapSystem
+    RollUpSapSystem,
+    UpdateDatabaseHealth
   }
 
   alias Trento.Clusters
@@ -89,7 +90,8 @@ defmodule Trento.Router do
              RestoreSapSystem,
              MarkApplicationInstanceAbsent,
              RegisterApplicationInstance,
-             RollUpSapSystem
+             RollUpSapSystem,
+             UpdateDatabaseHealth
            ],
            to: SapSystems.SapSystem,
            lifespan: SapSystems.Lifespan

--- a/lib/trento/sap_systems/commands/register_application_instance.ex
+++ b/lib/trento/sap_systems/commands/register_application_instance.ex
@@ -50,6 +50,7 @@ defmodule Trento.SapSystems.Commands.RegisterApplicationInstance do
     field :database_id, Ecto.UUID
     field :start_priority, :string
     field :health, Ecto.Enum, values: Health.values()
+    field :database_health, Ecto.Enum, values: Health.values()
     field :ensa_version, Ecto.Enum, values: EnsaVersion.values()
   end
 end

--- a/lib/trento/sap_systems/commands/update_database_health.ex
+++ b/lib/trento/sap_systems/commands/update_database_health.ex
@@ -1,6 +1,6 @@
-defmodule Trento.SapSystems.Commands.RestoreSapSystem do
+defmodule Trento.SapSystems.Commands.UpdateDatabaseHealth do
   @moduledoc """
-  Restore a previously deregistered SapSystem.
+  Update the health of the database associated to the SAP system.
   """
 
   @required_fields :all
@@ -11,8 +11,6 @@ defmodule Trento.SapSystems.Commands.RestoreSapSystem do
 
   defcommand do
     field :sap_system_id, Ecto.UUID
-    field :db_host, :string
-    field :tenant, :string
     field :database_health, Ecto.Enum, values: Health.values()
   end
 end

--- a/lib/trento/sap_systems/events/sap_system_database_health_changed.ex
+++ b/lib/trento/sap_systems/events/sap_system_database_health_changed.ex
@@ -1,0 +1,14 @@
+defmodule Trento.SapSystems.Events.SapSystemDatabaseHealthChanged do
+  @moduledoc """
+  This event is emitted when the SAP System database health has changed.
+  """
+
+  use Trento.Support.Event
+
+  require Trento.Enums.Health, as: Health
+
+  defevent do
+    field :sap_system_id, Ecto.UUID
+    field :database_health, Ecto.Enum, values: Health.values()
+  end
+end

--- a/lib/trento/sap_systems/events/sap_system_registered.ex
+++ b/lib/trento/sap_systems/events/sap_system_registered.ex
@@ -15,6 +15,7 @@ defmodule Trento.SapSystems.Events.SapSystemRegistered do
     field :db_host, :string
     field :database_id, Ecto.UUID
     field :health, Ecto.Enum, values: Health.values()
+    field :database_health, Ecto.Enum, values: Health.values()
     field :ensa_version, Ecto.Enum, values: EnsaVersion.values(), default: EnsaVersion.no_ensa()
   end
 end

--- a/lib/trento/sap_systems/events/sap_system_restored.ex
+++ b/lib/trento/sap_systems/events/sap_system_restored.ex
@@ -12,5 +12,6 @@ defmodule Trento.SapSystems.Events.SapSystemRestored do
     field :tenant, :string
     field :db_host, :string
     field :health, Ecto.Enum, values: Health.values()
+    field :database_health, Ecto.Enum, values: Health.values()
   end
 end

--- a/test/e2e/cypress/e2e/sap_systems_overview.cy.js
+++ b/test/e2e/cypress/e2e/sap_systems_overview.cy.js
@@ -265,10 +265,19 @@ context('SAP Systems Overview', () => {
       });
     });
 
-    it(`should have RED health in SAP system and when HANA instance when SAPControl-RED state is received`, () => {
+    it(`should have RED health in SAP system when HANA instance with SAPControl-RED state is received`, () => {
       cy.loadScenario(`sap-systems-overview-hana-RED`);
 
       const healthClasses = healthMap['RED'];
+
+      cy.get('table.table-fixed > tbody > tr')
+        .filter(':visible')
+        .eq(0)
+        .find('td')
+        .eq(0)
+        .get('svg')
+        .should('have.class', healthClasses);
+
       cy.get('table.table-fixed > tbody > tr').filter(':visible').eq(0).click();
       cy.get('table.table-fixed > tbody > tr')
         .filter(':visible')

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -413,6 +413,7 @@ defmodule Trento.Factory do
       db_host: Faker.Internet.ip_v4_address(),
       tenant: Faker.Beer.hop(),
       health: Health.passing(),
+      database_health: Health.passing(),
       ensa_version: EnsaVersion.ensa1()
     }
   end
@@ -640,7 +641,8 @@ defmodule Trento.Factory do
       host_id: Faker.UUID.v4(),
       health: Health.passing(),
       ensa_version: EnsaVersion.ensa1(),
-      database_id: Faker.UUID.v4()
+      database_id: Faker.UUID.v4(),
+      database_health: Health.passing()
     })
   end
 

--- a/test/trento/infrastructure/commanded/event_handlers/database_restore_event_handler_test.exs
+++ b/test/trento/infrastructure/commanded/event_handlers/database_restore_event_handler_test.exs
@@ -17,12 +17,13 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.DatabaseRestoreEventHand
     %{id: sap_system_id, tenant: tenant, db_host: db_host} =
       insert(:sap_system, database_id: database_id)
 
-    event = %DatabaseRestored{database_id: database_id}
+    event = %DatabaseRestored{database_id: database_id, health: :passing}
 
     expect(Trento.Commanded.Mock, :dispatch, fn %RestoreSapSystem{
                                                   sap_system_id: ^sap_system_id,
                                                   tenant: ^tenant,
-                                                  db_host: ^db_host
+                                                  db_host: ^db_host,
+                                                  database_health: :passing
                                                 },
                                                 _ ->
       :ok

--- a/test/trento/infrastructure/commanded/event_handlers/sap_system_database_health_event_handler_test.exs
+++ b/test/trento/infrastructure/commanded/event_handlers/sap_system_database_health_event_handler_test.exs
@@ -1,0 +1,40 @@
+defmodule Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseHealthEventHandlerTest do
+  use ExUnit.Case
+  use Trento.DataCase
+
+  import Mox
+  import Trento.Factory
+
+  alias Trento.Databases.Events.DatabaseHealthChanged
+  alias Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseHealthEventHandler
+  alias Trento.SapSystems.Commands.UpdateDatabaseHealth
+
+  setup [:set_mox_from_context, :verify_on_exit!]
+
+  test "should dispatch UpdateDatabaseHealth commands when a database health is changed" do
+    %{id: database_id} = insert(:database)
+
+    [%{id: first_sap_system_id}, %{id: second_sap_system_id}] =
+      insert_list(2, :sap_system, database_id: database_id)
+
+    event = %DatabaseHealthChanged{database_id: database_id, health: :critical}
+
+    expect(Trento.Commanded.Mock, :dispatch, fn %UpdateDatabaseHealth{
+                                                  sap_system_id: ^first_sap_system_id,
+                                                  database_health: :critical
+                                                },
+                                                _ ->
+      :ok
+    end)
+
+    expect(Trento.Commanded.Mock, :dispatch, fn %UpdateDatabaseHealth{
+                                                  sap_system_id: ^second_sap_system_id,
+                                                  database_health: :critical
+                                                },
+                                                _ ->
+      :ok
+    end)
+
+    assert :ok = SapSystemDatabaseHealthEventHandler.handle(event, %{})
+  end
+end

--- a/test/trento/infrastructure/commanded/middleware/enrich_register_application_instance_test.exs
+++ b/test/trento/infrastructure/commanded/middleware/enrich_register_application_instance_test.exs
@@ -9,22 +9,21 @@ defmodule Trento.Infrastructure.Commanded.Middleware.EnrichRegisterApplicationIn
 
   test "should return an enriched command if the database was found by the ip and tenant" do
     %{
-      database_id: database_id,
+      id: database_id,
+      health: health
+    } = insert(:database)
+
+    %{
       tenant: tenant,
       host: %{ip_addresses: [ip]}
-    } = insert(:database_instance)
+    } = insert(:database_instance, database_id: database_id)
 
     command =
       build(
         :register_application_instance_command,
         sap_system_id: nil,
-        sid: Faker.StarWars.planet(),
         db_host: ip,
-        tenant: tenant,
-        instance_number: "00",
-        features: Faker.Pokemon.name(),
-        host_id: Faker.UUID.v4(),
-        health: :passing
+        tenant: tenant
       )
 
     expected_sap_system_id = UUID.uuid5(database_id, tenant)
@@ -32,7 +31,8 @@ defmodule Trento.Infrastructure.Commanded.Middleware.EnrichRegisterApplicationIn
     assert {:ok,
             %RegisterApplicationInstance{
               sap_system_id: ^expected_sap_system_id,
-              database_id: ^database_id
+              database_id: ^database_id,
+              database_health: ^health
             }} =
              Enrichable.enrich(command, %{})
   end
@@ -40,11 +40,14 @@ defmodule Trento.Infrastructure.Commanded.Middleware.EnrichRegisterApplicationIn
   test "should return a database not found error if the database instance host has been deregistered" do
     deregistered_host = insert(:host, deregistered_at: DateTime.utc_now())
 
+    %{id: database_id} = insert(:database)
+
     %{
       tenant: tenant,
       host: %{ip_addresses: [ip]}
     } =
       insert(:database_instance_without_host,
+        database_id: database_id,
         host_id: deregistered_host.id,
         host: deregistered_host
       )
@@ -53,34 +56,18 @@ defmodule Trento.Infrastructure.Commanded.Middleware.EnrichRegisterApplicationIn
       build(
         :register_application_instance_command,
         sap_system_id: nil,
-        sid: Faker.StarWars.planet(),
         db_host: ip,
-        tenant: tenant,
-        instance_number: "00",
-        features: Faker.Pokemon.name(),
-        host_id: Faker.UUID.v4(),
-        health: :passing
+        tenant: tenant
       )
 
     assert {:error, :database_not_registered} = Enrichable.enrich(command, %{})
   end
 
   test "should return an error if the database was not found" do
-    %{
-      tenant: tenant
-    } = insert(:database_instance)
-
     command =
       build(
         :register_application_instance_command,
-        sap_system_id: nil,
-        sid: Faker.StarWars.planet(),
-        db_host: "not_found",
-        tenant: tenant,
-        instance_number: "00",
-        features: Faker.Pokemon.name(),
-        host_id: Faker.UUID.v4(),
-        health: :passing
+        sap_system_id: nil
       )
 
     assert {:error, :database_not_registered} = Enrichable.enrich(command, %{})


### PR DESCRIPTION
# Description

Listen and apply database health changes in the sap system aggregate.

@abravosuse This implements a 1:1 feature parity with the current implementation. We will work in any other related feature in the future

## How was this tested?

Tested with UT and a new e2e
