### PR TITLE
Add validation when a password is generated

### DIFF
--- a/assets/js/lib/forms/index.jsx
+++ b/assets/js/lib/forms/index.jsx
@@ -10,8 +10,8 @@ export const PASSWORD_POLICY_TEXT = (
     <br />
     - does not have 3 consecutive repeated numbers or letters (example: 111 or
     aaa)
-    <br />- does not have 3 consecutive sequential numbers or letters (example:
-    123 or abc)
+    <br />- does not have 4 consecutive sequential numbers or letters (example:
+    1234, abcd or ABCD)
   </div>
 );
 export const REQUIRED_FIELD_TEXT = 'Required field';

--- a/assets/js/pages/Users/UserForm.jsx
+++ b/assets/js/pages/Users/UserForm.jsx
@@ -17,7 +17,7 @@ import {
 } from '@lib/forms';
 import { getError } from '@lib/api/validationErrors';
 
-import { generatePassword } from './generatePassword';
+import { generateValidPassword } from './generatePassword';
 
 const USER_ENABLED = 'Enabled';
 
@@ -115,7 +115,7 @@ function UserForm({
   };
 
   const onGeneratePassword = () => {
-    const newPassword = generatePassword();
+    const newPassword = generateValidPassword();
     setPassword(newPassword);
     setConfirmPassword(newPassword);
   };

--- a/assets/js/pages/Users/generatePassword.js
+++ b/assets/js/pages/Users/generatePassword.js
@@ -6,28 +6,40 @@ const SPECIAL_CHARACTERS = '~!@#$%^&*()_+={}[]|:;<>,.?/-\'"`';
 const PASSWORD_CHARACTERS =
   DIGITS + UPPERCASE_LETTERS + LOWERCASE_LETTERS + SPECIAL_CHARACTERS;
 
-export const hasValidLength = (password, pwdLength = 8) =>
+export const hasValidPwdLength = (password, pwdLength = 8) =>
   password.length >= pwdLength;
 
 export const validateNoRepetitiveCharacters = (password) =>
   !/(.)\1{2,}/.test(password);
 
+const isAlphanumeric = (char) => /[A-Za-z0-9]/.test(char);
+
 export const validateNoSequentialCharacters = (password) => {
   if (password.length < 3) {
     return true;
   }
-  for (let i = 2; i < password.length; i += 1) {
-    const firstCharCode = password.charCodeAt(i - 2);
-    const secondCharCode = password.charCodeAt(i - 1);
-    const thirdCharCode = password.charCodeAt(i);
 
+  for (let i = 2; i < password.length; i += 1) {
+    const firstChar = password[i - 2];
+    const secondChar = password[i - 1];
+    const thirdChar = password[i];
     if (
-      (secondCharCode === firstCharCode + 1 &&
-        thirdCharCode === secondCharCode + 1) ||
-      (secondCharCode === firstCharCode - 1 &&
-        thirdCharCode === secondCharCode - 1)
+      isAlphanumeric(firstChar) &&
+      isAlphanumeric(secondChar) &&
+      isAlphanumeric(thirdChar)
     ) {
-      return false;
+      const firstCharCode = firstChar.charCodeAt(0);
+      const secondCharCode = secondChar.charCodeAt(0);
+      const thirdCharCode = thirdChar.charCodeAt(0);
+
+      if (
+        (secondCharCode === firstCharCode + 1 &&
+          thirdCharCode === secondCharCode + 1) ||
+        (secondCharCode === firstCharCode - 1 &&
+          thirdCharCode === secondCharCode - 1)
+      ) {
+        return false;
+      }
     }
   }
   return true;
@@ -41,7 +53,7 @@ const generatePassword = (length = 16, characters = PASSWORD_CHARACTERS) =>
 export const generateValidPassword = (length = 16) => {
   const password = generatePassword(length);
   if (
-    hasValidLength(password) &&
+    hasValidPwdLength(password) &&
     validateNoRepetitiveCharacters(password) &&
     validateNoSequentialCharacters(password)
   ) {

--- a/assets/js/pages/Users/generatePassword.js
+++ b/assets/js/pages/Users/generatePassword.js
@@ -6,10 +6,46 @@ const SPECIAL_CHARACTERS = '~!@#$%^&*()_+={}[]|:;<>,.?/-\'"`';
 const PASSWORD_CHARACTERS =
   DIGITS + UPPERCASE_LETTERS + LOWERCASE_LETTERS + SPECIAL_CHARACTERS;
 
-export const generatePassword = (
-  length = 16,
-  characters = PASSWORD_CHARACTERS
-) =>
+export const hasValidLength = (password, pwdLength = 8) =>
+  password.length >= pwdLength;
+
+export const validateNoRepetitiveCharacters = (password) =>
+  !/(.)\1{2,}/.test(password);
+
+export const validateNoSequentialCharacters = (password) => {
+  if (password.length < 3) {
+    return true;
+  }
+  for (let i = 2; i < password.length; i += 1) {
+    const firstCharCode = password.charCodeAt(i - 2);
+    const secondCharCode = password.charCodeAt(i - 1);
+    const thirdCharCode = password.charCodeAt(i);
+
+    if (
+      (secondCharCode === firstCharCode + 1 &&
+        thirdCharCode === secondCharCode + 1) ||
+      (secondCharCode === firstCharCode - 1 &&
+        thirdCharCode === secondCharCode - 1)
+    ) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const generatePassword = (length = 16, characters = PASSWORD_CHARACTERS) =>
   Array.from(crypto.getRandomValues(new Uint32Array(length)))
     .map((char) => characters[char % characters.length])
     .join('');
+
+export const generateValidPassword = (length = 16) => {
+  const password = generatePassword(length);
+  if (
+    hasValidLength(password) &&
+    validateNoRepetitiveCharacters(password) &&
+    validateNoSequentialCharacters(password)
+  ) {
+    return password;
+  }
+  return generateValidPassword(length);
+};

--- a/assets/js/pages/Users/generatePassword.test.js
+++ b/assets/js/pages/Users/generatePassword.test.js
@@ -5,52 +5,44 @@ import {
   generateValidPassword,
 } from './generatePassword';
 
-describe('generatePassword', () => {
-  test('generates a password of default length 16', () => {
+describe('Validation helper', () => {
+  test('should check password length to be minimum of 8', () => {
+    const validPwd = '12345678';
+    const invalidPwd = '1234567';
+    expect(hasValidPwdLength(validPwd)).toBe(true);
+    expect(hasValidPwdLength(invalidPwd)).toBe(false);
+  });
+
+  test('should check for repetitive characters', () => {
+    const validPwd = 'abcdef';
+    const invalidPwd = 'aaabbb';
+    expect(validateNoRepetitiveCharacters(validPwd)).toBe(true);
+    expect(validateNoRepetitiveCharacters(invalidPwd)).toBe(false);
+  });
+
+  test('should check for sequential characters', () => {
+    const validPwd = 'abd';
+    const invalidPwd = 'abc';
+    expect(validateNoSequentialCharacters(validPwd)).toBe(true);
+    expect(validateNoSequentialCharacters(invalidPwd)).toBe(false);
+  });
+});
+
+describe('generateValidPassword', () => {
+  test('should generate a password with a default length of 16', () => {
     const password = generateValidPassword();
     expect(password).toHaveLength(16);
   });
 
-  test('generates a password of specific length', () => {
+  test('should generate a password of specific length', () => {
     const length = 20;
     const password = generateValidPassword(length);
     expect(password).toHaveLength(length);
   });
 
-  test('generates passwords that vary', () => {
+  test('should generate passwords that vary', () => {
     const firstPassword = generateValidPassword();
     const secondPassword = generateValidPassword();
     expect(firstPassword).not.toBe(secondPassword);
-  });
-});
-
-describe('Validation helper', () => {
-  test('should check password length to be minimum of 8', () => {
-    const validPwdLength = '12345678';
-    const invalidPwdLength = '1234567';
-    expect(hasValidPwdLength(validPwdLength)).toBe(true);
-    expect(hasValidPwdLength(invalidPwdLength)).toBe(false);
-  });
-
-  test('should check for repetitive characters', () => {
-    const validPwdWithoutRepetition = 'abcdef';
-    const invalidPwdWithRepetition = 'aaabbb';
-    expect(validateNoRepetitiveCharacters(validPwdWithoutRepetition)).toBe(
-      true
-    );
-    expect(validateNoRepetitiveCharacters(invalidPwdWithRepetition)).toBe(
-      false
-    );
-  });
-
-  test('should check for sequential characters', () => {
-    const validPwdWithoutSequentialCharacters = 'abd';
-    const invalidPwdWithSequentialCharacters = 'abc';
-    expect(
-      validateNoSequentialCharacters(validPwdWithoutSequentialCharacters)
-    ).toBe(true);
-    expect(
-      validateNoSequentialCharacters(invalidPwdWithSequentialCharacters)
-    ).toBe(false);
   });
 });

--- a/assets/js/pages/Users/generatePassword.test.js
+++ b/assets/js/pages/Users/generatePassword.test.js
@@ -1,20 +1,56 @@
-import { generatePassword } from './generatePassword';
+import {
+  hasValidLength,
+  validateNoRepetitiveCharacters,
+  validateNoSequentialCharacters,
+  generateValidPassword,
+} from './generatePassword';
 
 describe('generatePassword', () => {
   test('generates a password of default length 16', () => {
-    const password = generatePassword();
+    const password = generateValidPassword();
     expect(password).toHaveLength(16);
   });
 
   test('generates a password of specific length', () => {
     const length = 20;
-    const password = generatePassword(length);
+    const password = generateValidPassword(length);
     expect(password).toHaveLength(length);
   });
 
   test('generates passwords that vary', () => {
-    const firstPassword = generatePassword();
-    const secondPassword = generatePassword();
+    const firstPassword = generateValidPassword();
+    const secondPassword = generateValidPassword();
     expect(firstPassword).not.toBe(secondPassword);
+  });
+});
+
+describe('Validation helpers', () => {
+  test('validates password length to be minimum of 8', () => {
+    const validPwdLength = '12345678';
+    const invalidPWDLength = '1234567';
+    expect(hasValidLength(validPwdLength)).toBe(true);
+    expect(hasValidLength(invalidPWDLength)).toBe(false);
+  });
+
+  test('checks for repetitive characters', () => {
+    const validPwdWithoutRepetition = 'abcdef';
+    const invalidPwdWithRepetition = 'aaabbb';
+    expect(validateNoRepetitiveCharacters(validPwdWithoutRepetition)).toBe(
+      true
+    );
+    expect(validateNoRepetitiveCharacters(invalidPwdWithRepetition)).toBe(
+      false
+    );
+  });
+
+  test('checks for sequential characters', () => {
+    const validPwdWithoutSequentialCharacters = 'abc';
+    const invalidPwdWithSequentialCharacters = 'abd';
+    expect(
+      validateNoSequentialCharacters(validPwdWithoutSequentialCharacters)
+    ).toBe(false);
+    expect(
+      validateNoSequentialCharacters(invalidPwdWithSequentialCharacters)
+    ).toBe(true);
   });
 });

--- a/assets/js/pages/Users/generatePassword.test.js
+++ b/assets/js/pages/Users/generatePassword.test.js
@@ -1,5 +1,5 @@
 import {
-  hasValidLength,
+  hasValidPwdLength,
   validateNoRepetitiveCharacters,
   validateNoSequentialCharacters,
   generateValidPassword,
@@ -24,15 +24,15 @@ describe('generatePassword', () => {
   });
 });
 
-describe('Validation helpers', () => {
-  test('validates password length to be minimum of 8', () => {
+describe('Validation helper', () => {
+  test('should check password length to be minimum of 8', () => {
     const validPwdLength = '12345678';
-    const invalidPWDLength = '1234567';
-    expect(hasValidLength(validPwdLength)).toBe(true);
-    expect(hasValidLength(invalidPWDLength)).toBe(false);
+    const invalidPwdLength = '1234567';
+    expect(hasValidPwdLength(validPwdLength)).toBe(true);
+    expect(hasValidPwdLength(invalidPwdLength)).toBe(false);
   });
 
-  test('checks for repetitive characters', () => {
+  test('should check for repetitive characters', () => {
     const validPwdWithoutRepetition = 'abcdef';
     const invalidPwdWithRepetition = 'aaabbb';
     expect(validateNoRepetitiveCharacters(validPwdWithoutRepetition)).toBe(
@@ -43,14 +43,14 @@ describe('Validation helpers', () => {
     );
   });
 
-  test('checks for sequential characters', () => {
-    const validPwdWithoutSequentialCharacters = 'abc';
-    const invalidPwdWithSequentialCharacters = 'abd';
+  test('should check for sequential characters', () => {
+    const validPwdWithoutSequentialCharacters = 'abd';
+    const invalidPwdWithSequentialCharacters = 'abc';
     expect(
       validateNoSequentialCharacters(validPwdWithoutSequentialCharacters)
-    ).toBe(false);
+    ).toBe(true);
     expect(
       validateNoSequentialCharacters(invalidPwdWithSequentialCharacters)
-    ).toBe(true);
+    ).toBe(false);
   });
 });

--- a/assets/js/pages/Users/generatePassword.test.js
+++ b/assets/js/pages/Users/generatePassword.test.js
@@ -1,32 +1,4 @@
-import {
-  hasValidPwdLength,
-  validateNoRepetitiveCharacters,
-  validateNoSequentialCharacters,
-  generateValidPassword,
-} from './generatePassword';
-
-describe('Validation helper', () => {
-  test('should check password length to be minimum of 8', () => {
-    const validPwd = '12345678';
-    const invalidPwd = '1234567';
-    expect(hasValidPwdLength(validPwd)).toBe(true);
-    expect(hasValidPwdLength(invalidPwd)).toBe(false);
-  });
-
-  test('should check for repetitive characters', () => {
-    const validPwd = 'abcdef';
-    const invalidPwd = 'aaabbb';
-    expect(validateNoRepetitiveCharacters(validPwd)).toBe(true);
-    expect(validateNoRepetitiveCharacters(invalidPwd)).toBe(false);
-  });
-
-  test('should check for sequential characters', () => {
-    const validPwd = 'abd';
-    const invalidPwd = 'abc';
-    expect(validateNoSequentialCharacters(validPwd)).toBe(true);
-    expect(validateNoSequentialCharacters(invalidPwd)).toBe(false);
-  });
-});
+import { isValidPassword, generateValidPassword } from './generatePassword';
 
 describe('generateValidPassword', () => {
   test('should generate a password with a default length of 16', () => {
@@ -44,5 +16,35 @@ describe('generateValidPassword', () => {
     const firstPassword = generateValidPassword();
     const secondPassword = generateValidPassword();
     expect(firstPassword).not.toBe(secondPassword);
+  });
+});
+describe('isValidPassword', () => {
+  const passwordList = [
+    {
+      expectedResult: false,
+      password: '1234567',
+    },
+    {
+      expectedResult: false,
+      password: 'aaabbbcccdddeee',
+    },
+    {
+      expectedResult: false,
+      password: 'ABCDabcd1234',
+    },
+    {
+      expectedResult: true,
+      password: 'H^a*~wvFSv88*NRG',
+    },
+  ];
+  it.each(passwordList)(
+    'should return false if the password is invalid',
+    ({ expectedResult, password }) => {
+      expect(isValidPassword(password)).toBe(expectedResult);
+    }
+  );
+  test('should return true if the password is valid', () => {
+    const password = generateValidPassword();
+    expect(isValidPassword(password)).toBe(true);
   });
 });

--- a/assets/js/pages/Users/generatePassword.test.js
+++ b/assets/js/pages/Users/generatePassword.test.js
@@ -1,36 +1,53 @@
 import { isValidPassword, generateValidPassword } from './generatePassword';
 
 describe('generateValidPassword', () => {
-  test('should generate a password with a default length of 16', () => {
+  it('should generate a password with a default length of 16', () => {
     const password = generateValidPassword();
     expect(password).toHaveLength(16);
   });
 
-  test('should generate a password of specific length', () => {
+  it('should generate a password of specific length', () => {
     const length = 20;
     const password = generateValidPassword(length);
     expect(password).toHaveLength(length);
   });
 
-  test('should generate passwords that vary', () => {
+  it('should generate passwords that vary', () => {
     const firstPassword = generateValidPassword();
     const secondPassword = generateValidPassword();
     expect(firstPassword).not.toBe(secondPassword);
   });
 });
+
 describe('isValidPassword', () => {
   const passwordList = [
     {
       expectedResult: false,
-      password: '1234567',
+      password: 'short',
     },
     {
       expectedResult: false,
-      password: 'aaabbbcccdddeee',
+      password: 'passwordaaa',
     },
     {
       expectedResult: false,
-      password: 'ABCDabcd1234',
+      password: 'passwordBBB',
+    },
+    {
+      expectedResult: false,
+      password: 'password555',
+    },
+    {
+      expectedResult: false,
+      password: 'password1234',
+    },
+    {
+      expectedResult: false,
+      password: 'passwordefgh',
+    },
+    {
+      expectedResult: false,
+      password: 'passwordKLMNO',
     },
     {
       expectedResult: true,
@@ -43,7 +60,7 @@ describe('isValidPassword', () => {
       expect(isValidPassword(password)).toBe(expectedResult);
     }
   );
-  test('should return true if the password is valid', () => {
+  it('should return true if the password is valid', () => {
     const password = generateValidPassword();
     expect(isValidPassword(password)).toBe(true);
   });

--- a/lib/trento/users/user.ex
+++ b/lib/trento/users/user.ex
@@ -20,7 +20,7 @@ defmodule Trento.Users.User do
 
   defdelegate authorize(action, user, params), to: Trento.Users.Policy
 
-  @sequences ["01234567890", "abcdefghijklmnopqrstuvwxyz"]
+  @sequences ["01234567890", "abcdefghijklmnopqrstuvwxyz", "ABCDEFGHIJKLMNOPQRSTUVWXYZ"]
   @max_sequential_chars 3
 
   schema "users" do


### PR DESCRIPTION
# Description

This pr aims to improve the password generation in order to support our password rules, as the current implementation has a very unlikely case not to meet the requirements.

 

Password Rules:
- at least have 8 characters --> added validation to check for minimum length
- does not have 3 consecutive repeated numbers or letters (example: 111 or aaa) --> added validation for repetitive chars by using a regex rule, which checks for any character that appears three or more times consecutively in a string.
- does not have 3 consecutive sequential numbers or letters (example: 123 or abc) --> added [ASCII  code validation](https://www.commfront.com/pages/ascii-chart) for sequence of chars ascending and descending, exluding special chars to allow combinations like 89: or yz{

Also, this pr will ensure the unlikely case that e2e test fail if the generated password does not meet the requirements
It is a follow-up to @rtorrero  comment: https://github.com/trento-project/web/pull/2576#discussion_r1590935557
## How was this tested?

Added test for validation functions
