### PR TITLE
Add `:ignore` behavior for discovery events

### DIFF
--- a/lib/trento/infrastructure/commanded/middleware/enrich.ex
+++ b/lib/trento/infrastructure/commanded/middleware/enrich.ex
@@ -26,6 +26,11 @@ defmodule Trento.Infrastructure.Commanded.Middleware.Enrich do
         pipeline
         |> respond({:error, reason})
         |> halt
+
+      {:ignore, reason} ->
+        pipeline
+        |> respond({:ignore, reason})
+        |> halt
     end
   end
 

--- a/lib/trento/infrastructure/commanded/middleware/enrich_register_application_instance.ex
+++ b/lib/trento/infrastructure/commanded/middleware/enrich_register_application_instance.ex
@@ -36,7 +36,7 @@ defimpl Trento.Infrastructure.Commanded.Middleware.Enrichable,
          }}
 
       nil ->
-        {:error, :database_not_registered}
+        {:ignore, :database_not_registered}
     end
   end
 end

--- a/test/trento/infrastructure/commanded/middleware/enrich_register_application_instance_test.exs
+++ b/test/trento/infrastructure/commanded/middleware/enrich_register_application_instance_test.exs
@@ -68,7 +68,7 @@ defmodule Trento.Infrastructure.Commanded.Middleware.EnrichRegisterApplicationIn
         health: :passing
       )
 
-    assert {:error, :database_not_registered} = Enrichable.enrich(command, %{})
+    assert {:ignore, :database_not_registered} = Enrichable.enrich(command, %{})
   end
 
   test "should return an error if the database was not found" do
@@ -85,6 +85,6 @@ defmodule Trento.Infrastructure.Commanded.Middleware.EnrichRegisterApplicationIn
         health: :passing
       )
 
-    assert {:error, :database_not_registered} = Enrichable.enrich(command, %{})
+    assert {:ignore, :database_not_registered} = Enrichable.enrich(command, %{})
   end
 end

--- a/test/trento_web/controllers/v1/discovery_controller_test.exs
+++ b/test/trento_web/controllers/v1/discovery_controller_test.exs
@@ -41,13 +41,13 @@ defmodule TrentoWeb.V1.DiscoveryControllerTest do
       |> json_response(202)
     end
 
-    test "collect action discards application instance registrations when the associated database does not exists",
+    test "collect action discards and store events when the command fails",
          %{conn: conn} do
       body =
         load_discovery_event_fixture("sap_system_discovery_application")
 
       expect(Trento.Commanded.Mock, :dispatch, fn _ ->
-        {:error, :any_error}
+        {:error, :any_reason}
       end)
 
       %{status: status} =
@@ -59,7 +59,29 @@ defmodule TrentoWeb.V1.DiscoveryControllerTest do
 
       [discarded_event] = Discovery.get_discarded_discovery_events(1)
 
-      assert %DiscardedDiscoveryEvent{payload: ^body, reason: "[:any_error]"} =
+      assert %DiscardedDiscoveryEvent{payload: ^body, reason: "[:any_reason]"} =
+               discarded_event
+    end
+
+    test "collect action discards and store events when the command is not dispatched",
+         %{conn: conn} do
+      body =
+        load_discovery_event_fixture("sap_system_discovery_application")
+
+      expect(Trento.Commanded.Mock, :dispatch, fn _ ->
+        {:ignore, :any_reason}
+      end)
+
+      %{status: status} =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/v1/collect", body)
+
+      assert status == 202
+
+      [discarded_event] = Discovery.get_discarded_discovery_events(1)
+
+      assert %DiscardedDiscoveryEvent{payload: ^body, reason: "[:any_reason]"} =
                discarded_event
     end
   end


### PR DESCRIPTION
A received discovery event is discarded even if valid and correctly mapped to a command. This can happen if it does not make sense for the state of the `SapSystem` aggregate at that moment.

Namely, this happens with the `RegisterApplicationInstance` command. When the relative database instance has not been registered yet, the command cannot be processed.

This scenario is not considered an error anymore; instead, the command is just ignored and the publishing client receives a `202 Accepted` response.

----

Despite being applied to discovery events, the behavior is available to any other command that's been enriched ([example](https://github.com/trento-project/web/blob/cea03fb8670accebb829cacacc85a2142c9560be/lib/trento/infrastructure/commanded/middleware/enrich_request_host_deregistration.ex#L44))



