### PR TITLE
Fix fullname entry in trento console for a new created user by idp provider

### DIFF
--- a/lib/trento/users/user.ex
+++ b/lib/trento/users/user.ex
@@ -61,7 +61,7 @@ defmodule Trento.Users.User do
     |> cast(attrs, [:username, :email])
     |> put_change(
       :fullname,
-      Map.get(attrs, "given_name", "Trento IDP User #{username}")
+      Map.get(attrs, "name", "Trento IDP User #{username}")
     )
     |> pow_assent_user_identity_changeset(user_identity, attrs, user_id_attrs)
   end

--- a/lib/trento/users/user.ex
+++ b/lib/trento/users/user.ex
@@ -61,7 +61,7 @@ defmodule Trento.Users.User do
     |> cast(attrs, [:username, :email])
     |> put_change(
       :fullname,
-      Map.get(attrs, "given_namme", "Trento IDP User #{username}")
+      Map.get(attrs, "given_name", "Trento IDP User #{username}")
     )
     |> pow_assent_user_identity_changeset(user_identity, attrs, user_id_attrs)
   end


### PR DESCRIPTION
# Description

This pr will fix a typo in the user_identity_changeset command. 
The typo was `given_namme` fixed to  `given_name` which caused a false full name entry
![image](https://github.com/user-attachments/assets/16504db8-563f-43af-af71-9200ac24acc8)

On a second look it would make sense to use name instead of given_name.
In trento console we use the full name, the given name does not include the last name. 

Example attrs map:
`  attrs: %{
    "email" => "goku@gmx.de",
    "email_verified" => true,
    "family_name" => "Goku",
    "given_name" => "Son",
    "name" => "Son Goku",
    "sid" => "ff5b46ff-7158-4a78-a167-aab3fa34a367",
    "username" => "goku"
  },
`
With this change the created idp user will be stored in trento console like this:
![image](https://github.com/user-attachments/assets/72c82d4e-c277-4d73-985a-036a6177e977)
