### PR TITLE
Make discovery payload nullable in schema

### DIFF
--- a/lib/trento_web/openapi/v1/schema/discovery_event.ex
+++ b/lib/trento_web/openapi/v1/schema/discovery_event.ex
@@ -14,6 +14,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.DiscoveryEvent do
       agent_id: %Schema{type: :string, format: :uuid},
       discovery_type: %Schema{type: :string},
       payload: %Schema{
+        nullable: true,
         oneOf: [%Schema{type: :object}, %Schema{type: :array}]
       }
     },

--- a/test/trento_web/controllers/v1/discovery_controller_test.exs
+++ b/test/trento_web/controllers/v1/discovery_controller_test.exs
@@ -20,5 +20,17 @@ defmodule TrentoWeb.V1.DiscoveryControllerTest do
                ]
              } = resp
     end
+
+    test "collect action should accept nil payloads",
+         %{conn: conn} do
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> post("/api/v1/collect", %{
+        "discovery_type" => "ha_cluster_discovery",
+        "agent_id" => UUID.uuid4(),
+        "payload" => nil
+      })
+      |> json_response(202)
+    end
   end
 end


### PR DESCRIPTION
# Description

Make discovery payload nullable in schema.
This field can be null when for example a host doesn't have a cluster installed.

This bug affects the scenario when a cluster node is removed from the cluster, because we wouldn't remove it properly as the discovery fails. This is unlikely scenario. But it happens.
Besides that, we remove an "wrong" error log in the agent side.
This error in the agent:

```
11:49:26.350 request_id=F9EwDTjMRMb4yvsAB4oR [info] POST /api/v1/collect
11:49:26.350 request_id=F9EwDTjMRMb4yvsAB4oR [debug] Processing with TrentoWeb.V1.DiscoveryController.collect/2
  Parameters: %{"agent_id" => "8b8f6760-e9f5-5014-893d-b154c537e964", "discovery_type" => "ha_cluster_discovery", "payload" => nil}
  Pipelines: [:api, :apikey_authenticated, :api_v1]
11:49:26.358 request_id=F9EwDTjMRMb4yvsAB4oR [debug] QUERY OK source="settings" db=6.1ms queue=0.4ms idle=249.3ms
SELECT s0."id", s0."api_key_settings_jti", s0."api_key_settings_created_at", s0."api_key_settings_expire_at", s0."inserted_at", s0."updated_at", s0."type" FROM "settings" AS s0 WHERE (s0."type" = 'api_key_settings') []
11:49:26.358 request_id=F9EwDTjMRMb4yvsAB4oR [info] Sent 422 in 7ms
11:49:26.358 request_id=F9EwDTjMRMb4yvsAB4oR [debug] TrentoWeb.V1.DiscoveryController halted in OpenApiSpex.Plug.CastAndValidate.call/2
```

FYI: @abravosuse 

## How was this tested?
Test added
