### PR TITLE
Password change request frontend

### DIFF
--- a/assets/js/common/ProfileMenu/ProfileMenu.jsx
+++ b/assets/js/common/ProfileMenu/ProfileMenu.jsx
@@ -6,7 +6,7 @@ import { EOS_ACCOUNT_CIRCLE_OUTLINED } from 'eos-icons-react';
 
 function ProfileMenu({ username, email, logout }) {
   return (
-    <Menu as="div" className="relative inline-block text-left z-10">
+    <Menu as="div" className="relative inline-block text-left z-[100]">
       <Menu.Button as="button" className="group">
         <span className="flex items-center">
           <EOS_ACCOUNT_CIRCLE_OUTLINED

--- a/assets/js/common/ToastNotifications/ToastNotifications.jsx
+++ b/assets/js/common/ToastNotifications/ToastNotifications.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { Link } from 'react-router-dom';
+import HealthIcon from '@common/HealthIcon';
+
+import { USER_PASSWORD_CHANGE_REQUESTED_NOTIFICATION_ID } from '@state/user';
+
+const passwordChangeNotification = () => ({
+  component: (
+    <p className="text-sm font-medium text-gray-900">
+      Password change is recommended.
+      <br />
+      Go to{' '}
+      <Link to="/profile" className="text-jungle-green-500 hover:opacity-75">
+        Profile
+      </Link>
+    </p>
+  ),
+  icon: <HealthIcon health="warning" />,
+});
+
+const customNotifications = {
+  [USER_PASSWORD_CHANGE_REQUESTED_NOTIFICATION_ID]: passwordChangeNotification,
+};
+
+export const getNotification = (payload) =>
+  customNotifications[payload.id](payload);

--- a/assets/js/common/ToastNotifications/ToastNotifications.jsx
+++ b/assets/js/common/ToastNotifications/ToastNotifications.jsx
@@ -1,23 +1,19 @@
 import React from 'react';
 
 import { Link } from 'react-router-dom';
-import HealthIcon from '@common/HealthIcon';
 
 import { USER_PASSWORD_CHANGE_REQUESTED_NOTIFICATION_ID } from '@state/user';
 
-const passwordChangeNotification = () => ({
-  component: (
-    <p className="text-sm font-medium text-gray-900">
-      Password change is recommended.
-      <br />
-      Go to{' '}
-      <Link to="/profile" className="text-jungle-green-500 hover:opacity-75">
-        Profile
-      </Link>
-    </p>
-  ),
-  icon: <HealthIcon health="warning" />,
-});
+const passwordChangeNotification = () => (
+  <p className="text-sm font-medium text-gray-900">
+    Password change is recommended.
+    <br />
+    Go to{' '}
+    <Link to="/profile" className="text-jungle-green-500 hover:opacity-75">
+      Profile
+    </Link>
+  </p>
+);
 
 const customNotifications = {
   [USER_PASSWORD_CHANGE_REQUESTED_NOTIFICATION_ID]: passwordChangeNotification,

--- a/assets/js/common/ToastNotifications/ToastNotifications.test.jsx
+++ b/assets/js/common/ToastNotifications/ToastNotifications.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { renderWithRouter } from '@lib/test-utils';
@@ -7,8 +7,8 @@ import { USER_PASSWORD_CHANGE_REQUESTED_NOTIFICATION_ID } from '@state/user';
 import { getNotification } from './ToastNotifications';
 
 describe('ToastNotifications', () => {
-  it('should return password change requested toast notifications', () => {
-    const { component, icon } = getNotification({
+  it('should return password change requested toast notification', () => {
+    const component = getNotification({
       id: USER_PASSWORD_CHANGE_REQUESTED_NOTIFICATION_ID,
     });
 
@@ -16,9 +16,5 @@ describe('ToastNotifications', () => {
     expect(
       screen.getByText('Password change is recommended', { exact: false })
     ).toBeVisible();
-
-    const { container } = render(icon);
-    const svgEl = container.querySelector("[data-testid='eos-svg-component']");
-    expect(svgEl.classList.toString()).toContain('fill-yellow-500');
   });
 });

--- a/assets/js/common/ToastNotifications/ToastNotifications.test.jsx
+++ b/assets/js/common/ToastNotifications/ToastNotifications.test.jsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { renderWithRouter } from '@lib/test-utils';
+import { USER_PASSWORD_CHANGE_REQUESTED_NOTIFICATION_ID } from '@state/user';
+
+import { getNotification } from './ToastNotifications';
+
+describe('ToastNotifications', () => {
+  it('should return password change requested toast notifications', () => {
+    const { component, icon } = getNotification({
+      id: USER_PASSWORD_CHANGE_REQUESTED_NOTIFICATION_ID,
+    });
+
+    renderWithRouter(component);
+    expect(
+      screen.getByText('Password change is recommended', { exact: false })
+    ).toBeVisible();
+
+    const { container } = render(icon);
+    const svgEl = container.querySelector("[data-testid='eos-svg-component']");
+    expect(svgEl.classList.toString()).toContain('fill-yellow-500');
+  });
+});

--- a/assets/js/common/ToastNotifications/index.js
+++ b/assets/js/common/ToastNotifications/index.js
@@ -1,0 +1,3 @@
+import { getNotification } from './ToastNotifications';
+
+export { getNotification };

--- a/assets/js/lib/test-utils/factories/users.js
+++ b/assets/js/lib/test-utils/factories/users.js
@@ -22,6 +22,17 @@ export const userFactory = Factory.define(() => ({
   updated_at: formatISO(faker.date.past()),
 }));
 
+export const profileFactory = Factory.define(() => ({
+  id: faker.number.int(),
+  username: faker.internet.userName(),
+  fullname: faker.internet.displayName(),
+  email: faker.internet.email(),
+  abilities: abilityFactory.buildList(2),
+  password_change_requested: false,
+  created_at: formatISO(faker.date.past()),
+  updated_at: formatISO(faker.date.past()),
+}));
+
 export const adminUser = userFactory.params({
   id: 1,
   username: 'admin',

--- a/assets/js/lib/test-utils/factories/users.js
+++ b/assets/js/lib/test-utils/factories/users.js
@@ -17,6 +17,7 @@ export const userFactory = Factory.define(() => ({
   fullname: faker.internet.displayName(),
   email: faker.internet.email(),
   abilities: abilityFactory.buildList(2),
+  password_change_requested_at: null,
   created_at: formatISO(faker.date.past()),
   updated_at: formatISO(faker.date.past()),
 }));

--- a/assets/js/pages/Profile/ProfilePage.jsx
+++ b/assets/js/pages/Profile/ProfilePage.jsx
@@ -44,7 +44,7 @@ function ProfilePage() {
         setUser(updatedUser);
         dispatch(setUserInState(updatedUser));
         setPasswordModalOpen(false);
-        if (updatedUser.password_change_requested_at === null) {
+        if (!updatedUser.password_change_requested) {
           dispatch(
             dismissNotification(USER_PASSWORD_CHANGE_REQUESTED_NOTIFICATION_ID)
           );

--- a/assets/js/pages/Profile/ProfilePage.jsx
+++ b/assets/js/pages/Profile/ProfilePage.jsx
@@ -5,7 +5,11 @@ import PageHeader from '@common/PageHeader';
 import { isAdmin } from '@lib/model/users';
 import ProfileForm from '@pages/Profile/ProfileForm';
 import { getUserProfile, editUserProfile } from '@lib/api/users';
-import { setUser as setUserInState } from '@state/user';
+import {
+  setUser as setUserInState,
+  USER_PASSWORD_CHANGE_REQUESTED_NOTIFICATION_ID,
+} from '@state/user';
+import { dismissNotification } from '@state/notifications';
 
 function ProfilePage() {
   const [errorsState, setErrors] = useState([]);
@@ -40,6 +44,11 @@ function ProfilePage() {
         setUser(updatedUser);
         dispatch(setUserInState(updatedUser));
         setPasswordModalOpen(false);
+        if (updatedUser.password_change_requested_at === null) {
+          dispatch(
+            dismissNotification(USER_PASSWORD_CHANGE_REQUESTED_NOTIFICATION_ID)
+          );
+        }
       })
       .catch(
         ({

--- a/assets/js/pages/Profile/ProfilePage.test.jsx
+++ b/assets/js/pages/Profile/ProfilePage.test.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { faker } from '@faker-js/faker';
-import { formatISO } from 'date-fns';
 
 import MockAdapter from 'axios-mock-adapter';
 import { toast } from 'react-hot-toast';
@@ -10,7 +8,7 @@ import { withState } from '@lib/test-utils';
 import { networkClient } from '@lib/network';
 import { screen, act, render } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
-import { userFactory, adminUser } from '@lib/test-utils/factories/users';
+import { profileFactory, adminUser } from '@lib/test-utils/factories/users';
 import { setUser } from '@state/user';
 
 import ProfilePage from '@pages/Profile';
@@ -38,7 +36,7 @@ describe('ProfilePage', () => {
   });
 
   it('should show the pre-filled form with profile information', async () => {
-    const user = userFactory.build();
+    const user = profileFactory.build();
 
     axiosMock.onGet(PROFILE_URL).reply(200, user);
 
@@ -72,11 +70,11 @@ describe('ProfilePage', () => {
   });
 
   it('should submit the profile form and show a success toast', async () => {
-    const user = userFactory.build();
+    const user = profileFactory.build();
     const updatedUser = {
       ...user,
       fullname: 'New fullname',
-      password_change_requested_at: formatISO(faker.date.past()),
+      password_change_requested: true,
     };
 
     axiosMock
@@ -102,7 +100,7 @@ describe('ProfilePage', () => {
   });
 
   it('should pass errors to form when patch call fails', async () => {
-    const user = userFactory.build();
+    const user = profileFactory.build();
 
     const errors = [
       {
@@ -133,8 +131,8 @@ describe('ProfilePage', () => {
   });
 
   it('should dismiss password change toast when password is changed', async () => {
-    const user = userFactory.build();
-    const updatedUser = { ...user, password_change_requested_at: null };
+    const user = profileFactory.build();
+    const updatedUser = { ...user, password_change_requested: false };
 
     axiosMock
       .onGet(PROFILE_URL)

--- a/assets/js/state/notifications.js
+++ b/assets/js/state/notifications.js
@@ -19,12 +19,9 @@ export const dismissableNotify = createAction(
   })
 );
 
-export const dismissNotification = createAction(
-  DISMISS_NOTIFICATION,
-  ({ notificationID }) => ({
-    payload: { notificationID },
-  })
-);
+export const dismissNotification = createAction(DISMISS_NOTIFICATION, (id) => ({
+  payload: { id },
+}));
 
 export const customNotify = createAction(
   CUSTOM_NOTIFICATION,

--- a/assets/js/state/notifications.js
+++ b/assets/js/state/notifications.js
@@ -3,6 +3,7 @@ import { createAction } from '@reduxjs/toolkit';
 export const NOTIFICATION = 'NOTIFICATION';
 export const DISMISSABLE_NOTIFICATION = 'DISMISSABLE_NOTIFICATION';
 export const DISMISS_NOTIFICATION = 'DISMISS_NOTIFICATION';
+export const CUSTOM_NOTIFICATION = 'CUSTOM_NOTIFICATION';
 
 export const notify = createAction(
   NOTIFICATION,
@@ -22,5 +23,12 @@ export const dismissNotification = createAction(
   DISMISS_NOTIFICATION,
   ({ notificationID }) => ({
     payload: { notificationID },
+  })
+);
+
+export const customNotify = createAction(
+  CUSTOM_NOTIFICATION,
+  ({ id, duration }) => ({
+    payload: { id, duration },
   })
 );

--- a/assets/js/state/notifications.js
+++ b/assets/js/state/notifications.js
@@ -2,30 +2,30 @@ import { createAction } from '@reduxjs/toolkit';
 
 export const NOTIFICATION = 'NOTIFICATION';
 export const DISMISSABLE_NOTIFICATION = 'DISMISSABLE_NOTIFICATION';
-export const DISMISS_NOTIFICATION = 'DISMISS_NOTIFICATION';
 export const CUSTOM_NOTIFICATION = 'CUSTOM_NOTIFICATION';
+export const DISMISS_NOTIFICATION = 'DISMISS_NOTIFICATION';
 
 export const notify = createAction(
   NOTIFICATION,
-  ({ text, icon, id, duration }) => ({
-    payload: { text, icon, id, duration },
+  ({ text, icon, id, duration, isHealthIcon }) => ({
+    payload: { text, icon, id, duration, isHealthIcon },
   })
 );
 
 export const dismissableNotify = createAction(
   DISMISSABLE_NOTIFICATION,
-  ({ text, icon, id, duration }) => ({
-    payload: { text, icon, id, duration },
+  ({ text, icon, id, duration, isHealthIcon }) => ({
+    payload: { text, icon, id, duration, isHealthIcon },
+  })
+);
+
+export const customNotify = createAction(
+  CUSTOM_NOTIFICATION,
+  ({ id, icon, duration, isHealthIcon }) => ({
+    payload: { id, icon, duration, isHealthIcon },
   })
 );
 
 export const dismissNotification = createAction(DISMISS_NOTIFICATION, (id) => ({
   payload: { id },
 }));
-
-export const customNotify = createAction(
-  CUSTOM_NOTIFICATION,
-  ({ id, duration }) => ({
-    payload: { id, duration },
-  })
-);

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -69,7 +69,10 @@ import { markDeregisterableHosts, watchHostEvents } from '@state/sagas/hosts';
 import { watchLastExecutionEvents } from '@state/sagas/lastExecutions';
 import { watchSapSystemEvents } from '@state/sagas/sapSystems';
 
-import { watchUserActions } from '@state/sagas/user';
+import {
+  watchUserActions,
+  checkUserPasswordChangeRequested,
+} from '@state/sagas/user';
 import { watchChecksSelectionEvents } from '@state/sagas/checksSelection';
 import { watchSoftwareUpdateSettings } from '@state/sagas/softwareUpdatesSettings';
 import { watchSoftwareUpdates } from '@state/sagas/softwareUpdates';
@@ -93,6 +96,8 @@ function* initialDataFetch() {
   yield loadSapSystemsHealthSummary();
 
   yield fork(checkApiKeyExpiration);
+
+  yield fork(checkUserPasswordChangeRequested);
 
   const {
     data: { premium_subscription },

--- a/assets/js/state/sagas/notifications.jsx
+++ b/assets/js/state/sagas/notifications.jsx
@@ -10,24 +10,42 @@ import {
 } from '@state/notifications';
 import DismissableToast from '@common/DismissableToast';
 import { getNotification } from '@common/ToastNotifications';
+import HealthIcon from '@common/HealthIcon';
 
 const DEFAULT_DURATION = 4000;
 
+const getIcon = (icon, isHealthIcon) =>
+  isHealthIcon ? <HealthIcon health={icon} /> : icon;
+
 export function* notification({ payload }) {
-  const { id, text, icon, duration } = payload;
+  const { id, text, icon, duration, isHealthIcon } = payload;
+  const toastIcon = getIcon(icon, isHealthIcon);
   toast(<p className="text-sm font-medium text-gray-900">{text}</p>, {
     position: 'top-right',
-    icon,
+    icon: toastIcon,
     id,
     duration: duration || DEFAULT_DURATION,
   });
 }
 
 export function* dismissableNotification({ payload }) {
-  const { id, text, icon, duration } = payload;
+  const { id, text, icon, duration, isHealthIcon } = payload;
+  const toastIcon = getIcon(icon, isHealthIcon);
   toast((t) => <DismissableToast text={text} toastID={t.id} />, {
     position: 'top-right',
-    icon,
+    icon: toastIcon,
+    id,
+    duration: duration || DEFAULT_DURATION,
+  });
+}
+
+export function* customNotification({ payload }) {
+  const { id, icon, duration, isHealthIcon } = payload;
+  const toastIcon = getIcon(icon, isHealthIcon);
+  const component = getNotification(payload);
+  toast(component, {
+    position: 'top-right',
+    icon: toastIcon,
     id,
     duration: duration || DEFAULT_DURATION,
   });
@@ -38,20 +56,9 @@ export function* dismissNotification({ payload }) {
   toast.dismiss(id);
 }
 
-export function* customNotification({ payload }) {
-  const { id, duration } = payload;
-  const { component, icon } = getNotification(payload);
-  toast(component, {
-    position: 'top-right',
-    icon,
-    id,
-    duration: duration || DEFAULT_DURATION,
-  });
-}
-
 export function* watchNotifications() {
   yield takeEvery(NOTIFICATION, notification);
   yield takeEvery(DISMISSABLE_NOTIFICATION, dismissableNotification);
-  yield takeEvery(DISMISS_NOTIFICATION, dismissNotification);
   yield takeEvery(CUSTOM_NOTIFICATION, customNotification);
+  yield takeEvery(DISMISS_NOTIFICATION, dismissNotification);
 }

--- a/assets/js/state/sagas/notifications.jsx
+++ b/assets/js/state/sagas/notifications.jsx
@@ -6,8 +6,10 @@ import {
   NOTIFICATION,
   DISMISSABLE_NOTIFICATION,
   DISMISS_NOTIFICATION,
+  CUSTOM_NOTIFICATION,
 } from '@state/notifications';
 import DismissableToast from '@common/DismissableToast';
+import { getNotification } from '@common/ToastNotifications';
 
 const DEFAULT_DURATION = 4000;
 
@@ -36,8 +38,20 @@ export function* dismissNotification({ payload }) {
   toast.dismiss(id);
 }
 
+export function* customNotification({ payload }) {
+  const { id, duration } = payload;
+  const { component, icon } = getNotification(payload);
+  toast(component, {
+    position: 'top-right',
+    icon,
+    id,
+    duration: duration || DEFAULT_DURATION,
+  });
+}
+
 export function* watchNotifications() {
   yield takeEvery(NOTIFICATION, notification);
   yield takeEvery(DISMISSABLE_NOTIFICATION, dismissableNotification);
   yield takeEvery(DISMISS_NOTIFICATION, dismissNotification);
+  yield takeEvery(CUSTOM_NOTIFICATION, customNotification);
 }

--- a/assets/js/state/sagas/notifications.test.jsx
+++ b/assets/js/state/sagas/notifications.test.jsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { toast } from 'react-hot-toast';
+
+import { recordSaga } from '@lib/test-utils';
+import { getNotification } from '@common/ToastNotifications';
+import HealthIcon from '@common/HealthIcon';
+
+import {
+  notification,
+  dismissableNotification,
+  customNotification,
+  dismissNotification,
+} from './notifications';
+
+jest.mock('@common/ToastNotifications', () => ({
+  getNotification: jest.fn(() => <span>custom toast!</span>),
+}));
+
+jest.mock('react-hot-toast', () => ({
+  toast: jest.fn(),
+}));
+
+describe('notifications saga', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('notification', () => {
+    it('should send a notification toast', async () => {
+      await recordSaga(notification, {
+        payload: { id: 1, icon: '❌', text: 'toast!' },
+      });
+
+      expect(toast).toHaveBeenCalledWith(
+        <p className="text-sm font-medium text-gray-900">toast!</p>,
+        { duration: 4000, icon: '❌', id: 1, position: 'top-right' }
+      );
+    });
+
+    it('should send a notification toast with a health icon', async () => {
+      await recordSaga(notification, {
+        payload: { id: 1, icon: 'warning', text: 'toast!', isHealthIcon: true },
+      });
+
+      expect(toast).toHaveBeenCalledWith(
+        <p className="text-sm font-medium text-gray-900">toast!</p>,
+        {
+          duration: 4000,
+          icon: <HealthIcon health="warning" />,
+          id: 1,
+          position: 'top-right',
+        }
+      );
+    });
+  });
+
+  it('should send a dismissable notification', async () => {
+    await recordSaga(dismissableNotification, {
+      payload: { id: 1, icon: '❌', text: 'toast!' },
+    });
+
+    expect(toast).toHaveBeenCalledWith(expect.any(Function), {
+      duration: 4000,
+      icon: '❌',
+      id: 1,
+      position: 'top-right',
+    });
+  });
+
+  describe('customNotification', () => {
+    it('should send a notification toast with a custom component', async () => {
+      await recordSaga(customNotification, {
+        payload: { id: 1, icon: '❌', text: 'toast!' },
+      });
+
+      expect(getNotification).toHaveBeenCalledWith({
+        id: 1,
+        icon: '❌',
+        text: 'toast!',
+      });
+
+      expect(toast).toHaveBeenCalledWith(<span>custom toast!</span>, {
+        duration: 4000,
+        icon: '❌',
+        id: 1,
+        position: 'top-right',
+      });
+    });
+  });
+
+  describe('dismissNotification', () => {
+    it('should dismiss notification', async () => {
+      toast.dismiss = jest.fn();
+
+      await recordSaga(dismissNotification, {
+        payload: { id: 1 },
+      });
+
+      expect(toast.dismiss).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/assets/js/state/sagas/settings.js
+++ b/assets/js/state/sagas/settings.js
@@ -1,8 +1,6 @@
-import React from 'react';
 import { get } from '@lib/network';
 import { differenceInDays, parseISO, isAfter } from 'date-fns';
 import { call, put } from 'redux-saga/effects';
-import HealthIcon from '@common/HealthIcon';
 import { notify, dismissableNotify } from '@state/notifications';
 
 export const API_KEY_EXPIRATION_NOTIFICATION_ID = 'api-key-expiration-toast';
@@ -25,9 +23,10 @@ export function* checkApiKeyExpiration() {
     yield put(
       notify({
         text: 'API Key has expired. Go to Settings to issue a new key',
-        icon: <HealthIcon health="critical" />,
+        icon: 'critical',
         duration: Infinity,
         id: API_KEY_EXPIRATION_NOTIFICATION_ID,
+        isHealthIcon: true,
       })
     );
     return;
@@ -41,9 +40,10 @@ export function* checkApiKeyExpiration() {
   yield put(
     dismissableNotify({
       text: notificationText,
-      icon: <HealthIcon health="warning" />,
+      icon: 'warning',
       duration: Infinity,
       id: API_KEY_EXPIRATION_NOTIFICATION_ID,
+      isHealthIcon: true,
     })
   );
 }

--- a/assets/js/state/sagas/settings.test.jsx
+++ b/assets/js/state/sagas/settings.test.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { recordSaga } from '@lib/test-utils';
 
 import { networkClient } from '@lib/network';
@@ -6,7 +5,6 @@ import MockAdapter from 'axios-mock-adapter';
 
 import { apiKeySettingsFactory } from '@lib/test-utils/factories/settings';
 import { addDays, addHours, formatISO, subDays } from 'date-fns';
-import HealthIcon from '@common/HealthIcon';
 import { notify, dismissableNotify } from '@state/notifications';
 import { checkApiKeyExpiration } from './settings';
 
@@ -39,9 +37,10 @@ describe('Settings sagas', () => {
       const dispatched = await recordSaga(checkApiKeyExpiration, {});
       const expectedAction = notify({
         text: 'API Key has expired. Go to Settings to issue a new key',
-        icon: <HealthIcon health="critical" />,
+        icon: 'critical',
         duration: Infinity,
         id: 'api-key-expiration-toast',
+        isHealthIcon: true,
       });
       expect(dispatched).toEqual([expectedAction]);
     });
@@ -57,9 +56,10 @@ describe('Settings sagas', () => {
       const dispatched = await recordSaga(checkApiKeyExpiration, {});
       const expectedAction = dismissableNotify({
         text: `API Key expires in 2 days`,
-        icon: <HealthIcon health="warning" />,
+        icon: 'warning',
         duration: Infinity,
         id: 'api-key-expiration-toast',
+        isHealthIcon: true,
       });
       expect(dispatched).toEqual([expectedAction]);
     });
@@ -86,9 +86,10 @@ describe('Settings sagas', () => {
       const dispatched = await recordSaga(checkApiKeyExpiration, {});
       const expectedAction = dismissableNotify({
         text: `API Key expires today`,
-        icon: <HealthIcon health="warning" />,
+        icon: 'warning',
         duration: Infinity,
         id: 'api-key-expiration-toast',
+        isHealthIcon: true,
       });
       expect(dispatched).toEqual([expectedAction]);
     });

--- a/assets/js/state/sagas/user.js
+++ b/assets/js/state/sagas/user.js
@@ -35,6 +35,7 @@ export function* performLogin({ payload: { username, password } }) {
       fullname,
       updated_at,
       abilities,
+      password_change_requested_at,
     } = yield call(profile, networkClient);
     yield put(
       setUser({
@@ -45,6 +46,7 @@ export function* performLogin({ payload: { username, password } }) {
         fullname,
         updated_at,
         abilities,
+        password_change_requested_at,
       })
     );
     yield put(setUserAsLogged());

--- a/assets/js/state/sagas/user.js
+++ b/assets/js/state/sagas/user.js
@@ -38,7 +38,7 @@ export function* performLogin({ payload: { username, password } }) {
       fullname,
       updated_at,
       abilities,
-      password_change_requested_at,
+      password_change_requested,
     } = yield call(profile, networkClient);
     yield put(
       setUser({
@@ -49,7 +49,7 @@ export function* performLogin({ payload: { username, password } }) {
         fullname,
         updated_at,
         abilities,
-        password_change_requested_at,
+        password_change_requested,
       })
     );
     yield put(setUserAsLogged());
@@ -71,9 +71,9 @@ export function* userUpdated() {
 }
 
 export function* checkUserPasswordChangeRequested() {
-  const { password_change_requested_at } = yield select(getUserProfile);
+  const { password_change_requested } = yield select(getUserProfile);
 
-  if (!password_change_requested_at) {
+  if (!password_change_requested) {
     return;
   }
 

--- a/assets/js/state/sagas/user.js
+++ b/assets/js/state/sagas/user.js
@@ -1,4 +1,4 @@
-import { call, put, takeEvery } from 'redux-saga/effects';
+import { call, put, takeEvery, select } from 'redux-saga/effects';
 import {
   setAuthInProgress,
   setAuthError,
@@ -8,7 +8,10 @@ import {
   USER_LOCKED,
   USER_UPDATED,
   PERFORM_LOGIN,
+  USER_PASSWORD_CHANGE_REQUESTED_NOTIFICATION_ID,
 } from '@state/user';
+import { customNotify } from '@state/notifications';
+import { getUserProfile } from '@state/selectors/user';
 import {
   login,
   profile,
@@ -65,6 +68,21 @@ export function* clearUserAndLogout() {
 
 export function* userUpdated() {
   yield window.location.reload();
+}
+
+export function* checkUserPasswordChangeRequested() {
+  const { password_change_requested_at } = yield select(getUserProfile);
+
+  if (!password_change_requested_at) {
+    return;
+  }
+
+  yield put(
+    customNotify({
+      duration: Infinity,
+      id: USER_PASSWORD_CHANGE_REQUESTED_NOTIFICATION_ID,
+    })
+  );
 }
 
 export function* watchUserActions() {

--- a/assets/js/state/sagas/user.js
+++ b/assets/js/state/sagas/user.js
@@ -81,6 +81,8 @@ export function* checkUserPasswordChangeRequested() {
     customNotify({
       duration: Infinity,
       id: USER_PASSWORD_CHANGE_REQUESTED_NOTIFICATION_ID,
+      icon: 'warning',
+      isHealthIcon: true,
     })
   );
 }

--- a/assets/js/state/sagas/user.test.js
+++ b/assets/js/state/sagas/user.test.js
@@ -1,5 +1,4 @@
 import MockAdapter from 'axios-mock-adapter';
-import { faker } from '@faker-js/faker';
 import { recordSaga } from '@lib/test-utils';
 import {
   authClient,
@@ -16,7 +15,7 @@ import {
 } from '@state/user';
 import { customNotify } from '@state/notifications';
 import { networkClient } from '@lib/network';
-import { userFactory } from '@lib/test-utils/factories/users';
+import { profileFactory } from '@lib/test-utils/factories/users';
 import {
   performLogin,
   clearUserAndLogout,
@@ -99,10 +98,10 @@ describe('user login saga', () => {
       id,
       fullname,
       abilities,
-      password_change_requested_at,
+      password_change_requested,
       created_at,
       updated_at,
-    } = userFactory.build();
+    } = profileFactory.build();
 
     axiosMock
       .onPost('/api/session', { username, password: 'good' })
@@ -114,7 +113,7 @@ describe('user login saga', () => {
       email,
       fullname,
       abilities,
-      password_change_requested_at,
+      password_change_requested,
       created_at,
       updated_at,
     });
@@ -134,7 +133,7 @@ describe('user login saga', () => {
         email,
         fullname,
         abilities,
-        password_change_requested_at,
+        password_change_requested,
         created_at,
         updated_at,
       })
@@ -153,7 +152,7 @@ describe('user login saga', () => {
       {},
       {
         user: {
-          password_change_requested_at: faker.date.past(),
+          password_change_requested: true,
         },
       }
     );
@@ -172,7 +171,7 @@ describe('user login saga', () => {
       {},
       {
         user: {
-          password_change_requested_at: null,
+          password_change_requested: false,
         },
       }
     );

--- a/assets/js/state/sagas/user.test.js
+++ b/assets/js/state/sagas/user.test.js
@@ -87,8 +87,16 @@ describe('user login saga', () => {
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJ0cmVudG8tcHJvamVjdCIsImV4cCI6MTY3MTY0MDY1NiwiaWF0IjoxNjcxNjQwNTk2LCJpc3MiOiJodHRwczovL2dpdGh1Yi5jb20vdHJlbnRvLXByb2plY3Qvd2ViIiwianRpIjoiMnNwZG9ndmxtZWhmbG1kdm1nMDAwbmMxIiwibmJmIjoxNjcxNjQwNTk2LCJzdWIiOjEsInR5cCI6IlJlZnJlc2gifQ.AW6-iV1XHWdzQKBVadhf7o7gUdidYg6mEyyuDke_zlA',
     };
 
-    const { email, username, id, fullname, abilities, created_at, updated_at } =
-      userFactory.build();
+    const {
+      email,
+      username,
+      id,
+      fullname,
+      abilities,
+      password_change_requested_at,
+      created_at,
+      updated_at,
+    } = userFactory.build();
 
     axiosMock
       .onPost('/api/session', { username, password: 'good' })
@@ -100,6 +108,7 @@ describe('user login saga', () => {
       email,
       fullname,
       abilities,
+      password_change_requested_at,
       created_at,
       updated_at,
     });
@@ -119,6 +128,7 @@ describe('user login saga', () => {
         email,
         fullname,
         abilities,
+        password_change_requested_at,
         created_at,
         updated_at,
       })

--- a/assets/js/state/sagas/user.test.js
+++ b/assets/js/state/sagas/user.test.js
@@ -160,6 +160,8 @@ describe('user login saga', () => {
     const expectedAction = customNotify({
       duration: Infinity,
       id: 'password-change-requested-toast',
+      icon: 'warning',
+      isHealthIcon: true,
     });
 
     expect(dispatched).toEqual([expectedAction]);

--- a/assets/js/state/user.js
+++ b/assets/js/state/user.js
@@ -8,7 +8,7 @@ export const initialState = {
   email: undefined,
   id: undefined,
   abilities: undefined,
-  password_change_requested_at: undefined,
+  password_change_requested: undefined,
   created_at: undefined,
   updated_at: undefined,
   authError: null,
@@ -43,7 +43,7 @@ export const userSlice = createSlice({
           fullname,
           updated_at,
           abilities,
-          password_change_requested_at,
+          password_change_requested,
         },
       }
     ) {
@@ -54,7 +54,7 @@ export const userSlice = createSlice({
       state.fullname = fullname;
       state.updated_at = updated_at;
       state.abilities = abilities;
-      state.password_change_requested_at = password_change_requested_at;
+      state.password_change_requested = password_change_requested;
     },
   },
 });

--- a/assets/js/state/user.js
+++ b/assets/js/state/user.js
@@ -8,6 +8,7 @@ export const initialState = {
   email: undefined,
   id: undefined,
   abilities: undefined,
+  password_change_requested_at: undefined,
   created_at: undefined,
   updated_at: undefined,
   authError: null,
@@ -42,6 +43,7 @@ export const userSlice = createSlice({
           fullname,
           updated_at,
           abilities,
+          password_change_requested_at,
         },
       }
     ) {
@@ -52,6 +54,7 @@ export const userSlice = createSlice({
       state.fullname = fullname;
       state.updated_at = updated_at;
       state.abilities = abilities;
+      state.password_change_requested_at = password_change_requested_at;
     },
   },
 });
@@ -62,6 +65,9 @@ export const USER_LOCKED = 'USER_LOCKED';
 export const USER_DELETED = 'USER_DELETED';
 
 export const SET_USER_AS_LOGGED = 'user/setUserAsLogged';
+
+export const USER_PASSWORD_CHANGE_REQUESTED_NOTIFICATION_ID =
+  'password-change-requested-toast';
 
 export const initiateLogin = createAction(
   PERFORM_LOGIN,

--- a/assets/js/state/user.test.js
+++ b/assets/js/state/user.test.js
@@ -43,14 +43,22 @@ describe('user reducer', () => {
   });
 
   it('should set the user when setUser is dispatched', () => {
-    const { email, username, fullname, abilities, created_at, updated_at } =
-      userFactory.build();
+    const {
+      email,
+      username,
+      fullname,
+      abilities,
+      password_change_requested_at,
+      created_at,
+      updated_at,
+    } = userFactory.build();
 
     const action = setUser({
       username,
       email,
       fullname,
       abilities,
+      password_change_requested_at,
       created_at,
       updated_at,
     });
@@ -61,6 +69,7 @@ describe('user reducer', () => {
       email,
       fullname,
       abilities,
+      password_change_requested_at,
       created_at,
       updated_at,
     });

--- a/assets/js/state/user.test.js
+++ b/assets/js/state/user.test.js
@@ -48,7 +48,7 @@ describe('user reducer', () => {
       username,
       fullname,
       abilities,
-      password_change_requested_at,
+      password_change_requested,
       created_at,
       updated_at,
     } = userFactory.build();
@@ -58,7 +58,7 @@ describe('user reducer', () => {
       email,
       fullname,
       abilities,
-      password_change_requested_at,
+      password_change_requested,
       created_at,
       updated_at,
     });
@@ -69,7 +69,7 @@ describe('user reducer', () => {
       email,
       fullname,
       abilities,
-      password_change_requested_at,
+      password_change_requested,
       created_at,
       updated_at,
     });

--- a/assets/js/trento.jsx
+++ b/assets/js/trento.jsx
@@ -45,7 +45,7 @@ function App() {
 
   return (
     <Provider store={store}>
-      <Toaster position="top-right" />
+      <Toaster position="top-right" containerStyle={{ top: 50, zIndex: 99 }} />
       <BrowserRouter>
         <ErrorBoundary
           FallbackComponent={SomethingWentWrong}

--- a/assets/js/trento.jsx
+++ b/assets/js/trento.jsx
@@ -45,8 +45,11 @@ function App() {
 
   return (
     <Provider store={store}>
-      <Toaster position="top-right" containerStyle={{ top: 50, zIndex: 99 }} />
       <BrowserRouter>
+        <Toaster
+          position="top-right"
+          containerStyle={{ top: 50, zIndex: 99 }}
+        />
         <ErrorBoundary
           FallbackComponent={SomethingWentWrong}
           onReset={() => {


### PR DESCRIPTION
# Description

Frontend part for the password change request feature.
The most relevant thing is the new `customNotify` and the `ToastNotificactions` pseudo react component.
We need to have it apart, as redux doesn't recommend to put non serializable data into actions (like react data in this case): https://redux.js.org/style-guide/#do-not-put-non-serializable-values-in-state-or-actions

In this case, using them is not that horrible, as they don't end up in any reducer state (which is something we shouldn't never do).

We could "ignore" the raised error (https://redux-toolkit.js.org/usage/usage-guide#working-with-non-serializable-data), and it would perfectly work, and the code would be way simpler, as we could simply put the component in the saga code itself.

With this `customNotify` we get the chance to simply send the id, and get the component from a predefined map.
It is a bit more complex, but we follow the redux recommendation by the book.

We can go with the "ignore" option as well, I don't see it that bad.

PD: More I see, more I prefer the "ignore" warning option. Ignoring means just putting the `NOTIFICATION` and `DISMISSABLE_NOTIFICATION` in a ignored list for the middleware. In fact, right now, the API key notifications are not having this warning. What do you think @CDimonaco @dottorblaster ?

Some other changes:
- Change the profile menu index so it is always in top of the toasts
- Move the toaster inside the router. Otherwise we cannot use `Link` component, for example.
- Fix `dismissionNotification` action. It was not working well. The `id` was not used properly, and the `toast.dismiss` was getting `undefined` as id, which made to dismiss all the existing toasts

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.

## How was this tested?

Describe what kind of tests for this functionality have been added.
