### PR TITLE
Fix indicator tooltip presence even when unknown

### DIFF
--- a/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
@@ -19,7 +19,7 @@ function Indicator({
   const clickHandler = isError ? () => {} : onNavigate;
 
   return (
-    <Tooltip isEnabled={isError} content={tooltip} wrap={false}>
+    <Tooltip isEnabled={isError && tooltip} content={tooltip} wrap={false}>
       <div
         role="button"
         tabIndex={0}


### PR DESCRIPTION
Just fixing a tooltip that shouldn't be there when SUSE Manager's state is unknown for a resource