### PR TITLE
Add a button to download upgradable packages as CSV

### DIFF
--- a/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.jsx
+++ b/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.jsx
@@ -46,7 +46,7 @@ function UpgradablePackagesList({
       },
       {
         title: 'Related Patches',
-        key: 'patches',
+        key: 'original_patches',
         render: (content, { to_package_id }) => {
           if (patchesLoading) {
             return (

--- a/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.jsx
+++ b/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.jsx
@@ -23,7 +23,7 @@ function UpgradablePackagesList({
   };
 
   const sortByLatestPackage = createStringSortingPredicate(
-    'latest_package',
+    'latestPackage',
     sortDirection
   );
 
@@ -33,12 +33,12 @@ function UpgradablePackagesList({
     columns: [
       {
         title: 'Installed Packages',
-        key: 'installed_package',
+        key: 'installedPackage',
         render: (content, _) => <div className="font-bold">{content}</div>,
       },
       {
         title: 'Latest Package',
-        key: 'latest_package',
+        key: 'latestPackage',
         sortable: true,
         sortDirection,
         handleClick: () => toggleSortDirection(),
@@ -46,7 +46,7 @@ function UpgradablePackagesList({
       },
       {
         title: 'Related Patches',
-        key: 'original_patches',
+        key: 'patches',
         render: (content, { to_package_id }) => {
           if (patchesLoading) {
             return (

--- a/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.jsx
+++ b/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.jsx
@@ -23,7 +23,7 @@ function UpgradablePackagesList({
   };
 
   const sortByLatestPackage = createStringSortingPredicate(
-    'latestPackage',
+    'latest_package',
     sortDirection
   );
 
@@ -33,12 +33,12 @@ function UpgradablePackagesList({
     columns: [
       {
         title: 'Installed Packages',
-        key: 'installedPackage',
+        key: 'installed_package',
         render: (content, _) => <div className="font-bold">{content}</div>,
       },
       {
         title: 'Latest Package',
-        key: 'latestPackage',
+        key: 'latest_package',
         sortable: true,
         sortDirection,
         handleClick: () => toggleSortDirection(),
@@ -76,18 +76,13 @@ function UpgradablePackagesList({
     ],
   };
 
-  const data = upgradablePackages.map((packageDetails) => {
-    const { name, from_version, from_release, to_version, to_release, arch } =
-      packageDetails;
-
-    return {
-      ...packageDetails,
-      installedPackage: `${name}-${from_version}-${from_release}.${arch}`,
-      latestPackage: `${name}-${to_version}-${to_release}.${arch}`,
-    };
-  });
-
-  return <Table config={config} data={data} sortBy={sortByLatestPackage} />;
+  return (
+    <Table
+      config={config}
+      data={upgradablePackages}
+      sortBy={sortByLatestPackage}
+    />
+  );
 }
 
 export default UpgradablePackagesList;

--- a/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.stories.jsx
+++ b/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.stories.jsx
@@ -1,4 +1,4 @@
-import { upgradablePackageFactory } from '@lib/test-utils/factories/upgradablePackage';
+import { upgradablePackageFactory } from '@lib/test-utils/factories/relevantPatches';
 import UpgradablePackagesList from './UpgradablePackagesList';
 
 export default {
@@ -9,6 +9,10 @@ export default {
       type: 'string',
       control: { type: 'text' },
       description: 'The name of the host',
+    },
+    onPatchClick: {
+      action: 'patch clicked',
+      description: 'Callback when patch is clicked',
     },
     upgradablePackages: {
       control: {
@@ -25,7 +29,8 @@ export default {
 export const Default = {
   args: {
     hostname: 'Example Host',
-    upgradablePackages: upgradablePackageFactory.buildList(4),
+    patchesLoading: false,
+    upgradablePackages: upgradablePackageFactory.buildList(2),
   },
 };
 
@@ -33,6 +38,6 @@ export const PatchesLoading = {
   args: {
     hostname: 'Example Host',
     patchesLoading: true,
-    upgradablePackages: upgradablePackageFactory.buildList(4),
+    upgradablePackages: upgradablePackageFactory.buildList(2),
   },
 };

--- a/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.test.jsx
+++ b/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.test.jsx
@@ -10,7 +10,9 @@ describe('UpgradablePackagesList component', () => {
     const { patches } = upgradablePackage;
 
     const expectedInstalledPackage = `${upgradablePackage.name}-${upgradablePackage.from_version}-${upgradablePackage.from_release}.${upgradablePackage.arch}`;
+    upgradablePackage.installed_package = expectedInstalledPackage;
     const expectedLatestPackage = `${upgradablePackage.name}-${upgradablePackage.to_version}-${upgradablePackage.to_release}.${upgradablePackage.arch}`;
+    upgradablePackage.latest_package = expectedLatestPackage;
 
     render(<UpgradablePackagesList upgradablePackages={[upgradablePackage]} />);
 

--- a/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.test.jsx
+++ b/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.test.jsx
@@ -7,18 +7,18 @@ import UpgradablePackagesList from './UpgradablePackagesList';
 describe('UpgradablePackagesList component', () => {
   it('should render the upgradable packages list', () => {
     const upgradablePackage = upgradablePackageFactory.build();
-    const { original_patches } = upgradablePackage;
+    const { patches } = upgradablePackage;
 
     const expectedInstalledPackage = `${upgradablePackage.name}-${upgradablePackage.from_version}-${upgradablePackage.from_release}.${upgradablePackage.arch}`;
-    upgradablePackage.installed_package = expectedInstalledPackage;
+    upgradablePackage.installedPackage = expectedInstalledPackage;
     const expectedLatestPackage = `${upgradablePackage.name}-${upgradablePackage.to_version}-${upgradablePackage.to_release}.${upgradablePackage.arch}`;
-    upgradablePackage.latest_package = expectedLatestPackage;
+    upgradablePackage.latestPackage = expectedLatestPackage;
 
     render(<UpgradablePackagesList upgradablePackages={[upgradablePackage]} />);
 
     expect(screen.getByText(expectedInstalledPackage)).toBeVisible();
     expect(screen.getByText(expectedLatestPackage)).toBeVisible();
-    original_patches.forEach(({ advisory }) => {
+    patches.forEach(({ advisory }) => {
       expect(screen.getByText(advisory)).toBeVisible();
     });
   });

--- a/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.test.jsx
+++ b/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.test.jsx
@@ -7,7 +7,7 @@ import UpgradablePackagesList from './UpgradablePackagesList';
 describe('UpgradablePackagesList component', () => {
   it('should render the upgradable packages list', () => {
     const upgradablePackage = upgradablePackageFactory.build();
-    const { patches } = upgradablePackage;
+    const { original_patches } = upgradablePackage;
 
     const expectedInstalledPackage = `${upgradablePackage.name}-${upgradablePackage.from_version}-${upgradablePackage.from_release}.${upgradablePackage.arch}`;
     upgradablePackage.installed_package = expectedInstalledPackage;
@@ -18,7 +18,7 @@ describe('UpgradablePackagesList component', () => {
 
     expect(screen.getByText(expectedInstalledPackage)).toBeVisible();
     expect(screen.getByText(expectedLatestPackage)).toBeVisible();
-    patches.forEach(({ advisory }) => {
+    original_patches.forEach(({ advisory }) => {
       expect(screen.getByText(advisory)).toBeVisible();
     });
   });

--- a/assets/js/lib/test-utils/factories/relevantPatches.js
+++ b/assets/js/lib/test-utils/factories/relevantPatches.js
@@ -2,7 +2,12 @@ import { faker } from '@faker-js/faker';
 import { Factory } from 'fishery';
 
 export const advisoryType = ['security_advisory', 'bugfix', 'enhancement'];
-
+function generateCustomVersion() {
+  const major = faker.number.int({ min: 0, max: 10 });
+  const minor = faker.number.int({ min: 0, max: 20 });
+  const patch = faker.number.int({ min: 0, max: 30 });
+  return `${major}.${minor}.${patch}`;
+}
 export const relevantPatchFactory = Factory.define(({ sequence }) => ({
   advisory_name: `${faker.animal.cat()}${sequence}`,
   advisory_type: faker.helpers.arrayElement(advisoryType),
@@ -20,4 +25,10 @@ export const patchForPackageFactory = Factory.define(({ sequence }) => ({
   issue_date: faker.date.anytime().toString(),
   update_date: faker.date.anytime().toString(),
   last_modified_date: faker.date.anytime().toString(),
+}));
+
+export const upgradablePackageFactory = Factory.define(() => ({
+  installed_package: `Package ${faker.animal.cat()}`,
+  latest_package: generateCustomVersion(),
+  patches: [{ advisory: faker.animal.cat() }],
 }));

--- a/assets/js/lib/test-utils/factories/relevantPatches.js
+++ b/assets/js/lib/test-utils/factories/relevantPatches.js
@@ -2,12 +2,7 @@ import { faker } from '@faker-js/faker';
 import { Factory } from 'fishery';
 
 export const advisoryType = ['security_advisory', 'bugfix', 'enhancement'];
-function generateCustomVersion() {
-  const major = faker.number.int({ min: 0, max: 10 });
-  const minor = faker.number.int({ min: 0, max: 20 });
-  const patch = faker.number.int({ min: 0, max: 30 });
-  return `${major}.${minor}.${patch}`;
-}
+
 export const relevantPatchFactory = Factory.define(({ sequence }) => ({
   advisory_name: `${faker.animal.cat()}${sequence}`,
   advisory_type: faker.helpers.arrayElement(advisoryType),
@@ -28,7 +23,7 @@ export const patchForPackageFactory = Factory.define(({ sequence }) => ({
 }));
 
 export const upgradablePackageFactory = Factory.define(() => ({
-  installed_package: `Package ${faker.animal.cat()}`,
-  latest_package: generateCustomVersion(),
+  installedPackage: `Package ${faker.animal.cat()}`,
+  latestPackage: faker.system.semver(),
   patches: [{ advisory: faker.animal.cat() }],
 }));

--- a/assets/js/lib/test-utils/factories/upgradablePackage.js
+++ b/assets/js/lib/test-utils/factories/upgradablePackage.js
@@ -6,16 +6,14 @@ const releaseVersionFactory = () =>
   `${faker.number.int({ min: 100000, max: 160000 })}.${faker.system.semver()}`;
 
 export const upgradablePackageFactory = Factory.define(({ sequence }) => ({
-  from_epoch: faker.date.anytime(),
-  to_release: releaseVersionFactory(),
-  name: `${faker.word.noun()}${sequence}`,
-  from_release: releaseVersionFactory(),
-  to_epoch: faker.date.anytime(),
   arch: faker.airline.flightNumber(),
-  to_package_id: faker.number.int({ min: 2000, max: 5000 }),
+  from_epoch: faker.date.anytime(),
+  from_release: releaseVersionFactory(),
   from_version: faker.system.semver(),
-  to_version: faker.system.semver(),
-  from_arch: faker.airline.flightNumber(),
-  to_arch: faker.airline.flightNumber(),
+  name: `${faker.word.noun()}${sequence}`,
   patches: patchForPackageFactory.buildList(2),
+  to_epoch: faker.date.anytime(),
+  to_package_id: faker.number.int({ min: 2000, max: 5000 }),
+  to_release: releaseVersionFactory(),
+  to_version: faker.system.semver(),
 }));

--- a/assets/js/lib/test-utils/factories/upgradablePackage.js
+++ b/assets/js/lib/test-utils/factories/upgradablePackage.js
@@ -11,7 +11,7 @@ export const upgradablePackageFactory = Factory.define(({ sequence }) => ({
   from_release: releaseVersionFactory(),
   from_version: faker.system.semver(),
   name: `${faker.word.noun()}${sequence}`,
-  patches: patchForPackageFactory.buildList(2),
+  original_patches: patchForPackageFactory.buildList(2),
   to_epoch: faker.date.anytime(),
   to_package_id: faker.number.int({ min: 2000, max: 5000 }),
   to_release: releaseVersionFactory(),

--- a/assets/js/lib/test-utils/factories/upgradablePackage.js
+++ b/assets/js/lib/test-utils/factories/upgradablePackage.js
@@ -11,7 +11,7 @@ export const upgradablePackageFactory = Factory.define(({ sequence }) => ({
   from_release: releaseVersionFactory(),
   from_version: faker.system.semver(),
   name: `${faker.word.noun()}${sequence}`,
-  original_patches: patchForPackageFactory.buildList(2),
+  patches: patchForPackageFactory.buildList(2),
   to_epoch: faker.date.anytime(),
   to_package_id: faker.number.int({ min: 2000, max: 5000 }),
   to_release: releaseVersionFactory(),

--- a/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.jsx
+++ b/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.jsx
@@ -99,7 +99,7 @@ function HostRelevantPatches({ hostName, onNavigate, patches }) {
             <Button
               className="w-max"
               type="primary-white"
-              disabled={displayedPatches?.length <= 0 || !csvURL}
+              disabled={patches.length <= 0 || !csvURL}
             >
               Download CSV
             </Button>

--- a/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.jsx
+++ b/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.jsx
@@ -59,7 +59,7 @@ function HostRelevantPatches({ hostName, onNavigate, patches }) {
         URL.revokeObjectURL?.(csvURL);
       }
     };
-  }, [patches]);
+  }, [patches.length]);
 
   useEffect(() => {
     const filteredByAdvisoryType = filterPatchesByAdvisoryType(

--- a/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.jsx
+++ b/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.jsx
@@ -26,29 +26,40 @@ function HostRelevantPatches({ hostName, onNavigate, patches }) {
 
   const [displayedPatches, setDisplayedPatches] = useState(patches);
 
-  const file =
-    window?.URL?.createObjectURL && displayedPatches?.length > 0
-      ? window.URL.createObjectURL(
-          new File(
-            [
-              Papa.unparse(
-                {
-                  fields: [
-                    'advisory_type',
-                    'advisory_name',
-                    'advisory_synopsis',
-                    'update_date',
-                  ],
-                  data: displayedPatches,
-                },
-                { header: true }
-              ),
-            ],
-            `${hostName}-patches.csv`,
-            { type: 'text/csv' }
+  const [csvURL, setCsvURL] = useState(null);
+
+  useEffect(() => {
+    setCsvURL(
+      patches.length > 0
+        ? URL.createObjectURL?.(
+            new File(
+              [
+                Papa.unparse(
+                  {
+                    fields: [
+                      'advisory_type',
+                      'advisory_name',
+                      'advisory_synopsis',
+                      'update_date',
+                    ],
+                    data: patches,
+                  },
+                  { header: true }
+                ),
+              ],
+              `${hostName}-patches.csv`,
+              { type: 'text/csv' }
+            )
           )
-        )
-      : null;
+        : null
+    );
+
+    return () => {
+      if (csvURL) {
+        URL.revokeObjectURL?.(csvURL);
+      }
+    };
+  }, [patches]);
 
   useEffect(() => {
     const filteredByAdvisoryType = filterPatchesByAdvisoryType(
@@ -60,12 +71,6 @@ function HostRelevantPatches({ hostName, onNavigate, patches }) {
         advisory_synopsis ? containsSubstring(advisory_synopsis, search) : false
     );
     setDisplayedPatches(searchResult);
-
-    return () => {
-      if (window?.URL?.revokeObjectURL && displayedPatches?.length > 0) {
-        window.URL.revokeObjectURL(file);
-      }
-    };
   }, [patches, displayedAdvisories, search]);
 
   return (
@@ -90,11 +95,11 @@ function HostRelevantPatches({ hostName, onNavigate, patches }) {
             placeholder="Search by Synopsis"
             prefix={<EOS_SEARCH size="l" />}
           />
-          <a href={file} download={`${hostName}-patches.csv`}>
+          <a href={csvURL} download={`${hostName}-patches.csv`}>
             <Button
               className="w-max"
               type="primary-white"
-              disabled={displayedPatches?.length <= 0}
+              disabled={displayedPatches?.length <= 0 || !csvURL}
             >
               Download CSV
             </Button>

--- a/assets/js/pages/UpgradablePackagesPage/UpgradablePackages.jsx
+++ b/assets/js/pages/UpgradablePackagesPage/UpgradablePackages.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { EOS_SEARCH } from 'eos-icons-react';
-import { noop, get } from 'lodash';
+import { noop } from 'lodash';
 import Papa from 'papaparse';
 
 import UpgradablePackagesList from '@common/UpgradablePackagesList';
@@ -19,9 +19,15 @@ export default function UpgradablePackages({
   const [search, setSearch] = useState('');
   const [csvURL, setCsvURL] = useState(null);
   const enrichedPackages = upgradablePackages.map((packageDetails) => {
-    const { name, from_version, from_release, to_version, to_release, arch } =
-      packageDetails;
-    const patches = get(packageDetails, 'patches', []);
+    const {
+      name,
+      from_version,
+      from_release,
+      to_version,
+      to_release,
+      arch,
+      patches = [],
+    } = packageDetails;
 
     return {
       ...packageDetails,

--- a/assets/js/pages/UpgradablePackagesPage/UpgradablePackages.jsx
+++ b/assets/js/pages/UpgradablePackagesPage/UpgradablePackages.jsx
@@ -96,7 +96,7 @@ export default function UpgradablePackages({
           />
           <a href={csvURL} download={`${hostName}-upgradable-packages.csv`}>
             <Button className="w-max" type="primary-white" disabled={!csvURL}>
-              download csv
+              Download csv
             </Button>
           </a>
         </div>

--- a/assets/js/pages/UpgradablePackagesPage/UpgradablePackages.jsx
+++ b/assets/js/pages/UpgradablePackagesPage/UpgradablePackages.jsx
@@ -52,7 +52,7 @@ export default function UpgradablePackages({
   );
 
   useEffect(() => {
-    // Ensure to revoke previous scvUrls
+    // Ensure to revoke previous csvUrls
     if (csvURL) {
       URL.revokeObjectURL(csvURL);
     }

--- a/assets/js/pages/UpgradablePackagesPage/UpgradablePackages.stories.jsx
+++ b/assets/js/pages/UpgradablePackagesPage/UpgradablePackages.stories.jsx
@@ -18,3 +18,11 @@ export const Default = {
     upgradablePackages: upgradablePackageFactory.buildList(15),
   },
 };
+
+export const Empty = {
+  args: {
+    hostName: hostFactory.build().hostname,
+    upgradablePackages: [],
+    patchesLoading: false,
+  },
+};

--- a/assets/js/pages/UpgradablePackagesPage/UpgradablePackages.test.jsx
+++ b/assets/js/pages/UpgradablePackagesPage/UpgradablePackages.test.jsx
@@ -90,22 +90,6 @@ describe('exports the packages in CSV format', () => {
         to_release: '1',
         to_version: '1.16.2',
         patches: ['SUSE-15-SP4-2024-630,SUSE-15-SP4-2024-619'],
-        original_patches: [
-          {
-            issue_date: '2024-02-27',
-            last_modified_date: '2024-02-27',
-            synopsis: 'Recommended update for cloud-netconfig',
-            advisory_type: 'bugfix',
-            advisory: 'SUSE-15-SP4-2024-630',
-          },
-          {
-            issue_date: '2024-02-26',
-            last_modified_date: '2024-02-26',
-            synopsis: 'important: Security update for java-1_8_0-ibm',
-            advisory_type: 'security_advisory',
-            advisory: 'SUSE-15-SP4-2024-619',
-          },
-        ],
       }),
     ];
     const patchesLoading = false;

--- a/assets/js/pages/UpgradablePackagesPage/UpgradablePackages.test.jsx
+++ b/assets/js/pages/UpgradablePackagesPage/UpgradablePackages.test.jsx
@@ -122,7 +122,7 @@ describe('exports the packages in CSV format', () => {
 
     expect(window.URL.createObjectURL).toHaveBeenCalledWith(new File([], ''));
     expect(window.URL.createObjectURL).toHaveReturnedWith({
-      name: `${hostName}-patches.csv`,
+      name: `${hostName}-upgradable-packages.csv`,
       size: 131,
     });
   });

--- a/assets/js/pages/UpgradablePackagesPage/UpgradablePackages.test.jsx
+++ b/assets/js/pages/UpgradablePackagesPage/UpgradablePackages.test.jsx
@@ -89,7 +89,8 @@ describe('exports the packages in CSV format', () => {
         from_version: '1.15.7',
         to_release: '1',
         to_version: '1.16.2',
-        patches: [
+        patches: ['SUSE-15-SP4-2024-630,SUSE-15-SP4-2024-619'],
+        original_patches: [
           {
             issue_date: '2024-02-27',
             last_modified_date: '2024-02-27',
@@ -123,7 +124,7 @@ describe('exports the packages in CSV format', () => {
     expect(window.URL.createObjectURL).toHaveBeenCalledWith(new File([], ''));
     expect(window.URL.createObjectURL).toHaveReturnedWith({
       name: `${hostName}-upgradable-packages.csv`,
-      size: 131,
+      size: 88,
     });
   });
 

--- a/assets/js/pages/UpgradablePackagesPage/UpgradablePackages.test.jsx
+++ b/assets/js/pages/UpgradablePackagesPage/UpgradablePackages.test.jsx
@@ -75,7 +75,7 @@ describe('exports the packages in CSV format', () => {
     expect(window.URL.revokeObjectURL).not.toHaveBeenCalled();
   });
 
-  it('Exports the packages in CSV format', () => {
+  it('exports the packages in CSV format', () => {
     const user = userEvent.setup();
     const hostName = faker.string.uuid();
     const upgradablePackage = [


### PR DESCRIPTION
# Description
This commit adds a CSV download button to include all patches to the UpgradablePackages view.

## Preview
![image](https://github.com/user-attachments/assets/e7e6c949-d452-4ca4-a9f8-e3305c50866b)

## How was this tested

- Added test for UpgradablePackages
- Added UpgradablePackages empty story

## What is open ? 
- Missing e2e test, maybe in follow up pr
