### PR TITLE
Fix process manager rename

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,8 +19,15 @@ env:
 
 jobs:
   elixir-deps:
-    name: Elixir dependencies
+    name: Elixir ${{ matrix.mix_env }} dependencies
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        include:
+          - mix_env: dev
+          - mix_env: test
+    env:
+      MIX_ENV: ${{ matrix.mix_env }}
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1
@@ -44,7 +51,7 @@ jobs:
         with:
           path: |
             deps
-            _build/test
+            _build/${{ matrix.mix_env }}
             priv/plts
           key: ${{ runner.os }}-${{ steps.setup-elixir.outputs.otp-version }}-${{ steps.setup-elixir.outputs.elixir-version }}-${{ hashFiles('mix.lock') }}
       - name: Install Dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -454,6 +454,16 @@ jobs:
       ]
     runs-on: ubuntu-22.04
     if: needs.check-regression-label.outputs.run_regression_test == 'true'
+    strategy:
+      matrix:
+        include:
+          - test: sap_system_split
+            cypress_spec: |
+              cypress/e2e/databases_overview.cy.js
+              cypress/e2e/sap_systems_overview.cy.js
+          - test: process_manager_rename
+            cypress_spec: |
+              cypress/e2e/host_details.cy.js
     env:
       MIX_ENV: dev
     steps:
@@ -509,13 +519,13 @@ jobs:
         uses: tj-actions/pg-restore@v6
         with:
           database_url: "postgresql://postgres:postgres@localhost:5433/postgres"
-          backup_file: "test/fixtures/regression/sap_system_split/trento_dev.sql"
+          backup_file: "test/fixtures/regression/${{ matrix.test }}/trento_dev.sql"
           postgresql_version: "15"
       - name: Postgres trento_eventstore_dev restore
         uses: tj-actions/pg-restore@v6
         with:
           database_url: "postgresql://postgres:postgres@localhost:5433/postgres"
-          backup_file: "test/fixtures/regression/sap_system_split/trento_eventstore_dev.sql"
+          backup_file: "test/fixtures/regression/${{ matrix.test }}/trento_eventstore_dev.sql"
           postgresql_version: "15"
       - name: Run DB migrations
         run: mix ecto.migrate
@@ -540,16 +550,14 @@ jobs:
           cypress_photofinish_binary: $(whereis photofinish | cut -d" " -f2)
         with:
           working-directory: test/e2e
-          spec: |
-            cypress/e2e/databases_overview.cy.js
-            cypress/e2e/sap_systems_overview.cy.js
+          spec: ${{ matrix.cypress_spec }}
           wait-on-timeout: 30
           config: baseUrl=http://localhost:4000
       - name: Upload cypress test screenshots
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: regression-e2e-screenshots
+          name: regression-${{ matrix.test }}-e2e-screenshots
           path: test/e2e/cypress/screenshots/
 
   main-branch-deps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -560,31 +560,33 @@ jobs:
           name: regression-${{ matrix.test }}-e2e-screenshots
           path: test/e2e/cypress/screenshots/
 
-  main-branch-deps:
-    name: Rebuild main branch dependencies
+  target-branch-deps:
+    name: Rebuild target branch dependencies
     runs-on: ubuntu-20.04
+    env:
+      BRANCH_NAME: ${{ github.event.pull_request.base.ref || github.ref_name }} 
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1
-        if: github.ref_name != 'main'
+        if: github.ref_name != '${{ env.BRANCH_NAME }}'
         with:
           access_token: ${{ github.token }}
-      - name: Checkout main branch
+      - name: Checkout target branch
         uses: actions/checkout@v4
-        if: github.ref_name != 'main'
+        if: github.ref_name != '${{ env.BRANCH_NAME }}'
         with:
-          ref: main
+          ref: ${{ env.BRANCH_NAME }}
       - name: Set up Elixir
         id: setup-elixir
         uses: erlef/setup-beam@v1
-        if: github.ref_name != 'main'
+        if: github.ref_name != '${{ env.BRANCH_NAME }}'
         with:
           version-file: .tool-versions
           version-type: strict
-      - name: Retrieve Cached Dependencies - main branch
+      - name: Retrieve Cached Dependencies - target branch
         uses: actions/cache@v4
-        id: mix-cache-main
-        if: github.ref_name != 'main'
+        id: mix-cache-target
+        if: github.ref_name != '${{ env.BRANCH_NAME }}'
         with:
           path: |
             deps
@@ -592,7 +594,7 @@ jobs:
             priv/plts
           key: ${{ runner.os }}-${{ steps.setup-elixir.outputs.otp-version }}-${{ steps.setup-elixir.outputs.elixir-version }}-${{ hashFiles('mix.lock') }}
       - name: Install missing dependencies
-        if: steps.mix-cache-main.outputs.cache-hit != 'true' && github.ref_name != 'main'
+        if: steps.mix-cache-target.outputs.cache-hit != 'true' && github.ref_name != '${{ env.BRANCH_NAME }}'
         run: |
           mkdir -p priv/plts
           mix local.rebar --force
@@ -603,7 +605,7 @@ jobs:
 
   api-bc-check:
     name: API bc check
-    needs: [elixir-deps, main-branch-deps]
+    needs: [elixir-deps, target-branch-deps]
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -636,28 +638,28 @@ jobs:
         run: |
           mix openapi.spec.json --start-app=false --spec TrentoWeb.OpenApi.${{ matrix.version }}.ApiSpec /tmp/specs/current-spec.json
 
-      - name: Checkout main branch
+      - name: Checkout target branch
         uses: actions/checkout@v4
         with:
-          ref: main
-      - name: Retrieve Cached Dependencies - main branch
+          ref: ${{ github.event.pull_request.base.ref || github.ref_name }} 
+      - name: Retrieve Cached Dependencies - target branch
         uses: actions/cache@v4
-        id: mix-cache-main
+        id: mix-cache-target
         with:
           path: |
             deps
             _build/test
             priv/plts
           key: ${{ runner.os }}-${{ steps.setup-elixir.outputs.otp-version }}-${{ steps.setup-elixir.outputs.elixir-version }}-${{ hashFiles('mix.lock') }}
-      - name: Generate main openapi.json
+      - name: Generate target openapi.json
         run: |
-          mix openapi.spec.json --start-app=false --spec TrentoWeb.OpenApi.${{ matrix.version }}.ApiSpec /tmp/specs/main-spec.json
+          mix openapi.spec.json --start-app=false --spec TrentoWeb.OpenApi.${{ matrix.version }}.ApiSpec /tmp/specs/target-spec.json
       - name: Locate generated specs
         run: mv /tmp/specs .
       - name: Find difference between OpenAPI specifications
         run: |
           docker run -v "$(pwd)/specs:/specs" --rm openapitools/openapi-diff:2.0.1 \
-            /specs/main-spec.json \
+            /specs/target-spec.json \
             /specs/current-spec.json \
             --fail-on-incompatible \
             --markdown /specs/changes.md \

--- a/lib/trento/infrastructure/commanded/process_managers/legacy/deregistration_process_manager.ex
+++ b/lib/trento/infrastructure/commanded/process_managers/legacy/deregistration_process_manager.ex
@@ -3,6 +3,6 @@ defmodule Trento.DeregistrationProcessManager do
   Legacy DeregistrationProcessManager module
   """
 
-  def supersede,
+  def superseded_by,
     do: Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessManager
 end

--- a/lib/trento/infrastructure/commanded/process_managers/legacy/deregistration_process_manager.ex
+++ b/lib/trento/infrastructure/commanded/process_managers/legacy/deregistration_process_manager.ex
@@ -1,0 +1,8 @@
+defmodule Trento.DeregistrationProcessManager do
+  @moduledoc """
+  Legacy DeregistrationProcessManager module
+  """
+
+  def supersede,
+    do: Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessManager
+end

--- a/lib/trento/support/jsonb_serializer.ex
+++ b/lib/trento/support/jsonb_serializer.ex
@@ -25,7 +25,7 @@ defmodule Trento.Support.JsonbSerializer do
   the event is wrapped in an `IntermediateEvent` struct.
   The upcaster protocol is implemented for `IntermediateEvent` and it will take care of calling the `new!/1` function
   after the upcasting is done.
-  If a process manager supports superseding because it was renamed (i.e. it has a `supersede/0` function),
+  If a process manager supports superseding because it was renamed (i.e. it has a `superseded_by/0` function),
   the snapshotted process manager is superseded by the new module.
   """
   def deserialize(term, config) do
@@ -41,8 +41,8 @@ defmodule Trento.Support.JsonbSerializer do
           Kernel.function_exported?(module, :upcast, 2) ->
             %IntermediateEvent{module: module, term: term}
 
-          Kernel.function_exported?(module, :supersede, 0) ->
-            module.supersede().new!(term)
+          Kernel.function_exported?(module, :superseded_by, 0) ->
+            module.superseded_by().new!(term)
 
           true ->
             module.new!(term)

--- a/lib/trento/support/jsonb_serializer.ex
+++ b/lib/trento/support/jsonb_serializer.ex
@@ -25,6 +25,8 @@ defmodule Trento.Support.JsonbSerializer do
   the event is wrapped in an `IntermediateEvent` struct.
   The upcaster protocol is implemented for `IntermediateEvent` and it will take care of calling the `new!/1` function
   after the upcasting is done.
+  If a process manager supports superseding because it was renamed (i.e. it has a `supersede/0` function),
+  the snapshotted process manager is superseded by the new module.
   """
   def deserialize(term, config) do
     case Keyword.get(config, :type) do
@@ -35,10 +37,15 @@ defmodule Trento.Support.JsonbSerializer do
         module = String.to_existing_atom(type)
         Code.ensure_loaded?(module)
 
-        if Kernel.function_exported?(module, :upcast, 2) do
-          %IntermediateEvent{module: module, term: term}
-        else
-          module.new!(term)
+        cond do
+          Kernel.function_exported?(module, :upcast, 2) ->
+            %IntermediateEvent{module: module, term: term}
+
+          Kernel.function_exported?(module, :supersede, 0) ->
+            module.supersede().new!(term)
+
+          true ->
+            module.new!(term)
         end
     end
   end

--- a/test/fixtures/regression/process_manager_rename/trento_dev.sql
+++ b/test/fixtures/regression/process_manager_rename/trento_dev.sql
@@ -1,0 +1,969 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 15.7 (Debian 15.7-1.pgdg120+1)
+-- Dumped by pg_dump version 16.3
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: trento_dev; Type: DATABASE; Schema: -; Owner: postgres
+--
+
+CREATE DATABASE trento_dev WITH TEMPLATE = template0 ENCODING = 'UTF8' LOCALE_PROVIDER = libc LOCALE = 'en_US.utf8';
+
+
+ALTER DATABASE trento_dev OWNER TO postgres;
+
+\connect trento_dev
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: application_instances; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.application_instances (
+    sap_system_id uuid NOT NULL,
+    host_id uuid NOT NULL,
+    instance_number character varying(255) NOT NULL,
+    instance_hostname character varying(255),
+    sid character varying(255),
+    features character varying(255),
+    http_port integer,
+    https_port integer,
+    start_priority character varying(255),
+    health character varying(255),
+    absent_at timestamp without time zone,
+    inserted_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.application_instances OWNER TO postgres;
+
+--
+-- Name: clusters; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.clusters (
+    id uuid NOT NULL,
+    name character varying(255),
+    sid character varying(255),
+    type character varying(255),
+    selected_checks character varying(255)[],
+    health character varying(255),
+    details jsonb,
+    checks_execution character varying(255),
+    resources_number integer,
+    hosts_number integer,
+    provider character varying(255),
+    deregistered_at timestamp without time zone,
+    additional_sids character varying(255)[] DEFAULT ARRAY[]::character varying[],
+    inserted_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.clusters OWNER TO postgres;
+
+--
+-- Name: clusters_enrichment_data; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.clusters_enrichment_data (
+    cluster_id uuid NOT NULL,
+    cib_last_written character varying(255),
+    inserted_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.clusters_enrichment_data OWNER TO postgres;
+
+--
+-- Name: database_instances; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.database_instances (
+    database_id uuid NOT NULL,
+    host_id uuid NOT NULL,
+    instance_number character varying(255) NOT NULL,
+    instance_hostname character varying(255),
+    sid character varying(255),
+    features character varying(255),
+    http_port integer,
+    https_port integer,
+    start_priority character varying(255),
+    health character varying(255),
+    system_replication character varying(255),
+    system_replication_status character varying(255),
+    absent_at timestamp without time zone,
+    inserted_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.database_instances OWNER TO postgres;
+
+--
+-- Name: databases; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.databases (
+    id uuid NOT NULL,
+    sid character varying(255),
+    health character varying(255),
+    deregistered_at timestamp without time zone,
+    inserted_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL,
+    tenants jsonb
+);
+
+
+ALTER TABLE public.databases OWNER TO postgres;
+
+--
+-- Name: discarded_discovery_events; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.discarded_discovery_events (
+    id bigint NOT NULL,
+    payload jsonb,
+    reason text,
+    inserted_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.discarded_discovery_events OWNER TO postgres;
+
+--
+-- Name: discarded_discovery_events_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.discarded_discovery_events_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.discarded_discovery_events_id_seq OWNER TO postgres;
+
+--
+-- Name: discarded_discovery_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.discarded_discovery_events_id_seq OWNED BY public.discarded_discovery_events.id;
+
+
+--
+-- Name: discovery_events; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.discovery_events (
+    id bigint NOT NULL,
+    agent_id uuid,
+    discovery_type character varying(255),
+    payload jsonb,
+    inserted_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.discovery_events OWNER TO postgres;
+
+--
+-- Name: discovery_events_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.discovery_events_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.discovery_events_id_seq OWNER TO postgres;
+
+--
+-- Name: discovery_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.discovery_events_id_seq OWNED BY public.discovery_events.id;
+
+
+--
+-- Name: fun_with_flags_toggles; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.fun_with_flags_toggles (
+    id bigint NOT NULL,
+    flag_name character varying(255) NOT NULL,
+    gate_type character varying(255) NOT NULL,
+    target character varying(255) NOT NULL,
+    enabled boolean NOT NULL
+);
+
+
+ALTER TABLE public.fun_with_flags_toggles OWNER TO postgres;
+
+--
+-- Name: fun_with_flags_toggles_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.fun_with_flags_toggles_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.fun_with_flags_toggles_id_seq OWNER TO postgres;
+
+--
+-- Name: fun_with_flags_toggles_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.fun_with_flags_toggles_id_seq OWNED BY public.fun_with_flags_toggles.id;
+
+
+--
+-- Name: heartbeats; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.heartbeats (
+    agent_id character varying(255) NOT NULL,
+    "timestamp" timestamp without time zone,
+    inserted_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.heartbeats OWNER TO postgres;
+
+--
+-- Name: hosts; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.hosts (
+    id uuid NOT NULL,
+    hostname character varying(255),
+    ip_addresses character varying(255)[],
+    agent_version character varying(255),
+    heartbeat character varying(255),
+    provider character varying(255),
+    cluster_id uuid,
+    provider_data jsonb,
+    deregistered_at timestamp without time zone,
+    selected_checks character varying(255)[] DEFAULT ARRAY[]::character varying[],
+    saptune_status jsonb,
+    health character varying(255),
+    fully_qualified_domain_name character varying(255),
+    inserted_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.hosts OWNER TO postgres;
+
+--
+-- Name: projection_versions; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.projection_versions (
+    projection_name text NOT NULL,
+    last_seen_event_number bigint,
+    inserted_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.projection_versions OWNER TO postgres;
+
+--
+-- Name: sap_systems; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sap_systems (
+    id uuid NOT NULL,
+    sid character varying(255),
+    tenant character varying(255),
+    db_host character varying(255),
+    health character varying(255),
+    deregistered_at timestamp without time zone,
+    ensa_version character varying(255),
+    inserted_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL,
+    database_id uuid
+);
+
+
+ALTER TABLE public.sap_systems OWNER TO postgres;
+
+--
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.schema_migrations (
+    version bigint NOT NULL,
+    inserted_at timestamp(0) without time zone
+);
+
+
+ALTER TABLE public.schema_migrations OWNER TO postgres;
+
+--
+-- Name: settings; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.settings (
+    installation_settings_installation_id uuid,
+    inserted_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL,
+    id uuid NOT NULL,
+    type character varying(255) NOT NULL,
+    api_key_settings_jti uuid,
+    api_key_settings_created_at timestamp without time zone,
+    api_key_settings_expire_at timestamp without time zone,
+    suse_manager_settings_url character varying(255),
+    suse_manager_settings_username character varying(255),
+    suse_manager_settings_password bytea,
+    suse_manager_settings_ca_cert bytea,
+    suse_manager_settings_ca_uploaded_at timestamp without time zone
+);
+
+
+ALTER TABLE public.settings OWNER TO postgres;
+
+--
+-- Name: sles_subscriptions; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.sles_subscriptions (
+    host_id uuid NOT NULL,
+    identifier character varying(255) NOT NULL,
+    version character varying(255),
+    arch character varying(255),
+    status character varying(255),
+    subscription_status character varying(255),
+    type character varying(255),
+    starts_at character varying(255),
+    expires_at character varying(255),
+    inserted_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.sles_subscriptions OWNER TO postgres;
+
+--
+-- Name: software_updates_discovery_result; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.software_updates_discovery_result (
+    host_id uuid NOT NULL,
+    system_id character varying(255),
+    relevant_patches jsonb,
+    upgradable_packages jsonb,
+    failure_reason character varying(255),
+    inserted_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.software_updates_discovery_result OWNER TO postgres;
+
+--
+-- Name: tags; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.tags (
+    id bigint NOT NULL,
+    value character varying(255),
+    resource_id uuid,
+    resource_type character varying(255),
+    inserted_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.tags OWNER TO postgres;
+
+--
+-- Name: tags_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.tags_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.tags_id_seq OWNER TO postgres;
+
+--
+-- Name: tags_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.tags_id_seq OWNED BY public.tags.id;
+
+
+--
+-- Name: users; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.users (
+    id bigint NOT NULL,
+    username character varying(255) NOT NULL,
+    password_hash character varying(255),
+    inserted_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone DEFAULT '2024-07-23 08:09:26.532937'::timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.users OWNER TO postgres;
+
+--
+-- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.users_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.users_id_seq OWNER TO postgres;
+
+--
+-- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
+
+
+--
+-- Name: discarded_discovery_events id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.discarded_discovery_events ALTER COLUMN id SET DEFAULT nextval('public.discarded_discovery_events_id_seq'::regclass);
+
+
+--
+-- Name: discovery_events id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.discovery_events ALTER COLUMN id SET DEFAULT nextval('public.discovery_events_id_seq'::regclass);
+
+
+--
+-- Name: fun_with_flags_toggles id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.fun_with_flags_toggles ALTER COLUMN id SET DEFAULT nextval('public.fun_with_flags_toggles_id_seq'::regclass);
+
+
+--
+-- Name: tags id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.tags ALTER COLUMN id SET DEFAULT nextval('public.tags_id_seq'::regclass);
+
+
+--
+-- Name: users id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
+
+
+--
+-- Data for Name: application_instances; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.application_instances (sap_system_id, host_id, instance_number, instance_hostname, sid, features, http_port, https_port, start_priority, health, absent_at, inserted_at, updated_at) FROM stdin;
+\.
+
+
+--
+-- Data for Name: clusters; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.clusters (id, name, sid, type, selected_checks, health, details, checks_execution, resources_number, hosts_number, provider, deregistered_at, additional_sids, inserted_at, updated_at) FROM stdin;
+\.
+
+
+--
+-- Data for Name: clusters_enrichment_data; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.clusters_enrichment_data (cluster_id, cib_last_written, inserted_at, updated_at) FROM stdin;
+\.
+
+
+--
+-- Data for Name: database_instances; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.database_instances (database_id, host_id, instance_number, instance_hostname, sid, features, http_port, https_port, start_priority, health, system_replication, system_replication_status, absent_at, inserted_at, updated_at) FROM stdin;
+\.
+
+
+--
+-- Data for Name: databases; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.databases (id, sid, health, deregistered_at, inserted_at, updated_at, tenants) FROM stdin;
+\.
+
+
+--
+-- Data for Name: discarded_discovery_events; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.discarded_discovery_events (id, payload, reason, inserted_at, updated_at) FROM stdin;
+\.
+
+
+--
+-- Data for Name: discovery_events; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.discovery_events (id, agent_id, discovery_type, payload, inserted_at, updated_at) FROM stdin;
+1	9cd46919-5f19-59aa-993e-cf3736c71053	host_discovery	{"hostname": "vmhdbprd01", "cpu_count": 4, "os_version": "15-SP3", "ip_addresses": ["127.0.0.1", "::1", "10.80.1.11", "10.80.1.13", "fe80::20d:3aff:fe23:2c6b"], "socket_count": 1, "agent_version": "2.1.0", "total_memory_mb": 32107, "fully_qualified_domain_name": "vmhdbprd01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"}	2024-07-23 08:10:21.857771	2024-07-23 08:10:21.857771
+\.
+
+
+--
+-- Data for Name: fun_with_flags_toggles; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.fun_with_flags_toggles (id, flag_name, gate_type, target, enabled) FROM stdin;
+\.
+
+
+--
+-- Data for Name: heartbeats; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.heartbeats (agent_id, "timestamp", inserted_at, updated_at) FROM stdin;
+\.
+
+
+--
+-- Data for Name: hosts; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.hosts (id, hostname, ip_addresses, agent_version, heartbeat, provider, cluster_id, provider_data, deregistered_at, selected_checks, saptune_status, health, fully_qualified_domain_name, inserted_at, updated_at) FROM stdin;
+9cd46919-5f19-59aa-993e-cf3736c71053	vmhdbprd01	{10.80.1.11,10.80.1.13}	2.1.0	unknown	\N	\N	\N	\N	{}	\N	unknown	vmhdbprd01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net	2024-07-23 08:10:22.264165	2024-07-23 08:10:22.264165
+\.
+
+
+--
+-- Data for Name: projection_versions; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.projection_versions (projection_name, last_seen_event_number, inserted_at, updated_at) FROM stdin;
+host_projector	1	2024-07-23 08:10:22.227934	2024-07-23 08:10:22.230343
+\.
+
+
+--
+-- Data for Name: sap_systems; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.sap_systems (id, sid, tenant, db_host, health, deregistered_at, ensa_version, inserted_at, updated_at, database_id) FROM stdin;
+\.
+
+
+--
+-- Data for Name: schema_migrations; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.schema_migrations (version, inserted_at) FROM stdin;
+20211211133519	2024-07-23 08:09:25
+20211212192656	2024-07-23 08:09:25
+20211228124832	2024-07-23 08:09:25
+20211228125531	2024-07-23 08:09:25
+20220119193711	2024-07-23 08:09:25
+20220129160042	2024-07-23 08:09:25
+20220129161631	2024-07-23 08:09:25
+20220209151154	2024-07-23 08:09:25
+20220302090722	2024-07-23 08:09:25
+20220302154246	2024-07-23 08:09:25
+20220302161146	2024-07-23 08:09:26
+20220303092533	2024-07-23 08:09:26
+20220303092814	2024-07-23 08:09:26
+20220303134205	2024-07-23 08:09:26
+20220304084057	2024-07-23 08:09:26
+20220308142241	2024-07-23 08:09:26
+20220309094147	2024-07-23 08:09:26
+20220311173044	2024-07-23 08:09:26
+20220314130006	2024-07-23 08:09:26
+20220315133348	2024-07-23 08:09:26
+20220316140828	2024-07-23 08:09:26
+20220320190026	2024-07-23 08:09:26
+20220329101245	2024-07-23 08:09:26
+20220331121957	2024-07-23 08:09:26
+20220404142441	2024-07-23 08:09:26
+20220405142819	2024-07-23 08:09:26
+20220411084543	2024-07-23 08:09:26
+20220420082408	2024-07-23 08:09:26
+20220420122023	2024-07-23 08:09:26
+20220518074335	2024-07-23 08:09:26
+20220601162519	2024-07-23 08:09:26
+20220729073320	2024-07-23 08:09:26
+20230118130238	2024-07-23 08:09:26
+20230123162618	2024-07-23 08:09:26
+20230123162816	2024-07-23 08:09:26
+20230123162928	2024-07-23 08:09:26
+20230309094053	2024-07-23 08:09:26
+20230323161309	2024-07-23 08:09:26
+20230505124514	2024-07-23 08:09:26
+20230509114833	2024-07-23 08:09:26
+20230608105745	2024-07-23 08:09:26
+20230613101433	2024-07-23 08:09:26
+20230613102033	2024-07-23 08:09:26
+20230616114036	2024-07-23 08:09:26
+20230822144338	2024-07-23 08:09:26
+20230822144348	2024-07-23 08:09:26
+20230905141817	2024-07-23 08:09:26
+20230926082236	2024-07-23 08:09:26
+20240118164648	2024-07-23 08:09:26
+20240130130617	2024-07-23 08:09:26
+20240214153742	2024-07-23 08:09:26
+20240221134250	2024-07-23 08:09:26
+20240227102315	2024-07-23 08:09:26
+20240319102315	2024-07-23 08:09:26
+20240320152419	2024-07-23 08:09:26
+20240321095516	2024-07-23 08:09:26
+20240327074541	2024-07-23 08:09:26
+20240404165703	2024-07-23 08:09:26
+20240408112012	2024-07-23 08:09:26
+20240408124205	2024-07-23 08:09:26
+20240422105737	2024-07-23 08:09:26
+20240502105156	2024-07-23 08:09:26
+\.
+
+
+--
+-- Data for Name: settings; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.settings (installation_settings_installation_id, inserted_at, updated_at, id, type, api_key_settings_jti, api_key_settings_created_at, api_key_settings_expire_at, suse_manager_settings_url, suse_manager_settings_username, suse_manager_settings_password, suse_manager_settings_ca_cert, suse_manager_settings_ca_uploaded_at) FROM stdin;
+b98efc75-e091-4ed7-bc86-7bda890e1f88	2024-07-23 08:09:26.532937	2024-07-23 08:09:26.532937	d471321c-e827-432b-a7e5-c1eb426c2552	installation_settings	\N	\N	\N	\N	\N	\N	\N	\N
+\N	2024-07-23 08:09:42.43469	2024-07-23 08:09:42.43469	020ce43b-80b5-4a98-823e-79483a321ee0	api_key_settings	254167af-2223-4abc-ae85-243405a2b308	2024-07-23 08:09:42.40808	\N	\N	\N	\N	\N	\N
+\.
+
+
+--
+-- Data for Name: sles_subscriptions; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.sles_subscriptions (host_id, identifier, version, arch, status, subscription_status, type, starts_at, expires_at, inserted_at, updated_at) FROM stdin;
+\.
+
+
+--
+-- Data for Name: software_updates_discovery_result; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.software_updates_discovery_result (host_id, system_id, relevant_patches, upgradable_packages, failure_reason, inserted_at, updated_at) FROM stdin;
+\.
+
+
+--
+-- Data for Name: tags; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.tags (id, value, resource_id, resource_type, inserted_at, updated_at) FROM stdin;
+\.
+
+
+--
+-- Data for Name: users; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.users (id, username, password_hash, inserted_at, updated_at) FROM stdin;
+1	admin	$pbkdf2-sha512$100000$TzHbgSTdl1Etyd4/omY4Tg==$Tpb69r8HTh/9hbMxBfJClpC3os23P62IZ9IqyavYB+ITMRbn7oE5vOVgbLCzwq4TO7NbNSkm5GOFkendqQ0cew==	2024-07-23 08:09:42.39273	2024-07-23 08:09:42.39273
+\.
+
+
+--
+-- Name: discarded_discovery_events_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('public.discarded_discovery_events_id_seq', 1, false);
+
+
+--
+-- Name: discovery_events_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('public.discovery_events_id_seq', 1, true);
+
+
+--
+-- Name: fun_with_flags_toggles_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('public.fun_with_flags_toggles_id_seq', 1, false);
+
+
+--
+-- Name: tags_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('public.tags_id_seq', 1, false);
+
+
+--
+-- Name: users_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('public.users_id_seq', 1, true);
+
+
+--
+-- Name: application_instances application_instances_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.application_instances
+    ADD CONSTRAINT application_instances_pkey PRIMARY KEY (sap_system_id, host_id, instance_number);
+
+
+--
+-- Name: clusters_enrichment_data clusters_enrichment_data_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.clusters_enrichment_data
+    ADD CONSTRAINT clusters_enrichment_data_pkey PRIMARY KEY (cluster_id);
+
+
+--
+-- Name: clusters clusters_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.clusters
+    ADD CONSTRAINT clusters_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: database_instances database_instances_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.database_instances
+    ADD CONSTRAINT database_instances_pkey PRIMARY KEY (database_id, host_id, instance_number);
+
+
+--
+-- Name: databases databases_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.databases
+    ADD CONSTRAINT databases_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: discarded_discovery_events discarded_discovery_events_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.discarded_discovery_events
+    ADD CONSTRAINT discarded_discovery_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: discovery_events discovery_events_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.discovery_events
+    ADD CONSTRAINT discovery_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: fun_with_flags_toggles fun_with_flags_toggles_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.fun_with_flags_toggles
+    ADD CONSTRAINT fun_with_flags_toggles_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: heartbeats heartbeats_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.heartbeats
+    ADD CONSTRAINT heartbeats_pkey PRIMARY KEY (agent_id);
+
+
+--
+-- Name: hosts hosts_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.hosts
+    ADD CONSTRAINT hosts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: projection_versions projection_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.projection_versions
+    ADD CONSTRAINT projection_versions_pkey PRIMARY KEY (projection_name);
+
+
+--
+-- Name: sap_systems sap_systems_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sap_systems
+    ADD CONSTRAINT sap_systems_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: settings settings_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.settings
+    ADD CONSTRAINT settings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: sles_subscriptions sles_subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.sles_subscriptions
+    ADD CONSTRAINT sles_subscriptions_pkey PRIMARY KEY (host_id, identifier);
+
+
+--
+-- Name: software_updates_discovery_result software_updates_discovery_result_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.software_updates_discovery_result
+    ADD CONSTRAINT software_updates_discovery_result_pkey PRIMARY KEY (host_id);
+
+
+--
+-- Name: tags tags_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.tags
+    ADD CONSTRAINT tags_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: application_instances_host_id_index; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX application_instances_host_id_index ON public.application_instances USING btree (host_id);
+
+
+--
+-- Name: clusters_id_index; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX clusters_id_index ON public.clusters USING btree (id);
+
+
+--
+-- Name: database_instances_host_id_index; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX database_instances_host_id_index ON public.database_instances USING btree (host_id);
+
+
+--
+-- Name: databases_tenants; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX databases_tenants ON public.databases USING gin (tenants);
+
+
+--
+-- Name: fwf_flag_name_gate_target_idx; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX fwf_flag_name_gate_target_idx ON public.fun_with_flags_toggles USING btree (flag_name, gate_type, target);
+
+
+--
+-- Name: settings_type_index; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX settings_type_index ON public.settings USING btree (type);
+
+
+--
+-- Name: sles_subscriptions_host_id_index; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE INDEX sles_subscriptions_host_id_index ON public.sles_subscriptions USING btree (host_id);
+
+
+--
+-- Name: tags_value_resource_id_index; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX tags_value_resource_id_index ON public.tags USING btree (value, resource_id);
+
+
+--
+-- Name: users_username_index; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX users_username_index ON public.users USING btree (username);
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/test/fixtures/regression/process_manager_rename/trento_eventstore_dev.sql
+++ b/test/fixtures/regression/process_manager_rename/trento_eventstore_dev.sql
@@ -1,0 +1,500 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 15.7 (Debian 15.7-1.pgdg120+1)
+-- Dumped by pg_dump version 16.3
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: trento_eventstore_dev; Type: DATABASE; Schema: -; Owner: postgres
+--
+
+CREATE DATABASE trento_eventstore_dev WITH TEMPLATE = template0 ENCODING = 'UTF8' LOCALE_PROVIDER = libc LOCALE = 'en_US.utf8';
+
+
+ALTER DATABASE trento_eventstore_dev OWNER TO postgres;
+
+\connect trento_eventstore_dev
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: event_store_delete(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.event_store_delete() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+  message text;
+BEGIN
+  IF current_setting('eventstore.enable_hard_deletes', true) = 'on' OR
+    current_setting('eventstore.reset', true) = 'on'
+  THEN
+    -- Allow DELETE
+    RETURN OLD;
+  ELSE
+    -- Prevent DELETE
+    message := 'EventStore: ' || TG_ARGV[0];
+
+    RAISE EXCEPTION USING MESSAGE = message, ERRCODE = 'feature_not_supported';
+  END IF;
+END;
+$$;
+
+
+ALTER FUNCTION public.event_store_delete() OWNER TO postgres;
+
+--
+-- Name: event_store_exception(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.event_store_exception() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+  message text;
+BEGIN
+  message := 'EventStore: ' || TG_ARGV[0];
+
+  RAISE EXCEPTION USING MESSAGE = message;
+END;
+$$;
+
+
+ALTER FUNCTION public.event_store_exception() OWNER TO postgres;
+
+--
+-- Name: notify_events(); Type: FUNCTION; Schema: public; Owner: postgres
+--
+
+CREATE FUNCTION public.notify_events() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+  old_stream_version bigint;
+  channel text;
+  payload text;
+BEGIN
+    -- Payload text contains:
+    --  * `stream_uuid`
+    --  * `stream_id`
+    --  * first `stream_version`
+    --  * last `stream_version`
+    -- Each separated by a comma (e.g. 'stream-12345,1,1,5')
+
+    IF TG_OP = 'UPDATE' THEN
+      old_stream_version := OLD.stream_version + 1;
+    ELSE
+      old_stream_version := 1;
+    END IF;
+
+    channel := TG_TABLE_SCHEMA || '.events';
+    payload := NEW.stream_uuid || ',' || NEW.stream_id || ',' || old_stream_version || ',' || NEW.stream_version;
+
+    -- Notify events to listeners
+    PERFORM pg_notify(channel, payload);
+
+    RETURN NULL;
+END;
+$$;
+
+
+ALTER FUNCTION public.notify_events() OWNER TO postgres;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: events; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.events (
+    event_id uuid NOT NULL,
+    event_type text NOT NULL,
+    causation_id uuid,
+    correlation_id uuid,
+    data jsonb NOT NULL,
+    metadata jsonb,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+ALTER TABLE public.events OWNER TO postgres;
+
+--
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.schema_migrations (
+    major_version integer NOT NULL,
+    minor_version integer NOT NULL,
+    patch_version integer NOT NULL,
+    migrated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+ALTER TABLE public.schema_migrations OWNER TO postgres;
+
+--
+-- Name: snapshots; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.snapshots (
+    source_uuid text NOT NULL,
+    source_version bigint NOT NULL,
+    source_type text NOT NULL,
+    data jsonb NOT NULL,
+    metadata jsonb,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+ALTER TABLE public.snapshots OWNER TO postgres;
+
+--
+-- Name: stream_events; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.stream_events (
+    event_id uuid NOT NULL,
+    stream_id bigint NOT NULL,
+    stream_version bigint NOT NULL,
+    original_stream_id bigint,
+    original_stream_version bigint
+);
+
+
+ALTER TABLE public.stream_events OWNER TO postgres;
+
+--
+-- Name: streams; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.streams (
+    stream_id bigint NOT NULL,
+    stream_uuid text NOT NULL,
+    stream_version bigint DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    deleted_at timestamp with time zone
+);
+
+
+ALTER TABLE public.streams OWNER TO postgres;
+
+--
+-- Name: streams_stream_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.streams_stream_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.streams_stream_id_seq OWNER TO postgres;
+
+--
+-- Name: streams_stream_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.streams_stream_id_seq OWNED BY public.streams.stream_id;
+
+
+--
+-- Name: subscriptions; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.subscriptions (
+    subscription_id bigint NOT NULL,
+    stream_uuid text NOT NULL,
+    subscription_name text NOT NULL,
+    last_seen bigint,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+ALTER TABLE public.subscriptions OWNER TO postgres;
+
+--
+-- Name: subscriptions_subscription_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.subscriptions_subscription_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE public.subscriptions_subscription_id_seq OWNER TO postgres;
+
+--
+-- Name: subscriptions_subscription_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.subscriptions_subscription_id_seq OWNED BY public.subscriptions.subscription_id;
+
+
+--
+-- Name: streams stream_id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.streams ALTER COLUMN stream_id SET DEFAULT nextval('public.streams_stream_id_seq'::regclass);
+
+
+--
+-- Name: subscriptions subscription_id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.subscriptions ALTER COLUMN subscription_id SET DEFAULT nextval('public.subscriptions_subscription_id_seq'::regclass);
+
+
+--
+-- Data for Name: events; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.events (event_id, event_type, causation_id, correlation_id, data, metadata, created_at) FROM stdin;
+35b8d0e2-fb1a-4eb7-923f-a7e1ed589f04	Elixir.Trento.Hosts.Events.HostRegistered	5ef6d63d-4947-4598-8850-62b0d41ec2e0	5c81f7de-49a8-49d2-ad09-3056b2cc1fa2	{"health": null, "host_id": "9cd46919-5f19-59aa-993e-cf3736c71053", "version": 4, "hostname": "vmhdbprd01", "cpu_count": 4, "heartbeat": "unknown", "os_version": "15-SP3", "ip_addresses": ["10.80.1.11", "10.80.1.13"], "socket_count": 1, "agent_version": "2.1.0", "total_memory_mb": 32107, "installation_source": "unknown", "fully_qualified_domain_name": "vmhdbprd01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"}	{}	2024-07-23 08:10:21.978494+00
+332d66ed-a947-4d8e-8bbd-64ed2ef1f357	Elixir.Trento.Hosts.Events.SoftwareUpdatesDiscoveryRequested	5ef6d63d-4947-4598-8850-62b0d41ec2e0	5c81f7de-49a8-49d2-ad09-3056b2cc1fa2	{"host_id": "9cd46919-5f19-59aa-993e-cf3736c71053", "version": 1, "fully_qualified_domain_name": "vmhdbprd01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"}	{}	2024-07-23 08:10:21.997606+00
+\.
+
+
+--
+-- Data for Name: schema_migrations; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.schema_migrations (major_version, minor_version, patch_version, migrated_at) FROM stdin;
+1	3	2	2024-07-23 08:09:39.285649+00
+\.
+
+
+--
+-- Data for Name: snapshots; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.snapshots (source_uuid, source_version, source_type, data, metadata, created_at) FROM stdin;
+"deregistration_process_manager"-"9cd46919-5f19-59aa-993e-cf3736c71053"	1	Elixir.Trento.DeregistrationProcessManager	{"cluster_id": null, "database_instances": [], "application_instances": []}	\N	2024-07-23 08:10:22.231113+00
+\.
+
+
+--
+-- Data for Name: stream_events; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.stream_events (event_id, stream_id, stream_version, original_stream_id, original_stream_version) FROM stdin;
+35b8d0e2-fb1a-4eb7-923f-a7e1ed589f04	0	1	1	1
+332d66ed-a947-4d8e-8bbd-64ed2ef1f357	0	2	1	2
+35b8d0e2-fb1a-4eb7-923f-a7e1ed589f04	1	1	1	1
+332d66ed-a947-4d8e-8bbd-64ed2ef1f357	1	2	1	2
+\.
+
+
+--
+-- Data for Name: streams; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.streams (stream_id, stream_uuid, stream_version, created_at, deleted_at) FROM stdin;
+0	$all	2	2024-07-23 08:09:39.285649+00	\N
+1	9cd46919-5f19-59aa-993e-cf3736c71053	2	2024-07-23 08:10:22.013573+00	\N
+\.
+
+
+--
+-- Data for Name: subscriptions; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public.subscriptions (subscription_id, stream_uuid, subscription_name, last_seen, created_at) FROM stdin;
+3	$all	database_deregistration_event_handler	2	2024-07-23 08:09:41.306434+00
+10	$all	roll_up_event_handler	2	2024-07-23 08:09:41.315213+00
+5	$all	stream_roll_up_event_handler	2	2024-07-23 08:09:41.307278+00
+2	$all	alerts_event_handler	2	2024-07-23 08:09:41.306467+00
+11	$all	sles_subscription_projector	2	2024-07-23 08:09:41.320901+00
+8	$all	database_projector	2	2024-07-23 08:09:41.314622+00
+6	$all	cluster_projector	2	2024-07-23 08:09:41.311857+00
+4	$all	sap_system_database_health_event_handler	2	2024-07-23 08:09:41.308056+00
+7	$all	sap_system_projector	2	2024-07-23 08:09:41.314542+00
+12	$all	database_restore_event_handler	2	2024-07-23 08:09:41.320517+00
+9	$all	software_updates_discovery_event_handler	2	2024-07-23 08:09:41.31494+00
+13	$all	deregistration_process_manager	2	2024-07-23 08:09:41.326737+00
+1	$all	host_projector	2	2024-07-23 08:09:41.306718+00
+\.
+
+
+--
+-- Name: streams_stream_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('public.streams_stream_id_seq', 1, true);
+
+
+--
+-- Name: subscriptions_subscription_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('public.subscriptions_subscription_id_seq', 13, true);
+
+
+--
+-- Name: events events_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.events
+    ADD CONSTRAINT events_pkey PRIMARY KEY (event_id);
+
+
+--
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.schema_migrations
+    ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (major_version, minor_version, patch_version);
+
+
+--
+-- Name: snapshots snapshots_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.snapshots
+    ADD CONSTRAINT snapshots_pkey PRIMARY KEY (source_uuid);
+
+
+--
+-- Name: stream_events stream_events_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.stream_events
+    ADD CONSTRAINT stream_events_pkey PRIMARY KEY (event_id, stream_id);
+
+
+--
+-- Name: streams streams_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.streams
+    ADD CONSTRAINT streams_pkey PRIMARY KEY (stream_id);
+
+
+--
+-- Name: subscriptions subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.subscriptions
+    ADD CONSTRAINT subscriptions_pkey PRIMARY KEY (subscription_id);
+
+
+--
+-- Name: ix_stream_events; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX ix_stream_events ON public.stream_events USING btree (stream_id, stream_version);
+
+
+--
+-- Name: ix_streams_stream_uuid; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX ix_streams_stream_uuid ON public.streams USING btree (stream_uuid);
+
+
+--
+-- Name: ix_subscriptions_stream_uuid_subscription_name; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX ix_subscriptions_stream_uuid_subscription_name ON public.subscriptions USING btree (stream_uuid, subscription_name);
+
+
+--
+-- Name: streams event_notification; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER event_notification AFTER INSERT OR UPDATE ON public.streams FOR EACH ROW EXECUTE FUNCTION public.notify_events();
+
+
+--
+-- Name: events no_delete_events; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER no_delete_events BEFORE DELETE ON public.events FOR EACH STATEMENT EXECUTE FUNCTION public.event_store_delete('Cannot delete events');
+
+
+--
+-- Name: stream_events no_delete_stream_events; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER no_delete_stream_events BEFORE DELETE ON public.stream_events FOR EACH STATEMENT EXECUTE FUNCTION public.event_store_delete('Cannot delete stream events');
+
+
+--
+-- Name: streams no_delete_streams; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER no_delete_streams BEFORE DELETE ON public.streams FOR EACH STATEMENT EXECUTE FUNCTION public.event_store_delete('Cannot delete streams');
+
+
+--
+-- Name: events no_update_events; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER no_update_events BEFORE UPDATE ON public.events FOR EACH STATEMENT EXECUTE FUNCTION public.event_store_exception('Cannot update events');
+
+
+--
+-- Name: stream_events no_update_stream_events; Type: TRIGGER; Schema: public; Owner: postgres
+--
+
+CREATE TRIGGER no_update_stream_events BEFORE UPDATE ON public.stream_events FOR EACH STATEMENT EXECUTE FUNCTION public.event_store_exception('Cannot update stream events');
+
+
+--
+-- Name: stream_events stream_events_event_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.stream_events
+    ADD CONSTRAINT stream_events_event_id_fkey FOREIGN KEY (event_id) REFERENCES public.events(event_id);
+
+
+--
+-- Name: stream_events stream_events_original_stream_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.stream_events
+    ADD CONSTRAINT stream_events_original_stream_id_fkey FOREIGN KEY (original_stream_id) REFERENCES public.streams(stream_id);
+
+
+--
+-- Name: stream_events stream_events_stream_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.stream_events
+    ADD CONSTRAINT stream_events_stream_id_fkey FOREIGN KEY (stream_id) REFERENCES public.streams(stream_id);
+
+
+--
+-- PostgreSQL database dump complete
+--
+


### PR DESCRIPTION
# Description

Fix issue happening when trento is upgraded from version 2.2.0 to 2.3.0 as the deregistration process manager name was updated, but the "superseding" not handled, so the old module is not found.

```
> ** (ArgumentError) errors were found at the given arguments:
> 
>   * 1st argument: not an already existing atom
> 
>     :erlang.binary_to_existing_atom("Elixir.Trento.DeregistrationProcessManager", :utf8)
>     (trento 2.3.1) lib/trento/support/jsonb_serializer.ex:35: Trento.Support.JsonbSerializer.deserialize/2
>     (eventstore 1.4.4) lib/event_store/snapshots/snapshot_data.ex:34: EventStore.Snapshots.SnapshotData.deserialize/2
>     (eventstore 1.4.4) lib/event_store/snapshots/snapshotter.ex:14: EventStore.Snapshots.Snapshotter.read_snapshot/3
```

## How was this tested?
Regression test with old `Trento.DeregistrationProcessManager` process manager entry. When new events affecting this PM entry are received, the PM snapshot is loaded and updated by the new one automaticlly.
