### PR TITLE
Extend `AvailableSoftwareUpdates` to display arbitrary errors

### DIFF
--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import { EOS_HEALING, EOS_PACKAGE_UPGRADE_OUTLINED } from 'eos-icons-react';
-import { noop, gt } from 'lodash';
+import { noop, gt, gte } from 'lodash';
 
 import Loading from './Loading';
 import SumaNotConfigured from './SumaNotConfigured';
@@ -24,6 +24,7 @@ function AvailableSoftwareUpdates({
   loading,
   relevantPatches,
   upgradablePackages,
+  errorMessage,
   tooltip,
   onBackToSettings = noop,
   onNavigateToPatches = noop,
@@ -58,21 +59,21 @@ function AvailableSoftwareUpdates({
       <Indicator
         title="Relevant Patches"
         critical={gt(relevantPatches, 0)}
+        isError={relevantPatches === undefined}
+        message={gte(relevantPatches, 0) ? relevantPatches : errorMessage}
         tooltip={tooltip}
         icon={<EOS_HEALING size="xl" />}
         onNavigate={onNavigateToPatches}
-      >
-        {relevantPatches}
-      </Indicator>
+      />
 
       <Indicator
         title="Upgradable Packages"
+        isError={upgradablePackages === undefined}
+        message={gte(upgradablePackages, 0) ? upgradablePackages : errorMessage}
         tooltip={tooltip}
         icon={<EOS_PACKAGE_UPGRADE_OUTLINED size="xl" />}
         onNavigate={onNavigateToPackages}
-      >
-        {upgradablePackages}
-      </Indicator>
+      />
     </div>
   );
 }

--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
@@ -41,15 +41,22 @@ describe('AvailableSoftwareUpdates component', () => {
     expect(screen.getAllByTestId('eos-svg-component')).toHaveLength(5);
   });
 
-  it('renders Unknown status', async () => {
+  it('renders error status', async () => {
     const user = userEvent.setup();
     const tooltip = faker.lorem.words({ min: 3, max: 5 });
-    render(<AvailableSoftwareUpdates settingsConfigured tooltip={tooltip} />);
+    const errorMessage = faker.person.jobType();
+    render(
+      <AvailableSoftwareUpdates
+        settingsConfigured
+        tooltip={tooltip}
+        errorMessage={errorMessage}
+      />
+    );
 
-    expect(screen.getAllByText('Unknown')).toHaveLength(2);
+    expect(screen.getAllByText(errorMessage)).toHaveLength(2);
     expect(screen.getAllByTestId('eos-svg-component')).toHaveLength(4);
 
-    await user.hover(screen.getAllByText('Unknown')[0]);
+    await user.hover(screen.getAllByText(errorMessage)[0]);
     expect(screen.getByText(tooltip)).toBeInTheDocument();
   });
 

--- a/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
@@ -14,21 +14,8 @@ function Indicator({
   message,
   icon,
   isError,
-  loading,
   onNavigate,
 }) {
-  if (loading) {
-    return (
-      <div className="flex flex-row items-center border border-gray-200 p-2 rounded-md grow">
-        <div className="px-2">{icon}</div>
-        <div>
-          <p className="font-bold">{title}</p>
-          <div className="text-gray-500">Loading...</div>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <Tooltip isEnabled={isError} content={tooltip} wrap={false}>
       <div

--- a/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
@@ -11,13 +11,12 @@ function Indicator({
   title,
   critical,
   tooltip,
+  message,
   icon,
+  isError,
   loading,
-  children,
   onNavigate,
 }) {
-  const unknown = children === undefined;
-
   if (loading) {
     return (
       <div className="flex flex-row items-center border border-gray-200 p-2 rounded-md grow">
@@ -31,13 +30,13 @@ function Indicator({
   }
 
   return (
-    <Tooltip isEnabled={unknown} content={tooltip} wrap={false}>
+    <Tooltip isEnabled={isError} content={tooltip} wrap={false}>
       <div
         role="button"
         tabIndex={0}
         className={classNames(
           'flex flex-row items-center border border-gray-200 p-2 rounded-md grow',
-          { 'cursor-pointer': !unknown }
+          { 'cursor-pointer': !isError }
         )}
         onClick={onNavigate}
         onKeyDown={({ code }) => {
@@ -51,11 +50,11 @@ function Indicator({
           <p className="font-bold">{title}</p>
           <div
             className={classNames({
-              'text-green-600': !unknown,
-              'text-gray-600': unknown,
+              'text-green-600': !isError,
+              'text-gray-600': isError,
             })}
           >
-            {critical || unknown ? (
+            {critical || isError ? (
               <div>
                 <EOS_ERROR_OUTLINED
                   size="l"
@@ -63,15 +62,15 @@ function Indicator({
                     critical && ' fill-red-500'
                   }`}
                 />{' '}
-                {critical && children ? children : 'Unknown'}
+                {message}
               </div>
             ) : (
-              children
+              message
             )}
           </div>
         </div>
         <div className="flex grow justify-end">
-          {!unknown && (
+          {!isError && (
             <div>
               <EOS_KEYBOARD_ARROW_RIGHT_FILLED
                 size="l"

--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -81,6 +81,7 @@ function HostDetails({
   upgradablePackages,
   softwareUpdatesLoading,
   softwareUpdatesSettingsSaved,
+  softwareUpdatesErrorMessage,
   softwareUpdatesTooltip,
   userAbilities,
   cleanUpHost,
@@ -251,6 +252,7 @@ function HostDetails({
             settingsConfigured={softwareUpdatesSettingsSaved}
             relevantPatches={relevantPatches}
             upgradablePackages={upgradablePackages}
+            errorMessage={softwareUpdatesErrorMessage}
             tooltip={softwareUpdatesTooltip}
             loading={softwareUpdatesLoading}
             onBackToSettings={() => navigate(`/settings`)}

--- a/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
@@ -300,7 +300,7 @@ describe('HostDetails component', () => {
       );
     });
 
-    it("should display software updates as 'Unknown' when no SUMA updates data is available", () => {
+    it('should display software updates showing an error message when no SUMA updates data is available', () => {
       const relevantPatches = undefined;
       const upgradablePackages = undefined;
 
@@ -309,6 +309,7 @@ describe('HostDetails component', () => {
           agentVersion="2.0.0"
           suseManagerEnabled
           softwareUpdatesSettingsSaved
+          softwareUpdatesErrorMessage="An error message"
           relevantPatches={relevantPatches}
           upgradablePackages={upgradablePackages}
           userAbilities={userAbilities}
@@ -322,8 +323,8 @@ describe('HostDetails component', () => {
         .getByText(/Upgradable Packages/)
         .closest('div');
 
-      expect(relevantPatchesElement).toHaveTextContent('Unknown');
-      expect(upgradablePackagesElement).toHaveTextContent('Unknown');
+      expect(relevantPatchesElement).toHaveTextContent('An error message');
+      expect(upgradablePackagesElement).toHaveTextContent('An error message');
     });
 
     it('should show the summary of SUMA software updates in a loading state', () => {

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -17,6 +17,7 @@ import {
   getSoftwareUpdatesSettingsConfigured,
   getSoftwareUpdatesLoading,
   getSoftwareUpdatesStats,
+  getSoftwareUpdatesErrors,
 } from '@state/selectors/softwareUpdates';
 
 import { getHost, getHostSelectedChecks } from '@state/selectors/host';
@@ -33,6 +34,42 @@ import HostDetails from './HostDetails';
 
 const chartsEnabled = getFromConfig('chartsEnabled');
 const suseManagerEnabled = getFromConfig('suseManagerEnabled');
+
+const getSoftwareUpdatesErrorMessage = (errors) => {
+  const hostNotFoundInSUMA = errors.some(
+    ({ detail }) =>
+      detail === 'The requested resource cannot be found.' ||
+      detail === 'No system ID was found on SUSE Manager for this host.'
+  );
+
+  if (hostNotFoundInSUMA) {
+    return 'Host not found in SUSE manager';
+  }
+
+  if (errors.length) {
+    return 'Connection to SUMA not working';
+  }
+
+  return undefined;
+};
+
+const getSoftwareUpdatesErrorTooltip = (errors) => {
+  const hostNotFoundInSUMA = errors.some(
+    ({ detail }) =>
+      detail === 'The requested resource cannot be found.' ||
+      detail === 'No system ID was found on SUSE Manager for this host.'
+  );
+
+  if (hostNotFoundInSUMA) {
+    return 'Contact your SUSE Manager admin to ensure the host is managed by SUSE Manager';
+  }
+
+  if (errors.length) {
+    return 'Please review SUSE Manager settings';
+  }
+
+  return undefined;
+};
 
 function HostDetailsPage() {
   const { hostID } = useParams();
@@ -66,6 +103,17 @@ function HostDetailsPage() {
 
   const softwareUpdatesLoading = useSelector((state) =>
     getSoftwareUpdatesLoading(state, hostID)
+  );
+
+  const softwareUpdatesErrors = useSelector((state) =>
+    getSoftwareUpdatesErrors(state, hostID)
+  );
+
+  const softwareUpdatesErrorMessage = getSoftwareUpdatesErrorMessage(
+    softwareUpdatesErrors
+  );
+  const softwareUpdatesTooltip = getSoftwareUpdatesErrorTooltip(
+    softwareUpdatesErrors
   );
 
   const getExportersStatus = async () => {
@@ -121,11 +169,8 @@ function HostDetailsPage() {
       upgradablePackages={numUpgradablePackages}
       softwareUpdatesSettingsSaved={settingsConfigured}
       softwareUpdatesLoading={softwareUpdatesLoading}
-      softwareUpdatesTooltip={
-        numRelevantPatches === undefined && numUpgradablePackages === undefined
-          ? 'Trento was not able to retrieve the requested data'
-          : undefined
-      }
+      softwareUpdatesErrorMessage={softwareUpdatesErrorMessage}
+      softwareUpdatesTooltip={softwareUpdatesTooltip}
       userAbilities={abilities}
       cleanUpHost={() => {
         dispatch(deregisterHost({ id: hostID, hostname: host.hostname }));

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -50,7 +50,7 @@ const getSoftwareUpdatesErrorMessage = (errors) => {
     return 'Connection to SUMA not working';
   }
 
-  return undefined;
+  return 'Unknown';
 };
 
 const getSoftwareUpdatesErrorTooltip = (errors) => {

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -43,7 +43,7 @@ const getSoftwareUpdatesErrorMessage = (errors) => {
   );
 
   if (hostNotFoundInSUMA) {
-    return 'Host not found in SUSE manager';
+    return 'Host not found in SUSE Manager';
   }
 
   if (errors.length) {

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.test.jsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import 'intersection-observer';
+import '@testing-library/jest-dom';
+import { networkClient } from '@lib/network';
+import MockAdapter from 'axios-mock-adapter';
+
+import {
+  renderWithRouterMatch,
+  defaultInitialState,
+  withState,
+} from '@lib/test-utils';
+import { hostFactory } from '@lib/test-utils/factories';
+
+import HostDetailsPage from '.';
+
+const axiosMock = new MockAdapter(networkClient);
+
+describe('HostDetailsPage', () => {
+  beforeEach(() => {
+    axiosMock.reset();
+    axiosMock.onGet(/\/api\/v1\/charts.*/gm).reply(200, {});
+    axiosMock.onGet(/\/api\/v1\/hosts.*/gm).reply(200, {});
+  });
+
+  it('Renders SUSE Manager error for host not found', async () => {
+    const user = userEvent.setup();
+
+    const host = hostFactory.build();
+    const { id: hostID } = host;
+
+    const state = {
+      ...defaultInitialState,
+      hostsList: {
+        hosts: [host],
+      },
+      lastExecutions: { data: null, loading: false, errors: null },
+      softwareUpdates: {
+        settingsConfigured: true,
+        softwareUpdates: {
+          [hostID]: {
+            loading: false,
+            errors: [{ detail: 'The requested resource cannot be found.' }],
+          },
+        },
+      },
+    };
+
+    const [StatefulHostDetails] = withState(<HostDetailsPage />, state);
+
+    await act(async () =>
+      renderWithRouterMatch(StatefulHostDetails, {
+        path: 'hosts/:hostID',
+        route: `/hosts/${hostID}`,
+      })
+    );
+
+    const relevantPatchesElement = screen
+      .getByText(/Relevant Patches/)
+      .closest('div');
+    const upgradablePackagesElement = screen
+      .getByText(/Upgradable Packages/)
+      .closest('div');
+
+    expect(relevantPatchesElement).toHaveTextContent(
+      'Relevant Patches Host not found in SUSE Manager'
+    );
+    expect(upgradablePackagesElement).toHaveTextContent(
+      'Upgradable Packages Host not found in SUSE Manager'
+    );
+
+    await user.hover(relevantPatchesElement);
+    expect(
+      screen.queryByText(
+        'Contact your SUSE Manager admin to ensure the host is managed by SUSE Manager'
+      )
+    ).toBeVisible();
+  });
+
+  it('Renders SUSE Manager error for connection not working', async () => {
+    const user = userEvent.setup();
+
+    const host = hostFactory.build();
+    const { id: hostID } = host;
+
+    const state = {
+      ...defaultInitialState,
+      hostsList: {
+        hosts: [host],
+      },
+      lastExecutions: { data: null, loading: false, errors: null },
+      softwareUpdates: {
+        settingsConfigured: true,
+        softwareUpdates: {
+          [hostID]: {
+            loading: false,
+            errors: [{ detail: 'Generic error' }],
+          },
+        },
+      },
+    };
+
+    const [StatefulHostDetails] = withState(<HostDetailsPage />, state);
+
+    await act(async () =>
+      renderWithRouterMatch(StatefulHostDetails, {
+        path: 'hosts/:hostID',
+        route: `/hosts/${hostID}`,
+      })
+    );
+
+    const relevantPatchesElement = screen
+      .getByText(/Relevant Patches/)
+      .closest('div');
+    const upgradablePackagesElement = screen
+      .getByText(/Upgradable Packages/)
+      .closest('div');
+
+    expect(relevantPatchesElement).toHaveTextContent(
+      'Relevant Patches Connection to SUMA not working'
+    );
+    expect(upgradablePackagesElement).toHaveTextContent(
+      'Upgradable Packages Connection to SUMA not working'
+    );
+
+    await user.hover(relevantPatchesElement);
+    expect(
+      screen.queryByText('Please review SUSE Manager settings')
+    ).toBeVisible();
+  });
+});

--- a/assets/js/state/sagas/softwareUpdates.js
+++ b/assets/js/state/sagas/softwareUpdates.js
@@ -35,6 +35,8 @@ export function* fetchSoftwareUpdates({ payload: hostID }) {
 
     if (errorCode === 422 && suma_unauthorized) {
       yield put(setSettingsNotConfigured());
+    } else {
+      yield put(setSettingsConfigured());
     }
 
     yield put(setSoftwareUpdatesErrors({ hostID, errors }));
@@ -59,7 +61,10 @@ export function* fetchUpgradablePackagesPatches({
 
     if (errorCode === 422 && suma_unauthorized) {
       yield put(setSettingsNotConfigured());
+    } else {
+      yield put(setSettingsConfigured());
     }
+
     yield put(setPatchesForPackages({ hostID, patches: [] }));
   }
 }

--- a/assets/js/state/sagas/softwareUpdates.test.js
+++ b/assets/js/state/sagas/softwareUpdates.test.js
@@ -107,6 +107,7 @@ describe('Software Updates saga', () => {
         expect(dispatched).toEqual([
           startLoadingSoftwareUpdates({ hostID }),
           setEmptySoftwareUpdates({ hostID }),
+          setSettingsConfigured(),
           setSoftwareUpdatesErrors({ hostID, errors: body.errors }),
         ]);
       }

--- a/assets/js/state/selectors/softwareUpdates.js
+++ b/assets/js/state/selectors/softwareUpdates.js
@@ -36,3 +36,8 @@ export const getSoftwareUpdatesLoading = createSelector(
   [(state, id) => getSoftwareUpdatesForHost(id)(state)],
   (softwareUpdates) => get(softwareUpdates, ['loading'], false)
 );
+
+export const getSoftwareUpdatesErrors = createSelector(
+  [(state, id) => getSoftwareUpdatesForHost(id)(state)],
+  (softwareUpdates) => get(softwareUpdates, ['errors'], [])
+);

--- a/assets/js/state/selectors/softwareUpdates.test.js
+++ b/assets/js/state/selectors/softwareUpdates.test.js
@@ -1,10 +1,12 @@
 import { faker } from '@faker-js/faker';
 import {
+  getSoftwareUpdatesSettingsConfigured,
   getSoftwareUpdates,
   getSoftwareUpdatesStats,
   getSoftwareUpdatesLoading,
   getSoftwareUpdatesPatches,
   getUpgradablePackages,
+  getSoftwareUpdatesErrors,
 } from './softwareUpdates';
 
 describe('Software Updates selector', () => {
@@ -96,14 +98,28 @@ describe('Software Updates selector', () => {
   };
   const state = {
     softwareUpdates: {
+      settingsConfigured: true,
       softwareUpdates,
     },
   };
 
   it('should return the software updates', () => {
-    expect(getSoftwareUpdates(state)).toEqual({
-      softwareUpdates,
-    });
+    expect(getSoftwareUpdates(state)).toEqual(state.softwareUpdates);
+  });
+
+  it('should return the software updates settings configured', () => {
+    expect(getSoftwareUpdatesSettingsConfigured(state)).toEqual(true);
+  });
+
+  it('should return the software updates settings not configured', () => {
+    expect(
+      getSoftwareUpdatesSettingsConfigured({
+        softwareUpdates: {
+          settingsConfigured: false,
+          softwareUpdates,
+        },
+      })
+    ).toEqual(false);
   });
 
   it('should return the correct software updates statistics', () => {
@@ -128,6 +144,30 @@ describe('Software Updates selector', () => {
       softwareUpdates: { softwareUpdates: { [hostID]: { loading: true } } },
     };
     expect(getSoftwareUpdatesLoading(newState, hostID)).toEqual(true);
+  });
+
+  it('should get errors', () => {
+    const errors = [
+      {
+        title: 'Internal Server Error',
+        detail: 'Something went wrong.',
+      },
+    ];
+
+    const softwareUpdatesWithError = {
+      ...softwareUpdates,
+      [hostID]: { ...softwareUpdates[hostID], errors },
+    };
+
+    expect(
+      getSoftwareUpdatesErrors(
+        {
+          ...state,
+          softwareUpdates: { softwareUpdates: softwareUpdatesWithError },
+        },
+        hostID
+      )
+    ).toEqual(errors);
   });
 
   it('should return the relevant patches', () => {


### PR DESCRIPTION
# Description

The `AvailableSoftwareUpdates` component requires refactoring to accommodate more fine-grained error reporting between Trento and SUSE Manager. This change will allow for the addition of further arbitrary error states in the future.

`AvailableSoftwareUpdates` can now report the following error states:
- _No SUSE Manager credentials configured_
- _SUSE Manager authentication error_
- _Host not found in SUSE Manager_

any other server error is assumed to be a _SUSE Manager connection error_.

## How was this tested?

**IN PROGRESS**

- [ ] **DONE**
