### PR TITLE
Handle software updates discovery errors

### DIFF
--- a/lib/trento/software_updates/discovery.ex
+++ b/lib/trento/software_updates/discovery.ex
@@ -80,54 +80,39 @@ defmodule Trento.SoftwareUpdates.Discovery do
   end
 
   def discover_host_software_updates(host_id, fully_qualified_domain_name) do
-    case discover_relevant_patches(fully_qualified_domain_name) do
-      {:ok, system_id, relevant_patches} ->
-        determine_health_and_dispatch_completion_command(host_id, system_id, relevant_patches)
-
+    with {:ok, system_id} <- get_system_id(fully_qualified_domain_name),
+         {:ok, relevant_patches} <- get_relevant_patches(system_id),
+         :ok <-
+           host_id
+           |> build_discovery_completion_command(relevant_patches)
+           |> commanded().dispatch() do
+      {:ok, host_id, system_id, relevant_patches}
+    else
       {:error, discovery_error} = error ->
         Logger.error(
           "An error occurred during software updates discovery for host #{host_id}:  #{inspect(error)}"
         )
 
-        dispatch_completion_command_on_discovery_error(host_id, discovery_error)
+        commanded().dispatch(
+          CompleteSoftwareUpdatesDiscovery.new!(%{
+            host_id: host_id,
+            health: SoftwareUpdatesHealth.unknown()
+          })
+        )
+
+        {:error, discovery_error}
     end
   end
 
-  defp discover_relevant_patches(fully_qualified_domain_name) do
-    with {:ok, system_id} <- get_system_id(fully_qualified_domain_name),
-         {:ok, relevant_patches} <- get_relevant_patches(system_id) do
-      {:ok, system_id, relevant_patches}
-    end
-  end
-
-  defp determine_health_and_dispatch_completion_command(host_id, system_id, relevant_patches) do
-    with :ok <-
-           relevant_patches
-           |> track_relevant_patches
-           |> compute_software_updates_discovery_health
-           |> dispatch_completion_command(host_id) do
-      {:ok, host_id, system_id, relevant_patches}
-    end
-  end
-
-  defp dispatch_completion_command(discovered_software_updates_health, host_id) do
-    commanded().dispatch(
+  defp build_discovery_completion_command(host_id, relevant_patches),
+    do:
       CompleteSoftwareUpdatesDiscovery.new!(%{
         host_id: host_id,
-        health: discovered_software_updates_health
+        health:
+          relevant_patches
+          |> track_relevant_patches
+          |> compute_software_updates_discovery_health
       })
-    )
-  end
-
-  defp dispatch_completion_command_on_discovery_error(host_id, discovery_error) do
-    case dispatch_completion_command(SoftwareUpdatesHealth.unknown(), host_id) do
-      :ok ->
-        {:error, discovery_error}
-
-      {:error, dispatching_error} ->
-        {:error, [discovery_error, dispatching_error]}
-    end
-  end
 
   defp track_relevant_patches(relevant_patches),
     do:

--- a/test/trento/hosts/host_test.exs
+++ b/test/trento/hosts/host_test.exs
@@ -1736,6 +1736,24 @@ defmodule Trento.Hosts.HostTest do
           initial_host_health: Health.critical(),
           software_updates_discovery_health: SoftwareUpdatesHealth.passing(),
           expected_host_health: Health.passing()
+        },
+        %{
+          initial_host_health: Health.passing(),
+          software_updates_discovery_health: SoftwareUpdatesHealth.unknown(),
+          expected_host_health: Health.unknown()
+        },
+        %{
+          initial_host_health: Health.critical(),
+          initial_heartbeat: :heartbeat_failed,
+          software_updates_discovery_health: SoftwareUpdatesHealth.unknown(),
+          expected_host_health: Health.unknown()
+        },
+        %{
+          initial_host_health: Health.unknown(),
+          initial_heartbeat: :heartbeat_failed,
+          software_updates_discovery_health: SoftwareUpdatesHealth.unknown(),
+          expect_host_health_changed: false,
+          expected_host_health: Health.unknown()
         }
       ]
 

--- a/test/trento/infrastructure/commanded/event_handlers/software_updates_discovery_event_handler_test.exs
+++ b/test/trento/infrastructure/commanded/event_handlers/software_updates_discovery_event_handler_test.exs
@@ -11,6 +11,8 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SoftwareUpdatesDiscovery
 
   alias Trento.Infrastructure.Commanded.EventHandlers.SoftwareUpdatesDiscoveryEventHandler
 
+  require Trento.SoftwareUpdates.Enums.SoftwareUpdatesHealth, as: SoftwareUpdatesHealth
+
   setup [:set_mox_from_context, :verify_on_exit!]
 
   test "should discover software updates when a SoftwareUpdatesDiscoveryRequested is emitted" do
@@ -63,8 +65,11 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SoftwareUpdatesDiscovery
     expect(
       Trento.Commanded.Mock,
       :dispatch,
-      0,
-      fn _ -> :ok end
+      fn %CompleteSoftwareUpdatesDiscovery{
+           health: SoftwareUpdatesHealth.unknown()
+         } ->
+        :ok
+      end
     )
 
     assert :ok = SoftwareUpdatesDiscoveryEventHandler.handle(event, %{})


### PR DESCRIPTION
# Description

This PR handles software updates discovery errors by dispatching an `unknown` health.

Cleaned a bit up error propagation.

## How was this tested?

Automated tests.