### PR TITLE
Display active users only in Activity Log filter

### DIFF
--- a/lib/trento/users.ex
+++ b/lib/trento/users.ex
@@ -37,16 +37,6 @@ defmodule Trento.Users do
     |> Repo.all()
   end
 
-  @doc """
-  Returns all usernames tupled with the deleted_at timestamp, including those for users that are soft-deleted.
-  """
-  @spec list_all_usernames :: list({String.t(), DateTime.t()})
-  def list_all_usernames do
-    User
-    |> select([u], {u.username, u.deleted_at})
-    |> Repo.all()
-  end
-
   def get_user(id) do
     case User
          |> where([u], is_nil(u.deleted_at) and u.id == ^id)

--- a/test/trento/users_test.exs
+++ b/test/trento/users_test.exs
@@ -117,25 +117,6 @@ defmodule Trento.UsersTest do
       assert length(users) == 1
     end
 
-    test "list_all_usernames returns all usernames tupled with the deleted_at field, including those for deleted users" do
-      %{username: username1, deleted_at: deleted_at1} = insert(:user)
-
-      %{username: username2, deleted_at: deleted_at2} =
-        insert(:user, deleted_at: DateTime.utc_now())
-
-      sorter_fn = fn {username, _deleted_at} -> username end
-
-      inserted_sorted_usernames =
-        Enum.sort_by([{username1, deleted_at1}, {username2, deleted_at2}], sorter_fn)
-
-      sorted_usernames =
-        Enum.sort_by(Users.list_all_usernames(), sorter_fn)
-
-      assert inserted_sorted_usernames == sorted_usernames
-      assert length(sorted_usernames) == 2
-      assert length(inserted_sorted_usernames) == 2
-    end
-
     test "get_user returns a user when the user exist" do
       %{id: user_id} = insert(:user)
 


### PR DESCRIPTION
Now only those usernames that correspond to active users are displayed in the users filter in the Activity Log page.
