### PR TITLE
Expose components retrieval by id

### DIFF
--- a/lib/trento/clusters.ex
+++ b/lib/trento/clusters.ex
@@ -27,6 +27,14 @@ defmodule Trento.Clusters do
 
   alias Trento.Repo
 
+  @spec by_id(String.t()) :: {:ok, ClusterReadModel.t()} | {:error, :not_found}
+  def by_id(id) do
+    case Repo.get(ClusterReadModel, id) do
+      %ClusterReadModel{} = cluster -> {:ok, cluster}
+      nil -> {:error, :not_found}
+    end
+  end
+
   @spec select_checks(String.t(), [String.t()]) :: :ok | {:error, any}
   def select_checks(cluster_id, checks) do
     Logger.debug("Selecting checks, cluster: #{cluster_id}")

--- a/lib/trento/databases.ex
+++ b/lib/trento/databases.ex
@@ -16,6 +16,14 @@ defmodule Trento.Databases do
 
   alias Trento.Repo
 
+  @spec by_id(String.t()) :: {:ok, DatabaseReadModel.t()} | {:error, :not_found}
+  def by_id(id) do
+    case Repo.get(DatabaseReadModel, id) do
+      %DatabaseReadModel{} = database -> {:ok, database}
+      nil -> {:error, :not_found}
+    end
+  end
+
   @spec get_all_databases :: [DatabaseReadModel.t()]
   def get_all_databases do
     DatabaseReadModel

--- a/lib/trento/hosts.ex
+++ b/lib/trento/hosts.ex
@@ -37,6 +37,14 @@ defmodule Trento.Hosts do
     |> Repo.preload([:sles_subscriptions, :tags])
   end
 
+  @spec by_id(String.t()) :: {:ok, HostReadModel.t()} | {:error, :not_found}
+  def by_id(id) do
+    case Repo.get(HostReadModel, id) do
+      %HostReadModel{} = host -> {:ok, host}
+      nil -> {:error, :not_found}
+    end
+  end
+
   @spec get_host_by_id(Ecto.UUID.t()) :: HostReadModel.t() | nil
   def get_host_by_id(id) do
     HostReadModel

--- a/lib/trento/sap_systems.ex
+++ b/lib/trento/sap_systems.ex
@@ -16,6 +16,14 @@ defmodule Trento.SapSystems do
 
   alias Trento.Repo
 
+  @spec by_id(String.t()) :: {:ok, SapSystemReadModel.t()} | {:error, :not_found}
+  def by_id(id) do
+    case Repo.get(SapSystemReadModel, id) do
+      %SapSystemReadModel{} = sap_system -> {:ok, sap_system}
+      nil -> {:error, :not_found}
+    end
+  end
+
   @spec get_all_sap_systems :: [SapSystemReadModel.t()]
   def get_all_sap_systems do
     SapSystemReadModel

--- a/test/trento/clusters_test.exs
+++ b/test/trento/clusters_test.exs
@@ -206,6 +206,23 @@ defmodule Trento.ClustersTest do
     end
   end
 
+  describe "retrieving a cluster by identifier" do
+    test "should not return a non existent cluster" do
+      assert {:error, :not_found} == Clusters.by_id(Faker.UUID.v4())
+    end
+
+    test "should return an existent cluster, whether it is registered or not" do
+      %{id: registered_cluster_id} = insert(:cluster)
+
+      %{id: deregistered_cluster_id} =
+        insert(:cluster, deregistered_at: Faker.DateTime.backward(1))
+
+      for cluster_id <- [registered_cluster_id, deregistered_cluster_id] do
+        assert {:ok, %ClusterReadModel{id: ^cluster_id}} = Clusters.by_id(cluster_id)
+      end
+    end
+  end
+
   describe "get clusters" do
     test "should not return soft deleted clusters" do
       cib_last_written = Date.to_string(Faker.Date.forward(0))

--- a/test/trento/databases_test.exs
+++ b/test/trento/databases_test.exs
@@ -35,6 +35,21 @@ defmodule Trento.DatabasesTest do
                }
              ] = Databases.get_all_databases()
     end
+
+    test "should not return a non existent database" do
+      assert {:error, :not_found} == Databases.by_id(Faker.UUID.v4())
+    end
+
+    test "should return an existent database, whether it is registered or not" do
+      %{id: registered_database_id} = insert(:database)
+
+      %{id: deregistered_database_id} =
+        insert(:database, deregistered_at: Faker.DateTime.backward(1))
+
+      for database_id <- [registered_database_id, deregistered_database_id] do
+        assert {:ok, %DatabaseReadModel{id: ^database_id}} = Databases.by_id(database_id)
+      end
+    end
   end
 
   describe "get_database_instances_by_host_id/1" do

--- a/test/trento/hosts_test.exs
+++ b/test/trento/hosts_test.exs
@@ -91,6 +91,23 @@ defmodule Trento.HostsTest do
     end
   end
 
+  describe "retrieving a host by identifier" do
+    test "should not return a non existent host" do
+      assert {:error, :not_found} == Hosts.by_id(Faker.UUID.v4())
+    end
+
+    test "should return an existent host, whether it is registered or not" do
+      %{id: registered_host_id} = insert(:host)
+
+      %{id: deregistered_host_id} =
+        insert(:host, deregistered_at: Faker.DateTime.backward(1))
+
+      for host_id <- [registered_host_id, deregistered_host_id] do
+        assert {:ok, %HostReadModel{id: ^host_id}} = Hosts.by_id(host_id)
+      end
+    end
+  end
+
   describe "Check Selection" do
     test "should dispatch command on Check Selection" do
       host_id = Faker.UUID.v4()

--- a/test/trento/sap_systems_test.exs
+++ b/test/trento/sap_systems_test.exs
@@ -51,6 +51,21 @@ defmodule Trento.SapSystemsTest do
                }
              ] = SapSystems.get_all_sap_systems()
     end
+
+    test "should not return a non existent sap system" do
+      assert {:error, :not_found} == SapSystems.by_id(Faker.UUID.v4())
+    end
+
+    test "should return an existent sap system, whether it is registered or not" do
+      %{id: registered_sap_system_id} = insert(:sap_system)
+
+      %{id: deregistered_sap_system_id} =
+        insert(:sap_system, deregistered_at: Faker.DateTime.backward(1))
+
+      for sap_system_id <- [registered_sap_system_id, deregistered_sap_system_id] do
+        assert {:ok, %SapSystemReadModel{id: ^sap_system_id}} = SapSystems.by_id(sap_system_id)
+      end
+    end
   end
 
   describe "get_application_instances_by_host_id/1" do


### PR DESCRIPTION
# Description

This PR exposes a `by_id` function for `Hosts`, `Clusters`, `Databases` and `SapSystems` returning the required item regardless of whether it is registered or not.

These kind of query will be necessary when enriching activity log metadata with a friendlier name of the component/entity.

See https://github.com/trento-project/web/pull/2951

Note: I have considered the alternative of keeping the `Repo.get(...)` function calls inside metadata enricher, without exposing them from the different entities' contexts, but it just felt the right thing adding them there. Open for feedback.

## How was this tested?

Automated tests added.
