### PR TITLE
User totp fields

### DIFF
--- a/lib/trento/users/user.ex
+++ b/lib/trento/users/user.ex
@@ -18,6 +18,8 @@ defmodule Trento.Users.User do
     UsersAbilities
   }
 
+  alias Trento.Support.Ecto.EncryptedBinary
+
   defdelegate authorize(action, user, params), to: Trento.Users.Policy
 
   @sequences ["01234567890", "abcdefghijklmnopqrstuvwxyz"]
@@ -31,6 +33,9 @@ defmodule Trento.Users.User do
     field :deleted_at, :utc_datetime_usec
     field :locked_at, :utc_datetime_usec
     field :password_change_requested_at, :utc_datetime_usec
+    field :totp_enabled_at, :utc_datetime_usec
+    field :totp_secret, EncryptedBinary, redact: true
+    field :totp_last_used_at, :utc_datetime_usec
     field :lock_version, :integer, default: 1
 
     many_to_many :abilities, Ability, join_through: UsersAbilities, unique: true
@@ -53,7 +58,7 @@ defmodule Trento.Users.User do
     |> pow_extension_changeset(attrs)
     |> validate_password()
     |> custom_fields_changeset(attrs)
-    |> cast(attrs, [:locked_at, :lock_version, :password_change_requested_at])
+    |> cast(attrs, [:locked_at, :lock_version, :password_change_requested_at, :totp_enabled_at])
     |> optimistic_lock(:lock_version)
   end
 
@@ -65,6 +70,11 @@ defmodule Trento.Users.User do
     |> validate_password()
     |> custom_fields_changeset(attrs)
     |> cast(attrs, [:password_change_requested_at])
+  end
+
+  def totp_update_changeset(user, attrs) do
+    user
+    |> cast(attrs, [:totp_enabled_at, :totp_secret, :totp_last_used_at])
   end
 
   def delete_changeset(

--- a/lib/trento/users/user.ex
+++ b/lib/trento/users/user.ex
@@ -74,8 +74,7 @@ defmodule Trento.Users.User do
   end
 
   def totp_update_changeset(user, attrs) do
-    user
-    |> cast(attrs, [:totp_enabled_at, :totp_secret, :totp_last_used_at])
+    cast(user, attrs, [:totp_enabled_at, :totp_secret, :totp_last_used_at])
   end
 
   def delete_changeset(

--- a/lib/trento/users/user.ex
+++ b/lib/trento/users/user.ex
@@ -59,6 +59,7 @@ defmodule Trento.Users.User do
     |> validate_password()
     |> custom_fields_changeset(attrs)
     |> cast(attrs, [:locked_at, :lock_version, :password_change_requested_at, :totp_enabled_at])
+    |> validate_inclusion(:totp_enabled_at, [nil])
     |> optimistic_lock(:lock_version)
   end
 

--- a/priv/repo/migrations/20240522122122_add_totp_fields_to_users.exs
+++ b/priv/repo/migrations/20240522122122_add_totp_fields_to_users.exs
@@ -1,0 +1,11 @@
+defmodule Trento.Repo.Migrations.AddTotpFieldsToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :totp_enabled_at, :utc_datetime_usec
+      add :totp_last_used_at, :utc_datetime_usec
+      add :totp_secret, :binary
+    end
+  end
+end

--- a/test/trento/users/user_test.exs
+++ b/test/trento/users/user_test.exs
@@ -37,5 +37,15 @@ defmodule Trento.Users.UsersTest do
       changeset = User.changeset(%User{}, %{"password" => "secretafgh"})
       refute changeset.errors[:password]
     end
+
+    test "update_changeset/2 validates totp_enabled_at unique valid value is nil" do
+      changeset = User.update_changeset(%User{}, %{"totp_enabled_at" => nil})
+      refute changeset.errors[:totp_enabled_at]
+
+      changeset = User.update_changeset(%User{}, %{"totp_enabled_at" => DateTime.utc_now()})
+
+      assert changeset.errors[:totp_enabled_at] ==
+               {"is invalid", [validation: :inclusion, enum: [nil]]}
+    end
   end
 end


### PR DESCRIPTION
# Description

Include `TOTP` multi factor authentication required fields to the user shema.
I'm excluding any change in the users context, as even though I have ideas of how it should be, I think it will be better to work on them when we actually start working on the features, as I might forget something otherwise.

I just added some small changes in the changeset functions. But well, we might change them afterwards as well.

## How was this tested?

No need for tests for this changes
