### PR TITLE
Validation global error

### DIFF
--- a/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.jsx
+++ b/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.jsx
@@ -7,7 +7,7 @@ import { InputNumber } from '@common/Input';
 import Select from '@common/Select';
 import Label from '@common/Label';
 
-import { getError } from '@lib/api/validationErrors';
+import { getError, getGlobalError } from '@lib/api/validationErrors';
 
 const defaultErrors = [];
 
@@ -22,9 +22,7 @@ const toRetentionTimeErrorMessage = (errors) =>
     .filter(Boolean)
     .join('; ');
 
-const toGenericErrorMessage = (errors) =>
-  // the first error of type string is considered the generic error
-  errors.find((error) => typeof error === 'string');
+const toGlobalErrorMessage = (errors) => capitalize(getGlobalError(errors));
 
 function TimeSpan({ time: initialTime, error = false, onChange = noop }) {
   const [time, setTime] = useState(initialTime);
@@ -90,7 +88,7 @@ function ActivityLogsSettingsModal({
   const [retentionTime, setRetentionTime] = useState(initialRetentionTime);
 
   const retentionTimeError = toRetentionTimeErrorMessage(errors);
-  const genericError = toGenericErrorMessage(errors);
+  const genericError = toGlobalErrorMessage(errors);
 
   return (
     <Modal title="Enter Activity Logs Settings" open={open} onClose={onCancel}>

--- a/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.stories.jsx
+++ b/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.stories.jsx
@@ -64,7 +64,7 @@ export const WithCompositeFieldValidationError = {
   },
 };
 
-export const WithGenericError = {
+export const WithGlobalError = {
   args: {
     open: false,
     initialRetentionTime: { value: 1, unit: 'month' },

--- a/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.test.jsx
+++ b/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.test.jsx
@@ -4,8 +4,8 @@ import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
-import ActivityLogsSettingsModal from '.';
 import { defaultGlobalError } from '@lib/api/validationErrors';
+import ActivityLogsSettingsModal from '.';
 
 const positiveInt = () => faker.number.int({ min: 1 });
 

--- a/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.test.jsx
+++ b/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.test.jsx
@@ -6,6 +6,7 @@ import '@testing-library/jest-dom';
 
 import { defaultGlobalError } from '@lib/api/validationErrors';
 import ActivityLogsSettingsModal from '.';
+import { defaultGlobalError } from '../../lib/api/validationErrors';
 
 const positiveInt = () => faker.number.int({ min: 1 });
 

--- a/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.test.jsx
+++ b/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.test.jsx
@@ -6,7 +6,6 @@ import '@testing-library/jest-dom';
 
 import { defaultGlobalError } from '@lib/api/validationErrors';
 import ActivityLogsSettingsModal from '.';
-import { defaultGlobalError } from '@lib/api/validationErrors';
 
 const positiveInt = () => faker.number.int({ min: 1 });
 

--- a/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.test.jsx
+++ b/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.test.jsx
@@ -6,7 +6,7 @@ import '@testing-library/jest-dom';
 
 import { defaultGlobalError } from '@lib/api/validationErrors';
 import ActivityLogsSettingsModal from '.';
-import { defaultGlobalError } from '../../lib/api/validationErrors';
+import { defaultGlobalError } from '@lib/api/validationErrors';
 
 const positiveInt = () => faker.number.int({ min: 1 });
 

--- a/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.test.jsx
+++ b/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.test.jsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
 import ActivityLogsSettingsModal from '.';
-import { defaultGlobalError } from '../../lib/api/validationErrors';
+import { defaultGlobalError } from '@lib/api/validationErrors';
 
 const positiveInt = () => faker.number.int({ min: 1 });
 

--- a/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.test.jsx
+++ b/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.test.jsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
 import ActivityLogsSettingsModal from '.';
+import { defaultGlobalError } from '../../lib/api/validationErrors';
 
 const positiveInt = () => faker.number.int({ min: 1 });
 
@@ -125,8 +126,8 @@ describe('ActivityLogsSettingsModal component', () => {
     ${'unit error'}                        | ${[unitError]}                     | ${unitError.detail}
     ${'value and unit errors (1)'}         | ${[valueError, unitError]}         | ${valueError.detail}
     ${'value and unit errors (2)'}         | ${[valueError, unitError]}         | ${unitError.detail}
-    ${'generic error'}                     | ${['a generic error']}             | ${'a generic error'}
-    ${'generic error and value error (1)'} | ${['a generic error', valueError]} | ${'a generic error'}
+    ${'generic error'}                     | ${['a generic error']}             | ${defaultGlobalError.detail}
+    ${'generic error and value error (1)'} | ${['a generic error', valueError]} | ${defaultGlobalError.detail}
     ${'generic error and value error (2)'} | ${['a generic error', valueError]} | ${valueError.detail}
   `(
     'should display errors on $scenario',

--- a/assets/js/lib/api/validationErrors.js
+++ b/assets/js/lib/api/validationErrors.js
@@ -1,20 +1,32 @@
 import { flow, first } from 'lodash';
-import { get, filter } from 'lodash/fp';
+import { get, filter, map } from 'lodash/fp';
 
-export const hasError = (keyword, errors) =>
-  errors.some((error) => {
-    const pointer = get(['source', 'pointer'], error);
+const selectField = (keyword) => (error) => {
+  const pointer = get(['source', 'pointer'], error);
 
-    return pointer === `/${keyword}`;
-  });
+  return pointer === `/${keyword}`;
+};
+
+export const hasError = (keyword, errors) => errors.some(selectField(keyword));
 
 export const getError = (keyword, errors) =>
-  flow([
-    filter((error) => {
-      const pointer = get(['source', 'pointer'], error);
+  flow([filter(selectField(keyword)), first, get('detail')])(errors);
 
-      return pointer === `/${keyword}`;
-    }),
+export const defaultGlobalError = {
+  title: 'Unexpected error',
+  detail: 'Something went wrong.',
+};
+
+export const getGlobalError = (errors) =>
+  flow([
+    filter(
+      (error) => !(typeof error === 'object' && error && 'source' in error)
+    ),
+    map((error) =>
+      typeof error === 'object' && error && 'detail' in error
+        ? error
+        : defaultGlobalError
+    ),
     first,
     get('detail'),
   ])(errors);

--- a/assets/js/lib/api/validationErrors.test.js
+++ b/assets/js/lib/api/validationErrors.test.js
@@ -1,4 +1,9 @@
-import { hasError, getError } from './validationErrors';
+import {
+  hasError,
+  getError,
+  getGlobalError,
+  defaultGlobalError,
+} from './validationErrors';
 
 describe('hasError', () => {
   it('should tell that a list contains an error about a specific field', () => {
@@ -90,4 +95,59 @@ describe('getError', () => {
 
     expect(getError('url', errors)).toBe(undefined);
   });
+});
+
+describe('getGlobalError', () => {
+  it('should return the first global error', () => {
+    const errors = [
+      {
+        detail: 'a detail',
+        title: 'a title',
+      },
+      {
+        detail: 'another detail',
+        source: { pointer: '/some_field' },
+        title: 'another title',
+      },
+      {
+        detail: 'do not return this detail',
+        title: 'do not return this title',
+      },
+    ];
+
+    expect(getGlobalError(errors)).toBe('a detail');
+  });
+
+  it('should return undefined when there is no global error', () => {
+    const errors = [
+      {
+        detail: "can't be blank",
+        source: { pointer: '/some_value' },
+        title: 'Invalid value',
+      },
+    ];
+
+    expect(getGlobalError(errors)).not.toBeDefined();
+  });
+
+  it('should return undefined when no error', () => {
+    const errors = [];
+
+    expect(getGlobalError(errors)).not.toBeDefined();
+  });
+
+  it.each`
+    input
+    ${{ malformed: true }}
+    ${undefined}
+    ${null}
+    ${'string'}
+    ${1234 /* number */}
+    ${[12, 34] /* array */}
+  `(
+    'should return the default error if the received error is malformed',
+    ({ input }) => {
+      expect(getGlobalError([input])).toBe(defaultGlobalError.detail);
+    }
+  );
 });

--- a/assets/js/state/sagas/activityLogsSettings.js
+++ b/assets/js/state/sagas/activityLogsSettings.js
@@ -11,6 +11,7 @@ import {
   setEditingActivityLogsSettings,
   setNetworkError,
 } from '@state/activityLogsSettings';
+import { defaultGlobalError } from '../../lib/api/validationErrors';
 
 export function* fetchActivityLogsSettings() {
   yield put(startLoadingActivityLogsSettings());
@@ -34,7 +35,7 @@ export function* updateActivityLogsSettings({ payload }) {
     const errors = get(
       error,
       ['response', 'data', 'errors'],
-      ['An error occurred while saving the settings']
+      [defaultGlobalError]
     );
     yield put(setActivityLogsSettingsErrors(errors));
   }

--- a/assets/js/state/sagas/activityLogsSettings.js
+++ b/assets/js/state/sagas/activityLogsSettings.js
@@ -11,7 +11,7 @@ import {
   setEditingActivityLogsSettings,
   setNetworkError,
 } from '@state/activityLogsSettings';
-import { defaultGlobalError } from '../../lib/api/validationErrors';
+import { defaultGlobalError } from '@lib/api/validationErrors';
 
 export function* fetchActivityLogsSettings() {
   yield put(startLoadingActivityLogsSettings());

--- a/assets/js/state/sagas/activityLogsSettings.test.js
+++ b/assets/js/state/sagas/activityLogsSettings.test.js
@@ -18,7 +18,6 @@ import {
   fetchActivityLogsSettings,
   updateActivityLogsSettings,
 } from './activityLogsSettings';
-import { defaultGlobalError } from '@lib/api/validationErrors';
 
 describe('Activity Logs Settings saga', () => {
   describe('Fetching Activity Logs Settings', () => {

--- a/assets/js/state/sagas/activityLogsSettings.test.js
+++ b/assets/js/state/sagas/activityLogsSettings.test.js
@@ -13,11 +13,11 @@ import {
   setNetworkError,
 } from '@state/activityLogsSettings';
 
+import { defaultGlobalError } from '@lib/api/validationErrors';
 import {
   fetchActivityLogsSettings,
   updateActivityLogsSettings,
 } from './activityLogsSettings';
-import { defaultGlobalError } from '@lib/api/validationErrors';
 
 describe('Activity Logs Settings saga', () => {
   describe('Fetching Activity Logs Settings', () => {

--- a/assets/js/state/sagas/activityLogsSettings.test.js
+++ b/assets/js/state/sagas/activityLogsSettings.test.js
@@ -17,7 +17,7 @@ import {
   fetchActivityLogsSettings,
   updateActivityLogsSettings,
 } from './activityLogsSettings';
-import { defaultGlobalError } from '../../lib/api/validationErrors';
+import { defaultGlobalError } from '@lib/api/validationErrors';
 
 describe('Activity Logs Settings saga', () => {
   describe('Fetching Activity Logs Settings', () => {

--- a/assets/js/state/sagas/activityLogsSettings.test.js
+++ b/assets/js/state/sagas/activityLogsSettings.test.js
@@ -18,7 +18,7 @@ import {
   fetchActivityLogsSettings,
   updateActivityLogsSettings,
 } from './activityLogsSettings';
-import { defaultGlobalError } from '../../lib/api/validationErrors';
+import { defaultGlobalError } from '@lib/api/validationErrors';
 
 describe('Activity Logs Settings saga', () => {
   describe('Fetching Activity Logs Settings', () => {

--- a/assets/js/state/sagas/activityLogsSettings.test.js
+++ b/assets/js/state/sagas/activityLogsSettings.test.js
@@ -18,6 +18,7 @@ import {
   fetchActivityLogsSettings,
   updateActivityLogsSettings,
 } from './activityLogsSettings';
+import { defaultGlobalError } from '../../lib/api/validationErrors';
 
 describe('Activity Logs Settings saga', () => {
   describe('Fetching Activity Logs Settings', () => {

--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -124,6 +124,13 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"422", reason: "Unable to retrieve errata details for this advisory.")
   end
 
+  def call(conn, {:error, :error_getting_cves}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(ErrorView)
+    |> render(:"422", reason: "Unable to retrieve CVEs for this advisory.")
+  end
+
   def call(conn, {:error, :error_getting_fixes}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/lib/trento_web/controllers/v1/suse_manager_controller.ex
+++ b/lib/trento_web/controllers/v1/suse_manager_controller.ex
@@ -95,8 +95,9 @@ defmodule TrentoWeb.V1.SUSEManagerController do
   @spec errata_details(Plug.Conn.t(), any) :: Plug.Conn.t()
   def errata_details(conn, %{advisory_name: advisory_name}) do
     with {:ok, errata_details} <- Discovery.get_errata_details(advisory_name),
+         {:ok, cves} <- Discovery.get_cves(advisory_name),
          {:ok, fixes} <- Discovery.get_bugzilla_fixes(advisory_name) do
-      render(conn, %{errata_details: errata_details, fixes: fixes})
+      render(conn, %{errata_details: errata_details, cves: cves, fixes: fixes})
     end
   end
 end

--- a/lib/trento_web/openapi/v1/schema/available_software_updates.ex
+++ b/lib/trento_web/openapi/v1/schema/available_software_updates.ex
@@ -172,6 +172,21 @@ defmodule TrentoWeb.OpenApi.V1.Schema.AvailableSoftwareUpdates do
     })
   end
 
+  defmodule CVEs do
+    @moduledoc false
+    OpenApiSpex.schema(%{
+      title: "CVEs",
+      description: "List of CVEs applicable to the errata with the given advisory name.",
+      type: :array,
+      additionalProperties: false,
+      items: %Schema{
+        title: "CVE",
+        description: "A fix for a publicly known security vulnerability",
+        type: :string
+      }
+    })
+  end
+
   defmodule AdvisoryFixes do
     @moduledoc false
     OpenApiSpex.schema(%{
@@ -191,6 +206,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.AvailableSoftwareUpdates do
       additionalProperties: false,
       properties: %{
         errata_details: ErrataDetails,
+        cves: CVEs,
         fixes: AdvisoryFixes
       }
     })

--- a/lib/trento_web/views/v1/suse_manager_view.ex
+++ b/lib/trento_web/views/v1/suse_manager_view.ex
@@ -65,6 +65,7 @@ defmodule TrentoWeb.V1.SUSEManagerView do
 
   def render("errata_details.json", %{
         errata_details: errata_details = %{errataFrom: errataFrom},
+        cves: cves,
         fixes: fixes
       }),
       do: %{
@@ -72,6 +73,7 @@ defmodule TrentoWeb.V1.SUSEManagerView do
           errata_details
           |> Map.drop([:errataFrom])
           |> Map.put(:errata_from, errataFrom),
+        cves: cves,
         fixes: fixes
       }
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -983,6 +983,13 @@ defmodule Trento.Factory do
     }
   end
 
+  def cve_factory(attrs) do
+    year = Enum.random(1_991..2_024)
+    id = Enum.random(0..9_999)
+    %{year: year, id: id} = Map.merge(%{year: year, id: id}, attrs)
+    "CVE-#{year}-#{id}"
+  end
+
   def bugzilla_fix_factory do
     1..Enum.random(1..4)
     |> Enum.map(fn _ ->

--- a/test/trento/infrastructure/software_updates/suma_test.exs
+++ b/test/trento/infrastructure/software_updates/suma_test.exs
@@ -263,10 +263,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaTest do
       advisory_name = Faker.UUID.v4()
 
       %{result: cves} =
-        suma_response_body = %{
-          success: true,
-          result: Enum.map(1..10, fn _ -> Faker.UUID.v4() end)
-        }
+        suma_response_body = %{success: true, result: build_list(10, :cve)}
 
       expect(SumaAuthMock, :authenticate, 1, fn -> {:ok, authenticated_state()} end)
 
@@ -274,8 +271,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaTest do
         {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(suma_response_body)}}
       end)
 
-      assert {:ok, ^cves} =
-               Suma.get_cves(advisory_name)
+      assert {:ok, ^cves} = Suma.get_cves(advisory_name)
     end
 
     test "should return a proper error when getting CVEs for a patch fails" do

--- a/test/trento_web/controllers/v1/suse_manager_controller_test.exs
+++ b/test/trento_web/controllers/v1/suse_manager_controller_test.exs
@@ -172,6 +172,12 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
         {:ok, errata_details}
       end)
 
+      cves = build_list(10, :cve)
+
+      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_cves, 1, fn _ ->
+        {:ok, cves}
+      end)
+
       fixes = build(:bugzilla_fix)
 
       expect(Trento.SoftwareUpdates.Discovery.Mock, :get_bugzilla_fixes, 1, fn _ ->
@@ -185,6 +191,8 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
 
       %{"fixes" => json_fixes} = json
 
+      # The returned struct from `assert_schema/3` empties the dynamic Map in `fixes`.
+      # Assert on the JSON response that the `fixes` Map contains entries.
       assert fixes |> Map.keys() |> length == json_fixes |> Map.keys() |> length
 
       result = assert_schema(json, "ErrataDetailsResponse", api_spec)
@@ -209,7 +217,8 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
           solution: ^solution,
           reboot_suggested: ^reboot_suggested,
           restart_suggested: ^restart_suggested
-        }
+        },
+        cves: ^cves
       } = result
     end
 
@@ -221,6 +230,36 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
 
       expect(Trento.SoftwareUpdates.Discovery.Mock, :get_errata_details, 1, fn _ ->
         {:error, :error_getting_errata_details}
+      end)
+
+      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_cves, 1, fn _ ->
+        {:ok, build_list(10, :cve)}
+      end)
+
+      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_bugzilla_fixes, 1, fn _ ->
+        {:ok, build(:bugzilla_fix)}
+      end)
+
+      advisory_name = Faker.Pokemon.name()
+
+      conn
+      |> get("/api/v1/software_updates/errata_details/#{advisory_name}")
+      |> json_response(:unprocessable_entity)
+      |> assert_schema("UnprocessableEntity", api_spec)
+    end
+
+    test "should return 422 when advisory CVEs are not found", %{
+      conn: conn,
+      api_spec: api_spec
+    } do
+      insert_software_updates_settings()
+
+      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_errata_details, 1, fn _ ->
+        {:ok, build(:errata_details)}
+      end)
+
+      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_cves, 1, fn _ ->
+        {:error, :error_getting_cves}
       end)
 
       expect(Trento.SoftwareUpdates.Discovery.Mock, :get_bugzilla_fixes, 1, fn _ ->
@@ -243,6 +282,10 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
 
       expect(Trento.SoftwareUpdates.Discovery.Mock, :get_errata_details, 1, fn _ ->
         {:ok, build(:errata_details)}
+      end)
+
+      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_cves, 1, fn _ ->
+        {:ok, build_list(10, :cve)}
       end)
 
       expect(Trento.SoftwareUpdates.Discovery.Mock, :get_bugzilla_fixes, 1, fn _ ->

--- a/test/trento_web/views/v1/suse_manager_view_test.exs
+++ b/test/trento_web/views/v1/suse_manager_view_test.exs
@@ -23,20 +23,25 @@ defmodule TrentoWeb.V1.SUSEManagerViewTest do
   describe "renders errata_details.json" do
     test "should render relevant fields" do
       %{errataFrom: errata_from} = errata_details = build(:errata_details)
-      fixes = build(:bugzilla_fix)
 
       errata_details_sans_errata_from = Map.delete(errata_details, :errataFrom)
 
       expected_errata_details =
         Map.put(errata_details_sans_errata_from, :errata_from, errata_from)
 
+      cves = build_list(10, :cve)
+
+      fixes = build(:bugzilla_fix)
+
       assert %{
                errata_details: ^expected_errata_details,
+               cves: ^cves,
                fixes: ^fixes
              } =
                render(SUSEManagerView, "errata_details.json", %{
                  errata_details:
                    Map.put(errata_details_sans_errata_from, :errataFrom, errata_from),
+                 cves: cves,
                  fixes: fixes
                })
     end


### PR DESCRIPTION
# Description

Add `getGlobalError` utility to map server validation error that not relate to a field. The use case is to render failures coming from the server when fetching/saving data.

This PR also applies the error handling as an improvement of https://github.com/trento-project/web/pull/2727.

See unit tests for expected usage.
