### PR TITLE
Add `<ComposedFilter />` component

### DIFF
--- a/assets/js/common/ComposedFilter/ComposedFilter.jsx
+++ b/assets/js/common/ComposedFilter/ComposedFilter.jsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import Button from '@common/Button';
+import Filter from '@common/Filter';
+
+const renderFilter = ({ type, ...filterProps }, value, onChange) =>
+  type === 'select' ? (
+    <Filter {...filterProps} value={value} onChange={onChange} />
+  ) : null;
+
+/**
+ * Define a filter which is the composition of several filters.
+ * Filters are specified through a list of objects, each containing the filter properties.
+ * The value of the composed filter is an object with the filter key as key and the selected value as value.
+ *
+ * @param {Array} props.filters - List of filters to be composed. Filters are displayed in order.
+ * @param {Object} props.value - Key/value pairs of selected filters, where key is the filter key
+ * @param {Function} props.onChange - Function to call when the composed value changes. If autoApply is true, this function is called on every filter change
+ * @param {Boolean} props.autoApply - If true, onChange is called on every filter change; otherwise, an apply button is shown
+ */
+function ComposedFilter({
+  filters = [],
+  onChange,
+  value: initialValue = {},
+  autoApply,
+}) {
+  const [value, setValue] = useState(initialValue);
+  const [isChanged, setIsChanged] = useState(false);
+  const onFilterChange = (key) => (filterValue) => {
+    const newValue = { ...value, [key]: filterValue };
+    setValue(newValue);
+    if (autoApply) {
+      onChange(newValue);
+    } else {
+      setIsChanged(true);
+    }
+  };
+
+  return (
+    <>
+      {filters
+        .map(({ key, ...rest }) => [rest, value[key], onFilterChange(key)])
+        .map((args) => renderFilter(...args))}
+      {!autoApply && (
+        <div className="flex flex-row w-80 space-x-2">
+          <Button
+            disabled={!isChanged}
+            onClick={() => {
+              setIsChanged(false);
+              onChange(value);
+            }}
+          >
+            Apply
+          </Button>
+          <Button
+            type="primary-white"
+            onClick={() => {
+              setValue({});
+              setIsChanged(false);
+              onChange({});
+            }}
+          >
+            Reset
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}
+
+export default ComposedFilter;

--- a/assets/js/common/ComposedFilter/ComposedFilter.stories.jsx
+++ b/assets/js/common/ComposedFilter/ComposedFilter.stories.jsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import { action } from '@storybook/addon-actions';
+
+import ComposedFilter from '.';
+
+export default {
+  title: 'Components/ComposedFilter',
+  component: ComposedFilter,
+  argTypes: {
+    options: {
+      type: { name: 'array', required: true, defaultValue: [] },
+      description:
+        'Describe the list of filters to be composed. Filters are displayed in order.',
+      control: { type: 'object' },
+    },
+    value: {
+      type: { name: 'object', required: false, defaultValue: {} },
+      description:
+        'Key/value pairs of selected filters, where key is the filter id',
+      control: { type: 'object' },
+    },
+    onChange: {
+      type: { name: 'function', required: false },
+      description:
+        'Function to call when the composed value changes. If autoApply is true, this function is called on every filter change',
+      control: { type: null },
+    },
+    autoApply: {
+      type: { name: 'boolean', required: false, defaultValue: false },
+      description:
+        'If true, onChange is called on every filter change; otherwise, an apply button is shown',
+      control: { type: 'boolean' },
+    },
+  },
+  render: ({ filters, value, onChange, autoApply }) => {
+    const [v, setValue] = useState(value);
+
+    return (
+      <ComposedFilter
+        filters={filters}
+        value={v}
+        onChange={(newValue) => {
+          setValue(newValue);
+          onChange(newValue);
+        }}
+        autoApply={autoApply}
+      />
+    );
+  },
+};
+
+export const Default = {
+  args: {
+    filters: [
+      {
+        key: 'filter1',
+        type: 'select',
+        title: 'Pasta',
+        options: ['Carbonara', 'Amatriciana', 'Ajo & Ojo', 'Gricia'],
+      },
+      {
+        key: 'filter2',
+        type: 'select',
+        title: 'Pizza',
+        options: ['Margherita', 'Marinara', 'Diavola', 'Capricciosa'],
+      },
+    ],
+    onChange: action('onChange'),
+  },
+};

--- a/assets/js/common/ComposedFilter/ComposedFilter.test.jsx
+++ b/assets/js/common/ComposedFilter/ComposedFilter.test.jsx
@@ -1,0 +1,156 @@
+import React, { act } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import ComposedFilter from '.';
+
+describe('ComposedFilter component', () => {
+  it('should render the specified filters', async () => {
+    const filters = [
+      {
+        key: 'filter1',
+        type: 'select',
+        title: 'Pasta',
+        options: ['Carbonara', 'Amatriciana', 'Ajo & Ojo', 'Gricia'],
+      },
+      {
+        key: 'filter2',
+        type: 'select',
+        title: 'Pizza',
+        options: ['Margherita', 'Marinara', 'Diavola', 'Bufalina'],
+      },
+    ];
+
+    render(<ComposedFilter filters={filters} />);
+
+    expect(screen.getByText('Filter Pasta...')).toBeInTheDocument();
+    expect(screen.getByText('Filter Pizza...')).toBeInTheDocument();
+  });
+
+  it('should call onChange once for each selection when a filter is changed and it is applied automatically', async () => {
+    const mockOnChange = jest.fn();
+    const filters = [
+      {
+        key: 'filter1',
+        type: 'select',
+        title: 'Pasta',
+        options: ['Carbonara', 'Amatriciana', 'Ajo & Ojo', 'Gricia'],
+      },
+      {
+        key: 'filter2',
+        type: 'select',
+        title: 'Pizza',
+        options: ['Margherita', 'Marinara', 'Diavola', 'Bufalina'],
+      },
+    ];
+
+    render(
+      <ComposedFilter filters={filters} onChange={mockOnChange} autoApply />
+    );
+
+    // select Carbonara and Gricia from pasta filter
+    await act(() => userEvent.click(screen.getByText('Filter Pasta...')));
+    await act(() => userEvent.click(screen.getByText('Carbonara')));
+    await act(() => userEvent.click(screen.getByText('Gricia')));
+    await act(() => userEvent.click(screen.getByText('Carbonara, Gricia')));
+
+    // select Diavola from pizza filter
+    await act(() => userEvent.click(screen.getByText('Filter Pizza...')));
+    await act(() => userEvent.click(screen.getByText('Diavola')));
+    await act(() => userEvent.click(screen.getAllByText('Diavola')[0]));
+
+    expect(mockOnChange).toHaveBeenCalledTimes(3);
+    expect(mockOnChange).toHaveBeenNthCalledWith(1, { filter1: ['Carbonara'] });
+    expect(mockOnChange).toHaveBeenNthCalledWith(2, {
+      filter1: ['Carbonara', 'Gricia'],
+    });
+    expect(mockOnChange).toHaveBeenNthCalledWith(3, {
+      filter1: ['Carbonara', 'Gricia'],
+      filter2: ['Diavola'],
+    });
+  });
+
+  it('should call onChange when a filter is changed and it is applied automatically', async () => {
+    const mockOnChange = jest.fn();
+    const filters = [
+      {
+        key: 'filter1',
+        type: 'select',
+        title: 'Pasta',
+        options: ['Carbonara', 'Amatriciana', 'Ajo & Ojo', 'Gricia'],
+      },
+      {
+        key: 'filter2',
+        type: 'select',
+        title: 'Pizza',
+        options: ['Margherita', 'Marinara', 'Diavola', 'Bufalina'],
+      },
+    ];
+
+    render(<ComposedFilter filters={filters} onChange={mockOnChange} />);
+
+    // select Carbonara and Gricia from pasta filter
+    await act(() => userEvent.click(screen.getByText('Filter Pasta...')));
+    await act(() => userEvent.click(screen.getByText('Carbonara')));
+    await act(() => userEvent.click(screen.getByText('Gricia')));
+    await act(() => userEvent.click(screen.getByText('Carbonara, Gricia')));
+
+    // select Diavola from pizza filter
+    await act(() => userEvent.click(screen.getByText('Filter Pizza...')));
+    await act(() => userEvent.click(screen.getByText('Diavola')));
+    await act(() => userEvent.click(screen.getAllByText('Diavola')[0]));
+
+    // not applied yet
+    expect(mockOnChange).not.toHaveBeenCalled();
+
+    // apply
+    await act(() => userEvent.click(screen.getByText('Apply')));
+
+    // after apply
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    expect(mockOnChange).toHaveBeenCalledWith({
+      filter1: ['Carbonara', 'Gricia'],
+      filter2: ['Diavola'],
+    });
+  });
+
+  it('should call reset filters', async () => {
+    const mockOnChange = jest.fn();
+    const filters = [
+      {
+        key: 'filter1',
+        type: 'select',
+        title: 'Pasta',
+        options: ['Carbonara', 'Amatriciana', 'Ajo & Ojo', 'Gricia'],
+      },
+      {
+        key: 'filter2',
+        type: 'select',
+        title: 'Pizza',
+        options: ['Margherita', 'Marinara', 'Diavola', 'Bufalina'],
+      },
+    ];
+
+    render(<ComposedFilter filters={filters} onChange={mockOnChange} />);
+
+    // select Carbonara and Gricia from pasta filter
+    await act(() => userEvent.click(screen.getByText('Filter Pasta...')));
+    await act(() => userEvent.click(screen.getByText('Carbonara')));
+    await act(() => userEvent.click(screen.getByText('Gricia')));
+    await act(() => userEvent.click(screen.getByText('Carbonara, Gricia')));
+
+    // select Diavola from pizza filter
+    await act(() => userEvent.click(screen.getByText('Filter Pizza...')));
+    await act(() => userEvent.click(screen.getByText('Diavola')));
+    await act(() => userEvent.click(screen.getAllByText('Diavola')[0]));
+
+    await act(() => userEvent.click(screen.getByText('Reset')));
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    expect(mockOnChange).toHaveBeenCalledWith({});
+
+    // filters are reset
+    expect(screen.getByText('Filter Pasta...')).toBeInTheDocument();
+    expect(screen.getByText('Filter Pizza...')).toBeInTheDocument();
+  });
+});

--- a/assets/js/common/ComposedFilter/index.js
+++ b/assets/js/common/ComposedFilter/index.js
@@ -1,0 +1,3 @@
+import ComposedFilter from './ComposedFilter';
+
+export default ComposedFilter;

--- a/assets/js/common/Table/Table.jsx
+++ b/assets/js/common/Table/Table.jsx
@@ -1,13 +1,9 @@
 /* eslint-disable react/no-array-index-key */
 
-import React, { Fragment, useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import classNames from 'classnames';
 import { page, pages } from '@lib/lists';
-import {
-  getDefaultFilterFunction,
-  createFilter,
-  TableFilters,
-} from './filters';
+import { TableFilters, createFilter } from './filters';
 import { defaultRowKey } from './defaultRowKey';
 import SortingIcon from './SortingIcon';
 import EmptyState from './EmptyState';
@@ -54,6 +50,14 @@ const updateSearchParams = (searchParams, values) => {
 
   return searchParams;
 };
+
+const getDefaultFilterFunction = (filter, key) => (element) =>
+  filter.includes(element[key]);
+
+const getFilterFunction = (column, value) =>
+  typeof column.filter === 'function'
+    ? column.filter(value, column.key)
+    : getDefaultFilterFunction(value, column.key);
 
 function Table({
   config,
@@ -107,10 +111,7 @@ function Table({
 
       if (paramsFilterValue.length === 0) return [...acc];
 
-      const filterFunction =
-        typeof curr.filter === 'function'
-          ? curr.filter(paramsFilterValue, curr.key)
-          : getDefaultFilterFunction(paramsFilterValue, curr.key);
+      const filterFunction = getFilterFunction(curr, paramsFilterValue);
 
       return [
         ...acc,
@@ -124,10 +125,14 @@ function Table({
   }, [searchParams]);
 
   const filteredData = filters
-    .map(({ value, filterFunction }) => {
+    .map(({ key, value }) => {
       if (value.length === 0) {
         return () => true;
       }
+
+      const column = config.columns.find((c) => c.key === key);
+
+      const filterFunction = getFilterFunction(column, value);
 
       return filterFunction;
     })


### PR DESCRIPTION
# Description

`<ComposedFilter />` generalized the usage of multiple filters on a dataset. It provides a common interface when integrating different kinds of filters.

# Usage
Filters are described using a collection of structs with the following fields:
* `key`: uniquely references the filter
* `type`: the type of filter to render
* `...props`: all other attributes will be considered as properties of the component to render.

As for now, only `type=select` is supported and renders a `<Filter />` component as described in https://github.com/trento-project/web/pull/2823.
The idea is to increase the kind of accepted filter types so that we can support more scenarios.

The `autoApply` flag indicates how selection changes are propagated:
* `true`: every time a single filter changes, the whole composed filter triggers the `onChange` function.
* `false` No changes are propagated until the user clicks on the `[Apply]` button.

When `autoApply=false` the `[Apply]` and `[Reset]` buttons are rendered.

# Test
Unit tests and storybook. No behavior change has been introduced.

---

`<ComposedFilter />`  is also integrated into the `<Table />` component.



