### PR TITLE
Fix the loading spinner for related patches misbehaving

### DIFF
--- a/assets/js/state/softwareUpdates.js
+++ b/assets/js/state/softwareUpdates.js
@@ -35,7 +35,8 @@ export const softwareUpdatesSlice = createSlice({
       state.softwareUpdates = {
         ...state.softwareUpdates,
         [hostID]: {
-          ...initialHostState,
+          ...state.softwareUpdates[hostID],
+          loading: false,
           relevant_patches,
           upgradable_packages,
         },


### PR DESCRIPTION
A tiny fix for the related patches column, apparently the spinner that we had in place was a little bit wonky

## Testing
Existing tests passing