### PR TITLE
Style TOTP enrollment box

### DIFF
--- a/assets/js/pages/Profile/ProfileForm.jsx
+++ b/assets/js/pages/Profile/ProfileForm.jsx
@@ -128,7 +128,7 @@ function ProfileForm({
 
           <Label
             className="col-start-1 col-span-1"
-            info="Setup a multi factor TOTP authentication besides your password to increase security
+            info="Setup a multi-factor TOTP authentication besides your password to increase security
               for your account."
           >
             Authenticator App

--- a/assets/js/pages/Profile/ProfileForm.jsx
+++ b/assets/js/pages/Profile/ProfileForm.jsx
@@ -25,6 +25,7 @@ function ProfileForm({
   disableForm,
   passwordModalOpen = false,
   totpBoxOpen = false,
+  toggleTotpBox = noop,
   togglePasswordModal = noop,
   onSave = noop,
   onResetTotp = noop,
@@ -124,35 +125,44 @@ function ProfileForm({
               Change Password
             </Button>
           </div>
-          {totpBoxOpen ? (
-            <div className="col-start-1 col-span-5">
-              <h2 className="font-bold text-xl"> Configure TOTP </h2>
-              <TotpEnrollementBox
-                errors={errors}
-                qrData={totpQrData}
-                secret={totpSecret}
-                loading={loading}
-                verifyTotp={onVerifyTotp}
-              />
-            </div>
-          ) : (
-            <>
-              <Label
-                className="col-start-1 col-span-1"
-                info="Setup a multi factor TOTP authentication besides your password to increase security
+
+          <Label
+            className="col-start-1 col-span-1"
+            info="Setup a multi factor TOTP authentication besides your password to increase security
               for your account."
-              >
-                Authenticator App
-              </Label>
+          >
+            Authenticator App
+          </Label>
+          <div className="col-start-2 col-span-3">
+            <div className="inline-flex">
+              <Switch
+                selected={totpEnabled}
+                onChange={toggleTotp}
+                disabled={loading || disableForm || totpBoxOpen}
+              />
+              {totpBoxOpen && (
+                <span
+                  className="ml-5 cursor-pointer text-jungle-green-500 hover:opacity-75"
+                  onClick={() => toggleTotpBox(false)}
+                  aria-hidden="true"
+                >
+                  Cancel
+                </span>
+              )}
+            </div>
+
+            {totpBoxOpen && (
               <div className="col-start-2 col-span-3">
-                <Switch
-                  selected={totpEnabled}
-                  onChange={toggleTotp}
-                  disabled={loading || disableForm}
+                <TotpEnrollementBox
+                  errors={errors}
+                  qrData={totpQrData}
+                  secret={totpSecret}
+                  loading={loading}
+                  verifyTotp={onVerifyTotp}
                 />
               </div>
-            </>
-          )}
+            )}
+          </div>
 
           <Label className="col-start-1 col-span-1">Permissions</Label>
           <div className="col-start-2 col-span-3">

--- a/assets/js/pages/Profile/ProfileForm.stories.jsx
+++ b/assets/js/pages/Profile/ProfileForm.stories.jsx
@@ -107,7 +107,7 @@ export const Loading = {
 export const WithTotpEnrollmentBoxEnabled = {
   args: {
     ...Default.args,
-    totpEnabled: true,
+    totpEnabled: false,
     totpBoxOpen: true,
   },
 };

--- a/assets/js/pages/Profile/ProfileForm.test.jsx
+++ b/assets/js/pages/Profile/ProfileForm.test.jsx
@@ -240,6 +240,39 @@ describe('ProfileForm', () => {
     expect(screen.getByText(totpSecret)).toBeVisible();
   });
 
+  it('should hide the totp enrollment box when Cancel button is clicked', async () => {
+    const username = faker.internet.userName();
+    const fullName = faker.person.fullName();
+    const email = faker.internet.email();
+    const abilities = abilityFactory.buildList(2);
+
+    const totpSecret = faker.string.uuid();
+    const toggleTotpBox = jest.fn();
+
+    const user = userEvent.setup();
+
+    render(
+      <ProfileForm
+        fullName={fullName}
+        emailAddress={email}
+        username={username}
+        abilities={abilities}
+        totpSecret={totpSecret}
+        totpQrData={totpSecret}
+        totpBoxOpen
+        toggleTotpBox={toggleTotpBox}
+      />
+    );
+
+    expect(screen.getByText(totpSecret)).toBeVisible();
+
+    await act(async () => {
+      await user.click(screen.getByText('Cancel'));
+    });
+
+    expect(toggleTotpBox).toHaveBeenCalledWith(false);
+  });
+
   it('should call onVerifyTotp when the totp box is shown and the verify button is clicked', async () => {
     const username = faker.internet.userName();
     const fullName = faker.person.fullName();

--- a/assets/js/pages/Profile/ProfileForm.test.jsx
+++ b/assets/js/pages/Profile/ProfileForm.test.jsx
@@ -4,20 +4,17 @@ import { render, screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { faker } from '@faker-js/faker';
-import { abilityFactory } from '@lib/test-utils/factories/users';
+import { profileFactory } from '@lib/test-utils/factories/users';
 
 import ProfileForm from '@pages/Profile/ProfileForm';
 
 describe('ProfileForm', () => {
   it('should render a pre-filled form', () => {
-    const username = faker.internet.userName();
-    const fullName = faker.person.fullName();
-    const email = faker.internet.email();
-    const abilities = abilityFactory.buildList(2);
+    const { username, fullname, email, abilities } = profileFactory.build();
 
     render(
       <ProfileForm
-        fullName={fullName}
+        fullName={fullname}
         emailAddress={email}
         username={username}
         abilities={abilities}
@@ -25,7 +22,7 @@ describe('ProfileForm', () => {
     );
 
     expect(screen.getByText('Full Name')).toBeVisible();
-    expect(screen.getByLabelText('fullname').value).toBe(fullName);
+    expect(screen.getByLabelText('fullname').value).toBe(fullname);
     expect(screen.getByText('Email Address')).toBeVisible();
     expect(screen.getByLabelText('email').value).toBe(email);
     expect(screen.getByText('Username')).toBeVisible();
@@ -69,15 +66,12 @@ describe('ProfileForm', () => {
   });
 
   it('should send the form values when correctly filled', async () => {
-    const username = faker.internet.userName();
-    const fullName = faker.person.fullName();
-    const email = faker.internet.email();
-    const abilities = abilityFactory.buildList(2);
+    const { username, fullname, email, abilities } = profileFactory.build();
     const mockOnSave = jest.fn();
 
     render(
       <ProfileForm
-        fullName={fullName}
+        fullName={fullname}
         emailAddress={email}
         username={username}
         abilities={abilities}
@@ -90,7 +84,7 @@ describe('ProfileForm', () => {
     await user.click(screen.getByRole('button', { name: 'Save' }));
 
     expect(mockOnSave).toHaveBeenNthCalledWith(1, {
-      fullname: fullName,
+      fullname,
       email,
     });
   });
@@ -112,14 +106,11 @@ describe('ProfileForm', () => {
   });
 
   it('should set the authenticator app switch when totpEnabled is true', async () => {
-    const username = faker.internet.userName();
-    const fullName = faker.person.fullName();
-    const email = faker.internet.email();
-    const abilities = abilityFactory.buildList(2);
+    const { username, fullname, email, abilities } = profileFactory.build();
 
     render(
       <ProfileForm
-        fullName={fullName}
+        fullName={fullname}
         emailAddress={email}
         username={username}
         abilities={abilities}
@@ -134,14 +125,11 @@ describe('ProfileForm', () => {
   });
 
   it('should not set the authenticator app switch when totpEnabled is false', async () => {
-    const username = faker.internet.userName();
-    const fullName = faker.person.fullName();
-    const email = faker.internet.email();
-    const abilities = abilityFactory.buildList(2);
+    const { username, fullname, email, abilities } = profileFactory.build();
 
     render(
       <ProfileForm
-        fullName={fullName}
+        fullName={fullname}
         emailAddress={email}
         username={username}
         abilities={abilities}
@@ -156,17 +144,14 @@ describe('ProfileForm', () => {
   });
 
   it('should call onEnableTotp when totpEnabled is false and the switch is clicked', async () => {
-    const username = faker.internet.userName();
-    const fullName = faker.person.fullName();
-    const email = faker.internet.email();
-    const abilities = abilityFactory.buildList(2);
+    const { username, fullname, email, abilities } = profileFactory.build();
 
     const onEnableTotp = jest.fn();
     const user = userEvent.setup();
 
     render(
       <ProfileForm
-        fullName={fullName}
+        fullName={fullname}
         emailAddress={email}
         username={username}
         abilities={abilities}
@@ -185,17 +170,14 @@ describe('ProfileForm', () => {
   });
 
   it('should call onResetTotp when totpEnabled is true, the switch is clicked and the user confirms with the modal', async () => {
-    const username = faker.internet.userName();
-    const fullName = faker.person.fullName();
-    const email = faker.internet.email();
-    const abilities = abilityFactory.buildList(2);
+    const { username, fullname, email, abilities } = profileFactory.build();
 
     const onResetTotp = jest.fn();
     const user = userEvent.setup();
 
     render(
       <ProfileForm
-        fullName={fullName}
+        fullName={fullname}
         emailAddress={email}
         username={username}
         abilities={abilities}
@@ -218,16 +200,13 @@ describe('ProfileForm', () => {
   });
 
   it('should show the totp enrollment box when totpBoxOpen is set to true', async () => {
-    const username = faker.internet.userName();
-    const fullName = faker.person.fullName();
-    const email = faker.internet.email();
-    const abilities = abilityFactory.buildList(2);
+    const { username, fullname, email, abilities } = profileFactory.build();
 
     const totpSecret = faker.string.uuid();
 
     render(
       <ProfileForm
-        fullName={fullName}
+        fullName={fullname}
         emailAddress={email}
         username={username}
         abilities={abilities}
@@ -241,10 +220,7 @@ describe('ProfileForm', () => {
   });
 
   it('should hide the totp enrollment box when Cancel button is clicked', async () => {
-    const username = faker.internet.userName();
-    const fullName = faker.person.fullName();
-    const email = faker.internet.email();
-    const abilities = abilityFactory.buildList(2);
+    const { username, fullname, email, abilities } = profileFactory.build();
 
     const totpSecret = faker.string.uuid();
     const toggleTotpBox = jest.fn();
@@ -253,7 +229,7 @@ describe('ProfileForm', () => {
 
     render(
       <ProfileForm
-        fullName={fullName}
+        fullName={fullname}
         emailAddress={email}
         username={username}
         abilities={abilities}
@@ -274,10 +250,7 @@ describe('ProfileForm', () => {
   });
 
   it('should call onVerifyTotp when the totp box is shown and the verify button is clicked', async () => {
-    const username = faker.internet.userName();
-    const fullName = faker.person.fullName();
-    const email = faker.internet.email();
-    const abilities = abilityFactory.buildList(2);
+    const { username, fullname, email, abilities } = profileFactory.build();
 
     const onVerifyTotp = jest.fn();
     const totpSecret = faker.string.uuid();
@@ -286,7 +259,7 @@ describe('ProfileForm', () => {
 
     render(
       <ProfileForm
-        fullName={fullName}
+        fullName={fullname}
         emailAddress={email}
         username={username}
         abilities={abilities}
@@ -306,10 +279,7 @@ describe('ProfileForm', () => {
   });
 
   it('should forward errors to the totp enrollment box', async () => {
-    const username = faker.internet.userName();
-    const fullName = faker.person.fullName();
-    const email = faker.internet.email();
-    const abilities = abilityFactory.buildList(2);
+    const { username, fullname, email, abilities } = profileFactory.build();
 
     const totpSecret = faker.string.uuid();
 
@@ -323,7 +293,7 @@ describe('ProfileForm', () => {
 
     render(
       <ProfileForm
-        fullName={fullName}
+        fullName={fullname}
         emailAddress={email}
         username={username}
         abilities={abilities}

--- a/assets/js/pages/Profile/ProfilePage.jsx
+++ b/assets/js/pages/Profile/ProfilePage.jsx
@@ -159,6 +159,7 @@ function ProfilePage() {
         togglePasswordModal={passwordModalToggle}
         passwordModalOpen={passwordModalOpen}
         totpBoxOpen={totpBoxOpen}
+        toggleTotpBox={setTotpBoxOpen}
         loading={loading || saving}
         disableForm={isDefaultAdmin}
         onSave={updateProfile}

--- a/assets/js/pages/Profile/TotpEnrollmentBox.jsx
+++ b/assets/js/pages/Profile/TotpEnrollmentBox.jsx
@@ -29,22 +29,21 @@ export default function TotpEnrollmentBox({
   }, [errors]);
 
   return (
-    <div className="container max-w-7xl mx-auto p-4 sm:p-6 lg:p-8 bg-white dark:bg-gray-800 rounded-lg">
+    <div className="container max-w-7xl mx-auto bg-white dark:bg-gray-800 rounded-lg">
       <div className="flex flex-col">
-        <div className="text-lg">
-          Your new TOTP secret is: <span className="font-bold">{secret}</span>
-        </div>
-        <div>
-          <span> For quick setup, scan this QR code with your TOTP app: </span>
+        <div>Your new TOTP secret is: </div>
+        <div className="font-bold text-lg">{secret}</div>
+        <div className="mt-1">
+          For quick setup, scan this QR code with your Authenticator App.
         </div>
         <div className="mt-4">
           <QRCodeSVG value={qrData} role="img" />
         </div>
         <div className="mt-4">
-          After you configured your app, enter a test code below to ensure
-          everything works correctly:
+          After you have configured your App, enter a test code below to ensure
+          everything works correctly.
         </div>
-        <div className="mt-4 flex w-1/4 space-x-4">
+        <div className="mt-4 flex space-x-4">
           <Input
             autoComplete="off"
             placeholder="TOTP code"

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -301,7 +301,7 @@ describe('Users', () => {
 
     it('should display TOTP enrollment failure if the given code is invalid', () => {
       cy.get('button[role="switch"]').click();
-      cy.get('h2').should('contain', 'Configure TOTP');
+      cy.get('div').should('contain', 'Your new TOTP secret is');
 
       cy.get('input[placeholder="TOTP code"]').type('invalid');
       cy.contains('button', 'Verify').click();
@@ -311,7 +311,8 @@ describe('Users', () => {
 
     it('should complete TOTP enrollment properly', () => {
       cy.get('input[placeholder="TOTP code"]').clear();
-      cy.get('div:contains("Your new TOTP secret is") > span')
+      cy.contains('Your new TOTP secret is')
+        .next()
         .invoke('text')
         .as('totpSecret');
 
@@ -337,7 +338,8 @@ describe('Users', () => {
 
     it('should reconfigure TOTP authentication with a new secret', () => {
       cy.get('button[role="switch"]').click();
-      cy.get('div:contains("Your new TOTP secret is") > span')
+      cy.contains('Your new TOTP secret is')
+        .next()
         .invoke('text')
         .as('totpSecret');
 


### PR DESCRIPTION
# Description
Style TOTP enrollment box.
The unique small addition is the `Cancel` button, which just closes the box.

![styled_totp_box](https://github.com/trento-project/web/assets/36370954/74e67fec-4e44-4382-981b-fd81a1301012)

@jagabomb I have not added the `(TOTP)` text in the label, as it is already mentioned in the info icon box, and it totally messes up the whole alignment of the box. I hope it works this way.

