### PR TITLE
Improve tag validation msg show up

### DIFF
--- a/assets/js/common/Tags/Tags.jsx
+++ b/assets/js/common/Tags/Tags.jsx
@@ -40,7 +40,10 @@ function Tags({
     setTags(tags);
   }, [tags]);
 
-  useOnClickOutside(inputRef, () => setAddingTag(false));
+  useOnClickOutside(inputRef, () => {
+    setAddingTag(false);
+    setShowValidationTooltip(false);
+  });
 
   return (
     <span

--- a/assets/js/common/Tags/Tags.test.jsx
+++ b/assets/js/common/Tags/Tags.test.jsx
@@ -31,4 +31,32 @@ describe('Tags', () => {
     // Being the css is not loaded, it cannot be detected by js-dom
     // await waitFor(() => expect(screen.queryByText(msg)).not.toBeVisible());
   });
+
+  it('should not show validation message when focusing back on the same tag', async () => {
+    const user = userEvent.setup();
+    const msg = 'invalid character';
+
+    render(
+      <>
+        <div>sibling</div>
+        <Tags tags={[]} validationMessage={msg} />
+      </>
+    );
+
+    expect(screen.queryByText(msg)).toBeNull();
+
+    await act(async () => user.click(screen.queryByText('Add Tag')));
+
+    await act(async () => userEvent.keyboard('>'));
+
+    await waitFor(() => expect(screen.queryByText(msg)).toBeVisible());
+
+    await act(async () => user.click(screen.queryByText('sibling')));
+
+    await waitFor(() => expect(screen.queryByText(msg)).toBeNull());
+
+    await act(async () => user.click(screen.queryByText('Add Tag')));
+
+    await waitFor(() => expect(screen.queryByText(msg)).toBeNull());
+  });
 });


### PR DESCRIPTION
# Description

Currently the validation message of a tag is kept between interactions with the same tag, which might be misleading.

https://github.com/trento-project/web/assets/8167114/6dbc6cc6-2f13-42cf-89da-78f06c4fa390

This PR makes sure that the state determining whether a validation message needs to be show is reset between tag interactions.

Just OCD :see_no_evil: 

## How was this tested?

Jest