### PR TITLE
Password change request

### DIFF
--- a/lib/trento/users.ex
+++ b/lib/trento/users.ex
@@ -45,9 +45,14 @@ defmodule Trento.Users do
   end
 
   def create_user(%{abilities: abilities} = attrs) when not is_nil(abilities) do
+    updated_attrs =
+      attrs
+      |> set_locked_at()
+      |> set_password_change_requested_at(false)
+
     result =
       Ecto.Multi.new()
-      |> Ecto.Multi.insert(:user, User.changeset(%User{}, set_locked_at(attrs)))
+      |> Ecto.Multi.insert(:user, User.changeset(%User{}, updated_attrs))
       |> insert_abilities_multi(abilities)
       |> Repo.transaction()
 
@@ -61,32 +66,49 @@ defmodule Trento.Users do
   end
 
   def create_user(attrs) do
+    updated_attrs =
+      attrs
+      |> set_locked_at()
+      |> set_password_change_requested_at(false)
+
     %User{abilities: []}
-    |> User.changeset(set_locked_at(attrs))
+    |> User.changeset(updated_attrs)
     |> Repo.insert()
   end
 
   def update_user_profile(%User{id: 1}, _), do: {:error, :forbidden}
 
   def update_user_profile(%User{} = user, attrs) do
+    updated_attrs = set_password_change_requested_at(attrs, true)
+
     user
-    |> User.profile_update_changeset(attrs)
+    |> User.profile_update_changeset(updated_attrs)
     |> Repo.update()
   end
 
   def update_user(%User{id: 1}, _), do: {:error, :forbidden}
 
   def update_user(%User{locked_at: nil} = user, %{enabled: false} = attrs) do
-    do_update(user, Map.put(attrs, :locked_at, DateTime.utc_now()))
+    updated_attrs =
+      attrs
+      |> Map.put(:locked_at, DateTime.utc_now())
+      |> set_password_change_requested_at(false)
+
+    do_update(user, updated_attrs)
   end
 
   def update_user(%User{locked_at: locked_at} = user, %{enabled: false} = attrs)
       when not is_nil(locked_at) do
-    do_update(user, attrs)
+    do_update(user, set_password_change_requested_at(attrs, false))
   end
 
   def update_user(%User{} = user, attrs) do
-    do_update(user, Map.put(attrs, :locked_at, nil))
+    updated_attrs =
+      attrs
+      |> Map.put(:locked_at, nil)
+      |> set_password_change_requested_at(false)
+
+    do_update(user, updated_attrs)
   end
 
   def delete_user(%User{id: 1}), do: {:error, :forbidden}
@@ -118,6 +140,17 @@ defmodule Trento.Users do
   end
 
   defp set_locked_at(attrs), do: attrs
+
+  # 2nd argument is a boolean. true if it is a profile change, false otherwise
+  defp set_password_change_requested_at(%{password: _} = attrs, true) do
+    Map.put(attrs, :password_change_requested_at, nil)
+  end
+
+  defp set_password_change_requested_at(%{password: _} = attrs, false) do
+    Map.put(attrs, :password_change_requested_at, DateTime.utc_now())
+  end
+
+  defp set_password_change_requested_at(attrs, _), do: attrs
 
   defp insert_abilities_multi(multi, []), do: multi
 

--- a/lib/trento/users/user.ex
+++ b/lib/trento/users/user.ex
@@ -30,6 +30,7 @@ defmodule Trento.Users.User do
     field :fullname, :string
     field :deleted_at, :utc_datetime_usec
     field :locked_at, :utc_datetime_usec
+    field :password_change_requested_at, :utc_datetime_usec
     field :lock_version, :integer, default: 1
 
     many_to_many :abilities, Ability, join_through: UsersAbilities, unique: true
@@ -43,7 +44,7 @@ defmodule Trento.Users.User do
     |> pow_extension_changeset(attrs)
     |> validate_password()
     |> custom_fields_changeset(attrs)
-    |> lock_changeset(attrs)
+    |> cast(attrs, [:locked_at, :password_change_requested_at])
   end
 
   def update_changeset(user, attrs) do
@@ -52,8 +53,7 @@ defmodule Trento.Users.User do
     |> pow_extension_changeset(attrs)
     |> validate_password()
     |> custom_fields_changeset(attrs)
-    |> lock_changeset(attrs)
-    |> cast(attrs, [:lock_version])
+    |> cast(attrs, [:locked_at, :lock_version, :password_change_requested_at])
     |> optimistic_lock(:lock_version)
   end
 
@@ -64,6 +64,7 @@ defmodule Trento.Users.User do
     |> pow_extension_changeset(attrs)
     |> validate_password()
     |> custom_fields_changeset(attrs)
+    |> cast(attrs, [:password_change_requested_at])
   end
 
   def delete_changeset(
@@ -81,10 +82,6 @@ defmodule Trento.Users.User do
     do: pow_current_password_changeset(changeset, attrs)
 
   defp validate_current_password(changeset, _), do: changeset
-
-  defp lock_changeset(user, attrs) do
-    cast(user, attrs, [:locked_at])
-  end
 
   defp validate_password(changeset) do
     changeset

--- a/lib/trento_web/openapi/v1/schema/user.ex
+++ b/lib/trento_web/openapi/v1/schema/user.ex
@@ -20,11 +20,10 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
         username: %Schema{type: :string, description: "User username", nullable: false},
         email: %Schema{type: :string, description: "User email", nullable: false, format: :email},
         abilities: AbilityCollection,
-        password_change_requested_at: %OpenApiSpex.Schema{
-          type: :string,
-          format: :"date-time",
-          description: "Date of password change request",
-          nullable: true
+        password_change_requested: %Schema{
+          type: :boolean,
+          description: "Password change is requested",
+          nullable: false
         },
         created_at: %OpenApiSpex.Schema{
           type: :string,
@@ -162,6 +161,12 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
           nullable: false
         },
         abilities: AbilityCollection,
+        password_change_requested_at: %OpenApiSpex.Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Date of password change request",
+          nullable: true
+        },
         created_at: %OpenApiSpex.Schema{
           type: :string,
           format: :"date-time",

--- a/lib/trento_web/openapi/v1/schema/user.ex
+++ b/lib/trento_web/openapi/v1/schema/user.ex
@@ -20,6 +20,12 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
         username: %Schema{type: :string, description: "User username", nullable: false},
         email: %Schema{type: :string, description: "User email", nullable: false, format: :email},
         abilities: AbilityCollection,
+        password_change_requested_at: %OpenApiSpex.Schema{
+          type: :string,
+          format: :"date-time",
+          description: "Date of password change request",
+          nullable: true
+        },
         created_at: %OpenApiSpex.Schema{
           type: :string,
           format: :"date-time",

--- a/lib/trento_web/views/v1/profile_view.ex
+++ b/lib/trento_web/views/v1/profile_view.ex
@@ -10,6 +10,7 @@ defmodule TrentoWeb.V1.ProfileView do
           username: username,
           email: email,
           abilities: abilities,
+          password_change_requested_at: password_change_requested_at,
           inserted_at: created_at,
           updated_at: updated_at
         }
@@ -20,6 +21,7 @@ defmodule TrentoWeb.V1.ProfileView do
       username: username,
       email: email,
       abilities: render_many(abilities, AbilityView, "ability.json", as: :ability),
+      password_change_requested_at: password_change_requested_at,
       created_at: created_at,
       updated_at: updated_at
     }

--- a/lib/trento_web/views/v1/profile_view.ex
+++ b/lib/trento_web/views/v1/profile_view.ex
@@ -21,7 +21,7 @@ defmodule TrentoWeb.V1.ProfileView do
       username: username,
       email: email,
       abilities: render_many(abilities, AbilityView, "ability.json", as: :ability),
-      password_change_requested_at: password_change_requested_at,
+      password_change_requested: password_change_requested_at != nil,
       created_at: created_at,
       updated_at: updated_at
     }

--- a/lib/trento_web/views/v1/users_view.ex
+++ b/lib/trento_web/views/v1/users_view.ex
@@ -19,6 +19,7 @@ defmodule TrentoWeb.V1.UsersView do
           email: email,
           abilities: abilities,
           locked_at: locked_at,
+          password_change_requested_at: password_change_requested_at,
           inserted_at: created_at,
           updated_at: updated_at
         }
@@ -30,6 +31,7 @@ defmodule TrentoWeb.V1.UsersView do
       email: email,
       abilities: render_many(abilities, AbilityView, "ability.json", as: :ability),
       enabled: locked_at == nil,
+      password_change_requested_at: password_change_requested_at,
       created_at: created_at,
       updated_at: updated_at
     }

--- a/priv/repo/migrations/20240508125711_add_password_change_requested_at_to_users.exs
+++ b/priv/repo/migrations/20240508125711_add_password_change_requested_at_to_users.exs
@@ -1,0 +1,9 @@
+defmodule Trento.Repo.Migrations.AddPasswordChangeRequestedAtToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :password_change_requested_at, :utc_datetime_usec
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -950,7 +950,8 @@ defmodule Trento.Factory do
       password_hash: Argon2.hash_pwd_salt(password),
       username: Faker.Pokemon.name(),
       deleted_at: nil,
-      locked_at: nil
+      locked_at: nil,
+      password_change_requested_at: nil
     }
   end
 


### PR DESCRIPTION
# Description

Password change request feature backend implementation.
It adds a new `password_change_requested_at` field, which is used to know if the password should be changed or not.

I'm not adding the frontend here, as it has some details that I prefer to have an additional separated PR, so this one becomes easy to review

## How was this tested?

UT added
