### PR TITLE
Activity log overview

### DIFF
--- a/assets/js/common/ActivityLogDetailsModal/ActivityLogDetailModal.jsx
+++ b/assets/js/common/ActivityLogDetailsModal/ActivityLogDetailModal.jsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { noop } from 'lodash';
+
+import Button from '@common/Button';
+import Modal from '@common/Modal';
+import ListView from '@common/ListView';
+
+import {
+  API_KEY_GENERATION,
+  CHANGING_SUMA_SETTINGS,
+  CLEARING_SUMA_SETTINGS,
+  CLUSTER_CHECKS_EXECUTION_REQUEST,
+  LOGIN_ATTEMPT,
+  PROFILE_UPDATE,
+  RESOURCE_TAGGING,
+  RESOURCE_UNTAGGING,
+  SAVING_SUMA_SETTINGS,
+  USER_CREATION,
+  USER_DELETION,
+  USER_MODIFICATION,
+} from '@lib/model/activityLog';
+
+const activityTypesLabels = {
+  [LOGIN_ATTEMPT]: 'Login Attempt',
+  [RESOURCE_TAGGING]: 'Tag Added',
+  [RESOURCE_UNTAGGING]: 'Tag Removed',
+  [API_KEY_GENERATION]: 'API Key Generated',
+  [SAVING_SUMA_SETTINGS]: 'SUMA Settings Saved',
+  [CHANGING_SUMA_SETTINGS]: 'SUMA Settings Changed',
+  [CLEARING_SUMA_SETTINGS]: 'SUMA Settings Cleared',
+  [USER_CREATION]: 'User Created',
+  [USER_MODIFICATION]: 'User Modified',
+  [USER_DELETION]: 'User Deleted',
+  [PROFILE_UPDATE]: 'Profile Updated',
+  [CLUSTER_CHECKS_EXECUTION_REQUEST]: 'Checks Execution Requested',
+};
+
+const resourceTypesLabels = {
+  host: 'Host',
+  cluster: 'Cluster',
+  database: 'Database',
+  sap_system: 'SAP System',
+};
+
+const keys = ['id', 'type', 'resource', 'user', 'message', 'time', 'metadata'];
+
+const keyToLabel = {
+  id: 'ID',
+  type: 'Activity Type',
+  resource: 'Resource',
+  user: 'User',
+  time: 'Created at',
+  message: 'Message',
+  metadata: 'Data',
+};
+
+const toResource = (activityLogEntry) => {
+  const { metadata, type } = activityLogEntry;
+  switch (type) {
+    case LOGIN_ATTEMPT:
+      return 'Application';
+    case RESOURCE_TAGGING:
+    case RESOURCE_UNTAGGING:
+      return (
+        resourceTypesLabels[metadata.resource_type] ??
+        'Unable to determine resource type'
+      );
+    case USER_CREATION:
+    case USER_MODIFICATION:
+    case USER_DELETION:
+      return 'User';
+    case PROFILE_UPDATE:
+      return 'Profile';
+    case SAVING_SUMA_SETTINGS:
+    case CHANGING_SUMA_SETTINGS:
+    case CLEARING_SUMA_SETTINGS:
+      return 'SUMA Settings';
+    case API_KEY_GENERATION:
+      return 'API Key';
+    case CLUSTER_CHECKS_EXECUTION_REQUEST:
+      return 'Cluster Checks';
+    default:
+      return 'Unrecognized resource';
+  }
+};
+
+const renderMetadata = (metadata) => (
+  <pre>{JSON.stringify(metadata, null, 2)}</pre>
+);
+
+const renderType = (type) => activityTypesLabels[type] ?? type;
+
+const renderResource = (entry) => (
+  <span aria-label="activity-log-resource">{toResource(entry)}</span>
+);
+
+const keyRenderers = {
+  metadata: renderMetadata,
+  type: renderType,
+  resource: renderResource,
+};
+
+function ActivityLogDetailModal({ open = false, entry, onClose = noop }) {
+  const data = keys.map((key) => ({
+    title: keyToLabel[key] || key,
+    content: key === 'resource' ? entry : entry[key],
+    render: keyRenderers[key] || undefined,
+    className: 'col-span-5',
+  }));
+
+  return (
+    <Modal
+      className="!w-3/4 !max-w-3xl"
+      title="Activity Details"
+      open={open}
+      onClose={onClose}
+    >
+      <ListView
+        titleClassName="col-span-2"
+        className="text-sm"
+        orientation="horizontal"
+        data={data}
+      />
+      <div className="flex flex-row w-1/6 space-x-2">
+        <Button type="primary-white" className="w-1/2" onClick={onClose}>
+          Close
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
+export default ActivityLogDetailModal;

--- a/assets/js/common/ActivityLogDetailsModal/ActivityLogDetailModal.jsx
+++ b/assets/js/common/ActivityLogDetailsModal/ActivityLogDetailModal.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { noop } from 'lodash';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 
 import Button from '@common/Button';
 import Modal from '@common/Modal';
@@ -19,6 +21,7 @@ import {
   USER_DELETION,
   USER_MODIFICATION,
 } from '@lib/model/activityLog';
+import classNames from 'classnames';
 
 const activityTypesLabels = {
   [LOGIN_ATTEMPT]: 'Login Attempt',
@@ -85,7 +88,9 @@ const toResource = (activityLogEntry) => {
 };
 
 const renderMetadata = (metadata) => (
-  <pre>{JSON.stringify(metadata, null, 2)}</pre>
+  <ReactMarkdown className="markdown text-sm" remarkPlugins={[remarkGfm]}>
+    {`\`\`\`json\n${JSON.stringify(metadata, null, 2)}\n\`\`\``}
+  </ReactMarkdown>
 );
 
 const renderType = (type) => activityTypesLabels[type] ?? type;
@@ -105,7 +110,9 @@ function ActivityLogDetailModal({ open = false, entry, onClose = noop }) {
     title: keyToLabel[key] || key,
     content: key === 'resource' ? entry : entry[key],
     render: keyRenderers[key] || undefined,
-    className: 'col-span-5',
+    className: classNames('col-span-5', {
+      'text-gray-500': key !== 'metadata',
+    }),
   }));
 
   return (
@@ -116,12 +123,12 @@ function ActivityLogDetailModal({ open = false, entry, onClose = noop }) {
       onClose={onClose}
     >
       <ListView
-        titleClassName="col-span-2"
+        titleClassName="col-span-2 text-gray-500"
         className="text-sm"
         orientation="horizontal"
         data={data}
       />
-      <div className="flex flex-row w-1/6 space-x-2">
+      <div className="flex flex-row w-24 space-x-2 mt-3">
         <Button type="primary-white" className="w-1/2" onClick={onClose}>
           Close
         </Button>

--- a/assets/js/common/ActivityLogDetailsModal/ActivityLogDetailModal.stories.jsx
+++ b/assets/js/common/ActivityLogDetailsModal/ActivityLogDetailModal.stories.jsx
@@ -1,0 +1,58 @@
+import { action } from '@storybook/addon-actions';
+import {
+  activityLogEntryFactory,
+  taggingMetadataFactory,
+} from '@lib/test-utils/factories/activityLog';
+import { RESOURCE_TAGGING } from '@lib/model/activityLog';
+import { toRenderedEntry } from '@common/ActivityLogOverview/ActivityLogOverview';
+import ActivityLogDetailModal from '.';
+
+export default {
+  title: 'Components/ActivityLogDetailModal',
+  component: ActivityLogDetailModal,
+  argTypes: {
+    open: {
+      description: 'Whether the dialog is open or not',
+      control: {
+        type: 'boolean',
+      },
+    },
+    entry: {
+      description: 'An Avtivity Log entry.',
+      control: {
+        type: 'object',
+      },
+    },
+    onClose: {
+      description: 'Callback when the Cancel button is clicked',
+      control: { type: 'function' },
+    },
+  },
+};
+
+export const Default = {
+  args: {
+    open: false,
+    entry: toRenderedEntry(activityLogEntryFactory.build()),
+    onClose: action('cancel clicked'),
+  },
+};
+
+export const UnknwonActivityType = {
+  args: {
+    ...Default.args,
+    entry: toRenderedEntry(activityLogEntryFactory.build({ type: 'foo_bar' })),
+  },
+};
+
+export const UnknwonResourceType = {
+  args: {
+    ...Default.args,
+    entry: toRenderedEntry(
+      activityLogEntryFactory.build({
+        type: RESOURCE_TAGGING,
+        metadata: taggingMetadataFactory.build({ resource_type: 'foo_bar' }),
+      })
+    ),
+  },
+};

--- a/assets/js/common/ActivityLogDetailsModal/ActivityLogDetailModal.test.jsx
+++ b/assets/js/common/ActivityLogDetailsModal/ActivityLogDetailModal.test.jsx
@@ -1,0 +1,204 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import {
+  activityLogEntryFactory,
+  taggingMetadataFactory,
+  untaggingMetadataFactory,
+} from '@lib/test-utils/factories/activityLog';
+
+import {
+  LOGIN_ATTEMPT,
+  RESOURCE_TAGGING,
+  RESOURCE_UNTAGGING,
+  API_KEY_GENERATION,
+  CHANGING_SUMA_SETTINGS,
+  CLEARING_SUMA_SETTINGS,
+  SAVING_SUMA_SETTINGS,
+  CLUSTER_CHECKS_EXECUTION_REQUEST,
+  PROFILE_UPDATE,
+  USER_CREATION,
+  USER_DELETION,
+  USER_MODIFICATION,
+  LEVEL_WARNING,
+} from '@lib/model/activityLog';
+import { toRenderedEntry } from '@common/ActivityLogOverview/ActivityLogOverview';
+import ActivityLogDetailModal from '.';
+
+describe('ActivityLogDetailModal component', () => {
+  const scenarios = [
+    {
+      name: LOGIN_ATTEMPT,
+      entry: activityLogEntryFactory.build({
+        type: LOGIN_ATTEMPT,
+        metadata: {},
+      }),
+      expectedActivityType: 'Login Attempt',
+      expectedResource: 'Application',
+    },
+    {
+      name: RESOURCE_TAGGING,
+      entry: activityLogEntryFactory.build({
+        type: RESOURCE_TAGGING,
+        metadata: taggingMetadataFactory.build({
+          resource_type: 'host',
+        }),
+      }),
+      expectedActivityType: 'Tag Added',
+      expectedResource: 'Host',
+    },
+    {
+      name: RESOURCE_UNTAGGING,
+      entry: activityLogEntryFactory.build({
+        type: RESOURCE_UNTAGGING,
+        level: LEVEL_WARNING,
+        metadata: untaggingMetadataFactory.build({
+          resource_type: 'cluster',
+        }),
+      }),
+      expectedActivityType: 'Tag Removed',
+      expectedResource: 'Cluster',
+    },
+    {
+      name: API_KEY_GENERATION,
+      entry: activityLogEntryFactory.build({
+        type: API_KEY_GENERATION,
+      }),
+      expectedActivityType: 'API Key Generated',
+      expectedResource: 'API Key',
+    },
+    {
+      name: SAVING_SUMA_SETTINGS,
+      entry: activityLogEntryFactory.build({
+        type: SAVING_SUMA_SETTINGS,
+      }),
+      expectedActivityType: 'SUMA Settings Saved',
+      expectedResource: 'SUMA Settings',
+    },
+    {
+      name: CHANGING_SUMA_SETTINGS,
+      entry: activityLogEntryFactory.build({
+        type: CHANGING_SUMA_SETTINGS,
+      }),
+      expectedActivityType: 'SUMA Settings Changed',
+      expectedResource: 'SUMA Settings',
+    },
+    {
+      name: CLEARING_SUMA_SETTINGS,
+      entry: activityLogEntryFactory.build({
+        type: CLEARING_SUMA_SETTINGS,
+      }),
+      expectedActivityType: 'SUMA Settings Cleared',
+      expectedResource: 'SUMA Settings',
+    },
+    {
+      name: USER_CREATION,
+      entry: activityLogEntryFactory.build({
+        type: USER_CREATION,
+      }),
+      expectedActivityType: 'User Created',
+      expectedResource: 'User',
+      userRelatedActivity: true,
+    },
+    {
+      name: USER_MODIFICATION,
+      entry: activityLogEntryFactory.build({
+        type: USER_MODIFICATION,
+      }),
+      expectedActivityType: 'User Modified',
+      expectedResource: 'User',
+      userRelatedActivity: true,
+    },
+    {
+      name: USER_DELETION,
+      entry: activityLogEntryFactory.build({
+        type: USER_DELETION,
+      }),
+      expectedActivityType: 'User Deleted',
+      expectedResource: 'User',
+      userRelatedActivity: true,
+    },
+    {
+      name: PROFILE_UPDATE,
+      entry: activityLogEntryFactory.build({
+        type: PROFILE_UPDATE,
+      }),
+      expectedActivityType: 'Profile Updated',
+      expectedResource: 'Profile',
+    },
+    {
+      name: CLUSTER_CHECKS_EXECUTION_REQUEST,
+      entry: activityLogEntryFactory.build({
+        type: CLUSTER_CHECKS_EXECUTION_REQUEST,
+      }),
+      expectedActivityType: 'Checks Execution Requested',
+      expectedResource: 'Cluster Checks',
+    },
+  ];
+
+  it.each(scenarios)(
+    'should render detail for activity entry `$name`',
+    async ({
+      entry,
+      expectedActivityType,
+      expectedResource,
+      userRelatedActivity = false,
+    }) => {
+      const { id } = entry;
+      await act(async () => {
+        render(<ActivityLogDetailModal open entry={toRenderedEntry(entry)} />);
+      });
+
+      expect(screen.getByText('ID')).toBeVisible();
+      expect(screen.getByText(id)).toBeVisible();
+
+      expect(screen.getByText('Activity Type')).toBeVisible();
+      expect(screen.getByText(expectedActivityType)).toBeVisible();
+
+      expect(screen.getByText('Resource')).toBeVisible();
+      const resource = screen.getByLabelText('activity-log-resource');
+      expect(resource).toBeVisible();
+      expect(resource).toHaveTextContent(expectedResource);
+
+      const userReferences = screen.getAllByText('User');
+      if (userRelatedActivity) {
+        expect(userReferences).toHaveLength(2);
+      }
+      userReferences.forEach((userReference) => {
+        expect(userReference).toBeVisible();
+      });
+
+      expect(screen.getByText('Message')).toBeVisible();
+      expect(screen.getByText('Created at')).toBeVisible();
+    }
+  );
+
+  it('should render detail for unknown activity type', async () => {
+    const entry = activityLogEntryFactory.build({ type: 'foo_bar' });
+    await act(async () => {
+      render(<ActivityLogDetailModal open entry={toRenderedEntry(entry)} />);
+    });
+
+    expect(screen.getByText('foo_bar')).toBeVisible();
+    expect(screen.getByText('Unrecognized resource')).toBeVisible();
+    expect(screen.getByText('Unrecognized activity')).toBeVisible();
+  });
+
+  it('should call onClose when the close button is clicked', async () => {
+    const onClose = jest.fn();
+    await act(async () => {
+      render(
+        <ActivityLogDetailModal
+          open
+          entry={activityLogEntryFactory.build()}
+          onClose={onClose}
+        />
+      );
+    });
+
+    await userEvent.click(screen.getByText('Close'));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/assets/js/common/ActivityLogDetailsModal/index.js
+++ b/assets/js/common/ActivityLogDetailsModal/index.js
@@ -1,0 +1,3 @@
+import ActivityLogDetailModal from './ActivityLogDetailModal';
+
+export default ActivityLogDetailModal;

--- a/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
+++ b/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
@@ -1,7 +1,15 @@
 import React, { useState } from 'react';
 import { noop } from 'lodash';
-import { EOS_KEYBOARD_ARROW_RIGHT_FILLED } from 'eos-icons-react';
+import {
+  EOS_BUG_REPORT_OUTLINED,
+  EOS_ERROR_OUTLINED,
+  EOS_INFO_OUTLINED,
+  EOS_KEYBOARD_ARROW_RIGHT_FILLED,
+  EOS_QUESTION_MARK,
+  EOS_WARNING_OUTLINED,
+} from 'eos-icons-react';
 import Table from '@common/Table';
+import Tooltip from '@common/Tooltip';
 
 import {
   API_KEY_GENERATION,
@@ -58,6 +66,12 @@ const toMessage = (activityLogEntry) => {
   }
 };
 
+const logLevelToIcon = {
+  [LEVEL_DEBUG]: <EOS_BUG_REPORT_OUTLINED className="w-full" />,
+  [LEVEL_INFO]: <EOS_INFO_OUTLINED className="w-full" />,
+  [LEVEL_WARNING]: <EOS_WARNING_OUTLINED className="fill-yellow-500 w-full" />,
+  [LEVEL_ERROR]: <EOS_ERROR_OUTLINED className="fill-red-500 w-full" />,
+};
 const logLevelToLabel = {
   [LEVEL_DEBUG]: 'Debug',
   [LEVEL_INFO]: 'Info',
@@ -71,7 +85,7 @@ export const toRenderedEntry = (entry) => ({
   time: format(entry.occurred_on, 'yyyy-MM-dd HH:mm:ss'),
   message: toMessage(entry),
   user: entry.actor,
-  level: logLevelToLabel[entry.level] ?? 'Unknown',
+  level: entry.level,
   metadata: entry.metadata,
 });
 
@@ -102,6 +116,16 @@ function ActivityLogOverview({
       {
         title: 'Level',
         key: 'level',
+        className: 'text-center',
+        render: (level) => (
+          <Tooltip content={logLevelToLabel[level] ?? 'Unknown'} wrap={false}>
+            <span aria-label={`log-level-${level}`}>
+              {logLevelToIcon[level] ?? (
+                <EOS_QUESTION_MARK className="w-full" />
+              )}
+            </span>
+          </Tooltip>
+        ),
       },
       {
         title: '',

--- a/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
+++ b/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { format } from 'date-fns';
+import Table from '@common/Table';
+
+import {
+  ACTIVITY_TYPES,
+  API_KEY_GENERATION,
+  CHANGING_SUMA_SETTINGS,
+  CLEARING_SUMA_SETTINGS,
+  CLUSTER_CHECKS_EXECUTION_REQUEST,
+  LOGIN_ATTEMPT,
+  PROFILE_UPDATE,
+  RESOURCE_TAGGING,
+  RESOURCE_UNTAGGING,
+  SAVING_SUMA_SETTINGS,
+  USER_CREATION,
+  USER_DELETION,
+  USER_MODIFICATION,
+} from '@lib/model/activityLog';
+
+const activityTypesLabels = {
+  [LOGIN_ATTEMPT]: 'Login Attempt',
+  [RESOURCE_TAGGING]: 'Tag Added',
+  [RESOURCE_UNTAGGING]: 'Tag Removed',
+  [API_KEY_GENERATION]: 'API Key Generated',
+  [SAVING_SUMA_SETTINGS]: 'SUMA Settings Saved',
+  [CHANGING_SUMA_SETTINGS]: 'SUMA Settings Changed',
+  [CLEARING_SUMA_SETTINGS]: 'SUMA Settings Cleared',
+  [USER_CREATION]: 'User Created',
+  [USER_MODIFICATION]: 'User Modified',
+  [USER_DELETION]: 'User Deleted',
+  [PROFILE_UPDATE]: 'Profile Updated',
+  [CLUSTER_CHECKS_EXECUTION_REQUEST]: 'Checks Execution Requested',
+};
+
+const resourceTypesLabels = {
+  host: 'Host',
+  cluster: 'Cluster',
+  database: 'Database',
+  sap_system: 'SAP System',
+};
+
+const toResource = (activityLogEntry) => {
+  const { metadata, type } = activityLogEntry;
+  switch (type) {
+    case LOGIN_ATTEMPT:
+      return 'Application';
+    case RESOURCE_TAGGING:
+    case RESOURCE_UNTAGGING:
+      return resourceTypesLabels[metadata.resource_type];
+    case USER_CREATION:
+    case USER_MODIFICATION:
+    case USER_DELETION:
+      return 'User';
+    case PROFILE_UPDATE:
+      return 'Profile';
+    case SAVING_SUMA_SETTINGS:
+    case CHANGING_SUMA_SETTINGS:
+    case CLEARING_SUMA_SETTINGS:
+      return 'SUMA Settings';
+    case API_KEY_GENERATION:
+      return 'API Key';
+    case CLUSTER_CHECKS_EXECUTION_REQUEST:
+      return 'Cluster Checks';
+    default:
+      return 'Unrecognized resource';
+  }
+};
+
+const toMessage = (activityLogEntry) => {
+  const { metadata, type } = activityLogEntry;
+
+  switch (type) {
+    case LOGIN_ATTEMPT:
+      return metadata?.reason ? 'Login failed' : 'User logged in';
+    case RESOURCE_TAGGING:
+      return `Tag "${metadata.added_tag}" added to "${metadata.resource_id}"`;
+    case RESOURCE_UNTAGGING:
+      return `Tag "${metadata.removed_tag}" removed from "${metadata.resource_id}"`;
+    case USER_CREATION:
+      return 'User was created';
+    case USER_MODIFICATION:
+      return 'User was modified';
+    case USER_DELETION:
+      return 'User was deleted';
+    case PROFILE_UPDATE:
+      return 'User modified profile';
+    case SAVING_SUMA_SETTINGS:
+      return 'SUMA Settings was saved';
+    case CHANGING_SUMA_SETTINGS:
+      return 'SUMA Settings was changed';
+    case CLEARING_SUMA_SETTINGS:
+      return 'SUMA Settings was cleared';
+    case API_KEY_GENERATION:
+      return 'API Key was generated';
+    case CLUSTER_CHECKS_EXECUTION_REQUEST:
+      return 'Checks execution requested for cluster';
+    default:
+      return 'Unrecognized activity';
+  }
+};
+
+const activityLogTableConfig = {
+  pagination: true,
+  usePadding: false,
+  columns: [
+    {
+      title: 'Time',
+      key: 'occurred_on',
+      render: (time) => format(time, 'yyyy-MM-dd HH:mm:ss'),
+    },
+    {
+      title: 'Event Type',
+      key: 'type',
+      render: (type) => (
+        <span aria-label="activity-log-type">
+          {ACTIVITY_TYPES.includes(type)
+            ? activityTypesLabels[type]
+            : 'Unknown'}
+        </span>
+      ),
+    },
+    {
+      title: 'Resource',
+      key: 'metadata',
+      render: (_, activityLogEntry) => (
+        <span aria-label="activity-log-resource">
+          {toResource(activityLogEntry)}
+        </span>
+      ),
+    },
+    {
+      title: 'User',
+      key: 'actor',
+    },
+    {
+      title: 'Message',
+      key: 'metadata',
+      render: (_, activityLogEntry) => toMessage(activityLogEntry),
+    },
+  ],
+  collapsibleDetailRenderer: ({ metadata }) => (
+    <pre>{JSON.stringify(metadata, null, 2)}</pre>
+  ),
+};
+
+export default function ActivityLogOverview({ activityLog }) {
+  return <Table config={activityLogTableConfig} data={activityLog} />;
+}

--- a/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
+++ b/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
@@ -129,7 +129,7 @@ function ActivityLogOverview({
       <ActivityLogDetailModal
         open={activityLogDetailModalOpen}
         entry={selectedEntry}
-        onCancel={onCloseActivityLogEntryDetails}
+        onClose={onCloseActivityLogEntryDetails}
       />
       <Table
         config={activityLogTableConfig}

--- a/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
+++ b/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
@@ -5,7 +5,6 @@ import {
   EOS_ERROR_OUTLINED,
   EOS_INFO_OUTLINED,
   EOS_KEYBOARD_ARROW_RIGHT_FILLED,
-  EOS_QUESTION_MARK,
   EOS_WARNING_OUTLINED,
 } from 'eos-icons-react';
 import Table from '@common/Table';
@@ -24,6 +23,7 @@ import {
   USER_CREATION,
   USER_DELETION,
   USER_MODIFICATION,
+  ACTIVITY_LOG_LEVELS,
   LEVEL_DEBUG,
   LEVEL_ERROR,
   LEVEL_INFO,
@@ -85,7 +85,7 @@ export const toRenderedEntry = (entry) => ({
   time: format(entry.occurred_on, 'yyyy-MM-dd HH:mm:ss'),
   message: toMessage(entry),
   user: entry.actor,
-  level: entry.level,
+  level: ACTIVITY_LOG_LEVELS.includes(entry?.level) ? entry?.level : LEVEL_INFO,
   metadata: entry.metadata,
 });
 
@@ -120,9 +120,7 @@ function ActivityLogOverview({
         render: (level) => (
           <Tooltip content={logLevelToLabel[level] ?? 'Unknown'} wrap={false}>
             <span aria-label={`log-level-${level}`}>
-              {logLevelToIcon[level] ?? (
-                <EOS_QUESTION_MARK className="w-full" />
-              )}
+              {logLevelToIcon[level]}
             </span>
           </Tooltip>
         ),

--- a/assets/js/common/ActivityLogOverview/ActivityLogOverview.stories.jsx
+++ b/assets/js/common/ActivityLogOverview/ActivityLogOverview.stories.jsx
@@ -1,4 +1,5 @@
 import { activityLogEntryFactory } from '@lib/test-utils/factories/activityLog';
+import _ from 'lodash';
 import ActivityLogOverview from './ActivityLogOverview';
 
 export default {
@@ -37,5 +38,12 @@ export const UnknwonLevel = {
   args: {
     ...Default.args,
     activityLog: [activityLogEntryFactory.build({ level: 'foo_bar' })],
+  },
+};
+
+export const MissingLevel = {
+  args: {
+    ...Default.args,
+    activityLog: [_.omit(activityLogEntryFactory.build(), 'level')],
   },
 };

--- a/assets/js/common/ActivityLogOverview/ActivityLogOverview.stories.jsx
+++ b/assets/js/common/ActivityLogOverview/ActivityLogOverview.stories.jsx
@@ -25,3 +25,17 @@ export const Empty = {
     activityLog: [],
   },
 };
+
+export const UnknwonActivityType = {
+  args: {
+    ...Default.args,
+    activityLog: [activityLogEntryFactory.build({ type: 'foo_bar' })],
+  },
+};
+
+export const UnknwonLevel = {
+  args: {
+    ...Default.args,
+    activityLog: [activityLogEntryFactory.build({ level: 'foo_bar' })],
+  },
+};

--- a/assets/js/common/ActivityLogOverview/ActivityLogOverview.stories.jsx
+++ b/assets/js/common/ActivityLogOverview/ActivityLogOverview.stories.jsx
@@ -1,0 +1,27 @@
+import { activityLogEntryFactory } from '@lib/test-utils/factories/activityLog';
+import ActivityLogOverview from './ActivityLogOverview';
+
+export default {
+  title: 'Components/ActivityLogOverview',
+  component: ActivityLogOverview,
+  argTypes: {
+    activityLog: {
+      description: 'List of the activity log entries',
+      control: {
+        type: 'array',
+      },
+    },
+  },
+};
+
+export const Default = {
+  args: {
+    activityLog: activityLogEntryFactory.buildList(20),
+  },
+};
+
+export const Empty = {
+  args: {
+    activityLog: [],
+  },
+};

--- a/assets/js/common/ActivityLogOverview/ActivityLogOverview.test.jsx
+++ b/assets/js/common/ActivityLogOverview/ActivityLogOverview.test.jsx
@@ -48,7 +48,7 @@ describe('Activity Log Overview', () => {
       }),
       expectedUser: 'admin',
       expectedMessage: 'User logged in',
-      expectedLevel: 'Debug',
+      expectedLevel: 'debug',
     },
     {
       name: RESOURCE_TAGGING,
@@ -64,7 +64,7 @@ describe('Activity Log Overview', () => {
       }),
       expectedUser: 'foo',
       expectedMessage: 'Tag "bar" added to "foo-bar"',
-      expectedLevel: 'Info',
+      expectedLevel: 'info',
     },
     {
       name: RESOURCE_UNTAGGING,
@@ -80,7 +80,7 @@ describe('Activity Log Overview', () => {
       }),
       expectedUser: 'bar',
       expectedMessage: 'Tag "foo" removed from "bar-foo"',
-      expectedLevel: 'Warning',
+      expectedLevel: 'warning',
     },
     {
       name: API_KEY_GENERATION,
@@ -91,7 +91,7 @@ describe('Activity Log Overview', () => {
       }),
       expectedUser: 'baz',
       expectedMessage: 'API Key was generated',
-      expectedLevel: 'Error',
+      expectedLevel: 'error',
     },
     {
       name: SAVING_SUMA_SETTINGS,
@@ -175,7 +175,9 @@ describe('Activity Log Overview', () => {
       expect(screen.getByText(expectedMessage)).toBeVisible();
       expect(screen.getByText(expectedUser)).toBeVisible();
       if (expectedLevel) {
-        expect(screen.getByText(expectedLevel)).toBeVisible();
+        expect(
+          screen.getByLabelText(`log-level-${expectedLevel}`)
+        ).toBeVisible();
       }
     }
   );

--- a/assets/js/common/ActivityLogOverview/ActivityLogOverview.test.jsx
+++ b/assets/js/common/ActivityLogOverview/ActivityLogOverview.test.jsx
@@ -1,0 +1,178 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import {
+  activityLogEntryFactory,
+  taggingMetadataFactory,
+  untaggingMetadataFactory,
+} from '@lib/test-utils/factories/activityLog';
+import {
+  LOGIN_ATTEMPT,
+  RESOURCE_TAGGING,
+  RESOURCE_UNTAGGING,
+  API_KEY_GENERATION,
+  CHANGING_SUMA_SETTINGS,
+  CLEARING_SUMA_SETTINGS,
+  SAVING_SUMA_SETTINGS,
+  CLUSTER_CHECKS_EXECUTION_REQUEST,
+  PROFILE_UPDATE,
+  USER_CREATION,
+  USER_DELETION,
+  USER_MODIFICATION,
+} from '@lib/model/activityLog';
+import '@testing-library/jest-dom';
+
+import ActivityLogOverview from '.';
+
+describe('Activity Log Overview', () => {
+  it('should render an empty activity log', () => {
+    render(<ActivityLogOverview activityLog={[]} />);
+
+    expect(screen.getByText('No data available')).toBeVisible();
+  });
+
+  const scenarios = [
+    {
+      name: LOGIN_ATTEMPT,
+      entry: activityLogEntryFactory.build({
+        actor: 'admin',
+        type: LOGIN_ATTEMPT,
+      }),
+      expectedEventType: 'Login Attempt',
+      expectedResource: 'Application',
+      expectedUser: 'admin',
+    },
+    {
+      name: RESOURCE_TAGGING,
+      entry: activityLogEntryFactory.build({
+        actor: 'foo',
+        type: RESOURCE_TAGGING,
+        metadata: taggingMetadataFactory.build({
+          resource_type: 'host',
+        }),
+      }),
+      expectedEventType: 'Tag Added',
+      expectedResource: 'Host',
+      expectedUser: 'foo',
+    },
+    {
+      name: RESOURCE_UNTAGGING,
+      entry: activityLogEntryFactory.build({
+        actor: 'bar',
+        type: RESOURCE_UNTAGGING,
+        metadata: untaggingMetadataFactory.build({
+          resource_type: 'cluster',
+        }),
+      }),
+      expectedEventType: 'Tag Removed',
+      expectedResource: 'Cluster',
+      expectedUser: 'bar',
+    },
+    {
+      name: API_KEY_GENERATION,
+      entry: activityLogEntryFactory.build({
+        actor: 'baz',
+        type: API_KEY_GENERATION,
+      }),
+      expectedEventType: 'API Key Generated',
+      expectedResource: 'API Key',
+      expectedUser: 'baz',
+    },
+    {
+      name: SAVING_SUMA_SETTINGS,
+      entry: activityLogEntryFactory.build({
+        actor: 'user-1',
+        type: SAVING_SUMA_SETTINGS,
+      }),
+      expectedEventType: 'SUMA Settings Saved',
+      expectedResource: 'SUMA Settings',
+      expectedUser: 'user-1',
+    },
+    {
+      name: CHANGING_SUMA_SETTINGS,
+      entry: activityLogEntryFactory.build({
+        actor: 'user-2',
+        type: CHANGING_SUMA_SETTINGS,
+      }),
+      expectedEventType: 'SUMA Settings Changed',
+      expectedResource: 'SUMA Settings',
+      expectedUser: 'user-2',
+    },
+    {
+      name: CLEARING_SUMA_SETTINGS,
+      entry: activityLogEntryFactory.build({
+        actor: 'user-3',
+        type: CLEARING_SUMA_SETTINGS,
+      }),
+      expectedEventType: 'SUMA Settings Cleared',
+      expectedResource: 'SUMA Settings',
+      expectedUser: 'user-3',
+    },
+    {
+      name: USER_CREATION,
+      entry: activityLogEntryFactory.build({
+        actor: 'user-4',
+        type: USER_CREATION,
+      }),
+      expectedEventType: 'User Created',
+      expectedResource: 'User',
+      expectedUser: 'user-4',
+    },
+    {
+      name: USER_MODIFICATION,
+      entry: activityLogEntryFactory.build({
+        actor: 'user-5',
+        type: USER_MODIFICATION,
+      }),
+      expectedEventType: 'User Modified',
+      expectedResource: 'User',
+      expectedUser: 'user-5',
+    },
+    {
+      name: USER_DELETION,
+      entry: activityLogEntryFactory.build({
+        actor: 'user-6',
+        type: USER_DELETION,
+      }),
+      expectedEventType: 'User Deleted',
+      expectedResource: 'User',
+      expectedUser: 'user-6',
+    },
+    {
+      name: PROFILE_UPDATE,
+      entry: activityLogEntryFactory.build({
+        actor: 'user-7',
+        type: PROFILE_UPDATE,
+      }),
+      expectedEventType: 'Profile Updated',
+      expectedResource: 'Profile',
+      expectedUser: 'user-7',
+    },
+    {
+      name: CLUSTER_CHECKS_EXECUTION_REQUEST,
+      entry: activityLogEntryFactory.build({
+        actor: 'user-8',
+        type: CLUSTER_CHECKS_EXECUTION_REQUEST,
+      }),
+      expectedEventType: 'Checks Execution Requested',
+      expectedResource: 'Cluster Checks',
+      expectedUser: 'user-8',
+    },
+  ];
+
+  it.each(scenarios)(
+    'should render log entry for activity `$name`',
+    ({ entry, expectedEventType, expectedResource, expectedUser }) => {
+      render(<ActivityLogOverview activityLog={[entry]} />);
+
+      const eventType = screen.getByLabelText('activity-log-type');
+      expect(eventType).toBeVisible();
+      expect(eventType).toHaveTextContent(expectedEventType);
+
+      const resource = screen.getByLabelText('activity-log-resource');
+      expect(resource).toBeVisible();
+      expect(resource).toHaveTextContent(expectedResource);
+
+      expect(screen.getByText(expectedUser)).toBeVisible();
+    }
+  );
+});

--- a/assets/js/common/ActivityLogOverview/index.js
+++ b/assets/js/common/ActivityLogOverview/index.js
@@ -1,0 +1,3 @@
+import ActivityLogOverview from './ActivityLogOverview';
+
+export default ActivityLogOverview;

--- a/assets/js/lib/model/activityLog.js
+++ b/assets/js/lib/model/activityLog.js
@@ -1,0 +1,28 @@
+export const LOGIN_ATTEMPT = 'login_attempt';
+export const RESOURCE_TAGGING = 'resource_tagging';
+export const RESOURCE_UNTAGGING = 'resource_untagging';
+export const API_KEY_GENERATION = 'api_key_generation';
+export const SAVING_SUMA_SETTINGS = 'saving_suma_settings';
+export const CHANGING_SUMA_SETTINGS = 'changing_suma_settings';
+export const CLEARING_SUMA_SETTINGS = 'clearing_suma_settings';
+export const USER_CREATION = 'user_creation';
+export const USER_MODIFICATION = 'user_modification';
+export const USER_DELETION = 'user_deletion';
+export const PROFILE_UPDATE = 'profile_update';
+export const CLUSTER_CHECKS_EXECUTION_REQUEST =
+  'cluster_checks_execution_request';
+
+export const ACTIVITY_TYPES = [
+  LOGIN_ATTEMPT,
+  RESOURCE_TAGGING,
+  RESOURCE_UNTAGGING,
+  API_KEY_GENERATION,
+  SAVING_SUMA_SETTINGS,
+  CHANGING_SUMA_SETTINGS,
+  CLEARING_SUMA_SETTINGS,
+  USER_CREATION,
+  USER_MODIFICATION,
+  USER_DELETION,
+  PROFILE_UPDATE,
+  CLUSTER_CHECKS_EXECUTION_REQUEST,
+];

--- a/assets/js/lib/model/activityLog.js
+++ b/assets/js/lib/model/activityLog.js
@@ -26,3 +26,15 @@ export const ACTIVITY_TYPES = [
   PROFILE_UPDATE,
   CLUSTER_CHECKS_EXECUTION_REQUEST,
 ];
+
+export const LEVEL_DEBUG = 'debug';
+export const LEVEL_INFO = 'info';
+export const LEVEL_WARNING = 'warning';
+export const LEVEL_ERROR = 'error';
+
+export const ACTIVITY_LOG_LEVELS = [
+  LEVEL_DEBUG,
+  LEVEL_INFO,
+  LEVEL_WARNING,
+  LEVEL_ERROR,
+];

--- a/assets/js/lib/test-utils/factories/activityLog.js
+++ b/assets/js/lib/test-utils/factories/activityLog.js
@@ -4,6 +4,7 @@ import {
   ACTIVITY_TYPES,
   RESOURCE_TAGGING,
   RESOURCE_UNTAGGING,
+  ACTIVITY_LOG_LEVELS,
 } from '@lib/model/activityLog';
 import { randomObjectFactory } from '.';
 
@@ -41,5 +42,6 @@ export const activityLogEntryFactory = Factory.define(() => {
     type: activityType,
     occurred_on: faker.date.anytime(),
     metadata: metadataForActivity(activityType),
+    level: faker.helpers.arrayElement(ACTIVITY_LOG_LEVELS),
   };
 });

--- a/assets/js/lib/test-utils/factories/activityLog.js
+++ b/assets/js/lib/test-utils/factories/activityLog.js
@@ -1,0 +1,45 @@
+import { faker } from '@faker-js/faker';
+import { Factory } from 'fishery';
+import {
+  ACTIVITY_TYPES,
+  RESOURCE_TAGGING,
+  RESOURCE_UNTAGGING,
+} from '@lib/model/activityLog';
+import { randomObjectFactory } from '.';
+
+const taggableResourceTypes = ['host', 'cluster', 'database', 'sap_system'];
+
+export const taggingMetadataFactory = Factory.define(() => ({
+  resource_id: faker.string.uuid(),
+  resource_type: faker.helpers.arrayElement(taggableResourceTypes),
+  added_tag: faker.lorem.word(),
+}));
+
+export const untaggingMetadataFactory = Factory.define(() => ({
+  resource_id: faker.string.uuid(),
+  resource_type: faker.helpers.arrayElement(taggableResourceTypes),
+  removed_tag: faker.lorem.word(),
+}));
+
+const metadataForActivity = (activityType) => {
+  switch (activityType) {
+    case RESOURCE_TAGGING:
+      return taggingMetadataFactory.build();
+    case RESOURCE_UNTAGGING:
+      return untaggingMetadataFactory.build();
+    default:
+      return randomObjectFactory.build();
+  }
+};
+
+export const activityLogEntryFactory = Factory.define(() => {
+  const activityType = faker.helpers.arrayElement(ACTIVITY_TYPES);
+
+  return {
+    id: faker.string.uuid(),
+    actor: faker.internet.userName(),
+    type: activityType,
+    occurred_on: faker.date.anytime(),
+    metadata: metadataForActivity(activityType),
+  };
+});


### PR DESCRIPTION
# Description

This PR introduces a pure `ActivityLogOverview` component rendering a list of activity log entries. Meant to be mounted in the specific new page that will be added later.

## How was this tested?

jest & storybook