### PR TITLE
Log retention time changes

### DIFF
--- a/lib/trento/activity_logging/activity_catalog.ex
+++ b/lib/trento/activity_logging/activity_catalog.ex
@@ -139,7 +139,9 @@ defmodule Trento.ActivityLog.ActivityCatalog do
       {TrentoWeb.V1.UsersController, :delete} => {:user_deletion, 204},
       {TrentoWeb.V1.ProfileController, :update} => {:profile_update, 200},
       {TrentoWeb.V1.ClusterController, :request_checks_execution} =>
-        {:cluster_checks_execution_request, 202}
+        {:cluster_checks_execution_request, 202},
+      {TrentoWeb.V1.SettingsController, :update_activity_log_settings} =>
+        {:activity_log_settings_update, 200}
     }
   end
 end

--- a/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
+++ b/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
@@ -67,11 +67,12 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
   end
 
   def get_activity_metadata(
-        :api_key_generation,
+        activity,
         %Plug.Conn{
           body_params: request_body
         }
-      ) do
+      )
+      when activity in [:api_key_generation, :activity_log_settings_update] do
     request_body
   end
 

--- a/test/trento/activity_logging/activity_catalog_test.exs
+++ b/test/trento/activity_logging/activity_catalog_test.exs
@@ -23,7 +23,8 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
         :user_modification,
         :user_deletion,
         :profile_update,
-        :cluster_checks_execution_request
+        :cluster_checks_execution_request,
+        :activity_log_settings_update
       ]
 
       connection_activity_catalog = ActivityCatalog.connection_activities()

--- a/test/trento/activity_logging/phoenix_conn_parser_test.exs
+++ b/test/trento/activity_logging/phoenix_conn_parser_test.exs
@@ -61,6 +61,20 @@ defmodule Trento.ActivityLog.PhoenixConnParserTest do
     end
   end
 
+  describe "metadata detection" do
+    test "should extract the request body as metadata for relevant activities", %{conn: conn} do
+      for activity <- [:api_key_generation, :activity_log_settings_update] do
+        request_body = %{"foo" => "bar"}
+
+        assert request_body ==
+                 PhoenixConnParser.get_activity_metadata(activity, %Plug.Conn{
+                   conn
+                   | body_params: request_body
+                 })
+      end
+    end
+  end
+
   defp assert_for_relevant_activity(assertion_function) do
     ActivityCatalog.connection_activities()
     |> Enum.filter(&(&1 != :login_attempt))


### PR DESCRIPTION
# Description

Adds tracking of successful changes to the activity log retention time.

I am going to adjust the frontend after we get https://github.com/trento-project/web/pull/2841 merged

## How was this tested?

Automated tests.