### PR TITLE
Add support for prev/next pagination

### DIFF
--- a/assets/js/common/Table/Pagination.jsx
+++ b/assets/js/common/Table/Pagination.jsx
@@ -3,16 +3,25 @@ import classNames from 'classnames';
 import { noop } from 'lodash';
 
 import Select from '@common/Select';
+import {
+  EOS_KEYBOARD_DOUBLE_ARROW_LEFT,
+  EOS_KEYBOARD_DOUBLE_ARROW_RIGHT,
+} from 'eos-icons-react';
 
 const getPagesArray = (pages) => Array.from({ length: pages }, (_, i) => 1 + i);
 
 function Pagination({
+  cursor = false,
   pages,
   currentPage,
   onSelect,
   currentItemsPerPage = 10,
   itemsPerPageOptions = [10],
   onChangeItemsPerPage = noop,
+  canNavigateToPreviousPage = undefined,
+  onPreviousPage = noop,
+  canNavigateToNextPage = undefined,
+  onNextPage = noop,
 }) {
   const pagesList = getPagesArray(pages);
 
@@ -23,6 +32,16 @@ function Pagination({
     // otherwise the user is always staying at page 0
     onSelect(pages || 1);
   }
+
+  const navigationToPreviousPageEnabled =
+    typeof canNavigateToPreviousPage !== 'undefined'
+      ? canNavigateToPreviousPage
+      : currentPage > 1;
+
+  const navigationToNextPageEnabled =
+    typeof canNavigateToNextPage !== 'undefined'
+      ? canNavigateToNextPage
+      : currentPage < pages;
 
   return (
     <div className="flex justify-between p-2 bg-gray-50 width-full">
@@ -41,41 +60,74 @@ function Pagination({
         <span />
       )}
       <div className="flex items-center">
-        {pagesList.map((pageNumber) => {
-          const isFirst = pageNumber === 1;
-          const isLast = pageNumber === pages;
-          const classes = classNames(
-            'tn-page-item',
-            'w-full',
-            'px-4',
-            'py-2',
-            'text-xs',
-            'bg-white',
-            'hover:bg-gray-100',
-            {
-              'rounded-l-lg': isFirst,
-              'rounded-r-lg': isLast,
-              'border-l': isFirst,
-              'border-r': isLast,
-              'text-gray-600': currentPage !== pageNumber,
-              'text-jungle-green-500': currentPage === pageNumber,
-              border: pageNumber % 2 === 0,
-              'border-t': pageNumber % 2 === 1,
-              'border-b': pageNumber % 2 === 1,
-            }
-          );
-
-          return (
+        {cursor ? (
+          <>
             <button
-              key={pageNumber}
+              aria-label="prev-page"
               type="button"
-              className={classes}
-              onClick={() => onSelect(pageNumber)}
+              className="w-full px-2 py-2 text-xs bg-white hover:bg-gray-100 rounded-l-lg border"
+              onClick={() => onPreviousPage()}
+              disabled={!navigationToPreviousPageEnabled}
             >
-              {pageNumber}
+              <EOS_KEYBOARD_DOUBLE_ARROW_LEFT
+                className={classNames({
+                  'fill-gray-500': navigationToPreviousPageEnabled,
+                  'fill-gray-200': !navigationToPreviousPageEnabled,
+                })}
+              />
             </button>
-          );
-        })}
+            <button
+              aria-label="next-page"
+              type="button"
+              className="w-full px-2 py-2 text-xs bg-white hover:bg-gray-100 rounded-r-lg border-r border-t border-b"
+              onClick={() => onNextPage()}
+              disabled={!navigationToNextPageEnabled}
+            >
+              <EOS_KEYBOARD_DOUBLE_ARROW_RIGHT
+                className={classNames({
+                  'fill-gray-500': navigationToNextPageEnabled,
+                  'fill-gray-200': !navigationToNextPageEnabled,
+                })}
+              />
+            </button>
+          </>
+        ) : (
+          pagesList.map((pageNumber) => {
+            const isFirst = pageNumber === 1;
+            const isLast = pageNumber === pages;
+            const classes = classNames(
+              'tn-page-item',
+              'w-full',
+              'px-4',
+              'py-2',
+              'text-xs',
+              'bg-white',
+              'hover:bg-gray-100',
+              {
+                'rounded-l-lg': isFirst,
+                'rounded-r-lg': isLast,
+                'border-l': isFirst,
+                'border-r': isLast,
+                'text-gray-600': currentPage !== pageNumber,
+                'text-jungle-green-500': currentPage === pageNumber,
+                border: pageNumber % 2 === 0,
+                'border-t': pageNumber % 2 === 1,
+                'border-b': pageNumber % 2 === 1,
+              }
+            );
+
+            return (
+              <button
+                key={pageNumber}
+                type="button"
+                className={classes}
+                onClick={() => onSelect(pageNumber)}
+              >
+                {pageNumber}
+              </button>
+            );
+          })
+        )}
       </div>
     </div>
   );

--- a/assets/js/common/Table/Table.jsx
+++ b/assets/js/common/Table/Table.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/no-array-index-key */
 
 import React, { useState, useEffect } from 'react';
+import { noop } from 'lodash';
 import classNames from 'classnames';
 import { page, pages } from '@lib/lists';
 import { TableFilters, createFilter } from './filters';
@@ -77,6 +78,12 @@ function Table({
     rowClassName = '',
     collapsedRowClassName = '',
     pagination,
+    cursorPagination = false,
+    onChangeItemsPerPage = noop,
+    canNavigateToPreviousPage = undefined,
+    onPreviousPage = undefined,
+    canNavigateToNextPage = undefined,
+    onNextPage = undefined,
     usePadding = true,
   } = config;
 
@@ -150,6 +157,10 @@ function Table({
     : sortedData;
 
   const totalPages = pages(sortedData, currentItemsPerPage);
+
+  const onPreviousPageClick =
+    onPreviousPage ?? (() => setCurrentPage(currentPage - 1));
+  const onNextPageClick = onNextPage ?? (() => setCurrentPage(currentPage + 1));
 
   return (
     <div
@@ -242,13 +253,19 @@ function Table({
             </table>
             {pagination && (
               <Pagination
+                cursor={cursorPagination}
                 pages={totalPages}
                 currentPage={currentPage}
                 itemsPerPageOptions={itemsPerPageOptions}
                 currentItemsPerPage={currentItemsPerPage}
-                onChangeItemsPerPage={(perPage) =>
-                  setCurrentItemsPerPage(perPage)
-                }
+                onChangeItemsPerPage={(perPage) => {
+                  setCurrentItemsPerPage(perPage);
+                  onChangeItemsPerPage(perPage);
+                }}
+                canNavigateToPreviousPage={canNavigateToPreviousPage}
+                onPreviousPage={onPreviousPageClick}
+                canNavigateToNextPage={canNavigateToNextPage}
+                onNextPage={onNextPageClick}
                 onSelect={(selectedPage) => setCurrentPage(selectedPage)}
               />
             )}

--- a/assets/js/common/Table/Table.stories.jsx
+++ b/assets/js/common/Table/Table.stories.jsx
@@ -1,4 +1,8 @@
 import React, { useState } from 'react';
+import { faker } from '@faker-js/faker';
+
+import { format } from 'date-fns';
+import { Factory } from 'fishery';
 
 import Table from '.';
 
@@ -97,6 +101,19 @@ const data = [
   },
 ];
 
+const dataFactory = Factory.define(() => ({
+  user: faker.internet.userName(),
+  role: faker.helpers.arrayElement([
+    'Administrator',
+    'Employee',
+    'Head of Keks',
+  ]),
+  status: faker.helpers.arrayElement(['active', 'inactive']),
+  created_at: format(faker.date.past(), 'yyyy-MM-dd'),
+}));
+
+const paginatableData = dataFactory.buildList(55);
+
 export const Sorted = {
   args: {},
   render: () => {
@@ -173,34 +190,69 @@ export const Sorted = {
   },
 };
 
-export function Populated() {
-  return <Table config={config} data={data} />;
-}
+export const Populated = {
+  args: {
+    config,
+    data,
+  },
+};
 
-export function Paginated() {
-  return (
-    <Table
-      config={{ ...config, pagination: true }}
-      data={[].concat(data, data, data, data)}
-    />
-  );
-}
+export const WithPageBasedPagination = {
+  args: {
+    config: { ...config, pagination: true },
+    data: paginatableData,
+  },
+};
 
-export function WithFilters(args) {
-  return <Table config={filteredConfig} data={data} {...args} />;
-}
+export const WithCursorPagination = {
+  args: {
+    ...WithPageBasedPagination.args,
+    config: {
+      ...config,
+      pagination: true,
+      cursorPagination: true,
+    },
+  },
+};
 
-export function WithHeader(args) {
-  return (
-    <Table
-      config={config}
-      data={data}
-      header={<h3 className="bg-white px-4 py-4">Header</h3>}
-      {...args}
-    />
-  );
-}
+export const WithFilters = {
+  args: {
+    ...Populated.args,
+    config: filteredConfig,
+  },
+};
 
-export function Empty() {
-  return <Table config={config} data={[]} />;
-}
+export const WithFiltersAndPageBasedPagination = {
+  args: {
+    data: paginatableData,
+    config: {
+      ...filteredConfig,
+      pagination: true,
+    },
+  },
+};
+
+export const WithFiltersAndCursorBasedPagination = {
+  args: {
+    data: paginatableData,
+    config: {
+      ...filteredConfig,
+      pagination: true,
+      cursorPagination: true,
+    },
+  },
+};
+
+export const WithHeader = {
+  args: {
+    ...Populated.args,
+    header: <h3 className="bg-white px-4 py-4">Header</h3>,
+  },
+};
+
+export const Empty = {
+  args: {
+    config,
+    data: [],
+  },
+};


### PR DESCRIPTION
# Description

This PR introduces support for a cursor (ie prev/next) based pagination.
It can be used purely on the client or it can be hooked with callbacks interacting with a backend paginated API (what would happen for activity log page)

## How was this tested?

Automated tests and storybook.
