### PR TITLE
Fix `<ComposedFilter>` behavior as controlled component

### DIFF
--- a/assets/js/common/ComposedFilter/ComposedFilter.jsx
+++ b/assets/js/common/ComposedFilter/ComposedFilter.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Button from '@common/Button';
 import Filter from '@common/Filter';
 import DateFilter from '@common/DateFilter';
@@ -50,6 +50,10 @@ function ComposedFilter({
       setIsChanged(true);
     }
   };
+
+  useEffect(() => {
+    setValue(initialValue);
+  }, [JSON.stringify(initialValue)]);
 
   return (
     <>

--- a/assets/js/common/ComposedFilter/ComposedFilter.test.jsx
+++ b/assets/js/common/ComposedFilter/ComposedFilter.test.jsx
@@ -1,9 +1,10 @@
-import React, { act } from 'react';
+import React, { act, useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import ComposedFilter from '.';
 
+jest.setTimeout(100000);
 describe('ComposedFilter component', () => {
   it('should render the specified filters', async () => {
     const filters = [
@@ -22,6 +23,85 @@ describe('ComposedFilter component', () => {
     ];
 
     render(<ComposedFilter filters={filters} />);
+
+    expect(screen.getByText('Filter Pasta...')).toBeInTheDocument();
+    expect(screen.getByText('Filter Pizza...')).toBeInTheDocument();
+  });
+
+  it('should select value', async () => {
+    const filters = [
+      {
+        key: 'filter1',
+        type: 'select',
+        title: 'Pasta',
+        options: ['Carbonara', 'Amatriciana', 'Ajo & Ojo', 'Gricia'],
+      },
+      {
+        key: 'filter2',
+        type: 'select',
+        title: 'Pizza',
+        options: ['Margherita', 'Marinara', 'Diavola', 'Bufalina'],
+      },
+    ];
+
+    const value = {
+      filter1: ['Carbonara', 'Gricia'],
+      filter2: ['Diavola'],
+    };
+
+    render(<ComposedFilter filters={filters} value={value} />);
+
+    expect(screen.getByText('Carbonara, Gricia')).toBeInTheDocument();
+    expect(screen.getByText('Diavola')).toBeInTheDocument();
+  });
+
+  it('should change selected value', async () => {
+    const filters = [
+      {
+        key: 'filter1',
+        type: 'select',
+        title: 'Pasta',
+        options: ['Carbonara', 'Amatriciana', 'Ajo & Ojo', 'Gricia'],
+      },
+      {
+        key: 'filter2',
+        type: 'select',
+        title: 'Pizza',
+        options: ['Margherita', 'Marinara', 'Diavola', 'Bufalina'],
+      },
+    ];
+
+    const initialValue = {
+      filter1: ['Carbonara', 'Gricia'],
+      filter2: ['Diavola'],
+    };
+
+    const nextValue = {};
+
+    function ControlledComponent() {
+      const [value, setValue] = useState(initialValue);
+
+      return (
+        <>
+          <button
+            type="button"
+            onClick={() => {
+              setValue(nextValue);
+            }}
+          >
+            Click me
+          </button>
+          <ComposedFilter filters={filters} value={value} autoApply />
+        </>
+      );
+    }
+
+    render(<ControlledComponent />);
+
+    expect(screen.getByText('Carbonara, Gricia')).toBeInTheDocument();
+    expect(screen.getByText('Diavola')).toBeInTheDocument();
+
+    await act(() => userEvent.click(screen.getByText('Click me')));
 
     expect(screen.getByText('Filter Pasta...')).toBeInTheDocument();
     expect(screen.getByText('Filter Pizza...')).toBeInTheDocument();

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -1,6 +1,20 @@
 /* eslint-disable cypress/no-unnecessary-waiting */
 
 context('Activity Log page', () => {
+  describe('Navigation', () => {
+    it('should reset querystring when reloading the page from navigation menu', () => {
+      cy.visit(
+        '/activity_log?from_date=custom&from_date=2024-08-14T10%3A21%3A00.000Z&to_date=custom&to_date=2024-08-13T10%3A21%3A00.000Z&type=login_attempt&type=resource_tagging'
+      );
+
+      cy.contains('Login Attempt, Tag Added').should('be.visible');
+
+      cy.get('nav').contains('Activity Log').click();
+
+      cy.get('body').should('not.include.text', 'Login Attempt, Tag Added');
+      cy.url().should('eq', `${Cypress.config().baseUrl}/activity_log`);
+    });
+  });
   describe('Filtering', () => {
     it('should render without selected filters', () => {
       cy.intercept({


### PR DESCRIPTION
# Description

The  `<ComposedFilter>` can now be used as a controlled component. The use case is when the `value` changes in parent component and thus it needs to be re-rendered.

Before this PR the `<ComposedFilter>` wouldn't show the changed value as the `useState` hook prevents it. The component re-renders as expected by forcing `setValue` on the initial value change. 

The bug has been spotted working on https://github.com/trento-project/web/pull/2967#pullrequestreview-2302325045, an e2e test has been added for that.