### PR TITLE
Add intermediate confirmation step in ApiKeySettingsModal

### DIFF
--- a/assets/js/common/ApiKeySettingsModal/ApiKeySettingsModal.jsx
+++ b/assets/js/common/ApiKeySettingsModal/ApiKeySettingsModal.jsx
@@ -201,7 +201,7 @@ function ApiKeySettingsModal({
           {showConfirmation ? (
             <>
               <Button
-                className="w-1/6 mr-2"
+                className="w-1/6 mr-2 generate-api-confirmation"
                 onClick={() => generateApiKeyExpiration()}
                 disabled={loading}
               >

--- a/assets/js/common/ApiKeySettingsModal/ApiKeySettingsModal.jsx
+++ b/assets/js/common/ApiKeySettingsModal/ApiKeySettingsModal.jsx
@@ -18,6 +18,7 @@ import Select from '@common/Select';
 import Switch from '@common/Switch';
 import CopyButton from '@common/CopyButton';
 import ApiKeyBox from '@common/ApiKeyBox';
+import Banner from '../Banners/Banner';
 
 const normalizeExpiration = (expiration) =>
   setMinutes(setHours(expiration, 0), 0);
@@ -52,15 +53,13 @@ function ApiKeySettingsModal({
 
   const [quantityError, setQuantityError] = useState(false);
   const [apiKeyNeverExpires, setApiKeyNeverExpires] = useState(false);
+  const [showConfirmation, setShowConfirmation] = useState(false);
 
   const generateApiKeyExpiration = () => {
     if (apiKeyNeverExpires) {
       onGenerate({ apiKeyExpiration: null });
       setKeyGenerated(true);
-      return;
-    }
-    if (timeQuantity === 0 || !timeQuantity) {
-      setQuantityError(true);
+      setShowConfirmation(false);
       return;
     }
     const timeQuantitySettings = availableTimeOptions.find(
@@ -70,6 +69,15 @@ function ApiKeySettingsModal({
 
     onGenerate({ apiKeyExpiration: normalizeExpiration(apiKeyExpiration) });
     setKeyGenerated(true);
+    setShowConfirmation(false);
+  };
+
+  const validateApiKeySettingsRequest = () => {
+    if (!apiKeyNeverExpires && (timeQuantity === 0 || !timeQuantity)) {
+      setQuantityError(true);
+      return;
+    }
+    setShowConfirmation(true);
   };
 
   useEffect(() => {
@@ -78,103 +86,140 @@ function ApiKeySettingsModal({
     setTimeQuantityType(timeOptions[0]);
     setTimeQuantity(0);
     setKeyGenerated(false);
+    setShowConfirmation(false);
   }, [open]);
 
   return (
     <Modal
-      title="API Key Settings"
+      title={showConfirmation ? 'Generate API Key' : 'API Key Settings'}
       className="!w-3/4 !max-w-3xl"
       open={open}
       onClose={onClose}
     >
       <div className="flex flex-col my-2">
-        <span className="my-1 mb-4 text-gray-500">
-          {' '}
-          By generating a new key, you will need to replace the API key on all
-          hosts.{' '}
-        </span>
+        {showConfirmation ? (
+          <>
+            <Banner type="warning">
+              <span className="text-sm">
+                Generating a new API Key forces an update of the agent
+                configuration in all the registered hosts. <br />
+                This action cannot be undone
+              </span>
+            </Banner>
+            <span className="my-1 mb-4 text-gray-500">
+              Are you sure you want to generate a new API key?
+            </span>
+          </>
+        ) : (
+          <>
+            <span className="my-1 mb-4 text-gray-500">
+              {' '}
+              By generating a new key, you will need to replace the API key on
+              all hosts.{' '}
+            </span>
 
-        <div className="flex space-x-1">
-          <div className="w-1/5">
-            <Label>Never Expires</Label>
-          </div>
+            <div className="flex space-x-1">
+              <div className="w-1/5">
+                <Label>Never Expires</Label>
+              </div>
 
-          <Switch
-            selected={apiKeyNeverExpires}
-            onChange={() => {
-              setApiKeyNeverExpires((enabled) => !enabled);
-              setQuantityError(false);
-            }}
-          />
-        </div>
-        <div className="flex items-center my-1 space-x-2">
-          <div className="w-1/3">
-            <Label>Key Expiration</Label>
-          </div>
-
-          <div className="w-2/4 pt-1">
-            <InputNumber
-              value={timeQuantity}
-              className="!h-8"
-              type="number"
-              min="0"
-              disabled={apiKeyNeverExpires}
-              error={quantityError}
-              onChange={(value) => {
-                setTimeQuantity(parseInt(value, 10));
-                setQuantityError(false);
-              }}
-            />
-          </div>
-          <div className="w-2/4 pt-4">
-            <Select
-              optionsName=""
-              options={timeOptions}
-              disabled={apiKeyNeverExpires}
-              value={timeQuantityType}
-              onChange={(value) => setTimeQuantityType(value)}
-            />
-          </div>
-          <div className="w-1/6 h-4/5">
-            <Button
-              className="generate-api-key"
-              onClick={() => generateApiKeyExpiration()}
-              disabled={quantityError || loading}
-            >
-              Generate
-            </Button>
-          </div>
-        </div>
-        {quantityError && (
-          <span className="my-1 mb-4 text-red-500">
-            {' '}
-            Key expiration value needs to be greater than 0{' '}
-          </span>
-        )}
-        {generatedApiKey && keyGenerated && !loading && (
-          <div className="flex flex-col my-1 mb-4">
-            <div className="flex space-x-2">
-              <ApiKeyBox apiKey={generatedApiKey} />
-              <CopyButton content={generatedApiKey} />
+              <Switch
+                selected={apiKeyNeverExpires}
+                onChange={() => {
+                  setApiKeyNeverExpires((enabled) => !enabled);
+                  setQuantityError(false);
+                }}
+              />
             </div>
-            <div className="flex space-x-2">
-              <EOS_INFO_OUTLINED size="20" className="mt-2" />
+            <div className="flex items-center my-1 space-x-2">
+              <div className="w-1/3">
+                <Label>Key Expiration</Label>
+              </div>
 
-              <div className="mt-2 text-gray-600 text-sm">
-                {generatedApiKeyExpiration
-                  ? `Key will expire ${format(
-                      parseISO(generatedApiKeyExpiration),
-                      'd LLL yyyy'
-                    )}`
-                  : 'Key will never expire'}
+              <div className="w-2/4 pt-1">
+                <InputNumber
+                  value={timeQuantity}
+                  className="!h-8"
+                  type="number"
+                  min="0"
+                  disabled={apiKeyNeverExpires}
+                  error={quantityError}
+                  onChange={(value) => {
+                    setTimeQuantity(parseInt(value, 10));
+                    setQuantityError(false);
+                  }}
+                />
+              </div>
+              <div className="w-2/4 pt-4">
+                <Select
+                  optionsName=""
+                  options={timeOptions}
+                  disabled={apiKeyNeverExpires}
+                  value={timeQuantityType}
+                  onChange={(value) => setTimeQuantityType(value)}
+                />
+              </div>
+              <div className="w-1/6 h-4/5">
+                <Button
+                  className="generate-api-key"
+                  onClick={() => validateApiKeySettingsRequest()}
+                  disabled={quantityError || loading}
+                >
+                  Generate
+                </Button>
               </div>
             </div>
-          </div>
+            {quantityError && (
+              <span className="my-1 mb-4 text-red-500">
+                {' '}
+                Key expiration value needs to be greater than 0{' '}
+              </span>
+            )}
+            {generatedApiKey && keyGenerated && !loading && (
+              <div className="flex flex-col my-1 mb-4">
+                <div className="flex space-x-2">
+                  <ApiKeyBox apiKey={generatedApiKey} />
+                  <CopyButton content={generatedApiKey} />
+                </div>
+                <div className="flex space-x-2">
+                  <EOS_INFO_OUTLINED size="20" className="mt-2" />
+
+                  <div className="mt-2 text-gray-600 text-sm">
+                    {generatedApiKeyExpiration
+                      ? `Key will expire ${format(
+                          parseISO(generatedApiKeyExpiration),
+                          'd LLL yyyy'
+                        )}`
+                      : 'Key will never expire'}
+                  </div>
+                </div>
+              </div>
+            )}
+          </>
         )}
-        <div className="w-1/6 h-4/5">
-          <Button type="primary-white" onClick={onClose}>
-            Close
-          </Button>
+        <div className="w-1/6 h-4/5 flex">
+          {showConfirmation ? (
+            <>
+              <Button
+                className="w-1/6 mr-2"
+                onClick={() => generateApiKeyExpiration()}
+                disabled={loading}
+              >
+                Generate
+              </Button>
+              <Button
+                type="primary-white"
+                onClick={() => setShowConfirmation(false)}
+                className="w-1/6"
+              >
+                Cancel
+              </Button>
+            </>
+          ) : (
+            <Button type="primary-white" onClick={onClose}>
+              Close
+            </Button>
+          )}
         </div>
       </div>
     </Modal>

--- a/assets/js/common/ApiKeySettingsModal/ApiKeySettingsModal.jsx
+++ b/assets/js/common/ApiKeySettingsModal/ApiKeySettingsModal.jsx
@@ -102,8 +102,8 @@ function ApiKeySettingsModal({
             <Banner type="warning">
               <span className="text-sm">
                 Generating a new API Key forces an update of the agent
-                configuration in all the registered hosts. <br />
-                This action cannot be undone
+                configuration on all the registered hosts. <br />
+                This action cannot be undone.
               </span>
             </Banner>
             <span className="my-1 mb-4 text-gray-500">

--- a/test/e2e/cypress/e2e/settings.cy.js
+++ b/test/e2e/cypress/e2e/settings.cy.js
@@ -31,6 +31,9 @@ context('Settings page', () => {
       cy.get('@quantityInput').type('2');
       cy.get('@generateButton').click();
 
+      cy.get('.generate-api-confirmation').as('confirmationGenerateButton');
+      cy.get('@confirmationGenerateButton').click();
+
       cy.get(':nth-child(1) > .w-full > code').as('generatedApiKey');
       cy.get('@generatedApiKey').should('not.be.empty');
 


### PR DESCRIPTION
# Description

Add confirmation modal in ApiKeySettings dialog, to double check if the user wants to generate a new Api key

## How was this tested?

Automated/e2e tests
