### PR TITLE
Add filters to Activity log page

### DIFF
--- a/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
+++ b/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import { noop } from 'lodash';
+import { format, toZonedTime } from 'date-fns-tz';
+
 import {
   EOS_BUG_REPORT_OUTLINED,
   EOS_ERROR_OUTLINED,
@@ -20,7 +22,6 @@ import {
 } from '@lib/model/activityLog';
 
 import ActivityLogDetailModal from '@common/ActivityLogDetailsModal';
-import { format } from 'date-fns';
 
 const logLevelToIcon = {
   [LEVEL_DEBUG]: <EOS_BUG_REPORT_OUTLINED className="w-full" />,
@@ -38,7 +39,7 @@ const logLevelToLabel = {
 export const toRenderedEntry = (entry) => ({
   id: entry.id,
   type: entry.type,
-  time: format(entry.occurred_on, 'yyyy-MM-dd HH:mm:ss'),
+  time: format(toZonedTime(entry.occurred_on), 'yyyy-MM-dd HH:mm:ss'),
   message: toMessage(entry),
   user: entry.actor,
   level: ACTIVITY_LOG_LEVELS.includes(entry?.level) ? entry?.level : LEVEL_INFO,

--- a/assets/js/common/ComposedFilter/ComposedFilter.jsx
+++ b/assets/js/common/ComposedFilter/ComposedFilter.jsx
@@ -57,7 +57,7 @@ function ComposedFilter({
         .map(({ key, ...rest }) => [key, rest, value[key], onFilterChange(key)])
         .map((args) => renderFilter(...args))}
       {!autoApply && (
-        <div className="flex flex-row w-80 space-x-2">
+        <div className="flex flex-row w-64 space-x-2">
           <Button
             disabled={!isChanged}
             onClick={() => {

--- a/assets/js/common/DateFilter/DateFilter.jsx
+++ b/assets/js/common/DateFilter/DateFilter.jsx
@@ -56,7 +56,8 @@ const parseInputOptions = (options) =>
 const getSelectedOption = (options, value) => {
   const selectedId = Array.isArray(value) ? value[0] : value;
   if (selectedId === 'custom') {
-    return ['custom', value[1], () => toHumanDate(value[1])];
+    const date = new Date(value[1]);
+    return ['custom', date, () => toHumanDate(date)];
   }
   if (typeof selectedId === 'string') {
     return options.find((option) => option[0] === selectedId);

--- a/assets/js/common/Filter/Filter.test.jsx
+++ b/assets/js/common/Filter/Filter.test.jsx
@@ -318,4 +318,47 @@ describe('Filter component', () => {
       });
     });
   });
+
+  it('should use options with label', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = jest.fn();
+    const options = [
+      ['john-doe', 'John Doe'],
+      ['jane-smith', 'Jane Smith'],
+      ['michael-scott', 'Michael Scott'],
+      ['ella-fitzgerald', 'Ella Fitzgerald'],
+    ];
+
+    const selectedItem = 'michael-scott';
+    const selectedItemLabel = 'Michael Scott';
+
+    const anotherSelectedItem = 'jane-smith';
+    const anotherSelectedItemLabel = 'Jane Smith';
+
+    render(
+      <Filter
+        options={options}
+        title="names"
+        onChange={mockOnChange}
+        value={['michael-scott']}
+      />
+    );
+
+    await act(() => user.click(screen.getByText(selectedItemLabel)));
+
+    await act(() => {
+      options.forEach(([, label]) => {
+        expect(screen.getAllByText(label)[0]).toBeInTheDocument();
+      });
+    });
+
+    await act(() =>
+      user.click(screen.getAllByText(anotherSelectedItemLabel)[0])
+    );
+
+    expect(mockOnChange).toHaveBeenCalledWith([
+      selectedItem,
+      anotherSelectedItem,
+    ]);
+  });
 });

--- a/assets/js/common/Filter/Filter.test.jsx
+++ b/assets/js/common/Filter/Filter.test.jsx
@@ -361,4 +361,102 @@ describe('Filter component', () => {
       anotherSelectedItem,
     ]);
   });
+
+  it('should render correctly mixed options', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = jest.fn();
+    const options = [
+      'Michael Scott',
+      undefined,
+      ['john-doe', 'John Doe'],
+      'Jane Smith',
+    ];
+
+    render(
+      <Filter
+        options={options}
+        title="names"
+        onChange={mockOnChange}
+        value={['Michael Scott']}
+      />
+    );
+
+    await act(() => user.click(screen.getByText('Michael Scott')));
+
+    await act(() => {
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
+      expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+    });
+
+    /* Remember that the component is stateless, 
+      it does not change its internal state on selection. */
+
+    await act(() => user.click(screen.getByText('John Doe')));
+    expect(mockOnChange).toHaveBeenCalledWith(['Michael Scott', 'john-doe']);
+
+    await act(() => user.click(screen.getByText('Jane Smith')));
+    expect(mockOnChange).toHaveBeenCalledWith(['Michael Scott', 'Jane Smith']);
+  });
+
+  it('should ignore undefined values', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = jest.fn();
+    const options = [
+      'John Doe',
+      'Jane Smith',
+      'Michael Scott',
+      'Ella Fitzgerald',
+    ];
+
+    render(
+      <Filter
+        options={options}
+        title="names"
+        onChange={mockOnChange}
+        value={['Michael Scott', undefined]}
+      />
+    );
+
+    await act(() => user.click(screen.getByText('Michael Scott')));
+
+    await act(() => {
+      options.forEach((label) => {
+        expect(screen.getAllByText(label)[0]).toBeInTheDocument();
+      });
+    });
+  });
+
+  it('should ignore undefined options', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = jest.fn();
+    const options = [
+      '5E8',
+      undefined,
+      '32S',
+      '4B9',
+      'MF5',
+      'PRD',
+      'QAS',
+      'HA1',
+      'HA2',
+    ];
+    const value = ['PRD'];
+
+    render(
+      <Filter
+        options={options}
+        title="names"
+        onChange={mockOnChange}
+        value={value}
+      />
+    );
+
+    await act(() => user.click(screen.getByText('PRD')));
+
+    await act(() => {
+      options.filter(Boolean).forEach((label) => {
+        expect(screen.getAllByText(label)[0]).toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/assets/js/lib/api/activityLogs.js
+++ b/assets/js/lib/api/activityLogs.js
@@ -1,3 +1,4 @@
 import { networkClient } from '@lib/network';
 
-export const getActivityLog = () => networkClient.get(`/activity_log`);
+export const getActivityLog = (params) =>
+  networkClient.get(`/activity_log`, { params });

--- a/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
+++ b/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
@@ -1,18 +1,62 @@
 import React, { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
 import PageHeader from '@common/PageHeader';
 import ActivityLogOverview from '@common/ActivityLogOverview';
+import ComposedFilter from '@common/ComposedFilter';
 
 import { getActivityLog } from '@lib/api/activityLogs';
+import { ACTIVITY_TYPES_CONFIG } from '@lib/model/activityLog';
+
+const filters = [
+  {
+    key: 'type',
+    type: 'select',
+    title: 'Resource type',
+    options: Object.entries(ACTIVITY_TYPES_CONFIG).map(([key, value]) => [
+      key,
+      value.label,
+    ]),
+  },
+  {
+    key: 'from_date',
+    title: 'From date',
+    type: 'date',
+    prefilled: true,
+  },
+];
+
+const removeUndefinedFields = (obj) =>
+  Object.fromEntries(
+    Object.entries(obj).filter(([_, v]) => typeof v !== 'undefined')
+  );
+
+const searchParamsToFilters = (searchParams) =>
+  [...searchParams.entries()].reduce(
+    (acc, [key, value]) => ({ ...acc, [key]: [...(acc[key] || []), value] }),
+    {}
+  );
+
+const filtersToParams = (selectedFilters) =>
+  Object.entries(selectedFilters).reduce((acc, [key, value]) => {
+    switch (key) {
+      case 'from_date':
+        return { ...acc, from_date: new Date(value[1]).toISOString() };
+      default:
+        return { ...acc, [key]: value };
+    }
+  }, {});
 
 function ActivityLogPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
   const [activityLog, setActivityLog] = useState([]);
   const [isLoading, setLoading] = useState(true);
   const [activityLogDetailModalOpen, setActivityLogDetailModalOpen] =
     useState(false);
 
-  useEffect(() => {
-    getActivityLog()
+  const fetchActivityLog = (selectedFilters) => {
+    setLoading(true);
+    getActivityLog(filtersToParams(selectedFilters))
       .then((response) => {
         setActivityLog(response.data?.data ?? []);
       })
@@ -20,20 +64,35 @@ function ActivityLogPage() {
       .finally(() => {
         setLoading(false);
       });
-  }, []);
+  };
+
+  useEffect(() => {
+    fetchActivityLog(searchParamsToFilters(searchParams));
+  }, [searchParams]);
 
   return (
     <>
       <PageHeader className="font-bold">Activity Log</PageHeader>
-      <ActivityLogOverview
-        activityLogDetailModalOpen={activityLogDetailModalOpen}
-        activityLog={activityLog}
-        loading={isLoading}
-        onActivityLogEntryClick={() => setActivityLogDetailModalOpen(true)}
-        onCloseActivityLogEntryDetails={() =>
-          setActivityLogDetailModalOpen(false)
-        }
-      />
+      <div className="bg-white rounded-lg shadow">
+        <div style={{ padding: '1rem' }} />
+        <div className="flex items-center px-4 space-x-4 pb-4">
+          <ComposedFilter
+            filters={filters}
+            autoApply={false}
+            value={searchParamsToFilters(searchParams)}
+            onChange={(p) => setSearchParams(removeUndefinedFields(p))}
+          />
+        </div>
+        <ActivityLogOverview
+          activityLogDetailModalOpen={activityLogDetailModalOpen}
+          activityLog={activityLog}
+          loading={isLoading}
+          onActivityLogEntryClick={() => setActivityLogDetailModalOpen(true)}
+          onCloseActivityLogEntryDetails={() =>
+            setActivityLogDetailModalOpen(false)
+          }
+        />
+      </div>
     </>
   );
 }

--- a/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
+++ b/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
@@ -25,7 +25,13 @@ const filters = [
   },
   {
     key: 'from_date',
-    title: 'From date',
+    title: 'older than',
+    type: 'date',
+    prefilled: true,
+  },
+  {
+    key: 'to_date',
+    title: 'newer than',
     type: 'date',
     prefilled: true,
   },

--- a/assets/js/pages/ActivityLogPage/ActivityLogPage.test.jsx
+++ b/assets/js/pages/ActivityLogPage/ActivityLogPage.test.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { act, screen } from '@testing-library/react';
+import React, { act } from 'react';
+import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import MockAdapter from 'axios-mock-adapter';

--- a/assets/js/pages/ActivityLogPage/searchParams.js
+++ b/assets/js/pages/ActivityLogPage/searchParams.js
@@ -1,0 +1,74 @@
+/**
+ * This module exposes helper functions to handle query search parameters
+ */
+
+import { uniq } from 'lodash';
+import { pipe, map, reduce, defaultTo } from 'lodash/fp';
+import { fromZonedTime, toZonedTime } from 'date-fns-tz';
+
+const omitUndefined = (obj) =>
+  Object.fromEntries(
+    Object.entries(obj).filter(([_, v]) => typeof v !== 'undefined')
+  );
+
+const searchParamsToEntries = (searchParams) =>
+  pipe(Array.from, uniq, (keys) =>
+    keys.map((key) => [key, searchParams.getAll(key)])
+  )(searchParams.keys());
+
+/**
+ * Convert a search params object to an API params object as expected by the API client
+ * Make the necessary transformations to the values before setting them in the search params
+ */
+export const searchParamsToAPIParams = pipe(
+  searchParamsToEntries,
+  map(([key, value]) => {
+    switch (key) {
+      case 'from_date':
+        return [key, new Date(value[1]).toISOString()];
+      default:
+        return [key, value];
+    }
+  }),
+  Object.fromEntries
+);
+
+/**
+ * Convert a search params object to a filter value object as expected by the ComposedFilter component
+ * Make the necessary transformations to the values before setting them in the search params
+ */
+export const searchParamsToFilterValue = pipe(
+  searchParamsToEntries,
+  map(([k, v]) => {
+    switch (k) {
+      case 'from_date':
+        return [k, [v[0], toZonedTime(new Date(v[1]))]];
+      default:
+        return [k, v];
+    }
+  }),
+  Object.fromEntries
+);
+
+/**
+ * Convert a filter value object to a search params object as expected by the URLSearchParams API
+ * Make the necessary transformations to the values before setting them in the search params
+ */
+export const filterValueToSearchParams = pipe(
+  omitUndefined,
+  Object.entries,
+  map(([k, v]) => {
+    switch (k) {
+      case 'from_date':
+        return [k, [v[0], fromZonedTime(new Date(v[1])).toISOString()]];
+      default:
+        return [k, v];
+    }
+  }),
+  reduce((acc, [k, v]) => {
+    const sp = acc || new URLSearchParams();
+    Array.from(v).forEach((value) => sp.append(k, value));
+    return sp;
+  }, null),
+  defaultTo(new URLSearchParams())
+);

--- a/assets/js/pages/ActivityLogPage/searchParams.js
+++ b/assets/js/pages/ActivityLogPage/searchParams.js
@@ -25,6 +25,7 @@ export const searchParamsToAPIParams = pipe(
   map(([key, value]) => {
     switch (key) {
       case 'from_date':
+      case 'to_date':
         return [key, new Date(value[1]).toISOString()];
       default:
         return [key, value];
@@ -42,6 +43,7 @@ export const searchParamsToFilterValue = pipe(
   map(([k, v]) => {
     switch (k) {
       case 'from_date':
+      case 'to_date':
         return [k, [v[0], toZonedTime(new Date(v[1]))]];
       default:
         return [k, v];
@@ -60,6 +62,7 @@ export const filterValueToSearchParams = pipe(
   map(([k, v]) => {
     switch (k) {
       case 'from_date':
+      case 'to_date':
         return [k, [v[0], fromZonedTime(new Date(v[1])).toISOString()]];
       default:
         return [k, v];

--- a/assets/js/pages/ActivityLogPage/searchParams.test.js
+++ b/assets/js/pages/ActivityLogPage/searchParams.test.js
@@ -1,0 +1,95 @@
+import { fromZonedTime } from 'date-fns-tz';
+import {
+  filterValueToSearchParams,
+  searchParamsToAPIParams,
+  searchParamsToFilterValue,
+} from './searchParams';
+
+describe('searchParams helpers', () => {});
+describe('searchParamsToAPIParams', () => {
+  it('should convert search params to API params', () => {
+    const nowUTC = '2024-08-01T17:23:00.000Z';
+
+    const sp = new URLSearchParams();
+    sp.append('from_date', 'custom');
+    sp.append('from_date', nowUTC);
+    sp.append('type', 'login_attempt');
+    sp.append('type', 'resource_tagging');
+
+    const result = searchParamsToAPIParams(sp);
+
+    expect(result).toEqual({
+      from_date: nowUTC,
+      type: ['login_attempt', 'resource_tagging'],
+    });
+  });
+});
+
+describe('searchParamsToFilterValue', () => {
+  it('should convert search params to filter value', () => {
+    const nowUTC = '2024-08-01T17:23:00.000Z';
+
+    const sp = new URLSearchParams();
+    sp.append('from_date', 'custom');
+    sp.append('from_date', nowUTC);
+    sp.append('type', 'login_attempt');
+    sp.append('type', 'resource_tagging');
+
+    const result = searchParamsToFilterValue(sp);
+
+    expect(result).toEqual({
+      from_date: ['custom', expect.any(Date)],
+      type: ['login_attempt', 'resource_tagging'],
+    });
+
+    expect(result.from_date[1].getHours()).toEqual(17);
+  });
+});
+
+describe('filterValueToSearchParams', () => {
+  it('should convert filter value to search params', () => {
+    const now = new Date();
+    const utcNow = fromZonedTime(now).toISOString();
+
+    const filterValue = {
+      from_date: ['custom', now],
+      type: ['login_attempt', 'resource_tagging'],
+    };
+
+    const result = filterValueToSearchParams(filterValue);
+
+    expect(result.getAll('from_date')).toEqual(['custom', utcNow]);
+    expect(result.getAll('type')).toEqual([
+      'login_attempt',
+      'resource_tagging',
+    ]);
+  });
+
+  it('should use a fresh URLSearchParams instance', () => {
+    const now = new Date();
+    const utcNow = fromZonedTime(now).toISOString();
+
+    const filterValue = {
+      from_date: ['custom', now],
+      type: ['login_attempt', 'resource_tagging'],
+    };
+
+    // apply two times to test if the function is using a fresh URLSearchParams instance
+    /*          */ filterValueToSearchParams(filterValue);
+    const result = filterValueToSearchParams(filterValue);
+
+    expect(result.getAll('from_date')).toEqual(['custom', utcNow]);
+    expect(result.getAll('type')).toEqual([
+      'login_attempt',
+      'resource_tagging',
+    ]);
+  });
+
+  it('should return an instance of URLSearchParams when filters are empty', () => {
+    const filterValue = {};
+
+    const result = filterValueToSearchParams(filterValue);
+
+    expect(result).toEqual(expect.any(URLSearchParams));
+  });
+});

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -16,6 +16,7 @@
         "classnames": "^2.5.1",
         "copy-to-clipboard": "^3.3.3",
         "date-fns": "^3.6.0",
+        "date-fns-tz": "^3.1.3",
         "eos-icons-react": "^2.4.0",
         "lodash": "^4.17.21",
         "papaparse": "^5.4.1",
@@ -8371,6 +8372,14 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.1.3.tgz",
+      "integrity": "sha512-ZfbMu+nbzW0mEzC8VZrLiSWvUIaI3aRHeq33mTe7Y38UctKukgqPR4nTDwcwS4d64Gf8GghnVsroBuMY3eiTeA==",
+      "peerDependencies": {
+        "date-fns": "^3.0.0"
       }
     },
     "node_modules/debug": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -58,6 +58,7 @@
     "classnames": "^2.5.1",
     "copy-to-clipboard": "^3.3.3",
     "date-fns": "^3.6.0",
+    "date-fns-tz": "^3.1.3",
     "eos-icons-react": "^2.4.0",
     "lodash": "^4.17.21",
     "papaparse": "^5.4.1",

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -18,11 +18,11 @@ context('Activity Log page', () => {
 
     it('should render with selected filters from querystring', () => {
       cy.intercept({
-        url: '/api/v1/activity_log?from_date=2024-08-14T08:21:00.000Z&type[]=login_attempt&type[]=resource_tagging',
+        url: '/api/v1/activity_log?from_date=2024-08-14T10:21:00.000Z&type[]=login_attempt&type[]=resource_tagging',
       }).as('data');
 
       cy.visit(
-        '/activity_log?from_date=custom&from_date=Wed+Aug+14+2024+10%3A21%3A00+GMT%2B0200+%28Central+European+Summer+Time%29&type=login_attempt&type=resource_tagging'
+        '/activity_log?from_date=custom&from_date=2024-08-14T10%3A21%3A00.000Z&type=login_attempt&type=resource_tagging'
       );
 
       cy.contains('Login Attempt, Tag Added').should('be.visible');
@@ -47,7 +47,7 @@ context('Activity Log page', () => {
         'eq',
         `${
           Cypress.config().baseUrl
-        }/activity_log?from_date=custom&from_date=Wed+Aug+14+2024+10%3A21%3A00+GMT%2B0200+%28Central+European+Summer+Time%29&type=login_attempt&type=resource_tagging`
+        }/activity_log?from_date=custom&from_date=2024-08-14T10%3A21%3A00.000Z&type=login_attempt&type=resource_tagging`
       );
     });
 
@@ -57,7 +57,7 @@ context('Activity Log page', () => {
       }).as('data');
 
       cy.visit(
-        '/activity_log?from_date=custom&from_date=Wed+Aug+14+2024+10%3A21%3A00+GMT%2B0200+%28Central+European+Summer+Time%29&type=login_attempt&type=resource_tagging'
+        '/activity_log?from_date=custom&from_date=2024-08-14T10%3A21%3A00.000Z&type=login_attempt&type=resource_tagging'
       );
 
       cy.contains('Reset').click();

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -11,22 +11,28 @@ context('Activity Log page', () => {
       cy.contains('Filter Resource type', { matchCase: false }).should(
         'be.visible'
       );
-      cy.contains('Filter From', { matchCase: false }).should('be.visible');
+      cy.contains('Filter older than', { matchCase: false }).should(
+        'be.visible'
+      );
+      cy.contains('Filter newer than', { matchCase: false }).should(
+        'be.visible'
+      );
 
       cy.wait('@data').its('response.statusCode').should('eq', 200);
     });
 
     it('should render with selected filters from querystring', () => {
       cy.intercept({
-        url: '/api/v1/activity_log?from_date=2024-08-14T10:21:00.000Z&type[]=login_attempt&type[]=resource_tagging',
+        url: '/api/v1/activity_log?from_date=2024-08-14T10:21:00.000Z&to_date=2024-08-13T10:21:00.000Z&type[]=login_attempt&type[]=resource_tagging',
       }).as('data');
 
       cy.visit(
-        '/activity_log?from_date=custom&from_date=2024-08-14T10%3A21%3A00.000Z&type=login_attempt&type=resource_tagging'
+        '/activity_log?from_date=custom&from_date=2024-08-14T10%3A21%3A00.000Z&to_date=custom&to_date=2024-08-13T10%3A21%3A00.000Z&type=login_attempt&type=resource_tagging'
       );
 
       cy.contains('Login Attempt, Tag Added').should('be.visible');
       cy.contains('8/14/2024 10:21:00 AM').should('be.visible');
+      cy.contains('8/13/2024 10:21:00 AM').should('be.visible');
 
       cy.wait('@data').its('response.statusCode').should('eq', 200);
     });
@@ -34,8 +40,11 @@ context('Activity Log page', () => {
     it('should update querystring when filters are selected', () => {
       cy.visit('/activity_log');
 
-      cy.contains('Filter From').click();
-      cy.get('input[type="datetime-local"]').type('2024-08-14T10:21');
+      cy.contains('Filter older than').click();
+      cy.get('input[type="datetime-local"]:first').type('2024-08-14T10:21');
+
+      cy.contains('Filter newer than').click();
+      cy.get('input[type="datetime-local"]:last').type('2024-08-13T10:21');
 
       cy.contains('Filter Resource type').click();
       cy.contains('Login Attempt').click();
@@ -47,7 +56,7 @@ context('Activity Log page', () => {
         'eq',
         `${
           Cypress.config().baseUrl
-        }/activity_log?from_date=custom&from_date=2024-08-14T10%3A21%3A00.000Z&type=login_attempt&type=resource_tagging`
+        }/activity_log?from_date=custom&from_date=2024-08-14T10%3A21%3A00.000Z&to_date=custom&to_date=2024-08-13T10%3A21%3A00.000Z&type=login_attempt&type=resource_tagging`
       );
     });
 
@@ -65,7 +74,12 @@ context('Activity Log page', () => {
       cy.contains('Filter Resource type', { matchCase: false }).should(
         'be.visible'
       );
-      cy.contains('Filter From', { matchCase: false }).should('be.visible');
+      cy.contains('Filter older than', { matchCase: false }).should(
+        'be.visible'
+      );
+      cy.contains('Filter newer than', { matchCase: false }).should(
+        'be.visible'
+      );
 
       cy.wait('@data').its('response.statusCode').should('eq', 200);
     });

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -1,0 +1,73 @@
+/* eslint-disable cypress/no-unnecessary-waiting */
+
+context('Activity Log page', () => {
+  describe('Filtering', () => {
+    it('should render without selected filters', () => {
+      cy.intercept({
+        url: '/api/v1/activity_log',
+      }).as('data');
+      cy.visit('/activity_log');
+
+      cy.contains('Filter Resource type', { matchCase: false }).should(
+        'be.visible'
+      );
+      cy.contains('Filter From', { matchCase: false }).should('be.visible');
+
+      cy.wait('@data').its('response.statusCode').should('eq', 200);
+    });
+
+    it('should render with selected filters from querystring', () => {
+      cy.intercept({
+        url: '/api/v1/activity_log?from_date=2024-08-14T08:21:00.000Z&type[]=login_attempt&type[]=resource_tagging',
+      }).as('data');
+
+      cy.visit(
+        '/activity_log?from_date=custom&from_date=Wed+Aug+14+2024+10%3A21%3A00+GMT%2B0200+%28Central+European+Summer+Time%29&type=login_attempt&type=resource_tagging'
+      );
+
+      cy.contains('Login Attempt, Tag Added').should('be.visible');
+      cy.contains('8/14/2024 10:21:00 AM').should('be.visible');
+
+      cy.wait('@data').its('response.statusCode').should('eq', 200);
+    });
+
+    it('should update querystring when filters are selected', () => {
+      cy.visit('/activity_log');
+
+      cy.contains('Filter From').click();
+      cy.get('input[type="datetime-local"]').type('2024-08-14T10:21');
+
+      cy.contains('Filter Resource type').click();
+      cy.contains('Login Attempt').click();
+      cy.contains('Tag Added').click();
+
+      cy.contains('Apply').click();
+
+      cy.url().should(
+        'eq',
+        `${
+          Cypress.config().baseUrl
+        }/activity_log?from_date=custom&from_date=Wed+Aug+14+2024+10%3A21%3A00+GMT%2B0200+%28Central+European+Summer+Time%29&type=login_attempt&type=resource_tagging`
+      );
+    });
+
+    it('should reset filters', () => {
+      cy.intercept({
+        url: '/api/v1/activity_log',
+      }).as('data');
+
+      cy.visit(
+        '/activity_log?from_date=custom&from_date=Wed+Aug+14+2024+10%3A21%3A00+GMT%2B0200+%28Central+European+Summer+Time%29&type=login_attempt&type=resource_tagging'
+      );
+
+      cy.contains('Reset').click();
+
+      cy.contains('Filter Resource type', { matchCase: false }).should(
+        'be.visible'
+      );
+      cy.contains('Filter From', { matchCase: false }).should('be.visible');
+
+      cy.wait('@data').its('response.statusCode').should('eq', 200);
+    });
+  });
+});


### PR DESCRIPTION
# Description

Add filtering to the Activity log page

## Changes
* Allow the page to call the underlying API with needed params
* Mount filter by resource type
* Mount filter by date from
* Allow filters to be loaded from querystring
* refine `[Apply]` and `[Reset]` button sizes
* refine `<DateFilter>` input

## How was this tested?
E2E tests
