### PR TITLE
Fix navigation form relevant patches to advisory details

### DIFF
--- a/assets/js/pages/HostRelevantPatches/Page.jsx
+++ b/assets/js/pages/HostRelevantPatches/Page.jsx
@@ -39,7 +39,7 @@ export default function Page() {
         patches={patches}
         hostName={hostName}
         onNavigate={(advisoryID) =>
-          navigate(`hosts/${hostID}/patches/${advisoryID}`)
+          navigate(`/hosts/${hostID}/patches/${advisoryID}`)
         }
       />
     </>


### PR DESCRIPTION
This commit fixes the navigation between the pages mentioned above. Previously it would append the path to the end of the current path.

## How was this tested?

~It isn't :D~ I clicked on it lol