### PR TITLE
Upgrade Node.js to version 20.14.0 LTS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 
 env:
   MIX_ENV: test
-  NODE_VERSION: "16"
+  NODE_VERSION: "20"
   MANTAINERS: '["cdimonaco", "dottorblaster", "janvhs", "rtorrero", "nelsonkopliku", "arbulu89","jagabomb","emaksy","jamie-suse"]'
   RG_TEST_LABEL: regression
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "16"
+          node-version: "20"
           cache: "npm"
           cache-dependency-path: test/e2e/package-lock.json
       - name: Checkout terraform repo

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 elixir 1.15.7-otp-26
 erlang 26.2.1
-nodejs 16.16.0
+nodejs 20.14.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG MIX_ENV=prod
 ENV MIX_ENV=$MIX_ENV
 RUN mix deps.get
 
-FROM registry.suse.com/bci/nodejs:16 AS assets-build
+FROM registry.suse.com/bci/nodejs:20 AS assets-build
 COPY --from=elixir-build /build /build
 WORKDIR /build/assets
 RUN npm install

--- a/guides/development/hack_on_the_trento.md
+++ b/guides/development/hack_on_the_trento.md
@@ -6,7 +6,7 @@ In order to run the Trento Web application, the following software must be insta
 
 1. [Elixir](https://elixir-lang.org/) - 1.15.7 preferred
 2. [Erlang OTP](https://www.erlang.org/) - 26.1.2 preferred
-3. [Node.js](https://nodejs.org/en/) - 16.16.0 preferred
+3. [Node.js](https://nodejs.org/en/) - 20.14.0 preferred
 4. [Docker](https://docs.docker.com/get-docker/)
 5. [Docker Compose](https://docs.docker.com/compose/install/)
 

--- a/packaging/suse/container/Dockerfile
+++ b/packaging/suse/container/Dockerfile
@@ -5,7 +5,7 @@
 #!UseOBSRepositories
 #!ExclusiveArch: x86_64
 
-FROM bci/nodejs:16 AS assets-build
+FROM bci/nodejs:20 AS assets-build
 ADD web.tar.gz /build/
 WORKDIR /build/web/assets
 RUN npm run tailwind:build

--- a/packaging/suse/rpm/trento-web.spec
+++ b/packaging/suse/rpm/trento-web.spec
@@ -28,7 +28,7 @@ Source2:        package-lock.json
 Source3:        node_modules.spec.inc
 %include        %{_sourcedir}/node_modules.spec.inc
 Group:          System/Monitoring
-BuildRequires:  elixir >= 1.15, elixir-hex, npm16, erlang-rebar3, git-core, local-npm-registry, make, gcc
+BuildRequires:  elixir >= 1.15, elixir-hex, npm20, erlang-rebar3, git-core, local-npm-registry, make, gcc
 
 %description
 Trento is an open cloud-native web application for SAP Applications administrators.


### PR DESCRIPTION
This commit upgrade the Node.js version to 20.14.0.

I am running this for several weeks on my MacBook Air M2 and it works without any problems. This will allow us to upgrade Storybook and ESLint, once all our ESLint plugins are compatible with ESLint 9.

## How was this tested?

Building booth the Dockerfile in the root, and in packaging with Podman and running frontend tests. 
I did not try asdf, since I don't have that installed. However, I am sure it will accept the version.