### PR TITLE
Activity log metadata enrichment

### DIFF
--- a/lib/trento/activity_logging/parser/metadata_enricher.ex
+++ b/lib/trento/activity_logging/parser/metadata_enricher.ex
@@ -1,0 +1,125 @@
+defmodule Trento.ActivityLog.Logger.Parser.MetadataEnricher do
+  @moduledoc """
+  Metadata enricher enriches metadata extracted by activity parser.
+  """
+
+  alias Trento.ActivityLog.ActivityCatalog
+
+  alias Trento.Clusters.Projections.ClusterReadModel
+  alias Trento.Databases.Projections.DatabaseReadModel
+  alias Trento.Hosts.Projections.HostReadModel
+  alias Trento.SapSystems.Projections.SapSystemReadModel
+
+  alias Trento.{Clusters, Databases, Hosts, SapSystems}
+
+  @spec enrich(activity :: ActivityCatalog.activity_type(), metadata :: map()) ::
+          {:ok, maybe_enriched_metadata :: map()}
+  def enrich(activity, metadata) do
+    case ActivityCatalog.detect_activity_category(activity) do
+      supported_activities
+      when supported_activities in [:connection_activity, :domain_event_activity] ->
+        {:ok, enrich_metadata(activity, metadata)}
+
+      _ ->
+        {:ok, metadata}
+    end
+  end
+
+  defp enrich_metadata(activity, metadata),
+    do:
+      {activity, metadata}
+      |> maybe_enrich_with_hostname()
+      |> maybe_enrich_with_cluster_name()
+      |> maybe_enrich_with_database_sid()
+      |> maybe_enrich_with_sap_system_sid()
+      |> elem(1)
+
+  defp maybe_enrich_with_hostname({activity, metadata}) do
+    enriched_metadata =
+      with {:ok, host_id} <- detect_enrichment(:host, {activity, metadata}),
+           {:ok, %HostReadModel{hostname: hostname}} <- Hosts.by_id(host_id) do
+        Map.put(metadata, :hostname, hostname)
+      else
+        _ -> metadata
+      end
+
+    {activity, enriched_metadata}
+  end
+
+  defp maybe_enrich_with_cluster_name({activity, metadata}) do
+    enriched_metadata =
+      with {:ok, cluster_id} <- detect_enrichment(:cluster, {activity, metadata}),
+           {:ok, %ClusterReadModel{name: cluster_name}} <- Clusters.by_id(cluster_id) do
+        Map.put(metadata, :name, cluster_name)
+      else
+        _ -> metadata
+      end
+
+    {activity, enriched_metadata}
+  end
+
+  defp maybe_enrich_with_database_sid({activity, metadata}) do
+    enriched_metadata =
+      with {:ok, database_id} <- detect_enrichment(:database, {activity, metadata}),
+           {:ok, %DatabaseReadModel{sid: sid}} <- Databases.by_id(database_id) do
+        Map.put(metadata, :sid, sid)
+      else
+        _ -> metadata
+      end
+
+    {activity, enriched_metadata}
+  end
+
+  defp maybe_enrich_with_sap_system_sid({activity, metadata}) do
+    enriched_metadata =
+      with {:ok, sap_system_id} <- detect_enrichment(:sap_system, {activity, metadata}),
+           {:ok, %SapSystemReadModel{sid: sid}} <- SapSystems.by_id(sap_system_id) do
+        Map.put(metadata, :sid, sid)
+      else
+        _ -> metadata
+      end
+
+    {activity, enriched_metadata}
+  end
+
+  defp detect_enrichment(
+         _target_resource,
+         {activity,
+          %{
+            resource_id: resource_id,
+            resource_type: resource_type
+          }}
+       )
+       when activity in [:resource_tagging, :resource_untagging] and
+              resource_type in [:host, :cluster, :database, :sap_system],
+       do: {:ok, resource_id}
+
+  defp detect_enrichment(:host, {:host_checks_execution_request, %{host_id: host_id}}),
+    do: {:ok, host_id}
+
+  defp detect_enrichment(
+         :cluster,
+         {:cluster_checks_execution_request, %{cluster_id: cluster_id}}
+       ),
+       do: {:ok, cluster_id}
+
+  defp detect_enrichment(:host, {_, %{host_id: _, hostname: _}}),
+    do: {:error, :no_enrichment_needed}
+
+  defp detect_enrichment(:cluster, {_, %{cluster_id: _, name: _}}),
+    do: {:error, :no_enrichment_needed}
+
+  defp detect_enrichment(:database, {_, %{database_id: _, sid: _}}),
+    do: {:error, :no_enrichment_needed}
+
+  defp detect_enrichment(:sap_system, {_, %{sap_system_id: _, sid: _}}),
+    do: {:error, :no_enrichment_needed}
+
+  defp detect_enrichment(:host, {_, %{host_id: id}}), do: {:ok, id}
+  defp detect_enrichment(:cluster, {_, %{cluster_id: id}}), do: {:ok, id}
+  defp detect_enrichment(:database, {_, %{database_id: id}}), do: {:ok, id}
+  defp detect_enrichment(:sap_system, {_, %{sap_system_id: id}}), do: {:ok, id}
+
+  defp detect_enrichment(_target_resource, {_activity, _metadata}),
+    do: {:error, :no_enrichment_needed}
+end

--- a/lib/trento/activity_logging/parser/metadata_enricher.ex
+++ b/lib/trento/activity_logging/parser/metadata_enricher.ex
@@ -23,53 +23,18 @@ defmodule Trento.ActivityLog.Logger.Parser.MetadataEnricher do
   defp enrich_metadata(activity, metadata),
     do:
       {activity, metadata}
-      |> maybe_enrich_with_hostname()
-      |> maybe_enrich_with_cluster_name()
-      |> maybe_enrich_with_database_sid()
-      |> maybe_enrich_with_sap_system_sid()
+      |> maybe_enrich(:host, Hosts, :hostname)
+      |> maybe_enrich(:cluster, Clusters, :name)
+      |> maybe_enrich(:database, Databases, :sid)
+      |> maybe_enrich(:sap_system, SapSystems, :sid)
       |> elem(1)
 
-  defp maybe_enrich_with_hostname({activity, metadata}) do
+  defp maybe_enrich({activity, metadata}, entity_reference, context_module, enriching_field) do
     enriched_metadata =
-      with {:ok, host_id} <- detect_enrichment(:host, {activity, metadata}),
-           {:ok, %{hostname: hostname}} <- Hosts.by_id(host_id) do
-        Map.put(metadata, :hostname, hostname)
-      else
-        _ -> metadata
-      end
-
-    {activity, enriched_metadata}
-  end
-
-  defp maybe_enrich_with_cluster_name({activity, metadata}) do
-    enriched_metadata =
-      with {:ok, cluster_id} <- detect_enrichment(:cluster, {activity, metadata}),
-           {:ok, %{name: cluster_name}} <- Clusters.by_id(cluster_id) do
-        Map.put(metadata, :name, cluster_name)
-      else
-        _ -> metadata
-      end
-
-    {activity, enriched_metadata}
-  end
-
-  defp maybe_enrich_with_database_sid({activity, metadata}) do
-    enriched_metadata =
-      with {:ok, database_id} <- detect_enrichment(:database, {activity, metadata}),
-           {:ok, %{sid: sid}} <- Databases.by_id(database_id) do
-        Map.put(metadata, :sid, sid)
-      else
-        _ -> metadata
-      end
-
-    {activity, enriched_metadata}
-  end
-
-  defp maybe_enrich_with_sap_system_sid({activity, metadata}) do
-    enriched_metadata =
-      with {:ok, sap_system_id} <- detect_enrichment(:sap_system, {activity, metadata}),
-           {:ok, %{sid: sid}} <- SapSystems.by_id(sap_system_id) do
-        Map.put(metadata, :sid, sid)
+      with {:ok, entity_id} <- detect_enrichment(entity_reference, {activity, metadata}),
+           {:ok, entity} <- context_module.by_id(entity_id),
+           {:ok, enriching_value} <- Map.fetch(entity, enriching_field) do
+        Map.put(metadata, enriching_field, enriching_value)
       else
         _ -> metadata
       end
@@ -78,7 +43,7 @@ defmodule Trento.ActivityLog.Logger.Parser.MetadataEnricher do
   end
 
   defp detect_enrichment(
-         _target_resource,
+         _target_entity,
          {activity,
           %{
             resource_id: resource_id,
@@ -115,6 +80,6 @@ defmodule Trento.ActivityLog.Logger.Parser.MetadataEnricher do
   defp detect_enrichment(:database, {_, %{database_id: id}}), do: {:ok, id}
   defp detect_enrichment(:sap_system, {_, %{sap_system_id: id}}), do: {:ok, id}
 
-  defp detect_enrichment(_target_resource, {_activity, _metadata}),
+  defp detect_enrichment(_target_entity, {_activity, _metadata}),
     do: {:error, :no_enrichment_needed}
 end

--- a/lib/trento/activity_logging/parser/metadata_enricher.ex
+++ b/lib/trento/activity_logging/parser/metadata_enricher.ex
@@ -5,11 +5,6 @@ defmodule Trento.ActivityLog.Logger.Parser.MetadataEnricher do
 
   alias Trento.ActivityLog.ActivityCatalog
 
-  alias Trento.Clusters.Projections.ClusterReadModel
-  alias Trento.Databases.Projections.DatabaseReadModel
-  alias Trento.Hosts.Projections.HostReadModel
-  alias Trento.SapSystems.Projections.SapSystemReadModel
-
   alias Trento.{Clusters, Databases, Hosts, SapSystems}
 
   @spec enrich(activity :: ActivityCatalog.activity_type(), metadata :: map()) ::
@@ -37,7 +32,7 @@ defmodule Trento.ActivityLog.Logger.Parser.MetadataEnricher do
   defp maybe_enrich_with_hostname({activity, metadata}) do
     enriched_metadata =
       with {:ok, host_id} <- detect_enrichment(:host, {activity, metadata}),
-           {:ok, %HostReadModel{hostname: hostname}} <- Hosts.by_id(host_id) do
+           {:ok, %{hostname: hostname}} <- Hosts.by_id(host_id) do
         Map.put(metadata, :hostname, hostname)
       else
         _ -> metadata
@@ -49,7 +44,7 @@ defmodule Trento.ActivityLog.Logger.Parser.MetadataEnricher do
   defp maybe_enrich_with_cluster_name({activity, metadata}) do
     enriched_metadata =
       with {:ok, cluster_id} <- detect_enrichment(:cluster, {activity, metadata}),
-           {:ok, %ClusterReadModel{name: cluster_name}} <- Clusters.by_id(cluster_id) do
+           {:ok, %{name: cluster_name}} <- Clusters.by_id(cluster_id) do
         Map.put(metadata, :name, cluster_name)
       else
         _ -> metadata
@@ -61,7 +56,7 @@ defmodule Trento.ActivityLog.Logger.Parser.MetadataEnricher do
   defp maybe_enrich_with_database_sid({activity, metadata}) do
     enriched_metadata =
       with {:ok, database_id} <- detect_enrichment(:database, {activity, metadata}),
-           {:ok, %DatabaseReadModel{sid: sid}} <- Databases.by_id(database_id) do
+           {:ok, %{sid: sid}} <- Databases.by_id(database_id) do
         Map.put(metadata, :sid, sid)
       else
         _ -> metadata
@@ -73,7 +68,7 @@ defmodule Trento.ActivityLog.Logger.Parser.MetadataEnricher do
   defp maybe_enrich_with_sap_system_sid({activity, metadata}) do
     enriched_metadata =
       with {:ok, sap_system_id} <- detect_enrichment(:sap_system, {activity, metadata}),
-           {:ok, %SapSystemReadModel{sid: sid}} <- SapSystems.by_id(sap_system_id) do
+           {:ok, %{sid: sid}} <- SapSystems.by_id(sap_system_id) do
         Map.put(metadata, :sid, sid)
       else
         _ -> metadata

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -51,6 +51,7 @@ defmodule Trento.Factory do
 
   alias Trento.Databases.Events.{
     DatabaseDeregistered,
+    DatabaseHealthChanged,
     DatabaseInstanceDeregistered,
     DatabaseInstanceMarkedAbsent,
     DatabaseInstanceRegistered,
@@ -65,14 +66,22 @@ defmodule Trento.Factory do
   alias Trento.SapSystems.Events.{
     ApplicationInstanceDeregistered,
     ApplicationInstanceMarkedAbsent,
+    ApplicationInstanceMoved,
     ApplicationInstanceRegistered,
     SapSystemDeregistered,
+    SapSystemHealthChanged,
     SapSystemRegistered,
+    SapSystemRestored,
     SapSystemTombstoned
   }
 
   alias Trento.Clusters.Events.{
+    ChecksSelected,
+    ClusterChecksHealthChanged,
     ClusterDeregistered,
+    ClusterDetailsUpdated,
+    ClusterDiscoveredHealthChanged,
+    ClusterHealthChanged,
     ClusterRegistered,
     ClusterTombstoned,
     HostAddedToCluster,
@@ -242,6 +251,48 @@ defmodule Trento.Factory do
       details: build(:hana_cluster_details),
       health: Health.passing(),
       type: ClusterType.hana_scale_up()
+    }
+  end
+
+  def cluster_details_updated_event_factory do
+    %ClusterDetailsUpdated{
+      cluster_id: Faker.UUID.v4(),
+      name: Faker.StarWars.character(),
+      type: ClusterType.hana_scale_up(),
+      sid: Faker.StarWars.planet(),
+      additional_sids: [],
+      provider: Enum.random(Provider.values()),
+      resources_number: 8,
+      hosts_number: 2,
+      details: build(:hana_cluster_details)
+    }
+  end
+
+  def cluster_discovered_health_changed_event_factory do
+    %ClusterDiscoveredHealthChanged{
+      cluster_id: Faker.UUID.v4(),
+      discovered_health: Health.passing()
+    }
+  end
+
+  def cluster_health_changed_event_factory do
+    %ClusterHealthChanged{
+      cluster_id: Faker.UUID.v4(),
+      health: Health.passing()
+    }
+  end
+
+  def cluster_checks_selected_event_factory do
+    %ChecksSelected{
+      cluster_id: Faker.UUID.v4(),
+      checks: Enum.map(0..4, fn _ -> Faker.UUID.v4() end)
+    }
+  end
+
+  def cluster_checks_health_changed_event_factory do
+    %ClusterChecksHealthChanged{
+      cluster_id: Faker.UUID.v4(),
+      checks_health: Health.passing()
     }
   end
 
@@ -433,6 +484,13 @@ defmodule Trento.Factory do
     }
   end
 
+  def database_health_changed_event_factory do
+    %DatabaseHealthChanged{
+      database_id: Faker.UUID.v4(),
+      health: Health.passing()
+    }
+  end
+
   def sap_system_registered_event_factory do
     %SapSystemRegistered{
       sap_system_id: Faker.UUID.v4(),
@@ -446,11 +504,37 @@ defmodule Trento.Factory do
     }
   end
 
+  def sap_system_health_changed_event_factory do
+    %SapSystemHealthChanged{
+      sap_system_id: Faker.UUID.v4(),
+      health: Health.passing()
+    }
+  end
+
+  def application_instance_moved_event_factory do
+    %ApplicationInstanceMoved{
+      sap_system_id: Faker.UUID.v4(),
+      instance_number: "00",
+      old_host_id: Faker.UUID.v4(),
+      new_host_id: Faker.UUID.v4()
+    }
+  end
+
   def sap_system_deregistered_event_factory do
     SapSystemDeregistered.new!(%{
       sap_system_id: Faker.UUID.v4(),
       deregistered_at: DateTime.utc_now()
     })
+  end
+
+  def sap_system_restored_event_factory do
+    %SapSystemRestored{
+      sap_system_id: Faker.UUID.v4(),
+      tenant: Faker.Beer.hop(),
+      db_host: Faker.Internet.ip_v4_address(),
+      health: Health.passing(),
+      database_health: Health.passing()
+    }
   end
 
   def rollup_sap_system_command_factory do

--- a/test/trento/activity_logging/metadata_enricher_test.exs
+++ b/test/trento/activity_logging/metadata_enricher_test.exs
@@ -1,0 +1,364 @@
+defmodule Trento.ActivityLog.MetadataEnricherTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+  use Trento.DataCase, async: true
+
+  import Trento.Factory
+
+  alias Trento.ActivityLog.Logger.Parser.MetadataEnricher
+
+  test "should pass through unsupported activities" do
+    scenarios = [
+      %{
+        activity: :foo,
+        metadata: %{foo: "bar"}
+      },
+      %{
+        activity: :bar,
+        metadata: %{}
+      },
+      %{
+        activity: :baz,
+        metadata: %{baz: "foo"}
+      }
+    ]
+
+    for %{activity: activity, metadata: metadata} <- scenarios do
+      assert {:ok, ^metadata} = MetadataEnricher.enrich(activity, metadata)
+    end
+  end
+
+  describe "enriching tagging/untagging activities" do
+    test "should pass through enriching unrecognized taggable resources" do
+      scenarios = [
+        %{
+          activity: :resource_tagging,
+          metadata: %{resource_id: Faker.UUID.v4(), resource_type: :foo}
+        },
+        %{
+          activity: :resource_untagging,
+          metadata: %{resource_id: Faker.UUID.v4(), resource_type: :bar}
+        }
+      ]
+
+      for %{activity: activity, metadata: metadata} <- scenarios do
+        assert {:ok, ^metadata} = MetadataEnricher.enrich(activity, metadata)
+      end
+    end
+
+    test "should not enrich tagging activities for missing resources" do
+      scenarios = [
+        %{
+          activity: :resource_tagging,
+          metadata: %{resource_id: Faker.UUID.v4(), resource_type: :host}
+        },
+        %{
+          activity: :resource_tagging,
+          metadata: %{resource_id: Faker.UUID.v4(), resource_type: :cluster}
+        },
+        %{
+          activity: :resource_tagging,
+          metadata: %{resource_id: Faker.UUID.v4(), resource_type: :database}
+        },
+        %{
+          activity: :resource_tagging,
+          metadata: %{resource_id: Faker.UUID.v4(), resource_type: :sap_system}
+        },
+        %{
+          activity: :resource_untagging,
+          metadata: %{resource_id: Faker.UUID.v4(), resource_type: :host}
+        },
+        %{
+          activity: :resource_untagging,
+          metadata: %{resource_id: Faker.UUID.v4(), resource_type: :cluster}
+        },
+        %{
+          activity: :resource_untagging,
+          metadata: %{resource_id: Faker.UUID.v4(), resource_type: :database}
+        },
+        %{
+          activity: :resource_untagging,
+          metadata: %{resource_id: Faker.UUID.v4(), resource_type: :sap_system}
+        }
+      ]
+
+      for %{activity: activity, metadata: metadata} <- scenarios do
+        assert {:ok, ^metadata} = MetadataEnricher.enrich(activity, metadata)
+      end
+    end
+
+    test "should enrich tagging activities" do
+      %{id: host_id, hostname: hostname} = insert(:host)
+      %{id: cluster_id, name: cluster_name} = insert(:cluster)
+      %{id: database_id, sid: database_sid} = insert(:database)
+      %{id: sap_system_id, sid: sap_system_sid} = insert(:sap_system)
+
+      initial_host_tagging_metadata = %{resource_id: host_id, resource_type: :host}
+      expected_host_tagging_metadata = Map.put(initial_host_tagging_metadata, :hostname, hostname)
+
+      initial_cluster_tagging_metadata = %{resource_id: cluster_id, resource_type: :cluster}
+
+      expected_cluster_tagging_metadata =
+        Map.put(initial_cluster_tagging_metadata, :name, cluster_name)
+
+      initial_database_tagging_metadata = %{resource_id: database_id, resource_type: :database}
+
+      expected_database_tagging_metadata =
+        Map.put(initial_database_tagging_metadata, :sid, database_sid)
+
+      initial_sap_system_tagging_metadata = %{
+        resource_id: sap_system_id,
+        resource_type: :sap_system
+      }
+
+      expected_sap_system_tagging_metadata =
+        Map.put(initial_sap_system_tagging_metadata, :sid, sap_system_sid)
+
+      scenarios = [
+        %{
+          activity: :resource_tagging,
+          metadata: initial_host_tagging_metadata,
+          expected_metadata: expected_host_tagging_metadata
+        },
+        %{
+          activity: :resource_tagging,
+          metadata: initial_cluster_tagging_metadata,
+          expected_metadata: expected_cluster_tagging_metadata
+        },
+        %{
+          activity: :resource_tagging,
+          metadata: initial_database_tagging_metadata,
+          expected_metadata: expected_database_tagging_metadata
+        },
+        %{
+          activity: :resource_tagging,
+          metadata: initial_sap_system_tagging_metadata,
+          expected_metadata: expected_sap_system_tagging_metadata
+        },
+        %{
+          activity: :resource_untagging,
+          metadata: initial_host_tagging_metadata,
+          expected_metadata: expected_host_tagging_metadata
+        },
+        %{
+          activity: :resource_untagging,
+          metadata: initial_cluster_tagging_metadata,
+          expected_metadata: expected_cluster_tagging_metadata
+        },
+        %{
+          activity: :resource_untagging,
+          metadata: initial_database_tagging_metadata,
+          expected_metadata: expected_database_tagging_metadata
+        },
+        %{
+          activity: :resource_untagging,
+          metadata: initial_sap_system_tagging_metadata,
+          expected_metadata: expected_sap_system_tagging_metadata
+        }
+      ]
+
+      for %{
+            activity: activity,
+            metadata: initial_metadata,
+            expected_metadata: expected_metadata
+          } <- scenarios do
+        assert {:ok, ^expected_metadata} = MetadataEnricher.enrich(activity, initial_metadata)
+      end
+    end
+  end
+
+  describe "enriching checks execution requests" do
+    test "should pass through unrecognizable checks execution requests" do
+      for activity <- [:host_checks_execution_request, :cluster_checks_execution_request] do
+        metadata_missing_recognizable_item = %{foo: "bar"}
+
+        assert {:ok, ^metadata_missing_recognizable_item} =
+                 MetadataEnricher.enrich(activity, metadata_missing_recognizable_item)
+      end
+    end
+
+    test "should enrich host checks execution request" do
+      %{id: host_id, hostname: hostname} = insert(:host)
+
+      initial_metadata = %{host_id: host_id}
+
+      assert {:ok,
+              %{
+                host_id: ^host_id,
+                hostname: ^hostname
+              }} =
+               MetadataEnricher.enrich(:host_checks_execution_request, initial_metadata)
+    end
+
+    test "should enrich cluster checks execution request" do
+      %{id: cluster_id, name: cluster_name} = insert(:cluster)
+
+      initial_metadata = %{cluster_id: cluster_id}
+
+      assert {:ok,
+              %{
+                cluster_id: ^cluster_id,
+                name: ^cluster_name
+              }} =
+               MetadataEnricher.enrich(:cluster_checks_execution_request, initial_metadata)
+    end
+  end
+
+  describe "domain event activity log metadata enrichment" do
+    test "should not enrich domain events related metadata already having required info" do
+      not_enrichable_events = [
+        {:host_registered, build(:host_registered_event)},
+        {:host_details_updated, build(:host_details_updated_event)},
+        {:cluster_registered, build(:cluster_registered_event)},
+        {:cluster_details_updated, build(:cluster_details_updated_event)},
+        {:database_registered_event, build(:database_registered_event)},
+        {:sap_system_registered_event, build(:sap_system_registered_event)}
+      ]
+
+      for {activity, event} <- not_enrichable_events do
+        metadata = Map.from_struct(event)
+        assert {:ok, ^metadata} = MetadataEnricher.enrich(activity, metadata)
+      end
+    end
+
+    test "should enrich with hostname" do
+      %{id: host_id, hostname: hostname} = insert(:host)
+
+      enrichable_events = [
+        {:heartbeat_succeeded, build(:heartbeat_succeded, host_id: host_id)},
+        {:heartbeat_failed, build(:heartbeat_failed, host_id: host_id)},
+        {:host_checks_health_changed, build(:host_checks_health_changed, host_id: host_id)},
+        {:host_checks_selected, build(:host_checks_selected, host_id: host_id)},
+        {:host_health_changed, build(:host_health_changed_event, host_id: host_id)},
+        {:saptune_status_updated, build(:saptune_status_updated_event, host_id: host_id)},
+        {:software_updates_discovery_requested,
+         build(:software_updates_discovery_requested_event, host_id: host_id)}
+      ]
+
+      for {activity, event} <- enrichable_events do
+        initial_metadata = Map.from_struct(event)
+        enriched_metadata = Map.put(initial_metadata, :hostname, hostname)
+
+        refute Map.has_key?(initial_metadata, :hostname)
+        assert {:ok, ^enriched_metadata} = MetadataEnricher.enrich(activity, initial_metadata)
+      end
+    end
+
+    test "should enrich with clustername" do
+      %{id: cluster_id, name: cluster_name} = insert(:cluster)
+
+      enrichable_events = [
+        {:cluster_checks_health_changed,
+         build(:cluster_checks_health_changed_event, cluster_id: cluster_id)},
+        {:checks_selected, build(:cluster_checks_selected_event, cluster_id: cluster_id)},
+        {:cluster_discovered_health_changed,
+         build(:cluster_discovered_health_changed_event, cluster_id: cluster_id)},
+        {:cluster_health_changed, build(:cluster_health_changed_event, cluster_id: cluster_id)}
+      ]
+
+      for {activity, event} <- enrichable_events do
+        initial_metadata = Map.from_struct(event)
+        enriched_metadata = Map.put(initial_metadata, :name, cluster_name)
+
+        refute Map.has_key?(initial_metadata, :name)
+        assert {:ok, ^enriched_metadata} = MetadataEnricher.enrich(activity, initial_metadata)
+      end
+    end
+
+    test "should enrich with database sid" do
+      %{id: database_id, sid: database_sid} = insert(:database)
+
+      enrichable_events = [
+        {:database_health_changed,
+         build(:database_health_changed_event, database_id: database_id)},
+        {:database_tenants_updated,
+         build(:database_tenants_updated_event, database_id: database_id)},
+        {:database_deregistered, build(:database_deregistered_event, database_id: database_id)},
+        {:database_restored, build(:database_restored_event, database_id: database_id)}
+      ]
+
+      for {activity, event} <- enrichable_events do
+        initial_metadata = Map.from_struct(event)
+        enriched_metadata = Map.put(initial_metadata, :sid, database_sid)
+
+        refute Map.has_key?(initial_metadata, :sid)
+        assert {:ok, ^enriched_metadata} = MetadataEnricher.enrich(activity, initial_metadata)
+      end
+    end
+
+    test "should enrich with sap system sid" do
+      %{id: sap_system_id, sid: sap_system_sid} = insert(:sap_system)
+
+      enrichable_events = [
+        {:sap_system_health_changed,
+         build(:sap_system_health_changed_event, sap_system_id: sap_system_id)},
+        {:sap_system_restored, build(:sap_system_restored_event, sap_system_id: sap_system_id)},
+        {:application_instance_moved,
+         build(:application_instance_moved_event, sap_system_id: sap_system_id)}
+      ]
+
+      for {activity, event} <- enrichable_events do
+        initial_metadata = Map.from_struct(event)
+        enriched_metadata = Map.put(initial_metadata, :sid, sap_system_sid)
+
+        refute Map.has_key?(initial_metadata, :sid)
+        assert {:ok, ^enriched_metadata} = MetadataEnricher.enrich(activity, initial_metadata)
+      end
+    end
+  end
+
+  describe "metadata enrichment combination" do
+    for scenario <- [:hostname_is_available, :hostname_is_not_available] do
+      @scenario scenario
+      test "should combine metadata enrichment when all components are available and '#{scenario}'" do
+        %{id: cluster_id, name: cluster_name} = insert(:cluster)
+
+        %{id: host_id, hostname: hostname} =
+          insert(:host,
+            hostname:
+              case @scenario do
+                :hostname_is_available -> Faker.Lorem.word()
+                :hostname_is_not_available -> nil
+              end
+          )
+
+        enrichable_events = [
+          {:host_added_to_cluster,
+           build(:host_added_to_cluster_event, host_id: host_id, cluster_id: cluster_id)},
+          {:host_removed_from_cluster,
+           build(:host_removed_from_cluster_event, host_id: host_id, cluster_id: cluster_id)}
+        ]
+
+        for {activity, event} <- enrichable_events do
+          metadata = Map.from_struct(event)
+
+          enriched_metadata =
+            metadata
+            |> Map.put(:hostname, hostname)
+            |> Map.put(:name, cluster_name)
+
+          assert {:ok, ^enriched_metadata} = MetadataEnricher.enrich(activity, metadata)
+        end
+      end
+    end
+
+    test "should combine metadata enrichment when some components are not yet available" do
+      %{id: cluster_id, name: cluster_name} = insert(:cluster)
+
+      enrichable_events = [
+        {:host_added_to_cluster, build(:host_added_to_cluster_event, cluster_id: cluster_id)},
+        {:host_removed_from_cluster,
+         build(:host_removed_from_cluster_event, cluster_id: cluster_id)}
+      ]
+
+      for {activity, event} <- enrichable_events do
+        metadata = Map.from_struct(event)
+
+        enriched_metadata = Map.put(metadata, :name, cluster_name)
+
+        assert {:ok, ^enriched_metadata} = MetadataEnricher.enrich(activity, metadata)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description

This PR introduces a `MetadataEnricher` enriching metadata extracted from activity parsing.

Depends on https://github.com/trento-project/web/pull/2992, see also https://github.com/trento-project/web/pull/2951

The rationale behind is improving human-friendly identification of the resource the activity log entry is related to and improving log searchability.

The thing could be summarized as: adding a human friendly resource name to the activity log metadata when it does not already have one

- host -> hostname - field named `hostname`
- cluster -> cluster name - field named `name` 
- database -> sid - field named `sid`
- sap system -> sid - field named `sid`
- application instance -> instance number (always present when needed, no enrichment required)
- database instance -> instance number (always present when needed, no enrichment required)

I just kept field names as they come from the read model (that is why we have `hostname` for a host and `name` for a cluster).
Had thought of options where:
- we always enrich with `component_name`|`resource_name`|`name`  or the like
- making `name` for clusters `clustername` to be consistent with `hostname`

Open for feedback.

## How was this tested?

Automated tests.
