### PR TITLE
Table Header Alignment

### DIFF
--- a/assets/js/common/Table/Table.jsx
+++ b/assets/js/common/Table/Table.jsx
@@ -206,7 +206,7 @@ function Table({
                             sortable
                               ? 'cursor-pointer hover:text-gray-700 '
                               : ''
-                          }px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider bg-gray-100`,
+                          }px-5 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider bg-gray-100`,
                           className
                         )}
                         onClick={handleClick}

--- a/assets/js/common/Table/Table.test.jsx
+++ b/assets/js/common/Table/Table.test.jsx
@@ -120,6 +120,25 @@ describe('Table component', () => {
     expect(onPageChange).toHaveBeenCalledWith(expectedPayload);
   });
 
+  it('should have the same horizontal padding for table header and rows', () => {
+    const data = tableDataFactory.buildList(10);
+
+    render(<Table config={tableConfig} data={data} />);
+
+    let pxClass;
+    screen
+      .getByRole('table')
+      .querySelector('th')
+      .classList.forEach((className) =>
+        className.match('px-') ? (pxClass = className) : ''
+      );
+
+    screen
+      .getByRole('table')
+      .querySelectorAll('tbody > tr > td')
+      .forEach((tableRow) => expect(tableRow).toHaveClass(pxClass));
+  });
+
   describe('filtering', () => {
     it('should filter by the chosen filter option with default filter', async () => {
       const data = tableDataFactory.buildList(10);

--- a/assets/js/common/Table/Table.test.jsx
+++ b/assets/js/common/Table/Table.test.jsx
@@ -129,9 +129,9 @@ describe('Table component', () => {
     screen
       .getByRole('table')
       .querySelector('th')
-      .classList.forEach((className) =>
-        className.match('px-') ? (pxClass = className) : ''
-      );
+      .classList.forEach((className) => {
+        className.match('px-') && (pxClass = className);
+      });
 
     screen
       .getByRole('table')


### PR DESCRIPTION
# Description

Tables displaying the text as left aligned for both the table header and rows had a slight misalignment of about 4px. This PR attempts to make the horizontal padding the same value for consistency purposes. There is also the inclusion of test to prevent values being changed independently and to prevent this issue resurfacing.

**Before** (Misalignment highlighted in red)
![Frame 56](https://github.com/user-attachments/assets/a9669395-aa3d-4d1c-8b4d-1df6ddf213db)

**Changes**
![Screenshot 2024-09-06 at 12 09 42](https://github.com/user-attachments/assets/dad9bb32-8f86-43a5-b883-ef0bfa5bafd1)

## How was this tested?

Describe the tests that have been added/changed for this new behaviour.
- [x] **DONE** Check for the same 'px-?' value between the table header and rows.
