### PR TITLE
Fix patches for packages' request too long

### DIFF
--- a/assets/js/common/Table/Table.jsx
+++ b/assets/js/common/Table/Table.jsx
@@ -2,6 +2,8 @@
 
 import React, { useState, useEffect } from 'react';
 import classNames from 'classnames';
+import { noop } from 'lodash';
+
 import { page, pages } from '@lib/lists';
 import Pagination from '@common/Pagination';
 import { TableFilters, createFilter } from './filters';
@@ -78,6 +80,7 @@ function Table({
     collapsedRowClassName = '',
     pagination,
     usePadding = true,
+    onPageChange = noop,
   } = config;
 
   const [filters, setFilters] = useState([]);
@@ -148,6 +151,10 @@ function Table({
   const renderedData = pagination
     ? page(currentPage, sortedData, currentItemsPerPage)
     : sortedData;
+
+  useEffect(() => {
+    onPageChange(renderedData);
+  }, [currentPage, renderedData.length]);
 
   const totalPages = pages(sortedData, currentItemsPerPage);
 

--- a/assets/js/common/Table/Table.test.jsx
+++ b/assets/js/common/Table/Table.test.jsx
@@ -97,6 +97,23 @@ describe('Table component', () => {
     expect(screen.queryByText(headerText)).toBeInTheDocument();
   });
 
+  it('should fire the onPageChange callback', () => {
+    const data = tableDataFactory.buildList(20);
+    const onPageChange = jest.fn();
+
+    const expectedPayload = data.slice(0, 10);
+
+    render(
+      <Table
+        config={{ ...tableConfig, onPageChange }}
+        data={data}
+        setSearchParams={() => {}}
+      />
+    );
+
+    expect(onPageChange).toHaveBeenCalledWith(expectedPayload);
+  });
+
   describe('filtering', () => {
     it('should filter by the chosen filter option with default filter', async () => {
       const data = tableDataFactory.buildList(10);

--- a/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.jsx
+++ b/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.jsx
@@ -9,6 +9,7 @@ const upgradablePackagesDefault = [];
 function UpgradablePackagesList({
   upgradablePackages = upgradablePackagesDefault,
   onPatchClick = noop,
+  onLoad = noop,
 }) {
   const [sortDirection, setSortDirection] = useState('asc');
 
@@ -28,6 +29,7 @@ function UpgradablePackagesList({
   const config = {
     pagination: true,
     usePadding: false,
+    onPageChange: onLoad,
     columns: [
       {
         title: 'Installed Packages',

--- a/assets/js/pages/UpgradablePackagesPage/UpgradablePackages.jsx
+++ b/assets/js/pages/UpgradablePackagesPage/UpgradablePackages.jsx
@@ -11,6 +11,7 @@ export default function UpgradablePackages({
   hostName,
   upgradablePackages,
   onPatchClick = noop,
+  onLoad = noop,
 }) {
   const [search, setSearch] = useState('');
 
@@ -42,6 +43,7 @@ export default function UpgradablePackages({
       <UpgradablePackagesList
         upgradablePackages={displayedPackages}
         onPatchClick={onPatchClick}
+        onLoad={onLoad}
       />
     </>
   );

--- a/assets/js/pages/UpgradablePackagesPage/UpgradablePackagesPage.jsx
+++ b/assets/js/pages/UpgradablePackagesPage/UpgradablePackagesPage.jsx
@@ -30,16 +30,6 @@ function UpgradablePackagesPage() {
     getUpgradablePackages(state, hostID)
   );
 
-  useEffect(() => {
-    if (upgradablePackages.length) {
-      const packageIDs = upgradablePackages.map(
-        ({ to_package_id: packageID }) => packageID
-      );
-
-      dispatch(fetchUpgradablePackagesPatches({ hostID, packageIDs }));
-    }
-  }, [upgradablePackages.length, hostID]);
-
   return (
     <>
       <BackButton url={`/hosts/${hostID}`}>Back to Host Details</BackButton>
@@ -49,6 +39,15 @@ function UpgradablePackagesPage() {
         onPatchClick={(advisoryID) =>
           navigate(`/hosts/${hostID}/patches/${advisoryID}`)
         }
+        onLoad={(items) => {
+          if (items.length) {
+            const packageIDs = items.map(
+              ({ to_package_id: packageID }) => packageID
+            );
+
+            dispatch(fetchUpgradablePackagesPatches({ hostID, packageIDs }));
+          }
+        }}
       />
     </>
   );

--- a/assets/js/state/sagas/softwareUpdates.test.js
+++ b/assets/js/state/sagas/softwareUpdates.test.js
@@ -147,7 +147,7 @@ describe('Software Updates saga', () => {
     it('sets patches for upgradable packages', async () => {
       const axiosMock = new MockAdapter(networkClient);
       const hostID = faker.string.uuid();
-      const packageIDs = [faker.string.uuid(), faker.string.uuid()];
+      const packageIDs = [faker.number.int(), faker.number.int()];
       const patches = patchForPackageFactory.buildList(3);
       const response = {
         patches: [
@@ -164,6 +164,37 @@ describe('Software Updates saga', () => {
 
       expect(dispatched).toEqual([
         setPatchesForPackages({ hostID, patches: response.patches }),
+        setSettingsConfigured(),
+      ]);
+    });
+
+    it('chunks 600 unique package IDs', async () => {
+      const axiosMock = new MockAdapter(networkClient);
+      const hostID = faker.string.uuid();
+      const packageIDs = Array.from(new Array(160)).map(() =>
+        faker.number.int()
+      );
+      const patches = patchForPackageFactory.buildList(3);
+      const response = {
+        patches: [{ package_id: packageIDs[0], patches }],
+      };
+
+      axiosMock.onGet(`/api/v1/software_updates/packages`).reply(200, response);
+
+      const dispatched = await recordSaga(fetchUpgradablePackagesPatches, {
+        payload: { hostID, packageIDs },
+      });
+
+      expect(dispatched).toEqual([
+        setPatchesForPackages({
+          hostID,
+          patches: [
+            ...response.patches,
+            ...response.patches,
+            ...response.patches,
+            ...response.patches,
+          ],
+        }),
         setSettingsConfigured(),
       ]);
     });

--- a/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
+++ b/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
@@ -59,7 +59,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.MockSuma do
            to_version: "1.16.2",
            to_release: "1",
            to_epoch: "0",
-           to_package_id: "92348112636"
+           to_package_id: 92_348_112_636
          },
          %{
            name: "systemd",
@@ -70,7 +70,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.MockSuma do
            to_version: "255",
            to_release: "1",
            to_epoch: "0",
-           to_package_id: "8912349843"
+           to_package_id: 8_912_349_843
          }
        ]}
 


### PR DESCRIPTION
This PR orthogonally applies two optimization in order to:

- Make things actually work;
- Reduce the load on the SUSE Manager instance linked to Trento.

The first optimization is about chunking the list of packages to request the current patches for, since otherwise the URI for the corresponding GET request becomes really massive and in the end the HTTP client just throws an error.

The second optimization is about just requesting patches for packages that a user is actually viewing, dramatically reducing the number of HTTP requests. A new callback called `onPageChange` was added to the `Table` component to achieve this.

## Testing
Jest tests added.