### PR TITLE
Enable user status update

### DIFF
--- a/assets/js/pages/Users/UserForm.jsx
+++ b/assets/js/pages/Users/UserForm.jsx
@@ -213,9 +213,8 @@ function UserForm({
             <Select
               optionsName="status"
               options={['Enabled', 'Disabled']}
-              value={status}
-              disabled
-              onChange={({ target: { value } }) => {
+              value={statusState}
+              onChange={(value) => {
                 setStatus(value);
               }}
             />

--- a/assets/js/pages/Users/UserForm.stories.jsx
+++ b/assets/js/pages/Users/UserForm.stories.jsx
@@ -41,6 +41,15 @@ export default {
         type: 'text',
       },
     },
+    status: {
+      control: { type: 'radio' },
+      options: ['Enabled', 'Disabled'],
+      description: 'Status',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'Enabled' },
+      },
+    },
     createdAt: {
       description: 'User creation timestamp',
       control: {

--- a/assets/js/pages/Users/UserForm.test.jsx
+++ b/assets/js/pages/Users/UserForm.test.jsx
@@ -133,7 +133,7 @@ describe('UserForm', () => {
     expect(screen.getAllByText('Required field').length).toBe(3);
   });
 
-  it('saves the user', async () => {
+  it('should save the user', async () => {
     const user = userEvent.setup();
     const { fullname, email, username } = userFactory.build();
     const password = faker.internet.password();
@@ -156,6 +156,47 @@ describe('UserForm', () => {
       password,
       password_confirmation: password,
       enabled: true,
+    });
+  });
+
+  it.each([
+    { option: 'Enabled', result: true },
+    { option: 'Disabled', result: false },
+  ])('should set the user status correctly', async ({ option, result }) => {
+    const user = userEvent.setup();
+    const mockOnSave = jest.fn();
+
+    const {
+      fullname,
+      email,
+      username,
+      created_at: createdAt,
+      updated_at: updatedAt,
+    } = userFactory.build();
+
+    await act(async () => {
+      render(
+        <UserForm
+          fullName={fullname}
+          emailAddress={email}
+          username={username}
+          createdAt={createdAt}
+          updatedAt={updatedAt}
+          editing
+          onSave={mockOnSave}
+        />
+      );
+    });
+
+    await user.click(screen.getByText('Enabled'));
+    await user.click(screen.getAllByText(option)[0]);
+
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(mockOnSave).toHaveBeenNthCalledWith(1, {
+      fullname,
+      email,
+      enabled: result,
     });
   });
 });

--- a/lib/trento/users.ex
+++ b/lib/trento/users.ex
@@ -45,7 +45,7 @@ defmodule Trento.Users do
 
   def create_user(attrs \\ %{}) do
     %User{}
-    |> User.changeset(attrs)
+    |> User.changeset(set_locked_at(attrs))
     |> Repo.insert()
   end
 
@@ -71,6 +71,12 @@ defmodule Trento.Users do
     |> User.delete_changeset(%{deleted_at: DateTime.utc_now()})
     |> Repo.update()
   end
+
+  defp set_locked_at(%{enabled: false} = attrs) do
+    Map.put(attrs, :locked_at, DateTime.utc_now())
+  end
+
+  defp set_locked_at(attrs), do: attrs
 
   defp do_update(user, attrs) do
     user

--- a/lib/trento/users/user.ex
+++ b/lib/trento/users/user.ex
@@ -42,6 +42,7 @@ defmodule Trento.Users.User do
     |> pow_extension_changeset(attrs)
     |> validate_password()
     |> custom_fields_changeset(attrs)
+    |> lock_changeset(attrs)
   end
 
   def update_changeset(user, attrs) do

--- a/test/trento/users_test.exs
+++ b/test/trento/users_test.exs
@@ -51,6 +51,23 @@ defmodule Trento.UsersTest do
       assert user.fullname == "some fullname"
       assert user.email == "test@trento.com"
       assert user.username == "username"
+      assert user.locked_at == nil
+    end
+
+    test "create_user creates a disabled user" do
+      %{username: username, email: email, fullname: fullname} = build(:user)
+
+      assert {:ok, %User{} = user} =
+               Users.create_user(%{
+                 username: username,
+                 password: "some password",
+                 email: email,
+                 fullname: fullname,
+                 confirm_password: "some password",
+                 enabled: false
+               })
+
+      refute user.locked_at == nil
     end
 
     test "create_user should return an error if the email has already been taken" do


### PR DESCRIPTION
# Description

Enable user status selection in frontend, it was disabled by now.
It requires a small modification in the backend to set the `locked_at` value during creation.

## How was this tested?

Tests added
