### PR TITLE
Add back the tooltip for SUSE Manager's unknown state

### DIFF
--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -30,54 +30,15 @@ import {
 
 import { deregisterHost } from '@state/hosts';
 import { fetchSoftwareUpdates } from '@state/softwareUpdates';
+
+import {
+  getSoftwareUpdatesErrorMessage,
+  getSoftwareUpdatesErrorTooltip,
+} from './suseManagerMessaging';
 import HostDetails from './HostDetails';
 
 const chartsEnabled = getFromConfig('chartsEnabled');
 const suseManagerEnabled = getFromConfig('suseManagerEnabled');
-
-const getSoftwareUpdatesErrorMessage = (errors) => {
-  const hostNotFoundInSUMA = errors.some(
-    ({ detail }) =>
-      detail === 'The requested resource cannot be found.' ||
-      detail === 'No system ID was found on SUSE Manager for this host.'
-  );
-
-  const connectionNotWorking = errors.some(
-    ({ detail }) => detail === 'Something went wrong.'
-  );
-
-  if (hostNotFoundInSUMA) {
-    return 'Host not found in SUSE Manager';
-  }
-
-  if (connectionNotWorking) {
-    return 'Connection to SUMA not working';
-  }
-
-  return 'Unknown';
-};
-
-const getSoftwareUpdatesErrorTooltip = (errors) => {
-  const hostNotFoundInSUMA = errors.some(
-    ({ detail }) =>
-      detail === 'The requested resource cannot be found.' ||
-      detail === 'No system ID was found on SUSE Manager for this host.'
-  );
-
-  const connectionNotWorking = errors.some(
-    ({ detail }) => detail === 'Something went wrong.'
-  );
-
-  if (hostNotFoundInSUMA) {
-    return 'Contact your SUSE Manager admin to ensure the host is managed by SUSE Manager';
-  }
-
-  if (connectionNotWorking) {
-    return 'Please review SUSE Manager settings';
-  }
-
-  return undefined;
-};
 
 function HostDetailsPage() {
   const { hostID } = useParams();

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.test.jsx
@@ -25,6 +25,8 @@ describe('HostDetailsPage', () => {
   });
 
   it('Renders SUSE Manager unknown status', async () => {
+    const user = userEvent.setup();
+
     const host = hostFactory.build();
     const { id: hostID } = host;
 
@@ -67,6 +69,11 @@ describe('HostDetailsPage', () => {
     expect(upgradablePackagesElement).toHaveTextContent(
       'Upgradable Packages Unknown'
     );
+
+    await user.hover(relevantPatchesElement);
+    expect(
+      screen.queryByText('Trento was not able to retrieve the requested data.')
+    ).toBeVisible();
   });
 
   it('Renders SUSE Manager error for host not found', async () => {

--- a/assets/js/pages/HostDetailsPage/suseManagerMessaging.js
+++ b/assets/js/pages/HostDetailsPage/suseManagerMessaging.js
@@ -1,0 +1,47 @@
+export const getSoftwareUpdatesErrorMessage = (errors) => {
+  const hostNotFoundInSUMA = errors.some(
+    ({ detail }) =>
+      detail === 'The requested resource cannot be found.' ||
+      detail === 'No system ID was found on SUSE Manager for this host.'
+  );
+
+  const connectionNotWorking = errors.some(
+    ({ detail }) => detail === 'Something went wrong.'
+  );
+
+  if (hostNotFoundInSUMA) {
+    return 'Host not found in SUSE Manager';
+  }
+
+  if (connectionNotWorking) {
+    return 'Connection to SUMA not working';
+  }
+
+  return 'Unknown';
+};
+
+export const getSoftwareUpdatesErrorTooltip = (errors) => {
+  const hostNotFoundInSUMA = errors.some(
+    ({ detail }) =>
+      detail === 'The requested resource cannot be found.' ||
+      detail === 'No system ID was found on SUSE Manager for this host.'
+  );
+
+  const connectionNotWorking = errors.some(
+    ({ detail }) => detail === 'Something went wrong.'
+  );
+
+  if (hostNotFoundInSUMA) {
+    return 'Contact your SUSE Manager admin to ensure the host is managed by SUSE Manager';
+  }
+
+  if (connectionNotWorking) {
+    return 'Please review SUSE Manager settings';
+  }
+
+  if (errors.length) {
+    return 'Trento was not able to retrieve the requested data.';
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
# Description
The unknown state for the SUSE manager overview in the host details should have had a tooltip. This PR implements it.

## Tests
Existing jest tests updated.