### PR TITLE
Hide misleading navigation icon from software updates indicator

### DIFF
--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
@@ -19,7 +19,7 @@ describe('AvailableSoftwareUpdates component', () => {
     );
 
     expect(screen.getByText(upgradablePackages)).toBeVisible();
-    expect(screen.getAllByTestId('eos-svg-component')).toHaveLength(4);
+    expect(screen.getAllByTestId('eos-svg-component')).toHaveLength(3);
   });
 
   it('renders critical counters', () => {
@@ -35,7 +35,7 @@ describe('AvailableSoftwareUpdates component', () => {
 
     expect(screen.getByText(relevantPatches)).toBeVisible();
     expect(screen.getByText(upgradablePackages)).toBeVisible();
-    expect(screen.getAllByTestId('eos-svg-component')).toHaveLength(5);
+    expect(screen.getAllByTestId('eos-svg-component')).toHaveLength(3);
   });
 
   it('renders Unknown status', async () => {

--- a/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import {
-  EOS_KEYBOARD_ARROW_RIGHT_FILLED,
+  // EOS_KEYBOARD_ARROW_RIGHT_FILLED,
   EOS_ERROR_OUTLINED,
   EOS_LOADING_ANIMATED,
 } from 'eos-icons-react';
@@ -58,14 +58,14 @@ function Indicator({ title, critical, tooltip, icon, loading, children }) {
           </div>
         </div>
         <div className="flex grow justify-end">
-          {!unknown && (
+          {/* {!unknown && (
             <div>
               <EOS_KEYBOARD_ARROW_RIGHT_FILLED
                 size="l"
                 className="fill-gray-400"
               />
             </div>
-          )}
+          )} */}
         </div>
       </div>
     </Tooltip>


### PR DESCRIPTION
# Description

Hiding a misleading icon currently not needed.