### PR TITLE
Fix navigation still possible from host details to SUSE Manager pages in case of error

### DIFF
--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
@@ -77,4 +77,46 @@ describe('AvailableSoftwareUpdates component', () => {
 
     expect(screen.getByRole('button', { name: 'Settings' })).toBeVisible();
   });
+
+  it('should navigate to a SUSE Manager view', async () => {
+    const user = userEvent.setup();
+    const relevantPatches = faker.number.int({ min: 1 });
+    const upgradablePackages = faker.number.int();
+    const navigateToPatches = jest.fn();
+
+    render(
+      <AvailableSoftwareUpdates
+        settingsConfigured
+        relevantPatches={relevantPatches}
+        upgradablePackages={upgradablePackages}
+        onNavigateToPatches={navigateToPatches}
+      />
+    );
+
+    const relevantPatchesBox = screen.getByText(relevantPatches);
+    await user.click(relevantPatchesBox);
+
+    expect(navigateToPatches).toHaveBeenCalled();
+  });
+
+  it('should not navigate to a SUSE Manager view when erroring', async () => {
+    const user = userEvent.setup();
+    const navigateToPatches = jest.fn();
+    const tooltip = faker.lorem.words({ min: 3, max: 5 });
+    const errorMessage = faker.person.jobType();
+
+    render(
+      <AvailableSoftwareUpdates
+        settingsConfigured
+        tooltip={tooltip}
+        errorMessage={errorMessage}
+        onNavigateToPatches={navigateToPatches}
+      />
+    );
+
+    const relevantPatchesBox = screen.getAllByText(errorMessage)[0];
+    await user.click(relevantPatchesBox);
+
+    expect(navigateToPatches).not.toHaveBeenCalled();
+  });
 });

--- a/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
@@ -16,6 +16,8 @@ function Indicator({
   isError,
   onNavigate,
 }) {
+  const clickHandler = isError ? () => {} : onNavigate;
+
   return (
     <Tooltip isEnabled={isError} content={tooltip} wrap={false}>
       <div
@@ -23,12 +25,12 @@ function Indicator({
         tabIndex={0}
         className={classNames(
           'flex flex-row items-center border border-gray-200 p-2 rounded-md grow',
-          { 'cursor-pointer': !isError }
+          { 'cursor-default': isError }
         )}
-        onClick={onNavigate}
+        onClick={clickHandler}
         onKeyDown={({ code }) => {
           if (code === 'Enter') {
-            onNavigate();
+            clickHandler();
           }
         }}
       >


### PR DESCRIPTION


# Description
Fixing navigation still possible from host details to suma pages in case of error.

## How was this tested?
Existing tests passing, I would like to add a Jest test to ensure it doesn't go off anymore.
