### PR TITLE
Use css style on component testing

### DIFF
--- a/assets/js/common/Tooltip/Tooltip.test.jsx
+++ b/assets/js/common/Tooltip/Tooltip.test.jsx
@@ -84,4 +84,25 @@ describe('Tooltip', () => {
       expect(screen.queryByText('This is my tooltip text')).toBeNull()
     );
   });
+
+  it('should hide the text when the mouse go away', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <div>
+        <Tooltip content="This is my tooltip text">This is my anchor</Tooltip>
+      </div>
+    );
+
+    expect(screen.queryByText('This is my tooltip text')).toBeNull();
+
+    await act(async () => user.hover(screen.queryByText('This is my anchor')));
+    await act(async () =>
+      user.unhover(screen.queryByText('This is my anchor'))
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByText('This is my tooltip text')).not.toBeVisible()
+    );
+  });
 });

--- a/assets/js/common/Tooltip/Tooltip.test.jsx
+++ b/assets/js/common/Tooltip/Tooltip.test.jsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
 import Tooltip from '.';
+import { WithStyle } from '../../lib/test-utils/ui';
 
 describe('Tooltip', () => {
   it('should show a text when mouse is hovering', async () => {
@@ -89,9 +90,11 @@ describe('Tooltip', () => {
     const user = userEvent.setup();
 
     render(
-      <div>
-        <Tooltip content="This is my tooltip text">This is my anchor</Tooltip>
-      </div>
+      <WithStyle>
+        <div>
+          <Tooltip content="This is my tooltip text">This is my anchor</Tooltip>
+        </div>
+      </WithStyle>
     );
 
     expect(screen.queryByText('This is my tooltip text')).toBeNull();

--- a/assets/js/lib/test-utils/ui/index.jsx
+++ b/assets/js/lib/test-utils/ui/index.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const css = require('fs').readFileSync(
+  `${__dirname}/../../../../../priv/static/assets/app.css`,
+  'utf8'
+);
+
+/**
+ * Prepend the application global css in a <style> element.
+ * It's meant to be used in component testing when css classes must be resolved.
+ *
+ * @example
+ *
+ * render(
+ *   <WithStyle>
+ *     <Elem />
+ *   </WithStyle>
+ * );
+ */
+export function WithStyle({ children }) {
+  return (
+    <>
+      <style>{css}</style>
+      {children}
+    </>
+  );
+}

--- a/assets/package.json
+++ b/assets/package.json
@@ -87,6 +87,7 @@
     "lint": "eslint . --ext js,jsx",
     "format:check": "prettier -c .",
     "format": "prettier --write .",
+    "pretest": "ls ../priv/static/assets/app.css || npm run tailwind:build",
     "test": "jest",
     "chromatic": "npx chromatic --exit-zero-on-changes"
   }


### PR DESCRIPTION
# Description

Some component tests rely on css class in order to determine the component properties. For example in https://github.com/trento-project/web/commit/56a978b615e4cdd191f5ddd37500d57ff262d293 the `toBeVisible()` matcher   look for style `display: none` to be applied to the element or one of its parents.

This PR proposes the `<WithStyle>` test utility. `<WithStyle>` is a higher-order component that prepends the application css to the component to be rendered. It's meant to be used only on tests that require such ability (for keeping the test footprint small).

In order to work the application css must be built already, thus a `pretest` script is added to package.json. 
~Furthermore, the package.json has been refactored a bit to make use of npm variables (not required, it can be reverted).~
