### PR TITLE
Add a generate password button for the UserForm

### DIFF
--- a/assets/js/common/Input/Password.jsx
+++ b/assets/js/common/Input/Password.jsx
@@ -12,6 +12,7 @@ function Password({
   id,
   name,
   value,
+  initialValue,
   placeholder = 'Password',
   error = false,
   disabled = false,
@@ -24,7 +25,8 @@ function Password({
       className={classNames(className)}
       id={id}
       name={name}
-      initialValue={value}
+      value={value}
+      initialValue={initialValue}
       placeholder={placeholder}
       type={inputType}
       error={error}

--- a/assets/js/common/Input/Password.stories.jsx
+++ b/assets/js/common/Input/Password.stories.jsx
@@ -35,13 +35,13 @@ export default {
 export const Default = {};
 export const WithValue = {
   args: {
-    value: 'somepassword',
+    initialValue: 'somepassword',
   },
 };
 
 export const WithError = {
   args: {
-    value: 'someotherpassword',
+    initialValue: 'someotherpassword',
     error: true,
   },
 };
@@ -52,7 +52,7 @@ export const Disabled = {
   },
 };
 
-export const WithDisabled = {
+export const DisabledWithInitialValue = {
   args: {
     ...WithValue.args,
     ...Disabled.args,

--- a/assets/js/pages/Users/EditUserPage.test.jsx
+++ b/assets/js/pages/Users/EditUserPage.test.jsx
@@ -165,6 +165,9 @@ describe('EditUserPage', () => {
       route: `/users/${userData.id}/edit`,
     });
 
+    const generatePasswordButton = await screen.findByText('Generate Password');
+    expect(generatePasswordButton).toBeDisabled();
+
     await screen.findByText('Edit User');
 
     const editButton = screen.getByRole('button', { name: 'Edit' });

--- a/assets/js/pages/Users/UserForm.jsx
+++ b/assets/js/pages/Users/UserForm.jsx
@@ -213,7 +213,11 @@ function UserForm({
               errorMessage(confirmPasswordErrorState)}
           </div>
           <div className="col-start-2 col-span-3">
-            <Button type="primary-white" onClick={onGeneratePassword}>
+            <Button
+              type="primary-white"
+              onClick={onGeneratePassword}
+              disabled={!saveEnabled}
+            >
               Generate Password
             </Button>
           </div>

--- a/assets/js/pages/Users/UserForm.jsx
+++ b/assets/js/pages/Users/UserForm.jsx
@@ -7,8 +7,8 @@ import Input, { Password } from '@common/Input';
 import Label from '@common/Label';
 import Select from '@common/Select';
 import Tooltip from '@common/Tooltip';
-
 import { getError } from '@lib/api/validationErrors';
+import { generatePassword } from './generatePassword';
 
 const USER_ENABLED = 'Enabled';
 const REQUIRED_FIELD_TEXT = 'Required field';
@@ -116,6 +116,12 @@ function UserForm({
     onSave(user);
   };
 
+  const onGeneratePassword = () => {
+    const newPassword = generatePassword();
+    setPassword(newPassword);
+    setConfirmPassword(newPassword);
+  };
+
   return (
     <div>
       <div className="container max-w-7xl mx-auto p-4 sm:p-6 lg:p-8 bg-white dark:bg-gray-800 rounded-lg">
@@ -205,6 +211,11 @@ function UserForm({
             />
             {confirmPasswordErrorState &&
               errorMessage(confirmPasswordErrorState)}
+          </div>
+          <div className="col-start-2 col-span-3">
+            <Button type="primary-white" onClick={onGeneratePassword}>
+              Generate Password
+            </Button>
           </div>
           <Label className="col-start-1 col-span-1">Permissions</Label>
           <div className="col-start-2 col-span-3">

--- a/assets/js/pages/Users/UserForm.stories.jsx
+++ b/assets/js/pages/Users/UserForm.stories.jsx
@@ -83,7 +83,7 @@ export default {
     saveEnabled: {
       description: 'User saving is enabled',
       control: {
-        type: 'text',
+        type: 'boolean',
       },
     },
     saveText: {

--- a/assets/js/pages/Users/UserForm.test.jsx
+++ b/assets/js/pages/Users/UserForm.test.jsx
@@ -24,6 +24,7 @@ describe('UserForm', () => {
     expect(screen.getByLabelText('password').value).toBe('');
     expect(screen.getByText('Confirm Password')).toBeVisible();
     expect(screen.getByLabelText('password-confirmation').value).toBe('');
+    expect(screen.getByText('Generate Password'));
     expect(screen.getByText('Permissions')).toBeVisible();
     expect(screen.getByText('Status')).toBeVisible();
     expect(screen.queryByText('Created')).not.toBeInTheDocument();
@@ -131,6 +132,28 @@ describe('UserForm', () => {
     await user.click(screen.getByRole('button', { name: 'Edit' }));
 
     expect(screen.getAllByText('Required field').length).toBe(3);
+  });
+
+  it('should generate a password on button click', async () => {
+    const user = userEvent.setup();
+    const defaultPasswordSize = 16;
+    render(<UserForm />);
+    const passwordValueDefault = screen.getByLabelText('password').value;
+    expect(passwordValueDefault).toBe('');
+    const confirmPasswordValueDefault = screen.getByLabelText(
+      'password-confirmation'
+    ).value;
+    expect(confirmPasswordValueDefault).toBe('');
+
+    await user.click(screen.getByRole('button', { name: 'Generate Password' }));
+    const passwordValue = screen.getByLabelText('password').value;
+    const confirmPasswordValue = screen.getByLabelText(
+      'password-confirmation'
+    ).value;
+    expect(passwordValue).not.toBe('');
+    expect(confirmPasswordValue).not.toBe('');
+    expect(passwordValue.length).toBe(defaultPasswordSize);
+    expect(confirmPasswordValue.length).toBe(defaultPasswordSize);
   });
 
   it('should save the user', async () => {

--- a/assets/js/pages/Users/generatePassword.js
+++ b/assets/js/pages/Users/generatePassword.js
@@ -1,0 +1,15 @@
+const DIGITS = '0123456789';
+const UPPERCASE_LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const LOWERCASE_LETTERS = 'abcdefghijklmnopqrstuvwxyz';
+const SPECIAL_CHARACTERS = '~!@#$%^&*()_+={}[]|:;<>,.?/-\'"`';
+
+const PASSWORD_CHARACTERS =
+  DIGITS + UPPERCASE_LETTERS + LOWERCASE_LETTERS + SPECIAL_CHARACTERS;
+
+export const generatePassword = (
+  length = 16,
+  characters = PASSWORD_CHARACTERS
+) =>
+  Array.from(crypto.getRandomValues(new Uint32Array(length)))
+    .map((char) => characters[char % characters.length])
+    .join('');

--- a/assets/js/pages/Users/generatePassword.test.js
+++ b/assets/js/pages/Users/generatePassword.test.js
@@ -1,0 +1,20 @@
+import { generatePassword } from './generatePassword';
+
+describe('generatePassword', () => {
+  test('generates a password of default length 16', () => {
+    const password = generatePassword();
+    expect(password).toHaveLength(16);
+  });
+
+  test('generates a password of specific length', () => {
+    const length = 20;
+    const password = generatePassword(length);
+    expect(password).toHaveLength(length);
+  });
+
+  test('generates passwords that vary', () => {
+    const firstPassword = generatePassword();
+    const secondPassword = generatePassword();
+    expect(firstPassword).not.toBe(secondPassword);
+  });
+});


### PR DESCRIPTION
# Description

This pr will add a generate password button to the User creation/edit form. 
As we can't use faker to produce some random password in production, I added a password generation helper function. 

After some research, using [crypto.getRandomValues](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues) seems like a valid solution to get cryptographically strong random values. 

Per default, we generate a 16 char long password which includes digits, uppercase/lowercase letters and special characters

### Preview


[Screencast from 2024-05-03 12-29-28.webm](https://github.com/trento-project/web/assets/54111255/b046f9b0-bd3c-475f-b10c-d85611b95acf)




## How was this tested?

User Create test updated and added new test
Storybook

## What is missing ? 

Add test for user edit after merge
