### PR TITLE
Send HANA architecture to wanda

### DIFF
--- a/lib/trento/clusters.ex
+++ b/lib/trento/clusters.ex
@@ -9,6 +9,7 @@ defmodule Trento.Clusters do
   require Trento.Clusters.Enums.ClusterType, as: ClusterType
   require Trento.Clusters.Enums.FilesystemType, as: FilesystemType
   require Trento.Clusters.Enums.ClusterEnsaVersion, as: ClusterEnsaVersion
+  require Trento.Clusters.Enums.HanaArchitectureType, as: HanaArchitectureType
 
   alias Trento.Hosts.Projections.HostReadModel
 
@@ -206,7 +207,8 @@ defmodule Trento.Clusters do
          id: cluster_id,
          provider: provider,
          type: cluster_type,
-         selected_checks: selected_checks
+         selected_checks: selected_checks,
+         details: details
        }) do
     hosts_data =
       Repo.all(
@@ -217,7 +219,8 @@ defmodule Trento.Clusters do
 
     env = %Checks.ClusterExecutionEnv{
       provider: provider,
-      cluster_type: cluster_type
+      cluster_type: cluster_type,
+      architecture_type: parse_architecture_type(details)
     }
 
     Checks.request_execution(
@@ -248,4 +251,9 @@ defmodule Trento.Clusters do
       _ -> ClusterEnsaVersion.mixed_versions()
     end
   end
+
+  defp parse_architecture_type(%{"architecture_type" => "angi"}),
+    do: HanaArchitectureType.angi()
+
+  defp parse_architecture_type(_), do: HanaArchitectureType.classic()
 end

--- a/lib/trento/infrastructure/checks/checks.ex
+++ b/lib/trento/infrastructure/checks/checks.ex
@@ -108,10 +108,15 @@ defmodule Trento.Infrastructure.Checks do
     }
   end
 
-  defp build_env(%ClusterExecutionEnv{cluster_type: cluster_type, provider: provider}) do
+  defp build_env(%ClusterExecutionEnv{
+         cluster_type: cluster_type,
+         provider: provider,
+         architecture_type: architecture_type
+       }) do
     %{
       "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
-      "provider" => %{kind: {:string_value, Atom.to_string(provider)}}
+      "provider" => %{kind: {:string_value, Atom.to_string(provider)}},
+      "architecture_type" => %{kind: {:string_value, Atom.to_string(architecture_type)}}
     }
   end
 

--- a/lib/trento/infrastructure/checks/cluster_execution_env.ex
+++ b/lib/trento/infrastructure/checks/cluster_execution_env.ex
@@ -10,11 +10,13 @@ defmodule Trento.Infrastructure.Checks.ClusterExecutionEnv do
   require Trento.Clusters.Enums.ClusterType, as: ClusterType
   require Trento.Clusters.Enums.FilesystemType, as: FilesystemType
   require Trento.Clusters.Enums.ClusterEnsaVersion, as: ClusterEnsaVersion
+  require Trento.Clusters.Enums.HanaArchitectureType, as: HanaArchitectureType
 
   deftype do
     field :cluster_type, Ecto.Enum, values: ClusterType.values()
     field :provider, Ecto.Enum, values: Provider.values()
     field :filesystem_type, Ecto.Enum, values: FilesystemType.values()
     field :ensa_version, Ecto.Enum, values: ClusterEnsaVersion.values()
+    field :architecture_type, Ecto.Enum, values: HanaArchitectureType.values()
   end
 end

--- a/test/trento/infrastructure/checks/checks_test.exs
+++ b/test/trento/infrastructure/checks/checks_test.exs
@@ -24,7 +24,8 @@ defmodule Trento.Infrastructure.Checks.ChecksTest do
 
       env = %Checks.ClusterExecutionEnv{
         cluster_type: :hana_scale_up,
-        provider: :azure
+        provider: :azure,
+        architecture_type: :classic
       }
 
       selected_checks = ["check_1", "check_2"]
@@ -44,7 +45,8 @@ defmodule Trento.Infrastructure.Checks.ChecksTest do
                  ],
                  env: %{
                    "cluster_type" => %{kind: {:string_value, "hana_scale_up"}},
-                   "provider" => %{kind: {:string_value, "azure"}}
+                   "provider" => %{kind: {:string_value, "azure"}},
+                   "architecture_type" => %{kind: {:string_value, "classic"}}
                  },
                  target_type: "cluster"
                } = event


### PR DESCRIPTION
# Description

Send HANA architecture value as `architecture_type` to wanda in the env variables.
Only applicable for HANA clusters of course.

## How was this tested?

UT done
