### PR TITLE
Clean and improve e2e performance

### DIFF
--- a/test/e2e/cypress/e2e/about.cy.js
+++ b/test/e2e/cypress/e2e/about.cy.js
@@ -2,6 +2,7 @@ import { getValue } from '../support/common';
 
 describe('User account page', () => {
   before(() => {
+    cy.loadScenario('healthy-27-node-SAP-cluster');
     cy.visit('/about');
     cy.url().should('include', '/about');
   });

--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -81,7 +81,7 @@ context('Clusters Overview', () => {
           clusterIdByName(healthyClusterScenario.clusterName),
           healthyClusterScenario.checks
         );
-        cy.setMockRunnerExpectedResult(healthyClusterScenario.result);
+        // wip: set expected results
         cy.requestChecksExecution(
           clusterIdByName(healthyClusterScenario.clusterName)
         );
@@ -90,7 +90,7 @@ context('Clusters Overview', () => {
           clusterIdByName(unhealthyClusterScenario.clusterName),
           healthyClusterScenario.checks
         );
-        cy.setMockRunnerExpectedResult(unhealthyClusterScenario.result);
+        // wip: set expected results
         cy.requestChecksExecution(
           clusterIdByName(unhealthyClusterScenario.clusterName)
         );

--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -15,6 +15,7 @@ const clusterTags = {
 
 context('Clusters Overview', () => {
   before(() => {
+    cy.loadScenario('healthy-27-node-SAP-cluster');
     cy.visit('/clusters');
     cy.url().should('include', '/clusters');
   });

--- a/test/e2e/cypress/e2e/databases_overview.cy.js
+++ b/test/e2e/cypress/e2e/databases_overview.cy.js
@@ -1,5 +1,6 @@
 context('Databases Overview', () => {
   before(() => {
+    cy.loadScenario('healthy-27-node-SAP-cluster');
     cy.visit('/databases');
     cy.url().should('include', '/databases');
   });

--- a/test/e2e/cypress/e2e/hana_cluster_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_cluster_details.cy.js
@@ -17,6 +17,7 @@ context('HANA cluster details', () => {
   const catalog = catalogFactory.build();
 
   before(() => {
+    cy.loadScenario('healthy-27-node-SAP-cluster');
     cy.intercept(lastExecutionURL, {
       body: lastExecution,
     }).as('lastExecution');

--- a/test/e2e/cypress/e2e/hana_database_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_database_details.cy.js
@@ -7,6 +7,7 @@ import {
 
 context('HANA database details', () => {
   before(() => {
+    cy.loadScenario('healthy-27-node-SAP-cluster');
     cy.visit(`/databases/${selectedDatabase.Id}`);
     cy.url().should('include', `/databases/${selectedDatabase.Id}`);
   });

--- a/test/e2e/cypress/e2e/home.cy.js
+++ b/test/e2e/cypress/e2e/home.cy.js
@@ -1,5 +1,6 @@
 context('Homepage', () => {
   before(() => {
+    cy.loadScenario('healthy-27-node-SAP-cluster');
     cy.visit('/');
     cy.url().should('include', '/');
   });

--- a/test/e2e/cypress/e2e/host_details.cy.js
+++ b/test/e2e/cypress/e2e/host_details.cy.js
@@ -6,6 +6,7 @@ import {
 
 context('Host Details', () => {
   before(() => {
+    cy.loadScenario('healthy-27-node-SAP-cluster');
     cy.task('startAgentHeartbeat', [selectedHost.agentId]);
     cy.visit('/hosts');
 

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -7,6 +7,7 @@ const availableHosts1stPage = availableHosts.slice(0, 10);
 
 context('Hosts Overview', () => {
   before(() => {
+    cy.loadScenario('healthy-27-node-SAP-cluster');
     cy.visit('/hosts');
     cy.url().should('include', '/hosts');
   });

--- a/test/e2e/cypress/e2e/sap_system_details.cy.js
+++ b/test/e2e/cypress/e2e/sap_system_details.cy.js
@@ -6,6 +6,7 @@ import {
 
 context('SAP system details', () => {
   before(() => {
+    cy.loadScenario('healthy-27-node-SAP-cluster');
     cy.visit(`/sap_systems/${selectedSystem.Id}`);
     cy.url().should('include', `/sap_systems/${selectedSystem.Id}`);
   });

--- a/test/e2e/cypress/e2e/sap_systems_overview.cy.js
+++ b/test/e2e/cypress/e2e/sap_systems_overview.cy.js
@@ -8,6 +8,7 @@ import {
 
 context('SAP Systems Overview', () => {
   before(() => {
+    cy.loadScenario('healthy-27-node-SAP-cluster');
     cy.visit('/sap_systems');
     cy.url().should('include', '/sap_systems');
   });

--- a/test/e2e/cypress/e2e/saptune_details.cy.js
+++ b/test/e2e/cypress/e2e/saptune_details.cy.js
@@ -16,6 +16,7 @@ describe('Saptune Details page', () => {
   const saptuneStagingStatusSelector = ':nth-child(11)';
 
   before(() => {
+    cy.loadScenario('healthy-27-node-SAP-cluster');
     cy.visit(`hosts/${hostID}/saptune`);
   });
 

--- a/test/e2e/cypress/support/commands.js
+++ b/test/e2e/cypress/support/commands.js
@@ -62,19 +62,6 @@ Cypress.Commands.add('apiLogin', () => {
   });
 });
 
-Cypress.Commands.add('acceptEula', () => {
-  apiLogin().then(({ accessToken }) => {
-    cy.request({
-      url: '/api/v1/accept_eula',
-      method: 'POST',
-      auth: {
-        bearer: accessToken,
-      },
-      body: {},
-    });
-  });
-});
-
 Cypress.Commands.add('updateApiKeyExpiration', (apiKeyExpiration) => {
   apiLogin().then(({ accessToken }) => {
     cy.request({
@@ -175,34 +162,6 @@ Cypress.Commands.add('resetFilterSelection', (filterName) => {
         cy.get(resetButton).click();
       }
     });
-});
-
-Cypress.Commands.add('setMockRunnerExpectedResult', (result) => {
-  const [webAPIHost, webAPIPort] = [
-    Cypress.env('web_api_host'),
-    Cypress.env('web_api_port'),
-  ];
-
-  const requestResultBody = JSON.stringify({
-    expected_results: result,
-  });
-
-  const headers = {
-    'Content-Type': 'application/json;charset=UTF-8',
-  };
-
-  apiLogin().then(({ accessToken }) => {
-    const url = `http://${webAPIHost}:${webAPIPort}/api/mockrunner/expected_result`;
-    cy.request({
-      method: 'POST',
-      url: url,
-      body: requestResultBody,
-      headers: headers,
-      auth: {
-        bearer: accessToken,
-      },
-    });
-  });
 });
 
 Cypress.Commands.add('requestChecksExecution', (clusterId) => {

--- a/test/e2e/cypress/support/e2e.js
+++ b/test/e2e/cypress/support/e2e.js
@@ -23,8 +23,5 @@ import './commands';
 //
 
 before(() => {
-  if (!Cypress.env('REAL_CLUSTER_TESTS')) {
-    cy.loadScenario('healthy-27-node-SAP-cluster');
-  }
   cy.initiateSession();
 });

--- a/test/e2e/cypress/support/e2e.js
+++ b/test/e2e/cypress/support/e2e.js
@@ -26,6 +26,5 @@ before(() => {
   if (!Cypress.env('REAL_CLUSTER_TESTS')) {
     cy.loadScenario('healthy-27-node-SAP-cluster');
   }
-  cy.acceptEula();
   cy.initiateSession();
 });


### PR DESCRIPTION
# Description
Two improvements in the e2e tests.

- Load initial photofinish scenario only if needed. With the generic `before`, we are running it even if we don't need, and for example, the `settings` and `catalog` don't need this, so it reduces some time the generic time of execution
- Clean some unused code

This PR could've gone to `main`, but as we are in a merge freeze...

