### PR TITLE
Update frontend to correlate SAP systems and databases properly

### DIFF
--- a/assets/js/lib/test-utils/factories/sapSystems.js
+++ b/assets/js/lib/test-utils/factories/sapSystems.js
@@ -35,14 +35,14 @@ export const sapSystemApplicationInstanceFactory = Factory.define(() => ({
 export const sapSystemFactory = Factory.define(({ params }) => {
   const id = params.id || faker.string.uuid();
   const sid = params.sid || faker.string.alphanumeric(3, { casing: 'upper' });
-
+  const databaseId = params.database_id || faker.string.uuid();
   return {
     application_instances: sapSystemApplicationInstanceFactory.buildList(2, {
       sap_system_id: id,
       sid,
     }),
     database_instances: databaseInstanceFactory.buildList(2, {
-      database_id: id,
+      database_id: databaseId,
       sid: faker.string.alphanumeric(3, { casing: 'upper' }),
     }),
     db_host: faker.internet.ip(),
@@ -53,5 +53,6 @@ export const sapSystemFactory = Factory.define(({ params }) => {
     sid,
     tags: [],
     tenant: faker.string.alphanumeric(3, { casing: 'upper' }),
+    database_id: databaseId,
   };
 });

--- a/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.jsx
+++ b/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.jsx
@@ -66,7 +66,7 @@ function SapSystemsOverview({
         render: (content, item) => (
           <Link
             className="text-jungle-green-500 hover:opacity-75"
-            to={`/databases/${item.id}`}
+            to={`/databases/${item.databaseId}`}
           >
             {content}
           </Link>
@@ -127,13 +127,13 @@ function SapSystemsOverview({
       sap_system_id: sapSystem.id,
     }),
     databaseInstances: filter(databaseInstances, {
-      database_id: sapSystem.id,
+      database_id: sapSystem.database_id,
     }),
     tags: (sapSystem.tags && sapSystem.tags.map((tag) => tag.value)) || [],
+    databaseId: sapSystem.database_id,
   }));
 
   const counters = getCounters(data || []);
-
   return loading ? (
     'Loading SAP Systems...'
   ) : (

--- a/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.test.jsx
+++ b/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.test.jsx
@@ -46,8 +46,8 @@ describe('SapSystemsOverviews component', () => {
         db_host: dbAddress,
         application_instances: applicationInstances,
         database_instances: databaseInstances,
+        database_id: databaseID,
       } = sapSystem;
-
       renderWithRouter(
         <SapSystemsOverview
           sapSystems={[sapSystem]}
@@ -69,7 +69,7 @@ describe('SapSystemsOverviews component', () => {
       );
       expect(mainRow.querySelector('td:nth-child(3) > a')).toHaveAttribute(
         'href',
-        `/databases/${sapSystemID}`
+        `/databases/${databaseID}`
       );
       expect(mainRow.querySelector('td:nth-child(4)')).toHaveTextContent(
         tenant
@@ -107,6 +107,7 @@ describe('SapSystemsOverviews component', () => {
 
       const enrichedDatabaseInstances = databaseInstances.map((instance) => {
         const host = hostFactory.build({ id: instance.host_id });
+
         return {
           ...instance,
           host: {
@@ -118,7 +119,6 @@ describe('SapSystemsOverviews component', () => {
           },
         };
       });
-
       renderWithRouter(
         <SapSystemsOverview
           sapSystems={[sapSystem]}

--- a/lib/trento_web/openapi/v1/schema/database.ex
+++ b/lib/trento_web/openapi/v1/schema/database.ex
@@ -30,12 +30,6 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Database do
           description: "Instance Hostname",
           nullable: true
         },
-        absent_at: %Schema{
-          type: :string,
-          description: "Absent instance timestamp",
-          format: :datetime,
-          nullable: true
-        },
         features: %Schema{type: :string, description: "Instance Features"},
         http_port: %Schema{type: :integer, description: "Instance HTTP Port", nullable: true},
         https_port: %Schema{type: :integer, description: "Instance HTTPS Port", nullable: true},
@@ -55,6 +49,12 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Database do
           description: "System Replication Status"
         },
         health: ResourceHealth,
+        absent_at: %Schema{
+          type: :string,
+          description: "Absent instance timestamp",
+          format: :datetime,
+          nullable: true
+        },
         inserted_at: %Schema{type: :string, format: :datetime},
         updated_at: %Schema{type: :string, format: :datetime, nullable: true}
       }

--- a/lib/trento_web/openapi/v1/schema/sap_system.ex
+++ b/lib/trento_web/openapi/v1/schema/sap_system.ex
@@ -76,6 +76,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.SAPSystem do
           type: :array,
           items: ApplicationInstance
         },
+        database_id: %Schema{type: :string, description: "Database ID", format: :uuid},
         database_instances: Database.DatabaseInstances,
         tags: Tags,
         inserted_at: %Schema{type: :string, format: :datetime},

--- a/lib/trento_web/views/v1/health_overview_view.ex
+++ b/lib/trento_web/views/v1/health_overview_view.ex
@@ -14,6 +14,7 @@ defmodule TrentoWeb.V1.HealthOverviewView do
           sid: sid,
           sapsystem_health: sapsystem_health,
           application_instances: application_instances,
+          database_id: database_id,
           database_instances: database_instances,
           database_health: database_health,
           application_cluster_health: application_cluster_health,
@@ -25,6 +26,7 @@ defmodule TrentoWeb.V1.HealthOverviewView do
       id: id,
       sid: sid,
       sapsystem_health: sapsystem_health,
+      database_id: database_id,
       database_health: database_health,
       # deprecated field
       clusters_health: database_cluster_health,
@@ -35,16 +37,9 @@ defmodule TrentoWeb.V1.HealthOverviewView do
       cluster_id: extract_cluster_id(database_instances),
       application_cluster_id: extract_cluster_id(application_instances),
       database_cluster_id: extract_cluster_id(database_instances),
-      database_id: extract_database_id(database_instances),
       tenant: extract_tenant(database_instances)
     }
   end
-
-  @spec extract_database_id([DatabaseInstanceReadModel.t()]) :: String.t() | nil
-  defp extract_database_id([]), do: nil
-
-  defp extract_database_id([%DatabaseInstanceReadModel{database_id: database_id} | _]),
-    do: database_id
 
   @spec extract_cluster_id([ApplicationInstanceReadModel.t()] | [DatabaseInstanceReadModel.t()]) ::
           String.t() | nil

--- a/lib/trento_web/views/v1/sap_system_view.ex
+++ b/lib/trento_web/views/v1/sap_system_view.ex
@@ -39,7 +39,6 @@ defmodule TrentoWeb.V1.SapSystemView do
     |> Map.delete(:__meta__)
     |> Map.delete(:deregistered_at)
     |> Map.delete(:database)
-    |> Map.delete(:database_id)
     |> Map.put(
       :database_instances,
       rendered_database_instances

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -536,7 +536,7 @@ defmodule Trento.Factory do
     %DatabaseReadModel{
       id: Faker.UUID.v4(),
       sid: Faker.StarWars.planet(),
-      health: Health.unknown(),
+      health: Health.unknown()
     }
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -535,7 +535,8 @@ defmodule Trento.Factory do
   def database_factory do
     %DatabaseReadModel{
       id: Faker.UUID.v4(),
-      sid: Faker.StarWars.planet()
+      sid: Faker.StarWars.planet(),
+      health: Health.unknown(),
     }
   end
 

--- a/test/trento/sap_systems/services/health_summary_service_test.exs
+++ b/test/trento/sap_systems/services/health_summary_service_test.exs
@@ -34,6 +34,8 @@ defmodule Trento.SapSystems.Services.HealthSummaryServiceTest do
         host_id: a_host_id
       )
 
+      insert(:database, id: database_id)
+      
       insert(
         :application_instance_without_host,
         sap_system_id: sap_system_id,
@@ -65,7 +67,7 @@ defmodule Trento.SapSystems.Services.HealthSummaryServiceTest do
       %HostReadModel{id: app_host_id_2} =
         app_host_2 = insert(:host, cluster_id: nil, heartbeat: Health.critical())
 
-      %{id: database_id} = insert(:database)
+      %{id: database_id} = insert(:database, health: Health.warning())
 
       %SapSystemReadModel{
         id: sap_system_id,
@@ -124,6 +126,7 @@ defmodule Trento.SapSystems.Services.HealthSummaryServiceTest do
                  database_cluster_health: Health.passing(),
                  application_cluster_health: Health.warning(),
                  hosts_health: Health.unknown(),
+                 database_id: database_id,
                  database_instances: database_instances,
                  application_instances: application_instances
                }
@@ -137,7 +140,7 @@ defmodule Trento.SapSystems.Services.HealthSummaryServiceTest do
       %HostReadModel{id: app_host_id} =
         app_host = insert(:host, cluster_id: nil, health: Health.passing())
 
-      %{id: database_id} = insert(:database)
+      %{id: database_id} = insert(:database, health: Health.warning())
 
       %SapSystemReadModel{
         id: sap_system_id,
@@ -176,6 +179,7 @@ defmodule Trento.SapSystems.Services.HealthSummaryServiceTest do
                  sapsystem_health: Health.critical(),
                  database_health: Health.warning(),
                  database_cluster_health: Health.unknown(),
+                 database_id: database_id,
                  application_cluster_health: Health.unknown(),
                  hosts_health: Health.passing(),
                  database_instances: database_instances,

--- a/test/trento/sap_systems/services/health_summary_service_test.exs
+++ b/test/trento/sap_systems/services/health_summary_service_test.exs
@@ -11,6 +11,7 @@ defmodule Trento.SapSystems.Services.HealthSummaryServiceTest do
   require Trento.Clusters.Enums.ClusterType, as: ClusterType
 
   alias Trento.Clusters.Projections.ClusterReadModel
+  alias Trento.Databases.Projections.DatabaseReadModel
   alias Trento.Hosts.Projections.HostReadModel
   alias Trento.SapSystems.Projections.SapSystemReadModel
 
@@ -22,11 +23,12 @@ defmodule Trento.SapSystems.Services.HealthSummaryServiceTest do
     test "should raise an exception when a cluster couldn't be loaded" do
       %HostReadModel{id: a_host_id} = insert(:host, cluster_id: Faker.UUID.v4())
 
+      %DatabaseReadModel{id: database_id} = insert(:database)
+
       %SapSystemReadModel{
         id: sap_system_id,
-        sid: sid,
-        database_id: database_id
-      } = insert(:sap_system)
+        sid: sid
+      } = insert(:sap_system, database_id: database_id)
 
       insert(
         :database_instance_without_host,
@@ -34,8 +36,6 @@ defmodule Trento.SapSystems.Services.HealthSummaryServiceTest do
         host_id: a_host_id
       )
 
-      insert(:database, id: database_id)
-      
       insert(
         :application_instance_without_host,
         sap_system_id: sap_system_id,
@@ -67,7 +67,7 @@ defmodule Trento.SapSystems.Services.HealthSummaryServiceTest do
       %HostReadModel{id: app_host_id_2} =
         app_host_2 = insert(:host, cluster_id: nil, heartbeat: Health.critical())
 
-      %{id: database_id} = insert(:database, health: Health.warning())
+      %DatabaseReadModel{id: database_id, health: database_health} = insert(:database)
 
       %SapSystemReadModel{
         id: sap_system_id,
@@ -122,7 +122,7 @@ defmodule Trento.SapSystems.Services.HealthSummaryServiceTest do
                  id: sap_system_id,
                  sid: sid,
                  sapsystem_health: Health.critical(),
-                 database_health: Health.warning(),
+                 database_health: database_health,
                  database_cluster_health: Health.passing(),
                  application_cluster_health: Health.warning(),
                  hosts_health: Health.unknown(),
@@ -140,7 +140,7 @@ defmodule Trento.SapSystems.Services.HealthSummaryServiceTest do
       %HostReadModel{id: app_host_id} =
         app_host = insert(:host, cluster_id: nil, health: Health.passing())
 
-      %{id: database_id} = insert(:database, health: Health.warning())
+      %DatabaseReadModel{id: database_id, health: database_health} = insert(:database)
 
       %SapSystemReadModel{
         id: sap_system_id,
@@ -177,7 +177,7 @@ defmodule Trento.SapSystems.Services.HealthSummaryServiceTest do
                  id: sap_system_id,
                  sid: sid,
                  sapsystem_health: Health.critical(),
-                 database_health: Health.warning(),
+                 database_health: database_health,
                  database_cluster_health: Health.unknown(),
                  database_id: database_id,
                  application_cluster_health: Health.unknown(),

--- a/test/trento_web/controllers/v1/health_overview_controller_test.exs
+++ b/test/trento_web/controllers/v1/health_overview_controller_test.exs
@@ -26,6 +26,8 @@ defmodule TrentoWeb.V1.HealthOverviewControllerTest do
       database_id: database_id
     } = insert(:sap_system, health: Health.critical())
 
+    insert(:database, id: database_id, health: Health.warning())
+
     insert(
       :database_instance_without_host,
       database_id: database_id,

--- a/test/trento_web/controllers/v1/health_overview_controller_test.exs
+++ b/test/trento_web/controllers/v1/health_overview_controller_test.exs
@@ -11,6 +11,7 @@ defmodule TrentoWeb.V1.HealthOverviewControllerTest do
 
   alias Trento.ClusterReadModel
   alias Trento.Clusters.Projections.ClusterReadModel
+  alias Trento.Databases.Projections.DatabaseReadModel
   alias Trento.Hosts.Projections.HostReadModel
   alias Trento.SapSystems.Projections.SapSystemReadModel
 
@@ -26,14 +27,14 @@ defmodule TrentoWeb.V1.HealthOverviewControllerTest do
       database_id: database_id
     } = insert(:sap_system, health: Health.critical())
 
-    insert(:database, id: database_id, health: Health.warning())
+    %DatabaseReadModel{health: database_health} = insert(:database, id: database_id)
 
     insert(
       :database_instance_without_host,
       database_id: database_id,
       sid: "HDD",
       host_id: host_1_id,
-      health: Health.warning()
+      health: database_health
     )
 
     insert(

--- a/test/trento_web/controllers/v1/health_overview_controller_test.exs
+++ b/test/trento_web/controllers/v1/health_overview_controller_test.exs
@@ -21,13 +21,12 @@ defmodule TrentoWeb.V1.HealthOverviewControllerTest do
 
     %HostReadModel{id: host_1_id} = insert(:host, cluster_id: cluster_id, heartbeat: :unknown)
 
+    %DatabaseReadModel{health: database_health, id: database_id} = insert(:database)
+
     %SapSystemReadModel{
       id: sap_system_id,
-      sid: sid,
-      database_id: database_id
-    } = insert(:sap_system, health: Health.critical())
-
-    %DatabaseReadModel{health: database_health} = insert(:database, id: database_id)
+      sid: sid
+    } = insert(:sap_system, database_id: database_id, health: Health.critical())
 
     insert(
       :database_instance_without_host,

--- a/test/trento_web/controllers/v1/sap_system_controller_test.exs
+++ b/test/trento_web/controllers/v1/sap_system_controller_test.exs
@@ -15,7 +15,8 @@ defmodule TrentoWeb.V1.SapSystemControllerTest do
 
   describe "list" do
     test "should list all sap_systems", %{conn: conn} do
-      %{id: sap_system_id, database_id: database_id} = build(:sap_system)
+      %{id: sap_system_id, database_id: database_id} = insert(:sap_system)
+
       insert_list(2, :database_instance, database_id: database_id)
       insert_list(2, :application_instance, sap_system_id: sap_system_id)
 

--- a/test/trento_web/controllers/v1/sap_system_controller_test.exs
+++ b/test/trento_web/controllers/v1/sap_system_controller_test.exs
@@ -15,7 +15,8 @@ defmodule TrentoWeb.V1.SapSystemControllerTest do
 
   describe "list" do
     test "should list all sap_systems", %{conn: conn} do
-      %{id: sap_system_id, database_id: database_id} = insert(:sap_system)
+      %{id: database_id} = insert(:database)
+      %{id: sap_system_id} = insert(:sap_system, database_id: database_id)
 
       insert_list(2, :database_instance, database_id: database_id)
       insert_list(2, :application_instance, sap_system_id: sap_system_id)

--- a/test/trento_web/views/v1/health_overview_view_test.exs
+++ b/test/trento_web/views/v1/health_overview_view_test.exs
@@ -28,7 +28,7 @@ defmodule TrentoWeb.V1.HealthOverviewViewTest do
             host: build(:host, cluster_id: app_cluster_id)
           )
 
-      insert(:database, id: database_id, health: Health.passing())
+      insert(:database, health: Health.passing())
 
       database_instances =
         build_list(

--- a/test/trento_web/views/v1/health_overview_view_test.exs
+++ b/test/trento_web/views/v1/health_overview_view_test.exs
@@ -28,6 +28,8 @@ defmodule TrentoWeb.V1.HealthOverviewViewTest do
             host: build(:host, cluster_id: app_cluster_id)
           )
 
+      insert(:database, id: database_id, health: Health.passing())
+
       database_instances =
         build_list(
           2,
@@ -39,18 +41,18 @@ defmodule TrentoWeb.V1.HealthOverviewViewTest do
 
       assert [
                %{
-                 cluster_id: db_cluster_id,
+                 id: sap_system_id,
+                 sid: sid,
+                 sapsystem_health: Health.passing(),
+                 database_id: database_id,
+                 database_health: Health.passing(),
                  clusters_health: Health.warning(),
-                 application_cluster_id: app_cluster_id,
-                 database_cluster_id: db_cluster_id,
                  application_cluster_health: Health.critical(),
                  database_cluster_health: Health.warning(),
-                 database_health: Health.passing(),
-                 database_id: database_id,
                  hosts_health: Health.warning(),
-                 id: sap_system_id,
-                 sapsystem_health: Health.passing(),
-                 sid: sid,
+                 cluster_id: db_cluster_id,
+                 application_cluster_id: app_cluster_id,
+                 database_cluster_id: db_cluster_id,
                  tenant: tenant
                }
              ] ==
@@ -60,12 +62,13 @@ defmodule TrentoWeb.V1.HealthOverviewViewTest do
                      id: sap_system_id,
                      sid: sid,
                      sapsystem_health: Health.passing(),
+                     application_instances: application_instances,
+                     database_id: database_id,
+                     database_instances: database_instances,
                      database_health: Health.passing(),
                      application_cluster_health: Health.critical(),
                      database_cluster_health: Health.warning(),
-                     hosts_health: Health.warning(),
-                     application_instances: application_instances,
-                     database_instances: database_instances
+                     hosts_health: Health.warning()
                    }
                  ]
                })
@@ -82,6 +85,8 @@ defmodule TrentoWeb.V1.HealthOverviewViewTest do
           sap_system_id: sap_system_id,
           host: build(:host, cluster_id: nil)
         )
+
+      insert(:database, id: database_id, health: Health.passing())
 
       database_instances =
         build_list(
@@ -108,12 +113,13 @@ defmodule TrentoWeb.V1.HealthOverviewViewTest do
                      id: sap_system_id,
                      sid: UUID.uuid4(),
                      sapsystem_health: Health.passing(),
+                     application_instances: application_instances,
+                     database_id: database_id,
+                     database_instances: database_instances,
                      database_health: Health.passing(),
                      application_cluster_health: Health.unknown(),
                      database_cluster_health: Health.unknown(),
-                     hosts_health: Health.warning(),
-                     application_instances: application_instances,
-                     database_instances: database_instances
+                     hosts_health: Health.warning()
                    }
                  ]
                })

--- a/test/trento_web/views/v1/health_overview_view_test.exs
+++ b/test/trento_web/views/v1/health_overview_view_test.exs
@@ -29,8 +29,6 @@ defmodule TrentoWeb.V1.HealthOverviewViewTest do
 
       %{id: database_id} = insert(:database, health: Health.passing())
 
-      insert(:database, health: Health.passing())
-
       database_instances =
         build_list(
           2,

--- a/test/trento_web/views/v1/health_overview_view_test.exs
+++ b/test/trento_web/views/v1/health_overview_view_test.exs
@@ -10,7 +10,6 @@ defmodule TrentoWeb.V1.HealthOverviewViewTest do
   describe "renders overview.json" do
     test "should render all the fields" do
       sap_system_id = UUID.uuid4()
-      database_id = UUID.uuid4()
       sid = UUID.uuid4()
       tenant = UUID.uuid4()
       app_cluster_id = UUID.uuid4()
@@ -27,6 +26,8 @@ defmodule TrentoWeb.V1.HealthOverviewViewTest do
             sap_system_id: sap_system_id,
             host: build(:host, cluster_id: app_cluster_id)
           )
+
+      %{id: database_id} = insert(:database, health: Health.passing())
 
       insert(:database, health: Health.passing())
 
@@ -76,7 +77,6 @@ defmodule TrentoWeb.V1.HealthOverviewViewTest do
 
     test "should send empty cluster ids" do
       sap_system_id = UUID.uuid4()
-      database_id = UUID.uuid4()
 
       application_instances =
         build_list(
@@ -86,7 +86,7 @@ defmodule TrentoWeb.V1.HealthOverviewViewTest do
           host: build(:host, cluster_id: nil)
         )
 
-      insert(:database, id: database_id, health: Health.passing())
+      %{id: database_id} = insert(:database, health: Health.passing())
 
       database_instances =
         build_list(


### PR DESCRIPTION
# Description

This pr aims to:
- Update the frontend to use database ID to create the links instead of sap system ID
- Update the health_summary_service.ex and health_overview_view.ex to use the new database_id and database healt
- Updated sapSystems factory to use the new databaseId

## How was this tested: 
Updated existing test in front end and backend
