### PR TITLE
Check selection abilities

### DIFF
--- a/assets/js/common/DisabledGuard/DisabledGuard.jsx
+++ b/assets/js/common/DisabledGuard/DisabledGuard.jsx
@@ -43,7 +43,7 @@ function DisabledGuard({
       place={tooltipPlace}
       wrap={false}
     >
-      <div>{disabledElement}</div>
+      {disabledElement}
     </Tooltip>
   );
 }

--- a/assets/js/pages/ChecksSelection/ChecksSelectionHeader.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelectionHeader.jsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 
 import Button from '@common/Button';
 import Tooltip from '@common/Tooltip';
+import DisabledGuard from '@common/DisabledGuard';
 
 import { canStartExecution } from '@pages/ChecksSelection';
 
@@ -15,6 +16,8 @@ function ChecksSelectionHeader({
   isSavingSelection,
   savedSelection,
   selection,
+  userAbilities,
+  checkSelectionPermittedFor,
   onSaveSelection = () => {},
   onStartExecution = () => {},
 }) {
@@ -31,14 +34,19 @@ function ChecksSelectionHeader({
         </div>
         <div className="flex w-1/2 justify-end">
           <div className="flex w-fit whitespace-nowrap">
-            <Button
-              type="primary-white"
-              className="mx-1 border-green-500 border"
-              onClick={() => onSaveSelection(selection, targetID, targetName)}
-              disabled={isSavingSelection}
+            <DisabledGuard
+              userAbilities={userAbilities}
+              permitted={checkSelectionPermittedFor}
             >
-              Save Checks Selection
-            </Button>
+              <Button
+                type="primary-white"
+                className="mx-1 border-green-500 border"
+                onClick={() => onSaveSelection(selection, targetID, targetName)}
+                disabled={isSavingSelection}
+              >
+                Save Checks Selection
+              </Button>
+            </DisabledGuard>
             <Tooltip
               className="w-56"
               content="Click Start Execution or wait for Trento to periodically run checks."

--- a/assets/js/pages/ChecksSelection/ChecksSelectionHeader.stories.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelectionHeader.stories.jsx
@@ -43,6 +43,14 @@ export default {
       control: 'array',
       description: 'The check selection currently displayed',
     },
+    userAbilities: {
+      control: 'array',
+      description: 'Current user abilities',
+    },
+    checkSelectionPermittedFor: {
+      control: 'array',
+      description: 'Abilities that allow check selection',
+    },
     savedSelection: {
       control: 'array',
       description: 'The last saved check selection for the target',
@@ -90,6 +98,8 @@ export const Default = {
       </PageHeader>
     ),
     selection,
+    userAbilities: [{ name: 'all', resource: 'all' }],
+    checkSelectionPermittedFor: ['all:cluster_checks_selection'],
     savedSelection,
     isSavingSelection: false,
   },
@@ -97,8 +107,7 @@ export const Default = {
 
 export const ClusterChecksSelection = {
   args: {
-    targetID,
-    targetName,
+    ...Default.args,
     backTo: (
       <BackButton url={`/clusters/${targetID}`}>
         Back to Cluster Details
@@ -109,16 +118,12 @@ export const ClusterChecksSelection = {
         Cluster Settings for <span className="font-bold">{targetName}</span>
       </PageHeader>
     ),
-    selection,
-    savedSelection,
-    isSavingSelection: false,
   },
 };
 
 export const HostChecksSelection = {
   args: {
-    targetID,
-    targetName,
+    ...Default.args,
     backTo: (
       <BackButton url={`/hosts/${targetID}`}>Back to Host Details</BackButton>
     ),
@@ -127,44 +132,27 @@ export const HostChecksSelection = {
         Check Settings for <span className="font-bold">{targetName}</span>
       </PageHeader>
     ),
-    selection,
-    savedSelection,
-    isSavingSelection: false,
   },
 };
 
 export const SavedSelectionDisabled = {
   args: {
-    targetID,
-    targetName,
-    backTo: (
-      <BackButton url={`/hosts/${targetID}`}>Back to Host Details</BackButton>
-    ),
-    pageHeader: (
-      <PageHeader>
-        Check Settings for <span className="font-bold">{targetName}</span>
-      </PageHeader>
-    ),
-    selection,
-    savedSelection,
+    ...Default.args,
     isSavingSelection: true,
   },
 };
 
 export const CannotStartExecution = {
   args: {
-    targetID,
-    targetName,
-    backTo: (
-      <BackButton url={`/hosts/${targetID}`}>Back to Host Details</BackButton>
-    ),
-    pageHeader: (
-      <PageHeader>
-        Check Settings for <span className="font-bold">{targetName}</span>
-      </PageHeader>
-    ),
-    selection,
+    ...Default.args,
     savedSelection: [],
     isSavingSelection: false,
+  },
+};
+
+export const CheckSelectionForbidden = {
+  args: {
+    ...Default.args,
+    userAbilities: [],
   },
 };

--- a/assets/js/pages/ChecksSelection/ChecksSelectionHeader.test.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelectionHeader.test.jsx
@@ -28,6 +28,8 @@ describe('ChecksSelectionHeader component', () => {
         pageHeader={<div>Target Check Settings</div>}
         isSavingSelection={false}
         selection={selection}
+        userAbilities={[{ name: 'all', resource: 'all' }]}
+        checkSelectionPermittedFor={['all:all']}
         savedSelection={savedSelection}
         onSaveSelection={onSaveSelection}
         onStartExecution={onStartExecution}
@@ -81,6 +83,8 @@ describe('ChecksSelectionHeader component', () => {
         pageHeader={<div>Target Check Settings</div>}
         isSavingSelection
         selection={selection}
+        userAbilities={[{ name: 'all', resource: 'all' }]}
+        checkSelectionPermittedFor={['all:all']}
         savedSelection={selection}
         onSaveSelection={onSaveSelection}
         onStartExecution={() => {}}
@@ -126,6 +130,8 @@ describe('ChecksSelectionHeader component', () => {
           pageHeader={<div>Target Check Settings</div>}
           isSavingSelection={isSavingSelection}
           selection={savedSelection}
+          userAbilities={[{ name: 'all', resource: 'all' }]}
+          checkSelectionPermittedFor={['all:all']}
           savedSelection={savedSelection}
           onSaveSelection={() => {}}
           onStartExecution={onStartExecution}
@@ -139,4 +145,41 @@ describe('ChecksSelectionHeader component', () => {
       expect(onStartExecution).not.toHaveBeenCalled();
     }
   );
+
+  it('should forbid saving a selection', async () => {
+    const user = userEvent.setup();
+
+    const targetID = faker.string.uuid();
+    const targetName = faker.lorem.word();
+    const selection = [faker.string.uuid(), faker.string.uuid()];
+    const onSaveSelection = jest.fn();
+
+    renderWithRouter(
+      <ChecksSelectionHeader
+        targetID={targetID}
+        targetName={targetName}
+        backTo={<button type="button">Back to Target Details</button>}
+        pageHeader={<div>Target Check Settings</div>}
+        isSavingSelection
+        selection={selection}
+        userAbilities={[]}
+        checkSelectionPermittedFor={['all:all']}
+        savedSelection={selection}
+        onSaveSelection={onSaveSelection}
+        onStartExecution={() => {}}
+      />
+    );
+
+    expect(screen.getByText('Save Checks Selection')).toBeDisabled();
+
+    await user.click(screen.getByText('Save Checks Selection'));
+
+    expect(onSaveSelection).not.toHaveBeenCalled();
+
+    await user.hover(screen.getByText('Save Checks Selection'));
+
+    expect(
+      screen.queryByText('You are not authorized for this action')
+    ).toBeVisible();
+  });
 });

--- a/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
+++ b/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
@@ -15,6 +15,7 @@ import {
 import { updateCatalog } from '@state/catalog';
 import { getCatalog } from '@state/selectors/catalog';
 import { isSaving } from '@state/selectors/checksSelection';
+import { getUserProfile } from '@state/selectors/user';
 import { executionRequested } from '@state/lastExecutions';
 
 import { buildEnv } from '@lib/checks';
@@ -46,6 +47,7 @@ function ClusterSettingsPage() {
   const { clusterID } = useParams();
   const [selection, setSelection] = useState([]);
 
+  const { abilities } = useSelector(getUserProfile);
   const cluster = useSelector(getCluster(clusterID));
   const clusterHosts = useSelector((state) =>
     getClusterHosts(state, clusterID)
@@ -124,6 +126,8 @@ function ClusterSettingsPage() {
         isSavingSelection={saving}
         savedSelection={selectedChecks}
         selection={selection}
+        userAbilities={abilities}
+        checkSelectionPermittedFor={['all:cluster_checks_selection']}
         onSaveSelection={saveSelection}
         onStartExecution={requestChecksExecution}
       />

--- a/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.test.jsx
+++ b/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.test.jsx
@@ -25,6 +25,7 @@ describe('ClusterDetails ClusterSettings component', () => {
       {
         ...defaultInitialState,
         catalog: { loading: false, data: catalog, error: null },
+        user: { abilities: [] },
       }
     );
 
@@ -54,6 +55,7 @@ describe('ClusterDetails ClusterSettings component', () => {
       ...defaultInitialState,
       catalog: { loading: false, data: catalog, error: null },
       clustersList: { clusters },
+      user: { abilities: [] },
     };
     const { id: clusterID } = clusters[0];
 
@@ -100,6 +102,7 @@ describe('ClusterDetails ClusterSettings component', () => {
       const [StatefulClusterSettings] = withState(<ClusterSettingsPage />, {
         ...defaultInitialState,
         clustersList: { clusters: [cluster] },
+        user: { abilities: [] },
       });
 
       renderWithRouterMatch(StatefulClusterSettings, {

--- a/assets/js/pages/HostSettingsPage/HostSettingsPage.jsx
+++ b/assets/js/pages/HostSettingsPage/HostSettingsPage.jsx
@@ -12,6 +12,7 @@ import { hostExecutionRequested } from '@state/lastExecutions';
 import { getCatalog } from '@state/selectors/catalog';
 import { getHost, getHostSelectedChecks } from '@state/selectors/host';
 import { isSaving } from '@state/selectors/checksSelection';
+import { getUserProfile } from '@state/selectors/user';
 
 import BackButton from '@common/BackButton';
 import HostInfoBox from '@common/HostInfoBox';
@@ -26,6 +27,7 @@ function HostSettingsPage() {
   const { hostID } = useParams();
   const [selection, setSelection] = useState([]);
 
+  const { abilities } = useSelector(getUserProfile);
   const host = useSelector(getHost(hostID));
   const selectedChecks = useSelector((state) =>
     getHostSelectedChecks(state, hostID)
@@ -86,6 +88,8 @@ function HostSettingsPage() {
         isSavingSelection={saving}
         savedSelection={selectedChecks}
         selection={selection}
+        userAbilities={abilities}
+        checkSelectionPermittedFor={['all:host_checks_selection']}
         onSaveSelection={saveSelection}
         onStartExecution={requestChecksExecution}
       />

--- a/assets/js/pages/HostSettingsPage/HostSettingsPage.test.jsx
+++ b/assets/js/pages/HostSettingsPage/HostSettingsPage.test.jsx
@@ -18,6 +18,7 @@ describe('HostSettingsPage component', () => {
     const state = {
       ...defaultInitialState,
       hostsList: { hosts: [] },
+      user: { abilities: [] },
     };
 
     const [StatefulHostSettingsPage] = withState(<HostSettingsPage />, state);
@@ -50,6 +51,7 @@ describe('HostSettingsPage component', () => {
       ...defaultInitialState,
       catalog: { ...defaultInitialState.catalog, data: catalog },
       hostsList: { hosts },
+      user: { abilities: [] },
     };
     const { id: hostID, agent_version: agentVersion } = hosts[1];
 
@@ -79,6 +81,7 @@ describe('HostSettingsPage component', () => {
     const state = {
       ...defaultInitialState,
       hostsList: { hosts },
+      user: { abilities: [] },
     };
     const { id: hostID } = hosts[1];
 
@@ -100,6 +103,7 @@ describe('HostSettingsPage component', () => {
     const state = {
       ...defaultInitialState,
       hostsList: { hosts },
+      user: { abilities: [] },
     };
     const { id: hostID } = hosts[1];
     const [StatefulHostSettingsPage] = withState(<HostSettingsPage />, state);

--- a/lib/trento/clusters/policy.ex
+++ b/lib/trento/clusters/policy.ex
@@ -1,0 +1,20 @@
+defmodule Trento.Clusters.Policy do
+  @moduledoc """
+  Policy for the Clusters resource
+  """
+  @behaviour Bodyguard.Policy
+
+  import Trento.Support.PolicyHelper
+  alias Trento.Clusters.Projections.ClusterReadModel
+  alias Trento.Users.User
+
+  def authorize(:select_checks, %User{} = user, ClusterReadModel),
+    do: has_select_checks_ability?(user)
+
+  def authorize(_, _, _), do: true
+
+  defp has_select_checks_ability?(user),
+    do:
+      has_global_ability?(user) or
+        user_has_ability?(user, %{name: "all", resource: "cluster_checks_selection"})
+end

--- a/lib/trento/hosts/policy.ex
+++ b/lib/trento/hosts/policy.ex
@@ -1,0 +1,20 @@
+defmodule Trento.Hosts.Policy do
+  @moduledoc """
+  Policy for the Hosts resource
+  """
+  @behaviour Bodyguard.Policy
+
+  import Trento.Support.PolicyHelper
+  alias Trento.Hosts.Projections.HostReadModel
+  alias Trento.Users.User
+
+  def authorize(:select_checks, %User{} = user, HostReadModel),
+    do: has_select_checks_ability?(user)
+
+  def authorize(_, _, _), do: true
+
+  defp has_select_checks_ability?(user),
+    do:
+      has_global_ability?(user) or
+        user_has_ability?(user, %{name: "all", resource: "host_checks_selection"})
+end

--- a/lib/trento_web/controllers/v1/cluster_controller.ex
+++ b/lib/trento_web/controllers/v1/cluster_controller.ex
@@ -6,6 +6,15 @@ defmodule TrentoWeb.V1.ClusterController do
 
   alias TrentoWeb.OpenApi.V1.Schema
 
+  plug TrentoWeb.Plugs.LoadUserPlug
+
+  plug Bodyguard.Plug.Authorize,
+    policy: Trento.Clusters.Policy,
+    action: {Phoenix.Controller, :action_name},
+    user: {Pow.Plug, :current_user},
+    params: {__MODULE__, :get_policy_resource},
+    fallback: TrentoWeb.FallbackController
+
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
   action_fallback TrentoWeb.FallbackController
 
@@ -79,4 +88,6 @@ defmodule TrentoWeb.V1.ClusterController do
       |> json(%{})
     end
   end
+
+  def get_policy_resource(_), do: Trento.Clusters.Projections.ClusterReadModel
 end

--- a/lib/trento_web/controllers/v1/host_controller.ex
+++ b/lib/trento_web/controllers/v1/host_controller.ex
@@ -15,7 +15,7 @@ defmodule TrentoWeb.V1.HostController do
     UnprocessableEntity
   }
 
-  plug TrentoWeb.Plugs.LoadUserPlug
+  plug TrentoWeb.Plugs.LoadUserPlug when action not in [:heartbeat]
 
   plug Bodyguard.Plug.Authorize,
     policy: Trento.Hosts.Policy,

--- a/lib/trento_web/controllers/v1/host_controller.ex
+++ b/lib/trento_web/controllers/v1/host_controller.ex
@@ -15,6 +15,15 @@ defmodule TrentoWeb.V1.HostController do
     UnprocessableEntity
   }
 
+  plug TrentoWeb.Plugs.LoadUserPlug
+
+  plug Bodyguard.Plug.Authorize,
+    policy: Trento.Hosts.Policy,
+    action: {Phoenix.Controller, :action_name},
+    user: {Pow.Plug, :current_user},
+    params: {__MODULE__, :get_policy_resource},
+    fallback: TrentoWeb.FallbackController
+
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
   action_fallback TrentoWeb.FallbackController
 
@@ -134,4 +143,6 @@ defmodule TrentoWeb.V1.HostController do
       |> json(%{})
     end
   end
+
+  def get_policy_resource(_), do: Trento.Hosts.Projections.HostReadModel
 end

--- a/priv/repo/migrations/20240626142750_add_check_selection_abilities.exs
+++ b/priv/repo/migrations/20240626142750_add_check_selection_abilities.exs
@@ -1,0 +1,14 @@
+defmodule Trento.Repo.Migrations.AddCheckSelectionAbilities do
+  use Ecto.Migration
+
+  def up do
+    execute "INSERT INTO abilities(name, resource, label, inserted_at, updated_at) VALUES ('all', 'host_checks_selection', 'Permits all operation on host checks selection', NOW(), NOW())"
+
+    execute "INSERT INTO abilities(name, resource, label, inserted_at, updated_at) VALUES ('all', 'cluster_checks_selection', 'Permits all operations on cluster checks selection', NOW(), NOW())"
+  end
+
+  def down do
+    execute "DELETE FROM abilities WHERE name = 'all' AND resource = 'host_checks_selection'"
+    execute "DELETE FROM abilities WHERE name = 'all' AND resource = 'cluster_checks_selection'"
+  end
+end

--- a/test/support/helpers/abilities_helper.ex
+++ b/test/support/helpers/abilities_helper.ex
@@ -1,0 +1,31 @@
+defmodule Trento.Support.Helpers.AbilitiesHelper do
+  @moduledoc """
+  Helper functions to setup abilities
+  """
+
+  import Plug.Conn
+  import Trento.Factory
+
+  alias TrentoWeb.OpenApi.V1
+
+  def setup_api_spec_v1(_context) do
+    {:ok, api_spec: V1.ApiSpec.spec()}
+  end
+
+  def setup_user(%{conn: conn, api_spec: api_spec}) do
+    conn =
+      conn
+      |> Plug.Conn.put_private(:plug_session, %{})
+      |> Plug.Conn.put_private(:plug_session_fetch, :done)
+      |> Pow.Plug.put_config(otp_app: :trento)
+
+    # Default inject all:all abilities user. ability_id 1 is all:all
+    %{id: user_id} = insert(:user)
+    insert(:users_abilities, user_id: user_id, ability_id: 1)
+
+    conn =
+      Pow.Plug.assign_current_user(conn, %{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
+
+    {:ok, conn: put_req_header(conn, "accept", "application/json"), api_spec: api_spec}
+  end
+end

--- a/test/support/helpers/abilities_test_helper.ex
+++ b/test/support/helpers/abilities_test_helper.ex
@@ -1,6 +1,8 @@
-defmodule Trento.Support.Helpers.AbilitiesHelper do
+defmodule Trento.Support.Helpers.AbilitiesTestHelper do
   @moduledoc """
-  Helper functions to setup abilities
+  Helper functions to setup abilities.
+
+  To be used in sandboxed test environment.
   """
 
   import Plug.Conn
@@ -13,19 +15,26 @@ defmodule Trento.Support.Helpers.AbilitiesHelper do
   end
 
   def setup_user(%{conn: conn, api_spec: api_spec}) do
+    delete_default_abilities()
+
     conn =
       conn
       |> Plug.Conn.put_private(:plug_session, %{})
       |> Plug.Conn.put_private(:plug_session_fetch, :done)
       |> Pow.Plug.put_config(otp_app: :trento)
 
-    # Default inject all:all abilities user. ability_id 1 is all:all
+    # Default inject all:all abilities user
     %{id: user_id} = insert(:user)
-    insert(:users_abilities, user_id: user_id, ability_id: 1)
+    %{id: ability_id} = insert(:ability, name: "all", resource: "all")
+    insert(:users_abilities, user_id: user_id, ability_id: ability_id)
 
     conn =
       Pow.Plug.assign_current_user(conn, %{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
 
     {:ok, conn: put_req_header(conn, "accept", "application/json"), api_spec: api_spec}
+  end
+
+  defp delete_default_abilities do
+    Trento.Repo.delete_all(Trento.Abilities.Ability)
   end
 end

--- a/test/trento/clusters/policy_test.exs
+++ b/test/trento/clusters/policy_test.exs
@@ -1,0 +1,28 @@
+defmodule Trento.Clusters.PolicyTest do
+  use ExUnit.Case
+
+  alias Trento.Abilities.Ability
+  alias Trento.Clusters.Policy
+  alias Trento.Clusters.Projections.ClusterReadModel
+  alias Trento.Users.User
+
+  test "should allow select_checks operations if the user has all:cluster_checks_selection ability" do
+    user = %User{abilities: [%Ability{name: "all", resource: "cluster_checks_selection"}]}
+
+    assert Policy.authorize(:select_checks, user, ClusterReadModel)
+  end
+
+  test "should disallow select_checks operations if the user does not have all:cluster_checks_selection ability" do
+    user = %User{abilities: []}
+
+    refute Policy.authorize(:select_checks, user, ClusterReadModel)
+  end
+
+  test "should allow unguarded actions" do
+    user = %User{abilities: []}
+
+    Enum.each([:list, :request_checks_execution], fn action ->
+      assert Policy.authorize(action, user, ClusterReadModel)
+    end)
+  end
+end

--- a/test/trento/hosts/policy_test.exs
+++ b/test/trento/hosts/policy_test.exs
@@ -21,7 +21,7 @@ defmodule Trento.Hosts.PolicyTest do
   test "should allow unguarded actions" do
     user = %User{abilities: []}
 
-    Enum.each([:list, :delete, :heartbeat, :request_checks_execution], fn action ->
+    Enum.each([:list, :delete, :request_checks_execution], fn action ->
       assert Policy.authorize(action, user, HostReadModel)
     end)
   end

--- a/test/trento/hosts/policy_test.exs
+++ b/test/trento/hosts/policy_test.exs
@@ -1,0 +1,28 @@
+defmodule Trento.Hosts.PolicyTest do
+  use ExUnit.Case
+
+  alias Trento.Abilities.Ability
+  alias Trento.Hosts.Policy
+  alias Trento.Hosts.Projections.HostReadModel
+  alias Trento.Users.User
+
+  test "should allow select_checks operations if the user has all:host_checks_selection ability" do
+    user = %User{abilities: [%Ability{name: "all", resource: "host_checks_selection"}]}
+
+    assert Policy.authorize(:select_checks, user, HostReadModel)
+  end
+
+  test "should disallow select_checks operations if the user does not have all:host_checks_selection ability" do
+    user = %User{abilities: []}
+
+    refute Policy.authorize(:select_checks, user, HostReadModel)
+  end
+
+  test "should allow unguarded actions" do
+    user = %User{abilities: []}
+
+    Enum.each([:list, :delete, :heartbeat, :request_checks_execution], fn action ->
+      assert Policy.authorize(action, user, HostReadModel)
+    end)
+  end
+end

--- a/test/trento_web/controllers/v1/cluster_controller_test.exs
+++ b/test/trento_web/controllers/v1/cluster_controller_test.exs
@@ -4,29 +4,14 @@ defmodule TrentoWeb.V1.ClusterControllerTest do
   import OpenApiSpex.TestAssertions
   import Mox
   import Trento.Factory
+  import Trento.Support.Helpers.AbilitiesHelper
 
   alias TrentoWeb.OpenApi.V1.ApiSpec
 
   setup [:set_mox_from_context, :verify_on_exit!]
 
-  setup %{conn: conn} do
-    conn =
-      conn
-      |> Plug.Conn.put_private(:plug_session, %{})
-      |> Plug.Conn.put_private(:plug_session_fetch, :done)
-      |> Pow.Plug.put_config(otp_app: :trento)
-
-    api_spec = ApiSpec.spec()
-
-    # Default inject all:all abilities user. ability_id 1 is all:all
-    %{id: user_id} = insert(:user)
-    insert(:users_abilities, user_id: user_id, ability_id: 1)
-
-    conn =
-      Pow.Plug.assign_current_user(conn, %{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
-
-    {:ok, conn: put_req_header(conn, "accept", "application/json"), api_spec: api_spec}
-  end
+  setup :setup_api_spec_v1
+  setup :setup_user
 
   describe "list" do
     test "should list all clusters", %{conn: conn} do

--- a/test/trento_web/controllers/v1/cluster_controller_test.exs
+++ b/test/trento_web/controllers/v1/cluster_controller_test.exs
@@ -4,7 +4,7 @@ defmodule TrentoWeb.V1.ClusterControllerTest do
   import OpenApiSpex.TestAssertions
   import Mox
   import Trento.Factory
-  import Trento.Support.Helpers.AbilitiesHelper
+  import Trento.Support.Helpers.AbilitiesTestHelper
 
   alias TrentoWeb.OpenApi.V1.ApiSpec
 

--- a/test/trento_web/controllers/v1/host_controller_test.exs
+++ b/test/trento_web/controllers/v1/host_controller_test.exs
@@ -2,29 +2,23 @@ defmodule TrentoWeb.V1.HostControllerTest do
   use TrentoWeb.ConnCase, async: true
 
   import OpenApiSpex.TestAssertions
-
-  alias TrentoWeb.OpenApi.V1.ApiSpec
+  import Mox
+  import Trento.Factory
+  import Trento.Support.Helpers.AbilitiesHelper
 
   alias Trento.Hosts.Commands.RequestHostDeregistration
 
-  import Trento.Factory
-
-  import Mox
-
   setup [:set_mox_from_context, :verify_on_exit!]
 
-  setup do
-    %{api_spec: ApiSpec.spec()}
-  end
+  setup :setup_api_spec_v1
+  setup :setup_user
 
   describe "list" do
-    test "should list all hosts", %{conn: conn} do
+    test "should list all hosts", %{conn: conn, api_spec: api_spec} do
       %{id: host_id} = insert(:host)
 
       insert_list(2, :sles_subscription, host_id: host_id)
       insert_list(2, :tag, resource_id: host_id)
-
-      api_spec = ApiSpec.spec()
 
       get(conn, "/api/v1/hosts")
       |> json_response(200)
@@ -303,6 +297,30 @@ defmodule TrentoWeb.V1.HostControllerTest do
       |> delete("/api/v1/hosts/#{host_id}")
       |> json_response(404)
       |> assert_schema("NotFound", api_spec)
+    end
+  end
+
+  describe "forbidden response" do
+    test "should return forbidden on any controller action if the user does not have the right permission",
+         %{conn: conn, api_spec: api_spec} do
+      %{id: user_id} = insert(:user)
+      %{id: host_id} = insert(:host)
+
+      conn =
+        conn
+        |> Pow.Plug.assign_current_user(%{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
+        |> put_req_header("content-type", "application/json")
+
+      Enum.each(
+        [
+          post(conn, "/api/v1/hosts/#{host_id}/checks", %{})
+        ],
+        fn conn ->
+          conn
+          |> json_response(:forbidden)
+          |> assert_schema("Forbidden", api_spec)
+        end
+      )
     end
   end
 end

--- a/test/trento_web/controllers/v1/host_controller_test.exs
+++ b/test/trento_web/controllers/v1/host_controller_test.exs
@@ -4,7 +4,7 @@ defmodule TrentoWeb.V1.HostControllerTest do
   import OpenApiSpex.TestAssertions
   import Mox
   import Trento.Factory
-  import Trento.Support.Helpers.AbilitiesHelper
+  import Trento.Support.Helpers.AbilitiesTestHelper
 
   alias Trento.Hosts.Commands.RequestHostDeregistration
 

--- a/test/trento_web/controllers/v1/users_controller_test.exs
+++ b/test/trento_web/controllers/v1/users_controller_test.exs
@@ -5,7 +5,7 @@ defmodule TrentoWeb.V1.UsersControllerTest do
   import Phoenix.ChannelTest
   import TrentoWeb.ChannelCase
   import Trento.Factory
-  import Trento.Support.Helpers.AbilitiesHelper
+  import Trento.Support.Helpers.AbilitiesTestHelper
 
   @endpoint TrentoWeb.Endpoint
 

--- a/test/trento_web/controllers/v1/users_controller_test.exs
+++ b/test/trento_web/controllers/v1/users_controller_test.exs
@@ -5,33 +5,12 @@ defmodule TrentoWeb.V1.UsersControllerTest do
   import Phoenix.ChannelTest
   import TrentoWeb.ChannelCase
   import Trento.Factory
-
-  alias Trento.Abilities
-  alias TrentoWeb.OpenApi.V1.ApiSpec
+  import Trento.Support.Helpers.AbilitiesHelper
 
   @endpoint TrentoWeb.Endpoint
 
-  setup %{conn: conn} do
-    delete_default_abilities()
-
-    conn =
-      conn
-      |> Plug.Conn.put_private(:plug_session, %{})
-      |> Plug.Conn.put_private(:plug_session_fetch, :done)
-      |> Pow.Plug.put_config(otp_app: :trento)
-
-    api_spec = ApiSpec.spec()
-
-    # Default inject all:all abilities user
-    %{id: user_id} = insert(:user)
-    %{id: ability_id} = insert(:ability, name: "all", resource: "all")
-    insert(:users_abilities, user_id: user_id, ability_id: ability_id)
-
-    conn =
-      Pow.Plug.assign_current_user(conn, %{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
-
-    {:ok, conn: put_req_header(conn, "accept", "application/json"), api_spec: api_spec}
-  end
+  setup :setup_api_spec_v1
+  setup :setup_user
 
   describe "forbidden response" do
     test "should return forbidden on any controller action if the user does not have the right permission",
@@ -390,9 +369,5 @@ defmodule TrentoWeb.V1.UsersControllerTest do
 
       assert_broadcast "user_deleted", %{}, 1000
     end
-  end
-
-  defp delete_default_abilities do
-    Trento.Repo.delete_all(Abilities.Ability)
   end
 end


### PR DESCRIPTION
# Description

Add permissions to handle `host` and `cluster` check selection.
The user having the `host_checks_selection` and `cluster_checks_selection` will be able to save new check selections.

![disabled_check_selection](https://github.com/trento-project/web/assets/36370954/b04905ba-59f7-4598-b91c-82588870480d)

PD: In the future this abilities will be grouped in the fronted

## How was this tested?

UT added.
We will work in the E2E tests in other PR, as we will want to have some generic functions for all permission testing (like creating users with abilities, etc).


