### PR TITLE
Allow to continue when cert-manager has already been installed in the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -771,6 +771,7 @@ jobs:
         run: kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.5/cert-manager.crds.yaml
       - name: Install cert-manager
         run: helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version v1.14.5
+        continue-on-error: true
       - name: Download and unzip helm chart
         run: |
           rm rolling.zip | true


### PR DESCRIPTION
# Description
Small missed change regarding our CI. For subsequent runs, cert-manager will be already installed and will fail. This should allow to continue in such case

## How was this tested?

