### PR TITLE
Interpolate validation errors in error view

### DIFF
--- a/lib/trento_web/views/error_view.ex
+++ b/lib/trento_web/views/error_view.ex
@@ -49,7 +49,11 @@ defmodule TrentoWeb.ErrorView do
     error =
       Ecto.Changeset.traverse_errors(
         changeset,
-        fn {message, _} -> message end
+        fn {message, opts} ->
+          Regex.replace(~r"%{(\w+)}", message, fn _, key ->
+            opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+          end)
+        end
       )
 
     %{

--- a/test/support/structs/test_data_with_validation.ex
+++ b/test/support/structs/test_data_with_validation.ex
@@ -1,0 +1,17 @@
+defmodule TestDataWithValidation do
+  @moduledoc false
+
+  @required_fields :all
+
+  use Trento.Support.Type
+
+  deftype do
+    field :password, :string
+  end
+
+  def changeset(changeset, attrs) do
+    changeset
+    |> cast(attrs, [:password])
+    |> validate_length(:password, min: 8)
+  end
+end

--- a/test/trento_web/views/error_view_test.exs
+++ b/test/trento_web/views/error_view_test.exs
@@ -111,6 +111,21 @@ defmodule TrentoWeb.ErrorViewTest do
            } == render(TrentoWeb.ErrorView, "422.json", changeset: changeset)
   end
 
+  test "should render a 422 error (changeset) with interpolated values" do
+    changeset =
+      TestDataWithValidation.changeset(%TestDataWithValidation{}, %{password: "short"})
+
+    assert %{
+             errors: [
+               %{
+                 detail: "should be at least 8 character(s)",
+                 source: %{pointer: "/password"},
+                 title: "Invalid value"
+               }
+             ]
+           } == render(TrentoWeb.ErrorView, "422.json", changeset: changeset)
+  end
+
   test "should render a 500 error" do
     assert %{
              errors: [


### PR DESCRIPTION
# Description

Simply interpolate the validation errors in the errors view. It interpolates all the potential keys (the `count` in our case).
Thank you ecto!
https://hexdocs.pm/ecto/Ecto.Changeset.html#traverse_errors/2

![image](https://github.com/trento-project/web/assets/36370954/a53c99a8-bf5d-4d05-8e99-d6cfcee816bb)

## How was this tested?

Tested
