### PR TITLE
Improve Activity Log page request lifecycle

### DIFF
--- a/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
+++ b/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { noop } from 'lodash';
 import { format, toZonedTime } from 'date-fns-tz';
 
 import {
@@ -46,14 +45,10 @@ export const toRenderedEntry = (entry) => ({
   metadata: entry.metadata,
 });
 
-function ActivityLogOverview({
-  activityLog,
-  activityLogDetailModalOpen = false,
-  loading = false,
-  onActivityLogEntryClick = noop,
-  onCloseActivityLogEntryDetails = noop,
-}) {
+function ActivityLogOverview({ activityLog, loading = false }) {
   const [selectedEntry, setEntry] = useState({});
+  const [activityLogDetailModalOpen, setActivityLogDetailModalOpen] =
+    useState(false);
 
   const activityLogTableConfig = {
     usePadding: false,
@@ -96,7 +91,7 @@ function ActivityLogOverview({
             className="cursor-pointer w-full inline-block"
             onClick={() => {
               setEntry(logEntry);
-              onActivityLogEntryClick();
+              setActivityLogDetailModalOpen(true);
             }}
             onKeyDown={() => {}}
           >
@@ -112,7 +107,7 @@ function ActivityLogOverview({
       <ActivityLogDetailModal
         open={activityLogDetailModalOpen}
         entry={selectedEntry}
-        onClose={onCloseActivityLogEntryDetails}
+        onClose={() => setActivityLogDetailModalOpen(false)}
       />
       <Table
         config={activityLogTableConfig}

--- a/assets/js/common/ActivityLogOverview/ActivityLogOverview.test.jsx
+++ b/assets/js/common/ActivityLogOverview/ActivityLogOverview.test.jsx
@@ -200,16 +200,14 @@ describe('Activity Log Overview', () => {
   );
 
   it('should call onActivityLogEntryClick when clicking on an entry in the table', async () => {
-    const onActivityLogEntryClick = jest.fn();
     const id = faker.string.uuid();
-    render(
-      <ActivityLogOverview
-        activityLog={[activityLogEntryFactory.build({ id })]}
-        onActivityLogEntryClick={onActivityLogEntryClick}
-      />
-    );
+    const entry = activityLogEntryFactory.build({ id });
+    render(<ActivityLogOverview activityLog={[entry]} />);
 
     await userEvent.click(screen.getByLabelText(`entry-${id}`));
-    expect(onActivityLogEntryClick).toHaveBeenCalled();
+
+    expect(screen.getByText('Activity Details')).toBeVisible();
+    expect(screen.getByText('ID')).toBeVisible();
+    expect(screen.getByText(id)).toBeVisible();
   });
 });

--- a/assets/js/lib/api/request.js
+++ b/assets/js/lib/api/request.js
@@ -1,0 +1,26 @@
+/**
+ * Model the lifecycle of an API request
+ *
+ * * initial: The request has not been made yet
+ * * loading: The request is in progress
+ * * success: The request was successful, and the response is available
+ * * failure: The request failed, and the error is available
+ */
+
+export const initial = () => ({
+  status: 'initial',
+});
+
+export const success = (response) => ({
+  status: 'success',
+  response,
+});
+
+export const failure = (error) => ({
+  status: 'failure',
+  error,
+});
+
+export const loading = () => ({
+  status: 'loading',
+});

--- a/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
+++ b/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
@@ -6,6 +6,7 @@ import { EOS_REFRESH } from 'eos-icons-react';
 import { map, pipe } from 'lodash/fp';
 
 import { getActivityLog } from '@lib/api/activityLogs';
+import * as request from '@lib/api/request';
 import { allowedActivities } from '@lib/model/activityLog';
 import { getActivityLogUsers } from '@state/selectors/activityLog';
 import { getUserProfile } from '@state/selectors/user';
@@ -15,7 +16,11 @@ import PageHeader from '@common/PageHeader';
 import ActivityLogOverview from '@common/ActivityLogOverview';
 import ComposedFilter from '@common/ComposedFilter';
 import Pagination, { defaultItemsPerPageOptions } from '@common/Pagination';
+import Spinner from '@common/Spinner';
 
+import ConnectionErrorAntenna from '@static/connection-error-antenna.svg';
+
+import NotificationBox from '@common/NotificationBox';
 import {
   applyItemsPerPage,
   setFilterValueToSearchParams,
@@ -25,8 +30,6 @@ import {
   setPaginationToSearchParams,
   resetPaginationToSearchParams,
 } from './searchParams';
-
-const emptyResponse = { data: [] };
 
 const defaultItemsPerPage = 20;
 const detectItemsPerPage = (number) =>
@@ -51,19 +54,86 @@ const applyDefaultItemsPerPage = (params) =>
     ? params
     : { first: defaultItemsPerPage, ...params };
 
-const activityLogRequest = pipe(
+const activityLogRequestClient = pipe(
   searchParamsToAPIParams,
   applyDefaultItemsPerPage,
   getActivityLog
 );
 
+function MainView({
+  request: { status, response },
+  itemsPerPage,
+  onPageChange,
+  onChangeItemsPerPage,
+}) {
+  if (status === 'initial') {
+    return <> </>;
+  }
+  if (status === 'loading') {
+    return (
+      <div className="flex flex-row min-h-screen justify-center items-center">
+        <Spinner size="xl" />
+      </div>
+    );
+  }
+  if (status === 'failure') {
+    return (
+      <div className="flex justify-center items-center p-10">
+        <NotificationBox
+          icon={
+            <img
+              src={ConnectionErrorAntenna}
+              className="m-auto w-48"
+              alt="Connection error"
+            />
+          }
+          title="Connection Error"
+          text="An error occurred while loading the activity log. Please try reloading the page."
+        />
+      </div>
+    );
+  }
+
+  const { data, pagination } = response;
+  return (
+    <>
+      <ActivityLogOverview activityLog={data} />
+      <Pagination
+        hasPrev={pagination?.has_previous_page}
+        hasNext={pagination?.has_next_page}
+        currentItemsPerPage={itemsPerPage}
+        onSelect={pipe((selection) => {
+          switch (selection) {
+            case 'prev':
+              return {
+                last: itemsPerPage,
+                before: pagination?.start_cursor,
+              };
+            case 'next':
+              return {
+                first: itemsPerPage,
+                after: pagination?.end_cursor,
+              };
+            case 'first':
+              return { first: itemsPerPage };
+            case 'last':
+              return { last: itemsPerPage };
+            default:
+              return {};
+          }
+        }, onPageChange)}
+        onChangeItemsPerPage={onChangeItemsPerPage}
+      />
+    </>
+  );
+}
+
 function ActivityLogPage() {
   const users = useSelector(getActivityLogUsers);
   const [searchParams, setSearchParams] = useSearchParams();
-  const [activityLogResponse, setActivityLogResponse] = useState(emptyResponse);
-  const [isLoading, setLoading] = useState(true);
-  const [activityLogDetailModalOpen, setActivityLogDetailModalOpen] =
-    useState(false);
+  const [activityLogRequest, setActivityLogRequest] = useState(
+    request.initial()
+  );
   const { abilities } = useSelector(getUserProfile);
 
   const filters = [
@@ -102,19 +172,21 @@ function ActivityLogPage() {
   )(searchParams);
 
   const fetchActivityLog = () => {
-    setLoading(true);
-
-    activityLogRequest(searchParams)
-      .then(({ data }) => {
-        setActivityLogResponse({
-          data: data?.data || [],
-          pagination: data?.pagination,
-        });
-      })
-      .catch(() => setActivityLogResponse(emptyResponse))
-      .finally(() => {
-        setLoading(false);
-      });
+    // defer the loading state to avoid flickering
+    const tid = setTimeout(() => setActivityLogRequest(request.loading()), 500);
+    activityLogRequestClient(searchParams)
+      .then(
+        pipe(
+          ({ data }) => ({
+            data: data?.data || [],
+            pagination: data?.pagination,
+          }),
+          request.success,
+          setActivityLogRequest
+        )
+      )
+      .catch(pipe(request.failure, setActivityLogRequest))
+      .finally(() => clearTimeout(tid));
   };
 
   useEffect(() => {
@@ -142,46 +214,15 @@ function ActivityLogPage() {
             type="primary-white"
             className="!w-28"
             onClick={fetchActivityLog}
-            disabled={isLoading}
           >
             <EOS_REFRESH className="inline-block fill-jungle-green-500" />{' '}
             Refresh
           </Button>
         </div>
-        <ActivityLogOverview
-          activityLogDetailModalOpen={activityLogDetailModalOpen}
-          activityLog={activityLogResponse.data}
-          loading={isLoading}
-          onActivityLogEntryClick={() => setActivityLogDetailModalOpen(true)}
-          onCloseActivityLogEntryDetails={() =>
-            setActivityLogDetailModalOpen(false)
-          }
-        />
-        <Pagination
-          hasPrev={activityLogResponse.pagination?.has_previous_page}
-          hasNext={activityLogResponse.pagination?.has_next_page}
-          currentItemsPerPage={itemsPerPage}
-          onSelect={pipe(
-            (selection) => {
-              switch (selection) {
-                case 'prev':
-                  return {
-                    last: itemsPerPage,
-                    before: activityLogResponse.pagination?.start_cursor,
-                  };
-                case 'next':
-                  return {
-                    first: itemsPerPage,
-                    after: activityLogResponse.pagination?.end_cursor,
-                  };
-                case 'first':
-                  return { first: itemsPerPage };
-                case 'last':
-                  return { last: itemsPerPage };
-                default:
-                  return {};
-              }
-            },
+        <MainView
+          request={activityLogRequest}
+          itemsPerPage={itemsPerPage}
+          onPageChange={pipe(
             setPaginationToSearchParams(searchParams),
             setSearchParams
           )}

--- a/assets/js/pages/ActivityLogPage/ActivityLogPage.test.jsx
+++ b/assets/js/pages/ActivityLogPage/ActivityLogPage.test.jsx
@@ -43,11 +43,6 @@ describe('ActivityLogPage', () => {
     ${200}         | ${{ foo: [] }}
     ${200}         | ${''}
     ${200}         | ${null}
-    ${404}         | ${[]}
-    ${404}         | ${{ data: [] }}
-    ${500}         | ${{ error: 'Internal Server Error' }}
-    ${503}         | ${null}
-    ${504}         | ${''}
   `(
     'should render empty activity log on responseStatus: `$responseStatus` and responseBody: `$responseBody`',
     async ({ responseStatus, responseBody }) => {
@@ -60,6 +55,28 @@ describe('ActivityLogPage', () => {
       await act(() => renderWithRouter(StatefulActivityLogPage));
 
       expect(screen.getByText('No data available')).toBeVisible();
+    }
+  );
+
+  it.each`
+    responseStatus | responseBody
+    ${404}         | ${[]}
+    ${404}         | ${{ data: [] }}
+    ${500}         | ${{ error: 'Internal Server Error' }}
+    ${503}         | ${null}
+    ${504}         | ${''}
+  `(
+    'should render error screen activity log on responseStatus: `$responseStatus` and responseBody: `$responseBody`',
+    async ({ responseStatus, responseBody }) => {
+      axiosMock
+        .onGet('/api/v1/activity_log')
+        .reply(responseStatus, responseBody);
+      const [StatefulActivityLogPage, _] = withDefaultState(
+        <ActivityLogPage />
+      );
+      await act(() => renderWithRouter(StatefulActivityLogPage));
+
+      expect(screen.getByText('Connection Error')).toBeVisible();
     }
   );
 


### PR DESCRIPTION
# Description

Refine how the Activity log page handles the API request
* define the HTTP request lifecycle in `lib/api/request`
* show an empty view initially
* show an error view in case an error occurred
* add a spinner when loading data

