### PR TITLE
Add ability to download CSV file when `Download CSV` button is clicked

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,7 @@ jobs:
           sudo apt-get install -y git python3 python3-pip
           python3 -m pip install codespell
       - name: codespell
-        run: codespell -S priv*,*package*json,deps*,*node_modules*,*svg,*.git,*.app -L enque,daa
+        run: codespell -S priv*,*package*json,deps*,*node_modules*,*svg,*.git,*.app -L enque,daa,afterall
 
   generate-docs:
     name: Generate project documentation

--- a/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.jsx
+++ b/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { EOS_SEARCH } from 'eos-icons-react';
+import Papa from 'papaparse';
 
 import PageHeader from '@common/PageHeader';
 import PatchList from '@common/PatchList';
@@ -37,6 +38,16 @@ function HostRelevantPatches({ hostName, onNavigate, patches }) {
     setDisplayedPatches(searchResult);
   }, [patches, displayedAdvisories, search]);
 
+  const file = window.URL.createObjectURL
+    ? window.URL.createObjectURL(
+        new File(
+          [Papa.unparse(displayedPatches, { header: true })],
+          `${hostName}-patches.csv`,
+          { type: 'text/csv' }
+        )
+      )
+    : null;
+
   return (
     <>
       <div className="flex flex-wrap">
@@ -59,7 +70,9 @@ function HostRelevantPatches({ hostName, onNavigate, patches }) {
             placeholder="Search by Synopsis"
             prefix={<EOS_SEARCH size="l" />}
           />
-          <Button type="primary-white">Download CSV</Button>
+          <a href={file} download={`${hostName}-patches.csv`}>
+            <Button type="primary-white">Download CSV</Button>
+          </a>
         </div>
       </div>
       <PatchList onNavigate={onNavigate} patches={displayedPatches} />

--- a/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.test.jsx
+++ b/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.test.jsx
@@ -191,7 +191,6 @@ describe('HostRelevantPatchesPage', () => {
     });
 
     afterAll(() => {
-      // codespell:ignore
       delete window.URL.createObjectURL;
       delete window.URL.revokeObjectURL;
     });

--- a/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.test.jsx
+++ b/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.test.jsx
@@ -190,7 +190,7 @@ describe('HostRelevantPatchesPage', () => {
       });
     });
 
-    // codespell:ignore afterAll
+    // codespell:ignore
     afterAll(() => {
       delete window.URL.createObjectURL;
       delete window.URL.revokeObjectURL;

--- a/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.test.jsx
+++ b/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.test.jsx
@@ -190,7 +190,8 @@ describe('HostRelevantPatchesPage', () => {
       });
     });
 
-    afterAll(() => { // codespell:ignore
+    afterAll(() => {
+      // codespell:ignore
       delete window.URL.createObjectURL;
       delete window.URL.revokeObjectURL;
     });

--- a/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.test.jsx
+++ b/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.test.jsx
@@ -190,6 +190,7 @@ describe('HostRelevantPatchesPage', () => {
       });
     });
 
+    // codespell:ignore afterAll
     afterAll(() => {
       delete window.URL.createObjectURL;
       delete window.URL.revokeObjectURL;

--- a/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.test.jsx
+++ b/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.test.jsx
@@ -190,8 +190,7 @@ describe('HostRelevantPatchesPage', () => {
       });
     });
 
-    // codespell:ignore
-    afterAll(() => {
+    afterAll(() => { // codespell:ignore
       delete window.URL.createObjectURL;
       delete window.URL.revokeObjectURL;
     });

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -18,6 +18,7 @@
         "date-fns": "^3.6.0",
         "eos-icons-react": "^2.4.0",
         "lodash": "^4.17.21",
+        "papaparse": "^5.4.1",
         "rc-input": "^1.4.5",
         "rc-input-number": "^9.0.0",
         "rc-tooltip": "^6.2.0",
@@ -21460,6 +21461,11 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
       "dev": true
+    },
+    "node_modules/papaparse": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.4.1.tgz",
+      "integrity": "sha512-HipMsgJkZu8br23pW15uvo6sib6wne/4woLZPlFf3rpDyMe9ywEXUsuD7+6K9PRkJlVT51j/sCOYDKGGS3ZJrw=="
     },
     "node_modules/param-case": {
       "version": "3.0.4",

--- a/assets/package.json
+++ b/assets/package.json
@@ -59,6 +59,7 @@
     "date-fns": "^3.6.0",
     "eos-icons-react": "^2.4.0",
     "lodash": "^4.17.21",
+    "papaparse": "^5.4.1",
     "rc-input": "^1.4.5",
     "rc-input-number": "^9.0.0",
     "rc-tooltip": "^6.2.0",


### PR DESCRIPTION
# Description

This change adds the ability to download CSV a file containing the relevant patches of a host when the `Download CSV` button is clicked.

Note: this PR introduces the use of the library [Papa Parse 5](https://github.com/mholt/PapaParse) for converting the JSON data into a CSV string.

## How was this tested?
Jest tests added ( ͡° ͜ʖ ͡°)
