### PR TITLE
Add a global config variable to Storybook

### DIFF
--- a/assets/.storybook/preview-head.html
+++ b/assets/.storybook/preview-head.html
@@ -2,3 +2,7 @@
   href="https://fonts.googleapis.com/css?family=Lato:400,700"
   rel="stylesheet"
 />
+
+<script>
+  const config = {};
+</script>


### PR DESCRIPTION
Since literally now our Storybook build began failing because of a missing `config` global variable. This PR fixes it.