### PR TITLE
Display CVEs and fixes in the advisory details page

### DIFF
--- a/assets/js/lib/test-utils/factories/advisoryErrata.js
+++ b/assets/js/lib/test-utils/factories/advisoryErrata.js
@@ -2,23 +2,36 @@ import { faker } from '@faker-js/faker';
 import { Factory } from 'fishery';
 import { advisoryType } from './relevantPatches';
 
+const buildFixes = (size) =>
+  Object.fromEntries(
+    new Array(size)
+      .fill(0)
+      .map(() => [
+        faker.number.int({ min: 1, max: 65536 }),
+        faker.lorem.sentence(),
+      ])
+  );
+
 export const advisoryErrataFactory = Factory.define(() => ({
-  id: faker.number.int({ min: 1, max: 65536 }),
-  issue_date: faker.date.recent({ days: 30 }),
-  update_date: faker.date.recent({ days: 30 }),
-  last_modified_date: faker.date.recent({ days: 30 }),
-  synopsis: faker.lorem.sentence(),
-  release: faker.number.int({ min: 1, max: 256 }),
-  advisory_status: 'stable',
-  vendor_advisory: faker.lorem.word(),
-  type: faker.helpers.arrayElement(advisoryType),
-  product: faker.internet.userName(),
-  errata_from: faker.lorem.word(),
-  topic: faker.animal.cat(),
-  description: faker.lorem.sentence(),
-  references: faker.lorem.sentence(),
-  notes: faker.lorem.sentence(),
-  solution: faker.lorem.sentence(),
-  reboot_suggested: faker.datatype.boolean(),
-  restart_suggested: faker.datatype.boolean(),
+  fixes: buildFixes(faker.number.int({ min: 1, max: 4 })),
+  errata_details: {
+    id: faker.number.int({ min: 1, max: 65536 }),
+    issue_date: faker.date.recent({ days: 30 }),
+    update_date: faker.date.recent({ days: 30 }),
+    last_modified_date: faker.date.recent({ days: 30 }),
+    synopsis: faker.lorem.sentence(),
+    release: faker.number.int({ min: 1, max: 256 }),
+    advisory_status: 'stable',
+    vendor_advisory: faker.lorem.word(),
+    type: faker.helpers.arrayElement(advisoryType),
+    product: faker.internet.userName(),
+    errata_from: faker.lorem.word(),
+    topic: faker.animal.cat(),
+    description: faker.lorem.sentence(),
+    references: faker.lorem.sentence(),
+    notes: faker.lorem.sentence(),
+    solution: faker.lorem.sentence(),
+    reboot_suggested: faker.datatype.boolean(),
+    restart_suggested: faker.datatype.boolean(),
+  },
 }));

--- a/assets/js/lib/test-utils/factories/advisoryErrata.js
+++ b/assets/js/lib/test-utils/factories/advisoryErrata.js
@@ -2,29 +2,35 @@ import { faker } from '@faker-js/faker';
 import { Factory } from 'fishery';
 import { advisoryType } from './relevantPatches';
 
-const fixMapFactory = Factory.define(({ transientParams }) =>
-  Object.fromEntries(
-    new Array(transientParams.length ?? 1)
+const fixMapFactory = Factory.define(({ transientParams }) => {
+  const { length = 1 } = transientParams;
+
+  return Object.fromEntries(
+    new Array(length)
       .fill(0)
       .map(() => [
         faker.number.int({ min: 1, max: 65536 }),
         faker.lorem.sentence(),
       ])
-  )
+  );
+});
+
+export const cveFactory = Factory.define(
+  () =>
+    `CVE-${faker.number.int({ min: 1991, max: 2024 })}-${faker.number.int({
+      min: 0,
+      max: 9999,
+    })}`
 );
 
-const buildCVE = () =>
-  `CVE-${faker.number.int({ min: 1991, max: 2024 })}-${faker.number.int({
-    min: 0,
-    max: 9999,
-  })}`;
-
-export const advisoryErrataFactory = Factory.define(({ transientParams }) => ({
-  fixes: fixMapFactory.build(
-    {},
-    { transient: { length: transientParams.fixesLength ?? 1 } }
-  ),
-  cves: faker.helpers.uniqueArray(buildCVE, transientParams.cvesLength ?? 1),
+export const advisoryErrataFactory = Factory.define(({ params }) => ({
+  fixes:
+    params.fixes ||
+    fixMapFactory.build(
+      {},
+      { transient: { length: faker.number.int({ min: 1, max: 10 }) } }
+    ),
+  cves: cveFactory.buildList(10),
   errata_details: {
     id: faker.number.int({ min: 1, max: 65536 }),
     issue_date: faker.date.recent({ days: 30 }),

--- a/assets/js/lib/test-utils/factories/advisoryErrata.js
+++ b/assets/js/lib/test-utils/factories/advisoryErrata.js
@@ -12,8 +12,18 @@ const buildFixes = (size) =>
       ])
   );
 
+const buildCVE = () =>
+  `CVE-${faker.number.int({ min: 1991, max: 2024 })}-${faker.number.int({
+    min: 0,
+    max: 9999,
+  })}`;
+
 export const advisoryErrataFactory = Factory.define(() => ({
   fixes: buildFixes(faker.number.int({ min: 1, max: 4 })),
+  cves: faker.helpers.uniqueArray(
+    buildCVE,
+    faker.number.int({ min: 1, max: 10 })
+  ),
   errata_details: {
     id: faker.number.int({ min: 1, max: 65536 }),
     issue_date: faker.date.recent({ days: 30 }),

--- a/assets/js/lib/test-utils/factories/advisoryErrata.js
+++ b/assets/js/lib/test-utils/factories/advisoryErrata.js
@@ -2,15 +2,16 @@ import { faker } from '@faker-js/faker';
 import { Factory } from 'fishery';
 import { advisoryType } from './relevantPatches';
 
-const buildFixes = (size) =>
+const fixMapFactory = Factory.define(({ transientParams }) =>
   Object.fromEntries(
-    new Array(size)
+    new Array(transientParams.length ?? 1)
       .fill(0)
       .map(() => [
         faker.number.int({ min: 1, max: 65536 }),
         faker.lorem.sentence(),
       ])
-  );
+  )
+);
 
 const buildCVE = () =>
   `CVE-${faker.number.int({ min: 1991, max: 2024 })}-${faker.number.int({
@@ -18,12 +19,12 @@ const buildCVE = () =>
     max: 9999,
   })}`;
 
-export const advisoryErrataFactory = Factory.define(() => ({
-  fixes: buildFixes(faker.number.int({ min: 1, max: 4 })),
-  cves: faker.helpers.uniqueArray(
-    buildCVE,
-    faker.number.int({ min: 1, max: 10 })
+export const advisoryErrataFactory = Factory.define(({ transientParams }) => ({
+  fixes: fixMapFactory.build(
+    {},
+    { transient: { length: transientParams.fixesLength ?? 1 } }
   ),
+  cves: faker.helpers.uniqueArray(buildCVE, transientParams.cvesLength ?? 1),
   errata_details: {
     id: faker.number.int({ min: 1, max: 65536 }),
     issue_date: faker.date.recent({ days: 30 }),

--- a/assets/js/lib/test-utils/factories/upgradablePackage.js
+++ b/assets/js/lib/test-utils/factories/upgradablePackage.js
@@ -8,7 +8,7 @@ const releaseVersionFactory = () =>
 export const upgradablePackageFactory = Factory.define(() => ({
   from_epoch: faker.date.anytime(),
   to_release: releaseVersionFactory(),
-  name: faker.company.buzzNoun(),
+  name: faker.word.noun(),
   from_release: releaseVersionFactory(),
   to_epoch: faker.date.anytime(),
   arch: faker.airline.flightNumber(),

--- a/assets/js/pages/AdvisoryDetails/AdvisoryDetails.jsx
+++ b/assets/js/pages/AdvisoryDetails/AdvisoryDetails.jsx
@@ -76,7 +76,7 @@ function AdvisoryDetails({
       <div className="flex flex-col mb-4">
         <h2 className="text-xl font-bold mb-2">Fixes</h2>
         <div className="bg-white py-4 px-6 shadow shadow-md rounded-lg">
-          {fixes && Object.keys(fixes).length >= 1 ? (
+          {fixes && Object.keys(fixes).length ? (
             <ul>
               {Object.entries(fixes).map(([id, fix]) => (
                 <li key={`bug-${id}`}>
@@ -97,7 +97,7 @@ function AdvisoryDetails({
       <div className="flex flex-col mb-4">
         <h2 className="text-xl font-bold mb-2">CVEs</h2>
         <div className="bg-white py-4 px-6 shadow shadow-md rounded-lg">
-          {cves && cves.length >= 1 ? (
+          {cves && cves.length ? (
             <ul>
               {cves.map((cve) => (
                 <li key={cve}>
@@ -118,7 +118,7 @@ function AdvisoryDetails({
       <div className="flex flex-col mb-4">
         <h2 className="text-xl font-bold mb-2">Affected Packages</h2>
         <div className="bg-white py-4 px-6 shadow shadow-md rounded-lg">
-          {packages && packages.length >= 1 ? (
+          {packages && packages.length ? (
             <ul>
               {packages.map((pkg) => (
                 <li>{pkg}</li>

--- a/assets/js/pages/AdvisoryDetails/AdvisoryDetails.jsx
+++ b/assets/js/pages/AdvisoryDetails/AdvisoryDetails.jsx
@@ -97,7 +97,7 @@ function AdvisoryDetails({
       <div className="flex flex-col mb-4">
         <h2 className="text-xl font-bold mb-2">CVEs</h2>
         <div className="bg-white py-4 px-6 shadow shadow-md rounded-lg">
-          {cves && cves.length > 1 ? (
+          {cves && cves.length >= 1 ? (
             <ul>
               {cves.map((cve) => (
                 <li>{cve}</li>
@@ -111,7 +111,7 @@ function AdvisoryDetails({
       <div className="flex flex-col mb-4">
         <h2 className="text-xl font-bold mb-2">Affected Packages</h2>
         <div className="bg-white py-4 px-6 shadow shadow-md rounded-lg">
-          {packages && packages.length > 1 ? (
+          {packages && packages.length >= 1 ? (
             <ul>
               {packages.map((pkg) => (
                 <li>{pkg}</li>

--- a/assets/js/pages/AdvisoryDetails/AdvisoryDetails.jsx
+++ b/assets/js/pages/AdvisoryDetails/AdvisoryDetails.jsx
@@ -79,7 +79,7 @@ function AdvisoryDetails({
           {fixes && Object.keys(fixes).length >= 1 ? (
             <ul>
               {Object.entries(fixes).map(([id, fix]) => (
-                <li key={`CVE-${id}`}>
+                <li key={`bug-${id}`}>
                   <a
                     className="text-jungle-green-500 hover:opacity-75"
                     href={`https://bugzilla.suse.com/show_bug.cgi?id=${id}`}
@@ -100,7 +100,14 @@ function AdvisoryDetails({
           {cves && cves.length >= 1 ? (
             <ul>
               {cves.map((cve) => (
-                <li>{cve}</li>
+                <li key={cve}>
+                  <a
+                    className="text-jungle-green-500 hover:opacity-75"
+                    href={`https://cve.mitre.org/cgi-bin/cvename.cgi?name=${cve}`}
+                  >
+                    {cve}
+                  </a>
+                </li>
               ))}
             </ul>
           ) : (

--- a/assets/js/pages/AdvisoryDetails/AdvisoryDetails.jsx
+++ b/assets/js/pages/AdvisoryDetails/AdvisoryDetails.jsx
@@ -12,8 +12,6 @@ function EmptyData() {
 function AdvisoryDetails({
   advisoryName,
   errata,
-  fixes,
-  cves,
   packages,
   affectsPackageMaintanaceStack,
 }) {
@@ -25,7 +23,9 @@ function AdvisoryDetails({
     type,
     description,
     reboot_suggested: rebootSuggested,
-  } = errata;
+  } = errata.errata_details;
+
+  const { fixes, cves } = errata;
 
   return (
     <div>
@@ -76,10 +76,17 @@ function AdvisoryDetails({
       <div className="flex flex-col mb-4">
         <h2 className="text-xl font-bold mb-2">Fixes</h2>
         <div className="bg-white py-4 px-6 shadow shadow-md rounded-lg">
-          {fixes && fixes.length > 1 ? (
+          {fixes && Object.keys(fixes).length >= 1 ? (
             <ul>
-              {fixes.map((fix) => (
-                <li>{fix}</li>
+              {Object.entries(fixes).map(([id, fix]) => (
+                <li key={`CVE-${id}`}>
+                  <a
+                    className="text-jungle-green-500 hover:opacity-75"
+                    href={`https://bugzilla.suse.com/show_bug.cgi?id=${id}`}
+                  >
+                    {fix}
+                  </a>
+                </li>
               ))}
             </ul>
           ) : (

--- a/assets/js/pages/AdvisoryDetails/AdvisoryDetails.stories.jsx
+++ b/assets/js/pages/AdvisoryDetails/AdvisoryDetails.stories.jsx
@@ -23,8 +23,6 @@ Yesterday, I left before the post arrived. Normally, the post just delivers my p
 However, the post didn't come by today, and I am starting to wonder, if my Geekos ate my quiche. AITA? 😟`,
       reboot_suggested: true,
     },
-    fixes: undefined,
-    cves: undefined,
     packages: undefined,
     affectsPackageMaintanaceStack: false,
   },

--- a/assets/js/pages/AdvisoryDetails/AdvisoryDetails.test.jsx
+++ b/assets/js/pages/AdvisoryDetails/AdvisoryDetails.test.jsx
@@ -12,6 +12,7 @@ import AdvisoryDetails from './AdvisoryDetails';
 describe('AdvisoryDetails', () => {
   it('displays a message, when the CVE, packages or fixes section is empty', () => {
     const errata = advisoryErrataFactory.build();
+    errata.fixes = {};
 
     render(
       <AdvisoryDetails advisoryName={faker.lorem.word()} errata={errata} />
@@ -27,32 +28,29 @@ describe('AdvisoryDetails', () => {
     render(<AdvisoryDetails advisoryName={advisoryName} errata={errata} />);
 
     expect(screen.getByText(advisoryName)).toBeVisible();
-    expect(screen.getByText(errata.synopsis)).toBeVisible();
-    expect(screen.getByText(errata.advisory_status)).toBeVisible();
-    expect(screen.getByText(errata.description)).toBeVisible();
+    expect(screen.getByText(errata.errata_details.synopsis)).toBeVisible();
+    expect(
+      screen.getByText(errata.errata_details.advisory_status)
+    ).toBeVisible();
+    expect(screen.getByText(errata.errata_details.description)).toBeVisible();
   });
 
-  it('displays CVEs, packages and fixes', () => {
+  it('displays CVEs, packages', () => {
     const errata = advisoryErrataFactory.build();
     const advisoryName = faker.lorem.word();
 
-    const fixes = faker.word.words(2).split(' ');
     const packages = faker.word.words(2).split(' ');
     const cves = faker.word.words(2).split(' ');
+
+    errata.cves = cves;
 
     render(
       <AdvisoryDetails
         advisoryName={advisoryName}
         errata={errata}
-        fixes={fixes}
-        cves={cves}
         packages={packages}
       />
     );
-
-    fixes.forEach((expectedWord) => {
-      expect(screen.getByText(expectedWord)).toBeVisible();
-    });
 
     cves.forEach((expectedWord) => {
       expect(screen.getByText(expectedWord)).toBeVisible();
@@ -60,6 +58,19 @@ describe('AdvisoryDetails', () => {
 
     packages.forEach((expectedWord) => {
       expect(screen.getByText(expectedWord)).toBeVisible();
+    });
+  });
+
+  it('displays fixes with according link', () => {
+    const errata = advisoryErrataFactory.build();
+    const advisoryName = faker.lorem.word();
+
+    render(<AdvisoryDetails advisoryName={advisoryName} errata={errata} />);
+
+    Object.entries(errata.fixes).forEach(([id, fixText]) => {
+      const el = screen.getByText(fixText);
+      el.href.includes(id);
+      expect(el).toBeVisible();
     });
   });
 });

--- a/assets/js/pages/AdvisoryDetails/AdvisoryDetails.test.jsx
+++ b/assets/js/pages/AdvisoryDetails/AdvisoryDetails.test.jsx
@@ -13,6 +13,7 @@ describe('AdvisoryDetails', () => {
   it('displays a message, when the CVE, packages or fixes section is empty', () => {
     const errata = advisoryErrataFactory.build();
     errata.fixes = {};
+    errata.cves = [];
 
     render(
       <AdvisoryDetails advisoryName={faker.lorem.word()} errata={errata} />
@@ -35,14 +36,11 @@ describe('AdvisoryDetails', () => {
     expect(screen.getByText(errata.errata_details.description)).toBeVisible();
   });
 
-  it('displays CVEs, packages', () => {
+  it('packages', () => {
     const errata = advisoryErrataFactory.build();
     const advisoryName = faker.lorem.word();
 
     const packages = faker.word.words(2).split(' ');
-    const cves = faker.word.words(2).split(' ');
-
-    errata.cves = cves;
 
     render(
       <AdvisoryDetails
@@ -51,10 +49,6 @@ describe('AdvisoryDetails', () => {
         packages={packages}
       />
     );
-
-    cves.forEach((expectedWord) => {
-      expect(screen.getByText(expectedWord)).toBeVisible();
-    });
 
     packages.forEach((expectedWord) => {
       expect(screen.getByText(expectedWord)).toBeVisible();
@@ -70,6 +64,47 @@ describe('AdvisoryDetails', () => {
     Object.entries(errata.fixes).forEach(([id, fixText]) => {
       const el = screen.getByText(fixText);
       el.href.includes(id);
+      expect(el).toBeVisible();
+    });
+  });
+
+  it('displays CVEs with according link', () => {
+    const errata = advisoryErrataFactory.build();
+    const advisoryName = faker.lorem.word();
+
+    render(<AdvisoryDetails advisoryName={advisoryName} errata={errata} />);
+
+    errata.cves.forEach((cve) => {
+      const el = screen.getByText(cve);
+      el.href.includes(cve);
+      expect(el).toBeVisible();
+    });
+  });
+
+  it('displays a single fix with according link', () => {
+    const errata = advisoryErrataFactory.build();
+    errata.fixes = Object.fromEntries([Object.entries(errata.fixes)[0]]);
+    const advisoryName = faker.lorem.word();
+
+    render(<AdvisoryDetails advisoryName={advisoryName} errata={errata} />);
+
+    Object.entries(errata.fixes).forEach(([id, fixText]) => {
+      const el = screen.getByText(fixText);
+      el.href.includes(id);
+      expect(el).toBeVisible();
+    });
+  });
+
+  it('displays a single CVE with according link', () => {
+    const errata = advisoryErrataFactory.build();
+    errata.cves = [errata.cves[0]];
+    const advisoryName = faker.lorem.word();
+
+    render(<AdvisoryDetails advisoryName={advisoryName} errata={errata} />);
+
+    errata.cves.forEach((cve) => {
+      const el = screen.getByText(cve);
+      el.href.includes(cve);
       expect(el).toBeVisible();
     });
   });

--- a/assets/js/pages/AdvisoryDetails/AdvisoryDetails.test.jsx
+++ b/assets/js/pages/AdvisoryDetails/AdvisoryDetails.test.jsx
@@ -5,16 +5,13 @@ import '@testing-library/jest-dom';
 import { faker } from '@faker-js/faker';
 
 import { renderWithRouter as render } from '@lib/test-utils';
-import { advisoryErrataFactory } from '@lib/test-utils/factories';
+import { advisoryErrataFactory, cveFactory } from '@lib/test-utils/factories';
 
 import AdvisoryDetails from './AdvisoryDetails';
 
 describe('AdvisoryDetails', () => {
   it('displays a message, when the CVE, packages or fixes section is empty', () => {
-    const errata = advisoryErrataFactory.build(
-      { cves: [] },
-      { transient: { fixesLength: 0 } }
-    );
+    const errata = advisoryErrataFactory.build({ cves: [], fixes: {} });
 
     render(
       <AdvisoryDetails advisoryName={faker.lorem.word()} errata={errata} />
@@ -57,10 +54,7 @@ describe('AdvisoryDetails', () => {
   });
 
   it('displays fixes with a valid link', () => {
-    const errata = advisoryErrataFactory.build(
-      {},
-      { transient: { fixesLength: faker.number.int({ min: 2, max: 10 }) } }
-    );
+    const errata = advisoryErrataFactory.build();
     const advisoryName = faker.lorem.word();
 
     render(<AdvisoryDetails advisoryName={advisoryName} errata={errata} />);
@@ -73,10 +67,10 @@ describe('AdvisoryDetails', () => {
   });
 
   it('displays CVEs with a valid link', () => {
-    const errata = advisoryErrataFactory.build(
-      {},
-      { transient: { cvesLength: faker.number.int({ min: 2, max: 10 }) } }
-    );
+    const errata = advisoryErrataFactory.build({
+      cves: cveFactory.buildList(faker.number.int({ min: 2, max: 10 })),
+    });
+
     const advisoryName = faker.lorem.word();
 
     render(<AdvisoryDetails advisoryName={advisoryName} errata={errata} />);
@@ -90,7 +84,6 @@ describe('AdvisoryDetails', () => {
 
   it('displays a single fix with a valid link', () => {
     const errata = advisoryErrataFactory.build();
-    errata.fixes = Object.fromEntries([Object.entries(errata.fixes)[0]]);
     const advisoryName = faker.lorem.word();
 
     render(<AdvisoryDetails advisoryName={advisoryName} errata={errata} />);
@@ -104,7 +97,6 @@ describe('AdvisoryDetails', () => {
 
   it('displays a single CVE with a valid link', () => {
     const errata = advisoryErrataFactory.build();
-    errata.cves = [errata.cves[0]];
     const advisoryName = faker.lorem.word();
 
     render(<AdvisoryDetails advisoryName={advisoryName} errata={errata} />);

--- a/assets/js/pages/AdvisoryDetails/AdvisoryDetails.test.jsx
+++ b/assets/js/pages/AdvisoryDetails/AdvisoryDetails.test.jsx
@@ -11,9 +11,10 @@ import AdvisoryDetails from './AdvisoryDetails';
 
 describe('AdvisoryDetails', () => {
   it('displays a message, when the CVE, packages or fixes section is empty', () => {
-    const errata = advisoryErrataFactory.build();
-    errata.fixes = {};
-    errata.cves = [];
+    const errata = advisoryErrataFactory.build(
+      { cves: [] },
+      { transient: { fixesLength: 0 } }
+    );
 
     render(
       <AdvisoryDetails advisoryName={faker.lorem.word()} errata={errata} />
@@ -36,7 +37,7 @@ describe('AdvisoryDetails', () => {
     expect(screen.getByText(errata.errata_details.description)).toBeVisible();
   });
 
-  it('packages', () => {
+  it('displays packages', () => {
     const errata = advisoryErrataFactory.build();
     const advisoryName = faker.lorem.word();
 
@@ -55,33 +56,39 @@ describe('AdvisoryDetails', () => {
     });
   });
 
-  it('displays fixes with according link', () => {
-    const errata = advisoryErrataFactory.build();
+  it('displays fixes with a valid link', () => {
+    const errata = advisoryErrataFactory.build(
+      {},
+      { transient: { fixesLength: faker.number.int({ min: 2, max: 10 }) } }
+    );
     const advisoryName = faker.lorem.word();
 
     render(<AdvisoryDetails advisoryName={advisoryName} errata={errata} />);
 
     Object.entries(errata.fixes).forEach(([id, fixText]) => {
       const el = screen.getByText(fixText);
-      el.href.includes(id);
+      expect(el.href.includes(id)).toBe(true);
       expect(el).toBeVisible();
     });
   });
 
-  it('displays CVEs with according link', () => {
-    const errata = advisoryErrataFactory.build();
+  it('displays CVEs with a valid link', () => {
+    const errata = advisoryErrataFactory.build(
+      {},
+      { transient: { cvesLength: faker.number.int({ min: 2, max: 10 }) } }
+    );
     const advisoryName = faker.lorem.word();
 
     render(<AdvisoryDetails advisoryName={advisoryName} errata={errata} />);
 
     errata.cves.forEach((cve) => {
       const el = screen.getByText(cve);
-      el.href.includes(cve);
+      expect(el.href.includes(cve)).toBe(true);
       expect(el).toBeVisible();
     });
   });
 
-  it('displays a single fix with according link', () => {
+  it('displays a single fix with a valid link', () => {
     const errata = advisoryErrataFactory.build();
     errata.fixes = Object.fromEntries([Object.entries(errata.fixes)[0]]);
     const advisoryName = faker.lorem.word();
@@ -90,12 +97,12 @@ describe('AdvisoryDetails', () => {
 
     Object.entries(errata.fixes).forEach(([id, fixText]) => {
       const el = screen.getByText(fixText);
-      el.href.includes(id);
+      expect(el.href.includes(id)).toBe(true);
       expect(el).toBeVisible();
     });
   });
 
-  it('displays a single CVE with according link', () => {
+  it('displays a single CVE with a valid link', () => {
     const errata = advisoryErrataFactory.build();
     errata.cves = [errata.cves[0]];
     const advisoryName = faker.lorem.word();
@@ -104,7 +111,7 @@ describe('AdvisoryDetails', () => {
 
     errata.cves.forEach((cve) => {
       const el = screen.getByText(cve);
-      el.href.includes(cve);
+      expect(el.href.includes(cve)).toBe(true);
       expect(el).toBeVisible();
     });
   });


### PR DESCRIPTION
# Description

This MR displays the fixes and CVEs in the advisory details view

## How was this tested?

The new Jest tests ensure that there is always a link to the corresponding Bugzilla issue.  Furthermore it updates the other tests to follow the new component API

## Did you update the documentation?

This MR does not require any changes to the existing documentation
