### PR TITLE
Raise an error during SAML init if decryption fails

### DIFF
--- a/lib/trento/release.ex
+++ b/lib/trento/release.ex
@@ -170,6 +170,12 @@ defmodule Trento.Release do
 
           {key, cert}
 
+        %SSOCertificatesSettings{key_file: :error, certificate_file: :error} ->
+          raise """
+          Error decrypting the SSO certificates.
+          The used SECRET_KEY_BASE value might be different for the one used during the encryption.
+          """
+
         %SSOCertificatesSettings{key_file: key, certificate_file: cert} ->
           {key, cert}
       end


### PR DESCRIPTION
# Description

There is one scenario (at least) that if the decryption of the encrypted entries in the DB fails, the SAML initialization might fail. The encryption is based on the SECRET_KEY_BASE value, so if this value is changed during different bootups, the decryption will start failing.

This can happen for example if helm chart installation is used, and you install trento server, uninstall and install back again (without wiping out the pvc containing the DB), the secret key base is auto generated again, so this fails.

This patch simply aims to help improving the user message received if this "corner case" happens.

## How was this tested?
 Manually, it is really difficult to add automated tests for this.
