### PR TITLE
Cleanup abilities/permissions

### DIFF
--- a/assets/js/common/CleanUpButton/CleanUpButton.jsx
+++ b/assets/js/common/CleanUpButton/CleanUpButton.jsx
@@ -5,12 +5,15 @@ import classNames from 'classnames';
 
 import Button from '@common/Button';
 import Spinner from '@common/Spinner';
+import DisabledGuard from '@common/DisabledGuard';
 
 function CleanUpButton({
   className,
   size = 'small',
   type = 'primary-white',
   cleaning,
+  userAbilities,
+  permittedFor,
   onClick,
 }) {
   const buttonClasses = classNames(
@@ -19,27 +22,29 @@ function CleanUpButton({
   );
 
   return (
-    <Button
-      type={type}
-      className={buttonClasses}
-      size={size}
-      disabled={cleaning}
-      onClick={() => onClick()}
-    >
-      {cleaning === true ? (
-        <Spinner className="justify-center flex" />
-      ) : (
-        <>
-          <EOS_CLEANING_SERVICES
-            size="base"
-            className="fill-jungle-green-500 inline"
-          />
-          <span className="text-jungle-green-500 text-sm font-bold pl-1.5">
-            Clean up
-          </span>
-        </>
-      )}
-    </Button>
+    <DisabledGuard userAbilities={userAbilities} permitted={permittedFor}>
+      <Button
+        type={type}
+        className={buttonClasses}
+        size={size}
+        disabled={cleaning}
+        onClick={() => onClick()}
+      >
+        {cleaning === true ? (
+          <Spinner className="justify-center flex" />
+        ) : (
+          <>
+            <EOS_CLEANING_SERVICES
+              size="base"
+              className="fill-jungle-green-500 inline"
+            />
+            <span className="text-jungle-green-500 text-sm font-bold pl-1.5">
+              Clean up
+            </span>
+          </>
+        )}
+      </Button>
+    </DisabledGuard>
   );
 }
 

--- a/assets/js/common/CleanUpButton/CleanUpButton.stories.jsx
+++ b/assets/js/common/CleanUpButton/CleanUpButton.stories.jsx
@@ -12,6 +12,14 @@ export default {
         defaultValue: { summary: false },
       },
     },
+    userAbilities: {
+      control: 'array',
+      description: 'Current user abilities',
+    },
+    permittedFor: {
+      control: 'array',
+      description: 'Abilities that allow check selection',
+    },
     onClick: { action: 'Click button' },
     className: {
       control: 'text',
@@ -42,7 +50,9 @@ export default {
 };
 
 export const Default = {
-  args: {},
+  args: {
+    userAbilities: [{ name: 'all', resource: 'all' }],
+  },
 };
 
 export const Cleaning = {
@@ -65,5 +75,12 @@ export const AbsentInstanceRow = {
     type: 'transparent',
     className: 'jungle-green-500 border-none shadown-none',
     size: 'fit',
+  },
+};
+
+export const Unauthorized = {
+  args: {
+    ...Default.args,
+    userAbilities: [],
   },
 };

--- a/assets/js/common/CleanUpButton/CleanUpButton.test.jsx
+++ b/assets/js/common/CleanUpButton/CleanUpButton.test.jsx
@@ -1,18 +1,38 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
 
 import CleanUpButton from '.';
 
 describe('Button', () => {
   it('should display the clean up button', () => {
-    render(<CleanUpButton />);
+    render(
+      <CleanUpButton userAbilities={[{ name: 'all', resource: 'all' }]} />
+    );
     expect(screen.getByRole('button')).toHaveTextContent('Clean up');
   });
 
   it('should display the clean up in cleaning state', () => {
-    render(<CleanUpButton cleaning />);
+    render(
+      <CleanUpButton
+        cleaning
+        userAbilities={[{ name: 'all', resource: 'all' }]}
+      />
+    );
     const spinnerElement = screen.getByRole('alert');
     expect(spinnerElement).toBeInTheDocument();
+  });
+
+  it('should forbid the cleanup', async () => {
+    const user = userEvent.setup();
+
+    render(<CleanUpButton userAbilities={[]} />);
+
+    await user.hover(screen.getByText('Clean up'));
+
+    expect(
+      screen.queryByText('You are not authorized for this action')
+    ).toBeVisible();
   });
 });

--- a/assets/js/lib/test-utils/index.jsx
+++ b/assets/js/lib/test-utils/index.jsx
@@ -35,6 +35,7 @@ export const defaultInitialState = {
   },
   checksSelection: { host: {}, cluster: {} },
   catalog: { loading: false, data: [], error: null },
+  user: { abilities: [{ name: 'all', resource: 'all' }] },
 };
 
 export const withState = (component, initialState = {}) => {

--- a/assets/js/pages/DatabaseDetails/DatabaseDetails.jsx
+++ b/assets/js/pages/DatabaseDetails/DatabaseDetails.jsx
@@ -9,6 +9,7 @@ import BackButton from '@common/BackButton';
 import { GenericSystemDetails } from '@pages/SapSystemDetails';
 
 import { getEnrichedDatabaseDetails } from '@state/selectors/sapSystem';
+import { getUserProfile } from '@state/selectors/user';
 import { deregisterDatabaseInstance } from '@state/databases';
 
 function DatabaseDetails() {
@@ -16,6 +17,7 @@ function DatabaseDetails() {
   const database = useSelector((state) =>
     getEnrichedDatabaseDetails(state, id)
   );
+  const { abilities } = useSelector(getUserProfile);
   const dispatch = useDispatch();
 
   if (!database) {
@@ -29,6 +31,8 @@ function DatabaseDetails() {
         title="HANA Database Details"
         type={DATABASE_TYPE}
         system={database}
+        userAbilities={abilities}
+        cleanUpPermittedFor={['cleanup:database_instance']}
         onInstanceCleanUp={(instance) => {
           dispatch(deregisterDatabaseInstance(instance));
         }}

--- a/assets/js/pages/DatabaseDetails/DatabaseDetails.stories.jsx
+++ b/assets/js/pages/DatabaseDetails/DatabaseDetails.stories.jsx
@@ -39,6 +39,14 @@ export default {
       control: 'object',
       description: 'The represented HANA database',
     },
+    userAbilities: {
+      control: 'array',
+      description: 'Current user abilities',
+    },
+    cleanUpPermittedFor: {
+      control: 'array',
+      description: 'Abilities that allow instance clean up',
+    },
     onInstanceCleanUp: {
       action: 'Clean up instance',
       description: 'Deregister and clean up an absent instance',
@@ -63,12 +71,21 @@ export const Database = {
     title: 'Database Details',
     type: DATABASE_TYPE,
     system: database,
+    userAbilities: [{ name: 'all', resource: 'all' }],
+    cleanUpPermittedFor: ['cleanup:database_instance'],
   },
 };
 
 export const DatabaseWithAbsentInstance = {
   args: {
-    ...Database,
+    ...Database.args,
     system: databaseWithAbsentInstance,
+  },
+};
+
+export const CleanUpUnauthorized = {
+  args: {
+    ...DatabaseWithAbsentInstance.args,
+    userAbilities: [],
   },
 };

--- a/assets/js/pages/DatabasesOverview/DatabaseItemOverview.jsx
+++ b/assets/js/pages/DatabasesOverview/DatabaseItemOverview.jsx
@@ -4,11 +4,13 @@ import React from 'react';
 import { DATABASE_TYPE } from '@lib/model/sapSystems';
 import InstanceOverview from '@pages/InstanceOverview';
 
-export function DatabaseInstance({ instance, onCleanUpClick }) {
+export function DatabaseInstance({ instance, userAbilities, onCleanUpClick }) {
   return (
     <InstanceOverview
       instanceType={DATABASE_TYPE}
       instance={instance}
+      userAbilities={userAbilities}
+      cleanUpPermittedFor={['cleanup:database_instance']}
       onCleanUpClick={onCleanUpClick}
     />
   );
@@ -27,6 +29,7 @@ const databaseInstanceColumns = [
 function PlainDatabaseItemOverview({
   instances,
   asDatabaseLayer = false,
+  userAbilities,
   onCleanUpClick,
 }) {
   return (
@@ -59,6 +62,7 @@ function PlainDatabaseItemOverview({
                 <DatabaseInstance
                   key={`${instance.host_id}_${instance.instance_number}`}
                   instance={instance}
+                  userAbilities={userAbilities}
                   onCleanUpClick={onCleanUpClick}
                 />
               ))}
@@ -69,21 +73,23 @@ function PlainDatabaseItemOverview({
   );
 }
 
-function DatabaseLayer({ instances, onCleanUpClick }) {
+function DatabaseLayer({ instances, userAbilities, onCleanUpClick }) {
   return (
     <PlainDatabaseItemOverview
       instances={instances}
       asDatabaseLayer
+      userAbilities={userAbilities}
       onCleanUpClick={onCleanUpClick}
     />
   );
 }
 
-function DatabaseInstances({ instances, onCleanUpClick }) {
+function DatabaseInstances({ instances, userAbilities, onCleanUpClick }) {
   return (
     <div className="p-2">
       <PlainDatabaseItemOverview
         instances={instances}
+        userAbilities={userAbilities}
         onCleanUpClick={onCleanUpClick}
       />
     </div>
@@ -93,6 +99,7 @@ function DatabaseInstances({ instances, onCleanUpClick }) {
 function DatabaseItemOverview({
   database,
   asDatabaseLayer = false,
+  userAbilities,
   onCleanUpClick,
 }) {
   const { databaseInstances } = database;
@@ -100,11 +107,13 @@ function DatabaseItemOverview({
   return asDatabaseLayer ? (
     <DatabaseLayer
       instances={databaseInstances}
+      userAbilities={userAbilities}
       onCleanUpClick={onCleanUpClick}
     />
   ) : (
     <DatabaseInstances
       instances={databaseInstances}
+      userAbilities={userAbilities}
       onCleanUpClick={onCleanUpClick}
     />
   );

--- a/assets/js/pages/DatabasesOverview/DatabasesOverview.jsx
+++ b/assets/js/pages/DatabasesOverview/DatabasesOverview.jsx
@@ -20,6 +20,7 @@ function DatabasesOverview({
   databases,
   databaseInstances,
   loading,
+  userAbilities,
   onTagAdd,
   onTagRemove,
   onInstanceCleanUp,
@@ -116,6 +117,7 @@ function DatabasesOverview({
     collapsibleDetailRenderer: (database) => (
       <DatabaseItemOverview
         database={database}
+        userAbilities={userAbilities}
         onCleanUpClick={(instance, _type) => {
           setCleanUpModalOpen(true);
           setInstanceToDeregister(instance);

--- a/assets/js/pages/DatabasesOverview/DatabasesOverview.stories.jsx
+++ b/assets/js/pages/DatabasesOverview/DatabasesOverview.stories.jsx
@@ -78,6 +78,10 @@ export default {
         defaultValue: { summary: false },
       },
     },
+    userAbilities: {
+      control: 'array',
+      description: 'Current user abilities',
+    },
     onTagAdd: {
       action: 'Add tag',
       description: 'Called when a new tag is added',
@@ -110,6 +114,7 @@ export const Databases = {
     databases,
     databaseInstances: enrichedInstances,
     loading: false,
+    userAbilities: [{ name: 'all', resource: 'all' }],
   },
 };
 
@@ -118,6 +123,7 @@ export const WithSystemReplication = {
     databases: [databaseWithSR],
     databaseInstances: systemReplicationInstances,
     loading: false,
+    userAbilities: [{ name: 'all', resource: 'all' }],
   },
 };
 
@@ -126,5 +132,13 @@ export const WithAbsentInstances = {
     databases: [databaseWithAbsentInstances],
     databaseInstances: absentInstance,
     loading: false,
+    userAbilities: [{ name: 'all', resource: 'all' }],
+  },
+};
+
+export const UnauthorizedCleanUp = {
+  args: {
+    ...WithAbsentInstances.args,
+    userAbilities: [],
   },
 };

--- a/assets/js/pages/DatabasesOverview/DatabasesOverview.test.jsx
+++ b/assets/js/pages/DatabasesOverview/DatabasesOverview.test.jsx
@@ -27,6 +27,7 @@ describe('DatabasesOverview component', () => {
         <DatabasesOverview
           databases={[database]}
           databaseInstances={database.database_instances}
+          userAbilities={[{ name: 'all', resource: 'all' }]}
           onInstanceCleanUp={mockedCleanUp}
         />
       );
@@ -46,6 +47,36 @@ describe('DatabasesOverview component', () => {
       expect(mockedCleanUp).toHaveBeenCalledWith(
         database.database_instances[0]
       );
+    });
+
+    it('should forbid instance cleanup', async () => {
+      const user = userEvent.setup();
+
+      const database = databaseFactory.build();
+
+      database.database_instances[0].absent_at = faker.date
+        .past()
+        .toISOString();
+
+      renderWithRouter(
+        <DatabasesOverview
+          databases={[database]}
+          databaseInstances={database.database_instances}
+          userAbilities={[]}
+        />
+      );
+
+      const cleanUpButton = screen.getByText('Clean up').closest('button');
+
+      expect(cleanUpButton).toBeDisabled();
+
+      await user.click(cleanUpButton);
+
+      await user.hover(cleanUpButton);
+
+      expect(
+        screen.queryByText('You are not authorized for this action')
+      ).toBeVisible();
     });
   });
 

--- a/assets/js/pages/DatabasesOverview/DatabasesOverviewPage.jsx
+++ b/assets/js/pages/DatabasesOverview/DatabasesOverviewPage.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
 import { getEnrichedDatabaseInstances } from '@state/selectors/sapSystem';
+import { getUserProfile } from '@state/selectors/user';
 import {
   addTagToDatabase,
   removeTagFromDatabase,
@@ -27,6 +28,7 @@ function DatabasesOverviewPage() {
   const enrichedDatabaseInstances = useSelector((state) =>
     getEnrichedDatabaseInstances(state)
   );
+  const { abilities } = useSelector(getUserProfile);
   const dispatch = useDispatch();
 
   return (
@@ -34,6 +36,7 @@ function DatabasesOverviewPage() {
       databases={databases}
       databaseInstances={enrichedDatabaseInstances}
       loading={loading}
+      userAbilities={abilities}
       onTagAdd={(tag, databaseID) => {
         addTag(tag, databaseID);
         dispatch(addTagToDatabase({ tags: [{ value: tag }], id: databaseID }));

--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -74,6 +74,7 @@ function HostDetails({
   softwareUpdatesSettingsSaved,
   softwareUpdatesSettingsLoading,
   softwareUpdatesTooltip,
+  userAbilities,
   cleanUpHost,
   requestHostChecksExecution,
   navigate,
@@ -136,6 +137,8 @@ function HostDetails({
               {deregisterable && (
                 <CleanUpButton
                   cleaning={deregistering}
+                  userAbilities={userAbilities}
+                  permittedFor={['cleanup:host']}
                   onClick={() => {
                     setCleanUpModalOpen(true);
                   }}

--- a/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
@@ -134,6 +134,10 @@ export default {
       control: 'object',
       description: 'Last execution data',
     },
+    userAbilities: {
+      control: 'array',
+      description: 'Current user abilities',
+    },
     cleanUpHost: {
       action: 'Deregister host',
       description: 'Deregister host',
@@ -197,6 +201,7 @@ export const Default = {
     softwareUpdatesTooltip: undefined,
     selectedChecks: [],
     slesSubscriptions: host.sles_subscriptions,
+    userAbilities: [{ name: 'all', resource: 'all' }],
   },
 };
 
@@ -218,6 +223,14 @@ export const Deregisterable = {
   args: {
     ...Default.args,
     deregisterable: true,
+  },
+};
+
+export const CleanUpUnauthorized = {
+  args: {
+    ...Default.args,
+    deregisterable: true,
+    userAbilities: [],
   },
 };
 

--- a/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
@@ -97,7 +97,13 @@ describe('HostDetails component', () => {
     });
 
     it('should display clean up button when host is deregisterable', () => {
-      renderWithRouter(<HostDetails agentVersion="2.0.0" deregisterable />);
+      renderWithRouter(
+        <HostDetails
+          agentVersion="2.0.0"
+          deregisterable
+          userAbilities={[{ name: 'all', resource: 'all' }]}
+        />
+      );
 
       expect(
         screen.getByRole('button', { name: 'Clean up' })
@@ -106,7 +112,12 @@ describe('HostDetails component', () => {
 
     it('should show the host in deregistering state', () => {
       renderWithRouter(
-        <HostDetails agentVersion="2.0.0" deregisterable deregistering />
+        <HostDetails
+          agentVersion="2.0.0"
+          deregisterable
+          deregistering
+          userAbilities={[{ name: 'all', resource: 'all' }]}
+        />
       );
 
       expect(
@@ -127,6 +138,7 @@ describe('HostDetails component', () => {
           agentVersion="2.0.0"
           deregisterable
           hostname={hostname}
+          userAbilities={[{ name: 'all', resource: 'all' }]}
           cleanUpHost={mockCleanUp}
         />
       );
@@ -146,6 +158,32 @@ describe('HostDetails component', () => {
       await user.click(cleanUpModalButton);
 
       expect(mockCleanUp).toHaveBeenCalled();
+    });
+
+    it('should forbid host cleanup', async () => {
+      const user = userEvent.setup();
+      const { hostname } = hostFactory.build();
+
+      renderWithRouter(
+        <HostDetails
+          agentVersion="2.0.0"
+          deregisterable
+          hostname={hostname}
+          userAbilities={[]}
+        />
+      );
+
+      const cleanUpButton = screen.getByText('Clean up').closest('button');
+
+      expect(cleanUpButton).toBeDisabled();
+
+      await user.click(cleanUpButton);
+
+      await user.hover(cleanUpButton);
+
+      expect(
+        screen.queryByText('You are not authorized for this action')
+      ).toBeVisible();
     });
   });
 

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -8,6 +8,7 @@ import { networkClient } from '@lib/network';
 
 import { TARGET_HOST } from '@lib/model';
 
+import { getUserProfile } from '@state/selectors/user';
 import { getClusterByHost } from '@state/selectors/cluster';
 import { getInstancesOnHost } from '@state/selectors/sapSystem';
 import { getCatalog } from '@state/selectors/catalog';
@@ -47,6 +48,7 @@ function HostDetailsPage() {
   const sapInstances = useSelector((state) =>
     getInstancesOnHost(state, hostID)
   );
+  const { abilities } = useSelector(getUserProfile);
 
   const lastExecution = useSelector(getLastExecution(hostID));
   const catalog = useSelector(getCatalog());
@@ -131,6 +133,7 @@ function HostDetailsPage() {
           ? 'Trento was not able to retrieve the requested data'
           : undefined
       }
+      userAbilities={abilities}
       cleanUpHost={() => {
         dispatch(deregisterHost({ id: hostID, hostname: host.hostname }));
       }}

--- a/assets/js/pages/HostsList/HostsList.jsx
+++ b/assets/js/pages/HostsList/HostsList.jsx
@@ -26,6 +26,7 @@ import { getCounters } from '@pages/HealthSummary/summarySelection';
 
 import { addTagToHost, removeTagFromHost, deregisterHost } from '@state/hosts';
 import { getAllSAPInstances } from '@state/selectors/sapSystem';
+import { getUserProfile } from '@state/selectors/user';
 import { getInstanceID } from '@state/instances';
 
 const getInstancesByHost = (instances, hostId) =>
@@ -45,6 +46,7 @@ function HostsList() {
   const hosts = useSelector((state) => state.hostsList.hosts);
   const clusters = useSelector((state) => state.clustersList.clusters);
   const allInstances = useSelector(getAllSAPInstances);
+  const { abilities } = useSelector(getUserProfile);
 
   const [searchParams, setSearchParams] = useSearchParams();
   const [cleanUpModalOpen, setCleanUpModalOpen] = useState(false);
@@ -201,6 +203,8 @@ function HostsList() {
               cleaning={item.deregistering}
               size="fit"
               className="border-none shadow-none"
+              userAbilities={abilities}
+              permittedFor={['cleanup:host']}
               onClick={() => {
                 openDeregistrationModal(item);
               }}

--- a/assets/js/pages/HostsList/HostsList.test.jsx
+++ b/assets/js/pages/HostsList/HostsList.test.jsx
@@ -93,6 +93,7 @@ describe('HostsLists component', () => {
         hostsList: {
           hosts: [].concat(host1, host2),
         },
+        user: { abilities: [{ name: 'all', resource: 'all' }] },
       };
 
       const [StatefulHostsList] = withState(<HostsList />, state);
@@ -165,6 +166,7 @@ describe('HostsLists component', () => {
         hostsList: {
           hosts: [].concat(host1, host2),
         },
+        user: { abilities: [{ name: 'all', resource: 'all' }] },
       };
 
       const [StatefulHostsList] = withState(<HostsList />, state);
@@ -191,6 +193,7 @@ describe('HostsLists component', () => {
         hostsList: {
           hosts: [host],
         },
+        user: { abilities: [{ name: 'all', resource: 'all' }] },
       };
 
       const [StatefulHostsList] = withState(<HostsList />, state);
@@ -208,6 +211,7 @@ describe('HostsLists component', () => {
         hostsList: {
           hosts: [host],
         },
+        user: { abilities: [{ name: 'all', resource: 'all' }] },
       };
 
       const [StatefulHostsList, store] = withState(<HostsList />, state);
@@ -245,6 +249,35 @@ describe('HostsLists component', () => {
       ];
       expect(actions).toEqual(expect.arrayContaining(expectedActions));
     });
+
+    it('should forbid cleaning up a host', async () => {
+      const user = userEvent.setup();
+
+      const host = hostFactory.build({ deregisterable: true });
+      const state = {
+        ...defaultInitialState,
+        hostsList: {
+          hosts: [host],
+        },
+        user: { abilities: [] },
+      };
+
+      const [StatefulHostsList] = withState(<HostsList />, state);
+
+      renderWithRouter(StatefulHostsList);
+
+      const cleanUpButton = screen.getByText('Clean up').closest('button');
+
+      expect(cleanUpButton).toBeDisabled();
+
+      await user.click(cleanUpButton);
+
+      await user.hover(cleanUpButton);
+
+      expect(
+        screen.queryByText('You are not authorized for this action')
+      ).toBeVisible();
+    });
   });
 
   describe('filtering', () => {
@@ -264,6 +297,7 @@ describe('HostsLists component', () => {
         databases: [],
         databaseInstances: [],
       },
+      user: { abilities: [{ name: 'all', resource: 'all' }] },
     };
 
     const scenarios = [

--- a/assets/js/pages/InstanceOverview/InstanceOverview.jsx
+++ b/assets/js/pages/InstanceOverview/InstanceOverview.jsx
@@ -26,6 +26,8 @@ function InstanceOverview({
     absent_at: absentAt,
     deregistering,
   },
+  userAbilities,
+  cleanUpPermittedFor,
   onCleanUpClick,
 }) {
   const isDatabase = DATABASE_TYPE === instanceType;
@@ -77,6 +79,8 @@ function InstanceOverview({
             type="transparent"
             className="jungle-green-500 border-none shadow-none"
             cleaning={deregistering}
+            userAbilities={userAbilities}
+            permittedFor={cleanUpPermittedFor}
             onClick={() => onCleanUpClick(instance, instanceType)}
           />
         </div>

--- a/assets/js/pages/InstanceOverview/InstanceOverview.test.jsx
+++ b/assets/js/pages/InstanceOverview/InstanceOverview.test.jsx
@@ -57,6 +57,7 @@ describe('InstanceOverview', () => {
       <InstanceOverview
         instanceType={APPLICATION_TYPE}
         instance={absentInstance}
+        userAbilities={[{ name: 'all', resource: 'all' }]}
       />
     );
 
@@ -95,9 +96,38 @@ describe('InstanceOverview', () => {
       <InstanceOverview
         instanceType={DATABASE_TYPE}
         instance={absentInstance}
+        userAbilities={[{ name: 'all', resource: 'all' }]}
       />
     );
 
     expect(screen.getByLabelText('Loading')).toBeInTheDocument();
+  });
+
+  it('should forbid instance cleanup', async () => {
+    const user = userEvent.setup();
+
+    const absentInstance = databaseInstanceFactory.build({
+      absent_at: faker.date.past().toISOString(),
+    });
+
+    renderWithRouter(
+      <InstanceOverview
+        instanceType={DATABASE_TYPE}
+        instance={absentInstance}
+        userAbilities={[]}
+      />
+    );
+
+    const cleanUpButton = screen.getByText('Clean up').closest('button');
+
+    expect(cleanUpButton).toBeDisabled();
+
+    await user.click(cleanUpButton);
+
+    await user.hover(cleanUpButton);
+
+    expect(
+      screen.queryByText('You are not authorized for this action')
+    ).toBeVisible();
   });
 });

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
@@ -34,6 +34,8 @@ export function GenericSystemDetails({
   title,
   type,
   system,
+  userAbilities,
+  cleanUpPermittedFor,
   onInstanceCleanUp,
 }) {
   if (!system) {
@@ -109,7 +111,11 @@ export function GenericSystemDetails({
           <h2 className="text-2xl font-bold self-center">Layout</h2>
         </div>
         <Table
-          config={getSystemInstancesTableConfiguration({ onCleanUpClick })}
+          config={getSystemInstancesTableConfiguration({
+            userAbilities,
+            cleanUpPermittedFor,
+            onCleanUpClick,
+          })}
           data={system.instances}
         />
       </div>

--- a/assets/js/pages/SapSystemDetails/SapSystemDetails.jsx
+++ b/assets/js/pages/SapSystemDetails/SapSystemDetails.jsx
@@ -4,6 +4,7 @@ import { useSelector, useDispatch } from 'react-redux';
 
 import { APPLICATION_TYPE } from '@lib/model/sapSystems';
 import { getEnrichedSapSystemDetails } from '@state/selectors/sapSystem';
+import { getUserProfile } from '@state/selectors/user';
 import { deregisterApplicationInstance } from '@state/sapSystems';
 
 import BackButton from '@common/BackButton';
@@ -14,6 +15,7 @@ function SapSystemDetails() {
   const sapSystem = useSelector((state) =>
     getEnrichedSapSystemDetails(state, id)
   );
+  const { abilities } = useSelector(getUserProfile);
   const dispatch = useDispatch();
 
   if (!sapSystem) {
@@ -27,6 +29,8 @@ function SapSystemDetails() {
         title="SAP System Details"
         type={APPLICATION_TYPE}
         system={sapSystem}
+        userAbilities={abilities}
+        cleanUpPermittedFor={['cleanup:application_instance']}
         onInstanceCleanUp={(instance) => {
           dispatch(deregisterApplicationInstance(instance));
         }}

--- a/assets/js/pages/SapSystemDetails/SapSystemDetails.stories.jsx
+++ b/assets/js/pages/SapSystemDetails/SapSystemDetails.stories.jsx
@@ -44,6 +44,14 @@ export default {
       description:
         'The object containing the details that are going to be represented in this view',
     },
+    userAbilities: {
+      control: 'array',
+      description: 'Current user abilities',
+    },
+    cleanUpPermittedFor: {
+      control: 'array',
+      description: 'Abilities that allow instance clean up',
+    },
     onInstanceCleanUp: {
       action: 'Clean up instance',
       description: 'Deregister and clean up an absent instance',
@@ -68,12 +76,21 @@ export const SapSystem = {
     title: 'SAP System Details',
     type: APPLICATION_TYPE,
     system,
+    userAbilities: [{ name: 'all', resource: 'all' }],
+    cleanUpPermittedFor: ['cleanup:application_instance'],
   },
 };
 
 export const SapSystemWithAbsentInstance = {
   args: {
-    ...SapSystem,
+    ...SapSystem.args,
     system: systemWithAbsentInstance,
+  },
+};
+
+export const CleanUpUnauthorized = {
+  args: {
+    ...SapSystemWithAbsentInstance.args,
+    userAbilities: [],
   },
 };

--- a/assets/js/pages/SapSystemDetails/tableConfigs.jsx
+++ b/assets/js/pages/SapSystemDetails/tableConfigs.jsx
@@ -16,7 +16,11 @@ const cellRender = (content, item) => (
   </span>
 );
 
-export const getSystemInstancesTableConfiguration = ({ onCleanUpClick }) => ({
+export const getSystemInstancesTableConfiguration = ({
+  userAbilities,
+  cleanUpPermittedFor,
+  onCleanUpClick,
+}) => ({
   usePadding: false,
   columns: [
     {
@@ -78,6 +82,8 @@ export const getSystemInstancesTableConfiguration = ({ onCleanUpClick }) => ({
             type="transparent"
             className="jungle-green-500 border-none shadow-none"
             cleaning={item.deregistering}
+            userAbilities={userAbilities}
+            permittedFor={cleanUpPermittedFor}
             onClick={() => {
               onCleanUpClick(item);
             }}

--- a/assets/js/pages/SapSystemsOverviewPage/SapSystemItemOverview.jsx
+++ b/assets/js/pages/SapSystemsOverviewPage/SapSystemItemOverview.jsx
@@ -5,11 +5,13 @@ import { APPLICATION_TYPE } from '@lib/model/sapSystems';
 import DatabaseItemOverview from '@pages/DatabasesOverview/DatabaseItemOverview';
 import InstanceOverview from '@pages/InstanceOverview';
 
-function ApplicationInstance({ instance, onCleanUpClick }) {
+function ApplicationInstance({ instance, userAbilities, onCleanUpClick }) {
   return (
     <InstanceOverview
       instanceType={APPLICATION_TYPE}
       instance={instance}
+      userAbilities={userAbilities}
+      cleanUpPermittedFor={['cleanup:application_instance']}
       onCleanUpClick={onCleanUpClick}
     />
   );
@@ -24,7 +26,7 @@ const applicationInstanceColumns = [
   { key: 'cleanupButton', cssClass: 'w-48' },
 ];
 
-function SapSystemItemOverview({ sapSystem, onCleanUpClick }) {
+function SapSystemItemOverview({ sapSystem, userAbilities, onCleanUpClick }) {
   const { applicationInstances, databaseInstances } = sapSystem;
 
   return (
@@ -56,6 +58,7 @@ function SapSystemItemOverview({ sapSystem, onCleanUpClick }) {
                   <ApplicationInstance
                     key={`${instance.host_id}_${instance.instance_number}`}
                     instance={instance}
+                    userAbilities={userAbilities}
                     onCleanUpClick={onCleanUpClick}
                   />
                 ))}
@@ -66,6 +69,7 @@ function SapSystemItemOverview({ sapSystem, onCleanUpClick }) {
       <DatabaseItemOverview
         database={{ databaseInstances }}
         asDatabaseLayer
+        userAbilities={userAbilities}
         onCleanUpClick={onCleanUpClick}
       />
     </div>

--- a/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.jsx
+++ b/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.jsx
@@ -20,6 +20,7 @@ function SapSystemsOverview({
   applicationInstances,
   databaseInstances,
   loading,
+  userAbilities,
   onTagAdd,
   onTagRemove,
   onInstanceCleanUp,
@@ -106,6 +107,7 @@ function SapSystemsOverview({
     collapsibleDetailRenderer: (sapSystem) => (
       <SAPSystemItemOverview
         sapSystem={sapSystem}
+        userAbilities={userAbilities}
         onCleanUpClick={(instance, type) => {
           setCleanUpModalOpen(true);
           setInstanceToDeregister(instance);

--- a/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.stories.jsx
+++ b/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.stories.jsx
@@ -82,6 +82,10 @@ export default {
         defaultValue: { summary: false },
       },
     },
+    userAbilities: {
+      control: 'array',
+      description: 'Current user abilities',
+    },
     onTagAdd: {
       action: 'Add tag',
       description: 'Called when a new tag is added',
@@ -115,6 +119,7 @@ export const SapSystems = {
     applicationInstances: enrichedApplicationInstances,
     databaseInstances: enrichedDatabaseInstances,
     loading: false,
+    userAbilities: [{ name: 'all', resource: 'all' }],
   },
 };
 
@@ -124,5 +129,13 @@ export const WithAbsentInstances = {
     applicationInstances: enrichedAbsentApplicationInstances,
     databaseInstances: enrichedAbsentDatabaseInstances,
     loading: false,
+    userAbilities: [{ name: 'all', resource: 'all' }],
+  },
+};
+
+export const UnauthorizedCleanUp = {
+  args: {
+    ...WithAbsentInstances.args,
+    userAbilities: [],
   },
 };

--- a/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverviewPage.jsx
+++ b/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverviewPage.jsx
@@ -8,6 +8,7 @@ import {
   getEnrichedApplicationInstances,
   getEnrichedDatabaseInstances,
 } from '@state/selectors/sapSystem';
+import { getUserProfile } from '@state/selectors/user';
 import {
   addTagToSAPSystem,
   removeTagFromSAPSystem,
@@ -35,6 +36,7 @@ function SapSystemOverviewPage() {
   const enrichedDatabaseInstances = useSelector((state) =>
     getEnrichedDatabaseInstances(state)
   );
+  const { abilities } = useSelector(getUserProfile);
   const dispatch = useDispatch();
 
   return (
@@ -43,6 +45,7 @@ function SapSystemOverviewPage() {
       applicationInstances={enrichedApplicationInstances}
       databaseInstances={enrichedDatabaseInstances}
       loading={loading}
+      userAbilities={abilities}
       onTagAdd={(tag, sapSystemID) => {
         addTag(tag, sapSystemID);
         dispatch(

--- a/lib/trento/databases/policy.ex
+++ b/lib/trento/databases/policy.ex
@@ -1,0 +1,20 @@
+defmodule Trento.Databases.Policy do
+  @moduledoc """
+  Policy for the Database resource
+
+  User with the ability cleanup:database_instance can cleanup a database instance.
+  """
+  @behaviour Bodyguard.Policy
+
+  import Trento.Support.PolicyHelper
+  alias Trento.Databases.Projections.DatabaseReadModel
+  alias Trento.Users.User
+
+  def authorize(:delete_database_instance, %User{} = user, DatabaseReadModel),
+    do: has_global_ability?(user) or has_cleanup_ability?(user)
+
+  def authorize(_, _, _), do: true
+
+  defp has_cleanup_ability?(user),
+    do: user_has_ability?(user, %{name: "cleanup", resource: "database_instance"})
+end

--- a/lib/trento/databases/projections/database_read_model.ex
+++ b/lib/trento/databases/projections/database_read_model.ex
@@ -15,6 +15,8 @@ defmodule Trento.Databases.Projections.DatabaseReadModel do
 
   alias Trento.Tags.Tag
 
+  defdelegate authorize(action, user, params), to: Trento.Databases.Policy
+
   @type t :: %__MODULE__{}
 
   @derive {Jason.Encoder, except: [:__meta__, :__struct__]}

--- a/lib/trento/hosts/policy.ex
+++ b/lib/trento/hosts/policy.ex
@@ -5,6 +5,7 @@ defmodule Trento.Hosts.Policy do
   User with the ability all:all can perform any operation on the hosts.
   User with the ability all:host_checks_execution can perform a check executions on Hosts.
   User with the ability all:host_checks_selection can perform a check selection on Hosts.
+  User with the ability cleanup:host can cleanup a host.
   """
   @behaviour Bodyguard.Policy
 
@@ -13,18 +14,22 @@ defmodule Trento.Hosts.Policy do
   alias Trento.Users.User
 
   def authorize(:select_checks, %User{} = user, HostReadModel),
-    do: has_select_checks_ability?(user)
+    do: has_global_ability?(user) or has_select_checks_ability?(user)
 
   def authorize(:request_checks_execution, %User{} = user, HostReadModel),
     do: has_global_ability?(user) or has_checks_execution_ability?(user)
 
+  def authorize(:delete, %User{} = user, HostReadModel),
+    do: has_global_ability?(user) or has_cleanup_ability?(user)
+
   def authorize(_, _, _), do: true
 
   defp has_select_checks_ability?(user),
-    do:
-      has_global_ability?(user) or
-        user_has_ability?(user, %{name: "all", resource: "host_checks_selection"})
+    do: user_has_ability?(user, %{name: "all", resource: "host_checks_selection"})
 
   defp has_checks_execution_ability?(user),
     do: user_has_ability?(user, %{name: "all", resource: "host_checks_execution"})
+
+  defp has_cleanup_ability?(user),
+    do: user_has_ability?(user, %{name: "cleanup", resource: "host"})
 end

--- a/lib/trento/sap_systems/policy.ex
+++ b/lib/trento/sap_systems/policy.ex
@@ -1,0 +1,20 @@
+defmodule Trento.SapSystems.Policy do
+  @moduledoc """
+  Policy for the SAP systems resource
+
+  User with the ability cleanup:application_instance can cleanup a SAP system instance.
+  """
+  @behaviour Bodyguard.Policy
+
+  import Trento.Support.PolicyHelper
+  alias Trento.SapSystems.Projections.SapSystemReadModel
+  alias Trento.Users.User
+
+  def authorize(:delete_application_instance, %User{} = user, SapSystemReadModel),
+    do: has_global_ability?(user) or has_cleanup_ability?(user)
+
+  def authorize(_, _, _), do: true
+
+  defp has_cleanup_ability?(user),
+    do: user_has_ability?(user, %{name: "cleanup", resource: "application_instance"})
+end

--- a/lib/trento/sap_systems/projections/sap_system_read_model.ex
+++ b/lib/trento/sap_systems/projections/sap_system_read_model.ex
@@ -19,6 +19,8 @@ defmodule Trento.SapSystems.Projections.SapSystemReadModel do
 
   alias Trento.Tags.Tag
 
+  defdelegate authorize(action, user, params), to: Trento.SapSystems.Policy
+
   @type t :: %__MODULE__{}
 
   @derive {Jason.Encoder, except: [:__meta__, :__struct__]}

--- a/lib/trento_web/controllers/v1/database_controller.ex
+++ b/lib/trento_web/controllers/v1/database_controller.ex
@@ -11,6 +11,15 @@ defmodule TrentoWeb.V1.DatabaseController do
     UnprocessableEntity
   }
 
+  plug TrentoWeb.Plugs.LoadUserPlug
+
+  plug Bodyguard.Plug.Authorize,
+    policy: Trento.Databases.Policy,
+    action: {Phoenix.Controller, :action_name},
+    user: {Pow.Plug, :current_user},
+    params: {__MODULE__, :get_policy_resource},
+    fallback: TrentoWeb.FallbackController
+
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
   action_fallback TrentoWeb.FallbackController
 
@@ -67,4 +76,6 @@ defmodule TrentoWeb.V1.DatabaseController do
       send_resp(conn, 204, "")
     end
   end
+
+  def get_policy_resource(_), do: Trento.Databases.Projections.DatabaseReadModel
 end

--- a/lib/trento_web/controllers/v1/sap_system_controller.ex
+++ b/lib/trento_web/controllers/v1/sap_system_controller.ex
@@ -11,6 +11,15 @@ defmodule TrentoWeb.V1.SapSystemController do
     UnprocessableEntity
   }
 
+  plug TrentoWeb.Plugs.LoadUserPlug
+
+  plug Bodyguard.Plug.Authorize,
+    policy: Trento.SapSystems.Policy,
+    action: {Phoenix.Controller, :action_name},
+    user: {Pow.Plug, :current_user},
+    params: {__MODULE__, :get_policy_resource},
+    fallback: TrentoWeb.FallbackController
+
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
   action_fallback TrentoWeb.FallbackController
 
@@ -69,4 +78,6 @@ defmodule TrentoWeb.V1.SapSystemController do
       send_resp(conn, 204, "")
     end
   end
+
+  def get_policy_resource(_), do: Trento.SapSystems.Projections.SapSystemReadModel
 end

--- a/priv/repo/migrations/20240702075045_add_clenaup_abilities.exs
+++ b/priv/repo/migrations/20240702075045_add_clenaup_abilities.exs
@@ -1,0 +1,19 @@
+defmodule Trento.Repo.Migrations.AddClenaupAbilities do
+  use Ecto.Migration
+
+  def up do
+    execute "INSERT INTO abilities(id, name, resource, label, inserted_at, updated_at) VALUES (DEFAULT, 'cleanup', 'host', 'Permits cleanup of hosts', NOW(), NOW())"
+
+    execute "INSERT INTO abilities(id, name, resource, label, inserted_at, updated_at) VALUES (DEFAULT, 'cleanup', 'application_instance', 'Permits cleanup of application instances', NOW(), NOW())"
+
+    execute "INSERT INTO abilities(id, name, resource, label, inserted_at, updated_at) VALUES (DEFAULT, 'cleanup', 'database_instance', 'Permits cleanup of database instances', NOW(), NOW())"
+  end
+
+  def down do
+    execute "DELETE FROM abilities WHERE name = 'cleanup' and resource = 'host'"
+
+    execute "DELETE FROM abilities WHERE name = 'cleanup' and resource = 'application_instance'"
+
+    execute "DELETE FROM abilities WHERE name = 'cleanup' and resource = 'database_instance'"
+  end
+end

--- a/test/trento/databases/policy_test.exs
+++ b/test/trento/databases/policy_test.exs
@@ -1,0 +1,34 @@
+defmodule Trento.Databases.PolicyTest do
+  use ExUnit.Case
+
+  alias Trento.Abilities.Ability
+  alias Trento.Databases.Policy
+  alias Trento.Databases.Projections.DatabaseReadModel
+  alias Trento.Users.User
+
+  test "should allow delete_database_instance action if the user has cleanup:database_instance ability" do
+    user = %User{abilities: [%Ability{name: "cleanup", resource: "database_instance"}]}
+
+    assert Policy.authorize(:delete_database_instance, user, DatabaseReadModel)
+  end
+
+  test "should allow delete_database_instance action if the user has all:all ability" do
+    user = %User{abilities: [%Ability{name: "all", resource: "all"}]}
+
+    assert Policy.authorize(:delete_database_instance, user, DatabaseReadModel)
+  end
+
+  test "should disallow delete_database_instance action if the user does not have cleanup:database_instance ability" do
+    user = %User{abilities: []}
+
+    refute Policy.authorize(:delete_database_instance, user, DatabaseReadModel)
+  end
+
+  test "should allow unguarded actions" do
+    user = %User{abilities: []}
+
+    Enum.each([:list], fn action ->
+      assert Policy.authorize(action, user, DatabaseReadModel)
+    end)
+  end
+end

--- a/test/trento/hosts/policy_test.exs
+++ b/test/trento/hosts/policy_test.exs
@@ -6,13 +6,13 @@ defmodule Trento.Hosts.PolicyTest do
   alias Trento.Hosts.Projections.HostReadModel
   alias Trento.Users.User
 
-  test "should allow select_checks operations if the user has all:host_checks_selection ability" do
+  test "should allow select_checks action if the user has all:host_checks_selection ability" do
     user = %User{abilities: [%Ability{name: "all", resource: "host_checks_selection"}]}
 
     assert Policy.authorize(:select_checks, user, HostReadModel)
   end
 
-  test "should disallow select_checks operations if the user does not have all:host_checks_selection ability" do
+  test "should disallow select_checks action if the user does not have all:host_checks_selection ability" do
     user = %User{abilities: []}
 
     refute Policy.authorize(:select_checks, user, HostReadModel)
@@ -36,10 +36,28 @@ defmodule Trento.Hosts.PolicyTest do
     refute Policy.authorize(:request_checks_execution, user, HostReadModel)
   end
 
+  test "should allow delete action if the user has cleanup:host ability" do
+    user = %User{abilities: [%Ability{name: "cleanup", resource: "host"}]}
+
+    assert Policy.authorize(:delete, user, HostReadModel)
+  end
+
+  test "should allow delete action if the user has all:all ability" do
+    user = %User{abilities: [%Ability{name: "all", resource: "all"}]}
+
+    assert Policy.authorize(:delete, user, HostReadModel)
+  end
+
+  test "should disallow delete action if the user does not have cleanup:host ability" do
+    user = %User{abilities: []}
+
+    refute Policy.authorize(:delete, user, HostReadModel)
+  end
+
   test "should allow unguarded actions" do
     user = %User{abilities: []}
 
-    Enum.each([:list, :delete], fn action ->
+    Enum.each([:list], fn action ->
       assert Policy.authorize(action, user, HostReadModel)
     end)
   end

--- a/test/trento/sap_systems/policy_test.exs
+++ b/test/trento/sap_systems/policy_test.exs
@@ -1,0 +1,34 @@
+defmodule Trento.SapSystems.PolicyTest do
+  use ExUnit.Case
+
+  alias Trento.Abilities.Ability
+  alias Trento.SapSystems.Policy
+  alias Trento.SapSystems.Projections.SapSystemReadModel
+  alias Trento.Users.User
+
+  test "should allow delete_application_instance action if the user has cleanup:application_instance ability" do
+    user = %User{abilities: [%Ability{name: "cleanup", resource: "application_instance"}]}
+
+    assert Policy.authorize(:delete_application_instance, user, SapSystemReadModel)
+  end
+
+  test "should allow delete_application_instance action if the user has all:all ability" do
+    user = %User{abilities: [%Ability{name: "all", resource: "all"}]}
+
+    assert Policy.authorize(:delete_application_instance, user, SapSystemReadModel)
+  end
+
+  test "should disallow delete_application_instance action if the user does not have cleanup:application_instance ability" do
+    user = %User{abilities: []}
+
+    refute Policy.authorize(:delete_application_instance, user, SapSystemReadModel)
+  end
+
+  test "should allow unguarded actions" do
+    user = %User{abilities: []}
+
+    Enum.each([:list], fn action ->
+      assert Policy.authorize(action, user, SapSystemReadModel)
+    end)
+  end
+end

--- a/test/trento_web/controllers/v1/database_controller_test.exs
+++ b/test/trento_web/controllers/v1/database_controller_test.exs
@@ -7,11 +7,16 @@ defmodule TrentoWeb.V1.DatabaseControllerTest do
 
   import Mox
 
+  import Trento.Support.Helpers.AbilitiesTestHelper
+
   alias TrentoWeb.OpenApi.V1.ApiSpec
 
   alias Trento.Databases.Commands.DeregisterDatabaseInstance
 
   setup [:set_mox_from_context, :verify_on_exit!]
+
+  setup :setup_api_spec_v1
+  setup :setup_user
 
   describe "list" do
     test "should list all databases", %{conn: conn} do
@@ -107,6 +112,36 @@ defmodule TrentoWeb.V1.DatabaseControllerTest do
       |> delete("/api/v1/databases/#{database_id}/hosts/#{host_id}/instances/#{instance_number}")
       |> json_response(404)
       |> assert_schema("NotFound", api_spec)
+    end
+  end
+
+  describe "forbidden response" do
+    test "should return forbidden on any controller action if the user does not have the right permission",
+         %{conn: conn, api_spec: api_spec} do
+      %{id: user_id} = insert(:user)
+      %{id: database_id} = build(:database)
+
+      %{host_id: host_id, instance_number: instance_number} =
+        build(:database_instance, database_id: database_id)
+
+      conn =
+        conn
+        |> Pow.Plug.assign_current_user(%{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
+        |> put_req_header("content-type", "application/json")
+
+      Enum.each(
+        [
+          delete(
+            conn,
+            "/api/v1/databases/#{database_id}/hosts/#{host_id}/instances/#{instance_number}"
+          )
+        ],
+        fn conn ->
+          conn
+          |> json_response(:forbidden)
+          |> assert_schema("Forbidden", api_spec)
+        end
+      )
     end
   end
 end

--- a/test/trento_web/controllers/v1/host_controller_test.exs
+++ b/test/trento_web/controllers/v1/host_controller_test.exs
@@ -13,31 +13,6 @@ defmodule TrentoWeb.V1.HostControllerTest do
   setup :setup_api_spec_v1
   setup :setup_user
 
-  describe "forbidden routes" do
-    test "should return forbidden on any controller action if the user does not have the right permission",
-         %{conn: conn, api_spec: api_spec} do
-      %{id: user_id} = insert(:user)
-      %{id: host_id} = insert(:host)
-
-      conn =
-        conn
-        |> Pow.Plug.assign_current_user(%{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
-        |> put_req_header("content-type", "application/json")
-
-      Enum.each(
-        [
-          post(conn, "/api/v1/hosts/#{host_id}/checks", %{}),
-          post(conn, "/api/v1/hosts/#{host_id}/checks/request_execution", %{})
-        ],
-        fn conn ->
-          conn
-          |> json_response(:forbidden)
-          |> assert_schema("Forbidden", api_spec)
-        end
-      )
-    end
-  end
-
   describe "list" do
     test "should list all hosts", %{conn: conn, api_spec: api_spec} do
       %{id: host_id} = insert(:host)
@@ -353,6 +328,32 @@ defmodule TrentoWeb.V1.HostControllerTest do
       |> delete("/api/v1/hosts/#{host_id}")
       |> json_response(404)
       |> assert_schema("NotFound", api_spec)
+    end
+  end
+
+  describe "forbidden response" do
+    test "should return forbidden on any controller action if the user does not have the right permission",
+         %{conn: conn, api_spec: api_spec} do
+      %{id: user_id} = insert(:user)
+      %{id: host_id} = insert(:host)
+
+      conn =
+        conn
+        |> Pow.Plug.assign_current_user(%{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
+        |> put_req_header("content-type", "application/json")
+
+      Enum.each(
+        [
+          post(conn, "/api/v1/hosts/#{host_id}/checks", %{}),
+          post(conn, "/api/v1/hosts/#{host_id}/checks/request_execution", %{}),
+          delete(conn, "/api/v1/hosts/#{host_id}")
+        ],
+        fn conn ->
+          conn
+          |> json_response(:forbidden)
+          |> assert_schema("Forbidden", api_spec)
+        end
+      )
     end
   end
 end


### PR DESCRIPTION
# Description

Add host/application instance/database instance cleanup abilities.
The `Clean up` is only available when the user has the proper abilities attached.

Even though we have a lot of new lines, almost everything is boilerplate and `userAbilities` movement in the frontend.

