### PR TITLE
Fix cluster type tooltip message formatting

### DIFF
--- a/assets/js/common/ClusterTypeLabel/ClusterTypeLabel.jsx
+++ b/assets/js/common/ClusterTypeLabel/ClusterTypeLabel.jsx
@@ -14,7 +14,7 @@ const MIGRATION_URL =
   'https://www.suse.com/c/how-to-upgrade-to-saphanasr-angi/';
 const ANGI_TOOLTIP_MESSAGE = 'Angi architecture';
 const CLASSIC_TOOLTIP_MESSAGE = (
-  <>
+  <span>
     Classic architecture. Recommended{' '}
     <Link
       to={MIGRATION_URL}
@@ -24,7 +24,7 @@ const CLASSIC_TOOLTIP_MESSAGE = (
       migration
     </Link>{' '}
     to Angi architecture
-  </>
+  </span>
 );
 
 const icons = {


### PR DESCRIPTION
# Description

This little pr fixes the spacing problem on the cluster type tooltip message. In chrome and chromium no empty space was rendered. Firefox rendered the tooltip message correctly.

Played with different[ Whitespaces options in tailwindcss](https://tailwindcss.com/docs/whitespace) without success, for some reasons in chrome "whitespace-pre" class was not applied, wrapping it in a span applies the css rules in chrome and chromium

## Correct rendering in Firefox: 
 
![image](https://github.com/user-attachments/assets/2d4f115b-4a7c-4ffc-893d-226ce6329a19)

## Wrong rendering in Chrome and Chromium
Space between "migration" and  "to Angi architecture"
![image](https://github.com/user-attachments/assets/45fae415-c104-43e2-8f4f-34a5ce729189)

## Fixed rendering in Chrome and Chromium
![image](https://github.com/user-attachments/assets/5f01850d-cda3-4ce9-ae7f-548ced7ddf28)


## How was this tested?
Tested on: 
- Google Chrome Version 125.0.6422.141 manually
- Chromium Version 127.0.6533.88 manually
- Mozilla Firefox 127.0.2 manually

