### PR TITLE
Change the tooltip message for SUMA's fallback scenario

### DIFF
--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.stories.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.stories.jsx
@@ -75,7 +75,10 @@ export const Cool = {
 export const NoSettingsConfigured = { args: { settingsConfigured: false } };
 
 export const Unknown = {
-  args: { tooltip: 'SUSE Manager is not available', settingsConfigured: true },
+  args: {
+    tooltip: 'SUSE Manager was not able to retrieve the requested data',
+    settingsConfigured: true,
+  },
 };
 
 export const SoftwareUpdateSettingsLoading = {

--- a/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
@@ -287,6 +287,7 @@ export const SuseManagerUnknown = {
     suseManagerEnabled: true,
     relevantPatches: undefined,
     upgradablePackages: undefined,
-    softwareUpdatesTooltip: 'SUSE Manager is not available',
+    softwareUpdatesTooltip:
+      'SUSE Manager was not able to retrieve the requested data',
   },
 };

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -132,7 +132,7 @@ function HostDetailsPage() {
       softwareUpdatesConnectionError={softwareUpdatesConnectionError}
       softwareUpdatesTooltip={
         numRelevantPatches === undefined && numUpgradablePackages === undefined
-          ? 'SUSE Manager is not available'
+          ? 'SUSE Manager was not able to retrieve the requested data'
           : undefined
       }
       cleanUpHost={() => {


### PR DESCRIPTION
# Description
As above, not much: just revisited SUMA's fallback scenario tooltip as per requirements. 

## How was this tested?

Storybook stories
