### PR TITLE
Singularize Activity Log retention period unit

### DIFF
--- a/lib/trento/activity_logging/retention_period_unit.ex
+++ b/lib/trento/activity_logging/retention_period_unit.ex
@@ -3,5 +3,5 @@ defmodule Trento.ActivityLog.RetentionPeriodUnit do
   Type that represents the possible retention period units.
   """
 
-  use Trento.Support.Enum, values: [:days, :weeks, :months, :years]
+  use Trento.Support.Enum, values: [:day, :week, :month, :year]
 end

--- a/lib/trento/activity_logging/retention_time.ex
+++ b/lib/trento/activity_logging/retention_time.ex
@@ -32,7 +32,7 @@ defmodule Trento.ActivityLog.RetentionTime do
   def default do
     %RetentionTime{
       value: 1,
-      unit: RetentionPeriodUnit.months()
+      unit: RetentionPeriodUnit.month()
     }
   end
 end

--- a/lib/trento_web/openapi/v1/schema/platform.ex
+++ b/lib/trento_web/openapi/v1/schema/platform.ex
@@ -119,7 +119,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Platform do
           type: :string,
           description:
             "The retention duration unit, that is used in conjunction with the retention time period.",
-          enum: [:days, :weeks, :months, :years]
+          enum: [:day, :week, :month, :year]
         }
       },
       required: [:value, :unit]

--- a/test/trento/activity_log_test.exs
+++ b/test/trento/activity_log_test.exs
@@ -41,7 +41,7 @@ defmodule Trento.ActivityLogTest do
   describe "changing activity log settings" do
     test "should not be able to change retention time if no activity log settings were previously saved" do
       assert {:error, :activity_log_settings_not_configured} ==
-               ActivityLog.change_retention_period(42, RetentionPeriodUnit.days())
+               ActivityLog.change_retention_period(42, RetentionPeriodUnit.day())
     end
 
     @validation_scenarios [
@@ -104,22 +104,22 @@ defmodule Trento.ActivityLogTest do
       %{
         name: "days",
         value: 1,
-        unit: RetentionPeriodUnit.days()
+        unit: RetentionPeriodUnit.day()
       },
       %{
         name: "weeks",
         value: 3,
-        unit: RetentionPeriodUnit.weeks()
+        unit: RetentionPeriodUnit.week()
       },
       %{
         name: "months",
         value: 5,
-        unit: RetentionPeriodUnit.months()
+        unit: RetentionPeriodUnit.month()
       },
       %{
         name: "years",
         value: 7,
-        unit: RetentionPeriodUnit.years()
+        unit: RetentionPeriodUnit.year()
       }
     ]
 
@@ -130,7 +130,7 @@ defmodule Trento.ActivityLogTest do
         insert(:activity_log_settings,
           retention_time: %{
             value: 92,
-            unit: RetentionPeriodUnit.years()
+            unit: RetentionPeriodUnit.year()
           }
         )
 
@@ -155,7 +155,7 @@ defmodule Trento.ActivityLogTest do
 
     test "should successfully handle unchanging retention periods" do
       initial_retention_period = 42
-      initial_retention_period_unit = RetentionPeriodUnit.days()
+      initial_retention_period_unit = RetentionPeriodUnit.day()
 
       insert(:activity_log_settings,
         retention_time: %{

--- a/test/trento/release_test.exs
+++ b/test/trento/release_test.exs
@@ -17,14 +17,14 @@ defmodule Trento.ReleaseTest do
       assert %ActivityLogSettings{
                retention_time: %RetentionTime{
                  value: 1,
-                 unit: RetentionPeriodUnit.months()
+                 unit: RetentionPeriodUnit.month()
                }
              } = Trento.Repo.one(ActivityLogSettings.base_query())
     end
 
     test "should not change previously saved retention time" do
       value = 3
-      unit = RetentionPeriodUnit.weeks()
+      unit = RetentionPeriodUnit.week()
 
       insert(:activity_log_settings,
         retention_time: %{

--- a/test/trento_web/controllers/v1/settings_controller_test.exs
+++ b/test/trento_web/controllers/v1/settings_controller_test.exs
@@ -147,7 +147,7 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
       |> put("/api/v1/settings/activity_log", %{
         retention_time: %{
           value: 42,
-          unit: :years
+          unit: :year
         }
       })
       |> json_response(200)
@@ -161,7 +161,7 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
       |> put("/api/v1/settings/activity_log", %{
         retention_time: %{
           value: 42,
-          unit: :years
+          unit: :year
         }
       })
       |> json_response(422)


### PR DESCRIPTION
# Description

Using singulars for retention time period unit.

Could be beneficial for this https://github.com/trento-project/web/pull/2706#discussion_r1651028091