### PR TITLE
Remove "SUSE Manager connection failed" error message

### DIFF
--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.jsx
@@ -21,13 +21,12 @@ const containerClassNames = classNames(
 function AvailableSoftwareUpdates({
   className,
   settingsConfigured = false,
+  softwareUpdatesSettingsLoading,
+  onBackToSettings = noop,
+  softwareUpdatesLoading,
   relevantPatches,
   upgradablePackages,
   tooltip,
-  softwareUpdatesSettingsLoading,
-  softwareUpdatesLoading,
-  connectionError = false,
-  onBackToSettings = noop,
 }) {
   if (softwareUpdatesSettingsLoading) {
     return <Loading className={containerClassNames} />;
@@ -60,7 +59,6 @@ function AvailableSoftwareUpdates({
         critical={gt(relevantPatches, 0)}
         tooltip={tooltip}
         loading={softwareUpdatesLoading}
-        connectionError={connectionError}
         icon={<EOS_HEALING size="xl" />}
       >
         {relevantPatches}
@@ -70,7 +68,6 @@ function AvailableSoftwareUpdates({
         title="Upgradable Packages"
         tooltip={tooltip}
         loading={softwareUpdatesLoading}
-        connectionError={connectionError}
         icon={<EOS_PACKAGE_UPGRADE_OUTLINED size="xl" />}
       >
         {upgradablePackages}

--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.stories.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.stories.jsx
@@ -10,6 +10,25 @@ export default {
       },
       description: 'Have settings been saved for the software updates service',
     },
+    onBackToSettings: {
+      description:
+        'Callback function to trigger when the "Settings" button is clicked',
+      control: {
+        type: 'function',
+      },
+    },
+    softwareUpdatesSettingsLoading: {
+      control: {
+        type: 'boolean',
+      },
+      description: 'are software updates settings being fetched?',
+    },
+    softwareUpdatesLoading: {
+      control: {
+        type: 'boolean',
+      },
+      description: 'are software updates being fetched?',
+    },
     relevantPatches: {
       type: 'number',
       description: 'Number of relevant patches available for the system',
@@ -28,67 +47,38 @@ export default {
       type: 'string',
       description: 'Content of the tooltip, if it is rendered',
     },
-    softwareUpdatesSettingsLoading: {
-      control: {
-        type: 'boolean',
-      },
-      description: 'are software updates settings being fetched?',
-    },
-    softwareUpdatesLoading: {
-      control: {
-        type: 'boolean',
-      },
-      description: 'are software updates being fetched?',
-    },
-    connectionError: {
-      control: {
-        type: 'boolean',
-      },
-      description: 'There an error connecting to the software updates service',
-    },
-    onBackToSettings: {
-      description:
-        'Callback function to trigger when the "Settings" button is clicked',
-      control: {
-        type: 'function',
-      },
-    },
   },
 };
 
 export const Default = {
   args: {
+    settingsConfigured: true,
     relevantPatches: 412,
     upgradablePackages: 234,
-    settingsConfigured: true,
   },
 };
 
 export const Cool = {
   args: {
+    settingsConfigured: true,
     relevantPatches: 0,
     upgradablePackages: 42,
-    settingsConfigured: true,
   },
 };
 
 export const NoSettingsConfigured = { args: { settingsConfigured: false } };
 
-export const Unknown = {
-  args: {
-    tooltip: 'SUSE Manager was not able to retrieve the requested data',
-    settingsConfigured: true,
-  },
-};
-
 export const SoftwareUpdateSettingsLoading = {
-  args: { softwareUpdateSettingsLoading: true, settingsConfigured: true },
+  args: { softwareUpdatesSettingsLoading: true },
 };
 
 export const SoftwareUpdatesLoading = {
-  args: { softwareUpdatesLoading: true, settingsConfigured: true },
+  args: { settingsConfigured: true, softwareUpdatesLoading: true },
 };
 
-export const ConnectionError = {
-  args: { connectionError: true, settingsConfigured: true },
+export const Unknown = {
+  args: {
+    settingsConfigured: true,
+    tooltip: 'SUSE Manager was not able to retrieve the requested data',
+  },
 };

--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.stories.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.stories.jsx
@@ -79,6 +79,6 @@ export const SoftwareUpdatesLoading = {
 export const Unknown = {
   args: {
     settingsConfigured: true,
-    tooltip: 'SUSE Manager was not able to retrieve the requested data',
+    tooltip: 'Trento was not able to retrieve the requested data',
   },
 };

--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
@@ -13,9 +13,9 @@ describe('AvailableSoftwareUpdates component', () => {
 
     render(
       <AvailableSoftwareUpdates
+        settingsConfigured
         relevantPatches={0}
         upgradablePackages={upgradablePackages}
-        settingsConfigured
       />
     );
 
@@ -30,9 +30,9 @@ describe('AvailableSoftwareUpdates component', () => {
 
     render(
       <AvailableSoftwareUpdates
+        settingsConfigured
         relevantPatches={relevantPatches}
         upgradablePackages={upgradablePackages}
-        settingsConfigured
       />
     );
 
@@ -44,7 +44,7 @@ describe('AvailableSoftwareUpdates component', () => {
   it('renders Unknown status', async () => {
     const user = userEvent.setup();
     const tooltip = faker.lorem.words({ min: 3, max: 5 });
-    render(<AvailableSoftwareUpdates tooltip={tooltip} settingsConfigured />);
+    render(<AvailableSoftwareUpdates settingsConfigured tooltip={tooltip} />);
 
     expect(screen.getAllByText('Unknown')).toHaveLength(2);
     expect(screen.getAllByTestId('eos-svg-component')).toHaveLength(4);
@@ -56,8 +56,8 @@ describe('AvailableSoftwareUpdates component', () => {
   it('renders Software Updates Settings Loading status', () => {
     render(
       <AvailableSoftwareUpdates
-        softwareUpdatesSettingsLoading
         settingsConfigured
+        softwareUpdatesSettingsLoading
       />
     );
 
@@ -66,7 +66,7 @@ describe('AvailableSoftwareUpdates component', () => {
 
   it('renders Software Updates Loading status', () => {
     render(
-      <AvailableSoftwareUpdates softwareUpdatesLoading settingsConfigured />
+      <AvailableSoftwareUpdates settingsConfigured softwareUpdatesLoading />
     );
 
     expect(screen.getAllByText('Loading...')).toHaveLength(2);
@@ -82,13 +82,5 @@ describe('AvailableSoftwareUpdates component', () => {
     ).toBeVisible();
 
     expect(screen.getByRole('button', { name: 'Settings' })).toBeVisible();
-  });
-
-  it('renders a connection error', () => {
-    render(<AvailableSoftwareUpdates settingsConfigured connectionError />);
-
-    expect(screen.getAllByText('SUSE Manager connection failed')).toHaveLength(
-      2
-    );
   });
 });

--- a/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
@@ -7,17 +7,8 @@ import {
 
 import Tooltip from '@common/Tooltip';
 
-function Indicator({
-  title,
-  critical,
-  tooltip,
-  icon,
-  loading,
-  connectionError,
-  children,
-}) {
+function Indicator({ title, critical, tooltip, icon, loading, children }) {
   const unknown = children === undefined;
-  const error = unknown || connectionError;
 
   if (loading) {
     return (
@@ -39,20 +30,19 @@ function Indicator({
           <p className="font-bold">{title}</p>
           <div
             className={classNames({
-              'text-green-600': !error,
-              'text-gray-600': error,
+              'text-green-600': !unknown,
+              'text-gray-600': unknown,
             })}
           >
-            {critical && (
-              <EOS_ERROR_OUTLINED
-                size="l"
-                className="inline align-bottom fill-red-500"
-              />
-            )}{' '}
-            {error ? (
+            {critical || unknown ? (
               <div>
-                <EOS_ERROR_OUTLINED size="l" className="inline align-bottom" />{' '}
-                {connectionError ? 'SUSE Manager connection failed' : 'Unknown'}
+                <EOS_ERROR_OUTLINED
+                  size="l"
+                  className={`inline align-bottom${
+                    critical && ' fill-red-500'
+                  }`}
+                />{' '}
+                {critical && children ? children : 'Unknown'}
               </div>
             ) : (
               children

--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -73,7 +73,6 @@ function HostDetails({
   softwareUpdatesLoading,
   softwareUpdatesSettingsSaved,
   softwareUpdatesSettingsLoading,
-  softwareUpdatesConnectionError = false,
   softwareUpdatesTooltip,
   cleanUpHost,
   requestHostChecksExecution,
@@ -239,7 +238,6 @@ function HostDetails({
             tooltip={softwareUpdatesTooltip}
             softwareUpdatesSettingsLoading={softwareUpdatesSettingsLoading}
             softwareUpdatesLoading={softwareUpdatesLoading}
-            connectionError={softwareUpdatesConnectionError}
             onBackToSettings={() => navigate(`/settings`)}
           />
         )}

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -17,7 +17,6 @@ import {
   getSoftwareUpdatesSettingsSaved,
 } from '@state/selectors/softwareUpdatesSettings';
 import {
-  getSoftwareUpdatesConnectionError,
   getSoftwareUpdates,
   getSoftwareUpdatesStats,
 } from '@state/selectors/softwareUpdates';
@@ -67,9 +66,6 @@ function HostDetailsPage() {
   );
   const softwareUpdatesConnectionSaved = useSelector((state) =>
     getSoftwareUpdatesSettingsSaved(state)
-  );
-  const softwareUpdatesConnectionError = useSelector((state) =>
-    getSoftwareUpdatesConnectionError(state)
   );
   const { numRelevantPatches, numUpgradablePackages } = useSelector((state) =>
     getSoftwareUpdatesStats(state, hostID)
@@ -129,10 +125,9 @@ function HostDetailsPage() {
       softwareUpdatesSettingsSaved={softwareUpdatesConnectionSaved}
       softwareUpdatesSettingsLoading={softwareUpdatesSettingsLoading}
       softwareUpdatesLoading={softwareUpdatesLoading}
-      softwareUpdatesConnectionError={softwareUpdatesConnectionError}
       softwareUpdatesTooltip={
         numRelevantPatches === undefined && numUpgradablePackages === undefined
-          ? 'SUSE Manager was not able to retrieve the requested data'
+          ? 'Trento was not able to retrieve the requested data'
           : undefined
       }
       cleanUpHost={() => {

--- a/assets/js/state/sagas/softwareUpdates.js
+++ b/assets/js/state/sagas/softwareUpdates.js
@@ -6,7 +6,6 @@ import {
   FETCH_SOFTWARE_UPDATES,
   startLoadingSoftwareUpdates,
   setSoftwareUpdates,
-  setSoftwareUpdatesConnectionError,
   setEmptySoftwareUpdates,
   setSoftwareUpdatesErrors,
 } from '@state/softwareUpdates';
@@ -19,8 +18,6 @@ export function* fetchSoftwareUpdates({ payload: hostID }) {
     yield put(setSoftwareUpdates({ hostID, ...response.data }));
   } catch (error) {
     yield put(setEmptySoftwareUpdates({ hostID }));
-
-    yield put(setSoftwareUpdatesConnectionError());
 
     const errors = get(error, ['response', 'data'], []);
     yield put(setSoftwareUpdatesErrors(errors));

--- a/assets/js/state/sagas/softwareUpdates.test.js
+++ b/assets/js/state/sagas/softwareUpdates.test.js
@@ -8,7 +8,6 @@ import { networkClient } from '@lib/network';
 import {
   startLoadingSoftwareUpdates,
   setSoftwareUpdates,
-  setSoftwareUpdatesConnectionError,
   setSoftwareUpdatesErrors,
   setEmptySoftwareUpdates,
 } from '@state/softwareUpdates';
@@ -83,7 +82,6 @@ describe('Software Updates saga', () => {
         expect(dispatched).toEqual([
           startLoadingSoftwareUpdates(),
           setEmptySoftwareUpdates({ hostID }),
-          setSoftwareUpdatesConnectionError(),
           setSoftwareUpdatesErrors(body),
         ]);
       }

--- a/assets/js/state/selectors/softwareUpdates.js
+++ b/assets/js/state/selectors/softwareUpdates.js
@@ -2,9 +2,6 @@ import { createSelector } from '@reduxjs/toolkit';
 
 export const getSoftwareUpdates = (state) => state?.softwareUpdates;
 
-export const getSoftwareUpdatesConnectionError = (state) =>
-  state?.softwareUpdates.connectionError;
-
 export const getSoftwareUpdatesForHost = (id) => (state) =>
   state?.softwareUpdates.softwareUpdates[id];
 

--- a/assets/js/state/selectors/softwareUpdates.test.js
+++ b/assets/js/state/selectors/softwareUpdates.test.js
@@ -1,9 +1,5 @@
 import { faker } from '@faker-js/faker';
-import {
-  getSoftwareUpdates,
-  getSoftwareUpdatesConnectionError,
-  getSoftwareUpdatesStats,
-} from './softwareUpdates';
+import { getSoftwareUpdates, getSoftwareUpdatesStats } from './softwareUpdates';
 
 describe('Software Updates selector', () => {
   const hostID = faker.string.uuid();
@@ -119,25 +115,5 @@ describe('Software Updates selector', () => {
       numRelevantPatches: undefined,
       numUpgradablePackages: undefined,
     });
-  });
-
-  it('should return the connection error', () => {
-    const stateWithError = {
-      softwareUpdates: {
-        connectionError: true,
-      },
-    };
-
-    const stateWithoutError = {
-      softwareUpdates: {
-        connectionError: false,
-      },
-    };
-
-    expect(getSoftwareUpdatesConnectionError(stateWithError)).toEqual(true);
-    expect(getSoftwareUpdatesConnectionError(stateWithoutError)).toEqual(false);
-    expect(getSoftwareUpdatesConnectionError({ softwareUpdates: {} })).toEqual(
-      undefined
-    );
   });
 });

--- a/assets/js/state/softwareUpdates.js
+++ b/assets/js/state/softwareUpdates.js
@@ -2,7 +2,6 @@ import { createAction, createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
   loading: false,
-  connectionError: false,
   softwareUpdates: {},
   errors: [],
 };
@@ -19,7 +18,6 @@ export const softwareUpdatesSlice = createSlice({
       { payload: { hostID, relevant_patches, upgradable_packages } }
     ) => {
       state.loading = false;
-      state.connectionError = false;
 
       state.softwareUpdates = {
         ...state.softwareUpdates,
@@ -28,9 +26,6 @@ export const softwareUpdatesSlice = createSlice({
           upgradable_packages,
         },
       };
-    },
-    setSoftwareUpdatesConnectionError: (state) => {
-      state.connectionError = true;
     },
     setEmptySoftwareUpdates: (state, { payload: { hostID } }) => {
       state.loading = false;
@@ -50,7 +45,6 @@ export const fetchSoftwareUpdates = createAction(FETCH_SOFTWARE_UPDATES);
 export const {
   startLoadingSoftwareUpdates,
   setSoftwareUpdates,
-  setSoftwareUpdatesConnectionError,
   setEmptySoftwareUpdates,
   setSoftwareUpdatesErrors,
 } = softwareUpdatesSlice.actions;

--- a/assets/js/state/softwareUpdates.test.js
+++ b/assets/js/state/softwareUpdates.test.js
@@ -3,7 +3,6 @@ import { faker } from '@faker-js/faker';
 import softwareUpdatesReducer, {
   startLoadingSoftwareUpdates,
   setSoftwareUpdates,
-  setSoftwareUpdatesConnectionError,
   setEmptySoftwareUpdates,
   setSoftwareUpdatesErrors,
 } from './softwareUpdates';
@@ -102,7 +101,6 @@ describe('SoftwareUpdates reducer', () => {
 
     expect(actual).toEqual({
       loading: false,
-      connectionError: false,
       softwareUpdates: {
         [host1]: { relevant_patches: [], upgradable_packages: [] },
         [host2]: newSoftwareUpdates,
@@ -149,21 +147,6 @@ describe('SoftwareUpdates reducer', () => {
       },
       errors: [],
     });
-  });
-
-  it('should set connection error when error occurs', () => {
-    const initialState = {
-      loading: true,
-      connectionError: false,
-      softwareUpdates: {},
-      errors: [],
-    };
-
-    const action = setSoftwareUpdatesConnectionError();
-
-    const actual = softwareUpdatesReducer(initialState, action);
-
-    expect(actual).toEqual({ ...initialState, connectionError: true });
   });
 
   it('should set errors upon if error occurred', () => {


### PR DESCRIPTION
# Description

Changes to the error handling in the `AvailableSoftwareUpdates` component, when a connection error happens while requesting software updates:

- Replaces message "_SUSE Manager connection failed_" with "_Unknown_"
- Replaces tooltip message "_**SUSE Manager** was not able to retrieve the requested data_" with "_**Trento** was not able to retrieve the requested data_"

These new requirements obviate the need for `connectionError` in the Redux state, originally added in https://github.com/trento-project/web/pull/2538

## How was this tested?

Updated unit tests
