### PR TITLE
Activity logger plug

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -203,6 +203,9 @@ config :trento, Trento.Infrastructure.SoftwareUpdates.MockSuma, relevant_patches
 config :trento, Trento.Infrastructure.SoftwareUpdates.SumaApi,
   executor: Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor
 
+config :trento, Trento.ActivityLog.ActivityLogger,
+  adapter: Trento.Infrastructure.ActivityLog.Logger.NoopLogger
+
 config :bodyguard,
   # The second element of the {:error, reason} tuple returned on auth failure
   default_error: :forbidden

--- a/lib/trento/activity_logging/activity_logger.ex
+++ b/lib/trento/activity_logging/activity_logger.ex
@@ -1,0 +1,11 @@
+defmodule Trento.ActivityLog.ActivityLogger do
+  @moduledoc """
+  ActivityLogger entry point
+  """
+
+  @callback log_activity(context :: any()) :: :ok
+
+  def log_activity(context), do: adapter().log_activity(context)
+
+  defp adapter, do: Application.fetch_env!(:trento, __MODULE__)[:adapter]
+end

--- a/lib/trento/infrastructure/activity_log/logger/adapter/noop_logger.ex
+++ b/lib/trento/infrastructure/activity_log/logger/adapter/noop_logger.ex
@@ -1,0 +1,10 @@
+defmodule Trento.Infrastructure.ActivityLog.Logger.NoopLogger do
+  @moduledoc """
+  Noop Activity Logger Adapter
+  """
+
+  @behaviour Trento.ActivityLog.ActivityLogger
+
+  @impl true
+  def log_activity(_), do: :ok
+end

--- a/lib/trento_web/endpoint.ex
+++ b/lib/trento_web/endpoint.ex
@@ -32,6 +32,8 @@ defmodule TrentoWeb.Endpoint do
     plug Phoenix.Ecto.CheckRepoStatus, otp_app: :trento
   end
 
+  plug TrentoWeb.Plugs.ActivityLoggingPlug
+
   plug Phoenix.LiveDashboard.RequestLogger,
     param_key: "request_logger",
     cookie_key: "request_logger"

--- a/lib/trento_web/plugs/activity_logging_plug.ex
+++ b/lib/trento_web/plugs/activity_logging_plug.ex
@@ -1,0 +1,33 @@
+defmodule TrentoWeb.Plugs.ActivityLoggingPlug do
+  @moduledoc """
+  This plug is responsible for auditing the requests made to the API.
+  """
+
+  @behaviour Plug
+
+  import Plug.Conn
+
+  alias Trento.ActivityLog.ActivityLogger
+  alias TrentoWeb.Plugs.LoadUserPlug
+
+  def init(default), do: default
+
+  def call(%Plug.Conn{} = conn, _default \\ nil), do: register_before_send(conn, &log_activity/1)
+
+  defp log_activity(conn) do
+    Task.Supervisor.start_child(Trento.TasksSupervisor, fn ->
+      conn
+      |> load_user()
+      |> ActivityLogger.log_activity()
+    end)
+
+    conn
+  end
+
+  defp load_user(conn) do
+    LoadUserPlug.call(conn, nil)
+  rescue
+    Pow.Config.ConfigError ->
+      conn
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -36,6 +36,16 @@ defmodule TrentoWeb.ConnCase do
   setup tags do
     pid = Sandbox.start_owner!(Trento.Repo, shared: not tags[:async])
     on_exit(fn -> Sandbox.stop_owner(pid) end)
+
+    stub_activity_logger()
+
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
+
+  defp stub_activity_logger,
+    do:
+      Mox.stub_with(
+        Trento.ActivityLog.ActivityLogger.Mock,
+        Trento.Infrastructure.ActivityLog.Logger.NoopLogger
+      )
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -30,6 +30,14 @@ Application.put_env(:trento, Trento.Infrastructure.SoftwareUpdates.Suma,
   auth: Trento.Infrastructure.SoftwareUpdates.Auth.Mock
 )
 
+Mox.defmock(Trento.ActivityLog.ActivityLogger.Mock,
+  for: Trento.ActivityLog.ActivityLogger
+)
+
+Application.put_env(:trento, Trento.ActivityLog.ActivityLogger,
+  adapter: Trento.ActivityLog.ActivityLogger.Mock
+)
+
 Mox.defmock(Trento.Infrastructure.Messaging.Adapter.Mock,
   for: Trento.Infrastructure.Messaging.Adapter.Gen
 )

--- a/test/trento_web/plugs/activity_logging_plug_test.exs
+++ b/test/trento_web/plugs/activity_logging_plug_test.exs
@@ -1,0 +1,116 @@
+defmodule TrentoWeb.Plugs.ActivityLoggingPlugTest do
+  @moduledoc false
+  use Plug.Test
+  use TrentoWeb.ConnCase, async: true
+  use Trento.TaskCase
+
+  import Mox
+
+  import Trento.Factory
+
+  alias Trento.Users.User
+  alias TrentoWeb.Plugs.ActivityLoggingPlug
+
+  require Logger
+
+  setup :verify_on_exit!
+
+  describe "logging activity on connections" do
+    for method <- [:get, :post, :put, :patch, :delete] do
+      @method method
+      test "should log activity on requests without user information - method: #{method}" do
+        %{private: private} = conn = build_conn(@method, "/foo/bar", nil)
+        refute Map.has_key?(private, :before_send)
+
+        expect(Trento.ActivityLog.ActivityLogger.Mock, :log_activity, 1, fn %Plug.Conn{
+                                                                              assigns: assigns
+                                                                            } ->
+          refute Map.has_key?(assigns, :current_user)
+          :ok
+        end)
+
+        %{private: %{before_send: [logging_function | _]}} =
+          conn_with_registered_logger = ActivityLoggingPlug.call(conn)
+
+        logging_function.(conn_with_registered_logger)
+
+        wait_for_tasks_completion()
+      end
+
+      test "should log activity on requests with stateless user information - method #{method}" do
+        %{id: user_id} = insert(:user)
+
+        pow_config = [otp_app: :trento]
+        conn = Pow.Plug.put_config(build_conn(), pow_config)
+
+        conn = Pow.Plug.assign_current_user(conn, %{"user_id" => user_id}, pow_config)
+
+        expect(Trento.ActivityLog.ActivityLogger.Mock, :log_activity, 1, fn %Plug.Conn{
+                                                                              assigns: %{
+                                                                                current_user:
+                                                                                  %User{
+                                                                                    id: ^user_id
+                                                                                  }
+                                                                              }
+                                                                            } ->
+          :ok
+        end)
+
+        %{private: %{before_send: [logging_function | _]}} =
+          conn_with_registered_logger = ActivityLoggingPlug.call(conn)
+
+        logging_function.(conn_with_registered_logger)
+
+        wait_for_tasks_completion()
+      end
+
+      test "should log activity on requests with already loaded user information - method #{method}" do
+        user = insert(:user)
+
+        pow_config = [otp_app: :trento]
+        conn = Pow.Plug.put_config(build_conn(), pow_config)
+
+        conn = Pow.Plug.assign_current_user(conn, user, pow_config)
+
+        expect(Trento.ActivityLog.ActivityLogger.Mock, :log_activity, 1, fn %Plug.Conn{
+                                                                              assigns: %{
+                                                                                current_user:
+                                                                                  ^user
+                                                                              }
+                                                                            } ->
+          :ok
+        end)
+
+        %{private: %{before_send: [logging_function | _]}} =
+          conn_with_registered_logger = ActivityLoggingPlug.call(conn)
+
+        logging_function.(conn_with_registered_logger)
+
+        wait_for_tasks_completion()
+      end
+    end
+  end
+
+  describe "logging activity on requests" do
+    test "should log tagging activity", %{conn: conn} do
+      expect(Trento.ActivityLog.ActivityLogger.Mock, :log_activity, 1, fn %Plug.Conn{
+                                                                            body_params: %{
+                                                                              value: "some-tag"
+                                                                            },
+                                                                            assigns: %{
+                                                                              current_user: _,
+                                                                              resource_type: :host
+                                                                            },
+                                                                            status: 201
+                                                                          } ->
+        :ok
+      end)
+
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> post("/api/v1/hosts/#{Faker.UUID.v4()}/tags", %{
+        "value" => "some-tag"
+      })
+    end
+  end
+end

--- a/test/trento_web/plugs/load_user_plug_test.exs
+++ b/test/trento_web/plugs/load_user_plug_test.exs
@@ -25,4 +25,21 @@ defmodule TrentoWeb.Plugs.LoadUserPlugTest do
 
     assert %User{id: ^user_id} = Pow.Plug.current_user(conn, config)
   end
+
+  test "should keep an already loaded user details", %{conn: conn} do
+    user = insert(:user)
+    config = Pow.Plug.fetch_config(conn)
+    conn = Pow.Plug.assign_current_user(conn, user, config)
+    conn = LoadUserPlug.call(conn, nil)
+
+    assert ^user = Pow.Plug.current_user(conn, config)
+  end
+
+  test "should pass through connections without user references", %{conn: conn} do
+    config = Pow.Plug.fetch_config(conn)
+
+    conn = LoadUserPlug.call(conn, nil)
+
+    assert nil == Pow.Plug.current_user(conn, config)
+  end
 end


### PR DESCRIPTION
# Description

This PR adds a Plug that loads the user for the current request and forwards the connection to an ActivityLogger that might or might not be interested in tracking current activity.

Actual implementation of the activity logger to followup.

## How was this tested?

Automated tests
