### PR TITLE
Set python3 as ansible interpreter

### DIFF
--- a/.github/workflows/pr_env.yaml
+++ b/.github/workflows/pr_env.yaml
@@ -88,6 +88,7 @@ jobs:
             all:
               vars:
                 ansible_user: ec2-user
+                ansible_python_interpreter: /usr/bin/python3
               children:
                 trento-server:
                   hosts:

--- a/.github/workflows/pr_env.yaml
+++ b/.github/workflows/pr_env.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
   check_env_creation_privilege:
     name: Check if the environment creation criteria are met, store in the job output
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       create_env: ${{ steps.check.outputs.create_env }}
     steps:
@@ -25,7 +25,7 @@ jobs:
   build-and-push-pr-image:
     needs: check_env_creation_privilege
     name: Build and push pull request container image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: needs.check_env_creation_privilege.outputs.create_env == 'true'
     permissions:
       contents: read
@@ -66,7 +66,7 @@ jobs:
 
   create_pr_environment:
     name: Create or update the pr environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: build-and-push-pr-image
     env:
       PR_BASE_URL: ${{ github.event.pull_request.number }}.prenv.trento.suse.com


### PR DESCRIPTION
# Description

Fix ansible interpreter version usage and pin ubuntu version.
The issue is that azure has pushed a new version of the `ubuntu-22.04` version that upgrades ansible to 2.17.0, which I think makes the playbook execution fail as they have dropped python 3.6 support (which we have in the PR env machine). Before we were using 2.16.7.
And we cannot choose the exact image version, so going to 20.04 fixes the issue.

This aims to fix this error: https://github.com/trento-project/web/actions/runs/9662207405/job/26652127841#step:4:74
