### PR TITLE
Add initiation for software updates discovery process

### DIFF
--- a/lib/trento/hosts/commands/discover_software_updates.ex
+++ b/lib/trento/hosts/commands/discover_software_updates.ex
@@ -1,0 +1,13 @@
+defmodule Trento.Hosts.Commands.DiscoverSoftwareUpdates do
+  @moduledoc """
+  Issues the software updates discovery for a host
+  """
+
+  @required_fields :all
+
+  use Trento.Support.Command
+
+  defcommand do
+    field :host_id, Ecto.UUID
+  end
+end

--- a/lib/trento/hosts/events/software_updates_discovery_requested.ex
+++ b/lib/trento/hosts/events/software_updates_discovery_requested.ex
@@ -1,0 +1,12 @@
+defmodule Trento.Hosts.Events.SoftwareUpdatesDiscoveryRequested do
+  @moduledoc """
+  This event is emitted when a host's software updates discovery process is issued
+  """
+
+  use Trento.Support.Event
+
+  defevent do
+    field :host_id, Ecto.UUID
+    field :fully_qualified_domain_name, :string
+  end
+end

--- a/lib/trento/router.ex
+++ b/lib/trento/router.ex
@@ -16,6 +16,7 @@ defmodule Trento.Router do
     CompleteHostChecksExecution,
     CompleteSoftwareUpdatesDiscovery,
     DeregisterHost,
+    DiscoverSoftwareUpdates,
     RegisterHost,
     RequestHostDeregistration,
     RollUpHost,
@@ -55,6 +56,7 @@ defmodule Trento.Router do
              RequestHostDeregistration,
              DeregisterHost,
              CompleteHostChecksExecution,
+             DiscoverSoftwareUpdates,
              CompleteSoftwareUpdatesDiscovery,
              ClearSoftwareUpdatesDiscovery
            ],

--- a/test/trento/hosts/host_test.exs
+++ b/test/trento/hosts/host_test.exs
@@ -8,6 +8,7 @@ defmodule Trento.Hosts.HostTest do
     CompleteHostChecksExecution,
     CompleteSoftwareUpdatesDiscovery,
     DeregisterHost,
+    DiscoverSoftwareUpdates,
     RegisterHost,
     RequestHostDeregistration,
     RollUpHost,
@@ -37,7 +38,8 @@ defmodule Trento.Hosts.HostTest do
     SaptuneStatusUpdated,
     SlesSubscriptionsUpdated,
     SoftwareUpdatesDiscoveryCleared,
-    SoftwareUpdatesDiscoveryCompleted
+    SoftwareUpdatesDiscoveryCompleted,
+    SoftwareUpdatesDiscoveryRequested
   }
 
   alias Trento.Hosts.ValueObjects.{
@@ -1408,6 +1410,7 @@ defmodule Trento.Hosts.HostTest do
   describe "software updates discovery" do
     test "should not accept software updates discovery commands if a host is not registered yet" do
       commands = [
+        %DiscoverSoftwareUpdates{host_id: Faker.UUID.v4()},
         %CompleteSoftwareUpdatesDiscovery{host_id: Faker.UUID.v4()},
         %ClearSoftwareUpdatesDiscovery{host_id: Faker.UUID.v4()}
       ]
@@ -1415,6 +1418,37 @@ defmodule Trento.Hosts.HostTest do
       for command <- commands do
         assert_error(command, {:error, :host_not_registered})
       end
+    end
+
+    test "should trigger the software updates discovery process" do
+      host_id = Faker.UUID.v4()
+      fully_qualified_domain_name = Faker.Internet.domain_name()
+
+      initial_events = [
+        build(:host_registered_event,
+          host_id: host_id,
+          fully_qualified_domain_name: fully_qualified_domain_name
+        ),
+        build(:heartbeat_succeded, host_id: host_id)
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        DiscoverSoftwareUpdates.new!(%{
+          host_id: host_id
+        }),
+        %SoftwareUpdatesDiscoveryRequested{
+          host_id: host_id,
+          fully_qualified_domain_name: fully_qualified_domain_name
+        },
+        fn host ->
+          assert %Host{
+                   host_id: ^host_id,
+                   fully_qualified_domain_name: ^fully_qualified_domain_name,
+                   heartbeat: Health.passing()
+                 } = host
+        end
+      )
     end
 
     defp get_host_health_changed_event(host_id, scenario) do
@@ -1713,8 +1747,7 @@ defmodule Trento.Hosts.HostTest do
         }
       ]
 
-      assert_error(
-        events,
+      commands_to_reject = [
         UpdateProvider.new!(%{
           host_id: host_id,
           provider: :azure,
@@ -1729,16 +1762,15 @@ defmodule Trento.Hosts.HostTest do
             vpc_id: "vpc-12345"
           }
         }),
-        {:error, :host_rolling_up}
-      )
-
-      assert_error(
-        events,
+        DiscoverSoftwareUpdates.new!(%{host_id: host_id}),
         RollUpHost.new!(%{
           host_id: host_id
-        }),
-        {:error, :host_rolling_up}
-      )
+        })
+      ]
+
+      for command <- commands_to_reject do
+        assert_error(events, command, {:error, :host_rolling_up})
+      end
     end
 
     test "should apply the rollup event and rehydrate the aggregate" do
@@ -1914,6 +1946,7 @@ defmodule Trento.Hosts.HostTest do
         %UpdateHeartbeat{host_id: host_id},
         %UpdateProvider{host_id: host_id},
         %UpdateSlesSubscriptions{host_id: host_id},
+        %DiscoverSoftwareUpdates{host_id: host_id},
         %CompleteSoftwareUpdatesDiscovery{host_id: host_id},
         %ClearSoftwareUpdatesDiscovery{host_id: host_id},
         %SelectHostChecks{host_id: host_id}


### PR DESCRIPTION
# Description

This PR adds a `DiscoverSoftwareUpdates`/`SoftwareUpdatesDiscoveryRequested` command/event pair that will initiate the software updates discovery process ie when a host is registered/restored/fqdn changed (happening in an upcoming process manager) or triggered on demand when credentials are saved/changed and on a tick happening every X amount of time (12h as of now.)

## How was this tested?

Automated tests.
