### PR TITLE
Fetch patches for packages only if list is populated

### DIFF
--- a/assets/js/pages/UpgradablePackagesPage/UpgradablePackagesPage.jsx
+++ b/assets/js/pages/UpgradablePackagesPage/UpgradablePackagesPage.jsx
@@ -31,11 +31,11 @@ function UpgradablePackagesPage() {
   );
 
   useEffect(() => {
-    const packageIDs = upgradablePackages.map(
-      ({ to_package_id: packageID }) => packageID
-    );
+    if (upgradablePackages.length) {
+      const packageIDs = upgradablePackages.map(
+        ({ to_package_id: packageID }) => packageID
+      );
 
-    if (packageIDs.length > 0) {
       dispatch(fetchUpgradablePackagesPatches({ hostID, packageIDs }));
     }
   }, [upgradablePackages.length, hostID]);

--- a/assets/js/pages/UpgradablePackagesPage/UpgradablePackagesPage.jsx
+++ b/assets/js/pages/UpgradablePackagesPage/UpgradablePackagesPage.jsx
@@ -35,7 +35,9 @@ function UpgradablePackagesPage() {
       ({ to_package_id: packageID }) => packageID
     );
 
-    dispatch(fetchUpgradablePackagesPatches({ hostID, packageIDs }));
+    if (packageIDs.length > 0) {
+      dispatch(fetchUpgradablePackagesPatches({ hostID, packageIDs }));
+    }
   }, [upgradablePackages.length, hostID]);
 
   return (


### PR DESCRIPTION
As above, just fetch patches for packages only if the list is actually populated. Otherwise save up on the HTTP request since it would return an error.

## How was this tested?
Existing unit tests in place