### PR TITLE
Allow only abilities update with OIDC

### DIFF
--- a/lib/trento_web/controllers/v1/users_controller.ex
+++ b/lib/trento_web/controllers/v1/users_controller.ex
@@ -182,7 +182,7 @@ defmodule TrentoWeb.V1.UsersController do
   end
 
   # when oidc is enabled, we only allow abilities as parameter
-  defp clean_params_for_oidc_integration(attrs, true), do: Map.take(attrs, [:abilities])
+  defp clean_params_for_oidc_integration(attrs, true), do: Map.take(attrs, [:abilities, :enabled])
   defp clean_params_for_oidc_integration(attrs, _), do: attrs
 
   defp oidc_enabled?, do: Application.fetch_env!(:trento, :oidc)[:enabled]

--- a/lib/trento_web/controllers/v1/users_controller.ex
+++ b/lib/trento_web/controllers/v1/users_controller.ex
@@ -130,6 +130,7 @@ defmodule TrentoWeb.V1.UsersController do
   def update(%{body_params: body_params} = conn, %{id: id}) do
     with {:ok, user} <- Users.get_user(id),
          {:ok, lock_version} <- user_version_from_if_match_header(conn),
+         body_params <- clean_params_for_oidc_integration(body_params, oidc_enabled?()),
          update_params <- Map.put(body_params, :lock_version, lock_version),
          {:ok, %User{} = user} <- Users.update_user(user, update_params),
          :ok <- broadcast_update_or_locked_user(user),
@@ -179,4 +180,10 @@ defmodule TrentoWeb.V1.UsersController do
   defp attach_user_version_as_etag_header(conn, %User{lock_version: lock_version}) do
     put_resp_header(conn, "etag", Integer.to_string(lock_version))
   end
+
+  # when oidc is enabled, we only allow abilities as parameter
+  defp clean_params_for_oidc_integration(attrs, true), do: Map.take(attrs, [:abilities])
+  defp clean_params_for_oidc_integration(attrs, _), do: attrs
+
+  defp oidc_enabled?, do: Application.fetch_env!(:trento, :oidc)[:enabled]
 end

--- a/test/trento/users_test.exs
+++ b/test/trento/users_test.exs
@@ -458,8 +458,9 @@ defmodule Trento.UsersTest do
 
       # we create the user with the user identity changeset
       {:ok, %User{} = user} =
-        User.user_identity_changeset(%User{}, user_identity_params, user_attrs, %{})
-        |> Trento.Repo.insert()
+        Trento.Repo.insert(
+          User.user_identity_changeset(%User{}, user_identity_params, user_attrs, %{})
+        )
 
       assert {:ok, %User{}} = Users.update_user(user, %{})
     end

--- a/test/trento_web/controllers/v1/users_controller_test.exs
+++ b/test/trento_web/controllers/v1/users_controller_test.exs
@@ -339,6 +339,71 @@ defmodule TrentoWeb.V1.UsersControllerTest do
       |> assert_schema("UserItem", api_spec)
     end
 
+    test "should only update abilities when oidc is enabled", %{conn: conn, api_spec: api_spec} do
+      Application.put_env(:trento, :oidc, enabled: true)
+
+      %{id: id, name: name, resource: resource, label: label} = insert(:ability)
+      %{id: user_id, lock_version: lock_version} = insert(:user)
+
+      valid_params = %{
+        fullname: Faker.Person.name(),
+        email: Faker.Internet.email(),
+        enabled: false,
+        password: "testpassword89",
+        password_confirmation: "testpassword89",
+        abilities: [%{id: id, name: name, resource: resource, label: label}]
+      }
+
+      %{abilities: abilities} =
+        resp =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("if-match", "#{lock_version}")
+        |> patch("/api/v1/users/#{user_id}", valid_params)
+        |> json_response(:ok)
+        |> assert_schema("UserItem", api_spec)
+
+      refute resp.fullname == valid_params.fullname
+      refute resp.email == valid_params.email
+      refute resp.enabled == valid_params.enabled
+      assert resp.password_change_requested_at == nil
+      assert abilities == [%{id: id, name: name, resource: resource, label: label}]
+
+      Application.put_env(:trento, :oidc, enabled: false)
+    end
+
+    test "should not perform an update when oidc is enabled and abilities are not passed", %{
+      conn: conn,
+      api_spec: api_spec
+    } do
+      Application.put_env(:trento, :oidc, enabled: true)
+
+      %{id: user_id, lock_version: lock_version} = insert(:user)
+
+      valid_params = %{
+        fullname: Faker.Person.name(),
+        email: Faker.Internet.email(),
+        enabled: false,
+        password: "testpassword89",
+        password_confirmation: "testpassword89"
+      }
+
+      resp =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("if-match", "#{lock_version}")
+        |> patch("/api/v1/users/#{user_id}", valid_params)
+        |> json_response(:ok)
+        |> assert_schema("UserItem", api_spec)
+
+      refute resp.fullname == valid_params.fullname
+      refute resp.email == valid_params.email
+      refute resp.enabled == valid_params.enabled
+      assert resp.password_change_requested_at == nil
+
+      Application.put_env(:trento, :oidc, enabled: false)
+    end
+
     test "should disable the TOTP feature for a user", %{conn: conn, api_spec: api_spec} do
       %{id: user_id, lock_version: lock_version} =
         insert(:user, totp_enabled_at: DateTime.utc_now())


### PR DESCRIPTION
# Description

This PR allows only the abilities to be updated when oidc is enabled and the users update endpoint is used.

## How was this tested?

Automated tests
