### PR TITLE
Log domain events

### DIFF
--- a/lib/trento/activity_logging/activity_catalog.ex
+++ b/lib/trento/activity_logging/activity_catalog.ex
@@ -10,78 +10,19 @@ defmodule Trento.ActivityLog.ActivityCatalog do
   @type domain_event_activity :: event_module :: module()
   @type logged_activity :: connection_activity() | domain_event_activity()
 
-  defp load_domain_events do
-    case :application.get_key(:trento, :modules) do
-      {:ok, modules} ->
-        modules
-        |> Enum.map(&Module.split/1)
-        |> Enum.filter(fn
-          ["Trento", resource_type, "Events", _]
-          when resource_type in [
-                 "Hosts",
-                 "Clusters",
-                 "SapSystems",
-                 "Databases"
-               ] ->
-            true
-
-          _ ->
-            false
-        end)
-        |> Enum.map(&Module.concat/1)
-        |> Enum.filter(&(not function_exported?(&1, :legacy, 0)))
-        |> Map.new(fn event_module ->
-          {event_module,
-           {event_module
-            |> Module.split()
-            |> List.last()
-            |> Macro.underscore()
-            |> String.to_atom(), :always}}
-        end)
-
-      _ ->
-        %{}
-    end
-  end
-
-  defp load_connection_activities do
-    %{
-      {TrentoWeb.SessionController, :create} => {:login_attempt, :always},
-      {TrentoWeb.V1.TagsController, :add_tag} => {:resource_tagging, 201},
-      {TrentoWeb.V1.TagsController, :remove_tag} => {:resource_untagging, 204},
-      {TrentoWeb.V1.SettingsController, :update_api_key_settings} => {:api_key_generation, 200},
-      {TrentoWeb.V1.SettingsController, :save_suse_manager_settings} =>
-        {:saving_suma_settings, 201},
-      {TrentoWeb.V1.SettingsController, :update_suse_manager_settings} =>
-        {:changing_suma_settings, 200},
-      {TrentoWeb.V1.SettingsController, :delete_suse_manager_settings} =>
-        {:clearing_suma_settings, 204},
-      {TrentoWeb.V1.UsersController, :create} => {:user_creation, 201},
-      {TrentoWeb.V1.UsersController, :update} => {:user_modification, 200},
-      {TrentoWeb.V1.UsersController, :delete} => {:user_deletion, 204},
-      {TrentoWeb.V1.ProfileController, :update} => {:profile_update, 200},
-      {TrentoWeb.V1.ClusterController, :request_checks_execution} =>
-        {:cluster_checks_execution_request, 202}
-    }
-  end
-
+  @spec supported_activities() :: [activity_type()]
   def supported_activities, do: Enum.map(activity_catalog(), &to_activity_type/1)
 
   @spec connection_activities() :: [activity_type()]
-  def connection_activities, do: Enum.map(load_connection_activities(), &to_activity_type/1)
+  def connection_activities, do: Enum.map(get_connection_activities(), &to_activity_type/1)
 
   @spec domain_event_activities() :: [activity_type()]
-  def domain_event_activities, do: Enum.map(load_domain_events(), &to_activity_type/1)
-
-  defp activity_catalog, do: Map.merge(load_connection_activities(), load_domain_events())
+  def domain_event_activities, do: Enum.map(get_domain_events_activities(), &to_activity_type/1)
 
   @spec detect_activity_category(activity_type()) ::
           :connection_activity | :domain_event_activity | :unsupported_activity
   def detect_activity_category(activity) do
-    is_connection_activity? = activity in connection_activities()
-    is_domain_event_activity? = activity in domain_event_activities()
-
-    case {is_connection_activity?, is_domain_event_activity?} do
+    case {activity in connection_activities(), activity in domain_event_activities()} do
       {true, false} ->
         :connection_activity
 
@@ -104,6 +45,9 @@ defmodule Trento.ActivityLog.ActivityCatalog do
   end
 
   defp to_activity_type({_, {activity_type, _}}), do: activity_type
+
+  defp activity_catalog,
+    do: Map.merge(get_connection_activities(), get_domain_events_activities())
 
   @spec get_activity_type(logged_activity()) :: activity_type() | nil
   defp get_activity_type(activity) do
@@ -143,4 +87,59 @@ defmodule Trento.ActivityLog.ActivityCatalog do
   defp interesting_occurrence?({_, :always}, _), do: true
   defp interesting_occurrence?({_, status}, %Plug.Conn{status: status}), do: true
   defp interesting_occurrence?(_, _), do: false
+
+  defp get_domain_events_activities do
+    case :application.get_key(:trento, :modules) do
+      {:ok, modules} ->
+        modules
+        |> Enum.map(&Module.split/1)
+        |> Enum.filter(fn
+          ["Trento", resource_type, "Events", _]
+          when resource_type in [
+                 "Hosts",
+                 "Clusters",
+                 "SapSystems",
+                 "Databases"
+               ] ->
+            true
+
+          _ ->
+            false
+        end)
+        |> Enum.map(&Module.concat/1)
+        |> Enum.filter(&(not function_exported?(&1, :legacy, 0)))
+        |> Map.new(fn event_module ->
+          {event_module,
+           {event_module
+            |> Module.split()
+            |> List.last()
+            |> Macro.underscore()
+            |> String.to_atom(), :always}}
+        end)
+
+      _ ->
+        %{}
+    end
+  end
+
+  defp get_connection_activities do
+    %{
+      {TrentoWeb.SessionController, :create} => {:login_attempt, :always},
+      {TrentoWeb.V1.TagsController, :add_tag} => {:resource_tagging, 201},
+      {TrentoWeb.V1.TagsController, :remove_tag} => {:resource_untagging, 204},
+      {TrentoWeb.V1.SettingsController, :update_api_key_settings} => {:api_key_generation, 200},
+      {TrentoWeb.V1.SettingsController, :save_suse_manager_settings} =>
+        {:saving_suma_settings, 201},
+      {TrentoWeb.V1.SettingsController, :update_suse_manager_settings} =>
+        {:changing_suma_settings, 200},
+      {TrentoWeb.V1.SettingsController, :delete_suse_manager_settings} =>
+        {:clearing_suma_settings, 204},
+      {TrentoWeb.V1.UsersController, :create} => {:user_creation, 201},
+      {TrentoWeb.V1.UsersController, :update} => {:user_modification, 200},
+      {TrentoWeb.V1.UsersController, :delete} => {:user_deletion, 204},
+      {TrentoWeb.V1.ProfileController, :update} => {:profile_update, 200},
+      {TrentoWeb.V1.ClusterController, :request_checks_execution} =>
+        {:cluster_checks_execution_request, 202}
+    }
+  end
 end

--- a/lib/trento/activity_logging/activity_catalog.ex
+++ b/lib/trento/activity_logging/activity_catalog.ex
@@ -59,10 +59,10 @@ defmodule Trento.ActivityLog.ActivityCatalog do
   # }
   #
   # <EventActivityType> is the lowercase and underscored version of the last part of the event module name.
-  # <WhenOccurrenceIsInteresting> is anything useful to mark as interesting an activity occurence.
+  # <WhenOccurrenceIsInteresting> is anything useful to mark as interesting an activity occurrence.
   # For connection related activities it is the status code that makes the occurrence interesting for logging.
   #
-  # Marking <WhenOccurrenceIsInteresting> as `:always` means the occurence is always interesting for logging.
+  # Marking <WhenOccurrenceIsInteresting> as `:always` means the occurrence is always interesting for logging.
   # Currently, all events are marked as `:always` interesting for logging.
   #
   # example:

--- a/lib/trento/activity_logging/activity_catalog.ex
+++ b/lib/trento/activity_logging/activity_catalog.ex
@@ -114,7 +114,7 @@ defmodule Trento.ActivityLog.ActivityCatalog do
                                     end)
 
                                   _ ->
-                                    %{}
+                                    %{:unsupported => {:unsupported, :always}}
                                 end)
     )
   end

--- a/lib/trento/activity_logging/activity_catalog.ex
+++ b/lib/trento/activity_logging/activity_catalog.ex
@@ -5,226 +5,123 @@ defmodule Trento.ActivityLog.ActivityCatalog do
 
   alias Phoenix.Controller
 
-  @login_attempt {TrentoWeb.SessionController, :create}
-  @api_key_generation {TrentoWeb.V1.SettingsController, :update_api_key_settings}
-  @saving_suma_settings {TrentoWeb.V1.SettingsController, :save_suse_manager_settings}
-  @changing_suma_settings {TrentoWeb.V1.SettingsController, :update_suse_manager_settings}
-  @clearing_suma_settings {TrentoWeb.V1.SettingsController, :delete_suse_manager_settings}
-  @tagging {TrentoWeb.V1.TagsController, :add_tag}
-  @untagging {TrentoWeb.V1.TagsController, :remove_tag}
-  @user_creation {TrentoWeb.V1.UsersController, :create}
-  @user_modification {TrentoWeb.V1.UsersController, :update}
-  @user_deletion {TrentoWeb.V1.UsersController, :delete}
-  @profile_update {TrentoWeb.V1.ProfileController, :update}
-  @cluster_checks_execution_request {TrentoWeb.V1.ClusterController, :request_checks_execution}
-
-  @connection_activities %{
-    @login_attempt => {:login_attempt, :always},
-    @tagging => {:resource_tagging, 201},
-    @untagging => {:resource_untagging, 204},
-    @api_key_generation => {:api_key_generation, 200},
-    @saving_suma_settings => {:saving_suma_settings, 201},
-    @changing_suma_settings => {:changing_suma_settings, 200},
-    @clearing_suma_settings => {:clearing_suma_settings, 204},
-    @user_creation => {:user_creation, 201},
-    @user_modification => {:user_modification, 200},
-    @user_deletion => {:user_deletion, 204},
-    @profile_update => {:profile_update, 200},
-    @cluster_checks_execution_request => {:cluster_checks_execution_request, 202}
-  }
-
-  # Make sure trento application is loaded so that we can safely access its modules
-  Application.ensure_loaded(:trento)
-
-  # The following code extracts the domain event activities from the event modules found in trento application.
-  # Event modules are expected to be in the form of `Trento.{ResourceType}.Events.{EventName}`, for instance:
-  #   - Trento.Hosts.Events.HostRegistered
-  #   - Trento.Clusters.Events.ChecksSelected
-  #   - Trento.SapSystems.Events.SapSystemDeregistered
-  #   - Trento.Databases.Events.DatabaseHealthChanged
-  #
-  # For an event to be taken into account, the <ResourceType> in the second position of the module name
-  # must be one of the following:
-  #   - Hosts
-  #   - Clusters
-  #   - SapSystems
-  #   - Databases
-  #
-  # Any event module that lives in a directory containing the word `legacy` is ignored.
-  # This check is needed to avoid naming clashes with the valid event modules.
-  #
-  # Once the list of the relevant event modules is extracted, it gets transformed to a map with the following shape:
-  # %{
-  #   <EventModule>: {<EventActivityType>, <WhenOccurrenceIsInteresting>}
-  # }
-  #
-  # <EventActivityType> is the lowercase and underscored version of the last part of the event module name.
-  # <WhenOccurrenceIsInteresting> is anything useful to mark as interesting an activity occurrence.
-  # For connection related activities it is the status code that makes the occurrence interesting for logging.
-  #
-  # Marking <WhenOccurrenceIsInteresting> as `:always` means the occurrence is always interesting for logging.
-  # Currently, all events are marked as `:always` interesting for logging.
-  #
-  # example:
-  # %{
-  #   Trento.Hosts.Events.HostRegistered: {:host_registered, :always},
-  #   Trento.Clusters.Events.ChecksSelected: {:checks_selected, :always},
-  #   Trento.SapSystems.Events.SapSystemDeregistered: {:sap_system_deregistered, :always},
-  #   Trento.Databases.Events.DatabaseHealthChanged: {:database_health_changed, :always},
-  #   ...
-  # }
-  #
-  # Note that this is the same shape as the @connection_activities map.
-
-  quote do
-    unquote(
-      @domain_event_activities (case :application.get_key(:trento, :modules) do
-                                  {:ok, modules} ->
-                                    modules
-                                    |> Enum.map(&Module.split/1)
-                                    |> Enum.filter(fn
-                                      ["Trento", resource_type, "Events", _]
-                                      when resource_type in [
-                                             "Hosts",
-                                             "Clusters",
-                                             "SapSystems",
-                                             "Databases"
-                                           ] ->
-                                        true
-
-                                      _ ->
-                                        false
-                                    end)
-                                    |> Enum.map(&Module.concat/1)
-                                    |> Enum.filter(fn module_name ->
-                                      module_location =
-                                        module_name.__info__(:compile)
-                                        |> Keyword.get(:source)
-                                        |> Path.split()
-
-                                      "legacy" not in module_location
-                                    end)
-                                    |> Map.new(fn event_module ->
-                                      {event_module,
-                                       {event_module
-                                        |> Module.split()
-                                        |> List.last()
-                                        |> Macro.underscore()
-                                        |> String.to_atom(), :always}}
-                                    end)
-
-                                  _ ->
-                                    %{:unsupported => {:unsupported, :always}}
-                                end)
-    )
-  end
-
-  @doc """
-  Merge connection activities and domain event activities into a single catalog
-  """
-  @activity_catalog Map.merge(@connection_activities, @domain_event_activities)
-
-  @type connection_activity_type ::
-          :login_attempt
-          | :resource_tagging
-          | :resource_untagging
-          | :api_key_generation
-          | :saving_suma_settings
-          | :changing_suma_settings
-          | :clearing_suma_settings
-          | :user_creation
-          | :user_modification
-          | :user_deletion
-          | :profile_update
-          | :cluster_checks_execution_request
-
-  # Define `domain_event_activity_type` based on the discovered domain event modules.
-  # The result is a union type of all the domain event activities types as follows:
-  #
-  # @type domain_event_activity_type ::
-  #         :provider_updated
-  #         | :host_deregistered
-  #         | :database_health_changed
-  #         | :cluster_tombstoned
-  #         | :cluster_deregistered
-  #         | :host_saptune_health_changed
-  #         | :host_checks_selected
-  #         | :cluster_health_changed
-  #         | :cluster_checks_health_changed
-  #         | ...
-  quote do
-    unquote(
-      @type domain_event_activity_type ::
-              unquote(
-                @domain_event_activities
-                |> Enum.map(fn {_, {event_activity_type, _}} -> event_activity_type end)
-                |> Enum.reduce(&{:|, [], [&1, &2]})
-              )
-    )
-  end
-
-  @type activity_type :: connection_activity_type() | domain_event_activity_type()
-
+  @type activity_type :: atom()
   @type connection_activity :: {controller :: module(), action :: atom()}
-
-  # Define `domain_event_activity` type based on the discovered domain event modules.
-  # The result is a union type of all the discovered domain event modules as follows:
-  #
-  # @type domain_event_activity ::
-  #         Trento.Hosts.Events.HostDetailsUpdated
-  #         | Trento.Clusters.Events.ChecksSelected
-  #         | Trento.Databases.Events.DatabaseTenantsUpdated
-  #         | Trento.Clusters.Events.HostRemovedFromCluster
-  #         | Trento.Hosts.Events.SlesSubscriptionsUpdated
-  #         | Trento.SapSystems.Events.ApplicationInstanceMarkedPresent
-  #         | Trento.SapSystems.Events.SapSystemRestored
-  #         | ...
-  quote do
-    unquote(
-      @type domain_event_activity ::
-              event_module ::
-              unquote(
-                @domain_event_activities
-                |> Enum.map(fn {event_module, _} -> event_module end)
-                |> Enum.reduce(&{:|, [], [&1, &2]})
-              )
-    )
-  end
-
+  @type domain_event_activity :: event_module :: module()
   @type logged_activity :: connection_activity() | domain_event_activity()
 
-  Enum.each(@activity_catalog, fn {activity, {activity_type, _}} ->
-    @spec unquote(activity_type)() :: logged_activity()
-    defmacro unquote(activity_type)(), do: unquote(activity)
-  end)
+  defp load_domain_events do
+    case :application.get_key(:trento, :modules) do
+      {:ok, modules} ->
+        modules
+        |> Enum.map(&Module.split/1)
+        |> Enum.filter(fn
+          ["Trento", resource_type, "Events", _]
+          when resource_type in [
+                 "Hosts",
+                 "Clusters",
+                 "SapSystems",
+                 "Databases"
+               ] ->
+            true
 
-  @spec connection_activities() :: [connection_activity()]
-  defmacro connection_activities, do: Map.keys(@connection_activities)
+          _ ->
+            false
+        end)
+        |> Enum.map(&Module.concat/1)
+        |> Enum.filter(fn module_name ->
+          module_location =
+            module_name.__info__(:compile)
+            |> Keyword.get(:source)
+            |> Path.split()
 
-  @spec domain_event_activities() :: [domain_event_activity()]
-  defmacro domain_event_activities, do: Map.keys(@domain_event_activities)
+          "legacy" not in module_location
+        end)
+        |> Map.new(fn event_module ->
+          {event_module,
+           {event_module
+            |> Module.split()
+            |> List.last()
+            |> Macro.underscore()
+            |> String.to_atom(), :always}}
+        end)
 
-  @spec activity_catalog() :: [logged_activity()]
-  defmacro activity_catalog, do: Map.keys(@activity_catalog)
+      _ ->
+        %{}
+    end
+  end
 
-  @spec detect_activity(any()) :: {:ok, logged_activity()} | {:error, any()}
+  defp load_connection_activities do
+    %{
+      {TrentoWeb.SessionController, :create} => {:login_attempt, :always},
+      {TrentoWeb.V1.TagsController, :add_tag} => {:resource_tagging, 201},
+      {TrentoWeb.V1.TagsController, :remove_tag} => {:resource_untagging, 204},
+      {TrentoWeb.V1.SettingsController, :update_api_key_settings} => {:api_key_generation, 200},
+      {TrentoWeb.V1.SettingsController, :save_suse_manager_settings} =>
+        {:saving_suma_settings, 201},
+      {TrentoWeb.V1.SettingsController, :update_suse_manager_settings} =>
+        {:changing_suma_settings, 200},
+      {TrentoWeb.V1.SettingsController, :delete_suse_manager_settings} =>
+        {:clearing_suma_settings, 204},
+      {TrentoWeb.V1.UsersController, :create} => {:user_creation, 201},
+      {TrentoWeb.V1.UsersController, :update} => {:user_modification, 200},
+      {TrentoWeb.V1.UsersController, :delete} => {:user_deletion, 204},
+      {TrentoWeb.V1.ProfileController, :update} => {:profile_update, 200},
+      {TrentoWeb.V1.ClusterController, :request_checks_execution} =>
+        {:cluster_checks_execution_request, 202}
+    }
+  end
+
+  def supported_activities, do: Enum.map(activity_catalog(), &to_activity_type/1)
+
+  @spec connection_activities() :: [activity_type()]
+  def connection_activities, do: Enum.map(load_connection_activities(), &to_activity_type/1)
+
+  @spec domain_event_activities() :: [activity_type()]
+  def domain_event_activities, do: Enum.map(load_domain_events(), &to_activity_type/1)
+
+  defp activity_catalog, do: Map.merge(load_connection_activities(), load_domain_events())
+
+  @spec detect_activity_category(activity_type()) ::
+          :connection_activity | :domain_event_activity | :unsupported_activity
+  def detect_activity_category(activity) do
+    is_connection_activity? = activity in connection_activities()
+    is_domain_event_activity? = activity in domain_event_activities()
+
+    case {is_connection_activity?, is_domain_event_activity?} do
+      {true, false} ->
+        :connection_activity
+
+      {false, true} ->
+        :domain_event_activity
+
+      _ ->
+        :unsupported_activity
+    end
+  end
+
+  @spec detect_activity(any()) :: {:ok, activity_type()} | {:error, :not_interesting}
   def detect_activity(activity_context) do
     with extracted_activity <- extract_activity(activity_context),
          true <- interested?(extracted_activity, activity_context) do
-      {:ok, extracted_activity}
+      {:ok, get_activity_type(extracted_activity)}
     else
       _ -> {:error, :not_interesting}
     end
   end
 
-  @spec get_activity_type(logged_activity()) :: activity_type() | nil
-  def get_activity_type(activity) when activity in activity_catalog() do
-    @activity_catalog
-    |> Map.fetch!(activity)
-    |> elem(0)
-  end
+  defp to_activity_type({_, {activity_type, _}}), do: activity_type
 
-  def get_activity_type(_), do: nil
+  @spec get_activity_type(logged_activity()) :: activity_type() | nil
+  defp get_activity_type(activity) do
+    case Map.fetch(activity_catalog(), activity) do
+      {:ok, {activity_type, _}} ->
+        activity_type
+
+      _ ->
+        nil
+    end
+  end
 
   defp extract_activity(%Plug.Conn{} = conn) do
     {Controller.controller_module(conn), Controller.action_name(conn)}
@@ -236,13 +133,15 @@ defmodule Trento.ActivityLog.ActivityCatalog do
 
   defp extract_activity(_), do: nil
 
-  defp interested?(activity, activity_context) when activity in activity_catalog(),
-    do:
-      @activity_catalog
-      |> Map.fetch!(activity)
-      |> interesting_occurrence?(activity_context)
+  defp interested?(activity, activity_context) do
+    case Map.fetch(activity_catalog(), activity) do
+      {:ok, activity} ->
+        interesting_occurrence?(activity, activity_context)
 
-  defp interested?(_, _), do: false
+      _ ->
+        false
+    end
+  end
 
   @spec interesting_occurrence?(
           activity_occurrence :: {activity_type(), relevant_context :: any() | :always},

--- a/lib/trento/activity_logging/activity_catalog.ex
+++ b/lib/trento/activity_logging/activity_catalog.ex
@@ -29,14 +29,7 @@ defmodule Trento.ActivityLog.ActivityCatalog do
             false
         end)
         |> Enum.map(&Module.concat/1)
-        |> Enum.filter(fn module_name ->
-          module_location =
-            module_name.__info__(:compile)
-            |> Keyword.get(:source)
-            |> Path.split()
-
-          "legacy" not in module_location
-        end)
+        |> Enum.filter(&(not function_exported?(&1, :legacy, 0)))
         |> Map.new(fn event_module ->
           {event_module,
            {event_module

--- a/lib/trento/activity_logging/activity_catalog.ex
+++ b/lib/trento/activity_logging/activity_catalog.ex
@@ -5,23 +5,6 @@ defmodule Trento.ActivityLog.ActivityCatalog do
 
   alias Phoenix.Controller
 
-  @type domain_event_activity :: module()
-
-  @type logged_activity :: {controller :: module(), activity :: atom()} | domain_event_activity()
-  @type activity_type ::
-          :login_attempt
-          | :resource_tagging
-          | :resource_untagging
-          | :api_key_generation
-          | :saving_suma_settings
-          | :changing_suma_settings
-          | :clearing_suma_settings
-          | :user_creation
-          | :user_modification
-          | :user_deletion
-          | :profile_update
-          | :cluster_checks_execution_request
-
   @login_attempt {TrentoWeb.SessionController, :create}
   @api_key_generation {TrentoWeb.V1.SettingsController, :update_api_key_settings}
   @saving_suma_settings {TrentoWeb.V1.SettingsController, :save_suse_manager_settings}
@@ -33,11 +16,10 @@ defmodule Trento.ActivityLog.ActivityCatalog do
   @user_modification {TrentoWeb.V1.UsersController, :update}
   @user_deletion {TrentoWeb.V1.UsersController, :delete}
   @profile_update {TrentoWeb.V1.ProfileController, :update}
-  # @cluster_checks_selection {TrentoWeb.V1.ClusterController, :select_checks} # <-- this is **also** event sourced
   @cluster_checks_execution_request {TrentoWeb.V1.ClusterController, :request_checks_execution}
 
-  @activity_catalog %{
-    @login_attempt => {:login_attempt, :any},
+  @connection_activities %{
+    @login_attempt => {:login_attempt, :always},
     @tagging => {:resource_tagging, 201},
     @untagging => {:resource_untagging, 204},
     @api_key_generation => {:api_key_generation, 200},
@@ -51,59 +33,222 @@ defmodule Trento.ActivityLog.ActivityCatalog do
     @cluster_checks_execution_request => {:cluster_checks_execution_request, 202}
   }
 
+  # Make sure trento application is loaded so that we can safely access its modules
+  Application.ensure_loaded(:trento)
+
+  # The following code extracts the domain event activities from the event modules found in trento application.
+  # Event modules are expected to be in the form of `Trento.{ResourceType}.Events.{EventName}`, for instance:
+  #   - Trento.Hosts.Events.HostRegistered
+  #   - Trento.Clusters.Events.ChecksSelected
+  #   - Trento.SapSystems.Events.SapSystemDeregistered
+  #   - Trento.Databases.Events.DatabaseHealthChanged
+  #
+  # For an event to be taken into account, the <ResourceType> in the second position of the module name
+  # must be one of the following:
+  #   - Hosts
+  #   - Clusters
+  #   - SapSystems
+  #   - Databases
+  #
+  # Any event module that lives in a directory containing the word `legacy` is ignored.
+  # This check is needed to avoid naming clashes with the valid event modules.
+  #
+  # Once the list of the relevant event modules is extracted, it gets transformed to a map with the following shape:
+  # %{
+  #   <EventModule>: {<EventActivityType>, <WhenOccurrenceIsInteresting>}
+  # }
+  #
+  # <EventActivityType> is the lowercase and underscored version of the last part of the event module name.
+  # <WhenOccurrenceIsInteresting> is anything useful to mark as interesting an activity occurence.
+  # For connection related activities it is the status code that makes the occurrence interesting for logging.
+  #
+  # Marking <WhenOccurrenceIsInteresting> as `:always` means the occurence is always interesting for logging.
+  # Currently, all events are marked as `:always` interesting for logging.
+  #
+  # example:
+  # %{
+  #   Trento.Hosts.Events.HostRegistered: {:host_registered, :always},
+  #   Trento.Clusters.Events.ChecksSelected: {:checks_selected, :always},
+  #   Trento.SapSystems.Events.SapSystemDeregistered: {:sap_system_deregistered, :always},
+  #   Trento.Databases.Events.DatabaseHealthChanged: {:database_health_changed, :always},
+  #   ...
+  # }
+  #
+  # Note that this is the same shape as the @connection_activities map.
+
+  quote do
+    unquote(
+      @domain_event_activities (case :application.get_key(:trento, :modules) do
+                                  {:ok, modules} ->
+                                    modules
+                                    |> Enum.map(&Module.split/1)
+                                    |> Enum.filter(fn
+                                      ["Trento", resource_type, "Events", _]
+                                      when resource_type in [
+                                             "Hosts",
+                                             "Clusters",
+                                             "SapSystems",
+                                             "Databases"
+                                           ] ->
+                                        true
+
+                                      _ ->
+                                        false
+                                    end)
+                                    |> Enum.map(&Module.concat/1)
+                                    |> Enum.filter(fn module_name ->
+                                      module_location =
+                                        module_name.__info__(:compile)
+                                        |> Keyword.get(:source)
+                                        |> Path.split()
+
+                                      "legacy" not in module_location
+                                    end)
+                                    |> Map.new(fn event_module ->
+                                      {event_module,
+                                       {event_module
+                                        |> Module.split()
+                                        |> List.last()
+                                        |> Macro.underscore()
+                                        |> String.to_atom(), :always}}
+                                    end)
+
+                                  _ ->
+                                    %{}
+                                end)
+    )
+  end
+
+  @doc """
+  Merge connection activities and domain event activities into a single catalog
+  """
+  @activity_catalog Map.merge(@connection_activities, @domain_event_activities)
+
+  @type connection_activity_type ::
+          :login_attempt
+          | :resource_tagging
+          | :resource_untagging
+          | :api_key_generation
+          | :saving_suma_settings
+          | :changing_suma_settings
+          | :clearing_suma_settings
+          | :user_creation
+          | :user_modification
+          | :user_deletion
+          | :profile_update
+          | :cluster_checks_execution_request
+
+  # Define `domain_event_activity_type` based on the discovered domain event modules.
+  # The result is a union type of all the domain event activities types as follows:
+  #
+  # @type domain_event_activity_type ::
+  #         :provider_updated
+  #         | :host_deregistered
+  #         | :database_health_changed
+  #         | :cluster_tombstoned
+  #         | :cluster_deregistered
+  #         | :host_saptune_health_changed
+  #         | :host_checks_selected
+  #         | :cluster_health_changed
+  #         | :cluster_checks_health_changed
+  #         | ...
+  quote do
+    unquote(
+      @type domain_event_activity_type ::
+              unquote(
+                @domain_event_activities
+                |> Enum.map(fn {_, {event_activity_type, _}} -> event_activity_type end)
+                |> Enum.reduce(&{:|, [], [&1, &2]})
+              )
+    )
+  end
+
+  @type activity_type :: connection_activity_type() | domain_event_activity_type()
+
+  @type connection_activity :: {controller :: module(), action :: atom()}
+
+  # Define `domain_event_activity` type based on the discovered domain event modules.
+  # The result is a union type of all the discovered domain event modules as follows:
+  #
+  # @type domain_event_activity ::
+  #         Trento.Hosts.Events.HostDetailsUpdated
+  #         | Trento.Clusters.Events.ChecksSelected
+  #         | Trento.Databases.Events.DatabaseTenantsUpdated
+  #         | Trento.Clusters.Events.HostRemovedFromCluster
+  #         | Trento.Hosts.Events.SlesSubscriptionsUpdated
+  #         | Trento.SapSystems.Events.ApplicationInstanceMarkedPresent
+  #         | Trento.SapSystems.Events.SapSystemRestored
+  #         | ...
+  quote do
+    unquote(
+      @type domain_event_activity ::
+              event_module ::
+              unquote(
+                @domain_event_activities
+                |> Enum.map(fn {event_module, _} -> event_module end)
+                |> Enum.reduce(&{:|, [], [&1, &2]})
+              )
+    )
+  end
+
+  @type logged_activity :: connection_activity() | domain_event_activity()
+
   Enum.each(@activity_catalog, fn {activity, {activity_type, _}} ->
+    @spec unquote(activity_type)() :: logged_activity()
     defmacro unquote(activity_type)(), do: unquote(activity)
   end)
 
-  @spec activity_catalog() :: [logged_activity()]
-  defmacro activity_catalog, do: Enum.map(@activity_catalog, fn {activity, _} -> activity end)
+  @spec connection_activities() :: [connection_activity()]
+  defmacro connection_activities, do: Map.keys(@connection_activities)
 
-  @spec detect_activity(any()) :: logged_activity() | nil
-  def detect_activity(%Plug.Conn{} = conn) do
-    {Controller.controller_module(conn), Controller.action_name(conn)}
-  rescue
-    _ -> nil
+  @spec domain_event_activities() :: [domain_event_activity()]
+  defmacro domain_event_activities, do: Map.keys(@domain_event_activities)
+
+  @spec activity_catalog() :: [logged_activity()]
+  defmacro activity_catalog, do: Map.keys(@activity_catalog)
+
+  @spec detect_activity(any()) :: {:ok, logged_activity()} | {:error, any()}
+  def detect_activity(activity_context) do
+    with extracted_activity <- extract_activity(activity_context),
+         true <- interested?(extracted_activity, activity_context) do
+      {:ok, extracted_activity}
+    else
+      _ -> {:error, :not_interesting}
+    end
   end
 
-  def detect_activity(%{event: %event{}}), do: event
-
-  def detect_activity(_), do: nil
-
-  @spec interested?(logged_activity(), any()) :: boolean()
-  def interested?(activity, %Plug.Conn{status: status}) when activity in activity_catalog(),
-    do:
-      @activity_catalog
-      |> Map.fetch!(activity)
-      |> interesting_occurrence?(status)
-
-  def interested?(_, %{event: _}),
-    do: true
-
-  def interested?(_, _), do: false
-
-  @spec get_activity_type(logged_activity()) :: atom() | nil
+  @spec get_activity_type(logged_activity()) :: activity_type() | nil
   def get_activity_type(activity) when activity in activity_catalog() do
     @activity_catalog
     |> Map.fetch!(activity)
     |> elem(0)
   end
 
-  def get_activity_type(activity) when is_atom(activity) do
-    activity
-    |> Module.split()
-    |> List.last()
-    |> Macro.underscore()
-    |> String.to_atom()
-  end
-
   def get_activity_type(_), do: nil
 
+  defp extract_activity(%Plug.Conn{} = conn) do
+    {Controller.controller_module(conn), Controller.action_name(conn)}
+  rescue
+    _ -> nil
+  end
+
+  defp extract_activity(%{event: %event_module{}}), do: event_module
+
+  defp extract_activity(_), do: nil
+
+  defp interested?(activity, activity_context) when activity in activity_catalog(),
+    do:
+      @activity_catalog
+      |> Map.fetch!(activity)
+      |> interesting_occurrence?(activity_context)
+
+  defp interested?(_, _), do: false
+
   @spec interesting_occurrence?(
-          conn_activity_occurrence :: {activity_type(), relevant_status :: integer() | :any},
-          detected_status :: integer()
-        ) ::
-          boolean()
-  defp interesting_occurrence?({_, :any}, _), do: true
-  defp interesting_occurrence?({_, status}, status), do: true
+          activity_occurrence :: {activity_type(), relevant_context :: any() | :always},
+          activity_context :: any()
+        ) :: boolean()
+  defp interesting_occurrence?({_, :always}, _), do: true
+  defp interesting_occurrence?({_, status}, %Plug.Conn{status: status}), do: true
   defp interesting_occurrence?(_, _), do: false
 end

--- a/lib/trento/activity_logging/activity_logger.ex
+++ b/lib/trento/activity_logging/activity_logger.ex
@@ -7,45 +7,19 @@ defmodule Trento.ActivityLog.ActivityLogger do
 
   alias Trento.ActivityLog.ActivityCatalog
   alias Trento.ActivityLog.ActivityLog
+  alias Trento.ActivityLog.Parser.ActivityParser
 
   require Logger
 
   def log_activity(activity_context) do
-    with {:ok, activity_parser} <- get_activity_parser(activity_context),
-         detected_activity <- detect_activity(activity_parser, activity_context),
-         true <- ActivityCatalog.interested?(detected_activity, activity_context) do
-      write_log(%{
-        type: get_activity_type(detected_activity),
-        actor: get_actor(activity_parser, detected_activity, activity_context),
-        metadata: get_metadata(activity_parser, detected_activity, activity_context)
-      })
+    with detected_activity <- ActivityCatalog.detect_activity(activity_context),
+         true <- ActivityCatalog.interested?(detected_activity, activity_context),
+         {:ok, log_entry} <- ActivityParser.to_activity_log(detected_activity, activity_context) do
+      write_log(log_entry)
     end
 
     :ok
   end
-
-  defp get_activity_parser(%Plug.Conn{}),
-    do: {:ok, Trento.ActivityLog.Logger.Parser.PhoenixConnParser}
-
-  defp get_activity_parser(_), do: {:error, :unsupported_activity}
-
-  # defp get_activity_parser(%Commanded.Middleware.Pipeline{}),
-  #   do: {:ok, Trento.ActivityLog.Logger.Parser.CommandedParser}
-
-  defp detect_activity(activity_parser, activity_context),
-    do: activity_parser.detect_activity(activity_context)
-
-  defp get_activity_type(detected_activity),
-    do:
-      detected_activity
-      |> ActivityCatalog.get_activity_type()
-      |> Atom.to_string()
-
-  defp get_actor(activity_parser, detected_activity, activity_context),
-    do: activity_parser.get_activity_actor(detected_activity, activity_context)
-
-  defp get_metadata(activity_parser, detected_activity, activity_context),
-    do: activity_parser.get_activity_metadata(detected_activity, activity_context)
 
   defp write_log(%{type: activity_type} = entry) do
     case %ActivityLog{}

--- a/lib/trento/activity_logging/activity_logger.ex
+++ b/lib/trento/activity_logging/activity_logger.ex
@@ -12,8 +12,7 @@ defmodule Trento.ActivityLog.ActivityLogger do
   require Logger
 
   def log_activity(activity_context) do
-    with detected_activity <- ActivityCatalog.detect_activity(activity_context),
-         true <- ActivityCatalog.interested?(detected_activity, activity_context),
+    with {:ok, detected_activity} <- ActivityCatalog.detect_activity(activity_context),
          {:ok, log_entry} <- ActivityParser.to_activity_log(detected_activity, activity_context) do
       write_log(log_entry)
     end

--- a/lib/trento/activity_logging/parser/activity_parser.ex
+++ b/lib/trento/activity_logging/parser/activity_parser.ex
@@ -4,7 +4,7 @@ defmodule Trento.ActivityLog.Parser.ActivityParser do
   """
 
   alias Trento.ActivityLog.ActivityCatalog
-  alias Trento.ActivityLog.Logger.Parser.PhoenixConnParser
+  alias Trento.ActivityLog.Logger.Parser.{EventParser, PhoenixConnParser}
 
   require Trento.ActivityLog.ActivityCatalog, as: ActivityCatalog
 
@@ -20,6 +20,18 @@ defmodule Trento.ActivityLog.Parser.ActivityParser do
          |> Atom.to_string(),
        actor: PhoenixConnParser.get_activity_actor(activity, activity_context),
        metadata: PhoenixConnParser.get_activity_metadata(activity, activity_context)
+     }}
+  end
+
+  def to_activity_log(event_activity, %{event: %event_activity{}} = activity_context) do
+    {:ok,
+     %{
+       type:
+         event_activity
+         |> ActivityCatalog.get_activity_type()
+         |> Atom.to_string(),
+       actor: EventParser.get_activity_actor(event_activity, activity_context),
+       metadata: EventParser.get_activity_metadata(event_activity, activity_context)
      }}
   end
 

--- a/lib/trento/activity_logging/parser/activity_parser.ex
+++ b/lib/trento/activity_logging/parser/activity_parser.ex
@@ -1,20 +1,27 @@
 defmodule Trento.ActivityLog.Parser.ActivityParser do
   @moduledoc """
-  Behavior for activity parsers.
-  It extracts the activity relevant information from the context.
+  Activity parser extracts the activity relevant information from the context.
   """
 
   alias Trento.ActivityLog.ActivityCatalog
+  alias Trento.ActivityLog.Logger.Parser.PhoenixConnParser
 
-  @callback detect_activity(activity_context :: any()) :: ActivityCatalog.logged_activity() | nil
+  require Trento.ActivityLog.ActivityCatalog, as: ActivityCatalog
 
-  @callback get_activity_actor(
-              activity :: ActivityCatalog.logged_activity(),
-              activity_context :: any()
-            ) :: any()
+  @spec to_activity_log(ActivityCatalog.logged_activity(), any()) ::
+          {:ok, map()} | {:error, any()}
+  def to_activity_log(activity, %Plug.Conn{} = activity_context)
+      when activity in ActivityCatalog.activity_catalog() do
+    {:ok,
+     %{
+       type:
+         activity
+         |> ActivityCatalog.get_activity_type()
+         |> Atom.to_string(),
+       actor: PhoenixConnParser.get_activity_actor(activity, activity_context),
+       metadata: PhoenixConnParser.get_activity_metadata(activity, activity_context)
+     }}
+  end
 
-  @callback get_activity_metadata(
-              activity :: ActivityCatalog.logged_activity(),
-              activity_context :: any()
-            ) :: map()
+  def to_activity_log(_, _), do: {:error, :cannot_parse_activity}
 end

--- a/lib/trento/activity_logging/parser/event_parser.ex
+++ b/lib/trento/activity_logging/parser/event_parser.ex
@@ -4,7 +4,11 @@ defmodule Trento.ActivityLog.Logger.Parser.EventParser do
   """
   require Trento.ActivityLog.ActivityCatalog, as: ActivityCatalog
 
-  def get_activity_actor(_, %{event: _}), do: "system"
+  def get_activity_actor(event_type, %{event: _})
+      when event_type in ActivityCatalog.domain_event_activities(),
+      do: "system"
+
+  def get_activity_actor(_, _), do: nil
 
   def get_activity_metadata(
         event_type,

--- a/lib/trento/activity_logging/parser/event_parser.ex
+++ b/lib/trento/activity_logging/parser/event_parser.ex
@@ -1,0 +1,14 @@
+defmodule Trento.ActivityLog.Logger.Parser.EventParser do
+  @moduledoc """
+  Event parser extracts the event relevant information from the context.
+  """
+
+  def get_activity_actor(_, %{event: _}), do: "system"
+
+  def get_activity_metadata(
+        event_type,
+        %{event: %event_type{} = event}
+      ) do
+    event
+  end
+end

--- a/lib/trento/activity_logging/parser/event_parser.ex
+++ b/lib/trento/activity_logging/parser/event_parser.ex
@@ -2,21 +2,10 @@ defmodule Trento.ActivityLog.Logger.Parser.EventParser do
   @moduledoc """
   Event parser extracts the event relevant information from the context.
   """
-  require Trento.ActivityLog.ActivityCatalog, as: ActivityCatalog
 
-  def get_activity_actor(event_type, %{event: _})
-      when event_type in ActivityCatalog.domain_event_activities(),
-      do: "system"
-
+  def get_activity_actor(_, %{event: _}), do: "system"
   def get_activity_actor(_, _), do: nil
 
-  def get_activity_metadata(
-        event_type,
-        %{event: event}
-      )
-      when event_type in ActivityCatalog.domain_event_activities() do
-    event
-  end
-
+  def get_activity_metadata(_, %{event: event}), do: event
   def get_activity_metadata(_, _), do: %{}
 end

--- a/lib/trento/activity_logging/parser/event_parser.ex
+++ b/lib/trento/activity_logging/parser/event_parser.ex
@@ -2,13 +2,17 @@ defmodule Trento.ActivityLog.Logger.Parser.EventParser do
   @moduledoc """
   Event parser extracts the event relevant information from the context.
   """
+  require Trento.ActivityLog.ActivityCatalog, as: ActivityCatalog
 
   def get_activity_actor(_, %{event: _}), do: "system"
 
   def get_activity_metadata(
         event_type,
-        %{event: %event_type{} = event}
-      ) do
+        %{event: event}
+      )
+      when event_type in ActivityCatalog.domain_event_activities() do
     event
   end
+
+  def get_activity_metadata(_, _), do: %{}
 end

--- a/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
+++ b/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
@@ -3,26 +3,13 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
   Phoenix connection activity parser
   """
 
-  alias Phoenix.Controller
-
   alias Trento.Users.User
 
   require Trento.ActivityLog.ActivityCatalog, as: ActivityCatalog
 
-  @behaviour Trento.ActivityLog.Parser.ActivityParser
-
-  @impl true
-  def detect_activity(%Plug.Conn{} = conn) do
-    {Controller.controller_module(conn), Controller.action_name(conn)}
-  rescue
-    _ -> nil
-  end
-
-  @impl true
   def get_activity_actor(ActivityCatalog.login_attempt(), %Plug.Conn{body_params: request_payload}),
       do: Map.get(request_payload, "username", "no_username")
 
-  @impl true
   def get_activity_actor(_, %Plug.Conn{} = conn) do
     case Pow.Plug.current_user(conn) do
       %User{username: username} -> username
@@ -30,7 +17,6 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
     end
   end
 
-  @impl true
   def get_activity_metadata(
         ActivityCatalog.login_attempt() = action,
         %Plug.Conn{
@@ -46,7 +32,6 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
     }
   end
 
-  @impl true
   def get_activity_metadata(
         ActivityCatalog.resource_tagging(),
         %Plug.Conn{
@@ -64,7 +49,6 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
     }
   end
 
-  @impl true
   def get_activity_metadata(
         ActivityCatalog.resource_untagging(),
         %Plug.Conn{
@@ -84,7 +68,6 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
     }
   end
 
-  @impl true
   def get_activity_metadata(
         ActivityCatalog.api_key_generation(),
         %Plug.Conn{
@@ -94,7 +77,6 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
     request_body
   end
 
-  @impl true
   def get_activity_metadata(
         action,
         %Plug.Conn{
@@ -110,7 +92,6 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
     |> redact(:ca_cert)
   end
 
-  @impl true
   def get_activity_metadata(
         action,
         %Plug.Conn{
@@ -128,7 +109,6 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
     |> redact(:password_confirmation)
   end
 
-  @impl true
   def get_activity_metadata(_, _), do: %{}
 
   defp redact(request_body, key) do

--- a/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
+++ b/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
@@ -5,10 +5,8 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
 
   alias Trento.Users.User
 
-  require Trento.ActivityLog.ActivityCatalog, as: ActivityCatalog
-
-  def get_activity_actor(ActivityCatalog.login_attempt(), %Plug.Conn{body_params: request_payload}),
-      do: Map.get(request_payload, "username", "no_username")
+  def get_activity_actor(:login_attempt, %Plug.Conn{body_params: request_payload}),
+    do: Map.get(request_payload, "username", "no_username")
 
   def get_activity_actor(_, %Plug.Conn{} = conn) do
     case Pow.Plug.current_user(conn) do
@@ -18,7 +16,7 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
   end
 
   def get_activity_metadata(
-        ActivityCatalog.login_attempt() = action,
+        :login_attempt = action,
         %Plug.Conn{
           assigns: %{
             reason: reason
@@ -33,7 +31,7 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
   end
 
   def get_activity_metadata(
-        ActivityCatalog.resource_tagging(),
+        :resource_tagging,
         %Plug.Conn{
           params: %{id: resource_id},
           assigns: %{
@@ -50,7 +48,7 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
   end
 
   def get_activity_metadata(
-        ActivityCatalog.resource_untagging(),
+        :resource_untagging,
         %Plug.Conn{
           params: %{
             id: resource_id,
@@ -69,7 +67,7 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
   end
 
   def get_activity_metadata(
-        ActivityCatalog.api_key_generation(),
+        :api_key_generation,
         %Plug.Conn{
           body_params: request_body
         }
@@ -84,8 +82,8 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
         }
       )
       when action in [
-             ActivityCatalog.saving_suma_settings(),
-             ActivityCatalog.changing_suma_settings()
+             :saving_suma_settings,
+             :changing_suma_setting
            ] do
     request_body
     |> redact(:password)
@@ -99,9 +97,9 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
         }
       )
       when action in [
-             ActivityCatalog.user_creation(),
-             ActivityCatalog.user_modification(),
-             ActivityCatalog.profile_update()
+             :user_creation,
+             :user_modification,
+             :profile_update
            ] do
     request_body
     |> redact(:password)

--- a/lib/trento/event_handlers_supervisor.ex
+++ b/lib/trento/event_handlers_supervisor.ex
@@ -4,6 +4,7 @@ defmodule Trento.EventHandlersSupervisor do
   use Supervisor
 
   alias Trento.Infrastructure.Commanded.EventHandlers.{
+    ActivityLogEventHandler,
     AlertsEventHandler,
     DatabaseDeregistrationEventHandler,
     DatabaseRestoreEventHandler,
@@ -20,6 +21,7 @@ defmodule Trento.EventHandlersSupervisor do
   @impl true
   def init(_init_arg) do
     children = [
+      ActivityLogEventHandler,
       AlertsEventHandler,
       RollUpEventHandler,
       StreamRollUpEventHandler,

--- a/lib/trento/infrastructure/commanded/event_handlers/activity_log_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/activity_log_event_handler.ex
@@ -1,0 +1,20 @@
+defmodule Trento.Infrastructure.Commanded.EventHandlers.ActivityLogEventHandler do
+  @moduledoc """
+  Event handler responsible to log activity from emitted domain events
+  """
+
+  use Commanded.Event.Handler,
+    application: Trento.Commanded,
+    name: "activity_log_event_handler"
+
+  alias Trento.ActivityLog.ActivityLogger
+
+  def handle(event, metadata) do
+    ActivityLogger.log_activity(%{
+      event: event,
+      metadata: metadata
+    })
+
+    :ok
+  end
+end

--- a/lib/trento/support/event.ex
+++ b/lib/trento/support/event.ex
@@ -19,6 +19,7 @@ defmodule Trento.Support.Event do
         def supersede(_params), do: __MODULE__
       else
         def supersede(_params), do: @superseded_by.supersede(_params)
+        def legacy?, do: true
       end
 
       def upcast(params, metadata) do

--- a/test/support/event_store_case.ex
+++ b/test/support/event_store_case.ex
@@ -6,7 +6,9 @@ defmodule Trento.EventStoreCase do
 
   use ExUnit.CaseTemplate
 
-  setup do
+  alias Ecto.Adapters.SQL.Sandbox
+
+  setup tags do
     :ok = Application.stop(:trento)
     :ok = Application.stop(:commanded)
     :ok = Application.stop(:eventstore)
@@ -17,6 +19,9 @@ defmodule Trento.EventStoreCase do
     EventStore.Storage.Initializer.reset!(conn, config)
 
     {:ok, _} = Application.ensure_all_started(:trento)
+
+    pid = Sandbox.start_owner!(Trento.Repo, shared: not tags[:async])
+    on_exit(fn -> Sandbox.stop_owner(pid) end)
 
     {:ok, %{conn: conn}}
   end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -36,6 +36,7 @@ defmodule Trento.Factory do
     HeartbeatFailed,
     HeartbeatSucceeded,
     HostChecksHealthChanged,
+    HostChecksSelected,
     HostDetailsUpdated,
     HostHealthChanged,
     HostRegistered,
@@ -793,6 +794,13 @@ defmodule Trento.Factory do
     HeartbeatFailed.new!(%{
       host_id: Faker.UUID.v4()
     })
+  end
+
+  def host_checks_selected_factory do
+    %HostChecksSelected{
+      host_id: Faker.UUID.v4(),
+      checks: Enum.map(0..4, fn _ -> Faker.UUID.v4() end)
+    }
   end
 
   def host_checks_health_changed_factory do

--- a/test/trento/activity_logging/activity_catalog_test.exs
+++ b/test/trento/activity_logging/activity_catalog_test.exs
@@ -291,7 +291,7 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
     end
 
     test "should detect correct activity type" do
-      %heartbeat_succeded_event{} = build(:heartbeat_succeded)
+      %heartbeat_succeeded_event{} = build(:heartbeat_succeded)
       %heartbeat_failed_event{} = build(:heartbeat_failed)
       %host_registered_event{} = build(:host_registered_event)
       %host_checks_health_changed_event{} = build(:host_checks_health_changed)
@@ -302,7 +302,7 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
 
       event_to_activity_type_map = [
         {host_registered_event, :host_registered},
-        {heartbeat_succeded_event, :heartbeat_succeeded},
+        {heartbeat_succeeded_event, :heartbeat_succeeded},
         {heartbeat_failed_event, :heartbeat_failed},
         {host_checks_health_changed_event, :host_checks_health_changed},
         {host_checks_selected_event, :host_checks_selected},

--- a/test/trento/activity_logging/activity_catalog_test.exs
+++ b/test/trento/activity_logging/activity_catalog_test.exs
@@ -12,18 +12,18 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
   describe "activity exposure" do
     test "should expose connection related activities" do
       logged_connection_activities = [
-        {TrentoWeb.SessionController, :create},
-        {TrentoWeb.V1.ClusterController, :request_checks_execution},
-        {TrentoWeb.V1.ProfileController, :update},
-        {TrentoWeb.V1.SettingsController, :delete_suse_manager_settings},
-        {TrentoWeb.V1.SettingsController, :save_suse_manager_settings},
-        {TrentoWeb.V1.SettingsController, :update_api_key_settings},
-        {TrentoWeb.V1.SettingsController, :update_suse_manager_settings},
-        {TrentoWeb.V1.TagsController, :add_tag},
-        {TrentoWeb.V1.TagsController, :remove_tag},
-        {TrentoWeb.V1.UsersController, :create},
-        {TrentoWeb.V1.UsersController, :delete},
-        {TrentoWeb.V1.UsersController, :update}
+        :login_attempt,
+        :resource_tagging,
+        :resource_untagging,
+        :api_key_generation,
+        :saving_suma_settings,
+        :changing_suma_settings,
+        :clearing_suma_settings,
+        :user_creation,
+        :user_modification,
+        :user_deletion,
+        :profile_update,
+        :cluster_checks_execution_request
       ]
 
       connection_activity_catalog = ActivityCatalog.connection_activities()
@@ -37,68 +37,68 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
 
     test "should expose domain event related activities" do
       domain_events = [
-        Trento.Hosts.Events.HostRestored,
-        Trento.Hosts.Events.HostRolledUp,
-        Trento.Hosts.Events.SoftwareUpdatesDiscoveryCleared,
-        Trento.Hosts.Events.SaptuneStatusUpdated,
-        Trento.Hosts.Events.HostRollUpRequested,
-        Trento.Hosts.Events.HeartbeatFailed,
-        Trento.Hosts.Events.HostDetailsUpdated,
-        Trento.Hosts.Events.HostHealthChanged,
-        Trento.Hosts.Events.HostDeregistered,
-        Trento.Hosts.Events.ProviderUpdated,
-        Trento.Hosts.Events.HostSaptuneHealthChanged,
-        Trento.Hosts.Events.SoftwareUpdatesHealthChanged,
-        Trento.Hosts.Events.SoftwareUpdatesDiscoveryRequested,
-        Trento.Hosts.Events.HeartbeatSucceeded,
-        Trento.Hosts.Events.HostChecksSelected,
-        Trento.Hosts.Events.SlesSubscriptionsUpdated,
-        Trento.Hosts.Events.HostChecksHealthChanged,
-        Trento.Hosts.Events.HostDeregistrationRequested,
-        Trento.Hosts.Events.HostTombstoned,
-        Trento.Hosts.Events.HostRegistered,
-        Trento.Clusters.Events.ClusterRegistered,
-        Trento.Clusters.Events.ClusterRolledUp,
-        Trento.Clusters.Events.ClusterTombstoned,
-        Trento.Clusters.Events.ClusterRollUpRequested,
-        Trento.Clusters.Events.ClusterChecksHealthChanged,
-        Trento.Clusters.Events.HostAddedToCluster,
-        Trento.Clusters.Events.ClusterDeregistered,
-        Trento.Clusters.Events.ClusterHealthChanged,
-        Trento.Clusters.Events.ClusterRestored,
-        Trento.Clusters.Events.ClusterDiscoveredHealthChanged,
-        Trento.Clusters.Events.HostRemovedFromCluster,
-        Trento.Clusters.Events.ChecksSelected,
-        Trento.Clusters.Events.ClusterDetailsUpdated,
-        Trento.Databases.Events.DatabaseDeregistered,
-        Trento.Databases.Events.DatabaseTombstoned,
-        Trento.Databases.Events.DatabaseRollUpRequested,
-        Trento.Databases.Events.DatabaseRolledUp,
-        Trento.Databases.Events.DatabaseInstanceSystemReplicationChanged,
-        Trento.Databases.Events.DatabaseInstanceMarkedAbsent,
-        Trento.Databases.Events.DatabaseInstanceHealthChanged,
-        Trento.Databases.Events.DatabaseInstanceMarkedPresent,
-        Trento.Databases.Events.DatabaseInstanceDeregistered,
-        Trento.Databases.Events.DatabaseTenantsUpdated,
-        Trento.Databases.Events.DatabaseRestored,
-        Trento.Databases.Events.DatabaseRegistered,
-        Trento.Databases.Events.DatabaseInstanceRegistered,
-        Trento.Databases.Events.DatabaseHealthChanged,
-        Trento.SapSystems.Events.ApplicationInstanceMarkedAbsent,
-        Trento.SapSystems.Events.SapSystemHealthChanged,
-        Trento.SapSystems.Events.SapSystemTombstoned,
-        Trento.SapSystems.Events.SapSystemDatabaseHealthChanged,
-        Trento.SapSystems.Events.SapSystemRolledUp,
-        Trento.SapSystems.Events.ApplicationInstanceDeregistered,
-        Trento.SapSystems.Events.SapSystemRegistered,
-        Trento.SapSystems.Events.ApplicationInstanceMarkedPresent,
-        Trento.SapSystems.Events.SapSystemRestored,
-        Trento.SapSystems.Events.SapSystemDeregistered,
-        Trento.SapSystems.Events.ApplicationInstanceHealthChanged,
-        Trento.SapSystems.Events.SapSystemRollUpRequested,
-        Trento.SapSystems.Events.SapSystemUpdated,
-        Trento.SapSystems.Events.ApplicationInstanceMoved,
-        Trento.SapSystems.Events.ApplicationInstanceRegistered
+        :host_restored,
+        :host_rolled_up,
+        :software_updates_discovery_cleared,
+        :saptune_status_updated,
+        :host_roll_up_requested,
+        :heartbeat_failed,
+        :host_details_updated,
+        :host_health_changed,
+        :host_deregistered,
+        :provider_updated,
+        :host_saptune_health_changed,
+        :software_updates_health_changed,
+        :software_updates_discovery_requested,
+        :heartbeat_succeeded,
+        :host_checks_selected,
+        :sles_subscriptions_updated,
+        :host_checks_health_changed,
+        :host_deregistration_requested,
+        :host_tombstoned,
+        :host_registered,
+        :cluster_registered,
+        :cluster_rolled_up,
+        :cluster_tombstoned,
+        :cluster_roll_up_requested,
+        :cluster_checks_health_changed,
+        :host_added_to_cluster,
+        :cluster_deregistered,
+        :cluster_health_changed,
+        :cluster_restored,
+        :cluster_discovered_health_changed,
+        :host_removed_from_cluster,
+        :checks_selected,
+        :cluster_details_updated,
+        :database_deregistered,
+        :database_tombstoned,
+        :database_roll_up_requested,
+        :database_rolled_up,
+        :database_instance_system_replication_changed,
+        :database_instance_marked_absent,
+        :database_instance_health_changed,
+        :database_instance_marked_present,
+        :database_instance_deregistered,
+        :database_tenants_updated,
+        :database_restored,
+        :database_registered,
+        :database_instance_registered,
+        :database_health_changed,
+        :application_instance_marked_absent,
+        :sap_system_health_changed,
+        :sap_system_tombstoned,
+        :sap_system_database_health_changed,
+        :sap_system_rolled_up,
+        :application_instance_deregistered,
+        :sap_system_registered,
+        :application_instance_marked_present,
+        :sap_system_restored,
+        :sap_system_deregistered,
+        :application_instance_health_changed,
+        :sap_system_roll_up_requested,
+        :sap_system_updated,
+        :application_instance_moved,
+        :application_instance_registered
       ]
 
       events_activities_catalog = ActivityCatalog.domain_event_activities()
@@ -113,7 +113,7 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
 
   describe "activity detection" do
     test "should not detect activity from invalid input" do
-      Enum.each([nil, %{}, "", 42], fn input ->
+      Enum.each([nil, %{}, "", 42, Foo.Bar.Event], fn input ->
         assert {:error, :not_interesting} == ActivityCatalog.detect_activity(input)
       end)
     end
@@ -135,79 +135,79 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
 
     scenarios = [
       %{
-        activity: ActivityCatalog.login_attempt(),
-        interesting_statuses: [200, 401, 404, 500],
-        name: :login_attempt
+        activity: :login_attempt,
+        connection_info: {TrentoWeb.SessionController, :create},
+        interesting_statuses: [200, 401, 404, 500]
       },
       %{
-        activity: ActivityCatalog.resource_tagging(),
+        activity: :resource_tagging,
+        connection_info: {TrentoWeb.V1.TagsController, :add_tag},
         interesting_statuses: 201,
-        not_interesting_statuses: [400, 401, 403, 404, 500],
-        name: :resource_tagging
+        not_interesting_statuses: [400, 401, 403, 404, 500]
       },
       %{
-        activity: ActivityCatalog.resource_untagging(),
+        activity: :resource_untagging,
+        connection_info: {TrentoWeb.V1.TagsController, :remove_tag},
         interesting_statuses: 204,
-        not_interesting_statuses: [400, 401, 403, 404, 500],
-        name: :resource_untagging
+        not_interesting_statuses: [400, 401, 403, 404, 500]
       },
       %{
-        activity: ActivityCatalog.api_key_generation(),
+        activity: :api_key_generation,
+        connection_info: {TrentoWeb.V1.SettingsController, :update_api_key_settings},
         interesting_statuses: 200,
-        not_interesting_statuses: [400, 401, 403, 404, 500],
-        name: :api_key_generation
+        not_interesting_statuses: [400, 401, 403, 404, 500]
       },
       %{
-        activity: ActivityCatalog.saving_suma_settings(),
+        activity: :saving_suma_settings,
+        connection_info: {TrentoWeb.V1.SettingsController, :save_suse_manager_settings},
         interesting_statuses: 201,
-        not_interesting_statuses: [400, 401, 403, 404, 500],
-        name: :saving_suma_settings
+        not_interesting_statuses: [400, 401, 403, 404, 500]
       },
       %{
-        activity: ActivityCatalog.changing_suma_settings(),
+        activity: :changing_suma_settings,
+        connection_info: {TrentoWeb.V1.SettingsController, :update_suse_manager_settings},
         interesting_statuses: 200,
-        not_interesting_statuses: [400, 401, 403, 404, 500],
-        name: :changing_suma_settings
+        not_interesting_statuses: [400, 401, 403, 404, 500]
       },
       %{
-        activity: ActivityCatalog.clearing_suma_settings(),
+        activity: :clearing_suma_settings,
+        connection_info: {TrentoWeb.V1.SettingsController, :delete_suse_manager_settings},
         interesting_statuses: 204,
-        not_interesting_statuses: [400, 401, 403, 404, 500],
-        name: :clearing_suma_settings
+        not_interesting_statuses: [400, 401, 403, 404, 500]
       },
       %{
-        activity: ActivityCatalog.user_creation(),
+        activity: :user_creation,
+        connection_info: {TrentoWeb.V1.UsersController, :create},
         interesting_statuses: 201,
-        not_interesting_statuses: [400, 401, 403, 404, 500],
-        name: :user_creation
+        not_interesting_statuses: [400, 401, 403, 404, 500]
       },
       %{
-        activity: ActivityCatalog.user_modification(),
+        activity: :user_modification,
+        connection_info: {TrentoWeb.V1.UsersController, :update},
         interesting_statuses: 200,
-        not_interesting_statuses: [400, 401, 403, 404, 500],
-        name: :user_modification
+        not_interesting_statuses: [400, 401, 403, 404, 500]
       },
       %{
-        activity: ActivityCatalog.user_deletion(),
+        activity: :user_deletion,
+        connection_info: {TrentoWeb.V1.UsersController, :delete},
         interesting_statuses: 204,
-        not_interesting_statuses: [400, 401, 403, 404, 500],
-        name: :user_deletion
+        not_interesting_statuses: [400, 401, 403, 404, 500]
       },
       %{
-        activity: ActivityCatalog.profile_update(),
+        activity: :profile_update,
+        connection_info: {TrentoWeb.V1.ProfileController, :update},
         interesting_statuses: 200,
-        not_interesting_statuses: [400, 401, 403, 404, 500],
-        name: :profile_update
+        not_interesting_statuses: [400, 401, 403, 404, 500]
       },
       %{
-        activity: ActivityCatalog.cluster_checks_execution_request(),
+        activity: :cluster_checks_execution_request,
+        connection_info: {TrentoWeb.V1.ClusterController, :request_checks_execution},
         interesting_statuses: 202,
-        not_interesting_statuses: [400, 401, 403, 404, 500],
-        name: :cluster_checks_execution_request
+        not_interesting_statuses: [400, 401, 403, 404, 500]
       }
     ]
 
-    for %{name: scenario_name} = scenario <- scenarios do
+    for %{activity: scenario_name} = scenario <- scenarios do
       @scenario scenario
 
       test "should detect connection activity for: #{scenario_name}",
@@ -216,6 +216,7 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
            } do
         %{
           activity: activity,
+          connection_info: connection_info,
           interesting_statuses: interesting_statuses
         } = @scenario
 
@@ -231,7 +232,7 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
         |> Enum.each(fn status ->
           assert {:ok, ^activity} =
                    conn
-                   |> populate_conn.(activity, status)
+                   |> populate_conn.(connection_info, status)
                    |> ActivityCatalog.detect_activity()
         end)
 
@@ -240,7 +241,7 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
         |> Enum.each(fn status ->
           assert {:error, :not_interesting} ==
                    conn
-                   |> populate_conn.(activity, status)
+                   |> populate_conn.(connection_info, status)
                    |> ActivityCatalog.detect_activity()
         end)
       end
@@ -248,69 +249,18 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
 
     test "should detect activity from domain events" do
       events = [
-        build(:heartbeat_succeded),
-        build(:heartbeat_failed),
-        build(:host_registered_event),
-        build(:host_checks_health_changed),
-        build(:host_checks_selected)
+        {build(:host_registered_event), :host_registered},
+        {build(:heartbeat_succeded), :heartbeat_succeeded},
+        {build(:heartbeat_failed), :heartbeat_failed},
+        {build(:host_checks_health_changed), :host_checks_health_changed},
+        {build(:host_checks_selected), :host_checks_selected},
+        {build(:software_updates_discovery_requested_event),
+         :software_updates_discovery_requested}
       ]
 
-      for %event_module{} = event <- events do
-        assert {:ok, event_module} ==
+      for {event, expected_activity_type} <- events do
+        assert {:ok, expected_activity_type} ==
                  ActivityCatalog.detect_activity(%{event: event, metadata: %{}})
-      end
-    end
-  end
-
-  describe "activity type detection" do
-    test "should ignore irrelevant activities" do
-      Enum.each([%{bar: "baz"}, "not-interesting", %{}, 42], fn activity ->
-        assert nil == ActivityCatalog.get_activity_type(activity)
-      end)
-    end
-
-    test "should detect activity type for interesting connections" do
-      scenarios = [
-        {ActivityCatalog.login_attempt(), :login_attempt},
-        {ActivityCatalog.resource_tagging(), :resource_tagging},
-        {ActivityCatalog.resource_untagging(), :resource_untagging},
-        {ActivityCatalog.api_key_generation(), :api_key_generation},
-        {ActivityCatalog.saving_suma_settings(), :saving_suma_settings},
-        {ActivityCatalog.changing_suma_settings(), :changing_suma_settings},
-        {ActivityCatalog.clearing_suma_settings(), :clearing_suma_settings},
-        {ActivityCatalog.user_creation(), :user_creation},
-        {ActivityCatalog.user_modification(), :user_modification},
-        {ActivityCatalog.user_deletion(), :user_deletion},
-        {ActivityCatalog.profile_update(), :profile_update},
-        {ActivityCatalog.cluster_checks_execution_request(), :cluster_checks_execution_request}
-      ]
-
-      for {activity, expected_activity_type} <- scenarios do
-        assert expected_activity_type == ActivityCatalog.get_activity_type(activity)
-      end
-    end
-
-    test "should detect correct activity type" do
-      %heartbeat_succeeded_event{} = build(:heartbeat_succeded)
-      %heartbeat_failed_event{} = build(:heartbeat_failed)
-      %host_registered_event{} = build(:host_registered_event)
-      %host_checks_health_changed_event{} = build(:host_checks_health_changed)
-      %host_checks_selected_event{} = build(:host_checks_selected)
-
-      %software_updates_discovery_requested_event{} =
-        build(:software_updates_discovery_requested_event)
-
-      event_to_activity_type_map = [
-        {host_registered_event, :host_registered},
-        {heartbeat_succeeded_event, :heartbeat_succeeded},
-        {heartbeat_failed_event, :heartbeat_failed},
-        {host_checks_health_changed_event, :host_checks_health_changed},
-        {host_checks_selected_event, :host_checks_selected},
-        {software_updates_discovery_requested_event, :software_updates_discovery_requested}
-      ]
-
-      for {event_module, expected_activity_type} <- event_to_activity_type_map do
-        assert expected_activity_type == ActivityCatalog.get_activity_type(event_module)
       end
     end
   end

--- a/test/trento/activity_logging/activity_catalog_test.exs
+++ b/test/trento/activity_logging/activity_catalog_test.exs
@@ -39,7 +39,7 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
   test "should ignore unknown activities", %{
     conn: conn
   } do
-    Enum.each([:foo_bar, %{bar: "baz"}, "not-interesting", nil, %{}, 42], fn activity ->
+    Enum.each([%{bar: "baz"}, "not-interesting", %{}, 42], fn activity ->
       refute ActivityCatalog.interested?(activity, conn)
       assert nil == ActivityCatalog.get_activity_type(activity)
     end)

--- a/test/trento/activity_logging/activity_catalog_test.exs
+++ b/test/trento/activity_logging/activity_catalog_test.exs
@@ -9,43 +9,287 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
 
   require Trento.ActivityLog.ActivityCatalog, as: ActivityCatalog
 
+  describe "activity exposure" do
+    test "should expose connection related activities" do
+      logged_connection_activities = [
+        {TrentoWeb.SessionController, :create},
+        {TrentoWeb.V1.ClusterController, :request_checks_execution},
+        {TrentoWeb.V1.ProfileController, :update},
+        {TrentoWeb.V1.SettingsController, :delete_suse_manager_settings},
+        {TrentoWeb.V1.SettingsController, :save_suse_manager_settings},
+        {TrentoWeb.V1.SettingsController, :update_api_key_settings},
+        {TrentoWeb.V1.SettingsController, :update_suse_manager_settings},
+        {TrentoWeb.V1.TagsController, :add_tag},
+        {TrentoWeb.V1.TagsController, :remove_tag},
+        {TrentoWeb.V1.UsersController, :create},
+        {TrentoWeb.V1.UsersController, :delete},
+        {TrentoWeb.V1.UsersController, :update}
+      ]
+
+      connection_activity_catalog = ActivityCatalog.connection_activities()
+
+      assert length(logged_connection_activities) == length(connection_activity_catalog)
+
+      for connection_activity <- logged_connection_activities do
+        assert connection_activity in connection_activity_catalog
+      end
+    end
+
+    test "should expose domain event related activities" do
+      domain_events = [
+        Trento.Hosts.Events.HostRestored,
+        Trento.Hosts.Events.HostRolledUp,
+        Trento.Hosts.Events.SoftwareUpdatesDiscoveryCleared,
+        Trento.Hosts.Events.SaptuneStatusUpdated,
+        Trento.Hosts.Events.HostRollUpRequested,
+        Trento.Hosts.Events.HeartbeatFailed,
+        Trento.Hosts.Events.HostDetailsUpdated,
+        Trento.Hosts.Events.HostHealthChanged,
+        Trento.Hosts.Events.HostDeregistered,
+        Trento.Hosts.Events.ProviderUpdated,
+        Trento.Hosts.Events.HostSaptuneHealthChanged,
+        Trento.Hosts.Events.SoftwareUpdatesHealthChanged,
+        Trento.Hosts.Events.SoftwareUpdatesDiscoveryRequested,
+        Trento.Hosts.Events.HeartbeatSucceeded,
+        Trento.Hosts.Events.HostChecksSelected,
+        Trento.Hosts.Events.SlesSubscriptionsUpdated,
+        Trento.Hosts.Events.HostChecksHealthChanged,
+        Trento.Hosts.Events.HostDeregistrationRequested,
+        Trento.Hosts.Events.HostTombstoned,
+        Trento.Hosts.Events.HostRegistered,
+        Trento.Clusters.Events.ClusterRegistered,
+        Trento.Clusters.Events.ClusterRolledUp,
+        Trento.Clusters.Events.ClusterTombstoned,
+        Trento.Clusters.Events.ClusterRollUpRequested,
+        Trento.Clusters.Events.ClusterChecksHealthChanged,
+        Trento.Clusters.Events.HostAddedToCluster,
+        Trento.Clusters.Events.ClusterDeregistered,
+        Trento.Clusters.Events.ClusterHealthChanged,
+        Trento.Clusters.Events.ClusterRestored,
+        Trento.Clusters.Events.ClusterDiscoveredHealthChanged,
+        Trento.Clusters.Events.HostRemovedFromCluster,
+        Trento.Clusters.Events.ChecksSelected,
+        Trento.Clusters.Events.ClusterDetailsUpdated,
+        Trento.Databases.Events.DatabaseDeregistered,
+        Trento.Databases.Events.DatabaseTombstoned,
+        Trento.Databases.Events.DatabaseRollUpRequested,
+        Trento.Databases.Events.DatabaseRolledUp,
+        Trento.Databases.Events.DatabaseInstanceSystemReplicationChanged,
+        Trento.Databases.Events.DatabaseInstanceMarkedAbsent,
+        Trento.Databases.Events.DatabaseInstanceHealthChanged,
+        Trento.Databases.Events.DatabaseInstanceMarkedPresent,
+        Trento.Databases.Events.DatabaseInstanceDeregistered,
+        Trento.Databases.Events.DatabaseTenantsUpdated,
+        Trento.Databases.Events.DatabaseRestored,
+        Trento.Databases.Events.DatabaseRegistered,
+        Trento.Databases.Events.DatabaseInstanceRegistered,
+        Trento.Databases.Events.DatabaseHealthChanged,
+        Trento.SapSystems.Events.ApplicationInstanceMarkedAbsent,
+        Trento.SapSystems.Events.SapSystemHealthChanged,
+        Trento.SapSystems.Events.SapSystemTombstoned,
+        Trento.SapSystems.Events.SapSystemDatabaseHealthChanged,
+        Trento.SapSystems.Events.SapSystemRolledUp,
+        Trento.SapSystems.Events.ApplicationInstanceDeregistered,
+        Trento.SapSystems.Events.SapSystemRegistered,
+        Trento.SapSystems.Events.ApplicationInstanceMarkedPresent,
+        Trento.SapSystems.Events.SapSystemRestored,
+        Trento.SapSystems.Events.SapSystemDeregistered,
+        Trento.SapSystems.Events.ApplicationInstanceHealthChanged,
+        Trento.SapSystems.Events.SapSystemRollUpRequested,
+        Trento.SapSystems.Events.SapSystemUpdated,
+        Trento.SapSystems.Events.ApplicationInstanceMoved,
+        Trento.SapSystems.Events.ApplicationInstanceRegistered
+      ]
+
+      events_activities_catalog = ActivityCatalog.domain_event_activities()
+
+      assert length(domain_events) <= length(events_activities_catalog)
+
+      for event_module <- domain_events do
+        assert event_module in events_activities_catalog
+      end
+    end
+  end
+
   describe "activity detection" do
     test "should not detect activity from invalid input" do
       Enum.each([nil, %{}, "", 42], fn input ->
-        assert nil == ActivityCatalog.detect_activity(input)
+        assert {:error, :not_interesting} == ActivityCatalog.detect_activity(input)
       end)
     end
 
     test "should not be able to detect an activity from a connection without controller/action info",
          %{conn: conn} do
-      assert nil == ActivityCatalog.detect_activity(conn)
+      assert {:error, :not_interesting} == ActivityCatalog.detect_activity(conn)
     end
 
-    test "should detect activity from a connection with controller/action info", %{conn: conn} do
-      assert {Foo.Bar.AcmeController, :foo_action} ==
+    test "should ignore activity from not interesting connections with controller/action info", %{
+      conn: conn
+    } do
+      assert {:error, :not_interesting} ==
                conn
                |> Plug.Conn.put_private(:phoenix_controller, Foo.Bar.AcmeController)
                |> Plug.Conn.put_private(:phoenix_action, :foo_action)
                |> ActivityCatalog.detect_activity()
     end
 
+    scenarios = [
+      %{
+        activity: ActivityCatalog.login_attempt(),
+        interesting_statuses: [200, 401, 404, 500],
+        name: :login_attempt
+      },
+      %{
+        activity: ActivityCatalog.resource_tagging(),
+        interesting_statuses: 201,
+        not_interesting_statuses: [400, 401, 403, 404, 500],
+        name: :resource_tagging
+      },
+      %{
+        activity: ActivityCatalog.resource_untagging(),
+        interesting_statuses: 204,
+        not_interesting_statuses: [400, 401, 403, 404, 500],
+        name: :resource_untagging
+      },
+      %{
+        activity: ActivityCatalog.api_key_generation(),
+        interesting_statuses: 200,
+        not_interesting_statuses: [400, 401, 403, 404, 500],
+        name: :api_key_generation
+      },
+      %{
+        activity: ActivityCatalog.saving_suma_settings(),
+        interesting_statuses: 201,
+        not_interesting_statuses: [400, 401, 403, 404, 500],
+        name: :saving_suma_settings
+      },
+      %{
+        activity: ActivityCatalog.changing_suma_settings(),
+        interesting_statuses: 200,
+        not_interesting_statuses: [400, 401, 403, 404, 500],
+        name: :changing_suma_settings
+      },
+      %{
+        activity: ActivityCatalog.clearing_suma_settings(),
+        interesting_statuses: 204,
+        not_interesting_statuses: [400, 401, 403, 404, 500],
+        name: :clearing_suma_settings
+      },
+      %{
+        activity: ActivityCatalog.user_creation(),
+        interesting_statuses: 201,
+        not_interesting_statuses: [400, 401, 403, 404, 500],
+        name: :user_creation
+      },
+      %{
+        activity: ActivityCatalog.user_modification(),
+        interesting_statuses: 200,
+        not_interesting_statuses: [400, 401, 403, 404, 500],
+        name: :user_modification
+      },
+      %{
+        activity: ActivityCatalog.user_deletion(),
+        interesting_statuses: 204,
+        not_interesting_statuses: [400, 401, 403, 404, 500],
+        name: :user_deletion
+      },
+      %{
+        activity: ActivityCatalog.profile_update(),
+        interesting_statuses: 200,
+        not_interesting_statuses: [400, 401, 403, 404, 500],
+        name: :profile_update
+      },
+      %{
+        activity: ActivityCatalog.cluster_checks_execution_request(),
+        interesting_statuses: 202,
+        not_interesting_statuses: [400, 401, 403, 404, 500],
+        name: :cluster_checks_execution_request
+      }
+    ]
+
+    for %{name: scenario_name} = scenario <- scenarios do
+      @scenario scenario
+
+      test "should detect connection activity for: #{scenario_name}",
+           %{
+             conn: conn
+           } do
+        %{
+          activity: activity,
+          interesting_statuses: interesting_statuses
+        } = @scenario
+
+        populate_conn = fn conn, {controller, action}, status ->
+          conn
+          |> Plug.Conn.put_private(:phoenix_controller, controller)
+          |> Plug.Conn.put_private(:phoenix_action, action)
+          |> put_status(status)
+        end
+
+        interesting_statuses
+        |> List.wrap()
+        |> Enum.each(fn status ->
+          assert {:ok, ^activity} =
+                   conn
+                   |> populate_conn.(activity, status)
+                   |> ActivityCatalog.detect_activity()
+        end)
+
+        Map.get(@scenario, :not_interesting_statuses, [])
+        |> List.wrap()
+        |> Enum.each(fn status ->
+          assert {:error, :not_interesting} ==
+                   conn
+                   |> populate_conn.(activity, status)
+                   |> ActivityCatalog.detect_activity()
+        end)
+      end
+    end
+
     test "should detect activity from domain events" do
-      %event_module{} = event = build(:host_registered_event)
-      metadata = %{}
-      assert event_module == ActivityCatalog.detect_activity(%{event: event, metadata: metadata})
+      events = [
+        build(:heartbeat_succeded),
+        build(:heartbeat_failed),
+        build(:host_registered_event),
+        build(:host_checks_health_changed),
+        build(:host_checks_selected)
+      ]
+
+      for %event_module{} = event <- events do
+        assert {:ok, event_module} ==
+                 ActivityCatalog.detect_activity(%{event: event, metadata: %{}})
+      end
     end
   end
 
-  test "should ignore unknown activities", %{
-    conn: conn
-  } do
-    Enum.each([%{bar: "baz"}, "not-interesting", %{}, 42], fn activity ->
-      refute ActivityCatalog.interested?(activity, conn)
-      assert nil == ActivityCatalog.get_activity_type(activity)
-    end)
-  end
+  describe "activity type detection" do
+    test "should ignore irrelevant activities" do
+      Enum.each([%{bar: "baz"}, "not-interesting", %{}, 42], fn activity ->
+        assert nil == ActivityCatalog.get_activity_type(activity)
+      end)
+    end
 
-  describe "activity type detectiion" do
+    test "should detect activity type for interesting connections" do
+      scenarios = [
+        {ActivityCatalog.login_attempt(), :login_attempt},
+        {ActivityCatalog.resource_tagging(), :resource_tagging},
+        {ActivityCatalog.resource_untagging(), :resource_untagging},
+        {ActivityCatalog.api_key_generation(), :api_key_generation},
+        {ActivityCatalog.saving_suma_settings(), :saving_suma_settings},
+        {ActivityCatalog.changing_suma_settings(), :changing_suma_settings},
+        {ActivityCatalog.clearing_suma_settings(), :clearing_suma_settings},
+        {ActivityCatalog.user_creation(), :user_creation},
+        {ActivityCatalog.user_modification(), :user_modification},
+        {ActivityCatalog.user_deletion(), :user_deletion},
+        {ActivityCatalog.profile_update(), :profile_update},
+        {ActivityCatalog.cluster_checks_execution_request(), :cluster_checks_execution_request}
+      ]
+
+      for {activity, expected_activity_type} <- scenarios do
+        assert expected_activity_type == ActivityCatalog.get_activity_type(activity)
+      end
+    end
+
     test "should detect correct activity type" do
       %heartbeat_succeded_event{} = build(:heartbeat_succeded)
       %heartbeat_failed_event{} = build(:heartbeat_failed)
@@ -68,108 +312,6 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
       for {event_module, expected_activity_type} <- event_to_activity_type_map do
         assert expected_activity_type == ActivityCatalog.get_activity_type(event_module)
       end
-    end
-  end
-
-  scenarios = [
-    %{
-      activity: ActivityCatalog.login_attempt(),
-      interesting_statuses: [200, 401, 404, 500],
-      expected_activity_type: :login_attempt
-    },
-    %{
-      activity: ActivityCatalog.resource_tagging(),
-      interesting_statuses: 201,
-      not_interesting_statuses: [400, 401, 403, 404, 500],
-      expected_activity_type: :resource_tagging
-    },
-    %{
-      activity: ActivityCatalog.resource_untagging(),
-      interesting_statuses: 204,
-      not_interesting_statuses: [400, 401, 403, 404, 500],
-      expected_activity_type: :resource_untagging
-    },
-    %{
-      activity: ActivityCatalog.api_key_generation(),
-      interesting_statuses: 200,
-      not_interesting_statuses: [400, 401, 403, 404, 500],
-      expected_activity_type: :api_key_generation
-    },
-    %{
-      activity: ActivityCatalog.saving_suma_settings(),
-      interesting_statuses: 201,
-      not_interesting_statuses: [400, 401, 403, 404, 500],
-      expected_activity_type: :saving_suma_settings
-    },
-    %{
-      activity: ActivityCatalog.changing_suma_settings(),
-      interesting_statuses: 200,
-      not_interesting_statuses: [400, 401, 403, 404, 500],
-      expected_activity_type: :changing_suma_settings
-    },
-    %{
-      activity: ActivityCatalog.clearing_suma_settings(),
-      interesting_statuses: 204,
-      not_interesting_statuses: [400, 401, 403, 404, 500],
-      expected_activity_type: :clearing_suma_settings
-    },
-    %{
-      activity: ActivityCatalog.user_creation(),
-      interesting_statuses: 201,
-      not_interesting_statuses: [400, 401, 403, 404, 500],
-      expected_activity_type: :user_creation
-    },
-    %{
-      activity: ActivityCatalog.user_modification(),
-      interesting_statuses: 200,
-      not_interesting_statuses: [400, 401, 403, 404, 500],
-      expected_activity_type: :user_modification
-    },
-    %{
-      activity: ActivityCatalog.user_deletion(),
-      interesting_statuses: 204,
-      not_interesting_statuses: [400, 401, 403, 404, 500],
-      expected_activity_type: :user_deletion
-    },
-    %{
-      activity: ActivityCatalog.profile_update(),
-      interesting_statuses: 200,
-      not_interesting_statuses: [400, 401, 403, 404, 500],
-      expected_activity_type: :profile_update
-    },
-    %{
-      activity: ActivityCatalog.cluster_checks_execution_request(),
-      interesting_statuses: 202,
-      not_interesting_statuses: [400, 401, 403, 404, 500],
-      expected_activity_type: :cluster_checks_execution_request
-    }
-  ]
-
-  for %{expected_activity_type: expected_activity_type} = scenario <- scenarios do
-    @scenario scenario
-
-    test "should detect interesting connection for activity #{expected_activity_type}", %{
-      conn: conn
-    } do
-      %{
-        activity: activity,
-        interesting_statuses: interesting_statuses,
-        expected_activity_type: expected_activity_type
-      } = @scenario
-
-      interesting_statuses
-      |> List.wrap()
-      |> Enum.each(fn status ->
-        assert ActivityCatalog.interested?(activity, put_status(conn, status))
-      end)
-
-      Map.get(@scenario, :not_interesting_statuses, [])
-      |> List.wrap()
-      |> Enum.each(fn status ->
-        refute ActivityCatalog.interested?(activity, put_status(conn, status))
-      end)
-
-      assert ActivityCatalog.get_activity_type(activity) == expected_activity_type
     end
   end
 end

--- a/test/trento/activity_logging/activity_logger_test.exs
+++ b/test/trento/activity_logging/activity_logger_test.exs
@@ -198,7 +198,7 @@ defmodule Trento.ActivityLog.ActivityLoggerTest do
   end
 
   test "domain event activity detection" do
-    heartbeat_succeded_event = build(:heartbeat_succeded)
+    heartbeat_succeeded_event = build(:heartbeat_succeded)
     heartbeat_failed_event = build(:heartbeat_failed)
     host_registered_event = build(:host_registered_event)
     host_checks_health_changed_event = build(:host_checks_health_changed)
@@ -209,7 +209,7 @@ defmodule Trento.ActivityLog.ActivityLoggerTest do
 
     events = [
       {host_registered_event, "host_registered"},
-      {heartbeat_succeded_event, "heartbeat_succeeded"},
+      {heartbeat_succeeded_event, "heartbeat_succeeded"},
       {heartbeat_failed_event, "heartbeat_failed"},
       {host_checks_health_changed_event, "host_checks_health_changed"},
       {host_checks_selected_event, "host_checks_selected"},

--- a/test/trento/activity_logging/activity_logger_test.exs
+++ b/test/trento/activity_logging/activity_logger_test.exs
@@ -197,7 +197,7 @@ defmodule Trento.ActivityLog.ActivityLoggerTest do
     end
   end
 
-  test "domain event activity detection" do
+  test "domain event activity logging" do
     heartbeat_succeeded_event = build(:heartbeat_succeded)
     heartbeat_failed_event = build(:heartbeat_failed)
     host_registered_event = build(:host_registered_event)

--- a/test/trento/activity_logging/event_parser_test.exs
+++ b/test/trento/activity_logging/event_parser_test.exs
@@ -1,0 +1,58 @@
+defmodule Trento.ActivityLog.EventParser do
+  @moduledoc false
+
+  use TrentoWeb.ConnCase, async: false
+  use Plug.Test
+
+  import Trento.Factory
+
+  alias Trento.ActivityLog.Logger.Parser.EventParser
+
+  require Trento.ActivityLog.ActivityCatalog, as: ActivityCatalog
+
+  @events [
+    build(:heartbeat_succeded),
+    build(:heartbeat_failed),
+    build(:host_registered_event),
+    build(:host_checks_health_changed),
+    build(:host_checks_selected),
+    build(:software_updates_discovery_requested_event)
+  ]
+
+  @unsupported_activities [
+    {Foo.Bar.Events.ThingHappened, %{event: %{"foo" => "bar"}}},
+    {"foo_bar", %{event: %{"bar" => "baz"}}},
+    {nil, %{event: %{"qux" => "quux"}}},
+    {42, %{event: %{"qux" => "quux"}}},
+    {[], %{event: %{"quux" => "bar"}}},
+    {{}, %{event: %{"quux" => "baz"}}}
+  ]
+
+  describe "actor detection" do
+    test "should not detect actor for unsupported domain event activities" do
+      for {event_type, event_context} <- @unsupported_activities do
+        assert nil == EventParser.get_activity_actor(event_type, event_context)
+      end
+    end
+
+    test "should detect actor for supported domain event activity" do
+      for %event_type{} = event <- @events do
+        assert "system" == EventParser.get_activity_actor(event_type, %{event: event})
+      end
+    end
+  end
+
+  describe "metadata extraction" do
+    test "should not detect metadata for unsupported domain event activities" do
+      for {event_type, event_context} <- @unsupported_activities do
+        assert %{} == EventParser.get_activity_metadata(event_type, event_context)
+      end
+    end
+
+    test "should detect metadata for supported domain event activity" do
+      for %event_type{} = event <- @events do
+        assert event == EventParser.get_activity_metadata(event_type, %{event: event})
+      end
+    end
+  end
+end

--- a/test/trento/activity_logging/event_parser_test.exs
+++ b/test/trento/activity_logging/event_parser_test.exs
@@ -8,8 +8,6 @@ defmodule Trento.ActivityLog.EventParser do
 
   alias Trento.ActivityLog.Logger.Parser.EventParser
 
-  require Trento.ActivityLog.ActivityCatalog, as: ActivityCatalog
-
   @events [
     build(:heartbeat_succeded),
     build(:heartbeat_failed),

--- a/test/trento/activity_logging/event_parser_test.exs
+++ b/test/trento/activity_logging/event_parser_test.exs
@@ -8,48 +8,50 @@ defmodule Trento.ActivityLog.EventParser do
 
   alias Trento.ActivityLog.Logger.Parser.EventParser
 
-  @events [
-    build(:heartbeat_succeded),
-    build(:heartbeat_failed),
-    build(:host_registered_event),
-    build(:host_checks_health_changed),
-    build(:host_checks_selected),
-    build(:software_updates_discovery_requested_event)
+  @recognized_inputs [
+    {:host_registered, build(:host_registered_event)},
+    {:heartbeat_succeeded, build(:heartbeat_succeded)},
+    {:heartbeat_failed, build(:heartbeat_failed)},
+    {:host_checks_health_changed, build(:host_checks_health_changed)},
+    {:host_checks_selected, build(:host_checks_selected)},
+    {:software_updates_discovery_requested, build(:software_updates_discovery_requested_event)},
+    {:foo_bar, %{some: "event"}}
   ]
 
-  @unsupported_activities [
-    {Foo.Bar.Events.ThingHappened, %{event: %{"foo" => "bar"}}},
-    {"foo_bar", %{event: %{"bar" => "baz"}}},
-    {nil, %{event: %{"qux" => "quux"}}},
-    {42, %{event: %{"qux" => "quux"}}},
-    {[], %{event: %{"quux" => "bar"}}},
-    {{}, %{event: %{"quux" => "baz"}}}
+  @unrecognized_inputs [
+    {:foo_bar, "baz"},
+    {"foo_bar", %{bar: "baz"}},
+    {nil, %{}},
+    {42, []},
+    {[], nil},
+    {{}, 42},
+    {build(:heartbeat_succeded), %{baz: "foo"}}
   ]
 
   describe "actor detection" do
-    test "should not detect actor for unsupported domain event activities" do
-      for {event_type, event_context} <- @unsupported_activities do
-        assert nil == EventParser.get_activity_actor(event_type, event_context)
+    test "should not detect actor for unrecognized input" do
+      for {event_activity, event_context} <- @unrecognized_inputs do
+        assert nil == EventParser.get_activity_actor(event_activity, event_context)
       end
     end
 
-    test "should detect actor for supported domain event activity" do
-      for %event_type{} = event <- @events do
-        assert "system" == EventParser.get_activity_actor(event_type, %{event: event})
+    test "should detect actor for recognized input" do
+      for {event_activity, event} <- @recognized_inputs do
+        assert "system" == EventParser.get_activity_actor(event_activity, %{event: event})
       end
     end
   end
 
   describe "metadata extraction" do
-    test "should not detect metadata for unsupported domain event activities" do
-      for {event_type, event_context} <- @unsupported_activities do
-        assert %{} == EventParser.get_activity_metadata(event_type, event_context)
+    test "should fallback to empty map for unrecognized input" do
+      for {event_activity, event_context} <- @unrecognized_inputs do
+        assert %{} == EventParser.get_activity_metadata(event_activity, event_context)
       end
     end
 
-    test "should detect metadata for supported domain event activity" do
-      for %event_type{} = event <- @events do
-        assert event == EventParser.get_activity_metadata(event_type, %{event: event})
+    test "should detect metadata for recognized input" do
+      for {event_activity, event} <- @recognized_inputs do
+        assert event == EventParser.get_activity_metadata(event_activity, %{event: event})
       end
     end
   end

--- a/test/trento/activity_logging/phoenix_conn_parser_test.exs
+++ b/test/trento/activity_logging/phoenix_conn_parser_test.exs
@@ -28,7 +28,7 @@ defmodule Trento.ActivityLog.PhoenixConnParserTest do
       ]
 
       for %{body_params: body_params, expected_username: expected_username} <- scenarios do
-        assert PhoenixConnParser.get_activity_actor(ActivityCatalog.login_attempt(), %{
+        assert PhoenixConnParser.get_activity_actor(:login_attempt, %{
                  conn
                  | body_params: body_params
                }) == expected_username
@@ -62,8 +62,8 @@ defmodule Trento.ActivityLog.PhoenixConnParserTest do
   end
 
   defp assert_for_relevant_activity(assertion_function) do
-    ActivityCatalog.activity_catalog()
-    |> Enum.filter(&(&1 != ActivityCatalog.login_attempt()))
+    ActivityCatalog.connection_activities()
+    |> Enum.filter(&(&1 != :login_attempt))
     |> Enum.each(fn activity -> assertion_function.(activity) end)
   end
 end

--- a/test/trento/activity_logging/phoenix_conn_parser_test.exs
+++ b/test/trento/activity_logging/phoenix_conn_parser_test.exs
@@ -10,21 +10,6 @@ defmodule Trento.ActivityLog.PhoenixConnParserTest do
 
   require Trento.ActivityLog.ActivityCatalog, as: ActivityCatalog
 
-  describe "activity detection" do
-    test "should not be able to detect an activity from a connection without controller/action info",
-         %{conn: conn} do
-      assert nil == PhoenixConnParser.detect_activity(conn)
-    end
-
-    test "should detect activity from a connection with controller/action info", %{conn: conn} do
-      assert {Foo.Bar.AcmeController, :foo_action} ==
-               conn
-               |> Plug.Conn.put_private(:phoenix_controller, Foo.Bar.AcmeController)
-               |> Plug.Conn.put_private(:phoenix_action, :foo_action)
-               |> PhoenixConnParser.detect_activity()
-    end
-  end
-
   describe "actor detection" do
     test "should get the actor from the request payload for login attempts", %{conn: conn} do
       scenarios = [

--- a/test/trento/infrastructure/commanded/event_handlers/activity_log_event_handler_test.exs
+++ b/test/trento/infrastructure/commanded/event_handlers/activity_log_event_handler_test.exs
@@ -1,0 +1,22 @@
+defmodule Trento.Infrastructure.Commanded.EventHandlers.ActivityLogEventHandlerTest do
+  @moduledoc false
+  use Trento.DataCase
+
+  import Trento.Factory
+
+  alias Trento.ActivityLog.ActivityLog
+  alias Trento.Infrastructure.Commanded.EventHandlers.ActivityLogEventHandler
+
+  test "should log a domain event" do
+    event = build(:host_checks_health_changed)
+
+    assert :ok == ActivityLogEventHandler.handle(event, %{})
+
+    assert [
+             %ActivityLog{
+               type: "host_checks_health_changed",
+               actor: "system"
+             }
+           ] = Trento.Repo.all(ActivityLog)
+  end
+end


### PR DESCRIPTION
# Description

This PR extends Activity Logging capabilities so that _all domain events_ can be tracked as activity log entries.

## How was this tested?

Automated tests.
