### PR TITLE
Deregister sap system on tenant removal

### DIFF
--- a/lib/trento/databases/database.ex
+++ b/lib/trento/databases/database.ex
@@ -134,7 +134,8 @@ defmodule Trento.Databases.Database do
       },
       %DatabaseTenantsUpdated{
         database_id: database_id,
-        tenants: tenants
+        tenants: tenants,
+        previous_tenants: []
       }
     ]
   end
@@ -530,7 +531,8 @@ defmodule Trento.Databases.Database do
     if sorted_current_tenants != sorted_new_tenants do
       %DatabaseTenantsUpdated{
         database_id: database_id,
-        tenants: new_tenants
+        tenants: new_tenants,
+        previous_tenants: current_tenants
       }
     end
   end

--- a/lib/trento/databases/events/database_tenants_updated.ex
+++ b/lib/trento/databases/events/database_tenants_updated.ex
@@ -11,5 +11,6 @@ defmodule Trento.Databases.Events.DatabaseTenantsUpdated do
     field :database_id, Ecto.UUID
 
     embeds_many :tenants, Tenant
+    embeds_many :previous_tenants, Tenant
   end
 end

--- a/lib/trento/databases/projections/database_read_model.ex
+++ b/lib/trento/databases/projections/database_read_model.ex
@@ -23,7 +23,7 @@ defmodule Trento.Databases.Projections.DatabaseReadModel do
     field :sid, :string
     field :health, Ecto.Enum, values: Health.values()
 
-    embeds_many :tenants, Tenant
+    embeds_many :tenants, Tenant, on_replace: :delete
 
     has_many :tags, Tag, foreign_key: :resource_id
 

--- a/test/trento/databases/database_test.exs
+++ b/test/trento/databases/database_test.exs
@@ -95,7 +95,8 @@ defmodule Trento.Databases.DatabaseTest do
           },
           %DatabaseTenantsUpdated{
             database_id: database_id,
-            tenants: tenants
+            tenants: tenants,
+            previous_tenants: []
           }
         ],
         %Database{
@@ -170,7 +171,8 @@ defmodule Trento.Databases.DatabaseTest do
           },
           %DatabaseTenantsUpdated{
             database_id: database_id,
-            tenants: tenants
+            tenants: tenants,
+            previous_tenants: []
           }
         ],
         %Database{
@@ -809,7 +811,8 @@ defmodule Trento.Databases.DatabaseTest do
           },
           %DatabaseTenantsUpdated{
             database_id: database_id,
-            tenants: tenants
+            tenants: tenants,
+            previous_tenants: []
           }
         ],
         %Database{
@@ -880,7 +883,12 @@ defmodule Trento.Databases.DatabaseTest do
             host_id: host_id,
             health: :passing
           ),
-          build(:database_tenants_updated_event, database_id: database_id, tenants: new_tenants)
+          build(
+            :database_tenants_updated_event,
+            database_id: database_id,
+            tenants: new_tenants,
+            previous_tenants: tenants
+          )
         ],
         fn state ->
           assert %Database{
@@ -1049,7 +1057,8 @@ defmodule Trento.Databases.DatabaseTest do
           },
           %DatabaseTenantsUpdated{
             database_id: database_id,
-            tenants: new_tenants
+            tenants: new_tenants,
+            previous_tenants: tenants
           }
         ],
         fn state ->

--- a/test/trento/infrastructure/commanded/event_handlers/database_deregistration_event_handler_test.exs
+++ b/test/trento/infrastructure/commanded/event_handlers/database_deregistration_event_handler_test.exs
@@ -5,7 +5,11 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.DatabaseDeregistrationEv
   import Mox
   import Trento.Factory
 
-  alias Trento.Databases.Events.DatabaseDeregistered
+  alias Trento.Databases.Events.{
+    DatabaseDeregistered,
+    DatabaseTenantsUpdated
+  }
+
   alias Trento.Infrastructure.Commanded.EventHandlers.DatabaseDeregistrationEventHandler
   alias Trento.SapSystems.Commands.DeregisterSapSystem
 
@@ -37,5 +41,48 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.DatabaseDeregistrationEv
     end)
 
     assert :ok = DatabaseDeregistrationEventHandler.handle(event, %{})
+  end
+
+  test "should dispatch DeregisterSapSystem commands when a tenant is removed" do
+    [%{name: tenant1}, %{name: tenant2}] = tenants = build_list(2, :tenant)
+    %{id: database_id} = insert(:database, tenants: tenants)
+
+    insert(:sap_system, database_id: database_id, tenant: tenant1)
+    %{id: second_sap_system_id} = insert(:sap_system, database_id: database_id, tenant: tenant2)
+    insert(:sap_system, database_id: database_id)
+
+    event = %DatabaseTenantsUpdated{
+      database_id: database_id,
+      tenants: Enum.take(tenants, 1),
+      previous_tenants: tenants
+    }
+
+    deregistered_at = DateTime.utc_now()
+
+    expect(Trento.Commanded.Mock, :dispatch, fn %DeregisterSapSystem{
+                                                  sap_system_id: ^second_sap_system_id,
+                                                  deregistered_at: ^deregistered_at
+                                                },
+                                                _ ->
+      :ok
+    end)
+
+    assert :ok = DatabaseDeregistrationEventHandler.handle(event, %{created_at: deregistered_at})
+  end
+
+  test "should not dispatch DeregisterSapSystem commands if tenants are added" do
+    tenants = build_list(2, :tenant)
+    %{id: database_id} = insert(:database, tenants: tenants)
+
+    event = %DatabaseTenantsUpdated{
+      database_id: database_id,
+      tenants: tenants,
+      previous_tenants: Enum.take(tenants, 1)
+    }
+
+    expect(Trento.Commanded.Mock, :dispatch, 0, fn _ -> :ok end)
+
+    assert :ok =
+             DatabaseDeregistrationEventHandler.handle(event, %{created_at: DateTime.utc_now()})
   end
 end


### PR DESCRIPTION
# Description

Fix 2 things:
- Add `on_replace` flag to enable tenants update in the database read model. This was causing an error otherwise
- Add a new event listening function, to deregister SAP systems if their tenants are removed from a database

## How was this tested?

Unit tests added. I have done some manual testing as well
