### PR TITLE
Activity log retention time endpoint

### DIFF
--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -164,6 +164,11 @@ defmodule TrentoWeb.FallbackController do
     |> put_status(:unprocessable_entity)
     |> put_view(ErrorView)
     |> render(:"422", reason: "TOTP code not valid for the enrollment procedure.")
+  def call(conn, {:error, :activity_log_settings_not_configured}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(ErrorView)
+    |> render(:"422", reason: "Activity Log Settings must be set up before being updated.")
   end
 
   def call(conn, {:error, [error | _]}), do: call(conn, {:error, error})

--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -164,6 +164,8 @@ defmodule TrentoWeb.FallbackController do
     |> put_status(:unprocessable_entity)
     |> put_view(ErrorView)
     |> render(:"422", reason: "TOTP code not valid for the enrollment procedure.")
+  end
+
   def call(conn, {:error, :activity_log_settings_not_configured}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/lib/trento_web/controllers/v1/settings_controller.ex
+++ b/lib/trento_web/controllers/v1/settings_controller.ex
@@ -108,7 +108,7 @@ defmodule TrentoWeb.V1.SettingsController do
     ]
 
   def update_activity_log_settings(%{body_params: body_params} = conn, _) do
-    %{retention_period: retention_period, retention_period_unit: retention_period_unit} =
+    %{retention_time: %{value: retention_period, unit: retention_period_unit}} =
       body_params
 
     with {:ok, updated_settings} <-

--- a/lib/trento_web/controllers/v1/settings_controller.ex
+++ b/lib/trento_web/controllers/v1/settings_controller.ex
@@ -137,6 +137,10 @@ defmodule TrentoWeb.V1.SettingsController do
         })
 
       _ ->
+        # Here we rebind the error returned by the ActivityLog.get_settings/0 function
+        # to a "not_found" in order to disambiguate from a similar error being returned by the
+        # ActivityLog.change_retention_period/2 function. This error gets picked up by the FallbackController
+        # and leads to dispatching to the appropriate error response.
         {:error, :not_found}
     end
   end

--- a/lib/trento_web/controllers/v1/settings_controller.ex
+++ b/lib/trento_web/controllers/v1/settings_controller.ex
@@ -118,8 +118,8 @@ defmodule TrentoWeb.V1.SettingsController do
           activity_log_settings: updated_settings
         })
 
-      _ ->
-        {:error, :unprocessable_entity}
+      error ->
+        error
     end
   end
 
@@ -134,8 +134,6 @@ defmodule TrentoWeb.V1.SettingsController do
          Schema.Platform.ActivityLogSettings},
       not_found: Schema.NotFound.response()
     ]
-
-  require Logger
 
   def get_activity_log_settings(conn, _) do
     case ActivityLog.get_settings() do

--- a/lib/trento_web/controllers/v1/settings_controller.ex
+++ b/lib/trento_web/controllers/v1/settings_controller.ex
@@ -111,14 +111,11 @@ defmodule TrentoWeb.V1.SettingsController do
     %{retention_period: retention_period, retention_period_unit: retention_period_unit} =
       body_params
 
-    case ActivityLog.change_retention_period(retention_period, retention_period_unit) do
-      {:ok, updated_settings} ->
-        render(conn, "activity_log_settings.json", %{
-          activity_log_settings: updated_settings
-        })
-
-      error ->
-        error
+    with {:ok, updated_settings} <-
+           ActivityLog.change_retention_period(retention_period, retention_period_unit) do
+      render(conn, "activity_log_settings.json", %{
+        activity_log_settings: updated_settings
+      })
     end
   end
 

--- a/lib/trento_web/controllers/v1/settings_controller.ex
+++ b/lib/trento_web/controllers/v1/settings_controller.ex
@@ -104,8 +104,7 @@ defmodule TrentoWeb.V1.SettingsController do
       ok:
         {"Activity Log settings saved successfully", "application/json",
          Schema.Platform.ActivityLogSettings},
-      unprocessable_entity: Schema.UnprocessableEntity.response(),
-      not_found: Schema.NotFound.response()
+      unprocessable_entity: Schema.UnprocessableEntity.response()
     ]
 
   def update_activity_log_settings(%{body_params: body_params} = conn, _) do
@@ -126,8 +125,6 @@ defmodule TrentoWeb.V1.SettingsController do
   operation :get_activity_log_settings,
     summary: "Fetches the Activity Log settings",
     tags: ["Platform"],
-    request_body:
-      {"ActivityLogSettings", "application/json", Schema.Platform.ActivityLogSettings},
     responses: [
       ok:
         {"Activity Log settings fetched successfully", "application/json",

--- a/lib/trento_web/openapi/v1/schema/platform.ex
+++ b/lib/trento_web/openapi/v1/schema/platform.ex
@@ -100,6 +100,32 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Platform do
     })
   end
 
+  defmodule RetentionTimeSettings do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "RetentionTimeSettings",
+      description: "Retention Time settings of the Activity Log",
+      type: :object,
+      additionalProperties: false,
+      properties: %{
+        value: %Schema{
+          type: :integer,
+          description:
+            "The integer retention duration, that is used in conjunction with the retention time unit.",
+          minimum: 1
+        },
+        unit: %Schema{
+          type: :string,
+          description:
+            "The retention duration unit, that is used in conjunction with the retention time period.",
+          enum: [:days, :weeks, :months, :years]
+        }
+      },
+      required: [:value, :unit]
+    })
+  end
+
   defmodule ActivityLogSettings do
     @moduledoc false
 
@@ -109,20 +135,9 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Platform do
       type: :object,
       additionalProperties: false,
       properties: %{
-        retention_period: %Schema{
-          type: :integer,
-          description:
-            "The integer retention duration, that is used in conjunction with the retention time unit.",
-          minimum: 1
-        },
-        retention_period_unit: %Schema{
-          type: :string,
-          description:
-            "The retention duration unit, that is used in conjunction with the retention time period.",
-          enum: [:days, :weeks, :months, :years]
-        }
+        retention_time: RetentionTimeSettings
       },
-      required: [:retention_period, :retention_period_unit]
+      required: [:retention_time]
     })
   end
 end

--- a/lib/trento_web/openapi/v1/schema/platform.ex
+++ b/lib/trento_web/openapi/v1/schema/platform.ex
@@ -99,4 +99,30 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Platform do
       }
     })
   end
+
+  defmodule ActivityLogSettings do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "ActivityLogSettings",
+      description: "Activity Log settings of the current installation",
+      type: :object,
+      additionalProperties: false,
+      properties: %{
+        retention_period: %Schema{
+          type: :integer,
+          description:
+            "The integer retention duration, that is used in conjunction with the retention time unit.",
+          minimum: 1
+        },
+        retention_period_unit: %Schema{
+          type: :string,
+          description:
+            "The retention duration unit, that is used in conjunction with the retention time period.",
+          enum: [:days, :weeks, :months, :years]
+        }
+      },
+      required: [:retention_period, :retention_period_unit]
+    })
+  end
 end

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -163,6 +163,10 @@ defmodule TrentoWeb.Router do
         get "/api_key", SettingsController, :get_api_key_settings
         patch "/api_key", SettingsController, :update_api_key_settings
 
+        # Activity Log Settings
+        put "/activity_log", SettingsController, :update_activity_log_settings
+        get "/activity_log", SettingsController, :get_activity_log_settings
+
         if Application.compile_env!(:trento, :suse_manager_enabled) do
           scope "/suma_credentials" do
             resources "/", SUMACredentialsController,

--- a/lib/trento_web/views/v1/settings_view.ex
+++ b/lib/trento_web/views/v1/settings_view.ex
@@ -27,12 +27,15 @@ defmodule TrentoWeb.V1.SettingsView do
     }
   end
 
-  def render("activity_log_settings.json", %{
-        activity_log_settings: %{retention_time: %{value: value, unit: unit}}
-      }) do
+  def render(
+        "activity_log_settings.json",
+        %{activity_log_settings: %{retention_time: %{value: value, unit: unit}}}
+      ) do
     %{
-      retention_period: value,
-      retention_period_unit: unit
+      retention_time: %{
+        value: value,
+        unit: unit
+      }
     }
   end
 end

--- a/lib/trento_web/views/v1/settings_view.ex
+++ b/lib/trento_web/views/v1/settings_view.ex
@@ -26,4 +26,13 @@ defmodule TrentoWeb.V1.SettingsView do
       expire_at: expire_at
     }
   end
+
+  def render("activity_log_settings.json", %{
+        activity_log_settings: %{retention_time: %{value: value, unit: unit}}
+      }) do
+    %{
+      retention_period: value,
+      retention_period_unit: unit
+    }
+  end
 end

--- a/test/trento_web/controllers/v1/settings_controller_test.exs
+++ b/test/trento_web/controllers/v1/settings_controller_test.exs
@@ -145,8 +145,10 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
       conn
       |> put_req_header("content-type", "application/json")
       |> put("/api/v1/settings/activity_log", %{
-        retention_period: 42,
-        retention_period_unit: :years
+        retention_time: %{
+          value: 42,
+          unit: :years
+        }
       })
       |> json_response(200)
       |> assert_schema("ActivityLogSettings", api_spec)
@@ -157,8 +159,10 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
       conn
       |> put_req_header("content-type", "application/json")
       |> put("/api/v1/settings/activity_log", %{
-        retention_period: 42,
-        retention_period_unit: :years
+        retention_time: %{
+          value: 42,
+          unit: :years
+        }
       })
       |> json_response(422)
       |> assert_schema("UnprocessableEntity", api_spec)

--- a/test/trento_web/controllers/v1/settings_controller_test.exs
+++ b/test/trento_web/controllers/v1/settings_controller_test.exs
@@ -110,4 +110,46 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
       assert expire_year == expected_infinite_year
     end
   end
+
+  describe "ActivityLogSettings" do
+    setup do
+      %{api_spec: ApiSpec.spec()}
+    end
+
+    test "should return activity retention settings after setting up", %{
+      conn: conn,
+      api_spec: api_spec
+    } do
+      insert(:activity_log_settings)
+
+      conn
+      |> get("/api/v1/settings/activity_log")
+      |> json_response(200)
+      |> assert_schema("ActivityLogSettings", api_spec)
+    end
+
+    test "should not return activity retention settings without setting up", %{
+      conn: conn,
+      api_spec: api_spec
+    } do
+      conn
+      |> get("/api/v1/settings/activity_log")
+      |> json_response(404)
+      |> assert_schema("NotFound", api_spec)
+    end
+
+    test "should update the activity log settings if it is configured returning the updated settings",
+         %{conn: conn, api_spec: api_spec} do
+      insert(:activity_log_settings)
+
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> put("/api/v1/settings/activity_log", %{
+        retention_period: 42,
+        retention_period_unit: :years
+      })
+      |> json_response(200)
+      |> assert_schema("ActivityLogSettings", api_spec)
+    end
+  end
 end

--- a/test/trento_web/controllers/v1/settings_controller_test.exs
+++ b/test/trento_web/controllers/v1/settings_controller_test.exs
@@ -151,5 +151,17 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
       |> json_response(200)
       |> assert_schema("ActivityLogSettings", api_spec)
     end
+
+    test "should not update the activity log settings if it is not already configured",
+         %{conn: conn, api_spec: api_spec} do
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> put("/api/v1/settings/activity_log", %{
+        retention_period: 42,
+        retention_period_unit: :years
+      })
+      |> json_response(422)
+      |> assert_schema("UnprocessableEntity", api_spec)
+    end
   end
 end


### PR DESCRIPTION
# Description

Implements an endpoint for getting and updating activity log retention time settings.

## Did you add the right label?

Yes.

## How was this tested?

Unit tests.
