### PR TITLE
Add a docs section to pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,26 +3,24 @@
 Please include a summary of the changes and the related issue, if it exists. 
 Also, include relevant motivation and context for this PR. List any dependencies that are required for this change.
 
-- Fixes # (issue)
+Fixes # (issue)
 
 ## Did you add the right label?
 
 Remember to add the right labels to this PR.
+- [ ] **DONE**
 
 ## How was this tested?
 
-Describe the types of tests that have been added for this functionality
-
+Describe the tests that have been added/changed for this new behavior.
+- [ ] **DONE**
 ## Did you update the documentation?
 
-Remember to ask yourself if your PR introduced changes to the following documentation:
+Remember to ask yourself if your PR requires changes to the following documentation:
 
-- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)?
-- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)?
-- [Alerting](https://github.com/trento-project/web/blob/main/guides/alerting/alerting.md)?
-- [Authentication](https://github.com/trento-project/web/blob/main/guides/authentication/jwt_specification.md)?
-- [Environment variables](https://github.com/trento-project/web/blob/main/guides/development/environment_variables.md)?
-- [Hack on Trento](https://github.com/trento-project/web/blob/main/guides/development/hack_on_the_trento.md)?
-- [Monitoring](https://github.com/trento-project/web/blob/main/guides/monitoring/monitoring.md)?
+- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
+- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
+- [Trento Web guides](https://github.com/trento-project/web/tree/main/guides)
 
 Add a documentation PR or write that no changes are required for the documentation.
+- [ ] **DONE**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,9 @@
 # Description
 
 Please include a summary of the changes and the related issue, if it exists. 
-Also, include relevant motivation and context for this PR. List any
-dependencies that are required for this change.
+Also, include relevant motivation and context for this PR. List any dependencies that are required for this change.
 
-Fixes # (issue)
+- Fixes # (issue)
 
 ## Did you add the right label?
 
@@ -12,4 +11,18 @@ Remember to add the right labels to this PR.
 
 ## How was this tested?
 
-Describe what kind of tests for this functionality have been added.
+Describe the types of tests that have been added for this functionality
+
+## Did you update the documentation?
+
+Remember to ask yourself if your PR introduced changes to the following documentation:
+
+- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)?
+- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)?
+- [Alerting](https://github.com/trento-project/web/blob/main/guides/alerting/alerting.md)?
+- [Authentication](https://github.com/trento-project/web/blob/main/guides/authentication/jwt_specification.md)?
+- [Environment variables](https://github.com/trento-project/web/blob/main/guides/development/environment_variables.md)?
+- [Hack on Trento](https://github.com/trento-project/web/blob/main/guides/development/hack_on_the_trento.md)?
+- [Monitoring](https://github.com/trento-project/web/blob/main/guides/monitoring/monitoring.md)?
+
+Add a documentation PR or write that no changes are required for the documentation.


### PR DESCRIPTION
# Description

This pr updates the pr template, by adding a docs section.
This change should remind every contributor about updating the documentation. Some parts of the documentation could be used in Trento's official documentation, so it is important that especially the [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md) and [Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md) is up-to-date.

Sometimes it would make sense to open a separate pr for a docs update, in this case it would not harm to add a reference in the pr description. 
If docs do not require an update, a simple **no docs update required** would be more than enough, similar like what we write in the "How was this tested" section

## How was this tested?
No tests needed
