### PR TITLE
Remove sid duplication from view

### DIFF
--- a/assets/js/pages/HostsList/HostsList.jsx
+++ b/assets/js/pages/HostsList/HostsList.jsx
@@ -117,21 +117,22 @@ function HostsList() {
         filter: (filter, key) => (element) =>
           element[key].some((sid) => filter.includes(sid)),
         render: (sids, { sap_systems }) => {
-          const sidsArray = sap_systems.map((instance, index) => {
-            const instanceID = getInstanceID(instance);
-            return [
-              index > 0 && ', ',
-              <SapSystemLink
-                key={`${instanceID}-${instance?.id}`}
-                systemType={instance?.type}
-                sapSystemId={instanceID}
-              >
-                {instance?.sid}
-              </SapSystemLink>,
-            ];
-          });
-          const extractSid = (item) => item[1]?.props?.children || null;
-          return uniqBy(sidsArray, extractSid);
+          const sidsArray = uniqBy(sap_systems, getInstanceID).map(
+            (instance, index) => {
+              const instanceID = getInstanceID(instance);
+              return [
+                index > 0 && ', ',
+                <SapSystemLink
+                  key={`${instanceID}-${instance?.id}`}
+                  systemType={instance?.type}
+                  sapSystemId={instanceID}
+                >
+                  {instance?.sid}
+                </SapSystemLink>,
+              ];
+            }
+          );
+          return sidsArray;
         },
       },
       {

--- a/assets/js/pages/HostsList/HostsList.jsx
+++ b/assets/js/pages/HostsList/HostsList.jsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import { EOS_WARNING_OUTLINED } from 'eos-icons-react';
+import { uniqBy } from 'lodash';
 
 import CleanUpButton from '@common/CleanUpButton';
 import HealthIcon from '@common/HealthIcon';
@@ -15,7 +16,6 @@ import Table from '@common/Table';
 import Tags from '@common/Tags';
 import Tooltip from '@common/Tooltip';
 
-import { uniqBy } from 'lodash';
 import { post, del } from '@lib/network';
 import { agentVersionWarning } from '@lib/agent';
 

--- a/assets/js/pages/HostsList/HostsList.jsx
+++ b/assets/js/pages/HostsList/HostsList.jsx
@@ -15,6 +15,7 @@ import Table from '@common/Table';
 import Tags from '@common/Tags';
 import Tooltip from '@common/Tooltip';
 
+import { uniqBy } from 'lodash';
 import { post, del } from '@lib/network';
 import { agentVersionWarning } from '@lib/agent';
 
@@ -129,8 +130,8 @@ function HostsList() {
               </SapSystemLink>,
             ];
           });
-
-          return sidsArray;
+          const extractSid = (item) => item[1]?.props?.children || null;
+          return uniqBy(sidsArray, extractSid);
         },
       },
       {

--- a/assets/js/pages/HostsList/HostsList.test.jsx
+++ b/assets/js/pages/HostsList/HostsList.test.jsx
@@ -136,8 +136,9 @@ describe('HostsLists component', () => {
         host_id: host.id,
       });
       const databaseInstances = databaseInstanceFactory.buildList(2, {
-        sid: duplicateSID,
+        database_id: id,
         host_id: host.id,
+        sid: duplicateSID,
       });
       const state = {
         ...defaultInitialState,
@@ -146,9 +147,9 @@ describe('HostsLists component', () => {
         },
         sapSystemsList: {
           applicationInstances: [...sapInstances],
-          databasesList: {
-            databaseInstances: [...databaseInstances],
-          },
+        },
+        databasesList: {
+          databaseInstances: [...databaseInstances],
         },
       };
 

--- a/assets/js/pages/HostsList/HostsList.test.jsx
+++ b/assets/js/pages/HostsList/HostsList.test.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import { act, screen, waitFor } from '@testing-library/react';
+import { faker } from '@faker-js/faker';
 import userEvent from '@testing-library/user-event';
 import 'intersection-observer';
 import '@testing-library/jest-dom';
-import { hostFactory } from '@lib/test-utils/factories';
+import {
+  hostFactory,
+  sapSystemApplicationInstanceFactory,
+} from '@lib/test-utils/factories';
 
 import {
   renderWithRouter,
@@ -54,7 +58,6 @@ describe('HostsLists component', () => {
           const [StatefulHostsList] = withDefaultState(<HostsList />);
           const params = { route: `/hosts?hostname=${host}` };
           renderWithRouter(StatefulHostsList, params);
-
           const table = screen.getByRole('table');
           expect(table.querySelector('td:nth-child(2)')).toHaveTextContent(
             host
@@ -120,6 +123,30 @@ describe('HostsLists component', () => {
           )
         ).toBeVisible()
       );
+    });
+
+    it('should show only unique SIDs', async () => {
+      const host = hostFactory.build();
+      const duplicateSID = faker.string.alpha({ casing: 'upper', count: 3 });
+      const sapInstances = sapSystemApplicationInstanceFactory.buildList(2, {
+        sid: duplicateSID,
+        host_id: host.id,
+      });
+
+      const state = {
+        ...defaultInitialState,
+        hostsList: {
+          hosts: [host],
+        },
+        sapSystemsList: {
+          applicationInstances: [...sapInstances],
+        },
+      };
+
+      const [StatefulHostsList] = withState(<HostsList />, state);
+      renderWithRouter(StatefulHostsList);
+
+      expect(screen.getAllByText(duplicateSID).length).toBe(1);
     });
   });
 

--- a/assets/js/pages/HostsList/HostsList.test.jsx
+++ b/assets/js/pages/HostsList/HostsList.test.jsx
@@ -128,34 +128,30 @@ describe('HostsLists component', () => {
 
     it('should show only unique SIDs', async () => {
       const host = hostFactory.build();
-      const duplicateSID = faker.string.alpha({ casing: 'upper', count: 3 });
+      const duplicatedSID = faker.string.alpha({ casing: 'upper', count: 3 });
       const id = faker.string.uuid();
-      const sapInstances = sapSystemApplicationInstanceFactory.buildList(2, {
-        sap_system_id: id,
-        sid: duplicateSID,
-        host_id: host.id,
-      });
+      const applicationInstances =
+        sapSystemApplicationInstanceFactory.buildList(2, {
+          sap_system_id: id,
+          sid: duplicatedSID,
+          host_id: host.id,
+        });
       const databaseInstances = databaseInstanceFactory.buildList(2, {
         database_id: id,
         host_id: host.id,
-        sid: duplicateSID,
+        sid: duplicatedSID,
       });
       const state = {
         ...defaultInitialState,
         hostsList: {
           hosts: [host],
         },
-        sapSystemsList: {
-          applicationInstances: [...sapInstances],
-        },
-        databasesList: {
-          databaseInstances: [...databaseInstances],
-        },
+        sapSystemsList: { applicationInstances },
+        databasesList: { databaseInstances },
       };
-
       const [StatefulHostsList] = withState(<HostsList />, state);
       renderWithRouter(StatefulHostsList);
-      expect(screen.getAllByText(duplicateSID).length).toBe(1);
+      expect(screen.getAllByText(duplicatedSID).length).toBe(1);
     });
   });
 

--- a/assets/js/pages/HostsList/HostsList.test.jsx
+++ b/assets/js/pages/HostsList/HostsList.test.jsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import 'intersection-observer';
 import '@testing-library/jest-dom';
 import {
+  databaseInstanceFactory,
   hostFactory,
   sapSystemApplicationInstanceFactory,
 } from '@lib/test-utils/factories';
@@ -128,11 +129,16 @@ describe('HostsLists component', () => {
     it('should show only unique SIDs', async () => {
       const host = hostFactory.build();
       const duplicateSID = faker.string.alpha({ casing: 'upper', count: 3 });
+      const id = faker.string.uuid();
       const sapInstances = sapSystemApplicationInstanceFactory.buildList(2, {
+        sap_system_id: id,
         sid: duplicateSID,
         host_id: host.id,
       });
-
+      const databaseInstances = databaseInstanceFactory.buildList(2, {
+        sid: duplicateSID,
+        host_id: host.id,
+      });
       const state = {
         ...defaultInitialState,
         hostsList: {
@@ -140,12 +146,14 @@ describe('HostsLists component', () => {
         },
         sapSystemsList: {
           applicationInstances: [...sapInstances],
+          databasesList: {
+            databaseInstances: [...databaseInstances],
+          },
         },
       };
 
       const [StatefulHostsList] = withState(<HostsList />, state);
       renderWithRouter(StatefulHostsList);
-
       expect(screen.getAllByText(duplicateSID).length).toBe(1);
     });
   });


### PR DESCRIPTION
# Description

This Pr will remove duplicated SID when multiple instances of the same SAP system are running on the same host. 
SID shows only once in the SID column of the Host's Overview.

## How was this tested?

Added unit test