### PR TITLE
Pin docker-compose postgres to 15

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
     ports:
       - 9090:9090
   postgres:
-    image: postgres:latest
+    image: postgres:15
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
# Description

Pin the docker-compose postgres version to `15`.
I'm not adding the minor version, as SUSE does a pretty good job updating it to the latest.
For example, now it is `15.6` in the public docker container and in SUSE repos, so they will be matched.
Or do you think we should pin the minor version as well?

I will update it in `wanda`.

We cannot change the `helm-chart` version from 14, due that nasty thing we had with `trento-db` without migrations, so that will stay as it is.

Sending to `main`, I will rebase to `multi-tenant` afterwards