### PR TITLE
Switch to use link in ProfileMenu

### DIFF
--- a/assets/js/common/ProfileMenu/ProfileMenu.jsx
+++ b/assets/js/common/ProfileMenu/ProfileMenu.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Menu } from '@headlessui/react';
+import { Link } from 'react-router-dom';
 
 import { EOS_ACCOUNT_CIRCLE_OUTLINED } from 'eos-icons-react';
 
@@ -43,12 +44,12 @@ function ProfileMenu({ username, email, logout }) {
           </span>
         </Menu.Item>
         <Menu.Item>
-          <a
-            href="/profile"
+          <Link
+            to="/profile"
             className="text-gray-700 hover:bg-gray-100 block px-4 py-4 text-sm"
           >
             Profile
-          </a>
+          </Link>
         </Menu.Item>
         <Menu.Item>
           <button

--- a/assets/js/common/ProfileMenu/ProfileMenu.stories.jsx
+++ b/assets/js/common/ProfileMenu/ProfileMenu.stories.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import { MemoryRouter } from 'react-router-dom';
 import { action } from '@storybook/addon-actions';
 import ProfileMenu from '.';
 
@@ -19,6 +19,13 @@ export default {
     email: { control: 'text' },
     logout: { action: 'logout' },
   },
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
   render: (args) => (
     <ContainerWrapper>
       <ProfileMenu {...args} />

--- a/assets/js/common/ProfileMenu/ProfileMenu.test.jsx
+++ b/assets/js/common/ProfileMenu/ProfileMenu.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
+import { renderWithRouter } from '@lib/test-utils';
 import { userFactory } from '@lib/test-utils/factories/users';
 
 import ProfileMenu from './ProfileMenu';
@@ -9,7 +9,7 @@ import ProfileMenu from './ProfileMenu';
 describe('ProfileMenu component', () => {
   test('should render a profile menu button with username', () => {
     const { email, username } = userFactory.build();
-    const { getByText } = render(
+    const { getByText } = renderWithRouter(
       <ProfileMenu username={username} email={email} />
     );
     const usernameElement = getByText(username);
@@ -20,7 +20,7 @@ describe('ProfileMenu component', () => {
     const user = userEvent.setup();
 
     const { email, username } = userFactory.build();
-    const { getByText, getByRole } = render(
+    const { getByText, getByRole } = renderWithRouter(
       <ProfileMenu username={username} email={email} />
     );
     await user.click(getByRole('button'));
@@ -33,7 +33,7 @@ describe('ProfileMenu component', () => {
 
     const logoutMock = jest.fn();
     const { email, username } = userFactory.build();
-    const { getByText, getByRole } = render(
+    const { getByText, getByRole } = renderWithRouter(
       <ProfileMenu username={username} email={email} logout={logoutMock} />
     );
 


### PR DESCRIPTION
# Description

The profile menu was wrongly using an <a> element for linking. This should fix it. Also:
  - test have been adjusted
  - storybook now includes a way to prevent navigation when clicking on the profile link
