### PR TITLE
Load cacerts in sso

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 # tar is required by kubectl cp
-RUN zypper -n in tar
+RUN zypper -n in tar ca-certificates ca-certificates-cacert
 WORKDIR /app
 COPY --from=release /build/_build/$MIX_ENV/rel/trento .
 EXPOSE 4000/tcp

--- a/assets/js/pages/Login/Login.test.jsx
+++ b/assets/js/pages/Login/Login.test.jsx
@@ -206,5 +206,26 @@ describe('Login component', () => {
       });
       expect(loginButton).toBeVisible();
     });
+
+    it('should display an error message is the SSO url is empty', async () => {
+      jest.spyOn(authConfig, 'isSingleSignOnEnabled').mockReturnValue(true);
+      jest.spyOn(authConfig, 'getSingleSignOnLoginUrl').mockReturnValue('');
+
+      const [StatefulLogin] = withState(<Login />, {
+        user: {
+          loggedIn: false,
+          authInProgress: false,
+        },
+      });
+
+      renderWithRouter(StatefulLogin);
+
+      await waitFor(() =>
+        screen.getByText(
+          `An error occurred while trying to access the Single Sign-On IDP host.`,
+          { exact: false }
+        )
+      );
+    });
   });
 });

--- a/assets/js/pages/Login/LoginSSO.jsx
+++ b/assets/js/pages/Login/LoginSSO.jsx
@@ -3,6 +3,15 @@ import React from 'react';
 import Button from '@common/Button';
 
 export default function LoginSSO({ singleSignOnUrl, error }) {
+  if (!singleSignOnUrl) {
+    return (
+      <span className="block text-sm font-medium">
+        An error occurred while trying to access the Single Sign-On IDP host.
+        Should the error persist, contact the administrator.
+      </span>
+    );
+  }
+
   return (
     <>
       {error && (

--- a/assets/js/pages/SSOCallback/SSOCallback.test.jsx
+++ b/assets/js/pages/SSOCallback/SSOCallback.test.jsx
@@ -4,6 +4,7 @@ import 'intersection-observer';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { withState, renderWithRouterMatch } from '@lib/test-utils';
+import * as authConfig from '@lib/auth/config';
 import SSOCallback from './SSOCallback';
 
 describe('SSOCallback component', () => {
@@ -49,6 +50,10 @@ describe('SSOCallback component', () => {
 
   it('should display an error message if authentication fails', async () => {
     const user = userEvent.setup();
+
+    jest
+      .spyOn(authConfig, 'getSingleSignOnLoginUrl')
+      .mockReturnValue('http://idp-url');
 
     const [StatefulOidCallback] = withState(<SSOCallback />, {
       user: {

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -185,6 +185,8 @@ if config_env() in [:prod, :demo] do
     )
   end
 
+  config :assent, http_adapter: {Assent.HTTPAdapter.Httpc, [ssl: [cacerts: cacerts]]}
+
   config :trento, :oidc,
     enabled: enable_oidc,
     callback_url:

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Trento.MixProject do
   def application do
     [
       mod: {Trento.Application, []},
-      extra_applications: [:logger, :runtime_tools]
+      extra_applications: [:logger, :runtime_tools, :inets]
     ]
   end
 

--- a/packaging/suse/container/Dockerfile
+++ b/packaging/suse/container/Dockerfile
@@ -36,7 +36,7 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 # tar is required by kubectl cp
-RUN zypper -n in tar
+RUN zypper -n in tar ca-certificates ca-certificates-cacert
 WORKDIR /app
 COPY --from=release /build/web/_build/prod/rel/trento .
 EXPOSE 4000/tcp


### PR DESCRIPTION
**Update**: Apparently, the initial certificates we created for our demo IDP, they were created wrong, and that's why we were required to upload them to the machine. This means, that the requirement of uploading custom CA certs shouldn't be that important (actually, It would become a small corner case), so we can postpone this by now

# Description

Load CA certificates for Assent to enable https connection in SSO.
Otherwise, we get the imfamous `{:tls_alert, {:unknown_ca, ~c"TLS client: In state wait_cert_cr at ssl_handshake.erl:2133 generated CLIENT ALERT: Fatal - Unknown CA\n"}}` error.

Besides that, I have improved a bit the SSO login page to prompt a basic error message if the configuration fails.
We could've gone with the standard 500 error, but it looks less obvious. Either way, you need to access the server logs to see the exact error (which can be of different reason).

This is how it looks like:
![image](https://github.com/user-attachments/assets/be867e3c-d4fd-499e-a270-6c96fc13771e)

PD: To test it locally, add the next lines to your local `dev.local.exs` file:
```
:ok = :public_key.cacerts_load()
[_ | _] = cacerts = :public_key.cacerts_get()

config :assent, http_adapter: {Assent.HTTPAdapter.Httpc, [ssl: [cacerts: cacerts]]}
```

## How was this tested?

Tested with some test and specially manually, using our demo IDP environment.

## Did you update the documentation?
No, but we should consider adding maybe some troubleshooting section. 
Besides, once we decide how to load the CA certificates, specially in helm, we will need to document this is it requires user intervention (which will be the case almost certainly)
