### PR TITLE
Discover host vulnerabilities only if SUSE Manager is enabled

### DIFF
--- a/lib/trento/infrastructure/commanded/event_handlers/software_updates_discovery_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/software_updates_discovery_event_handler.ex
@@ -14,6 +14,8 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SoftwareUpdatesDiscovery
     SoftwareUpdatesHealthChanged
   }
 
+  alias Trento.Settings
+
   alias Trento.SoftwareUpdates.Discovery
 
   def handle(
@@ -23,9 +25,14 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SoftwareUpdatesDiscovery
         },
         _
       ) do
-    Discovery.discover_host_software_updates(host_id, fully_qualified_domain_name)
+    case Settings.get_suse_manager_settings() do
+      {:ok, _} ->
+        Discovery.discover_host_software_updates(host_id, fully_qualified_domain_name)
+        :ok
 
-    :ok
+      _ ->
+        :ok
+    end
   end
 
   def handle(%SoftwareUpdatesHealthChanged{host_id: host_id}, _) do

--- a/test/trento/infrastructure/commanded/event_handlers/software_updates_discovery_event_handler_test.exs
+++ b/test/trento/infrastructure/commanded/event_handlers/software_updates_discovery_event_handler_test.exs
@@ -32,6 +32,8 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SoftwareUpdatesDiscovery
 
   describe "Discovering software updates" do
     test "should discover software updates when a SoftwareUpdatesDiscoveryRequested is emitted" do
+      insert_software_updates_settings()
+
       %SoftwareUpdatesDiscoveryRequested{
         host_id: host_id,
         fully_qualified_domain_name: fully_qualified_domain_name
@@ -66,7 +68,43 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SoftwareUpdatesDiscovery
       assert :ok = SoftwareUpdatesDiscoveryEventHandler.handle(event, %{})
     end
 
+    test "should discover data about hosts just when SUSE Manager's settings are set" do
+      event = build(:software_updates_discovery_requested_event)
+
+      expect(
+        SoftwareUpdatesDiscoveryMock,
+        :get_system_id,
+        0,
+        fn _ -> :ok end
+      )
+
+      expect(
+        SoftwareUpdatesDiscoveryMock,
+        :get_relevant_patches,
+        0,
+        fn _ -> :ok end
+      )
+
+      expect(
+        SoftwareUpdatesDiscoveryMock,
+        :get_upgradable_packages,
+        0,
+        fn _ -> :ok end
+      )
+
+      expect(
+        Trento.Commanded.Mock,
+        :dispatch,
+        0,
+        fn _ -> :ok end
+      )
+
+      assert :ok = SoftwareUpdatesDiscoveryEventHandler.handle(event, %{})
+    end
+
     test "should pass through failures" do
+      insert_software_updates_settings()
+
       %SoftwareUpdatesDiscoveryRequested{
         fully_qualified_domain_name: fully_qualified_domain_name
       } = event = build(:software_updates_discovery_requested_event)


### PR DESCRIPTION
Just discover SUSE Manager's vulnerability info only if the SUSE Manager integration is enabled

## How was this tested?
Unit tests. This bug was discovered thanks to the end to end testing I developed in #2798.