### PR TITLE
Adjust suma timeouts

### DIFF
--- a/lib/trento/infrastructure/software_updates/adapter/suma_http_executor.ex
+++ b/lib/trento/infrastructure/software_updates/adapter/suma_http_executor.ex
@@ -51,7 +51,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor do
       "#{base_url}/auth/login",
       payload,
       [{"Content-type", "application/json"}],
-      ssl_options(use_ca_cert) ++ [timeout: 1_000]
+      ssl_options(use_ca_cert) ++ timeout_options()
     )
   end
 
@@ -83,7 +83,9 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor do
   end
 
   defp request_options(auth, use_ca_cert),
-    do: [hackney: [cookie: [auth]]] ++ ssl_options(use_ca_cert)
+    do: [hackney: [cookie: [auth]]] ++ ssl_options(use_ca_cert) ++ timeout_options()
+
+  defp timeout_options, do: [timeout: 500, recv_timeout: 1_500]
 
   defp ssl_options(true),
     do: [ssl: [verify: :verify_peer, cacertfile: SumaApi.ca_cert_path()]]

--- a/lib/trento/infrastructure/software_updates/suma.ex
+++ b/lib/trento/infrastructure/software_updates/suma.ex
@@ -93,7 +93,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma do
     end
   end
 
-  defp call(server, request), do: GenServer.call(server, request, 10_000)
+  defp call(server, request), do: GenServer.call(server, request, 15_000)
 
   defp authenticate_and_handle(request, state) do
     case setup_auth(state) do


### PR DESCRIPTION
# Description

Adjusting timeouts for suma requests.

By default all requests to suma have been set to `[timeout: 500, recv_timeout: 1_500]`

> https://hexdocs.pm/httpoison/HTTPoison.Request.html
> 
> `:timeout` - timeout for establishing a TCP or SSL connection, in milliseconds. Default is 8000
> `:recv_timeout` - timeout for receiving an HTTP response from the socket. Default is 5000

Also the SUMA genserver call timeout has been increased to `15s` which covers the worst case scenarios where:
- all 5 retrials of login fail responding in time ~10s or less
- login succeeds only on the last try plus discovery request: 4 login failures + 1 login success + 1 specific api for a total amount of ~12s or less

This would benefit also applied in this case https://github.com/trento-project/web/pull/2531. 
And besides that, as discussed with @arbulu89, we could also consider breaking the loop of login retrial if we detect a 401 during a login attempt.

## How was this tested?

Manual testing.
