### PR TITLE
Log host checks execution request

### DIFF
--- a/assets/js/lib/model/activityLog.js
+++ b/assets/js/lib/model/activityLog.js
@@ -15,6 +15,7 @@ export const USER_DELETION = 'user_deletion';
 export const PROFILE_UPDATE = 'profile_update';
 export const CLUSTER_CHECKS_EXECUTION_REQUEST =
   'cluster_checks_execution_request';
+export const HOST_CHECKS_EXECUTION_REQUEST = 'host_checks_execution_request';
 export const ACTIVITY_LOG_SETTINGS_UPDATE = 'activity_log_settings_update';
 
 // Host events
@@ -187,6 +188,11 @@ export const ACTIVITY_TYPES_CONFIG = {
     label: 'Checks Execution Requested',
     message: (_entry) => `Checks execution requested for cluster`,
     resource: clusterResourceType,
+  },
+  [HOST_CHECKS_EXECUTION_REQUEST]: {
+    label: 'Checks Execution Requested',
+    message: (_entry) => `Checks execution requested for host`,
+    resource: hostResourceType,
   },
   [ACTIVITY_LOG_SETTINGS_UPDATE]: {
     label: 'Activity Log Settings Updated',

--- a/lib/trento/activity_logging/activity_catalog.ex
+++ b/lib/trento/activity_logging/activity_catalog.ex
@@ -140,6 +140,8 @@ defmodule Trento.ActivityLog.ActivityCatalog do
       {TrentoWeb.V1.ProfileController, :update} => {:profile_update, 200},
       {TrentoWeb.V1.ClusterController, :request_checks_execution} =>
         {:cluster_checks_execution_request, 202},
+      {TrentoWeb.V1.HostController, :request_checks_execution} =>
+        {:host_checks_execution_request, 202},
       {TrentoWeb.V1.SettingsController, :update_activity_log_settings} =>
         {:activity_log_settings_update, 200}
     }

--- a/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
+++ b/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
@@ -109,23 +109,20 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
   end
 
   def get_activity_metadata(
-        action,
+        :cluster_checks_execution_request,
         %Plug.Conn{
           params: params
         }
-      )
-      when action in [
-             :cluster_checks_execution_request,
-             :host_checks_execution_request
-           ] do
-    action
-    |> case do
-      :cluster_checks_execution_request -> {:cluster_id, Map.get(params, :cluster_id)}
-      :host_checks_execution_request -> {:host_id, Map.get(params, :id)}
-    end
-    |> List.wrap()
-    |> Map.new()
-  end
+      ),
+      do: %{cluster_id: Map.get(params, :cluster_id)}
+
+  def get_activity_metadata(
+        :host_checks_execution_request,
+        %Plug.Conn{
+          params: params
+        }
+      ),
+      do: %{host_id: Map.get(params, :id)}
 
   def get_activity_metadata(_, _), do: %{}
 

--- a/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
+++ b/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
@@ -108,6 +108,25 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
     |> redact(:password_confirmation)
   end
 
+  def get_activity_metadata(
+        action,
+        %Plug.Conn{
+          params: params
+        }
+      )
+      when action in [
+             :cluster_checks_execution_request,
+             :host_checks_execution_request
+           ] do
+    action
+    |> case do
+      :cluster_checks_execution_request -> {:cluster_id, Map.get(params, :cluster_id)}
+      :host_checks_execution_request -> {:host_id, Map.get(params, :id)}
+    end
+    |> List.wrap()
+    |> Map.new()
+  end
+
   def get_activity_metadata(_, _), do: %{}
 
   defp redact(request_body, key) do

--- a/lib/trento/clusters.ex
+++ b/lib/trento/clusters.ex
@@ -160,7 +160,8 @@ defmodule Trento.Clusters do
     end
   end
 
-  defp maybe_request_checks_execution(%ClusterReadModel{selected_checks: []}), do: :ok
+  defp maybe_request_checks_execution(%ClusterReadModel{selected_checks: []}),
+    do: {:error, :no_checks_selected}
 
   defp maybe_request_checks_execution(%ClusterReadModel{
          id: cluster_id,

--- a/test/support/messaging_case.ex
+++ b/test/support/messaging_case.ex
@@ -1,0 +1,19 @@
+defmodule Trento.MessagingCase do
+  @moduledoc """
+  This test case makes sure that the messaging system is properly stubbed for tests where a defined behavior is sufficient.
+  """
+
+  use ExUnit.CaseTemplate
+
+  setup _ do
+    Mox.stub(
+      Trento.Infrastructure.Messaging.Adapter.Mock,
+      :publish,
+      fn _, _ ->
+        :ok
+      end
+    )
+
+    :ok
+  end
+end

--- a/test/trento/activity_logging/activity_catalog_test.exs
+++ b/test/trento/activity_logging/activity_catalog_test.exs
@@ -24,6 +24,7 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
         :user_deletion,
         :profile_update,
         :cluster_checks_execution_request,
+        :host_checks_execution_request,
         :activity_log_settings_update
       ]
 

--- a/test/trento/activity_logging/phoenix_conn_parser_test.exs
+++ b/test/trento/activity_logging/phoenix_conn_parser_test.exs
@@ -73,6 +73,46 @@ defmodule Trento.ActivityLog.PhoenixConnParserTest do
                  })
       end
     end
+
+    test "should extract component id when requesting checks execution", %{conn: conn} do
+      host_id = Faker.UUID.v4()
+      cluster_id = Faker.UUID.v4()
+
+      scenarios = [
+        %{
+          action: :cluster_checks_execution_request,
+          params: %{:cluster_id => cluster_id},
+          expected_metadata: %{:cluster_id => cluster_id}
+        },
+        %{
+          action: :host_checks_execution_request,
+          params: %{:id => host_id},
+          expected_metadata: %{:host_id => host_id}
+        },
+        %{
+          action: :host_checks_execution_request,
+          params: %{:foo => "bar"},
+          expected_metadata: %{:host_id => nil}
+        },
+        %{
+          action: :cluster_checks_execution_request,
+          params: %{:foo => "bar"},
+          expected_metadata: %{:cluster_id => nil}
+        }
+      ]
+
+      for %{
+            action: action,
+            params: params,
+            expected_metadata: expected_metadata
+          } <- scenarios do
+        assert expected_metadata ==
+                 PhoenixConnParser.get_activity_metadata(action, %Plug.Conn{
+                   conn
+                   | params: params
+                 })
+      end
+    end
   end
 
   defp assert_for_relevant_activity(assertion_function) do

--- a/test/trento/clusters_test.exs
+++ b/test/trento/clusters_test.exs
@@ -136,7 +136,7 @@ defmodule Trento.ClustersTest do
         :ok
       end)
 
-      assert :ok = Clusters.request_checks_execution(cluster_id)
+      assert {:error, :no_checks_selected} = Clusters.request_checks_execution(cluster_id)
     end
 
     test "should return an error if the checks execution start fails" do

--- a/test/trento_web/controllers/v1/cluster_controller_test.exs
+++ b/test/trento_web/controllers/v1/cluster_controller_test.exs
@@ -93,6 +93,24 @@ defmodule TrentoWeb.V1.ClusterControllerTest do
              } == resp
     end
 
+    test "should return 422 when the selection is empty", %{conn: conn} do
+      %{id: cluster_id} = insert(:cluster, selected_checks: [])
+
+      resp =
+        conn
+        |> post("/api/v1/clusters/#{cluster_id}/checks/request_execution")
+        |> json_response(:unprocessable_entity)
+
+      assert %{
+               "errors" => [
+                 %{
+                   "title" => "Unprocessable Entity",
+                   "detail" => "No checks were selected for the target."
+                 }
+               ]
+             } == resp
+    end
+
     test "should return 500 if messaging returns an error", %{conn: conn} do
       expect(
         Trento.Infrastructure.Messaging.Adapter.Mock,


### PR DESCRIPTION
# Description

This PR adds checks execution requests for hosts to the logged activities:
- mapping added to the activity catalog
- improved metadata extraction for both cluster and host related requests
- mapped the new logged activity in the UI

Bonus point: streamlined behaviour between hosts and clusters when an execution is requested but the checks selection is empty.

## How was this tested?

Added automated tests and enhanced current ones.