### PR TITLE
Handle ApplicationInstanceMoved event in deregistration

### DIFF
--- a/lib/trento/infrastructure/commanded/process_managers/deregistration_process_manager.ex
+++ b/lib/trento/infrastructure/commanded/process_managers/deregistration_process_manager.ex
@@ -370,6 +370,13 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
   def error({:error, :sap_system_not_registered}, _command_or_event, _context),
     do: {:skip, :continue_pending}
 
+  # Ignore error if deregistration command returns application_instance_not_registered error.
+  # This happens in deployments with legacy code where ApplicationInstanceMoved was not
+  # being handled and instances that were moved were still in the Process Manager state incorrectly.
+
+  def error({:error, :application_instance_not_registered}, _command_or_event, _context),
+    do: {:skip, :continue_pending}
+
   # Retry the rollup errors, stop the process on other errors
 
   def error({:error, :host_rolling_up}, _command_or_event, %{context: context}),

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -354,28 +354,39 @@ context('Hosts Overview', () => {
       });
 
       describe('Movement of application instances on hosts', () => {
-        const sapSystemHostToDeregister = {
-          id: '7269ee51-5007-5849-aaa7-7c4a98b0c9ce',
+        const sapSystemHostsToDeregister = {
           sid: 'NWD',
-          hostname: 'vmnwdev01',
+          movedHostId: 'fb2c6b8a-9915-5969-a6b7-8b5a42de1971',
+          initialHostId: '7269ee51-5007-5849-aaa7-7c4a98b0c9ce',
+          initialHostname: 'vmnwdev01',
         };
 
         before(() => {
           cy.visit('/hosts');
           cy.url().should('include', '/hosts');
-          cy.loadScenario(`sapsystem-${sapSystemHostToDeregister.sid}-restore`);
+          cy.loadScenario(
+            `sapsystem-${sapSystemHostsToDeregister.sid}-restore`
+          );
+          cy.loadScenario('sap-systems-overview-moved');
         });
 
         after(() => {
-          cy.loadScenario(`sapsystem-${sapSystemHostToDeregister.sid}-restore`);
+          cy.loadScenario(
+            `sapsystem-${sapSystemHostsToDeregister.sid}-restore`
+          );
         });
 
-        it('should not impact host deregistration', () => {
-          cy.loadScenario('sap-systems-overview-moved');
+        it('should associate instances to the correct host during deregistration', () => {
           cy.get(NEXT_PAGE_SELECTOR).click();
-          cy.contains('a', sapSystemHostToDeregister.hostname).should('exist');
-          cy.deregisterHost(sapSystemHostToDeregister.id);
-          cy.contains('a', sapSystemHostToDeregister.hostname).should(
+          cy.contains('a', sapSystemHostsToDeregister.sid).should('exist');
+          cy.deregisterHost(sapSystemHostsToDeregister.movedHostId);
+          cy.contains('a', sapSystemHostsToDeregister.sid).should('not.exist');
+        });
+
+        it('should complete host deregistration when all instances are moved out', () => {
+          cy.contains('a', sapSystemHostsToDeregister.hostname).should('exist');
+          cy.deregisterHost(sapSystemHostsToDeregister.initialHostId);
+          cy.contains('a', sapSystemHostsToDeregister.initialHostname).should(
             'not.exist'
           );
         });

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -352,6 +352,34 @@ context('Hosts Overview', () => {
           cy.contains('a', sapSystemHostToDeregister.sid).should('not.exist');
         });
       });
+
+      describe('Movement of application instances on hosts', () => {
+        const sapSystemHostToDeregister = {
+          id: '7269ee51-5007-5849-aaa7-7c4a98b0c9ce',
+          sid: 'NWD',
+          hostname: 'vmnwdev01',
+        };
+
+        before(() => {
+          cy.visit('/hosts');
+          cy.url().should('include', '/hosts');
+          cy.loadScenario(`sapsystem-${sapSystemHostToDeregister.sid}-restore`);
+        });
+
+        after(() => {
+          cy.loadScenario(`sapsystem-${sapSystemHostToDeregister.sid}-restore`);
+        });
+
+        it('should not impact host deregistration', () => {
+          cy.loadScenario('sap-systems-overview-moved');
+          cy.get(NEXT_PAGE_SELECTOR).click();
+          cy.contains('a', sapSystemHostToDeregister.hostname).should('exist');
+          cy.deregisterHost(sapSystemHostToDeregister.id);
+          cy.contains('a', sapSystemHostToDeregister.hostname).should(
+            'not.exist'
+          );
+        });
+      });
     });
   });
 


### PR DESCRIPTION
# Description

Bugfix for crash caused during deregistration when multiple duplicated application instances are added to one host deregistration process manager instance.

There are multiple factors when this can happen. I have fixed once of them, where we were not taking care of the `ApplicationInstanceMoved` event, which was of course moving instances from one host to another, leaving "zombie" instances in the Process manager instance and the deregistration command fails.

The other scenario that can happen is when an Agent machine reboots and for different reasons the cluster takes a long time to start. In this scenario, the SAP system aggregate sends a `AplicationInstanceRegistered` event instead of `ApplicationInstanceMoved` event, as the instance is not clustered yet, adding some duplicated instances to the SAP systems. These instances are marked as absent later on, so it is not that important for the user, they can clean them up.

Now, we need to handle the applications that are already having the issue. As always, Process managers are not created using stored events, they are simply stored with the latest state. This means, that this solution doesn't fix already crashed states. For that, we need to include the `error` clause where `application_instance_not_registered` error is skipped.

I thought a lot about adding some additional pattern matching with the current process manager state, but at the end, as this is caused due not being handling the `ApplicationInstanceMoved` event (that now it is fixed), we can never know from the PM state what to pattern match.

The error looks like this:
```
09:31:42.260 [debug] Trento.SapSystems.SapSystem<079d40b1-8b45-5ba2-85ee-7a28c429d94f@134> executing command: %Trento.SapSystems.Commands.DeregisterApplicationInstance{instance_number: "00", host_id: "e5b05a11-d196-5d02-aa5b-94be60ae07cc", sap_system_id: "079d40b1-8b45-5ba2-85ee-7a28c429d94f", deregistered_at: ~U[2024-10-22 09:19:35.468062Z]}
09:31:42.260 [warning] Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessManager failed to dispatch command %Trento.SapSystems.Commands.DeregisterApplicationInstance{instance_number: "00", host_id: "e5b05a11-d196-5d02-aa5b-94be60ae07cc", sap_system_id: "079d40b1-8b45-5ba2-85ee-7a28c429d94f", deregistered_at: ~U[2024-10-22 09:19:35.468062Z]} due to: {:error, :application_instance_not_registered}
09:31:42.260 [warning] Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessManager has requested to stop: :application_instance_not_registered
09:31:42.260 [error] GenServer #PID<0.4483.0> terminating
** (stop) :application_instance_not_registered
Last message: {:"$gen_cast", {:process_event, %Commanded.EventStore.RecordedEvent{event_id: "b1d448be-c369-429a-8de3-a791cf78aefa", event_number: 7156, stream_id: "e5b05a11-d196-5d02-aa5b-94be60ae07cc", stream_version: 57, causation_id: "227a6ecb-1c11-4bac-97ce-fc4534043224", correlation_id: "b29d96f0-d191-43e2-bb1a-8391db93bc2d", event_type: "Elixir.Trento.Hosts.Events.HostDeregistrationRequested", data: %Trento.Hosts.Events.HostDeregistrationRequested{version: 1, host_id: "e5b05a11-d196-5d02-aa5b-94be60ae07cc", requested_at: ~U[2024-10-22 09:19:35.468062Z]}, created_at: ~U[2024-10-22 09:19:35.499939Z], metadata: %{}}}}
State: %Commanded.ProcessManagers.ProcessManagerInstance.State{application: Trento.Commanded, idle_timeout: :infinity, process_router: #PID<0.4445.0>, process_manager_name: "deregistration_process_manager", process_manager_module: Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessManager, process_uuid: "e5b05a11-d196-5d02-aa5b-94be60ae07cc", process_state: %Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessManager{cluster_id: "9cb6ef67-fdf6-5807-bd04-f6d68ea6ccb3", application_instances: [%Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessManager.Instance{sap_system_id: "079d40b1-8b45-5ba2-85ee-7a28c429d94f", instance_number: "00"}, %Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessManager.Instance{sap_system_id: "079d40b1-8b45-5ba2-85ee-7a28c429d94f", instance_number: "10"}, %Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessManager.Instance{sap_system_id: "079d40b1-8b45-5ba2-85ee-7a28c429d94f", instance_number: "10"}], database_instances: []}, last_seen_event: 6963}
09:31:42.267 [warning] Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessManager is stopping due to: :application_instance_not_registered
09:31:42.267 [error] GenServer {Trento.Commanded.LocalRegistry, {Trento.Commanded, Commanded.ProcessManagers.ProcessRouter, "deregistration_process_manager"}} terminating
** (stop) :application_instance_not_registered
```

## How was this tested?

Unit tests added. Tested manually as well.
