### PR TITLE
Fix non existent path

### DIFF
--- a/test/trento_web/controllers/v1/host_controller_test.exs
+++ b/test/trento_web/controllers/v1/host_controller_test.exs
@@ -27,7 +27,7 @@ defmodule TrentoWeb.V1.HostControllerTest do
       Enum.each(
         [
           post(conn, "/api/v1/hosts/#{host_id}/checks", %{}),
-          post(conn, "/api/v1/hosts/host_id/#{host_id}/request_execution", %{})
+          post(conn, "/api/v1/hosts/#{host_id}/checks/request_execution", %{})
         ],
         fn conn ->
           conn


### PR DESCRIPTION
# Description

Fixing host checks execution request path that is meant to return 403, but goes 404.

Fixes failing CI https://github.com/trento-project/web/actions/runs/9758779367/job/26934132210#step:8:95
