### PR TITLE
Fixes DBConnection checkout related flakiness

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -12,6 +12,8 @@ config :trento, Trento.Repo,
   hostname: "localhost",
   port: 5433,
   pool: Ecto.Adapters.SQL.Sandbox,
+  queue_target: 200,
+  queue_interval: 2000,
   pool_size: 10
 
 config :trento, Trento.EventStore,


### PR DESCRIPTION
# Description

Some flakiness/test failures were being observed due to processes timing out while waiting to checkout the DBConnection during test runs.  This config changes tries to fix the issue. From https://hexdocs.pm/db_connection/DBConnection.html#start_link/2-queue-config :

Our goal is to wait at most :queue_target for a connection. If all connections checked out during a :queue_interval takes more than :queue_target, then we double the :queue_target. If checking out connections take longer than the new target, then we start dropping messages.
Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**
## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
- [Trento Web guides](https://github.com/trento-project/web/tree/main/guides)

Add a documentation PR or write that no changes are required for the documentation.
- [ ] **DONE**
