### PR TITLE
Refactor pagination tests

### DIFF
--- a/assets/js/common/Pagination/Pagination.jsx
+++ b/assets/js/common/Pagination/Pagination.jsx
@@ -25,7 +25,10 @@ function Pagination({
   }
 
   return (
-    <div className="flex justify-between p-2 bg-gray-50 width-full">
+    <div
+      className="flex justify-between p-2 bg-gray-50 width-full"
+      data-testid="pagination"
+    >
       {itemsPerPageOptions.length > 1 ? (
         <div className="flex pl-3 items-center text-sm">
           <span className="pr-2 text-gray-600">Results per page</span>

--- a/assets/js/common/Table/Table.test.jsx
+++ b/assets/js/common/Table/Table.test.jsx
@@ -1,7 +1,13 @@
 import React from 'react';
 
 import { noop } from 'lodash';
-import { screen, fireEvent, render, waitFor } from '@testing-library/react';
+import {
+  screen,
+  fireEvent,
+  render,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import 'intersection-observer';
 import '@testing-library/jest-dom';
 
@@ -141,11 +147,13 @@ describe('Table component', () => {
         tableDataFactory.buildList(1, { column3: 'value3' })
       );
 
-      const { container } = render(
+      render(
         <Table config={tableConfig} data={data} setSearchParams={() => {}} />
       );
 
-      fireEvent.click(container.querySelector('.tn-page-item:nth-child(2)'));
+      const pages = screen.getByTestId('pagination');
+      const page2Button = within(pages).getByText('2');
+      fireEvent.click(page2Button);
 
       filterTable('Column3', 'value3');
 
@@ -158,14 +166,16 @@ describe('Table component', () => {
     it('should display the correct items per page', () => {
       const data = tableDataFactory.buildList(11);
 
-      const { container } = render(
+      render(
         <Table config={tableConfig} data={data} setSearchParams={() => {}} />
       );
 
       const page1 = screen.getByRole('table');
       expect(page1.querySelectorAll('tbody > tr')).toHaveLength(10);
 
-      fireEvent.click(container.querySelector('.tn-page-item:nth-child(2)'));
+      const pages = screen.getByTestId('pagination');
+      const page2Button = within(pages).getByText('2');
+      fireEvent.click(page2Button);
 
       const page2 = screen.getByRole('table');
       expect(page2.querySelectorAll('tbody > tr')).toHaveLength(1);
@@ -174,7 +184,7 @@ describe('Table component', () => {
     it('should be able to change the items per page', () => {
       const data = tableDataFactory.buildList(11);
 
-      const { container } = render(
+      render(
         <Table config={tableConfig} data={data} setSearchParams={() => {}} />
       );
 
@@ -187,7 +197,8 @@ describe('Table component', () => {
       const pageMoreItems = screen.getByRole('table');
       expect(pageMoreItems.querySelectorAll('tbody > tr')).toHaveLength(11);
 
-      expect(container.querySelector('.tn-page-item:nth-child(2)')).toBeNull();
+      const pages = screen.getByTestId('pagination');
+      expect(within(pages).queryByText('2')).toBeNull();
     });
 
     it('should return empty state message when data is empty', () => {

--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -29,7 +29,8 @@ context('Clusters Overview', () => {
         .should('eq', availableClusters.length);
     });
     it('should have 1 pages', () => {
-      cy.get('.tn-page-item').its('length').should('eq', 1);
+      cy.get(`[data-testid="pagination"]`).should('include.text', '1');
+      cy.get(`[data-testid="pagination"]`).should('not.include.text', '2');
     });
     it('should show the expected clusters data', () => {
       cy.get('.container').eq(0).as('clustersTable');

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -24,7 +24,10 @@ context('Hosts Overview', () => {
       cy.get('.tn-hostname').its('length').should('eq', 10);
     });
     it('should have 3 pages', () => {
-      cy.get('.tn-page-item').its('length').should('eq', 3);
+      cy.get(`[data-testid="pagination"]`).should('include.text', '1');
+      cy.get(`[data-testid="pagination"]`).should('include.text', '2');
+      cy.get(`[data-testid="pagination"]`).should('include.text', '3');
+      cy.get(`[data-testid="pagination"]`).should('not.include.text', '4');
     });
     it('should show the ip addresses, provider and agent version data for the hosts in the 1st page', () => {
       cy.get('.container').eq(0).as('hostsTable');


### PR DESCRIPTION
# Description

Following [this comment](https://github.com/trento-project/web/pull/2918#issuecomment-2307179719) in #2918, this PR rewrites the test suites so that they do not rely on pagination internals anymore.

A test ID `pagination` is assigned to the pagination container. Then, pagination elements are selected by their text, making tests more resilient as they don't rely on the internal structure of the component (the test ID is the only structural requirement to be kept across refactors).

