### PR TITLE
Add fqdns to photofinish fixtures

### DIFF
--- a/test/fixtures/discovery/host_discovery.json
+++ b/test/fixtures/discovery/host_discovery.json
@@ -8,6 +8,7 @@
     "cpu_count": 2,
     "socket_count": 1,
     "total_memory_mb": 4096,
-    "agent_version": "0.1.0"
+    "agent_version": "0.1.0",
+    "fully_qualified_domain_name": "suse.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/discovery/host_discovery_with_installation_source.json
+++ b/test/fixtures/discovery/host_discovery_with_installation_source.json
@@ -9,6 +9,7 @@
     "socket_count": 1,
     "total_memory_mb": 4096,
     "agent_version": "0.1.0",
-    "installation_source": "Community"
+    "installation_source": "Community",
+    "fully_qualified_domain_name": "suse.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/aws-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_host_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_host_discovery.json
@@ -13,6 +13,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 32107
+    "total_memory_mb": 32107,
+    "fully_qualified_domain_name": "vmhdbdev02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/aws-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_host_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 32107
+    "total_memory_mb": 32107,
+    "fully_qualified_domain_name": "vmhdbdev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/aws-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_host_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwdev04.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/aws-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_host_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwdev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/aws-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_host_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwdev03.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/aws-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_host_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwdev02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/gcp-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_host_discovery.json
@@ -13,6 +13,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 32107
+    "total_memory_mb": 32107,
+    "fully_qualified_domain_name": "vmhdbdev02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/gcp-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 32107
+    "total_memory_mb": 32107,
+    "fully_qualified_domain_name": "vmhdbdev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/gcp-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwdev04.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/gcp-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwdev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/gcp-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwdev03.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/gcp-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwdev02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/hana-diskless-sbd/0f6e6491-21f2-495e-9f2d-bc50b872efaf_host_discovery.json
+++ b/test/fixtures/scenarios/hana-diskless-sbd/0f6e6491-21f2-495e-9f2d-bc50b872efaf_host_discovery.json
@@ -16,6 +16,7 @@
     ],
     "os_version": "15-SP4",
     "socket_count": 2,
-    "total_memory_mb": 1547378
+    "total_memory_mb": 1547378,
+    "fully_qualified_domain_name": "vmh3shdb01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/hana-diskless-sbd/43dcb497-2652-4254-b53a-3ff1d3b2a0ff_host_discovery.json
+++ b/test/fixtures/scenarios/hana-diskless-sbd/43dcb497-2652-4254-b53a-3ff1d3b2a0ff_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "os_version": "15-SP4",
     "socket_count": 1,
-    "total_memory_mb": 128418
+    "total_memory_mb": 128418,
+    "fully_qualified_domain_name": "vmh3shdb03.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/hana-diskless-sbd/5f2632a9-7b18-4c37-955a-fe16cadaaef4_host_discovery.json
+++ b/test/fixtures/scenarios/hana-diskless-sbd/5f2632a9-7b18-4c37-955a-fe16cadaaef4_host_discovery.json
@@ -15,6 +15,7 @@
     ],
     "os_version": "15-SP4",
     "socket_count": 1,
-    "total_memory_mb": 1547378
+    "total_memory_mb": 1547378,
+    "fully_qualified_domain_name": "vmh3shdb02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/hana-scale-out/1109be4b-54fb-4796-b073-f4cc04d2ca55_host_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-out/1109be4b-54fb-4796-b073-f4cc04d2ca55_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "os_version": "15-SP5",
     "socket_count": 1,
-    "total_memory_mb": 7888
+    "total_memory_mb": 7888,
+    "fully_qualified_domain_name": "vms4prdiscsi.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/hana-scale-out/12ab9a68-c047-4eda-81c8-1e24578d9973_host_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-out/12ab9a68-c047-4eda-81c8-1e24578d9973_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "os_version": "15-SP5",
     "socket_count": 1,
-    "total_memory_mb": 32043
+    "total_memory_mb": 32043,
+    "fully_qualified_domain_name": "vms4prdhdb04.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/hana-scale-out/16bd3ed1-923d-46ff-b6d0-9bfed42e387b_host_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-out/16bd3ed1-923d-46ff-b6d0-9bfed42e387b_host_discovery.json
@@ -15,6 +15,7 @@
     ],
     "os_version": "15-SP5",
     "socket_count": 1,
-    "total_memory_mb": 32043
+    "total_memory_mb": 32043,
+    "fully_qualified_domain_name": "vms4prdhdb03.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/hana-scale-out/28edd956-2155-487e-a4eb-f3d4cf7c9543_host_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-out/28edd956-2155-487e-a4eb-f3d4cf7c9543_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "os_version": "15-SP5",
     "socket_count": 1,
-    "total_memory_mb": 3862
+    "total_memory_mb": 3862,
+    "fully_qualified_domain_name": "vms4prdmm.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/hana-scale-out/33ec3a15-103b-453b-b6b2-f3f971582dc_host_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-out/33ec3a15-103b-453b-b6b2-f3f971582dc_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "os_version": "15-SP5",
     "socket_count": 1,
-    "total_memory_mb": 32043
+    "total_memory_mb": 32043,
+    "fully_qualified_domain_name": "vms4prdhdb02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/hana-scale-out/f3463fd1-004a-4214-afd4-b15160b0d521_host_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-out/f3463fd1-004a-4214-afd4-b15160b0d521_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "os_version": "15-SP5",
     "socket_count": 1,
-    "total_memory_mb": 32043
+    "total_memory_mb": 32043,
+    "fully_qualified_domain_name": "vms4prdhdb01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/098fc159-3ed6-58e7-91be-38fda8a833ea_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/098fc159-3ed6-58e7-91be-38fda8a833ea_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwqas03.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_host_discovery.json
@@ -13,6 +13,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 32107
+    "total_memory_mb": 32107,
+    "fully_qualified_domain_name": "vmhdbdev02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0fc07435-7ee2-54ca-b0de-fb27ffdc5deb_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0fc07435-7ee2-54ca-b0de-fb27ffdc5deb_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwprd04.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/116d49bd-85e1-5e59-b820-83f66db8800c_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/116d49bd-85e1-5e59-b820-83f66db8800c_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwprd01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 32107
+    "total_memory_mb": 32107,
+    "fully_qualified_domain_name": "vmhdbdev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/1b0e9297-97dd-55d6-9874-8efde4d84c90_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/1b0e9297-97dd-55d6-9874-8efde4d84c90_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwdev04.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmdrbddev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/25677e37-fd33-5005-896c-9275b1284534_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/25677e37-fd33-5005-896c-9275b1284534_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwqas01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/3711ea88-9ccc-5b07-8f9d-042be449d72b_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/3711ea88-9ccc-5b07-8f9d-042be449d72b_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwqas02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/422686d6-b2d1-5092-93e8-a744854f5085_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/422686d6-b2d1-5092-93e8-a744854f5085_host_discovery.json
@@ -13,6 +13,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmdrbdqas02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/4b30a6af-4b52-5bda-bccb-f2248a12c992_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/4b30a6af-4b52-5bda-bccb-f2248a12c992_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwprd02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/69f4dcbb-efa2-5a16-8bc8-01df7dbb7384_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/69f4dcbb-efa2-5a16-8bc8-01df7dbb7384_host_discovery.json
@@ -13,6 +13,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 3421
+    "total_memory_mb": 3421,
+    "fully_qualified_domain_name": "vmiscsi01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwdev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/81e9b629-c1e7-538f-bff1-47d3a6580522_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/81e9b629-c1e7-538f-bff1-47d3a6580522_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwqas04.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/927901fa-2c87-524e-b18c-3ef5187f504f_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/927901fa-2c87-524e-b18c-3ef5187f504f_host_discovery.json
@@ -13,6 +13,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmdrbdprd02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/99cf8a3a-48d6-57a4-b302-6e4482227ab6_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/99cf8a3a-48d6-57a4-b302-6e4482227ab6_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 32107
+    "total_memory_mb": 32107,
+    "fully_qualified_domain_name": "vmhdbqas01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a26b6d0-6e72-597c-9fe5-152a6875f214_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a26b6d0-6e72-597c-9fe5-152a6875f214_host_discovery.json
@@ -13,6 +13,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 3421
+    "total_memory_mb": 3421,
+    "fully_qualified_domain_name": "vmiscsi01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwdev03.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9cd46919-5f19-59aa-993e-cf3736c71053_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9cd46919-5f19-59aa-993e-cf3736c71053_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 32107
+    "total_memory_mb": 32107,
+    "fully_qualified_domain_name": "vmhdbprd01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a09d9cf3-46c1-505c-8fb8-4b0a71a9114e_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a09d9cf3-46c1-505c-8fb8-4b0a71a9114e_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmdrbdprd01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a3297d85-5e8b-5ac5-b8a3-55eebc2b8d12_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a3297d85-5e8b-5ac5-b8a3-55eebc2b8d12_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwprd03.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_host_discovery.json
@@ -13,6 +13,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 32107
+    "total_memory_mb": 32107,
+    "fully_qualified_domain_name": "vmhdbprd02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/ddcb7992-2ffb-5c10-8b39-80685f6eaaba_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/ddcb7992-2ffb-5c10-8b39-80685f6eaaba_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmdrbdqas01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/e0c182db-32ff-55c6-a9eb-2b82dd21bc8b_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/e0c182db-32ff-55c6-a9eb-2b82dd21bc8b_host_discovery.json
@@ -13,6 +13,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 32107
+    "total_memory_mb": 32107,
+    "fully_qualified_domain_name": "vmhdbqas02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/f0c808b3-d869-5192-a944-20f66a6a8449_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/f0c808b3-d869-5192-a944-20f66a6a8449_host_discovery.json
@@ -13,6 +13,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 3422
+    "total_memory_mb": 3422,
+    "fully_qualified_domain_name": "vmiscsi01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwdev02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/single-hana-single-app/c4914bd4-efa3-553a-9a52-e9b562e210e5_host_discovery.json
+++ b/test/fixtures/scenarios/single-hana-single-app/c4914bd4-efa3-553a-9a52-e9b562e210e5_host_discovery.json
@@ -14,6 +14,7 @@
     ],
     "os_version": "15-SP4",
     "socket_count": 1,
-    "total_memory_mb": 31578
+    "total_memory_mb": 31578,
+    "fully_qualified_domain_name": "trento-hana01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }

--- a/test/fixtures/scenarios/single-hana-single-app/e77ab524-c4e4-5381-bb59-5af8639d52a4_host_discovery.json
+++ b/test/fixtures/scenarios/single-hana-single-app/e77ab524-c4e4-5381-bb59-5af8639d52a4_host_discovery.json
@@ -21,6 +21,7 @@
     ],
     "os_version": "15-SP4",
     "socket_count": 1,
-    "total_memory_mb": 15699
+    "total_memory_mb": 15699,
+    "fully_qualified_domain_name": "trento-vmnetweaver01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
   }
 }


### PR DESCRIPTION
# Description

Adding fqdns for completeness in our fixtures. `vmdrbddev02` has been left as the no-fqdn case.
They come handy for SUMA integration mocking.