### PR TITLE
Track software update discoveries

### DIFF
--- a/lib/trento/infrastructure/commanded/event_handlers/software_updates_discovery_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/software_updates_discovery_event_handler.ex
@@ -8,7 +8,10 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SoftwareUpdatesDiscovery
     application: Trento.Commanded,
     name: "software_updates_discovery_event_handler"
 
-  alias Trento.Hosts.Events.SoftwareUpdatesDiscoveryRequested
+  alias Trento.Hosts.Events.{
+    SoftwareUpdatesDiscoveryCleared,
+    SoftwareUpdatesDiscoveryRequested
+  }
 
   alias Trento.SoftwareUpdates.Discovery
 
@@ -23,4 +26,12 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SoftwareUpdatesDiscovery
 
     :ok
   end
+
+  def handle(
+        %SoftwareUpdatesDiscoveryCleared{
+          host_id: host_id
+        },
+        _
+      ),
+      do: Discovery.clear_tracked_discovery_result(host_id)
 end

--- a/lib/trento/software_updates/discovery.ex
+++ b/lib/trento/software_updates/discovery.ex
@@ -3,6 +3,10 @@ defmodule Trento.SoftwareUpdates.Discovery do
   Software updates integration service
   """
 
+  alias Trento.Repo
+
+  alias Ecto.Multi
+
   alias Trento.Hosts
 
   alias Trento.Hosts.Commands.{
@@ -11,6 +15,7 @@ defmodule Trento.SoftwareUpdates.Discovery do
   }
 
   alias Trento.Hosts.Projections.HostReadModel
+  alias Trento.SoftwareUpdates.Discovery.DiscoveryResult
 
   require Trento.SoftwareUpdates.Enums.SoftwareUpdatesHealth, as: SoftwareUpdatesHealth
   require Trento.SoftwareUpdates.Enums.AdvisoryType, as: AdvisoryType
@@ -49,12 +54,12 @@ defmodule Trento.SoftwareUpdates.Discovery do
            {:error, error} ->
              {:error, host_id, error}
 
-           {:ok, _, _, _} = success ->
+           {:ok, _, _, _, _} = success ->
              success
          end
      end)
      |> Enum.split_with(fn
-       {:ok, _, _, _} -> true
+       {:ok, _, _, _, _} -> true
        _ -> false
      end)}
   end
@@ -75,7 +80,7 @@ defmodule Trento.SoftwareUpdates.Discovery do
   end
 
   @spec discover_host_software_updates(String.t(), String.t()) ::
-          {:ok, String.t(), String.t(), any()} | {:error, any()}
+          {:ok, String.t(), String.t(), any(), any()} | {:error, any()}
   def discover_host_software_updates(host_id, nil) do
     Logger.info("Host #{host_id} does not have an fqdn. Skipping software updates discovery")
     {:error, :host_without_fqdn}
@@ -84,11 +89,9 @@ defmodule Trento.SoftwareUpdates.Discovery do
   def discover_host_software_updates(host_id, fully_qualified_domain_name) do
     with {:ok, system_id} <- get_system_id(fully_qualified_domain_name),
          {:ok, relevant_patches} <- get_relevant_patches(system_id),
-         :ok <-
-           host_id
-           |> build_discovery_completion_command(relevant_patches)
-           |> commanded().dispatch() do
-      {:ok, host_id, system_id, relevant_patches}
+         {:ok, upgradable_packages} <- get_upgradable_packages(system_id),
+         {:ok, _} <- finalize_discovery(host_id, system_id, relevant_patches, upgradable_packages) do
+      {:ok, host_id, system_id, relevant_patches, upgradable_packages}
     else
       {:error, :settings_not_configured} ->
         {:error, :settings_not_configured}
@@ -98,12 +101,7 @@ defmodule Trento.SoftwareUpdates.Discovery do
           "An error occurred during software updates discovery for host #{host_id}:  #{inspect(error)}"
         )
 
-        commanded().dispatch(
-          CompleteSoftwareUpdatesDiscovery.new!(%{
-            host_id: host_id,
-            health: SoftwareUpdatesHealth.unknown()
-          })
-        )
+        dispatch_completion_command(host_id, SoftwareUpdatesHealth.unknown())
 
         {:error, discovery_error}
     end
@@ -112,29 +110,69 @@ defmodule Trento.SoftwareUpdates.Discovery do
   defp discover_host_software_updates(_, _, {:error, :settings_not_configured} = error),
     do: error
 
-  defp discover_host_software_updates(host_id, _, {:error, error}) do
-    commanded().dispatch(
-      CompleteSoftwareUpdatesDiscovery.new!(%{
-        host_id: host_id,
-        health: SoftwareUpdatesHealth.unknown()
-      })
-    )
-
-    {:error, error}
+  defp discover_host_software_updates(host_id, _, {:error, _} = error) do
+    dispatch_completion_command(host_id, SoftwareUpdatesHealth.unknown())
+    error
   end
 
   defp discover_host_software_updates(host_id, fully_qualified_domain_name, _),
     do: discover_host_software_updates(host_id, fully_qualified_domain_name)
 
-  defp build_discovery_completion_command(host_id, relevant_patches),
-    do:
-      CompleteSoftwareUpdatesDiscovery.new!(%{
+  defp finalize_discovery(host_id, system_id, relevant_patches, upgradable_packages) do
+    discovery_result =
+      DiscoveryResult.changeset(%DiscoveryResult{}, %{
         host_id: host_id,
-        health:
+        system_id: "#{system_id}",
+        relevant_patches: relevant_patches,
+        upgradable_packages: upgradable_packages
+      })
+
+    transaction_result =
+      Multi.new()
+      |> Multi.insert(:insert, discovery_result,
+        conflict_target: :host_id,
+        on_conflict: :replace_all
+      )
+      |> Multi.run(:command_dispatching, fn _, _ ->
+        discovered_health =
           relevant_patches
           |> track_relevant_patches
           |> compute_software_updates_discovery_health
-      })
+
+        dispatch_completion_command(host_id, discovered_health)
+      end)
+      |> Repo.transaction()
+
+    case transaction_result do
+      {:ok, _} = success ->
+        success
+
+      {:error, :command_dispatching, dispatching_error, _} ->
+        {:error, dispatching_error}
+
+      {:error, _} = error ->
+        Logger.error(
+          "Error while finalizing software updates discovery for host #{host_id}, error: #{inspect(error)}"
+        )
+
+        error
+    end
+  end
+
+  defp dispatch_completion_command(host_id, discovered_health) do
+    case %{
+           host_id: host_id,
+           health: discovered_health
+         }
+         |> CompleteSoftwareUpdatesDiscovery.new!()
+         |> commanded().dispatch() do
+      :ok ->
+        {:ok, :dispatched}
+
+      {:error, _} = error ->
+        error
+    end
+  end
 
   defp track_relevant_patches(relevant_patches),
     do:

--- a/lib/trento/software_updates/discovery.ex
+++ b/lib/trento/software_updates/discovery.ex
@@ -3,6 +3,8 @@ defmodule Trento.SoftwareUpdates.Discovery do
   Software updates integration service
   """
 
+  import Ecto.Query
+
   alias Trento.Repo
 
   alias Ecto.Multi
@@ -76,6 +78,12 @@ defmodule Trento.SoftwareUpdates.Discovery do
 
     clear()
 
+    :ok
+  end
+
+  @spec clear_tracked_discovery_result(String.t()) :: :ok
+  def clear_tracked_discovery_result(host_id) do
+    Repo.delete_all(from d in DiscoveryResult, where: d.host_id == ^host_id)
     :ok
   end
 

--- a/lib/trento/software_updates/discovery.ex
+++ b/lib/trento/software_updates/discovery.ex
@@ -125,7 +125,7 @@ defmodule Trento.SoftwareUpdates.Discovery do
     do: error
 
   defp discover_host_software_updates(host_id, _, {:error, _} = error) do
-    dispatch_completion_command(host_id, SoftwareUpdatesHealth.unknown())
+    finalize_failed_discovery(host_id, error)
     error
   end
 

--- a/lib/trento/software_updates/discovery/discovery_result.ex
+++ b/lib/trento/software_updates/discovery/discovery_result.ex
@@ -1,0 +1,22 @@
+defmodule Trento.SoftwareUpdates.Discovery.DiscoveryResult do
+  @moduledoc """
+  This is the schema used to store the results of the software updates discovery process.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:host_id, :binary_id, autogenerate: false}
+  schema "software_updates_discovery_result" do
+    field :system_id, :string
+    field :relevant_patches, Trento.Support.Ecto.Payload
+    field :upgradable_packages, Trento.Support.Ecto.Payload
+    field :failure_reason, :string
+
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  def changeset(discovery_result, attrs) do
+    cast(discovery_result, attrs, __MODULE__.__schema__(:fields))
+  end
+end

--- a/priv/repo/migrations/20240422105737_create_software_updates_discovery_result.exs
+++ b/priv/repo/migrations/20240422105737_create_software_updates_discovery_result.exs
@@ -1,0 +1,15 @@
+defmodule Trento.Repo.Migrations.CreateSoftwareUpdatesDiscoveryResult do
+  use Ecto.Migration
+
+  def change do
+    create table(:software_updates_discovery_result, primary_key: false) do
+      add :host_id, :uuid, primary_key: true
+      add :system_id, :string
+      add :relevant_patches, :map
+      add :upgradable_packages, :map
+      add :failure_reason, :string
+
+      timestamps(type: :utc_datetime_usec)
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -40,6 +40,7 @@ defmodule Trento.Factory do
     HostTombstoned,
     SaptuneStatusUpdated,
     SlesSubscriptionsUpdated,
+    SoftwareUpdatesDiscoveryCleared,
     SoftwareUpdatesDiscoveryRequested,
     SoftwareUpdatesHealthChanged
   }
@@ -114,6 +115,7 @@ defmodule Trento.Factory do
     DiscoveryEvent
   }
 
+  alias Trento.SoftwareUpdates.Discovery.DiscoveryResult
   alias Trento.SoftwareUpdates.Settings
 
   alias Trento.Settings.{
@@ -805,6 +807,12 @@ defmodule Trento.Factory do
     }
   end
 
+  def software_updates_discovery_cleared_event_factory do
+    SoftwareUpdatesDiscoveryCleared.new!(%{
+      host_id: Faker.UUID.v4()
+    })
+  end
+
   def host_health_changed_event_factory do
     HostHealthChanged.new!(%{
       host_id: Faker.UUID.v4(),
@@ -882,6 +890,16 @@ defmodule Trento.Factory do
       to_release: "#{RandomElixir.random_between(0, 100)}",
       to_epoch: "#{RandomElixir.random_between(0, 50)}",
       to_package_id: "#{RandomElixir.random_between(0, 1000)}"
+    }
+  end
+
+  def software_updates_discovery_result_factory do
+    %DiscoveryResult{
+      host_id: Faker.UUID.v4(),
+      system_id: Faker.UUID.v4(),
+      relevant_patches: build_list(2, :relevant_patch),
+      upgradable_packages: build_list(2, :upgradable_package),
+      failure_reason: Faker.Lorem.word()
     }
   end
 end

--- a/test/trento/infrastructure/commanded/event_handlers/software_updates_discovery_event_handler_test.exs
+++ b/test/trento/infrastructure/commanded/event_handlers/software_updates_discovery_event_handler_test.exs
@@ -1,5 +1,5 @@
 defmodule Trento.Infrastructure.Commanded.EventHandlers.SoftwareUpdatesDiscoveryEventHandlerTest do
-  use ExUnit.Case
+  use Trento.DataCase
 
   import Mox
   import Trento.Factory
@@ -36,6 +36,12 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SoftwareUpdatesDiscovery
     )
 
     expect(
+      SoftwareUpdatesDiscoveryMock,
+      :get_upgradable_packages,
+      fn ^system_id -> {:ok, []} end
+    )
+
+    expect(
       Trento.Commanded.Mock,
       :dispatch,
       fn %CompleteSoftwareUpdatesDiscovery{host_id: ^host_id} -> :ok end
@@ -58,6 +64,13 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SoftwareUpdatesDiscovery
     expect(
       SoftwareUpdatesDiscoveryMock,
       :get_relevant_patches,
+      0,
+      fn _ -> :ok end
+    )
+
+    expect(
+      SoftwareUpdatesDiscoveryMock,
+      :get_upgradable_packages,
       0,
       fn _ -> :ok end
     )

--- a/test/trento/software_updates/discovery_test.exs
+++ b/test/trento/software_updates/discovery_test.exs
@@ -278,7 +278,7 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
         assert {:error, host_id, :auth_error} in errored_discoveries
       end)
 
-      assert 0 ==
+      assert 2 ==
                DiscoveryResult
                |> Trento.Repo.all()
                |> length()

--- a/test/trento/software_updates/discovery_test.exs
+++ b/test/trento/software_updates/discovery_test.exs
@@ -584,6 +584,39 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
 
       assert :ok = Discovery.clear_software_updates_discoveries()
     end
+
+    test "should clear a previously tracked software updates discovery result" do
+      %{host_id: host_id} = insert(:software_updates_discovery_result)
+      insert_list(4, :software_updates_discovery_result)
+
+      assert %DiscoveryResult{host_id: ^host_id} = Trento.Repo.get(DiscoveryResult, host_id)
+
+      assert :ok == Discovery.clear_tracked_discovery_result(host_id)
+
+      assert nil == Trento.Repo.get(DiscoveryResult, host_id)
+
+      assert 4 ==
+               DiscoveryResult
+               |> Trento.Repo.all()
+               |> length()
+    end
+
+    test "should ignore not tracked software updates discovery results" do
+      insert_list(4, :software_updates_discovery_result)
+
+      host_id = Faker.UUID.v4()
+
+      assert nil == Trento.Repo.get(DiscoveryResult, host_id)
+
+      assert :ok == Discovery.clear_tracked_discovery_result(host_id)
+
+      assert nil == Trento.Repo.get(DiscoveryResult, host_id)
+
+      assert 4 ==
+               DiscoveryResult
+               |> Trento.Repo.all()
+               |> length()
+    end
   end
 
   defp fail_on_getting_system_id(host_id, fully_qualified_domain_name, discovery_error) do

--- a/test/trento/software_updates/discovery_test.exs
+++ b/test/trento/software_updates/discovery_test.exs
@@ -12,6 +12,7 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
   }
 
   alias Trento.SoftwareUpdates.Discovery
+  alias Trento.SoftwareUpdates.Discovery.DiscoveryResult
   alias Trento.SoftwareUpdates.Discovery.Mock, as: SoftwareUpdatesDiscoveryMock
 
   require Trento.SoftwareUpdates.Enums.AdvisoryType, as: AdvisoryType
@@ -20,57 +21,87 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
   setup :verify_on_exit!
 
   describe "Discovering software updates for a specific host" do
-    test "should return an error when a null FQDN is provided" do
-      host_id = Faker.UUID.v4()
+    test "should handle failures and not track discovery result" do
+      scenarios = [
+        %{
+          name: "should return an error when a null FQDN is provided",
+          host_id: Faker.UUID.v4(),
+          fully_qualified_domain_name: nil,
+          expected_error: :host_without_fqdn
+        },
+        %{
+          name: "should handle failure when getting host's system id",
+          host_id: Faker.UUID.v4(),
+          fully_qualified_domain_name: Faker.Internet.domain_name(),
+          failure_setup: fn scenario ->
+            fail_on_getting_system_id(
+              scenario.host_id,
+              scenario.fully_qualified_domain_name,
+              scenario.expected_error
+            )
+          end,
+          expected_error: :some_error_while_getting_system_id
+        },
+        %{
+          name: "should handle failure when getting relevant patches",
+          host_id: Faker.UUID.v4(),
+          fully_qualified_domain_name: Faker.Internet.domain_name(),
+          failure_setup: fn scenario ->
+            fail_on_getting_relevant_patches(
+              scenario.host_id,
+              scenario.fully_qualified_domain_name,
+              100,
+              scenario.expected_error
+            )
+          end,
+          expected_error: :some_error_while_getting_relevant_patches
+        },
+        %{
+          name: "should handle failure when getting upgradable packages",
+          host_id: Faker.UUID.v4(),
+          fully_qualified_domain_name: Faker.Internet.domain_name(),
+          failure_setup: fn scenario ->
+            fail_on_getting_upgradable_packages(
+              scenario.host_id,
+              scenario.fully_qualified_domain_name,
+              100,
+              scenario.expected_error
+            )
+          end,
+          expected_error: :some_error_while_getting_relevant_patches
+        },
+        %{
+          name: "should handle failure when dispatching discovery completion command",
+          host_id: Faker.UUID.v4(),
+          fully_qualified_domain_name: Faker.Internet.domain_name(),
+          failure_setup: fn scenario ->
+            fail_on_dispatching_completion_command(
+              scenario.host_id,
+              scenario.fully_qualified_domain_name,
+              100,
+              scenario.expected_error
+            )
+          end,
+          expected_error: :error_while_dispatching_completion_command
+        }
+      ]
 
-      assert {:error, :host_without_fqdn} =
-               Discovery.discover_host_software_updates(host_id, nil)
-    end
+      for %{
+            host_id: host_id,
+            fully_qualified_domain_name: fully_qualified_domain_name,
+            expected_error: expected_error
+          } = scenario <- scenarios do
+        failure_setup = Map.get(scenario, :failure_setup, fn _ -> nil end)
+        failure_setup.(scenario)
 
-    test "should handle failure when getting host's system id" do
-      host_id = Faker.UUID.v4()
-      fully_qualified_domain_name = Faker.Internet.domain_name()
+        {:error, ^expected_error} =
+          Discovery.discover_host_software_updates(host_id, fully_qualified_domain_name)
 
-      discovery_error = :some_error_while_getting_system_id
-
-      fail_on_getting_system_id(host_id, fully_qualified_domain_name, discovery_error)
-
-      {:error, ^discovery_error} =
-        Discovery.discover_host_software_updates(host_id, fully_qualified_domain_name)
-    end
-
-    test "should handle failure when getting relevant patches" do
-      host_id = Faker.UUID.v4()
-      fully_qualified_domain_name = Faker.Internet.domain_name()
-      system_id = 100
-      discovery_error = :some_error_while_getting_relevant_patches
-
-      fail_on_getting_relevant_patches(
-        host_id,
-        fully_qualified_domain_name,
-        system_id,
-        discovery_error
-      )
-
-      {:error, ^discovery_error} =
-        Discovery.discover_host_software_updates(host_id, fully_qualified_domain_name)
-    end
-
-    test "should handle failure when dispatching discovery completion command" do
-      host_id = Faker.UUID.v4()
-      fully_qualified_domain_name = Faker.Internet.domain_name()
-      system_id = 100
-      dispatching_error = :error_while_dispatching_completion_command
-
-      fail_on_dispatching_completion_command(
-        host_id,
-        fully_qualified_domain_name,
-        system_id,
-        dispatching_error
-      )
-
-      {:error, ^dispatching_error} =
-        Discovery.discover_host_software_updates(host_id, fully_qualified_domain_name)
+        assert 0 ==
+                 DiscoveryResult
+                 |> Trento.Repo.all()
+                 |> length()
+      end
     end
 
     test "should handle failure when SUMA settings are not configured" do
@@ -105,6 +136,7 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
             %{advisory_type: AdvisoryType.bugfix()},
             %{advisory_type: AdvisoryType.enhancement()}
           ],
+          discovered_upgradable_packages: build_list(3, :upgradable_package),
           expected_health: SoftwareUpdatesHealth.critical()
         },
         %{
@@ -112,31 +144,37 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
             %{advisory_type: AdvisoryType.bugfix()},
             %{advisory_type: AdvisoryType.enhancement()}
           ],
+          discovered_upgradable_packages: build_list(3, :upgradable_package),
           expected_health: SoftwareUpdatesHealth.warning()
         },
         %{
           discovered_relevant_patches: [
             %{advisory_type: AdvisoryType.enhancement()}
           ],
+          discovered_upgradable_packages: [],
           expected_health: SoftwareUpdatesHealth.warning()
         },
         %{
           discovered_relevant_patches: [
             %{advisory_type: AdvisoryType.bugfix()}
           ],
+          discovered_upgradable_packages: build_list(3, :upgradable_package),
           expected_health: SoftwareUpdatesHealth.warning()
         },
         %{
           discovered_relevant_patches: [],
+          discovered_upgradable_packages: build_list(3, :upgradable_package),
           expected_health: SoftwareUpdatesHealth.passing()
         }
       ]
 
       for %{
             discovered_relevant_patches: discovered_relevant_patches,
+            discovered_upgradable_packages: discovered_upgradable_packages,
             expected_health: expected_health
           } <- scenarios do
         host_id = Faker.UUID.v4()
+
         fully_qualified_domain_name = Faker.Internet.domain_name()
         system_id = 100
 
@@ -153,6 +191,12 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
         )
 
         expect(
+          SoftwareUpdatesDiscoveryMock,
+          :get_upgradable_packages,
+          fn ^system_id -> {:ok, discovered_upgradable_packages} end
+        )
+
+        expect(
           Trento.Commanded.Mock,
           :dispatch,
           fn %CompleteSoftwareUpdatesDiscovery{
@@ -163,8 +207,23 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
           end
         )
 
-        {:ok, ^host_id, ^system_id, ^discovered_relevant_patches} =
+        {:ok, ^host_id, ^system_id, ^discovered_relevant_patches, ^discovered_upgradable_packages} =
           Discovery.discover_host_software_updates(host_id, fully_qualified_domain_name)
+
+        stored_discovered_relevant_patches = to_stored_representation(discovered_relevant_patches)
+
+        stored_discovered_upgradable_packages =
+          to_stored_representation(discovered_upgradable_packages)
+
+        stored_system_id = "#{system_id}"
+
+        assert %DiscoveryResult{
+                 host_id: ^host_id,
+                 system_id: ^stored_system_id,
+                 relevant_patches: ^stored_discovered_relevant_patches,
+                 upgradable_packages: ^stored_discovered_upgradable_packages,
+                 failure_reason: nil
+               } = Trento.Repo.get(DiscoveryResult, host_id)
       end
     end
   end
@@ -174,6 +233,11 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
       expect(SoftwareUpdatesDiscoveryMock, :setup, fn -> :ok end)
 
       assert {:ok, {[], []}} = Discovery.discover_software_updates()
+
+      assert 0 ==
+               DiscoveryResult
+               |> Trento.Repo.all()
+               |> length()
     end
 
     test "should handle authentication error" do
@@ -205,6 +269,11 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
       Enum.each([host_id1, host_id2], fn host_id ->
         assert {:error, host_id, :auth_error} in errored_discoveries
       end)
+
+      assert 0 ==
+               DiscoveryResult
+               |> Trento.Repo.all()
+               |> length()
     end
 
     test "should handle SUMA settings not configured error" do
@@ -239,6 +308,11 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
       Enum.each([host_id1, host_id2], fn host_id ->
         assert {:error, host_id, :host_without_fqdn} in errored_discoveries
       end)
+
+      assert 0 ==
+               DiscoveryResult
+               |> Trento.Repo.all()
+               |> length()
     end
 
     test "should handle errors when getting a system id" do
@@ -253,6 +327,11 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
       {:ok, {[], errored_discoveries}} = Discovery.discover_software_updates()
 
       assert {:error, host_id, discovery_error} in errored_discoveries
+
+      assert 0 ==
+               DiscoveryResult
+               |> Trento.Repo.all()
+               |> length()
     end
 
     test "should handle errors when getting relevant patches" do
@@ -273,6 +352,36 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
       {:ok, {[], errored_discoveries}} = Discovery.discover_software_updates()
 
       assert {:error, host_id, discovery_error} in errored_discoveries
+
+      assert 0 ==
+               DiscoveryResult
+               |> Trento.Repo.all()
+               |> length()
+    end
+
+    test "should handle errors when getting upgradable packages" do
+      expect(SoftwareUpdatesDiscoveryMock, :setup, fn -> :ok end)
+
+      %{id: host_id, fully_qualified_domain_name: fully_qualified_domain_name} = insert(:host)
+
+      system_id = 100
+      discovery_error = {:error, :some_error_while_getting_upgradable_packages}
+
+      fail_on_getting_upgradable_packages(
+        host_id,
+        fully_qualified_domain_name,
+        system_id,
+        discovery_error
+      )
+
+      {:ok, {[], errored_discoveries}} = Discovery.discover_software_updates()
+
+      assert {:error, host_id, discovery_error} in errored_discoveries
+
+      assert 0 ==
+               DiscoveryResult
+               |> Trento.Repo.all()
+               |> length()
     end
 
     test "should handle errors when dispatching discovery completion command" do
@@ -294,6 +403,11 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
       {:ok, {[], errored_discoveries}} = Discovery.discover_software_updates()
 
       assert {:error, host_id, dispatching_error} in errored_discoveries
+
+      assert 0 ==
+               DiscoveryResult
+               |> Trento.Repo.all()
+               |> length()
     end
 
     test "should complete discovery" do
@@ -368,6 +482,15 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
         end
       )
 
+      upgradable_packages = build_list(3, :upgradable_package)
+
+      expect(
+        SoftwareUpdatesDiscoveryMock,
+        :get_upgradable_packages,
+        2,
+        fn _ -> {:ok, upgradable_packages} end
+      )
+
       expect(
         Trento.Commanded.Mock,
         :dispatch,
@@ -386,13 +509,31 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
       assert length(errored_discoveries) == 2
 
       assert [
-               {:ok, host_id1, system_id1, discovered_relevant_patches},
-               {:ok, host_id3, system_id3, discovered_relevant_patches}
+               {:ok, host_id1, system_id1, discovered_relevant_patches, upgradable_packages},
+               {:ok, host_id3, system_id3, discovered_relevant_patches, upgradable_packages}
              ] ==
                successful_discoveries
 
       assert {:error, host_id2, :some_error} in errored_discoveries
       assert {:error, host_id4, :host_without_fqdn} in errored_discoveries
+
+      assert 2 ==
+               DiscoveryResult
+               |> Trento.Repo.all()
+               |> length()
+
+      assert nil == Trento.Repo.get(DiscoveryResult, host_id2)
+      assert nil == Trento.Repo.get(DiscoveryResult, host_id4)
+
+      assert %DiscoveryResult{
+               host_id: ^host_id1,
+               failure_reason: nil
+             } = Trento.Repo.get(DiscoveryResult, host_id1)
+
+      assert %DiscoveryResult{
+               host_id: ^host_id3,
+               failure_reason: nil
+             } = Trento.Repo.get(DiscoveryResult, host_id3)
     end
   end
 
@@ -443,6 +584,13 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
     )
 
     expect(
+      SoftwareUpdatesDiscoveryMock,
+      :get_upgradable_packages,
+      0,
+      fn _ -> :ok end
+    )
+
+    expect(
       Trento.Commanded.Mock,
       :dispatch,
       fn %CompleteSoftwareUpdatesDiscovery{
@@ -470,6 +618,49 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
       SoftwareUpdatesDiscoveryMock,
       :get_relevant_patches,
       fn ^system_id -> {:error, discovery_error} end
+    )
+
+    expect(
+      SoftwareUpdatesDiscoveryMock,
+      :get_upgradable_packages,
+      0,
+      fn _ -> :ok end
+    )
+
+    expect(
+      Trento.Commanded.Mock,
+      :dispatch,
+      fn %CompleteSoftwareUpdatesDiscovery{
+           host_id: ^host_id,
+           health: SoftwareUpdatesHealth.unknown()
+         } ->
+        :ok
+      end
+    )
+  end
+
+  defp fail_on_getting_upgradable_packages(
+         host_id,
+         fully_qualified_domain_name,
+         system_id,
+         discovery_error
+       ) do
+    expect(
+      SoftwareUpdatesDiscoveryMock,
+      :get_system_id,
+      fn ^fully_qualified_domain_name -> {:ok, system_id} end
+    )
+
+    expect(
+      SoftwareUpdatesDiscoveryMock,
+      :get_relevant_patches,
+      fn ^system_id -> {:ok, [%{advisory_type: AdvisoryType.security_advisory()}]} end
+    )
+
+    expect(
+      SoftwareUpdatesDiscoveryMock,
+      :get_upgradable_packages,
+      fn _ -> {:error, discovery_error} end
     )
 
     expect(
@@ -503,6 +694,12 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
     )
 
     expect(
+      SoftwareUpdatesDiscoveryMock,
+      :get_upgradable_packages,
+      fn _ -> {:ok, build_list(3, :upgradable_package)} end
+    )
+
+    expect(
       Trento.Commanded.Mock,
       :dispatch,
       fn %CompleteSoftwareUpdatesDiscovery{
@@ -523,5 +720,11 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
         :ok
       end
     )
+  end
+
+  defp to_stored_representation(map_with_atoms) do
+    map_with_atoms
+    |> Jason.encode!()
+    |> Jason.decode!()
   end
 end


### PR DESCRIPTION
# Description

This PR introduces tracking of software updates discovery results.

- on a successful discovery `relevant_patches` and `upgradable_packages` of a host are tracked
- on a failed discovery the `failure reason` is tracked (issues when authenticating/system id retrieval/relevant patches retrieval/upgradable packages retrieval)
- on clear up, relevant previously tracked discoveries are removed

Note that there can be at most one tracked discovery per host, that gets replaced by newer discoveries.

What's next: the tracked discoveries can be queried in `/hosts/:host_id/software_updates` and possibly later also on overviews.

## How was this tested?

Automated tests and manually.