### PR TITLE
Switch to 404 for SUSE Manager settings

### DIFF
--- a/assets/js/state/sagas/softwareUpdatesSettings.js
+++ b/assets/js/state/sagas/softwareUpdatesSettings.js
@@ -33,7 +33,7 @@ export function* fetchSoftwareUpdatesSettings() {
   } catch (error) {
     const errorCode = get(error, ['response', 'status']);
     yield put(setEmptySoftwareUpdatesSettings());
-    if (errorCode !== 403) {
+    if (errorCode !== 404) {
       yield put(setNetworkError(true));
     }
   }

--- a/assets/js/state/sagas/softwareUpdatesSettings.test.js
+++ b/assets/js/state/sagas/softwareUpdatesSettings.test.js
@@ -46,7 +46,7 @@ describe('Software Updates Settings saga', () => {
     it('should empty software updates settings when no configured settings were found', async () => {
       const axiosMock = new MockAdapter(networkClient);
 
-      axiosMock.onGet('/settings/suma_credentials').reply(403);
+      axiosMock.onGet('/settings/suma_credentials').reply(404);
 
       const dispatched = await recordSaga(fetchSoftwareUpdatesSettings);
 
@@ -56,7 +56,7 @@ describe('Software Updates Settings saga', () => {
       ]);
     });
 
-    it.each([404, 500, 502, 504])(
+    it.each([400, 500, 502, 504])(
       'should empty software updates settings and put a network error flag on failed fetching',
       async (status) => {
         const axiosMock = new MockAdapter(networkClient);

--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -12,9 +12,9 @@ defmodule TrentoWeb.FallbackController do
 
   def call(conn, {:error, :settings_not_configured}) do
     conn
-    |> put_status(:forbidden)
+    |> put_status(:not_found)
     |> put_view(ErrorView)
-    |> render(:"403", reason: "SUSE Manager settings not configured.")
+    |> render(:"404", reason: "SUSE Manager settings not configured.")
   end
 
   def call(conn, {:error, :invalid_refresh_token}) do

--- a/test/trento_web/controllers/v1/suma_credentials_controller_test.exs
+++ b/test/trento_web/controllers/v1/suma_credentials_controller_test.exs
@@ -33,7 +33,7 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
 
       conn
       |> get("/api/v1/settings/suma_credentials")
-      |> json_response(:forbidden)
+      |> json_response(:not_found)
       |> assert_schema("NotFound", api_spec)
     end
   end
@@ -177,11 +177,11 @@ defmodule TrentoWeb.V1.SUMACredentialsControllerTest do
         conn
         |> put_req_header("content-type", "application/json")
         |> patch("/api/v1/settings/suma_credentials", submission)
-        |> json_response(:forbidden)
+        |> json_response(:not_found)
 
       assert %{
                "errors" => [
-                 %{"detail" => "SUSE Manager settings not configured.", "title" => "Forbidden"}
+                 %{"detail" => "The requested resource cannot be found.", "title" => "Not Found"}
                ]
              } == resp
     end

--- a/test/trento_web/controllers/v1/suse_manager_controller_test.exs
+++ b/test/trento_web/controllers/v1/suse_manager_controller_test.exs
@@ -70,11 +70,11 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
       resp =
         conn
         |> get("/api/v1/hosts/#{host_id}/software_updates")
-        |> json_response(:forbidden)
+        |> json_response(:not_found)
 
       assert %{
                "errors" => [
-                 %{"detail" => "SUSE Manager settings not configured.", "title" => "Forbidden"}
+                 %{"detail" => "The requested resource cannot be found.", "title" => "Not Found"}
                ]
              } == resp
     end


### PR DESCRIPTION
Just switching to 404 since now 403 has a differentic semantic meaning for our frontend :+1: 