### PR TITLE
Revert wrongly changed path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -547,7 +547,7 @@ jobs:
         if: failure()
         with:
           name: regression-e2e-screenshots
-          path: test/e2e/cypress/regression-screenshots/
+          path: test/e2e/cypress/screenshots/
 
 
   main-branch-deps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -549,7 +549,6 @@ jobs:
           name: regression-e2e-screenshots
           path: test/e2e/cypress/screenshots/
 
-
   main-branch-deps:
     name: Rebuild main branch dependencies
     runs-on: ubuntu-20.04


### PR DESCRIPTION
# Description

Revert the change of the path. This path is a variable used to decide what artifacts to upload and it can't change the path where cypress outputs these files.
