### PR TITLE
Navigate on sap system deregistration

### DIFF
--- a/assets/js/lib/test-utils/index.jsx
+++ b/assets/js/lib/test-utils/index.jsx
@@ -72,13 +72,19 @@ export function renderWithRouterMatch(ui, { path = '/', route = '/' } = {}) {
   };
 }
 
-export async function recordSaga(saga, initialAction, state = {}) {
+export async function recordSaga(
+  saga,
+  initialAction,
+  state = {},
+  context = {}
+) {
   const dispatched = [];
 
   await runSaga(
     {
       dispatch: (action) => dispatched.push(action),
       getState: () => state,
+      context,
     },
     saga,
     initialAction

--- a/assets/js/state/index.js
+++ b/assets/js/state/index.js
@@ -16,26 +16,34 @@ import softwareUpdatesReducer from './softwareUpdates';
 import softwareUpdatesSettingsReducer from './softwareUpdatesSettings';
 import rootSaga from './sagas';
 
-const sagaMiddleware = createSagaMiddleware();
+export const createStore = (router) => {
+  const sagaMiddleware = createSagaMiddleware({
+    context: {
+      router,
+    },
+  });
 
-export const store = configureStore({
-  reducer: {
-    sapSystemsHealthSummary: sapSystemsHealthSummaryReducer,
-    hostsList: hostsListReducer,
-    clustersList: clustersListReducer,
-    checksSelection: checksSelectionReducer,
-    checksResultsFilters: checksResultsFiltersReducer,
-    sapSystemsList: sapSystemListReducer,
-    databasesList: databasesListReducer,
-    catalog: catalogReducer,
-    lastExecutions: lastExecutionsReducer,
-    settings: settingsReducer,
-    user: userReducer,
-    softwareUpdates: softwareUpdatesReducer,
-    softwareUpdatesSettings: softwareUpdatesSettingsReducer,
-  },
-  middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware().concat(sagaMiddleware),
-});
+  const store = configureStore({
+    reducer: {
+      sapSystemsHealthSummary: sapSystemsHealthSummaryReducer,
+      hostsList: hostsListReducer,
+      clustersList: clustersListReducer,
+      checksSelection: checksSelectionReducer,
+      checksResultsFilters: checksResultsFiltersReducer,
+      sapSystemsList: sapSystemListReducer,
+      databasesList: databasesListReducer,
+      catalog: catalogReducer,
+      lastExecutions: lastExecutionsReducer,
+      settings: settingsReducer,
+      user: userReducer,
+      softwareUpdates: softwareUpdatesReducer,
+      softwareUpdatesSettings: softwareUpdatesSettingsReducer,
+    },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware().concat(sagaMiddleware),
+  });
 
-sagaMiddleware.run(rootSaga);
+  sagaMiddleware.run(rootSaga);
+
+  return store;
+};

--- a/assets/js/state/sagas/sapSystems.js
+++ b/assets/js/state/sagas/sapSystems.js
@@ -1,4 +1,4 @@
-import { call, put, select, takeEvery } from 'redux-saga/effects';
+import { call, put, select, takeEvery, getContext } from 'redux-saga/effects';
 import { del } from '@lib/network';
 
 import {
@@ -101,6 +101,11 @@ export function* sapSystemDeregistered({ payload: { id, sid } }) {
       icon: 'ℹ️',
     })
   );
+
+  const router = yield getContext('router');
+  if (router.state.location.pathname === `/sap_systems/${id}`) {
+    yield call(router.navigate, '/sap_systems');
+  }
 }
 
 export function* sapSystemRestored({ payload }) {

--- a/assets/js/state/sagas/sapSystems.test.js
+++ b/assets/js/state/sagas/sapSystems.test.js
@@ -45,11 +45,52 @@ describe('SAP Systems sagas', () => {
   it('should remove the SAP system', async () => {
     const { id, sid } = sapSystemFactory.build();
 
-    const dispatched = await recordSaga(sapSystemDeregistered, {
-      payload: { id, sid },
-    });
+    const router = {
+      state: {
+        location: {
+          pathname: '/home',
+        },
+      },
+    };
+    const context = { router };
+
+    const dispatched = await recordSaga(
+      sapSystemDeregistered,
+      {
+        payload: { id, sid },
+      },
+      {},
+      context
+    );
 
     expect(dispatched).toContainEqual(removeSAPSystem({ id }));
+  });
+
+  it('should remove the SAP system and navigate to overview page', async () => {
+    const { id, sid } = sapSystemFactory.build();
+
+    const mockNavigate = jest.fn();
+    const router = {
+      navigate: mockNavigate,
+      state: {
+        location: {
+          pathname: `/sap_systems/${id}`,
+        },
+      },
+    };
+    const context = { router };
+
+    const dispatched = await recordSaga(
+      sapSystemDeregistered,
+      {
+        payload: { id, sid },
+      },
+      {},
+      context
+    );
+
+    expect(dispatched).toContainEqual(removeSAPSystem({ id }));
+    expect(mockNavigate).toHaveBeenCalledWith('/sap_systems');
   });
 
   it('should restore the SAP system', async () => {

--- a/assets/js/trento.jsx
+++ b/assets/js/trento.jsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 
-import { Routes, Route, BrowserRouter } from 'react-router-dom';
+import {
+  createRoutesFromElements,
+  createBrowserRouter,
+  Route,
+  RouterProvider,
+} from 'react-router-dom';
 
 import { Toaster } from 'react-hot-toast';
 import { Provider } from 'react-redux';
@@ -38,106 +43,95 @@ import { profile } from '@lib/auth';
 import { networkClient } from '@lib/network';
 import { TARGET_CLUSTER, TARGET_HOST } from '@lib/model';
 
-import { store } from './state';
+import { createStore } from './state';
+
+const createRouter = ({ getUser }) =>
+  createBrowserRouter(
+    createRoutesFromElements(
+      <>
+        <Route path="/session/new" element={<Login />} />
+        <Route path="/">
+          <Route
+            element={<Guard redirectPath="/session/new" getUser={getUser} />}
+          >
+            <Route element={<Layout />}>
+              <Route index element={<Home />} />
+              <Route index path="profile" element={<ProfilePage />} />
+              <Route index path="hosts" element={<HostsList />} />
+              <Route
+                path="hosts/:hostID/settings"
+                element={<HostSettingsPage />}
+              />
+              <Route
+                path="hosts/:hostID/saptune"
+                element={<SaptuneDetailsPage />}
+              />
+              <Route path="clusters" element={<ClustersList />} />
+              <Route path="sap_systems" element={<SapSystemsOverviewPage />} />
+              <Route path="databases" element={<DatabasesOverviewPage />} />
+              <Route path="catalog" element={<ChecksCatalogPage />} />
+              <Route path="settings" element={<SettingsPage />} />
+              <Route path="about" element={<AboutPage />} />
+              <Route path="hosts/:hostID" element={<HostDetailsPage />} />
+              <Route path="sap_systems/:id" element={<SapSystemDetails />} />
+              <Route path="databases/:id" element={<DatabaseDetails />} />
+              <Route
+                path="clusters/:clusterID"
+                element={<ClusterDetailsPage />}
+              />
+              <Route
+                path="clusters/:clusterID/settings"
+                element={<ClusterSettingsPage />}
+              />
+              <Route
+                path="clusters/:targetID/executions/last"
+                element={<ExecutionResultsPage targetType={TARGET_CLUSTER} />}
+              />
+              <Route
+                path="hosts/:targetID/executions/last"
+                element={<ExecutionResultsPage targetType={TARGET_HOST} />}
+              />
+              <Route
+                path="clusters/:targetID/executions/last/:checkID/:resultTargetType/:resultTargetName"
+                element={<CheckResultDetailPage targetType={TARGET_CLUSTER} />}
+              />
+              <Route
+                path="hosts/:targetID/executions/last/:checkID/:resultTargetType/:resultTargetName"
+                element={<CheckResultDetailPage targetType={TARGET_HOST} />}
+              />
+              <Route
+                element={
+                  <ForbiddenGuard permitted={['all:users']} outletMode />
+                }
+              >
+                <Route path="users" element={<UsersPage />} />
+                <Route path="users/new" element={<CreateUserPage />} />
+                <Route path="users/:userID/edit" element={<EditUserPage />} />
+              </Route>
+            </Route>
+          </Route>
+        </Route>
+        <Route path="*" element={<NotFound />} />
+      </>
+    )
+  );
 
 function App() {
   const getUser = () => profile(networkClient);
+  const router = createRouter({ getUser });
+  const store = createStore(router);
 
   return (
     <Provider store={store}>
-      <BrowserRouter>
-        <Toaster
-          position="top-right"
-          containerStyle={{ top: 50, zIndex: 99 }}
-        />
-        <ErrorBoundary
-          FallbackComponent={SomethingWentWrong}
-          onReset={() => {
-            store.dispatch({ type: 'RESET_STATE' });
-          }}
-        >
-          <Routes>
-            <Route path="/session/new" element={<Login />} />
-            <Route path="/">
-              <Route
-                element={
-                  <Guard redirectPath="/session/new" getUser={getUser} />
-                }
-              >
-                <Route element={<Layout />}>
-                  <Route index element={<Home />} />
-                  <Route index path="profile" element={<ProfilePage />} />
-                  <Route index path="hosts" element={<HostsList />} />
-                  <Route
-                    path="hosts/:hostID/settings"
-                    element={<HostSettingsPage />}
-                  />
-                  <Route
-                    path="hosts/:hostID/saptune"
-                    element={<SaptuneDetailsPage />}
-                  />
-                  <Route path="clusters" element={<ClustersList />} />
-                  <Route
-                    path="sap_systems"
-                    element={<SapSystemsOverviewPage />}
-                  />
-                  <Route path="databases" element={<DatabasesOverviewPage />} />
-                  <Route path="catalog" element={<ChecksCatalogPage />} />
-                  <Route path="settings" element={<SettingsPage />} />
-                  <Route path="about" element={<AboutPage />} />
-                  <Route path="hosts/:hostID" element={<HostDetailsPage />} />
-                  <Route
-                    path="sap_systems/:id"
-                    element={<SapSystemDetails />}
-                  />
-                  <Route path="databases/:id" element={<DatabaseDetails />} />
-                  <Route
-                    path="clusters/:clusterID"
-                    element={<ClusterDetailsPage />}
-                  />
-                  <Route
-                    path="clusters/:clusterID/settings"
-                    element={<ClusterSettingsPage />}
-                  />
-                  <Route
-                    path="clusters/:targetID/executions/last"
-                    element={
-                      <ExecutionResultsPage targetType={TARGET_CLUSTER} />
-                    }
-                  />
-                  <Route
-                    path="hosts/:targetID/executions/last"
-                    element={<ExecutionResultsPage targetType={TARGET_HOST} />}
-                  />
-                  <Route
-                    path="clusters/:targetID/executions/last/:checkID/:resultTargetType/:resultTargetName"
-                    element={
-                      <CheckResultDetailPage targetType={TARGET_CLUSTER} />
-                    }
-                  />
-                  <Route
-                    path="hosts/:targetID/executions/last/:checkID/:resultTargetType/:resultTargetName"
-                    element={<CheckResultDetailPage targetType={TARGET_HOST} />}
-                  />
-                  <Route
-                    element={
-                      <ForbiddenGuard permitted={['all:users']} outletMode />
-                    }
-                  >
-                    <Route path="users" element={<UsersPage />} />
-                    <Route path="users/new" element={<CreateUserPage />} />
-                    <Route
-                      path="users/:userID/edit"
-                      element={<EditUserPage />}
-                    />
-                  </Route>
-                </Route>
-              </Route>
-            </Route>
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-        </ErrorBoundary>
-      </BrowserRouter>
+      <Toaster position="top-right" />
+      <ErrorBoundary
+        FallbackComponent={SomethingWentWrong}
+        onReset={() => {
+          store.dispatch({ type: 'RESET_STATE' });
+        }}
+      >
+        <RouterProvider router={router} />
+      </ErrorBoundary>
     </Provider>
   );
 }

--- a/assets/js/trento.jsx
+++ b/assets/js/trento.jsx
@@ -6,12 +6,11 @@ import {
   createBrowserRouter,
   Route,
   RouterProvider,
+  Outlet,
 } from 'react-router-dom';
 
 import { Toaster } from 'react-hot-toast';
 import { Provider } from 'react-redux';
-
-import { ErrorBoundary } from 'react-error-boundary';
 
 import AboutPage from '@pages/AboutPage';
 import CheckResultDetailPage from '@pages/ExecutionResults/CheckResultDetail';
@@ -48,7 +47,7 @@ import { createStore } from './state';
 const createRouter = ({ getUser }) =>
   createBrowserRouter(
     createRoutesFromElements(
-      <>
+      <Route element={<RoutesWrapper />} ErrorBoundary={SomethingWentWrong}>
         <Route path="/session/new" element={<Login />} />
         <Route path="/">
           <Route
@@ -112,9 +111,18 @@ const createRouter = ({ getUser }) =>
           </Route>
         </Route>
         <Route path="*" element={<NotFound />} />
-      </>
+      </Route>
     )
   );
+
+function RoutesWrapper() {
+  return (
+    <>
+      <Toaster position="top-right" />
+      <Outlet />
+    </>
+  );
+}
 
 function App() {
   const getUser = () => profile(networkClient);
@@ -123,15 +131,7 @@ function App() {
 
   return (
     <Provider store={store}>
-      <Toaster position="top-right" />
-      <ErrorBoundary
-        FallbackComponent={SomethingWentWrong}
-        onReset={() => {
-          store.dispatch({ type: 'RESET_STATE' });
-        }}
-      >
-        <RouterProvider router={router} />
-      </ErrorBoundary>
+      <RouterProvider router={router} />
     </Provider>
   );
 }


### PR DESCRIPTION
# Description

Navigate to `/sap_systems` from the detail view if the sap system is completely deregistered.
To achieve this, the `router` is added in the sagas context, so we can use the navigation functions there, without passing them to the store (which usually is not a good practice, as functions are not serializable).
Besides that, the redux store is not stored as "global" variable anymore, which was as well not a good practice.

Once this is merged, I will create other PR removing the navigate passing usage in remaining code places.

## How was this tested?

UT added
