### PR TITLE
Activity log add pagination (rework)

### DIFF
--- a/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
+++ b/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
@@ -56,7 +56,6 @@ function ActivityLogOverview({
   const [selectedEntry, setEntry] = useState({});
 
   const activityLogTableConfig = {
-    pagination: true,
     usePadding: false,
     columns: [
       {

--- a/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
+++ b/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
@@ -46,6 +46,16 @@ const changeItemsPerPage = (searchParams) => (items) => {
   }
   return { first: items };
 };
+const applyDefaultItemsPerPage = (params) =>
+  'first' in params || 'last' in params
+    ? params
+    : { first: defaultItemsPerPage, ...params };
+
+const activityLogRequest = pipe(
+  searchParamsToAPIParams,
+  applyDefaultItemsPerPage,
+  getActivityLog
+);
 
 function ActivityLogPage() {
   const users = useSelector(getActivityLogUsers);
@@ -93,8 +103,8 @@ function ActivityLogPage() {
 
   const fetchActivityLog = () => {
     setLoading(true);
-    const params = searchParamsToAPIParams(searchParams);
-    getActivityLog(params)
+
+    activityLogRequest(searchParams)
       .then(({ data }) => {
         setActivityLogResponse({
           data: data?.data || [],

--- a/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
+++ b/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
@@ -19,10 +19,12 @@ import {
   searchParamsToFilterValue,
 } from './searchParams';
 
+const emptyResponse = { data: [] };
+
 function ActivityLogPage() {
   const users = useSelector(getActivityLogUsers);
   const [searchParams, setSearchParams] = useSearchParams();
-  const [activityLog, setActivityLog] = useState([]);
+  const [activityLogResponse, setActivityLogResponse] = useState(emptyResponse);
   const [isLoading, setLoading] = useState(true);
   const [activityLogDetailModalOpen, setActivityLogDetailModalOpen] =
     useState(false);
@@ -62,10 +64,13 @@ function ActivityLogPage() {
     setLoading(true);
     const params = searchParamsToAPIParams(searchParams);
     getActivityLog(params)
-      .then((response) => {
-        setActivityLog(response.data?.data ?? []);
+      .then(({ data }) => {
+        setActivityLogResponse({
+          data: data?.data || [],
+          pagination: data?.pagination,
+        });
       })
-      .catch(() => setActivityLog([]))
+      .catch(() => setActivityLogResponse(emptyResponse))
       .finally(() => {
         setLoading(false);
       });
@@ -90,7 +95,7 @@ function ActivityLogPage() {
         </div>
         <ActivityLogOverview
           activityLogDetailModalOpen={activityLogDetailModalOpen}
-          activityLog={activityLog}
+          activityLog={activityLogResponse.data}
           loading={isLoading}
           onActivityLogEntryClick={() => setActivityLogDetailModalOpen(true)}
           onCloseActivityLogEntryDetails={() =>

--- a/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
+++ b/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
@@ -12,14 +12,40 @@ import { getUserProfile } from '@state/selectors/user';
 import PageHeader from '@common/PageHeader';
 import ActivityLogOverview from '@common/ActivityLogOverview';
 import ComposedFilter from '@common/ComposedFilter';
+import {
+  PaginationPrevNext,
+  defaultItemsPerPageOptions,
+} from '@common/Pagination';
 
 import {
-  filterValueToSearchParams,
+  applyItemsPerPage,
+  setFilterValueToSearchParams,
   searchParamsToAPIParams,
   searchParamsToFilterValue,
+  getItemsPerPageFromSearchParams,
+  setPaginationToSearchParams,
 } from './searchParams';
 
 const emptyResponse = { data: [] };
+
+const defaultItemsPerPage = 20;
+const detectItemsPerPage = (number) =>
+  defaultItemsPerPageOptions.includes(number) ? number : defaultItemsPerPage;
+const changeItemsPerPage = (searchParams) => (items) => {
+  if (searchParams.has('after')) {
+    return {
+      first: items,
+      after: searchParams.get('after'),
+    };
+  }
+  if (searchParams.has('before')) {
+    return {
+      last: items,
+      before: searchParams.get('before'),
+    };
+  }
+  return { first: items };
+};
 
 function ActivityLogPage() {
   const users = useSelector(getActivityLogUsers);
@@ -60,6 +86,11 @@ function ActivityLogPage() {
     },
   ];
 
+  const itemsPerPage = pipe(
+    getItemsPerPageFromSearchParams,
+    detectItemsPerPage
+  )(searchParams);
+
   const fetchActivityLog = () => {
     setLoading(true);
     const params = searchParamsToAPIParams(searchParams);
@@ -90,7 +121,11 @@ function ActivityLogPage() {
             filters={filters}
             autoApply={false}
             value={searchParamsToFilterValue(searchParams)}
-            onChange={(p) => setSearchParams(filterValueToSearchParams(p))}
+            onChange={pipe(
+              setFilterValueToSearchParams,
+              applyItemsPerPage(itemsPerPage),
+              setSearchParams
+            )}
           />
         </div>
         <ActivityLogOverview
@@ -101,6 +136,30 @@ function ActivityLogPage() {
           onCloseActivityLogEntryDetails={() =>
             setActivityLogDetailModalOpen(false)
           }
+        />
+        <PaginationPrevNext
+          hasPrev={activityLogResponse.pagination?.has_previous_page}
+          hasNext={activityLogResponse.pagination?.has_next_page}
+          currentItemsPerPage={itemsPerPage}
+          onSelect={pipe(
+            (selection) =>
+              selection === 'prev'
+                ? {
+                    last: itemsPerPage,
+                    before: activityLogResponse.pagination?.start_cursor,
+                  }
+                : {
+                    first: itemsPerPage,
+                    after: activityLogResponse.pagination?.end_cursor,
+                  },
+            setPaginationToSearchParams(searchParams),
+            setSearchParams
+          )}
+          onChangeItemsPerPage={pipe(
+            changeItemsPerPage(searchParams),
+            setPaginationToSearchParams(searchParams),
+            setSearchParams
+          )}
         />
       </div>
     </>

--- a/assets/js/pages/ActivityLogPage/searchParams.js
+++ b/assets/js/pages/ActivityLogPage/searchParams.js
@@ -63,7 +63,7 @@ export const searchParamsToFilterValue = pipe(
     switch (k) {
       case 'from_date':
       case 'to_date':
-        return [k, [v[0], toZonedTime(new Date(v[1]))]];
+        return [k, [v[0], toZonedTime(v[1])]];
       default:
         return [k, v];
     }
@@ -91,6 +91,13 @@ export const filterValueToSearchParams = pipe(
   defaultTo(new URLSearchParams())
 );
 
+export const structToSearchParams = pipe(
+  omitUndefined,
+  Object.entries,
+  entriesToSearchParams,
+  defaultTo(new URLSearchParams())
+);
+
 export const setPaginationToSearchParams =
   (searchParams = new URLSearchParams()) =>
   (pagination) => {
@@ -101,7 +108,7 @@ export const setPaginationToSearchParams =
       omit(paginationFields)
     )(searchParams);
 
-    const v = filterValueToSearchParams({ ...pagination, ...filters });
+    const v = structToSearchParams({ ...pagination, ...filters });
     return v;
   };
 

--- a/assets/js/pages/ActivityLogPage/searchParams.js
+++ b/assets/js/pages/ActivityLogPage/searchParams.js
@@ -3,7 +3,7 @@
  */
 
 import { uniq } from 'lodash';
-import { pipe, map, reduce, defaultTo } from 'lodash/fp';
+import { pipe, map, reduce, defaultTo, omit } from 'lodash/fp';
 import { format as formatDate, toZonedTime } from 'date-fns-tz';
 
 const toUTC = (date) => formatDate(date, "yyyy-MM-dd'T'HH:mm:ss.000'Z'");
@@ -13,10 +13,27 @@ const omitUndefined = (obj) =>
     Object.entries(obj).filter(([_, v]) => typeof v !== 'undefined')
   );
 
+const paginationFields = ['after', 'before', 'first', 'last'];
+const scalarKeys = [...paginationFields];
+
 const searchParamsToEntries = (searchParams) =>
   pipe(Array.from, uniq, (keys) =>
-    keys.map((key) => [key, searchParams.getAll(key)])
+    keys.map((key) => [
+      key,
+      scalarKeys.includes(key)
+        ? searchParams.get(key)
+        : searchParams.getAll(key),
+    ])
   )(searchParams.keys());
+
+const entriesToSearchParams = (entries) =>
+  entries.reduce((acc, [k, v]) => {
+    const sp = acc || new URLSearchParams();
+    scalarKeys.includes(k)
+      ? sp.set(k, v)
+      : Array.from(v).forEach((value) => sp.append(k, value));
+    return sp;
+  }, null);
 
 /**
  * Convert a search params object to an API params object as expected by the API client
@@ -70,10 +87,44 @@ export const filterValueToSearchParams = pipe(
         return [k, v];
     }
   }),
-  reduce((acc, [k, v]) => {
-    const sp = acc || new URLSearchParams();
-    Array.from(v).forEach((value) => sp.append(k, value));
-    return sp;
-  }, null),
+  entriesToSearchParams,
   defaultTo(new URLSearchParams())
 );
+
+export const setPaginationToSearchParams =
+  (searchParams = new URLSearchParams()) =>
+  (pagination) => {
+    // eslint-disable-next-line no-unused-vars
+    const filters = pipe(
+      searchParamsToEntries,
+      Object.fromEntries,
+      omit(paginationFields)
+    )(searchParams);
+
+    const v = filterValueToSearchParams({ ...pagination, ...filters });
+    return v;
+  };
+
+export const setFilterValueToSearchParams = (
+  filterValue,
+  searchParams = new URLSearchParams()
+) =>
+  pipe(
+    searchParamsToEntries,
+    reduce(
+      (acc, [k, v]) =>
+        paginationFields.includes(k) ? { ...acc, [k]: v } : acc,
+      {}
+    ),
+    (x) => ({ ...x, ...filterValue }),
+    filterValueToSearchParams
+  )(searchParams);
+
+export const getItemsPerPageFromSearchParams = (searchParams) =>
+  Number(searchParams.get('first') || searchParams.get('last'));
+
+export const applyItemsPerPage = (itemsPerPage) => (searchParams) => {
+  searchParams.set('first', itemsPerPage);
+
+  return searchParams;
+};

--- a/assets/js/pages/ActivityLogPage/searchParams.test.js
+++ b/assets/js/pages/ActivityLogPage/searchParams.test.js
@@ -2,6 +2,7 @@ import {
   filterValueToSearchParams,
   searchParamsToAPIParams,
   searchParamsToFilterValue,
+  setPaginationToSearchParams,
 } from './searchParams';
 
 describe('searchParams helpers', () => {
@@ -95,6 +96,49 @@ describe('searchParams helpers', () => {
       const result = filterValueToSearchParams(filterValue);
 
       expect(result).toEqual(expect.any(URLSearchParams));
+    });
+  });
+
+  describe('setPaginationToSearchParams', () => {
+    it('should set pagination on empty search params object', () => {
+      const sp = new URLSearchParams();
+      const pagination = { first: 20, after: 'sds' };
+
+      const newSp = setPaginationToSearchParams(sp)(pagination);
+
+      expect(newSp.get('first')).toEqual('20');
+      expect(newSp.get('after')).toEqual('sds');
+      expect([...newSp.keys()]).toEqual(['first', 'after']);
+    });
+
+    it('should override pagination if present', () => {
+      const sp = new URLSearchParams();
+      sp.set('last', '10');
+      sp.set('before', 'abc');
+      const pagination = { first: 20, after: 'sds' };
+
+      const newSp = setPaginationToSearchParams(sp)(pagination);
+
+      expect(newSp.get('first')).toEqual('20');
+      expect(newSp.get('after')).toEqual('sds');
+      expect([...newSp.keys()]).toEqual(['first', 'after']);
+    });
+
+    it('should preserve filters if present', () => {
+      const sp = new URLSearchParams();
+      sp.append('type', 'login_attempt');
+      sp.append('type', 'resource_tagging');
+      const pagination = { first: 20, after: 'sds' };
+
+      const newSp = setPaginationToSearchParams(sp)(pagination);
+
+      expect(newSp.get('first')).toEqual('20');
+      expect(newSp.get('after')).toEqual('sds');
+      expect(newSp.getAll('type')).toEqual([
+        'login_attempt',
+        'resource_tagging',
+      ]);
+      expect([...newSp.keys()]).toEqual(['first', 'after', 'type', 'type']);
     });
   });
 });

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -280,7 +280,7 @@ context('Activity Log page', () => {
     });
   });
 
-  it('should navigate backward', () => {
+  it.only('should navigate backward', () => {
     cy.intercept({
       url: '/api/v1/activity_log?first=20',
     }).as('firstPage');
@@ -297,15 +297,18 @@ context('Activity Log page', () => {
 
       cy.contains('>').click();
 
-      cy.wait('@firstPage').then(({ response: firstPageResponse }) => {
-        expect(firstPageResponse.body.pagination).to.have.property('first', 20);
-        expect(firstPageResponse.body.pagination).to.have.property(
+      cy.wait('@secondPage').then(({ response: secondPageResponse }) => {
+        expect(secondPageResponse.body.pagination).to.have.property(
+          'first',
+          20
+        );
+        expect(secondPageResponse.body.pagination).to.have.property(
           'end_cursor'
         );
-        expect(firstPageResponse.body.pagination).to.have.property(
+        expect(secondPageResponse.body.pagination).to.have.property(
           'has_next_page'
         );
-        expect(firstPageResponse.body.pagination.has_next_page).to.be.true;
+        expect(secondPageResponse.body.pagination.has_next_page).to.be.true;
 
         cy.intercept({
           url: `/api/v1/activity_log?last=20&before=*`,

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -168,5 +168,32 @@ context('Activity Log page', () => {
         );
       });
     });
+
+    it('should select correct date filter when changing page', () => {
+      cy.intercept({
+        url: '/api/v1/activity_log?to_date=2024-08-14T10:21:00.000Z',
+      }).as('firstPage');
+
+      cy.visit(
+        '/activity_log?to_date=custom&to_date=2024-08-14T10%3A21%3A00.000Z'
+      );
+
+      cy.contains('08/14/2024 10:21:00 AM').should('be.visible');
+
+      
+      
+      cy.wait('@firstPage').then(({ response }) => {
+        const after = response.body.pagination.end_cursor;
+
+        cy.intercept({
+          url: `/api/v1/activity_log?first=20&after=${after}&to_date=2024-08-14T10:21:00.000Z`,
+        }).as('secondPage');
+        
+        cy.contains('>').click();
+
+        cy.wait('@secondPage').its('response.statusCode').should('eq', 200);
+        cy.contains('08/14/2024 10:21:00 AM').should('be.visible');
+      });
+    });
   });
 });

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -2,6 +2,30 @@
 
 context('Activity Log page', () => {
   describe('Navigation', () => {
+    it('should navigate to Activity Log page', () => {
+      cy.visit('/');
+
+      cy.get('nav').contains('Activity Log').click();
+
+      cy.url().should('eq', `${Cypress.config().baseUrl}/activity_log`);
+      cy.get('h1').contains('Activity Log').should('be.visible');
+    });
+
+    it('should not load the page twice', () => {
+      cy.visit('/');
+
+      cy.intercept({
+        url: '/api/v1/activity_log*',
+      }).as('data');
+
+      for (let i = 0; i < 5; i++) {
+        cy.get('nav').contains('Activity Log').click();
+      }
+
+      cy.wait('@data');
+      cy.get('@data.all').should('have.length', 1);
+    });
+
     it('should reset querystring when reloading the page from navigation menu', () => {
       cy.visit(
         '/activity_log?from_date=custom&from_date=2024-08-14T10%3A21%3A00.000Z&to_date=custom&to_date=2024-08-13T10%3A21%3A00.000Z&type=login_attempt&type=resource_tagging'
@@ -15,6 +39,7 @@ context('Activity Log page', () => {
       cy.url().should('eq', `${Cypress.config().baseUrl}/activity_log`);
     });
   });
+
   describe('Filtering', () => {
     it('should render without selected filters', () => {
       cy.intercept({


### PR DESCRIPTION
# Description

Retaking the work from https://github.com/trento-project/web/pull/2930 as the original PR got too messy and required more work for rebasing on the main branch. Also, some of the suggestions have been addressed in https://github.com/trento-project/web/pull/2961 and https://github.com/trento-project/web/pull/2960.

In respect of the original PR, this one keeps the proposed key features:

* The default page size is 20 items, which can be changed due to the options in the dropdown
* the list can be navigated sequentially forward and backward
* if there are no previous entries, the [<] button is disabled. The same goes for the [>] if no entries are next.
* when filters change, the pagination is reset to the first page

It also addressed the found issues:
* items per page to be maintained when scrolling pages
* filters to be maintained when scrolling pages
* default of 20 elements per page
* no duplicate requests when clicking multiple times on the navigation link


-----


Depends on #2960
Depends on #2961