### PR TITLE
Validation of CA certificate inside SUSE Manager settings

### DIFF
--- a/lib/trento/software_updates.ex
+++ b/lib/trento/software_updates.ex
@@ -26,12 +26,12 @@ defmodule Trento.SoftwareUpdates do
 
   @spec get_settings :: {:ok, Settings.t()} | {:error, :settings_not_configured}
   def get_settings do
-    case has_settings?(settings = Repo.one(Settings.base_query())) do
-      true ->
-        {:ok, settings}
+    settings = Repo.one(Settings.base_query())
 
-      false ->
-        {:error, :settings_not_configured}
+    if has_settings?(settings) do
+      {:ok, settings}
+    else
+      {:error, :settings_not_configured}
     end
   end
 

--- a/lib/trento/software_updates.ex
+++ b/lib/trento/software_updates.ex
@@ -28,7 +28,7 @@ defmodule Trento.SoftwareUpdates do
   def get_settings do
     settings = Repo.one(Settings.base_query())
 
-    if has_settings?(settings) do
+    if settings do
       {:ok, settings}
     else
       {:error, :settings_not_configured}
@@ -113,18 +113,12 @@ defmodule Trento.SoftwareUpdates do
     end
   end
 
-  defp has_settings?(%Settings{}),
-    do: true
-
-  defp has_settings?(nil),
-    do: false
-
   defp ensure_no_settings_configured do
-    case has_settings?(settings = Repo.one(Settings.base_query())) do
-      false ->
-        {:ok, :settings_not_configured, settings}
+    case Repo.one(Settings.base_query()) do
+      nil ->
+        {:ok, :settings_not_configured, nil}
 
-      true ->
+      %Settings{} ->
         Logger.error("Error: software updates settings already configured")
         {:error, :settings_already_configured}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -109,7 +109,8 @@ defmodule Trento.MixProject do
       {:ecto, "~> 3.10", override: true},
       # https://github.com/deadtrickster/ssl_verify_fun.erl/pull/27
       {:ssl_verify_fun, "~> 1.1", manager: :rebar3, override: true},
-      {:parallel_stream, "~> 1.1.0"}
+      {:parallel_stream, "~> 1.1.0"},
+      {:x509, "~> 0.8.8"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -94,4 +94,5 @@
   "tzdata": {:hex, :tzdata, "1.1.1", "20c8043476dfda8504952d00adac41c6eda23912278add38edc140ae0c5bcc46", [:mix], [{:hackney, "~> 1.17", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm", "a69cec8352eafcd2e198dea28a34113b60fdc6cb57eb5ad65c10292a6ba89787"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
   "unplug": {:hex, :unplug, "1.0.0", "8ec2479de0baa9a6283c04a1cc616c5ca6c5b80b8ff1d857481bb2943368dbbc", [:mix], [{:plug, "~> 1.8", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm", "d171a85758aa412d4e85b809c203e1b1c4c76a4d6ab58e68dc9a8a8acd9b7c3a"},
+  "x509": {:hex, :x509, "0.8.8", "aaf5e58b19a36a8e2c5c5cff0ad30f64eef5d9225f0fd98fb07912ee23f7aba3", [:mix], [], "hexpm", "ccc3bff61406e5bb6a63f06d549f3dba3a1bbb456d84517efaaa210d8a33750f"},
 }

--- a/priv/repo/migrations/20240502105156_migrate_suma_settings_sti.exs
+++ b/priv/repo/migrations/20240502105156_migrate_suma_settings_sti.exs
@@ -1,0 +1,15 @@
+defmodule Trento.Repo.Migrations.MigrateSumaSettingsSti do
+  use Ecto.Migration
+
+  def change do
+    alter table(:settings) do
+      add :suse_manager_settings_url, :string
+      add :suse_manager_settings_username, :string
+      add :suse_manager_settings_password, :binary
+      add :suse_manager_settings_ca_cert, :binary
+      add :suse_manager_settings_ca_uploaded_at, :utc_datetime_usec
+    end
+
+    drop table(:software_update_settings)
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -822,7 +822,7 @@ defmodule Trento.Factory do
   end
 
   def software_updates_settings_factory(attrs) do
-    self_signed_cert = build(:self_signed_certificate) 
+    self_signed_cert = build(:self_signed_certificate)
 
     url = Map.get(attrs, :url, Faker.Internet.url())
     username = Map.get(attrs, :username, Faker.Internet.user_name())
@@ -832,6 +832,7 @@ defmodule Trento.Factory do
 
     %Settings{}
     |> Settings.changeset(%{
+      type: :suse_manager_settings,
       url: url,
       username: username,
       password: password,
@@ -862,7 +863,7 @@ defmodule Trento.Factory do
     insert(
       :software_updates_settings,
       attrs,
-      conflict_target: :id,
+      conflict_target: :type,
       on_conflict: :replace_all
     )
   end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -922,10 +922,14 @@ defmodule Trento.Factory do
     }
   end
 
-  def self_signed_certificate_factory(_) do
+  def self_signed_certificate_factory(attrs) do
+    validity = Map.get(attrs, :validity, 500)
+
     2048
     |> X509.PrivateKey.new_rsa()
-    |> X509.Certificate.self_signed("/C=US/ST=NT/L=Springfield/O=ACME Inc./CN=Intermediate CA")
+    |> X509.Certificate.self_signed("/C=US/ST=NT/L=Springfield/O=ACME Inc./CN=Intermediate CA",
+      validity: validity
+    )
     |> X509.Certificate.to_pem()
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -822,10 +822,12 @@ defmodule Trento.Factory do
   end
 
   def software_updates_settings_factory(attrs) do
+    self_signed_cert = build(:self_signed_certificate) 
+
     url = Map.get(attrs, :url, Faker.Internet.url())
     username = Map.get(attrs, :username, Faker.Internet.user_name())
     password = Map.get(attrs, :password, Faker.Lorem.word())
-    ca_cert = Map.get(attrs, :ca_cert, Faker.Lorem.sentence())
+    ca_cert = Map.get(attrs, :ca_cert, self_signed_cert)
     ca_uploaded_at = Map.get(attrs, :ca_uploaded_at, DateTime.utc_now())
 
     %Settings{}
@@ -917,5 +919,12 @@ defmodule Trento.Factory do
           "max_login_retries_reached"
         ])
     }
+  end
+
+  def self_signed_certificate_factory(_) do
+    2048
+    |> X509.PrivateKey.new_rsa()
+    |> X509.Certificate.self_signed("/C=US/ST=NT/L=Springfield/O=ACME Inc./CN=Intermediate CA")
+    |> X509.Certificate.to_pem()
   end
 end

--- a/test/trento/software_updates_test.exs
+++ b/test/trento/software_updates_test.exs
@@ -50,7 +50,7 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
         ca_uploaded_at: ca_uploaded_at
       } =
         insert_software_updates_settings(
-          ca_cert: Faker.Lorem.sentence(),
+          ca_cert: build(:self_signed_certificate),
           ca_uploaded_at: DateTime.utc_now()
         )
 
@@ -172,7 +172,7 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
         url: url = "https://valid.com",
         username: username = Faker.Internet.user_name(),
         password: password = Faker.Lorem.word(),
-        ca_cert: ca_cert = Faker.Lorem.sentence()
+        ca_cert: ca_cert = build(:self_signed_certificate)
       }
 
       assert {:ok,
@@ -221,7 +221,7 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
           url: "https://valid.com",
           username: Faker.Internet.user_name(),
           password: Faker.Lorem.word(),
-          ca_cert: Faker.Lorem.sentence()
+          ca_cert: build(:self_signed_certificate)
         }
 
         assert {:ok, _} = operation.(settings)
@@ -358,7 +358,7 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
 
       change_submission = %{
         url: new_url = "https://new.com",
-        ca_cert: new_ca_cert = "new_ca_cert"
+        ca_cert: new_ca_cert = build(:self_signed_certificate)
       }
 
       assert {:ok,
@@ -381,7 +381,7 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
         ca_uploaded_at: _initial_ca_uploaded_at
       } =
         insert_software_updates_settings(
-          ca_cert: Faker.Lorem.sentence(),
+          ca_cert: build(:self_signed_certificate),
           ca_uploaded_at: DateTime.utc_now()
         )
 
@@ -395,7 +395,7 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
 
       change_submission = %{
         url: new_url = "https://new.com",
-        ca_cert: new_ca_cert = "new_ca_cert"
+        ca_cert: new_ca_cert = build(:self_signed_certificate)
       }
 
       Enum.each(1..3, fn run_iteration ->

--- a/test/trento/software_updates_test.exs
+++ b/test/trento/software_updates_test.exs
@@ -461,6 +461,25 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
               }} = SoftwareUpdates.change_settings(change_submission)
     end
 
+    test "should reject a 'foobar' SSL certificate" do
+      insert_software_updates_settings(ca_cert: nil)
+
+      change_submission = %{
+        ca_cert: """
+        -----BEGIN CERTIFICATE-----
+        foobar
+        -----END CERTIFICATE-----
+        """
+      }
+
+      assert {:error,
+              %{
+                errors: [
+                  ca_cert: {"unable to parse X.509 certificate", [validation: :ca_cert_parsing]}
+                ]
+              }} = SoftwareUpdates.change_settings(change_submission)
+    end
+
     test "should reject an expired SSL certificate" do
       insert_software_updates_settings(ca_cert: nil)
 

--- a/test/trento/software_updates_test.exs
+++ b/test/trento/software_updates_test.exs
@@ -445,6 +445,36 @@ defmodule Trento.SoftwareUpdates.SettingsTest do
                 ca_uploaded_at: nil
               }} = SoftwareUpdates.change_settings(change_submission)
     end
+
+    test "should reject an invalid SSL certificate" do
+      insert_software_updates_settings(ca_cert: nil)
+
+      change_submission = %{
+        ca_cert: Faker.Lorem.word()
+      }
+
+      assert {:error,
+              %{
+                errors: [
+                  ca_cert: {"unable to parse X.509 certificate", [validation: :ca_cert_parsing]}
+                ]
+              }} = SoftwareUpdates.change_settings(change_submission)
+    end
+
+    test "should reject an expired SSL certificate" do
+      insert_software_updates_settings(ca_cert: nil)
+
+      change_submission = %{
+        ca_cert: build(:self_signed_certificate, validity: 0)
+      }
+
+      assert {:error,
+              %{
+                errors: [
+                  ca_cert: {"the X.509 certificate is not valid", [validation: :ca_cert_validity]}
+                ]
+              }} = SoftwareUpdates.change_settings(change_submission)
+    end
   end
 
   describe "clearing software update settings" do

--- a/test/trento_web/controllers/v1/suma_credentials_controller_test.exs
+++ b/test/trento_web/controllers/v1/suma_credentials_controller_test.exs
@@ -16,7 +16,7 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
   describe "retrieve user settings" do
     test "should return user settings", %{conn: conn} do
       insert_software_updates_settings(
-        ca_cert: Faker.Lorem.sentence(),
+        ca_cert: build(:self_signed_certificate),
         ca_uploaded_at: DateTime.utc_now()
       )
 
@@ -45,7 +45,7 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
           url: Faker.Internet.image_url(),
           username: Faker.Internet.user_name(),
           password: Faker.Lorem.word(),
-          ca_cert: Faker.Lorem.sentence()
+          ca_cert: build(:self_signed_certificate)
         }
 
       %{"ca_uploaded_at" => ca_uploaded_at} =
@@ -64,7 +64,7 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
         url: "http://insecureurl.com",
         username: Faker.Internet.user_name(),
         password: Faker.Lorem.word(),
-        ca_cert: Faker.Lorem.sentence()
+        ca_cert: build(:self_signed_certificate)
       }
 
       resp =
@@ -119,7 +119,7 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
         url: Faker.Internet.image_url(),
         username: Faker.Internet.user_name(),
         password: Faker.Lorem.word(),
-        ca_cert: Faker.Lorem.sentence()
+        ca_cert: build(:self_signed_certificate)
       }
 
       resp =
@@ -341,7 +341,7 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
         ca_uploaded_at: initial_ca_uploaded_at
       } =
         insert_software_updates_settings(
-          ca_cert: Faker.Lorem.sentence(),
+          ca_cert: build(:self_signed_certificate),
           ca_uploaded_at: DateTime.utc_now()
         )
 
@@ -374,11 +374,14 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
         ca_uploaded_at: initial_ca_uploaded_at
       } =
         insert_software_updates_settings(
-          ca_cert: Faker.Lorem.sentence(),
+          ca_cert: build(:self_signed_certificate),
           ca_uploaded_at: DateTime.utc_now()
         )
 
-      change_submission = %{url: new_url = "https://new.com", ca_cert: "new_ca_cert"}
+      change_submission = %{
+        url: new_url = "https://new.com",
+        ca_cert: build(:self_signed_certificate)
+      }
 
       resp =
         conn
@@ -402,7 +405,7 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
         ca_uploaded_at: _initial_ca_uploaded_at
       } =
         insert_software_updates_settings(
-          ca_cert: Faker.Lorem.sentence(),
+          ca_cert: build(:self_signed_certificate),
           ca_uploaded_at: DateTime.utc_now()
         )
 


### PR DESCRIPTION
# Description
Introducing validation for the CA certificate uploaded in SUSE Manager settings.

Took advantage of this to also migrate the settings schema to the Single Table Inheritance pattern implemented across the rest of our settings.

## How was this tested?

Existing unit tests
