### PR TITLE
Support multi line text on tooltip

### DIFF
--- a/assets/js/common/Tooltip/Tooltip.jsx
+++ b/assets/js/common/Tooltip/Tooltip.jsx
@@ -21,7 +21,7 @@ const getPlacement = (place) => (PLACES.includes(place) ? place : 'top');
 
 function Tooltip({
   className,
-  content,
+  content = '',
   children,
   place = 'top',
   isEnabled = true,
@@ -32,13 +32,13 @@ function Tooltip({
     return children;
   }
   const overlayClasses = classNames(
-    'leading-5 text-xs font-semibold bg-black text-white flex items-center px-4 py-2 rounded',
+    'leading-5 text-xs font-semibold bg-black text-white flex items-center px-4 py-2 rounded whitespace-pre-line text-center',
     className
   );
   return (
     <RcTooltip
       motion={{ motionName: 'rc-tooltip-fade' }}
-      overlay={<span className={overlayClasses}>{content}</span>}
+      overlay={<span className={overlayClasses}>{content.trim()}</span>}
       placement={getPlacement(place)}
       {...rest}
     >

--- a/assets/js/common/Tooltip/Tooltip.stories.jsx
+++ b/assets/js/common/Tooltip/Tooltip.stories.jsx
@@ -61,3 +61,20 @@ export const Positioning = {
     </div>
   ),
 };
+
+// Prove tooltips can render multiline text
+// Extra spaces such as leading and trailing newlines are collapsed
+export const MultilineText = {
+  args: {
+    content: '\nthe head line\nthe middle line\nthe bottom line\n',
+  },
+  render: (args) => (
+    <div className="p-12 flex items-center justify-center">
+      <Tooltip {...args}>
+        <div className="bg-sky-400 p-2 text-white font-semibold rounded">
+          Hover me!
+        </div>
+      </Tooltip>
+    </div>
+  ),
+};


### PR DESCRIPTION
# Description

Allow the `<Tooltip />` component to display multi line text. Extra spaces are collapsed as `white-space: pre-line` is used.

Example:
![image](https://github.com/trento-project/web/assets/265564/5230d010-6bfd-4675-9dd5-d4f8c56b3174)

