### PR TITLE
Forbidden guard for user entries

### DIFF
--- a/assets/js/pages/ForbiddenGuard/ForbiddeGuard.test.jsx
+++ b/assets/js/pages/ForbiddenGuard/ForbiddeGuard.test.jsx
@@ -1,0 +1,126 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import 'intersection-observer';
+import '@testing-library/jest-dom';
+import { Route, Routes } from 'react-router-dom';
+import { renderWithRouter, withState } from '@lib/test-utils';
+import ForbiddenGuard from './ForbiddenGuard';
+
+describe('ForbiddenGuard component', () => {
+  describe('Normal guard', () => {
+    it('should permit children if the user is authorized', () => {
+      const [StatefulGuard] = withState(
+        <ForbiddenGuard permitted={['show:test']}>
+          <div>Permitted</div>
+        </ForbiddenGuard>,
+        {
+          user: {
+            abilities: [{ name: 'show', resource: 'test' }],
+          },
+        }
+      );
+
+      render(StatefulGuard);
+
+      expect(screen.getByText('Permitted')).toBeVisible();
+    });
+
+    it('should permit for user with all abilities', () => {
+      const [StatefulGuard] = withState(
+        <ForbiddenGuard permitted={[]}>
+          <div>Permitted</div>
+        </ForbiddenGuard>,
+        {
+          user: {
+            abilities: [{ name: 'all', resource: 'all' }],
+          },
+        }
+      );
+
+      render(StatefulGuard);
+
+      expect(screen.getByText('Permitted')).toBeVisible();
+    });
+
+    it('should forbid and return null if user is not authorized', () => {
+      const [StatefulGuard] = withState(
+        <ForbiddenGuard permitted={['show:test']}>
+          <div>Permitted</div>
+        </ForbiddenGuard>,
+        {
+          user: {
+            abilities: [],
+          },
+        }
+      );
+
+      render(StatefulGuard);
+
+      expect(screen.queryByText('Permitted')).not.toBeInTheDocument();
+    });
+
+    it('should skip authorization check if the guard is disabled', () => {
+      const [StatefulGuard] = withState(
+        <ForbiddenGuard permitted={['show:test']} disabled>
+          <div>Permitted</div>
+        </ForbiddenGuard>,
+        {
+          user: {
+            abilities: [],
+          },
+        }
+      );
+
+      render(StatefulGuard);
+
+      expect(screen.getByText('Permitted')).toBeVisible();
+    });
+  });
+
+  describe('Outlet mode', () => {
+    it('should show a permitted outlet', async () => {
+      const [StatefulGuard] = withState(
+        <Routes>
+          <Route
+            element={<ForbiddenGuard outletMode permitted={['all:all']} />}
+          >
+            <Route path="/" element={<div>Outlet content</div>} />
+          </Route>
+        </Routes>,
+        {
+          user: {
+            abilities: [{ name: 'all', resource: 'all' }],
+          },
+        }
+      );
+
+      renderWithRouter(StatefulGuard);
+
+      expect(screen.getByText('Outlet content')).toBeVisible();
+    });
+
+    it('should show a forbidden view if the user is not authorized', async () => {
+      const [StatefulGuard] = withState(
+        <Routes>
+          <Route
+            element={<ForbiddenGuard outletMode permitted={['all:all']} />}
+          >
+            <Route path="/" element={<div>Outlet content</div>} />
+          </Route>
+        </Routes>,
+        {
+          user: {
+            abilities: [],
+          },
+        }
+      );
+
+      renderWithRouter(StatefulGuard);
+
+      expect(
+        screen.getByText('Access to this page is forbidden')
+      ).toBeVisible();
+    });
+  });
+});

--- a/assets/js/pages/ForbiddenGuard/ForbiddenGuard.jsx
+++ b/assets/js/pages/ForbiddenGuard/ForbiddenGuard.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { Outlet } from 'react-router-dom';
+
+import { getUserProfile } from '@state/selectors/user';
+
+const ALL_PERMITTED = ['all:all'];
+
+const FORBIDDEN_VIEW = <div>Access to this page is forbidden</div>;
+
+function ForbiddenGuard({
+  permitted,
+  outletMode = false,
+  disabled = false,
+  children,
+}) {
+  if (disabled) {
+    return children;
+  }
+
+  const permittedFor = ALL_PERMITTED.concat(permitted);
+  const { abilities } = useSelector(getUserProfile);
+
+  const userAbilities = abilities.map(
+    ({ name, resource }) => `${name}:${resource}`
+  );
+
+  const isPermitted = userAbilities.some((ability) =>
+    permittedFor.includes(ability)
+  );
+
+  if (isPermitted) {
+    return outletMode ? <Outlet /> : children;
+  }
+
+  if (outletMode) {
+    return FORBIDDEN_VIEW;
+  }
+
+  return null;
+}
+
+export default ForbiddenGuard;

--- a/assets/js/pages/ForbiddenGuard/index.js
+++ b/assets/js/pages/ForbiddenGuard/index.js
@@ -1,0 +1,3 @@
+import ForbiddenGuard from './ForbiddenGuard';
+
+export default ForbiddenGuard;

--- a/assets/js/pages/Layout/Layout.jsx
+++ b/assets/js/pages/Layout/Layout.jsx
@@ -25,6 +25,8 @@ import TrentoLogo from '@static/trento-logo-stacked.svg';
 import classNames from 'classnames';
 import ProfileMenu from '@common/ProfileMenu';
 
+import ForbiddenGuard from '@pages/ForbiddenGuard';
+
 const navigation = [
   { name: 'Dashboard', href: '/', icon: EOS_HOME_OUTLINED },
   {
@@ -56,6 +58,7 @@ const navigation = [
     name: 'Users',
     href: '/users',
     icon: EOS_SUPERVISED_USER_CIRCLE_OUTLINED,
+    permittedFor: ['all:users'],
   },
   {
     name: 'Settings',
@@ -140,30 +143,35 @@ function Layout() {
             <nav className="mt-6">
               <div>
                 {navigation.map((item) => (
-                  <NavLink
+                  <ForbiddenGuard
                     key={item.name}
-                    className={({ isActive }) =>
-                      `tn-menu-item w-full text-gray-800 dark:text-white flex items-center pl-6 p-2 my-2 transition-colors duration-200 justify-start ${
-                        isActive
-                          ? 'pl-5 border-l-4 border-jungle-green-500'
-                          : 'hover:pl-5 hover:border-l-4 hover:border-jungle-green-300'
-                      }`
-                    }
-                    to={item.href}
-                    end={item.href === '/'}
-                    title={item.name}
+                    disabled={!item.permittedFor}
+                    permitted={item.permittedFor}
                   >
-                    <span className="text-left">
-                      <item.icon />
-                    </span>
-                    <span
-                      className={classNames('mx-2 text-sm font-normal', {
-                        hidden: isCollapsed,
-                      })}
+                    <NavLink
+                      className={({ isActive }) =>
+                        `tn-menu-item w-full text-gray-800 dark:text-white flex items-center pl-6 p-2 my-2 transition-colors duration-200 justify-start ${
+                          isActive
+                            ? 'pl-5 border-l-4 border-jungle-green-500'
+                            : 'hover:pl-5 hover:border-l-4 hover:border-jungle-green-300'
+                        }`
+                      }
+                      to={item.href}
+                      end={item.href === '/'}
+                      title={item.name}
                     >
-                      {item.name}
-                    </span>
-                  </NavLink>
+                      <span className="text-left">
+                        <item.icon />
+                      </span>
+                      <span
+                        className={classNames('mx-2 text-sm font-normal', {
+                          hidden: isCollapsed,
+                        })}
+                      >
+                        {item.name}
+                      </span>
+                    </NavLink>
+                  </ForbiddenGuard>
                 ))}
               </div>
             </nav>

--- a/assets/js/state/sagas/user.js
+++ b/assets/js/state/sagas/user.js
@@ -34,6 +34,7 @@ export function* performLogin({ payload: { username, password } }) {
       email,
       fullname,
       updated_at,
+      abilities,
     } = yield call(profile, networkClient);
     yield put(
       setUser({
@@ -43,6 +44,7 @@ export function* performLogin({ payload: { username, password } }) {
         email,
         fullname,
         updated_at,
+        abilities,
       })
     );
     yield put(setUserAsLogged());

--- a/assets/js/state/sagas/user.test.js
+++ b/assets/js/state/sagas/user.test.js
@@ -87,16 +87,22 @@ describe('user login saga', () => {
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0cmVudG8tcHJvamVjdCIsImV4cCI6MTY3MTY0MDY1NiwiaWF0IjoxNjcxNjQwNTk2LCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vdHJlbnRvLXByb2plY3Qvd2ViIiwianRpIjoiMnNwZG9ndmxtZWhmbG1kdm1nMDAwbmMxIiwibmJmIjoxNjcxNjQwNTk2LCJzdWIiOjEsInR5cCI6IlJlZnJlc2gifQ.AW6-iV1XHWdzQKBVadhf7o7gUdidYg6mEyyuDke_zlA',
     };
 
-    const { email, username, id, fullname, created_at, updated_at } =
+    const { email, username, id, fullname, abilities, created_at, updated_at } =
       userFactory.build();
 
     axiosMock
       .onPost('/api/session', { username, password: 'good' })
       .reply(200, credentialResponse);
 
-    networkClientAxiosMock
-      .onGet('/api/v1/profile')
-      .reply(200, { username, id, email, fullname, created_at, updated_at });
+    networkClientAxiosMock.onGet('/api/v1/profile').reply(200, {
+      username,
+      id,
+      email,
+      fullname,
+      abilities,
+      created_at,
+      updated_at,
+    });
 
     const dispatched = await recordSaga(performLogin, {
       payload: {
@@ -107,7 +113,15 @@ describe('user login saga', () => {
 
     expect(dispatched).toContainEqual(setAuthInProgress());
     expect(dispatched).toContainEqual(
-      setUser({ username, id, email, fullname, created_at, updated_at })
+      setUser({
+        username,
+        id,
+        email,
+        fullname,
+        abilities,
+        created_at,
+        updated_at,
+      })
     );
     expect(dispatched).toContainEqual(setUserAsLogged());
 

--- a/assets/js/state/user.js
+++ b/assets/js/state/user.js
@@ -7,6 +7,7 @@ export const initialState = {
   fullname: undefined,
   email: undefined,
   id: undefined,
+  abilities: undefined,
   created_at: undefined,
   updated_at: undefined,
   authError: null,

--- a/assets/js/state/user.js
+++ b/assets/js/state/user.js
@@ -32,7 +32,17 @@ export const userSlice = createSlice({
     },
     setUser(
       state,
-      { payload: { username, id, email, created_at, fullname, updated_at } }
+      {
+        payload: {
+          username,
+          id,
+          email,
+          created_at,
+          fullname,
+          updated_at,
+          abilities,
+        },
+      }
     ) {
       state.username = username;
       state.email = email;
@@ -40,6 +50,7 @@ export const userSlice = createSlice({
       state.created_at = created_at;
       state.fullname = fullname;
       state.updated_at = updated_at;
+      state.abilities = abilities;
     },
   },
 });

--- a/assets/js/state/user.test.js
+++ b/assets/js/state/user.test.js
@@ -43,13 +43,14 @@ describe('user reducer', () => {
   });
 
   it('should set the user when setUser is dispatched', () => {
-    const { email, username, fullname, created_at, updated_at } =
+    const { email, username, fullname, abilities, created_at, updated_at } =
       userFactory.build();
 
     const action = setUser({
       username,
       email,
       fullname,
+      abilities,
       created_at,
       updated_at,
     });
@@ -59,6 +60,7 @@ describe('user reducer', () => {
       username,
       email,
       fullname,
+      abilities,
       created_at,
       updated_at,
     });

--- a/assets/js/trento.jsx
+++ b/assets/js/trento.jsx
@@ -18,6 +18,7 @@ import DatabasesOverviewPage from '@pages/DatabasesOverview';
 import DatabaseDetails from '@pages//DatabaseDetails';
 import { ExecutionResultsPage } from '@pages/ExecutionResults';
 import Guard from '@pages/Guard';
+import ForbiddenGuard from '@pages/ForbiddenGuard';
 import Home from '@pages/Home';
 import HostDetailsPage from '@pages/HostDetailsPage';
 import HostSettingsPage from '@pages/HostSettingsPage';
@@ -79,9 +80,6 @@ function App() {
                   <Route path="catalog" element={<ChecksCatalogPage />} />
                   <Route path="settings" element={<SettingsPage />} />
                   <Route path="about" element={<AboutPage />} />
-                  <Route path="users" element={<UsersPage />} />
-                  <Route path="users/new" element={<CreateUserPage />} />
-                  <Route path="users/:userID/edit" element={<EditUserPage />} />
                   <Route path="hosts/:hostID" element={<HostDetailsPage />} />
                   <Route
                     path="sap_systems/:id"
@@ -116,7 +114,18 @@ function App() {
                     path="hosts/:targetID/executions/last/:checkID/:resultTargetType/:resultTargetName"
                     element={<CheckResultDetailPage targetType={TARGET_HOST} />}
                   />
-                  <Route path="users/new" element={<CreateUserPage />} />
+                  <Route
+                    element={
+                      <ForbiddenGuard permitted={['all:users']} outletMode />
+                    }
+                  >
+                    <Route path="users" element={<UsersPage />} />
+                    <Route path="users/new" element={<CreateUserPage />} />
+                    <Route
+                      path="users/:userID/edit"
+                      element={<EditUserPage />}
+                    />
+                  </Route>
                 </Route>
               </Route>
             </Route>


### PR DESCRIPTION
# Description
Add the new `ForbiddenGuard` component that takes care of permitting or forbidding certain user related views and entries, in this case the `Users` entry in the side bar and any user related view.

The `ForbiddenGuard` has 2 modes:
- "Normal", which just removes the guarded children if they are not permitted
- Outlet, where it forbids the complete outlet entry showing a forbidden text

![forbidden_guard](https://github.com/trento-project/web/assets/36370954/2117319b-0e50-4eca-9f75-6a3bea5ed64a)

## How was this tested?

Tests added, and some manual testing
