### PR TITLE
Software updates event handler

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -191,7 +191,7 @@ config :trento, Trento.Vault,
 config :trento, Trento.SoftwareUpdates.Discovery,
   adapter: Trento.Infrastructure.SoftwareUpdates.MockSuma
 
-config :trento, Trento.Infrastructure.SoftwareUpdates.MockSuma, relevant_patches: []
+config :trento, Trento.Infrastructure.SoftwareUpdates.MockSuma, relevant_patches: %{}
 
 config :trento, Trento.Infrastructure.SoftwareUpdates.SumaApi,
   executor: Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor

--- a/config/config.exs
+++ b/config/config.exs
@@ -191,6 +191,8 @@ config :trento, Trento.Vault,
 config :trento, Trento.SoftwareUpdates.Discovery,
   adapter: Trento.Infrastructure.SoftwareUpdates.MockSuma
 
+config :trento, Trento.Infrastructure.SoftwareUpdates.MockSuma, relevant_patches: []
+
 config :trento, Trento.Infrastructure.SoftwareUpdates.SumaApi,
   executor: Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor
 

--- a/config/demo.exs
+++ b/config/demo.exs
@@ -35,23 +35,26 @@ config :trento, Trento.Charts,
 config :trento, suse_manager_enabled: true
 
 config :trento, Trento.Infrastructure.SoftwareUpdates.MockSuma,
-  relevant_patches: [
-    %{
-      date: "2024-02-27",
-      advisory_name: "SUSE-15-SP4-2024-630",
-      advisory_type: :bugfix,
-      advisory_status: "stable",
-      id: 4182,
-      advisory_synopsis: "Recommended update for cloud-netconfig",
-      update_date: "2024-02-27"
-    },
-    %{
-      date: "2024-02-26",
-      advisory_name: "SUSE-15-SP4-2024-619",
-      advisory_type: :security_advisory,
-      advisory_status: "stable",
-      id: 4174,
-      advisory_synopsis: "important: Security update for java-1_8_0-ibm",
-      update_date: "2024-02-26"
-    }
-  ]
+  relevant_patches: %{
+    # 5870 matches to "vmhdbdev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net" fqdn
+    5870 => [
+      %{
+        date: "2024-02-27",
+        advisory_name: "SUSE-15-SP4-2024-630",
+        advisory_type: :bugfix,
+        advisory_status: "stable",
+        id: 4182,
+        advisory_synopsis: "Recommended update for cloud-netconfig",
+        update_date: "2024-02-27"
+      },
+      %{
+        date: "2024-02-26",
+        advisory_name: "SUSE-15-SP4-2024-619",
+        advisory_type: :security_advisory,
+        advisory_status: "stable",
+        id: 4174,
+        advisory_synopsis: "important: Security update for java-1_8_0-ibm",
+        update_date: "2024-02-26"
+      }
+    ]
+  }

--- a/config/demo.exs
+++ b/config/demo.exs
@@ -33,3 +33,25 @@ config :trento, Trento.Charts,
   host_data_fetcher: Trento.Infrastructure.Prometheus.MockPrometheusApi
 
 config :trento, suse_manager_enabled: true
+
+config :trento, Trento.Infrastructure.SoftwareUpdates.MockSuma,
+  relevant_patches: [
+    %{
+      date: "2024-02-27",
+      advisory_name: "SUSE-15-SP4-2024-630",
+      advisory_type: :bugfix,
+      advisory_status: "stable",
+      id: 4182,
+      advisory_synopsis: "Recommended update for cloud-netconfig",
+      update_date: "2024-02-27"
+    },
+    %{
+      date: "2024-02-26",
+      advisory_name: "SUSE-15-SP4-2024-619",
+      advisory_type: :security_advisory,
+      advisory_status: "stable",
+      id: 4174,
+      advisory_synopsis: "important: Security update for java-1_8_0-ibm",
+      update_date: "2024-02-26"
+    }
+  ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -85,23 +85,26 @@ config :joken,
   refresh_token_signer: "L0wvcZh3ACQpibVhV/nh5jd/NaZWL4ijZxTxGJMGpacuXIBc4In3YCwXeVM98ygp"
 
 config :trento, Trento.Infrastructure.SoftwareUpdates.MockSuma,
-  relevant_patches: [
-    %{
-      date: "2024-02-27",
-      advisory_name: "SUSE-15-SP4-2024-630",
-      advisory_type: :bugfix,
-      advisory_status: "stable",
-      id: 4182,
-      advisory_synopsis: "Recommended update for cloud-netconfig",
-      update_date: "2024-02-27"
-    },
-    %{
-      date: "2024-02-26",
-      advisory_name: "SUSE-15-SP4-2024-619",
-      advisory_type: :security_advisory,
-      advisory_status: "stable",
-      id: 4174,
-      advisory_synopsis: "important: Security update for java-1_8_0-ibm",
-      update_date: "2024-02-26"
-    }
-  ]
+  relevant_patches: %{
+    # 448 matches to "test" fqdn
+    448 => [
+      %{
+        date: "2024-02-27",
+        advisory_name: "SUSE-15-SP4-2024-630",
+        advisory_type: :bugfix,
+        advisory_status: "stable",
+        id: 4182,
+        advisory_synopsis: "Recommended update for cloud-netconfig",
+        update_date: "2024-02-27"
+      },
+      %{
+        date: "2024-02-26",
+        advisory_name: "SUSE-15-SP4-2024-619",
+        advisory_type: :security_advisory,
+        advisory_status: "stable",
+        id: 4174,
+        advisory_synopsis: "important: Security update for java-1_8_0-ibm",
+        update_date: "2024-02-26"
+      }
+    ]
+  }

--- a/config/test.exs
+++ b/config/test.exs
@@ -83,3 +83,25 @@ config :trento, Trento.Infrastructure.Commanded.EventHandlers.StreamRollUpEventH
 config :joken,
   access_token_signer: "s2ZdE+3+ke1USHEJ5O45KT364KiXPYaB9cJPdH3p60t8yT0nkLexLBNw8TFSzC7k",
   refresh_token_signer: "L0wvcZh3ACQpibVhV/nh5jd/NaZWL4ijZxTxGJMGpacuXIBc4In3YCwXeVM98ygp"
+
+config :trento, Trento.Infrastructure.SoftwareUpdates.MockSuma,
+  relevant_patches: [
+    %{
+      date: "2024-02-27",
+      advisory_name: "SUSE-15-SP4-2024-630",
+      advisory_type: :bugfix,
+      advisory_status: "stable",
+      id: 4182,
+      advisory_synopsis: "Recommended update for cloud-netconfig",
+      update_date: "2024-02-27"
+    },
+    %{
+      date: "2024-02-26",
+      advisory_name: "SUSE-15-SP4-2024-619",
+      advisory_type: :security_advisory,
+      advisory_status: "stable",
+      id: 4174,
+      advisory_synopsis: "important: Security update for java-1_8_0-ibm",
+      update_date: "2024-02-26"
+    }
+  ]

--- a/lib/trento/event_handlers_supervisor.ex
+++ b/lib/trento/event_handlers_supervisor.ex
@@ -6,6 +6,7 @@ defmodule Trento.EventHandlersSupervisor do
   alias Trento.Infrastructure.Commanded.EventHandlers.{
     AlertsEventHandler,
     RollUpEventHandler,
+    SoftwareUpdatesDiscoveryEventHandler,
     StreamRollUpEventHandler
   }
 
@@ -18,7 +19,8 @@ defmodule Trento.EventHandlersSupervisor do
     children = [
       AlertsEventHandler,
       RollUpEventHandler,
-      StreamRollUpEventHandler
+      StreamRollUpEventHandler,
+      SoftwareUpdatesDiscoveryEventHandler
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/trento/infrastructure/commanded/event_handlers/software_updates_discovery_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/software_updates_discovery_event_handler.ex
@@ -8,8 +8,6 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SoftwareUpdatesDiscovery
     application: Trento.Commanded,
     name: "software_updates_discovery_event_handler"
 
-  require Logger
-
   alias Trento.Hosts.Events.SoftwareUpdatesDiscoveryRequested
 
   alias Trento.SoftwareUpdates.Discovery

--- a/lib/trento/infrastructure/commanded/event_handlers/software_updates_discovery_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/software_updates_discovery_event_handler.ex
@@ -1,0 +1,28 @@
+defmodule Trento.Infrastructure.Commanded.EventHandlers.SoftwareUpdatesDiscoveryEventHandler do
+  @moduledoc """
+  Event handler for software updates discovery related events.
+  Here is where the actual integration with the external system happens and relevant changes in Host are triggered.
+  """
+
+  use Commanded.Event.Handler,
+    application: Trento.Commanded,
+    name: "software_updates_discovery_event_handler"
+
+  require Logger
+
+  alias Trento.Hosts.Events.SoftwareUpdatesDiscoveryRequested
+
+  alias Trento.SoftwareUpdates.Discovery
+
+  def handle(
+        %SoftwareUpdatesDiscoveryRequested{
+          host_id: host_id,
+          fully_qualified_domain_name: fully_qualified_domain_name
+        },
+        _
+      ) do
+    Discovery.discover_host_software_updates(host_id, fully_qualified_domain_name)
+
+    :ok
+  end
+end

--- a/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
+++ b/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
@@ -17,29 +17,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.MockSuma do
        |> Enum.sum()}
 
   @impl true
-  def get_relevant_patches(_system_id),
-    do:
-      {:ok,
-       [
-         %{
-           date: "2024-02-27",
-           advisory_name: "SUSE-15-SP4-2024-630",
-           advisory_type: :bugfix,
-           advisory_status: "stable",
-           id: 4182,
-           advisory_synopsis: "Recommended update for cloud-netconfig",
-           update_date: "2024-02-27"
-         },
-         %{
-           date: "2024-02-26",
-           advisory_name: "SUSE-15-SP4-2024-619",
-           advisory_type: :security_advisory,
-           advisory_status: "stable",
-           id: 4174,
-           advisory_synopsis: "important: Security update for java-1_8_0-ibm",
-           update_date: "2024-02-26"
-         }
-       ]}
+  def get_relevant_patches(_system_id), do: {:ok, mocked_relevant_patches()}
 
   @impl true
   def get_upgradable_packages(_system_id),
@@ -72,4 +50,6 @@ defmodule Trento.Infrastructure.SoftwareUpdates.MockSuma do
 
   @impl true
   def clear, do: :ok
+
+  defp mocked_relevant_patches, do: Application.fetch_env!(:trento, __MODULE__)[:relevant_patches]
 end

--- a/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
+++ b/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
@@ -17,7 +17,12 @@ defmodule Trento.Infrastructure.SoftwareUpdates.MockSuma do
        |> Enum.sum()}
 
   @impl true
-  def get_relevant_patches(_system_id), do: {:ok, mocked_relevant_patches()}
+  def get_relevant_patches(system_id) do
+    case Map.get(mocked_relevant_patches(), system_id) do
+      nil -> {:ok, []}
+      patches -> {:ok, patches}
+    end
+  end
 
   @impl true
   def get_upgradable_packages(_system_id),

--- a/lib/trento/software_updates/discovery.ex
+++ b/lib/trento/software_updates/discovery.ex
@@ -37,24 +37,24 @@ defmodule Trento.SoftwareUpdates.Discovery do
     do: adapter().get_upgradable_packages(system_id)
 
   @spec discover_software_updates :: {:ok, {list(), list()}}
-  def discover_software_updates,
-    do:
-      {:ok,
-       Hosts.get_all_hosts()
-       |> Enum.map(fn
-         %HostReadModel{id: host_id, fully_qualified_domain_name: fully_qualified_domain_name} ->
-           case discover_host_software_updates(host_id, fully_qualified_domain_name) do
-             {:error, error} ->
-               {:error, host_id, error}
+  def discover_software_updates do
+    {:ok,
+     Hosts.get_all_hosts()
+     |> Enum.map(fn
+       %HostReadModel{id: host_id, fully_qualified_domain_name: fully_qualified_domain_name} ->
+         case discover_host_software_updates(host_id, fully_qualified_domain_name) do
+           {:error, error} ->
+             {:error, host_id, error}
 
-             _ = success ->
-               success
-           end
-       end)
-       |> Enum.split_with(fn
-         {:ok, _, _, _} -> true
-         _ -> false
-       end)}
+           {:ok, _, _, _} = success ->
+             success
+         end
+     end)
+     |> Enum.split_with(fn
+       {:ok, _, _, _} -> true
+       _ -> false
+     end)}
+  end
 
   @spec clear_software_updates_discoveries :: :ok | {:error, any()}
   def clear_software_updates_discoveries do
@@ -82,8 +82,6 @@ defmodule Trento.SoftwareUpdates.Discovery do
     {:error, :host_without_fqdn}
   end
 
-  @spec discover_host_software_updates(String.t(), String.t()) ::
-          {:ok, String.t(), String.t(), any()} | {:error, any()}
   def discover_host_software_updates(host_id, fully_qualified_domain_name) do
     with {:ok, system_id} <- get_system_id(fully_qualified_domain_name),
          {:ok, relevant_patches} <- get_relevant_patches(system_id),

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -39,7 +39,8 @@ defmodule Trento.Factory do
     HostTombstoned,
     SaptuneStatusUpdated,
     SlesSubscriptionsUpdated,
-    SoftwareUpdatesDiscoveryCompleted
+    SoftwareUpdatesDiscoveryCompleted,
+    SoftwareUpdatesDiscoveryRequested
   }
 
   alias Trento.SapSystems.Events.{
@@ -758,6 +759,13 @@ defmodule Trento.Factory do
       host_id: Faker.UUID.v4(),
       relevant_patches: %{}
     })
+  end
+
+  def software_updates_discovery_requested_event_factory do
+    %SoftwareUpdatesDiscoveryRequested{
+      host_id: Faker.UUID.v4(),
+      fully_qualified_domain_name: Faker.Internet.domain_name()
+    }
   end
 
   def host_health_changed_event_factory do

--- a/test/trento/infrastructure/commanded/event_handlers/software_updates_discovery_event_handler_test.exs
+++ b/test/trento/infrastructure/commanded/event_handlers/software_updates_discovery_event_handler_test.exs
@@ -19,7 +19,7 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SoftwareUpdatesDiscovery
       fully_qualified_domain_name: fully_qualified_domain_name
     } = event = build(:software_updates_discovery_requested_event)
 
-    system_id = 100
+    system_id = Faker.UUID.v4()
 
     expect(
       SoftwareUpdatesDiscoveryMock,

--- a/test/trento/infrastructure/commanded/event_handlers/software_updates_discovery_event_handler_test.exs
+++ b/test/trento/infrastructure/commanded/event_handlers/software_updates_discovery_event_handler_test.exs
@@ -1,0 +1,72 @@
+defmodule Trento.Infrastructure.Commanded.EventHandlers.SoftwareUpdatesDiscoveryEventHandlerTest do
+  use ExUnit.Case
+
+  import Mox
+  import Trento.Factory
+
+  alias Trento.SoftwareUpdates.Discovery.Mock, as: SoftwareUpdatesDiscoveryMock
+
+  alias Trento.Hosts.Commands.CompleteSoftwareUpdatesDiscovery
+  alias Trento.Hosts.Events.SoftwareUpdatesDiscoveryRequested
+
+  alias Trento.Infrastructure.Commanded.EventHandlers.SoftwareUpdatesDiscoveryEventHandler
+
+  setup [:set_mox_from_context, :verify_on_exit!]
+
+  test "should discover software updates when a SoftwareUpdatesDiscoveryRequested is emitted" do
+    %SoftwareUpdatesDiscoveryRequested{
+      host_id: host_id,
+      fully_qualified_domain_name: fully_qualified_domain_name
+    } = event = build(:software_updates_discovery_requested_event)
+
+    system_id = 100
+
+    expect(
+      SoftwareUpdatesDiscoveryMock,
+      :get_system_id,
+      fn ^fully_qualified_domain_name -> {:ok, system_id} end
+    )
+
+    expect(
+      SoftwareUpdatesDiscoveryMock,
+      :get_relevant_patches,
+      fn ^system_id -> {:ok, []} end
+    )
+
+    expect(
+      Trento.Commanded.Mock,
+      :dispatch,
+      fn %CompleteSoftwareUpdatesDiscovery{host_id: ^host_id} -> :ok end
+    )
+
+    assert :ok = SoftwareUpdatesDiscoveryEventHandler.handle(event, %{})
+  end
+
+  test "should pass through failures" do
+    %SoftwareUpdatesDiscoveryRequested{
+      fully_qualified_domain_name: fully_qualified_domain_name
+    } = event = build(:software_updates_discovery_requested_event)
+
+    expect(
+      SoftwareUpdatesDiscoveryMock,
+      :get_system_id,
+      fn ^fully_qualified_domain_name -> {:error, :some_error} end
+    )
+
+    expect(
+      SoftwareUpdatesDiscoveryMock,
+      :get_relevant_patches,
+      0,
+      fn _ -> :ok end
+    )
+
+    expect(
+      Trento.Commanded.Mock,
+      :dispatch,
+      0,
+      fn _ -> :ok end
+    )
+
+    assert :ok = SoftwareUpdatesDiscoveryEventHandler.handle(event, %{})
+  end
+end

--- a/test/trento/software_updates/discovery_test.exs
+++ b/test/trento/software_updates/discovery_test.exs
@@ -19,7 +19,57 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
 
   setup :verify_on_exit!
 
-  describe "Discovering software updates" do
+  describe "Discovering software updates for a specific host" do
+    test "should return an error when a null FQDN is provided" do
+      host_id = Faker.UUID.v4()
+
+      assert {:error, :host_without_fqdn} =
+               Discovery.discover_host_software_updates(host_id, nil)
+    end
+
+    test "should handle failure when getting host's system id" do
+      host_id = Faker.UUID.v4()
+      fully_qualified_domain_name = Faker.Internet.domain_name()
+
+      discovery_error = {:error, :some_error_while_getting_system_id}
+
+      fail_on_getting_system_id(fully_qualified_domain_name, discovery_error)
+
+      {:error, ^discovery_error} =
+        Discovery.discover_host_software_updates(host_id, fully_qualified_domain_name)
+    end
+
+    test "should handle failure when getting relevant patches" do
+      host_id = Faker.UUID.v4()
+      fully_qualified_domain_name = Faker.Internet.domain_name()
+      system_id = 100
+      discovery_error = {:error, :some_error_while_getting_relevant_patches}
+
+      fail_on_getting_relevant_patches(fully_qualified_domain_name, system_id, discovery_error)
+
+      {:error, ^discovery_error} =
+        Discovery.discover_host_software_updates(host_id, fully_qualified_domain_name)
+    end
+
+    test "should handle failure when dispatching discovery completion command" do
+      host_id = Faker.UUID.v4()
+      fully_qualified_domain_name = Faker.Internet.domain_name()
+      system_id = 100
+      dispatching_error = {:error, :error_while_dispatching_completion_command}
+
+      fail_on_dispatching_completion_command(
+        host_id,
+        fully_qualified_domain_name,
+        system_id,
+        dispatching_error
+      )
+
+      {:error, ^dispatching_error} =
+        Discovery.discover_host_software_updates(host_id, fully_qualified_domain_name)
+    end
+  end
+
+  describe "Discovering software updates for a collection of hosts" do
     test "should handle empty hosts list" do
       assert {:ok, {[], []}} = Discovery.discover_software_updates()
     end
@@ -40,25 +90,7 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
 
       discovery_error = {:error, :some_error_while_getting_system_id}
 
-      expect(
-        SoftwareUpdatesDiscoveryMock,
-        :get_system_id,
-        fn ^fully_qualified_domain_name -> discovery_error end
-      )
-
-      expect(
-        SoftwareUpdatesDiscoveryMock,
-        :get_relevant_patches,
-        0,
-        fn _ -> :ok end
-      )
-
-      expect(
-        Trento.Commanded.Mock,
-        :dispatch,
-        0,
-        fn _ -> :ok end
-      )
+      fail_on_getting_system_id(fully_qualified_domain_name, discovery_error)
 
       {:ok, {[], errored_discoveries}} = Discovery.discover_software_updates()
 
@@ -71,24 +103,7 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
       system_id = 100
       discovery_error = {:error, :some_error_while_getting_relevant_patches}
 
-      expect(
-        SoftwareUpdatesDiscoveryMock,
-        :get_system_id,
-        fn ^fully_qualified_domain_name -> {:ok, system_id} end
-      )
-
-      expect(
-        SoftwareUpdatesDiscoveryMock,
-        :get_relevant_patches,
-        fn ^system_id -> discovery_error end
-      )
-
-      expect(
-        Trento.Commanded.Mock,
-        :dispatch,
-        0,
-        fn _ -> :ok end
-      )
+      fail_on_getting_relevant_patches(fully_qualified_domain_name, system_id, discovery_error)
 
       {:ok, {[], errored_discoveries}} = Discovery.discover_software_updates()
 
@@ -100,24 +115,13 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
 
       system_id = 100
 
-      expect(
-        SoftwareUpdatesDiscoveryMock,
-        :get_system_id,
-        fn ^fully_qualified_domain_name -> {:ok, system_id} end
-      )
-
-      expect(
-        SoftwareUpdatesDiscoveryMock,
-        :get_relevant_patches,
-        fn ^system_id -> {:ok, [%{advisory_type: AdvisoryType.security_advisory()}]} end
-      )
-
       dispatching_error = {:error, :error_while_dispatching_completion_command}
 
-      expect(
-        Trento.Commanded.Mock,
-        :dispatch,
-        fn %CompleteSoftwareUpdatesDiscovery{host_id: ^host_id} -> dispatching_error end
+      fail_on_dispatching_completion_command(
+        host_id,
+        fully_qualified_domain_name,
+        system_id,
+        dispatching_error
       )
 
       {:ok, {[], errored_discoveries}} = Discovery.discover_software_updates()
@@ -250,6 +254,74 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
       assert {:error, host_id2, {:error, :some_error}} in errored_discoveries
       assert {:error, host_id4, :host_without_fqdn} in errored_discoveries
     end
+  end
+
+  defp fail_on_getting_system_id(fully_qualified_domain_name, discovery_error) do
+    expect(
+      SoftwareUpdatesDiscoveryMock,
+      :get_system_id,
+      fn ^fully_qualified_domain_name -> discovery_error end
+    )
+
+    expect(
+      SoftwareUpdatesDiscoveryMock,
+      :get_relevant_patches,
+      0,
+      fn _ -> :ok end
+    )
+
+    expect(
+      Trento.Commanded.Mock,
+      :dispatch,
+      0,
+      fn _ -> :ok end
+    )
+  end
+
+  defp fail_on_getting_relevant_patches(fully_qualified_domain_name, system_id, discovery_error) do
+    expect(
+      SoftwareUpdatesDiscoveryMock,
+      :get_system_id,
+      fn ^fully_qualified_domain_name -> {:ok, system_id} end
+    )
+
+    expect(
+      SoftwareUpdatesDiscoveryMock,
+      :get_relevant_patches,
+      fn ^system_id -> discovery_error end
+    )
+
+    expect(
+      Trento.Commanded.Mock,
+      :dispatch,
+      0,
+      fn _ -> :ok end
+    )
+  end
+
+  defp fail_on_dispatching_completion_command(
+         host_id,
+         fully_qualified_domain_name,
+         system_id,
+         dispatching_error
+       ) do
+    expect(
+      SoftwareUpdatesDiscoveryMock,
+      :get_system_id,
+      fn ^fully_qualified_domain_name -> {:ok, system_id} end
+    )
+
+    expect(
+      SoftwareUpdatesDiscoveryMock,
+      :get_relevant_patches,
+      fn ^system_id -> {:ok, [%{advisory_type: AdvisoryType.security_advisory()}]} end
+    )
+
+    expect(
+      Trento.Commanded.Mock,
+      :dispatch,
+      fn %CompleteSoftwareUpdatesDiscovery{host_id: ^host_id} -> dispatching_error end
+    )
   end
 
   describe "Clearing up software updates discoveries" do

--- a/test/trento/software_updates_test.exs
+++ b/test/trento/software_updates_test.exs
@@ -457,7 +457,7 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
   describe "getting software updates" do
     test "successfully returns software updates" do
       insert_software_updates_settings()
-      %{id: host_id} = insert(:host)
+      %{id: host_id} = insert(:host, fully_qualified_domain_name: "test")
 
       assert {:ok, %{relevant_patches: [_, _], upgradable_packages: [_, _]}} =
                SoftwareUpdates.get_software_updates(host_id)
@@ -472,7 +472,7 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
 
     test "returns errors when fetching upgradable packages" do
       insert_software_updates_settings()
-      %{id: host_id} = insert(:host)
+      %{id: host_id} = insert(:host, fully_qualified_domain_name: "test")
 
       expect(Trento.SoftwareUpdates.Discovery.Mock, :get_upgradable_packages, 1, fn _ ->
         {:error, :error_getting_packages}

--- a/test/trento_web/controllers/v1/suse_manager_controller_test.exs
+++ b/test/trento_web/controllers/v1/suse_manager_controller_test.exs
@@ -23,7 +23,7 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
       api_spec: api_spec
     } do
       insert_software_updates_settings()
-      %{id: host_id} = insert(:host)
+      %{id: host_id} = insert(:host, fully_qualified_domain_name: "test")
 
       %AvailableSoftwareUpdatesResponse{
         relevant_patches: [


### PR DESCRIPTION
# Description

This PR introduces a `SoftwareUpdatesDiscoveryEventHandler` reacting to `SoftwareUpdatesDiscoveryRequested` events, getting information from SUMA and dispatching back in the system a `CompleteSoftwareUpdatesDiscovery` possibly resulting in a host's health change.

What's next:
- make the discovery tick dispatch `DiscoverSoftwareUpdates` command so that `SoftwareUpdatesDiscoveryRequested` + event listener is triggered (currently we'd only have a completion event without an initiation event)
- trigger software updates discovery process for all the registered hosts when saving/changing suma settings
- improve consistency between health in hosts list and what gets returned in GET `/hosts/:id/software_updates` 

## How was this tested?

Automated tests.