### PR TITLE
Optimistic lock for users

### DIFF
--- a/assets/js/lib/api/users.js
+++ b/assets/js/lib/api/users.js
@@ -6,6 +6,11 @@ export const getUser = (userID) => get(`/users/${userID}`);
 
 export const createUser = (payload) => post('/users', payload);
 
-export const editUser = (userID, payload) => patch(`/users/${userID}`, payload);
+export const editUser = (userID, payload, version) =>
+  patch(`/users/${userID}`, payload, {
+    headers: {
+      'if-match': version,
+    },
+  });
 
 export const deleteUser = (userID) => del(`/users/${userID}`);

--- a/assets/js/pages/Users/EditUserPage.jsx
+++ b/assets/js/pages/Users/EditUserPage.jsx
@@ -17,11 +17,13 @@ function EditUserPage() {
   const [errorsState, setErrors] = useState([]);
   const [loading, setLoading] = useState(true);
   const [userState, setUser] = useState(null);
+  const [userVersion, setUserVersion] = useState(null);
   const [updatedByOther, setUpdatedByOther] = useState(false);
 
   useEffect(() => {
     getUser(userID)
-      .then(({ data: user }) => {
+      .then(({ data: user, headers: { etag } }) => {
+        setUserVersion(etag);
         setUser(user);
       })
       .catch(() => {})
@@ -32,7 +34,7 @@ function EditUserPage() {
 
   const onEditUser = (payload) => {
     setSaving(true);
-    editUser(userID, payload)
+    editUser(userID, payload, userVersion)
       .then(() => {
         navigate('/users');
       })

--- a/lib/trento/users.ex
+++ b/lib/trento/users.ex
@@ -87,12 +87,10 @@ defmodule Trento.Users do
   defp set_locked_at(attrs), do: attrs
 
   defp do_update(user, attrs) do
-    try do
-      user
-      |> User.update_changeset(attrs)
-      |> Repo.update()
-    rescue
-      Ecto.StaleEntryError -> {:error, :stale_entry}
-    end
+    user
+    |> User.update_changeset(attrs)
+    |> Repo.update()
+  rescue
+    Ecto.StaleEntryError -> {:error, :stale_entry}
   end
 end

--- a/lib/trento/users.ex
+++ b/lib/trento/users.ex
@@ -87,8 +87,12 @@ defmodule Trento.Users do
   defp set_locked_at(attrs), do: attrs
 
   defp do_update(user, attrs) do
-    user
-    |> User.update_changeset(attrs)
-    |> Repo.update()
+    try do
+      user
+      |> User.update_changeset(attrs)
+      |> Repo.update()
+    rescue
+      Ecto.StaleEntryError -> {:error, :stale_entry}
+    end
   end
 end

--- a/lib/trento/users/user.ex
+++ b/lib/trento/users/user.ex
@@ -30,6 +30,7 @@ defmodule Trento.Users.User do
     field :fullname, :string
     field :deleted_at, :utc_datetime_usec
     field :locked_at, :utc_datetime_usec
+    field :lock_version, :integer, default: 1
 
     many_to_many :abilities, Ability, join_through: UsersAbilities, unique: true
 
@@ -52,6 +53,8 @@ defmodule Trento.Users.User do
     |> validate_password()
     |> custom_fields_changeset(attrs)
     |> lock_changeset(attrs)
+    |> cast(attrs, [:lock_version])
+    |> optimistic_lock(:lock_version)
   end
 
   def profile_update_changeset(user, attrs) do

--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -138,6 +138,20 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"403")
   end
 
+  def call(conn, {:error, :stale_entry}) do
+    conn
+    |> put_status(:precondition_failed)
+    |> put_view(ErrorView)
+    |> render(:"412")
+  end
+
+  def call(conn, {:error, :precondition_missing}) do
+    conn
+    |> put_status(:precondition_required)
+    |> put_view(ErrorView)
+    |> render(:"428")
+  end
+
   def call(conn, {:error, [error | _]}), do: call(conn, {:error, error})
 
   def call(conn, {:error, _}) do

--- a/lib/trento_web/controllers/v1/users_controller.ex
+++ b/lib/trento_web/controllers/v1/users_controller.ex
@@ -133,4 +133,11 @@ defmodule TrentoWeb.V1.UsersController do
 
   defp broadcast_update_or_locked_user(%User{id: id}),
     do: TrentoWeb.Endpoint.broadcast("users:#{id}", "user_locked", %{})
+
+  defp user_version_from_if_match_header(conn) do
+    case get_req_header(conn, "If-Match") do
+      [version, _] -> version
+      _ -> {:error, :precondition_missing}
+    end
+  end
 end

--- a/lib/trento_web/controllers/v1/users_controller.ex
+++ b/lib/trento_web/controllers/v1/users_controller.ex
@@ -101,7 +101,8 @@ defmodule TrentoWeb.V1.UsersController do
         type: %OpenApiSpex.Schema{type: :integer}
       ],
       "if-match": [
-        required: true,
+        # The field is required, we put to false to avoid openapispex validate that value with 422 status code.
+        required: false,
         in: :header,
         type: %OpenApiSpex.Schema{type: :integer}
       ]

--- a/lib/trento_web/controllers/v1/users_controller.ex
+++ b/lib/trento_web/controllers/v1/users_controller.ex
@@ -52,6 +52,7 @@ defmodule TrentoWeb.V1.UsersController do
     with {:ok, %User{} = user} <- Users.create_user(user_params) do
       conn
       |> put_status(:created)
+      |> attach_user_version_as_etag_header(user)
       |> render("show.json", user: user)
     end
   end
@@ -67,13 +68,23 @@ defmodule TrentoWeb.V1.UsersController do
       ]
     ],
     responses: [
-      ok: {"UserItem", "application/json", UserItem},
+      ok:
+        {"UserItem", "application/json", UserItem,
+         headers: %{
+           etag: %{
+             required: true,
+             description: "Entity version, used in conditional http requests",
+             type: %OpenApiSpex.Schema{type: :string},
+             allowEmptyValues: false
+           }
+         }},
       not_found: Schema.NotFound.response(),
       unprocessable_entity: Schema.UnprocessableEntity.response()
     ]
 
   def show(conn, %{id: id}) do
-    with {:ok, user} <- Users.get_user(id) do
+    with {:ok, user} <- Users.get_user(id),
+         conn <- attach_user_version_as_etag_header(conn, user) do
       render(conn, "show.json", user: user)
     end
   end
@@ -81,24 +92,45 @@ defmodule TrentoWeb.V1.UsersController do
   operation :update,
     summary: "Update an existing user",
     tags: ["User Management"],
+    description:
+      "Update an existing user, this is a conditional HTTP request, make sure you provide precondition with the If-Match header",
     parameters: [
       id: [
         in: :path,
         required: true,
         type: %OpenApiSpex.Schema{type: :integer}
+      ],
+      "if-match": [
+        required: true,
+        in: :header,
+        type: %OpenApiSpex.Schema{type: :integer}
       ]
     ],
     request_body: {"UserUpdateRequest", "application/json", UserUpdateRequest},
     responses: [
-      created: {"User updated successfully", "application/json", UserItem},
+      created:
+        {"User updated successfully", "application/json", UserItem,
+         headers: %{
+           etag: %{
+             required: true,
+             description: "Entity version, used in conditional http requests",
+             type: %OpenApiSpex.Schema{type: :string},
+             allowEmptyValues: false
+           }
+         }},
       unprocessable_entity: UnprocessableEntity.response(),
-      forbidden: Schema.Forbidden.response()
+      forbidden: Schema.Forbidden.response(),
+      precondition_failed: Schema.PreconditionFailed.response(),
+      precondition_required: Schema.PreconditionRequired.response()
     ]
 
   def update(%{body_params: body_params} = conn, %{id: id}) do
     with {:ok, user} <- Users.get_user(id),
-         {:ok, %User{} = user} <- Users.update_user(user, body_params),
-         :ok <- broadcast_update_or_locked_user(user) do
+         {:ok, lock_version} <- user_version_from_if_match_header(conn),
+         update_params <- Map.put(body_params, :lock_version, lock_version),
+         {:ok, %User{} = user} <- Users.update_user(user, update_params),
+         :ok <- broadcast_update_or_locked_user(user),
+         conn <- attach_user_version_as_etag_header(conn, user) do
       render(conn, "show.json", user: user)
     end
   end
@@ -135,9 +167,13 @@ defmodule TrentoWeb.V1.UsersController do
     do: TrentoWeb.Endpoint.broadcast("users:#{id}", "user_locked", %{})
 
   defp user_version_from_if_match_header(conn) do
-    case get_req_header(conn, "If-Match") do
-      [version, _] -> version
+    case get_req_header(conn, "if-match") do
+      [version] -> {:ok, version}
       _ -> {:error, :precondition_missing}
     end
+  end
+
+  defp attach_user_version_as_etag_header(conn, %User{lock_version: lock_version}) do
+    put_resp_header(conn, "etag", Integer.to_string(lock_version))
   end
 end

--- a/lib/trento_web/openapi/v1/schema/precondition_failed.ex
+++ b/lib/trento_web/openapi/v1/schema/precondition_failed.ex
@@ -1,0 +1,39 @@
+defmodule TrentoWeb.OpenApi.V1.Schema.PreconditionFailed do
+  @moduledoc """
+  412 - Precondition Failed
+  """
+  require OpenApiSpex
+
+  alias OpenApiSpex.Operation
+  alias OpenApiSpex.Schema
+
+  OpenApiSpex.schema(%{
+    title: "PreconditionFailed",
+    type: :object,
+    additionalProperties: false,
+    properties: %{
+      errors: %Schema{
+        type: :array,
+        items: %Schema{
+          type: :object,
+          properties: %{
+            detail: %Schema{
+              type: :string,
+              example:
+                "Mid-air collision detected, please refresh the resource you are trying to update."
+            },
+            title: %Schema{type: :string, example: "Precondition Failed"}
+          }
+        }
+      }
+    }
+  })
+
+  def response do
+    Operation.response(
+      "Precondition Failed",
+      "application/json",
+      __MODULE__
+    )
+  end
+end

--- a/lib/trento_web/openapi/v1/schema/precondition_required.ex
+++ b/lib/trento_web/openapi/v1/schema/precondition_required.ex
@@ -1,0 +1,38 @@
+defmodule TrentoWeb.OpenApi.V1.Schema.PreconditionRequired do
+  @moduledoc """
+  428 - Precondition Required
+  """
+  require OpenApiSpex
+
+  alias OpenApiSpex.Operation
+  alias OpenApiSpex.Schema
+
+  OpenApiSpex.schema(%{
+    title: "PreconditionRequired",
+    type: :object,
+    additionalProperties: false,
+    properties: %{
+      errors: %Schema{
+        type: :array,
+        items: %Schema{
+          type: :object,
+          properties: %{
+            detail: %Schema{
+              type: :string,
+              example: "Request needs to be conditional, please provide If-Match header."
+            },
+            title: %Schema{type: :string, example: "Precondition Required"}
+          }
+        }
+      }
+    }
+  })
+
+  def response do
+    Operation.response(
+      "Precondition Required",
+      "application/json",
+      __MODULE__
+    )
+  end
+end

--- a/lib/trento_web/views/error_view.ex
+++ b/lib/trento_web/views/error_view.ex
@@ -101,7 +101,8 @@ defmodule TrentoWeb.ErrorView do
       errors: [
         %{
           title: "Precondition failed",
-          detail: "Mid-air collision detected, please refresh the resource you are trying to update."
+          detail:
+            "Mid-air collision detected, please refresh the resource you are trying to update."
         }
       ]
     }

--- a/lib/trento_web/views/error_view.ex
+++ b/lib/trento_web/views/error_view.ex
@@ -96,6 +96,28 @@ defmodule TrentoWeb.ErrorView do
     }
   end
 
+  def render("412.json", _) do
+    %{
+      errors: [
+        %{
+          title: "Precondition failed",
+          detail: "Mid-air collision detected, please refresh the resource you are trying to update."
+        }
+      ]
+    }
+  end
+
+  def render("428.json", _) do
+    %{
+      errors: [
+        %{
+          title: "Precondition required",
+          detail: "Request needs to be conditional, please provide If-Match header."
+        }
+      ]
+    }
+  end
+
   def template_not_found(template, _assigns) do
     %{
       errors: [

--- a/priv/repo/migrations/20240506100222_add_lock_version_to_users.exs
+++ b/priv/repo/migrations/20240506100222_add_lock_version_to_users.exs
@@ -1,0 +1,9 @@
+defmodule Trento.Repo.Migrations.AddLockVersionToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :lock_version, :integer, default: 1
+    end
+  end
+end

--- a/test/trento/users_test.exs
+++ b/test/trento/users_test.exs
@@ -267,7 +267,7 @@ defmodule Trento.UsersTest do
                Users.update_user(%User{id: 1}, %{fullname: "new fullname"})
     end
 
-    test "update_user/2 return stale error when the lock version in the update is not valid" do
+    test "update_user/2 returns stale error when the lock version in the update is not valid" do
       user = insert(:user)
       {:ok, user} = Users.get_user(user.id)
 

--- a/test/trento/users_test.exs
+++ b/test/trento/users_test.exs
@@ -267,6 +267,22 @@ defmodule Trento.UsersTest do
                Users.update_user(%User{id: 1}, %{fullname: "new fullname"})
     end
 
+    test "update_user/2 return stale error when the lock version in the update is not valid" do
+      user = insert(:user)
+      {:ok, user} = Users.get_user(user.id)
+
+      assert {:ok, updated_user} =
+               Users.update_user(user, %{
+                 fullname: "some updated fullname"
+               })
+
+      assert {:error, :stale_entry} =
+               Users.update_user(updated_user, %{
+                 fullname: "some updated fullname 2",
+                 lock_version: 1
+               })
+    end
+
     test "delete_user/2 does not delete user with id 1" do
       assert {:error, :forbidden} = Users.delete_user(%User{id: 1})
     end

--- a/test/trento_web/controllers/v1/users_controller_test.exs
+++ b/test/trento_web/controllers/v1/users_controller_test.exs
@@ -78,7 +78,7 @@ defmodule TrentoWeb.V1.UsersControllerTest do
 
   describe "show user" do
     test "should show the user when user exists", %{conn: conn, api_spec: api_spec} do
-      %{id: id} = insert(:user)
+      %{id: id, lock_version: lock_version} = insert(:user)
 
       conn = get(conn, "/api/v1/users/#{id}")
 
@@ -87,6 +87,8 @@ defmodule TrentoWeb.V1.UsersControllerTest do
         |> json_response(200)
         |> assert_schema("UserItem", api_spec)
 
+      [etag] = get_resp_header(conn, "etag")
+      assert etag == Integer.to_string(lock_version)
       assert %{id: ^id} = resp
     end
 
@@ -108,11 +110,17 @@ defmodule TrentoWeb.V1.UsersControllerTest do
         password_confirmation: "testpassword89"
       }
 
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/v1/users", valid_params)
+
       conn
-      |> put_req_header("content-type", "application/json")
-      |> post("/api/v1/users", valid_params)
       |> json_response(:created)
       |> assert_schema("UserItem", api_spec)
+
+      [etag] = get_resp_header(conn, "etag")
+      assert etag == "1"
     end
 
     test "should not create the user when request parameters are not valid", %{
@@ -160,7 +168,7 @@ defmodule TrentoWeb.V1.UsersControllerTest do
       conn: conn,
       api_spec: api_spec
     } do
-      %{id: id, updated_at: updated_at} = insert(:user)
+      %{id: id, updated_at: updated_at, lock_version: lock_version} = insert(:user)
 
       {:ok, _, _} =
         TrentoWeb.UserSocket
@@ -170,6 +178,7 @@ defmodule TrentoWeb.V1.UsersControllerTest do
       resp =
         conn
         |> put_req_header("content-type", "application/json")
+        |> put_req_header("if-match", "#{lock_version}")
         |> patch("/api/v1/users/#{id}", %{})
         |> json_response(:ok)
         |> assert_schema("UserItem", api_spec)
@@ -192,7 +201,7 @@ defmodule TrentoWeb.V1.UsersControllerTest do
 
     test "should not update the user if parameters are valid but an error is returned from update operation",
          %{conn: conn, api_spec: api_spec} do
-      %{email: already_taken_email} = insert(:user)
+      %{email: already_taken_email, lock_version: lock_version} = insert(:user)
       %{id: id} = insert(:user)
 
       valid_params = %{
@@ -201,6 +210,7 @@ defmodule TrentoWeb.V1.UsersControllerTest do
 
       conn
       |> put_req_header("content-type", "application/json")
+      |> put_req_header("if-match", "#{lock_version}")
       |> patch("/api/v1/users/#{id}", valid_params)
       |> json_response(:unprocessable_entity)
       |> assert_schema("UnprocessableEntity", api_spec)
@@ -223,8 +233,22 @@ defmodule TrentoWeb.V1.UsersControllerTest do
       |> assert_schema("UnprocessableEntity", api_spec)
     end
 
-    test "should update the user if parameters are valid", %{conn: conn, api_spec: api_spec} do
-      %{id: id, email: email, fullname: fullname} = insert(:user)
+    test "should not update the user when the request conditional prerequisite is missing", %{
+      conn: conn,
+      api_spec: api_spec
+    } do
+      %{id: id} = insert(:user)
+
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> patch("/api/v1/users/#{id}", %{})
+      |> json_response(:precondition_required)
+      |> assert_schema("PreconditionRequired", api_spec)
+    end
+
+    test "should not update the user when the request conditional prerequisite is failing due to mid-air collision",
+         %{conn: conn, api_spec: api_spec} do
+      %{id: id} = insert(:user)
 
       {:ok, _, _} =
         TrentoWeb.UserSocket
@@ -239,10 +263,38 @@ defmodule TrentoWeb.V1.UsersControllerTest do
         password_confirmation: "testpassword89"
       }
 
-      resp =
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("if-match", "222")
+      |> patch("/api/v1/users/#{id}", valid_params)
+      |> json_response(:precondition_failed)
+      |> assert_schema("PreconditionFailed", api_spec)
+    end
+
+    test "should update the user if parameters are valid", %{conn: conn, api_spec: api_spec} do
+      %{id: id, email: email, fullname: fullname, lock_version: lock_version} = insert(:user)
+
+      {:ok, _, _} =
+        TrentoWeb.UserSocket
+        |> socket("user_id", %{current_user_id: id})
+        |> subscribe_and_join(TrentoWeb.UserChannel, "users:#{id}")
+
+      valid_params = %{
+        fullname: Faker.Person.name(),
+        email: Faker.Internet.email(),
+        enabled: false,
+        password: "testpassword89",
+        password_confirmation: "testpassword89"
+      }
+
+      conn =
         conn
         |> put_req_header("content-type", "application/json")
+        |> put_req_header("if-match", "#{lock_version}")
         |> patch("/api/v1/users/#{id}", valid_params)
+
+      resp =
+        conn
         |> json_response(:ok)
         |> assert_schema("UserItem", api_spec)
 
@@ -251,6 +303,9 @@ defmodule TrentoWeb.V1.UsersControllerTest do
       refute resp.email == email
 
       assert_broadcast "user_locked", %{}, 1000
+
+      [etag] = get_resp_header(conn, "etag")
+      assert etag == "#{lock_version + 1}"
     end
   end
 


### PR DESCRIPTION
# Description

Optimistic locking on user resource.
On the http side it's done via http conditional requests, using etag and if-match header.
Openapi updated with the proper headers for requests and responses.
![Recording 2024-05-06 at 16 32 07](https://github.com/trento-project/web/assets/9409502/e3051087-8dd7-4df6-b655-0bbcbca77dd5)

Swagger playground updated.



Frontend updated.

## How was this tested?

Automated tests
