### PR TITLE
Patches for a single package plus errata details infrastructure

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -194,7 +194,7 @@ config :trento, Trento.SoftwareUpdates.Discovery,
 config :trento, Trento.Infrastructure.SoftwareUpdates.Suma,
   auth: Trento.Infrastructure.SoftwareUpdates.Auth.SumaAuth
 
-config :trento, Trento.Infrastructure.SoftwareUpdates.MockSuma, relevant_patches_hosts: []
+config :trento, Trento.Infrastructure.SoftwareUpdates.MockSuma, relevant_patches_system_ids: []
 
 config :trento, Trento.Infrastructure.SoftwareUpdates.SumaApi,
   executor: Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor

--- a/config/config.exs
+++ b/config/config.exs
@@ -194,7 +194,7 @@ config :trento, Trento.SoftwareUpdates.Discovery,
 config :trento, Trento.Infrastructure.SoftwareUpdates.Suma,
   auth: Trento.Infrastructure.SoftwareUpdates.Auth.SumaAuth
 
-config :trento, Trento.Infrastructure.SoftwareUpdates.MockSuma, relevant_patches: %{}
+config :trento, Trento.Infrastructure.SoftwareUpdates.MockSuma, relevant_patches_hosts: []
 
 config :trento, Trento.Infrastructure.SoftwareUpdates.SumaApi,
   executor: Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor

--- a/config/demo.exs
+++ b/config/demo.exs
@@ -35,7 +35,7 @@ config :trento, Trento.Charts,
 config :trento, suse_manager_enabled: true
 
 config :trento, Trento.Infrastructure.SoftwareUpdates.MockSuma,
-  relevant_patches_hosts: [
+  relevant_patches_system_ids: [
     # 5870 matches to "vmhdbdev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net" fqdn
     5870
   ]

--- a/config/demo.exs
+++ b/config/demo.exs
@@ -35,26 +35,7 @@ config :trento, Trento.Charts,
 config :trento, suse_manager_enabled: true
 
 config :trento, Trento.Infrastructure.SoftwareUpdates.MockSuma,
-  relevant_patches: %{
+  relevant_patches_hosts: [
     # 5870 matches to "vmhdbdev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net" fqdn
-    5870 => [
-      %{
-        date: "2024-02-27",
-        advisory_name: "SUSE-15-SP4-2024-630",
-        advisory_type: :bugfix,
-        advisory_status: "stable",
-        id: 4182,
-        advisory_synopsis: "Recommended update for cloud-netconfig",
-        update_date: "2024-02-27"
-      },
-      %{
-        date: "2024-02-26",
-        advisory_name: "SUSE-15-SP4-2024-619",
-        advisory_type: :security_advisory,
-        advisory_status: "stable",
-        id: 4174,
-        advisory_synopsis: "important: Security update for java-1_8_0-ibm",
-        update_date: "2024-02-26"
-      }
-    ]
-  }
+    5870
+  ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -85,26 +85,7 @@ config :joken,
   refresh_token_signer: "L0wvcZh3ACQpibVhV/nh5jd/NaZWL4ijZxTxGJMGpacuXIBc4In3YCwXeVM98ygp"
 
 config :trento, Trento.Infrastructure.SoftwareUpdates.MockSuma,
-  relevant_patches: %{
+  relevant_patches_hosts: [
     # 448 matches to "test" fqdn
-    448 => [
-      %{
-        date: "2024-02-27",
-        advisory_name: "SUSE-15-SP4-2024-630",
-        advisory_type: :bugfix,
-        advisory_status: "stable",
-        id: 4182,
-        advisory_synopsis: "Recommended update for cloud-netconfig",
-        update_date: "2024-02-27"
-      },
-      %{
-        date: "2024-02-26",
-        advisory_name: "SUSE-15-SP4-2024-619",
-        advisory_type: :security_advisory,
-        advisory_status: "stable",
-        id: 4174,
-        advisory_synopsis: "important: Security update for java-1_8_0-ibm",
-        update_date: "2024-02-26"
-      }
-    ]
-  }
+    448
+  ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -85,7 +85,7 @@ config :joken,
   refresh_token_signer: "L0wvcZh3ACQpibVhV/nh5jd/NaZWL4ijZxTxGJMGpacuXIBc4In3YCwXeVM98ygp"
 
 config :trento, Trento.Infrastructure.SoftwareUpdates.MockSuma,
-  relevant_patches_hosts: [
+  relevant_patches_system_ids: [
     # 448 matches to "test" fqdn
     448
   ]

--- a/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
+++ b/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
@@ -18,9 +18,30 @@ defmodule Trento.Infrastructure.SoftwareUpdates.MockSuma do
 
   @impl true
   def get_relevant_patches(system_id) do
-    case Map.get(mocked_relevant_patches(), system_id) do
-      nil -> {:ok, []}
-      patches -> {:ok, patches}
+    if system_id in mocked_relevant_patches_hosts() do
+      {:ok,
+       [
+         %{
+           date: "2024-02-27",
+           advisory_name: "SUSE-15-SP4-2024-630",
+           advisory_type: :bugfix,
+           advisory_status: "stable",
+           id: 4182,
+           advisory_synopsis: "Recommended update for cloud-netconfig",
+           update_date: "2024-02-27"
+         },
+         %{
+           date: "2024-02-26",
+           advisory_name: "SUSE-15-SP4-2024-619",
+           advisory_type: :security_advisory,
+           advisory_status: "stable",
+           id: 4174,
+           advisory_synopsis: "important: Security update for java-1_8_0-ibm",
+           update_date: "2024-02-26"
+         }
+       ]}
+    else
+      {:ok, []}
     end
   end
 
@@ -54,7 +75,81 @@ defmodule Trento.Infrastructure.SoftwareUpdates.MockSuma do
        ]}
 
   @impl true
+  def get_patches_for_package(_package_id),
+    do:
+      {:ok,
+       [
+         %{
+           advisory: "SUSE-15-SP4-2024-630",
+           type: "bugfix",
+           synopsis: "Recommended update for cloud-netconfig",
+           issue_date: "2024-02-27",
+           update_date: "2024-02-27",
+           last_modified_date: "2024-02-27"
+         },
+         %{
+           advisory: "SUSE-15-SP4-2024-619",
+           type: "security_advisory",
+           synopsis: "important: Security update for java-1_8_0-ibm",
+           issue_date: "2024-02-27",
+           update_date: "2024-02-27",
+           last_modified_date: "2024-02-27"
+         }
+       ]}
+
+  @impl true
+  def get_errata_details(_advisory_name),
+    do:
+      {:ok,
+       %{
+         type: "security_advisory",
+         synopsis: "important: Security update for java-1_8_0-ibm",
+         issue_date: "2024-02-27",
+         update_date: "2024-02-27",
+         last_modified_date: "2024-02-27",
+         advisory_status: "stable",
+         reboot_suggested: true,
+         restart_suggested: true
+       }}
+
+  @impl true
+  def get_affected_systems(_advisory_name),
+    do:
+      {:ok,
+       [
+         %{
+           name: "test"
+         },
+         %{name: "test2"}
+       ]}
+
+  @impl true
+  def get_cves(_advisory_name),
+    do:
+      {:ok,
+       [
+         "SUSE-15-SP4-2024-630",
+         "SUSE-15-SP4-2024-234",
+         "SUSE-15-SP4-2024-990"
+       ]}
+
+  @impl true
+  def get_affected_packages(_advisory_name),
+    do:
+      {:ok,
+       [
+         %{
+           name: "kernel",
+           version: "6.9.7",
+           release: "2",
+           arch_label: "x86_64",
+           epoch: "0"
+         }
+       ]}
+
+  @impl true
   def clear, do: :ok
 
-  defp mocked_relevant_patches, do: Application.fetch_env!(:trento, __MODULE__)[:relevant_patches]
+  defp mocked_relevant_patches_hosts,
+    do: Application.fetch_env!(:trento, __MODULE__)[:relevant_patches_hosts]
 end

--- a/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
+++ b/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
@@ -18,7 +18,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.MockSuma do
 
   @impl true
   def get_relevant_patches(system_id) do
-    if system_id in mocked_relevant_patches_hosts() do
+    if system_id in mocked_relevant_patches_system_ids() do
       {:ok,
        [
          %{
@@ -150,6 +150,6 @@ defmodule Trento.Infrastructure.SoftwareUpdates.MockSuma do
   @impl true
   def clear, do: :ok
 
-  defp mocked_relevant_patches_hosts,
-    do: Application.fetch_env!(:trento, __MODULE__)[:relevant_patches_hosts]
+  defp mocked_relevant_patches_system_ids,
+    do: Application.fetch_env!(:trento, __MODULE__)[:relevant_patches_system_ids]
 end

--- a/lib/trento/infrastructure/software_updates/adapter/suma_http_executor.ex
+++ b/lib/trento/infrastructure/software_updates/adapter/suma_http_executor.ex
@@ -35,6 +35,46 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor do
             ) ::
               {:ok, HTTPoison.Response.t()} | {:error, HTTPoison.Error.t()}
 
+  @callback get_errata_details(
+              base_url :: String.t(),
+              auth :: String.t(),
+              advisory_name :: String.t(),
+              ca_cert :: String.t() | nil
+            ) ::
+              {:ok, HTTPoison.Response.t()} | {:error, HTTPoison.Error.t()}
+
+  @callback get_affected_systems(
+              base_url :: String.t(),
+              auth :: String.t(),
+              advisory_name :: String.t(),
+              ca_cert :: String.t() | nil
+            ) ::
+              {:ok, HTTPoison.Response.t()} | {:error, HTTPoison.Error.t()}
+
+  @callback get_cves(
+              base_url :: String.t(),
+              auth :: String.t(),
+              advisory_name :: String.t(),
+              ca_cert :: String.t() | nil
+            ) ::
+              {:ok, HTTPoison.Response.t()} | {:error, HTTPoison.Error.t()}
+
+  @callback get_affected_packages(
+              base_url :: String.t(),
+              auth :: String.t(),
+              advisory_name :: String.t(),
+              ca_cert :: String.t() | nil
+            ) ::
+              {:ok, HTTPoison.Response.t()} | {:error, HTTPoison.Error.t()}
+
+  @callback get_patches_for_package(
+              base_url :: String.t(),
+              auth :: String.t(),
+              package_id :: String.t(),
+              ca_cert :: String.t() | nil
+            ) ::
+              {:ok, HTTPoison.Response.t()} | {:error, HTTPoison.Error.t()}
+
   @behaviour Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor
 
   @impl true
@@ -55,28 +95,81 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor do
 
   @impl true
   def get_system_id(base_url, auth, fully_qualified_domain_name, ca_cert) do
-    HTTPoison.get(
-      "#{base_url}/system/getId?name=#{fully_qualified_domain_name}",
+    HTTPoison.request(
+      :get,
+      "#{base_url}/system/getId",
       [{"Content-type", "application/json"}],
-      request_options(auth, ca_cert)
+      [params: %{name: fully_qualified_domain_name}] ++ request_options(auth, ca_cert)
     )
   end
 
   @impl true
   def get_relevant_patches(base_url, auth, system_id, ca_cert) do
-    HTTPoison.get(
-      "#{base_url}/system/getRelevantErrata?sid=#{system_id}",
+    HTTPoison.request(
+      :get,
+      "#{base_url}/system/getRelevantErrata",
       [{"Content-type", "application/json"}],
-      request_options(auth, ca_cert)
+      [params: %{sid: system_id}] ++ request_options(auth, ca_cert)
     )
   end
 
   @impl true
   def get_upgradable_packages(base_url, auth, system_id, ca_cert) do
-    HTTPoison.get(
-      "#{base_url}/system/listLatestUpgradablePackages?sid=#{system_id}",
+    HTTPoison.request(
+      :get,
+      "#{base_url}/system/listLatestUpgradablePackages",
       [{"Content-type", "application/json"}],
-      request_options(auth, ca_cert)
+      [params: %{sid: system_id}] ++ request_options(auth, ca_cert)
+    )
+  end
+
+  @impl true
+  def get_errata_details(base_url, auth, advisory_name, ca_cert) do
+    HTTPoison.request(
+      :get,
+      "#{base_url}/errata/getDetails",
+      [{"Content-type", "application/json"}],
+      [params: %{"advisoryName" => advisory_name}] ++ request_options(auth, ca_cert)
+    )
+  end
+
+  @impl true
+  def get_affected_systems(base_url, auth, advisory_name, ca_cert) do
+    HTTPoison.request(
+      :get,
+      "#{base_url}/errata/listAffectedSystems",
+      [{"Content-type", "application/json"}],
+      [params: %{"advisoryName" => advisory_name}] ++ request_options(auth, ca_cert)
+    )
+  end
+
+  @impl true
+  def get_cves(base_url, auth, advisory_name, ca_cert) do
+    HTTPoison.request(
+      :get,
+      "#{base_url}/errata/listCves",
+      [{"Content-type", "application/json"}],
+      [params: %{"advisoryName" => advisory_name}] ++ request_options(auth, ca_cert)
+    )
+  end
+
+  @impl true
+  def get_affected_packages(base_url, auth, advisory_name, ca_cert) do
+    HTTPoison.request(
+      :get,
+      "#{base_url}/errata/listPackages",
+      [{"Content-type", "application/json"}],
+      [params: %{"advisoryName" => advisory_name}] ++ request_options(auth, ca_cert)
+    )
+  end
+
+  @impl true
+  def get_patches_for_package(base_url, auth, package_id, ca_cert) do
+    HTTPoison.request(
+      :get,
+      "#{base_url}/packages/listProvidingErrata",
+      [{"Content-type", "application/json"}],
+      [params: %{pid: Integer.parse(package_id)}] ++ request_options(auth, ca_cert)
     )
   end
 

--- a/lib/trento/infrastructure/software_updates/suma.ex
+++ b/lib/trento/infrastructure/software_updates/suma.ex
@@ -34,6 +34,26 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma do
   def get_upgradable_packages(system_id),
     do: handle_request({:get_upgradable_packages, system_id})
 
+  @impl Trento.SoftwareUpdates.Discovery.Gen
+  def get_patches_for_package(package_id),
+    do: handle_request({:get_patches_for_package, package_id})
+
+  @impl Trento.SoftwareUpdates.Discovery.Gen
+  def get_errata_details(advisory_name),
+    do: handle_request({:get_errata_details, advisory_name})
+
+  @impl Trento.SoftwareUpdates.Discovery.Gen
+  def get_affected_systems(advisory_name),
+    do: handle_request({:get_affected_systems, advisory_name})
+
+  @impl Trento.SoftwareUpdates.Discovery.Gen
+  def get_cves(advisory_name),
+    do: handle_request({:get_cves, advisory_name})
+
+  @impl Trento.SoftwareUpdates.Discovery.Gen
+  def get_affected_packages(advisory_name),
+    do: handle_request({:get_affected_packages, advisory_name})
+
   defp handle_request(request) do
     case auth().authenticate() do
       {:ok, new_state} ->
@@ -73,6 +93,41 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma do
          ca_cert: ca_cert
        }),
        do: SumaApi.get_upgradable_packages(url, auth_cookie, system_id, ca_cert)
+
+  defp do_handle({:get_patches_for_package, package_id}, %State{
+         url: url,
+         auth: auth_cookie,
+         ca_cert: ca_cert
+       }),
+       do: SumaApi.get_patches_for_package(url, auth_cookie, package_id, ca_cert)
+
+  defp do_handle({:get_errata_details, advisory_name}, %State{
+         url: url,
+         auth: auth_cookie,
+         ca_cert: ca_cert
+       }),
+       do: SumaApi.get_errata_details(url, auth_cookie, advisory_name, ca_cert)
+
+  defp do_handle({:get_affected_systems, advisory_name}, %State{
+         url: url,
+         auth: auth_cookie,
+         ca_cert: ca_cert
+       }),
+       do: SumaApi.get_affected_systems(url, auth_cookie, advisory_name, ca_cert)
+
+  defp do_handle({:get_cves, advisory_name}, %State{
+         url: url,
+         auth: auth_cookie,
+         ca_cert: ca_cert
+       }),
+       do: SumaApi.get_cves(url, auth_cookie, advisory_name, ca_cert)
+
+  defp do_handle({:get_affected_packages, advisory_name}, %State{
+         url: url,
+         auth: auth_cookie,
+         ca_cert: ca_cert
+       }),
+       do: SumaApi.get_affected_packages(url, auth_cookie, advisory_name, ca_cert)
 
   defp auth, do: Application.fetch_env!(:trento, __MODULE__)[:auth]
 end

--- a/lib/trento/infrastructure/software_updates/suma_api.ex
+++ b/lib/trento/infrastructure/software_updates/suma_api.ex
@@ -309,7 +309,13 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
     {:ok, system_id}
   end
 
-  defp extract_system_id({:ok, _}), do: {:error, :system_id_not_found}
+  defp extract_system_id({:ok, response}) do
+    Logger.error(
+      "Could not get system id for host from suma result. Result: #{inspect(response)}"
+    )
+
+    {:error, :system_id_not_found}
+  end
 
   defp extract_system_id({:error, _} = error), do: error
 

--- a/lib/trento/infrastructure/software_updates/suma_api.ex
+++ b/lib/trento/infrastructure/software_updates/suma_api.ex
@@ -29,26 +29,15 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
         ) ::
           {:ok, pos_integer()} | {:error, :system_id_not_found | :authentication_error}
   def get_system_id(url, auth, fully_qualified_domain_name, ca_cert) do
-    response =
-      url
-      |> get_suma_api_url()
-      |> http_executor().get_system_id(auth, fully_qualified_domain_name, ca_cert)
-
-    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- response,
-         {:ok, %{success: true, result: result}} <- Jason.decode(body, keys: :atoms),
-         {:ok, system_id} <- extract_system_id(result) do
-      {:ok, system_id}
-    else
-      {:ok, %HTTPoison.Response{status_code: 401}} ->
-        {:error, :authentication_error}
-
-      error ->
-        Logger.error(
-          "Failed to get system id for host #{fully_qualified_domain_name}. Error: #{inspect(error)}"
-        )
-
-        {:error, :system_id_not_found}
-    end
+    url
+    |> get_suma_api_url()
+    |> http_executor().get_system_id(auth, fully_qualified_domain_name, ca_cert)
+    |> handle_auth_error()
+    |> decode_response(
+      error_atom: :system_id_not_found,
+      error_log: "Failed to get system id for host #{fully_qualified_domain_name}."
+    )
+    |> extract_system_id()
   end
 
   @spec get_relevant_patches(
@@ -60,26 +49,15 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
           {:ok, [map()]}
           | {:error, :error_getting_patches | :authentication_error}
   def get_relevant_patches(url, auth, system_id, ca_cert) do
-    response =
-      url
-      |> get_suma_api_url()
-      |> http_executor().get_relevant_patches(auth, system_id, ca_cert)
-
-    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <- response,
-         {:ok, %{success: true, result: result}} <- Jason.decode(body, keys: :atoms) do
-      {:ok,
-       Enum.map(result, fn %{advisory_type: advisory_type} = advisory ->
-         %{advisory | advisory_type: AdvisoryType.from_string(advisory_type)}
-       end)}
-    else
-      {:ok, %HTTPoison.Response{status_code: 401}} ->
-        {:error, :authentication_error}
-
-      error ->
-        Logger.error("Failed to get errata for system ID #{system_id}. Error: #{inspect(error)}")
-
-        {:error, :error_getting_patches}
-    end
+    url
+    |> get_suma_api_url()
+    |> http_executor().get_relevant_patches(auth, system_id, ca_cert)
+    |> handle_auth_error()
+    |> decode_response(
+      error_atom: :error_getting_patches,
+      error_log: "Failed to get errata for system ID #{system_id}."
+    )
+    |> extract_relevant_patches()
   end
 
   @spec get_upgradable_packages(
@@ -102,15 +80,133 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
     |> extract_upgradable_packages()
   end
 
-  defp handle_auth_error({:ok, %HTTPoison.Response{status_code: 200, body: body}}),
-    do: {:ok, body}
+  @spec get_patches_for_package(
+          url :: String.t(),
+          auth :: any(),
+          package_id :: String.t(),
+          ca_cert :: String.t() | nil
+        ) ::
+          {:ok, [map()]}
+          | {:error, :error_getting_patches | :authentication_error}
+  def get_patches_for_package(url, auth, package_id, ca_cert) do
+    url
+    |> get_suma_api_url()
+    |> http_executor().get_patches_for_package(auth, package_id, ca_cert)
+    |> handle_auth_error()
+    |> decode_response(
+      error_atom: :error_getting_patches,
+      error_log: "Failed to get patches for package ID #{package_id}."
+    )
+    |> extract_result()
+  end
+
+  @spec get_affected_systems(
+          url :: String.t(),
+          auth :: any(),
+          advisory_name :: String.t(),
+          ca_cert :: String.t() | nil
+        ) ::
+          {:ok, [map()]}
+          | {:error, :error_getting_affected_systems | :authentication_error}
+  def get_affected_systems(url, auth, advisory_name, ca_cert) do
+    url
+    |> get_suma_api_url()
+    |> http_executor().get_affected_systems(auth, advisory_name, ca_cert)
+    |> handle_auth_error()
+    |> decode_response(
+      error_atom: :error_getting_affected_systems,
+      error_log: "Failed to get affected systems for advisory #{advisory_name}."
+    )
+    |> extract_result()
+  end
+
+  @spec get_errata_details(
+          url :: String.t(),
+          auth :: any(),
+          advisory_name :: String.t(),
+          ca_cert :: String.t() | nil
+        ) ::
+          {:ok, [map()]}
+          | {:error, :error_getting_errata_details | :authentication_error}
+  def get_errata_details(url, auth, advisory_name, ca_cert) do
+    url
+    |> get_suma_api_url()
+    |> http_executor().get_errata_details(auth, advisory_name, ca_cert)
+    |> handle_auth_error()
+    |> decode_response(
+      error_atom: :error_getting_errata_details,
+      error_log: "Failed to get patches for advisory #{advisory_name}."
+    )
+    |> extract_result()
+  end
+
+  @spec get_cves(
+          url :: String.t(),
+          auth :: any(),
+          advisory_name :: String.t(),
+          ca_cert :: String.t() | nil
+        ) ::
+          {:ok, [map()]}
+          | {:error, :error_getting_cves | :authentication_error}
+  def get_cves(url, auth, advisory_name, ca_cert) do
+    url
+    |> get_suma_api_url()
+    |> http_executor().get_cves(auth, advisory_name, ca_cert)
+    |> handle_auth_error()
+    |> decode_response(
+      error_atom: :error_getting_cves,
+      error_log: "Failed to get CVEs for advisory #{advisory_name}."
+    )
+    |> extract_result()
+  end
+
+  @spec get_affected_packages(
+          url :: String.t(),
+          auth :: any(),
+          advisory_name :: String.t(),
+          ca_cert :: String.t() | nil
+        ) ::
+          {:ok, [map()]}
+          | {:error, :error_getting_affected_packages | :authentication_error}
+  def get_affected_packages(url, auth, advisory_name, ca_cert) do
+    url
+    |> get_suma_api_url()
+    |> http_executor().get_affected_packages(auth, advisory_name, ca_cert)
+    |> handle_auth_error()
+    |> decode_response(
+      error_atom: :error_getting_affected_packages,
+      error_log: "Failed to get affected packages for advisory #{advisory_name}."
+    )
+    |> extract_result()
+  end
 
   defp handle_auth_error({:ok, %HTTPoison.Response{status_code: 401}}),
     do: {:error, :authentication_error}
 
+  defp handle_auth_error({:ok, %HTTPoison.Response{status_code: _, body: body}}),
+    do: {:ok, body}
+
   defp handle_auth_error(error), do: error
 
-  defp decode_response({:ok, body}, _), do: Jason.decode(body, keys: :atoms)
+  defp decode_response({:ok, nil}, error_atom: error_atom, error_log: error_log) do
+    Logger.error("#{error_log}. Nil body received.")
+
+    {:error, error_atom}
+  end
+
+  defp decode_response({:ok, body}, error_atom: error_atom, error_log: error_log) do
+    case Jason.decode(body, keys: :atoms) do
+      {:ok, %{success: true}} = result ->
+        result
+
+      error ->
+        Logger.error("#{error_log} Error: #{inspect(error)}")
+
+        {:error, error_atom}
+    end
+  end
+
+  defp decode_response({:error, :authentication_error}, _), do: {:error, :authentication_error}
 
   defp decode_response({:error, _} = error, error_atom: error_atom, error_log: error_log) do
     Logger.error("#{error_log} Error: #{inspect(error)}")
@@ -118,11 +214,26 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
     {:error, error_atom}
   end
 
+  defp extract_relevant_patches({:ok, %{success: true, result: result}}) do
+    {:ok,
+     Enum.map(result, fn %{advisory_type: advisory_type} = advisory ->
+       %{advisory | advisory_type: AdvisoryType.from_string(advisory_type)}
+     end)}
+  end
+
+  defp extract_relevant_patches({:error, _} = error), do: error
+
   defp extract_upgradable_packages({:ok, %{success: true, result: result}}) do
     {:ok, result}
   end
 
   defp extract_upgradable_packages({:error, _} = error), do: error
+
+  defp extract_result({:ok, %{success: true, result: result}}) do
+    {:ok, result}
+  end
+
+  defp extract_result({:error, _} = error), do: error
 
   defp get_suma_api_url(base_url),
     do: String.trim_trailing(base_url, "/") <> "/rhn/manager/api"
@@ -183,19 +294,24 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
       |> String.split(";")
       |> Enum.find(&match_suma_session_cookie(&1))
 
-  defp extract_system_id(result) do
-    with false <- Enum.empty?(result),
-         %{id: system_id} <- Enum.at(result, 0) do
-      {:ok, system_id}
-    else
-      _ ->
-        Logger.error(
-          "Could not get system id for host from suma result. Result: #{inspect(result)}"
-        )
-
-        {:error, :system_id_not_found}
-    end
+  defp extract_system_id(
+         {:ok,
+          %{
+            success: true,
+            result: [
+              %{
+                id: system_id
+              }
+              | _
+            ]
+          }}
+       ) do
+    {:ok, system_id}
   end
+
+  defp extract_system_id({:ok, _}), do: {:error, :system_id_not_found}
+
+  defp extract_system_id({:error, _} = error), do: error
 
   defp http_executor, do: Application.fetch_env!(:trento, __MODULE__)[:executor]
 end

--- a/lib/trento/software_updates/discovery.ex
+++ b/lib/trento/software_updates/discovery.ex
@@ -44,6 +44,25 @@ defmodule Trento.SoftwareUpdates.Discovery do
   def get_upgradable_packages(system_id),
     do: adapter().get_upgradable_packages(system_id)
 
+  @impl true
+  def get_patches_for_package(package_id),
+    do: adapter().get_patches_for_package(package_id)
+
+  @impl true
+  def get_errata_details(advisory_name),
+    do: adapter().get_errata_details(advisory_name)
+
+  @impl true
+  def get_cves(advisory_name),
+    do: adapter().get_cves(advisory_name)
+
+  @impl true
+  def get_affected_systems(advisory_name),
+    do: adapter().get_affected_systems(advisory_name)
+
+  @impl true
+  def get_affected_packages(advisory_name), do: adapter().get_affected_packages(advisory_name)
+
   @spec discover_software_updates :: {:ok, {list(), list()}}
   def discover_software_updates do
     authentication = setup()

--- a/lib/trento/software_updates/discovery/gen.ex
+++ b/lib/trento/software_updates/discovery/gen.ex
@@ -9,10 +9,25 @@ defmodule Trento.SoftwareUpdates.Discovery.Gen do
               {:ok, pos_integer()} | {:error, any()}
 
   @callback get_relevant_patches(system_id :: pos_integer()) ::
-              {:ok, [map]} | {:error, any()}
+              {:ok, [map()]} | {:error, any()}
 
   @callback get_upgradable_packages(system_id :: pos_integer()) ::
-              {:ok, [map]} | {:error, any()}
+              {:ok, [map()]} | {:error, any()}
+
+  @callback get_patches_for_package(package_id :: String.t()) ::
+              {:ok, [map()]} | {:error, any()}
+
+  @callback get_errata_details(advisory_name :: String.t()) ::
+              {:ok, map()} | {:error, any()}
+
+  @callback get_affected_systems(advisory_name :: String.t()) ::
+              {:ok, [map()]} | {:error, any()}
+
+  @callback get_cves(advisory_name :: String.t()) ::
+              {:ok, [String.t()]} | {:error, any()}
+
+  @callback get_affected_packages(advisory_name :: String.t()) ::
+              {:ok, [map()]} | {:error, any()}
 
   @callback clear() :: :ok
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -896,6 +896,17 @@ defmodule Trento.Factory do
     }
   end
 
+  def patch_for_package_factory do
+    %{
+      advisory: String.downcase(Faker.Pokemon.name()),
+      type: AdvisoryType.values() |> Faker.Util.pick() |> Atom.to_string(),
+      synopsis: Faker.Lorem.sentence(),
+      issue_date: 30 |> Faker.Date.backward() |> Date.to_string(),
+      update_date: 30 |> Faker.Date.backward() |> Date.to_string(),
+      last_modified_date: 30 |> Faker.Date.backward() |> Date.to_string()
+    }
+  end
+
   def software_updates_discovery_result_factory do
     %DiscoveryResult{
       host_id: Faker.UUID.v4(),
@@ -919,6 +930,35 @@ defmodule Trento.Factory do
           "error_getting_packages",
           "max_login_retries_reached"
         ])
+    }
+  end
+
+  def affected_package_factory do
+    package_name = Faker.Pokemon.name()
+
+    %{
+      name: String.downcase(package_name),
+      arch_label: Faker.Util.pick(["x86_64", "i586", "aarch64"]),
+      version: Faker.App.version(),
+      release: "#{RandomElixir.random_between(0, 100)}",
+      epoch: "#{RandomElixir.random_between(0, 50)}"
+    }
+  end
+
+  def affected_system_factory do
+    %{name: Faker.UUID.v4()}
+  end
+
+  def errata_details_factory do
+    %{
+      type: AdvisoryType.values() |> Faker.Util.pick() |> Atom.to_string(),
+      synopsis: Faker.Lorem.sentence(),
+      issue_date: 30 |> Faker.Date.backward() |> Date.to_string(),
+      update_date: 30 |> Faker.Date.backward() |> Date.to_string(),
+      last_modified_date: 30 |> Faker.Date.backward() |> Date.to_string(),
+      advisory_status: "stable",
+      reboot_suggested: Faker.Util.pick([true, false]),
+      restart_suggested: Faker.Util.pick([true, false])
     }
   end
 

--- a/test/trento/infrastructure/software_updates/suma_test.exs
+++ b/test/trento/infrastructure/software_updates/suma_test.exs
@@ -336,7 +336,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaTest do
                Suma.get_errata_details(advisory_name)
     end
 
-    test "should return a proper error when getting " do
+    test "should return a proper error when getting errata details" do
       advisory_name = Faker.UUID.v4()
 
       expect(SumaAuthMock, :authenticate, 1, fn -> {:ok, authenticated_state()} end)

--- a/test/trento/infrastructure/software_updates/suma_test.exs
+++ b/test/trento/infrastructure/software_updates/suma_test.exs
@@ -194,11 +194,159 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaTest do
       expect(SumaAuthMock, :authenticate, 1, fn -> {:ok, authenticated_state()} end)
 
       expect(SumaApiMock, :get_upgradable_packages, 1, fn _, _, ^system_id, _ ->
-        {:error, %HTTPoison.Response{status_code: 500, body: Jason.encode!(%{})}}
+        {:ok, %HTTPoison.Response{status_code: 500, body: Jason.encode!(%{})}}
       end)
 
       assert {:error, :error_getting_packages} =
                Suma.get_upgradable_packages(system_id)
+    end
+
+    test "should get patches for a single package" do
+      package_id = Faker.UUID.v4()
+
+      %{result: patches} =
+        suma_response_body = %{success: true, result: build_list(10, :patch_for_package)}
+
+      expect(SumaAuthMock, :authenticate, 1, fn -> {:ok, authenticated_state()} end)
+
+      expect(SumaApiMock, :get_patches_for_package, 1, fn _, _, ^package_id, _ ->
+        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(suma_response_body)}}
+      end)
+
+      assert {:ok, ^patches} =
+               Suma.get_patches_for_package(package_id)
+    end
+
+    test "should return a proper error when getting patches for a specific package fails" do
+      package_id = Faker.UUID.v4()
+
+      expect(SumaAuthMock, :authenticate, 1, fn -> {:ok, authenticated_state()} end)
+
+      expect(SumaApiMock, :get_patches_for_package, 1, fn _, _, ^package_id, _ ->
+        {:ok, %HTTPoison.Response{status_code: 500, body: Jason.encode!(%{})}}
+      end)
+
+      assert {:error, :error_getting_patches} =
+               Suma.get_patches_for_package(package_id)
+    end
+
+    test "should get affected systems for a single patch" do
+      advisory_name = Faker.UUID.v4()
+
+      %{result: affected_systems} =
+        suma_response_body = %{success: true, result: build_list(10, :affected_system)}
+
+      expect(SumaAuthMock, :authenticate, 1, fn -> {:ok, authenticated_state()} end)
+
+      expect(SumaApiMock, :get_affected_systems, 1, fn _, _, ^advisory_name, _ ->
+        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(suma_response_body)}}
+      end)
+
+      assert {:ok, ^affected_systems} =
+               Suma.get_affected_systems(advisory_name)
+    end
+
+    test "should return a proper error when getting affected systems for a patch fails" do
+      advisory_name = Faker.UUID.v4()
+
+      expect(SumaAuthMock, :authenticate, 1, fn -> {:ok, authenticated_state()} end)
+
+      expect(SumaApiMock, :get_affected_systems, 1, fn _, _, ^advisory_name, _ ->
+        {:ok, %HTTPoison.Response{status_code: 500, body: Jason.encode!(%{})}}
+      end)
+
+      assert {:error, :error_getting_affected_systems} =
+               Suma.get_affected_systems(advisory_name)
+    end
+
+    test "should get covered CVEs for a single patch" do
+      advisory_name = Faker.UUID.v4()
+
+      %{result: cves} =
+        suma_response_body = %{
+          success: true,
+          result: Enum.map(1..10, fn _ -> Faker.UUID.v4() end)
+        }
+
+      expect(SumaAuthMock, :authenticate, 1, fn -> {:ok, authenticated_state()} end)
+
+      expect(SumaApiMock, :get_cves, 1, fn _, _, ^advisory_name, _ ->
+        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(suma_response_body)}}
+      end)
+
+      assert {:ok, ^cves} =
+               Suma.get_cves(advisory_name)
+    end
+
+    test "should return a proper error when getting CVEs for a patch fails" do
+      advisory_name = Faker.UUID.v4()
+
+      expect(SumaAuthMock, :authenticate, 1, fn -> {:ok, authenticated_state()} end)
+
+      expect(SumaApiMock, :get_cves, 1, fn _, _, ^advisory_name, _ ->
+        {:ok, %HTTPoison.Response{status_code: 500, body: Jason.encode!(%{})}}
+      end)
+
+      assert {:error, :error_getting_cves} =
+               Suma.get_cves(advisory_name)
+    end
+
+    test "should get affected packages for a single patch" do
+      advisory_name = Faker.UUID.v4()
+
+      %{result: affected_packages} =
+        suma_response_body = %{success: true, result: build_list(10, :affected_package)}
+
+      expect(SumaAuthMock, :authenticate, 1, fn -> {:ok, authenticated_state()} end)
+
+      expect(SumaApiMock, :get_affected_packages, 1, fn _, _, ^advisory_name, _ ->
+        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(suma_response_body)}}
+      end)
+
+      assert {:ok, ^affected_packages} =
+               Suma.get_affected_packages(advisory_name)
+    end
+
+    test "should return a proper error when getting affected packages for a patch fails" do
+      advisory_name = Faker.UUID.v4()
+
+      expect(SumaAuthMock, :authenticate, 1, fn -> {:ok, authenticated_state()} end)
+
+      expect(SumaApiMock, :get_affected_packages, 1, fn _, _, ^advisory_name, _ ->
+        {:ok, %HTTPoison.Response{status_code: 500, body: Jason.encode!(%{})}}
+      end)
+
+      assert {:error, :error_getting_affected_packages} =
+               Suma.get_affected_packages(advisory_name)
+    end
+
+    test "should get details for a single errata" do
+      advisory_name = Faker.UUID.v4()
+
+      %{result: errata_details} =
+        suma_response_body = %{success: true, result: build(:errata_details)}
+
+      expect(SumaAuthMock, :authenticate, 1, fn -> {:ok, authenticated_state()} end)
+
+      expect(SumaApiMock, :get_errata_details, 1, fn _, _, ^advisory_name, _ ->
+        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(suma_response_body)}}
+      end)
+
+      assert {:ok, ^errata_details} =
+               Suma.get_errata_details(advisory_name)
+    end
+
+    test "should return a proper error when getting " do
+      advisory_name = Faker.UUID.v4()
+
+      expect(SumaAuthMock, :authenticate, 1, fn -> {:ok, authenticated_state()} end)
+
+      expect(SumaApiMock, :get_errata_details, 1, fn _, _, ^advisory_name, _ ->
+        {:ok, %HTTPoison.Response{status_code: 500, body: Jason.encode!(%{})}}
+      end)
+
+      assert {:error, :error_getting_errata_details} =
+               Suma.get_errata_details(advisory_name)
     end
 
     test "should handle expired authentication" do


### PR DESCRIPTION
# Description
This PR implements a context function to retrieve relevant patches covered by a package upgrade, needed by the upgradable packages overview. In addition to that, I also felt free to implement the ground work to get the specific details for a relevant patch, to be used in the detailed view of a relevant patch itself.

I'm really sorry for messing up the reviewability of this a little bit, but I meant no harm :crying_cat_face: 

## How was this tested?

Existing tests passing, unit tests added
