### PR TITLE
Install make and gcc in container and rpm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM opensuse/tumbleweed AS elixir-build
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
-RUN zypper -n in make git-core elixir elixir-hex erlang-rebar3
+RUN zypper -n in make gcc git-core elixir elixir-hex erlang-rebar3
 COPY . /build
 WORKDIR /build
 ARG MIX_ENV=prod

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM opensuse/tumbleweed AS elixir-build
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
-RUN zypper -n in git-core elixir elixir-hex erlang-rebar3
+RUN zypper -n in make git-core elixir elixir-hex erlang-rebar3
 COPY . /build
 WORKDIR /build
 ARG MIX_ENV=prod

--- a/packaging/suse/container/Dockerfile
+++ b/packaging/suse/container/Dockerfile
@@ -14,7 +14,7 @@ RUN npm run build
 FROM bci/bci-base:15.4 AS release
 # Workaround for https://github.com/openSUSE/obs-build/issues/487
 RUN zypper --non-interactive in sles-release
-RUN zypper -n in make git-core elixir elixir-hex erlang-rebar3
+RUN zypper -n in make gcc git-core elixir elixir-hex erlang-rebar3
 COPY --from=assets-build /build /build
 WORKDIR /build/web/
 ENV LANG en_US.UTF-8

--- a/packaging/suse/container/Dockerfile
+++ b/packaging/suse/container/Dockerfile
@@ -14,7 +14,7 @@ RUN npm run build
 FROM bci/bci-base:15.4 AS release
 # Workaround for https://github.com/openSUSE/obs-build/issues/487
 RUN zypper --non-interactive in sles-release
-RUN zypper -n in git-core elixir elixir-hex erlang-rebar3
+RUN zypper -n in make git-core elixir elixir-hex erlang-rebar3
 COPY --from=assets-build /build /build
 WORKDIR /build/web/
 ENV LANG en_US.UTF-8

--- a/packaging/suse/rpm/trento-web.spec
+++ b/packaging/suse/rpm/trento-web.spec
@@ -28,7 +28,7 @@ Source2:        package-lock.json
 Source3:        node_modules.spec.inc
 %include        %{_sourcedir}/node_modules.spec.inc
 Group:          System/Monitoring
-BuildRequires:  elixir, elixir-hex, npm16, erlang-rebar3, git-core, local-npm-registry
+BuildRequires:  elixir, elixir-hex, npm16, erlang-rebar3, git-core, local-npm-registry, make
 
 %description
 Trento is an open cloud-native web application for SAP Applications administrators.

--- a/packaging/suse/rpm/trento-web.spec
+++ b/packaging/suse/rpm/trento-web.spec
@@ -28,7 +28,7 @@ Source2:        package-lock.json
 Source3:        node_modules.spec.inc
 %include        %{_sourcedir}/node_modules.spec.inc
 Group:          System/Monitoring
-BuildRequires:  elixir, elixir-hex, npm16, erlang-rebar3, git-core, local-npm-registry, make
+BuildRequires:  elixir, elixir-hex, npm16, erlang-rebar3, git-core, local-npm-registry, make, gcc
 
 %description
 Trento is an open cloud-native web application for SAP Applications administrators.


### PR DESCRIPTION
# Description

Install `make/gcc` in container and rpms. `make/gcc` are a required dependency to compile the new dependency `argon`
