### PR TITLE
SoftwareUpdatesDiscovery Process Manager

### DIFF
--- a/lib/trento/infrastructure/commanded/process_managers/software_updates_discovery_process_manager.ex
+++ b/lib/trento/infrastructure/commanded/process_managers/software_updates_discovery_process_manager.ex
@@ -1,0 +1,155 @@
+defmodule Trento.Infrastructure.Commanded.ProcessManagers.SoftwareUpdatesDiscoveryProcessManager do
+  @moduledoc """
+  Process Manager for Software Updates Discovery.
+  It triggers the process of discovering software updates for a host when:
+  - a host gets registered
+  - the fqdn of a host changes
+  - when a host gets restored after being deregistered
+
+  For more information see https://hexdocs.pm/commanded/process-managers.html
+  """
+
+  use Commanded.ProcessManagers.ProcessManager,
+    application: Trento.Commanded,
+    name: "software_updates_discovery_process_manager"
+
+  alias Trento.Infrastructure.Commanded.ProcessManagers.SoftwareUpdatesDiscoveryProcessManager
+
+  @required_fields []
+  use Trento.Support.Type
+
+  deftype do
+    field :host_id, Ecto.UUID
+    field :fully_qualified_domain_name, :string
+  end
+
+  alias Trento.Hosts.Events.{
+    HostDeregistered,
+    HostDetailsUpdated,
+    HostRegistered,
+    HostRestored
+  }
+
+  alias Trento.Hosts.Commands.{
+    ClearSoftwareUpdatesDiscovery,
+    DiscoverSoftwareUpdates
+  }
+
+  # Start the Process Manager
+  def interested?(%HostRegistered{host_id: host_id}),
+    do: {:start, host_id}
+
+  def interested?(%HostRestored{host_id: host_id}),
+    do: {:start, host_id}
+
+  # Continue the Process Manager
+  def interested?(%HostDetailsUpdated{host_id: host_id}),
+    do: {:continue, host_id}
+
+  # Stop the Process Manager
+  def interested?(%HostDeregistered{host_id: host_id}),
+    do: {:stop, host_id}
+
+  def interested?(_event), do: false
+
+  # on host registration, if the registered host has an FQDN, trigger the software updates discovery
+  def handle(
+        %SoftwareUpdatesDiscoveryProcessManager{
+          host_id: nil,
+          fully_qualified_domain_name: nil
+        },
+        %HostRegistered{
+          host_id: host_id,
+          fully_qualified_domain_name: fully_qualified_domain_name
+        }
+      )
+      when not is_nil(fully_qualified_domain_name),
+      do: %DiscoverSoftwareUpdates{host_id: host_id}
+
+  # on host restoration, trigger the software updates discovery
+  def handle(
+        %SoftwareUpdatesDiscoveryProcessManager{
+          host_id: nil,
+          fully_qualified_domain_name: nil
+        },
+        %HostRestored{host_id: host_id}
+      ),
+      do: %DiscoverSoftwareUpdates{host_id: host_id}
+
+  # when host details changed but FQDN did NOT change, ignore
+  def handle(
+        %SoftwareUpdatesDiscoveryProcessManager{
+          host_id: host_id,
+          fully_qualified_domain_name: fully_qualified_domain_name
+        },
+        %HostDetailsUpdated{
+          host_id: host_id,
+          fully_qualified_domain_name: fully_qualified_domain_name
+        }
+      ),
+      do: []
+
+  # when FQDN changes to nil, clear the software updates discovery
+  def handle(
+        %SoftwareUpdatesDiscoveryProcessManager{
+          host_id: host_id,
+          fully_qualified_domain_name: current_fully_qualified_domain_name
+        },
+        %HostDetailsUpdated{
+          host_id: host_id,
+          fully_qualified_domain_name: new_fully_qualified_domain_name
+        }
+      )
+      when current_fully_qualified_domain_name != new_fully_qualified_domain_name and
+             is_nil(new_fully_qualified_domain_name),
+      do: %ClearSoftwareUpdatesDiscovery{host_id: host_id}
+
+  # when FQDN changes, re-trigger the software updates discovery
+  def handle(
+        %SoftwareUpdatesDiscoveryProcessManager{
+          host_id: host_id,
+          fully_qualified_domain_name: current_fully_qualified_domain_name
+        },
+        %HostDetailsUpdated{
+          host_id: host_id,
+          fully_qualified_domain_name: new_fully_qualified_domain_name
+        }
+      )
+      when current_fully_qualified_domain_name != new_fully_qualified_domain_name,
+      do: %DiscoverSoftwareUpdates{host_id: host_id}
+
+  def apply(
+        %SoftwareUpdatesDiscoveryProcessManager{} = state,
+        %HostRegistered{
+          host_id: host_id,
+          fully_qualified_domain_name: fully_qualified_domain_name
+        }
+      ),
+      do: %SoftwareUpdatesDiscoveryProcessManager{
+        state
+        | host_id: host_id,
+          fully_qualified_domain_name: fully_qualified_domain_name
+      }
+
+  def apply(
+        %SoftwareUpdatesDiscoveryProcessManager{} = state,
+        %HostRestored{
+          host_id: host_id
+        }
+      ),
+      do: %SoftwareUpdatesDiscoveryProcessManager{
+        state
+        | host_id: host_id
+      }
+
+  def apply(
+        %SoftwareUpdatesDiscoveryProcessManager{} = state,
+        %HostDetailsUpdated{
+          fully_qualified_domain_name: new_fully_qualified_domain_name
+        }
+      ),
+      do: %SoftwareUpdatesDiscoveryProcessManager{
+        state
+        | fully_qualified_domain_name: new_fully_qualified_domain_name
+      }
+end

--- a/lib/trento/process_managers_supervisor.ex
+++ b/lib/trento/process_managers_supervisor.ex
@@ -3,6 +3,11 @@ defmodule Trento.ProcessManagersSupervisor do
 
   use Supervisor
 
+  alias Trento.Infrastructure.Commanded.ProcessManagers.{
+    DeregistrationProcessManager,
+    SoftwareUpdatesDiscoveryProcessManager
+  }
+
   def start_link(init_arg) do
     Supervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
   end
@@ -10,7 +15,8 @@ defmodule Trento.ProcessManagersSupervisor do
   @impl true
   def init(_init_arg) do
     children = [
-      Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessManager
+      DeregistrationProcessManager,
+      SoftwareUpdatesDiscoveryProcessManager
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -35,6 +35,7 @@ defmodule Trento.Factory do
     HostDetailsUpdated,
     HostHealthChanged,
     HostRegistered,
+    HostRestored,
     HostSaptuneHealthChanged,
     HostTombstoned,
     SaptuneStatusUpdated,
@@ -136,6 +137,12 @@ defmodule Trento.Factory do
       socket_count: Enum.random(1..16),
       os_version: Faker.App.semver(),
       installation_source: Enum.random([:community, :suse, :unknown])
+    }
+  end
+
+  def host_restored_event_factory do
+    %HostRestored{
+      host_id: Faker.UUID.v4()
     }
   end
 

--- a/test/trento/infrastructure/commanded/process_managers/software_updates_discovery_process_manager_test.exs
+++ b/test/trento/infrastructure/commanded/process_managers/software_updates_discovery_process_manager_test.exs
@@ -1,0 +1,234 @@
+defmodule Trento.Infrastructure.Commanded.ProcessManagers.SoftwareUpdatesProcessManagerTest do
+  use ExUnit.Case
+
+  import Trento.Factory
+
+  alias Trento.Hosts.Events.{
+    HostDeregistered,
+    HostDetailsUpdated,
+    HostRegistered,
+    HostRestored
+  }
+
+  alias Trento.Hosts.Commands.{
+    ClearSoftwareUpdatesDiscovery,
+    DiscoverSoftwareUpdates
+  }
+
+  alias Trento.Infrastructure.Commanded.ProcessManagers.SoftwareUpdatesDiscoveryProcessManager
+
+  describe "events interested" do
+    test "should start the process manager when HostRegistered event is emitted" do
+      host_id = UUID.uuid4()
+
+      assert {:start, ^host_id} =
+               SoftwareUpdatesDiscoveryProcessManager.interested?(%HostRegistered{
+                 host_id: host_id
+               })
+    end
+
+    test "should start the process manager when HostRestored event is emitted" do
+      host_id = UUID.uuid4()
+
+      assert {:start, ^host_id} =
+               SoftwareUpdatesDiscoveryProcessManager.interested?(%HostRestored{host_id: host_id})
+    end
+
+    test "should continue the process manager when HostDetailsUpdated is emitted" do
+      host_id = UUID.uuid4()
+
+      assert {:continue, ^host_id} =
+               SoftwareUpdatesDiscoveryProcessManager.interested?(%HostDetailsUpdated{
+                 host_id: host_id
+               })
+    end
+
+    test "should stop the process manager when HostDeregistered arrives" do
+      host_id = UUID.uuid4()
+
+      assert {:stop, ^host_id} =
+               SoftwareUpdatesDiscoveryProcessManager.interested?(%HostDeregistered{
+                 host_id: host_id
+               })
+    end
+  end
+
+  describe "initiating software updates discovery process" do
+    test "should ignore hosts registered without an FQDN" do
+      initial_state = %SoftwareUpdatesDiscoveryProcessManager{}
+      host_id = UUID.uuid4()
+
+      {commands, state} =
+        :host_registered_event
+        |> build(host_id: host_id, fully_qualified_domain_name: nil)
+        |> reduce_events(initial_state)
+
+      assert [] == commands
+
+      assert %SoftwareUpdatesDiscoveryProcessManager{
+               host_id: ^host_id,
+               fully_qualified_domain_name: nil
+             } = state
+    end
+
+    test "should initiate software updates discovery when a host with FQDN is registered" do
+      initial_state = %SoftwareUpdatesDiscoveryProcessManager{}
+      host_id = UUID.uuid4()
+      fqdn = Faker.Internet.domain_name()
+
+      {commands, state} =
+        :host_registered_event
+        |> build(host_id: host_id, fully_qualified_domain_name: fqdn)
+        |> reduce_events(initial_state)
+
+      assert [%DiscoverSoftwareUpdates{host_id: host_id}] == commands
+
+      assert %SoftwareUpdatesDiscoveryProcessManager{
+               host_id: ^host_id,
+               fully_qualified_domain_name: ^fqdn
+             } = state
+    end
+
+    test "should initiate software updates discovery when a host is restored" do
+      initial_state = %SoftwareUpdatesDiscoveryProcessManager{}
+      host_id = UUID.uuid4()
+
+      {commands, state} =
+        :host_restored_event
+        |> build(host_id: host_id)
+        |> reduce_events(initial_state)
+
+      assert [%DiscoverSoftwareUpdates{host_id: host_id}] == commands
+
+      assert %SoftwareUpdatesDiscoveryProcessManager{
+               host_id: ^host_id,
+               fully_qualified_domain_name: nil
+             } = state
+    end
+
+    test "should initiate software updates discovery twice when a host is restored and fqdn changed contextually" do
+      initial_state = %SoftwareUpdatesDiscoveryProcessManager{}
+      host_id = UUID.uuid4()
+      new_fqdn = Faker.Internet.domain_name()
+
+      events = [
+        build(:host_restored_event, host_id: host_id),
+        build(:host_details_updated_event,
+          host_id: host_id,
+          fully_qualified_domain_name: new_fqdn
+        )
+      ]
+
+      {commands, state} = reduce_events(events, initial_state)
+
+      assert [
+               %DiscoverSoftwareUpdates{host_id: host_id},
+               %DiscoverSoftwareUpdates{host_id: host_id}
+             ] == commands
+
+      assert %SoftwareUpdatesDiscoveryProcessManager{
+               host_id: ^host_id,
+               fully_qualified_domain_name: ^new_fqdn
+             } = state
+    end
+
+    test "should ignore hosts detail changes when FQDN does not change" do
+      scenarios = [
+        %{
+          initial_fqdn: nil
+        },
+        %{
+          initial_fqdn: Faker.Internet.domain_name()
+        }
+      ]
+
+      for %{initial_fqdn: initial_fqdn} <- scenarios do
+        host_id = UUID.uuid4()
+
+        initial_state = %SoftwareUpdatesDiscoveryProcessManager{
+          host_id: host_id,
+          fully_qualified_domain_name: initial_fqdn
+        }
+
+        {commands, state} =
+          :host_details_updated_event
+          |> build(
+            host_id: host_id,
+            fully_qualified_domain_name: initial_fqdn
+          )
+          |> reduce_events(initial_state)
+
+        assert [] == commands
+
+        assert ^initial_state = state
+      end
+    end
+
+    test "should initiate software updates discovery when FQDN changes" do
+      scenarios = [
+        %{
+          initial_fqdn: nil,
+          new_fqdn: Faker.Internet.domain_name()
+        },
+        %{
+          initial_fqdn: Faker.Internet.domain_name(),
+          new_fqdn: Faker.StarWars.planet()
+        }
+      ]
+
+      for %{initial_fqdn: initial_fqdn, new_fqdn: new_fqdn} <- scenarios do
+        host_id = UUID.uuid4()
+
+        initial_state = %SoftwareUpdatesDiscoveryProcessManager{
+          host_id: host_id,
+          fully_qualified_domain_name: initial_fqdn
+        }
+
+        {commands, state} =
+          :host_details_updated_event
+          |> build(host_id: host_id, fully_qualified_domain_name: new_fqdn)
+          |> reduce_events(initial_state)
+
+        assert [%DiscoverSoftwareUpdates{host_id: host_id}] == commands
+
+        assert %SoftwareUpdatesDiscoveryProcessManager{
+                 host_id: ^host_id,
+                 fully_qualified_domain_name: ^new_fqdn
+               } = state
+      end
+    end
+
+    test "should trigger software updates clear up when FQDN changes to nil" do
+      host_id = UUID.uuid4()
+      initial_fqdn = Faker.Internet.domain_name()
+
+      initial_state = %SoftwareUpdatesDiscoveryProcessManager{
+        host_id: host_id,
+        fully_qualified_domain_name: initial_fqdn
+      }
+
+      {commands, state} =
+        :host_details_updated_event
+        |> build(host_id: host_id, fully_qualified_domain_name: nil)
+        |> reduce_events(initial_state)
+
+      assert [%ClearSoftwareUpdatesDiscovery{host_id: host_id}] == commands
+
+      assert %SoftwareUpdatesDiscoveryProcessManager{
+               host_id: ^host_id,
+               fully_qualified_domain_name: nil
+             } = state
+    end
+  end
+
+  defp reduce_events(events, initial_state) do
+    events
+    |> List.wrap()
+    |> Enum.reduce({[], initial_state}, fn event, {commands, state} ->
+      new_commands = SoftwareUpdatesDiscoveryProcessManager.handle(state, event)
+      new_state = SoftwareUpdatesDiscoveryProcessManager.apply(state, event)
+
+      {commands ++ List.wrap(new_commands), new_state}
+    end)
+  end
+end


### PR DESCRIPTION
# Description

This PR introduces a `SoftwareUpdatesDiscoveryProcessManager` orchestrating the software updates discovery process.

The discovery is triggered in the following scenarios:
- when a host is registered
- when a host is restored
- when the fqdn of a host changes

Additionally when the fqdn of the host transitions from a meaningful value to `null` we take care of dispatching a `ClearSoftwareUpdatesDiscovery` for clean up purposes.

## How was this tested?

Automated tests + manual local testing
