### PR TITLE
Fix flacky UserPage test

### DIFF
--- a/assets/js/pages/Users/UsersPage.test.jsx
+++ b/assets/js/pages/Users/UsersPage.test.jsx
@@ -36,9 +36,7 @@ describe('UsersPage', () => {
     await act(async () => {
       renderWithRouter(<UsersPage />);
     });
-    await waitFor(() => {
-      expect(screen.getByText('No data available')).toBeVisible();
-    });
+    expect(await screen.getByText('No data available')).toBeVisible();
   });
 
   it('should render table with users', async () => {
@@ -51,10 +49,8 @@ describe('UsersPage', () => {
       renderWithRouter(<UsersPage />);
     });
 
-    await waitFor(() => {
-      expect(screen.getByText(admin.username)).toBeInTheDocument();
-      expect(screen.getByText(user.username)).toBeInTheDocument();
-    });
+    expect(await screen.getByText(admin.username)).toBeInTheDocument();
+    expect(await screen.getByText(user.username)).toBeInTheDocument();
   });
 
   it('should render toast with failing message when fetching users failed', async () => {

--- a/assets/js/pages/Users/UsersPage.test.jsx
+++ b/assets/js/pages/Users/UsersPage.test.jsx
@@ -5,7 +5,7 @@ import MockAdapter from 'axios-mock-adapter';
 import { toast } from 'react-hot-toast';
 
 import { networkClient } from '@lib/network';
-import { screen, act } from '@testing-library/react';
+import { screen, act, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { adminUser, userFactory } from '@lib/test-utils/factories/users';
 import { renderWithRouter } from '@lib/test-utils';
@@ -36,7 +36,9 @@ describe('UsersPage', () => {
     await act(async () => {
       renderWithRouter(<UsersPage />);
     });
-    expect(await screen.getByText('No data available')).toBeVisible();
+    await waitFor(() => {
+      expect(screen.getByText('No data available')).toBeVisible();
+    });
   });
 
   it('should render table with users', async () => {
@@ -49,8 +51,10 @@ describe('UsersPage', () => {
       renderWithRouter(<UsersPage />);
     });
 
-    expect(await screen.getByText(admin.username)).toBeInTheDocument();
-    expect(await screen.getByText(user.username)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(admin.username)).toBeInTheDocument();
+      expect(screen.getByText(user.username)).toBeInTheDocument();
+    });
   });
 
   it('should render toast with failing message when fetching users failed', async () => {
@@ -59,7 +63,9 @@ describe('UsersPage', () => {
     await act(async () => {
       renderWithRouter(<UsersPage />);
     });
-    expect(toast.error).toHaveBeenCalledWith(fetchErrorMessage);
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(fetchErrorMessage);
+    });
   });
 
   it('should render toast with success message when deleting was successfully', async () => {
@@ -86,7 +92,9 @@ describe('UsersPage', () => {
 
     expect(axiosMock.history.delete.length).toBe(1);
     expect(axiosMock.history.delete[0].url).toBe(`/users/${user.id}`);
-    expect(toast.success).toHaveBeenCalledWith(deleteMessage);
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(deleteMessage);
+    });
   });
 
   it('should render toast with error message when deleting failed', async () => {
@@ -107,6 +115,8 @@ describe('UsersPage', () => {
 
     expect(axiosMock.history.delete.length).toBe(1);
     expect(axiosMock.history.delete[0].url).toBe(`/users/${user.id}`);
-    expect(toast.error).toHaveBeenCalledWith(userNotFoundMessage);
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(userNotFoundMessage);
+    });
   });
 });


### PR DESCRIPTION
# Description

Long Ci runs may cause some timing issues in the UserPage test. Adding [waitFor](https://testing-library.com/docs/dom-testing-library/api-async/#waitfor) should help.

## How was this tested?

Run locally multiple times, let's rerun it some times in the whole ci.
After running the ci 5 times, no more errors.
