### PR TITLE
Listening to user related events on the frontend

### DIFF
--- a/assets/js/lib/network/socket.js
+++ b/assets/js/lib/network/socket.js
@@ -2,7 +2,12 @@
 // eslint-disable-next-line
 import { Socket } from 'phoenix';
 import { logMessage, logError } from '@lib/log';
-import { getAccessTokenFromStore } from '@lib/auth';
+import {
+  getAccessTokenFromStore,
+  getRefreshTokenFromStore,
+  refreshAccessToken,
+  storeAccessToken,
+} from '@lib/auth';
 
 export const joinChannel = (channel) => {
   channel
@@ -12,9 +17,32 @@ export const joinChannel = (channel) => {
     .receive('timeout', () => logMessage('Networking issue. Still waiting...'));
 };
 
+const refreshAuthTokenForSocket = async () => {
+  const refreshToken = getRefreshTokenFromStore();
+  if (!refreshToken) {
+    logError(
+      'could not refresh the access token for websockets, refresh token not found'
+    );
+    throw new Error('could not refresh access token for websocket connection');
+  }
+
+  const {
+    data: { access_token: accessToken },
+  } = await refreshAccessToken(refreshToken);
+  storeAccessToken(accessToken);
+};
+
+const getWebsocketParams = () => ({
+  access_token: getAccessTokenFromStore(),
+});
+
 export const initSocketConnection = () => {
   const socket = new Socket('/socket', {
-    params: { access_token: getAccessTokenFromStore() },
+    params: () => getWebsocketParams(),
+  });
+  socket.onError(async () => {
+    logMessage('socket error try to refresh access token before reconnecting');
+    await refreshAuthTokenForSocket();
   });
   socket.connect();
 

--- a/assets/js/lib/network/socket.js
+++ b/assets/js/lib/network/socket.js
@@ -41,7 +41,9 @@ export const initSocketConnection = () => {
     params: () => getWebsocketParams(),
   });
   socket.onError(async () => {
-    logMessage('socket error try to refresh access token before reconnecting');
+    logMessage(
+      'socket error. trying to refresh the access token before reconnecting'
+    );
     await refreshAuthTokenForSocket();
   });
   socket.connect();

--- a/assets/js/pages/Guard/Guard.jsx
+++ b/assets/js/pages/Guard/Guard.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Outlet, useNavigate } from 'react-router-dom';
-import { setUserAsLogged } from '@state/user';
+import { setUserAsLogged, setUser as setUserInState } from '@state/user';
 import { clearCredentialsFromStore } from '@lib/auth';
 
 export default function Guard({ redirectPath, getUser }) {
@@ -15,6 +15,7 @@ export default function Guard({ redirectPath, getUser }) {
     getUser()
       .then((trentoUser) => {
         setUser(trentoUser);
+        dispatch(setUserInState(trentoUser));
         setUserLoading(false);
         // If the user in the store is already loggedIn, means
         // that the store is hydrated so the guard is triggered on the spa full loaded

--- a/assets/js/pages/Guard/Guard.test.jsx
+++ b/assets/js/pages/Guard/Guard.test.jsx
@@ -7,6 +7,7 @@ import { act } from 'react-dom/test-utils';
 import { Route, Routes } from 'react-router-dom';
 import { renderWithRouter, withState } from '@lib/test-utils';
 import Guard from './Guard';
+import { setUser, setUserAsLogged } from '../../state/user';
 
 describe('Guard component', () => {
   it('should redirect to the redirectPath prop plus the current pathname if present when the user cannot be loaded', async () => {
@@ -65,8 +66,8 @@ describe('Guard component', () => {
   });
 
   it('should render the outlet when the user can be loaded', async () => {
-    const goodGetUser = () => Promise.resolve({ username: 'admin' });
-    const [StatefulGuard] = withState(
+    const goodGetUser = () => Promise.resolve({ username: 'admin', id: 1 });
+    const [StatefulGuard, store] = withState(
       <Routes>
         <Route
           element={<Guard redirectPath="/session/new" getUser={goodGetUser} />}
@@ -84,7 +85,17 @@ describe('Guard component', () => {
       }
     );
 
-    renderWithRouter(StatefulGuard);
+    await act(async () => {
+      renderWithRouter(StatefulGuard);
+    });
+
+    const actions = store.getActions();
+    const expectedPayload = [
+      setUser({ username: 'admin', id: 1 }),
+      setUserAsLogged(),
+    ];
+
+    expect(actions).toEqual(expectedPayload);
 
     await waitFor(() => {
       expect(screen.getByTestId('inner-component')).toBeDefined();

--- a/assets/js/pages/Login/Login.jsx
+++ b/assets/js/pages/Login/Login.jsx
@@ -4,7 +4,7 @@ import TrentoLogo from '@static/trento-dark.svg';
 import { useDispatch, useSelector } from 'react-redux';
 import { toast } from 'react-hot-toast';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { performLoginAction } from '@state/sagas/user';
+import { initiateLogin } from '@state/user';
 import classNames from 'classnames';
 
 export default function Login() {
@@ -34,7 +34,7 @@ export default function Login() {
 
   const handleLoginSubmit = (e) => {
     e.preventDefault();
-    dispatch(performLoginAction({ username, password }));
+    dispatch(initiateLogin({ username, password }));
   };
 
   const isUnauthorized = authError && authError.code === 401;

--- a/assets/js/state/channels.js
+++ b/assets/js/state/channels.js
@@ -18,6 +18,15 @@ const registerEvents = (store, socket, channelName, events) => {
 };
 
 const processChannelEvents = (reduxStore, socket) => {
+  const {
+    user: { id },
+  } = reduxStore.getState();
+
+  registerEvents(reduxStore, socket, `users:${id}`, [
+    'user_updated',
+    'user_locked',
+    'user_deleted',
+  ]);
   registerEvents(reduxStore, socket, 'monitoring:hosts', [
     'host_registered',
     'host_details_updated',

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -70,7 +70,7 @@ import { markDeregisterableHosts, watchHostEvents } from '@state/sagas/hosts';
 import { watchLastExecutionEvents } from '@state/sagas/lastExecutions';
 import { watchSapSystemEvents } from '@state/sagas/sapSystems';
 
-import { watchPerformLogin } from '@state/sagas/user';
+import { watchPerformLogin, watchUserActions } from '@state/sagas/user';
 import { watchChecksSelectionEvents } from '@state/sagas/checksSelection';
 import { watchSoftwareUpdateSettings } from '@state/sagas/softwareUpdatesSettings';
 import { watchSoftwareUpdates } from '@state/sagas/softwareUpdates';
@@ -245,6 +245,7 @@ export default function* rootSaga() {
     watchLastExecutionEvents(),
     watchNotifications(),
     watchPerformLogin(),
+    watchUserActions(),
     watchResetState(),
     watchSapSystemEvents(),
     watchUserLoggedIn(),

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -70,7 +70,7 @@ import { markDeregisterableHosts, watchHostEvents } from '@state/sagas/hosts';
 import { watchLastExecutionEvents } from '@state/sagas/lastExecutions';
 import { watchSapSystemEvents } from '@state/sagas/sapSystems';
 
-import { watchPerformLogin, watchUserActions } from '@state/sagas/user';
+import { watchUserActions } from '@state/sagas/user';
 import { watchChecksSelectionEvents } from '@state/sagas/checksSelection';
 import { watchSoftwareUpdateSettings } from '@state/sagas/softwareUpdatesSettings';
 import { watchSoftwareUpdates } from '@state/sagas/softwareUpdates';
@@ -244,7 +244,6 @@ export default function* rootSaga() {
     watchHostEvents(),
     watchLastExecutionEvents(),
     watchNotifications(),
-    watchPerformLogin(),
     watchUserActions(),
     watchResetState(),
     watchSapSystemEvents(),

--- a/assets/js/state/sagas/user.js
+++ b/assets/js/state/sagas/user.js
@@ -8,10 +8,12 @@ import {
 } from '@state/user';
 import {
   login,
+  me,
   storeAccessToken,
   storeRefreshToken,
   clearCredentialsFromStore,
 } from '@lib/auth';
+import { networkClient } from '@lib/network';
 
 export const PERFORM_LOGIN = 'PERFORM_LOGIN';
 export const performLoginAction = createAction(
@@ -25,9 +27,11 @@ export function* performLogin({ payload: { username, password } }) {
     const {
       data: { access_token: accessToken, refresh_token: refreshToken },
     } = yield call(login, { username, password });
-    yield put(setUser({ username }));
     yield call(storeAccessToken, accessToken);
     yield call(storeRefreshToken, refreshToken);
+    // Get logged user information
+    const { id, username: profileUsername } = yield call(me, networkClient);
+    yield put(setUser({ username: profileUsername, id }));
     yield put(setUserAsLogged());
   } catch (error) {
     yield put(

--- a/assets/js/state/sagas/user.js
+++ b/assets/js/state/sagas/user.js
@@ -1,10 +1,13 @@
 import { call, put, takeEvery } from 'redux-saga/effects';
-import { createAction } from '@reduxjs/toolkit';
 import {
   setAuthInProgress,
   setAuthError,
   setUser,
   setUserAsLogged,
+  USER_DELETED,
+  USER_LOCKED,
+  USER_UPDATED,
+  PERFORM_LOGIN,
 } from '@state/user';
 import {
   login,
@@ -14,16 +17,6 @@ import {
   clearCredentialsFromStore,
 } from '@lib/auth';
 import { networkClient } from '@lib/network';
-
-export const PERFORM_LOGIN = 'PERFORM_LOGIN';
-export const USER_UPDATED = 'USER_UPDATED';
-export const USER_LOCKED = 'USER_LOCKED';
-export const USER_DELETED = 'USER_DELETED';
-
-export const performLoginAction = createAction(
-  PERFORM_LOGIN,
-  ({ username, password }) => ({ payload: { username, password } })
-);
 
 export function* performLogin({ payload: { username, password } }) {
   yield put(setAuthInProgress());
@@ -58,8 +51,5 @@ export function* watchUserActions() {
   yield takeEvery(USER_DELETED, clearUserAndLogout);
   yield takeEvery(USER_LOCKED, clearUserAndLogout);
   yield takeEvery(USER_UPDATED, userUpdated);
-}
-
-export function* watchPerformLogin() {
   yield takeEvery(PERFORM_LOGIN, performLogin);
 }

--- a/assets/js/state/sagas/user.js
+++ b/assets/js/state/sagas/user.js
@@ -16,6 +16,10 @@ import {
 import { networkClient } from '@lib/network';
 
 export const PERFORM_LOGIN = 'PERFORM_LOGIN';
+export const USER_UPDATED = 'USER_UPDATED';
+export const USER_LOCKED = 'USER_LOCKED';
+export const USER_DELETED = 'USER_DELETED';
+
 export const performLoginAction = createAction(
   PERFORM_LOGIN,
   ({ username, password }) => ({ payload: { username, password } })
@@ -39,6 +43,21 @@ export function* performLogin({ payload: { username, password } }) {
     );
     yield call(clearCredentialsFromStore);
   }
+}
+
+export function* clearUserAndLogout() {
+  yield call(clearCredentialsFromStore);
+  window.location.href = '/session/new';
+}
+
+export function* userUpdated() {
+  yield window.location.reload();
+}
+
+export function* watchUserActions() {
+  yield takeEvery(USER_DELETED, clearUserAndLogout);
+  yield takeEvery(USER_LOCKED, clearUserAndLogout);
+  yield takeEvery(USER_UPDATED, userUpdated);
 }
 
 export function* watchPerformLogin() {

--- a/assets/js/state/sagas/user.test.js
+++ b/assets/js/state/sagas/user.test.js
@@ -4,6 +4,8 @@ import {
   authClient,
   getAccessTokenFromStore,
   getRefreshTokenFromStore,
+  storeRefreshToken,
+  storeAccessToken,
 } from '@lib/auth';
 import {
   setAuthInProgress,
@@ -12,10 +14,32 @@ import {
   setUserAsLogged,
 } from '@state/user';
 import { networkClient } from '@lib/network';
-import { performLogin } from './user';
+import { performLogin, clearUserAndLogout } from './user';
 
 const axiosMock = new MockAdapter(authClient);
 const networkClientAxiosMock = new MockAdapter(networkClient);
+
+describe('user actions saga', () => {
+  beforeEach(() => {
+    axiosMock.reset();
+    jest.spyOn(console, 'error').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    /* eslint-disable-next-line */
+    console.error.mockRestore();
+  });
+
+  it('should clear the storage in clearUserAndLogout saga', async () => {
+    storeAccessToken('access_token');
+    storeRefreshToken('refresh_token');
+
+    await recordSaga(clearUserAndLogout);
+
+    expect(getAccessTokenFromStore()).toEqual(null);
+    expect(getRefreshTokenFromStore()).toEqual(null);
+  });
+});
 
 describe('user login saga', () => {
   beforeEach(() => {

--- a/assets/js/state/sagas/user.test.js
+++ b/assets/js/state/sagas/user.test.js
@@ -11,9 +11,11 @@ import {
   setUser,
   setUserAsLogged,
 } from '@state/user';
+import { networkClient } from '@lib/network';
 import { performLogin } from './user';
 
 const axiosMock = new MockAdapter(authClient);
+const networkClientAxiosMock = new MockAdapter(networkClient);
 
 describe('user login saga', () => {
   beforeEach(() => {
@@ -64,6 +66,10 @@ describe('user login saga', () => {
       .onPost('/api/session', { username: 'good', password: 'good' })
       .reply(200, credentialResponse);
 
+    networkClientAxiosMock
+      .onGet('/api/me')
+      .reply(200, { username: 'good', id: 1 });
+
     const dispatched = await recordSaga(performLogin, {
       payload: {
         username: 'good',
@@ -72,7 +78,7 @@ describe('user login saga', () => {
     });
 
     expect(dispatched).toContainEqual(setAuthInProgress());
-    expect(dispatched).toContainEqual(setUser({ username: 'good' }));
+    expect(dispatched).toContainEqual(setUser({ username: 'good', id: 1 }));
     expect(dispatched).toContainEqual(setUserAsLogged());
 
     expect(getAccessTokenFromStore()).toEqual(credentialResponse.access_token);

--- a/assets/js/state/user.js
+++ b/assets/js/state/user.js
@@ -1,9 +1,10 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createAction, createSlice } from '@reduxjs/toolkit';
 
 // Fields set to undefined for the sake of documenting the state shape
 export const initialState = {
   loggedIn: false,
   username: undefined,
+  id: undefined,
   authError: null,
   authInProgress: false,
 };
@@ -32,7 +33,17 @@ export const userSlice = createSlice({
   },
 });
 
+export const PERFORM_LOGIN = 'PERFORM_LOGIN';
+export const USER_UPDATED = 'USER_UPDATED';
+export const USER_LOCKED = 'USER_LOCKED';
+export const USER_DELETED = 'USER_DELETED';
+
 export const SET_USER_AS_LOGGED = 'user/setUserAsLogged';
+
+export const initiateLogin = createAction(
+  PERFORM_LOGIN,
+  ({ username, password }) => ({ payload: { username, password } })
+);
 
 export const { setUserAsLogged, setUser, setAuthError, setAuthInProgress } =
   userSlice.actions;

--- a/assets/js/state/user.js
+++ b/assets/js/state/user.js
@@ -25,8 +25,9 @@ export const userSlice = createSlice({
       state.authInProgress = false;
       state.authError = null;
     },
-    setUser(state, { payload: { username } }) {
+    setUser(state, { payload: { username, id } }) {
       state.username = username;
+      state.id = id;
     },
   },
 });


### PR DESCRIPTION
# Description

This pr refactor user websocket authentication, and subscribe to the dedicated and personal user channel on phoenix.
The guard frontend component when retrieving the user from me endpoint will update the user info in redux state.
This is done also on first session login.

the me endpoint will be updated in future prs with more information about the user profile

We listen to user events and react accordingly.

When a user is deleted or locked -> we log out immediately
When a user is updated -> we refresh to page to reflect the changes

## How was this tested?

Automated tests
