### PR TITLE
Update installation instructions

### DIFF
--- a/guides/development/hack_on_the_trento.md
+++ b/guides/development/hack_on_the_trento.md
@@ -13,13 +13,13 @@ In order to run the Trento Web application, the following software must be insta
 ### Additional requirements
 
 Some platforms might not be able to use pre-built versions of some dependencies.
-Therefore, some additional dependencies might be required. This will not effect
-most users and should be referred to when installation issues come up.
-For these dependencies, the distro packaged version will usually be sufficient.
+Therefore, some additional dependencies might be required. This does not effect
+most users and can be referred to, when installation issues come up.
+For these dependencies, the distro packaged version is usually sufficient.
 
 1. [Python3](https://www.python.org/)
 2. [setuptools](https://setuptools.pypa.io/en/latest/index.html)
-3. [gcc](https://gcc.gnu.org/) or [clang](https://clang.llvm.org/)
+3. [gcc](https://gcc.gnu.org/)
 4. [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/)
 
 ### Ensure Compatibility with asdf

--- a/guides/development/hack_on_the_trento.md
+++ b/guides/development/hack_on_the_trento.md
@@ -4,9 +4,9 @@
 
 In order to run the Trento Web application, the following software must be installed:
 
-1. [Elixir](https://elixir-lang.org/)
-2. [Erlang OTP](https://www.erlang.org/)
-3. [Node.js](https://nodejs.org/en/)
+1. [Elixir](https://elixir-lang.org/) - 1.15.7 preferred
+2. [Erlang OTP](https://www.erlang.org/) - 26.1.2 preferred
+3. [Node.js](https://nodejs.org/en/) - 16.16.0 preferred
 4. [Docker](https://docs.docker.com/get-docker/)
 5. [Docker Compose](https://docs.docker.com/compose/install/)
 

--- a/guides/development/hack_on_the_trento.md
+++ b/guides/development/hack_on_the_trento.md
@@ -10,6 +10,18 @@ In order to run the Trento Web application, the following software must be insta
 4. [Docker](https://docs.docker.com/get-docker/)
 5. [Docker Compose](https://docs.docker.com/compose/install/)
 
+### Additional requirements
+
+Some platforms might not be able to use pre-built versions of some dependencies.
+Therefore, some additional dependencies might be required. This will not effect
+most users and should be referred to when installation issues come up.
+For these dependencies, the distro packaged version will usually be sufficient.
+
+1. [Python3](https://www.python.org/)
+2. [setuptools](https://setuptools.pypa.io/en/latest/index.html)
+3. [gcc](https://gcc.gnu.org/) or [clang](https://clang.llvm.org/)
+4. [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/)
+
 ### Ensure Compatibility with asdf
 
 [asdf](https://asdf-vm.com/guide/introduction.html) allows to use specific versions of programming language tools that are known to be compatible with the project, rather than relying on the version that's installed globally on the host system.

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Trento.MixProject do
       app: :trento,
       description: "Easing your life in administering SAP applications",
       version: get_version(),
-      elixir: "~> 1.13",
+      elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: Mix.compilers(),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
# Description

This patchset documents the preferred version of the required dependencies
in the documentation, documents additional dependencies, which might be
required for some users and synchronises the compiler version in the `mix.exs` file
with the version managed by `asdf`.

These are mainly inconveniences I encountered during the first setup on a MacBook.

An explanation and reasoning for these changes is available as part of the individual
commit descriptions. Those are accessible by pressing on the `...` next to the commit
headline below.