### PR TITLE
Updates jest config for Junit files

### DIFF
--- a/assets/jest.config.js
+++ b/assets/jest.config.js
@@ -133,6 +133,7 @@ module.exports = {
         classNameTemplate: '{classname}',
         titleTemplate: '{title}', // outputname
         includeConsoleOutput: true,
+        outputDirectory: "/tmp"
       },
     ],
   ],


### PR DESCRIPTION
With this change, jest junit files will by default be written to `/tmp `. This behvaiour can be overridden by:

`JEST_JUNIT_OUTPUT_DIR=$DESIRED_DIRECTORY npm test`
