### PR TITLE
Add validation tooltip on tag creation

### DIFF
--- a/assets/js/common/Tags/Tags.jsx
+++ b/assets/js/common/Tags/Tags.jsx
@@ -7,7 +7,7 @@ import useOnClickOutside from '@hooks/useOnClickOutside';
 // eslint-disable-next-line
 const tagRegexValidation = /^[\+\-=.,_:@\p{L}\w]*$/u;
 const tagValidation = (char) => tagRegexValidation.test(char);
-const tagValidationMessage = (
+const tagValidationDefaultMessage = (
   <>
     Only alphanumeric characters
     <br />
@@ -15,9 +15,18 @@ const tagValidationMessage = (
   </>
 );
 
-function Tags({ className, tags, onChange, onAdd, onRemove, resourceId }) {
+function Tags({
+  className,
+  tags,
+  onChange,
+  onAdd,
+  onRemove,
+  resourceId,
+  validationMessage = tagValidationDefaultMessage,
+}) {
   const [renderedTags, setTags] = useState(tags);
   const [addingTag, setAddingTag] = useState(false);
+  const [showValidationTooltip, setShowValidationTooltip] = useState(false);
   const [newTagValue, setNewTagValue] = useState('');
   const inputRef = useRef(null);
 
@@ -81,15 +90,15 @@ function Tags({ className, tags, onChange, onAdd, onRemove, resourceId }) {
         </Pill>
       ))}
       {addingTag ? (
-        <Tooltip content={tagValidationMessage} trigger={'focus'}>
+        <Tooltip content={validationMessage} visible={showValidationTooltip}>
           <Pill className="ml-2 bg-green-100 text-green-800 animate-fade">
             <input
               ref={inputRef}
               className="bg-green-100"
               onChange={({ target: { value } }) => {
-                if (tagValidation(value)) {
-                  setNewTagValue(value);
-                }
+                const isValid = tagValidation(value);
+                setShowValidationTooltip(!isValid);
+                isValid && setNewTagValue(value);
               }}
               onKeyDown={({ key }) => {
                 if (key === 'Enter') {

--- a/assets/js/common/Tags/Tags.jsx
+++ b/assets/js/common/Tags/Tags.jsx
@@ -2,10 +2,18 @@ import React, { useState, useEffect, useRef } from 'react';
 import classNames from 'classnames';
 import { EOS_NEW_LABEL, EOS_CLOSE } from 'eos-icons-react';
 import Pill from '@common/Pill';
+import Tooltip from '@common/Tooltip';
 import useOnClickOutside from '@hooks/useOnClickOutside';
 // eslint-disable-next-line
 const tagRegexValidation = /^[\+\-=.,_:@\p{L}\w]*$/u;
 const tagValidation = (char) => tagRegexValidation.test(char);
+const tagValidationMessage = (
+  <>
+    Only alphanumeric characters
+    <br />
+    are allowed, e.g. A-Z and 0-9
+  </>
+);
 
 function Tags({ className, tags, onChange, onAdd, onRemove, resourceId }) {
   const [renderedTags, setTags] = useState(tags);
@@ -73,33 +81,35 @@ function Tags({ className, tags, onChange, onAdd, onRemove, resourceId }) {
         </Pill>
       ))}
       {addingTag ? (
-        <Pill className="ml-2 bg-green-100 text-green-800 animate-fade">
-          <input
-            ref={inputRef}
-            className="bg-green-100"
-            onChange={({ target: { value } }) => {
-              if (tagValidation(value)) {
-                setNewTagValue(value);
-              }
-            }}
-            onKeyDown={({ key }) => {
-              if (key === 'Enter') {
-                if (
-                  newTagValue.length === 0 ||
-                  renderedTags.includes(newTagValue)
-                ) {
-                  return;
+        <Tooltip content={tagValidationMessage} trigger={'focus'}>
+          <Pill className="ml-2 bg-green-100 text-green-800 animate-fade">
+            <input
+              ref={inputRef}
+              className="bg-green-100"
+              onChange={({ target: { value } }) => {
+                if (tagValidation(value)) {
+                  setNewTagValue(value);
                 }
-                renderedTags.push(newTagValue);
-                setAddingTag(false);
-                setNewTagValue('');
-                onChange(renderedTags);
-                onAdd(newTagValue);
-              }
-            }}
-            value={newTagValue}
-          />
-        </Pill>
+              }}
+              onKeyDown={({ key }) => {
+                if (key === 'Enter') {
+                  if (
+                    newTagValue.length === 0 ||
+                    renderedTags.includes(newTagValue)
+                  ) {
+                    return;
+                  }
+                  renderedTags.push(newTagValue);
+                  setAddingTag(false);
+                  setNewTagValue('');
+                  onChange(renderedTags);
+                  onAdd(newTagValue);
+                }
+              }}
+              value={newTagValue}
+            />
+          </Pill>
+        </Tooltip>
       ) : (
         <Pill
           className={classNames({

--- a/assets/js/common/Tags/Tags.stories.jsx
+++ b/assets/js/common/Tags/Tags.stories.jsx
@@ -15,7 +15,3 @@ export function Populated(args) {
 export function Empty(args) {
   return <Tags tags={[]} {...args} />;
 }
-
-export function WithValidation(args) {
-  return <Tags tags={[]} {...args} />;
-}

--- a/assets/js/common/Tags/Tags.stories.jsx
+++ b/assets/js/common/Tags/Tags.stories.jsx
@@ -15,3 +15,7 @@ export function Populated(args) {
 export function Empty(args) {
   return <Tags tags={[]} {...args} />;
 }
+
+export function WithValidation(args) {
+  return <Tags tags={[]} {...args} />;
+}

--- a/assets/js/common/Tags/Tags.test.jsx
+++ b/assets/js/common/Tags/Tags.test.jsx
@@ -7,7 +7,7 @@ import '@testing-library/jest-dom';
 import Tags from '.';
 
 describe('Tags', () => {
-  it('should show validation tooltip when inserting an unsuported character in a tag', async () => {
+  it('should show validation tooltip when inserting an unsupported character in a tag', async () => {
     const user = userEvent.setup();
     const msg = 'invalid character';
 

--- a/assets/js/common/Tags/Tags.test.jsx
+++ b/assets/js/common/Tags/Tags.test.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import Tags from '.';
+
+describe('Tags', () => {
+  it('should show validation tooltip when inserting an unsuported character in a tag', async () => {
+    const user = userEvent.setup();
+    const msg = 'invalid character';
+
+    render(<Tags tags={[]} validationMessage={msg} />);
+
+    expect(screen.queryByText(msg)).toBeNull();
+
+    await act(async () => user.click(screen.queryByText('Add Tag')));
+
+    await act(async () => userEvent.keyboard('A'));
+
+    await waitFor(() => expect(screen.queryByText(msg)).toBeNull());
+
+    await act(async () => userEvent.keyboard('>'));
+
+    await waitFor(() => expect(screen.queryByText(msg)).toBeVisible());
+
+    await act(async () => userEvent.keyboard('Z'));
+
+    // FIXME: The visibility is due to a css class.
+    // Being the css is not loaded, it cannot be detected by js-dom
+    // await waitFor(() => expect(screen.queryByText(msg)).not.toBeVisible());
+  });
+});

--- a/assets/js/common/Tooltip/Tooltip.jsx
+++ b/assets/js/common/Tooltip/Tooltip.jsx
@@ -26,6 +26,11 @@ function Tooltip({
   place = 'top',
   isEnabled = true,
   wrap = true,
+  // The visible ternary flag forces the tooltip to show/hide
+  // regardless of the user interaction.
+  //  true -> tooltip is always visible
+  //  false -> tooltip is never visible
+  //  undefined -> tooltip is visible when the user triggers the action (e.g. hover)
   visible,
   ...rest
 }) {

--- a/assets/js/common/Tooltip/Tooltip.jsx
+++ b/assets/js/common/Tooltip/Tooltip.jsx
@@ -26,6 +26,7 @@ function Tooltip({
   place = 'top',
   isEnabled = true,
   wrap = true,
+  visible,
   ...rest
 }) {
   if (!isEnabled) {
@@ -40,6 +41,7 @@ function Tooltip({
       motion={{ motionName: 'rc-tooltip-fade' }}
       overlay={<span className={overlayClasses}>{content}</span>}
       placement={getPlacement(place)}
+      visible={visible}
       {...rest}
     >
       {wrap ? <span>{children}</span> : children}

--- a/assets/js/common/Tooltip/Tooltip.stories.jsx
+++ b/assets/js/common/Tooltip/Tooltip.stories.jsx
@@ -28,6 +28,11 @@ export default {
       type: 'boolean',
       description: 'Whether to wrap children in a span or not.',
     },
+    visible: {
+      type: 'boolean',
+      description:
+        'If specified, force to show or hide the tooltip regardless of the trigger event',
+    },
   },
   render: (args) => (
     <div className="p-12 flex items-center justify-center">

--- a/assets/js/common/Tooltip/Tooltip.test.jsx
+++ b/assets/js/common/Tooltip/Tooltip.test.jsx
@@ -44,4 +44,44 @@ describe('Tooltip', () => {
       expect(screen.queryByText('This is my tooltip text')).toBeVisible()
     );
   });
+
+  it('should show a text regardless of the mouse event when visible is set to true', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <div>
+        <Tooltip content="This is my tooltip text" wrap={false} visible>
+          <div>This is my anchor</div>
+        </Tooltip>
+      </div>
+    );
+
+    expect(screen.queryByText('This is my tooltip text')).toBeVisible();
+
+    await act(async () => user.hover(screen.queryByText('This is my anchor')));
+
+    await waitFor(() =>
+      expect(screen.queryByText('This is my tooltip text')).toBeVisible()
+    );
+  });
+
+  it('should not show a text regardless of the mouse event when visible is set to false', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <div>
+        <Tooltip content="This is my tooltip text" wrap={false} visible={false}>
+          <div>This is my anchor</div>
+        </Tooltip>
+      </div>
+    );
+
+    expect(screen.queryByText('This is my tooltip text')).toBeNull();
+
+    await act(async () => user.hover(screen.queryByText('This is my anchor')));
+
+    await waitFor(() =>
+      expect(screen.queryByText('This is my tooltip text')).toBeNull()
+    );
+  });
 });


### PR DESCRIPTION
# Description

Add a validation tooltip on tag creation. When the user type an unsupported character, the tooltip appears to communicate the failure; the tooltip disappears when adding a valid character.

![ezgif-3-d916a02f2f](https://github.com/trento-project/web/assets/265564/e3a3db4a-6be1-4277-9527-be2006547bbb)

The feature is added to all editable tags in the application. 


