### PR TITLE
Return CVEs from `Errata Details` endpoint

### DIFF
--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -124,6 +124,13 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"422", reason: "Unable to retrieve errata details for this advisory.")
   end
 
+  def call(conn, {:error, :error_getting_cves}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(ErrorView)
+    |> render(:"422", reason: "Unable to retrieve CVEs for this advisory.")
+  end
+
   def call(conn, {:error, :error_getting_fixes}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/lib/trento_web/controllers/v1/suse_manager_controller.ex
+++ b/lib/trento_web/controllers/v1/suse_manager_controller.ex
@@ -95,8 +95,9 @@ defmodule TrentoWeb.V1.SUSEManagerController do
   @spec errata_details(Plug.Conn.t(), any) :: Plug.Conn.t()
   def errata_details(conn, %{advisory_name: advisory_name}) do
     with {:ok, errata_details} <- Discovery.get_errata_details(advisory_name),
+         {:ok, cves} <- Discovery.get_cves(advisory_name),
          {:ok, fixes} <- Discovery.get_bugzilla_fixes(advisory_name) do
-      render(conn, %{errata_details: errata_details, fixes: fixes})
+      render(conn, %{errata_details: errata_details, cves: cves, fixes: fixes})
     end
   end
 end

--- a/lib/trento_web/openapi/v1/schema/available_software_updates.ex
+++ b/lib/trento_web/openapi/v1/schema/available_software_updates.ex
@@ -172,6 +172,21 @@ defmodule TrentoWeb.OpenApi.V1.Schema.AvailableSoftwareUpdates do
     })
   end
 
+  defmodule CVEs do
+    @moduledoc false
+    OpenApiSpex.schema(%{
+      title: "CVEs",
+      description: "List of CVEs applicable to the errata with the given advisory name.",
+      type: :array,
+      additionalProperties: false,
+      items: %Schema{
+        title: "CVE",
+        description: "A fix for a publicly known security vulnerability",
+        type: :string
+      }
+    })
+  end
+
   defmodule AdvisoryFixes do
     @moduledoc false
     OpenApiSpex.schema(%{
@@ -191,6 +206,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.AvailableSoftwareUpdates do
       additionalProperties: false,
       properties: %{
         errata_details: ErrataDetails,
+        cves: CVEs,
         fixes: AdvisoryFixes
       }
     })

--- a/lib/trento_web/views/v1/suse_manager_view.ex
+++ b/lib/trento_web/views/v1/suse_manager_view.ex
@@ -65,6 +65,7 @@ defmodule TrentoWeb.V1.SUSEManagerView do
 
   def render("errata_details.json", %{
         errata_details: errata_details = %{errataFrom: errataFrom},
+        cves: cves,
         fixes: fixes
       }),
       do: %{
@@ -72,6 +73,7 @@ defmodule TrentoWeb.V1.SUSEManagerView do
           errata_details
           |> Map.drop([:errataFrom])
           |> Map.put(:errata_from, errataFrom),
+        cves: cves,
         fixes: fixes
       }
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -983,6 +983,13 @@ defmodule Trento.Factory do
     }
   end
 
+  def cve_factory(attrs) do
+    year = Enum.random(1_991..2_024)
+    id = Enum.random(0..9_999)
+    %{year: year, id: id} = Map.merge(%{year: year, id: id}, attrs)
+    "CVE-#{year}-#{id}"
+  end
+
   def bugzilla_fix_factory do
     1..Enum.random(1..4)
     |> Enum.map(fn _ ->

--- a/test/trento/infrastructure/software_updates/suma_test.exs
+++ b/test/trento/infrastructure/software_updates/suma_test.exs
@@ -274,8 +274,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaTest do
         {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(suma_response_body)}}
       end)
 
-      assert {:ok, ^cves} =
-               Suma.get_cves(advisory_name)
+      assert {:ok, ^cves} = Suma.get_cves(advisory_name)
     end
 
     test "should return a proper error when getting CVEs for a patch fails" do

--- a/test/trento/infrastructure/software_updates/suma_test.exs
+++ b/test/trento/infrastructure/software_updates/suma_test.exs
@@ -263,10 +263,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaTest do
       advisory_name = Faker.UUID.v4()
 
       %{result: cves} =
-        suma_response_body = %{
-          success: true,
-          result: Enum.map(1..10, fn _ -> Faker.UUID.v4() end)
-        }
+        suma_response_body = %{success: true, result: build_list(10, :cve)}
 
       expect(SumaAuthMock, :authenticate, 1, fn -> {:ok, authenticated_state()} end)
 

--- a/test/trento_web/controllers/v1/suse_manager_controller_test.exs
+++ b/test/trento_web/controllers/v1/suse_manager_controller_test.exs
@@ -172,7 +172,7 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
         {:ok, errata_details}
       end)
 
-      cves = generate_cves(10)
+      cves = build_list(10, :cve)
 
       expect(Trento.SoftwareUpdates.Discovery.Mock, :get_cves, 1, fn _ ->
         {:ok, cves}
@@ -233,7 +233,7 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
       end)
 
       expect(Trento.SoftwareUpdates.Discovery.Mock, :get_cves, 1, fn _ ->
-        {:ok, generate_cves(10)}
+        {:ok, build_list(10, :cve)}
       end)
 
       expect(Trento.SoftwareUpdates.Discovery.Mock, :get_bugzilla_fixes, 1, fn _ ->
@@ -285,7 +285,7 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
       end)
 
       expect(Trento.SoftwareUpdates.Discovery.Mock, :get_cves, 1, fn _ ->
-        {:ok, generate_cves(10)}
+        {:ok, build_list(10, :cve)}
       end)
 
       expect(Trento.SoftwareUpdates.Discovery.Mock, :get_bugzilla_fixes, 1, fn _ ->
@@ -299,16 +299,5 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
       |> json_response(:unprocessable_entity)
       |> assert_schema("UnprocessableEntity", api_spec)
     end
-  end
-
-  defp generate_cves(n) do
-    Enum.map(
-      1..n,
-      fn _ ->
-        year = Enum.random(1_991..2_024)
-        id = Enum.random(0..9_999)
-        "CVE-#{year}-#{id}"
-      end
-    )
   end
 end

--- a/test/trento_web/views/v1/suse_manager_view_test.exs
+++ b/test/trento_web/views/v1/suse_manager_view_test.exs
@@ -23,6 +23,17 @@ defmodule TrentoWeb.V1.SUSEManagerViewTest do
   describe "renders errata_details.json" do
     test "should render relevant fields" do
       %{errataFrom: errata_from} = errata_details = build(:errata_details)
+
+      cves =
+        Enum.map(
+          1..10,
+          fn _ ->
+            year = Enum.random(1_991..2_024)
+            id = Enum.random(0..9_999)
+            "CVE-#{year}-#{id}"
+          end
+        )
+
       fixes = build(:bugzilla_fix)
 
       errata_details_sans_errata_from = Map.delete(errata_details, :errataFrom)
@@ -32,11 +43,13 @@ defmodule TrentoWeb.V1.SUSEManagerViewTest do
 
       assert %{
                errata_details: ^expected_errata_details,
+               cves: ^cves,
                fixes: ^fixes
              } =
                render(SUSEManagerView, "errata_details.json", %{
                  errata_details:
                    Map.put(errata_details_sans_errata_from, :errataFrom, errata_from),
+                 cves: cves,
                  fixes: fixes
                })
     end

--- a/test/trento_web/views/v1/suse_manager_view_test.exs
+++ b/test/trento_web/views/v1/suse_manager_view_test.exs
@@ -24,22 +24,14 @@ defmodule TrentoWeb.V1.SUSEManagerViewTest do
     test "should render relevant fields" do
       %{errataFrom: errata_from} = errata_details = build(:errata_details)
 
-      cves =
-        Enum.map(
-          1..10,
-          fn _ ->
-            year = Enum.random(1_991..2_024)
-            id = Enum.random(0..9_999)
-            "CVE-#{year}-#{id}"
-          end
-        )
-
-      fixes = build(:bugzilla_fix)
-
       errata_details_sans_errata_from = Map.delete(errata_details, :errataFrom)
 
       expected_errata_details =
         Map.put(errata_details_sans_errata_from, :errata_from, errata_from)
+
+      cves = build_list(10, :cve)
+
+      fixes = build(:bugzilla_fix)
 
       assert %{
                errata_details: ^expected_errata_details,


### PR DESCRIPTION
# Description

This PR adds the ability to return the list of CVEs for a given advisory queried from the `v1/software_updates/errata_details/:advisory_name` endpoint.

## How was this tested?

Updated related unit tests.

## Did you update the documentation?

No changes are required for the documentation.
