### PR TITLE
Asynchronously run software updates discovery when applying settings

### DIFF
--- a/lib/trento/application.ex
+++ b/lib/trento/application.ex
@@ -25,7 +25,8 @@ defmodule Trento.Application do
         Trento.Infrastructure.Messaging.Adapter.AMQP.Publisher,
         Trento.Infrastructure.Checks.AMQP.Consumer,
         Trento.Vault,
-        Trento.Infrastructure.SoftwareUpdates.Suma
+        Trento.Infrastructure.SoftwareUpdates.Suma,
+        {Task.Supervisor, name: Trento.TasksSupervisor}
         # Start a worker by calling: Trento.Worker.start_link(arg)
         # {Trento.Worker, arg}
       ] ++

--- a/lib/trento/software_updates.ex
+++ b/lib/trento/software_updates.ex
@@ -160,7 +160,12 @@ defmodule Trento.SoftwareUpdates do
 
     case result do
       {:ok, _} = success ->
-        Discovery.discover_software_updates()
+        Discovery.clear()
+
+        Task.Supervisor.start_child(Trento.TasksSupervisor, fn ->
+          Discovery.discover_software_updates()
+        end)
+
         success
 
       {:error, _} = error ->

--- a/test/support/task_case.ex
+++ b/test/support/task_case.ex
@@ -1,0 +1,33 @@
+defmodule Trento.TaskCase do
+  @moduledoc """
+  This module defines the test case to be used by tests that require operating on asynv tasks.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      def wait_for_tasks_completion do
+        Trento.TasksSupervisor
+        |> Task.Supervisor.children()
+        |> Enum.map(fn pid ->
+          Process.monitor(pid)
+
+          pid
+        end)
+        |> wait_for_pids()
+      end
+
+      defp wait_for_pids([]), do: nil
+
+      defp wait_for_pids(pids) do
+        receive do
+          {:DOWN, _ref, :process, pid, _reason} ->
+            pids
+            |> List.delete(pid)
+            |> wait_for_pids()
+        end
+      end
+    end
+  end
+end

--- a/test/support/task_case.ex
+++ b/test/support/task_case.ex
@@ -1,13 +1,13 @@
 defmodule Trento.TaskCase do
   @moduledoc """
-  This module defines the test case to be used by tests that require operating on asynv tasks.
+  This module defines the test case to be used by tests that require operating on async tasks.
   """
 
   use ExUnit.CaseTemplate
 
   using do
     quote do
-      def wait_for_tasks_completion do
+      def wait_for_tasks_completion(timeout \\ 5_000) do
         Trento.TasksSupervisor
         |> Task.Supervisor.children()
         |> Enum.map(fn pid ->
@@ -15,17 +15,19 @@ defmodule Trento.TaskCase do
 
           pid
         end)
-        |> wait_for_pids()
+        |> wait_for_pids(timeout)
       end
 
-      defp wait_for_pids([]), do: nil
+      defp wait_for_pids([], timeout), do: nil
 
-      defp wait_for_pids(pids) do
+      defp wait_for_pids(pids, timeout) do
         receive do
           {:DOWN, _ref, :process, pid, _reason} ->
             pids
             |> List.delete(pid)
-            |> wait_for_pids()
+            |> wait_for_pids(timeout)
+        after
+          timeout -> :timeout
         end
       end
     end

--- a/test/trento/software_updates_test.exs
+++ b/test/trento/software_updates_test.exs
@@ -3,6 +3,7 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
   use Trento.CommandedCase
   use Trento.DataCase
   use Trento.SoftwareUpdates.DiscoveryCase
+  use Trento.TaskCase
 
   import Mox
 
@@ -207,6 +208,8 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
       ]
 
       for operation <- operations do
+        expect(Trento.SoftwareUpdates.Discovery.Mock, :clear, 1, fn -> :ok end)
+
         expect(
           Trento.Commanded.Mock,
           :dispatch,
@@ -222,6 +225,8 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
         }
 
         assert {:ok, _} = operation.(settings)
+
+        wait_for_tasks_completion()
       end
     end
   end


### PR DESCRIPTION
# Description

This PR makes sure the software updates discovery for all the hosts in the system is triggered asynchronously on save/change settings.
Also, in order to avoid unwanted side effects the Discovery state gets cleared right before triggering async discovery, so that the state gest reconstituted with new settings.

Keeps the save/change settings operation quite immediate not impacting performance when discovery needs to be executed for many hosts.

## How was this tested?

Automated tests.