### PR TITLE
User edit create toast

### DIFF
--- a/assets/js/pages/Users/CreateUserPage.jsx
+++ b/assets/js/pages/Users/CreateUserPage.jsx
@@ -11,6 +11,8 @@ import { createUser } from '@lib/api/users';
 import UserForm from './UserForm';
 
 const ERROR_GETTING_ABILITIES = 'Error getting user abilities';
+const SUCCESS_USER_CREATION = 'User created succesfuly';
+const UNEXPECTED_ERROR_MESSAGE = 'Unexpected error occurred, refresh the page';
 
 export const fetchAbilities = (setAbilities) => {
   listAbilities()
@@ -33,17 +35,17 @@ function CreateUserPage() {
     setSaving(true);
     createUser(payload)
       .then(() => {
+        toast.success(SUCCESS_USER_CREATION);
         navigate('/users');
       })
-      .catch(
-        ({
-          response: {
-            data: { errors },
-          },
-        }) => {
+      .catch((error) => {
+        if (error.response) {
+          const { errors } = error.response.data;
           setErrors(errors);
+          return;
         }
-      )
+        toast.error(UNEXPECTED_ERROR_MESSAGE);
+      })
       .finally(() => {
         setSaving(false);
       });

--- a/assets/js/pages/Users/CreateUserPage.jsx
+++ b/assets/js/pages/Users/CreateUserPage.jsx
@@ -11,7 +11,7 @@ import { createUser } from '@lib/api/users';
 import UserForm from './UserForm';
 
 const ERROR_GETTING_ABILITIES = 'Error getting user abilities';
-const SUCCESS_USER_CREATION = 'User created succesfuly';
+const SUCCESS_USER_CREATION = 'User created successfully';
 const UNEXPECTED_ERROR_MESSAGE = 'Unexpected error occurred, refresh the page';
 
 export const fetchAbilities = (setAbilities) => {

--- a/assets/js/pages/Users/CreateUserPage.test.jsx
+++ b/assets/js/pages/Users/CreateUserPage.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { render, screen } from '@testing-library/react';
+import { toast } from 'react-hot-toast';
 import 'intersection-observer';
 import '@testing-library/jest-dom';
 
@@ -20,6 +21,13 @@ import CreateUserPage from './CreateUserPage';
 const ABILITIES_URL = `/api/v1/abilities`;
 const USERS_URL = '/api/v1/users';
 const axiosMock = new MockAdapter(networkClient);
+
+jest.mock('react-hot-toast', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
 
 describe('CreateUserPage', () => {
   beforeEach(() => {
@@ -52,6 +60,7 @@ describe('CreateUserPage', () => {
   });
 
   it('should save a new user and redirect to users view', async () => {
+    const toastMessage = 'User created successfully';
     const user = userEvent.setup();
     const navigate = jest.fn();
     jest.spyOn(router, 'useNavigate').mockImplementation(() => navigate);
@@ -82,6 +91,7 @@ describe('CreateUserPage', () => {
     await user.click(screen.getByRole('button', { name: 'Create' }));
 
     expect(navigate).toHaveBeenCalledWith('/users');
+    expect(toast.success).toHaveBeenCalledWith(toastMessage);
   });
 
   it('should display validation errors', async () => {
@@ -112,5 +122,26 @@ describe('CreateUserPage', () => {
     await user.click(screen.getByRole('button', { name: 'Create' }));
 
     await screen.findByText('Error validating fullname');
+  });
+
+  it('should render toast with failing message when creating user failed on network error', async () => {
+    const toastMessage = 'Unexpected error occurred, refresh the page';
+    const user = userEvent.setup();
+
+    const { fullname, email, username } = userFactory.build();
+    const password = faker.internet.password();
+
+    axiosMock.onPost(USERS_URL).networkError();
+
+    render(<CreateUserPage />);
+
+    await user.type(screen.getByPlaceholderText('Enter full name'), fullname);
+    await user.type(screen.getByPlaceholderText('Enter email address'), email);
+    await user.type(screen.getByPlaceholderText('Enter username'), username);
+    await user.type(screen.getByPlaceholderText('Enter password'), password);
+    await user.type(screen.getByPlaceholderText('Re-enter password'), password);
+
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+    expect(toast.error).toHaveBeenCalledWith(toastMessage);
   });
 });

--- a/assets/js/pages/Users/CreateUserPage.test.jsx
+++ b/assets/js/pages/Users/CreateUserPage.test.jsx
@@ -59,7 +59,7 @@ describe('CreateUserPage', () => {
     expect(navigate).toHaveBeenCalledWith('/users');
   });
 
-  it('should save a new user and redirect to users view', async () => {
+  it('should save a new user, redirect to users view and render success toast', async () => {
     const toastMessage = 'User created successfully';
     const user = userEvent.setup();
     const navigate = jest.fn();
@@ -124,7 +124,7 @@ describe('CreateUserPage', () => {
     await screen.findByText('Error validating fullname');
   });
 
-  it('should render toast with failing message when creating user failed on network error', async () => {
+  it('should render toast with an error message when creating a user failed because of a network error', async () => {
     const toastMessage = 'Unexpected error occurred, refresh the page';
     const user = userEvent.setup();
 

--- a/assets/js/pages/Users/EditUserPage.jsx
+++ b/assets/js/pages/Users/EditUserPage.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { toast } from 'react-hot-toast';
 
 import BackButton from '@common/BackButton';
 import Banner from '@common/Banners/Banner';
@@ -10,6 +11,9 @@ import { editUser, getUser } from '@lib/api/users';
 
 import { fetchAbilities } from './CreateUserPage';
 import UserForm from './UserForm';
+
+const SUCCESS_EDIT_MESSAGE = 'User edited successfully';
+const UNEXPECTED_ERROR_MESSAGE = 'Unexpected error occurred, refresh the page';
 
 function EditUserPage() {
   const { userID } = useParams();
@@ -42,22 +46,23 @@ function EditUserPage() {
     setSaving(true);
     editUser(userID, payload, userVersion)
       .then(() => {
+        toast.success(SUCCESS_EDIT_MESSAGE);
         navigate('/users');
       })
-      .catch(
-        ({
-          response: {
-            status,
-            data: { errors },
-          },
-        }) => {
+      .catch((error) => {
+        if (error.response) {
+          const { data, status } = error.response;
           if (status === 412) {
             setUpdatedByOther(true);
             return;
           }
-          setErrors(errors);
+          setErrors(data.errors);
+
+          return;
         }
-      )
+        toast.error(UNEXPECTED_ERROR_MESSAGE);
+      })
+
       .finally(() => {
         setSaving(false);
       });

--- a/assets/js/pages/Users/EditUserPage.jsx
+++ b/assets/js/pages/Users/EditUserPage.jsx
@@ -32,7 +32,9 @@ function EditUserPage() {
         setUserVersion(etag);
         setUser(user);
       })
-      .catch(() => {})
+      .catch(() => {
+        toast.error(UNEXPECTED_ERROR_MESSAGE);
+      })
       .finally(() => {
         setLoading(false);
       });

--- a/assets/js/pages/Users/EditUserPage.test.jsx
+++ b/assets/js/pages/Users/EditUserPage.test.jsx
@@ -24,6 +24,7 @@ import EditUserPage from './EditUserPage';
 
 const ABILITIES_URL = `/api/v1/abilities`;
 const USERS_URL = '/api/v1/users/';
+const TOAST_ERROR_MESSAGE = 'Unexpected error occurred, refresh the page';
 const axiosMock = new MockAdapter(networkClient);
 
 jest.mock('react-hot-toast', () => ({
@@ -87,6 +88,7 @@ describe('EditUserPage', () => {
     });
 
     await screen.findByText('Not found');
+    expect(toast.error).toHaveBeenCalledWith(TOAST_ERROR_MESSAGE);
   });
 
   it('should edit a user and redirect to users view', async () => {
@@ -202,7 +204,6 @@ describe('EditUserPage', () => {
   });
 
   it('should render toast with an error message when editing a user failed because of a network error', async () => {
-    const toastMessage = 'Unexpected error occurred, refresh the page';
     const user = userEvent.setup();
     const userData = userFactory.build();
 
@@ -218,6 +219,6 @@ describe('EditUserPage', () => {
     });
     await screen.findByText('Edit User');
     await user.click(screen.getByRole('button', { name: 'Edit' }));
-    expect(toast.error).toHaveBeenCalledWith(toastMessage);
+    expect(toast.error).toHaveBeenCalledWith(TOAST_ERROR_MESSAGE);
   });
 });

--- a/assets/js/pages/Users/EditUserPage.test.jsx
+++ b/assets/js/pages/Users/EditUserPage.test.jsx
@@ -201,7 +201,7 @@ describe('EditUserPage', () => {
     expect(await screen.findByText(toolTipText)).toBeVisible();
   });
 
-  it('should render toast with failing message when editing user failed', async () => {
+  it('should render toast with an error message when editing a user failed because of a network error', async () => {
     const toastMessage = 'Unexpected error occurred, refresh the page';
     const user = userEvent.setup();
     const userData = userFactory.build();


### PR DESCRIPTION
# Description

This pr will enrich the CreateUser and EditUser pages.
When a user was created or edited, a success toast will pop up to inform the user.
Similar like in the Users Page. 

Also added a toast to inform the user when something went wrong.
The biggest case would be if a network error happens.

## Demo 

### Create user:
[create_toast.webm](https://github.com/trento-project/web/assets/54111255/50c05c2f-4d57-4482-8c1b-0b8b5ab7fa6a)



### Edit user
[edit_toast.webm](https://github.com/trento-project/web/assets/54111255/e2e3ad6c-8956-433d-8694-bdbaf9d5b4ab)


### Network Error on EditPage when web server crashed
[network_error_edit.webm](https://github.com/trento-project/web/assets/54111255/4941bcb2-ecee-4626-875a-5f4913236017)



## How was this tested?
Enriched existing test
Added network test
