### PR TITLE
Add `Errata Details` controller

### DIFF
--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -117,6 +117,13 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"422", reason: "Unable to retrieve upgradable packages for this host.")
   end
 
+  def call(conn, {:error, :error_getting_errata_details}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(ErrorView)
+    |> render(:"422", reason: "Unable to retrieve errata details for this advisory.")
+  end
+
   def call(conn, {:error, :connection_test_failed}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/lib/trento_web/controllers/v1/suse_manager_controller.ex
+++ b/lib/trento_web/controllers/v1/suse_manager_controller.ex
@@ -3,11 +3,13 @@ defmodule TrentoWeb.V1.SUSEManagerController do
   use OpenApiSpex.ControllerSpecs
 
   alias Trento.SoftwareUpdates
+  alias Trento.SoftwareUpdates.Discovery
 
   alias TrentoWeb.OpenApi.V1.Schema
 
   alias TrentoWeb.OpenApi.V1.Schema.AvailableSoftwareUpdates.{
     AvailableSoftwareUpdatesResponse,
+    ErrataDetailsResponse,
     PatchesForPackagesResponse
   }
 
@@ -72,6 +74,28 @@ defmodule TrentoWeb.V1.SUSEManagerController do
   def patches_for_packages(conn, %{package_ids: package_ids}) do
     with {:ok, packages_patches} <- SoftwareUpdates.get_packages_patches(package_ids) do
       render(conn, %{patches: packages_patches})
+    end
+  end
+
+  operation :errata_details,
+    summary: "Gets the details for an advisory",
+    tags: ["Platform"],
+    description: "Endpoint to fetch advisory details for a given advisory name",
+    parameters: [
+      advisory_name: [
+        in: :path,
+        required: true,
+        type: %OpenApiSpex.Schema{type: :string}
+      ]
+    ],
+    responses: [
+      ok: {"Errata details for the advisory", "application/json", ErrataDetailsResponse}
+    ]
+
+  @spec errata_details(Plug.Conn.t(), any) :: Plug.Conn.t()
+  def errata_details(conn, %{advisory_name: advisory_name}) do
+    with {:ok, errata_details} <- Discovery.get_errata_details(advisory_name) do
+      render(conn, %{errata_details: errata_details})
     end
   end
 end

--- a/lib/trento_web/openapi/v1/schema/available_software_updates.ex
+++ b/lib/trento_web/openapi/v1/schema/available_software_updates.ex
@@ -121,4 +121,54 @@ defmodule TrentoWeb.OpenApi.V1.Schema.AvailableSoftwareUpdates do
       }
     })
   end
+
+  defmodule ErrataDetailsResponse do
+    @moduledoc false
+    OpenApiSpex.schema(%{
+      title: "ErrataDetailsResponse",
+      description: "Response returned from the errata details endpoint",
+      type: :object,
+      additionalProperties: false,
+      properties: %{
+        id: %Schema{type: :number, format: :int, description: "Advisory ID number"},
+        issue_date: %Schema{
+          type: :string,
+          format: "date",
+          description: "Advisory issue date"
+        },
+        update_date: %Schema{
+          type: :string,
+          format: "date",
+          description: "Advisory update date"
+        },
+        last_modified_date: %Schema{
+          type: :string,
+          format: "date",
+          description: "Advisory last modified date"
+        },
+        synopsis: %Schema{type: :string, description: "Advisory synopsis"},
+        release: %Schema{type: :number, format: :int, description: "Advisory Release number"},
+        advisory_status: %Schema{type: :string, description: "Advisory status"},
+        vendor_advisory: %Schema{type: :string, description: "Vendor advisory"},
+        type: %Schema{type: :string, description: "Advisory type"},
+        product: %Schema{type: :string, description: "Advisory product"},
+        errataFrom: %Schema{type: :string, description: "Advisory errata"},
+        topic: %Schema{type: :string, description: "Advisory topic"},
+        description: %Schema{type: :string, description: "Advisory description"},
+        references: %Schema{type: :string, description: "Advisory references"},
+        notes: %Schema{type: :string, description: "Advisory notes"},
+        solution: %Schema{type: :string, description: "Advisory solution"},
+        reboot_suggested: %Schema{
+          type: :boolean,
+          description:
+            "A boolean flag signaling whether a system reboot is advisable following the application of the errata. Typical example is upon kernel update."
+        },
+        restart_suggested: %Schema{
+          type: :boolean,
+          description:
+            "A boolean flag signaling a weather reboot of the package manager is advisable following the application of the errata. This is commonly used to address update stack issues before proceeding with other updates."
+        }
+      }
+    })
+  end
 end

--- a/lib/trento_web/openapi/v1/schema/available_software_updates.ex
+++ b/lib/trento_web/openapi/v1/schema/available_software_updates.ex
@@ -152,7 +152,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.AvailableSoftwareUpdates do
         vendor_advisory: %Schema{type: :string, description: "Vendor advisory"},
         type: %Schema{type: :string, description: "Advisory type"},
         product: %Schema{type: :string, description: "Advisory product"},
-        errataFrom: %Schema{type: :string, description: "Advisory errata"},
+        errata_from: %Schema{type: :string, description: "Advisory errata"},
         topic: %Schema{type: :string, description: "Advisory topic"},
         description: %Schema{type: :string, description: "Advisory description"},
         references: %Schema{type: :string, description: "Advisory references"},

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -120,6 +120,10 @@ defmodule TrentoWeb.Router do
       if Application.compile_env!(:trento, :suse_manager_enabled) do
         get "/hosts/:id/software_updates", SUSEManagerController, :software_updates
         get "/software_updates/packages", SUSEManagerController, :patches_for_packages
+
+        get "/software_updates/errata_details/:advisory_name",
+            SUSEManagerController,
+            :errata_details
       end
 
       post "/clusters/:id/tags", TagsController, :add_tag,

--- a/lib/trento_web/views/v1/suse_manager_view.ex
+++ b/lib/trento_web/views/v1/suse_manager_view.ex
@@ -96,7 +96,7 @@ defmodule TrentoWeb.V1.SUSEManagerView do
         vendor_advisory: vendor_advisory,
         type: type,
         product: product,
-        errataFrom: errataFrom,
+        errata_from: errataFrom,
         topic: topic,
         description: description,
         references: references,

--- a/lib/trento_web/views/v1/suse_manager_view.ex
+++ b/lib/trento_web/views/v1/suse_manager_view.ex
@@ -63,46 +63,9 @@ defmodule TrentoWeb.V1.SUSEManagerView do
 
   def render("patches_for_packages.json", %{patches: patches}), do: %{patches: patches}
 
-  def render("errata_details.json", %{
-        errata_details: %{
-          id: id,
-          issue_date: issue_date,
-          update_date: update_date,
-          last_modified_date: last_modified_date,
-          synopsis: synopsis,
-          release: release,
-          advisory_status: advisory_status,
-          vendor_advisory: vendor_advisory,
-          type: type,
-          product: product,
-          errataFrom: errataFrom,
-          topic: topic,
-          description: description,
-          references: references,
-          notes: notes,
-          solution: solution,
-          reboot_suggested: reboot_suggested,
-          restart_suggested: restart_suggested
-        }
-      }),
-      do: %{
-        id: id,
-        issue_date: issue_date,
-        update_date: update_date,
-        last_modified_date: last_modified_date,
-        synopsis: synopsis,
-        release: release,
-        advisory_status: advisory_status,
-        vendor_advisory: vendor_advisory,
-        type: type,
-        product: product,
-        errata_from: errataFrom,
-        topic: topic,
-        description: description,
-        references: references,
-        notes: notes,
-        solution: solution,
-        reboot_suggested: reboot_suggested,
-        restart_suggested: restart_suggested
-      }
+  def render("errata_details.json", %{errata_details: errata_details = %{errataFrom: errataFrom}}),
+    do:
+      errata_details
+      |> Map.drop([:errataFrom])
+      |> Map.put(:errata_from, errataFrom)
 end

--- a/lib/trento_web/views/v1/suse_manager_view.ex
+++ b/lib/trento_web/views/v1/suse_manager_view.ex
@@ -62,4 +62,47 @@ defmodule TrentoWeb.V1.SUSEManagerView do
       }
 
   def render("patches_for_packages.json", %{patches: patches}), do: %{patches: patches}
+
+  def render("errata_details.json", %{
+        errata_details: %{
+          id: id,
+          issue_date: issue_date,
+          update_date: update_date,
+          last_modified_date: last_modified_date,
+          synopsis: synopsis,
+          release: release,
+          advisory_status: advisory_status,
+          vendor_advisory: vendor_advisory,
+          type: type,
+          product: product,
+          errataFrom: errataFrom,
+          topic: topic,
+          description: description,
+          references: references,
+          notes: notes,
+          solution: solution,
+          reboot_suggested: reboot_suggested,
+          restart_suggested: restart_suggested
+        }
+      }),
+      do: %{
+        id: id,
+        issue_date: issue_date,
+        update_date: update_date,
+        last_modified_date: last_modified_date,
+        synopsis: synopsis,
+        release: release,
+        advisory_status: advisory_status,
+        vendor_advisory: vendor_advisory,
+        type: type,
+        product: product,
+        errataFrom: errataFrom,
+        topic: topic,
+        description: description,
+        references: references,
+        notes: notes,
+        solution: solution,
+        reboot_suggested: reboot_suggested,
+        restart_suggested: restart_suggested
+      }
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -951,12 +951,22 @@ defmodule Trento.Factory do
 
   def errata_details_factory do
     %{
-      type: AdvisoryType.values() |> Faker.Util.pick() |> Atom.to_string(),
-      synopsis: Faker.Lorem.sentence(),
+      id: Enum.random(1..65_536),
       issue_date: 30 |> Faker.Date.backward() |> Date.to_string(),
       update_date: 30 |> Faker.Date.backward() |> Date.to_string(),
       last_modified_date: 30 |> Faker.Date.backward() |> Date.to_string(),
+      synopsis: Faker.Lorem.sentence(),
+      release: Enum.random(1..256),
       advisory_status: "stable",
+      vendor_advisory: Faker.Lorem.word(),
+      type: Faker.Beer.name(),
+      product: Faker.StarWars.character(),
+      errataFrom: Faker.Lorem.word(),
+      topic: Faker.StarWars.planet(),
+      description: Faker.Lorem.sentence(),
+      references: Faker.Lorem.sentence(),
+      notes: Faker.Lorem.sentence(),
+      solution: Faker.Lorem.sentence(),
       reboot_suggested: Faker.Util.pick([true, false]),
       restart_suggested: Faker.Util.pick([true, false])
     }

--- a/test/trento_web/controllers/v1/suse_manager_controller_test.exs
+++ b/test/trento_web/controllers/v1/suse_manager_controller_test.exs
@@ -146,13 +146,53 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
       insert_software_updates_settings()
 
       advisory_name = Faker.Pokemon.name()
-      errata_details = build(:errata_details)
+
+      %{
+        id: id,
+        issue_date: issue_date,
+        update_date: update_date,
+        last_modified_date: last_modified_date,
+        synopsis: synopsis,
+        release: release,
+        advisory_status: advisory_status,
+        vendor_advisory: vendor_advisory,
+        type: type,
+        product: product,
+        errataFrom: errata_from,
+        topic: topic,
+        description: description,
+        references: references,
+        notes: notes,
+        solution: solution,
+        reboot_suggested: reboot_suggested,
+        restart_suggested: restart_suggested
+      } = errata_details = build(:errata_details)
 
       expect(Trento.SoftwareUpdates.Discovery.Mock, :get_errata_details, 1, fn _ ->
         {:ok, errata_details}
       end)
 
-      resp = struct(ErrataDetailsResponse, errata_details)
+      resp =
+        struct(ErrataDetailsResponse, %{
+          id: id,
+          issue_date: issue_date,
+          update_date: update_date,
+          last_modified_date: last_modified_date,
+          synopsis: synopsis,
+          release: release,
+          advisory_status: advisory_status,
+          vendor_advisory: vendor_advisory,
+          type: type,
+          product: product,
+          errata_from: errata_from,
+          topic: topic,
+          description: description,
+          references: references,
+          notes: notes,
+          solution: solution,
+          reboot_suggested: reboot_suggested,
+          restart_suggested: restart_suggested
+        })
 
       ^resp =
         conn

--- a/test/trento_web/controllers/v1/suse_manager_controller_test.exs
+++ b/test/trento_web/controllers/v1/suse_manager_controller_test.exs
@@ -147,21 +147,51 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
 
       advisory_name = Faker.Pokemon.name()
 
-      %{errataFrom: errata_from} = errata_details = build(:errata_details)
+      %{
+        id: id,
+        issue_date: issue_date,
+        update_date: update_date,
+        last_modified_date: last_modified_date,
+        synopsis: synopsis,
+        release: release,
+        advisory_status: advisory_status,
+        vendor_advisory: vendor_advisory,
+        type: type,
+        product: product,
+        errataFrom: errata_from,
+        topic: topic,
+        description: description,
+        references: references,
+        notes: notes,
+        solution: solution,
+        reboot_suggested: reboot_suggested,
+        restart_suggested: restart_suggested
+      } = errata_details = build(:errata_details)
 
       expect(Trento.SoftwareUpdates.Discovery.Mock, :get_errata_details, 1, fn _ ->
         {:ok, errata_details}
       end)
 
-      resp =
-        struct(
-          ErrataDetailsResponse,
-          errata_details
-          |> Map.drop([:errataFrom])
-          |> Map.put(:errata_from, errata_from)
-        )
-
-      ^resp =
+      %ErrataDetailsResponse{
+        id: ^id,
+        issue_date: ^issue_date,
+        update_date: ^update_date,
+        last_modified_date: ^last_modified_date,
+        synopsis: ^synopsis,
+        release: ^release,
+        advisory_status: ^advisory_status,
+        vendor_advisory: ^vendor_advisory,
+        type: ^type,
+        product: ^product,
+        errata_from: ^errata_from,
+        topic: ^topic,
+        description: ^description,
+        references: ^references,
+        notes: ^notes,
+        solution: ^solution,
+        reboot_suggested: ^reboot_suggested,
+        restart_suggested: ^restart_suggested
+      } =
         conn
         |> get("/api/v1/software_updates/errata_details/#{advisory_name}")
         |> json_response(:ok)

--- a/test/trento_web/controllers/v1/suse_manager_controller_test.exs
+++ b/test/trento_web/controllers/v1/suse_manager_controller_test.exs
@@ -147,52 +147,19 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
 
       advisory_name = Faker.Pokemon.name()
 
-      %{
-        id: id,
-        issue_date: issue_date,
-        update_date: update_date,
-        last_modified_date: last_modified_date,
-        synopsis: synopsis,
-        release: release,
-        advisory_status: advisory_status,
-        vendor_advisory: vendor_advisory,
-        type: type,
-        product: product,
-        errataFrom: errata_from,
-        topic: topic,
-        description: description,
-        references: references,
-        notes: notes,
-        solution: solution,
-        reboot_suggested: reboot_suggested,
-        restart_suggested: restart_suggested
-      } = errata_details = build(:errata_details)
+      %{errataFrom: errata_from} = errata_details = build(:errata_details)
 
       expect(Trento.SoftwareUpdates.Discovery.Mock, :get_errata_details, 1, fn _ ->
         {:ok, errata_details}
       end)
 
       resp =
-        struct(ErrataDetailsResponse, %{
-          id: id,
-          issue_date: issue_date,
-          update_date: update_date,
-          last_modified_date: last_modified_date,
-          synopsis: synopsis,
-          release: release,
-          advisory_status: advisory_status,
-          vendor_advisory: vendor_advisory,
-          type: type,
-          product: product,
-          errata_from: errata_from,
-          topic: topic,
-          description: description,
-          references: references,
-          notes: notes,
-          solution: solution,
-          reboot_suggested: reboot_suggested,
-          restart_suggested: restart_suggested
-        })
+        struct(
+          ErrataDetailsResponse,
+          errata_details
+          |> Map.drop([:errataFrom])
+          |> Map.put(:errata_from, errata_from)
+        )
 
       ^resp =
         conn

--- a/test/trento_web/views/v1/suse_manager_view_test.exs
+++ b/test/trento_web/views/v1/suse_manager_view_test.exs
@@ -33,7 +33,7 @@ defmodule TrentoWeb.V1.SUSEManagerViewTest do
         vendor_advisory: vendor_advisory,
         type: type,
         product: product,
-        errataFrom: errataFrom,
+        errataFrom: errata_from,
         topic: topic,
         description: description,
         references: references,
@@ -41,9 +41,28 @@ defmodule TrentoWeb.V1.SUSEManagerViewTest do
         solution: solution,
         reboot_suggested: reboot_suggested,
         restart_suggested: restart_suggested
-      } = errata_details = build(:errata_details)
+      } = build(:errata_details)
 
-      assert errata_details ==
+      assert %{
+               id: id,
+               issue_date: issue_date,
+               update_date: update_date,
+               last_modified_date: last_modified_date,
+               synopsis: synopsis,
+               release: release,
+               advisory_status: advisory_status,
+               vendor_advisory: vendor_advisory,
+               type: type,
+               product: product,
+               errata_from: errata_from,
+               topic: topic,
+               description: description,
+               references: references,
+               notes: notes,
+               solution: solution,
+               reboot_suggested: reboot_suggested,
+               restart_suggested: restart_suggested
+             } ==
                render(SUSEManagerView, "errata_details.json", %{
                  errata_details: %{
                    id: id,
@@ -56,7 +75,7 @@ defmodule TrentoWeb.V1.SUSEManagerViewTest do
                    vendor_advisory: vendor_advisory,
                    type: type,
                    product: product,
-                   errataFrom: errataFrom,
+                   errataFrom: errata_from,
                    topic: topic,
                    description: description,
                    references: references,

--- a/test/trento_web/views/v1/suse_manager_view_test.exs
+++ b/test/trento_web/views/v1/suse_manager_view_test.exs
@@ -22,68 +22,14 @@ defmodule TrentoWeb.V1.SUSEManagerViewTest do
 
   describe "renders errata_details.json" do
     test "should render relevant fields" do
-      %{
-        id: id,
-        issue_date: issue_date,
-        update_date: update_date,
-        last_modified_date: last_modified_date,
-        synopsis: synopsis,
-        release: release,
-        advisory_status: advisory_status,
-        vendor_advisory: vendor_advisory,
-        type: type,
-        product: product,
-        errataFrom: errata_from,
-        topic: topic,
-        description: description,
-        references: references,
-        notes: notes,
-        solution: solution,
-        reboot_suggested: reboot_suggested,
-        restart_suggested: restart_suggested
-      } = build(:errata_details)
+      %{errataFrom: errata_from} = errata_details = build(:errata_details)
 
-      assert %{
-               id: id,
-               issue_date: issue_date,
-               update_date: update_date,
-               last_modified_date: last_modified_date,
-               synopsis: synopsis,
-               release: release,
-               advisory_status: advisory_status,
-               vendor_advisory: vendor_advisory,
-               type: type,
-               product: product,
-               errata_from: errata_from,
-               topic: topic,
-               description: description,
-               references: references,
-               notes: notes,
-               solution: solution,
-               reboot_suggested: reboot_suggested,
-               restart_suggested: restart_suggested
-             } ==
+      errata_details_sans_errata_from = Map.delete(errata_details, :errataFrom)
+
+      assert Map.put(errata_details_sans_errata_from, :errata_from, errata_from) ==
                render(SUSEManagerView, "errata_details.json", %{
-                 errata_details: %{
-                   id: id,
-                   issue_date: issue_date,
-                   update_date: update_date,
-                   last_modified_date: last_modified_date,
-                   synopsis: synopsis,
-                   release: release,
-                   advisory_status: advisory_status,
-                   vendor_advisory: vendor_advisory,
-                   type: type,
-                   product: product,
-                   errataFrom: errata_from,
-                   topic: topic,
-                   description: description,
-                   references: references,
-                   notes: notes,
-                   solution: solution,
-                   reboot_suggested: reboot_suggested,
-                   restart_suggested: restart_suggested
-                 }
+                 errata_details:
+                   Map.put(errata_details_sans_errata_from, :errataFrom, errata_from)
                })
     end
   end

--- a/test/trento_web/views/v1/suse_manager_view_test.exs
+++ b/test/trento_web/views/v1/suse_manager_view_test.exs
@@ -19,4 +19,53 @@ defmodule TrentoWeb.V1.SUSEManagerViewTest do
                })
     end
   end
+
+  describe "renders errata_details.json" do
+    test "should render relevant fields" do
+      %{
+        id: id,
+        issue_date: issue_date,
+        update_date: update_date,
+        last_modified_date: last_modified_date,
+        synopsis: synopsis,
+        release: release,
+        advisory_status: advisory_status,
+        vendor_advisory: vendor_advisory,
+        type: type,
+        product: product,
+        errataFrom: errataFrom,
+        topic: topic,
+        description: description,
+        references: references,
+        notes: notes,
+        solution: solution,
+        reboot_suggested: reboot_suggested,
+        restart_suggested: restart_suggested
+      } = errata_details = build(:errata_details)
+
+      assert errata_details ==
+               render(SUSEManagerView, "errata_details.json", %{
+                 errata_details: %{
+                   id: id,
+                   issue_date: issue_date,
+                   update_date: update_date,
+                   last_modified_date: last_modified_date,
+                   synopsis: synopsis,
+                   release: release,
+                   advisory_status: advisory_status,
+                   vendor_advisory: vendor_advisory,
+                   type: type,
+                   product: product,
+                   errataFrom: errataFrom,
+                   topic: topic,
+                   description: description,
+                   references: references,
+                   notes: notes,
+                   solution: solution,
+                   reboot_suggested: reboot_suggested,
+                   restart_suggested: restart_suggested
+                 }
+               })
+    end
+  end
 end


### PR DESCRIPTION
# Description

This PR adds an endpoint that allows the user to retrieve errata details for a given advisory name.

## How was this tested?

Units tests added.
