### PR TITLE
Improve suma authentication concurrency

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -191,6 +191,9 @@ config :trento, Trento.Vault,
 config :trento, Trento.SoftwareUpdates.Discovery,
   adapter: Trento.Infrastructure.SoftwareUpdates.MockSuma
 
+config :trento, Trento.Infrastructure.SoftwareUpdates.Suma,
+  auth: Trento.Infrastructure.SoftwareUpdates.Auth.SumaAuth
+
 config :trento, Trento.Infrastructure.SoftwareUpdates.MockSuma, relevant_patches: %{}
 
 config :trento, Trento.Infrastructure.SoftwareUpdates.SumaApi,

--- a/lib/trento/application.ex
+++ b/lib/trento/application.ex
@@ -25,7 +25,7 @@ defmodule Trento.Application do
         Trento.Infrastructure.Messaging.Adapter.AMQP.Publisher,
         Trento.Infrastructure.Checks.AMQP.Consumer,
         Trento.Vault,
-        Trento.Infrastructure.SoftwareUpdates.Suma,
+        Trento.Infrastructure.SoftwareUpdates.Auth.SumaAuth,
         {Task.Supervisor, name: Trento.TasksSupervisor}
         # Start a worker by calling: Trento.Worker.start_link(arg)
         # {Trento.Worker, arg}

--- a/lib/trento/infrastructure/software_updates/auth/gen.ex
+++ b/lib/trento/infrastructure/software_updates/auth/gen.ex
@@ -1,0 +1,17 @@
+defmodule Trento.Infrastructure.SoftwareUpdates.Auth.Gen do
+  @moduledoc """
+  Behaviour of the SUMA authentication process.
+  """
+
+  alias Trento.Infrastructure.SoftwareUpdates.Suma.State
+
+  @callback authenticate() ::
+              {:ok, %State{}} | {:error, any()}
+
+  @callback authenticate(server_name :: String.t()) ::
+              {:ok, %State{}} | {:error, any()}
+
+  @callback clear() :: :ok
+
+  @callback clear(server_name :: String.t()) :: :ok
+end

--- a/lib/trento/infrastructure/software_updates/auth/gen.ex
+++ b/lib/trento/infrastructure/software_updates/auth/gen.ex
@@ -3,7 +3,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Auth.Gen do
   Behaviour of the SUMA authentication process.
   """
 
-  alias Trento.Infrastructure.SoftwareUpdates.Suma.State
+  alias Trento.Infrastructure.SoftwareUpdates.Auth.State
 
   @callback authenticate() :: {:ok, %State{}} | {:error, any()}
 

--- a/lib/trento/infrastructure/software_updates/auth/gen.ex
+++ b/lib/trento/infrastructure/software_updates/auth/gen.ex
@@ -5,13 +5,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Auth.Gen do
 
   alias Trento.Infrastructure.SoftwareUpdates.Suma.State
 
-  @callback authenticate() ::
-              {:ok, %State{}} | {:error, any()}
-
-  @callback authenticate(server_name :: String.t()) ::
-              {:ok, %State{}} | {:error, any()}
+  @callback authenticate() :: {:ok, %State{}} | {:error, any()}
 
   @callback clear() :: :ok
-
-  @callback clear(server_name :: String.t()) :: :ok
 end

--- a/lib/trento/infrastructure/software_updates/auth/state.ex
+++ b/lib/trento/infrastructure/software_updates/auth/state.ex
@@ -1,4 +1,4 @@
-defmodule Trento.Infrastructure.SoftwareUpdates.Suma.State do
+defmodule Trento.Infrastructure.SoftwareUpdates.Auth.State do
   @moduledoc """
   State for the SUMA Software Updates discovery adapter
   """

--- a/lib/trento/infrastructure/software_updates/auth/suma_auth.ex
+++ b/lib/trento/infrastructure/software_updates/auth/suma_auth.ex
@@ -41,7 +41,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Auth.SumaAuth do
   def handle_call(:authenticate, _, %State{} = state) do
     case setup_auth(state) do
       {:ok, new_state} ->
-        {:reply, :ok, new_state}
+        {:reply, {:ok, new_state}, new_state}
 
       {:error, _} = error ->
         {:reply, error, state}
@@ -51,7 +51,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Auth.SumaAuth do
   @impl GenServer
   def handle_call(:clear, _, _), do: {:reply, :ok, %State{}}
 
-  defp call(server, request), do: GenServer.call(server, request, 10_000)
+  defp call(server, request), do: GenServer.call(server, request, 15_000)
 
   defp process_identifier(server_name), do: {:global, identification_tuple(server_name)}
 

--- a/lib/trento/infrastructure/software_updates/auth/suma_auth.ex
+++ b/lib/trento/infrastructure/software_updates/auth/suma_auth.ex
@@ -3,6 +3,8 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Auth.SumaAuth do
   GenServer module to authenticate with SUMA
   """
 
+  @behaviour Trento.Infrastructure.SoftwareUpdates.Auth.Gen
+
   use GenServer, restart: :transient
 
   alias Trento.Infrastructure.SoftwareUpdates.{Suma.State, SumaApi}
@@ -25,12 +27,14 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Auth.SumaAuth do
       |> identification_tuple
       |> :global.whereis_name()
 
+  @impl Trento.Infrastructure.SoftwareUpdates.Auth.Gen
   def authenticate(server_name \\ @default_name),
     do:
       server_name
       |> process_identifier
       |> call(:authenticate)
 
+  @impl Trento.Infrastructure.SoftwareUpdates.Auth.Gen
   def clear(server_name \\ @default_name),
     do:
       server_name

--- a/lib/trento/infrastructure/software_updates/auth/suma_auth.ex
+++ b/lib/trento/infrastructure/software_updates/auth/suma_auth.ex
@@ -7,7 +7,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Auth.SumaAuth do
 
   use GenServer, restart: :transient
 
-  alias Trento.Infrastructure.SoftwareUpdates.{Suma.State, SumaApi}
+  alias Trento.Infrastructure.SoftwareUpdates.Auth.State
   alias Trento.Infrastructure.SoftwareUpdates.SumaApi
   alias Trento.SoftwareUpdates
 

--- a/lib/trento/infrastructure/software_updates/auth/suma_auth.ex
+++ b/lib/trento/infrastructure/software_updates/auth/suma_auth.ex
@@ -1,0 +1,94 @@
+defmodule Trento.Infrastructure.SoftwareUpdates.Auth.SumaAuth do
+  @moduledoc """
+  GenServer module to authenticate with SUMA
+  """
+
+  use GenServer, restart: :transient
+
+  alias Trento.Infrastructure.SoftwareUpdates.{Suma.State, SumaApi}
+  alias Trento.Infrastructure.SoftwareUpdates.SumaApi
+  alias Trento.SoftwareUpdates
+
+  @default_name "suma_authentication"
+
+  def start_link([]), do: start_link(@default_name)
+
+  def start_link(server_name),
+    do: GenServer.start_link(__MODULE__, %State{}, name: process_identifier(server_name))
+
+  @impl GenServer
+  def init(%State{} = state), do: {:ok, state}
+
+  def identify(server_name \\ @default_name),
+    do:
+      server_name
+      |> identification_tuple
+      |> :global.whereis_name()
+
+  def authenticate(server_name \\ @default_name),
+    do:
+      server_name
+      |> process_identifier
+      |> call(:authenticate)
+
+  def clear(server_name \\ @default_name),
+    do:
+      server_name
+      |> process_identifier
+      |> call(:clear)
+
+  @impl GenServer
+  def handle_call(:authenticate, _, %State{} = state) do
+    case setup_auth(state) do
+      {:ok, new_state} ->
+        {:reply, :ok, new_state}
+
+      {:error, _} = error ->
+        {:reply, error, state}
+    end
+  end
+
+  @impl GenServer
+  def handle_call(:clear, _, _), do: {:reply, :ok, %State{}}
+
+  defp call(server, request), do: GenServer.call(server, request, 10_000)
+
+  defp process_identifier(server_name), do: {:global, identification_tuple(server_name)}
+
+  defp identification_tuple(server_name), do: {__MODULE__, server_name}
+
+  defp setup_auth(%State{auth: nil} = state) do
+    with {:ok, %{url: url, username: username, password: password, ca_cert: ca_cert}} <-
+           SoftwareUpdates.get_settings(),
+         :ok <- write_ca_cert_file(ca_cert),
+         {:ok, auth_cookie} <- SumaApi.login(url, username, password, ca_cert != nil) do
+      {:ok,
+       %State{
+         state
+         | url: url,
+           username: username,
+           password: password,
+           ca_cert: ca_cert,
+           auth: auth_cookie,
+           use_ca_cert: ca_cert != nil
+       }}
+    end
+  end
+
+  defp setup_auth(%State{} = state), do: {:ok, state}
+
+  defp write_ca_cert_file(nil) do
+    case File.rm_rf(SumaApi.ca_cert_path()) do
+      {:ok, _} -> :ok
+      _ -> :error
+    end
+  end
+
+  defp write_ca_cert_file(ca_cert) do
+    SumaApi.ca_cert_path()
+    |> Path.dirname()
+    |> File.mkdir_p!()
+
+    File.write(SumaApi.ca_cert_path(), ca_cert)
+  end
+end

--- a/lib/trento/infrastructure/software_updates/auth/suma_auth.ex
+++ b/lib/trento/infrastructure/software_updates/auth/suma_auth.ex
@@ -51,6 +51,20 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Auth.SumaAuth do
   @impl GenServer
   def handle_call(:clear, _, _), do: {:reply, :ok, %State{}}
 
+  @impl GenServer
+  def format_status(_reason, [pdict, state]) do
+    {:ok,
+     [
+       pdict,
+       %{
+         state
+         | auth: "<REDACTED>",
+           password: "<REDACTED>",
+           ca_cert: "<REDACTED>"
+       }
+     ]}
+  end
+
   defp call(server, request), do: GenServer.call(server, request, 15_000)
 
   defp process_identifier(server_name), do: {:global, identification_tuple(server_name)}

--- a/lib/trento/infrastructure/software_updates/suma.ex
+++ b/lib/trento/infrastructure/software_updates/suma.ex
@@ -5,105 +5,53 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma do
 
   @behaviour Trento.SoftwareUpdates.Discovery.Gen
 
-  use GenServer, restart: :transient
-
-  alias Trento.Infrastructure.SoftwareUpdates.{Suma.State, SumaApi}
+  alias Trento.Infrastructure.SoftwareUpdates.Suma.State
   alias Trento.Infrastructure.SoftwareUpdates.SumaApi
-  alias Trento.SoftwareUpdates
-
-  require Logger
-
-  @default_name "suma"
-
-  def start_link([]), do: start_link(@default_name)
-
-  def start_link(server_name),
-    do: GenServer.start_link(__MODULE__, %State{}, name: process_identifier(server_name))
-
-  @impl GenServer
-  def init(%State{} = state), do: {:ok, state}
-
-  def identify(server_name \\ @default_name),
-    do:
-      server_name
-      |> identification_tuple
-      |> :global.whereis_name()
 
   @impl Trento.SoftwareUpdates.Discovery.Gen
-  def setup(server_name \\ @default_name),
-    do:
-      server_name
-      |> process_identifier
-      |> call(:setup)
-
-  @impl Trento.SoftwareUpdates.Discovery.Gen
-  def clear(server_name \\ @default_name),
-    do:
-      server_name
-      |> process_identifier
-      |> call(:clear)
-
-  @impl Trento.SoftwareUpdates.Discovery.Gen
-  def get_system_id(fully_qualified_domain_name, server_name \\ @default_name),
-    do:
-      server_name
-      |> process_identifier
-      |> call({:get_system_id, fully_qualified_domain_name})
-
-  @impl Trento.SoftwareUpdates.Discovery.Gen
-  def get_relevant_patches(system_id, server_name \\ @default_name),
-    do:
-      server_name
-      |> process_identifier
-      |> call({:get_relevant_patches, system_id})
-
-  @impl Trento.SoftwareUpdates.Discovery.Gen
-  def get_upgradable_packages(system_id, server_name \\ @default_name),
-    do:
-      server_name
-      |> process_identifier
-      |> call({:get_upgradable_packages, system_id})
-
-  @impl GenServer
-  def handle_call(:setup, _from, %State{} = state) do
-    case setup_auth(state) do
-      {:ok, new_state} ->
-        {:reply, :ok, new_state}
-
+  def setup do
+    case auth().authenticate() do
       {:error, _} = error ->
-        {:reply, error, state}
+        error
+
+      {:ok, _} ->
+        :ok
     end
   end
 
-  @impl GenServer
-  def handle_call(:clear, _, _), do: {:reply, :ok, %State{}}
+  @impl Trento.SoftwareUpdates.Discovery.Gen
+  def clear, do: auth().clear()
 
-  @impl GenServer
-  def handle_call(request, _, %State{auth: nil} = state),
-    do: authenticate_and_handle(request, state)
+  @impl Trento.SoftwareUpdates.Discovery.Gen
+  def get_system_id(fully_qualified_domain_name),
+    do: handle_request({:get_system_id, fully_qualified_domain_name})
 
-  @impl GenServer
-  def handle_call(request, _, %State{} = state) do
-    case handle_result = do_handle(request, state) do
-      {:error, :authentication_error} ->
-        authenticate_and_handle(request, state)
+  @impl Trento.SoftwareUpdates.Discovery.Gen
+  def get_relevant_patches(system_id),
+    do: handle_request({:get_relevant_patches, system_id})
 
-      _ ->
-        {:reply, handle_result, state}
-    end
-  end
+  @impl Trento.SoftwareUpdates.Discovery.Gen
+  def get_upgradable_packages(system_id),
+    do: handle_request({:get_upgradable_packages, system_id})
 
-  defp call(server, request), do: GenServer.call(server, request, 15_000)
-
-  defp authenticate_and_handle(request, state) do
-    case setup_auth(state) do
+  defp handle_request(request) do
+    case auth().authenticate() do
       {:ok, new_state} ->
-        {:reply, do_handle(request, new_state), new_state}
+        request
+        |> do_handle(new_state)
+        |> handle_authentication_error(request)
 
-      {:error, _} = error ->
-        {:reply, error, state}
+      error ->
+        error
     end
   end
+
+  defp handle_authentication_error({:error, :authentication_error}, request) do
+    clear()
+    handle_request(request)
+  end
+
+  defp handle_authentication_error(result, _), do: result
 
   defp do_handle({:get_system_id, fully_qualified_domain_name}, %State{
          url: url,
@@ -126,40 +74,5 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma do
        }),
        do: SumaApi.get_upgradable_packages(url, auth_cookie, system_id, use_ca_cert)
 
-  defp process_identifier(server_name), do: {:global, identification_tuple(server_name)}
-
-  defp identification_tuple(server_name), do: {__MODULE__, server_name}
-
-  defp setup_auth(%State{} = state) do
-    with {:ok, %{url: url, username: username, password: password, ca_cert: ca_cert}} <-
-           SoftwareUpdates.get_settings(),
-         :ok <- write_ca_cert_file(ca_cert),
-         {:ok, auth_cookie} <- SumaApi.login(url, username, password, ca_cert != nil) do
-      {:ok,
-       %State{
-         state
-         | url: url,
-           username: username,
-           password: password,
-           ca_cert: ca_cert,
-           auth: auth_cookie,
-           use_ca_cert: ca_cert != nil
-       }}
-    end
-  end
-
-  defp write_ca_cert_file(nil) do
-    case File.rm_rf(SumaApi.ca_cert_path()) do
-      {:ok, _} -> :ok
-      _ -> :error
-    end
-  end
-
-  defp write_ca_cert_file(ca_cert) do
-    SumaApi.ca_cert_path()
-    |> Path.dirname()
-    |> File.mkdir_p!()
-
-    File.write(SumaApi.ca_cert_path(), ca_cert)
-  end
+  defp auth, do: Application.fetch_env!(:trento, __MODULE__)[:auth]
 end

--- a/lib/trento/infrastructure/software_updates/suma.ex
+++ b/lib/trento/infrastructure/software_updates/suma.ex
@@ -5,7 +5,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma do
 
   @behaviour Trento.SoftwareUpdates.Discovery.Gen
 
-  alias Trento.Infrastructure.SoftwareUpdates.Suma.State
+  alias Trento.Infrastructure.SoftwareUpdates.Auth.State
   alias Trento.Infrastructure.SoftwareUpdates.SumaApi
 
   @impl Trento.SoftwareUpdates.Discovery.Gen

--- a/lib/trento/software_updates/discovery.ex
+++ b/lib/trento/software_updates/discovery.ex
@@ -39,13 +39,13 @@ defmodule Trento.SoftwareUpdates.Discovery do
 
   @spec discover_software_updates :: {:ok, {list(), list()}}
   def discover_software_updates do
-    authenticated = setup()
+    authentication = setup()
 
     {:ok,
      Hosts.get_all_hosts()
      |> ParallelStream.map(fn
        %HostReadModel{id: host_id, fully_qualified_domain_name: fully_qualified_domain_name} ->
-         case discover_host_software_updates(host_id, fully_qualified_domain_name, authenticated) do
+         case discover_host_software_updates(host_id, fully_qualified_domain_name, authentication) do
            {:error, error} ->
              {:error, host_id, error}
 

--- a/lib/trento/software_updates/discovery.ex
+++ b/lib/trento/software_updates/discovery.ex
@@ -39,11 +39,13 @@ defmodule Trento.SoftwareUpdates.Discovery do
 
   @spec discover_software_updates :: {:ok, {list(), list()}}
   def discover_software_updates do
+    authenticated = setup()
+
     {:ok,
      Hosts.get_all_hosts()
      |> ParallelStream.map(fn
        %HostReadModel{id: host_id, fully_qualified_domain_name: fully_qualified_domain_name} ->
-         case discover_host_software_updates(host_id, fully_qualified_domain_name) do
+         case discover_host_software_updates(host_id, fully_qualified_domain_name, authenticated) do
            {:error, error} ->
              {:error, host_id, error}
 
@@ -103,6 +105,12 @@ defmodule Trento.SoftwareUpdates.Discovery do
         {:error, discovery_error}
     end
   end
+
+  defp discover_host_software_updates(_, _, {:error, error}),
+    do: {:error, error}
+
+  defp discover_host_software_updates(host_id, fully_qualified_domain_name, _),
+    do: discover_host_software_updates(host_id, fully_qualified_domain_name)
 
   defp build_discovery_completion_command(host_id, relevant_patches),
     do:

--- a/lib/trento/software_updates/discovery.ex
+++ b/lib/trento/software_updates/discovery.ex
@@ -106,8 +106,16 @@ defmodule Trento.SoftwareUpdates.Discovery do
     end
   end
 
-  defp discover_host_software_updates(_, _, {:error, error}),
-    do: {:error, error}
+  defp discover_host_software_updates(host_id, _, {:error, error}) do
+    commanded().dispatch(
+      CompleteSoftwareUpdatesDiscovery.new!(%{
+        host_id: host_id,
+        health: SoftwareUpdatesHealth.unknown()
+      })
+    )
+
+    {:error, error}
+  end
 
   defp discover_host_software_updates(host_id, fully_qualified_domain_name, _),
     do: discover_host_software_updates(host_id, fully_qualified_domain_name)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -22,6 +22,14 @@ Application.put_env(:trento, Trento.SoftwareUpdates.Discovery,
   adapter: Trento.SoftwareUpdates.Discovery.Mock
 )
 
+Mox.defmock(Trento.Infrastructure.SoftwareUpdates.Auth.Mock,
+  for: Trento.Infrastructure.SoftwareUpdates.Auth.Gen
+)
+
+Application.put_env(:trento, Trento.Infrastructure.SoftwareUpdates.Suma,
+  auth: Trento.Infrastructure.SoftwareUpdates.Auth.Mock
+)
+
 Mox.defmock(Trento.Infrastructure.Messaging.Adapter.Mock,
   for: Trento.Infrastructure.Messaging.Adapter.Gen
 )

--- a/test/trento/infrastructure/software_updates/auth/suma_auth_test.exs
+++ b/test/trento/infrastructure/software_updates/auth/suma_auth_test.exs
@@ -1,0 +1,267 @@
+defmodule Trento.Infrastructure.SoftwareUpdates.Auth.SumaAuthTest do
+  use Trento.DataCase
+
+  import Mox
+
+  import Trento.Factory
+
+  alias Trento.Infrastructure.SoftwareUpdates.Auth.SumaAuth
+  alias Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor.Mock, as: SumaApiMock
+  alias Trento.Infrastructure.SoftwareUpdates.Suma.State
+  alias Trento.SoftwareUpdates.Settings
+
+  setup [:set_mox_from_context, :verify_on_exit!]
+
+  @test_integration_name "test_integration"
+
+  defp setup_initial_settings, do: {:ok, %{settings: insert_software_updates_settings()}}
+
+  describe "Process start up and identification" do
+    test "should find an already started SUMA process" do
+      assert {_, {:already_started, pid}} = start_supervised(SumaAuth)
+
+      assert pid == SumaAuth.identify()
+    end
+
+    test "should start a new identifiable process" do
+      assert {:ok, pid} = start_supervised({SumaAuth, @test_integration_name})
+
+      assert pid == SumaAuth.identify(@test_integration_name)
+    end
+
+    test "should have expected initial state" do
+      {_, {:already_started, _}} = start_supervised(SumaAuth)
+      {:ok, _} = start_supervised({SumaAuth, @test_integration_name})
+
+      expected_state = %State{
+        url: nil,
+        username: nil,
+        password: nil,
+        ca_cert: nil,
+        use_ca_cert: false,
+        auth: nil
+      }
+
+      assert :sys.get_state(SumaAuth.identify()) == expected_state
+      assert :sys.get_state(SumaAuth.identify(@test_integration_name)) == expected_state
+    end
+  end
+
+  describe "Authenticate" do
+    setup do
+      setup_initial_settings()
+    end
+
+    test "should save existing CA certificate to local file", %{
+      settings: %Settings{ca_cert: ca_cert}
+    } do
+      assert {:ok, _} = start_supervised({SumaAuth, @test_integration_name})
+
+      expect(SumaApiMock, :login, fn _, _, _, true -> successful_login_response() end)
+
+      assert {:ok, %State{ca_cert: ^ca_cert}} = SumaAuth.authenticate(@test_integration_name)
+
+      cert_file_path = "/tmp/suma_ca_cert.crt"
+
+      assert File.exists?(cert_file_path)
+      ^ca_cert = File.read!(cert_file_path)
+    end
+
+    test "should not save CA certificate file if no cert is provided" do
+      insert_software_updates_settings(ca_cert: nil, ca_uploaded_at: nil)
+
+      assert {:ok, _} = start_supervised({SumaAuth, @test_integration_name})
+
+      expect(SumaApiMock, :login, fn _, _, _, false -> successful_login_response() end)
+
+      assert {:ok, %State{ca_cert: nil}} =
+               SumaAuth.authenticate(@test_integration_name)
+
+      refute File.exists?("/tmp/suma_ca_cert.crt")
+    end
+
+    test "should redact sensitive data in SUMA state", %{
+      settings: %Settings{url: url, username: username, password: password}
+    } do
+      {:ok, _} = start_supervised({SumaAuth, @test_integration_name})
+
+      base_api_url = "#{url}/rhn/manager/api"
+
+      expect(SumaApiMock, :login, fn ^base_api_url, ^username, ^password, _ ->
+        successful_login_response()
+      end)
+
+      assert {:ok, %State{username: ^username}} = SumaAuth.authenticate(@test_integration_name)
+
+      expected = %{
+        url: url,
+        username: username,
+        password: "<REDACTED>",
+        ca_cert: "<REDACTED>",
+        use_ca_cert: true,
+        auth: "<REDACTED>"
+      }
+
+      {output, _} =
+        @test_integration_name
+        |> SumaAuth.identify()
+        |> :sys.get_state()
+        |> inspect
+        |> Code.eval_string()
+
+      assert expected == output
+    end
+
+    test "should use an already authenticated auth cookie", %{
+      settings: %Settings{url: url, username: username, password: password}
+    } do
+      {:ok, _} = start_supervised({SumaAuth, @test_integration_name})
+
+      base_api_url = "#{url}/rhn/manager/api"
+
+      expect(SumaApiMock, :login, 1, fn ^base_api_url, ^username, ^password, _ ->
+        successful_login_response()
+      end)
+
+      assert {:ok, %State{username: ^username, ca_cert: initial_cookie}} =
+               SumaAuth.authenticate(@test_integration_name)
+
+      assert {:ok, %State{username: ^username, ca_cert: ^initial_cookie}} =
+               SumaAuth.authenticate(@test_integration_name)
+    end
+
+    test "should handle error when reaching maximum login retries" do
+      {:ok, _} = start_supervised({SumaAuth, @test_integration_name})
+
+      error_causes = [
+        {:ok, %HTTPoison.Response{status_code: 401}},
+        {:ok, %HTTPoison.Response{status_code: 503}},
+        {:error, %HTTPoison.Error{reason: "kaboom"}}
+      ]
+
+      for error_cause <- error_causes do
+        expect(SumaApiMock, :login, 5, fn _, _, _, _ -> error_cause end)
+
+        assert {:error, :max_login_retries_reached} =
+                 SumaAuth.authenticate(@test_integration_name)
+
+        expected_state = %State{
+          url: nil,
+          username: nil,
+          password: nil,
+          ca_cert: nil,
+          use_ca_cert: false,
+          auth: nil
+        }
+
+        assert @test_integration_name
+               |> SumaAuth.identify()
+               |> :sys.get_state() == expected_state
+      end
+    end
+
+    test "should successfully login after retrying" do
+      {:ok, _} = start_supervised({SumaAuth, @test_integration_name})
+
+      auth_cookie = "pxt-session-cookie=4321"
+
+      responses = [
+        {:ok, %HTTPoison.Response{status_code: 401}},
+        {:error, %HTTPoison.Error{reason: "kaboom"}},
+        successful_login_response()
+      ]
+
+      {:ok, _} = Agent.start_link(fn -> 0 end, name: :login_call_iteration)
+
+      expect(SumaApiMock, :login, 3, fn _, _, _, _ ->
+        iteration = Agent.get(:login_call_iteration, & &1)
+
+        iteration_response = Enum.at(responses, iteration)
+        Agent.update(:login_call_iteration, &(&1 + 1))
+
+        iteration_response
+      end)
+
+      assert {:ok, %State{auth: ^auth_cookie}} = SumaAuth.authenticate(@test_integration_name)
+    end
+  end
+
+  describe "Authenticate without settings" do
+    test "should return an error when settings are not configured" do
+      {:ok, _} = start_supervised({SumaAuth, @test_integration_name})
+
+      assert {:error, :settings_not_configured} = SumaAuth.authenticate(@test_integration_name)
+    end
+  end
+
+  describe "clearing up integration service" do
+    setup do
+      setup_initial_settings()
+    end
+
+    test "should clear service state", %{
+      settings: %Settings{url: url, username: username, password: password, ca_cert: ca_cert}
+    } do
+      {:ok, _} = start_supervised({SumaAuth, @test_integration_name})
+
+      expect(SumaApiMock, :login, fn _, _, _, _ -> successful_login_response() end)
+
+      expected_state = %State{
+        url: url,
+        username: username,
+        password: password,
+        ca_cert: ca_cert,
+        use_ca_cert: true,
+        auth: "pxt-session-cookie=4321"
+      }
+
+      assert {:ok, ^expected_state} = SumaAuth.authenticate(@test_integration_name)
+
+      assert :ok = SumaAuth.clear(@test_integration_name)
+
+      assert @test_integration_name
+             |> SumaAuth.identify()
+             |> :sys.get_state() == %State{}
+    end
+
+    test "should support clearing an already empty service state" do
+      {:ok, _} = start_supervised({SumaAuth, @test_integration_name})
+
+      empty_state = %State{
+        url: nil,
+        username: nil,
+        password: nil,
+        ca_cert: nil,
+        use_ca_cert: false,
+        auth: nil
+      }
+
+      assert @test_integration_name
+             |> SumaAuth.identify()
+             |> :sys.get_state() == empty_state
+
+      assert :ok = SumaAuth.clear(@test_integration_name)
+
+      assert @test_integration_name
+             |> SumaAuth.identify()
+             |> :sys.get_state() == empty_state
+    end
+  end
+
+  defp successful_login_response(
+         auth_cookie \\ "pxt-session-cookie=4321",
+         ignored_cookie \\ "pxt-session-cookie=1234"
+       ) do
+    {:ok,
+     %HTTPoison.Response{
+       status_code: 200,
+       headers: [
+         {"Set-Cookie", "JSESSIONID=FOOBAR; Path=/; Secure; HttpOnly; HttpOnly;HttpOnly;Secure"},
+         {"Set-Cookie",
+          "#{ignored_cookie}; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:10 GMT; Path=/; Secure; HttpOnly;HttpOnly;Secure"},
+         {"Set-Cookie",
+          "#{auth_cookie}; Max-Age=3600; Expires=Mon, 26 Feb 2024 10:53:57 GMT; Path=/; Secure; HttpOnly;HttpOnly;Secure"}
+       ]
+     }}
+  end
+end

--- a/test/trento/infrastructure/software_updates/auth/suma_auth_test.exs
+++ b/test/trento/infrastructure/software_updates/auth/suma_auth_test.exs
@@ -5,9 +5,12 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Auth.SumaAuthTest do
 
   import Trento.Factory
 
-  alias Trento.Infrastructure.SoftwareUpdates.Auth.SumaAuth
+  alias Trento.Infrastructure.SoftwareUpdates.Auth.{
+    State,
+    SumaAuth
+  }
+
   alias Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor.Mock, as: SumaApiMock
-  alias Trento.Infrastructure.SoftwareUpdates.Suma.State
   alias Trento.SoftwareUpdates.Settings
 
   setup [:set_mox_from_context, :verify_on_exit!]

--- a/test/trento/infrastructure/software_updates/suma_test.exs
+++ b/test/trento/infrastructure/software_updates/suma_test.exs
@@ -8,8 +8,8 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaTest do
   alias Trento.Infrastructure.SoftwareUpdates.Suma
 
   alias Trento.Infrastructure.SoftwareUpdates.Auth.Mock, as: SumaAuthMock
+  alias Trento.Infrastructure.SoftwareUpdates.Auth.State
   alias Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor.Mock, as: SumaApiMock
-  alias Trento.Infrastructure.SoftwareUpdates.Suma.State
 
   setup [:set_mox_from_context, :verify_on_exit!]
 

--- a/test/trento/software_updates/discovery_test.exs
+++ b/test/trento/software_updates/discovery_test.exs
@@ -148,10 +148,26 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
 
   describe "Discovering software updates for a collection of hosts" do
     test "should handle empty hosts list" do
+      expect(SoftwareUpdatesDiscoveryMock, :setup, fn -> :ok end)
+
       assert {:ok, {[], []}} = Discovery.discover_software_updates()
     end
 
+    test "should handle authentication error" do
+      expect(SoftwareUpdatesDiscoveryMock, :setup, fn -> {:error, :auth_error} end)
+
+      [%{id: host_id1}, %{id: host_id2}] = insert_list(2, :host)
+
+      {:ok, {[], errored_discoveries}} = Discovery.discover_software_updates()
+
+      Enum.each([host_id1, host_id2], fn host_id ->
+        assert {:error, host_id, :auth_error} in errored_discoveries
+      end)
+    end
+
     test "should handle hosts without fqdn" do
+      expect(SoftwareUpdatesDiscoveryMock, :setup, fn -> :ok end)
+
       %{id: host_id1} = insert(:host, fully_qualified_domain_name: nil)
       %{id: host_id2} = insert(:host, fully_qualified_domain_name: nil)
 
@@ -163,6 +179,8 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
     end
 
     test "should handle errors when getting a system id" do
+      expect(SoftwareUpdatesDiscoveryMock, :setup, fn -> :ok end)
+
       %{id: host_id, fully_qualified_domain_name: fully_qualified_domain_name} = insert(:host)
 
       discovery_error = :some_error_while_getting_system_id
@@ -175,6 +193,8 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
     end
 
     test "should handle errors when getting relevant patches" do
+      expect(SoftwareUpdatesDiscoveryMock, :setup, fn -> :ok end)
+
       %{id: host_id, fully_qualified_domain_name: fully_qualified_domain_name} = insert(:host)
 
       system_id = 100
@@ -193,6 +213,8 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
     end
 
     test "should handle errors when dispatching discovery completion command" do
+      expect(SoftwareUpdatesDiscoveryMock, :setup, fn -> :ok end)
+
       %{id: host_id, fully_qualified_domain_name: fully_qualified_domain_name} = insert(:host)
 
       system_id = 100
@@ -212,6 +234,8 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
     end
 
     test "should complete discovery" do
+      expect(SoftwareUpdatesDiscoveryMock, :setup, fn -> :ok end)
+
       %{id: host_id1, fully_qualified_domain_name: fully_qualified_domain_name1} =
         insert(:host, hostname: "host1")
 

--- a/test/trento/software_updates/discovery_test.exs
+++ b/test/trento/software_updates/discovery_test.exs
@@ -158,6 +158,25 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
 
       [%{id: host_id1}, %{id: host_id2}] = insert_list(2, :host)
 
+      expect(
+        Trento.Commanded.Mock,
+        :dispatch,
+        2,
+        fn
+          %CompleteSoftwareUpdatesDiscovery{
+            host_id: ^host_id1,
+            health: SoftwareUpdatesHealth.unknown()
+          } ->
+            :ok
+
+          %CompleteSoftwareUpdatesDiscovery{
+            host_id: ^host_id2,
+            health: SoftwareUpdatesHealth.unknown()
+          } ->
+            :ok
+        end
+      )
+
       {:ok, {[], errored_discoveries}} = Discovery.discover_software_updates()
 
       Enum.each([host_id1, host_id2], fn host_id ->


### PR DESCRIPTION
# Description

Change the SUMA interaction module to use the GenServer only to handle the authentication, not the whole sequence of queries. This way, only the authentication is a "locked" process, and all the other requests can happen concurrently.

The other "small" improvement is that the when we do a "batch" discovery (on saving SUMA settings for instance), we just authenticate once, and use that data for the rest. Otherwise, as the auth is still sequential, it would've been tried for each individual host, and when the user/password are wrong for instance, this could take a lot (5-10 seconds per host).

It is just an improvement of performance in reality, nothing else.
As things happen in the background the user might not even notice things (except, some toast are happening faster, etc).

## How was this tested?

Unit tests updated, and I have tested manually with our own SUMA instance.

Next:
The `discovery` when we save the settings must happen async, so the `patch` is not holded there for a while (which can even create timeout issues)
