### PR TITLE
Add sorting in `Upgradable Packages` & `Available Patches` lists

### DIFF
--- a/assets/js/common/PatchList/PatchList.jsx
+++ b/assets/js/common/PatchList/PatchList.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   EOS_SHIELD_OUTLINED,
   EOS_CRITICAL_BUG_OUTLINED,
@@ -8,6 +8,10 @@ import { format as formatDate } from 'date-fns';
 import classNames from 'classnames';
 import { noop } from 'lodash';
 
+import {
+  createStringSortingPredicate,
+  createDateSortingPredicate,
+} from '@common/Table/sorting';
 import Table from '@common/Table';
 import { computedIconCssClass } from '@lib/icon';
 
@@ -59,6 +63,49 @@ const iconFromAdvisoryType = (
 };
 
 export default function PatchList({ patches, onNavigate = noop }) {
+  const [sortingColumn, setSortingColumn] = useState(null);
+  const [sortDirection, setSortDirection] = useState('asc');
+
+  const toggleSortDirection = () => {
+    if (sortDirection === 'asc') {
+      setSortDirection('desc');
+    } else {
+      setSortDirection('asc');
+    }
+  };
+
+  const createOnClickHandler = (key) => () => {
+    if (sortingColumn === key) {
+      toggleSortDirection();
+    } else {
+      setSortDirection('asc');
+    }
+    setSortingColumn(key);
+  };
+
+  const handleNameColClick = createOnClickHandler('advisory_name');
+  const handleSynopsisColClick = createOnClickHandler('advisory_synopsis');
+  const handleUpdateDateColClick = createOnClickHandler('update_date');
+
+  const sortByAdvisoryName = createStringSortingPredicate(
+    'advisory_name',
+    sortDirection
+  );
+  const sortByLatestPackage = createStringSortingPredicate(
+    'advisory_synopsis',
+    sortDirection
+  );
+  const sortByUpdateDate = createDateSortingPredicate(
+    'update_date',
+    sortDirection
+  );
+
+  const columnToSortingFunc = {
+    advisory_name: sortByAdvisoryName,
+    advisory_synopsis: sortByLatestPackage,
+    update_date: sortByUpdateDate,
+  };
+
   const patchListConfig = {
     usePadding: false,
     pagination: true,
@@ -71,6 +118,9 @@ export default function PatchList({ patches, onNavigate = noop }) {
       {
         title: 'Advisory',
         key: 'advisory_name',
+        sortable: true,
+        sortDirection: sortingColumn === 'advisory_name' ? sortDirection : null,
+        handleClick: handleNameColClick,
         render: (content, item) => (
           <button
             type="button"
@@ -84,14 +134,27 @@ export default function PatchList({ patches, onNavigate = noop }) {
       {
         title: 'Synopsis',
         key: 'advisory_synopsis',
+        sortable: true,
+        sortDirection:
+          sortingColumn === 'advisory_synopsis' ? sortDirection : null,
+        handleClick: handleSynopsisColClick,
       },
       {
         title: 'Updated',
         key: 'update_date',
+        sortable: true,
+        sortDirection: sortingColumn === 'update_date' ? sortDirection : null,
+        handleClick: handleUpdateDateColClick,
         render: (content, _) => formatDate(content, 'd MMM y'),
       },
     ],
   };
 
-  return <Table config={patchListConfig} data={patches} />;
+  return (
+    <Table
+      config={patchListConfig}
+      data={patches}
+      sortBy={columnToSortingFunc[sortingColumn]}
+    />
+  );
 }

--- a/assets/js/common/PatchList/PatchList.jsx
+++ b/assets/js/common/PatchList/PatchList.jsx
@@ -8,11 +8,10 @@ import { format as formatDate } from 'date-fns';
 import classNames from 'classnames';
 import { noop } from 'lodash';
 
-import {
+import Table, {
   createStringSortingPredicate,
   createDateSortingPredicate,
-} from '@common/Table/sorting';
-import Table from '@common/Table';
+} from '@common/Table';
 import { computedIconCssClass } from '@lib/icon';
 
 const iconFromAdvisoryType = (

--- a/assets/js/common/Table/index.js
+++ b/assets/js/common/Table/index.js
@@ -1,3 +1,9 @@
 import Table from './Table';
 
+export {
+  createStringSortingPredicate,
+  createNumberSortingPredicate,
+  createDateSortingPredicate,
+} from './sorting';
+
 export default Table;

--- a/assets/js/common/Table/sorting.js
+++ b/assets/js/common/Table/sorting.js
@@ -4,14 +4,14 @@ export const createStringSortingPredicate = (key, direction) => {
   }
 
   return (a, b) => {
-    const stringA = a[key].toUpperCase();
-    const stringB = b[key].toUpperCase();
+    const string1 = a[key].toUpperCase();
+    const string2 = b[key].toUpperCase();
 
-    if (stringA < stringB) {
+    if (string1 < string2) {
       return direction === 'asc' ? -1 : 1;
     }
 
-    if (stringA > stringB) {
+    if (string1 > string2) {
       return direction === 'asc' ? 1 : -1;
     }
 
@@ -43,14 +43,14 @@ export const createDateSortingPredicate = (key, direction) => {
   }
 
   return (a, b) => {
-    const dateA = Date.parse(a[key]);
-    const dateB = Date.parse(b[key]);
+    const date1 = Date.parse(a[key]);
+    const date2 = Date.parse(b[key]);
 
-    if (dateA < dateB) {
+    if (date1 < date2) {
       return direction === 'asc' ? -1 : 1;
     }
 
-    if (dateA > dateB) {
+    if (date1 > date2) {
       return direction === 'asc' ? 1 : -1;
     }
 

--- a/assets/js/common/Table/sorting.js
+++ b/assets/js/common/Table/sorting.js
@@ -4,14 +4,14 @@ export const createStringSortingPredicate = (key, direction) => {
   }
 
   return (a, b) => {
-    const keyA = a[key].toUpperCase();
-    const keyB = b[key].toUpperCase();
+    const stringA = a[key].toUpperCase();
+    const stringB = b[key].toUpperCase();
 
-    if (keyA < keyB) {
+    if (stringA < stringB) {
       return direction === 'asc' ? -1 : 1;
     }
 
-    if (keyA > keyB) {
+    if (stringA > stringB) {
       return direction === 'asc' ? 1 : -1;
     }
 
@@ -30,6 +30,27 @@ export const createNumberSortingPredicate = (key, direction) => {
     }
 
     if (a[key] > b[key]) {
+      return direction === 'asc' ? 1 : -1;
+    }
+
+    return 0;
+  };
+};
+
+export const createDateSortingPredicate = (key, direction) => {
+  if (!key) {
+    return null;
+  }
+
+  return (a, b) => {
+    const dateA = Date.parse(a[key]);
+    const dateB = Date.parse(b[key]);
+
+    if (dateA < dateB) {
+      return direction === 'asc' ? -1 : 1;
+    }
+
+    if (dateA > dateB) {
       return direction === 'asc' ? 1 : -1;
     }
 

--- a/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.jsx
+++ b/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { createStringSortingPredicate } from '@common/Table/sorting';
 import Table from '@common/Table';
 
 const upgradablePackagesDefault = [];
@@ -6,6 +7,21 @@ const upgradablePackagesDefault = [];
 function UpgradablePackagesList({
   upgradablePackages = upgradablePackagesDefault,
 }) {
+  const [sortDirection, setSortDirection] = useState('asc');
+
+  const toggleSortDirection = () => {
+    if (sortDirection === 'asc') {
+      setSortDirection('desc');
+    } else {
+      setSortDirection('asc');
+    }
+  };
+
+  const sortByLatestPackage = createStringSortingPredicate(
+    'latestPackage',
+    sortDirection
+  );
+
   const config = {
     pagination: true,
     usePadding: false,
@@ -18,6 +34,9 @@ function UpgradablePackagesList({
       {
         title: 'Latest Package',
         key: 'latestPackage',
+        sortable: true,
+        sortDirection,
+        handleClick: () => toggleSortDirection(),
         render: (content, _) => <div>{content}</div>,
       },
       {
@@ -46,7 +65,7 @@ function UpgradablePackagesList({
     };
   });
 
-  return <Table config={config} data={data} />;
+  return <Table config={config} data={data} sortBy={sortByLatestPackage} />;
 }
 
 export default UpgradablePackagesList;

--- a/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.jsx
+++ b/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-import { createStringSortingPredicate } from '@common/Table/sorting';
-import Table from '@common/Table';
+import Table, { createStringSortingPredicate } from '@common/Table';
 
 const upgradablePackagesDefault = [];
 

--- a/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.jsx
+++ b/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.jsx
@@ -23,7 +23,7 @@ const filterPatchesBySynopsis = (patches, synopsis) =>
       : advisory_synopsis.trim().startsWith(synopsis.trim())
   );
 
-function HostRelevanPatches({ hostName, onNavigate, patches }) {
+function HostRelevantPatches({ hostName, onNavigate, patches }) {
   const advisoryTypes = ['all'].concat(advisoryTypesFromPatches(patches));
 
   const [displayedAdvisories, setDisplayedAdvisories] = useState('all');
@@ -53,7 +53,7 @@ function HostRelevanPatches({ hostName, onNavigate, patches }) {
             className=""
             onChange={setDisplayedAdvisories}
             options={advisoryTypes}
-            optionsName="optionz"
+            optionsName="options"
             value={displayedAdvisories}
           />
           <Input
@@ -70,4 +70,4 @@ function HostRelevanPatches({ hostName, onNavigate, patches }) {
   );
 }
 
-export default HostRelevanPatches;
+export default HostRelevantPatches;

--- a/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.stories.jsx
+++ b/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.stories.jsx
@@ -4,13 +4,13 @@ import { action } from '@storybook/addon-actions';
 import { relevantPatchFactory } from '@lib/test-utils/factories/relevantPatches';
 import { hostFactory } from '@lib/test-utils/factories/hosts';
 
-import HostRelevanPatchesPage from './HostRelevantPatchesPage';
+import HostRelevantPatchesPage from './HostRelevantPatchesPage';
 
 export default {
-  title: 'Layouts/HostRelevanPatchesPage',
-  components: HostRelevanPatchesPage,
+  title: 'Layouts/HostRelevantPatchesPage',
+  components: HostRelevantPatchesPage,
   argTypes: {},
-  render: (args) => <HostRelevanPatchesPage {...args} />,
+  render: (args) => <HostRelevantPatchesPage {...args} />,
 };
 
 export const HasPatches = {

--- a/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.test.jsx
+++ b/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.test.jsx
@@ -8,7 +8,7 @@ import { hostFactory, relevantPatchFactory } from '@lib/test-utils/factories';
 
 import HostRelevantPatchesPage from './HostRelevantPatchesPage';
 
-const enhancePachesWithAdvisoryType = (
+const enhancePatchesWithAdvisoryType = (
   patches,
   { amount = 2, prefix = 'adv' } = {}
 ) =>
@@ -32,7 +32,7 @@ describe('HostRelevantPatchesPage', () => {
 
     it('shows all unique advisory types to select from', async () => {
       const host = hostFactory.build();
-      const patches = enhancePachesWithAdvisoryType(
+      const patches = enhancePatchesWithAdvisoryType(
         relevantPatchFactory.buildList(8)
       );
       const user = userEvent.setup();
@@ -48,7 +48,7 @@ describe('HostRelevantPatchesPage', () => {
 
       Array.from(new Set(patches.map((patch) => patch.advisory_type))).forEach(
         (advisoryType) => {
-          // This tests for uniqeness as well.
+          // This tests for uniqueness as well.
           expect(
             screen.getByRole('option', { name: advisoryType })
           ).toBeVisible();
@@ -93,7 +93,7 @@ describe('HostRelevantPatchesPage', () => {
     it('only shows the selected patch kind', async () => {
       const user = userEvent.setup();
 
-      const patches = enhancePachesWithAdvisoryType(
+      const patches = enhancePatchesWithAdvisoryType(
         relevantPatchFactory.buildList(8)
       );
 

--- a/assets/js/trento.jsx
+++ b/assets/js/trento.jsx
@@ -21,7 +21,7 @@ import Guard from '@pages/Guard';
 import Home from '@pages/Home';
 import HostDetailsPage from '@pages/HostDetailsPage';
 import HostSettingsPage from '@pages/HostSettingsPage';
-import HostRelevanPatchesPage from '@pages/HostRelevantPatches';
+import HostRelevantPatchesPage from '@pages/HostRelevantPatches';
 import UpgradablePackagesPage from '@pages/UpgradablePackagesPage';
 import HostsList from '@pages/HostsList';
 import Layout from '@pages/Layout';
@@ -73,7 +73,7 @@ function App() {
                   />
                   <Route
                     path="hosts/:hostID/patches"
-                    element={<HostRelevanPatchesPage />}
+                    element={<HostRelevantPatchesPage />}
                   />
                   <Route
                     path="hosts/:hostID/packages"


### PR DESCRIPTION
# Description

Adds sorting to `UpgradablePackagesList` and `PatchList` tables.

`UpgradablePackagesList` can be sorted by `Latest Package`.

`PatchList` can be sorted by `Advisory`, `Synopsis` or `Updated`.

## How was this tested?

Existing `Table`, `UpgradablePackagesList` and `PatchList` unit tests.
