### PR TITLE
Extend error handling of `AvailableSoftwareUpdates` component

### DIFF
--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.jsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { EOS_HEALING, EOS_PACKAGE_UPGRADE_OUTLINED } from 'eos-icons-react';
 import { noop, gt } from 'lodash';
 
+import Loading from './Loading';
 import SumaNotConfigured from './SumaNotConfigured';
 import Indicator from './Indicator';
 
@@ -11,7 +12,6 @@ const containerClassNames = classNames(
   'items-center',
   'bg-white',
   'rounded-md',
-  'm-2',
   'p-5',
   'gap-x-8',
   'shadow'
@@ -23,10 +23,15 @@ function AvailableSoftwareUpdates({
   relevantPatches,
   upgradablePackages,
   tooltip,
-  loading,
+  softwareUpdatesSettingsLoading,
+  softwareUpdatesLoading,
   connectionError = false,
   onBackToSettings = noop,
 }) {
+  if (softwareUpdatesSettingsLoading) {
+    return <Loading className={containerClassNames} />;
+  }
+
   if (!settingsConfigured) {
     return (
       <SumaNotConfigured
@@ -43,6 +48,7 @@ function AvailableSoftwareUpdates({
         'flex-row',
         'place-content-stretch',
         'w-full',
+        'm-2',
         className
       )}
     >
@@ -52,7 +58,7 @@ function AvailableSoftwareUpdates({
         title="Relevant Patches"
         critical={gt(relevantPatches, 0)}
         tooltip={tooltip}
-        loading={loading}
+        loading={softwareUpdatesLoading}
         connectionError={connectionError}
         icon={<EOS_HEALING size="xl" />}
       >
@@ -62,7 +68,7 @@ function AvailableSoftwareUpdates({
       <Indicator
         title="Upgradable Packages"
         tooltip={tooltip}
-        loading={loading}
+        loading={softwareUpdatesLoading}
         connectionError={connectionError}
         icon={<EOS_PACKAGE_UPGRADE_OUTLINED size="xl" />}
       >

--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.jsx
@@ -1,14 +1,21 @@
 import React from 'react';
 import classNames from 'classnames';
-import {
-  EOS_HEALING,
-  EOS_PACKAGE_UPGRADE_OUTLINED,
-  EOS_SETTINGS,
-} from 'eos-icons-react';
+import { EOS_HEALING, EOS_PACKAGE_UPGRADE_OUTLINED } from 'eos-icons-react';
 import { noop, gt } from 'lodash';
 
-import Button from '@common/Button';
+import SumaNotConfigured from './SumaNotConfigured';
 import Indicator from './Indicator';
+
+const containerClassNames = classNames(
+  'flex',
+  'items-center',
+  'bg-white',
+  'rounded-md',
+  'm-2',
+  'p-5',
+  'gap-x-8',
+  'shadow'
+);
 
 function AvailableSoftwareUpdates({
   className,
@@ -20,52 +27,19 @@ function AvailableSoftwareUpdates({
   connectionError = false,
   onBackToSettings = noop,
 }) {
-  const containerStyles = classNames(
-    'flex',
-    'items-center',
-    'bg-white',
-    'rounded-md',
-    'm-2',
-    'p-5',
-    'gap-x-8',
-    'shadow'
-  );
-
   if (!settingsConfigured) {
     return (
-      <div
-        className={classNames(
-          containerStyles,
-          'place-content-between',
-          className
-        )}
-      >
-        <div>
-          <p className="font-bold text-2xl">Available Software Updates</p>
-
-          <p>
-            SUSE Manager is not configured. Go to Settings to add your SUSE
-            Manager connection credentials.
-          </p>
-        </div>
-
-        <Button
-          type="primary-white-fit"
-          className="inline-block mx-0.5 border-green-500 border"
-          size="small"
-          onClick={onBackToSettings}
-        >
-          <EOS_SETTINGS className="inline-block fill-jungle-green-500" />{' '}
-          Settings
-        </Button>
-      </div>
+      <SumaNotConfigured
+        className={containerClassNames}
+        onBackToSettings={onBackToSettings}
+      />
     );
   }
 
   return (
     <div
       className={classNames(
-        containerStyles,
+        containerClassNames,
         'flex-row',
         'place-content-stretch',
         'w-full',

--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.jsx
@@ -1,31 +1,74 @@
 import React from 'react';
 import classNames from 'classnames';
-import { gt } from 'lodash';
-import { EOS_HEALING, EOS_PACKAGE_UPGRADE_OUTLINED } from 'eos-icons-react';
+import {
+  EOS_HEALING,
+  EOS_PACKAGE_UPGRADE_OUTLINED,
+  EOS_SETTINGS,
+} from 'eos-icons-react';
+import { noop, gt } from 'lodash';
 
+import Button from '@common/Button';
 import Indicator from './Indicator';
 
 function AvailableSoftwareUpdates({
   className,
+  settingsConfigured = false,
   relevantPatches,
   upgradablePackages,
   tooltip,
   loading,
+  connectionError = false,
+  onBackToSettings = noop,
 }) {
+  const containerStyles = classNames(
+    'flex',
+    'items-center',
+    'bg-white',
+    'rounded-md',
+    'm-2',
+    'p-5',
+    'gap-x-8',
+    'shadow'
+  );
+
+  if (!settingsConfigured) {
+    return (
+      <div
+        className={classNames(
+          containerStyles,
+          'place-content-between',
+          className
+        )}
+      >
+        <div>
+          <p className="font-bold text-2xl">Available Software Updates</p>
+
+          <p>
+            SUSE Manager is not configured. Go to Settings to add your SUSE
+            Manager connection credentials.
+          </p>
+        </div>
+
+        <Button
+          type="primary-white-fit"
+          className="inline-block mx-0.5 border-green-500 border"
+          size="small"
+          onClick={onBackToSettings}
+        >
+          <EOS_SETTINGS className="inline-block fill-jungle-green-500" />{' '}
+          Settings
+        </Button>
+      </div>
+    );
+  }
+
   return (
     <div
       className={classNames(
-        'flex',
+        containerStyles,
         'flex-row',
-        'items-center',
         'place-content-stretch',
         'w-full',
-        'bg-white',
-        'rounded-md',
-        'm-2',
-        'p-5',
-        'gap-x-8',
-        'shadow',
         className
       )}
     >
@@ -36,6 +79,7 @@ function AvailableSoftwareUpdates({
         critical={gt(relevantPatches, 0)}
         tooltip={tooltip}
         loading={loading}
+        connectionError={connectionError}
         icon={<EOS_HEALING size="xl" />}
       >
         {relevantPatches}
@@ -45,6 +89,7 @@ function AvailableSoftwareUpdates({
         title="Upgradable Packages"
         tooltip={tooltip}
         loading={loading}
+        connectionError={connectionError}
         icon={<EOS_PACKAGE_UPGRADE_OUTLINED size="xl" />}
       >
         {upgradablePackages}

--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.jsx
@@ -12,7 +12,8 @@ const containerClassNames = classNames(
   'items-center',
   'bg-white',
   'rounded-md',
-  'p-5',
+  'px-8',
+  'py-4',
   'gap-x-8',
   'shadow'
 );

--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.stories.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.stories.jsx
@@ -5,7 +5,9 @@ export default {
   component: AvailableSoftwareUpdates,
   argTypes: {
     settingsConfigured: {
-      type: 'bool',
+      control: {
+        type: 'boolean',
+      },
       description: 'Have settings been saved for the software updates service',
     },
     relevantPatches: {
@@ -27,11 +29,15 @@ export default {
       description: 'Content of the tooltip, if it is rendered',
     },
     loading: {
-      type: 'bool',
+      control: {
+        type: 'boolean',
+      },
       description: 'Is data being fetched?',
     },
     connectionError: {
-      type: 'bool',
+      control: {
+        type: 'boolean',
+      },
       description: 'There an error connecting to the software updates service',
     },
     onBackToSettings: {

--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.stories.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.stories.jsx
@@ -4,6 +4,10 @@ export default {
   title: 'Components/AvailableSoftwareUpdates',
   component: AvailableSoftwareUpdates,
   argTypes: {
+    settingsConfigured: {
+      type: 'bool',
+      description: 'Have settings been saved for the software updates service',
+    },
     relevantPatches: {
       type: 'number',
       description: 'Number of relevant patches available for the system',
@@ -26,17 +30,44 @@ export default {
       type: 'bool',
       description: 'Is data being fetched?',
     },
+    connectionError: {
+      type: 'bool',
+      description: 'There an error connecting to the software updates service',
+    },
+    onBackToSettings: {
+      description:
+        'Callback function to trigger when the "Settings" button is clicked',
+      control: {
+        type: 'function',
+      },
+    },
   },
 };
 
 export const Default = {
-  args: { relevantPatches: 412, upgradablePackages: 234 },
+  args: {
+    relevantPatches: 412,
+    upgradablePackages: 234,
+    settingsConfigured: true,
+  },
 };
 
 export const Cool = {
-  args: { relevantPatches: 0, upgradablePackages: 42 },
+  args: {
+    relevantPatches: 0,
+    upgradablePackages: 42,
+    settingsConfigured: true,
+  },
 };
 
-export const Unknown = { args: { tooltip: 'SUSE Manager is not available' } };
+export const NoSettingsConfigured = { args: { settingsConfigured: false } };
 
-export const Loading = { args: { loading: true } };
+export const Unknown = {
+  args: { tooltip: 'SUSE Manager is not available', settingsConfigured: true },
+};
+
+export const Loading = { args: { loading: true, settingsConfigured: true } };
+
+export const ConnectionError = {
+  args: { connectionError: true, settingsConfigured: true },
+};

--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.stories.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.stories.jsx
@@ -28,11 +28,17 @@ export default {
       type: 'string',
       description: 'Content of the tooltip, if it is rendered',
     },
-    loading: {
+    softwareUpdatesSettingsLoading: {
       control: {
         type: 'boolean',
       },
-      description: 'Is data being fetched?',
+      description: 'are software updates settings being fetched?',
+    },
+    softwareUpdatesLoading: {
+      control: {
+        type: 'boolean',
+      },
+      description: 'are software updates being fetched?',
     },
     connectionError: {
       control: {
@@ -72,7 +78,13 @@ export const Unknown = {
   args: { tooltip: 'SUSE Manager is not available', settingsConfigured: true },
 };
 
-export const Loading = { args: { loading: true, settingsConfigured: true } };
+export const SoftwareUpdateSettingsLoading = {
+  args: { softwareUpdateSettingsLoading: true, settingsConfigured: true },
+};
+
+export const SoftwareUpdatesLoading = {
+  args: { softwareUpdatesLoading: true, settingsConfigured: true },
+};
 
 export const ConnectionError = {
   args: { connectionError: true, settingsConfigured: true },

--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
@@ -69,7 +69,7 @@ describe('AvailableSoftwareUpdates component', () => {
       <AvailableSoftwareUpdates softwareUpdatesLoading settingsConfigured />
     );
 
-    expect(screen.getAllByLabelText('Loading')).toHaveLength(2);
+    expect(screen.getAllByText('Loading...')).toHaveLength(2);
   });
 
   it('renders "SUSE Manager is not configured"', () => {

--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
@@ -15,6 +15,7 @@ describe('AvailableSoftwareUpdates component', () => {
       <AvailableSoftwareUpdates
         relevantPatches={0}
         upgradablePackages={upgradablePackages}
+        settingsConfigured
       />
     );
 
@@ -31,6 +32,7 @@ describe('AvailableSoftwareUpdates component', () => {
       <AvailableSoftwareUpdates
         relevantPatches={relevantPatches}
         upgradablePackages={upgradablePackages}
+        settingsConfigured
       />
     );
 
@@ -42,7 +44,7 @@ describe('AvailableSoftwareUpdates component', () => {
   it('renders Unknown status', async () => {
     const user = userEvent.setup();
     const tooltip = faker.lorem.words({ min: 3, max: 5 });
-    render(<AvailableSoftwareUpdates tooltip={tooltip} />);
+    render(<AvailableSoftwareUpdates tooltip={tooltip} settingsConfigured />);
 
     expect(screen.getAllByText('Unknown')).toHaveLength(2);
     expect(screen.getAllByTestId('eos-svg-component')).toHaveLength(4);
@@ -52,8 +54,28 @@ describe('AvailableSoftwareUpdates component', () => {
   });
 
   it('renders Loading status', () => {
-    render(<AvailableSoftwareUpdates loading />);
+    render(<AvailableSoftwareUpdates loading settingsConfigured />);
 
     expect(screen.getAllByText('Loading...')).toHaveLength(2);
+  });
+
+  it('renders "SUSE Manager is not configured"', () => {
+    render(<AvailableSoftwareUpdates settingsConfigured={false} />);
+
+    expect(
+      screen.getByText(
+        'SUSE Manager is not configured. Go to Settings to add your SUSE Manager connection credentials.'
+      )
+    ).toBeVisible();
+
+    expect(screen.getByRole('button', { name: 'Settings' })).toBeVisible();
+  });
+
+  it('renders a connection error', () => {
+    render(<AvailableSoftwareUpdates settingsConfigured connectionError />);
+
+    expect(screen.getAllByText('SUSE Manager connection failed')).toHaveLength(
+      2
+    );
   });
 });

--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
@@ -53,8 +53,21 @@ describe('AvailableSoftwareUpdates component', () => {
     expect(screen.getByText(tooltip)).toBeInTheDocument();
   });
 
-  it('renders Loading status', () => {
-    render(<AvailableSoftwareUpdates loading settingsConfigured />);
+  it('renders Software Updates Settings Loading status', () => {
+    render(
+      <AvailableSoftwareUpdates
+        softwareUpdatesSettingsLoading
+        settingsConfigured
+      />
+    );
+
+    expect(screen.getAllByLabelText('Loading')).toHaveLength(1);
+  });
+
+  it('renders Software Updates Loading status', () => {
+    render(
+      <AvailableSoftwareUpdates softwareUpdatesLoading settingsConfigured />
+    );
 
     expect(screen.getAllByLabelText('Loading')).toHaveLength(2);
   });

--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
@@ -56,7 +56,7 @@ describe('AvailableSoftwareUpdates component', () => {
   it('renders Loading status', () => {
     render(<AvailableSoftwareUpdates loading settingsConfigured />);
 
-    expect(screen.getAllByText('Loading...')).toHaveLength(2);
+    expect(screen.getAllByLabelText('Loading')).toHaveLength(2);
   });
 
   it('renders "SUSE Manager is not configured"', () => {

--- a/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
@@ -5,7 +5,6 @@ import {
   EOS_ERROR_OUTLINED,
 } from 'eos-icons-react';
 
-import Spinner from '@common/Spinner';
 import Tooltip from '@common/Tooltip';
 
 function Indicator({
@@ -26,9 +25,7 @@ function Indicator({
         <div className="px-2">{icon}</div>
         <div>
           <p className="font-bold">{title}</p>
-          <div className="text-gray-500">
-            <Spinner size="l" />
-          </div>
+          <div className="text-gray-500">Loading...</div>
         </div>
       </div>
     );

--- a/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
@@ -3,9 +3,9 @@ import classNames from 'classnames';
 import {
   // EOS_KEYBOARD_ARROW_RIGHT_FILLED,
   EOS_ERROR_OUTLINED,
-  EOS_LOADING_ANIMATED,
 } from 'eos-icons-react';
 
+import Spinner from '@common/Spinner';
 import Tooltip from '@common/Tooltip';
 
 function Indicator({
@@ -26,13 +26,7 @@ function Indicator({
         <div>
           <p className="font-bold">{title}</p>
           <div className="text-gray-500">
-            <div>
-              <EOS_LOADING_ANIMATED
-                size="l"
-                className="inline align-bottom fill-gray-400"
-              />
-              Loading...
-            </div>
+            <Spinner size="l" />
           </div>
         </div>
       </div>

--- a/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
@@ -18,6 +18,7 @@ function Indicator({
   children,
 }) {
   const unknown = children === undefined;
+  const error = unknown || connectionError;
 
   if (loading) {
     return (
@@ -41,8 +42,8 @@ function Indicator({
           <p className="font-bold">{title}</p>
           <div
             className={classNames({
-              'text-green-600': !unknown,
-              'text-gray-600': unknown,
+              'text-green-600': !error,
+              'text-gray-600': error,
             })}
           >
             {critical && (
@@ -51,7 +52,7 @@ function Indicator({
                 className="inline align-bottom fill-red-500"
               />
             )}{' '}
-            {connectionError || unknown ? (
+            {error ? (
               <div>
                 <EOS_ERROR_OUTLINED size="l" className="inline align-bottom" />{' '}
                 {connectionError ? 'SUSE Manager connection failed' : 'Unknown'}

--- a/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
@@ -8,7 +8,15 @@ import {
 
 import Tooltip from '@common/Tooltip';
 
-function Indicator({ title, critical, tooltip, icon, loading, children }) {
+function Indicator({
+  title,
+  critical,
+  tooltip,
+  icon,
+  loading,
+  connectionError,
+  children,
+}) {
   const unknown = children === undefined;
 
   if (loading) {
@@ -49,10 +57,10 @@ function Indicator({ title, critical, tooltip, icon, loading, children }) {
                 className="inline align-bottom fill-red-500"
               />
             )}{' '}
-            {unknown ? (
+            {connectionError || unknown ? (
               <div>
                 <EOS_ERROR_OUTLINED size="l" className="inline align-bottom" />{' '}
-                Unknown
+                {connectionError ? 'SUSE Manager connection failed' : 'Unknown'}
               </div>
             ) : (
               children

--- a/assets/js/common/AvailableSoftwareUpdates/Loading.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/Loading.jsx
@@ -4,7 +4,7 @@ import Spinner from '@common/Spinner';
 
 function Loading({ className }) {
   return (
-    <div className={classNames(className, 'w-full', 'my-4')}>
+    <div className={classNames(className, 'w-full', 'my-4', 'py-8')}>
       <p className="font-bold text-2xl">Available Software Updates</p>
       <Spinner size="xl" />
     </div>

--- a/assets/js/common/AvailableSoftwareUpdates/Loading.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/Loading.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import classNames from 'classnames';
+import Spinner from '@common/Spinner';
+
+function Loading({ className }) {
+  return (
+    <div className={classNames(className, 'w-full', 'my-4')}>
+      <p className="font-bold text-2xl">Available Software Updates</p>
+      <Spinner size="xl" />
+    </div>
+  );
+}
+
+export default Loading;

--- a/assets/js/common/AvailableSoftwareUpdates/SumaNotConfigured.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/SumaNotConfigured.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import classNames from 'classnames';
+import { noop } from 'lodash';
+import { EOS_SETTINGS } from 'eos-icons-react';
+
+import Button from '@common/Button';
+
+function SumaNotConfigured({ className, onBackToSettings = noop }) {
+  return (
+    <div className={classNames(className, 'place-content-between')}>
+      <div>
+        <p className="font-bold text-2xl">Available Software Updates</p>
+
+        <p>
+          SUSE Manager is not configured. Go to Settings to add your SUSE
+          Manager connection credentials.
+        </p>
+      </div>
+
+      <Button
+        type="primary-white-fit"
+        className="inline-block mx-0.5 border-green-500 border"
+        size="small"
+        onClick={onBackToSettings}
+      >
+        <EOS_SETTINGS className="inline-block fill-jungle-green-500" /> Settings
+      </Button>
+    </div>
+  );
+}
+
+export default SumaNotConfigured;

--- a/assets/js/common/AvailableSoftwareUpdates/SumaNotConfigured.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/SumaNotConfigured.jsx
@@ -7,7 +7,14 @@ import Button from '@common/Button';
 
 function SumaNotConfigured({ className, onBackToSettings = noop }) {
   return (
-    <div className={classNames(className, 'place-content-between')}>
+    <div
+      className={classNames(
+        className,
+        'place-content-between',
+        'w-full',
+        'my-4'
+      )}
+    >
       <div>
         <p className="font-bold text-2xl">Available Software Updates</p>
 

--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -1,7 +1,11 @@
 import React, { useState } from 'react';
 import { get } from 'lodash';
 import classNames from 'classnames';
-import { EOS_CLEAR_ALL, EOS_PLAY_CIRCLE, EOS_SETTINGS } from 'eos-icons-react';
+import {
+  EOS_CLEAR_ALL,
+  EOS_PLAY_CIRCLE,
+  EOS_PLAYLIST_ADD_CHECK_FILLED,
+} from 'eos-icons-react';
 
 import { agentVersionWarning } from '@lib/agent';
 
@@ -67,6 +71,8 @@ function HostDetails({
   relevantPatches,
   upgradablePackages,
   softwareUpdatesLoading,
+  softwareUpdatesSettingsSaved,
+  softwareUpdatesConnectionError = false,
   softwareUpdatesTooltip,
   cleanUpHost,
   requestHostChecksExecution,
@@ -141,7 +147,7 @@ function HostDetails({
                 size="small"
                 onClick={() => navigate(`/hosts/${hostID}/settings`)}
               >
-                <EOS_SETTINGS className="inline-block fill-jungle-green-500" />{' '}
+                <EOS_PLAYLIST_ADD_CHECK_FILLED className="inline-block fill-jungle-green-500" />{' '}
                 Check Selection
               </Button>
 
@@ -226,10 +232,13 @@ function HostDetails({
         {suseManagerEnabled && (
           <AvailableSoftwareUpdates
             className="mx-0 my-4"
+            settingsConfigured={softwareUpdatesSettingsSaved}
             relevantPatches={relevantPatches}
             upgradablePackages={upgradablePackages}
             tooltip={softwareUpdatesTooltip}
             loading={softwareUpdatesLoading}
+            connectionError={softwareUpdatesConnectionError}
+            onBackToSettings={() => navigate(`/settings`)}
           />
         )}
         <ChartsFeatureWrapper chartsEnabled={chartsEnabled}>

--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -72,6 +72,7 @@ function HostDetails({
   upgradablePackages,
   softwareUpdatesLoading,
   softwareUpdatesSettingsSaved,
+  softwareUpdatesSettingsLoading,
   softwareUpdatesConnectionError = false,
   softwareUpdatesTooltip,
   cleanUpHost,
@@ -236,7 +237,8 @@ function HostDetails({
             relevantPatches={relevantPatches}
             upgradablePackages={upgradablePackages}
             tooltip={softwareUpdatesTooltip}
-            loading={softwareUpdatesLoading}
+            softwareUpdatesSettingsLoading={softwareUpdatesSettingsLoading}
+            softwareUpdatesLoading={softwareUpdatesLoading}
             connectionError={softwareUpdatesConnectionError}
             onBackToSettings={() => navigate(`/settings`)}
           />

--- a/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
@@ -254,10 +254,10 @@ describe('HostDetails component', () => {
         .closest('div');
 
       expect(
-        within(relevantPatchesElement).getByLabelText('Loading')
+        within(relevantPatchesElement).getByText('Loading...')
       ).toBeVisible();
       expect(
-        within(upgradablePackagesElement).getByLabelText('Loading')
+        within(upgradablePackagesElement).getByText('Loading...')
       ).toBeVisible();
     });
 
@@ -284,10 +284,10 @@ describe('HostDetails component', () => {
         .closest('div');
 
       expect(
-        within(relevantPatchesElement).getByLabelText('Loading')
+        within(relevantPatchesElement).getByText('Loading...')
       ).toBeVisible();
       expect(
-        within(upgradablePackagesElement).getByLabelText('Loading')
+        within(upgradablePackagesElement).getByText('Loading...')
       ).toBeVisible();
     });
   });

--- a/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import 'intersection-observer';
 import '@testing-library/jest-dom';
@@ -253,8 +253,12 @@ describe('HostDetails component', () => {
         .getByText(/Upgradable Packages/)
         .closest('div');
 
-      expect(relevantPatchesElement).toHaveTextContent('Loading');
-      expect(upgradablePackagesElement).toHaveTextContent('Loading');
+      expect(
+        within(relevantPatchesElement).getByLabelText('Loading')
+      ).toBeVisible();
+      expect(
+        within(upgradablePackagesElement).getByLabelText('Loading')
+      ).toBeVisible();
     });
 
     it('should a SUMA software updates when a connection error occurred', () => {
@@ -279,8 +283,12 @@ describe('HostDetails component', () => {
         .getByText(/Upgradable Packages/)
         .closest('div');
 
-      expect(relevantPatchesElement).toHaveTextContent('Loading');
-      expect(upgradablePackagesElement).toHaveTextContent('Loading');
+      expect(
+        within(relevantPatchesElement).getByLabelText('Loading')
+      ).toBeVisible();
+      expect(
+        within(upgradablePackagesElement).getByLabelText('Loading')
+      ).toBeVisible();
     });
   });
 

--- a/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
@@ -185,6 +185,7 @@ describe('HostDetails component', () => {
         <HostDetails
           agentVersion="2.0.0"
           suseManagerEnabled
+          softwareUpdatesSettingsSaved
           relevantPatches={relevantPatches}
           upgradablePackages={upgradablePackages}
         />
@@ -213,6 +214,7 @@ describe('HostDetails component', () => {
         <HostDetails
           agentVersion="2.0.0"
           suseManagerEnabled
+          softwareUpdatesSettingsSaved
           relevantPatches={relevantPatches}
           upgradablePackages={upgradablePackages}
         />
@@ -237,6 +239,33 @@ describe('HostDetails component', () => {
         <HostDetails
           agentVersion="2.0.0"
           suseManagerEnabled
+          softwareUpdatesSettingsSaved
+          softwareUpdatesLoading
+          relevantPatches={relevantPatches}
+          upgradablePackages={upgradablePackages}
+        />
+      );
+
+      const relevantPatchesElement = screen
+        .getByText(/Relevant Patches/)
+        .closest('div');
+      const upgradablePackagesElement = screen
+        .getByText(/Upgradable Packages/)
+        .closest('div');
+
+      expect(relevantPatchesElement).toHaveTextContent('Loading');
+      expect(upgradablePackagesElement).toHaveTextContent('Loading');
+    });
+
+    it('should a SUMA software updates when a connection error occurred', () => {
+      const relevantPatches = faker.number.int(100);
+      const upgradablePackages = faker.number.int(100);
+
+      renderWithRouter(
+        <HostDetails
+          agentVersion="2.0.0"
+          suseManagerEnabled
+          softwareUpdatesSettingsSaved
           softwareUpdatesLoading
           relevantPatches={relevantPatches}
           upgradablePackages={upgradablePackages}

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -12,7 +12,10 @@ import { getClusterByHost } from '@state/selectors/cluster';
 import { getInstancesOnHost } from '@state/selectors/sapSystem';
 import { getCatalog } from '@state/selectors/catalog';
 import { getLastExecution } from '@state/selectors/lastExecutions';
-import { getSoftwareUpdatesSettingsSaved } from '@state/selectors/softwareUpdatesSettings';
+import {
+  getSoftwareUpdatesSettingsLoading,
+  getSoftwareUpdatesSettingsSaved,
+} from '@state/selectors/softwareUpdatesSettings';
 import {
   getSoftwareUpdatesConnectionError,
   getSoftwareUpdates,
@@ -58,6 +61,9 @@ function HostDetailsPage() {
 
   const { loading: softwareUpdatesLoading } = useSelector((state) =>
     getSoftwareUpdates(state)
+  );
+  const softwareUpdatesSettingsLoading = useSelector((state) =>
+    getSoftwareUpdatesSettingsLoading(state)
   );
   const softwareUpdatesConnectionSaved = useSelector((state) =>
     getSoftwareUpdatesSettingsSaved(state)
@@ -121,6 +127,7 @@ function HostDetailsPage() {
       relevantPatches={numRelevantPatches}
       upgradablePackages={numUpgradablePackages}
       softwareUpdatesSettingsSaved={softwareUpdatesConnectionSaved}
+      softwareUpdatesSettingsLoading={softwareUpdatesSettingsLoading}
       softwareUpdatesLoading={softwareUpdatesLoading}
       softwareUpdatesConnectionError={softwareUpdatesConnectionError}
       softwareUpdatesTooltip={

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -12,7 +12,9 @@ import { getClusterByHost } from '@state/selectors/cluster';
 import { getInstancesOnHost } from '@state/selectors/sapSystem';
 import { getCatalog } from '@state/selectors/catalog';
 import { getLastExecution } from '@state/selectors/lastExecutions';
+import { getSoftwareUpdatesSettingsSaved } from '@state/selectors/softwareUpdatesSettings';
 import {
+  getSoftwareUpdatesConnectionError,
   getSoftwareUpdates,
   getSoftwareUpdatesStats,
 } from '@state/selectors/softwareUpdates';
@@ -55,6 +57,12 @@ function HostDetailsPage() {
 
   const { loading: softwareUpdatesLoading } = useSelector((state) =>
     getSoftwareUpdates(state)
+  );
+  const softwareUpdatesConnectionSaved = useSelector((state) =>
+    getSoftwareUpdatesSettingsSaved(state)
+  );
+  const softwareUpdatesConnectionError = useSelector((state) =>
+    getSoftwareUpdatesConnectionError(state)
   );
   const { numRelevantPatches, numUpgradablePackages } = useSelector((state) =>
     getSoftwareUpdatesStats(state, hostID)
@@ -110,7 +118,9 @@ function HostDetailsPage() {
       suseManagerEnabled={suseManagerEnabled}
       relevantPatches={numRelevantPatches}
       upgradablePackages={numUpgradablePackages}
+      softwareUpdatesSettingsSaved={softwareUpdatesConnectionSaved}
       softwareUpdatesLoading={softwareUpdatesLoading}
+      softwareUpdatesConnectionError={softwareUpdatesConnectionError}
       softwareUpdatesTooltip={
         numRelevantPatches === undefined && numUpgradablePackages === undefined
           ? 'SUSE Manager is not available'

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -28,6 +28,7 @@ import {
 } from '@state/lastExecutions';
 
 import { deregisterHost } from '@state/hosts';
+import { fetchSoftwareUpdatesSettings } from '@state/softwareUpdatesSettings';
 import { fetchSoftwareUpdates } from '@state/softwareUpdates';
 import HostDetails from './HostDetails';
 
@@ -88,6 +89,7 @@ function HostDetailsPage() {
     refreshCatalog();
     dispatch(updateLastExecution(hostID));
     dispatch(fetchSoftwareUpdates(hostID));
+    dispatch(fetchSoftwareUpdatesSettings());
   }, []);
 
   if (!host) {

--- a/assets/js/state/sagas/softwareUpdates.js
+++ b/assets/js/state/sagas/softwareUpdates.js
@@ -6,6 +6,7 @@ import {
   FETCH_SOFTWARE_UPDATES,
   startLoadingSoftwareUpdates,
   setSoftwareUpdates,
+  setSoftwareUpdatesConnectionError,
   setEmptySoftwareUpdates,
   setSoftwareUpdatesErrors,
 } from '@state/softwareUpdates';
@@ -18,6 +19,9 @@ export function* fetchSoftwareUpdates({ payload: hostID }) {
     yield put(setSoftwareUpdates({ hostID, ...response.data }));
   } catch (error) {
     yield put(setEmptySoftwareUpdates({ hostID }));
+
+    yield put(setSoftwareUpdatesConnectionError());
+
     const errors = get(error, ['response', 'data'], []);
     yield put(setSoftwareUpdatesErrors(errors));
   }

--- a/assets/js/state/sagas/softwareUpdates.test.js
+++ b/assets/js/state/sagas/softwareUpdates.test.js
@@ -8,6 +8,7 @@ import { networkClient } from '@lib/network';
 import {
   startLoadingSoftwareUpdates,
   setSoftwareUpdates,
+  setSoftwareUpdatesConnectionError,
   setSoftwareUpdatesErrors,
   setEmptySoftwareUpdates,
 } from '@state/softwareUpdates';
@@ -82,6 +83,7 @@ describe('Software Updates saga', () => {
         expect(dispatched).toEqual([
           startLoadingSoftwareUpdates(),
           setEmptySoftwareUpdates({ hostID }),
+          setSoftwareUpdatesConnectionError(),
           setSoftwareUpdatesErrors(body),
         ]);
       }

--- a/assets/js/state/selectors/softwareUpdates.js
+++ b/assets/js/state/selectors/softwareUpdates.js
@@ -2,6 +2,9 @@ import { createSelector } from '@reduxjs/toolkit';
 
 export const getSoftwareUpdates = (state) => state?.softwareUpdates;
 
+export const getSoftwareUpdatesConnectionError = (state) =>
+  state?.softwareUpdates.connectionError;
+
 export const getSoftwareUpdatesForHost = (id) => (state) =>
   state?.softwareUpdates.softwareUpdates[id];
 

--- a/assets/js/state/selectors/softwareUpdates.test.js
+++ b/assets/js/state/selectors/softwareUpdates.test.js
@@ -1,5 +1,9 @@
 import { faker } from '@faker-js/faker';
-import { getSoftwareUpdates, getSoftwareUpdatesStats } from './softwareUpdates';
+import {
+  getSoftwareUpdates,
+  getSoftwareUpdatesConnectionError,
+  getSoftwareUpdatesStats,
+} from './softwareUpdates';
 
 describe('Software Updates selector', () => {
   const hostID = faker.string.uuid();
@@ -115,5 +119,25 @@ describe('Software Updates selector', () => {
       numRelevantPatches: undefined,
       numUpgradablePackages: undefined,
     });
+  });
+
+  it('should return the connection error', () => {
+    const stateWithError = {
+      softwareUpdates: {
+        connectionError: true,
+      },
+    };
+
+    const stateWithoutError = {
+      softwareUpdates: {
+        connectionError: false,
+      },
+    };
+
+    expect(getSoftwareUpdatesConnectionError(stateWithError)).toEqual(true);
+    expect(getSoftwareUpdatesConnectionError(stateWithoutError)).toEqual(false);
+    expect(getSoftwareUpdatesConnectionError({ softwareUpdates: {} })).toEqual(
+      undefined
+    );
   });
 });

--- a/assets/js/state/selectors/softwareUpdatesSettings.js
+++ b/assets/js/state/selectors/softwareUpdatesSettings.js
@@ -19,6 +19,11 @@ export const getSoftwareUpdatesSettings = createSelector(
   })
 );
 
+export const getSoftwareUpdatesSettingsLoading = createSelector(
+  [getSoftwareUpdatesSettings],
+  ({ loading }) => loading
+);
+
 export const getSoftwareUpdatesSettingsSaved = createSelector(
   [getSoftwareUpdatesSettings],
   ({ settings: { url, username } }) => !!(url && username)

--- a/assets/js/state/selectors/softwareUpdatesSettings.js
+++ b/assets/js/state/selectors/softwareUpdatesSettings.js
@@ -19,6 +19,11 @@ export const getSoftwareUpdatesSettings = createSelector(
   })
 );
 
+export const getSoftwareUpdatesSettingsSaved = createSelector(
+  [getSoftwareUpdatesSettings],
+  ({ settings: { url, username } }) => !!(url && username)
+);
+
 export const getSoftwareUpdatesSettingsErrors = createSelector(
   [getSoftwareUpdatesSettings],
   ({ errors }) => errors

--- a/assets/js/state/selectors/softwareUpdatesSettings.test.js
+++ b/assets/js/state/selectors/softwareUpdatesSettings.test.js
@@ -1,36 +1,95 @@
-import { getSoftwareUpdatesSettings } from './softwareUpdatesSettings';
+import {
+  getSoftwareUpdatesSettings,
+  getSoftwareUpdatesSettingsSaved,
+} from './softwareUpdatesSettings';
 
 describe('Software Updates Settings selector', () => {
-  const stateScenarios = [
-    {
-      loading: false,
-      settings: {
-        url: 'https://valid.url',
-        username: 'username',
-        ca_uploaded_at: '2021-01-01T00:00:00Z',
+  describe('get software updates settings', () => {
+    const stateScenarios = [
+      {
+        loading: false,
+        settings: {
+          url: 'https://valid.url',
+          username: 'username',
+          ca_uploaded_at: '2021-01-01T00:00:00Z',
+        },
+        errors: null,
+        editing: false,
       },
-      errors: null,
-      editing: false,
-    },
-    {
-      loading: true,
-      settings: {
-        url: undefined,
-        username: undefined,
-        ca_uploaded_at: undefined,
+      {
+        loading: true,
+        settings: {
+          url: undefined,
+          username: undefined,
+          ca_uploaded_at: undefined,
+        },
+        errors: null,
+        editing: false,
+        testingConnection: false,
       },
-      errors: null,
-      editing: false,
-      testingConnection: false,
-    },
-  ];
+    ];
 
-  it.each(stateScenarios)(
-    'should return the correct catalog state',
-    (softwareUpdatesSettings) => {
-      expect(getSoftwareUpdatesSettings({ softwareUpdatesSettings })).toEqual(
-        softwareUpdatesSettings
-      );
-    }
-  );
+    it.each(stateScenarios)(
+      'should return the correct catalog state',
+      (softwareUpdatesSettings) => {
+        expect(getSoftwareUpdatesSettings({ softwareUpdatesSettings })).toEqual(
+          softwareUpdatesSettings
+        );
+      }
+    );
+  });
+
+  describe('getSoftwareUpdatesSettings', () => {
+    const scenarios = [
+      {
+        state: {
+          loading: false,
+          settings: {
+            url: 'https://valid.url',
+            username: 'username',
+            ca_uploaded_at: '2021-01-01T00:00:00Z',
+          },
+          errors: null,
+          editing: false,
+        },
+        result: true,
+      },
+      {
+        state: {
+          loading: false,
+          settings: {
+            url: 'https://valid.url',
+            username: undefined,
+            ca_uploaded_at: '2021-01-01T00:00:00Z',
+          },
+          errors: null,
+          editing: false,
+        },
+        result: false,
+      },
+      {
+        state: {
+          loading: true,
+          settings: {
+            url: undefined,
+            username: undefined,
+            ca_uploaded_at: undefined,
+          },
+          errors: null,
+          editing: false,
+          testingConnection: false,
+        },
+        result: false,
+      },
+    ];
+
+    it.each(scenarios)(
+      'should return if the software updates settings are saved',
+      ({ state, result }) => {
+        expect(
+          getSoftwareUpdatesSettingsSaved({ softwareUpdatesSettings: state })
+        ).toEqual(result);
+      }
+    );
+  });
 });

--- a/assets/js/state/selectors/softwareUpdatesSettings.test.js
+++ b/assets/js/state/selectors/softwareUpdatesSettings.test.js
@@ -1,5 +1,6 @@
 import {
   getSoftwareUpdatesSettings,
+  getSoftwareUpdatesSettingsLoading,
   getSoftwareUpdatesSettingsSaved,
 } from './softwareUpdatesSettings';
 
@@ -39,7 +40,29 @@ describe('Software Updates Settings selector', () => {
     );
   });
 
-  describe('getSoftwareUpdatesSettings', () => {
+  describe('get software updates settings loading', () => {
+    const scenarios = [
+      {
+        state: { loading: false },
+        result: false,
+      },
+      {
+        state: { loading: true },
+        result: true,
+      },
+    ];
+
+    it.each(scenarios)(
+      'should return if the software updates settings are loading',
+      ({ state, result }) => {
+        expect(
+          getSoftwareUpdatesSettingsLoading({ softwareUpdatesSettings: state })
+        ).toEqual(result);
+      }
+    );
+  });
+
+  describe('get if software updates settings saved', () => {
     const scenarios = [
       {
         state: {
@@ -77,7 +100,6 @@ describe('Software Updates Settings selector', () => {
           },
           errors: null,
           editing: false,
-          testingConnection: false,
         },
         result: false,
       },

--- a/assets/js/state/softwareUpdates.js
+++ b/assets/js/state/softwareUpdates.js
@@ -2,6 +2,7 @@ import { createAction, createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
   loading: false,
+  connectionError: false,
   softwareUpdates: {},
   errors: [],
 };
@@ -18,6 +19,7 @@ export const softwareUpdatesSlice = createSlice({
       { payload: { hostID, relevant_patches, upgradable_packages } }
     ) => {
       state.loading = false;
+      state.connectionError = false;
 
       state.softwareUpdates = {
         ...state.softwareUpdates,
@@ -26,6 +28,9 @@ export const softwareUpdatesSlice = createSlice({
           upgradable_packages,
         },
       };
+    },
+    setSoftwareUpdatesConnectionError: (state) => {
+      state.connectionError = true;
     },
     setEmptySoftwareUpdates: (state, { payload: { hostID } }) => {
       state.loading = false;
@@ -45,6 +50,7 @@ export const fetchSoftwareUpdates = createAction(FETCH_SOFTWARE_UPDATES);
 export const {
   startLoadingSoftwareUpdates,
   setSoftwareUpdates,
+  setSoftwareUpdatesConnectionError,
   setEmptySoftwareUpdates,
   setSoftwareUpdatesErrors,
 } = softwareUpdatesSlice.actions;

--- a/assets/js/state/softwareUpdates.test.js
+++ b/assets/js/state/softwareUpdates.test.js
@@ -3,6 +3,7 @@ import { faker } from '@faker-js/faker';
 import softwareUpdatesReducer, {
   startLoadingSoftwareUpdates,
   setSoftwareUpdates,
+  setSoftwareUpdatesConnectionError,
   setEmptySoftwareUpdates,
   setSoftwareUpdatesErrors,
 } from './softwareUpdates';
@@ -101,6 +102,7 @@ describe('SoftwareUpdates reducer', () => {
 
     expect(actual).toEqual({
       loading: false,
+      connectionError: false,
       softwareUpdates: {
         [host1]: { relevant_patches: [], upgradable_packages: [] },
         [host2]: newSoftwareUpdates,
@@ -147,6 +149,21 @@ describe('SoftwareUpdates reducer', () => {
       },
       errors: [],
     });
+  });
+
+  it('should set connection error when error occurs', () => {
+    const initialState = {
+      loading: true,
+      connectionError: false,
+      softwareUpdates: {},
+      errors: [],
+    };
+
+    const action = setSoftwareUpdatesConnectionError();
+
+    const actual = softwareUpdatesReducer(initialState, action);
+
+    expect(actual).toEqual({ ...initialState, connectionError: true });
   });
 
   it('should set errors upon if error occurred', () => {


### PR DESCRIPTION
# Description

This PR extends error handling for the `AvailableSoftwareUpdates` component.

On initial load, the Host Details page will display a loading spinner while the software updates settings are being retrieved.

![image](https://github.com/trento-project/web/assets/113615552/cfb1a8c9-cc86-445f-9e17-91eaaf6219a2)

If once the response is received, no SUSE Manager settings are saved, display the following to the user:

![image](https://github.com/trento-project/web/assets/113615552/ef6f4e26-e7c8-438a-9d3b-775c96d2658f)

If some SUSE Manager settings have been saved, we enter the second loading state:

![image](https://github.com/trento-project/web/assets/113615552/1ec9c38a-9adc-425a-8149-92ac0a6c054c)

If we get _any_ error response from SUSE Manager, we display it to the user as follows:

![image](https://github.com/trento-project/web/assets/113615552/4e490a3c-08bf-4ebf-ba14-706855ab77b9)

Finally, there is a catch-all _unknown_ state. Where if for some reason we receive a `2XX` response but there is no data in the response, we display the following:

![image](https://github.com/trento-project/web/assets/113615552/16fac67a-efb1-4ec5-8c64-9b400f072c1b)


## How was this tested?

Added unit tests for the new states
