### PR TITLE
Add migration and schema for ActivityLog

### DIFF
--- a/lib/trento/activity_logging/activity_log.ex
+++ b/lib/trento/activity_logging/activity_log.ex
@@ -1,0 +1,22 @@
+defmodule Trento.ActivityLog.ActivityLog do
+  @moduledoc """
+  ActivityLog represents an interesting activity that is tracked
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  schema "activity_logs" do
+    field :type, :string
+    field :actor, :string
+    field :metadata, :map
+
+    timestamps(type: :utc_datetime_usec)
+  end
+
+  def changeset(activity_log, attrs) do
+    activity_log
+    |> cast(attrs, __MODULE__.__schema__(:fields))
+    |> validate_required([:type, :actor, :metadata])
+  end
+end

--- a/priv/repo/migrations/20240626103903_create_activity_logs.exs
+++ b/priv/repo/migrations/20240626103903_create_activity_logs.exs
@@ -10,9 +10,5 @@ defmodule Trento.Repo.Migrations.CreateActivityLogs do
 
       timestamps(type: :utc_datetime_usec)
     end
-
-    create index(:activity_logs, [:type])
-    create index(:activity_logs, [:actor])
-    create index(:activity_logs, [:inserted_at])
   end
 end

--- a/priv/repo/migrations/20240626103903_create_activity_logs.exs
+++ b/priv/repo/migrations/20240626103903_create_activity_logs.exs
@@ -1,0 +1,18 @@
+defmodule Trento.Repo.Migrations.CreateActivityLogs do
+  use Ecto.Migration
+
+  def change do
+    create table(:activity_logs, primary_key: false) do
+      add :id, :uuid, primary_key: true
+      add :type, :string
+      add :actor, :string
+      add :metadata, :map
+
+      timestamps(type: :utc_datetime_usec)
+    end
+
+    create index(:activity_logs, [:type])
+    create index(:activity_logs, [:actor])
+    create index(:activity_logs, [:inserted_at])
+  end
+end


### PR DESCRIPTION
# Description

Migration and schema for `ActivityLog`.
The idea is that:
- `type` represents the occurence type (ie `resource_tagging`, `resource_untagging`, `api_key_generation` etc...)
- `actor` is the username of the user that initiated the action, or fallback to `system` for automatic operations
- `metadata` a bunch of context for the occurence (ie, the resource that has been tagged/untagged, the tag involved...) 

Indexes have been added for `type`, `actor` and `inserted_at` as they would very likely be used in queries.

Correlation ids and causation ids are intentionally left out from this iteration, and would be added at a later stage.  
## How was this tested?

running the migration
