### PR TITLE
Discarded discovery events to be recorded 

### DIFF
--- a/lib/trento/discovery.ex
+++ b/lib/trento/discovery.ex
@@ -32,8 +32,9 @@ defmodule Trento.Discovery do
   @spec handle(map) :: :ok | {:error, any}
   def handle(event) do
     with {:ok, commands} <- do_handle(event),
-         {:ok, _} <- store_discovery_event(event) do
-      dispatch(commands)
+         {:ok, _} <- store_discovery_event(event),
+         :ok <- dispatch(commands) do
+      :ok
     else
       {:error, reason} = error ->
         Logger.error("Failed to handle discovery event: #{inspect(reason)}")

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -902,6 +902,20 @@ defmodule Trento.Factory do
     }
   end
 
+  def host_discovery_event_factory do
+    %{
+      "hostname" => Faker.StarWars.character(),
+      "ip_addresses" => [Faker.Internet.ip_v4_address()],
+      "agent_version" => Faker.App.semver(),
+      "cpu_count" => Enum.random(1..16),
+      "total_memory_mb" => Enum.random(1..128),
+      "socket_count" => Enum.random(1..16),
+      "os_version" => Faker.App.semver(),
+      "installation_source" => Enum.random(["community", "suse", "unknown"]),
+      "fully_qualified_domain_name" => Faker.Internet.domain_name()
+    }
+  end
+
   def software_updates_discovery_health_changed_event_factory do
     SoftwareUpdatesHealthChanged.new!(%{
       host_id: Faker.UUID.v4(),

--- a/test/trento_web/controllers/v1/discovery_controller_test.exs
+++ b/test/trento_web/controllers/v1/discovery_controller_test.exs
@@ -59,7 +59,7 @@ defmodule TrentoWeb.V1.DiscoveryControllerTest do
 
       [discarded_event] = Discovery.get_discarded_discovery_events(1)
 
-      assert %DiscardedDiscoveryEvent{payload: ^body} =
+      assert %DiscardedDiscoveryEvent{payload: ^body, reason: "[:any_error]"} =
                discarded_event
     end
   end


### PR DESCRIPTION
# Description

Discovery Events that fail to parse into commands are discarded and stored in the `discarded_discovery_events` table.

However, if a Discovery Event requires a step in the `before_dispatch` handler of a Commanded Middleware, and the step fails, the Discovery Event is still discarded, but it's not saved.

So far, this only applies to application instance registration events in the context of a sap system discovery.
