### PR TITLE
Change format of ABAP JAVA system type in SapSystemOverview

### DIFF
--- a/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.jsx
+++ b/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.jsx
@@ -85,7 +85,7 @@ function SapSystemsOverview({
             .filter((item) => item === 'J2EE' || item === 'ABAP')
             .map((item) => (item === 'J2EE' ? 'JAVA' : item))
             .toSorted()
-            .join('/'),
+            .join('+'),
       },
 
       {

--- a/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.test.jsx
+++ b/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.test.jsx
@@ -143,7 +143,7 @@ describe('SapSystemsOverviews component', () => {
     });
 
     it('should display the correct SAP system type JAVA and ABAP', () => {
-      const expectedSapSystemTypes = 'ABAP/JAVA';
+      const expectedSapSystemTypes = 'ABAP+JAVA';
       const sapSystemID = faker.string.uuid();
       const sapSystem = sapSystemFactory.build({
         id: sapSystemID,


### PR DESCRIPTION
# Description

A small follow up pr to change the format of a mixed sap system type from "ABAP/JAVA" to "ABAP + JAVA" in the sap system overview. 

## Before: 
![image](https://github.com/user-attachments/assets/9acb9d1f-ae72-419c-b3ac-0ee4bd57fa97)

## Now:
![image](https://github.com/user-attachments/assets/e782b99b-dffe-4ae9-8fb3-1811427bbf3a)



## Did you add the right label?

- [x] **DONE**

## How was this tested?

Updated existing test
- [x] **DONE**
## Did you update the documentation?

No update required
- [x] **DONE**
