### PR TITLE
Ensure SUMA related controllers return 403 when credentials were not set

### DIFF
--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -12,9 +12,9 @@ defmodule TrentoWeb.FallbackController do
 
   def call(conn, {:error, :settings_not_configured}) do
     conn
-    |> put_status(:unauthorized)
+    |> put_status(:forbidden)
     |> put_view(ErrorView)
-    |> render(:"401", reason: "SUSE Manager settings not configured.")
+    |> render(:"403", reason: "SUSE Manager settings not configured.")
   end
 
   def call(conn, {:error, :invalid_refresh_token}) do

--- a/lib/trento_web/views/error_view.ex
+++ b/lib/trento_web/views/error_view.ex
@@ -23,6 +23,17 @@ defmodule TrentoWeb.ErrorView do
     }
   end
 
+  def render("403.json", %{reason: reason}) do
+    %{
+      errors: [
+        %{
+          title: "Forbidden",
+          detail: reason
+        }
+      ]
+    }
+  end
+
   def render("404.json", _) do
     %{
       errors: [

--- a/test/trento_web/controllers/v1/suma_credentials_controller_test.exs
+++ b/test/trento_web/controllers/v1/suma_credentials_controller_test.exs
@@ -28,12 +28,12 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
       |> assert_schema("SUMACredentials", api_spec)
     end
 
-    test "should return 401 if no user settings have been saved", %{conn: conn} do
+    test "should return 403 if no user settings have been saved", %{conn: conn} do
       api_spec = ApiSpec.spec()
 
       conn
       |> get("/api/v1/settings/suma_credentials")
-      |> json_response(:unauthorized)
+      |> json_response(:forbidden)
       |> assert_schema("NotFound", api_spec)
     end
   end
@@ -177,11 +177,11 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
         conn
         |> put_req_header("content-type", "application/json")
         |> patch("/api/v1/settings/suma_credentials", submission)
-        |> json_response(:unauthorized)
+        |> json_response(:forbidden)
 
       assert %{
                "errors" => [
-                 %{"detail" => "SUSE Manager settings not configured.", "title" => "Unauthorized"}
+                 %{"detail" => "SUSE Manager settings not configured.", "title" => "Forbidden"}
                ]
              } == resp
     end

--- a/test/trento_web/controllers/v1/suse_manager_controller_test.exs
+++ b/test/trento_web/controllers/v1/suse_manager_controller_test.exs
@@ -64,17 +64,17 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
         |> assert_schema("AvailableSoftwareUpdatesResponse", api_spec)
     end
 
-    test "should return 401 when no settings have been saved", %{conn: conn} do
+    test "should return 403 when no settings have been saved", %{conn: conn} do
       %{id: host_id} = insert(:host)
 
       resp =
         conn
         |> get("/api/v1/hosts/#{host_id}/software_updates")
-        |> json_response(:unauthorized)
+        |> json_response(:forbidden)
 
       assert %{
                "errors" => [
-                 %{"detail" => "SUSE Manager settings not configured.", "title" => "Unauthorized"}
+                 %{"detail" => "SUSE Manager settings not configured.", "title" => "Forbidden"}
                ]
              } == resp
     end

--- a/test/trento_web/views/error_view_test.exs
+++ b/test/trento_web/views/error_view_test.exs
@@ -25,6 +25,17 @@ defmodule TrentoWeb.ErrorViewTest do
            } == render(TrentoWeb.ErrorView, "401.json", reason: "Invalid credentials.")
   end
 
+  test "should render a 403 error" do
+    assert %{
+             errors: [
+               %{
+                 detail: "Insufficient permissions.",
+                 title: "Forbidden"
+               }
+             ]
+           } == render(TrentoWeb.ErrorView, "403.json", reason: "Insufficient permissions.")
+  end
+
   test "should render a 404 error" do
     assert %{
              errors: [


### PR DESCRIPTION
# Description

Following up an offline discussion about avoiding returning 401 for non trento related auth.

## How was this tested?

Tests updated.