### PR TITLE
Add labeling opportunity to `<Filter>` component

### DIFF
--- a/assets/js/common/Filter/Filter.jsx
+++ b/assets/js/common/Filter/Filter.jsx
@@ -16,7 +16,7 @@ const getLabel = (value, placeholder) =>
  *
  * @param {string[]|[string, string][]} props.options List of options to filter, e.g. ['Option 1', 'Option 2']
  * @param {string} props.title Title of the filter. It will be displayed in the button when the filter is empty
- * @param {string[]} props.value Selected options. Default is an empty array
+ * @param {string|string[]} props.value Selected options. Default is an empty array
  * @param {function} props.onChange Function to call when the selected options change
  */
 function Filter({ options, title, value = [], onChange }) {
@@ -32,7 +32,9 @@ function Filter({ options, title, value = [], onChange }) {
     option[0].toLowerCase().includes(query.toLowerCase())
   );
 
-  const selectedLabels = value.reduce((acc, key) => {
+  const parsedValue = typeof value === 'string' ? [value] : value;
+
+  const selectedLabels = parsedValue.reduce((acc, key) => {
     const e = labeledOptions.find(([optionKey]) => optionKey === key);
     return e ? [...acc, e[1]] : acc;
   }, []);
@@ -42,7 +44,7 @@ function Filter({ options, title, value = [], onChange }) {
   return (
     <div className="flex-1 w-64 top-16" ref={ref}>
       <div className="mt-1 relative">
-        {value.length !== 0 && (
+        {parsedValue.length !== 0 && (
           <button
             type="button"
             aria-label="Clear filter"
@@ -66,14 +68,14 @@ function Filter({ options, title, value = [], onChange }) {
           <span className="flex items-center">
             <span
               className={classNames('ml-3 block truncate', {
-                'text-gray-500': value.length === 0,
+                'text-gray-500': parsedValue.length === 0,
               })}
             >
               {getLabel(selectedLabels, `Filter ${title}...`)}
             </span>
           </span>
           <span className="ml-3 absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-            {value.length === 0 && (
+            {parsedValue.length === 0 && (
               <svg
                 className="h-5 w-5 text-gray-400"
                 xmlns="http://www.w3.org/2000/svg"
@@ -120,17 +122,17 @@ function Filter({ options, title, value = [], onChange }) {
                   <li
                     key={index}
                     role="option"
-                    aria-selected={hasOne(value, [key])}
+                    aria-selected={hasOne(parsedValue, [key])}
                     aria-hidden="true"
                     className="text-gray-900 cursor-default select-none hover:bg-jungle-green-500 hover:text-white relative py-2 pl-3 pr-9"
-                    onClick={() => onChange(toggle(key, value))}
+                    onClick={() => onChange(toggle(key, parsedValue))}
                   >
                     <div className="flex items-center">
                       <span className="ml-3 block font-normal truncate">
                         {label}
                       </span>
                     </div>
-                    {hasOne(value, [key]) && (
+                    {hasOne(parsedValue, [key]) && (
                       <span className="absolute inset-y-0 right-0 flex items-center pr-4">
                         <EOS_CHECK size="m" />
                       </span>

--- a/assets/js/common/Filter/Filter.jsx
+++ b/assets/js/common/Filter/Filter.jsx
@@ -35,8 +35,8 @@ function Filter({ options, title, value = [], onChange }) {
   const parsedValue = typeof value === 'string' ? [value] : value;
 
   const selectedLabels = parsedValue.reduce((acc, key) => {
-    const e = labeledOptions.find(([optionKey]) => optionKey === key);
-    return e ? [...acc, e[1]] : acc;
+    const element = labeledOptions.find(([optionKey]) => optionKey === key);
+    return element ? [...acc, element[1]] : acc;
   }, []);
 
   useOnClickOutside(ref, () => setOpen(false));

--- a/assets/js/common/Filter/Filter.jsx
+++ b/assets/js/common/Filter/Filter.jsx
@@ -14,7 +14,7 @@ const getLabel = (value, placeholder) =>
 /**
  * Filter component
  *
- * @param {string[]} props.options List of options to filter, e.g. ['Option 1', 'Option 2']
+ * @param {string[]|[string, string][]} props.options List of options to filter, e.g. ['Option 1', 'Option 2']
  * @param {string} props.title Title of the filter. It will be displayed in the button when the filter is empty
  * @param {string[]} props.value Selected options. Default is an empty array
  * @param {function} props.onChange Function to call when the selected options change
@@ -24,9 +24,18 @@ function Filter({ options, title, value = [], onChange }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
 
-  const filteredOptions = options
+  const labeledOptions = options.map((option) =>
+    typeof option === 'string' ? [option, option] : option
+  );
+
+  const filteredOptions = labeledOptions
     .filter((option) => option !== undefined && option !== null)
-    .filter((option) => option.toLowerCase().includes(query.toLowerCase()));
+    .filter((option) => option[0].toLowerCase().includes(query.toLowerCase()));
+
+  const selectedLabels = value.reduce((acc, key) => {
+    const e = labeledOptions.find(([optionKey]) => optionKey === key);
+    return e ? [...acc, e[1]] : acc;
+  }, []);
 
   useOnClickOutside(ref, () => setOpen(false));
 
@@ -60,7 +69,7 @@ function Filter({ options, title, value = [], onChange }) {
                 'text-gray-500': value.length === 0,
               })}
             >
-              {getLabel(value, `Filter ${title}...`)}
+              {getLabel(selectedLabels, `Filter ${title}...`)}
             </span>
           </span>
           <span className="ml-3 absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
@@ -107,21 +116,21 @@ function Filter({ options, title, value = [], onChange }) {
                 aria-labelledby="listbox-label"
                 className="max-h-56 py-2 text-base overflow-auto focus:outline-none sm:text-sm"
               >
-                {filteredOptions.map((option, index) => (
+                {filteredOptions.map(([key, label], index) => (
                   <li
                     key={index}
                     role="option"
-                    aria-selected={hasOne(value, [option])}
+                    aria-selected={hasOne(value, [key])}
                     aria-hidden="true"
                     className="text-gray-900 cursor-default select-none hover:bg-jungle-green-500 hover:text-white relative py-2 pl-3 pr-9"
-                    onClick={() => onChange(toggle(option, value))}
+                    onClick={() => onChange(toggle(key, value))}
                   >
                     <div className="flex items-center">
                       <span className="ml-3 block font-normal truncate">
-                        {option}
+                        {label}
                       </span>
                     </div>
-                    {hasOne(value, [option]) && (
+                    {hasOne(value, [key]) && (
                       <span className="absolute inset-y-0 right-0 flex items-center pr-4">
                         <EOS_CHECK size="m" />
                       </span>

--- a/assets/js/common/Filter/Filter.jsx
+++ b/assets/js/common/Filter/Filter.jsx
@@ -24,13 +24,13 @@ function Filter({ options, title, value = [], onChange }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
 
-  const labeledOptions = options.map((option) =>
-    typeof option === 'string' ? [option, option] : option
-  );
-
-  const filteredOptions = labeledOptions
+  const labeledOptions = options
     .filter((option) => option !== undefined && option !== null)
-    .filter((option) => option[0].toLowerCase().includes(query.toLowerCase()));
+    .map((option) => (typeof option === 'string' ? [option, option] : option));
+
+  const filteredOptions = labeledOptions.filter((option) =>
+    option[0].toLowerCase().includes(query.toLowerCase())
+  );
 
   const selectedLabels = value.reduce((acc, key) => {
     const e = labeledOptions.find(([optionKey]) => optionKey === key);

--- a/assets/js/common/Filter/Filter.stories.jsx
+++ b/assets/js/common/Filter/Filter.stories.jsx
@@ -73,3 +73,17 @@ export const WithMultipleValues = {
     value: ['Tony Kekw', 'Chad Carbonara'],
   },
 };
+
+export const WithLabel = {
+  args: {
+    ...Default.args,
+    options: [
+      ['tony-kekw', 'Tony Kekw'],
+      ['chad-carbonara', 'Chad Carbonara'],
+      ['chuck-amatriciana', 'Chuck Amatriciana'],
+      ['kco-pepe', 'K.C.O. Pepe'],
+      ['virginia-gricia', 'Virginia Gricia'],
+    ],
+    value: ['tony-kekw'],
+  },
+};

--- a/assets/js/common/Filter/Filter.test.jsx
+++ b/assets/js/common/Filter/Filter.test.jsx
@@ -147,4 +147,47 @@ describe('Filter component', () => {
 
     expect(mockOnChange).toHaveBeenCalledWith([]);
   });
+
+  it('should use options with label', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = jest.fn();
+    const options = [
+      ['john-doe', 'John Doe'],
+      ['jane-smith', 'Jane Smith'],
+      ['michael-scott', 'Michael Scott'],
+      ['ella-fitzgerald', 'Ella Fitzgerald'],
+    ];
+
+    const selectedItem = 'michael-scott';
+    const selectedItemLabel = 'Michael Scott';
+
+    const anotherSelectedItem = 'jane-smith';
+    const anotherSelectedItemLabel = 'Jane Smith';
+
+    render(
+      <Filter
+        options={options}
+        title="names"
+        onChange={mockOnChange}
+        value={['michael-scott']}
+      />
+    );
+
+    await act(() => user.click(screen.getByText(selectedItemLabel)));
+
+    await act(() => {
+      options.forEach(([, label]) => {
+        expect(screen.getAllByText(label)[0]).toBeInTheDocument();
+      });
+    });
+
+    await act(() =>
+      user.click(screen.getAllByText(anotherSelectedItemLabel)[0])
+    );
+
+    expect(mockOnChange).toHaveBeenCalledWith([
+      selectedItem,
+      anotherSelectedItem,
+    ]);
+  });
 });

--- a/assets/js/common/Filter/Filter.test.jsx
+++ b/assets/js/common/Filter/Filter.test.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { render, screen, act } from '@testing-library/react';
+import React, { act } from 'react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import Filter from '.';

--- a/assets/js/common/Filter/Filter.test.jsx
+++ b/assets/js/common/Filter/Filter.test.jsx
@@ -190,4 +190,102 @@ describe('Filter component', () => {
       anotherSelectedItem,
     ]);
   });
+
+  it('should render correctly mixed options', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = jest.fn();
+    const options = [
+      'Michael Scott',
+      undefined,
+      ['john-doe', 'John Doe'],
+      'Jane Smith',
+    ];
+
+    render(
+      <Filter
+        options={options}
+        title="names"
+        onChange={mockOnChange}
+        value={['Michael Scott']}
+      />
+    );
+
+    await act(() => user.click(screen.getByText('Michael Scott')));
+
+    await act(() => {
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
+      expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+    });
+
+    /* Remember that the component is stateless, 
+      it does not change its internal state on selection. */
+
+    await act(() => user.click(screen.getByText('John Doe')));
+    expect(mockOnChange).toHaveBeenCalledWith(['Michael Scott', 'john-doe']);
+
+    await act(() => user.click(screen.getByText('Jane Smith')));
+    expect(mockOnChange).toHaveBeenCalledWith(['Michael Scott', 'Jane Smith']);
+  });
+
+  it('should ignore undefined values', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = jest.fn();
+    const options = [
+      'John Doe',
+      'Jane Smith',
+      'Michael Scott',
+      'Ella Fitzgerald',
+    ];
+
+    render(
+      <Filter
+        options={options}
+        title="names"
+        onChange={mockOnChange}
+        value={['Michael Scott', undefined]}
+      />
+    );
+
+    await act(() => user.click(screen.getByText('Michael Scott')));
+
+    await act(() => {
+      options.forEach((label) => {
+        expect(screen.getAllByText(label)[0]).toBeInTheDocument();
+      });
+    });
+  });
+
+  it('should ignore undefined options', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = jest.fn();
+    const options = [
+      '5E8',
+      undefined,
+      '32S',
+      '4B9',
+      'MF5',
+      'PRD',
+      'QAS',
+      'HA1',
+      'HA2',
+    ];
+    const value = ['PRD'];
+
+    render(
+      <Filter
+        options={options}
+        title="names"
+        onChange={mockOnChange}
+        value={value}
+      />
+    );
+
+    await act(() => user.click(screen.getByText('PRD')));
+
+    await act(() => {
+      options.filter(Boolean).forEach((label) => {
+        expect(screen.getAllByText(label)[0]).toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/assets/js/common/Filter/Filter.test.jsx
+++ b/assets/js/common/Filter/Filter.test.jsx
@@ -83,6 +83,36 @@ describe('Filter component', () => {
     expect(mockOnChange).toHaveBeenCalledWith([selectedItem, 'Jane Smith']);
   });
 
+  it('should select with one element if passed as string', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = jest.fn();
+    const options = [
+      'John Doe',
+      'Jane Smith',
+      'Michael Scott',
+      'Ella Fitzgerald',
+    ];
+
+    const selectedItem = 'Michael Scott';
+
+    render(
+      <Filter
+        options={options}
+        title="names"
+        onChange={mockOnChange}
+        value={selectedItem}
+      />
+    );
+
+    await act(() => user.click(screen.getByText(selectedItem)));
+
+    await act(() => user.click(screen.getByText('Jane Smith')));
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+
+    expect(mockOnChange).toHaveBeenCalledWith([selectedItem, 'Jane Smith']);
+  });
+
   it('should deselect an item on multiple item selected', async () => {
     const user = userEvent.setup();
     const mockOnChange = jest.fn();


### PR DESCRIPTION
# Description

The `<Filter>` component now allows options as key/value pairs. This is to cope with cases in which the value of the element must be different than the one shown.
Also, it enables a single value to be selected using a simple string, being more permissive on the allowed input.

This PR introduces no breaking changes.

## Usage
```ts
// normal usage
<Filter 
     value={["Mario Rossi"]}
     options={["Mario Rossi", "Giuseppe Verdi"]} />

// using string as value
<Filter 
     value="Mario Rossi"
     options={["Mario Rossi", "Giuseppe Verdi"]} />

// with key/value
<Filter 
     value={["mario_rossi"}
     options={[
       ["mario_rossi", "Mario Rossi"], 
       ["giuseppe_verdi", "Giuseppe Verdi"]
     ]} />
```

