### PR TITLE
Fix flickering in `Available Software Updates` panel

### DIFF
--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.jsx
@@ -21,8 +21,7 @@ const containerClassNames = classNames(
 function AvailableSoftwareUpdates({
   className,
   settingsConfigured = false,
-  softwareUpdatesSettingsLoading,
-  softwareUpdatesLoading,
+  loading,
   relevantPatches,
   upgradablePackages,
   tooltip,
@@ -30,7 +29,7 @@ function AvailableSoftwareUpdates({
   onNavigateToPatches = noop,
   onNavigateToPackages = noop,
 }) {
-  if (softwareUpdatesSettingsLoading) {
+  if (loading) {
     return <Loading className={containerClassNames} />;
   }
 
@@ -60,7 +59,6 @@ function AvailableSoftwareUpdates({
         title="Relevant Patches"
         critical={gt(relevantPatches, 0)}
         tooltip={tooltip}
-        loading={softwareUpdatesLoading}
         icon={<EOS_HEALING size="xl" />}
         onNavigate={onNavigateToPatches}
       >
@@ -70,7 +68,6 @@ function AvailableSoftwareUpdates({
       <Indicator
         title="Upgradable Packages"
         tooltip={tooltip}
-        loading={softwareUpdatesLoading}
         icon={<EOS_PACKAGE_UPGRADE_OUTLINED size="xl" />}
         onNavigate={onNavigateToPackages}
       >

--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
@@ -54,22 +54,9 @@ describe('AvailableSoftwareUpdates component', () => {
   });
 
   it('renders Software Updates Settings Loading status', () => {
-    render(
-      <AvailableSoftwareUpdates
-        settingsConfigured
-        softwareUpdatesSettingsLoading
-      />
-    );
+    render(<AvailableSoftwareUpdates settingsConfigured loading />);
 
     expect(screen.getAllByLabelText('Loading')).toHaveLength(1);
-  });
-
-  it('renders Software Updates Loading status', () => {
-    render(
-      <AvailableSoftwareUpdates settingsConfigured softwareUpdatesLoading />
-    );
-
-    expect(screen.getAllByText('Loading...')).toHaveLength(2);
   });
 
   it('renders "SUSE Manager is not configured"', () => {

--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -73,7 +73,6 @@ function HostDetails({
   upgradablePackages,
   softwareUpdatesLoading,
   softwareUpdatesSettingsSaved,
-  softwareUpdatesSettingsLoading,
   softwareUpdatesTooltip,
   userAbilities,
   cleanUpHost,
@@ -245,8 +244,7 @@ function HostDetails({
             relevantPatches={relevantPatches}
             upgradablePackages={upgradablePackages}
             tooltip={softwareUpdatesTooltip}
-            softwareUpdatesSettingsLoading={softwareUpdatesSettingsLoading}
-            softwareUpdatesLoading={softwareUpdatesLoading}
+            loading={softwareUpdatesLoading}
             onBackToSettings={() => navigate(`/settings`)}
             onNavigateToPatches={() => navigate(`/hosts/${hostID}/patches`)}
             onNavigateToPackages={() => navigate(`/hosts/${hostID}/packages`)}

--- a/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, within } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import 'intersection-observer';
 import '@testing-library/jest-dom';
@@ -310,50 +310,7 @@ describe('HostDetails component', () => {
         />
       );
 
-      const relevantPatchesElement = screen
-        .getByText(/Relevant Patches/)
-        .closest('div');
-      const upgradablePackagesElement = screen
-        .getByText(/Upgradable Packages/)
-        .closest('div');
-
-      expect(
-        within(relevantPatchesElement).getByText('Loading...')
-      ).toBeVisible();
-      expect(
-        within(upgradablePackagesElement).getByText('Loading...')
-      ).toBeVisible();
-    });
-
-    it('should a SUMA software updates when a connection error occurred', () => {
-      const relevantPatches = faker.number.int(100);
-      const upgradablePackages = faker.number.int(100);
-
-      renderWithRouter(
-        <HostDetails
-          agentVersion="2.0.0"
-          suseManagerEnabled
-          softwareUpdatesSettingsSaved
-          softwareUpdatesLoading
-          relevantPatches={relevantPatches}
-          upgradablePackages={upgradablePackages}
-          userAbilities={userAbilities}
-        />
-      );
-
-      const relevantPatchesElement = screen
-        .getByText(/Relevant Patches/)
-        .closest('div');
-      const upgradablePackagesElement = screen
-        .getByText(/Upgradable Packages/)
-        .closest('div');
-
-      expect(
-        within(relevantPatchesElement).getByText('Loading...')
-      ).toBeVisible();
-      expect(
-        within(upgradablePackagesElement).getByText('Loading...')
-      ).toBeVisible();
+      expect(screen.getAllByLabelText('Loading')).toHaveLength(1);
     });
   });
 

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -14,10 +14,7 @@ import { getInstancesOnHost } from '@state/selectors/sapSystem';
 import { getCatalog } from '@state/selectors/catalog';
 import { getLastExecution } from '@state/selectors/lastExecutions';
 import {
-  getSoftwareUpdatesSettingsLoading,
-  getSoftwareUpdatesSettingsSaved,
-} from '@state/selectors/softwareUpdatesSettings';
-import {
+  getSoftwareUpdatesSettingsConfigured,
   getSoftwareUpdatesLoading,
   getSoftwareUpdatesStats,
 } from '@state/selectors/softwareUpdates';
@@ -31,7 +28,6 @@ import {
 } from '@state/lastExecutions';
 
 import { deregisterHost } from '@state/hosts';
-import { fetchSoftwareUpdatesSettings } from '@state/softwareUpdatesSettings';
 import { fetchSoftwareUpdates } from '@state/softwareUpdates';
 import HostDetails from './HostDetails';
 
@@ -60,12 +56,10 @@ function HostDetailsPage() {
 
   const [exportersStatus, setExportersStatus] = useState([]);
 
-  const softwareUpdatesSettingsLoading = useSelector((state) =>
-    getSoftwareUpdatesSettingsLoading(state)
+  const settingsConfigured = useSelector((state) =>
+    getSoftwareUpdatesSettingsConfigured(state)
   );
-  const softwareUpdatesConnectionSaved = useSelector((state) =>
-    getSoftwareUpdatesSettingsSaved(state)
-  );
+
   const { numRelevantPatches, numUpgradablePackages } = useSelector((state) =>
     getSoftwareUpdatesStats(state, hostID)
   );
@@ -90,11 +84,10 @@ function HostDetailsPage() {
     );
 
   useEffect(() => {
+    dispatch(fetchSoftwareUpdates(hostID));
     getExportersStatus();
     refreshCatalog();
     dispatch(updateLastExecution(hostID));
-    dispatch(fetchSoftwareUpdates(hostID));
-    dispatch(fetchSoftwareUpdatesSettings());
   }, []);
 
   if (!host) {
@@ -125,8 +118,7 @@ function HostDetailsPage() {
       suseManagerEnabled={suseManagerEnabled}
       relevantPatches={numRelevantPatches}
       upgradablePackages={numUpgradablePackages}
-      softwareUpdatesSettingsSaved={softwareUpdatesConnectionSaved}
-      softwareUpdatesSettingsLoading={softwareUpdatesSettingsLoading}
+      softwareUpdatesSettingsSaved={settingsConfigured}
       softwareUpdatesLoading={softwareUpdatesLoading}
       softwareUpdatesTooltip={
         numRelevantPatches === undefined && numUpgradablePackages === undefined

--- a/assets/js/state/sagas/softwareUpdates.js
+++ b/assets/js/state/sagas/softwareUpdates.js
@@ -28,12 +28,15 @@ export function* fetchSoftwareUpdates({ payload: hostID }) {
     yield put(setEmptySoftwareUpdates({ hostID }));
 
     const errorCode = get(error, ['response', 'status']);
+    const { errors } = get(error, ['response', 'data'], []);
+    const suma_unauthorized = errors.some(
+      ({ detail }) => detail === 'SUSE Manager authentication error.'
+    );
 
-    if (errorCode === 403) {
+    if (errorCode === 422 && suma_unauthorized) {
       yield put(setSettingsNotConfigured());
     }
 
-    const errors = get(error, ['response', 'data'], []);
     yield put(setSoftwareUpdatesErrors({ hostID, errors }));
   }
 }
@@ -49,8 +52,12 @@ export function* fetchUpgradablePackagesPatches({
     yield put(setSettingsConfigured());
   } catch (error) {
     const errorCode = get(error, ['response', 'status']);
+    const { errors } = get(error, ['response', 'data'], []);
+    const suma_unauthorized = errors.some(
+      ({ detail }) => detail === 'SUSE Manager authentication error.'
+    );
 
-    if (errorCode === 403) {
+    if (errorCode === 422 && suma_unauthorized) {
       yield put(setSettingsNotConfigured());
     }
     yield put(setPatchesForPackages({ hostID, patches: [] }));

--- a/assets/js/state/selectors/softwareUpdates.js
+++ b/assets/js/state/selectors/softwareUpdates.js
@@ -17,6 +17,11 @@ export const getSoftwareUpdatesStats = createSelector(
   })
 );
 
+export const getSoftwareUpdatesSettingsConfigured = createSelector(
+  [(state) => getSoftwareUpdates(state)],
+  (softwareUpdates) => get(softwareUpdates, ['settingsConfigured'], false)
+);
+
 export const getSoftwareUpdatesPatches = createSelector(
   [(state, id) => getSoftwareUpdatesForHost(id)(state)],
   (softwareUpdates) => get(softwareUpdates, ['relevant_patches'], [])

--- a/assets/js/state/softwareUpdates.js
+++ b/assets/js/state/softwareUpdates.js
@@ -2,6 +2,7 @@ import { createAction, createSlice } from '@reduxjs/toolkit';
 import { find, get, isEmpty } from 'lodash';
 
 const initialState = {
+  settingsConfigured: false,
   softwareUpdates: {},
 };
 
@@ -14,6 +15,12 @@ export const softwareUpdatesSlice = createSlice({
   name: 'softwareUpdates',
   initialState,
   reducers: {
+    setSettingsConfigured: (state) => {
+      state.settingsConfigured = true;
+    },
+    setSettingsNotConfigured: (state) => {
+      state.settingsConfigured = false;
+    },
     startLoadingSoftwareUpdates: (state, { payload: { hostID } }) => {
       state.softwareUpdates = {
         ...state.softwareUpdates,
@@ -81,6 +88,8 @@ export const fetchUpgradablePackagesPatches = createAction(
 );
 
 export const {
+  setSettingsConfigured,
+  setSettingsNotConfigured,
   startLoadingSoftwareUpdates,
   setSoftwareUpdates,
   setEmptySoftwareUpdates,

--- a/lib/trento/infrastructure/software_updates/suma.ex
+++ b/lib/trento/infrastructure/software_updates/suma.ex
@@ -62,19 +62,19 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma do
       {:ok, new_state} ->
         request
         |> do_handle(new_state)
-        |> handle_authentication_error(request)
+        |> handle_suma_authentication_error(request)
 
       error ->
         error
     end
   end
 
-  defp handle_authentication_error({:error, :authentication_error}, request) do
+  defp handle_suma_authentication_error({:error, :suma_authentication_error}, request) do
     clear()
     handle_request(request)
   end
 
-  defp handle_authentication_error(result, _), do: result
+  defp handle_suma_authentication_error(result, _), do: result
 
   defp do_handle({:get_system_id, fully_qualified_domain_name}, %State{
          url: url,

--- a/lib/trento/infrastructure/software_updates/suma_api.ex
+++ b/lib/trento/infrastructure/software_updates/suma_api.ex
@@ -27,7 +27,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
           fully_qualified_domain_name :: String.t(),
           ca_cert :: String.t() | nil
         ) ::
-          {:ok, pos_integer()} | {:error, :system_id_not_found | :authentication_error}
+          {:ok, pos_integer()} | {:error, :system_id_not_found | :suma_authentication_error}
   def get_system_id(url, auth, fully_qualified_domain_name, ca_cert) do
     url
     |> get_suma_api_url()
@@ -47,7 +47,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
           ca_cert :: String.t() | nil
         ) ::
           {:ok, [map()]}
-          | {:error, :error_getting_patches | :authentication_error}
+          | {:error, :error_getting_patches | :suma_authentication_error}
   def get_relevant_patches(url, auth, system_id, ca_cert) do
     url
     |> get_suma_api_url()
@@ -67,7 +67,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
           ca_cert :: String.t() | nil
         ) ::
           {:ok, [map()]}
-          | {:error, :error_getting_packages | :authentication_error}
+          | {:error, :error_getting_packages | :suma_authentication_error}
   def get_upgradable_packages(url, auth, system_id, ca_cert) do
     url
     |> get_suma_api_url()
@@ -87,7 +87,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
           ca_cert :: String.t() | nil
         ) ::
           {:ok, [map()]}
-          | {:error, :error_getting_patches | :authentication_error}
+          | {:error, :error_getting_patches | :suma_authentication_error}
   def get_patches_for_package(url, auth, package_id, ca_cert) do
     url
     |> get_suma_api_url()
@@ -107,7 +107,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
           ca_cert :: String.t() | nil
         ) ::
           {:ok, [map()]}
-          | {:error, :error_getting_affected_systems | :authentication_error}
+          | {:error, :error_getting_affected_systems | :suma_authentication_error}
   def get_affected_systems(url, auth, advisory_name, ca_cert) do
     url
     |> get_suma_api_url()
@@ -127,7 +127,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
           ca_cert :: String.t() | nil
         ) ::
           {:ok, [map()]}
-          | {:error, :error_getting_errata_details | :authentication_error}
+          | {:error, :error_getting_errata_details | :suma_authentication_error}
   def get_errata_details(url, auth, advisory_name, ca_cert) do
     url
     |> get_suma_api_url()
@@ -147,7 +147,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
           ca_cert :: String.t() | nil
         ) ::
           {:ok, [map()]}
-          | {:error, :error_getting_cves | :authentication_error}
+          | {:error, :error_getting_cves | :suma_authentication_error}
   def get_cves(url, auth, advisory_name, ca_cert) do
     url
     |> get_suma_api_url()
@@ -167,7 +167,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
           ca_cert :: String.t() | nil
         ) ::
           {:ok, [map()]}
-          | {:error, :error_getting_affected_packages | :authentication_error}
+          | {:error, :error_getting_affected_packages | :suma_authentication_error}
   def get_affected_packages(url, auth, advisory_name, ca_cert) do
     url
     |> get_suma_api_url()
@@ -187,7 +187,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
           ca_cert :: String.t() | nil
         ) ::
           {:ok, [map()]}
-          | {:error, :error_getting_fixes | :authentication_error}
+          | {:error, :error_getting_fixes | :suma_authentication_error}
   def get_bugzilla_fixes(url, auth, advisory_name, ca_cert) do
     url
     |> get_suma_api_url()
@@ -201,7 +201,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
   end
 
   defp handle_auth_error({:ok, %HTTPoison.Response{status_code: 401}}),
-    do: {:error, :authentication_error}
+    do: {:error, :suma_authentication_error}
 
   defp handle_auth_error({:ok, %HTTPoison.Response{status_code: _, body: body}}),
     do: {:ok, body}
@@ -226,7 +226,8 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
     end
   end
 
-  defp decode_response({:error, :authentication_error}, _), do: {:error, :authentication_error}
+  defp decode_response({:error, :suma_authentication_error}, _),
+    do: {:error, :suma_authentication_error}
 
   defp decode_response({:error, _} = error, error_atom: error_atom, error_log: error_log) do
     Logger.error("#{error_log} Error: #{inspect(error)}")

--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -17,6 +17,13 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"404", reason: "SUSE Manager settings not configured.")
   end
 
+  def call(conn, {:error, :suma_authentication_error}) do
+    conn
+    |> put_status(:forbidden)
+    |> put_view(ErrorView)
+    |> render(:"403", reason: "SUSE Manager authentication error.")
+  end
+
   def call(conn, {:error, :invalid_refresh_token}) do
     conn
     |> put_status(:unauthorized)

--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -19,9 +19,9 @@ defmodule TrentoWeb.FallbackController do
 
   def call(conn, {:error, :suma_authentication_error}) do
     conn
-    |> put_status(:forbidden)
+    |> put_status(:unprocessable_entity)
     |> put_view(ErrorView)
-    |> render(:"403", reason: "SUSE Manager authentication error.")
+    |> render(:"422", reason: "SUSE Manager authentication error.")
   end
 
   def call(conn, {:error, :invalid_refresh_token}) do

--- a/test/trento_web/controllers/v1/suse_manager_controller_test.exs
+++ b/test/trento_web/controllers/v1/suse_manager_controller_test.exs
@@ -355,7 +355,7 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
     for %{name: name} = scenario <- unauthorized_scenarios do
       @scenario scenario
 
-      test "should return 403 for #{name}", %{conn: conn, api_spec: api_spec} do
+      test "should return 422 for #{name}", %{conn: conn, api_spec: api_spec} do
         %{mocks: mocks} = @scenario
 
         Enum.each(mocks, fn {network_call, response} ->
@@ -366,8 +366,8 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
 
         conn
         |> get("/api/v1/software_updates/errata_details/#{advisory_name}")
-        |> json_response(:forbidden)
-        |> assert_schema("Forbidden", api_spec)
+        |> json_response(:unprocessable_entity)
+        |> assert_schema("UnprocessableEntity", api_spec)
       end
     end
   end

--- a/test/trento_web/controllers/v1/suse_manager_controller_test.exs
+++ b/test/trento_web/controllers/v1/suse_manager_controller_test.exs
@@ -227,174 +227,148 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
       } = result
     end
 
-    test "should return 422 when advisory details are not found", %{
-      conn: conn,
-      api_spec: api_spec
-    } do
-      insert_software_updates_settings()
+    error_scenarios = [
+      %{
+        name: "advisory details not found",
+        mocks: [
+          get_errata_details: {:error, :error_getting_errata_details},
+          get_cves: {:ok, build_list(10, :cve)},
+          get_bugzilla_fixes: {:ok, build(:bugzilla_fix)},
+          get_affected_packages: {:ok, build_list(10, :affected_package)},
+          get_affected_systems: {:ok, build_list(10, :affected_system)}
+        ]
+      },
+      %{
+        name: "CVEs not found",
+        mocks: [
+          get_errata_details: {:ok, build(:errata_details)},
+          get_cves: {:error, :error_getting_cves},
+          get_bugzilla_fixes: {:ok, build(:bugzilla_fix)},
+          get_affected_packages: {:ok, build_list(10, :affected_package)},
+          get_affected_systems: {:ok, build_list(10, :affected_system)}
+        ]
+      },
+      %{
+        name: "advisory fixes not found",
+        mocks: [
+          get_errata_details: {:ok, build(:errata_details)},
+          get_cves: {:ok, build_list(10, :cve)},
+          get_bugzilla_fixes: {:error, :error_getting_fixes},
+          get_affected_packages: {:ok, build_list(10, :affected_package)},
+          get_affected_systems: {:ok, build_list(10, :affected_system)}
+        ]
+      },
+      %{
+        name: "affected packages not found",
+        mocks: [
+          get_errata_details: {:ok, build(:errata_details)},
+          get_cves: {:ok, build_list(10, :cve)},
+          get_bugzilla_fixes: {:ok, build(:bugzilla_fix)},
+          get_affected_packages: {:error, :error_getting_affected_packages},
+          get_affected_systems: {:ok, build_list(10, :affected_system)}
+        ]
+      },
+      %{
+        name: "affected systems not found",
+        mocks: [
+          get_errata_details: {:ok, build(:errata_details)},
+          get_cves: {:ok, build_list(10, :cve)},
+          get_bugzilla_fixes: {:ok, build(:bugzilla_fix)},
+          get_affected_packages: {:ok, build_list(10, :affected_package)},
+          get_affected_systems: {:error, :error_getting_affected_systems}
+        ]
+      }
+    ]
 
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_errata_details, 1, fn _ ->
-        {:error, :error_getting_errata_details}
-      end)
+    for %{name: name} = scenario <- error_scenarios do
+      @scenario scenario
 
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_cves, 1, fn _ ->
-        {:ok, build_list(10, :cve)}
-      end)
+      test "should return 422 when #{name}", %{conn: conn, api_spec: api_spec} do
+        %{mocks: mocks} = @scenario
 
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_bugzilla_fixes, 1, fn _ ->
-        {:ok, build(:bugzilla_fix)}
-      end)
+        Enum.each(mocks, fn {network_call, response} ->
+          expect(Trento.SoftwareUpdates.Discovery.Mock, network_call, 1, fn _ -> response end)
+        end)
 
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_affected_packages, 1, fn _ ->
-        {:ok, build_list(10, :affected_package)}
-      end)
+        advisory_name = Faker.Pokemon.name()
 
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_affected_systems, 1, fn _ ->
-        {:ok, build_list(10, :affected_system)}
-      end)
-
-      advisory_name = Faker.Pokemon.name()
-
-      conn
-      |> get("/api/v1/software_updates/errata_details/#{advisory_name}")
-      |> json_response(:unprocessable_entity)
-      |> assert_schema("UnprocessableEntity", api_spec)
+        conn
+        |> get("/api/v1/software_updates/errata_details/#{advisory_name}")
+        |> json_response(:unprocessable_entity)
+        |> assert_schema("UnprocessableEntity", api_spec)
+      end
     end
 
-    test "should return 422 when advisory CVEs are not found", %{
-      conn: conn,
-      api_spec: api_spec
-    } do
-      insert_software_updates_settings()
+    unauthorized_scenarios = [
+      %{
+        name: "get_errata_details unauthorized",
+        mocks: [
+          get_errata_details: {:error, :suma_authentication_error},
+          get_cves: {:ok, build_list(10, :cve)},
+          get_bugzilla_fixes: {:ok, build(:bugzilla_fix)},
+          get_affected_packages: {:ok, build_list(10, :affected_package)},
+          get_affected_systems: {:ok, build_list(10, :affected_system)}
+        ]
+      },
+      %{
+        name: "get_cves unauthorized",
+        mocks: [
+          get_errata_details: {:ok, build(:errata_details)},
+          get_cves: {:error, :suma_authentication_error},
+          get_bugzilla_fixes: {:ok, build(:bugzilla_fix)},
+          get_affected_packages: {:ok, build_list(10, :affected_package)},
+          get_affected_systems: {:ok, build_list(10, :affected_system)}
+        ]
+      },
+      %{
+        name: "get_bugzilla_fixes unauthorized",
+        mocks: [
+          get_errata_details: {:ok, build(:errata_details)},
+          get_cves: {:ok, build_list(10, :cve)},
+          get_bugzilla_fixes: {:error, :suma_authentication_error},
+          get_affected_packages: {:ok, build_list(10, :affected_package)},
+          get_affected_systems: {:ok, build_list(10, :affected_system)}
+        ]
+      },
+      %{
+        name: "get_affected_packages unauthorized",
+        mocks: [
+          get_errata_details: {:ok, build(:errata_details)},
+          get_cves: {:ok, build_list(10, :cve)},
+          get_bugzilla_fixes: {:ok, build(:bugzilla_fix)},
+          get_affected_packages: {:error, :suma_authentication_error},
+          get_affected_systems: {:ok, build_list(10, :affected_system)}
+        ]
+      },
+      %{
+        name: "get_affected_systems unauthorized",
+        mocks: [
+          get_errata_details: {:ok, build(:errata_details)},
+          get_cves: {:ok, build_list(10, :cve)},
+          get_bugzilla_fixes: {:ok, build(:bugzilla_fix)},
+          get_affected_packages: {:ok, build_list(10, :affected_package)},
+          get_affected_systems: {:error, :suma_authentication_error}
+        ]
+      }
+    ]
 
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_errata_details, 1, fn _ ->
-        {:ok, build(:errata_details)}
-      end)
+    for %{name: name} = scenario <- unauthorized_scenarios do
+      @scenario scenario
 
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_cves, 1, fn _ ->
-        {:error, :error_getting_cves}
-      end)
+      test "should return 403 for #{name}", %{conn: conn, api_spec: api_spec} do
+        %{mocks: mocks} = @scenario
 
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_bugzilla_fixes, 1, fn _ ->
-        {:ok, build(:bugzilla_fix)}
-      end)
+        Enum.each(mocks, fn {network_call, response} ->
+          expect(Trento.SoftwareUpdates.Discovery.Mock, network_call, 1, fn _ -> response end)
+        end)
 
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_affected_packages, 1, fn _ ->
-        {:ok, build_list(10, :affected_package)}
-      end)
+        advisory_name = Faker.Pokemon.name()
 
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_affected_systems, 1, fn _ ->
-        {:ok, build_list(10, :affected_system)}
-      end)
-
-      advisory_name = Faker.Pokemon.name()
-
-      conn
-      |> get("/api/v1/software_updates/errata_details/#{advisory_name}")
-      |> json_response(:unprocessable_entity)
-      |> assert_schema("UnprocessableEntity", api_spec)
-    end
-
-    test "should return 422 when advisory fixes are not found", %{
-      conn: conn,
-      api_spec: api_spec
-    } do
-      insert_software_updates_settings()
-
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_errata_details, 1, fn _ ->
-        {:ok, build(:errata_details)}
-      end)
-
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_cves, 1, fn _ ->
-        {:ok, build_list(10, :cve)}
-      end)
-
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_bugzilla_fixes, 1, fn _ ->
-        {:error, :error_getting_fixes}
-      end)
-
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_affected_packages, 1, fn _ ->
-        {:ok, build_list(10, :affected_package)}
-      end)
-
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_affected_systems, 1, fn _ ->
-        {:ok, build_list(10, :affected_system)}
-      end)
-
-      advisory_name = Faker.Pokemon.name()
-
-      conn
-      |> get("/api/v1/software_updates/errata_details/#{advisory_name}")
-      |> json_response(:unprocessable_entity)
-      |> assert_schema("UnprocessableEntity", api_spec)
-    end
-
-    test "should return 422 when advisory affected packages are not found", %{
-      conn: conn,
-      api_spec: api_spec
-    } do
-      insert_software_updates_settings()
-
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_errata_details, 1, fn _ ->
-        {:ok, build(:errata_details)}
-      end)
-
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_cves, 1, fn _ ->
-        {:ok, build_list(10, :cve)}
-      end)
-
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_bugzilla_fixes, 1, fn _ ->
-        {:ok, build(:bugzilla_fix)}
-      end)
-
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_affected_packages, 1, fn _ ->
-        {:error, :error_getting_affected_packages}
-      end)
-
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_affected_systems, 1, fn _ ->
-        {:ok, build_list(10, :affected_system)}
-      end)
-
-      advisory_name = Faker.Pokemon.name()
-
-      conn
-      |> get("/api/v1/software_updates/errata_details/#{advisory_name}")
-      |> json_response(:unprocessable_entity)
-      |> assert_schema("UnprocessableEntity", api_spec)
-    end
-
-    test "should return 422 when advisory affected systems are not found", %{
-      conn: conn,
-      api_spec: api_spec
-    } do
-      insert_software_updates_settings()
-
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_errata_details, 1, fn _ ->
-        {:ok, build(:errata_details)}
-      end)
-
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_cves, 1, fn _ ->
-        {:ok, build_list(10, :cve)}
-      end)
-
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_bugzilla_fixes, 1, fn _ ->
-        {:ok, build(:bugzilla_fix)}
-      end)
-
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_affected_packages, 1, fn _ ->
-        {:ok, build_list(10, :affected_package)}
-      end)
-
-      expect(Trento.SoftwareUpdates.Discovery.Mock, :get_affected_systems, 1, fn _ ->
-        {:error, :error_getting_affected_systems}
-      end)
-
-      advisory_name = Faker.Pokemon.name()
-
-      conn
-      |> get("/api/v1/software_updates/errata_details/#{advisory_name}")
-      |> json_response(:unprocessable_entity)
-      |> assert_schema("UnprocessableEntity", api_spec)
+        conn
+        |> get("/api/v1/software_updates/errata_details/#{advisory_name}")
+        |> json_response(:forbidden)
+        |> assert_schema("Forbidden", api_spec)
+      end
     end
   end
 end


### PR DESCRIPTION
# Description

This PR fixes an issue in the UI where the _Available Software Updates_ panel was rendering two different _loading_ states at two different times. The result of this was that the users were seeing a flicker as the panel (briefly) moved into a loading state a second time. This created a confusing user experience.

See the image below for the typical sequence of Redux events that would happen during rendering:

![software_updates_loading](https://github.com/user-attachments/assets/0e93d1e1-6039-4684-b9ec-8d2dd8d5c25b)

Note how the panel enters a _loading_ state while retrieving the software updates, the response returns and the software updates are saved. Much later however the network call to retrieve the SUSE Manager settings begins, and sets the second _loading_ state. The settings are then returned, and the panel is set into the _display_ state again. This is a confusing user experience.

This was fixed by removing the superfluous call to retrieve the SUSE Manager settings, as they are not actually relevant to the _Host Details_ page, nor the _Available Software Updates_ panel. Since we know that if we can retrieve the software updates, then obviously the settings are configured correctly. To emphasize; we don't care about the specific SUSE Manager settings, just if we are authorized to access SUSE Manager with our settings.

We differentiate between being unauthorized vs some other network or server error by returning a `422` status code and corresponding error message `"SUSE Manager authentication error."` in the response from Trento's _SUSE Manager Controller_. The frontend can then know that the SUSE Manager settings are not configured correctly and displays the _SUSE Manager is not configured_ state to the user.

## How was this tested?

Units tests updated.

## Did you update the documentation?

No changes are required for the documentation.
