### PR TITLE
Add optimistic lock profile

### DIFF
--- a/lib/trento/users.ex
+++ b/lib/trento/users.ex
@@ -72,6 +72,8 @@ defmodule Trento.Users do
     user
     |> User.profile_update_changeset(attrs)
     |> Repo.update()
+  rescue
+    Ecto.StaleEntryError -> {:error, :stale_entry}
   end
 
   def update_user(%User{id: 1}, _), do: {:error, :forbidden}

--- a/lib/trento/users/user.ex
+++ b/lib/trento/users/user.ex
@@ -53,8 +53,7 @@ defmodule Trento.Users.User do
     |> validate_password()
     |> custom_fields_changeset(attrs)
     |> lock_changeset(attrs)
-    |> cast(attrs, [:lock_version])
-    |> optimistic_lock(:lock_version)
+    |> optimistic_lock_changeset(attrs)
   end
 
   def profile_update_changeset(user, attrs) do
@@ -64,6 +63,7 @@ defmodule Trento.Users.User do
     |> pow_extension_changeset(attrs)
     |> validate_password()
     |> custom_fields_changeset(attrs)
+    |> optimistic_lock_changeset(attrs)
   end
 
   def delete_changeset(
@@ -84,6 +84,12 @@ defmodule Trento.Users.User do
 
   defp lock_changeset(user, attrs) do
     cast(user, attrs, [:locked_at])
+  end
+
+  defp optimistic_lock_changeset(user, attrs) do
+    user
+    |> cast(attrs, [:lock_version])
+    |> optimistic_lock(:lock_version)
   end
 
   defp validate_password(changeset) do

--- a/lib/trento_web/controllers/v1/profile_controller.ex
+++ b/lib/trento_web/controllers/v1/profile_controller.ex
@@ -19,8 +19,10 @@ defmodule TrentoWeb.V1.ProfileController do
     ]
 
   def show(conn, _) do
-    %User{} = user = Pow.Plug.current_user(conn)
-    render(conn, "profile.json", user: user)
+    with %User{} = user <- Pow.Plug.current_user(conn),
+         conn <- attach_user_version_as_etag_header(conn, user) do
+      render(conn, "profile.json", user: user)
+    end
   end
 
   operation :update,

--- a/test/trento/users_test.exs
+++ b/test/trento/users_test.exs
@@ -70,6 +70,22 @@ defmodule Trento.UsersTest do
       assert nil == locked_at
       assert password_hash != updated_password_hash
     end
+
+    test "update_user_profile returns stale error when the lock version in the update is not valid" do
+      user = insert(:user)
+      {:ok, user} = Users.get_user(user.id)
+
+      assert {:ok, updated_user} =
+               Users.update_user_profile(user, %{
+                 fullname: "some updated fullname"
+               })
+
+      assert {:error, :stale_entry} =
+               Users.update_user_profile(updated_user, %{
+                 fullname: "some updated fullname 2",
+                 lock_version: 1
+               })
+    end
   end
 
   describe "users" do

--- a/test/trento_web/controllers/v1/profile_controller_test.exs
+++ b/test/trento_web/controllers/v1/profile_controller_test.exs
@@ -43,7 +43,7 @@ defmodule TrentoWeb.V1.ProfileControllerTest do
   test "should update the profile with allowed fields", %{
     conn: conn,
     api_spec: api_spec,
-    user: %{id: user_id, password: current_password}
+    user: %{id: user_id, password: current_password, lock_version: lock_version}
   } do
     %{fullname: fullname, email: email} =
       valid_params = %{
@@ -57,10 +57,37 @@ defmodule TrentoWeb.V1.ProfileControllerTest do
     resp =
       conn
       |> put_req_header("content-type", "application/json")
+      |> put_req_header("if-match", "#{lock_version}")
       |> patch("/api/v1/profile", valid_params)
       |> json_response(:ok)
       |> assert_schema("UserProfile", api_spec)
 
     assert %{id: ^user_id, fullname: ^fullname, email: ^email} = resp
+  end
+
+  test "should not update the user when the request conditional prerequisite is missing", %{
+    conn: conn,
+    api_spec: api_spec
+  } do
+    conn
+    |> put_req_header("content-type", "application/json")
+    |> patch("/api/v1/profile", %{})
+    |> json_response(:precondition_required)
+    |> assert_schema("PreconditionRequired", api_spec)
+  end
+
+  test "should not update the user when the request conditional prerequisite is failing due to mid-air collision",
+       %{conn: conn, api_spec: api_spec} do
+    valid_params = %{
+      fullname: Faker.Person.name(),
+      email: Faker.Internet.email()
+    }
+
+    conn
+    |> put_req_header("content-type", "application/json")
+    |> put_req_header("if-match", "222")
+    |> patch("/api/v1/profile", valid_params)
+    |> json_response(:precondition_failed)
+    |> assert_schema("PreconditionFailed", api_spec)
   end
 end

--- a/test/trento_web/controllers/v1/profile_controller_test.exs
+++ b/test/trento_web/controllers/v1/profile_controller_test.exs
@@ -38,6 +38,9 @@ defmodule TrentoWeb.V1.ProfileControllerTest do
       |> assert_schema("UserProfile", api_spec)
 
     assert %{id: ^user_id} = resp
+
+    [etag] = get_resp_header(conn, "etag")
+    assert etag == "1"
   end
 
   test "should update the profile with allowed fields", %{


### PR DESCRIPTION
# Description

Add optimistic locking to the profile patch operation, for the same reason we do for the users patch.

PD: It duplicates some functions that we use in the `users_controller`. I think by now it is OK, but at some point, if we continue having this feature expanded, maybe we want to have something more generic

PD2: This PR doesn't change the frontend. I don't know how we will implement the `etag` usage, if we will query `/api/v1/profile` everytime we go to the page, or we just get it from redux. I would vote for the first, but now i'm wondering why did we store values like `createdAt` and `updatedAt` in the store

## How was this tested?

Tested with UT
