### PR TITLE
Disable and update user forms if OIDC is enabled

### DIFF
--- a/assets/jest.config.js
+++ b/assets/jest.config.js
@@ -67,7 +67,7 @@ module.exports = {
     config: {
       checksServiceBaseUrl: '',
       suseManagerEnabled: true,
-      adminUsernam: 'admin',
+      adminUsername: 'admin',
       oidcEnabled: false,
       aTestVariable: 123,
     },

--- a/assets/jest.config.js
+++ b/assets/jest.config.js
@@ -67,6 +67,8 @@ module.exports = {
     config: {
       checksServiceBaseUrl: '',
       suseManagerEnabled: true,
+      adminUsernam: 'admin',
+      oidcEnabled: false,
       aTestVariable: 123,
     },
   },

--- a/assets/js/lib/auth/config.js
+++ b/assets/js/lib/auth/config.js
@@ -1,0 +1,5 @@
+import { getFromConfig } from '@lib/config';
+
+const OIDC_ENABLED = getFromConfig('oidcEnabled') || false;
+
+export const isSingleSignOnEnabled = () => OIDC_ENABLED;

--- a/assets/js/lib/auth/config.test.js
+++ b/assets/js/lib/auth/config.test.js
@@ -1,0 +1,7 @@
+import { isSingleSignOnEnabled } from './config';
+
+describe('auth config', () => {
+  it('should check if single sign on is enabled', () => {
+    expect(isSingleSignOnEnabled()).toBe(false);
+  });
+});

--- a/assets/js/lib/model/users.js
+++ b/assets/js/lib/model/users.js
@@ -1,5 +1,7 @@
 import { getFromConfig } from '@lib/config';
 
 const TRENTO_ADMIN_USERNAME = getFromConfig('adminUsername') || 'admin';
+const OIDC_ENABLED = getFromConfig('oidcEnabled') || false;
 
 export const isAdmin = (user) => user.username === TRENTO_ADMIN_USERNAME;
+export const isSingleSignOnEnabled = () => OIDC_ENABLED;

--- a/assets/js/lib/model/users.js
+++ b/assets/js/lib/model/users.js
@@ -1,7 +1,5 @@
 import { getFromConfig } from '@lib/config';
 
 const TRENTO_ADMIN_USERNAME = getFromConfig('adminUsername') || 'admin';
-const OIDC_ENABLED = getFromConfig('oidcEnabled') || false;
 
 export const isAdmin = (user) => user.username === TRENTO_ADMIN_USERNAME;
-export const isSingleSignOnEnabled = () => OIDC_ENABLED;

--- a/assets/js/lib/model/users.test.js
+++ b/assets/js/lib/model/users.test.js
@@ -1,6 +1,6 @@
 import { adminUser, userFactory } from '@lib/test-utils/factories/users';
 
-import { isAdmin, isSingleSignOnEnabled } from './users';
+import { isAdmin } from './users';
 
 describe('users', () => {
   it('should check if a user is admin', () => {
@@ -9,9 +9,5 @@ describe('users', () => {
 
     const user = userFactory.build({ username: 'other' });
     expect(isAdmin(user)).toBe(false);
-  });
-
-  it('should check if single sign on is enabled', () => {
-    expect(isSingleSignOnEnabled()).toBe(false);
   });
 });

--- a/assets/js/lib/model/users.test.js
+++ b/assets/js/lib/model/users.test.js
@@ -1,13 +1,17 @@
 import { adminUser, userFactory } from '@lib/test-utils/factories/users';
 
-import { isAdmin } from './users';
+import { isAdmin, isSingleSignOnEnabled } from './users';
 
 describe('users', () => {
   it('should check if a user is admin', () => {
-    const admin = adminUser.build();
+    const admin = adminUser.build({ username: 'admin' });
     expect(isAdmin(admin)).toBe(true);
 
-    const user = userFactory.build({ id: 2 });
+    const user = userFactory.build({ username: 'other' });
     expect(isAdmin(user)).toBe(false);
+  });
+
+  it('should check if single sign on is enabled', () => {
+    expect(isSingleSignOnEnabled()).toBe(false);
   });
 });

--- a/assets/js/pages/Profile/ProfileForm.jsx
+++ b/assets/js/pages/Profile/ProfileForm.jsx
@@ -25,6 +25,7 @@ function ProfileForm({
   disableForm,
   passwordModalOpen = false,
   totpBoxOpen = false,
+  singleSignOnEnabled = false,
   toggleTotpBox = noop,
   togglePasswordModal = noop,
   onSave = noop,
@@ -94,6 +95,7 @@ function ProfileForm({
                 setFullName(value);
                 setFullNameError(null);
               }}
+              disabled={singleSignOnEnabled}
             />
             {fullNameErrorState && errorMessage(fullNameErrorState)}
           </div>
@@ -108,6 +110,7 @@ function ProfileForm({
                 setEmailAddress(value);
                 setEmailAddressError(null);
               }}
+              disabled={singleSignOnEnabled}
             />
             {emailAddressErrorState && errorMessage(emailAddressErrorState)}
           </div>
@@ -115,54 +118,58 @@ function ProfileForm({
           <div className="col-start-2 col-span-3">
             <Input value={username} aria-label="username" disabled />
           </div>
-          <Label className="col-start-1 col-span-1">Password</Label>
-          <div className="col-start-2 col-span-3">
-            <Button
-              onClick={togglePasswordModal}
-              type="primary-white"
-              disabled={loading || disableForm}
-            >
-              Change Password
-            </Button>
-          </div>
-
-          <Label
-            className="col-start-1 col-span-1"
-            info="Setup a multi-factor TOTP authentication besides your password to increase security
-              for your account."
-          >
-            Authenticator App
-          </Label>
-          <div className="col-start-2 col-span-3">
-            <div className="inline-flex">
-              <Switch
-                selected={totpEnabled}
-                onChange={toggleTotp}
-                disabled={loading || disableForm || totpBoxOpen}
-              />
-              {totpBoxOpen && (
-                <span
-                  className="ml-5 cursor-pointer text-jungle-green-500 hover:opacity-75"
-                  onClick={() => toggleTotpBox(false)}
-                  aria-hidden="true"
-                >
-                  Cancel
-                </span>
-              )}
-            </div>
-
-            {totpBoxOpen && (
+          {!singleSignOnEnabled && (
+            <>
+              <Label className="col-start-1 col-span-1">Password</Label>
               <div className="col-start-2 col-span-3">
-                <TotpEnrollementBox
-                  errors={errors}
-                  qrData={totpQrData}
-                  secret={totpSecret}
-                  loading={loading}
-                  verifyTotp={onVerifyTotp}
-                />
+                <Button
+                  onClick={togglePasswordModal}
+                  type="primary-white"
+                  disabled={loading || disableForm || singleSignOnEnabled}
+                >
+                  Change Password
+                </Button>
               </div>
-            )}
-          </div>
+
+              <Label
+                className="col-start-1 col-span-1"
+                info="Setup a multi-factor TOTP authentication besides your password to increase security
+              for your account."
+              >
+                Authenticator App
+              </Label>
+              <div className="col-start-2 col-span-3">
+                <div className="inline-flex">
+                  <Switch
+                    selected={totpEnabled}
+                    onChange={toggleTotp}
+                    disabled={loading || disableForm || totpBoxOpen}
+                  />
+                  {totpBoxOpen && (
+                    <span
+                      className="ml-5 cursor-pointer text-jungle-green-500 hover:opacity-75"
+                      onClick={() => toggleTotpBox(false)}
+                      aria-hidden="true"
+                    >
+                      Cancel
+                    </span>
+                  )}
+                </div>
+
+                {totpBoxOpen && (
+                  <div className="col-start-2 col-span-3">
+                    <TotpEnrollementBox
+                      errors={errors}
+                      qrData={totpQrData}
+                      secret={totpSecret}
+                      loading={loading}
+                      verifyTotp={onVerifyTotp}
+                    />
+                  </div>
+                )}
+              </div>
+            </>
+          )}
 
           <Label className="col-start-1 col-span-1">Permissions</Label>
           <div className="col-start-2 col-span-3">
@@ -174,15 +181,17 @@ function ProfileForm({
             />
           </div>
         </div>
-        <div className="flex flex-row w-80 space-x-2 mt-5">
-          <Button
-            disabled={loading || disableForm}
-            type="default-fit"
-            onClick={onSaveClicked}
-          >
-            Save
-          </Button>
-        </div>
+        {!singleSignOnEnabled && (
+          <div className="flex flex-row w-80 space-x-2 mt-5">
+            <Button
+              disabled={loading || disableForm}
+              type="default-fit"
+              onClick={onSaveClicked}
+            >
+              Save
+            </Button>
+          </div>
+        )}
       </div>
       <Modal
         title="Disable TOTP"

--- a/assets/js/pages/Profile/ProfileForm.stories.jsx
+++ b/assets/js/pages/Profile/ProfileForm.stories.jsx
@@ -74,6 +74,10 @@ export default {
         type: 'text',
       },
     },
+    singleSignOnEnabled: {
+      description: 'Single sign on login is enabled',
+      control: { type: 'boolean' },
+    },
   },
   render: (args) => (
     <ContainerWrapper>
@@ -127,5 +131,12 @@ export const WithErrors = {
         title: 'Invalid value',
       },
     ],
+  },
+};
+
+export const SingleSignOnEnabled = {
+  args: {
+    ...Default.args,
+    singleSignOnEnabled: true,
   },
 };

--- a/assets/js/pages/Profile/ProfileForm.test.jsx
+++ b/assets/js/pages/Profile/ProfileForm.test.jsx
@@ -305,4 +305,59 @@ describe('ProfileForm', () => {
     );
     expect(screen.getByText('Error validating totp code')).toBeVisible();
   });
+
+  describe('Single sign on', () => {
+    it('should disable fullname, email and username fields', () => {
+      const { username, fullname, email, abilities } = profileFactory.build();
+
+      render(
+        <ProfileForm
+          fullName={fullname}
+          emailAddress={email}
+          username={username}
+          abilities={abilities}
+          singleSignOnEnabled
+        />
+      );
+
+      expect(screen.getByLabelText('fullname')).toBeDisabled();
+      expect(screen.getByLabelText('email')).toBeDisabled();
+      expect(screen.getByLabelText('username')).toBeDisabled();
+      expect(screen.getByLabelText('permissions')).toBeDisabled();
+    });
+
+    it('should remove password and totp fields', () => {
+      const { username, fullname, email, abilities } = profileFactory.build();
+
+      render(
+        <ProfileForm
+          fullName={fullname}
+          emailAddress={email}
+          username={username}
+          abilities={abilities}
+          singleSignOnEnabled
+        />
+      );
+
+      expect(screen.queryByText('Password')).not.toBeInTheDocument();
+      expect(screen.queryByText('Authenticator App')).not.toBeInTheDocument();
+      expect(screen.getByText('Permissions')).toBeVisible();
+    });
+
+    it('should remove save button', () => {
+      const { username, fullname, email, abilities } = profileFactory.build();
+
+      render(
+        <ProfileForm
+          fullName={fullname}
+          emailAddress={email}
+          username={username}
+          abilities={abilities}
+          singleSignOnEnabled
+        />
+      );
+
+      expect(screen.queryByText('Save')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/assets/js/pages/Profile/ProfilePage.jsx
+++ b/assets/js/pages/Profile/ProfilePage.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { useDispatch } from 'react-redux';
 import PageHeader from '@common/PageHeader';
-import { isAdmin } from '@lib/model/users';
+import { isAdmin, isSingleSignOnEnabled } from '@lib/model/users';
 import ProfileForm from '@pages/Profile/ProfileForm';
 import {
   getUserProfile,
@@ -162,6 +162,7 @@ function ProfilePage() {
         toggleTotpBox={setTotpBoxOpen}
         loading={loading || saving}
         disableForm={isDefaultAdmin}
+        singleSignOnEnabled={isSingleSignOnEnabled()}
         onSave={updateProfile}
         onEnableTotp={totpInitiateEnrolling}
         onVerifyTotp={verifyTotpEnrollment}

--- a/assets/js/pages/Profile/ProfilePage.jsx
+++ b/assets/js/pages/Profile/ProfilePage.jsx
@@ -2,7 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { useDispatch } from 'react-redux';
 import PageHeader from '@common/PageHeader';
-import { isAdmin, isSingleSignOnEnabled } from '@lib/model/users';
+import { isAdmin } from '@lib/model/users';
+import { isSingleSignOnEnabled } from '@lib/auth/config';
 import ProfileForm from '@pages/Profile/ProfileForm';
 import {
   getUserProfile,

--- a/assets/js/pages/Users/CreateUserPage.jsx
+++ b/assets/js/pages/Users/CreateUserPage.jsx
@@ -6,7 +6,7 @@ import BackButton from '@common/BackButton';
 import PageHeader from '@common/PageHeader';
 import NotFound from '@pages/NotFound';
 
-import { isSingleSignOnEnabled } from '@lib/model/users';
+import { isSingleSignOnEnabled } from '@lib/auth/config';
 import { listAbilities } from '@lib/api/abilities';
 import { createUser } from '@lib/api/users';
 

--- a/assets/js/pages/Users/CreateUserPage.jsx
+++ b/assets/js/pages/Users/CreateUserPage.jsx
@@ -4,7 +4,9 @@ import { toast } from 'react-hot-toast';
 
 import BackButton from '@common/BackButton';
 import PageHeader from '@common/PageHeader';
+import NotFound from '@pages/NotFound';
 
+import { isSingleSignOnEnabled } from '@lib/model/users';
 import { listAbilities } from '@lib/api/abilities';
 import { createUser } from '@lib/api/users';
 
@@ -54,6 +56,10 @@ function CreateUserPage() {
   const onCancel = () => {
     navigate('/users');
   };
+
+  if (isSingleSignOnEnabled()) {
+    return <NotFound />;
+  }
 
   useEffect(() => {
     fetchAbilities(setAbilities);

--- a/assets/js/pages/Users/CreateUserPage.test.jsx
+++ b/assets/js/pages/Users/CreateUserPage.test.jsx
@@ -13,7 +13,7 @@ import { faker } from '@faker-js/faker';
 import * as router from 'react-router';
 
 import { networkClient } from '@lib/network';
-import * as usersModel from '@lib/model/users';
+import * as authConfig from '@lib/auth/config';
 import { abilityFactory, userFactory } from '@lib/test-utils/factories/users';
 
 import CreateUserPage from './CreateUserPage';
@@ -147,7 +147,7 @@ describe('CreateUserPage', () => {
 
   describe('Single sign on', () => {
     it('should redirect to not found page', async () => {
-      jest.spyOn(usersModel, 'isSingleSignOnEnabled').mockReturnValue(true);
+      jest.spyOn(authConfig, 'isSingleSignOnEnabled').mockReturnValue(true);
 
       render(<CreateUserPage />);
 

--- a/assets/js/pages/Users/CreateUserPage.test.jsx
+++ b/assets/js/pages/Users/CreateUserPage.test.jsx
@@ -13,7 +13,7 @@ import { faker } from '@faker-js/faker';
 import * as router from 'react-router';
 
 import { networkClient } from '@lib/network';
-
+import * as usersModel from '@lib/model/users';
 import { abilityFactory, userFactory } from '@lib/test-utils/factories/users';
 
 import CreateUserPage from './CreateUserPage';
@@ -143,5 +143,17 @@ describe('CreateUserPage', () => {
 
     await user.click(screen.getByRole('button', { name: 'Create' }));
     expect(toast.error).toHaveBeenCalledWith(toastMessage);
+  });
+
+  describe('Single sign on', () => {
+    it('should redirect to not found page', async () => {
+      jest.spyOn(usersModel, 'isSingleSignOnEnabled').mockReturnValue(true);
+
+      render(<CreateUserPage />);
+
+      expect(
+        screen.getByText('the page is in another castle', { exact: false })
+      ).toBeVisible();
+    });
   });
 });

--- a/assets/js/pages/Users/EditUserPage.jsx
+++ b/assets/js/pages/Users/EditUserPage.jsx
@@ -6,7 +6,7 @@ import BackButton from '@common/BackButton';
 import Banner from '@common/Banners/Banner';
 import PageHeader from '@common/PageHeader';
 
-import { isAdmin } from '@lib/model/users';
+import { isAdmin, isSingleSignOnEnabled } from '@lib/model/users';
 import { editUser, getUser } from '@lib/api/users';
 
 import { fetchAbilities } from './CreateUserPage';
@@ -123,6 +123,7 @@ function EditUserPage() {
         onSave={onEditUser}
         onCancel={onCancel}
         editing
+        singleSignOnEnabled={isSingleSignOnEnabled()}
       />
     </div>
   );

--- a/assets/js/pages/Users/EditUserPage.jsx
+++ b/assets/js/pages/Users/EditUserPage.jsx
@@ -6,7 +6,9 @@ import BackButton from '@common/BackButton';
 import Banner from '@common/Banners/Banner';
 import PageHeader from '@common/PageHeader';
 
-import { isAdmin, isSingleSignOnEnabled } from '@lib/model/users';
+import { isAdmin } from '@lib/model/users';
+import { isSingleSignOnEnabled } from '@lib/auth/config';
+
 import { editUser, getUser } from '@lib/api/users';
 
 import { fetchAbilities } from './CreateUserPage';

--- a/assets/js/pages/Users/UserForm.stories.jsx
+++ b/assets/js/pages/Users/UserForm.stories.jsx
@@ -117,6 +117,10 @@ export default {
     errors: {
       description: 'OpenAPI errors coming from backend validation',
     },
+    singleSignOnEnabled: {
+      description: 'Single sign on login is enabled',
+      control: { type: 'boolean' },
+    },
     onSave: {
       action: 'Save user',
       description: 'Save user action',
@@ -203,5 +207,12 @@ export const WithErrors = {
         title: 'Invalid value',
       },
     ],
+  },
+};
+
+export const SingleSignOnEnabled = {
+  args: {
+    ...Editing.args,
+    singleSignOnEnabled: true,
   },
 };

--- a/assets/js/pages/Users/UserForm.test.jsx
+++ b/assets/js/pages/Users/UserForm.test.jsx
@@ -422,8 +422,6 @@ describe('UserForm', () => {
 
       await user.click(screen.getByRole('button', { name: 'Save' }));
 
-      screen.debug(undefined, 100000);
-
       expect(mockOnSave).toHaveBeenNthCalledWith(1, {
         enabled: true,
         abilities: abilities.slice(0, 2),

--- a/assets/js/pages/Users/Users.jsx
+++ b/assets/js/pages/Users/Users.jsx
@@ -19,6 +19,7 @@ function Users({
   navigate = noop,
   users = defaultUsers,
   loading = false,
+  singleSignOnEnabled = false,
 }) {
   const [modalOpen, setModalOpen] = useState(false);
   const [user, setUser] = useState(null);
@@ -92,18 +93,20 @@ function Users({
       <div className="flex w-1/2 h-auto overflow-hidden overflow-ellipsis break-words">
         <PageHeader className="font-bold">Users</PageHeader>
       </div>
-      <div className="flex w-1/2 justify-end">
-        <div className="flex w-fit whitespace-nowrap">
-          <Button
-            className="inline-block mx-1"
-            size="small"
-            disabled={loading}
-            onClick={() => navigate('/users/new')}
-          >
-            Create User
-          </Button>
+      {!singleSignOnEnabled && (
+        <div className="flex w-1/2 justify-end">
+          <div className="flex w-fit whitespace-nowrap">
+            <Button
+              className="inline-block mx-1"
+              size="small"
+              disabled={loading}
+              onClick={() => navigate('/users/new')}
+            >
+              Create User
+            </Button>
+          </div>
         </div>
-      </div>
+      )}
       <Modal
         open={modalOpen}
         className="!w-3/4 !max-w-3xl"

--- a/assets/js/pages/Users/Users.stories.jsx
+++ b/assets/js/pages/Users/Users.stories.jsx
@@ -49,6 +49,10 @@ export default {
       description: 'Display loading state of the component',
       control: { type: 'boolean' },
     },
+    singleSignOnEnabled: {
+      description: 'Single sign on login is enabled',
+      control: { type: 'boolean' },
+    },
   },
 };
 
@@ -73,5 +77,9 @@ export const UsersOverview = {
       userFactory.build(),
     ],
   },
+  render: withContainerWrapper,
+};
+export const SingleSignOn = {
+  args: { singleSignOnEnabled: true },
   render: withContainerWrapper,
 };

--- a/assets/js/pages/Users/Users.test.jsx
+++ b/assets/js/pages/Users/Users.test.jsx
@@ -95,4 +95,11 @@ describe('Users', () => {
     await userEvent.click(cancelButton);
     expect(modalTitel).not.toBeInTheDocument();
   });
+
+  describe('Single sign on', () => {
+    it('should disable user creation', () => {
+      renderWithRouter(<Users users={[]} singleSignOnEnabled />);
+      expect(screen.queryByText('Create User')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/assets/js/pages/Users/UsersPage.jsx
+++ b/assets/js/pages/Users/UsersPage.jsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { listUsers, deleteUser } from '@lib/api/users';
-
 import { toast } from 'react-hot-toast';
+
+import { listUsers, deleteUser } from '@lib/api/users';
+import { isSingleSignOnEnabled } from '@lib/model/users';
 
 import Users from './Users';
 
@@ -62,6 +63,7 @@ function UsersPage() {
       navigate={navigate}
       users={users}
       loading={loading}
+      singleSignOnEnabled={isSingleSignOnEnabled()}
     />
   );
 }

--- a/assets/js/pages/Users/UsersPage.jsx
+++ b/assets/js/pages/Users/UsersPage.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { toast } from 'react-hot-toast';
 
 import { listUsers, deleteUser } from '@lib/api/users';
-import { isSingleSignOnEnabled } from '@lib/model/users';
+import { isSingleSignOnEnabled } from '@lib/auth/config';
 
 import Users from './Users';
 

--- a/assets/js/state/sagas/user.js
+++ b/assets/js/state/sagas/user.js
@@ -22,6 +22,7 @@ import {
   clearCredentialsFromStore,
 } from '@lib/auth';
 import { networkClient } from '@lib/network';
+import { isSingleSignOnEnabled } from '@lib/model/users';
 
 export function* performOIDCEnrollment({ payload: { code, state } }) {
   yield put(setAuthInProgress());
@@ -113,6 +114,10 @@ export function* userUpdated() {
 }
 
 export function* checkUserPasswordChangeRequested() {
+  if (isSingleSignOnEnabled()) {
+    return;
+  }
+
   const { password_change_requested } = yield select(getUserProfile);
 
   if (!password_change_requested) {

--- a/assets/js/state/sagas/user.js
+++ b/assets/js/state/sagas/user.js
@@ -22,7 +22,7 @@ import {
   clearCredentialsFromStore,
 } from '@lib/auth';
 import { networkClient } from '@lib/network';
-import { isSingleSignOnEnabled } from '@lib/model/users';
+import { isSingleSignOnEnabled } from '@lib/auth/config';
 
 export function* performOIDCEnrollment({ payload: { code, state } }) {
   yield put(setAuthInProgress());

--- a/assets/js/state/sagas/user.test.js
+++ b/assets/js/state/sagas/user.test.js
@@ -16,6 +16,7 @@ import {
 import { customNotify } from '@state/notifications';
 import { networkClient } from '@lib/network';
 import { profileFactory } from '@lib/test-utils/factories/users';
+import * as usersModel from '@lib/model/users';
 import {
   performLogin,
   clearUserAndLogout,
@@ -168,7 +169,7 @@ describe('user login saga', () => {
     expect(dispatched).toEqual([expectedAction]);
   });
 
-  it('should not dispatch notification is password change is not requested', async () => {
+  it('should not dispatch notification if password change is not requested', async () => {
     const dispatched = await recordSaga(
       checkUserPasswordChangeRequested,
       {},
@@ -180,5 +181,23 @@ describe('user login saga', () => {
     );
 
     expect(dispatched).toEqual([]);
+  });
+
+  describe('Single sign on', () => {
+    it('should not dispatch notification if single sign on is enabled', async () => {
+      jest.spyOn(usersModel, 'isSingleSignOnEnabled').mockReturnValue(true);
+
+      const dispatched = await recordSaga(
+        checkUserPasswordChangeRequested,
+        {},
+        {
+          user: {
+            password_change_requested: true,
+          },
+        }
+      );
+
+      expect(dispatched).toEqual([]);
+    });
   });
 });

--- a/assets/js/state/sagas/user.test.js
+++ b/assets/js/state/sagas/user.test.js
@@ -16,7 +16,7 @@ import {
 import { customNotify } from '@state/notifications';
 import { networkClient } from '@lib/network';
 import { profileFactory } from '@lib/test-utils/factories/users';
-import * as usersModel from '@lib/model/users';
+import * as authConfig from '@lib/auth/config';
 import {
   performLogin,
   clearUserAndLogout,
@@ -185,7 +185,7 @@ describe('user login saga', () => {
 
   describe('Single sign on', () => {
     it('should not dispatch notification if single sign on is enabled', async () => {
-      jest.spyOn(usersModel, 'isSingleSignOnEnabled').mockReturnValue(true);
+      jest.spyOn(authConfig, 'isSingleSignOnEnabled').mockReturnValue(true);
 
       const dispatched = await recordSaga(
         checkUserPasswordChangeRequested,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -136,7 +136,7 @@ config :unplug, :init_mode, :runtime
 config :open_api_spex, :cache_adapter, OpenApiSpex.Plug.NoneCache
 
 config :trento, :oidc,
-  enabled: true,
+  enabled: false,
   callback_url: "http://localhost:4000/auth/oidc_callback"
 
 config :trento, :pow_assent,

--- a/lib/trento_web/controllers/page_controller.ex
+++ b/lib/trento_web/controllers/page_controller.ex
@@ -15,6 +15,7 @@ defmodule TrentoWeb.PageController do
       deregistration_debounce: deregistration_debounce,
       suse_manager_enabled: suse_manager_enabled,
       admin_username: admin_username,
+      oidc_enabled: oidc_enabled,
       oidc_login_url: oidc_login_url(conn, oidc_enabled)
     )
   end

--- a/lib/trento_web/templates/page/index.html.heex
+++ b/lib/trento_web/templates/page/index.html.heex
@@ -7,6 +7,7 @@
       chartsEnabled: <%= @charts_enabled %>,
       suseManagerEnabled: <%= @suse_manager_enabled %>,
       adminUsername: '<%= @admin_username %>',
+      oidcEnabled: <%= @oidc_enabled %>,
       oidcLoginUrl: '<%= raw @oidc_login_url %>',
   };
 </script>

--- a/mix.exs
+++ b/mix.exs
@@ -118,7 +118,7 @@ defmodule Trento.MixProject do
       {:nimble_totp, "~> 1.0"},
       {:phoenix_view, "~> 2.0"},
       {:phoenix_html_helpers, "~> 1.0"},
-      {:pow_assent, "~> 0.4.18"},
+      {:pow_assent, "~> 0.4.18"}
     ]
   end
 


### PR DESCRIPTION
# Description

Disable certain fields and options in user management views if SSO (OIDC in this case) is enabled.
The `/users/new` url is redirected to not found.

![image](https://github.com/user-attachments/assets/eee889c6-7852-43d6-96c0-51ceef9dfbe5)

![image](https://github.com/user-attachments/assets/beb38201-0f91-4636-a056-be5c52ad7d4d)

## How was this tested?

Tested with jest and storybook
