### PR TITLE
Disable actions when external idp is enabled

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -47,6 +47,8 @@ config :trento, Trento.Heartbeats, interval: :timer.seconds(6)
 # to wait before displaying the deregistration button
 config :trento, deregistration_debounce: :timer.seconds(5)
 
+config :trento, :oidc, enabled: false
+
 config :trento,
   api_key_authentication_enabled: false,
   jwt_authentication_enabled: false,

--- a/config/test.exs
+++ b/config/test.exs
@@ -47,8 +47,6 @@ config :trento, Trento.Heartbeats, interval: :timer.seconds(6)
 # to wait before displaying the deregistration button
 config :trento, deregistration_debounce: :timer.seconds(5)
 
-config :trento, :oidc, enabled: false
-
 config :trento,
   api_key_authentication_enabled: false,
   jwt_authentication_enabled: false,

--- a/lib/trento/user_identities/user_identity.ex
+++ b/lib/trento/user_identities/user_identity.ex
@@ -1,4 +1,5 @@
 defmodule Trento.UserIdentities.UserIdentity do
+  @moduledoc false
   use Ecto.Schema
   use PowAssent.Ecto.UserIdentities.Schema, user: Trento.Users.User
 

--- a/lib/trento_web/controllers/page_controller.ex
+++ b/lib/trento_web/controllers/page_controller.ex
@@ -24,7 +24,7 @@ defmodule TrentoWeb.PageController do
     oidc_callback = Application.fetch_env!(:trento, :oidc)[:callback_url]
 
     {:ok, url, _} =
-      PowAssent.Plug.authorize_url(conn, :oidc_local, oidc_callback)
+      PowAssent.Plug.authorize_url(conn, "oidc_local", oidc_callback)
 
     url
   end

--- a/lib/trento_web/controllers/session_controller.ex
+++ b/lib/trento_web/controllers/session_controller.ex
@@ -1,12 +1,11 @@
 defmodule TrentoWeb.SessionController do
+  alias Plug.Conn
+  alias PowAssent.Plug, as: PowAssentPlug
   alias Trento.Repo
   alias Trento.Users
   alias Trento.Users.User
   alias TrentoWeb.OpenApi.V1.Schema
-
   alias TrentoWeb.Plugs.AppJWTAuthPlug
-  alias PowAssent.Plug, as: PowAssentPlug
-  alias Plug.Conn
 
   use TrentoWeb, :controller
   use OpenApiSpex.ControllerSpecs
@@ -271,5 +270,5 @@ defmodule TrentoWeb.SessionController do
 
   defp maybe_validate_totp(_, _), do: {:error, :totp_code_missing}
 
-  defp idp_redirect_uri(), do: Application.fetch_env!(:trento, :oidc)[:callback_url]
+  defp idp_redirect_uri, do: Application.fetch_env!(:trento, :oidc)[:callback_url]
 end

--- a/lib/trento_web/controllers/session_controller.ex
+++ b/lib/trento_web/controllers/session_controller.ex
@@ -13,6 +13,8 @@ defmodule TrentoWeb.SessionController do
 
   action_fallback TrentoWeb.FallbackController
 
+  plug TrentoWeb.Plugs.ExternalIdpGuardPlug when action in [:create]
+
   require Logger
 
   operation :create,

--- a/lib/trento_web/controllers/v1/profile_controller.ex
+++ b/lib/trento_web/controllers/v1/profile_controller.ex
@@ -6,7 +6,11 @@ defmodule TrentoWeb.V1.ProfileController do
   alias Trento.Users.User
   alias TrentoWeb.OpenApi.V1.Schema
 
+  plug TrentoWeb.Plugs.ExternalIdpGuardPlug
+       when action in [:update, :reset_totp, :get_totp_enrollment_data, :confirm_totp_enrollment]
+
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
+
   plug TrentoWeb.Plugs.LoadUserPlug
   action_fallback TrentoWeb.FallbackController
 

--- a/lib/trento_web/controllers/v1/users_controller.ex
+++ b/lib/trento_web/controllers/v1/users_controller.ex
@@ -14,6 +14,8 @@ defmodule TrentoWeb.V1.UsersController do
     UserUpdateRequest
   }
 
+  plug TrentoWeb.Plugs.ExternalIdpGuardPlug when action in [:create]
+
   plug TrentoWeb.Plugs.LoadUserPlug
 
   plug Bodyguard.Plug.Authorize,

--- a/lib/trento_web/plugs/external_idp_guard_plug.ex
+++ b/lib/trento_web/plugs/external_idp_guard_plug.ex
@@ -33,5 +33,5 @@ defmodule TrentoWeb.Plugs.ExternalIdpGuardPlug do
 
   def call(conn, _), do: conn
 
-  defp oidc_enabled?(), do: Application.fetch_env!(:trento, :oidc)[:enabled]
+  defp oidc_enabled?, do: Application.fetch_env!(:trento, :oidc)[:enabled]
 end

--- a/lib/trento_web/plugs/external_idp_guard_plug.ex
+++ b/lib/trento_web/plugs/external_idp_guard_plug.ex
@@ -1,7 +1,6 @@
 defmodule TrentoWeb.Plugs.ExternalIdpGuardPlug do
   @moduledoc """
-  This plug acts as a guard for certain actions/endpoint, to disable them when an external idp integration
-  is enabled
+  This plug acts as a guard for certain actions/endpoint to disable them when an external idp integration is enabled
   """
   @behaviour Plug
 
@@ -23,8 +22,7 @@ defmodule TrentoWeb.Plugs.ExternalIdpGuardPlug do
       501,
       Jason.encode!(
         ErrorView.render("501.json", %{
-          reason:
-            "Endpoint disabled, external idp enabled, check the documentation for further details"
+          reason: "Endpoint disabled due an external IDP is enabled"
         })
       )
     )

--- a/lib/trento_web/plugs/external_idp_guard_plug.ex
+++ b/lib/trento_web/plugs/external_idp_guard_plug.ex
@@ -1,0 +1,37 @@
+defmodule TrentoWeb.Plugs.ExternalIdpGuardPlug do
+  @moduledoc """
+  This plug acts as a guard for certain actions/endpoint, to disable them when an external idp integration
+  is enabled
+  """
+  @behaviour Plug
+
+  alias TrentoWeb.ErrorView
+
+  import Plug.Conn
+
+  @impl true
+  def init(opts) do
+    Keyword.put(opts, :external_idp_enabled, oidc_enabled?())
+  end
+
+  @impl true
+  @spec call(Plug.Conn.t(), keyword()) :: Plug.Conn.t()
+  def call(conn, external_idp_enabled: true) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> resp(
+      501,
+      Jason.encode!(
+        ErrorView.render("501.json", %{
+          reason:
+            "Endpoint disabled, external idp enabled, check the documentation for further details"
+        })
+      )
+    )
+    |> halt()
+  end
+
+  def call(conn, _), do: conn
+
+  defp oidc_enabled?(), do: Application.fetch_env!(:trento, :oidc)[:enabled]
+end

--- a/test/trento_web/controllers/session_controller_test.exs
+++ b/test/trento_web/controllers/session_controller_test.exs
@@ -389,6 +389,18 @@ defmodule TrentoWeb.SessionControllerTest do
       |> json_response(200)
       |> assert_schema("Credentials", api_spec)
     end
+
+    test "should return 501 if external IDP integration is enabled", %{conn: conn} do
+      Application.put_env(:trento, :oidc, enabled: true)
+
+      conn =
+        post(conn, "/api/session", %{
+          "username" => "trento_user",
+          "password" => "testpassword"
+        })
+
+      json_response(conn, 501)
+    end
   end
 
   describe "callback endpoint" do

--- a/test/trento_web/controllers/session_controller_test.exs
+++ b/test/trento_web/controllers/session_controller_test.exs
@@ -400,6 +400,8 @@ defmodule TrentoWeb.SessionControllerTest do
         })
 
       json_response(conn, 501)
+
+      Application.put_env(:trento, :oidc, enabled: false)
     end
   end
 

--- a/test/trento_web/controllers/v1/profile_controller_test.exs
+++ b/test/trento_web/controllers/v1/profile_controller_test.exs
@@ -25,6 +25,27 @@ defmodule TrentoWeb.V1.ProfileControllerTest do
      conn: put_req_header(conn, "accept", "application/json"), api_spec: api_spec, user: user}
   end
 
+  test "should disable write profile action when external idp integration is enabled", %{
+    conn: conn
+  } do
+    Application.put_env(:trento, :oidc, enabled: true)
+
+    conn = put_req_header(conn, "content-type", "application/json")
+
+    Enum.each(
+      [
+        patch(conn, "/api/v1/profile", %{}),
+        get(conn, "/api/v1/profile/totp_enrollment"),
+        post(conn, "/api/v1/profile/totp_enrollment", %{}),
+        delete(conn, "/api/v1/profile/totp_enrollment")
+      ],
+      fn conn ->
+        conn
+        |> json_response(501)
+      end
+    )
+  end
+
   test "should show the current user profile", %{
     user: %{id: user_id},
     conn: conn,

--- a/test/trento_web/controllers/v1/profile_controller_test.exs
+++ b/test/trento_web/controllers/v1/profile_controller_test.exs
@@ -44,6 +44,8 @@ defmodule TrentoWeb.V1.ProfileControllerTest do
         |> json_response(501)
       end
     )
+
+    Application.put_env(:trento, :oidc, enabled: false)
   end
 
   test "should show the current user profile", %{

--- a/test/trento_web/controllers/v1/profile_controller_test.exs
+++ b/test/trento_web/controllers/v1/profile_controller_test.exs
@@ -25,7 +25,7 @@ defmodule TrentoWeb.V1.ProfileControllerTest do
      conn: put_req_header(conn, "accept", "application/json"), api_spec: api_spec, user: user}
   end
 
-  test "should disable write profile action when external idp integration is enabled", %{
+  test "should disable write profile action when external IDP integration is enabled", %{
     conn: conn
   } do
     Application.put_env(:trento, :oidc, enabled: true)

--- a/test/trento_web/controllers/v1/profile_controller_test.exs
+++ b/test/trento_web/controllers/v1/profile_controller_test.exs
@@ -40,8 +40,7 @@ defmodule TrentoWeb.V1.ProfileControllerTest do
         delete(conn, "/api/v1/profile/totp_enrollment")
       ],
       fn conn ->
-        conn
-        |> json_response(501)
+        json_response(conn, 501)
       end
     )
 

--- a/test/trento_web/controllers/v1/users_controller_test.exs
+++ b/test/trento_web/controllers/v1/users_controller_test.exs
@@ -13,6 +13,15 @@ defmodule TrentoWeb.V1.UsersControllerTest do
   setup :setup_user
 
   describe "forbidden response" do
+    test "should return not implemented on create endpoint when external idp integration is enabled",
+         %{conn: conn} do
+      Application.put_env(:trento, :oidc, enabled: true)
+
+      res = post(conn, "/api/v1/users", %{})
+
+      json_response(res, 501)
+    end
+
     test "should return forbidden on any controller action if the user does not have the right permission",
          %{conn: conn, api_spec: api_spec} do
       %{id: user_id} = insert(:user)

--- a/test/trento_web/controllers/v1/users_controller_test.exs
+++ b/test/trento_web/controllers/v1/users_controller_test.exs
@@ -20,6 +20,8 @@ defmodule TrentoWeb.V1.UsersControllerTest do
       res = post(conn, "/api/v1/users", %{})
 
       json_response(res, 501)
+
+      Application.put_env(:trento, :oidc, enabled: false)
     end
 
     test "should return forbidden on any controller action if the user does not have the right permission",

--- a/test/trento_web/plugs/external_idp_guard_plug_test.exs
+++ b/test/trento_web/plugs/external_idp_guard_plug_test.exs
@@ -1,0 +1,27 @@
+defmodule TrentoWeb.Plugs.ExternalIdpGuardPlugTest do
+  @moduledoc false
+
+  use TrentoWeb.ConnCase, async: true
+  use Plug.Test
+
+  alias TrentoWeb.Plugs.ExternalIdpGuardPlug
+
+  describe "call/2" do
+    test "should return 501 when external idp integration is enabled", %{conn: conn} do
+      Application.put_env(:trento, :oidc, enabled: true)
+
+      opts = ExternalIdpGuardPlug.init([])
+      res = ExternalIdpGuardPlug.call(conn, opts)
+
+      assert res.status == 501
+      assert res.halted
+    end
+
+    test "should not halt connection when external idp integration is disabled", %{conn: conn} do
+      opts = ExternalIdpGuardPlug.init([])
+      res = ExternalIdpGuardPlug.call(conn, opts)
+
+      refute res.halted
+    end
+  end
+end

--- a/test/trento_web/plugs/external_idp_guard_plug_test.exs
+++ b/test/trento_web/plugs/external_idp_guard_plug_test.exs
@@ -15,6 +15,8 @@ defmodule TrentoWeb.Plugs.ExternalIdpGuardPlugTest do
 
       assert res.status == 501
       assert res.halted
+
+      Application.put_env(:trento, :oidc, enabled: false)
     end
 
     test "should not halt connection when external idp integration is disabled", %{conn: conn} do


### PR DESCRIPTION
# Description

This pr disable some controller action when external IDP is enabled

Disables:

- User create endpoint
- Profile Update endpoint with all the totp configuration
- Username/Password login endpoint


## How was this tested?

Automated tests 

