### PR TITLE
Handle requests for software updates discoveries from Host aggregate

### DIFF
--- a/lib/trento/hosts/host.ex
+++ b/lib/trento/hosts/host.ex
@@ -158,7 +158,7 @@ defmodule Trento.Hosts.Host do
 
   # New host registered
   def execute(
-        %Host{host_id: nil} = host,
+        %Host{host_id: nil},
         %RegisterHost{
           host_id: host_id,
           hostname: hostname,
@@ -172,9 +172,7 @@ defmodule Trento.Hosts.Host do
           installation_source: installation_source
         }
       ) do
-    host
-    |> Multi.new()
-    |> Multi.execute(fn _ ->
+    [
       %HostRegistered{
         host_id: host_id,
         hostname: hostname,
@@ -188,8 +186,7 @@ defmodule Trento.Hosts.Host do
         fully_qualified_domain_name: fully_qualified_domain_name,
         heartbeat: :unknown
       }
-    end)
-    |> Multi.execute(&maybe_emit_software_updates_discovery_requested_event/1)
+    ] ++ maybe_emit_software_updates_discovery_events(host_id, nil, fully_qualified_domain_name)
   end
 
   # Reject all the commands, except for the registration ones when the host_id does not exists
@@ -214,7 +211,7 @@ defmodule Trento.Hosts.Host do
           fully_qualified_domain_name: fully_qualified_domain_name,
           installation_source: installation_source,
           deregistered_at: deregistered_at
-        } = host,
+        },
         %RegisterHost{
           hostname: hostname,
           ip_addresses: ip_addresses,
@@ -228,19 +225,17 @@ defmodule Trento.Hosts.Host do
         }
       )
       when not is_nil(deregistered_at) do
-    host
-    |> Multi.new()
-    |> Multi.execute(fn _ ->
+    [
       %HostRestored{host_id: host_id}
-    end)
-    |> Multi.execute(&maybe_emit_software_updates_discovery_requested_event/1)
+    ] ++ maybe_emit_software_updates_discovery_events(host_id, nil, fully_qualified_domain_name)
   end
 
   def execute(
         %Host{
           host_id: host_id,
-          deregistered_at: deregistered_at
-        } = host,
+          deregistered_at: deregistered_at,
+          fully_qualified_domain_name: current_fully_qualified_domain_name
+        },
         %RegisterHost{
           hostname: hostname,
           ip_addresses: ip_addresses,
@@ -249,17 +244,13 @@ defmodule Trento.Hosts.Host do
           total_memory_mb: total_memory_mb,
           socket_count: socket_count,
           os_version: os_version,
-          fully_qualified_domain_name: fully_qualified_domain_name,
+          fully_qualified_domain_name: new_fully_qualified_domain_name,
           installation_source: installation_source
         }
       )
       when not is_nil(deregistered_at) do
-    host
-    |> Multi.new()
-    |> Multi.execute(fn _ ->
-      %HostRestored{host_id: host_id}
-    end)
-    |> Multi.execute(fn _ ->
+    [
+      %HostRestored{host_id: host_id},
       %HostDetailsUpdated{
         host_id: host_id,
         hostname: hostname,
@@ -269,11 +260,15 @@ defmodule Trento.Hosts.Host do
         total_memory_mb: total_memory_mb,
         socket_count: socket_count,
         os_version: os_version,
-        fully_qualified_domain_name: fully_qualified_domain_name,
+        fully_qualified_domain_name: new_fully_qualified_domain_name,
         installation_source: installation_source
       }
-    end)
-    |> Multi.execute(&maybe_emit_software_updates_discovery_requested_event/1)
+    ] ++
+      maybe_emit_software_updates_discovery_events(
+        host_id,
+        current_fully_qualified_domain_name,
+        new_fully_qualified_domain_name
+      )
   end
 
   def execute(
@@ -325,7 +320,7 @@ defmodule Trento.Hosts.Host do
   def execute(
         %Host{
           fully_qualified_domain_name: current_fully_qualified_domain_name
-        } = host,
+        },
         %RegisterHost{
           host_id: host_id,
           hostname: hostname,
@@ -339,9 +334,7 @@ defmodule Trento.Hosts.Host do
           installation_source: installation_source
         }
       ) do
-    host
-    |> Multi.new()
-    |> Multi.execute(fn _ ->
+    [
       %HostDetailsUpdated{
         host_id: host_id,
         hostname: hostname,
@@ -354,14 +347,12 @@ defmodule Trento.Hosts.Host do
         os_version: os_version,
         installation_source: installation_source
       }
-    end)
-    |> Multi.execute(fn _ ->
-      maybe_emit_software_updates_discovery_requested_event_or_clear_up(
+    ] ++
+      maybe_emit_software_updates_discovery_events(
         host_id,
         current_fully_qualified_domain_name,
         new_fully_qualified_domain_name
       )
-    end)
   end
 
   def execute(
@@ -851,44 +842,23 @@ defmodule Trento.Hosts.Host do
     end
   end
 
-  defp maybe_emit_software_updates_discovery_requested_event(%Host{
-         fully_qualified_domain_name: nil
-       }),
-       do: nil
+  def maybe_emit_software_updates_discovery_events(_host_id, nil, nil), do: []
+  def maybe_emit_software_updates_discovery_events(_host_id, fqdn, fqdn), do: []
 
-  defp maybe_emit_software_updates_discovery_requested_event(%Host{
-         host_id: host_id,
-         fully_qualified_domain_name: fully_qualified_domain_name
-       }) do
-    %SoftwareUpdatesDiscoveryRequested{
-      host_id: host_id,
-      fully_qualified_domain_name: fully_qualified_domain_name
-    }
-  end
+  def maybe_emit_software_updates_discovery_events(host_id, _old_fqdn, nil),
+    do: [
+      %SoftwareUpdatesDiscoveryCleared{
+        host_id: host_id
+      }
+    ]
 
-  defp maybe_emit_software_updates_discovery_requested_event_or_clear_up(
-         host_id,
-         current_fully_qualified_domain_name,
-         new_fully_qualified_domain_name
-       )
-       when current_fully_qualified_domain_name != new_fully_qualified_domain_name and
-              is_nil(new_fully_qualified_domain_name),
-       do: %SoftwareUpdatesDiscoveryCleared{
-         host_id: host_id
-       }
-
-  defp maybe_emit_software_updates_discovery_requested_event_or_clear_up(
-         host_id,
-         current_fully_qualified_domain_name,
-         new_fully_qualified_domain_name
-       )
-       when current_fully_qualified_domain_name != new_fully_qualified_domain_name,
-       do: %SoftwareUpdatesDiscoveryRequested{
-         host_id: host_id,
-         fully_qualified_domain_name: new_fully_qualified_domain_name
-       }
-
-  defp maybe_emit_software_updates_discovery_requested_event_or_clear_up(_, _, _), do: nil
+  def maybe_emit_software_updates_discovery_events(host_id, _old_fqdn, new_fqdn),
+    do: [
+      %SoftwareUpdatesDiscoveryRequested{
+        host_id: host_id,
+        fully_qualified_domain_name: new_fqdn
+      }
+    ]
 
   defp compute_saptune_health(nil), do: Health.warning()
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -722,7 +722,8 @@ defmodule Trento.Factory do
       total_memory_mb: Enum.random(1..128),
       socket_count: Enum.random(1..16),
       os_version: Faker.App.semver(),
-      installation_source: Enum.random([:community, :suse, :unknown])
+      installation_source: Enum.random([:community, :suse, :unknown]),
+      fully_qualified_domain_name: Faker.Internet.domain_name()
     })
   end
 


### PR DESCRIPTION
# Description

> Yet another alternative to https://github.com/trento-project/web/pull/2505 and https://github.com/trento-project/web/pull/2506

This PR moves the logic for software updates discovery inside the host aggregate which is going to emit a `SoftwareUpdatesDiscoveryRequested` in the following scenarios:

- when a host is registered
- when a host is restored
- when the fqdn of a host changes

Additionally when the fqdn of the host transitions from a meaningful value to `null` we take care of dispatching a `ClearSoftwareUpdatesDiscovery` for clean up purposes.

Following this we will have a `SoftwareUpdatesDiscoveryEventHandler` listening to `SoftwareUpdatesDiscoveryRequested` getting information from suma and dispatching back a `CompleteSoftwareUpdatesDiscovery` command

When implementing the new event handler some minor changes to `Trento.SoftwareUpdates.Discovery` might be needed. Here's [some reference](https://github.com/trento-project/web/pull/2506/files#diff-873065796eb0fae979370c63b209d8c71480e0d3e4b14bf74474da07f3638c81)


## How was this tested?

Automated tests
