### PR TITLE
Address flakiness in Activity Log tests

### DIFF
--- a/test/trento/activity_log_test.exs
+++ b/test/trento/activity_log_test.exs
@@ -213,7 +213,7 @@ defmodule Trento.ActivityLogTest do
       assert length(logs) == 25
       # default order is by inserted_at timestamp
       all_logs_sorted =
-        all_logs |> Enum.sort_by(fn entry -> entry.inserted_at end, :desc) |> Enum.take(25)
+        all_logs |> Enum.sort_by(& &1.inserted_at, {:desc, DateTime}) |> Enum.take(25)
 
       assert logs == all_logs_sorted
     end
@@ -228,7 +228,7 @@ defmodule Trento.ActivityLogTest do
 
       all_logs_sorted =
         all_logs
-        |> Enum.sort_by(fn entry -> entry.inserted_at end, :desc)
+        |> Enum.sort_by(& &1.inserted_at, {:desc, DateTime})
         |> Enum.drop(95)
 
       assert length(all_logs_sorted) == length(logs)
@@ -245,7 +245,7 @@ defmodule Trento.ActivityLogTest do
 
       all_logs_sorted =
         all_logs
-        |> Enum.sort_by(fn entry -> entry.inserted_at end, :desc)
+        |> Enum.sort_by(& &1.inserted_at, {:desc, DateTime})
         |> Enum.take(5)
 
       assert length(all_logs_sorted) == length(logs)
@@ -265,7 +265,7 @@ defmodule Trento.ActivityLogTest do
 
       next_logs_alt =
         all_logs
-        |> Enum.sort_by(fn entry -> entry.inserted_at end, :desc)
+        |> Enum.sort_by(& &1.inserted_at, {:desc, DateTime})
         |> Enum.drop(25)
         |> Enum.take(25)
 
@@ -287,7 +287,7 @@ defmodule Trento.ActivityLogTest do
 
       next_logs_alt =
         all_logs
-        |> Enum.sort_by(fn entry -> entry.inserted_at end, :desc)
+        |> Enum.sort_by(& &1.inserted_at, {:desc, DateTime})
         |> Enum.drop(20)
         |> Enum.take(5)
 


### PR DESCRIPTION
I experienced some flakiness in some of our [activity log tests](https://github.com/trento-project/web/blob/0472d2817eb084086263cf8eb80a965291d5aa23/test/trento/activity_log_test.exs#L221) we've recently introduced. 

It seems there is some inconsistency in how we slice data in pages. For example [here](https://github.com/trento-project/web/actions/runs/10148044580/job/28059912934#step:8:1319) the test fails because it was expecting two identical lists of entries in `next_logs_alt` and `next_logs`, but they where different. By re-running the job, the error disappeared.

The problem may be in how we sort entries by date. As per the [Elixir docs](https://github.com/elixir-lang/elixir/blob/b799e9eda4613a1bc40fd0824fb08d5df3b3e24b/lib/elixir/lib/enum.ex#L3272):
> [...] avoid using the default sorting function to sort
  structs, as by default it performs structural comparison instead of
  a semantic one. In such cases, you shall pass a sorting function as
  third element or any module that implements a `compare/2` function.
  For example, to sort users by their birthday in both ascending and
  descending order respectively:
>
>      iex> users = [
>      ...>   %{name: "Ellis", birthday: ~D[1943-05-11]},
>      ...>   %{name: "Lovelace", birthday: ~D[1815-12-10]},
>      ...>   %{name: "Turing", birthday: ~D[1912-06-23]}
>      ...> ]
>      iex> Enum.sort_by(users, &(&1.birthday), Date)


The fix improves how we sort data. We should keep an eye on the overall test, to see if it's enough do remove the flakiness.





