### PR TITLE
Checks execution abilities

### DIFF
--- a/assets/js/pages/ChecksSelection/ChecksSelectionHeader.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelectionHeader.jsx
@@ -48,15 +48,16 @@ function ChecksSelectionHeader({
                 Save Checks Selection
               </Button>
             </DisabledGuard>
-            <Tooltip
-              className="w-56"
-              content="Click Start Execution or wait for Trento to periodically run checks."
-              visible={isAbleToStartExecution}
-              wrap={false}
+
+            <DisabledGuard
+              userAbilities={userAbilities}
+              permitted={checkExecutionPermittedFor}
             >
-              <DisabledGuard
-                userAbilities={userAbilities}
-                permitted={checkExecutionPermittedFor}
+              <Tooltip
+                className="w-56"
+                content="Click Start Execution or wait for Trento to periodically run checks."
+                visible={isAbleToStartExecution}
+                wrap={false}
               >
                 <Button
                   type="primary"
@@ -72,8 +73,8 @@ function ChecksSelectionHeader({
                   />{' '}
                   Start Execution
                 </Button>
-              </DisabledGuard>
-            </Tooltip>
+              </Tooltip>
+            </DisabledGuard>
           </div>
         </div>
       </div>

--- a/assets/js/pages/ChecksSelection/ChecksSelectionHeader.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelectionHeader.jsx
@@ -18,6 +18,7 @@ function ChecksSelectionHeader({
   selection,
   userAbilities,
   checkSelectionPermittedFor,
+  checkExecutionPermettidedFor,
   onSaveSelection = () => {},
   onStartExecution = () => {},
 }) {
@@ -53,20 +54,25 @@ function ChecksSelectionHeader({
               visible={isAbleToStartExecution}
               wrap={false}
             >
-              <Button
-                type="primary"
-                className="mx-1"
-                onClick={onStartExecution}
-                disabled={!isAbleToStartExecution}
+              <DisabledGuard
+                userAbilities={userAbilities}
+                permitted={checkExecutionPermettidedFor}
               >
-                <EOS_PLAY_CIRCLE
-                  className={classNames('inline-block align-sub', {
-                    'fill-white': isAbleToStartExecution,
-                    'fill-gray-200': !isAbleToStartExecution,
-                  })}
-                />{' '}
-                Start Execution
-              </Button>
+                <Button
+                  type="primary"
+                  className="mx-1"
+                  onClick={onStartExecution}
+                  disabled={!isAbleToStartExecution}
+                >
+                  <EOS_PLAY_CIRCLE
+                    className={classNames('inline-block align-sub', {
+                      'fill-white': isAbleToStartExecution,
+                      'fill-gray-200': !isAbleToStartExecution,
+                    })}
+                  />{' '}
+                  Start Execution
+                </Button>
+              </DisabledGuard>
             </Tooltip>
           </div>
         </div>

--- a/assets/js/pages/ChecksSelection/ChecksSelectionHeader.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelectionHeader.jsx
@@ -18,7 +18,7 @@ function ChecksSelectionHeader({
   selection,
   userAbilities,
   checkSelectionPermittedFor,
-  checkExecutionPermettidedFor,
+  checkExecutionPermittedFor,
   onSaveSelection = () => {},
   onStartExecution = () => {},
 }) {
@@ -56,7 +56,7 @@ function ChecksSelectionHeader({
             >
               <DisabledGuard
                 userAbilities={userAbilities}
-                permitted={checkExecutionPermettidedFor}
+                permitted={checkExecutionPermittedFor}
               >
                 <Button
                   type="primary"

--- a/assets/js/pages/ChecksSelection/ChecksSelectionHeader.stories.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelectionHeader.stories.jsx
@@ -51,6 +51,10 @@ export default {
       control: 'array',
       description: 'Abilities that allow check selection',
     },
+    checkExecutionPermittedFor: {
+      control: 'array',
+      description: 'Abilities that allow check execution',
+    },
     savedSelection: {
       control: 'array',
       description: 'The last saved check selection for the target',
@@ -100,6 +104,7 @@ export const Default = {
     selection,
     userAbilities: [{ name: 'all', resource: 'all' }],
     checkSelectionPermittedFor: ['all:cluster_checks_selection'],
+    checkExecutionPermittedFor: ['all:cluster_checks_execution'],
     savedSelection,
     isSavingSelection: false,
   },

--- a/assets/js/pages/ChecksSelection/ChecksSelectionHeader.test.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelectionHeader.test.jsx
@@ -149,6 +149,44 @@ describe('ChecksSelectionHeader component', () => {
     }
   );
 
+  it('should forbid starting a check execution', async () => {
+    const user = userEvent.setup();
+
+    const targetID = faker.string.uuid();
+    const targetName = faker.lorem.word();
+    const selection = [faker.string.uuid(), faker.string.uuid()];
+    const onStartExecution = jest.fn();
+
+    renderWithRouter(
+      <ChecksSelectionHeader
+        targetID={targetID}
+        targetName={targetName}
+        backTo={<button type="button">Back to Target Details</button>}
+        pageHeader={<div>Target Check Settings</div>}
+        isSavingSelection
+        selection={selection}
+        userAbilities={[{ name: 'all', resource: 'other_resource' }]}
+        checkSelectionPermittedFor={['all:all']}
+        checkExecutionPermittedFor={['all:host_check_execution']}
+        savedSelection={selection}
+        onSaveSelection={() => {}}
+        onStartExecution={onStartExecution}
+      />
+    );
+
+    expect(screen.getByText('Start Execution')).toBeDisabled();
+
+    await user.click(screen.getByText('Start Execution'));
+
+    expect(onStartExecution).not.toHaveBeenCalled();
+
+    await user.hover(screen.getByText('Start Execution'));
+
+    expect(
+      screen.queryByText('You are not authorized for this action')
+    ).toBeVisible();
+  });
+
   it('should forbid saving a selection', async () => {
     const user = userEvent.setup();
 

--- a/assets/js/pages/ChecksSelection/ChecksSelectionHeader.test.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelectionHeader.test.jsx
@@ -30,6 +30,7 @@ describe('ChecksSelectionHeader component', () => {
         selection={selection}
         userAbilities={[{ name: 'all', resource: 'all' }]}
         checkSelectionPermittedFor={['all:all']}
+        checkExecutionPermittedFor={['all:all']}
         savedSelection={savedSelection}
         onSaveSelection={onSaveSelection}
         onStartExecution={onStartExecution}
@@ -85,6 +86,7 @@ describe('ChecksSelectionHeader component', () => {
         selection={selection}
         userAbilities={[{ name: 'all', resource: 'all' }]}
         checkSelectionPermittedFor={['all:all']}
+        checkExecutionPermittedFor={['all:all']}
         savedSelection={selection}
         onSaveSelection={onSaveSelection}
         onStartExecution={() => {}}
@@ -132,6 +134,7 @@ describe('ChecksSelectionHeader component', () => {
           selection={savedSelection}
           userAbilities={[{ name: 'all', resource: 'all' }]}
           checkSelectionPermittedFor={['all:all']}
+          checkExecutionPermittedFor={['all:all']}
           savedSelection={savedSelection}
           onSaveSelection={() => {}}
           onStartExecution={onStartExecution}
@@ -164,6 +167,7 @@ describe('ChecksSelectionHeader component', () => {
         selection={selection}
         userAbilities={[]}
         checkSelectionPermittedFor={['all:all']}
+        checkExecutionPermittedFor={['all:all']}
         savedSelection={selection}
         onSaveSelection={onSaveSelection}
         onStartExecution={() => {}}

--- a/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
+++ b/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
@@ -128,6 +128,7 @@ function ClusterSettingsPage() {
         selection={selection}
         userAbilities={abilities}
         checkSelectionPermittedFor={['all:cluster_checks_selection']}
+        checkExecutionPermittedFor={['all:cluster_checks_execution']}
         onSaveSelection={saveSelection}
         onStartExecution={requestChecksExecution}
       />

--- a/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.test.jsx
+++ b/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.test.jsx
@@ -102,7 +102,7 @@ describe('ClusterDetails ClusterSettings component', () => {
       const [StatefulClusterSettings] = withState(<ClusterSettingsPage />, {
         ...defaultInitialState,
         clustersList: { clusters: [cluster] },
-        user: { abilities: [] },
+        user: { abilities: [{ name: 'all', resource: 'all' }] },
       });
 
       renderWithRouterMatch(StatefulClusterSettings, {

--- a/assets/js/pages/HostSettingsPage/HostSettingsPage.jsx
+++ b/assets/js/pages/HostSettingsPage/HostSettingsPage.jsx
@@ -90,6 +90,7 @@ function HostSettingsPage() {
         selection={selection}
         userAbilities={abilities}
         checkSelectionPermittedFor={['all:host_checks_selection']}
+        checkExecutionPermittedFor={['all:host_checks_execution']}
         onSaveSelection={saveSelection}
         onStartExecution={requestChecksExecution}
       />

--- a/assets/js/pages/HostSettingsPage/HostSettingsPage.test.jsx
+++ b/assets/js/pages/HostSettingsPage/HostSettingsPage.test.jsx
@@ -81,7 +81,7 @@ describe('HostSettingsPage component', () => {
     const state = {
       ...defaultInitialState,
       hostsList: { hosts },
-      user: { abilities: [] },
+      user: { abilities: [{ name: 'all', resource: 'host_checks_execution' }] },
     };
     const { id: hostID } = hosts[1];
 
@@ -103,7 +103,7 @@ describe('HostSettingsPage component', () => {
     const state = {
       ...defaultInitialState,
       hostsList: { hosts },
-      user: { abilities: [] },
+      user: { abilities: [{ name: 'all', resource: 'host_checks_execution' }] },
     };
     const { id: hostID } = hosts[1];
     const [StatefulHostSettingsPage] = withState(<HostSettingsPage />, state);

--- a/lib/trento/clusters/policy.ex
+++ b/lib/trento/clusters/policy.ex
@@ -11,10 +11,16 @@ defmodule Trento.Clusters.Policy do
   def authorize(:select_checks, %User{} = user, ClusterReadModel),
     do: has_select_checks_ability?(user)
 
+  def authorize(:request_checks_execution, %User{} = user, ClusterReadModel),
+    do: has_global_ability?(user) or has_checks_execution_ability?(user)
+
   def authorize(_, _, _), do: true
 
   defp has_select_checks_ability?(user),
     do:
       has_global_ability?(user) or
         user_has_ability?(user, %{name: "all", resource: "cluster_checks_selection"})
+
+  defp has_checks_execution_ability?(user),
+    do: user_has_ability?(user, %{name: "all", resource: "cluster_checks_execution"})
 end

--- a/lib/trento/clusters/projections/cluster_read_model.ex
+++ b/lib/trento/clusters/projections/cluster_read_model.ex
@@ -13,6 +13,8 @@ defmodule Trento.Clusters.Projections.ClusterReadModel do
 
   alias Trento.Tags.Tag
 
+  defdelegate authorize(action, user, params), to: Trento.Clusters.Policy
+
   @type t :: %__MODULE__{}
 
   @derive {Jason.Encoder, except: [:__meta__, :__struct__]}

--- a/lib/trento/hosts/policy.ex
+++ b/lib/trento/hosts/policy.ex
@@ -1,6 +1,10 @@
 defmodule Trento.Hosts.Policy do
   @moduledoc """
-  Policy for the Hosts resource
+  Policy for the Host resource
+
+  User with the ability all:all can perform any operation on the hosts.
+  User with the ability all:hosts_checks_execution can perform a check executions on Hosts.
+  User with the ability all:host_checks_selection can perform a check selection on Hosts.
   """
   @behaviour Bodyguard.Policy
 
@@ -11,10 +15,16 @@ defmodule Trento.Hosts.Policy do
   def authorize(:select_checks, %User{} = user, HostReadModel),
     do: has_select_checks_ability?(user)
 
+  def authorize(:request_checks_execution, %User{} = user, HostReadModel),
+    do: has_global_ability?(user) or has_checks_execution_ability?(user)
+
   def authorize(_, _, _), do: true
 
   defp has_select_checks_ability?(user),
     do:
       has_global_ability?(user) or
         user_has_ability?(user, %{name: "all", resource: "host_checks_selection"})
+
+  defp has_checks_execution_ability?(user),
+    do: user_has_ability?(user, %{name: "all", resource: "hosts_checks_execution"})
 end

--- a/lib/trento/hosts/policy.ex
+++ b/lib/trento/hosts/policy.ex
@@ -3,7 +3,7 @@ defmodule Trento.Hosts.Policy do
   Policy for the Host resource
 
   User with the ability all:all can perform any operation on the hosts.
-  User with the ability all:hosts_checks_execution can perform a check executions on Hosts.
+  User with the ability all:host_checks_execution can perform a check executions on Hosts.
   User with the ability all:host_checks_selection can perform a check selection on Hosts.
   """
   @behaviour Bodyguard.Policy
@@ -26,5 +26,5 @@ defmodule Trento.Hosts.Policy do
         user_has_ability?(user, %{name: "all", resource: "host_checks_selection"})
 
   defp has_checks_execution_ability?(user),
-    do: user_has_ability?(user, %{name: "all", resource: "hosts_checks_execution"})
+    do: user_has_ability?(user, %{name: "all", resource: "host_checks_execution"})
 end

--- a/lib/trento/hosts/projections/host_read_model.ex
+++ b/lib/trento/hosts/projections/host_read_model.ex
@@ -13,6 +13,8 @@ defmodule Trento.Hosts.Projections.HostReadModel do
   alias Trento.Hosts.Projections.SlesSubscriptionReadModel
   alias Trento.Tags.Tag
 
+  defdelegate authorize(action, user, params), to: Trento.Hosts.Policy
+
   @type t :: %__MODULE__{}
 
   @derive {Jason.Encoder, except: [:__meta__, :__struct__]}

--- a/priv/repo/migrations/20240626142058_add_check_execution_permissions.exs
+++ b/priv/repo/migrations/20240626142058_add_check_execution_permissions.exs
@@ -2,9 +2,9 @@ defmodule Trento.Repo.Migrations.AddCheckExecutionPermissions do
   use Ecto.Migration
 
   def up do
-    execute "INSERT INTO abilities(id, name, resource, label, inserted_at, updated_at) VALUES (DEFAULT, 'all', 'cluster_checks_execution', 'Permits all operations on the Cluster checks executions', NOW(), NOW())"
+    execute "INSERT INTO abilities(id, name, resource, label, inserted_at, updated_at) VALUES (DEFAULT, 'all', 'cluster_checks_execution', 'Permits all operations on cluster checks executions', NOW(), NOW())"
 
-    execute "INSERT INTO abilities(id, name, resource, label, inserted_at, updated_at) VALUES (DEFAULT, 'all', 'host_checks_execution', 'Permits all operations on the Host checks executions', NOW(), NOW())"
+    execute "INSERT INTO abilities(id, name, resource, label, inserted_at, updated_at) VALUES (DEFAULT, 'all', 'host_checks_execution', 'Permits all operations on host checks executions', NOW(), NOW())"
   end
 
   def down do

--- a/priv/repo/migrations/20240626142058_add_check_execution_permissions.exs
+++ b/priv/repo/migrations/20240626142058_add_check_execution_permissions.exs
@@ -1,0 +1,15 @@
+defmodule Trento.Repo.Migrations.AddCheckExecutionPermissions do
+  use Ecto.Migration
+
+  def up do
+    execute "INSERT INTO abilities(id, name, resource, label, inserted_at, updated_at) VALUES (DEFAULT, 'all', 'cluster_checks_execution', 'Permits all operations on the Cluster checks executions', NOW(), NOW())"
+
+    execute "INSERT INTO abilities(id, name, resource, label, inserted_at, updated_at) VALUES (DEFAULT, 'all', 'hosts_checks_execution', 'Permits all operations on the Host checks executions', NOW(), NOW())"
+  end
+
+  def down do
+    execute "DELETE FROM abilities WHERE abilities.name = 'all' and abilities.resource = 'cluster_checks_execution'"
+
+    execute "DELETE FROM abilities WHERE abilities.name = 'all' and abilities.resource = 'hosts_checks_execution'"
+  end
+end

--- a/priv/repo/migrations/20240626142058_add_check_execution_permissions.exs
+++ b/priv/repo/migrations/20240626142058_add_check_execution_permissions.exs
@@ -4,12 +4,12 @@ defmodule Trento.Repo.Migrations.AddCheckExecutionPermissions do
   def up do
     execute "INSERT INTO abilities(id, name, resource, label, inserted_at, updated_at) VALUES (DEFAULT, 'all', 'cluster_checks_execution', 'Permits all operations on the Cluster checks executions', NOW(), NOW())"
 
-    execute "INSERT INTO abilities(id, name, resource, label, inserted_at, updated_at) VALUES (DEFAULT, 'all', 'hosts_checks_execution', 'Permits all operations on the Host checks executions', NOW(), NOW())"
+    execute "INSERT INTO abilities(id, name, resource, label, inserted_at, updated_at) VALUES (DEFAULT, 'all', 'host_checks_execution', 'Permits all operations on the Host checks executions', NOW(), NOW())"
   end
 
   def down do
     execute "DELETE FROM abilities WHERE abilities.name = 'all' and abilities.resource = 'cluster_checks_execution'"
 
-    execute "DELETE FROM abilities WHERE abilities.name = 'all' and abilities.resource = 'hosts_checks_execution'"
+    execute "DELETE FROM abilities WHERE abilities.name = 'all' and abilities.resource = 'host_checks_execution'"
   end
 end

--- a/test/trento/clusters/policy_test.exs
+++ b/test/trento/clusters/policy_test.exs
@@ -18,10 +18,22 @@ defmodule Trento.Clusters.PolicyTest do
     refute Policy.authorize(:select_checks, user, ClusterReadModel)
   end
 
+  test "should allow request_check_execution operations if the user has all:cluster_checks_execution ability" do
+    user = %User{abilities: [%Ability{name: "all", resource: "cluster_checks_execution"}]}
+
+    assert Policy.authorize(:request_checks_execution, user, ClusterReadModel)
+  end
+
+  test "should disallow request_check_execution operations if the user does not have all:cluster_checks_execution ability" do
+    user = %User{abilities: []}
+
+    refute Policy.authorize(:request_checks_execution, user, ClusterReadModel)
+  end
+
   test "should allow unguarded actions" do
     user = %User{abilities: []}
 
-    Enum.each([:list, :request_checks_execution], fn action ->
+    Enum.each([:list], fn action ->
       assert Policy.authorize(action, user, ClusterReadModel)
     end)
   end

--- a/test/trento/hosts/policy_test.exs
+++ b/test/trento/hosts/policy_test.exs
@@ -18,29 +18,29 @@ defmodule Trento.Hosts.PolicyTest do
     refute Policy.authorize(:select_checks, user, HostReadModel)
   end
 
+  test "should allow request_checks_execution action if the user has all:host_checks_execution ability" do
+    user = %User{abilities: [%Ability{name: "all", resource: "host_checks_execution"}]}
+
+    assert Policy.authorize(:request_checks_execution, user, HostReadModel)
+  end
+
+  test "should allow request_checks_execution action if the user has all:all ability" do
+    user = %User{abilities: [%Ability{name: "all", resource: "all"}]}
+
+    assert Policy.authorize(:request_checks_execution, user, HostReadModel)
+  end
+
+  test "should not allow request_checks_execution action if the user does not have the all:host_checks_execution ability" do
+    user = %User{abilities: [%Ability{name: "all", resource: "other_resource"}]}
+
+    refute Policy.authorize(:request_checks_execution, user, HostReadModel)
+  end
+
   test "should allow unguarded actions" do
     user = %User{abilities: []}
 
     Enum.each([:list, :delete], fn action ->
       assert Policy.authorize(action, user, HostReadModel)
     end)
-  end
-
-  test "should allow request_checks_execution action if the user has all:host_checks_execution ability" do
-    user = %User{abilities: [%Ability{name: "all", resource: "host_checks_execution"}]}
-
-    assert true == Policy.authorize(:request_checks_execution, user, HostReadModel)
-  end
-
-  test "should allow request_checks_execution action if the user has all:all ability" do
-    user = %User{abilities: [%Ability{name: "all", resource: "all"}]}
-
-    assert true == Policy.authorize(:request_checks_execution, user, HostReadModel)
-  end
-
-  test "should not allow request_checks_execution action if the user does not have the all:host_checks_execution ability" do
-    user = %User{abilities: [%Ability{name: "all", resource: "other_resource"}]}
-
-    assert false == Policy.authorize(:request_checks_execution, user, HostReadModel)
   end
 end

--- a/test/trento/hosts/policy_test.exs
+++ b/test/trento/hosts/policy_test.exs
@@ -26,8 +26,8 @@ defmodule Trento.Hosts.PolicyTest do
     end)
   end
 
-  test "should allow request_checks_execution action if the user has all:hosts_checks_execution ability" do
-    user = %User{abilities: [%Ability{name: "all", resource: "hosts_checks_execution"}]}
+  test "should allow request_checks_execution action if the user has all:host_checks_execution ability" do
+    user = %User{abilities: [%Ability{name: "all", resource: "host_checks_execution"}]}
 
     assert true == Policy.authorize(:request_checks_execution, user, HostReadModel)
   end
@@ -38,7 +38,7 @@ defmodule Trento.Hosts.PolicyTest do
     assert true == Policy.authorize(:request_checks_execution, user, HostReadModel)
   end
 
-  test "should not allow request_checks_execution action if the user does not have the all:hosts_checks_execution ability" do
+  test "should not allow request_checks_execution action if the user does not have the all:host_checks_execution ability" do
     user = %User{abilities: [%Ability{name: "all", resource: "other_resource"}]}
 
     assert false == Policy.authorize(:request_checks_execution, user, HostReadModel)

--- a/test/trento/hosts/policy_test.exs
+++ b/test/trento/hosts/policy_test.exs
@@ -21,7 +21,7 @@ defmodule Trento.Hosts.PolicyTest do
   test "should allow unguarded actions" do
     user = %User{abilities: []}
 
-    Enum.each([:list, :delete, :request_checks_execution], fn action ->
+    Enum.each([:list, :delete], fn action ->
       assert Policy.authorize(action, user, HostReadModel)
     end)
   end

--- a/test/trento/hosts/policy_test.exs
+++ b/test/trento/hosts/policy_test.exs
@@ -25,4 +25,22 @@ defmodule Trento.Hosts.PolicyTest do
       assert Policy.authorize(action, user, HostReadModel)
     end)
   end
+
+  test "should allow request_checks_execution action if the user has all:hosts_checks_execution ability" do
+    user = %User{abilities: [%Ability{name: "all", resource: "hosts_checks_execution"}]}
+
+    assert true == Policy.authorize(:request_checks_execution, user, HostReadModel)
+  end
+
+  test "should allow request_checks_execution action if the user has all:all ability" do
+    user = %User{abilities: [%Ability{name: "all", resource: "all"}]}
+
+    assert true == Policy.authorize(:request_checks_execution, user, HostReadModel)
+  end
+
+  test "should not allow request_checks_execution action if the user does not have the all:hosts_checks_execution ability" do
+    user = %User{abilities: [%Ability{name: "all", resource: "other_resource"}]}
+
+    assert false == Policy.authorize(:request_checks_execution, user, HostReadModel)
+  end
 end

--- a/test/trento_web/controllers/v1/host_controller_test.exs
+++ b/test/trento_web/controllers/v1/host_controller_test.exs
@@ -14,7 +14,7 @@ defmodule TrentoWeb.V1.HostControllerTest do
   setup :setup_user
 
   describe "forbidden routes" do
-    test "should return forbidden on request_check_execution controller action when the user does not have all:all or all:hosts_checks_execution abilities",
+    test "should return forbidden on request_check_execution controller action when the user does not have all:all or all:host_checks_execution abilities",
          %{conn: conn, api_spec: api_spec} do
       %{id: user_id} = insert(:user)
 
@@ -221,14 +221,14 @@ defmodule TrentoWeb.V1.HostControllerTest do
   end
 
   describe "Request check executions" do
-    test "should perform the request when the user has all:hosts_checks_execution ability", %{
+    test "should perform the request when the user has all:host_checks_execution ability", %{
       conn: conn
     } do
       %{id: host_id} = insert(:host)
 
       %{id: user_id} = insert(:user)
 
-      %{id: ability_id} = insert(:ability, name: "all", resource: "hosts_checks_execution")
+      %{id: ability_id} = insert(:ability, name: "all", resource: "host_checks_execution")
       insert(:users_abilities, user_id: user_id, ability_id: ability_id)
 
       conn =

--- a/test/trento_web/controllers/v1/host_controller_test.exs
+++ b/test/trento_web/controllers/v1/host_controller_test.exs
@@ -7,7 +7,6 @@ defmodule TrentoWeb.V1.HostControllerTest do
   import Trento.Support.Helpers.AbilitiesTestHelper
 
   alias Trento.Hosts.Commands.RequestHostDeregistration
-  alias Trento.Abilities
 
   setup [:set_mox_from_context, :verify_on_exit!]
 

--- a/test/trento_web/controllers/v1/host_controller_test.exs
+++ b/test/trento_web/controllers/v1/host_controller_test.exs
@@ -7,11 +7,51 @@ defmodule TrentoWeb.V1.HostControllerTest do
   import Trento.Support.Helpers.AbilitiesTestHelper
 
   alias Trento.Hosts.Commands.RequestHostDeregistration
+  alias Trento.Abilities
 
   setup [:set_mox_from_context, :verify_on_exit!]
 
   setup :setup_api_spec_v1
   setup :setup_user
+
+  describe "forbidden routes" do
+    test "should return forbidden on request_check_execution controller action when the user does not have all:all or all:hosts_checks_execution abilities",
+         %{conn: conn, api_spec: api_spec} do
+      %{id: user_id} = insert(:user)
+
+      conn =
+        conn
+        |> Pow.Plug.assign_current_user(%{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
+        |> put_req_header("content-type", "application/json")
+
+      conn
+      |> post("/api/v1/hosts/host_id/checks/request_execution")
+      |> json_response(:forbidden)
+      |> assert_schema("Forbidden", api_spec)
+    end
+
+    test "should return forbidden on any controller action if the user does not have the right permission",
+         %{conn: conn, api_spec: api_spec} do
+      %{id: user_id} = insert(:user)
+      %{id: host_id} = insert(:host)
+
+      conn =
+        conn
+        |> Pow.Plug.assign_current_user(%{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
+        |> put_req_header("content-type", "application/json")
+
+      Enum.each(
+        [
+          post(conn, "/api/v1/hosts/#{host_id}/checks", %{})
+        ],
+        fn conn ->
+          conn
+          |> json_response(:forbidden)
+          |> assert_schema("Forbidden", api_spec)
+        end
+      )
+    end
+  end
 
   describe "list" do
     test "should list all hosts", %{conn: conn, api_spec: api_spec} do
@@ -182,6 +222,37 @@ defmodule TrentoWeb.V1.HostControllerTest do
   end
 
   describe "Request check executions" do
+    test "should perform the request when the user has all:hosts_checks_execution ability", %{
+      conn: conn
+    } do
+      %{id: host_id} = insert(:host)
+
+      %{id: user_id} = insert(:user)
+
+      %{id: ability_id} = insert(:ability, name: "all", resource: "hosts_checks_execution")
+      insert(:users_abilities, user_id: user_id, ability_id: ability_id)
+
+      conn =
+        conn
+        |> Pow.Plug.assign_current_user(%{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
+        |> put_req_header("content-type", "application/json")
+
+      expect(
+        Trento.Infrastructure.Messaging.Adapter.Mock,
+        :publish,
+        fn _, _ ->
+          :ok
+        end
+      )
+
+      resp =
+        conn
+        |> post("/api/v1/hosts/#{host_id}/checks/request_execution")
+        |> json_response(:accepted)
+
+      assert resp == %{}
+    end
+
     test "should return 202 when the execution was successfully started", %{conn: conn} do
       %{id: host_id} = insert(:host)
 
@@ -297,30 +368,6 @@ defmodule TrentoWeb.V1.HostControllerTest do
       |> delete("/api/v1/hosts/#{host_id}")
       |> json_response(404)
       |> assert_schema("NotFound", api_spec)
-    end
-  end
-
-  describe "forbidden response" do
-    test "should return forbidden on any controller action if the user does not have the right permission",
-         %{conn: conn, api_spec: api_spec} do
-      %{id: user_id} = insert(:user)
-      %{id: host_id} = insert(:host)
-
-      conn =
-        conn
-        |> Pow.Plug.assign_current_user(%{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
-        |> put_req_header("content-type", "application/json")
-
-      Enum.each(
-        [
-          post(conn, "/api/v1/hosts/#{host_id}/checks", %{})
-        ],
-        fn conn ->
-          conn
-          |> json_response(:forbidden)
-          |> assert_schema("Forbidden", api_spec)
-        end
-      )
     end
   end
 end

--- a/test/trento_web/controllers/v1/host_controller_test.exs
+++ b/test/trento_web/controllers/v1/host_controller_test.exs
@@ -14,21 +14,6 @@ defmodule TrentoWeb.V1.HostControllerTest do
   setup :setup_user
 
   describe "forbidden routes" do
-    test "should return forbidden on request_check_execution controller action when the user does not have all:all or all:host_checks_execution abilities",
-         %{conn: conn, api_spec: api_spec} do
-      %{id: user_id} = insert(:user)
-
-      conn =
-        conn
-        |> Pow.Plug.assign_current_user(%{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
-        |> put_req_header("content-type", "application/json")
-
-      conn
-      |> post("/api/v1/hosts/host_id/checks/request_execution")
-      |> json_response(:forbidden)
-      |> assert_schema("Forbidden", api_spec)
-    end
-
     test "should return forbidden on any controller action if the user does not have the right permission",
          %{conn: conn, api_spec: api_spec} do
       %{id: user_id} = insert(:user)
@@ -41,7 +26,8 @@ defmodule TrentoWeb.V1.HostControllerTest do
 
       Enum.each(
         [
-          post(conn, "/api/v1/hosts/#{host_id}/checks", %{})
+          post(conn, "/api/v1/hosts/#{host_id}/checks", %{}),
+          post(conn, "/api/v1/hosts/host_id/#{host_id}/request_execution", %{})
         ],
         fn conn ->
           conn


### PR DESCRIPTION
# Description

This PR, implements abilities on both frontend and backend for checks executions.
The user can execute checks on both hosts and clusters only if the correct ability is present in the user abilities.

- `all:host_checks_execution` enable host check execution
- `all:cluster_checks_execution` enable cluster check execution

![Recording 2024-06-28 at 10 47 50](https://github.com/trento-project/web/assets/9409502/a0bf0655-f87c-4fed-9207-d814c374e106)

The backend returns forbidden when the user has not the correct ability.
Frontend buttons are disabled when the user has not the correct ability.

## How was this tested?

Automated tests
