### PR TITLE
Handle `associated_database_not_found` as accepted event.

### DIFF
--- a/lib/trento/infrastructure/commanded/middleware/enrich_register_application_instance.ex
+++ b/lib/trento/infrastructure/commanded/middleware/enrich_register_application_instance.ex
@@ -12,8 +12,13 @@ defimpl Trento.Infrastructure.Commanded.Middleware.Enrichable,
   alias Trento.Repo
   import Ecto.Query
 
+  require Logger
+
   @spec enrich(RegisterApplicationInstance.t(), map) :: {:ok, map} | {:error, any}
-  def enrich(%RegisterApplicationInstance{db_host: db_host, tenant: tenant} = command, _) do
+  def enrich(
+        %RegisterApplicationInstance{db_host: db_host, tenant: tenant, sid: sid} = command,
+        _
+      ) do
     query =
       from d in DatabaseReadModel,
         join: di in DatabaseInstanceReadModel,
@@ -36,7 +41,11 @@ defimpl Trento.Infrastructure.Commanded.Middleware.Enrichable,
          }}
 
       nil ->
-        {:error, :database_not_registered}
+        Logger.warning(
+          "database instance associated to application instance #{sid} not registered in Trento. Please make sure that Trento agent is running on database instances associated to this SAP system"
+        )
+
+        {:error, :associated_database_not_found}
     end
   end
 end

--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -75,6 +75,12 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"422", changeset: changeset)
   end
 
+  def call(conn, {:error, :associated_database_not_found}) do
+    conn
+    |> put_status(:accepted)
+    |> json(%{})
+  end
+
   def call(conn, {:error, {:validation, _} = reason}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/test/trento/infrastructure/commanded/middleware/enrich_register_application_instance_test.exs
+++ b/test/trento/infrastructure/commanded/middleware/enrich_register_application_instance_test.exs
@@ -68,7 +68,7 @@ defmodule Trento.Infrastructure.Commanded.Middleware.EnrichRegisterApplicationIn
         health: :passing
       )
 
-    assert {:error, :database_not_registered} = Enrichable.enrich(command, %{})
+    assert {:error, :associated_database_not_found} = Enrichable.enrich(command, %{})
   end
 
   test "should return an error if the database was not found" do
@@ -85,6 +85,6 @@ defmodule Trento.Infrastructure.Commanded.Middleware.EnrichRegisterApplicationIn
         health: :passing
       )
 
-    assert {:error, :database_not_registered} = Enrichable.enrich(command, %{})
+    assert {:error, :associated_database_not_found} = Enrichable.enrich(command, %{})
   end
 end


### PR DESCRIPTION
# Description

This PR comes as a rework of https://github.com/trento-project/web/pull/3069 after the review. The purpose is the same:
A valid discovery event that is discarded for context reasons should be considered as accepted.

It does it by handling the `:associated_database_not_found` rejection as an exceptional case in the fallback controller.