### PR TITLE
Read tracked software updates discoveries

### DIFF
--- a/lib/trento/software_updates.ex
+++ b/lib/trento/software_updates.ex
@@ -4,9 +4,6 @@ defmodule Trento.SoftwareUpdates do
   """
   require Logger
 
-  alias Trento.Hosts
-  alias Trento.Hosts.Projections.HostReadModel
-
   alias Trento.Support.DateService
 
   alias Trento.Repo
@@ -114,27 +111,14 @@ defmodule Trento.SoftwareUpdates do
           {:ok, map()}
           | {:error,
              :settings_not_configured
-             | :system_id_not_found
              | :not_found
-             | :fqdn_not_found
+             | :system_id_not_found
              | :error_getting_patches
              | :error_getting_packages}
   def get_software_updates(host_id) do
     with {:ok, _} <- get_settings(),
-         {:ok, fqdn} <- get_host_fqdn(host_id),
-         {:ok, system_id} <- Discovery.get_system_id(fqdn),
-         {:ok, relevant_patches} <- Discovery.get_relevant_patches(system_id),
-         {:ok, upgradable_packages} <-
-           Discovery.get_upgradable_packages(system_id) do
+         {:ok, relevant_patches, upgradable_packages} <- Discovery.get_discovery_result(host_id) do
       {:ok, %{relevant_patches: relevant_patches, upgradable_packages: upgradable_packages}}
-    end
-  end
-
-  defp get_host_fqdn(host_id) do
-    case Hosts.get_host_by_id(host_id) do
-      nil -> {:error, :not_found}
-      %HostReadModel{fully_qualified_domain_name: nil} -> {:error, :fqdn_not_found}
-      %HostReadModel{fully_qualified_domain_name: fqdn} -> {:ok, fqdn}
     end
   end
 

--- a/lib/trento/software_updates.ex
+++ b/lib/trento/software_updates.ex
@@ -114,7 +114,8 @@ defmodule Trento.SoftwareUpdates do
              | :not_found
              | :system_id_not_found
              | :error_getting_patches
-             | :error_getting_packages}
+             | :error_getting_packages
+             | :max_login_retries_reached}
   def get_software_updates(host_id) do
     with {:ok, _} <- get_settings(),
          {:ok, relevant_patches, upgradable_packages} <- Discovery.get_discovery_result(host_id) do

--- a/lib/trento/software_updates/discovery.ex
+++ b/lib/trento/software_updates/discovery.ex
@@ -273,8 +273,8 @@ defmodule Trento.SoftwareUpdates.Discovery do
        }) do
     {
       :ok,
-      normalize_discovered_result_list(relevant_patches),
-      normalize_discovered_result_list(upgradable_packages)
+      keys_to_atoms(relevant_patches),
+      keys_to_atoms(upgradable_packages)
     }
   end
 
@@ -284,7 +284,7 @@ defmodule Trento.SoftwareUpdates.Discovery do
   defp failure_reason_to_atom("max_login_retries_reached"), do: :max_login_retries_reached
   defp failure_reason_to_atom(_), do: :unknown_discovery_error
 
-  defp normalize_discovered_result_list(discovered_result_list),
+  defp keys_to_atoms(discovered_result_list),
     do:
       discovered_result_list
       |> Jason.encode!()

--- a/lib/trento/software_updates/discovery.ex
+++ b/lib/trento/software_updates/discovery.ex
@@ -265,7 +265,7 @@ defmodule Trento.SoftwareUpdates.Discovery do
 
   defp handle_discovery_result(%DiscoveryResult{failure_reason: failure_reason})
        when not is_nil(failure_reason),
-       do: {:error, String.to_existing_atom(failure_reason)}
+       do: {:error, failure_reason_to_atom(failure_reason)}
 
   defp handle_discovery_result(%DiscoveryResult{
          relevant_patches: relevant_patches,
@@ -277,6 +277,12 @@ defmodule Trento.SoftwareUpdates.Discovery do
       normalize_discovered_result_list(upgradable_packages)
     }
   end
+
+  defp failure_reason_to_atom("system_id_not_found"), do: :system_id_not_found
+  defp failure_reason_to_atom("error_getting_patches"), do: :error_getting_patches
+  defp failure_reason_to_atom("error_getting_packages"), do: :error_getting_packages
+  defp failure_reason_to_atom("max_login_retries_reached"), do: :max_login_retries_reached
+  defp failure_reason_to_atom(_), do: :unknown_discovery_error
 
   defp normalize_discovered_result_list(discovered_result_list),
     do:

--- a/lib/trento/software_updates/discovery/discovery_result.ex
+++ b/lib/trento/software_updates/discovery/discovery_result.ex
@@ -6,6 +6,8 @@ defmodule Trento.SoftwareUpdates.Discovery.DiscoveryResult do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @type t :: %__MODULE__{}
+
   @primary_key {:host_id, :binary_id, autogenerate: false}
   schema "software_updates_discovery_result" do
     field :system_id, :string

--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -96,13 +96,6 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"422", reason: "No checks were selected for the target.")
   end
 
-  def call(conn, {:error, :fqdn_not_found}) do
-    conn
-    |> put_status(:unprocessable_entity)
-    |> put_view(ErrorView)
-    |> render(:"422", reason: "No FQDN was found for the target host.")
-  end
-
   def call(conn, {:error, :system_id_not_found}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -909,7 +909,13 @@ defmodule Trento.Factory do
       system_id: nil,
       relevant_patches: nil,
       upgradable_packages: nil,
-      failure_reason: Faker.Lorem.word()
+      failure_reason:
+        Faker.Util.pick([
+          "system_id_not_found",
+          "error_getting_patches",
+          "error_getting_packages",
+          "max_login_retries_reached"
+        ])
     }
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -7,6 +7,7 @@ defmodule Trento.Factory do
   require Trento.Clusters.Enums.ClusterType, as: ClusterType
   require Trento.SapSystems.Enums.EnsaVersion, as: EnsaVersion
   require Trento.Enums.Health, as: Health
+  require Trento.SoftwareUpdates.Enums.AdvisoryType, as: AdvisoryType
   require Trento.SoftwareUpdates.Enums.SoftwareUpdatesHealth, as: SoftwareUpdatesHealth
 
   alias Faker.Random.Elixir, as: RandomElixir
@@ -868,11 +869,10 @@ defmodule Trento.Factory do
     %{
       date: Faker.Date.backward(30),
       advisory_name: String.downcase(Faker.Pokemon.name()),
-      advisory_type:
-        Faker.Util.pick(["Bug Fix Advisory", "Security Advisory", "Product Enhancement"]),
+      advisory_type: Faker.Util.pick(AdvisoryType.values()),
       advisory_status: "stable",
       id: RandomElixir.random_between(2000, 5000),
-      advisory_synopsis: Faker.Lorem.words(30),
+      advisory_synopsis: Faker.Lorem.sentence(),
       update_date: Faker.Date.backward(30)
     }
   end
@@ -899,6 +899,16 @@ defmodule Trento.Factory do
       system_id: Faker.UUID.v4(),
       relevant_patches: build_list(2, :relevant_patch),
       upgradable_packages: build_list(2, :upgradable_package),
+      failure_reason: nil
+    }
+  end
+
+  def failed_software_updates_discovery_result_factory do
+    %DiscoveryResult{
+      host_id: Faker.UUID.v4(),
+      system_id: nil,
+      relevant_patches: nil,
+      upgradable_packages: nil,
       failure_reason: Faker.Lorem.word()
     }
   end

--- a/test/trento/software_updates/discovery_test.exs
+++ b/test/trento/software_updates/discovery_test.exs
@@ -658,6 +658,10 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
         %{
           failure_reason: "error_getting_packages",
           expected_error: :error_getting_packages
+        },
+        %{
+          failure_reason: "max_login_retries_reached",
+          expected_error: :max_login_retries_reached
         }
       ]
 

--- a/test/trento/software_updates_test.exs
+++ b/test/trento/software_updates_test.exs
@@ -516,30 +516,10 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
     test "returns errors on failed discoveries" do
       insert_software_updates_settings()
 
-      scenarios = [
-        %{
-          failure_reason: "system_id_not_found",
-          expected_error: :system_id_not_found
-        },
-        %{
-          failure_reason: "error_getting_patches",
-          expected_error: :error_getting_patches
-        },
-        %{
-          failure_reason: "error_getting_packages",
-          expected_error: :error_getting_packages
-        }
-      ]
+      %{host_id: host_id} =
+        insert(:failed_software_updates_discovery_result)
 
-      for %{
-            failure_reason: failure_reason,
-            expected_error: expected_error
-          } <- scenarios do
-        %{host_id: host_id} =
-          insert(:failed_software_updates_discovery_result, failure_reason: failure_reason)
-
-        assert {:error, ^expected_error} = SoftwareUpdates.get_software_updates(host_id)
-      end
+      assert {:error, _} = SoftwareUpdates.get_software_updates(host_id)
     end
   end
 

--- a/test/trento_web/controllers/v1/suse_manager_controller_test.exs
+++ b/test/trento_web/controllers/v1/suse_manager_controller_test.exs
@@ -23,7 +23,22 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
       api_spec: api_spec
     } do
       insert_software_updates_settings()
-      %{id: host_id} = insert(:host, fully_qualified_domain_name: "test")
+
+      relevant_patches = [
+        build(:relevant_patch, id: 4182),
+        build(:relevant_patch, id: 4174)
+      ]
+
+      upgradable_packages = [
+        build(:upgradable_package, name: "elixir"),
+        build(:upgradable_package, name: "systemd")
+      ]
+
+      %{host_id: host_id} =
+        insert(:software_updates_discovery_result,
+          relevant_patches: relevant_patches,
+          upgradable_packages: upgradable_packages
+        )
 
       %AvailableSoftwareUpdatesResponse{
         relevant_patches: [
@@ -75,19 +90,6 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
       |> get("/api/v1/hosts/#{host_id}/software_updates")
       |> json_response(:not_found)
       |> assert_schema("NotFound", api_spec)
-    end
-
-    test "should return 422 when a host does not have an fqdn", %{
-      conn: conn,
-      api_spec: api_spec
-    } do
-      insert_software_updates_settings()
-      %{id: host_id} = insert(:host, fully_qualified_domain_name: nil)
-
-      conn
-      |> get("/api/v1/hosts/#{host_id}/software_updates")
-      |> json_response(:unprocessable_entity)
-      |> assert_schema("UnprocessableEntity", api_spec)
     end
   end
 end


### PR DESCRIPTION
# Description

This PR changes the data source of the `GET /hosts/:host_id/software_updates` endpoint.
It now reads from previously tracked discovery result.

- if a discovery result for the given host id is not found the endpoint ends up in a 404 (either the host id is invalid or a discovery for the host has not been tracked, very likely because of a missing fqdn*)
- if there is a failure reason in the discovery result, it gets returned as part of an `{:error, reason}` tuple. The endpoint in this case is going to return what defined in the fallback controller (very likely a 422 on `system_id_not_found`, `error_getting_patches`, `error_getting_packages`)


Note* the `fqdn_not_found` error becomes a tricky one. 
It would be great to track it as a possible failure reason for a discovery result, however since the discovery process is not always triggered the same way, it might happen that when detected null in the domain, a discovery for the specific host is not attempted at all, making it impossible to track where we track results currently. 
We could instead track it when discovery is initiated via the ticker or when saving settings. However I preferred keeping at least some consistency by _not tracking_ it at all.

If we want to keep `fqdn_not_found` explicit we could keep the `get_host_fqdn` function, but we'd be querying the hosts unnecessarily, imho.
So since we are currently only really interested in `:settings_not_configured` error (which is still properly handled) and all other error fall into a generic bucket, I believe we can just defer further changes to when we refine error handling.

## How was this tested?

Automated + manual.