### PR TITLE
Improve usability of select search on large options content

### DIFF
--- a/assets/js/common/Filter/Filter.jsx
+++ b/assets/js/common/Filter/Filter.jsx
@@ -18,15 +18,8 @@ const getLabel = (value, placeholder) =>
  * @param {string} props.title Title of the filter. It will be displayed in the button when the filter is empty
  * @param {string|string[]} props.value Selected options. Default is an empty array
  * @param {function} props.onChange Function to call when the selected options change
- * @param {boolean} props.truncateOptionsContent If true, the options will be truncated to fit the width of the filter select, otherwise the full value will be displayed. Default is true
  */
-function Filter({
-  options,
-  title,
-  value = [],
-  onChange,
-  truncateOptionsContent = true,
-}) {
+function Filter({ options, title, value = [], onChange }) {
   const ref = useRef();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
@@ -107,14 +100,7 @@ function Filter({
           afterLeave={() => setQuery('')}
           show={open}
         >
-          <div
-            className={classNames(
-              'absolute mt-1 z-10 rounded-md bg-white shadow-lg',
-              {
-                'w-full': truncateOptionsContent,
-              }
-            )}
-          >
+          <div className="absolute mt-1 z-10 rounded-md bg-white shadow-lg min-w-full">
             <div className="ring-1 ring-black ring-opacity-5 rounded-md">
               <div className="pt-2 pb-1 px-2 flex justify-center">
                 <input

--- a/assets/js/common/Filter/Filter.jsx
+++ b/assets/js/common/Filter/Filter.jsx
@@ -18,8 +18,15 @@ const getLabel = (value, placeholder) =>
  * @param {string} props.title Title of the filter. It will be displayed in the button when the filter is empty
  * @param {string|string[]} props.value Selected options. Default is an empty array
  * @param {function} props.onChange Function to call when the selected options change
+ * @param {boolean} props.truncateOptionsContent If true, the options will be truncated to fit the width of the filter select, otherwise the full value will be displayed. Default is true
  */
-function Filter({ options, title, value = [], onChange }) {
+function Filter({
+  options,
+  title,
+  value = [],
+  onChange,
+  truncateOptionsContent = true,
+}) {
   const ref = useRef();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
@@ -100,7 +107,14 @@ function Filter({ options, title, value = [], onChange }) {
           afterLeave={() => setQuery('')}
           show={open}
         >
-          <div className="absolute mt-1 w-full z-10 rounded-md bg-white shadow-lg">
+          <div
+            className={classNames(
+              'absolute mt-1 z-10 rounded-md bg-white shadow-lg',
+              {
+                'w-full': truncateOptionsContent,
+              }
+            )}
+          >
             <div className="ring-1 ring-black ring-opacity-5 rounded-md">
               <div className="pt-2 pb-1 px-2 flex justify-center">
                 <input

--- a/assets/js/common/Filter/Filter.stories.jsx
+++ b/assets/js/common/Filter/Filter.stories.jsx
@@ -28,14 +28,19 @@ export default {
       description: 'Function to call when the selected options change',
       control: { type: null },
     },
+    truncateOptionsContent: {
+      type: { name: 'boolean', required: false, defaultValue: true },
+      description:
+        'If true, the options content will be truncated to fit the width of the filter select, otherwise the full value will be displayed',
+      control: { type: 'boolean' },
+    },
   },
   render: (args) => {
     const [value, setValue] = useState(args.value);
 
     return (
       <Filter
-        title={args.title}
-        options={args.options}
+        {...args}
         value={value}
         onChange={(newValue) => {
           setValue(newValue);
@@ -85,5 +90,24 @@ export const WithLabel = {
       ['virginia-gricia', 'Virginia Gricia'],
     ],
     value: ['tony-kekw'],
+  },
+};
+
+export const WithTruncatedOptions = {
+  args: {
+    ...Default.args,
+    options: [
+      'Tony Kekw',
+      'Chad Carbonara',
+      'Chuck Amatriciana',
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+    ],
+  },
+};
+
+export const WithFullOptionsContent = {
+  args: {
+    ...WithTruncatedOptions.args,
+    truncateOptionsContent: false,
   },
 };

--- a/assets/js/common/Filter/Filter.stories.jsx
+++ b/assets/js/common/Filter/Filter.stories.jsx
@@ -28,12 +28,6 @@ export default {
       description: 'Function to call when the selected options change',
       control: { type: null },
     },
-    truncateOptionsContent: {
-      type: { name: 'boolean', required: false, defaultValue: true },
-      description:
-        'If true, the options content will be truncated to fit the width of the filter select, otherwise the full value will be displayed',
-      control: { type: 'boolean' },
-    },
   },
   render: (args) => {
     const [value, setValue] = useState(args.value);
@@ -93,7 +87,7 @@ export const WithLabel = {
   },
 };
 
-export const WithTruncatedOptions = {
+export const WithLargeOptionContent = {
   args: {
     ...Default.args,
     options: [
@@ -102,12 +96,5 @@ export const WithTruncatedOptions = {
       'Chuck Amatriciana',
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
     ],
-  },
-};
-
-export const WithFullOptionsContent = {
-  args: {
-    ...WithTruncatedOptions.args,
-    truncateOptionsContent: false,
   },
 };

--- a/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
+++ b/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
@@ -141,11 +141,12 @@ function ActivityLogPage() {
     {
       key: 'type',
       type: 'select',
-      title: 'Resource type',
+      title: 'Type',
       options: pipe(
         allowedActivities,
         map(([key, value]) => [key, value.label])
       )(abilities),
+      truncateOptionsContent: false,
     },
     {
       key: 'actor',

--- a/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
+++ b/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
@@ -146,7 +146,6 @@ function ActivityLogPage() {
         allowedActivities,
         map(([key, value]) => [key, value.label])
       )(abilities),
-      truncateOptionsContent: false,
     },
     {
       key: 'actor',

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -54,9 +54,7 @@ context('Activity Log page', () => {
       }).as('data');
       cy.visit('/activity_log');
 
-      cy.contains('Filter Resource type', { matchCase: false }).should(
-        'be.visible'
-      );
+      cy.contains('Filter Type', { matchCase: false }).should('be.visible');
       cy.contains('Filter older than', { matchCase: false }).should(
         'be.visible'
       );
@@ -92,7 +90,7 @@ context('Activity Log page', () => {
       cy.contains('Filter newer than').click();
       cy.get('input[type="datetime-local"]:first').type('2024-08-13T10:21');
 
-      cy.contains('Filter Resource type').click();
+      cy.contains('Filter Type').click();
       cy.contains('Login Attempt').click();
       cy.contains('Tag Added').click();
 
@@ -117,9 +115,7 @@ context('Activity Log page', () => {
 
       cy.contains('Reset').click();
 
-      cy.contains('Filter Resource type', { matchCase: false }).should(
-        'be.visible'
-      );
+      cy.contains('Filter Type', { matchCase: false }).should('be.visible');
       cy.contains('Filter older than', { matchCase: false }).should(
         'be.visible'
       );
@@ -246,7 +242,7 @@ context('Activity Log page', () => {
         );
       });
 
-      cy.contains('Filter Resource type').click();
+      cy.contains('Filter Type').click();
       cy.contains('Login Attempt').click();
       cy.contains('Apply').click();
 


### PR DESCRIPTION
# Description

This PR hopefully improves usability of Activity Log's search filters, specifically the filter by type.

Currently the activity types options are truncated in the selection, and it might be difficult identifying an exact type.

https://github.com/user-attachments/assets/7d425fae-dcc7-429a-83ad-4017bf190edb


With the proposed change we show the whole options content.

https://github.com/user-attachments/assets/59bf95ab-4048-43ff-adbc-1ed3b331a8b0

## How was this tested?

Storybook.