### PR TITLE
Fix get systems by cluster selector

### DIFF
--- a/assets/js/state/selectors/cluster.js
+++ b/assets/js/state/selectors/cluster.js
@@ -1,4 +1,4 @@
-import { get, find, uniq, has, set } from 'lodash';
+import { get, find, uniq, has } from 'lodash';
 import { createSelector } from '@reduxjs/toolkit';
 
 import {
@@ -45,8 +45,7 @@ const getSystemsByClusterHosts = (instances, systems, clusterHostIDs) =>
   systems.filter((system) =>
     clusterHostIDs.some((hostID) =>
       instances
-        .map((instance) => set(instance, 'instanceID', getInstanceID(instance)))
-        .filter(({ instanceID }) => instanceID === system.id)
+        .filter((instance) => getInstanceID(instance) === system.id)
         .map(({ host_id }) => host_id)
         .includes(hostID)
     )

--- a/test/e2e/cypress/e2e/hana_cluster_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_cluster_details.cy.js
@@ -43,7 +43,12 @@ context('HANA cluster details', () => {
       cy.get('.tn-cluster-details')
         .contains('SID')
         .next()
-        .contains(availableHanaCluster.sid);
+        .contains(availableHanaCluster.sid)
+        .should(
+          'have.attr',
+          'href',
+          `/databases/${availableHanaCluster.systemID}`
+        );
     });
 
     it(`should have cluster type ${availableHanaCluster.clusterType}`, () => {

--- a/test/e2e/cypress/fixtures/hana-cluster-details/available_hana_cluster.js
+++ b/test/e2e/cypress/fixtures/hana-cluster-details/available_hana_cluster.js
@@ -2,6 +2,7 @@ export const availableHanaCluster = {
   id: '469e7be5-4e20-5007-b044-c6f540a87493',
   name: 'hana_cluster_3',
   sid: 'HDP',
+  systemID: '6c9208eb-a5bb-57ef-be5c-6422dedab602',
   clusterType: 'HANA Scale Up',
   provider: 'Azure',
   hanaSystemReplicationMode: 'sync',


### PR DESCRIPTION
# Description
Fix regression we had during the sap system/database split.

![image](https://github.com/trento-project/web/assets/36370954/2e6a5562-b2df-49fd-bcf3-4b2dd316b99d)

The sap system/database URL was not being populated.
The more I check, i don't know how this happened, since the UT looks totally correct.
Maybe the update to redux toolkit 2 has changed something, and the lodash set does something that it doesn't like...

## How was this tested?

E2E test improved to cover this case
