### PR TITLE
Fix SUSE Manager errors label computation

### DIFF
--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -42,11 +42,15 @@ const getSoftwareUpdatesErrorMessage = (errors) => {
       detail === 'No system ID was found on SUSE Manager for this host.'
   );
 
+  const connectionNotWorking = errors.some(
+    ({ detail }) => detail === 'Something went wrong.'
+  );
+
   if (hostNotFoundInSUMA) {
     return 'Host not found in SUSE Manager';
   }
 
-  if (errors.length) {
+  if (connectionNotWorking) {
     return 'Connection to SUMA not working';
   }
 
@@ -60,11 +64,15 @@ const getSoftwareUpdatesErrorTooltip = (errors) => {
       detail === 'No system ID was found on SUSE Manager for this host.'
   );
 
+  const connectionNotWorking = errors.some(
+    ({ detail }) => detail === 'Something went wrong.'
+  );
+
   if (hostNotFoundInSUMA) {
     return 'Contact your SUSE Manager admin to ensure the host is managed by SUSE Manager';
   }
 
-  if (errors.length) {
+  if (connectionNotWorking) {
     return 'Please review SUSE Manager settings';
   }
 

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.test.jsx
@@ -24,6 +24,51 @@ describe('HostDetailsPage', () => {
     axiosMock.onGet(/\/api\/v1\/hosts.*/gm).reply(200, {});
   });
 
+  it('Renders SUSE Manager unknown status', async () => {
+    const host = hostFactory.build();
+    const { id: hostID } = host;
+
+    const state = {
+      ...defaultInitialState,
+      hostsList: {
+        hosts: [host],
+      },
+      lastExecutions: { data: null, loading: false, errors: null },
+      softwareUpdates: {
+        settingsConfigured: true,
+        softwareUpdates: {
+          [hostID]: {
+            loading: false,
+            errors: [{ detail: 'Generic error' }],
+          },
+        },
+      },
+    };
+
+    const [StatefulHostDetails] = withState(<HostDetailsPage />, state);
+
+    await act(async () =>
+      renderWithRouterMatch(StatefulHostDetails, {
+        path: 'hosts/:hostID',
+        route: `/hosts/${hostID}`,
+      })
+    );
+
+    const relevantPatchesElement = screen
+      .getByText(/Relevant Patches/)
+      .closest('div');
+    const upgradablePackagesElement = screen
+      .getByText(/Upgradable Packages/)
+      .closest('div');
+
+    expect(relevantPatchesElement).toHaveTextContent(
+      'Relevant Patches Unknown'
+    );
+    expect(upgradablePackagesElement).toHaveTextContent(
+      'Upgradable Packages Unknown'
+    );
+  });
+
   it('Renders SUSE Manager error for host not found', async () => {
     const user = userEvent.setup();
 
@@ -95,7 +140,7 @@ describe('HostDetailsPage', () => {
         softwareUpdates: {
           [hostID]: {
             loading: false,
-            errors: [{ detail: 'Generic error' }],
+            errors: [{ detail: 'Something went wrong.' }],
           },
         },
       },


### PR DESCRIPTION
The computation for the SUSE Manager status of the host was wrong. Even when the errors weren't critical it reported `SUMA connection not working`. This PR fixes it making the unknown state reachable again.

## Testing
Jest tests both updated and added