### PR TITLE
Remove unused prop in `<Table />` component

### DIFF
--- a/assets/js/common/Table/Table.jsx
+++ b/assets/js/common/Table/Table.jsx
@@ -62,7 +62,6 @@ function Table({
   searchParams,
   setSearchParams,
   emptyStateText = 'No data available',
-  withPadding = true,
   header = null,
   rowKey = defaultRowKey,
 }) {
@@ -160,7 +159,7 @@ function Table({
       <div className="">
         <div
           className={classNames('-mx-4 sm:-mx-8 px-4 sm:px-8', {
-            'pt-4': withPadding,
+            'pt-4': usePadding,
           })}
         >
           <div

--- a/assets/js/pages/ClusterDetails/HanaClusterSite.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterSite.jsx
@@ -84,7 +84,6 @@ function HanaClusterSite({ name, nodes, state = null, srHealthState = null }) {
         className="tn-site-table"
         config={siteDetailsConfig}
         data={nodes}
-        withPadding={false}
         header={
           <div className="flex space-x-2 p-4">
             {state && (

--- a/assets/js/pages/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/pages/ExecutionResults/ExecutionResults.jsx
@@ -209,7 +209,6 @@ function ExecutionResults({
             <Table
               config={resultsTableConfig}
               data={filterAndSortData(tableData, item)}
-              withPadding={false}
             />
           </Accordion>
         ))}


### PR DESCRIPTION
# Description

The `withPadding` property is completely overlapped by the `config.usePadding` property. We removed the first and used the latter when needed.