### PR TITLE
Table Component Rounded Corners Fix

### DIFF
--- a/assets/js/common/Table/Table.jsx
+++ b/assets/js/common/Table/Table.jsx
@@ -182,9 +182,12 @@ function Table({
           })}
         >
           <div
-            className={classNames('min-w-fit shadow rounded-b-lg', {
-              'rounded-t-lg': !hasFilters,
-            })}
+            className={classNames(
+              'min-w-fit shadow overflow-hidden rounded-b-lg',
+              {
+                'rounded-t-lg': !hasFilters,
+              }
+            )}
           >
             {header}
             <table className="min-w-full leading-normal table-fixed">

--- a/assets/js/common/Table/Table.test.jsx
+++ b/assets/js/common/Table/Table.test.jsx
@@ -139,6 +139,16 @@ describe('Table component', () => {
       .forEach((tableRow) => expect(tableRow).toHaveClass(pxClass));
   });
 
+  it('should have wrapper div classes with rounded and overflow hidden', () => {
+    const data = tableDataFactory.buildList(10);
+
+    render(<Table config={tableConfig} data={data} />);
+
+    const wrapperDiv = screen.getByRole('table').closest('div');
+
+    expect(wrapperDiv).toHaveClass(/rounded/, 'overflow-hidden');
+  });
+
   describe('filtering', () => {
     it('should filter by the chosen filter option with default filter', async () => {
       const data = tableDataFactory.buildList(10);


### PR DESCRIPTION
# Description

This PR attempts to fix a visual issue where tables were not displaying the rounded corners correctly even though that had the correct corner rounding classes. An `overflow-hidden` class was added since nested elements (th and td items) have background colours.

## Changes (Before and After)
![Frame 79](https://github.com/user-attachments/assets/0054adad-03ea-4a89-a2e9-b58f871430f4)

## How was this tested?

Describe the tests that have been added/changed for this new behaviour.
- [x] **DONE** Test written to check for the existence of the both the `rounded` class and `overflow-hidden` class. (Might be overkill but I am open to feedback)
- [x] **DONE** Visually in Storybook across other components that use tables like Overview pages and the Dashboard. 
