### PR TITLE
Activity log retention time

### DIFF
--- a/lib/trento/activity_log.ex
+++ b/lib/trento/activity_log.ex
@@ -24,13 +24,13 @@ defmodule Trento.ActivityLog do
           {:ok, Settings.t()}
           | {:error, :activity_log_settings_not_configured}
           | {:error, any()}
-  def change_retention_period(retention_period, unit) do
+  def change_retention_period(value, unit) do
     with {:ok, settings} <- get_settings() do
       settings
       |> Settings.changeset(%{
         retention_time: %{
-          retention_period: retention_period,
-          retention_period_unit: unit
+          value: value,
+          unit: unit
         }
       })
       |> Repo.update()

--- a/lib/trento/activity_log.ex
+++ b/lib/trento/activity_log.ex
@@ -1,0 +1,47 @@
+defmodule Trento.ActivityLog do
+  @moduledoc """
+  Activity Log module provides functionality to manage activity log settings and track activity.
+  """
+
+  require Logger
+
+  require Trento.ActivityLog.RetentionPeriodUnit, as: RetentionPeriodUnit
+
+  alias Trento.ActivityLog.Settings
+
+  alias Trento.Repo
+
+  @spec get_settings() ::
+          {:ok, Settings.t()} | {:error, :activity_log_settings_not_configured}
+  def get_settings do
+    case Repo.one(Settings.base_query()) do
+      %Settings{} = settings -> {:ok, settings}
+      nil -> {:error, :activity_log_settings_not_configured}
+    end
+  end
+
+  @spec change_retention_period(integer(), RetentionPeriodUnit.t()) ::
+          {:ok, Settings.t()}
+          | {:error, :activity_log_settings_not_configured}
+          | {:error, any()}
+  def change_retention_period(retention_period, unit) do
+    with {:ok, settings} <- get_settings() do
+      settings
+      |> Settings.changeset(%{
+        retention_time: %{
+          retention_period: retention_period,
+          retention_period_unit: unit
+        }
+      })
+      |> Repo.update()
+      |> log_error("Error while updating activity log retention period")
+    end
+  end
+
+  defp log_error({:error, _} = error, message) do
+    Logger.error("#{message}: #{inspect(error)}")
+    error
+  end
+
+  defp log_error(result, _), do: result
+end

--- a/lib/trento/activity_logging/retention_period_unit.ex
+++ b/lib/trento/activity_logging/retention_period_unit.ex
@@ -1,0 +1,7 @@
+defmodule Trento.ActivityLog.RetentionPeriodUnit do
+  @moduledoc """
+  Type that represents the possible retention period units.
+  """
+
+  use Trento.Support.Enum, values: [:days, :weeks, :months, :years]
+end

--- a/lib/trento/activity_logging/retention_time.ex
+++ b/lib/trento/activity_logging/retention_time.ex
@@ -12,9 +12,9 @@ defmodule Trento.ActivityLog.RetentionTime do
   alias __MODULE__
 
   deftype do
-    field :retention_period, :integer
+    field :value, :integer
 
-    field :retention_period_unit, Ecto.Enum, values: RetentionPeriodUnit.values()
+    field :unit, Ecto.Enum, values: RetentionPeriodUnit.values()
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()
@@ -23,16 +23,16 @@ defmodule Trento.ActivityLog.RetentionTime do
 
   def changeset(retention_time, attrs) do
     retention_time
-    |> cast(attrs, [:retention_period, :retention_period_unit])
-    |> validate_required([:retention_period, :retention_period_unit])
-    |> validate_number(:retention_period, greater_than: 0)
-    |> validate_inclusion(:retention_period_unit, RetentionPeriodUnit.values())
+    |> cast(attrs, [:value, :unit])
+    |> validate_required([:value, :unit])
+    |> validate_number(:value, greater_than: 0)
+    |> validate_inclusion(:unit, RetentionPeriodUnit.values())
   end
 
   def default do
     %RetentionTime{
-      retention_period: 1,
-      retention_period_unit: RetentionPeriodUnit.months()
+      value: 1,
+      unit: RetentionPeriodUnit.months()
     }
   end
 end

--- a/lib/trento/activity_logging/retention_time.ex
+++ b/lib/trento/activity_logging/retention_time.ex
@@ -1,0 +1,38 @@
+defmodule Trento.ActivityLog.RetentionTime do
+  @moduledoc """
+  This module Represents the Activity Log Retention Time
+  """
+
+  @required_fields :all
+
+  use Trento.Support.Type
+
+  require Trento.ActivityLog.RetentionPeriodUnit, as: RetentionPeriodUnit
+
+  alias __MODULE__
+
+  deftype do
+    field :retention_period, :integer
+
+    field :retention_period_unit, Ecto.Enum, values: RetentionPeriodUnit.values()
+  end
+
+  @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()
+  def changeset(retention_time, %RetentionTime{} = attrs),
+    do: changeset(retention_time, Map.from_struct(attrs))
+
+  def changeset(retention_time, attrs) do
+    retention_time
+    |> cast(attrs, [:retention_period, :retention_period_unit])
+    |> validate_required([:retention_period, :retention_period_unit])
+    |> validate_number(:retention_period, greater_than: 0)
+    |> validate_inclusion(:retention_period_unit, RetentionPeriodUnit.values())
+  end
+
+  def default do
+    %RetentionTime{
+      retention_period: 1,
+      retention_period_unit: RetentionPeriodUnit.months()
+    }
+  end
+end

--- a/lib/trento/activity_logging/settings.ex
+++ b/lib/trento/activity_logging/settings.ex
@@ -1,0 +1,39 @@
+defmodule Trento.ActivityLog.Settings do
+  @moduledoc """
+  ActivityLog Settings is the STI projection of activity log related settings
+  """
+
+  use Ecto.Schema
+  use Trento.Support.Ecto.STI, sti_identifier: :activity_log_settings
+
+  import Ecto.Changeset
+
+  alias __MODULE__
+  alias Trento.ActivityLog.RetentionTime
+
+  @type t :: %__MODULE__{}
+
+  @derive {Jason.Encoder, except: [:__meta__, :__struct__]}
+  @primary_key {:id, :binary_id, autogenerate: true}
+  schema "settings" do
+    embeds_one :retention_time, RetentionTime,
+      source: :activity_log_retention_time,
+      on_replace: :update
+
+    timestamps(type: :utc_datetime_usec)
+    sti_fields()
+  end
+
+  @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()
+  def changeset(settings, attrs) do
+    settings
+    |> cast(attrs, [])
+    |> cast_embed(:retention_time, required: true)
+    |> sti_changes()
+    |> unique_constraint(:type)
+  end
+
+  def with_default_retention_time do
+    changeset(%Settings{}, %{retention_time: RetentionTime.default()})
+  end
+end

--- a/lib/trento/release.ex
+++ b/lib/trento/release.ex
@@ -5,6 +5,7 @@ defmodule Trento.Release do
   """
 
   alias Pow.Ecto.Schema.Password
+  alias Trento.ActivityLog.Settings, as: ActivityLogSettings
   alias Trento.Settings.ApiKeySettings
 
   @app :trento
@@ -15,6 +16,7 @@ defmodule Trento.Release do
     migrate_event_store()
     init_admin_user()
     init_default_api_key()
+    init_default_activity_log_retention_time()
   end
 
   def migrate do
@@ -99,6 +101,17 @@ defmodule Trento.Release do
       })
       |> Trento.Repo.insert!()
     end
+  end
+
+  def init_default_activity_log_retention_time do
+    load_app()
+    Enum.each([:postgrex, :ecto], &Application.ensure_all_started/1)
+    Trento.Repo.start_link()
+
+    Trento.Repo.insert!(ActivityLogSettings.with_default_retention_time(),
+      on_conflict: :nothing,
+      conflict_target: :type
+    )
   end
 
   defp repos do

--- a/priv/repo/migrations/20240612081138_add_activity_log_settings.exs
+++ b/priv/repo/migrations/20240612081138_add_activity_log_settings.exs
@@ -1,0 +1,9 @@
+defmodule Trento.Repo.Migrations.AddActivityLogSettings do
+  use Ecto.Migration
+
+  def change do
+    alter table(:settings) do
+      add :activity_log_retention_time, :map
+    end
+  end
+end

--- a/priv/repo/migrations/20240612081138_add_activity_log_settings.exs
+++ b/priv/repo/migrations/20240612081138_add_activity_log_settings.exs
@@ -6,4 +6,12 @@ defmodule Trento.Repo.Migrations.AddActivityLogSettings do
       add :activity_log_retention_time, :map
     end
   end
+
+  def down do
+    execute "DELETE from settings WHERE type = 'activity_log_settings'"
+
+    alter table(:settings) do
+      remove :activity_log_retention_time
+    end
+  end
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -24,3 +24,7 @@
   created_at: DateTime.utc_now()
 })
 |> Trento.Repo.insert!(on_conflict: :nothing)
+
+Trento.Repo.insert!(Trento.ActivityLog.Settings.with_default_retention_time(),
+  on_conflict: :nothing
+)

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -9,6 +9,7 @@ defmodule Trento.Factory do
   require Trento.Enums.Health, as: Health
   require Trento.SoftwareUpdates.Enums.AdvisoryType, as: AdvisoryType
   require Trento.SoftwareUpdates.Enums.SoftwareUpdatesHealth, as: SoftwareUpdatesHealth
+  require Trento.ActivityLog.RetentionPeriodUnit, as: RetentionPeriodUnit
 
   alias Faker.Random.Elixir, as: RandomElixir
 
@@ -123,6 +124,9 @@ defmodule Trento.Factory do
     ApiKeySettings,
     InstallationSettings
   }
+
+  alias Trento.ActivityLog.RetentionTime
+  alias Trento.ActivityLog.Settings, as: ActivityLogSettings
 
   use ExMachina.Ecto, repo: Trento.Repo
 
@@ -931,5 +935,19 @@ defmodule Trento.Factory do
       validity: validity
     )
     |> X509.Certificate.to_pem()
+  end
+
+  def activity_log_retention_time_factory do
+    RetentionTime.new!(%{
+      retention_period: Enum.random(1..30),
+      retention_period_unit: Faker.Util.pick(RetentionPeriodUnit.values())
+    })
+  end
+
+  def activity_log_settings_factory do
+    %ActivityLogSettings{
+      type: :activity_log_settings,
+      retention_time: build(:activity_log_retention_time)
+    }
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -939,8 +939,8 @@ defmodule Trento.Factory do
 
   def activity_log_retention_time_factory do
     RetentionTime.new!(%{
-      retention_period: Enum.random(1..30),
-      retention_period_unit: Faker.Util.pick(RetentionPeriodUnit.values())
+      value: Enum.random(1..30),
+      unit: Faker.Util.pick(RetentionPeriodUnit.values())
     })
   end
 

--- a/test/trento/activity_log_test.exs
+++ b/test/trento/activity_log_test.exs
@@ -23,16 +23,16 @@ defmodule Trento.ActivityLogTest do
     test "should return settings" do
       %{
         retention_time: %{
-          retention_period: retention_period,
-          retention_period_unit: retention_period_unit
+          value: value,
+          unit: unit
         }
       } = insert(:activity_log_settings)
 
       assert {:ok,
               %Settings{
                 retention_time: %RetentionTime{
-                  retention_period: ^retention_period,
-                  retention_period_unit: ^retention_period_unit
+                  value: ^value,
+                  unit: ^unit
                 }
               }} = ActivityLog.get_settings()
     end
@@ -48,14 +48,14 @@ defmodule Trento.ActivityLogTest do
       %{
         invalid_retention_periods: [-1, 0],
         expected_errors: [
-          retention_period:
+          value:
             {"must be greater than %{number}",
              [validation: :number, kind: :greater_than, number: 0]}
         ]
       },
       %{
         invalid_retention_periods: [nil, "", "  "],
-        expected_errors: [retention_period: {"can't be blank", [validation: :required]}]
+        expected_errors: [value: {"can't be blank", [validation: :required]}]
       }
     ]
 
@@ -67,7 +67,7 @@ defmodule Trento.ActivityLogTest do
             expected_errors: expected_errors
           } <- @validation_scenarios do
         Enum.each(invalid_retention_periods, fn invalid_retention_period ->
-          retention_period_unit = Faker.Util.pick(RetentionPeriodUnit.values())
+          unit = Faker.Util.pick(RetentionPeriodUnit.values())
 
           assert {:error,
                   %{
@@ -76,7 +76,7 @@ defmodule Trento.ActivityLogTest do
                   }} =
                    ActivityLog.change_retention_period(
                      invalid_retention_period,
-                     retention_period_unit
+                     unit
                    )
         end)
       end
@@ -85,41 +85,41 @@ defmodule Trento.ActivityLogTest do
     test "should not accept unsupported retention period units" do
       insert(:activity_log_settings)
 
-      for retention_period_unit <- [:foo, :bar, :baz] do
+      for unit <- [:foo, :bar, :baz] do
         assert {:error,
                 %{
                   valid?: false,
                   changes: %{
                     retention_time: %{
                       errors: [
-                        retention_period_unit: {"is invalid", _}
+                        unit: {"is invalid", _}
                       ]
                     }
                   }
-                }} = ActivityLog.change_retention_period(42, retention_period_unit)
+                }} = ActivityLog.change_retention_period(42, unit)
       end
     end
 
     scenarios = [
       %{
         name: "days",
-        retention_period: 1,
-        retention_period_unit: RetentionPeriodUnit.days()
+        value: 1,
+        unit: RetentionPeriodUnit.days()
       },
       %{
         name: "weeks",
-        retention_period: 3,
-        retention_period_unit: RetentionPeriodUnit.weeks()
+        value: 3,
+        unit: RetentionPeriodUnit.weeks()
       },
       %{
         name: "months",
-        retention_period: 5,
-        retention_period_unit: RetentionPeriodUnit.months()
+        value: 5,
+        unit: RetentionPeriodUnit.months()
       },
       %{
         name: "years",
-        retention_period: 7,
-        retention_period_unit: RetentionPeriodUnit.years()
+        value: 7,
+        unit: RetentionPeriodUnit.years()
       }
     ]
 
@@ -129,26 +129,26 @@ defmodule Trento.ActivityLogTest do
       test "should successfully change retention periods #{name}" do
         insert(:activity_log_settings,
           retention_time: %{
-            retention_period: 92,
-            retention_period_unit: RetentionPeriodUnit.years()
+            value: 92,
+            unit: RetentionPeriodUnit.years()
           }
         )
 
         %{
-          retention_period: retention_period,
-          retention_period_unit: retention_period_unit
+          value: value,
+          unit: unit
         } = @scenario
 
         assert {:ok,
                 %Settings{
                   retention_time: %RetentionTime{
-                    retention_period: ^retention_period,
-                    retention_period_unit: ^retention_period_unit
+                    value: ^value,
+                    unit: ^unit
                   }
                 }} =
                  ActivityLog.change_retention_period(
-                   retention_period,
-                   retention_period_unit
+                   value,
+                   unit
                  )
       end
     end
@@ -159,16 +159,16 @@ defmodule Trento.ActivityLogTest do
 
       insert(:activity_log_settings,
         retention_time: %{
-          retention_period: initial_retention_period,
-          retention_period_unit: initial_retention_period_unit
+          value: initial_retention_period,
+          unit: initial_retention_period_unit
         }
       )
 
       assert {:ok,
               %Settings{
                 retention_time: %RetentionTime{
-                  retention_period: ^initial_retention_period,
-                  retention_period_unit: ^initial_retention_period_unit
+                  value: ^initial_retention_period,
+                  unit: ^initial_retention_period_unit
                 }
               }} =
                ActivityLog.change_retention_period(

--- a/test/trento/activity_log_test.exs
+++ b/test/trento/activity_log_test.exs
@@ -1,0 +1,180 @@
+defmodule Trento.ActivityLogTest do
+  @moduledoc false
+  use ExUnit.Case
+  use Trento.DataCase
+
+  import Mox
+
+  import Trento.Factory
+
+  require Trento.ActivityLog.RetentionPeriodUnit, as: RetentionPeriodUnit
+
+  alias Trento.ActivityLog
+  alias Trento.ActivityLog.RetentionTime
+  alias Trento.ActivityLog.Settings
+
+  setup :verify_on_exit!
+
+  describe "retrieving activity log settings" do
+    test "should return an error when settings are not available" do
+      assert {:error, :activity_log_settings_not_configured} == ActivityLog.get_settings()
+    end
+
+    test "should return settings" do
+      %{
+        retention_time: %{
+          retention_period: retention_period,
+          retention_period_unit: retention_period_unit
+        }
+      } = insert(:activity_log_settings)
+
+      assert {:ok,
+              %Settings{
+                retention_time: %RetentionTime{
+                  retention_period: ^retention_period,
+                  retention_period_unit: ^retention_period_unit
+                }
+              }} = ActivityLog.get_settings()
+    end
+  end
+
+  describe "changing activity log settings" do
+    test "should not be able to change retention time if no activity log settings were previously saved" do
+      assert {:error, :activity_log_settings_not_configured} ==
+               ActivityLog.change_retention_period(42, RetentionPeriodUnit.days())
+    end
+
+    @validation_scenarios [
+      %{
+        invalid_retention_periods: [-1, 0],
+        expected_errors: [
+          retention_period:
+            {"must be greater than %{number}",
+             [validation: :number, kind: :greater_than, number: 0]}
+        ]
+      },
+      %{
+        invalid_retention_periods: [nil, "", "  "],
+        expected_errors: [retention_period: {"can't be blank", [validation: :required]}]
+      }
+    ]
+
+    test "should not accept invalid retention periods" do
+      insert(:activity_log_settings)
+
+      for %{
+            invalid_retention_periods: invalid_retention_periods,
+            expected_errors: expected_errors
+          } <- @validation_scenarios do
+        Enum.each(invalid_retention_periods, fn invalid_retention_period ->
+          retention_period_unit = Faker.Util.pick(RetentionPeriodUnit.values())
+
+          assert {:error,
+                  %{
+                    valid?: false,
+                    changes: %{retention_time: %{errors: ^expected_errors}}
+                  }} =
+                   ActivityLog.change_retention_period(
+                     invalid_retention_period,
+                     retention_period_unit
+                   )
+        end)
+      end
+    end
+
+    test "should not accept unsupported retention period units" do
+      insert(:activity_log_settings)
+
+      for retention_period_unit <- [:foo, :bar, :baz] do
+        assert {:error,
+                %{
+                  valid?: false,
+                  changes: %{
+                    retention_time: %{
+                      errors: [
+                        retention_period_unit: {"is invalid", _}
+                      ]
+                    }
+                  }
+                }} = ActivityLog.change_retention_period(42, retention_period_unit)
+      end
+    end
+
+    scenarios = [
+      %{
+        name: "days",
+        retention_period: 1,
+        retention_period_unit: RetentionPeriodUnit.days()
+      },
+      %{
+        name: "weeks",
+        retention_period: 3,
+        retention_period_unit: RetentionPeriodUnit.weeks()
+      },
+      %{
+        name: "months",
+        retention_period: 5,
+        retention_period_unit: RetentionPeriodUnit.months()
+      },
+      %{
+        name: "years",
+        retention_period: 7,
+        retention_period_unit: RetentionPeriodUnit.years()
+      }
+    ]
+
+    for %{name: name} = scenario <- scenarios do
+      @scenario scenario
+
+      test "should successfully change retention periods #{name}" do
+        insert(:activity_log_settings,
+          retention_time: %{
+            retention_period: 92,
+            retention_period_unit: RetentionPeriodUnit.years()
+          }
+        )
+
+        %{
+          retention_period: retention_period,
+          retention_period_unit: retention_period_unit
+        } = @scenario
+
+        assert {:ok,
+                %Settings{
+                  retention_time: %RetentionTime{
+                    retention_period: ^retention_period,
+                    retention_period_unit: ^retention_period_unit
+                  }
+                }} =
+                 ActivityLog.change_retention_period(
+                   retention_period,
+                   retention_period_unit
+                 )
+      end
+    end
+
+    test "should successfully handle unchanging retention periods" do
+      initial_retention_period = 42
+      initial_retention_period_unit = RetentionPeriodUnit.days()
+
+      insert(:activity_log_settings,
+        retention_time: %{
+          retention_period: initial_retention_period,
+          retention_period_unit: initial_retention_period_unit
+        }
+      )
+
+      assert {:ok,
+              %Settings{
+                retention_time: %RetentionTime{
+                  retention_period: ^initial_retention_period,
+                  retention_period_unit: ^initial_retention_period_unit
+                }
+              }} =
+               ActivityLog.change_retention_period(
+                 initial_retention_period,
+                 initial_retention_period_unit
+               )
+    end
+  end
+end

--- a/test/trento/release_test.exs
+++ b/test/trento/release_test.exs
@@ -1,0 +1,46 @@
+defmodule Trento.ReleaseTest do
+  @moduledoc false
+  use ExUnit.Case
+  use Trento.DataCase
+
+  import Trento.Factory
+
+  require Trento.ActivityLog.RetentionPeriodUnit, as: RetentionPeriodUnit
+
+  alias Trento.ActivityLog.RetentionTime
+  alias Trento.ActivityLog.Settings, as: ActivityLogSettings
+
+  describe "Activity Log settings initiation" do
+    test "should init default activity log retention time" do
+      Trento.Release.init_default_activity_log_retention_time()
+
+      assert %ActivityLogSettings{
+               retention_time: %RetentionTime{
+                 retention_period: 1,
+                 retention_period_unit: RetentionPeriodUnit.months()
+               }
+             } = Trento.Repo.one(ActivityLogSettings.base_query())
+    end
+
+    test "should not change previously saved retention time" do
+      retention_period = 3
+      retention_period_unit = RetentionPeriodUnit.weeks()
+
+      insert(:activity_log_settings,
+        retention_time: %{
+          retention_period: retention_period,
+          retention_period_unit: retention_period_unit
+        }
+      )
+
+      Trento.Release.init_default_activity_log_retention_time()
+
+      assert %ActivityLogSettings{
+               retention_time: %RetentionTime{
+                 retention_period: ^retention_period,
+                 retention_period_unit: ^retention_period_unit
+               }
+             } = Trento.Repo.one(ActivityLogSettings.base_query())
+    end
+  end
+end

--- a/test/trento/release_test.exs
+++ b/test/trento/release_test.exs
@@ -16,20 +16,20 @@ defmodule Trento.ReleaseTest do
 
       assert %ActivityLogSettings{
                retention_time: %RetentionTime{
-                 retention_period: 1,
-                 retention_period_unit: RetentionPeriodUnit.months()
+                 value: 1,
+                 unit: RetentionPeriodUnit.months()
                }
              } = Trento.Repo.one(ActivityLogSettings.base_query())
     end
 
     test "should not change previously saved retention time" do
-      retention_period = 3
-      retention_period_unit = RetentionPeriodUnit.weeks()
+      value = 3
+      unit = RetentionPeriodUnit.weeks()
 
       insert(:activity_log_settings,
         retention_time: %{
-          retention_period: retention_period,
-          retention_period_unit: retention_period_unit
+          value: value,
+          unit: unit
         }
       )
 
@@ -37,8 +37,8 @@ defmodule Trento.ReleaseTest do
 
       assert %ActivityLogSettings{
                retention_time: %RetentionTime{
-                 retention_period: ^retention_period,
-                 retention_period_unit: ^retention_period_unit
+                 value: ^value,
+                 unit: ^unit
                }
              } = Trento.Repo.one(ActivityLogSettings.base_query())
     end


### PR DESCRIPTION
# Description

Adds the foundation for the activity log settings, specifically retention time.

- migration to add the required fields into the settings STI
- schema and constraints
- initial default retention time is provided
- context exposing basic read/update operations

The context functions can be then used in a controller to expose desired operations.