### PR TITLE
Fix SAP systems policy receiving an empty list of instances

### DIFF
--- a/lib/trento/discovery/payloads/sap_system_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/sap_system_discovery_payload.ex
@@ -40,7 +40,7 @@ defmodule Trento.Discovery.Payloads.SapSystemDiscoveryPayload do
       required: true
     )
     |> cast_embed(:Databases)
-    |> cast_embed(:Instances, required: true)
+    |> cast_embed(:Instances)
     |> validate_required_fields(@required_fields)
     |> validate_inclusion(:Type, @system_types)
   end

--- a/test/fixtures/discovery/sap_system_discovery_empty_application_instances.json
+++ b/test/fixtures/discovery/sap_system_discovery_empty_application_instances.json
@@ -1,0 +1,47 @@
+{
+  "agent_id": "9cd46919-5f19-59aa-993e-cf3736c71053",
+  "discovery_type": "sap_system_discovery",
+  "payload": [
+    {
+      "DBAddress": "",
+      "Databases": null,
+      "Id": "-",
+      "Instances": [],
+      "Profile": {
+        "SAPDBHOST": "10.90.1.13",
+        "SAPGLOBALHOST": "sapnwqas",
+        "SAPSYSTEMNAME": "NWQ",
+        "dbms/name": "HDQ",
+        "dbms/type": "hdb",
+        "dbs/hdb/dbname": "HDQ",
+        "dbs/hdb/schema": "SAPABAP1",
+        "enque/deque_wait_answer": "TRUE",
+        "enque/process_location": "REMOTESA",
+        "enque/serverhost": "sapnwqas",
+        "enque/serverinst": "00",
+        "gw/acl_mode": "1",
+        "gw/sec_info": "$(DIR_GLOBAL)$(DIR_SEP)secinfo$(FT_DAT)",
+        "icf/user_recheck": "1",
+        "icm/HTTP/ASJava/disable_url_session_tracking": "TRUE",
+        "is/HTTP/show_detailed_errors": "FALSE",
+        "login/password_downwards_compatibility": "0",
+        "login/system_client": "001",
+        "rdisp/autoabaptime": "0",
+        "rdisp/btctime": "0",
+        "rdisp/bufrefmode": "sendoff",
+        "rdisp/mshost": "sapnwqas",
+        "rdisp/msserv": "sapmsNWQ",
+        "rdisp/msserv_internal": "3900",
+        "rsdb/ssfs_connect": "0",
+        "rsec/ssfs_datapath": "$(DIR_GLOBAL)$(DIR_SEP)security$(DIR_SEP)rsecssfs$(DIR_SEP)data",
+        "rsec/ssfs_keypath": "$(DIR_GLOBAL)$(DIR_SEP)security$(DIR_SEP)rsecssfs$(DIR_SEP)key",
+        "service/protectedwebmethods": "SDEFAULT",
+        "system/secure_communication": "ON",
+        "system/type": "ABAP",
+        "vmcj/enable": "off"
+      },
+      "SID": "NWQ",
+      "Type": 0
+    }
+  ]
+}

--- a/test/trento/discovery/policies/sap_system_policy_test.exs
+++ b/test/trento/discovery/policies/sap_system_policy_test.exs
@@ -324,5 +324,30 @@ defmodule Trento.Discovery.Policies.SapSystemPolicyTest do
                |> load_discovery_event_fixture()
                |> SapSystemPolicy.handle([application_instance, database_instance], nil)
     end
+
+    test "should deregister all instances if the discovered instances contains an empty list inside a regular payload" do
+      application_instance =
+        build(:application_instance_without_host,
+          instance_number: "02"
+        )
+
+      database_instance =
+        build(:database_instance_without_host,
+          instance_number: "10"
+        )
+
+      assert {:ok,
+              [
+                %MarkApplicationInstanceAbsent{
+                  instance_number: "02"
+                },
+                %MarkDatabaseInstanceAbsent{
+                  instance_number: "10"
+                }
+              ]} =
+               "sap_system_discovery_empty_application_instances"
+               |> load_discovery_event_fixture()
+               |> SapSystemPolicy.handle([application_instance, database_instance], nil)
+    end
   end
 end


### PR DESCRIPTION
# Description
Fix SAP systems policy receiving an empty list of instances and marking that as not valid, thus making impossible in some cases to deregister an existing system.

## How was this tested?
Existing unit tests passing, added a unit test to make sure this doesn't incur again
