### PR TITLE
Dynamic catalog filters

### DIFF
--- a/assets/js/pages/ChecksCatalog/ChecksCatalog.stories.jsx
+++ b/assets/js/pages/ChecksCatalog/ChecksCatalog.stories.jsx
@@ -1,17 +1,16 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { faker } from '@faker-js/faker';
 
 import { catalogCheckFactory } from '@lib/test-utils/factories';
 import ChecksCatalog from './ChecksCatalog';
 
-const groupName1 = faker.string.uuid();
-const groupName2 = faker.string.uuid();
-const groupName3 = faker.string.uuid();
+const groupName1 = 'group 1';
+const groupName2 = 'group 2';
+const groupName3 = 'group 3';
 
 const clusterCheck = catalogCheckFactory.build({
   group: groupName1,
-  metadata: { target_type: 'cluster' },
+  metadata: { target_type: 'cluster', cluster_type: 'hana_scale_up' },
 });
 
 const hostCheck = catalogCheckFactory.build({
@@ -22,11 +21,11 @@ const hostCheck = catalogCheckFactory.build({
 const group1 = [
   clusterCheck,
   hostCheck,
-  ...catalogCheckFactory.buildList(5, { group: groupName1 }),
+  ...catalogCheckFactory.buildList(1, { group: groupName1 }),
 ];
 
-const group2 = catalogCheckFactory.buildList(5, { group: groupName2 });
-const group3 = catalogCheckFactory.buildList(5, { group: groupName3 });
+const group2 = catalogCheckFactory.buildList(2, { group: groupName2 });
+const group3 = catalogCheckFactory.buildList(2, { group: groupName3 });
 const catalogData = [...group1, ...group2, ...group3];
 
 function ContainerWrapper({ children }) {
@@ -39,9 +38,13 @@ export default {
   title: 'Layouts/ChecksCatalog',
   component: ChecksCatalog,
   argTypes: {
-    catalogData: {
+    completeCatalog: {
       control: 'object',
-      description: 'Catalog content',
+      description: 'The whole Catalog content',
+    },
+    filteredCatalog: {
+      control: 'object',
+      description: 'The filtered Catalog content',
     },
     catalogError: {
       control: 'text',
@@ -79,7 +82,7 @@ export default {
 
 export const Default = {
   args: {
-    catalogData,
+    completeCatalog: catalogData,
   },
 };
 
@@ -100,6 +103,6 @@ export const Error = {
 export const Empty = {
   args: {
     ...Default.args,
-    catalogData: [],
+    filteredCatalog: [],
   },
 };

--- a/assets/js/pages/ChecksCatalog/ChecksCatalogPage.jsx
+++ b/assets/js/pages/ChecksCatalog/ChecksCatalogPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
-import { pickBy } from 'lodash';
+import { pickBy, values } from 'lodash';
 
 import { getCatalog } from '@state/selectors/catalog';
 import { updateCatalog } from '@state/catalog';
@@ -9,21 +9,31 @@ import { OPTION_ALL } from '@common/Select';
 
 import ChecksCatalog from './ChecksCatalog';
 
-const buildUpdateCatalogAction = (selectedFilters) =>
-  updateCatalog(pickBy(selectedFilters, (value) => value !== OPTION_ALL));
+const isSomeFilter = (value) => value !== OPTION_ALL;
+
+const buildUpdateCatalogAction = (selectedFilters) => {
+  const hasFilters = values(selectedFilters).some(isSomeFilter);
+  const payload = {
+    ...pickBy(selectedFilters, isSomeFilter),
+    ...(hasFilters ? { filteredCatalog: true } : {}),
+  };
+  return updateCatalog(payload);
+};
 
 function ChecksCatalogPage() {
   const dispatch = useDispatch();
 
   const {
-    data: catalogData,
+    data: completeCatalog,
+    filteredCatalog,
     error: catalogError,
     loading,
   } = useSelector(getCatalog());
 
   return (
     <ChecksCatalog
-      catalogData={catalogData}
+      completeCatalog={completeCatalog}
+      filteredCatalog={filteredCatalog}
       catalogError={catalogError}
       loading={loading}
       updateCatalog={({

--- a/assets/js/state/catalog.js
+++ b/assets/js/state/catalog.js
@@ -6,6 +6,7 @@ export const updateCatalog = createAction(UPDATE_CATALOG);
 const initialState = {
   loading: true,
   data: [],
+  filteredCatalog: [],
   error: null,
 };
 
@@ -18,18 +19,29 @@ export const catalogSlice = createSlice({
     },
     setCatalogData: (state, action) => {
       state.data = action.payload.data;
+      state.filteredCatalog = action.payload.data;
+      state.error = null;
+      state.loading = false;
+    },
+    setFilteredCatalog: (state, action) => {
+      state.filteredCatalog = action.payload.data;
       state.error = null;
       state.loading = false;
     },
     setCatalogError: (state, action) => {
       state.data = [];
+      state.filteredCatalog = [];
       state.error = action.payload.error;
       state.loading = false;
     },
   },
 });
 
-export const { setCatalogLoading, setCatalogData, setCatalogError } =
-  catalogSlice.actions;
+export const {
+  setCatalogLoading,
+  setFilteredCatalog,
+  setCatalogData,
+  setCatalogError,
+} = catalogSlice.actions;
 
 export default catalogSlice.reducer;

--- a/assets/js/state/catalog.test.js
+++ b/assets/js/state/catalog.test.js
@@ -2,6 +2,7 @@ import catalogReducer, {
   setCatalogLoading,
   setCatalogData,
   setCatalogError,
+  setFilteredCatalog,
 } from './catalog';
 
 describe('Catalog reducer', () => {
@@ -23,35 +24,64 @@ describe('Catalog reducer', () => {
     const initialState = {
       loading: true,
       data: [],
+      filteredCatalog: [],
     };
 
-    const action = setCatalogData({ data: [1, 2, 3] });
+    [[1, 2, 3], []].forEach((data) => {
+      const action = setCatalogData({ data });
 
-    const expectedState = {
-      loading: false,
-      data: [1, 2, 3],
-      error: null,
+      const expectedState = {
+        loading: false,
+        data,
+        filteredCatalog: data,
+        error: null,
+      };
+
+      const actual = catalogReducer(initialState, action);
+
+      expect(actual).toEqual(expectedState);
+    });
+  });
+
+  it('should set filtered catalog', () => {
+    const initialState = {
+      loading: true,
+      data: [1, 2, 3, 4, 5],
+      filteredCatalog: [1, 2, 3, 4, 5],
     };
 
-    const actual = catalogReducer(initialState, action);
+    [[1, 2, 3], [2, 5], []].forEach((filteredCatalog) => {
+      const action = setFilteredCatalog({ data: filteredCatalog });
 
-    expect(actual).toEqual(expectedState);
+      const expectedState = {
+        loading: false,
+        data: initialState.data,
+        filteredCatalog,
+        error: null,
+      };
+
+      const actual = catalogReducer(initialState, action);
+
+      expect(actual).toEqual(expectedState);
+    });
   });
 
   it('should set catalog error', () => {
     const initialState = {
       loading: true,
-      data: [],
+      data: [1, 2, 3],
+      filteredCatalog: [2, 3],
       error: null,
     };
 
     const error = 'some-error';
 
-    const action = setCatalogError({ data: [], error });
+    const action = setCatalogError({ error });
 
     const expectedState = {
       loading: false,
       data: [],
+      filteredCatalog: [],
       error,
     };
 

--- a/assets/js/state/sagas/catalog.js
+++ b/assets/js/state/sagas/catalog.js
@@ -4,15 +4,29 @@ import { getCatalog } from '@lib/api/checks';
 import {
   UPDATE_CATALOG,
   setCatalogLoading,
+  setFilteredCatalog,
   setCatalogData,
   setCatalogError,
 } from '@state/catalog';
+import { get, pickBy } from 'lodash';
+
+const requiresFilteredCatalog = (payload) =>
+  get(payload, 'filteredCatalog', false);
+
+const plainPayload = (payload) =>
+  pickBy(payload, (_, key) => key !== 'filteredCatalog');
 
 export function* updateCatalog({ payload }) {
   yield put(setCatalogLoading());
   try {
-    const { data } = yield call(getCatalog, payload);
-    yield put(setCatalogData({ data: data.items }));
+    const {
+      data: { items },
+    } = yield call(getCatalog, plainPayload(payload));
+    yield put(
+      requiresFilteredCatalog(payload)
+        ? setFilteredCatalog({ data: items })
+        : setCatalogData({ data: items })
+    );
   } catch (error) {
     yield put(setCatalogError({ error: error.message }));
   }

--- a/assets/js/state/sagas/catalog.test.js
+++ b/assets/js/state/sagas/catalog.test.js
@@ -3,14 +3,14 @@ import { catalogCheckFactory } from '@lib/test-utils/factories';
 import { recordSaga } from '@lib/test-utils';
 
 import { networkClient } from '@lib/network';
-import { updateCatalog } from './catalog';
-
 import {
   setCatalogLoading,
   setCatalogData,
   setCatalogError,
   setFilteredCatalog,
-} from '../catalog';
+} from '@state/catalog';
+
+import { updateCatalog } from './catalog';
 
 const getCatalogUrl = '/api/v3/checks/catalog';
 const axiosMock = new MockAdapter(networkClient);

--- a/assets/js/state/selectors/catalog.js
+++ b/assets/js/state/selectors/catalog.js
@@ -1,8 +1,12 @@
 import { createSelector } from '@reduxjs/toolkit';
 
 export const getCatalog = () =>
-  createSelector([({ catalog }) => catalog], ({ data, error, loading }) => ({
-    data,
-    error,
-    loading,
-  }));
+  createSelector(
+    [({ catalog }) => catalog],
+    ({ data, filteredCatalog, error, loading }) => ({
+      data,
+      filteredCatalog,
+      error,
+      loading,
+    })
+  );

--- a/assets/js/state/selectors/catalog.test.js
+++ b/assets/js/state/selectors/catalog.test.js
@@ -6,6 +6,7 @@ describe('Catalog selector', () => {
       catalog: {
         loading: false,
         data: [1, 2, 3],
+        filteredCatalog: [1, 2],
         error: null,
       },
     };
@@ -13,6 +14,7 @@ describe('Catalog selector', () => {
     const expectedState = {
       loading: false,
       data: [1, 2, 3],
+      filteredCatalog: [1, 2],
       error: null,
     };
 

--- a/test/e2e/cypress/e2e/checks_catalog.cy.js
+++ b/test/e2e/cypress/e2e/checks_catalog.cy.js
@@ -21,7 +21,7 @@ context('Checks catalog', () => {
 
   const group1 = catalogCheckFactory.buildList(group1Checks, {
     group: clusterChecksGroup,
-    metadata: { target_type: 'cluster' },
+    metadata: { target_type: 'cluster', cluster_type: 'hana_scale_up' },
   });
   const group2 = catalogCheckFactory.buildList(group2Checks, {
     group: hostChecksGroup,


### PR DESCRIPTION
# Description

This PR allows filters in the catalog page to be populated based on the whole catalog content, while the actual list below is based on a filteredCatalog.

This requires making a differentiation in the intent: loading the whole catalog vs getting a filtered version of it, and I ended up adding this tiny seed `filteredCatalog: true` in the `updateCatalog` action.

However, I am not totally happy with it.
I attempted polishing catalog state and saga even further, but that would require rationalizing everything catalog related and updating many other places where the catalog is queried, like the checks selection, checks result page, etc... then I preferred keeping the change at minimum and defer further refactoring.

## How was this tested?

Automated tests
