### PR TITLE
Reduce ClusterDetailsUpdated events on irrelevant node attribute change

### DIFF
--- a/lib/trento/clusters.ex
+++ b/lib/trento/clusters.ex
@@ -95,8 +95,12 @@ defmodule Trento.Clusters do
       nil ->
         cluster
 
-      enriched_data ->
-        %ClusterReadModel{cluster | cib_last_written: enriched_data.cib_last_written}
+      %{cib_last_written: cib_last_written, details: enriching_details} ->
+        enrich_cluster_details(%ClusterReadModel{
+          cluster
+          | cib_last_written: cib_last_written,
+            enriching_details: enriching_details
+        })
     end
   end
 

--- a/lib/trento/clusters.ex
+++ b/lib/trento/clusters.ex
@@ -124,13 +124,13 @@ defmodule Trento.Clusters do
     end)
   end
 
-  @spec update_cib_last_written(String.t(), String.t()) :: {:ok, Ecto.Schema.t()} | {:error, any}
-  def update_cib_last_written(cluster_id, cib_last_written) do
+  @spec update_enrichment_data(String.t(), map()) :: {:ok, Ecto.Schema.t()} | {:error, any}
+  def update_enrichment_data(cluster_id, enriching_changeset) do
     case Repo.get(ClusterEnrichmentData, cluster_id) do
       nil -> %ClusterEnrichmentData{cluster_id: cluster_id}
       enriched_cluster -> enriched_cluster
     end
-    |> ClusterEnrichmentData.changeset(%{cib_last_written: cib_last_written})
+    |> ClusterEnrichmentData.changeset(enriching_changeset)
     |> Repo.insert_or_update()
   end
 

--- a/lib/trento/clusters.ex
+++ b/lib/trento/clusters.ex
@@ -169,14 +169,12 @@ defmodule Trento.Clusters do
   defp enrich_cluster_details(cluster), do: cluster
 
   defp enrich_hana_scale_up_nodes(initial_nodes, enriching_nodes) do
-    Enum.map(initial_nodes, fn %{
-                                 "name" => node_name,
-                                 "attributes" => initial_attributes
-                               } = node ->
+    Enum.map(initial_nodes, fn %{"name" => node_name, "attributes" => initial_attributes} = node ->
       enriching_attributes =
-        enriching_nodes
-        |> Enum.find(%{}, &(Map.get(&1, "name") == node_name))
-        |> Map.get("attributes", %{})
+        Enum.find_value(enriching_nodes, %{}, fn
+          %{"name" => ^node_name, "attributes" => enriching_attributes} -> enriching_attributes
+          _ -> false
+        end)
 
       %{
         node

--- a/lib/trento/clusters.ex
+++ b/lib/trento/clusters.ex
@@ -152,14 +152,11 @@ defmodule Trento.Clusters do
   defp enrich_cluster_details(
          %ClusterReadModel{
            type: ClusterType.hana_scale_up(),
-           details: initial_details,
-           enriching_details: enriching_details
+           details: %{"nodes" => initial_nodes} = initial_details,
+           enriching_details: %{"nodes" => enriching_nodes} = enriching_details
          } = cluster
        )
        when is_map(initial_details) and is_map(enriching_details) do
-    initial_nodes = Map.get(initial_details, "nodes", [])
-    enriching_nodes = Map.get(enriching_details, "nodes", [])
-
     %ClusterReadModel{
       cluster
       | details: %{

--- a/lib/trento/clusters/cluster_enrichment_data.ex
+++ b/lib/trento/clusters/cluster_enrichment_data.ex
@@ -13,7 +13,7 @@ defmodule Trento.Clusters.ClusterEnrichmentData do
   @primary_key {:cluster_id, :binary_id, autogenerate: false}
   schema "clusters_enrichment_data" do
     field :cib_last_written, :string
-    field :nodes_attributes, :map, default: %{}
+    field :details, :map, default: %{}
 
     timestamps(type: :utc_datetime_usec)
   end

--- a/lib/trento/clusters/cluster_enrichment_data.ex
+++ b/lib/trento/clusters/cluster_enrichment_data.ex
@@ -13,6 +13,7 @@ defmodule Trento.Clusters.ClusterEnrichmentData do
   @primary_key {:cluster_id, :binary_id, autogenerate: false}
   schema "clusters_enrichment_data" do
     field :cib_last_written, :string
+    field :nodes_attributes, :map, default: %{}
 
     timestamps(type: :utc_datetime_usec)
   end

--- a/lib/trento/clusters/projections/cluster_read_model.ex
+++ b/lib/trento/clusters/projections/cluster_read_model.ex
@@ -35,6 +35,7 @@ defmodule Trento.Clusters.Projections.ClusterReadModel do
 
     # Virtually enriched fields
     field :cib_last_written, :string, virtual: true
+    field :enriching_details, :map, virtual: true, default: %{}
 
     field :deregistered_at, :utc_datetime_usec
 

--- a/lib/trento/infrastructure/commanded/middleware/enrich_register_cluster_host.ex
+++ b/lib/trento/infrastructure/commanded/middleware/enrich_register_cluster_host.ex
@@ -17,11 +17,12 @@ defimpl Trento.Infrastructure.Commanded.Middleware.Enrichable,
           cluster_id: cluster_id,
           cib_last_written: cib_last_written,
           type: type,
+          sid: sid,
           details: details
         } = command,
         _
       ) do
-    {stripped_details, new_details} = strip_irrelevant_details(type, details)
+    {stripped_details, new_details} = strip_irrelevant_details(type, sid, details)
 
     case Clusters.update_enrichment_data(cluster_id, %{
            cib_last_written: cib_last_written,
@@ -47,37 +48,36 @@ defimpl Trento.Infrastructure.Commanded.Middleware.Enrichable,
 
   defp strip_irrelevant_details(
          ClusterType.hana_scale_up(),
+         sid,
          %HanaClusterDetails{nodes: cluster_nodes} = details
        ) do
     {stripped_nodes, ignored_nodes_attributes} =
-      Enum.map_reduce(
-        cluster_nodes,
-        %{},
-        fn %HanaClusterNode{name: node_name} = node, ignored_node_attributes ->
-          {ignored_attributes, retained_attributes} = split_node_attributes(node)
+      cluster_nodes
+      |> Enum.map(&strip_irrelevant_nodes_data(&1, sid))
+      |> Enum.unzip()
 
-          {
-            %HanaClusterNode{
-              node
-              | attributes: retained_attributes
-            },
-            Map.put(ignored_node_attributes, node_name, ignored_attributes)
-          }
-        end
-      )
-
-    {ignored_nodes_attributes,
+    {Map.new(ignored_nodes_attributes),
      %HanaClusterDetails{
        details
        | nodes: stripped_nodes
      }}
   end
 
-  defp strip_irrelevant_details(_, details), do: {%{}, details}
+  defp strip_irrelevant_details(_, _, details), do: {%{}, details}
 
-  defp split_node_attributes(%HanaClusterNode{attributes: attributes}) do
-    Map.split_with(attributes, fn {key, _value} ->
-      String.starts_with?(key, "lpa_") and String.ends_with?(key, "_lpt")
-    end)
+  defp strip_irrelevant_nodes_data(
+         %HanaClusterNode{name: node_name, attributes: attributes} = node,
+         sid
+       ) do
+    {ignored_attributes, retained_attributes} =
+      Map.split_with(attributes, fn {key, _value} -> key == "lpa_#{String.downcase(sid)}_lpt" end)
+
+    {
+      %HanaClusterNode{
+        node
+        | attributes: retained_attributes
+      },
+      {node_name, ignored_attributes}
+    }
   end
 end

--- a/lib/trento/infrastructure/commanded/middleware/enrich_register_cluster_host.ex
+++ b/lib/trento/infrastructure/commanded/middleware/enrich_register_cluster_host.ex
@@ -51,15 +51,15 @@ defimpl Trento.Infrastructure.Commanded.Middleware.Enrichable,
          sid,
          %HanaClusterDetails{nodes: cluster_nodes} = details
        ) do
-    {stripped_nodes, ignored_nodes_attributes} =
+    {stripped_nodes, new_nodes} =
       cluster_nodes
       |> Enum.map(&strip_irrelevant_nodes_data(&1, sid))
       |> Enum.unzip()
 
-    {%{nodes: ignored_nodes_attributes},
+    {%{nodes: stripped_nodes},
      %HanaClusterDetails{
        details
-       | nodes: stripped_nodes
+       | nodes: new_nodes
      }}
   end
 
@@ -69,15 +69,15 @@ defimpl Trento.Infrastructure.Commanded.Middleware.Enrichable,
          %HanaClusterNode{name: node_name, attributes: attributes} = node,
          sid
        ) do
-    {ignored_attributes, retained_attributes} =
+    {stripped_attributes, new_attributes} =
       Map.split_with(attributes, fn {key, _value} -> key == "lpa_#{String.downcase(sid)}_lpt" end)
 
     {
+      %{name: node_name, attributes: stripped_attributes},
       %HanaClusterNode{
         node
-        | attributes: retained_attributes
-      },
-      %{name: node_name, attributes: ignored_attributes}
+        | attributes: new_attributes
+      }
     }
   end
 end

--- a/lib/trento/infrastructure/commanded/middleware/enrich_register_cluster_host.ex
+++ b/lib/trento/infrastructure/commanded/middleware/enrich_register_cluster_host.ex
@@ -1,16 +1,32 @@
 defimpl Trento.Infrastructure.Commanded.Middleware.Enrichable,
   for: Trento.Clusters.Commands.RegisterClusterHost do
+  require Trento.Clusters.Enums.ClusterType, as: ClusterType
+
+  alias Trento.Clusters.ValueObjects.{
+    HanaClusterDetails,
+    HanaClusterNode
+  }
+
   alias Trento.Clusters.Commands.RegisterClusterHost
 
   alias Trento.Clusters
 
   @spec enrich(RegisterClusterHost.t(), map) :: {:ok, map} | {:error, any}
   def enrich(
-        %RegisterClusterHost{cluster_id: cluster_id, cib_last_written: cib_last_written} =
-          command,
+        %RegisterClusterHost{
+          cluster_id: cluster_id,
+          cib_last_written: cib_last_written,
+          type: type,
+          details: details
+        } = command,
         _
       ) do
-    case Clusters.update_cib_last_written(cluster_id, cib_last_written) do
+    {stripped_details, new_details} = strip_irrelevant_details(type, details)
+
+    case Clusters.update_enrichment_data(cluster_id, %{
+           cib_last_written: cib_last_written,
+           nodes_attributes: stripped_details
+         }) do
       {:ok, cluster} ->
         TrentoWeb.Endpoint.broadcast(
           "monitoring:clusters",
@@ -22,6 +38,46 @@ defimpl Trento.Infrastructure.Commanded.Middleware.Enrichable,
         error
     end
 
-    {:ok, command}
+    {:ok,
+     %RegisterClusterHost{
+       command
+       | details: new_details
+     }}
+  end
+
+  defp strip_irrelevant_details(
+         ClusterType.hana_scale_up(),
+         %HanaClusterDetails{nodes: cluster_nodes} = details
+       ) do
+    {stripped_nodes, ignored_nodes_attributes} =
+      Enum.map_reduce(
+        cluster_nodes,
+        %{},
+        fn %HanaClusterNode{name: node_name} = node, ignored_node_attributes ->
+          {ignored_attributes, retained_attributes} = split_node_attributes(node)
+
+          {
+            %HanaClusterNode{
+              node
+              | attributes: retained_attributes
+            },
+            Map.put(ignored_node_attributes, node_name, ignored_attributes)
+          }
+        end
+      )
+
+    {ignored_nodes_attributes,
+     %HanaClusterDetails{
+       details
+       | nodes: stripped_nodes
+     }}
+  end
+
+  defp strip_irrelevant_details(_, details), do: {%{}, details}
+
+  defp split_node_attributes(%HanaClusterNode{attributes: attributes}) do
+    Map.split_with(attributes, fn {key, _value} ->
+      String.starts_with?(key, "lpa_") and String.ends_with?(key, "_lpt")
+    end)
   end
 end

--- a/lib/trento/infrastructure/commanded/middleware/enrich_register_cluster_host.ex
+++ b/lib/trento/infrastructure/commanded/middleware/enrich_register_cluster_host.ex
@@ -26,7 +26,7 @@ defimpl Trento.Infrastructure.Commanded.Middleware.Enrichable,
 
     case Clusters.update_enrichment_data(cluster_id, %{
            cib_last_written: cib_last_written,
-           nodes_attributes: stripped_details
+           details: stripped_details
          }) do
       {:ok, cluster} ->
         TrentoWeb.Endpoint.broadcast(
@@ -56,7 +56,7 @@ defimpl Trento.Infrastructure.Commanded.Middleware.Enrichable,
       |> Enum.map(&strip_irrelevant_nodes_data(&1, sid))
       |> Enum.unzip()
 
-    {Map.new(ignored_nodes_attributes),
+    {%{nodes: ignored_nodes_attributes},
      %HanaClusterDetails{
        details
        | nodes: stripped_nodes
@@ -77,7 +77,7 @@ defimpl Trento.Infrastructure.Commanded.Middleware.Enrichable,
         node
         | attributes: retained_attributes
       },
-      {node_name, ignored_attributes}
+      %{name: node_name, attributes: ignored_attributes}
     }
   end
 end

--- a/lib/trento/support/map_helper.ex
+++ b/lib/trento/support/map_helper.ex
@@ -1,0 +1,14 @@
+defmodule Trento.Support.MapHelper do
+  @moduledoc """
+  This module provides map utility functions
+  """
+
+  @doc """
+  Converts any map to a map with atom keys.
+  """
+  def atomize_keys(map) do
+    map
+    |> Jason.encode!()
+    |> Jason.decode!(keys: :atoms)
+  end
+end

--- a/lib/trento_web/controllers/v1/cluster_json.ex
+++ b/lib/trento_web/controllers/v1/cluster_json.ex
@@ -8,6 +8,7 @@ defmodule TrentoWeb.V1.ClusterJSON do
     |> Map.from_struct()
     |> Map.delete(:deregistered_at)
     |> Map.delete(:__meta__)
+    |> Map.delete(:enriching_details)
     |> adapt_v1()
   end
 

--- a/lib/trento_web/controllers/v2/cluster_json.ex
+++ b/lib/trento_web/controllers/v2/cluster_json.ex
@@ -6,6 +6,7 @@ defmodule TrentoWeb.V2.ClusterJSON do
     |> Map.from_struct()
     |> Map.delete(:deregistered_at)
     |> Map.delete(:__meta__)
+    |> Map.delete(:enriching_details)
   end
 
   def cluster_registered(%{cluster: cluster}), do: Map.delete(cluster(%{cluster: cluster}), :tags)

--- a/priv/repo/migrations/20241022133945_add_cluster_details_enrichment.exs
+++ b/priv/repo/migrations/20241022133945_add_cluster_details_enrichment.exs
@@ -3,7 +3,7 @@ defmodule Trento.Repo.Migrations.AddClusterDetailsEnrichment do
 
   def change do
     alter table(:clusters_enrichment_data) do
-      add :details, :map
+      add :details, :map, default: %{}
     end
   end
 end

--- a/priv/repo/migrations/20241022133945_add_cluster_details_enrichment.exs
+++ b/priv/repo/migrations/20241022133945_add_cluster_details_enrichment.exs
@@ -1,0 +1,9 @@
+defmodule Trento.Repo.Migrations.AddClusterDetailsEnrichment do
+  use Ecto.Migration
+
+  def change do
+    alter table(:clusters_enrichment_data) do
+      add :details, :map
+    end
+  end
+end

--- a/priv/repo/migrations/20241022133945_add_cluster_node_attributes_enrichment.exs
+++ b/priv/repo/migrations/20241022133945_add_cluster_node_attributes_enrichment.exs
@@ -1,9 +1,0 @@
-defmodule Trento.Repo.Migrations.AddClusterNodeAttributesEnrichment do
-  use Ecto.Migration
-
-  def change do
-    alter table(:clusters_enrichment_data) do
-      add :nodes_attributes, :map
-    end
-  end
-end

--- a/priv/repo/migrations/20241022133945_add_cluster_node_attributes_enrichment.exs
+++ b/priv/repo/migrations/20241022133945_add_cluster_node_attributes_enrichment.exs
@@ -1,0 +1,9 @@
+defmodule Trento.Repo.Migrations.AddClusterNodeAttributesEnrichment do
+  use Ecto.Migration
+
+  def change do
+    alter table(:clusters_enrichment_data) do
+      add :nodes_attributes, :map
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -351,7 +351,10 @@ defmodule Trento.Factory do
   def cluster_enrichment_data_factory do
     %ClusterEnrichmentData{
       cluster_id: Faker.UUID.v4(),
-      cib_last_written: Date.to_string(Faker.Date.forward(0))
+      cib_last_written: Date.to_string(Faker.Date.forward(0)),
+      nodes_attributes: %{
+        "foo" => "bar"
+      }
     }
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -352,7 +352,7 @@ defmodule Trento.Factory do
     %ClusterEnrichmentData{
       cluster_id: Faker.UUID.v4(),
       cib_last_written: Date.to_string(Faker.Date.forward(0)),
-      nodes_attributes: %{
+      details: %{
         "foo" => "bar"
       }
     }

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -220,7 +220,8 @@ defmodule Trento.Factory do
       details: build(:hana_cluster_details),
       type: ClusterType.hana_scale_up(),
       discovered_health: Health.passing(),
-      designated_controller: true
+      designated_controller: true,
+      cib_last_written: Date.to_string(Faker.Date.forward(0))
     }
   end
 

--- a/test/trento/clusters_test.exs
+++ b/test/trento/clusters_test.exs
@@ -295,6 +295,37 @@ defmodule Trento.ClustersTest do
         }
       ] = Clusters.get_all_clusters()
     end
+
+    test "should properly merge clusters details when enriched details are missing" do
+      cluster_id = Faker.UUID.v4()
+
+      details =
+        build(:hana_cluster_details,
+          nodes: [
+            build(:hana_cluster_node, attributes: %{foo_attribute: "foo_value"}),
+            build(:hana_cluster_node, attributes: %{bar_attribute: "bar_value"})
+          ]
+        )
+
+      insert(:cluster_enrichment_data,
+        cluster_id: cluster_id,
+        details: %{}
+      )
+
+      insert(:cluster, id: cluster_id, details: details)
+
+      expected_details =
+        details
+        |> Jason.encode!()
+        |> Jason.decode!()
+
+      [
+        %ClusterReadModel{
+          id: ^cluster_id,
+          details: ^expected_details
+        }
+      ] = Clusters.get_all_clusters()
+    end
   end
 
   describe "get_cluster_id_by_host_id/1" do

--- a/test/trento/clusters_test.exs
+++ b/test/trento/clusters_test.exs
@@ -413,7 +413,7 @@ defmodule Trento.ClustersTest do
                })
     end
 
-    test "shuld enrich a cluster read model with enrichment data" do
+    test "should enrich a cluster read model with enrichment data" do
       cluster_id = Faker.UUID.v4()
       cib_last_written = Date.to_string(Faker.Date.forward(0))
 

--- a/test/trento/clusters_test.exs
+++ b/test/trento/clusters_test.exs
@@ -7,6 +7,8 @@ defmodule Trento.ClustersTest do
 
   import Trento.Factory
 
+  alias Trento.Support.MapHelper
+
   alias Trento.Clusters
 
   alias Trento.Clusters.ClusterEnrichmentData
@@ -279,14 +281,14 @@ defmodule Trento.ClustersTest do
               %{
                 node
                 | attributes: %{
-                    "foo_attribute" => "foo_value",
-                    "bar_attribute" => "bar_value"
+                    foo_attribute: "foo_value",
+                    bar_attribute: "bar_value"
                   }
               }
             ]
         }
-        |> Jason.encode!()
-        |> Jason.decode!()
+
+      expected_details = MapHelper.atomize_keys(expected_details)
 
       [
         %ClusterReadModel{
@@ -314,10 +316,7 @@ defmodule Trento.ClustersTest do
 
       insert(:cluster, id: cluster_id, details: details)
 
-      expected_details =
-        details
-        |> Jason.encode!()
-        |> Jason.decode!()
+      expected_details = MapHelper.atomize_keys(details)
 
       [
         %ClusterReadModel{
@@ -449,10 +448,14 @@ defmodule Trento.ClustersTest do
       cib_last_written = Date.to_string(Faker.Date.forward(0))
 
       %{
-        name: node_name
-      } = node = build(:hana_cluster_node, attributes: %{foo_attribute: "foo_value"})
+        name: node_name1
+      } = node1 = build(:hana_cluster_node, attributes: %{foo_attribute1: "foo_value1"})
 
-      details = build(:hana_cluster_details, nodes: [node])
+      %{
+        name: node_name2
+      } = node2 = build(:hana_cluster_node, attributes: %{foo_attribute2: "foo_value2"})
+
+      details = build(:hana_cluster_details, nodes: [node1, node2])
 
       insert(:cluster_enrichment_data,
         cluster_id: cluster_id,
@@ -460,9 +463,15 @@ defmodule Trento.ClustersTest do
         details: %{
           nodes: [
             %{
-              name: node_name,
+              name: node_name1,
               attributes: %{
-                bar_attribute: "bar_value"
+                bar_attribute1: "bar_value1"
+              }
+            },
+            %{
+              name: node_name2,
+              attributes: %{
+                bar_attribute2: "bar_value2"
               }
             }
           ]
@@ -476,16 +485,23 @@ defmodule Trento.ClustersTest do
           details
           | nodes: [
               %{
-                node
+                node1
                 | attributes: %{
-                    "foo_attribute" => "foo_value",
-                    "bar_attribute" => "bar_value"
+                    foo_attribute1: "foo_value1",
+                    bar_attribute1: "bar_value1"
+                  }
+              },
+              %{
+                node2
+                | attributes: %{
+                    foo_attribute2: "foo_value2",
+                    bar_attribute2: "bar_value2"
                   }
               }
             ]
         }
-        |> Jason.encode!()
-        |> Jason.decode!()
+
+      expected_details = MapHelper.atomize_keys(expected_details)
 
       %ClusterReadModel{
         id: ^cluster_id,

--- a/test/trento/infrastructure/commanded/middleware/enrich_register_cluster_host_test.exs
+++ b/test/trento/infrastructure/commanded/middleware/enrich_register_cluster_host_test.exs
@@ -107,9 +107,11 @@ defmodule Trento.Infrastructure.Commanded.Middleware.EnrichRegisterClusterHostTe
       assert expected_enriched_command == enriched_command
 
       assert %ClusterEnrichmentData{
-               nodes_attributes: %{
-                 ^first_node_name => %{^lpa_attribute => "17465345"},
-                 ^second_node_name => %{^lpa_attribute => "30"}
+               details: %{
+                 "nodes" => [
+                   %{"name" => ^first_node_name, "attributes" => %{^lpa_attribute => "17465345"}},
+                   %{"name" => ^second_node_name, "attributes" => %{^lpa_attribute => "30"}}
+                 ]
                }
              } = Repo.get(ClusterEnrichmentData, cluster_id)
     end
@@ -138,7 +140,7 @@ defmodule Trento.Infrastructure.Commanded.Middleware.EnrichRegisterClusterHostTe
       assert {:ok, ^initial_command} = Enrichable.enrich(initial_command, %{})
 
       assert %ClusterEnrichmentData{
-               nodes_attributes: %{}
+               details: %{}
              } = Repo.get(ClusterEnrichmentData, cluster_id)
     end
   end

--- a/test/trento/support/map_helper_test.exs
+++ b/test/trento/support/map_helper_test.exs
@@ -1,0 +1,52 @@
+defmodule Trento.Support.MapHelperTest do
+  use ExUnit.Case
+
+  alias Trento.Support.MapHelper
+
+  test "atomize_keys/1 transforms an input to a map with atom keys" do
+    scenarios = [
+      %{
+        input: %{"a" => "foo", "b" => 2},
+        expected: %{a: "foo", b: 2}
+      },
+      %{
+        input: %{"a" => "foo", "b" => %{"c" => "bar"}},
+        expected: %{a: "foo", b: %{c: "bar"}}
+      },
+      %{
+        input: %{"a" => "foo", "b" => [%{"c" => "bar"}, %{"d" => "baz"}]},
+        expected: %{a: "foo", b: [%{c: "bar"}, %{d: "baz"}]}
+      },
+      %{
+        input: [%{"a" => "foo", "b" => 2}, %{"c" => "bar", "d" => 3}],
+        expected: [%{a: "foo", b: 2}, %{c: "bar", d: 3}]
+      }
+    ]
+
+    for %{input: input, expected: expected} <- scenarios do
+      assert MapHelper.atomize_keys(input) == expected
+    end
+  end
+
+  test "atomize_keys/1 passes through non maps" do
+    scenarios = [
+      %{input: nil, expected: nil},
+      %{
+        input: "foo",
+        expected: "foo"
+      },
+      %{
+        input: 42,
+        expected: 42
+      },
+      %{
+        input: ["foo", "bar"],
+        expected: ["foo", "bar"]
+      }
+    ]
+
+    for %{input: input, expected: expected} <- scenarios do
+      assert MapHelper.atomize_keys(input) == expected
+    end
+  end
+end

--- a/test/trento_web/views/v1/cluster_view_json_test.exs
+++ b/test/trento_web/views/v1/cluster_view_json_test.exs
@@ -3,6 +3,8 @@ defmodule TrentoWeb.V1.ClusterJSONTest do
 
   import Trento.Factory
 
+  require Trento.Clusters.Enums.ClusterType, as: ClusterType
+  alias Trento.Clusters.Enums.ClusterType
   alias TrentoWeb.V1.ClusterJSON
 
   describe "adapt to V1 version" do
@@ -49,6 +51,16 @@ defmodule TrentoWeb.V1.ClusterJSONTest do
       Enum.each(node.resources, fn resource ->
         refute Map.has_key?(resource, :managed)
       end)
+    end
+
+    test "should remove cluster detail enrichment virtual field" do
+      for type <- ClusterType.values() do
+        cluster = build(:cluster, type: type)
+        assert Map.has_key?(cluster, :enriching_details)
+
+        cluster_view = ClusterJSON.cluster(%{cluster: cluster})
+        refute Map.has_key?(cluster_view, :enriching_details)
+      end
     end
   end
 end

--- a/test/trento_web/views/v2/cluster_view_json_test.exs
+++ b/test/trento_web/views/v2/cluster_view_json_test.exs
@@ -2,6 +2,7 @@ defmodule TrentoWeb.V2.ClusterJSONTest do
   use TrentoWeb.ConnCase, async: true
   import Trento.Factory
 
+  require Trento.Clusters.Enums.ClusterType, as: ClusterType
   alias TrentoWeb.V2.ClusterJSON
 
   alias Trento.Clusters.Projections.ClusterReadModel
@@ -23,5 +24,15 @@ defmodule TrentoWeb.V2.ClusterJSONTest do
 
     assert %{details: %{maintenance_mode: false}} =
              ClusterJSON.cluster(%{cluster: cluster})
+  end
+
+  test "should remove cluster detail enrichment virtual field" do
+    for type <- ClusterType.values() do
+      cluster = build(:cluster, type: type)
+      assert Map.has_key?(cluster, :enriching_details)
+
+      cluster_view = ClusterJSON.cluster(%{cluster: cluster})
+      refute Map.has_key?(cluster_view, :enriching_details)
+    end
   end
 end


### PR DESCRIPTION
# Description

This PR sptrip `lpa_<sid>_lpt` cluster node attributes during a cluster discovery, specifically when a `RegisterClusterHost` command is dispatched.

`lpa_<sid>_lpt` is a timestamp attribute attached to a cluster node that possibly changes at every discovery tick, resulting in many `ClusterDetailsUpdated` being emitted.

We want those possibly frequent changes to that attribute not be issuing the mentioned domain event.

Considerations:
- change is currently implemented for hana scale up clusters only. We will extend to other cluster types when/if detected it being necessary
- `lpa_<sid>_lpt` might be present for every cluster node, and it is being ignored for every cluster node
- cluster enrichment data is extended with a `nodes_attributes` jsonb field in order to keep an up to date representation of that piece of information and its content will be merged into clusters read model, similarly to what happens for `cib_last_written`
- enrichment data write is kept in one query

**Note:** besides a silly mistake of mine, the initial aggregate based implementation was working fine. However if there is preference in dropping the information at middleware level I am fine with it.

Latest changes in the UI will follow up when this PR gets through.

## How was this tested?

Automated tests.