### PR TITLE
OIDC integration E2E  tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ env:
   NODE_VERSION: "20"
   MANTAINERS: '["cdimonaco", "dottorblaster", "janvhs", "rtorrero", "nelsonkopliku", "arbulu89","jagabomb","emaksy","jamie-suse"]'
   RG_TEST_LABEL: regression
+  INTEGRATION_TEST_LABEL: integration
 
 jobs:
   elixir-deps:
@@ -567,6 +568,108 @@ jobs:
         if: failure()
         with:
           name: regression-${{ matrix.test }}-e2e-screenshots
+          path: test/e2e/cypress/screenshots/
+
+  check-integration-tests-label:
+    name: Check if the integration test criteria are met, store in the job output
+    runs-on: ubuntu-22.04
+    outputs:
+      run_integration_test: ${{ steps.check.outputs.run_integration_test }}
+    steps:
+      - id: check
+        run: echo "run_integration_test=${{ contains(fromJson(env.MANTAINERS), github.event.sender.login) && contains(github.event.pull_request.labels.*.name, env.INTEGRATION_TEST_LABEL) }}" >> "$GITHUB_OUTPUT"
+
+  integration-test-e2e:
+    name: Integration tests
+    needs: [check-integration-tests-label, elixir-deps, npm-deps, npm-e2e-deps]
+    runs-on: ubuntu-22.04
+    if: needs.check-integration-tests-label.outputs.run_integration_test == 'true'
+    strategy:
+      matrix:
+        include:
+          - test: oidc
+            cypress_spec: |
+              cypress/e2e/oidc_integration.cy.js
+            config_file_content: |
+              import Config
+
+              config :trento, :oidc, enabled: true
+            env:
+              MIX_ENV: dev
+              CYPRESS_OIDC_INTEGRATION_TESTS: true
+    env: ${{ matrix.env }}      
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.12.1
+        with:
+          access_token: ${{ github.token }}
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup
+        id: setup-elixir
+        uses: erlef/setup-beam@v1
+        with:
+          version-file: .tool-versions
+          version-type: strict
+        env:
+          ImageOS: ubuntu20
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Retrieve Cached Dependencies
+        uses: actions/cache@v4
+        id: mix-cache
+        with:
+          path: |
+            deps
+            _build/dev
+            priv/plts
+          key: ${{ runner.os }}-${{ steps.setup-elixir.outputs.otp-version }}-${{ steps.setup-elixir.outputs.elixir-version }}-${{ hashFiles('mix.lock') }}
+      - name: Retrieve NPM Cached Dependencies
+        uses: actions/cache@v4
+        id: npm-cache
+        with:
+          path: |
+            assets/node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('assets/package-lock.json') }}
+      - name: Retrieve E2E NPM Cached Dependencies
+        uses: actions/cache@v4
+        id: npm-e2e-cache
+        with:
+          path: |
+            test/e2e/node_modules
+          key: ${{ runner.os }}-${{ env.NODE_VERSION }}-${{ hashFiles('test/e2e/package-lock.json') }}
+      - name: "Docker compose dependencies"
+        uses: isbang/compose-action@v2.0.1
+        with:
+          compose-file: "./docker-compose.yaml"
+          compose-flags: "--profile idp"
+          down-flags: "--volumes"
+      - name: Create dev.local.exs file
+        run: echo "${{ matrix.config_file_content }}" > config/dev.local.exs
+      - name: Mix setup
+        run: mix setup
+      - name: Run trento detached
+        run: mix phx.server &
+      - name: Cypress run
+        uses: cypress-io/github-action@v6
+        env:
+          cypress_video: false
+          cypress_db_host: postgres
+          cypress_db_port: 5432
+        with:
+          working-directory: test/e2e
+          spec: ${{ matrix.cypress_spec }}
+          wait-on-timeout: 30
+          config: baseUrl=http://localhost:4000
+      - name: Upload cypress test screenshots
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: integration-${{ matrix.test }}-e2e-screenshots
           path: test/e2e/cypress/screenshots/
 
   target-branch-deps:

--- a/container_fixtures/keycloak/realm.json
+++ b/container_fixtures/keycloak/realm.json
@@ -28,6 +28,22 @@
   ],
   "users": [
     {
+      "id": "trento-admin",
+      "email": "trentoadmin@trento.suse.com",
+      "username": "admin",
+      "firstName": "Trento admin user",
+      "lastName": "Superadmin",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        {
+          "temporary": false,
+          "type": "admin",
+          "value": "admin"
+        }
+      ]
+    },
+    {
       "id": "trento-idp-user",
       "email": "trentoidp@trento.suse.com",
       "username": "trentoidp",

--- a/test/e2e/cypress.config.js
+++ b/test/e2e/cypress.config.js
@@ -5,16 +5,17 @@ module.exports = defineConfig({
   viewportHeight: 768,
   defaultCommandTimeout: 10000,
   env: {
-    web_api_host: '127.0.0.1',
+    web_api_host: 'localhost',
     web_api_port: 4000,
     heartbeat_interval: 5000,
-    db_host: '127.0.0.1',
+    db_host: 'localhost',
     db_port: 5432,
     project_root: '../..',
     photofinish_binary: 'photofinish',
     login_user: 'admin',
     login_password: 'adminpassword',
     destination_environment: 'dev',
+    oidc_url: 'http://localhost:8081',
   },
   e2e: {
     // We've imported your old cypress plugins here.
@@ -23,6 +24,6 @@ module.exports = defineConfig({
       return require('./cypress/plugins/index.js')(on, config);
     },
     testIsolation: false,
-    baseUrl: 'http://127.0.0.1:4000',
+    baseUrl: 'http://localhost:4000',
   },
 });

--- a/test/e2e/cypress/e2e/oidc_integration.cy.js
+++ b/test/e2e/cypress/e2e/oidc_integration.cy.js
@@ -1,0 +1,104 @@
+import { adminUser, plainUser } from '../fixtures/oidc-integration/users';
+
+const loginWithOIDC = (username, password) => {
+  const args = [username, password];
+  cy.session(args, () => {
+    cy.visit('/');
+    cy.get('button').contains('Login with Single Sign-on').click();
+    cy.origin(Cypress.env('oidc_url'), { args }, ([username, password]) => {
+      cy.get('[id="username"]').type(username);
+      cy.get('[id="password"]').type(password);
+      cy.get('input').contains('Sign In').click();
+    });
+
+    cy.url().should('contain', '/auth/oidc_callback');
+    cy.get('h2').contains('Loading...');
+    cy.get('h1').contains('At a glance');
+  });
+};
+
+describe('OIDC integration', () => {
+  before(() => {
+    cy.clearAllLocalStorage();
+    cy.clearAllCookies();
+  });
+
+  it('should display Single Sign-on login page', () => {
+    cy.visit('/');
+    cy.get('h2').contains('Login to Trento');
+    cy.get('button').contains('Login with Single Sign-on');
+  });
+
+  it('should redirect to external IDP login page when login button is clicked', () => {
+    cy.get('button').contains('Login with Single Sign-on').click();
+    cy.origin(Cypress.env('oidc_url'), () => {
+      cy.url().should('contain', '/realms/trento');
+    });
+  });
+
+  it('should login properly once authentication is completed', () => {
+    loginWithOIDC(plainUser.username, plainUser.password);
+    cy.get('span').contains(plainUser.username);
+  });
+
+  describe('Plain user', () => {
+    beforeEach(() => {
+      loginWithOIDC(plainUser.username, plainUser.password);
+    });
+
+    it('should have a read only profile view and empty list of permissions', () => {
+      cy.visit('/profile');
+      cy.get('input').eq(0).should('have.value', plainUser.fullname);
+      cy.get('input').eq(1).should('have.value', plainUser.email);
+      cy.get('input').eq(2).should('have.value', plainUser.username);
+    });
+
+    it('should be able to logout and login without a new authentication request', () => {
+      cy.get('span').contains(plainUser.username).click();
+      cy.get('button').contains('Sign out').click();
+      cy.get('button').contains('Login with Single Sign-on').click();
+      cy.get('h2').contains('Loading...');
+      cy.get('h1').contains('At a glance');
+    });
+  });
+
+  describe('Admin user', () => {
+    beforeEach(() => {
+      loginWithOIDC(adminUser.username, adminUser.password);
+    });
+
+    it('should have access to Users view', () => {
+      cy.visit('/users');
+      cy.url().should('include', '/users');
+      cy.get('a').contains(plainUser.username);
+      cy.get('a').contains(adminUser.username);
+    });
+
+    it('should not have user creation button', () => {
+      cy.get('button').contains('Create User').should('not.exist');
+    });
+
+    it('should have the ability to update user permissions and status', () => {
+      cy.get('a').contains(plainUser.username).click();
+      cy.get('div').contains('Default').click({ force: true });
+      cy.get('div').contains('all:users').click();
+      cy.get('div').contains('Enabled').click();
+      cy.get('div').contains('Disabled').click();
+      cy.get('button').contains('Save').click();
+
+      cy.get('a').contains(plainUser.username).click();
+      cy.get('div').contains('all:users').parent().find('svg').click();
+      cy.get('div').contains('Disabled').click();
+      cy.get('div').contains('Enabled').click();
+      cy.get('button').contains('Save').click();
+    });
+
+    it('should have a read only profile view and all:all permissions', () => {
+      cy.visit('/profile');
+      cy.get('input').eq(0).should('have.value', adminUser.fullname);
+      cy.get('input').eq(1).should('have.value', adminUser.email);
+      cy.get('input').eq(2).should('have.value', adminUser.username);
+      cy.get('div').contains(adminUser.permissions);
+    });
+  });
+});

--- a/test/e2e/cypress/e2e/oidc_integration.cy.js
+++ b/test/e2e/cypress/e2e/oidc_integration.cy.js
@@ -18,6 +18,10 @@ const loginWithOIDC = (username, password) => {
 };
 
 describe('OIDC integration', () => {
+  if (!Cypress.env('OIDC_INTEGRATION_TESTS')) {
+    return;
+  }
+
   before(() => {
     cy.clearAllLocalStorage();
     cy.clearAllCookies();

--- a/test/e2e/cypress/fixtures/oidc-integration/users.js
+++ b/test/e2e/cypress/fixtures/oidc-integration/users.js
@@ -1,0 +1,14 @@
+export const plainUser = {
+  username: 'trentoidp',
+  password: 'password',
+  fullname: 'Trento IDP user Of Monk',
+  email: 'trentoidp@trento.suse.com',
+};
+
+export const adminUser = {
+  username: 'admin',
+  password: 'admin',
+  fullname: 'Trento Admin',
+  email: 'admin@trento.suse.com',
+  permissions: 'all:all',
+};

--- a/test/e2e/cypress/support/e2e.js
+++ b/test/e2e/cypress/support/e2e.js
@@ -24,5 +24,7 @@ import './commands';
 
 before(() => {
   Cypress.session.clearAllSavedSessions();
-  cy.login();
+  if (!Cypress.env('OIDC_INTEGRATION_TESTS')) {
+    cy.login();
+  }
 });


### PR DESCRIPTION
# Description

Add e2e tests for the OIDC feature integration.
In order to run them, we need to start our docker compose with the `--profile idp` flag, as it will use our keycloack deployment in the testing.

In the same case, to run the tests in the github CI, we need to add the `integration` label to the PR.

## How was this tested?

E2e tests
