### PR TITLE
Change SAML_SP_DIR default location

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -252,7 +252,7 @@ if config_env() in [:prod, :demo] do
   end
 
   if enable_saml do
-    saml_dir = System.get_env("SAML_SP_DIR", "/etc/trento/trento-web/saml")
+    saml_dir = System.get_env("SAML_SP_DIR", "/etc/trento/saml")
 
     config :trento, :saml,
       enabled: true,

--- a/lib/trento/release.ex
+++ b/lib/trento/release.ex
@@ -146,7 +146,7 @@ defmodule Trento.Release do
         For example: yourdomain.example.com
         """
 
-    saml_dir = System.get_env("SAML_SP_DIR", "/etc/trento/trento-web/saml")
+    saml_dir = System.get_env("SAML_SP_DIR", "/etc/trento/saml")
 
     certificates_settings =
       Trento.Repo.one(SSOCertificatesSettings.base_query())


### PR DESCRIPTION
# Description

Change SAML certs default folder as it collides with the documented `/etc/trento/trento-web` configuration file

## Did you update the documentation?

Documentation updated
