### PR TITLE
Add factories to eslint dev list

### DIFF
--- a/assets/.eslintrc.js
+++ b/assets/.eslintrc.js
@@ -66,6 +66,7 @@ module.exports = {
           '**/*.stories.*',
           '**/.storybook/**/*',
           '**/*{.,_}{test,spec}.{js,jsx}',
+          '**/test-utils/factories/*',
         ],
       },
     ],

--- a/assets/js/lib/test-utils/factories/clusters.js
+++ b/assets/js/lib/test-utils/factories/clusters.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import { faker } from '@faker-js/faker';
 import { Factory } from 'fishery';
 import { format } from 'date-fns';

--- a/assets/js/lib/test-utils/factories/databases.js
+++ b/assets/js/lib/test-utils/factories/databases.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import { faker } from '@faker-js/faker';
 import { Factory } from 'fishery';
 import { generateSid } from '.';

--- a/assets/js/lib/test-utils/factories/executions.js
+++ b/assets/js/lib/test-utils/factories/executions.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import { faker } from '@faker-js/faker';
 import { Factory } from 'fishery';
 import { hostFactory, randomObjectFactory } from '.';

--- a/assets/js/lib/test-utils/factories/hosts.js
+++ b/assets/js/lib/test-utils/factories/hosts.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import { faker } from '@faker-js/faker';
 import { Factory } from 'fishery';
 import { format, formatISO } from 'date-fns';

--- a/assets/js/lib/test-utils/factories/index.js
+++ b/assets/js/lib/test-utils/factories/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import { faker } from '@faker-js/faker';
 import { Factory } from 'fishery';
 

--- a/assets/js/lib/test-utils/factories/sapSystems.js
+++ b/assets/js/lib/test-utils/factories/sapSystems.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import { faker } from '@faker-js/faker';
 import { Factory } from 'fishery';
 

--- a/assets/js/lib/test-utils/factories/settings.js
+++ b/assets/js/lib/test-utils/factories/settings.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import { faker } from '@faker-js/faker';
 import { Factory } from 'fishery';
 import { formatISO } from 'date-fns';

--- a/assets/js/lib/test-utils/factories/softwareUpdatesSettings.js
+++ b/assets/js/lib/test-utils/factories/softwareUpdatesSettings.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import { faker } from '@faker-js/faker';
 import { formatISO } from 'date-fns';
 import { Factory } from 'fishery';


### PR DESCRIPTION
# Description

Add `factories` folder to `eslint` dev list. This way, we can remove all of those `eslint-disable` from all the factories.

## How was this tested?

eslint happy
