### PR TITLE
Renaming PolicyHelper to AbilitiesHelper

### DIFF
--- a/lib/trento/clusters/policy.ex
+++ b/lib/trento/clusters/policy.ex
@@ -4,7 +4,7 @@ defmodule Trento.Clusters.Policy do
   """
   @behaviour Bodyguard.Policy
 
-  import Trento.Support.PolicyHelper
+  import Trento.Support.AbilitiesHelper
   alias Trento.Clusters.Projections.ClusterReadModel
   alias Trento.Users.User
 

--- a/lib/trento/databases/policy.ex
+++ b/lib/trento/databases/policy.ex
@@ -6,7 +6,7 @@ defmodule Trento.Databases.Policy do
   """
   @behaviour Bodyguard.Policy
 
-  import Trento.Support.PolicyHelper
+  import Trento.Support.AbilitiesHelper
   alias Trento.Databases.Projections.DatabaseReadModel
   alias Trento.Users.User
 

--- a/lib/trento/hosts/policy.ex
+++ b/lib/trento/hosts/policy.ex
@@ -9,7 +9,7 @@ defmodule Trento.Hosts.Policy do
   """
   @behaviour Bodyguard.Policy
 
-  import Trento.Support.PolicyHelper
+  import Trento.Support.AbilitiesHelper
   alias Trento.Hosts.Projections.HostReadModel
   alias Trento.Users.User
 

--- a/lib/trento/sap_systems/policy.ex
+++ b/lib/trento/sap_systems/policy.ex
@@ -6,7 +6,7 @@ defmodule Trento.SapSystems.Policy do
   """
   @behaviour Bodyguard.Policy
 
-  import Trento.Support.PolicyHelper
+  import Trento.Support.AbilitiesHelper
   alias Trento.SapSystems.Projections.SapSystemReadModel
   alias Trento.Users.User
 

--- a/lib/trento/settings/policy.ex
+++ b/lib/trento/settings/policy.ex
@@ -8,7 +8,7 @@ defmodule Trento.Settings.Policy do
   """
   @behaviour Bodyguard.Policy
 
-  import Trento.Support.PolicyHelper
+  import Trento.Support.AbilitiesHelper
   alias Trento.ActivityLog.Settings, as: ActivityLogSettings
   alias Trento.Settings.ApiKeySettings
   alias Trento.Settings.SuseManagerSettings

--- a/lib/trento/support/abilities_helper.ex
+++ b/lib/trento/support/abilities_helper.ex
@@ -1,4 +1,4 @@
-defmodule Trento.Support.PolicyHelper do
+defmodule Trento.Support.AbilitiesHelper do
   @moduledoc """
   Helper functions for bodyguard policies
   """

--- a/lib/trento/tags/policy.ex
+++ b/lib/trento/tags/policy.ex
@@ -13,7 +13,7 @@ defmodule Trento.Tags.Policy do
   """
   @behaviour Bodyguard.Policy
 
-  import Trento.Support.PolicyHelper
+  import Trento.Support.AbilitiesHelper
   alias Trento.Tags.Tag
   alias Trento.Users.User
 

--- a/lib/trento/users/policy.ex
+++ b/lib/trento/users/policy.ex
@@ -6,7 +6,7 @@ defmodule Trento.Users.Policy do
   """
   @behaviour Bodyguard.Policy
 
-  import Trento.Support.PolicyHelper
+  import Trento.Support.AbilitiesHelper
   alias Trento.Users.User
 
   def authorize(action, %User{} = user, User) when action in [:index, :show],

--- a/lib/trento_web/controllers/v1/activity_log_controller.ex
+++ b/lib/trento_web/controllers/v1/activity_log_controller.ex
@@ -3,7 +3,7 @@ defmodule TrentoWeb.V1.ActivityLogController do
   use OpenApiSpex.ControllerSpecs
 
   alias Trento.ActivityLog
-  alias Trento.Support.PolicyHelper
+  alias Trento.Support.AbilitiesHelper
   alias TrentoWeb.OpenApi.V1.Schema
 
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
@@ -76,8 +76,8 @@ defmodule TrentoWeb.V1.ActivityLogController do
 
   defp include_all_logs?(user),
     do:
-      PolicyHelper.has_global_ability?(user) or
-        PolicyHelper.user_has_ability?(user, %{
+      AbilitiesHelper.has_global_ability?(user) or
+        AbilitiesHelper.user_has_ability?(user, %{
           name: "all",
           resource: "users"
         })

--- a/test/trento/support/abilities_helper_test.exs
+++ b/test/trento/support/abilities_helper_test.exs
@@ -1,9 +1,9 @@
-defmodule Trento.Support.PolicyHelperTest do
+defmodule Trento.Support.AbilitiesHelperTest do
   use ExUnit.Case
 
   import Trento.Factory
 
-  alias Trento.Support.PolicyHelper
+  alias Trento.Support.AbilitiesHelper
 
   test "user_has_ability/2 returns true if user has the ability on the resource" do
     first_ability = build(:ability, name: "manage", resource: "things")
@@ -11,7 +11,7 @@ defmodule Trento.Support.PolicyHelperTest do
 
     user = build(:user, abilities: [first_ability, second_ability])
 
-    assert true == PolicyHelper.user_has_ability?(user, %{name: "manage", resource: "things"})
+    assert true == AbilitiesHelper.user_has_ability?(user, %{name: "manage", resource: "things"})
   end
 
   test "user_has_ability/2 returns false if user does not have the ability on the resource" do
@@ -20,7 +20,7 @@ defmodule Trento.Support.PolicyHelperTest do
 
     user = build(:user, abilities: [first_ability, second_ability])
 
-    assert false == PolicyHelper.user_has_ability?(user, %{name: "write", resource: "things"})
+    assert false == AbilitiesHelper.user_has_ability?(user, %{name: "write", resource: "things"})
   end
 
   test "has_global_ability/2 returns true if user does have the global ability" do
@@ -29,6 +29,6 @@ defmodule Trento.Support.PolicyHelperTest do
 
     user = build(:user, abilities: [first_ability, second_ability])
 
-    assert true == PolicyHelper.has_global_ability?(user)
+    assert true == AbilitiesHelper.has_global_ability?(user)
   end
 end


### PR DESCRIPTION
`PolicyHelper` renamed to `AbilitiesHelper` everywhere.
Following up on previously received feedback:
- https://github.com/trento-project/web/pull/2903#issuecomment-2298204585
- https://github.com/trento-project/web/pull/2903#pullrequestreview-2247336268
