### PR TITLE
Add junit.xml to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ npm-debug.log
 /assets/node_modules/
 /assets/.env
 
+/assets/junit.xml
+
 .pgdata/
 
 # Local dev.local.exs file


### PR DESCRIPTION
# Description
Right now a `junit.xml` file gets generated upon `npm test`, I'm just adding it to the gitignore in order to avoid committing it by mistake.