### PR TITLE
Add migration to restart the abilities sequence from 3

### DIFF
--- a/priv/repo/migrations/20240626134815_restart_abilities_sequence.exs
+++ b/priv/repo/migrations/20240626134815_restart_abilities_sequence.exs
@@ -1,0 +1,11 @@
+defmodule Trento.Repo.Migrations.RestartAbilitiesSequence do
+  use Ecto.Migration
+
+  def up do
+    execute "ALTER SEQUENCE abilities_id_seq RESTART WITH 3"
+  end
+
+  def down do
+    execute "ALTER SEQUENCE abilities_id_seq RESTART WITH 1"
+  end
+end


### PR DESCRIPTION
# Description

This PR, manually restarts the abilities table primary key sequence from 3.

We forced the ids of the global abilities, with id 1 and id 2.
We need to manually increment the abilities sequence to interact with the records using the postgres sequence mechanism.

Without this change the sequence does not know about record 1 and 2 created, it starts from one, so all the insert will fail.
