### PR TITLE
Provide explicit ordering for CSV file columns

### DIFF
--- a/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.jsx
+++ b/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.jsx
@@ -30,7 +30,21 @@ function HostRelevantPatches({ hostName, onNavigate, patches }) {
     window?.URL?.createObjectURL && displayedPatches?.length > 0
       ? window.URL.createObjectURL(
           new File(
-            [Papa.unparse(displayedPatches, { header: true })],
+            [
+              Papa.unparse(
+                {
+                  fields: [
+                    'id',
+                    'advisory_type',
+                    'advisory_name',
+                    'advisory_synopsis',
+                    'update_date',
+                  ],
+                  data: displayedPatches,
+                },
+                { header: true }
+              ),
+            ],
             `${hostName}-patches.csv`,
             { type: 'text/csv' }
           )

--- a/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.test.jsx
+++ b/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.test.jsx
@@ -186,7 +186,7 @@ describe('HostRelevantPatchesPage', () => {
       expect(window.URL.createObjectURL).toHaveBeenCalledWith(new File([], ''));
       expect(window.URL.createObjectURL).toHaveReturnedWith({
         name: `${hostName}-patches.csv`,
-        size: 148,
+        size: 110,
       });
     });
 


### PR DESCRIPTION
# Description

As per feedback, when a user clicks on the _Download CSV_ button, the generated CSV file will now explicitly provide **only** the columns `id`, `advisory_type`, `advisory_name`, `advisory_synopsis` & `update_date`, in that order.

## How was this tested?

This was manually verified, as we can't assert on the _contents_ of an Object URL. However I did verify and update the size of the new file in the existing unit test.
