### PR TITLE
Remove navigate usage in redux action dispatching

### DIFF
--- a/assets/js/pages/ClusterDetails/AscsErsClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/AscsErsClusterDetails.jsx
@@ -157,7 +157,7 @@ function AscsErsClusterDetails({
                 className="mx-0.5"
                 size="small"
                 onClick={() => {
-                  onStartExecution(clusterID, hosts, selectedChecks, navigate);
+                  onStartExecution(clusterID, hosts, selectedChecks);
                 }}
                 disabled={startExecutionDisabled}
               >

--- a/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
@@ -88,10 +88,8 @@ export function ClusterDetailsPage() {
           details={cluster.details}
           catalog={catalog}
           lastExecution={lastExecution}
-          onStartExecution={(_, hostList, checks, navigateFunction) =>
-            dispatch(
-              executionRequested(clusterID, hostList, checks, navigateFunction)
-            )
+          onStartExecution={(_, hostList, checks) =>
+            dispatch(executionRequested(clusterID, hostList, checks))
           }
           navigate={navigate}
         />
@@ -110,10 +108,8 @@ export function ClusterDetailsPage() {
           details={cluster.details}
           catalog={catalog}
           lastExecution={lastExecution}
-          onStartExecution={(_, hostList, checks, navigateFunction) =>
-            dispatch(
-              executionRequested(clusterID, hostList, checks, navigateFunction)
-            )
+          onStartExecution={(_, hostList, checks) =>
+            dispatch(executionRequested(clusterID, hostList, checks))
           }
           navigate={navigate}
         />

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
@@ -109,7 +109,7 @@ function HanaClusterDetails({
                 className="mx-0.5 border border-green-500"
                 size="small"
                 onClick={() => {
-                  onStartExecution(clusterID, hosts, selectedChecks, navigate);
+                  onStartExecution(clusterID, hosts, selectedChecks);
                 }}
                 disabled={startExecutionDisabled}
               >

--- a/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
+++ b/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { get } from 'lodash';
 
 import { clusterChecksSelected } from '@state/checksSelection';
@@ -41,7 +41,6 @@ const catalogBanner = {
 };
 
 function ClusterSettingsPage() {
-  const navigate = useNavigate();
   const dispatch = useDispatch();
   const { clusterID } = useParams();
   const [selection, setSelection] = useState([]);
@@ -100,9 +99,7 @@ function ClusterSettingsPage() {
     );
 
   const requestChecksExecution = () => {
-    dispatch(
-      executionRequested(clusterID, clusterHosts, selectedChecks, navigate)
-    );
+    dispatch(executionRequested(clusterID, clusterHosts, selectedChecks));
   };
 
   return (

--- a/assets/js/pages/ExecutionResults/CheckResultDetail/CheckResultDetailPage.jsx
+++ b/assets/js/pages/ExecutionResults/CheckResultDetail/CheckResultDetailPage.jsx
@@ -206,15 +206,11 @@ function CheckResultDetailPage({ targetType }) {
             dispatch(updateLastExecution(targetID));
           }
         }}
-        onStartExecution={(targetId, hosts, selectedChecks, onNavigate) => {
+        onStartExecution={(targetId, hosts, selectedChecks) => {
           isTargetHost(targetType) &&
-            dispatch(
-              hostExecutionRequested(target, selectedChecks, onNavigate)
-            );
+            dispatch(hostExecutionRequested(target, selectedChecks));
           isTargetCluster(targetType) &&
-            dispatch(
-              executionRequested(targetId, hosts, selectedChecks, onNavigate)
-            );
+            dispatch(executionRequested(targetId, hosts, selectedChecks));
         }}
       >
         <CheckResultDetail

--- a/assets/js/pages/ExecutionResults/ExecutionResultsPage.jsx
+++ b/assets/js/pages/ExecutionResults/ExecutionResultsPage.jsx
@@ -78,13 +78,10 @@ function ExecutionResultsPage({ targetType }) {
       executionError={executionError}
       targetSelectedChecks={target.selected_checks}
       savedFilters={savedFilters}
-      onStartExecution={(targetId, hosts, selectedChecks, navigate) => {
-        isHost &&
-          dispatch(hostExecutionRequested(target, selectedChecks, navigate));
+      onStartExecution={(targetId, hosts, selectedChecks) => {
+        isHost && dispatch(hostExecutionRequested(target, selectedChecks));
         isCluster &&
-          dispatch(
-            executionRequested(targetId, hosts, selectedChecks, navigate)
-          );
+          dispatch(executionRequested(targetId, hosts, selectedChecks));
       }}
       onSaveFilters={(filters) =>
         dispatch(setSelectedFilters({ resourceID: targetID, filters }))

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -132,9 +132,7 @@ function HostDetailsPage() {
           : undefined
       }
       cleanUpHost={() => {
-        dispatch(
-          deregisterHost({ id: hostID, hostname: host.hostname, navigate })
-        );
+        dispatch(deregisterHost({ id: hostID, hostname: host.hostname }));
       }}
       requestHostChecksExecution={() => {
         dispatch(hostExecutionRequested(host, hostSelectedChecks, navigate));

--- a/assets/js/pages/HostSettingsPage/HostSettingsPage.jsx
+++ b/assets/js/pages/HostSettingsPage/HostSettingsPage.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import LoadingBox from '@common/LoadingBox';
 
@@ -22,7 +22,6 @@ import ChecksSelectionHeader from '@pages/ChecksSelection/ChecksSelectionHeader'
 
 function HostSettingsPage() {
   const dispatch = useDispatch();
-  const navigate = useNavigate();
   const { hostID } = useParams();
   const [selection, setSelection] = useState([]);
 
@@ -67,7 +66,7 @@ function HostSettingsPage() {
   };
 
   const requestChecksExecution = () => {
-    dispatch(hostExecutionRequested(host, selectedChecks, navigate));
+    dispatch(hostExecutionRequested(host, selectedChecks));
   };
 
   return (

--- a/assets/js/pages/HostsList/HostsList.jsx
+++ b/assets/js/pages/HostsList/HostsList.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import { EOS_WARNING_OUTLINED } from 'eos-icons-react';
 import { uniqBy } from 'lodash';
@@ -51,7 +51,6 @@ function HostsList() {
   const [hostToDeregister, setHostToDeregister] = useState(undefined);
 
   const dispatch = useDispatch();
-  const navigate = useNavigate();
 
   const openDeregistrationModal = (host) => {
     setHostToDeregister(host);
@@ -60,7 +59,7 @@ function HostsList() {
 
   const cleanUpHost = ({ id, hostname }) => {
     setCleanUpModalOpen(false);
-    dispatch(deregisterHost({ id, hostname, navigate }));
+    dispatch(deregisterHost({ id, hostname }));
   };
 
   const config = {

--- a/assets/js/pages/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.jsx
+++ b/assets/js/pages/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import classNames from 'classnames';
-import { useNavigate } from 'react-router-dom';
 
 function TriggerChecksExecutionRequest({
   targetID,
@@ -12,7 +11,6 @@ function TriggerChecksExecutionRequest({
   cssOverride = null,
   ...props
 }) {
-  const navigate = useNavigate();
   const baseStyle =
     'items-center text-sm border-green-500 px-2 text-jungle-green-500 bg-white border border-green hover:opacity-75 focus:outline-none transition ease-in duration-200 text-center font-semibold rounded shadow';
 
@@ -21,7 +19,7 @@ function TriggerChecksExecutionRequest({
       className={cssOverride || classNames(baseStyle, cssClasses)}
       type="button"
       onClick={() => {
-        onStartExecution(targetID, hosts, checks, navigate);
+        onStartExecution(targetID, hosts, checks);
       }}
       {...props}
     >

--- a/assets/js/pages/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.test.jsx
+++ b/assets/js/pages/TriggerChecksExecutionRequest/TriggerChecksExecutionRequest.test.jsx
@@ -12,11 +12,7 @@ describe('TriggerChecksExecutionRequest component', () => {
   it('should dispatch execution requested on click and navigate to the correct url', async () => {
     const user = userEvent.setup();
 
-    const onStartExecution = jest.fn(
-      (targetID, _hosts, _selectedChecks, navigate) => {
-        navigate(`/clusters/${targetID}/executions/last`);
-      }
-    );
+    const onStartExecution = jest.fn();
 
     const targetID = faker.string.uuid();
     const hosts = hostFactory.buildList(2);
@@ -39,11 +35,7 @@ describe('TriggerChecksExecutionRequest component', () => {
     expect(onStartExecution).toHaveBeenCalledWith(
       targetID,
       hosts,
-      selectedChecks,
-      expect.any(Function)
-    );
-    expect(window.location.pathname).toBe(
-      `/clusters/${targetID}/executions/last`
+      selectedChecks
     );
   });
 });

--- a/assets/js/state/lastExecutions.js
+++ b/assets/js/state/lastExecutions.js
@@ -8,14 +8,14 @@ export const CLUSTER_EXECUTION_REQUESTED = 'CLUSTER_EXECUTION_REQUESTED';
 export const HOST_EXECUTION_REQUESTED = 'HOST_EXECUTION_REQUESTED';
 export const UPDATE_LAST_EXECUTION = 'UPDATE_LAST_EXECUTION';
 
-export const executionRequested = (clusterID, hosts, checks, navigate) => ({
+export const executionRequested = (clusterID, hosts, checks) => ({
   type: CLUSTER_EXECUTION_REQUESTED,
-  payload: { clusterID, hosts, checks, navigate },
+  payload: { clusterID, hosts, checks },
 });
 
-export const hostExecutionRequested = (host, checks, navigate) => ({
+export const hostExecutionRequested = (host, checks) => ({
   type: HOST_EXECUTION_REQUESTED,
-  payload: { host, checks, navigate },
+  payload: { host, checks },
 });
 
 export const updateLastExecution = (groupID) => ({

--- a/assets/js/state/sagas/hosts.js
+++ b/assets/js/state/sagas/hosts.js
@@ -1,4 +1,12 @@
-import { delay, put, race, call, take, takeEvery } from 'redux-saga/effects';
+import {
+  delay,
+  put,
+  race,
+  call,
+  take,
+  takeEvery,
+  getContext,
+} from 'redux-saga/effects';
 import { del } from '@lib/network';
 
 import {
@@ -109,14 +117,12 @@ export function* hostDeregistered({ payload }) {
   );
 }
 
-export function* deregisterHost({
-  payload,
-  payload: { id, hostname, navigate },
-}) {
+export function* deregisterHost({ payload, payload: { id, hostname } }) {
   yield put(setHostDeregistering(payload));
+  const router = yield getContext('router');
   try {
     yield call(del, `/hosts/${id}`);
-    navigate('/hosts');
+    yield call(router.navigate, '/hosts');
   } catch (error) {
     yield put(
       notify({

--- a/assets/js/state/sagas/hosts.test.js
+++ b/assets/js/state/sagas/hosts.test.js
@@ -94,16 +94,28 @@ describe('Hosts sagas', () => {
 
   it('should send host deregister request', async () => {
     const { id, hostname } = hostFactory.build();
-    const payload = { id, hostname, navigate: () => {} };
+    const payload = { id, hostname };
+    const mockNavigate = jest.fn();
+    const router = {
+      navigate: mockNavigate,
+    };
+    const context = { router };
 
     axiosMock.onDelete(`/hosts/${id}`).reply(204, {});
 
-    const dispatched = await recordSaga(deregisterHost, { payload });
+    const dispatched = await recordSaga(
+      deregisterHost,
+      { payload },
+      {},
+      context
+    );
 
     expect(dispatched).toEqual([
       setHostDeregistering(payload),
       unsetHostDeregistering(payload),
     ]);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/hosts');
   });
 
   it('should notify error on host deregistration request', async () => {

--- a/assets/js/state/sagas/lastExecutions.js
+++ b/assets/js/state/sagas/lastExecutions.js
@@ -1,4 +1,4 @@
-import { put, call, takeEvery, select } from 'redux-saga/effects';
+import { put, call, takeEvery, select, getContext } from 'redux-saga/effects';
 
 import { notify } from '@state/notifications';
 import {
@@ -41,8 +41,9 @@ export function* updateLastExecution({ payload }) {
 }
 
 export function* requestExecution({ payload }) {
-  const { clusterID, navigate } = payload;
+  const { clusterID } = payload;
   const clusterName = yield select(getClusterName(clusterID));
+  const router = yield getContext('router');
 
   try {
     yield call(triggerClusterChecksExecution, clusterID);
@@ -53,7 +54,7 @@ export function* requestExecution({ payload }) {
         icon: '🐰',
       })
     );
-    navigate(`/clusters/${clusterID}/executions/last`);
+    yield call(router.navigate, `/clusters/${clusterID}/executions/last`);
   } catch (error) {
     yield put(
       notify({
@@ -65,8 +66,9 @@ export function* requestExecution({ payload }) {
 }
 
 export function* requestHostExecution({ payload }) {
-  const { host, navigate } = payload;
+  const { host } = payload;
   const { id: hostID, hostname: hostName } = host;
+  const router = yield getContext('router');
 
   try {
     yield call(triggerHostChecksExecution, hostID);
@@ -77,7 +79,7 @@ export function* requestHostExecution({ payload }) {
         icon: '🐰',
       })
     );
-    navigate(`/hosts/${hostID}/executions/last`);
+    yield call(router.navigate, `/hosts/${hostID}/executions/last`);
   } catch (error) {
     yield put(
       notify({

--- a/assets/js/state/sagas/lastExecutions.test.js
+++ b/assets/js/state/sagas/lastExecutions.test.js
@@ -96,13 +96,17 @@ describe('lastExecutions saga', () => {
     const clusterName = faker.animal.cat();
     const hosts = [faker.string.uuid(), faker.string.uuid()];
     const checks = [faker.color.human(), faker.color.human()];
-    const navigate = jest.fn();
+    const mockNavigate = jest.fn();
+    const router = {
+      navigate: mockNavigate,
+    };
+    const context = { router };
 
     axiosMock
       .onPost(triggerClusterChecksExecutionURL(clusterID))
       .reply(202, {});
 
-    const payload = { clusterID, hosts, checks, navigate };
+    const payload = { clusterID, hosts, checks };
     const dispatched = await recordSaga(
       requestExecution,
       {
@@ -112,7 +116,8 @@ describe('lastExecutions saga', () => {
         clustersList: {
           clusters: [{ id: clusterID, name: clusterName }],
         },
-      }
+      },
+      context
     );
 
     expect(dispatched).toContainEqual(setExecutionRequested(payload));
@@ -122,7 +127,7 @@ describe('lastExecutions saga', () => {
         icon: '🐰',
       })
     );
-    expect(navigate).toHaveBeenCalledWith(
+    expect(mockNavigate).toHaveBeenCalledWith(
       `/clusters/${clusterID}/executions/last`
     );
   });
@@ -132,13 +137,17 @@ describe('lastExecutions saga', () => {
     const clusterName = faker.animal.cat();
     const hosts = [faker.string.uuid(), faker.string.uuid()];
     const checks = [faker.color.human(), faker.color.human()];
-    const navigate = jest.fn();
+    const mockNavigate = jest.fn();
+    const router = {
+      navigate: mockNavigate,
+    };
+    const context = { router };
 
     axiosMock
       .onPost(triggerClusterChecksExecutionURL(clusterID))
       .reply(400, {});
 
-    const payload = { clusterID, hosts, checks, navigate };
+    const payload = { clusterID, hosts, checks };
     const dispatched = await recordSaga(
       requestExecution,
       {
@@ -148,7 +157,8 @@ describe('lastExecutions saga', () => {
         clustersList: {
           clusters: [{ id: clusterID, name: clusterName }],
         },
-      }
+      },
+      context
     );
 
     expect(dispatched).not.toContainEqual(setExecutionRequested(payload));
@@ -158,21 +168,30 @@ describe('lastExecutions saga', () => {
         icon: '❌',
       })
     );
-    expect(navigate).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it('should set the last host execution to requested state', async () => {
     const host = hostFactory.build();
     const { id: hostID, hostname: hostName } = host;
     const checks = [faker.string.uuid(), faker.string.uuid()];
-    const navigate = jest.fn();
+    const mockNavigate = jest.fn();
+    const router = {
+      navigate: mockNavigate,
+    };
+    const context = { router };
 
     axiosMock.onPost(triggerHostChecksExecutionURL(hostID)).reply(202, {});
-    const payload = { checks, host, navigate };
+    const payload = { checks, host };
 
-    const dispatched = await recordSaga(requestHostExecution, {
-      payload,
-    });
+    const dispatched = await recordSaga(
+      requestHostExecution,
+      {
+        payload,
+      },
+      {},
+      context
+    );
     expect(dispatched).toContainEqual(setHostChecksExecutionRequested(payload));
     expect(dispatched).toContainEqual(
       notify({
@@ -180,21 +199,32 @@ describe('lastExecutions saga', () => {
         icon: '🐰',
       })
     );
-    expect(navigate).toHaveBeenCalledWith(`/hosts/${hostID}/executions/last`);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `/hosts/${hostID}/executions/last`
+    );
   });
 
   it('should not set the host last execution to requested state on failure', async () => {
     const host = hostFactory.build();
     const { id: hostID, hostname: hostName } = host;
     const checks = [faker.string.uuid(), faker.string.uuid()];
-    const navigate = jest.fn();
+    const mockNavigate = jest.fn();
+    const router = {
+      navigate: mockNavigate,
+    };
+    const context = { router };
 
     axiosMock.onPost(triggerHostChecksExecutionURL(hostID)).reply(400, {});
 
-    const payload = { checks, host, navigate };
-    const dispatched = await recordSaga(requestHostExecution, {
-      payload,
-    });
+    const payload = { checks, host };
+    const dispatched = await recordSaga(
+      requestHostExecution,
+      {
+        payload,
+      },
+      {},
+      context
+    );
     expect(dispatched).not.toContainEqual(
       setHostChecksExecutionRequested(payload)
     );
@@ -204,6 +234,6 @@ describe('lastExecutions saga', () => {
         icon: '❌',
       })
     );
-    expect(navigate).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 });

--- a/assets/js/trento.jsx
+++ b/assets/js/trento.jsx
@@ -118,7 +118,7 @@ const createRouter = ({ getUser }) =>
 function RoutesWrapper() {
   return (
     <>
-      <Toaster position="top-right" />
+      <Toaster position="top-right" containerStyle={{ top: 50, zIndex: 99 }} />
       <Outlet />
     </>
   );


### PR DESCRIPTION
# Description
Remove `navigate` function usage in redux action dispatching. The navigate is coming now from the redux saga context

Related to: https://github.com/trento-project/web/pull/2716

PD: And a fix for the toaster location that i have messed during previous PR conflicts resolution...
