### PR TITLE
Fix items-per-page table footer's CSS

### DIFF
--- a/assets/js/common/Table/Pagination.jsx
+++ b/assets/js/common/Table/Pagination.jsx
@@ -27,10 +27,10 @@ function Pagination({
   return (
     <div className="flex justify-between p-2 bg-gray-50 width-full">
       {itemsPerPageOptions.length > 1 ? (
-        <div className="flex pl-3 items-center">
+        <div className="flex pl-3 items-center text-sm">
           <span className="pr-2 text-gray-600">Results per page</span>
           <Select
-            className=""
+            className="z-40"
             optionsName=""
             options={itemsPerPageOptions}
             value={currentItemsPerPage}


### PR DESCRIPTION
# Description
Just fixing z-index for the select in the table's footer otherwise the selection box gets overlapped by the app footer. I also took the chance to make the text smaller.

## How was it tested?
Existing unit tests are ensuring I didn't break anything
