### PR TITLE
Use uuids for usernames in user factory

### DIFF
--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1042,7 +1042,7 @@ defmodule Trento.Factory do
       fullname: Faker.Pokemon.name(),
       password: password,
       password_hash: Argon2.hash_pwd_salt(password),
-      username: Faker.Pokemon.name(),
+      username: Faker.UUID.v4(),
       deleted_at: nil,
       locked_at: nil,
       password_change_requested_at: nil,


### PR DESCRIPTION
Since we were getting occasional violations of primary keys for usernames in tests, I'm just switching to uuids for those in the dedicated factory.