### PR TITLE
Fix SUSE Manager settings CTA not showing up

### DIFF
--- a/assets/js/state/sagas/softwareUpdates.js
+++ b/assets/js/state/sagas/softwareUpdates.js
@@ -30,10 +30,10 @@ export function* fetchSoftwareUpdates({ payload: hostID }) {
     const errorCode = get(error, ['response', 'status']);
     const errors = get(error, ['response', 'data', 'errors'], []);
     const suma_unauthorized = errors.some(
-      ({ detail }) => detail === 'SUSE Manager authentication error.'
+      ({ detail }) => detail === 'SUSE Manager settings not configured.'
     );
 
-    if (errorCode === 422 && suma_unauthorized) {
+    if (errorCode === 404 && suma_unauthorized) {
       yield put(setSettingsNotConfigured());
     } else {
       yield put(setSettingsConfigured());
@@ -70,10 +70,10 @@ export function* fetchUpgradablePackagesPatches({
     const errors = get(error, ['response', 'data', 'errors'], []);
 
     const suma_unauthorized = errors.some(
-      ({ detail }) => detail === 'SUSE Manager authentication error.'
+      ({ detail }) => detail === 'SUSE Manager settings not configured.'
     );
 
-    if (errorCode === 422 && suma_unauthorized) {
+    if (errorCode === 404 && suma_unauthorized) {
       yield put(setSettingsNotConfigured());
     } else {
       yield put(setSettingsConfigured());

--- a/assets/js/state/sagas/softwareUpdates.test.js
+++ b/assets/js/state/sagas/softwareUpdates.test.js
@@ -120,15 +120,15 @@ describe('Software Updates saga', () => {
       const errorBody = {
         errors: [
           {
-            title: 'Unprocessable Entity',
-            detail: 'SUSE Manager authentication error.',
+            title: 'Not Found',
+            detail: 'SUSE Manager settings not configured.',
           },
         ],
       };
 
       axiosMock
         .onGet(`/api/v1/hosts/${hostID}/software_updates`)
-        .reply(422, errorBody);
+        .reply(404, errorBody);
 
       const dispatched = await recordSaga(fetchSoftwareUpdates, {
         payload: hostID,
@@ -206,15 +206,15 @@ describe('Software Updates saga', () => {
       const errorBody = {
         errors: [
           {
-            title: 'Unprocessable Entity',
-            detail: 'SUSE Manager authentication error.',
+            title: 'Not Found',
+            detail: 'SUSE Manager settings not configured.',
           },
         ],
       };
 
       axiosMock
         .onGet(`/api/v1/hosts/${hostID}/software_updates`)
-        .reply(422, errorBody);
+        .reply(404, errorBody);
 
       const dispatched = await recordSaga(fetchSoftwareUpdates, {
         payload: hostID,

--- a/lib/trento_web/views/error_view.ex
+++ b/lib/trento_web/views/error_view.ex
@@ -34,6 +34,17 @@ defmodule TrentoWeb.ErrorView do
     }
   end
 
+  def render("404.json", %{reason: reason}) do
+    %{
+      errors: [
+        %{
+          title: "Not Found",
+          detail: reason
+        }
+      ]
+    }
+  end
+
   def render("404.json", _) do
     %{
       errors: [

--- a/test/trento_web/controllers/v1/settings_controller_test.exs
+++ b/test/trento_web/controllers/v1/settings_controller_test.exs
@@ -339,7 +339,7 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
 
       assert %{
                "errors" => [
-                 %{"detail" => "The requested resource cannot be found.", "title" => "Not Found"}
+                 %{"detail" => "SUSE Manager settings not configured.", "title" => "Not Found"}
                ]
              } == resp
     end

--- a/test/trento_web/controllers/v1/suse_manager_controller_test.exs
+++ b/test/trento_web/controllers/v1/suse_manager_controller_test.exs
@@ -69,7 +69,7 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
 
       assert %{
                "errors" => [
-                 %{"detail" => "The requested resource cannot be found.", "title" => "Not Found"}
+                 %{"detail" => "SUSE Manager settings not configured.", "title" => "Not Found"}
                ]
              } == resp
     end


### PR DESCRIPTION
# Description
The call to action to configure SUSE Manager wasn't showing up anymore due to a different HTTP status code returned by the backend. It's all right now.

## How was this tested?
Automatic tests updated
