### PR TITLE
Domain events activity frontend

### DIFF
--- a/assets/js/common/ActivityLogDetailsModal/ActivityLogDetailModal.jsx
+++ b/assets/js/common/ActivityLogDetailsModal/ActivityLogDetailModal.jsx
@@ -7,43 +7,8 @@ import Button from '@common/Button';
 import Modal from '@common/Modal';
 import ListView from '@common/ListView';
 
-import {
-  API_KEY_GENERATION,
-  CHANGING_SUMA_SETTINGS,
-  CLEARING_SUMA_SETTINGS,
-  CLUSTER_CHECKS_EXECUTION_REQUEST,
-  LOGIN_ATTEMPT,
-  PROFILE_UPDATE,
-  RESOURCE_TAGGING,
-  RESOURCE_UNTAGGING,
-  SAVING_SUMA_SETTINGS,
-  USER_CREATION,
-  USER_DELETION,
-  USER_MODIFICATION,
-} from '@lib/model/activityLog';
+import { toResource, toLabel } from '@lib/model/activityLog';
 import classNames from 'classnames';
-
-const activityTypesLabels = {
-  [LOGIN_ATTEMPT]: 'Login Attempt',
-  [RESOURCE_TAGGING]: 'Tag Added',
-  [RESOURCE_UNTAGGING]: 'Tag Removed',
-  [API_KEY_GENERATION]: 'API Key Generated',
-  [SAVING_SUMA_SETTINGS]: 'SUMA Settings Saved',
-  [CHANGING_SUMA_SETTINGS]: 'SUMA Settings Changed',
-  [CLEARING_SUMA_SETTINGS]: 'SUMA Settings Cleared',
-  [USER_CREATION]: 'User Created',
-  [USER_MODIFICATION]: 'User Modified',
-  [USER_DELETION]: 'User Deleted',
-  [PROFILE_UPDATE]: 'Profile Updated',
-  [CLUSTER_CHECKS_EXECUTION_REQUEST]: 'Checks Execution Requested',
-};
-
-const resourceTypesLabels = {
-  host: 'Host',
-  cluster: 'Cluster',
-  database: 'Database',
-  sap_system: 'SAP System',
-};
 
 const keys = ['id', 'type', 'resource', 'user', 'message', 'time', 'metadata'];
 
@@ -57,43 +22,13 @@ const keyToLabel = {
   metadata: 'Data',
 };
 
-const toResource = (activityLogEntry) => {
-  const { metadata, type } = activityLogEntry;
-  switch (type) {
-    case LOGIN_ATTEMPT:
-      return 'Application';
-    case RESOURCE_TAGGING:
-    case RESOURCE_UNTAGGING:
-      return (
-        resourceTypesLabels[metadata.resource_type] ??
-        'Unable to determine resource type'
-      );
-    case USER_CREATION:
-    case USER_MODIFICATION:
-    case USER_DELETION:
-      return 'User';
-    case PROFILE_UPDATE:
-      return 'Profile';
-    case SAVING_SUMA_SETTINGS:
-    case CHANGING_SUMA_SETTINGS:
-    case CLEARING_SUMA_SETTINGS:
-      return 'SUMA Settings';
-    case API_KEY_GENERATION:
-      return 'API Key';
-    case CLUSTER_CHECKS_EXECUTION_REQUEST:
-      return 'Cluster Checks';
-    default:
-      return 'Unrecognized resource';
-  }
-};
-
 const renderMetadata = (metadata) => (
   <ReactMarkdown className="markdown text-sm" remarkPlugins={[remarkGfm]}>
     {`\`\`\`json\n${JSON.stringify(metadata, null, 2)}\n\`\`\``}
   </ReactMarkdown>
 );
 
-const renderType = (type) => activityTypesLabels[type] ?? type;
+const renderType = (type) => toLabel({ type });
 
 const renderResource = (entry) => (
   <span aria-label="activity-log-resource">{toResource(entry)}</span>

--- a/assets/js/common/ActivityLogDetailsModal/ActivityLogDetailModal.test.jsx
+++ b/assets/js/common/ActivityLogDetailsModal/ActivityLogDetailModal.test.jsx
@@ -4,140 +4,24 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
 import { faker } from '@faker-js/faker';
-import {
-  activityLogEntryFactory,
-  taggingMetadataFactory,
-  untaggingMetadataFactory,
-} from '@lib/test-utils/factories/activityLog';
+import { activityLogEntryFactory } from '@lib/test-utils/factories/activityLog';
 
-import {
-  LOGIN_ATTEMPT,
-  RESOURCE_TAGGING,
-  RESOURCE_UNTAGGING,
-  API_KEY_GENERATION,
-  CHANGING_SUMA_SETTINGS,
-  CLEARING_SUMA_SETTINGS,
-  SAVING_SUMA_SETTINGS,
-  CLUSTER_CHECKS_EXECUTION_REQUEST,
-  PROFILE_UPDATE,
-  USER_CREATION,
-  USER_DELETION,
-  USER_MODIFICATION,
-  LEVEL_WARNING,
-} from '@lib/model/activityLog';
+import { ACTIVITY_TYPES, toLabel, toResource } from '@lib/model/activityLog';
 import { toRenderedEntry } from '@common/ActivityLogOverview/ActivityLogOverview';
 import ActivityLogDetailModal from '.';
 
 describe('ActivityLogDetailModal component', () => {
-  const scenarios = [
-    {
-      name: LOGIN_ATTEMPT,
-      entry: activityLogEntryFactory.build({
-        type: LOGIN_ATTEMPT,
-        metadata: {},
-      }),
-      expectedActivityType: 'Login Attempt',
-      expectedResource: 'Application',
-    },
-    {
-      name: RESOURCE_TAGGING,
-      entry: activityLogEntryFactory.build({
-        type: RESOURCE_TAGGING,
-        metadata: taggingMetadataFactory.build({
-          resource_type: 'host',
-        }),
-      }),
-      expectedActivityType: 'Tag Added',
-      expectedResource: 'Host',
-    },
-    {
-      name: RESOURCE_UNTAGGING,
-      entry: activityLogEntryFactory.build({
-        type: RESOURCE_UNTAGGING,
-        level: LEVEL_WARNING,
-        metadata: untaggingMetadataFactory.build({
-          resource_type: 'cluster',
-        }),
-      }),
-      expectedActivityType: 'Tag Removed',
-      expectedResource: 'Cluster',
-    },
-    {
-      name: API_KEY_GENERATION,
-      entry: activityLogEntryFactory.build({
-        type: API_KEY_GENERATION,
-      }),
-      expectedActivityType: 'API Key Generated',
-      expectedResource: 'API Key',
-    },
-    {
-      name: SAVING_SUMA_SETTINGS,
-      entry: activityLogEntryFactory.build({
-        type: SAVING_SUMA_SETTINGS,
-      }),
-      expectedActivityType: 'SUMA Settings Saved',
-      expectedResource: 'SUMA Settings',
-    },
-    {
-      name: CHANGING_SUMA_SETTINGS,
-      entry: activityLogEntryFactory.build({
-        type: CHANGING_SUMA_SETTINGS,
-      }),
-      expectedActivityType: 'SUMA Settings Changed',
-      expectedResource: 'SUMA Settings',
-    },
-    {
-      name: CLEARING_SUMA_SETTINGS,
-      entry: activityLogEntryFactory.build({
-        type: CLEARING_SUMA_SETTINGS,
-      }),
-      expectedActivityType: 'SUMA Settings Cleared',
-      expectedResource: 'SUMA Settings',
-    },
-    {
-      name: USER_CREATION,
-      entry: activityLogEntryFactory.build({
-        type: USER_CREATION,
-      }),
-      expectedActivityType: 'User Created',
-      expectedResource: 'User',
-      userRelatedActivity: true,
-    },
-    {
-      name: USER_MODIFICATION,
-      entry: activityLogEntryFactory.build({
-        type: USER_MODIFICATION,
-      }),
-      expectedActivityType: 'User Modified',
-      expectedResource: 'User',
-      userRelatedActivity: true,
-    },
-    {
-      name: USER_DELETION,
-      entry: activityLogEntryFactory.build({
-        type: USER_DELETION,
-      }),
-      expectedActivityType: 'User Deleted',
-      expectedResource: 'User',
-      userRelatedActivity: true,
-    },
-    {
-      name: PROFILE_UPDATE,
-      entry: activityLogEntryFactory.build({
-        type: PROFILE_UPDATE,
-      }),
-      expectedActivityType: 'Profile Updated',
-      expectedResource: 'Profile',
-    },
-    {
-      name: CLUSTER_CHECKS_EXECUTION_REQUEST,
-      entry: activityLogEntryFactory.build({
-        type: CLUSTER_CHECKS_EXECUTION_REQUEST,
-      }),
-      expectedActivityType: 'Checks Execution Requested',
-      expectedResource: 'Cluster',
-    },
-  ];
+  const scenarios = ACTIVITY_TYPES.map((activityType) => {
+    const entry = activityLogEntryFactory.build({
+      type: activityType,
+    });
+    return {
+      name: activityType,
+      entry,
+      expectedActivityType: toLabel(entry),
+      expectedResource: toResource(entry),
+    };
+  });
 
   it.each(scenarios)(
     'should render detail for activity entry `$name`',

--- a/assets/js/common/ActivityLogDetailsModal/ActivityLogDetailModal.test.jsx
+++ b/assets/js/common/ActivityLogDetailsModal/ActivityLogDetailModal.test.jsx
@@ -135,7 +135,7 @@ describe('ActivityLogDetailModal component', () => {
         type: CLUSTER_CHECKS_EXECUTION_REQUEST,
       }),
       expectedActivityType: 'Checks Execution Requested',
-      expectedResource: 'Cluster Checks',
+      expectedResource: 'Cluster',
     },
   ];
 

--- a/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
+++ b/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
@@ -11,60 +11,16 @@ import Table from '@common/Table';
 import Tooltip from '@common/Tooltip';
 
 import {
-  API_KEY_GENERATION,
-  CHANGING_SUMA_SETTINGS,
-  CLEARING_SUMA_SETTINGS,
-  CLUSTER_CHECKS_EXECUTION_REQUEST,
-  LOGIN_ATTEMPT,
-  PROFILE_UPDATE,
-  RESOURCE_TAGGING,
-  RESOURCE_UNTAGGING,
-  SAVING_SUMA_SETTINGS,
-  USER_CREATION,
-  USER_DELETION,
-  USER_MODIFICATION,
   ACTIVITY_LOG_LEVELS,
   LEVEL_DEBUG,
   LEVEL_ERROR,
   LEVEL_INFO,
   LEVEL_WARNING,
+  toMessage,
 } from '@lib/model/activityLog';
 
 import ActivityLogDetailModal from '@common/ActivityLogDetailsModal';
 import { format } from 'date-fns';
-
-const toMessage = (activityLogEntry) => {
-  const { metadata, type } = activityLogEntry;
-
-  switch (type) {
-    case LOGIN_ATTEMPT:
-      return metadata?.reason ? 'Login failed' : 'User logged in';
-    case RESOURCE_TAGGING:
-      return `Tag "${metadata.added_tag}" added to "${metadata.resource_id}"`;
-    case RESOURCE_UNTAGGING:
-      return `Tag "${metadata.removed_tag}" removed from "${metadata.resource_id}"`;
-    case USER_CREATION:
-      return 'User was created';
-    case USER_MODIFICATION:
-      return 'User was modified';
-    case USER_DELETION:
-      return 'User was deleted';
-    case PROFILE_UPDATE:
-      return 'User modified profile';
-    case SAVING_SUMA_SETTINGS:
-      return 'SUMA Settings was saved';
-    case CHANGING_SUMA_SETTINGS:
-      return 'SUMA Settings was changed';
-    case CLEARING_SUMA_SETTINGS:
-      return 'SUMA Settings was cleared';
-    case API_KEY_GENERATION:
-      return 'API Key was generated';
-    case CLUSTER_CHECKS_EXECUTION_REQUEST:
-      return 'Checks execution requested for cluster';
-    default:
-      return type;
-  }
-};
 
 const logLevelToIcon = {
   [LEVEL_DEBUG]: <EOS_BUG_REPORT_OUTLINED className="w-full" />,

--- a/assets/js/common/ActivityLogOverview/ActivityLogOverview.test.jsx
+++ b/assets/js/common/ActivityLogOverview/ActivityLogOverview.test.jsx
@@ -3,29 +3,8 @@ import { faker } from '@faker-js/faker';
 
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {
-  activityLogEntryFactory,
-  taggingMetadataFactory,
-  untaggingMetadataFactory,
-} from '@lib/test-utils/factories/activityLog';
-import {
-  LOGIN_ATTEMPT,
-  RESOURCE_TAGGING,
-  RESOURCE_UNTAGGING,
-  API_KEY_GENERATION,
-  CHANGING_SUMA_SETTINGS,
-  CLEARING_SUMA_SETTINGS,
-  SAVING_SUMA_SETTINGS,
-  CLUSTER_CHECKS_EXECUTION_REQUEST,
-  PROFILE_UPDATE,
-  USER_CREATION,
-  USER_DELETION,
-  USER_MODIFICATION,
-  LEVEL_DEBUG,
-  LEVEL_ERROR,
-  LEVEL_INFO,
-  LEVEL_WARNING,
-} from '@lib/model/activityLog';
+import { activityLogEntryFactory } from '@lib/test-utils/factories/activityLog';
+import { ACTIVITY_TYPES, toMessage } from '@lib/model/activityLog';
 import '@testing-library/jest-dom';
 
 import ActivityLogOverview from '.';
@@ -43,144 +22,27 @@ describe('Activity Log Overview', () => {
     expect(screen.getByText('Loading...')).toBeVisible();
   });
 
-  const scenarios = [
-    {
-      name: LOGIN_ATTEMPT,
-      entry: activityLogEntryFactory.build({
-        actor: 'admin',
-        type: LOGIN_ATTEMPT,
-        level: LEVEL_DEBUG,
-        metadata: {},
-      }),
-      expectedUser: 'admin',
-      expectedMessage: 'User logged in',
-      expectedLevel: 'debug',
-    },
-    {
-      name: RESOURCE_TAGGING,
-      entry: activityLogEntryFactory.build({
-        actor: 'foo',
-        type: RESOURCE_TAGGING,
-        level: LEVEL_INFO,
-        metadata: taggingMetadataFactory.build({
-          resource_type: 'host',
-          added_tag: 'bar',
-          resource_id: 'foo-bar',
-        }),
-      }),
-      expectedUser: 'foo',
-      expectedMessage: 'Tag "bar" added to "foo-bar"',
-      expectedLevel: 'info',
-    },
-    {
-      name: RESOURCE_UNTAGGING,
-      entry: activityLogEntryFactory.build({
-        actor: 'bar',
-        type: RESOURCE_UNTAGGING,
-        level: LEVEL_WARNING,
-        metadata: untaggingMetadataFactory.build({
-          resource_type: 'cluster',
-          removed_tag: 'foo',
-          resource_id: 'bar-foo',
-        }),
-      }),
-      expectedUser: 'bar',
-      expectedMessage: 'Tag "foo" removed from "bar-foo"',
-      expectedLevel: 'warning',
-    },
-    {
-      name: API_KEY_GENERATION,
-      entry: activityLogEntryFactory.build({
-        actor: 'baz',
-        type: API_KEY_GENERATION,
-        level: LEVEL_ERROR,
-      }),
-      expectedUser: 'baz',
-      expectedMessage: 'API Key was generated',
-      expectedLevel: 'error',
-    },
-    {
-      name: SAVING_SUMA_SETTINGS,
-      entry: activityLogEntryFactory.build({
-        actor: 'user-1',
-        type: SAVING_SUMA_SETTINGS,
-      }),
-      expectedUser: 'user-1',
-      expectedMessage: 'SUMA Settings was saved',
-    },
-    {
-      name: CHANGING_SUMA_SETTINGS,
-      entry: activityLogEntryFactory.build({
-        actor: 'user-2',
-        type: CHANGING_SUMA_SETTINGS,
-      }),
-      expectedUser: 'user-2',
-      expectedMessage: 'SUMA Settings was changed',
-    },
-    {
-      name: CLEARING_SUMA_SETTINGS,
-      entry: activityLogEntryFactory.build({
-        actor: 'user-3',
-        type: CLEARING_SUMA_SETTINGS,
-      }),
-      expectedUser: 'user-3',
-      expectedMessage: 'SUMA Settings was cleared',
-    },
-    {
-      name: USER_CREATION,
-      entry: activityLogEntryFactory.build({
-        actor: 'user-4',
-        type: USER_CREATION,
-      }),
-      expectedUser: 'user-4',
-      expectedMessage: 'User was created',
-    },
-    {
-      name: USER_MODIFICATION,
-      entry: activityLogEntryFactory.build({
-        actor: 'user-5',
-        type: USER_MODIFICATION,
-      }),
-      expectedUser: 'user-5',
-      expectedMessage: 'User was modified',
-    },
-    {
-      name: USER_DELETION,
-      entry: activityLogEntryFactory.build({
-        actor: 'user-6',
-        type: USER_DELETION,
-      }),
-      expectedUser: 'user-6',
-      expectedMessage: 'User was deleted',
-    },
-    {
-      name: PROFILE_UPDATE,
-      entry: activityLogEntryFactory.build({
-        actor: 'user-7',
-        type: PROFILE_UPDATE,
-      }),
-      expectedUser: 'user-7',
-      expectedMessage: 'User modified profile',
-    },
-    {
-      name: CLUSTER_CHECKS_EXECUTION_REQUEST,
-      entry: activityLogEntryFactory.build({
-        actor: 'user-8',
-        type: CLUSTER_CHECKS_EXECUTION_REQUEST,
-      }),
-      expectedUser: 'user-8',
-      expectedMessage: 'Checks execution requested for cluster',
-    },
-    {
-      name: 'unknown activity type',
-      entry: activityLogEntryFactory.build({
-        actor: 'user-9',
-        type: 'foo_bar',
-      }),
-      expectedUser: 'user-9',
-      expectedMessage: 'foo_bar',
-    },
-  ];
+  const scenarios = ACTIVITY_TYPES.map((activityType) => {
+    const entry = activityLogEntryFactory.build({
+      type: activityType,
+    });
+    const { actor, level } = entry;
+    return {
+      name: activityType,
+      entry,
+      expectedUser: actor,
+      expectedMessage: toMessage(entry),
+      expectedLevel: level,
+    };
+  }).concat({
+    name: 'unknown activity type',
+    entry: activityLogEntryFactory.build({
+      actor: 'user-9',
+      type: 'foo_bar',
+    }),
+    expectedUser: 'user-9',
+    expectedMessage: 'foo_bar',
+  });
 
   it.each(scenarios)(
     'should render log entry for activity `$name`',

--- a/assets/js/lib/model/activityLog.js
+++ b/assets/js/lib/model/activityLog.js
@@ -12,6 +12,91 @@ export const PROFILE_UPDATE = 'profile_update';
 export const CLUSTER_CHECKS_EXECUTION_REQUEST =
   'cluster_checks_execution_request';
 
+// Host events
+export const HEARTBEAT_FAILED = 'heartbeat_failed';
+export const HEARTBEAT_SUCCEEDED = 'heartbeat_succeeded';
+export const HOST_CHECKS_HEALTH_CHANGED = 'host_checks_health_changed';
+export const HOST_CHECKS_SELECTED = 'host_checks_selected';
+export const HOST_DEREGISTERED = 'host_deregistered';
+export const HOST_DEREGISTRATION_REQUESTED = 'host_deregistration_requested';
+export const HOST_DETAILS_UPDATED = 'host_details_updated';
+export const HOST_HEALTH_CHANGED = 'host_health_changed';
+export const HOST_REGISTERED = 'host_registered';
+export const HOST_RESTORED = 'host_restored';
+export const HOST_ROLLED_UP = 'host_rolled_up';
+export const HOST_ROLL_UP_REQUESTED = 'host_roll_up_requested';
+export const HOST_SAPTUNE_HEALTH_CHANGED = 'host_saptune_health_changed';
+export const HOST_TOMBSTONED = 'host_tombstoned';
+export const PROVIDER_UPDATED = 'provider_updated';
+export const SAPTUNE_STATUS_UPDATED = 'saptune_status_updated';
+export const SLES_SUBSCRIPTIONS_UPDATED = 'sles_subscriptions_updated';
+export const SOFTWARE_UPDATES_DISCOVERY_CLEARED =
+  'software_updates_discovery_cleared';
+export const SOFTWARE_UPDATES_DISCOVERY_REQUESTED =
+  'software_updates_discovery_requested';
+export const SOFTWARE_UPDATES_HEALTH_CHANGED =
+  'software_updates_health_changed';
+
+// Cluster events
+export const CHECKS_SELECTED = 'checks_selected';
+export const CLUSTER_CHECKS_HEALTH_CHANGED = 'cluster_checks_health_changed';
+export const CLUSTER_DEREGISTERED = 'cluster_deregistered';
+export const CLUSTER_DETAILS_UPDATED = 'cluster_details_updated';
+export const CLUSTER_DISCOVERED_HEALTH_CHANGED =
+  'cluster_discovered_health_changed';
+export const CLUSTER_HEALTH_CHANGED = 'cluster_health_changed';
+export const CLUSTER_REGISTERED = 'cluster_registered';
+export const CLUSTER_RESTORED = 'cluster_restored';
+export const CLUSTER_ROLLED_UP = 'cluster_rolled_up';
+export const CLUSTER_ROLL_UP_REQUESTED = 'cluster_roll_up_requested';
+export const CLUSTER_TOMBSTONED = 'cluster_tombstoned';
+export const HOST_ADDED_TO_CLUSTER = 'host_added_to_cluster';
+export const HOST_REMOVED_FROM_CLUSTER = 'host_removed_from_cluster';
+
+// SAP System events
+
+export const APPLICATION_INSTANCE_DEREGISTERED =
+  'application_instance_deregistered';
+export const APPLICATION_INSTANCE_HEALTH_CHANGED =
+  'application_instance_health_changed';
+export const APPLICATION_INSTANCE_MARKED_ABSENT =
+  'application_instance_marked_absent';
+export const APPLICATION_INSTANCE_MARKED_PRESENT =
+  'application_instance_marked_present';
+export const APPLICATION_INSTANCE_MOVED = 'application_instance_moved';
+export const APPLICATION_INSTANCE_REGISTERED =
+  'application_instance_registered';
+export const SAP_SYSTEM_DATABASE_HEALTH_CHANGED =
+  'sap_system_database_health_changed';
+export const SAP_SYSTEM_DEREGISTERED = 'sap_system_deregistered';
+export const SAP_SYSTEM_HEALTH_CHANGED = 'sap_system_health_changed';
+export const SAP_SYSTEM_REGISTERED = 'sap_system_registered';
+export const SAP_SYSTEM_RESTORED = 'sap_system_restored';
+export const SAP_SYSTEM_ROLLED_UP = 'sap_system_rolled_up';
+export const SAP_SYSTEM_ROLL_UP_REQUESTED = 'sap_system_roll_up_requested';
+export const SAP_SYSTEM_TOMBSTONED = 'sap_system_tombstoned';
+export const SAP_SYSTEM_UPDATED = 'sap_system_updated';
+
+// Database events
+export const DATABASE_DEREGISTERED = 'database_deregistered';
+export const DATABASE_HEALTH_CHANGED = 'database_health_changed';
+export const DATABASE_INSTANCE_DEREGISTERED = 'database_instance_deregistered';
+export const DATABASE_INSTANCE_HEALTH_CHANGED =
+  'database_instance_health_changed';
+export const DATABASE_INSTANCE_MARKED_ABSENT =
+  'database_instance_marked_absent';
+export const DATABASE_INSTANCE_MARKED_PRESENT =
+  'database_instance_marked_present';
+export const DATABASE_INSTANCE_REGISTERED = 'database_instance_registered';
+export const DATABASE_INSTANCE_SYSTEM_REPLICATION_CHANGED =
+  'database_instance_system_replication_changed';
+export const DATABASE_REGISTERED = 'database_registered';
+export const DATABASE_RESTORED = 'database_restored';
+export const DATABASE_ROLLED_UP = 'database_rolled_up';
+export const DATABASE_ROLL_UP_REQUESTED = 'database_roll_up_requested';
+export const DATABASE_TENANTS_UPDATED = 'database_tenants_updated';
+export const DATABASE_TOMBSTONED = 'database_tombstoned';
+
 export const ACTIVITY_TYPES = [
   LOGIN_ATTEMPT,
   RESOURCE_TAGGING,
@@ -25,7 +110,479 @@ export const ACTIVITY_TYPES = [
   USER_DELETION,
   PROFILE_UPDATE,
   CLUSTER_CHECKS_EXECUTION_REQUEST,
+  // Host events
+  HEARTBEAT_FAILED,
+  HEARTBEAT_SUCCEEDED,
+  HOST_CHECKS_HEALTH_CHANGED,
+  HOST_CHECKS_SELECTED,
+  HOST_DEREGISTERED,
+  HOST_DEREGISTRATION_REQUESTED,
+  HOST_DETAILS_UPDATED,
+  HOST_HEALTH_CHANGED,
+  HOST_REGISTERED,
+  HOST_RESTORED,
+  HOST_ROLLED_UP,
+  HOST_ROLL_UP_REQUESTED,
+  HOST_SAPTUNE_HEALTH_CHANGED,
+  HOST_TOMBSTONED,
+  PROVIDER_UPDATED,
+  SAPTUNE_STATUS_UPDATED,
+  SLES_SUBSCRIPTIONS_UPDATED,
+  SOFTWARE_UPDATES_DISCOVERY_CLEARED,
+  SOFTWARE_UPDATES_DISCOVERY_REQUESTED,
+  SOFTWARE_UPDATES_HEALTH_CHANGED,
+  // Cluster events
+  CHECKS_SELECTED,
+  CLUSTER_CHECKS_HEALTH_CHANGED,
+  CLUSTER_DEREGISTERED,
+  CLUSTER_DETAILS_UPDATED,
+  CLUSTER_DISCOVERED_HEALTH_CHANGED,
+  CLUSTER_HEALTH_CHANGED,
+  CLUSTER_REGISTERED,
+  CLUSTER_RESTORED,
+  CLUSTER_ROLLED_UP,
+  CLUSTER_ROLL_UP_REQUESTED,
+  CLUSTER_TOMBSTONED,
+  HOST_ADDED_TO_CLUSTER,
+  HOST_REMOVED_FROM_CLUSTER,
+  // SAP System events
+  APPLICATION_INSTANCE_DEREGISTERED,
+  APPLICATION_INSTANCE_HEALTH_CHANGED,
+  APPLICATION_INSTANCE_MARKED_ABSENT,
+  APPLICATION_INSTANCE_MARKED_PRESENT,
+  APPLICATION_INSTANCE_MOVED,
+  APPLICATION_INSTANCE_REGISTERED,
+  SAP_SYSTEM_DATABASE_HEALTH_CHANGED,
+  SAP_SYSTEM_DEREGISTERED,
+  SAP_SYSTEM_HEALTH_CHANGED,
+  SAP_SYSTEM_REGISTERED,
+  SAP_SYSTEM_RESTORED,
+  SAP_SYSTEM_ROLLED_UP,
+  SAP_SYSTEM_ROLL_UP_REQUESTED,
+  SAP_SYSTEM_TOMBSTONED,
+  SAP_SYSTEM_UPDATED,
+  // Database events
+  DATABASE_DEREGISTERED,
+  DATABASE_HEALTH_CHANGED,
+  DATABASE_INSTANCE_DEREGISTERED,
+  DATABASE_INSTANCE_HEALTH_CHANGED,
+  DATABASE_INSTANCE_MARKED_ABSENT,
+  DATABASE_INSTANCE_MARKED_PRESENT,
+  DATABASE_INSTANCE_REGISTERED,
+  DATABASE_INSTANCE_SYSTEM_REPLICATION_CHANGED,
+  DATABASE_REGISTERED,
+  DATABASE_RESTORED,
+  DATABASE_ROLLED_UP,
+  DATABASE_ROLL_UP_REQUESTED,
+  DATABASE_TENANTS_UPDATED,
+  DATABASE_TOMBSTONED,
 ];
+
+const sumaSettingsResourceType = (_entry) => 'SUMA Settings';
+const userResourceType = (_entry) => 'User';
+const clusterResourceType = (_entry) => 'Cluster';
+const hostResourceType = (_entry) => 'Host';
+const sapSystemResourceType = (_entry) => 'SAP System';
+const databaseResourceType = (_entry) => 'Database';
+
+const taggingResourceType = (entry) =>
+  ({
+    host: hostResourceType(entry),
+    cluster: clusterResourceType(entry),
+    database: databaseResourceType(entry),
+    sap_system: sapSystemResourceType(entry),
+  })[entry.metadata?.resource_type] ?? 'Unable to determine resource type';
+
+export const ACTIVITY_TYPES_CONFIG = {
+  [LOGIN_ATTEMPT]: {
+    label: 'Login Attempt',
+    message: ({ metadata }) =>
+      metadata?.reason ? 'Login failed' : 'User logged in',
+    resource: (_entry) => 'Application',
+  },
+  [RESOURCE_TAGGING]: {
+    label: 'Tag Added',
+    message: ({ metadata }) =>
+      `Tag "${metadata.added_tag}" added to "${metadata.resource_id}"`,
+    resource: taggingResourceType,
+  },
+  [RESOURCE_UNTAGGING]: {
+    label: 'Tag Removed',
+    message: ({ metadata }) =>
+      `Tag "${metadata.removed_tag}" removed from "${metadata.resource_id}"`,
+    resource: taggingResourceType,
+  },
+  [API_KEY_GENERATION]: {
+    label: 'API Key Generated',
+    message: (_entry) => 'API Key was generated',
+    resource: (_entry) => 'API Key',
+  },
+  [SAVING_SUMA_SETTINGS]: {
+    label: 'SUMA Settings Saved',
+    message: (_entry) => 'SUMA Settings was saved',
+    resource: sumaSettingsResourceType,
+  },
+  [CHANGING_SUMA_SETTINGS]: {
+    label: 'SUMA Settings Changed',
+    message: (_entry) => 'SUMA Settings was changed',
+    resource: sumaSettingsResourceType,
+  },
+  [CLEARING_SUMA_SETTINGS]: {
+    label: 'SUMA Settings Cleared',
+    message: (_entry) => 'SUMA Settings was cleared',
+    resource: sumaSettingsResourceType,
+  },
+  [USER_CREATION]: {
+    label: 'User Created',
+    message: (_entry) => `User was created`,
+    resource: userResourceType,
+  },
+  [USER_MODIFICATION]: {
+    label: 'User Modified',
+    message: (_entry) => `User was modified`,
+    resource: userResourceType,
+  },
+  [USER_DELETION]: {
+    label: 'User Deleted',
+    message: (_entry) => `User was deleted`,
+    resource: userResourceType,
+  },
+  [PROFILE_UPDATE]: {
+    label: 'Profile Updated',
+    message: (_entry) => `User modified profile`,
+    resource: (_entry) => 'Profile',
+  },
+  [CLUSTER_CHECKS_EXECUTION_REQUEST]: {
+    label: 'Checks Execution Requested',
+    message: (_entry) => `Checks execution requested for cluster`,
+    resource: clusterResourceType,
+  },
+  // Host events
+  [HEARTBEAT_FAILED]: {
+    label: 'Heartbeat Failed',
+    message: (_entry) => `Host heartbeat failed`,
+    resource: hostResourceType,
+  },
+  [HEARTBEAT_SUCCEEDED]: {
+    label: 'Heartbeat Succeeded',
+    message: (_entry) => `Host heartbeat succeeded`,
+    resource: hostResourceType,
+  },
+  [HOST_CHECKS_HEALTH_CHANGED]: {
+    label: 'Checks Health Changed',
+    message: (_entry) => `Checks health for host changed`,
+    resource: hostResourceType,
+  },
+  [HOST_CHECKS_SELECTED]: {
+    label: 'Host Checks Selected',
+    message: (_entry) => `Checks were selected for host`,
+    resource: hostResourceType,
+  },
+  [HOST_DEREGISTERED]: {
+    label: 'Host Deregistered',
+    message: (_entry) => `Host was deregistered`,
+    resource: hostResourceType,
+  },
+  [HOST_DEREGISTRATION_REQUESTED]: {
+    label: 'Host Deregistration Requested',
+    message: (_entry) => `Deregistration for host was requested`,
+    resource: hostResourceType,
+  },
+  [HOST_DETAILS_UPDATED]: {
+    label: 'Host Details Updated',
+    message: (_entry) => `Host details were updated`,
+    resource: hostResourceType,
+  },
+  [HOST_HEALTH_CHANGED]: {
+    label: 'Host Health Changed',
+    message: (_entry) => `Host health changed`,
+    resource: hostResourceType,
+  },
+  [HOST_REGISTERED]: {
+    label: 'Host Registered',
+    message: (_entry) => `A new host was registered`,
+    resource: hostResourceType,
+  },
+  [HOST_RESTORED]: {
+    label: 'Host Restored',
+    message: (_entry) => `Host was restored`,
+    resource: hostResourceType,
+  },
+  [HOST_ROLLED_UP]: {
+    label: 'Host Rolled Up',
+    message: (_entry) => `Host was rolled up`,
+    resource: hostResourceType,
+  },
+  [HOST_ROLL_UP_REQUESTED]: {
+    label: 'Host Roll Up Requested',
+    message: (_entry) => `Roll up for host was requested`,
+    resource: hostResourceType,
+  },
+  [HOST_SAPTUNE_HEALTH_CHANGED]: {
+    label: 'Host Saptune Health Changed',
+    message: (_entry) => `Host saptune health changed`,
+    resource: hostResourceType,
+  },
+  [HOST_TOMBSTONED]: {
+    label: 'Host Tombstoned',
+    message: (_entry) => `Host was tombstoned`,
+    resource: hostResourceType,
+  },
+  [PROVIDER_UPDATED]: {
+    label: 'Provider Updated',
+    message: (_entry) => `Host Provider was updated`,
+    resource: hostResourceType,
+  },
+  [SAPTUNE_STATUS_UPDATED]: {
+    label: 'Saptune Status Updated',
+    message: (_entry) => `Host Saptune status was updated`,
+    resource: hostResourceType,
+  },
+  [SLES_SUBSCRIPTIONS_UPDATED]: {
+    label: 'SLES Subscriptions Updated',
+    message: (_entry) => `SLES subscriptions were updated`,
+    resource: hostResourceType,
+  },
+  [SOFTWARE_UPDATES_DISCOVERY_CLEARED]: {
+    label: 'Software Updates Discovery Cleared',
+    message: (_entry) => `Software updates discovery was cleared`,
+    resource: hostResourceType,
+  },
+  [SOFTWARE_UPDATES_DISCOVERY_REQUESTED]: {
+    label: 'Software Updates Discovery Requested',
+    message: (_entry) => `Software updates discovery was requested`,
+    resource: hostResourceType,
+  },
+  [SOFTWARE_UPDATES_HEALTH_CHANGED]: {
+    label: 'Software Updates Health Changed',
+    message: (_entry) => `Software updates health changed`,
+    resource: hostResourceType,
+  },
+  // Cluster events
+  [CHECKS_SELECTED]: {
+    label: 'Cluster Checks Selected',
+    message: (_entry) => `Checks were selected for cluster`,
+    resource: clusterResourceType,
+  },
+  [CLUSTER_CHECKS_HEALTH_CHANGED]: {
+    label: 'Cluster Checks Health Changed',
+    message: (_entry) => `Checks health for cluster changed`,
+    resource: clusterResourceType,
+  },
+  [CLUSTER_DEREGISTERED]: {
+    label: 'Cluster Deregistered',
+    message: (_entry) => `Cluster was deregistered`,
+    resource: clusterResourceType,
+  },
+  [CLUSTER_DETAILS_UPDATED]: {
+    label: 'Cluster Details Updated',
+    message: (_entry) => `Cluster details were updated`,
+    resource: clusterResourceType,
+  },
+  [CLUSTER_DISCOVERED_HEALTH_CHANGED]: {
+    label: 'Cluster Discovered Health Changed',
+    message: (_entry) => `Cluster's discovered health changed`,
+    resource: clusterResourceType,
+  },
+  [CLUSTER_HEALTH_CHANGED]: {
+    label: 'Cluster Health Changed',
+    message: (_entry) => `Cluster health changed`,
+    resource: clusterResourceType,
+  },
+  [CLUSTER_REGISTERED]: {
+    label: 'Cluster Registered',
+    message: (_entry) => `A new cluster was registered`,
+    resource: clusterResourceType,
+  },
+  [CLUSTER_RESTORED]: {
+    label: 'Cluster Restored',
+    message: (_entry) => `Cluster was restored`,
+    resource: clusterResourceType,
+  },
+  [CLUSTER_ROLLED_UP]: {
+    label: 'Cluster Rolled Up',
+    message: (_entry) => `Cluster was rolled up`,
+    resource: clusterResourceType,
+  },
+  [CLUSTER_ROLL_UP_REQUESTED]: {
+    label: 'Cluster Roll Up Requested',
+    message: (_entry) => `Roll up for cluster was requested`,
+    resource: clusterResourceType,
+  },
+  [CLUSTER_TOMBSTONED]: {
+    label: 'Cluster Tombstoned',
+    message: (_entry) => `Cluster was tombstoned`,
+    resource: clusterResourceType,
+  },
+  [HOST_ADDED_TO_CLUSTER]: {
+    label: 'Host Added to Cluster',
+    message: (_entry) => `Host was added to cluster`,
+    resource: clusterResourceType,
+  },
+  [HOST_REMOVED_FROM_CLUSTER]: {
+    label: 'Host Removed from Cluster',
+    message: (_entry) => `Host was removed from cluster`,
+    resource: clusterResourceType,
+  },
+  // SAP System events
+  [APPLICATION_INSTANCE_DEREGISTERED]: {
+    label: 'Application Instance Deregistered',
+    message: (_entry) => `Application instance was deregistered`,
+    resource: sapSystemResourceType,
+  },
+  [APPLICATION_INSTANCE_HEALTH_CHANGED]: {
+    label: 'Application Instance Health Changed',
+    message: (_entry) => `Application instance health changed`,
+    resource: sapSystemResourceType,
+  },
+  [APPLICATION_INSTANCE_MARKED_ABSENT]: {
+    label: 'Application Instance Marked Absent',
+    message: (_entry) => `Application instance was marked absent`,
+    resource: sapSystemResourceType,
+  },
+  [APPLICATION_INSTANCE_MARKED_PRESENT]: {
+    label: 'Application Instance Marked Present',
+    message: (_entry) => `Application instance was marked present`,
+    resource: sapSystemResourceType,
+  },
+  [APPLICATION_INSTANCE_MOVED]: {
+    label: 'Application Instance Moved',
+    message: (_entry) => `Application instance was moved`,
+    resource: sapSystemResourceType,
+  },
+  [APPLICATION_INSTANCE_REGISTERED]: {
+    label: 'Application Instance Registered',
+    message: (_entry) => `Application instance was registered`,
+    resource: sapSystemResourceType,
+  },
+  [SAP_SYSTEM_DATABASE_HEALTH_CHANGED]: {
+    label: 'SAP System Database Health Changed',
+    message: (_entry) => `SAP system database health changed`,
+    resource: sapSystemResourceType,
+  },
+  [SAP_SYSTEM_DEREGISTERED]: {
+    label: 'SAP System Deregistered',
+    message: (_entry) => `SAP system was deregistered`,
+    resource: sapSystemResourceType,
+  },
+  [SAP_SYSTEM_HEALTH_CHANGED]: {
+    label: 'SAP System Health Changed',
+    message: (_entry) => `SAP system health changed`,
+    resource: sapSystemResourceType,
+  },
+  [SAP_SYSTEM_REGISTERED]: {
+    label: 'SAP System Registered',
+    message: (_entry) => `A new SAP system was registered`,
+    resource: sapSystemResourceType,
+  },
+  [SAP_SYSTEM_RESTORED]: {
+    label: 'SAP System Restored',
+    message: (_entry) => `SAP system was restored`,
+    resource: sapSystemResourceType,
+  },
+  [SAP_SYSTEM_ROLLED_UP]: {
+    label: 'SAP System Rolled Up',
+    message: (_entry) => `SAP system was rolled up`,
+    resource: sapSystemResourceType,
+  },
+  [SAP_SYSTEM_ROLL_UP_REQUESTED]: {
+    label: 'SAP System Roll Up Requested',
+    message: (_entry) => `Roll up for SAP system was requested`,
+    resource: sapSystemResourceType,
+  },
+  [SAP_SYSTEM_TOMBSTONED]: {
+    label: 'SAP System Tombstoned',
+    message: (_entry) => `SAP system was tombstoned`,
+    resource: sapSystemResourceType,
+  },
+  [SAP_SYSTEM_UPDATED]: {
+    label: 'SAP System Updated',
+    message: (_entry) => `SAP system was updated`,
+    resource: sapSystemResourceType,
+  },
+  // Database events
+  [DATABASE_DEREGISTERED]: {
+    label: 'Database Deregistered',
+    message: (_entry) => `Database was deregistered`,
+    resource: databaseResourceType,
+  },
+  [DATABASE_HEALTH_CHANGED]: {
+    label: 'Database Health Changed',
+    message: (_entry) => `Database health changed`,
+    resource: databaseResourceType,
+  },
+  [DATABASE_INSTANCE_DEREGISTERED]: {
+    label: 'Database Instance Deregistered',
+    message: (_entry) => `Database instance was deregistered`,
+    resource: databaseResourceType,
+  },
+  [DATABASE_INSTANCE_HEALTH_CHANGED]: {
+    label: 'Database Instance Health Changed',
+    message: (_entry) => `Database instance health changed`,
+    resource: databaseResourceType,
+  },
+  [DATABASE_INSTANCE_MARKED_ABSENT]: {
+    label: 'Database Instance Marked Absent',
+    message: (_entry) => `Database instance was marked absent`,
+    resource: databaseResourceType,
+  },
+  [DATABASE_INSTANCE_MARKED_PRESENT]: {
+    label: 'Database Instance Marked Present',
+    message: (_entry) => `Database instance was marked present`,
+    resource: databaseResourceType,
+  },
+  [DATABASE_INSTANCE_REGISTERED]: {
+    label: 'Database Instance Registered',
+    message: (_entry) => `Database instance was registered`,
+    resource: databaseResourceType,
+  },
+  [DATABASE_INSTANCE_SYSTEM_REPLICATION_CHANGED]: {
+    label: 'Database Instance System Replication Changed',
+    message: (_entry) => `Database instance system replication changed`,
+    resource: databaseResourceType,
+  },
+  [DATABASE_REGISTERED]: {
+    label: 'Database Registered',
+    message: (_entry) => `A new database was registered`,
+    resource: databaseResourceType,
+  },
+  [DATABASE_RESTORED]: {
+    label: 'Database Restored',
+    message: (_entry) => `Database was restored`,
+    resource: databaseResourceType,
+  },
+  [DATABASE_ROLLED_UP]: {
+    label: 'Database Rolled Up',
+    message: (_entry) => `Database was rolled up`,
+    resource: databaseResourceType,
+  },
+  [DATABASE_ROLL_UP_REQUESTED]: {
+    label: 'Database Roll Up Requested',
+    message: (_entry) => `Roll up for database was requested`,
+    resource: databaseResourceType,
+  },
+  [DATABASE_TENANTS_UPDATED]: {
+    label: 'Database Tenants Updated',
+    message: (_entry) => `Database tenants were updated`,
+    resource: databaseResourceType,
+  },
+  [DATABASE_TOMBSTONED]: {
+    label: 'Database Tombstoned',
+    message: (_entry) => `Database was tombstoned`,
+    resource: databaseResourceType,
+  },
+};
+
+const activityTypeConfig = ({ type }) => ACTIVITY_TYPES_CONFIG[type];
+
+export const toLabel = (entry) =>
+  activityTypeConfig(entry)?.label ?? entry.type;
+
+export const toMessage = (entry) =>
+  activityTypeConfig(entry)?.message(entry) ?? entry.type;
+
+export const toResource = (entry) =>
+  activityTypeConfig(entry)?.resource(entry) ?? 'Unrecognized resource';
 
 export const LEVEL_DEBUG = 'debug';
 export const LEVEL_INFO = 'info';


### PR DESCRIPTION
# Description

Mapping messages/activity types/resources to the domain events activities in the UI.
I found it useful consolidating the mapping in one place.

As we iterate we'll figure out what kind of mapping should be moved from the frontend to the backend. 

## How was this tested?

Automated tests.
