### PR TITLE
SUSE Manager - Navigate from patch detail to previews pages

### DIFF
--- a/assets/js/common/BackButton/BackButton.jsx
+++ b/assets/js/common/BackButton/BackButton.jsx
@@ -3,8 +3,10 @@ import Button from '@common/Button';
 import { useNavigate } from 'react-router-dom';
 import { EOS_ARROW_BACK } from 'eos-icons-react';
 
-export function BackButton({ children, url }) {
+export function BackButton({ children, url, onClick }) {
   const navigate = useNavigate();
+
+  const clickHandler = onClick || (() => navigate(url));
 
   return (
     <div className="flex mb-4">
@@ -13,7 +15,7 @@ export function BackButton({ children, url }) {
           className="w-2/3 text-jungle-green-500 text-left py-0 px-0"
           size="small"
           type="transparent"
-          onClick={() => navigate(url)}
+          onClick={clickHandler}
         >
           <EOS_ARROW_BACK className="inline-block fill-jungle-green-500" />
           {children}

--- a/assets/js/lib/history/index.js
+++ b/assets/js/lib/history/index.js
@@ -1,2 +1,2 @@
 // HANDLE WITH CARE
-export const historyLength = (windowImpl = window) => windowImpl.history.length;
+export const length = ({ history } = window) => history.length;

--- a/assets/js/lib/history/index.js
+++ b/assets/js/lib/history/index.js
@@ -1,0 +1,2 @@
+// HANDLE WITH CARE
+export const historyLength = (windowImpl = window) => windowImpl.history.length;

--- a/assets/js/lib/history/index.test.js
+++ b/assets/js/lib/history/index.test.js
@@ -1,16 +1,16 @@
 import { faker } from '@faker-js/faker';
 
-import { historyLength } from '.';
+import * as history from '.';
 
 describe('historyLength', () => {
   it('should return the current history length with a mocked window implementation', () => {
     const length = faker.number.int();
     const mockWindow = { history: { length } };
 
-    expect(historyLength(mockWindow)).toBe(length);
+    expect(history.length(mockWindow)).toBe(length);
   });
 
   it('should return the current history length using the native window as default', () => {
-    expect(historyLength()).toBe(1);
+    expect(history.length()).toBe(1);
   });
 });

--- a/assets/js/lib/history/index.test.js
+++ b/assets/js/lib/history/index.test.js
@@ -1,0 +1,16 @@
+import { faker } from '@faker-js/faker';
+
+import { historyLength } from '.';
+
+describe('historyLength', () => {
+  it('should return the current history length with a mocked window implementation', () => {
+    const length = faker.number.int();
+    const mockWindow = { history: { length } };
+
+    expect(historyLength(mockWindow)).toBe(length);
+  });
+
+  it('should return the current history length using the native window as default', () => {
+    expect(historyLength()).toBe(1);
+  });
+});

--- a/assets/js/pages/AdvisoryDetails/AdvisoryDetails.jsx
+++ b/assets/js/pages/AdvisoryDetails/AdvisoryDetails.jsx
@@ -37,9 +37,9 @@ function AdvisoryDetails({
   return (
     <div>
       <PageHeader className="flex h-auto items-center">
-        <h1 className="mr-2">
+        <div className="mr-2">
           Advisory Details: <span className="font-bold">{advisoryName}</span>
-        </h1>{' '}
+        </div>{' '}
         <AdvisoryIcon type={type} />
       </PageHeader>
       <div className="flex flex-col mb-4">

--- a/assets/js/pages/AdvisoryDetails/AdvisoryDetailsPage.jsx
+++ b/assets/js/pages/AdvisoryDetails/AdvisoryDetailsPage.jsx
@@ -1,12 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 
 import { getAdvisoryErrata } from '@lib/api/softwareUpdates';
 import { logError } from '@lib/log';
+import { historyLength } from '@lib/history';
 import BackButton from '@common/BackButton';
 import AdvisoryDetails from './AdvisoryDetails';
 
 function AdvisoryDetailsPage() {
+  const navigate = useNavigate();
   const [advisoryErrata, setAdvisoryErrata] = useState(undefined);
   const [isLoading, setIsLoading] = useState(true);
   const { hostID, advisoryID } = useParams();
@@ -22,10 +24,20 @@ function AdvisoryDetailsPage() {
 
   return (
     <>
-      <BackButton url={`/hosts/${hostID}`}>Back</BackButton>
-      {!isLoading ? (
+      <BackButton
+        onClick={() => {
+          if (historyLength() < 3) {
+            navigate(`/hosts/${hostID}/patches`);
+          } else {
+            navigate(-1);
+          }
+        }}
+      >
+        Back
+      </BackButton>
+      {!isLoading && (
         <AdvisoryDetails advisoryName={advisoryID} errata={advisoryErrata} />
-      ) : null}
+      )}
     </>
   );
 }

--- a/assets/js/pages/AdvisoryDetails/AdvisoryDetailsPage.jsx
+++ b/assets/js/pages/AdvisoryDetails/AdvisoryDetailsPage.jsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 
 import { getAdvisoryErrata } from '@lib/api/softwareUpdates';
 import { logError } from '@lib/log';
-import { historyLength } from '@lib/history';
+import * as history from '@lib/history';
 import BackButton from '@common/BackButton';
 import AdvisoryDetails from './AdvisoryDetails';
 
@@ -25,13 +25,11 @@ function AdvisoryDetailsPage() {
   return (
     <>
       <BackButton
-        onClick={() => {
-          if (historyLength() < 3) {
-            navigate(`/hosts/${hostID}/patches`);
-          } else {
-            navigate(-1);
-          }
-        }}
+        onClick={() =>
+          history.length() < 3
+            ? navigate(`/hosts/${hostID}/patches`)
+            : navigate(-1)
+        }
       >
         Back
       </BackButton>


### PR DESCRIPTION
# Description
Right now the patch detail view brings back the user to the host details page upon clicking the back link.

This PR implements a lookup on the history stack to determine if we have enough history to go back to the previous page or navigate back to related patches page by default.

## How was this tested?
Jest tests added.