### PR TITLE
Activity log add pagination

### DIFF
--- a/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
+++ b/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
@@ -56,7 +56,7 @@ function ActivityLogOverview({
   const [selectedEntry, setEntry] = useState({});
 
   const activityLogTableConfig = {
-    pagination: true,
+    pagination: false,
     usePadding: false,
     columns: [
       {

--- a/assets/js/common/Pagination/Pagination.jsx
+++ b/assets/js/common/Pagination/Pagination.jsx
@@ -35,8 +35,11 @@ const disabledLinkClassNames = classNames(
 );
 const containerClassNames = 'flex items-center';
 
+const defaultItemsPerPageOptions = [10, 20, 50, 75, 100];
+const defaultItemsPerPage = 10;
+
 function ItemsPerPageSelector({
-  itemsPerPageOptions,
+  itemsPerPageOptions = defaultItemsPerPageOptions,
   currentItemsPerPage,
   onChange,
 }) {
@@ -60,8 +63,8 @@ function PaginationPrevNext({
   hasPrev = true,
   hasNext = true,
   onSelect,
-  currentItemsPerPage = 10,
-  itemsPerPageOptions = [10],
+  currentItemsPerPage = defaultItemsPerPage,
+  itemsPerPageOptions = defaultItemsPerPageOptions,
   onChangeItemsPerPage = noop,
 }) {
   return (
@@ -108,8 +111,8 @@ function Pagination({
   pages,
   currentPage,
   onSelect,
-  currentItemsPerPage = 10,
-  itemsPerPageOptions = [10],
+  currentItemsPerPage = defaultItemsPerPage,
+  itemsPerPageOptions = defaultItemsPerPageOptions,
   onChangeItemsPerPage = noop,
 }) {
   const selectedPage = Math.min(currentPage, pages);
@@ -151,4 +154,4 @@ function Pagination({
 
 export default Pagination;
 
-export { PaginationPrevNext };
+export { PaginationPrevNext, defaultItemsPerPageOptions, defaultItemsPerPage };

--- a/assets/js/common/Pagination/index.js
+++ b/assets/js/common/Pagination/index.js
@@ -1,4 +1,8 @@
-import Pagination, { PaginationPrevNext } from './Pagination';
+import Pagination, {
+  PaginationPrevNext,
+  defaultItemsPerPageOptions,
+  defaultItemsPerPage,
+} from './Pagination';
 
 export default Pagination;
-export { PaginationPrevNext };
+export { PaginationPrevNext, defaultItemsPerPageOptions, defaultItemsPerPage };

--- a/assets/js/common/Table/Table.jsx
+++ b/assets/js/common/Table/Table.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import { noop } from 'lodash';
 
 import { page, pages } from '@lib/lists';
-import Pagination from '@common/Pagination';
+import Pagination, { defaultItemsPerPage } from '@common/Pagination';
 import { TableFilters, createFilter } from './filters';
 import { defaultRowKey } from './defaultRowKey';
 import SortingIcon from './SortingIcon';
@@ -61,8 +61,6 @@ const getFilterFunction = (column, value) =>
     ? column.filter(value, column.key)
     : getDefaultFilterFunction(value, column.key);
 
-const itemsPerPageOptions = [10, 20, 50, 75, 100];
-
 function Table({
   config,
   data = [],
@@ -85,9 +83,8 @@ function Table({
 
   const [filters, setFilters] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
-  const [currentItemsPerPage, setCurrentItemsPerPage] = useState(
-    itemsPerPageOptions[0]
-  );
+  const [currentItemsPerPage, setCurrentItemsPerPage] =
+    useState(defaultItemsPerPage);
 
   const searchParamsEnabled = Boolean(searchParams && setSearchParams);
 
@@ -251,7 +248,6 @@ function Table({
               <Pagination
                 pages={totalPages}
                 currentPage={currentPage}
-                itemsPerPageOptions={itemsPerPageOptions}
                 currentItemsPerPage={currentItemsPerPage}
                 onChangeItemsPerPage={(perPage) =>
                   setCurrentItemsPerPage(perPage)

--- a/assets/js/lib/test-utils/factories/pagination.js
+++ b/assets/js/lib/test-utils/factories/pagination.js
@@ -1,0 +1,11 @@
+import { faker } from '@faker-js/faker';
+import { Factory } from 'fishery';
+
+export const paginationFirstPageFactory = Factory.define(() => ({
+  first: faker.number.int({ min: 1, max: 20 }),
+  last: null,
+  start_cursor: faker.string.binary(),
+  end_cursor: faker.string.binary(),
+  has_next_page: true,
+  has_previous_page: false,
+}));

--- a/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
+++ b/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
@@ -7,7 +7,10 @@ import ComposedFilter from '@common/ComposedFilter';
 
 import { getActivityLog } from '@lib/api/activityLogs';
 import { ACTIVITY_TYPES_CONFIG } from '@lib/model/activityLog';
-import { PaginationPrevNext } from '@common/Pagination/Pagination';
+import {
+  PaginationPrevNext,
+  defaultItemsPerPageOptions,
+} from '@common/Pagination/Pagination';
 import { pipe } from 'lodash/fp';
 import {
   getItemsPerPageFromSearchParams,
@@ -43,7 +46,6 @@ const filters = [
 ];
 
 const defaultItemsPerPage = 20;
-const itemsPerPageOptions = [10, 20, 50, 75, 100];
 
 const changeItemsPerPage = (searchParams) => (items) => {
   if (searchParams.has('after')) {
@@ -72,7 +74,7 @@ function ActivityLogPage() {
     useState(false);
 
   const itemsPerPage = pipe(getItemsPerPageFromSearchParams, (n) =>
-    itemsPerPageOptions.includes(n) ? n : itemsPerPageOptions[0]
+    defaultItemsPerPageOptions.includes(n) ? n : defaultItemsPerPageOptions[0]
   )(searchParams);
 
   const fetchActivityLog = () => {
@@ -121,7 +123,6 @@ function ActivityLogPage() {
           hasPrev={activityLogResponse.pagination?.has_previous_page}
           hasNext={activityLogResponse.pagination?.has_next_page}
           currentItemsPerPage={itemsPerPage}
-          itemsPerPageOptions={itemsPerPageOptions}
           onSelect={pipe(
             (selection) =>
               selection === 'prev'

--- a/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
+++ b/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
@@ -65,8 +65,7 @@ function ActivityLogPage() {
   const [searchParams, setSearchParams] = useSearchParams(
     resetPaginationToSearchParams(defaultItemsPerPage)()
   );
-  const [activityLog, setActivityLog] = useState([]);
-  const [activityLogMetadata, setActivityLogMetadata] = useState({});
+  const [activityLogResponse, setActivityLogResponse] = useState({ data: [] });
 
   const [isLoading, setLoading] = useState(true);
   const [activityLogDetailModalOpen, setActivityLogDetailModalOpen] =
@@ -80,11 +79,10 @@ function ActivityLogPage() {
     setLoading(true);
     const params = searchParamsToAPIParams(searchParams);
     getActivityLog(params)
-      .then(({ data: { data = [], ...metadata } = {} }) => {
-        setActivityLog(data);
-        setActivityLogMetadata(metadata);
+      .then(({ data }) => {
+        setActivityLogResponse(data);
       })
-      .catch(() => setActivityLog([]))
+      .catch(() => setActivityLogResponse({ data: [] }))
       .finally(() => {
         setLoading(false);
       });
@@ -109,7 +107,7 @@ function ActivityLogPage() {
         </div>
         <ActivityLogOverview
           activityLogDetailModalOpen={activityLogDetailModalOpen}
-          activityLog={activityLog}
+          activityLog={activityLogResponse.data}
           loading={isLoading}
           onActivityLogEntryClick={() => setActivityLogDetailModalOpen(true)}
           onCloseActivityLogEntryDetails={() =>
@@ -117,8 +115,8 @@ function ActivityLogPage() {
           }
         />
         <PaginationPrevNext
-          hasPrev={activityLogMetadata.pagination?.has_previous_page}
-          hasNext={activityLogMetadata.pagination?.has_next_page}
+          hasPrev={activityLogResponse.pagination?.has_previous_page}
+          hasNext={activityLogResponse.pagination?.has_next_page}
           currentItemsPerPage={itemsPerPage}
           itemsPerPageOptions={itemsPerPageOptions}
           onSelect={pipe(
@@ -126,11 +124,11 @@ function ActivityLogPage() {
               selection === 'prev'
                 ? {
                     last: itemsPerPage,
-                    before: activityLogMetadata.pagination.start_cursor,
+                    before: activityLogResponse.pagination?.start_cursor,
                   }
                 : {
                     first: itemsPerPage,
-                    after: activityLogMetadata.pagination.end_cursor,
+                    after: activityLogResponse.pagination?.end_cursor,
                   },
             setPaginationToSearchParams,
             setSearchParams

--- a/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
+++ b/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
@@ -104,11 +104,7 @@ function ActivityLogPage() {
             filters={filters}
             autoApply={false}
             value={searchParamsToFilterValue(searchParams)}
-            onChange={pipe(
-              setFilterValueToSearchParams,
-              resetPaginationToSearchParams(itemsPerPage),
-              setSearchParams
-            )}
+            onChange={pipe(setFilterValueToSearchParams, setSearchParams)}
           />
         </div>
         <ActivityLogOverview

--- a/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
+++ b/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
@@ -80,7 +80,10 @@ function ActivityLogPage() {
     const params = searchParamsToAPIParams(searchParams);
     getActivityLog(params)
       .then(({ data }) => {
-        setActivityLogResponse(data);
+        setActivityLogResponse({
+          data: data?.data || [],
+          pagination: data?.pagination,
+        });
       })
       .catch(() => setActivityLogResponse({ data: [] }))
       .finally(() => {

--- a/assets/js/pages/ActivityLogPage/ActivityLogPage.test.jsx
+++ b/assets/js/pages/ActivityLogPage/ActivityLogPage.test.jsx
@@ -7,6 +7,7 @@ import { renderWithRouter } from '@lib/test-utils';
 
 import { networkClient } from '@lib/network';
 import { activityLogEntryFactory } from '@lib/test-utils/factories/activityLog';
+import { paginationFirstPageFactory } from '@lib/test-utils/factories/pagination';
 
 import ActivityLogPage from './ActivityLogPage';
 
@@ -55,5 +56,19 @@ describe('ActivityLogPage', () => {
     );
 
     expect(container.querySelectorAll('tbody > tr')).toHaveLength(5);
+  });
+
+  it('should render pagination', async () => {
+    const response = {
+      data: activityLogEntryFactory.buildList(20),
+      pagination: paginationFirstPageFactory.build(),
+    };
+
+    axiosMock.onGet('/api/v1/activity_log').reply(200, response);
+
+    await act(() => renderWithRouter(<ActivityLogPage />));
+
+    expect(screen.getByText('<')).toBeInTheDocument();
+    expect(screen.getByText('>')).toBeInTheDocument();
   });
 });

--- a/assets/js/pages/ActivityLogPage/searchParams.js
+++ b/assets/js/pages/ActivityLogPage/searchParams.js
@@ -47,12 +47,6 @@ export const searchParamsToAPIParams = pipe(
  * Make the necessary transformations to the values before setting them in the search params
  */
 export const searchParamsToFilterValue = pipe(
-  /*   (sp) => {
-    if (!sp.has('first') && !sp.has('last')) {
-      sp.set('first', '20');
-    }
-    return sp;
-  }, */
   searchParamsToEntries,
   map(([k, v]) => {
     switch (k) {
@@ -64,6 +58,21 @@ export const searchParamsToFilterValue = pipe(
     }
   }),
   Object.fromEntries
+);
+
+const structToSearchParams = pipe(
+  omitUndefined,
+  Object.entries,
+  reduce((acc, [k, v]) => {
+    const sp = acc || new URLSearchParams();
+    if (scalarKeys.includes(k)) {
+      sp.set(k, v);
+    } else {
+      Array.from(v).forEach((value) => sp.append(k, value));
+    }
+    return sp;
+  }, null),
+  defaultTo(new URLSearchParams())
 );
 
 /**
@@ -146,5 +155,5 @@ export const resetPaginationToSearchParams =
       omit(paginationFields)
     )(searchParams);
 
-    return filterValueToSearchParams({ first: itemsPerPage, ...filters });
+    return structToSearchParams({ first: itemsPerPage, ...filters });
   };

--- a/assets/js/pages/ActivityLogPage/searchParams.test.js
+++ b/assets/js/pages/ActivityLogPage/searchParams.test.js
@@ -207,13 +207,10 @@ describe('searchParams helpers', () => {
       const newFirst = faker.number.int();
       const newAfter = faker.string.uuid();
 
-      const result = setPaginationToSearchParams(
-        {
-          after: newAfter,
-          first: newFirst,
-        },
-        sp
-      );
+      const result = setPaginationToSearchParams(sp)({
+        after: newAfter,
+        first: newFirst,
+      });
 
       expect(result.get('after')).toEqual(newAfter);
       expect(result.get('first')).toEqual(`${newFirst}`);
@@ -231,13 +228,10 @@ describe('searchParams helpers', () => {
       const newFirst = faker.number.int();
       const newAfter = faker.string.uuid();
 
-      const result = setPaginationToSearchParams(
-        {
-          after: newAfter,
-          first: newFirst,
-        },
-        sp
-      );
+      const result = setPaginationToSearchParams(sp)({
+        after: newAfter,
+        first: newFirst,
+      });
 
       expect(result.get('after')).toEqual(newAfter);
       expect(result.get('first')).toEqual(`${newFirst}`);
@@ -262,13 +256,10 @@ describe('searchParams helpers', () => {
       const newFirst = faker.number.int();
       const newAfter = faker.string.uuid();
 
-      const result = setPaginationToSearchParams(
-        {
-          after: newAfter,
-          first: newFirst,
-        },
-        sp
-      );
+      const result = setPaginationToSearchParams(sp)({
+        after: newAfter,
+        first: newFirst,
+      });
 
       expect(result.get('after')).toEqual(newAfter);
       expect(result.get('first')).toEqual(`${newFirst}`);

--- a/assets/js/pages/ActivityLogPage/searchParams.test.js
+++ b/assets/js/pages/ActivityLogPage/searchParams.test.js
@@ -1,95 +1,278 @@
 import { fromZonedTime } from 'date-fns-tz';
+import { faker } from '@faker-js/faker';
 import {
   filterValueToSearchParams,
   searchParamsToAPIParams,
   searchParamsToFilterValue,
+  setFilterValueToSearchParams,
+  setPaginationToSearchParams,
 } from './searchParams';
 
-describe('searchParams helpers', () => {});
-describe('searchParamsToAPIParams', () => {
-  it('should convert search params to API params', () => {
-    const nowUTC = '2024-08-01T17:23:00.000Z';
+describe('searchParams helpers', () => {
+  describe('searchParamsToAPIParams', () => {
+    it('should convert search params to API params', () => {
+      const nowUTC = '2024-08-01T17:23:00.000Z';
+      const first = `${faker.number.int()}`;
+      const after = faker.string.uuid();
 
-    const sp = new URLSearchParams();
-    sp.append('from_date', 'custom');
-    sp.append('from_date', nowUTC);
-    sp.append('type', 'login_attempt');
-    sp.append('type', 'resource_tagging');
+      const sp = new URLSearchParams();
+      sp.append('from_date', 'custom');
+      sp.append('from_date', nowUTC);
+      sp.append('type', 'login_attempt');
+      sp.append('type', 'resource_tagging');
+      sp.append('first', first);
+      sp.append('after', after);
 
-    const result = searchParamsToAPIParams(sp);
+      const result = searchParamsToAPIParams(sp);
 
-    expect(result).toEqual({
-      from_date: nowUTC,
-      type: ['login_attempt', 'resource_tagging'],
+      expect(result).toEqual({
+        from_date: nowUTC,
+        type: ['login_attempt', 'resource_tagging'],
+        first,
+        after,
+      });
     });
   });
-});
 
-describe('searchParamsToFilterValue', () => {
-  it('should convert search params to filter value', () => {
-    const nowUTC = '2024-08-01T17:23:00.000Z';
+  describe('searchParamsToFilterValue', () => {
+    it('should convert search params to filter value', () => {
+      const nowUTC = '2024-08-01T17:23:00.000Z';
 
-    const sp = new URLSearchParams();
-    sp.append('from_date', 'custom');
-    sp.append('from_date', nowUTC);
-    sp.append('type', 'login_attempt');
-    sp.append('type', 'resource_tagging');
+      const sp = new URLSearchParams();
+      sp.append('from_date', 'custom');
+      sp.append('from_date', nowUTC);
+      sp.append('type', 'login_attempt');
+      sp.append('type', 'resource_tagging');
 
-    const result = searchParamsToFilterValue(sp);
+      const result = searchParamsToFilterValue(sp);
 
-    expect(result).toEqual({
-      from_date: ['custom', expect.any(Date)],
-      type: ['login_attempt', 'resource_tagging'],
+      expect(result).toEqual({
+        from_date: ['custom', expect.any(Date)],
+        type: ['login_attempt', 'resource_tagging'],
+      });
+
+      expect(result.from_date[1].getHours()).toEqual(17);
+    });
+  });
+
+  describe('filterValueToSearchParams', () => {
+    it('should convert filter value to search params', () => {
+      const now = new Date();
+      const utcNow = fromZonedTime(now).toISOString();
+      const first = faker.number.int();
+      const after = faker.string.uuid();
+
+      const filterValue = {
+        from_date: ['custom', now],
+        type: ['login_attempt', 'resource_tagging'],
+        first,
+        after,
+      };
+
+      const result = filterValueToSearchParams(filterValue);
+
+      expect(result.getAll('from_date')).toEqual(['custom', utcNow]);
+      expect(result.getAll('type')).toEqual([
+        'login_attempt',
+        'resource_tagging',
+      ]);
+      expect(result.get('first')).toEqual(`${first}`);
+      expect(result.get('after')).toEqual(after);
     });
 
-    expect(result.from_date[1].getHours()).toEqual(17);
-  });
-});
+    it('should use a fresh URLSearchParams instance', () => {
+      const now = new Date();
+      const utcNow = fromZonedTime(now).toISOString();
 
-describe('filterValueToSearchParams', () => {
-  it('should convert filter value to search params', () => {
-    const now = new Date();
-    const utcNow = fromZonedTime(now).toISOString();
+      const filterValue = {
+        from_date: ['custom', now],
+        type: ['login_attempt', 'resource_tagging'],
+      };
 
-    const filterValue = {
-      from_date: ['custom', now],
-      type: ['login_attempt', 'resource_tagging'],
-    };
+      // apply two times to test if the function is using a fresh URLSearchParams instance
+      /*          */ filterValueToSearchParams(filterValue);
+      const result = filterValueToSearchParams(filterValue);
 
-    const result = filterValueToSearchParams(filterValue);
+      expect(result.getAll('from_date')).toEqual(['custom', utcNow]);
+      expect(result.getAll('type')).toEqual([
+        'login_attempt',
+        'resource_tagging',
+      ]);
+    });
 
-    expect(result.getAll('from_date')).toEqual(['custom', utcNow]);
-    expect(result.getAll('type')).toEqual([
-      'login_attempt',
-      'resource_tagging',
-    ]);
-  });
+    it('should return an instance of URLSearchParams when filters are empty', () => {
+      const filterValue = {};
 
-  it('should use a fresh URLSearchParams instance', () => {
-    const now = new Date();
-    const utcNow = fromZonedTime(now).toISOString();
+      const result = filterValueToSearchParams(filterValue);
 
-    const filterValue = {
-      from_date: ['custom', now],
-      type: ['login_attempt', 'resource_tagging'],
-    };
-
-    // apply two times to test if the function is using a fresh URLSearchParams instance
-    /*          */ filterValueToSearchParams(filterValue);
-    const result = filterValueToSearchParams(filterValue);
-
-    expect(result.getAll('from_date')).toEqual(['custom', utcNow]);
-    expect(result.getAll('type')).toEqual([
-      'login_attempt',
-      'resource_tagging',
-    ]);
+      expect(result).toEqual(expect.any(URLSearchParams));
+    });
   });
 
-  it('should return an instance of URLSearchParams when filters are empty', () => {
-    const filterValue = {};
+  describe('setFilterValueToSearchParams', () => {
+    it('should set filter value to empty search params', () => {
+      const sp = new URLSearchParams();
 
-    const result = filterValueToSearchParams(filterValue);
+      const result = setFilterValueToSearchParams(
+        {
+          type: ['login_attempt', 'resource_tagging'],
+        },
+        sp
+      );
 
-    expect(result).toEqual(expect.any(URLSearchParams));
+      expect(result.getAll('type')).toEqual([
+        'login_attempt',
+        'resource_tagging',
+      ]);
+      expect([...result.keys()]).toEqual(['type', 'type']);
+    });
+
+    it('should set filter value and preserve pagination (after/first)', () => {
+      const first = faker.number.int();
+      const after = faker.string.uuid();
+      const sp = new URLSearchParams();
+      sp.set('first', first);
+      sp.set('after', after);
+
+      const result = setFilterValueToSearchParams(
+        {
+          type: ['login_attempt', 'resource_tagging'],
+        },
+        sp
+      );
+
+      expect(result.getAll('type')).toEqual([
+        'login_attempt',
+        'resource_tagging',
+      ]);
+      expect(result.get('after')).toEqual(after);
+      expect(result.get('first')).toEqual(`${first}`);
+      expect([...result.keys()]).toEqual(['first', 'after', 'type', 'type']);
+    });
+
+    it('should set filter value and preserve pagination (before/last)', () => {
+      const last = faker.number.int();
+      const before = faker.string.uuid();
+      const sp = new URLSearchParams();
+      sp.set('last', last);
+      sp.set('before', before);
+
+      const result = setFilterValueToSearchParams(
+        {
+          type: ['login_attempt', 'resource_tagging'],
+        },
+        sp
+      );
+
+      expect(result.getAll('type')).toEqual([
+        'login_attempt',
+        'resource_tagging',
+      ]);
+      expect(result.get('before')).toEqual(before);
+      expect(result.get('last')).toEqual(`${last}`);
+      expect([...result.keys()]).toEqual(['last', 'before', 'type', 'type']);
+    });
+
+    it('should set override any filter', () => {
+      const first = faker.number.int();
+      const after = faker.string.uuid();
+      const type1 = faker.string.alphanumeric(20);
+      const utcNow = fromZonedTime(new Date()).toISOString();
+      const sp = new URLSearchParams();
+      sp.set('first', first);
+      sp.set('after', after);
+      sp.append('type', type1);
+      sp.append('from_date', utcNow);
+
+      const type2 = faker.string.alphanumeric(20);
+      const type3 = faker.string.alphanumeric(20);
+      const result = setFilterValueToSearchParams(
+        {
+          type: [type2, type3],
+        },
+        sp
+      );
+
+      expect(result.getAll('type')).toEqual([type2, type3]);
+      expect(result.get('after')).toEqual(after);
+      expect(result.get('first')).toEqual(`${first}`);
+      expect([...result.keys()]).toEqual(['first', 'after', 'type', 'type']);
+    });
+  });
+
+  describe('setPaginationToSearchParams', () => {
+    it('should set pagination to empty search params', () => {
+      const sp = new URLSearchParams();
+
+      const newFirst = faker.number.int();
+      const newAfter = faker.string.uuid();
+
+      const result = setPaginationToSearchParams(
+        {
+          after: newAfter,
+          first: newFirst,
+        },
+        sp
+      );
+
+      expect(result.get('after')).toEqual(newAfter);
+      expect(result.get('first')).toEqual(`${newFirst}`);
+      expect([...result.keys()]).toEqual(['after', 'first']);
+    });
+
+    it('should set pagination and preserve filter values', () => {
+      const type = faker.string.alphanumeric(20);
+      const utcNow = fromZonedTime(new Date()).toISOString();
+      const sp = new URLSearchParams();
+      sp.append('type', type);
+      sp.append('from_date', 'custom');
+      sp.append('from_date', utcNow);
+
+      const newFirst = faker.number.int();
+      const newAfter = faker.string.uuid();
+
+      const result = setPaginationToSearchParams(
+        {
+          after: newAfter,
+          first: newFirst,
+        },
+        sp
+      );
+
+      expect(result.get('after')).toEqual(newAfter);
+      expect(result.get('first')).toEqual(`${newFirst}`);
+      expect(result.getAll('type')).toEqual([type]);
+      expect(result.getAll('from_date')).toEqual(['custom', utcNow]);
+      expect([...result.keys()]).toEqual([
+        'after',
+        'first',
+        'type',
+        'from_date',
+        'from_date',
+      ]);
+    });
+
+    it('should override previous pagination', () => {
+      const last = faker.number.int();
+      const before = faker.string.uuid();
+      const sp = new URLSearchParams();
+      sp.set('last', last);
+      sp.set('before', before);
+
+      const newFirst = faker.number.int();
+      const newAfter = faker.string.uuid();
+
+      const result = setPaginationToSearchParams(
+        {
+          after: newAfter,
+          first: newFirst,
+        },
+        sp
+      );
+
+      expect(result.get('after')).toEqual(newAfter);
+      expect(result.get('first')).toEqual(`${newFirst}`);
+      expect([...result.keys()]).toEqual(['after', 'first']);
+    });
   });
 });

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -60,7 +60,7 @@ context('Activity Log page', () => {
         'eq',
         `${
           Cypress.config().baseUrl
-        }/activity_log?first=20&from_date=custom&from_date=2024-08-14T10%3A21%3A00.000Z&to_date=custom&to_date=2024-08-13T10%3A21%3A00.000Z&type=login_attempt&type=resource_tagging`
+        }/activity_log?from_date=custom&from_date=2024-08-14T10%3A21%3A00.000Z&to_date=custom&to_date=2024-08-13T10%3A21%3A00.000Z&type=login_attempt&type=resource_tagging&first=20`
       );
     });
 

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -1,10 +1,14 @@
 /* eslint-disable cypress/no-unnecessary-waiting */
 
 context('Activity Log page', () => {
+  before(() => {
+    cy.loadScenario('healthy-27-node-SAP-cluster');
+  });
+
   describe('Filtering', () => {
     it('should render without selected filters', () => {
       cy.intercept({
-        url: '/api/v1/activity_log',
+        url: '/api/v1/activity_log?first=20',
       }).as('data');
       cy.visit('/activity_log');
 
@@ -23,7 +27,7 @@ context('Activity Log page', () => {
 
     it('should render with selected filters from querystring', () => {
       cy.intercept({
-        url: '/api/v1/activity_log?from_date=2024-08-14T10:21:00.000Z&to_date=2024-08-13T10:21:00.000Z&type[]=login_attempt&type[]=resource_tagging',
+        url: '/api/v1/activity_log?from_date=2024-08-14T10:21:00.000Z&to_date=2024-08-13T10:21:00.000Z&type[]=login_attempt&type[]=resource_tagging&first=20',
       }).as('data');
 
       cy.visit(
@@ -56,13 +60,13 @@ context('Activity Log page', () => {
         'eq',
         `${
           Cypress.config().baseUrl
-        }/activity_log?from_date=custom&from_date=2024-08-14T10%3A21%3A00.000Z&to_date=custom&to_date=2024-08-13T10%3A21%3A00.000Z&type=login_attempt&type=resource_tagging`
+        }/activity_log?first=20&from_date=custom&from_date=2024-08-14T10%3A21%3A00.000Z&to_date=custom&to_date=2024-08-13T10%3A21%3A00.000Z&type=login_attempt&type=resource_tagging`
       );
     });
 
     it('should reset filters', () => {
       cy.intercept({
-        url: '/api/v1/activity_log',
+        url: '/api/v1/activity_log?first=20',
       }).as('data');
 
       cy.visit(


### PR DESCRIPTION
This PR allows browsing the entire activity log by scrolling different pages.

Key features:
* The default page size is 20 items, which can be changed due to the options in the dropdown
* the list can be navigated sequentially forward and backward
* if there are no previous entries, the `[<]` button is disabled. The same goes for the `[>]` if no entries are next.
* when filters change, the pagination is reset to the first page