### PR TITLE
Do not show page stats when data set is empty

### DIFF
--- a/assets/js/common/Pagination/PageStats.jsx
+++ b/assets/js/common/Pagination/PageStats.jsx
@@ -6,6 +6,9 @@ function PageStats({
   itemsTotal = 1,
   selectedPage,
 }) {
+  if (itemsTotal === 0) {
+    return null;
+  }
   const itemsBase = (selectedPage - 1) * currentItemsPerPage;
   const lowerBound = itemsBase + 1;
   const upperBound = itemsBase + itemsPresent;

--- a/assets/js/common/Pagination/PageStats.test.jsx
+++ b/assets/js/common/Pagination/PageStats.test.jsx
@@ -7,6 +7,14 @@ import '@testing-library/jest-dom';
 import Pagination from '.';
 
 describe('Page stats', () => {
+  it('should not render when there are no items', () => {
+    render(<Pagination itemsTotal={0} />);
+
+    expect(
+      screen.queryByText('Showing', { exact: false })
+    ).not.toBeInTheDocument();
+  });
+
   it('should render', () => {
     render(
       <Pagination

--- a/assets/js/common/Pagination/Pagination.stories.jsx
+++ b/assets/js/common/Pagination/Pagination.stories.jsx
@@ -31,13 +31,15 @@ export default {
       },
       defaultValue: [10],
     },
+    itemsTotal: {
+      control: {
+        type: 'number',
+      },
+    },
   },
   render: (args) => (
     <Pagination
-      pages={args.pages}
-      currentPage={args.currentPage}
-      currentItemsPerPage={args.currentItemsPerPage}
-      itemsPerPageOptions={args.itemsPerPageOptions}
+      {...args}
       onSelect={(value) => {
         action('onSelect')(value);
       }}
@@ -62,5 +64,11 @@ export const WithManyPages = {
     ...Default.args,
     pages: 99,
     currentPage: 20,
+  },
+};
+
+export const EmptyDataset = {
+  args: {
+    itemsTotal: 0,
   },
 };


### PR DESCRIPTION
# Description

When showing `PageStats` for an empty dataset shows inconsistent values.
This change makes sure `PageStats` is not even rendered if the total of items is `0`

![Screenshot from 2024-09-18 10-29-41](https://github.com/user-attachments/assets/b54cffcb-d6f9-4b1e-a6c2-a85fead76e5c)


## How was this tested?

Automated tests and storybook.
