### PR TITLE
Handle unexpected successful api response

### DIFF
--- a/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
+++ b/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
@@ -14,7 +14,7 @@ function ActivityLogPage() {
   useEffect(() => {
     getActivityLog()
       .then((response) => {
-        setActivityLog(response.data);
+        setActivityLog(response.data?.data ?? []);
       })
       .catch(() => setActivityLog([]))
       .finally(() => {

--- a/assets/js/pages/ActivityLogPage/ActivityLogPage.test.jsx
+++ b/assets/js/pages/ActivityLogPage/ActivityLogPage.test.jsx
@@ -14,19 +14,26 @@ const axiosMock = new MockAdapter(networkClient);
 
 describe('ActivityLogPage', () => {
   it('should render table without data', async () => {
-    axiosMock.onGet('/api/v1/activity_log').reply(200, []);
+    axiosMock.onGet('/api/v1/activity_log').reply(200, { data: [] });
     await act(async () => renderWithRouter(<ActivityLogPage />));
     expect(screen.getByText('No data available')).toBeVisible();
   });
 
   it.each`
     responseStatus | responseBody
+    ${200}         | ${{ dataz: [] }}
+    ${200}         | ${[]}
+    ${200}         | ${{}}
+    ${200}         | ${{ foo: [] }}
+    ${200}         | ${''}
+    ${200}         | ${null}
     ${404}         | ${[]}
+    ${404}         | ${{ data: [] }}
     ${500}         | ${{ error: 'Internal Server Error' }}
     ${503}         | ${null}
     ${504}         | ${''}
   `(
-    'should render empty activity log on error `$responseStatus`',
+    'should render empty activity log on responseStatus: `$responseStatus` and responseBody: `$responseBody`',
     async ({ responseStatus, responseBody }) => {
       axiosMock
         .onGet('/api/v1/activity_log')
@@ -41,7 +48,7 @@ describe('ActivityLogPage', () => {
   it('should render tracked activity log', async () => {
     axiosMock
       .onGet('/api/v1/activity_log')
-      .reply(200, activityLogEntryFactory.buildList(5));
+      .reply(200, { data: activityLogEntryFactory.buildList(5) });
 
     const { container } = await act(() =>
       renderWithRouter(<ActivityLogPage />)


### PR DESCRIPTION
# Description

Recent changes to the shape of the activity log api response broke the frontend.
This PR makes the client more reliable on unexpected successful response shapes from the api.

## How was this tested?
Automated tests
