### PR TITLE
Some small improvements in the user forms

### DIFF
--- a/assets/js/common/Switch/Switch.jsx
+++ b/assets/js/common/Switch/Switch.jsx
@@ -4,15 +4,21 @@ import classNames from 'classnames';
 
 import { Switch as HeadlessSwitch } from '@headlessui/react';
 
-function Switch({ onChange, selected }) {
+function Switch({ onChange, selected, disabled }) {
   return (
     <HeadlessSwitch.Group as="div" className="flex items-center">
       <HeadlessSwitch
         checked={selected}
         className={classNames(
-          'tn-check-switch relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer focus:outline-none transition-colors ease-in-out duration-200',
-          { 'bg-jungle-green-500': selected, 'bg-gray-200': !selected }
+          'tn-check-switch relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full focus:outline-none transition-colors ease-in-out duration-200',
+          {
+            'bg-jungle-green-500': selected,
+            'bg-gray-200': !selected,
+            'opacity-50': disabled,
+            'cursor-pointer': !disabled,
+          }
         )}
+        disabled={disabled}
         onChange={onChange}
       >
         <span

--- a/assets/js/common/Switch/Switch.stories.jsx
+++ b/assets/js/common/Switch/Switch.stories.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+
+import Switch from '.';
+
+export default {
+  title: 'Components/Switch',
+  component: Switch,
+  argTypes: {
+    selected: {
+      control: { type: 'boolean' },
+      description: 'Switch is in selected state',
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Disabled state',
+    },
+    onChange: {
+      action: 'Toogle',
+      description: 'Change switch state',
+    },
+  },
+};
+
+export const Default = {
+  args: {},
+  render: (args) => {
+    const [selected, setSelected] = useState(args.selected);
+    return <Switch {...args} selected={selected} onChange={setSelected} />;
+  },
+};
+
+export const Disabled = {
+  args: {
+    ...Default.args,
+    disabled: true,
+  },
+};

--- a/assets/js/pages/Profile/ProfileForm.jsx
+++ b/assets/js/pages/Profile/ProfileForm.jsx
@@ -145,7 +145,11 @@ function ProfileForm({
                 Authenticator App
               </Label>
               <div className="col-start-2 col-span-3">
-                <Switch selected={totpEnabled} onChange={toggleTotp} />
+                <Switch
+                  selected={totpEnabled}
+                  onChange={toggleTotp}
+                  disabled={loading || disableForm}
+                />
               </div>
             </>
           )}

--- a/assets/js/pages/Users/UserForm.jsx
+++ b/assets/js/pages/Users/UserForm.jsx
@@ -245,26 +245,30 @@ function UserForm({
               }}
             />
           </div>
-          <Label
-            className="col-start-1 col-span-1"
-            htmlFor="totp"
-            aria-label="totp"
-          >
-            TOTP
-          </Label>
-          <div className="col-start-2 col-span-3">
-            <Select
-              optionsName="totp"
-              options={[
-                { value: 'Enabled', disabled: !totpEnabledAt },
-                'Disabled',
-              ]}
-              value={totpState ? 'Enabled' : 'Disabled'}
-              onChange={(value) => {
-                setTotpState(value === 'Enabled');
-              }}
-            />
-          </div>
+          {editing && (
+            <>
+              <Label
+                className="col-start-1 col-span-1"
+                htmlFor="totp"
+                aria-label="totp"
+              >
+                TOTP
+              </Label>
+              <div className="col-start-2 col-span-3">
+                <Select
+                  optionsName="totp"
+                  options={[
+                    { value: 'Enabled', disabled: !totpEnabledAt },
+                    'Disabled',
+                  ]}
+                  value={totpState ? 'Enabled' : 'Disabled'}
+                  onChange={(value) => {
+                    setTotpState(value === 'Enabled');
+                  }}
+                />
+              </div>
+            </>
+          )}
           {editing && (
             <>
               <Label className="col-start-1 col-span-1">Created</Label>

--- a/assets/js/pages/Users/UserForm.test.jsx
+++ b/assets/js/pages/Users/UserForm.test.jsx
@@ -27,7 +27,7 @@ describe('UserForm', () => {
     expect(screen.getByText('Generate Password'));
     expect(screen.getByText('Permissions')).toBeVisible();
     expect(screen.getByText('Status')).toBeVisible();
-    expect(screen.getByText('TOTP')).toBeVisible();
+    expect(screen.queryByText('TOTP')).not.toBeInTheDocument();
     expect(screen.queryByText('Created')).not.toBeInTheDocument();
     expect(screen.queryByText('Updated')).not.toBeInTheDocument();
 


### PR DESCRIPTION
# Description

Basically 2 improvements:
- Remove the TOTP configuration select in the user creation form. It cannot be changed, so better remove it
- Disable the TOTP enrollment option in the user profile view for the admin user. Otherwise, the clicking just fails with a forbidden request error.

This 2nd has forced me to add the `disabled` state in the switch. @jagabomb you can change the style change in storybook.

