### PR TITLE
Add soft delete for email and update test

### DIFF
--- a/lib/trento/users/user.ex
+++ b/lib/trento/users/user.ex
@@ -62,11 +62,15 @@ defmodule Trento.Users.User do
     |> custom_fields_changeset(attrs)
   end
 
-  def delete_changeset(%__MODULE__{username: username} = user, %{deleted_at: deleted_at} = attrs) do
+  def delete_changeset(
+        %__MODULE__{username: username, email: email} = user,
+        %{deleted_at: deleted_at} = attrs
+      ) do
     user
     |> cast(attrs, [:deleted_at])
     |> validate_required(:deleted_at)
     |> put_change(:username, "#{username}__#{deleted_at}")
+    |> put_change(:email, "#{email}__#{deleted_at}")
   end
 
   defp validate_current_password(changeset, %{password: _password} = attrs),

--- a/test/trento/users_test.exs
+++ b/test/trento/users_test.exs
@@ -255,14 +255,19 @@ defmodule Trento.UsersTest do
     end
 
     test "delete_user/1 deletes the user" do
-      %{id: user_id, username: original_username} = user = insert(:user)
+      %{id: user_id, username: original_username, email: original_email} = user = insert(:user)
+
       assert {:ok, %User{}} = Users.delete_user(user)
       assert {:error, :not_found} == Users.get_user(user.id)
 
-      %User{deleted_at: deleted_at, username: username} = Trento.Repo.get_by!(User, id: user_id)
+      %User{deleted_at: deleted_at, username: username, email: email} =
+        Trento.Repo.get_by!(User, id: user_id)
 
       refute deleted_at == nil
       refute username == original_username
+      refute email == original_email
+      assert username == "#{original_username}__#{deleted_at}"
+      assert email == "#{original_email}__#{deleted_at}"
     end
   end
 end


### PR DESCRIPTION
# Description
The backend user management supports soft deletion.  
When a user is deleted, we apply soft deletion on the username.
With this we unlock the username which must be unique.

This pr will also soft delete the mail of a user, not only username.


## How was this tested?
Manual testing + existing test was updated to check for mail
