### PR TITLE
Change placeholders

### DIFF
--- a/assets/js/pages/Users/EditUserPage.jsx
+++ b/assets/js/pages/Users/EditUserPage.jsx
@@ -108,7 +108,7 @@ function EditUserPage() {
       <UserForm
         abilities={abilitiesState}
         userAbilities={userAbilities}
-        saveText="Edit"
+        saveText="Save"
         fullName={fullname}
         emailAddress={email}
         username={username}

--- a/assets/js/pages/Users/EditUserPage.test.jsx
+++ b/assets/js/pages/Users/EditUserPage.test.jsx
@@ -120,7 +120,7 @@ describe('EditUserPage', () => {
       expect(screen.getAllByText(`${name}:${resource}`).length).toBe(1)
     );
 
-    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
 
     expect(navigate).toHaveBeenCalledWith('/users');
     expect(toast.success).toHaveBeenCalledWith(toastMessage);
@@ -151,7 +151,7 @@ describe('EditUserPage', () => {
 
     await screen.findByText('Edit User');
 
-    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
 
     await screen.findByText('Error validating fullname');
   });
@@ -173,7 +173,7 @@ describe('EditUserPage', () => {
 
     await screen.findByText('Edit User');
 
-    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
 
     await screen.findByText('Information has been updated by another user', {
       exact: false,
@@ -196,7 +196,7 @@ describe('EditUserPage', () => {
 
     await screen.findByText('Edit User');
 
-    const editButton = screen.getByRole('button', { name: 'Edit' });
+    const editButton = screen.getByRole('button', { name: 'Save' });
     expect(editButton).toBeDisabled();
     const toolTipText = 'Admin user cannot be edited';
     await user.hover(editButton);
@@ -218,7 +218,7 @@ describe('EditUserPage', () => {
       route: `/users/${userData.id}/edit`,
     });
     await screen.findByText('Edit User');
-    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
     expect(toast.error).toHaveBeenCalledWith(TOAST_ERROR_MESSAGE);
   });
 });

--- a/assets/js/pages/Users/UserForm.jsx
+++ b/assets/js/pages/Users/UserForm.jsx
@@ -223,6 +223,7 @@ function UserForm({
           <div className="col-start-2 col-span-3">
             <MultiSelect
               aria-label="permissions"
+              placeholder="Default"
               values={mapAbilities(userAbilities)}
               options={mapAbilities(abilities)}
               onChange={(values) =>

--- a/assets/js/pages/Users/UserForm.stories.jsx
+++ b/assets/js/pages/Users/UserForm.stories.jsx
@@ -143,7 +143,7 @@ export const Editing = {
     createdAt,
     updatedAt,
     editing: true,
-    saveText: 'Edit',
+    saveText: 'Save',
   },
 };
 

--- a/assets/js/pages/Users/UserForm.test.jsx
+++ b/assets/js/pages/Users/UserForm.test.jsx
@@ -122,14 +122,14 @@ describe('UserForm', () => {
 
     render(
       <UserForm
-        saveText="Edit"
+        saveText="Save"
         createdAt={createdAt}
         updatedAt={updatedAt}
         editing
       />
     );
 
-    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
 
     expect(screen.getAllByText('Required field').length).toBe(3);
   });


### PR DESCRIPTION
# Description

This pr will change the permission placeholder from: ```Select...``` to  ```Default``` in the userForm
Additionally, in the EditUserPage the saveText was changed from ```Edit``` to ```Save```

These changes were made to improve the ui like discussed in the review meeting.


![image](https://github.com/trento-project/web/assets/54111255/bfaf7409-bf6f-4793-8af3-3f23d6a740c5)




## How was this tested?

Updated existing tests
Updated storybook
