### PR TITLE
Fetch developers from GH API instead of hardcoded list

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,6 @@ env:
   OTP_VERSION: 26
   MIX_ENV: test
   NODE_VERSION: "16"
-  MANTAINERS: '["cdimonaco", "dottorblaster", "janvhs", "rtorrero", "nelsonkopliku", "arbulu89","jagabomb","emaksy","jamie-suse"]'
   RG_TEST_LABEL: regression
 
 jobs:
@@ -445,8 +444,20 @@ jobs:
     outputs:
       run_regression_test: ${{ steps.check.outputs.run_regression_test }}
     steps:
+      - name: Get developers group members
+        run: |
+          MEMBERS_JSON=$(curl -s -H "Authorization: token ${{ secrets.READ_TEAM_MEMBERS_PAT }}" \
+            "https://api.github.com/orgs/trento-project/teams/developers/members")
+          MEMBERS=$(echo "$MEMBERS_JSON" | jq -r '.[] | .login' | jq -Rsc 'split("\n")[:-1]')
+          echo "DEVELOPERS_JSON=$MEMBERS" >> $GITHUB_ENV    
       - id: check
-        run: echo "run_regression_test=${{ contains(fromJson(env.MANTAINERS), github.event.sender.login) && contains(github.event.pull_request.labels.*.name, env.RG_TEST_LABEL) }}" >> "$GITHUB_OUTPUT"
+        run: |
+          DEVELOPERS=$(echo $DEVELOPERS_JSON | jq -r 'join(",")')
+          RUN_REGRESSION_TEST="false"
+          if [[ "$DEVELOPERS" == *"${{ github.event.sender.login }}"* && "$(echo '${{ toJson(github.event.pull_request.labels.*.name) }}')" == *"$RG_TEST_LABEL"* ]]; then
+            RUN_REGRESSION_TEST="true"
+          fi
+          echo "run_regression_test=$RUN_REGRESSION_TEST" >> "$GITHUB_OUTPUT"        
 
   regression-test-e2e:
     name: Regression tests

--- a/.github/workflows/pr_env.yaml
+++ b/.github/workflows/pr_env.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Get developers group members
         run: |
-          MEMBERS_JSON=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          MEMBERS_JSON=$(curl -s -H "Authorization: token ${{ secrets.READ_TEAM_MEMBERS_PAT }}" \
             "https://api.github.com/orgs/trento-project/teams/developers/members")
           
           echo "API Response:"

--- a/.github/workflows/pr_env.yaml
+++ b/.github/workflows/pr_env.yaml
@@ -1,4 +1,4 @@
-name:  Pull request environment
+name: Pull request environment
 
 on:
   pull_request:
@@ -8,7 +8,6 @@ on:
       - labeled
 
 env:
-  MANTAINERS: "[\"cdimonaco\", \"dottorblaster\", \"fabriziosestito\", \"rtorrero\", \"nelsonkopliku\", \"arbulu89\",\"jagabomb\",\"emaksy\",\"jamie-suse\"]"
   PR_ENV_LABEL: env
   PR_NUMBER: "${{ github.event.pull_request.number }}"
 
@@ -18,9 +17,31 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       create_env: ${{ steps.check.outputs.create_env }}
+    permissions:
+      contents: read
+      packages: write
     steps:
+      - name: Get developers group members
+        run: |
+          MEMBERS_JSON=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/orgs/trento-project/teams/developers/members")
+          
+          echo "API Response:"
+          echo "$MEMBERS_JSON"
+          
+          MEMBERS=$(echo "$MEMBERS_JSON" | jq -r '.[] | .login' | jq -Rsc 'split("\n")[:-1]')
+          echo "Processed Members:"
+          echo "$MEMBERS"
+          
+          echo "DEVELOPERS_JSON=$MEMBERS" >> $GITHUB_ENV
       - id: check
-        run: echo "create_env=${{ contains(fromJson(env.MANTAINERS), github.event.sender.login) && contains(github.event.pull_request.labels.*.name, env.PR_ENV_LABEL) }}" >> "$GITHUB_OUTPUT"
+        run: |
+          DEVELOPERS=$(echo $DEVELOPERS_JSON | jq -r 'join(",")')
+          CREATE_ENV="false"
+          if [[ "$DEVELOPERS" == *"${{ github.event.sender.login }}"* && "$(echo '${{ toJson(github.event.pull_request.labels.*.name) }}')" == *"$PR_ENV_LABEL"* ]]; then
+            CREATE_ENV="true"
+          fi
+          echo "create_env=$CREATE_ENV" >> "$GITHUB_OUTPUT"
 
   build-and-push-pr-image:
     needs: check_env_creation_privilege

--- a/.github/workflows/pr_env.yaml
+++ b/.github/workflows/pr_env.yaml
@@ -17,22 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       create_env: ${{ steps.check.outputs.create_env }}
-    permissions:
-      contents: read
-      packages: write
     steps:
       - name: Get developers group members
         run: |
           MEMBERS_JSON=$(curl -s -H "Authorization: token ${{ secrets.READ_TEAM_MEMBERS_PAT }}" \
             "https://api.github.com/orgs/trento-project/teams/developers/members")
-          
-          echo "API Response:"
-          echo "$MEMBERS_JSON"
-          
           MEMBERS=$(echo "$MEMBERS_JSON" | jq -r '.[] | .login' | jq -Rsc 'split("\n")[:-1]')
-          echo "Processed Members:"
-          echo "$MEMBERS"
-          
           echo "DEVELOPERS_JSON=$MEMBERS" >> $GITHUB_ENV
       - id: check
         run: |


### PR DESCRIPTION
# Description

This PR aims to make it easier to maintain the list of maintainers by using the GH API to fetch the developers group from our organization instead of having two separate hardcoded lists in the CI yaml.

As a test, I've added the two relevant labels to see if they would run, and they run correctly.