### PR TITLE
User profile routes

### DIFF
--- a/lib/trento/users.ex
+++ b/lib/trento/users.ex
@@ -49,13 +49,15 @@ defmodule Trento.Users do
     |> Repo.insert()
   end
 
-  def update_user(%User{id: 1}, _), do: {:error, :forbidden}
+  def update_user_profile(%User{id: 1}, _), do: {:error, :forbidden}
 
   def update_user_profile(%User{} = user, attrs) do
     user
     |> User.profile_update_changeset(attrs)
     |> Repo.update()
   end
+
+  def update_user(%User{id: 1}, _), do: {:error, :forbidden}
 
   def update_user(%User{locked_at: nil} = user, %{enabled: false} = attrs) do
     do_update(user, Map.put(attrs, :locked_at, DateTime.utc_now()))

--- a/lib/trento/users.ex
+++ b/lib/trento/users.ex
@@ -51,6 +51,12 @@ defmodule Trento.Users do
 
   def update_user(%User{id: 1}, _), do: {:error, :forbidden}
 
+  def update_user_profile(%User{} = user, attrs) do
+    user
+    |> User.profile_update_changeset(attrs)
+    |> Repo.update()
+  end
+
   def update_user(%User{locked_at: nil} = user, %{enabled: false} = attrs) do
     do_update(user, Map.put(attrs, :locked_at, DateTime.utc_now()))
   end

--- a/lib/trento/users/user.ex
+++ b/lib/trento/users/user.ex
@@ -70,7 +70,7 @@ defmodule Trento.Users.User do
   end
 
   defp validate_current_password(changeset, %{password: _password} = attrs),
-    do: changeset |> pow_current_password_changeset(attrs)
+    do: pow_current_password_changeset(changeset, attrs)
 
   defp validate_current_password(changeset, _), do: changeset
 

--- a/lib/trento/users/user.ex
+++ b/lib/trento/users/user.ex
@@ -55,6 +55,7 @@ defmodule Trento.Users.User do
 
   def profile_update_changeset(user, attrs) do
     user
+    |> validate_current_password(attrs)
     |> pow_password_changeset(attrs)
     |> pow_extension_changeset(attrs)
     |> validate_password()
@@ -67,6 +68,11 @@ defmodule Trento.Users.User do
     |> validate_required(:deleted_at)
     |> put_change(:username, "#{username}__#{deleted_at}")
   end
+
+  defp validate_current_password(changeset, %{password: _password} = attrs),
+    do: changeset |> pow_current_password_changeset(attrs)
+
+  defp validate_current_password(changeset, _), do: changeset
 
   defp lock_changeset(user, attrs) do
     cast(user, attrs, [:locked_at])

--- a/lib/trento/users/user.ex
+++ b/lib/trento/users/user.ex
@@ -53,6 +53,14 @@ defmodule Trento.Users.User do
     |> lock_changeset(attrs)
   end
 
+  def profile_update_changeset(user, attrs) do
+    user
+    |> pow_password_changeset(attrs)
+    |> pow_extension_changeset(attrs)
+    |> validate_password()
+    |> custom_fields_changeset(attrs)
+  end
+
   def delete_changeset(%__MODULE__{username: username} = user, %{deleted_at: deleted_at} = attrs) do
     user
     |> cast(attrs, [:deleted_at])

--- a/lib/trento_web/controllers/v1/profile_controller.ex
+++ b/lib/trento_web/controllers/v1/profile_controller.ex
@@ -1,0 +1,39 @@
+defmodule TrentoWeb.V1.ProfileController do
+  use TrentoWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias TrentoWeb.OpenApi.V1.Schema
+  alias Trento.Users
+
+  plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
+  action_fallback TrentoWeb.FallbackController
+
+  operation :show,
+    summary: "Get profile",
+    tags: ["Platform"],
+    description: "Retrieve the current user profile",
+    responses: [
+      ok: {"The user profile", "application/json", Schema.User.UserProfile}
+    ]
+
+  def show(conn, _) do
+    with %{"user_id" => user_id} <- Pow.Plug.current_user(conn),
+         {user_id, _} <- Integer.parse(user_id),
+         {:ok, user} <- Users.get_user(user_id) do
+      render(conn, "profile.json", user: user)
+    end
+  end
+
+  operation :update,
+    summary: "Update the current user profile",
+    tags: ["Platform"],
+    request_body:
+      {"UserProfileUpdateRequest", "application/json", Schema.User.UserProfileUpdateRequest},
+    responses: [
+      created: {"Profile updated successfully", "application/json", Schema.User.UserProfile},
+      unprocessable_entity: Schema.UnprocessableEntity.response()
+    ]
+
+  def update(conn, _) do
+  end
+end

--- a/lib/trento_web/controllers/v1/profile_controller.ex
+++ b/lib/trento_web/controllers/v1/profile_controller.ex
@@ -30,7 +30,8 @@ defmodule TrentoWeb.V1.ProfileController do
       {"UserProfileUpdateRequest", "application/json", Schema.User.UserProfileUpdateRequest},
     responses: [
       ok: {"Profile updated successfully", "application/json", Schema.User.UserProfile},
-      unprocessable_entity: Schema.UnprocessableEntity.response()
+      unprocessable_entity: Schema.UnprocessableEntity.response(),
+      forbidden: Schema.Forbidden.response()
     ]
 
   def update(%{body_params: profile_params} = conn, _) do

--- a/lib/trento_web/controllers/v1/profile_controller.ex
+++ b/lib/trento_web/controllers/v1/profile_controller.ex
@@ -2,10 +2,12 @@ defmodule TrentoWeb.V1.ProfileController do
   use TrentoWeb, :controller
   use OpenApiSpex.ControllerSpecs
 
-  alias TrentoWeb.OpenApi.V1.Schema
   alias Trento.Users
+  alias Trento.Users.User
+  alias TrentoWeb.OpenApi.V1.Schema
 
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
+  plug TrentoWeb.Plugs.LoadUserPlug
   action_fallback TrentoWeb.FallbackController
 
   operation :show,
@@ -17,11 +19,8 @@ defmodule TrentoWeb.V1.ProfileController do
     ]
 
   def show(conn, _) do
-    with %{"user_id" => user_id} <- Pow.Plug.current_user(conn),
-         {user_id, _} <- Integer.parse(user_id),
-         {:ok, user} <- Users.get_user(user_id) do
-      render(conn, "profile.json", user: user)
-    end
+    %User{} = user = Pow.Plug.current_user(conn)
+    render(conn, "profile.json", user: user)
   end
 
   operation :update,
@@ -30,10 +29,15 @@ defmodule TrentoWeb.V1.ProfileController do
     request_body:
       {"UserProfileUpdateRequest", "application/json", Schema.User.UserProfileUpdateRequest},
     responses: [
-      created: {"Profile updated successfully", "application/json", Schema.User.UserProfile},
+      ok: {"Profile updated successfully", "application/json", Schema.User.UserProfile},
       unprocessable_entity: Schema.UnprocessableEntity.response()
     ]
 
-  def update(conn, _) do
+  def update(%{body_params: profile_params} = conn, _) do
+    %User{} = user = Pow.Plug.current_user(conn)
+
+    with {:ok, %User{} = updated_user} <- Users.update_user_profile(user, profile_params) do
+      render(conn, "profile.json", user: updated_user)
+    end
   end
 end

--- a/lib/trento_web/openapi/v1/schema/user.ex
+++ b/lib/trento_web/openapi/v1/schema/user.ex
@@ -48,6 +48,11 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
         fullname: %Schema{type: :string, description: "User full name", nullable: false},
         email: %Schema{type: :string, description: "User email", nullable: false, format: :email},
         password: %Schema{type: :string, description: "User new password", nullable: false},
+        current_password: %Schema{
+          type: :string,
+          description: "User current password, used to set a new password",
+          nullable: false
+        },
         password_confirmation: %Schema{
           type: :string,
           description: "User new password, should be the same as password field",

--- a/lib/trento_web/openapi/v1/schema/user.ex
+++ b/lib/trento_web/openapi/v1/schema/user.ex
@@ -4,6 +4,61 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
   require OpenApiSpex
   alias OpenApiSpex.Schema
 
+  defmodule UserProfile do
+    @moduledoc false
+
+    @schema %Schema{
+      title: "UserProfile",
+      description: "Trento User profile",
+      type: :object,
+      additionalProperties: false,
+      properties: %{
+        id: %Schema{type: :integer, description: "User ID", nullable: false},
+        fullname: %Schema{type: :string, description: "User full name", nullable: false},
+        username: %Schema{type: :string, description: "User username", nullable: false},
+        email: %Schema{type: :string, description: "User email", nullable: false, format: :email},
+        created_at: %OpenApiSpex.Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Date of user creation",
+          nullable: false
+        },
+        updated_at: %OpenApiSpex.Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Date of user last update",
+          nullable: true
+        }
+      },
+      required: [:username, :id, :fullname, :email, :created_at]
+    }
+
+    def schema, do: @schema
+  end
+
+  defmodule UserProfileUpdateRequest do
+    @moduledoc false
+
+    @schema %Schema{
+      title: "UserProfileUpdateRequest",
+      description: "Request body to update a user profile",
+      additionalProperties: false,
+      type: :object,
+      properties: %{
+        fullname: %Schema{type: :string, description: "User full name", nullable: false},
+        email: %Schema{type: :string, description: "User email", nullable: false, format: :email},
+        password: %Schema{type: :string, description: "User new password", nullable: false},
+        password_confirmation: %Schema{
+          type: :string,
+          description: "User new password, should be the same as password field",
+          nullable: false
+        }
+      }
+    }
+
+    def schema, do: @schema
+  end
+
   defmodule UserCreationRequest do
     @moduledoc false
 

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -86,6 +86,9 @@ defmodule TrentoWeb.Router do
     scope "/v1", TrentoWeb.V1 do
       pipe_through [:api_v1]
 
+      get "/profile", ProfileController, :show
+      patch "/profile", ProfileController, :update
+
       get "/about", AboutController, :info
 
       get "/installation/api-key", InstallationController, :get_api_key

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -86,9 +86,6 @@ defmodule TrentoWeb.Router do
     scope "/v1", TrentoWeb.V1 do
       pipe_through [:api_v1]
 
-      get "/profile", ProfileController, :show
-      patch "/profile", ProfileController, :update
-
       get "/about", AboutController, :info
 
       get "/installation/api-key", InstallationController, :get_api_key
@@ -151,6 +148,9 @@ defmodule TrentoWeb.Router do
              :delete_database_instance
 
       resources "/users", UsersController, except: [:new, :edit]
+
+      get "/profile", ProfileController, :show
+      patch "/profile", ProfileController, :update
 
       scope "/settings" do
         get "/", SettingsController, :settings

--- a/lib/trento_web/views/v1/profile_view.ex
+++ b/lib/trento_web/views/v1/profile_view.ex
@@ -1,0 +1,23 @@
+defmodule TrentoWeb.V1.ProfileView do
+  use TrentoWeb, :view
+
+  def render("profile.json", %{
+        user: %{
+          id: id,
+          fullname: fullname,
+          username: username,
+          email: email,
+          inserted_at: created_at,
+          updated_at: updated_at
+        }
+      }) do
+    %{
+      id: id,
+      fullname: fullname,
+      username: username,
+      email: email,
+      created_at: created_at,
+      updated_at: updated_at
+    }
+  end
+end

--- a/test/trento/users_test.exs
+++ b/test/trento/users_test.exs
@@ -26,8 +26,26 @@ defmodule Trento.UsersTest do
       assert password_hash == updated_password_hash
     end
 
+    test "update_user_profile does not require current password when the password field is not involved in the update" do
+      %{id: user_id} =
+        insert(:user)
+
+      {:ok, user} = Users.get_user(user_id)
+
+      assert {:ok, %User{} = user} =
+               Users.update_user_profile(user, %{
+                 fullname: "some updated fullname",
+                 email: "newemail@test.com"
+               })
+
+      assert user.fullname == "some updated fullname"
+      assert user.email == "newemail@test.com"
+    end
+
     test "update_user_profile update only the user profile fields" do
-      %{id: user_id, username: username, password_hash: password_hash} = insert(:user)
+      %{id: user_id, username: username, password_hash: password_hash, password: current_password} =
+        insert(:user)
+
       {:ok, user} = Users.get_user(user_id)
 
       assert {:ok, %User{locked_at: locked_at, password_hash: updated_password_hash} = user} =
@@ -36,6 +54,7 @@ defmodule Trento.UsersTest do
                  email: "newemail@test.com",
                  username: "new_username",
                  enabled: false,
+                 current_password: current_password,
                  password: "newpassword989",
                  confirm_password: "newpassword989"
                })

--- a/test/trento/users_test.exs
+++ b/test/trento/users_test.exs
@@ -5,6 +5,49 @@ defmodule Trento.UsersTest do
   alias Trento.Users.User
   import Trento.Factory
 
+  describe "user profile" do
+    test "update_user_profile does not update the profile when fields are not present" do
+      %{id: user_id, username: username, password_hash: password_hash} = insert(:user)
+      {:ok, user} = Users.get_user(user_id)
+
+      assert {:ok,
+              %User{
+                locked_at: locked_at,
+                password_hash: updated_password_hash,
+                fullname: updated_fullname,
+                email: updated_email
+              } = user} =
+               Users.update_user_profile(user, %{})
+
+      assert user.fullname == updated_fullname
+      assert user.email == updated_email
+      assert user.username == username
+      assert nil == locked_at
+      assert password_hash == updated_password_hash
+    end
+
+    test "update_user_profile update only the user profile fields" do
+      %{id: user_id, username: username, password_hash: password_hash} = insert(:user)
+      {:ok, user} = Users.get_user(user_id)
+
+      assert {:ok, %User{locked_at: locked_at, password_hash: updated_password_hash} = user} =
+               Users.update_user_profile(user, %{
+                 fullname: "some updated fullname",
+                 email: "newemail@test.com",
+                 username: "new_username",
+                 enabled: false,
+                 password: "newpassword989",
+                 confirm_password: "newpassword989"
+               })
+
+      assert user.fullname == "some updated fullname"
+      assert user.email == "newemail@test.com"
+      assert user.username == username
+      assert nil == locked_at
+      assert password_hash != updated_password_hash
+    end
+  end
+
   describe "users" do
     test "list_users returns all users except the deleted ones" do
       %{id: user_id} = insert(:user)

--- a/test/trento_web/controllers/v1/profile_controller_test.exs
+++ b/test/trento_web/controllers/v1/profile_controller_test.exs
@@ -41,13 +41,14 @@ defmodule TrentoWeb.V1.ProfileControllerTest do
   test "should update the profile with allowed fields", %{
     conn: conn,
     api_spec: api_spec,
-    user: %{id: user_id}
+    user: %{id: user_id, password: current_password}
   } do
     %{fullname: fullname, email: email} =
       valid_params = %{
         fullname: Faker.Person.name(),
         email: Faker.Internet.email(),
         password: "testpassword89",
+        current_password: current_password,
         password_confirmation: "testpassword89"
       }
 

--- a/test/trento_web/controllers/v1/profile_controller_test.exs
+++ b/test/trento_web/controllers/v1/profile_controller_test.exs
@@ -1,0 +1,63 @@
+defmodule TrentoWeb.V1.ProfileControllerTest do
+  use TrentoWeb.ConnCase, async: true
+
+  import OpenApiSpex.TestAssertions
+  import Trento.Factory
+  alias TrentoWeb.OpenApi.V1.ApiSpec
+
+  setup %{conn: conn} do
+    user = insert(:user)
+
+    conn =
+      conn
+      |> Plug.Conn.put_private(:plug_session, %{})
+      |> Plug.Conn.put_private(:plug_session_fetch, :done)
+      |> Pow.Plug.put_config(otp_app: :trento)
+
+    api_spec = ApiSpec.spec()
+
+    conn =
+      Pow.Plug.assign_current_user(conn, %{"user_id" => user.id}, Pow.Plug.fetch_config(conn))
+
+    {:ok,
+     conn: put_req_header(conn, "accept", "application/json"), api_spec: api_spec, user: user}
+  end
+
+  test "should show the current user profile", %{
+    user: %{id: user_id},
+    conn: conn,
+    api_spec: api_spec
+  } do
+    conn = get(conn, "/api/v1/profile")
+
+    resp =
+      conn
+      |> json_response(200)
+      |> assert_schema("UserProfile", api_spec)
+
+    assert %{id: ^user_id} = resp
+  end
+
+  test "should update the profile with allowed fields", %{
+    conn: conn,
+    api_spec: api_spec,
+    user: %{id: user_id}
+  } do
+    %{fullname: fullname, email: email} =
+      valid_params = %{
+        fullname: Faker.Person.name(),
+        email: Faker.Internet.email(),
+        password: "testpassword89",
+        password_confirmation: "testpassword89"
+      }
+
+    resp =
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> patch("/api/v1/profile", valid_params)
+      |> json_response(:ok)
+      |> assert_schema("UserProfile", api_spec)
+
+    assert %{id: ^user_id, fullname: ^fullname, email: ^email} = resp
+  end
+end


### PR DESCRIPTION
# Description

Routes for updating/showing a logged user profile.
Like the normal user updates, the default admin could not update profile.

## How was this tested?

Automated tests
