### PR TITLE
Review CI job dependencies for faster execution.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,7 +151,7 @@ jobs:
 
   static-code-analysis:
     name: Static Code Analysis
-    needs: [elixir-deps, npm-deps, api-bc-check]
+    needs: [elixir-deps, npm-deps]
     runs-on: ubuntu-20.04
     steps:
       - name: Cancel Previous Runs
@@ -232,7 +232,7 @@ jobs:
 
   test:
     name: Test
-    needs: [elixir-deps, api-bc-check]
+    needs: [elixir-deps]
     runs-on: ubuntu-20.04
     steps:
       - name: Cancel Previous Runs
@@ -451,14 +451,7 @@ jobs:
 
   regression-test-e2e:
     name: Regression tests
-    needs:
-      [
-        check-regression-label,
-        elixir-deps,
-        npm-deps,
-        npm-e2e-deps,
-        api-bc-check,
-      ]
+    needs: [check-regression-label, elixir-deps, npm-deps, npm-e2e-deps]
     runs-on: ubuntu-22.04
     if: needs.check-regression-label.outputs.run_regression_test == 'true'
     strategy:
@@ -573,7 +566,7 @@ jobs:
     name: Rebuild target branch dependencies
     runs-on: ubuntu-20.04
     env:
-      BRANCH_NAME: ${{ github.event.pull_request.base.ref || github.ref_name }} 
+      BRANCH_NAME: ${{ github.event.pull_request.base.ref || github.ref_name }}
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1
@@ -650,7 +643,7 @@ jobs:
       - name: Checkout target branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.ref || github.ref_name }} 
+          ref: ${{ github.event.pull_request.base.ref || github.ref_name }}
       - name: Retrieve Cached Dependencies - target branch
         uses: actions/cache@v4
         id: mix-cache-target

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -353,7 +353,7 @@ jobs:
 
   test-e2e:
     name: End to end tests
-    needs: [elixir-deps, npm-deps, npm-e2e-deps, api-bc-check]
+    needs: [elixir-deps, npm-deps, npm-e2e-deps]
     runs-on: ubuntu-20.04
     env:
       MIX_ENV: dev


### PR DESCRIPTION
# Description
Remove the dependency to `API bc check` step for the `End to end test` job.

The dependency is semantically correct (you don't need to run e2e if the contract is broken). However, the `API bc check` fails very rarely. As it lasts ~1 minute, it delays the execution of the e2e test by such time. 

Being the e2e test the most time-consuming job, by removing this dependency we get the CI workflow to be ~1 minute faster :rocket: 

![Screenshot from 2024-08-15 17-17-28](https://github.com/user-attachments/assets/7c1cae41-ce88-41f9-8497-352a640d2663)


Removed also from `Static Code Analysis`, `Test` and `Regression Test` for the same reason (but the time improvement will hide by e2e duration)