### PR TITLE
Raise when waiting for tasks completion times out

### DIFF
--- a/test/support/task_case.ex
+++ b/test/support/task_case.ex
@@ -27,7 +27,8 @@ defmodule Trento.TaskCase do
             |> List.delete(pid)
             |> wait_for_pids(timeout)
         after
-          timeout -> :timeout
+          timeout ->
+            raise "Timeout waiting for tasks to complete"
         end
       end
     end


### PR DESCRIPTION
# Description

Follows up https://github.com/trento-project/web/pull/2533 by raising when waiting for tasks completion times out