### PR TITLE
Filter out non-registered hosts from affected systems in SUMA patch

### DIFF
--- a/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
+++ b/lib/trento/infrastructure/software_updates/adapter/mock_suma.ex
@@ -128,9 +128,9 @@ defmodule Trento.Infrastructure.SoftwareUpdates.MockSuma do
       {:ok,
        [
          %{
-           name: "test"
+           name: "vmdrbddev01"
          },
-         %{name: "test2"}
+         %{name: "vmdrbddev02"}
        ]}
 
   @impl true

--- a/test/e2e/cypress/e2e/suse_manager_overviews.cy.js
+++ b/test/e2e/cypress/e2e/suse_manager_overviews.cy.js
@@ -62,8 +62,8 @@ context('SUSE Manager overviews', () => {
       cy.contains('Affected Packages').next().should('contain', 'kernel');
       cy.contains('Affected Systems')
         .next()
-        .should('contain', 'test')
-        .should('contain', 'test2');
+        .should('contain', 'vmdrbddev01')
+        .should('contain', 'vmdrbddev02');
 
       cy.clearSUMASettings();
     });


### PR DESCRIPTION
# Description
Filter out non-registered hosts from affected systems in SUMA patch. 

# Testing
Unit tests were updated. A new one is provided.

