### PR TITLE
Add `<PaginationPrevNext>` component

### DIFF
--- a/assets/js/common/Pagination/Pagination.jsx
+++ b/assets/js/common/Pagination/Pagination.jsx
@@ -35,6 +35,27 @@ const disabledLinkClassNames = classNames(
 );
 const containerClassNames = 'flex items-center';
 
+function ItemsPerPageSelector({
+  itemsPerPageOptions,
+  currentItemsPerPage,
+  onChange,
+}) {
+  return (
+    itemsPerPageOptions.length > 1 && (
+      <div className="flex pl-3 items-center text-sm">
+        <span className="pr-2 text-gray-600">Results per page</span>
+        <Select
+          className="z-40"
+          optionsName=""
+          options={itemsPerPageOptions}
+          value={currentItemsPerPage}
+          onChange={onChange}
+        />
+      </div>
+    )
+  );
+}
+
 function Pagination({
   pages,
   currentPage,
@@ -50,20 +71,11 @@ function Pagination({
       className="flex justify-between p-2 bg-gray-50 width-full"
       data-testid="pagination"
     >
-      {itemsPerPageOptions.length > 1 ? (
-        <div className="flex pl-3 items-center text-sm">
-          <span className="pr-2 text-gray-600">Results per page</span>
-          <Select
-            className="z-40"
-            optionsName=""
-            options={itemsPerPageOptions}
-            value={currentItemsPerPage}
-            onChange={onChangeItemsPerPage}
-          />
-        </div>
-      ) : (
-        <span />
-      )}
+      <ItemsPerPageSelector
+        itemsPerPageOptions={itemsPerPageOptions}
+        currentItemsPerPage={currentItemsPerPage}
+        onChange={onChangeItemsPerPage}
+      />
 
       {/* ReactPaginate paged are 0-based */}
       <ReactPaginate

--- a/assets/js/common/Pagination/Pagination.jsx
+++ b/assets/js/common/Pagination/Pagination.jsx
@@ -85,13 +85,8 @@ function Pagination({
         pageCount={pages}
         breakLabel="..."
         renderOnZeroPageCount={null}
-        onClick={(e) => {
-          const selected =
-            typeof e.nextSelectedPage === 'number'
-              ? e.nextSelectedPage
-              : e.selected;
-          onSelect(selected + 1);
-        }}
+        onPageActive={({ selected }) => onSelect(selected + 1)}
+        onPageChange={({ selected }) => onSelect(selected + 1)}
         previousLabel={PREV_LABEL}
         nextLabel={NEXT_LABEL}
         containerClassName={containerClassNames}

--- a/assets/js/common/Pagination/Pagination.jsx
+++ b/assets/js/common/Pagination/Pagination.jsx
@@ -5,6 +5,36 @@ import ReactPaginate from 'react-paginate';
 
 import Select from '@common/Select';
 
+const PREV_LABEL = '<';
+const NEXT_LABEL = '>';
+
+const boxClassNames = classNames(
+  'tn-page-item',
+  'w-full',
+  'px-4',
+  'py-2',
+  'text-xs',
+  'bg-white',
+  'border-t',
+  'border-b',
+  'border-l',
+  'hover:bg-gray-100'
+);
+
+const leftBoxClassNames = classNames(boxClassNames, 'rounded-l-lg');
+const rightBoxClassNames = classNames(
+  boxClassNames,
+  'border-r',
+  'rounded-r-lg'
+);
+const activeLinkClassNames = 'text-jungle-green-500';
+const disabledLinkClassNames = classNames(
+  'text-zinc-400',
+  'hover:bg-white',
+  'cursor-default'
+);
+const containerClassNames = 'flex items-center';
+
 function Pagination({
   pages,
   currentPage,
@@ -14,19 +44,6 @@ function Pagination({
   onChangeItemsPerPage = noop,
 }) {
   const selectedPage = Math.min(currentPage, pages);
-
-  const boxStyle = classNames(
-    'tn-page-item',
-    'w-full',
-    'px-4',
-    'py-2',
-    'text-xs',
-    'bg-white',
-    'border-t',
-    'border-b',
-    'border-l',
-    'hover:bg-gray-100'
-  );
 
   return (
     <div
@@ -53,8 +70,9 @@ function Pagination({
         forcePage={selectedPage - 1}
         pageRangeDisplayed={3}
         marginPagesDisplayed={1}
+        pageCount={pages}
         breakLabel="..."
-        nextLabel=">"
+        renderOnZeroPageCount={null}
         onClick={(e) => {
           const selected =
             typeof e.nextSelectedPage === 'number'
@@ -62,15 +80,15 @@ function Pagination({
               : e.selected;
           onSelect(selected + 1);
         }}
-        pageCount={pages}
-        previousLabel="<"
-        renderOnZeroPageCount={null}
-        containerClassName="flex items-center"
-        pageClassName={boxStyle}
-        activeLinkClassName="text-gray-600 text-jungle-green-500"
-        previousClassName={classNames(boxStyle, 'rounded-l-lg')}
-        nextClassName={classNames(boxStyle, 'border-r', 'rounded-r-lg')}
-        breakClassName={boxStyle}
+        previousLabel={PREV_LABEL}
+        nextLabel={NEXT_LABEL}
+        containerClassName={containerClassNames}
+        pageLinkClassName={boxClassNames}
+        activeLinkClassName={activeLinkClassNames}
+        disabledLinkClassName={disabledLinkClassNames}
+        previousLinkClassName={leftBoxClassNames}
+        nextLinkClassName={rightBoxClassNames}
+        breakLinkClassName={boxClassNames}
       />
     </div>
   );

--- a/assets/js/common/Pagination/Pagination.jsx
+++ b/assets/js/common/Pagination/Pagination.jsx
@@ -76,36 +76,28 @@ function PaginationPrevNext({
       />
       <ul className={containerClassNames}>
         <li>
-          <a
-            role="button"
-            href
+          <button
+            type="button"
             className={classNames(
               leftBoxClassNames,
               hasPrev || disabledLinkClassNames
             )}
-            onClick={() => {
-              hasPrev && onSelect('prev');
-              return false;
-            }}
+            onClick={() => hasPrev && onSelect('prev')}
           >
             {PREV_LABEL}
-          </a>
+          </button>
         </li>
         <li>
-          <a
-            role="button"
-            href
+          <button
+            type="button"
             className={classNames(
               rightBoxClassNames,
               hasNext || disabledLinkClassNames
             )}
-            onClick={() => {
-              hasNext && onSelect('next');
-              return false;
-            }}
+            onClick={() => hasNext && onSelect('next')}
           >
             {NEXT_LABEL}
-          </a>
+          </button>
         </li>
       </ul>
     </div>

--- a/assets/js/common/Pagination/Pagination.jsx
+++ b/assets/js/common/Pagination/Pagination.jsx
@@ -56,6 +56,62 @@ function ItemsPerPageSelector({
   );
 }
 
+function PaginationPrevNext({
+  hasPrev = true,
+  hasNext = true,
+  onSelect,
+  currentItemsPerPage = 10,
+  itemsPerPageOptions = [10],
+  onChangeItemsPerPage = noop,
+}) {
+  return (
+    <div
+      className="flex justify-between p-2 bg-gray-50 width-full"
+      data-testid="pagination"
+    >
+      <ItemsPerPageSelector
+        itemsPerPageOptions={itemsPerPageOptions}
+        currentItemsPerPage={currentItemsPerPage}
+        onChange={onChangeItemsPerPage}
+      />
+      <ul className={containerClassNames}>
+        <li>
+          <a
+            role="button"
+            href
+            className={classNames(
+              leftBoxClassNames,
+              hasPrev || disabledLinkClassNames
+            )}
+            onClick={() => {
+              hasPrev && onSelect('prev');
+              return false;
+            }}
+          >
+            {PREV_LABEL}
+          </a>
+        </li>
+        <li>
+          <a
+            role="button"
+            href
+            className={classNames(
+              rightBoxClassNames,
+              hasNext || disabledLinkClassNames
+            )}
+            onClick={() => {
+              hasNext && onSelect('next');
+              return false;
+            }}
+          >
+            {NEXT_LABEL}
+          </a>
+        </li>
+      </ul>
+    </div>
+  );
+}
+
 function Pagination({
   pages,
   currentPage,
@@ -102,3 +158,5 @@ function Pagination({
 }
 
 export default Pagination;
+
+export { PaginationPrevNext };

--- a/assets/js/common/Pagination/Pagination.test.jsx
+++ b/assets/js/common/Pagination/Pagination.test.jsx
@@ -120,12 +120,10 @@ describe('Pagination component', () => {
 
   it.each`
     currentPage | pages | previousPage
-    ${1}        | ${5}  | ${1}
     ${2}        | ${5}  | ${1}
     ${5}        | ${5}  | ${4}
     ${5}        | ${15} | ${4}
     ${15}       | ${99} | ${14}
-    ${1}        | ${99} | ${1}
     ${99}       | ${99} | ${98}
   `(
     'should select previous page ($pages, $currentPage)',
@@ -150,14 +148,38 @@ describe('Pagination component', () => {
   );
 
   it.each`
+    currentPage | pages
+    ${1}        | ${5}
+    ${1}        | ${99}
+  `(
+    'should disable prev button ($pages, $currentPage)',
+    async ({ pages, currentPage }) => {
+      const user = userEvent.setup();
+      const onSelect = jest.fn();
+
+      render(
+        <Pagination
+          pages={pages}
+          currentPage={currentPage}
+          currentItemsPerPage={10}
+          itemsPerPageOptions={[10, 20, 50]}
+          onSelect={onSelect}
+          onChangeItemsPerPage={noop}
+        />
+      );
+
+      await act(() => user.click(screen.getByText(`<`)));
+      expect(onSelect).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each`
     currentPage | pages | nextPage
     ${1}        | ${5}  | ${2}
     ${2}        | ${5}  | ${3}
-    ${5}        | ${5}  | ${5}
     ${5}        | ${15} | ${6}
     ${15}       | ${99} | ${16}
     ${1}        | ${99} | ${2}
-    ${99}       | ${99} | ${99}
   `(
     'should select next page ($pages, $currentPage)',
     async ({ pages, currentPage, nextPage }) => {
@@ -177,6 +199,32 @@ describe('Pagination component', () => {
 
       await act(() => user.click(screen.getByText(`>`)));
       expect(onSelect).toHaveBeenCalledWith(nextPage);
+    }
+  );
+
+  it.each`
+    currentPage | pages
+    ${5}        | ${5}
+    ${99}       | ${99}
+  `(
+    'should disable next button ($pages, $currentPage)',
+    async ({ pages, currentPage }) => {
+      const user = userEvent.setup();
+      const onSelect = jest.fn();
+
+      render(
+        <Pagination
+          pages={pages}
+          currentPage={currentPage}
+          currentItemsPerPage={10}
+          itemsPerPageOptions={[10, 20, 50]}
+          onSelect={onSelect}
+          onChangeItemsPerPage={noop}
+        />
+      );
+
+      await act(() => user.click(screen.getByText(`>`)));
+      expect(onSelect).not.toHaveBeenCalled();
     }
   );
 
@@ -206,18 +254,23 @@ describe('Pagination component', () => {
     render(<ControlledComponent />);
 
     const actions = [
-      { action: `<`, expected: 1 }, // previous of the first is the first
+      { action: `<`, expected: null }, // previous of the first is noop
       { action: `>`, expected: 2 },
       { action: `>`, expected: 3 },
-      { action: `>`, expected: 3 }, // next of the last is the last
+      { action: `>`, expected: null }, // next of the last is noop
       { action: `<`, expected: 2 },
     ];
 
     for (let i = 0; i < actions.length; i += 1) {
+      const { action, expected } = actions[i];
       // eslint-disable-next-line no-await-in-loop
-      await act(() => user.click(screen.getByText(actions[i].action)));
-      expect(onSelect).toHaveBeenCalledWith(actions[i].expected);
-      expect(onSelect).toHaveBeenCalledTimes(1);
+      await act(() => user.click(screen.getByText(action)));
+      if (expected === null) {
+        expect(onSelect).not.toHaveBeenCalled();
+      } else {
+        expect(onSelect).toHaveBeenCalledWith(expected);
+        expect(onSelect).toHaveBeenCalledTimes(1);
+      }
       onSelect.mockClear();
     }
   });

--- a/assets/js/common/Pagination/Pagination.test.jsx
+++ b/assets/js/common/Pagination/Pagination.test.jsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { noop } from 'lodash';
-import Pagination from '.';
+import Pagination, { PaginationPrevNext } from '.';
 
 describe('Pagination component', () => {
   it('should render', () => {
@@ -304,4 +304,59 @@ describe('Pagination component', () => {
       );
     }
   );
+});
+
+describe('PaginationPrevNext component', () => {
+  it('should render', () => {
+    render(<PaginationPrevNext hasNext onSelect={noop} />);
+
+    expect(screen.getByText('<')).toBeInTheDocument();
+    expect(screen.getByText('>')).toBeInTheDocument();
+  });
+
+  it('should call onSelect', async () => {
+    const onSelect = jest.fn();
+    const user = userEvent.setup();
+
+    render(<PaginationPrevNext onSelect={onSelect} />);
+
+    await act(() => user.click(screen.getByText('<')));
+    expect(onSelect).toHaveBeenCalledWith('prev');
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    onSelect.mockClear();
+
+    await act(() => user.click(screen.getByText('>')));
+    expect(onSelect).toHaveBeenCalledWith('next');
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('should disable prev button', async () => {
+    const onSelect = jest.fn();
+    const user = userEvent.setup();
+
+    render(<PaginationPrevNext hasPrev={false} onSelect={onSelect} />);
+
+    await act(() => user.click(screen.getByText('<')));
+    expect(onSelect).not.toHaveBeenCalled();
+
+    await act(() => user.click(screen.getByText('>')));
+    expect(onSelect).toHaveBeenCalledWith('next');
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    onSelect.mockClear();
+  });
+
+  it('should disable next button', async () => {
+    const onSelect = jest.fn();
+    const user = userEvent.setup();
+
+    render(<PaginationPrevNext hasNext={false} onSelect={onSelect} />);
+
+    await act(() => user.click(screen.getByText('>')));
+    expect(onSelect).not.toHaveBeenCalled();
+    onSelect.mockClear();
+
+    await act(() => user.click(screen.getByText('<')));
+    expect(onSelect).toHaveBeenCalledWith('prev');
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
 });

--- a/assets/js/common/Pagination/PrevNextPagination.stories.jsx
+++ b/assets/js/common/Pagination/PrevNextPagination.stories.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+
+import { PaginationPrevNext } from '.';
+
+export default {
+  title: 'Components/PaginationPrevNext',
+  component: PaginationPrevNext,
+  argTypes: {
+    hasPrev: { control: { type: 'boolean' }, defaultValue: true },
+    hasNext: { control: { type: 'boolean' }, defaultValue: true },
+    currentItemsPerPage: {
+      control: {
+        type: 'number',
+      },
+      defaultValue: 10,
+    },
+    itemsPerPageOptions: {
+      control: {
+        type: 'array',
+      },
+      defaultValue: [10],
+    },
+  },
+  render: (args) => (
+    <PaginationPrevNext
+      hasPrev={args.hasPrev}
+      hasNext={args.hasNext}
+      currentItemsPerPage={args.currentItemsPerPage}
+      itemsPerPageOptions={args.itemsPerPageOptions}
+      onSelect={(value) => {
+        action('onSelect')(value);
+      }}
+      onChangeItemsPerPage={(value) => {
+        action('onChangeItemsPerPage')(value);
+      }}
+    />
+  ),
+};
+
+export const Default = {
+  args: {
+    currentItemsPerPage: 10,
+    itemsPerPageOptions: [10, 20, 50],
+  },
+};

--- a/assets/js/common/Pagination/index.js
+++ b/assets/js/common/Pagination/index.js
@@ -1,3 +1,4 @@
-import Pagination from './Pagination';
+import Pagination, { PaginationPrevNext } from './Pagination';
 
 export default Pagination;
+export { PaginationPrevNext };


### PR DESCRIPTION
# Description

Add a variant to the `<Pagination>` component that only has `[<]` `[>]` buttons.  The component accepts the following properties

|property|description|
|-|-|
|hasPrev|When false, the `[<]` button is not clickable. Default: `true` |
|hasNext|When false, the `[>]` button is not clickable. Default: `true` |
|onSelect|Execute with string argument `prev` when clicking on `[<]`, with `next` when clicking on `[>]`|

It also accepts properties configuring the items-per-page dropdown as in the `<Pagination>` component.

This PR refactors the `<Pagination>` component, too. See the commit list for detailed changes.



