### PR TITLE
Add e2e test for settings view to test abilities/permissions

### DIFF
--- a/test/e2e/cypress/e2e/settings.cy.js
+++ b/test/e2e/cypress/e2e/settings.cy.js
@@ -807,7 +807,8 @@ context('Settings page', () => {
       });
     });
   });
-  describe('Forbidden action', () => {
+
+  describe('Forbidden actions', () => {
     const password = 'password';
 
     beforeEach(() => {

--- a/test/e2e/cypress/e2e/settings.cy.js
+++ b/test/e2e/cypress/e2e/settings.cy.js
@@ -838,18 +838,16 @@ context('Settings page', () => {
         .and('be.enabled');
       // SUSE Manager config settings button
       cy.contains('button', 'Test Connection').should('be.enabled');
-      cy.get(
-        '.py-4 > .container > :nth-child(1) > .float-right > .text-jungle-green-500'
-      )
-        .should('be.enabled')
-        .and('contain.text', 'Edit Settings');
+      cy.contains('h2', 'SUSE Manager Config')
+        .next()
+        .contains('button', 'Edit Settings')
+        .should('be.enabled');
       cy.contains('button', 'Clear Settings').should('be.enabled');
       // Activity Logs settings button
-      cy.get(
-        ':nth-child(4) > .container > :nth-child(1) > .float-right > .bg-white'
-      )
-        .should('be.enabled')
-        .and('contain.text', 'Edit Settings');
+      cy.contains('h2', 'Activity Logs')
+        .next()
+        .contains('button', 'Edit Settings')
+        .should('be.enabled');
     });
 
     it('should disable settings buttons if the user has no abilities', () => {
@@ -863,18 +861,16 @@ context('Settings page', () => {
       cy.contains('button', 'Generate Key').should('be.disabled');
       // SUSE Manager config settings button
       cy.contains('button', 'Test Connection').should('be.enabled');
-      cy.get(
-        '.py-4 > .container > :nth-child(1) > .float-right > .text-jungle-green-500'
-      )
-        .should('be.disabled')
-        .and('contain.text', 'Edit Settings');
+      cy.contains('h2', 'SUSE Manager Config')
+        .next()
+        .contains('button', 'Edit Settings')
+        .should('be.disabled');
       cy.contains('button', 'Clear Settings').should('be.disabled');
       // Activity Logs settings button
-      cy.get(
-        ':nth-child(4) > .container > :nth-child(1) > .float-right > .bg-white'
-      )
-        .should('be.disabled')
-        .and('contain.text', 'Edit Settings');
+      cy.contains('h2', 'Activity Logs')
+        .next()
+        .contains('button', 'Edit Settings')
+        .should('be.disabled');
     });
   });
 });


### PR DESCRIPTION
# Description

This pr i a follow up pr to https://github.com/trento-project/web/pull/2760. 
Adding cypress e2e test to do what:
- Test if a user has no abilities/permissions the settings view has disabled buttons (all besides test connection button)
- Test if a user has proper abilities/permissions the settings buttons are enabled
- Fix a missed only 

## Did you add the right label?

- [x] **DONE**

## How was this tested?

Added missing cypress e2e test for settings view. 
Tests were already done in  [previous pr](https://github.com/trento-project/web/pull/2760.)

- [x] **DONE**

## Did you update the documentation?

No docs update required
- [x] **DONE**