### PR TITLE
Second attempt to fix empty tooltip showing up in host details

### DIFF
--- a/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/Indicator.jsx
@@ -17,9 +17,10 @@ function Indicator({
   onNavigate,
 }) {
   const clickHandler = isError ? () => {} : onNavigate;
+  const tooltipEnabled = Boolean(isError && tooltip);
 
   return (
-    <Tooltip isEnabled={isError && tooltip} content={tooltip} wrap={false}>
+    <Tooltip isEnabled={tooltipEnabled} content={tooltip} wrap={false}>
       <div
         role="button"
         tabIndex={0}


### PR DESCRIPTION
It was very childish of me to assume #3103 would just fix this behavior so here we go on a second attempt