### PR TITLE
SUSE Manager views navigation

### DIFF
--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.jsx
@@ -62,7 +62,7 @@ function AvailableSoftwareUpdates({
         tooltip={tooltip}
         loading={softwareUpdatesLoading}
         icon={<EOS_HEALING size="xl" />}
-        navigate={onNavigateToPatches}
+        onNavigate={onNavigateToPatches}
       >
         {relevantPatches}
       </Indicator>
@@ -72,7 +72,7 @@ function AvailableSoftwareUpdates({
         tooltip={tooltip}
         loading={softwareUpdatesLoading}
         icon={<EOS_PACKAGE_UPGRADE_OUTLINED size="xl" />}
-        navigate={onNavigateToPackages}
+        onNavigate={onNavigateToPackages}
       >
         {upgradablePackages}
       </Indicator>

--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.jsx
@@ -22,11 +22,13 @@ function AvailableSoftwareUpdates({
   className,
   settingsConfigured = false,
   softwareUpdatesSettingsLoading,
-  onBackToSettings = noop,
   softwareUpdatesLoading,
   relevantPatches,
   upgradablePackages,
   tooltip,
+  onBackToSettings = noop,
+  onNavigateToPatches = noop,
+  onNavigateToPackages = noop,
 }) {
   if (softwareUpdatesSettingsLoading) {
     return <Loading className={containerClassNames} />;
@@ -60,6 +62,7 @@ function AvailableSoftwareUpdates({
         tooltip={tooltip}
         loading={softwareUpdatesLoading}
         icon={<EOS_HEALING size="xl" />}
+        navigate={onNavigateToPatches}
       >
         {relevantPatches}
       </Indicator>
@@ -69,6 +72,7 @@ function AvailableSoftwareUpdates({
         tooltip={tooltip}
         loading={softwareUpdatesLoading}
         icon={<EOS_PACKAGE_UPGRADE_OUTLINED size="xl" />}
+        navigate={onNavigateToPackages}
       >
         {upgradablePackages}
       </Indicator>

--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.stories.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.stories.jsx
@@ -17,6 +17,20 @@ export default {
         type: 'function',
       },
     },
+    onNavigateToPatches: {
+      description:
+        'Callback function to trigger when the "Relevant Patches" area is clicked',
+      control: {
+        type: 'function',
+      },
+    },
+    onNavigateToPackages: {
+      description:
+        'Callback function to trigger when the "Upgradable Packages" area is clicked',
+      control: {
+        type: 'function',
+      },
+    },
     softwareUpdatesSettingsLoading: {
       control: {
         type: 'boolean',

--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
@@ -21,7 +21,7 @@ describe('AvailableSoftwareUpdates component', () => {
 
     expect(screen.getByText('0')).toBeVisible();
     expect(screen.getByText(upgradablePackages)).toBeVisible();
-    expect(screen.getAllByTestId('eos-svg-component')).toHaveLength(3);
+    expect(screen.getAllByTestId('eos-svg-component')).toHaveLength(4);
   });
 
   it('renders critical counters', () => {

--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
@@ -21,7 +21,7 @@ describe('AvailableSoftwareUpdates component', () => {
 
     expect(screen.getByText('0')).toBeVisible();
     expect(screen.getByText(upgradablePackages)).toBeVisible();
-    expect(screen.getAllByTestId('eos-svg-component')).toHaveLength(2);
+    expect(screen.getAllByTestId('eos-svg-component')).toHaveLength(3);
   });
 
   it('renders critical counters', () => {
@@ -38,7 +38,7 @@ describe('AvailableSoftwareUpdates component', () => {
 
     expect(screen.getByText(relevantPatches)).toBeVisible();
     expect(screen.getByText(upgradablePackages)).toBeVisible();
-    expect(screen.getAllByTestId('eos-svg-component')).toHaveLength(3);
+    expect(screen.getAllByTestId('eos-svg-component')).toHaveLength(5);
   });
 
   it('renders Unknown status', async () => {

--- a/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
@@ -13,8 +13,8 @@ function Indicator({
   tooltip,
   icon,
   loading,
-  navigate,
   children,
+  onNavigate,
 }) {
   const unknown = children === undefined;
 
@@ -39,10 +39,10 @@ function Indicator({
           'flex flex-row items-center border border-gray-200 p-2 rounded-md grow',
           { 'cursor-pointer': !unknown }
         )}
-        onClick={navigate}
+        onClick={onNavigate}
         onKeyDown={({ code }) => {
           if (code === 'Enter') {
-            navigate();
+            onNavigate();
           }
         }}
       >

--- a/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
@@ -1,13 +1,21 @@
 import React from 'react';
 import classNames from 'classnames';
 import {
-  // EOS_KEYBOARD_ARROW_RIGHT_FILLED,
+  EOS_KEYBOARD_ARROW_RIGHT_FILLED,
   EOS_ERROR_OUTLINED,
 } from 'eos-icons-react';
 
 import Tooltip from '@common/Tooltip';
 
-function Indicator({ title, critical, tooltip, icon, loading, children }) {
+function Indicator({
+  title,
+  critical,
+  tooltip,
+  icon,
+  loading,
+  navigate,
+  children,
+}) {
   const unknown = children === undefined;
 
   if (loading) {
@@ -24,7 +32,13 @@ function Indicator({ title, critical, tooltip, icon, loading, children }) {
 
   return (
     <Tooltip isEnabled={unknown} content={tooltip} wrap={false}>
-      <div className="flex flex-row items-center border border-gray-200 p-2 rounded-md grow">
+      <div
+        className={classNames(
+          'flex flex-row items-center border border-gray-200 p-2 rounded-md grow',
+          { 'cursor-pointer': !unknown }
+        )}
+        onClick={navigate}
+      >
         <div className="px-2">{icon}</div>
         <div>
           <p className="font-bold">{title}</p>
@@ -50,14 +64,14 @@ function Indicator({ title, critical, tooltip, icon, loading, children }) {
           </div>
         </div>
         <div className="flex grow justify-end">
-          {/* {!unknown && (
+          {!unknown && (
             <div>
               <EOS_KEYBOARD_ARROW_RIGHT_FILLED
                 size="l"
                 className="fill-gray-400"
               />
             </div>
-          )} */}
+          )}
         </div>
       </div>
     </Tooltip>

--- a/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
@@ -33,11 +33,18 @@ function Indicator({
   return (
     <Tooltip isEnabled={unknown} content={tooltip} wrap={false}>
       <div
+        role="button"
+        tabIndex={0}
         className={classNames(
           'flex flex-row items-center border border-gray-200 p-2 rounded-md grow',
           { 'cursor-pointer': !unknown }
         )}
         onClick={navigate}
+        onKeyDown={({ code }) => {
+          if (code === 'Enter') {
+            navigate();
+          }
+        }}
       >
         <div className="px-2">{icon}</div>
         <div>

--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -239,6 +239,8 @@ function HostDetails({
             softwareUpdatesSettingsLoading={softwareUpdatesSettingsLoading}
             softwareUpdatesLoading={softwareUpdatesLoading}
             onBackToSettings={() => navigate(`/settings`)}
+            onNavigateToPatches={() => navigate(`/hosts/${hostID}/patches`)}
+            onNavigateToPackages={() => navigate(`/hosts/${hostID}/packages`)}
           />
         )}
         <ChartsFeatureWrapper chartsEnabled={chartsEnabled}>


### PR DESCRIPTION
# Description
Enabling navigation from the available software updates widget to detail pages for upgradable packages and relevant patches

## How was this tested?
Jest :+1: 
