### PR TITLE
Properly clear suma genserver state when clearing software updates settings

### DIFF
--- a/lib/trento/software_updates/discovery.ex
+++ b/lib/trento/software_updates/discovery.ex
@@ -58,9 +58,7 @@ defmodule Trento.SoftwareUpdates.Discovery do
 
   @spec clear_software_updates_discoveries :: :ok | {:error, any()}
   def clear_software_updates_discoveries do
-    hosts = Hosts.get_all_hosts()
-
-    hosts
+    Hosts.get_all_hosts()
     |> Enum.map(fn %HostReadModel{id: host_id} -> %{host_id: host_id} end)
     |> Enum.each(fn command_payload ->
       command_payload
@@ -68,9 +66,7 @@ defmodule Trento.SoftwareUpdates.Discovery do
       |> commanded().dispatch()
     end)
 
-    if !Enum.empty?(hosts) do
-      clear()
-    end
+    clear()
 
     :ok
   end

--- a/test/trento/software_updates/discovery_test.exs
+++ b/test/trento/software_updates/discovery_test.exs
@@ -230,8 +230,8 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
   end
 
   describe "Clearing up software updates discoveries" do
-    test "should pass through an empty hosts list" do
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :clear, 0, fn -> :ok end)
+    test "should pass through an empty hosts list and clear settings" do
+      expect(Trento.SoftwareUpdates.Discovery.Mock, :clear, fn -> :ok end)
 
       assert :ok = Discovery.clear_software_updates_discoveries()
     end


### PR DESCRIPTION
# Description

This makes sure the state of suma genserver is cleared up always when clearing software updates settings, otherwise might happen that genserver state is kept, causing discoveries to happen when they should not.

## How was this tested?

Automated tests and on a real infrastructure.