### PR TITLE
Fix empty relevant patches visualization

### DIFF
--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.stories.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.stories.jsx
@@ -5,12 +5,18 @@ export default {
   component: AvailableSoftwareUpdates,
   argTypes: {
     relevantPatches: {
-      type: 'string',
+      type: 'number',
       description: 'Number of relevant patches available for the system',
+      control: {
+        type: 'number',
+      },
     },
     upgradablePackages: {
-      type: 'string',
+      type: 'number',
       description: 'Number of upgradable packages for the system',
+      control: {
+        type: 'number',
+      },
     },
     tooltip: {
       type: 'string',
@@ -24,11 +30,11 @@ export default {
 };
 
 export const Default = {
-  args: { relevantPatches: '412', upgradablePackages: '234' },
+  args: { relevantPatches: 412, upgradablePackages: 234 },
 };
 
 export const Cool = {
-  args: { relevantPatches: '0', upgradablePackages: '42' },
+  args: { relevantPatches: 0, upgradablePackages: 42 },
 };
 
 export const Unknown = { args: { tooltip: 'SUSE Manager is not available' } };

--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
@@ -18,8 +18,9 @@ describe('AvailableSoftwareUpdates component', () => {
       />
     );
 
+    expect(screen.getByText('0')).toBeVisible();
     expect(screen.getByText(upgradablePackages)).toBeVisible();
-    expect(screen.getAllByTestId('eos-svg-component')).toHaveLength(3);
+    expect(screen.getAllByTestId('eos-svg-component')).toHaveLength(2);
   });
 
   it('renders critical counters', () => {

--- a/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
@@ -9,7 +9,7 @@ import {
 import Tooltip from '@common/Tooltip';
 
 function Indicator({ title, critical, tooltip, icon, loading, children }) {
-  const unknown = !children;
+  const unknown = children === undefined;
 
   if (loading) {
     return (
@@ -49,11 +49,13 @@ function Indicator({ title, critical, tooltip, icon, loading, children }) {
                 className="inline align-bottom fill-red-500"
               />
             )}{' '}
-            {children || (
+            {unknown ? (
               <div>
                 <EOS_ERROR_OUTLINED size="l" className="inline align-bottom" />{' '}
                 Unknown
               </div>
+            ) : (
+              children
             )}
           </div>
         </div>


### PR DESCRIPTION
# Description

Fix empty relevant patches visualization. When relevant patches is coming as an empty list (all green!), a unknown icon was being shown.

![image](https://github.com/trento-project/web/assets/36370954/17dca673-2fc1-40ef-ae1d-fae68e56c534)

Some type missmatch between string and int (thank you js).
In fact, storybook and the tests were done in a way that actual failure was masked hehe

Check the PR env to see the `0` value and other value for hosts `vmdrbddev02` (unknown) and `vmhdbdev01` (2 patches).
Damn: the PR env doesn't show what I want, as it doesn't mock suma calls as expected, as it is released as `prod`

## How was this tested?

Tests updated, and manually confirmed
