### PR TITLE
Rescue StaleError in user update function when abilities are present

### DIFF
--- a/lib/trento/users.ex
+++ b/lib/trento/users.ex
@@ -154,6 +154,8 @@ defmodule Trento.Users do
       {:error, _, changeset_error, _} ->
         {:error, changeset_error}
     end
+  rescue
+    Ecto.StaleEntryError -> {:error, :stale_entry}
   end
 
   defp do_update(user, attrs) do


### PR DESCRIPTION
# Description

Fix optimistic locking handling in the users context when we update a user with abilities.

