### PR TITLE
Avoid SUMA health complete on settings not configured error

### DIFF
--- a/lib/trento/software_updates/discovery.ex
+++ b/lib/trento/software_updates/discovery.ex
@@ -90,6 +90,9 @@ defmodule Trento.SoftwareUpdates.Discovery do
            |> commanded().dispatch() do
       {:ok, host_id, system_id, relevant_patches}
     else
+      {:error, :settings_not_configured} ->
+        {:error, :settings_not_configured}
+
       {:error, discovery_error} = error ->
         Logger.error(
           "An error occurred during software updates discovery for host #{host_id}:  #{inspect(error)}"
@@ -105,6 +108,9 @@ defmodule Trento.SoftwareUpdates.Discovery do
         {:error, discovery_error}
     end
   end
+
+  defp discover_host_software_updates(_, _, {:error, :settings_not_configured} = error),
+    do: error
 
   defp discover_host_software_updates(host_id, _, {:error, error}) do
     commanded().dispatch(


### PR DESCRIPTION
# Description

Avoid sending `CompleteSoftwareUpdatesDiscovery` during the discovery if the SUMA settings are not configured.
This is needed in scenarios like when the `SoftwareUpdatesDiscoveryEventHandler` handler runs the discovery.
Without this change, the health of the software updates is set to `unknown`, even though we shouldn't be changing it, as SUMA settings are not configured.

So the unique difference is that the `settings_not_configured` error doesn't dispatch the command, nothing else.

## How was this tested?

UT added and tested manually
