### PR TITLE
Fix typo in DeregistrationModal tests

### DIFF
--- a/assets/js/pages/DeregistrationModal/DeregistrationModal.test.jsx
+++ b/assets/js/pages/DeregistrationModal/DeregistrationModal.test.jsx
@@ -59,7 +59,7 @@ describe('Deregistration Modal component', () => {
     ).toBeTruthy();
   });
 
-  it('should render an application instance deregistration modal correctly', async () => {
+  it('should render a database instance deregistration modal correctly', async () => {
     const sid = generateSid();
     const instanceNumber = '00';
 


### PR DESCRIPTION
As above :DDD

A unit test had the exact same `it` description as the previous one.