### PR TITLE
General Form Label Alignment Fixes

### DIFF
--- a/assets/js/pages/Profile/ProfileForm.jsx
+++ b/assets/js/pages/Profile/ProfileForm.jsx
@@ -83,9 +83,9 @@ function ProfileForm({
   return (
     <div>
       <div className="container max-w-7xl mx-auto p-4 sm:p-6 lg:p-8 bg-white dark:bg-gray-800 rounded-lg">
-        <div className="grid grid-cols-6 gap-6">
-          <Label className="col-start-1 col-span-1 pt-2">Full Name</Label>
-          <div className="col-start-2 col-span-3">
+        <div className="grid grid-cols-8 gap-6">
+          <Label className="col-start-1 col-span-2 pt-2">Full Name</Label>
+          <div className="col-start-3 col-span-4">
             <Input
               value={fullNameState}
               aria-label="fullname"
@@ -99,8 +99,8 @@ function ProfileForm({
             />
             {fullNameErrorState && errorMessage(fullNameErrorState)}
           </div>
-          <Label className="col-start-1 col-span-1 pt-2">Email Address</Label>
-          <div className="col-start-2 col-span-3">
+          <Label className="col-start-1 col-span-2 pt-2">Email Address</Label>
+          <div className="col-start-3 col-span-4">
             <Input
               value={emailAddressState}
               aria-label="email"
@@ -114,14 +114,14 @@ function ProfileForm({
             />
             {emailAddressErrorState && errorMessage(emailAddressErrorState)}
           </div>
-          <Label className="col-start-1 col-span-1 pt-2">Username</Label>
-          <div className="col-start-2 col-span-3">
+          <Label className="col-start-1 col-span-2 pt-2">Username</Label>
+          <div className="col-start-3 col-span-4">
             <Input value={username} aria-label="username" disabled />
           </div>
           {!singleSignOnEnabled && (
             <>
-              <Label className="col-start-1 col-span-1 pt-2">Password</Label>
-              <div className="col-start-2 col-span-3">
+              <Label className="col-start-1 col-span-2 pt-2">Password</Label>
+              <div className="col-start-3 col-span-4">
                 <Button
                   onClick={togglePasswordModal}
                   type="primary-white"
@@ -132,13 +132,13 @@ function ProfileForm({
               </div>
 
               <Label
-                className="col-start-1 col-span-1"
+                className="col-start-1 col-span-2"
                 info="Setup a multi-factor TOTP authentication besides your password to increase security
               for your account."
               >
                 Authenticator App
               </Label>
-              <div className="col-start-2 col-span-3">
+              <div className="col-start-3 col-span-4">
                 <div className="inline-flex">
                   <Switch
                     selected={totpEnabled}
@@ -171,8 +171,8 @@ function ProfileForm({
             </>
           )}
 
-          <Label className="col-start-1 col-span-1 pt-2">Permissions</Label>
-          <div className="col-start-2 col-span-3">
+          <Label className="col-start-1 col-span-2 pt-2">Permissions</Label>
+          <div className="col-start-3 col-span-4">
             <AbilitiesMultiSelect
               userAbilities={abilities}
               abilities={abilities}

--- a/assets/js/pages/Profile/ProfileForm.jsx
+++ b/assets/js/pages/Profile/ProfileForm.jsx
@@ -84,7 +84,7 @@ function ProfileForm({
     <div>
       <div className="container max-w-7xl mx-auto p-4 sm:p-6 lg:p-8 bg-white dark:bg-gray-800 rounded-lg">
         <div className="grid grid-cols-6 gap-6">
-          <Label className="col-start-1 col-span-1">Full Name</Label>
+          <Label className="col-start-1 col-span-1 pt-2">Full Name</Label>
           <div className="col-start-2 col-span-3">
             <Input
               value={fullNameState}
@@ -99,7 +99,7 @@ function ProfileForm({
             />
             {fullNameErrorState && errorMessage(fullNameErrorState)}
           </div>
-          <Label className="col-start-1 col-span-1">Email Address</Label>
+          <Label className="col-start-1 col-span-1 pt-2">Email Address</Label>
           <div className="col-start-2 col-span-3">
             <Input
               value={emailAddressState}
@@ -114,13 +114,13 @@ function ProfileForm({
             />
             {emailAddressErrorState && errorMessage(emailAddressErrorState)}
           </div>
-          <Label className="col-start-1 col-span-1">Username</Label>
+          <Label className="col-start-1 col-span-1 pt-2">Username</Label>
           <div className="col-start-2 col-span-3">
             <Input value={username} aria-label="username" disabled />
           </div>
           {!singleSignOnEnabled && (
             <>
-              <Label className="col-start-1 col-span-1">Password</Label>
+              <Label className="col-start-1 col-span-1 pt-2">Password</Label>
               <div className="col-start-2 col-span-3">
                 <Button
                   onClick={togglePasswordModal}
@@ -171,7 +171,7 @@ function ProfileForm({
             </>
           )}
 
-          <Label className="col-start-1 col-span-1">Permissions</Label>
+          <Label className="col-start-1 col-span-1 pt-2">Permissions</Label>
           <div className="col-start-2 col-span-3">
             <AbilitiesMultiSelect
               userAbilities={abilities}

--- a/assets/js/pages/Users/UserForm.jsx
+++ b/assets/js/pages/Users/UserForm.jsx
@@ -135,11 +135,11 @@ function UserForm({
   return (
     <div>
       <div className="container max-w-7xl mx-auto p-4 sm:p-6 lg:p-8 bg-white dark:bg-gray-800 rounded-lg">
-        <div className="grid grid-cols-6 gap-6">
-          <Label className="col-start-1 col-span-1 sm:pt-2" required>
+        <div className="grid grid-cols-8 gap-6">
+          <Label className="col-start-1 col-span-2 sm:pt-2" required>
             Full Name
           </Label>
-          <div className="col-start-2 col-span-3">
+          <div className="col-start-3 col-span-4">
             <Input
               value={fullNameState}
               aria-label="fullname"
@@ -153,10 +153,10 @@ function UserForm({
             />
             {fullNameErrorState && errorMessage(fullNameErrorState)}
           </div>
-          <Label className="col-start-1 col-span-1 sm:pt-2" required>
+          <Label className="col-start-1 col-span-2 sm:pt-2" required>
             Email Address
           </Label>
-          <div className="col-start-2 col-span-3">
+          <div className="col-start-3 col-span-4">
             <Input
               value={emailAddressState}
               aria-label="email"
@@ -170,10 +170,10 @@ function UserForm({
             />
             {emailAddressErrorState && errorMessage(emailAddressErrorState)}
           </div>
-          <Label className="col-start-1 col-span-1 sm:pt-2" required>
+          <Label className="col-start-1 col-span-2 sm:pt-2" required>
             Username
           </Label>
-          <div className="col-start-2 col-span-3">
+          <div className="col-start-3 col-span-4">
             <Input
               value={usernameState}
               aria-label="username"
@@ -190,13 +190,13 @@ function UserForm({
           {!singleSignOnEnabled && (
             <>
               <Label
-                className="col-start-1 col-span-1 sm:pt-2"
+                className="col-start-1 col-span-2 sm:pt-2"
                 info={PASSWORD_POLICY_TEXT}
                 required
               >
                 Password
               </Label>
-              <div className="col-start-2 col-span-3">
+              <div className="col-start-3 col-span-4">
                 <Password
                   value={passwordState}
                   aria-label="password"
@@ -211,10 +211,10 @@ function UserForm({
                 />
                 {passwordErrorState && errorMessage(passwordErrorState)}
               </div>
-              <Label className="col-start-1 col-span-1 sm:pt-2" required>
+              <Label className="col-start-1 col-span-2 sm:pt-2" required>
                 Confirm Password
               </Label>
-              <div className="col-start-2 col-span-3">
+              <div className="col-start-3 col-span-4">
                 <Password
                   value={confirmPasswordState}
                   aria-label="password-confirmation"
@@ -230,7 +230,7 @@ function UserForm({
                 {confirmPasswordErrorState &&
                   errorMessage(confirmPasswordErrorState)}
               </div>
-              <div className="col-start-2 col-span-3">
+              <div className="col-start-3 col-span-4">
                 <Button
                   type="primary-white"
                   onClick={onGeneratePassword}
@@ -241,8 +241,8 @@ function UserForm({
               </div>
             </>
           )}
-          <Label className="col-start-1 col-span-1 sm:pt-2">Permissions</Label>
-          <div className="col-start-2 col-span-3">
+          <Label className="col-start-1 col-span-2 sm:pt-2">Permissions</Label>
+          <div className="col-start-3 col-span-4">
             <AbilitiesMultiSelect
               userAbilities={userAbilities}
               abilities={abilities}
@@ -250,8 +250,8 @@ function UserForm({
               setAbilities={setAbilities}
             />
           </div>
-          <Label className="col-start-1 col-span-1 sm:pt-2">Status</Label>
-          <div className="col-start-2 col-span-3">
+          <Label className="col-start-1 col-span-2 sm:pt-2">Status</Label>
+          <div className="col-start-3 col-span-4">
             <Select
               optionsName="status"
               options={['Enabled', 'Disabled']}
@@ -264,13 +264,13 @@ function UserForm({
           {editing && !singleSignOnEnabled && (
             <>
               <Label
-                className="col-start-1 col-span-1 sm:pt-2"
+                className="col-start-1 col-span-2 sm:pt-2"
                 htmlFor="totp"
                 aria-label="totp"
               >
                 TOTP
               </Label>
-              <div className="col-start-2 col-span-3">
+              <div className="col-start-3 col-span-4">
                 <Select
                   optionsName="totp"
                   options={[
@@ -283,12 +283,12 @@ function UserForm({
                   }}
                 />
               </div>
-              <Label className="col-start-1 col-span-1 sm:pt-2">Created</Label>
-              <span className="col-start-2 col-span-3">
+              <Label className="col-start-1 col-span-2 sm:pt-2">Created</Label>
+              <span className="col-start-3 col-span-4">
                 {format(parseISO(createdAt), 'PPpp')}
               </span>
-              <Label className="col-start-1 col-span-1 sm:pt-2">Updated</Label>
-              <span className="col-start-2 col-span-3">
+              <Label className="col-start-1 col-span-2 sm:pt-2">Updated</Label>
+              <span className="col-start-3 col-span-4">
                 {format(parseISO(updatedAt), 'PPpp')}
               </span>
             </>

--- a/assets/js/pages/Users/UserForm.jsx
+++ b/assets/js/pages/Users/UserForm.jsx
@@ -198,6 +198,7 @@ function UserForm({
               </Label>
               <div className="col-start-3 col-span-4">
                 <Password
+                  className="border-none"
                   value={passwordState}
                   aria-label="password"
                   placeholder={
@@ -216,6 +217,7 @@ function UserForm({
               </Label>
               <div className="col-start-3 col-span-4">
                 <Password
+                  className="border-none"
                   value={confirmPasswordState}
                   aria-label="password-confirmation"
                   placeholder={

--- a/assets/js/pages/Users/UserForm.jsx
+++ b/assets/js/pages/Users/UserForm.jsx
@@ -136,7 +136,7 @@ function UserForm({
     <div>
       <div className="container max-w-7xl mx-auto p-4 sm:p-6 lg:p-8 bg-white dark:bg-gray-800 rounded-lg">
         <div className="grid grid-cols-6 gap-6">
-          <Label className="col-start-1 col-span-1" required>
+          <Label className="col-start-1 col-span-1 sm:pt-2" required>
             Full Name
           </Label>
           <div className="col-start-2 col-span-3">
@@ -153,7 +153,7 @@ function UserForm({
             />
             {fullNameErrorState && errorMessage(fullNameErrorState)}
           </div>
-          <Label className="col-start-1 col-span-1" required>
+          <Label className="col-start-1 col-span-1 sm:pt-2" required>
             Email Address
           </Label>
           <div className="col-start-2 col-span-3">
@@ -170,7 +170,7 @@ function UserForm({
             />
             {emailAddressErrorState && errorMessage(emailAddressErrorState)}
           </div>
-          <Label className="col-start-1 col-span-1" required>
+          <Label className="col-start-1 col-span-1 sm:pt-2" required>
             Username
           </Label>
           <div className="col-start-2 col-span-3">
@@ -190,7 +190,7 @@ function UserForm({
           {!singleSignOnEnabled && (
             <>
               <Label
-                className="col-start-1 col-span-1"
+                className="col-start-1 col-span-1 sm:pt-2"
                 info={PASSWORD_POLICY_TEXT}
                 required
               >
@@ -211,7 +211,7 @@ function UserForm({
                 />
                 {passwordErrorState && errorMessage(passwordErrorState)}
               </div>
-              <Label className="col-start-1 col-span-1" required>
+              <Label className="col-start-1 col-span-1 sm:pt-2" required>
                 Confirm Password
               </Label>
               <div className="col-start-2 col-span-3">
@@ -241,7 +241,7 @@ function UserForm({
               </div>
             </>
           )}
-          <Label className="col-start-1 col-span-1">Permissions</Label>
+          <Label className="col-start-1 col-span-1 sm:pt-2">Permissions</Label>
           <div className="col-start-2 col-span-3">
             <AbilitiesMultiSelect
               userAbilities={userAbilities}
@@ -250,7 +250,7 @@ function UserForm({
               setAbilities={setAbilities}
             />
           </div>
-          <Label className="col-start-1 col-span-1">Status</Label>
+          <Label className="col-start-1 col-span-1 sm:pt-2">Status</Label>
           <div className="col-start-2 col-span-3">
             <Select
               optionsName="status"
@@ -264,7 +264,7 @@ function UserForm({
           {editing && !singleSignOnEnabled && (
             <>
               <Label
-                className="col-start-1 col-span-1"
+                className="col-start-1 col-span-1 sm:pt-2"
                 htmlFor="totp"
                 aria-label="totp"
               >
@@ -283,11 +283,11 @@ function UserForm({
                   }}
                 />
               </div>
-              <Label className="col-start-1 col-span-1">Created</Label>
+              <Label className="col-start-1 col-span-1 sm:pt-2">Created</Label>
               <span className="col-start-2 col-span-3">
                 {format(parseISO(createdAt), 'PPpp')}
               </span>
-              <Label className="col-start-1 col-span-1">Updated</Label>
+              <Label className="col-start-1 col-span-1 sm:pt-2">Updated</Label>
               <span className="col-start-2 col-span-3">
                 {format(parseISO(updatedAt), 'PPpp')}
               </span>

--- a/assets/js/pages/Users/UserForm.jsx
+++ b/assets/js/pages/Users/UserForm.jsx
@@ -287,11 +287,11 @@ function UserForm({
                   }}
                 />
               </div>
-              <Label className="col-start-1 col-span-2 sm:pt-2">Created</Label>
+              <Label className="col-start-1 col-span-2">Created</Label>
               <span className="col-start-3 col-span-4">
                 {format(parseISO(createdAt), 'PPpp')}
               </span>
-              <Label className="col-start-1 col-span-2 sm:pt-2">Updated</Label>
+              <Label className="col-start-1 col-span-2">Updated</Label>
               <span className="col-start-3 col-span-4">
                 {format(parseISO(updatedAt), 'PPpp')}
               </span>

--- a/assets/js/pages/Users/UserForm.jsx
+++ b/assets/js/pages/Users/UserForm.jsx
@@ -253,6 +253,7 @@ function UserForm({
           <Label className="col-start-1 col-span-2 sm:pt-2">Status</Label>
           <div className="col-start-3 col-span-4">
             <Select
+              className="w-full"
               optionsName="status"
               options={['Enabled', 'Disabled']}
               value={statusState}
@@ -272,6 +273,7 @@ function UserForm({
               </Label>
               <div className="col-start-3 col-span-4">
                 <Select
+                  className="w-full"
                   optionsName="totp"
                   options={[
                     { value: 'Enabled', disabled: !totpEnabledAt },


### PR DESCRIPTION
# Description

This PR makes the following improvements to the **UserForm** and **ProfileForm** components.

1. Improves the alignment of the **Label** so that it is more vertically centred with each corresponding input field.
2. Increases the width of the **Label** (column) so that slightly longer labels (e.g: Confirm Password and Authenticator App) don't wrap over two lines.

Below are the comparisions:
![UserForm](https://github.com/user-attachments/assets/61380e0d-944f-43a5-818a-628a87cecf46)
![ProfileForm](https://github.com/user-attachments/assets/efc70057-95cf-49a3-91e0-304251f1a270)


## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [x] **DONE** Visually
