### PR TITLE
Add HTTPS using cert-manager for demo env

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -752,6 +752,10 @@ jobs:
         )
     env:
       IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}
+      TRENTO_DOMAIN: ${{ secrets.TRENTO_DEMO_IP }}
+      TRENTO_NAMESPACE: ${{ secrets.TRENTO_NAMESPACE }}
+      TRENTO_ADMIN_EMAIL: ${{ secrets.TRENTO_ADMIN_EMAIL }}
+      TRENTO_INGRESS_CLASS: ${{ secrets.TRENTO_INGRESS_CLASS }}
     needs: [build-demo-img, test-e2e]
     steps:
       - name: Start a local k8s cluster
@@ -773,6 +777,11 @@ jobs:
           rm -rf helm-charts-rolling | true
           wget https://github.com/trento-project/helm-charts/archive/refs/tags/rolling.zip
           unzip rolling.zip
+      - name: Prepare valid cluster-issuer and certificate (for cert-manager)
+        run: |
+          envsubst < helm-charts-rolling/hack/cert-manager/certificate.tpl.yaml > helm-charts-rolling/hack/cert-manager/certificate.yaml
+          envsubst < helm-charts-rolling/hack/cert-manager/cluster-issuer.tpl.yaml > helm-charts-rolling/hack/cert-manager/cluster-issuer.yaml
+          envsubst < helm-charts-rolling/hack/cert-manager/override-values.tpl.yaml > helm-charts-rolling/hack/cert-manager/override-values.yaml
       - name: Apply cluster-issuer and certificate (for cert-manager)
         run: |
           kubectl apply -f helm-charts-rolling/hack/cert-manager/cluster-issuer.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -798,6 +798,7 @@ jobs:
             --set trento-wanda.image.pullPolicy=Always \
             --set trento-wanda.image.repository="${IMAGE_REPOSITORY}/trento-wanda" \
             --set trento-wanda.image.tag="demo" \
+            --set trento-web.trentoDomain="${TRENTO_DOMAIN}" \
             -f ../../hack/cert-manager/override-values.yaml
 
   run-photofinish-demo-env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -758,16 +758,25 @@ jobs:
         uses: jupyterhub/action-k3s-helm@v4
         with:
           k3s-channel: latest
-      - name: Add bitnami helm deps
+      - name: Add bitnami & jetstack(cert-manager) helm deps
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add jetstack https://charts.jetstack.io
           helm repo update
+      - name: Install CRDs for cert-manager
+        run: kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.5/cert-manager.crds.yaml
+      - name: Install cert-manager
+        run: helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version v1.14.5
       - name: Download and unzip helm chart
         run: |
           rm rolling.zip | true
           rm -rf helm-charts-rolling | true
           wget https://github.com/trento-project/helm-charts/archive/refs/tags/rolling.zip
           unzip rolling.zip
+      - name: Apply cluster-issuer and certificate (for cert-manager)
+        run: |
+          kubectl apply -f helm-charts-rolling/hack/cert-manager/cluster-issuer.yaml
+          kubectl apply -f helm-charts-rolling/hack/cert-manager/certificate.yaml
       - name: Install trento-server helm chart
         run: |
           cd helm-charts-rolling/charts/trento-server
@@ -779,7 +788,8 @@ jobs:
             --set trento-web.image.tag="demo" \
             --set trento-wanda.image.pullPolicy=Always \
             --set trento-wanda.image.repository="${IMAGE_REPOSITORY}/trento-wanda" \
-            --set trento-wanda.image.tag="demo"
+            --set trento-wanda.image.tag="demo" \
+            -f ../../hack/cert-manager/override-values.yaml
 
   run-photofinish-demo-env:
     name: Use photofinish to push mock data to the demo environment


### PR DESCRIPTION
# Description

This PR enables the usage of cert-manager during the deployment of our demo environment. This will result in https://demo.trento-project.io having a validly signed certificate after deployment.

## How was this tested?
This was tested manually on the demo env by deploying the helm chart using the same commands that are added here in the CI.

NOTE: Setting this as draft until we merge https://github.com/trento-project/helm-charts/pull/95. That PR is needed before this can work.