### PR TITLE
View field for idp users

### DIFF
--- a/lib/trento/users.ex
+++ b/lib/trento/users.ex
@@ -33,6 +33,7 @@ defmodule Trento.Users do
     User
     |> where([u], is_nil(u.deleted_at))
     |> preload(:abilities)
+    |> preload(:user_identities)
     |> Repo.all()
   end
 
@@ -40,6 +41,7 @@ defmodule Trento.Users do
     case User
          |> where([u], is_nil(u.deleted_at) and u.id == ^id)
          |> preload(:abilities)
+         |> preload(:user_identities)
          |> Repo.one() do
       nil -> {:error, :not_found}
       user -> {:ok, user}

--- a/lib/trento/users.ex
+++ b/lib/trento/users.ex
@@ -56,7 +56,7 @@ defmodule Trento.Users do
 
     result =
       Ecto.Multi.new()
-      |> Ecto.Multi.insert(:user, User.changeset(%User{}, updated_attrs))
+      |> Ecto.Multi.insert(:user, User.changeset(%User{user_identities: []}, updated_attrs))
       |> insert_abilities_multi(abilities)
       |> Repo.transaction()
 
@@ -75,7 +75,7 @@ defmodule Trento.Users do
       |> maybe_set_locked_at()
       |> maybe_set_password_change_requested_at(false)
 
-    %User{abilities: []}
+    %User{abilities: [], user_identities: []}
     |> User.changeset(updated_attrs)
     |> Repo.insert()
   end

--- a/lib/trento_web/openapi/v1/schema/user.ex
+++ b/lib/trento_web/openapi/v1/schema/user.ex
@@ -270,6 +270,11 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             description: "User enabled in the system",
             nullable: false
           },
+          idp_user: %Schema{
+            type: :boolean,
+            description: "User coming from an external IDP",
+            nullable: false
+          },
           abilities: AbilityCollection,
           password_change_requested_at: %OpenApiSpex.Schema{
             type: :string,

--- a/lib/trento_web/openapi/v1/schema/user.ex
+++ b/lib/trento_web/openapi/v1/schema/user.ex
@@ -93,6 +93,11 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             nullable: false,
             format: :email
           },
+          idp_user: %Schema{
+            type: :boolean,
+            description: "User coming from an external IDP",
+            nullable: false
+          },
           abilities: AbilityCollection,
           password_change_requested: %Schema{
             type: :boolean,

--- a/lib/trento_web/views/v1/profile_view.ex
+++ b/lib/trento_web/views/v1/profile_view.ex
@@ -12,6 +12,7 @@ defmodule TrentoWeb.V1.ProfileView do
           abilities: abilities,
           password_change_requested_at: password_change_requested_at,
           totp_enabled_at: totp_enabled_at,
+          user_identities: user_identities,
           inserted_at: created_at,
           updated_at: updated_at
         }
@@ -25,6 +26,7 @@ defmodule TrentoWeb.V1.ProfileView do
       password_change_requested: password_change_requested_at != nil,
       totp_enabled: totp_enabled_at != nil,
       created_at: created_at,
+      idp_user: length(user_identities) > 0,
       updated_at: updated_at
     }
   end

--- a/lib/trento_web/views/v1/users_view.ex
+++ b/lib/trento_web/views/v1/users_view.ex
@@ -20,6 +20,7 @@ defmodule TrentoWeb.V1.UsersView do
           abilities: abilities,
           locked_at: locked_at,
           password_change_requested_at: password_change_requested_at,
+          user_identities: user_identities,
           totp_enabled_at: totp_enabled_at,
           inserted_at: created_at,
           updated_at: updated_at
@@ -32,6 +33,7 @@ defmodule TrentoWeb.V1.UsersView do
       email: email,
       abilities: render_many(abilities, AbilityView, "ability.json", as: :ability),
       enabled: locked_at == nil,
+      idp_user: length(user_identities) > 0,
       password_change_requested_at: password_change_requested_at,
       totp_enabled_at: totp_enabled_at,
       created_at: created_at,

--- a/test/trento/users_test.exs
+++ b/test/trento/users_test.exs
@@ -101,10 +101,19 @@ defmodule Trento.UsersTest do
       %{id: user_id} = insert(:user)
       %{id: ability_id} = insert(:ability)
       insert(:users_abilities, user_id: user_id, ability_id: ability_id)
+      %{id: identity_id} = insert(:user_identity, user_id: user_id)
 
       insert(:user, deleted_at: DateTime.utc_now())
       users = Users.list_users()
-      assert [%User{id: ^user_id, abilities: [%{id: ^ability_id}]}] = users
+
+      assert [
+               %User{
+                 id: ^user_id,
+                 user_identities: [%{id: ^identity_id}],
+                 abilities: [%{id: ^ability_id}]
+               }
+             ] = users
+
       assert length(users) == 1
     end
 
@@ -126,6 +135,20 @@ defmodule Trento.UsersTest do
       insert(:users_abilities, user_id: user_id, ability_id: ability_id)
 
       assert {:ok, %User{id: ^user_id, abilities: [%{id: ^ability_id}]}} = Users.get_user(user_id)
+    end
+
+    test "get_user return a user with the user identities" do
+      %{id: user_id} = insert(:user)
+      %{id: ability_id} = insert(:ability)
+      insert(:users_abilities, user_id: user_id, ability_id: ability_id)
+      %{id: identity_id} = insert(:user_identity, user_id: user_id)
+
+      assert {:ok,
+              %User{
+                id: ^user_id,
+                user_identities: [%{id: ^identity_id}],
+                abilities: [%{id: ^ability_id}]
+              }} = Users.get_user(user_id)
     end
 
     test "create_user with valid data creates a user" do

--- a/test/trento_web/views/v1/users_view_test.exs
+++ b/test/trento_web/views/v1/users_view_test.exs
@@ -1,0 +1,47 @@
+defmodule TrentoWeb.V1.UsersViewtest do
+  use TrentoWeb.ConnCase, async: true
+
+  import Phoenix.View
+  import Trento.Factory
+
+  alias TrentoWeb.V1.UsersView
+
+  describe "renders user.json" do
+    test "should correctly render a user when the user has user identities" do
+      identities = build_list(1, :user_identity)
+      abilities = build_list(1, :ability)
+
+      %{
+        email: email,
+        fullname: fullname,
+        id: id
+      } = user = build(:user, user_identities: identities, abilities: abilities)
+
+      assert %{
+               email: ^email,
+               enabled: true,
+               fullname: ^fullname,
+               id: ^id,
+               idp_user: true
+             } = render(UsersView, "user.json", user: user)
+    end
+
+    test "should correctly render a user when the user has no user identities" do
+      abilities = build_list(1, :ability)
+
+      %{
+        email: email,
+        fullname: fullname,
+        id: id
+      } = user = build(:user, abilities: abilities, user_identities: [])
+
+      assert %{
+               email: ^email,
+               enabled: true,
+               fullname: ^fullname,
+               id: ^id,
+               idp_user: false
+             } = render(UsersView, "user.json", user: user)
+    end
+  end
+end


### PR DESCRIPTION
# Description

This PR includes a new field called `idp_user` in the api response of profile and users controller.
This field will be true when the user has one or more user_identities associated, so it comes from an external IDP

## How was this tested?

Automated tests
