### PR TITLE
Default to activity type as a message for unrecognized activities

### DIFF
--- a/assets/js/common/ActivityLogDetailsModal/ActivityLogDetailModal.test.jsx
+++ b/assets/js/common/ActivityLogDetailsModal/ActivityLogDetailModal.test.jsx
@@ -3,6 +3,7 @@ import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
+import { faker } from '@faker-js/faker';
 import {
   activityLogEntryFactory,
   taggingMetadataFactory,
@@ -176,14 +177,19 @@ describe('ActivityLogDetailModal component', () => {
   );
 
   it('should render detail for unknown activity type', async () => {
-    const entry = activityLogEntryFactory.build({ type: 'foo_bar' });
+    const unknownActivityType = faker.lorem.word();
+    const entry = activityLogEntryFactory.build({ type: unknownActivityType });
     await act(async () => {
       render(<ActivityLogDetailModal open entry={toRenderedEntry(entry)} />);
     });
 
-    expect(screen.getByText('foo_bar')).toBeVisible();
+    const activityReferences = screen.getAllByText(unknownActivityType);
+    expect(activityReferences).toHaveLength(2);
+    activityReferences.forEach((activityReference) => {
+      expect(activityReference).toBeVisible();
+    });
+
     expect(screen.getByText('Unrecognized resource')).toBeVisible();
-    expect(screen.getByText('Unrecognized activity')).toBeVisible();
   });
 
   it('should call onClose when the close button is clicked', async () => {

--- a/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
+++ b/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
@@ -62,7 +62,7 @@ const toMessage = (activityLogEntry) => {
     case CLUSTER_CHECKS_EXECUTION_REQUEST:
       return 'Checks execution requested for cluster';
     default:
-      return 'Unrecognized activity';
+      return type;
   }
 };
 

--- a/assets/js/common/ActivityLogOverview/ActivityLogOverview.test.jsx
+++ b/assets/js/common/ActivityLogOverview/ActivityLogOverview.test.jsx
@@ -171,6 +171,15 @@ describe('Activity Log Overview', () => {
       expectedUser: 'user-8',
       expectedMessage: 'Checks execution requested for cluster',
     },
+    {
+      name: 'unknown activity type',
+      entry: activityLogEntryFactory.build({
+        actor: 'user-9',
+        type: 'foo_bar',
+      }),
+      expectedUser: 'user-9',
+      expectedMessage: 'foo_bar',
+    },
   ];
 
   it.each(scenarios)(


### PR DESCRIPTION
# Description

With this PR the frontend uses the activity type as the message for an activity which is not yet mapped to be nicely shown in the UI.

In this way we avoid a perhaps too generic `Unrecognized activity` as message, and we show `the_new_unmapped_activity_log_type`, which provides at least some value.

## How was this tested?
Automated test.
