### PR TITLE
Add sap hana scale up cost optimized and performance optimized discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,3 @@ npm-debug.log
 
 # Local dev.local.exs file
 config/dev.local.exs
-
-# ignore scenario
-/test/fixtures/scenarios/cost_optimised_sap_scenario

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ npm-debug.log
 
 # Local dev.local.exs file
 config/dev.local.exs
+
+# ignore scenario
+/test/fixtures/scenarios/cost_optimised_sap_scenario

--- a/assets/js/common/ClusterTypeLabel/ClusterTypeLabel.jsx
+++ b/assets/js/common/ClusterTypeLabel/ClusterTypeLabel.jsx
@@ -52,9 +52,7 @@ function ClusterTypeLabel({
 }) {
   const clusterTypeLabel = getClusterTypeLabel(clusterType);
   const clusterTypeScenarioLabel = getClusterTypeScenarioLabel(clusterScenario);
-  const combinedClusterTypeLabel = `${clusterTypeLabel}${
-    clusterScenario ? ` ${clusterTypeScenarioLabel}` : ''
-  }`;
+  const combinedClusterTypeLabel = `${clusterTypeLabel} ${clusterTypeScenarioLabel}`;
 
   return (
     <span className="group flex items-center relative">

--- a/assets/js/common/ClusterTypeLabel/ClusterTypeLabel.jsx
+++ b/assets/js/common/ClusterTypeLabel/ClusterTypeLabel.jsx
@@ -45,11 +45,7 @@ const icons = {
   ),
 };
 
-function ClusterTypeLabel({
-  clusterType,
-  clusterScenario = '',
-  architectureType,
-}) {
+function ClusterTypeLabel({ clusterType, clusterScenario, architectureType }) {
   const clusterTypeLabel = getClusterTypeLabel(clusterType);
   const clusterTypeScenarioLabel = getClusterTypeScenarioLabel(clusterScenario);
   const combinedClusterTypeLabel = `${clusterTypeLabel} ${clusterTypeScenarioLabel}`;

--- a/assets/js/common/ClusterTypeLabel/ClusterTypeLabel.jsx
+++ b/assets/js/common/ClusterTypeLabel/ClusterTypeLabel.jsx
@@ -8,6 +8,7 @@ import {
   ANGI_ARCHITECTURE,
   CLASSIC_ARCHITECTURE,
   getClusterTypeLabel,
+  getClusterTypeScenarioLabel,
 } from '@lib/model/clusters';
 
 const MIGRATION_URL =
@@ -44,11 +45,21 @@ const icons = {
   ),
 };
 
-function ClusterTypeLabel({ clusterType, architectureType }) {
+function ClusterTypeLabel({
+  clusterType,
+  clusterScenario = '',
+  architectureType,
+}) {
+  const clusterTypeLabel = getClusterTypeLabel(clusterType);
+  const clusterTypeScenarioLabel = getClusterTypeScenarioLabel(clusterScenario);
+  const combinedClusterTypeLabel = `${clusterTypeLabel}${
+    clusterScenario ? ` ${clusterTypeScenarioLabel}` : ''
+  }`;
+
   return (
     <span className="group flex items-center relative">
       {icons[architectureType]}
-      {getClusterTypeLabel(clusterType)}
+      {combinedClusterTypeLabel}
     </span>
   );
 }

--- a/assets/js/common/ClusterTypeLabel/ClusterTypeLabel.jsx
+++ b/assets/js/common/ClusterTypeLabel/ClusterTypeLabel.jsx
@@ -8,7 +8,7 @@ import {
   ANGI_ARCHITECTURE,
   CLASSIC_ARCHITECTURE,
   getClusterTypeLabel,
-  getClusterTypeScenarioLabel,
+  getClusterScenarioLabel,
 } from '@lib/model/clusters';
 
 const MIGRATION_URL =
@@ -47,13 +47,13 @@ const icons = {
 
 function ClusterTypeLabel({ clusterType, clusterScenario, architectureType }) {
   const clusterTypeLabel = getClusterTypeLabel(clusterType);
-  const clusterTypeScenarioLabel = getClusterTypeScenarioLabel(clusterScenario);
-  const combinedClusterTypeLabel = `${clusterTypeLabel} ${clusterTypeScenarioLabel}`;
+  const clusterScenarioLabel = getClusterScenarioLabel(clusterScenario);
+  const clusterLabel = `${clusterTypeLabel} ${clusterScenarioLabel}`;
 
   return (
     <span className="group flex items-center relative">
       {icons[architectureType]}
-      {combinedClusterTypeLabel}
+      {clusterLabel}
     </span>
   );
 }

--- a/assets/js/common/SapSystemLink/SapSystemLink.jsx
+++ b/assets/js/common/SapSystemLink/SapSystemLink.jsx
@@ -7,7 +7,6 @@ import { Link } from 'react-router-dom';
 function SapSystemLink({ systemType, sapSystemId, children }) {
   return sapSystemId && systemType ? (
     <Link
-      key={sapSystemId}
       className="text-jungle-green-500 hover:opacity-75"
       to={`/${systemType}/${sapSystemId}`}
     >

--- a/assets/js/lib/model/clusters.js
+++ b/assets/js/lib/model/clusters.js
@@ -1,8 +1,24 @@
+// Cluster types
 export const HANA_SCALE_UP = 'hana_scale_up';
 export const HANA_SCALE_OUT = 'hana_scale_out';
 export const ASCS_ERS = 'ascs_ers';
 
-export const clusterTypes = [HANA_SCALE_UP, HANA_SCALE_OUT, ASCS_ERS];
+// Hana scale up scenarios
+export const HANA_SCALE_UP_PERFORMANCE_SCENARIO = 'performance_optimized';
+export const HANA_SCALE_UP_COST_OPT_SCENARIO = 'cost_optimized';
+export const HANA_SCALE_UP_UNKNOWN_SCENARIO = 'unknown';
+
+export const clusterTypes = [
+  HANA_SCALE_UP,
+  HANA_SCALE_UP_PERFORMANCE_SCENARIO,
+  HANA_SCALE_OUT,
+  ASCS_ERS,
+];
+export const hanaClusterScenarioTypes = [
+  HANA_SCALE_UP_PERFORMANCE_SCENARIO,
+  HANA_SCALE_UP_UNKNOWN_SCENARIO,
+  HANA_SCALE_UP_COST_OPT_SCENARIO,
+];
 
 export const isValidClusterType = (clusterType) =>
   clusterTypes.includes(clusterType);
@@ -15,6 +31,14 @@ const clusterTypeLabels = {
 
 export const getClusterTypeLabel = (type) =>
   clusterTypeLabels[type] || 'Unknown';
+
+const clusterTypeScenarioLabels = {
+  [HANA_SCALE_UP_PERFORMANCE_SCENARIO]: 'performance optimized',
+  [HANA_SCALE_UP_COST_OPT_SCENARIO]: 'cost optimized',
+};
+
+export const getClusterTypeScenarioLabel = (type) =>
+  clusterTypeScenarioLabels[type] || '';
 
 export const ANGI_ARCHITECTURE = 'angi';
 export const CLASSIC_ARCHITECTURE = 'classic';

--- a/assets/js/lib/model/clusters.js
+++ b/assets/js/lib/model/clusters.js
@@ -4,20 +4,13 @@ export const HANA_SCALE_OUT = 'hana_scale_out';
 export const ASCS_ERS = 'ascs_ers';
 
 // Hana scale up scenarios
-export const HANA_SCALE_UP_PERFORMANCE_SCENARIO = 'performance_optimized';
 export const HANA_SCALE_UP_COST_OPT_SCENARIO = 'cost_optimized';
-export const HANA_SCALE_UP_UNKNOWN_SCENARIO = 'unknown';
+export const PERFORMANCE_SCENARIO = 'performance_optimized';
 
-export const clusterTypes = [
-  HANA_SCALE_UP,
-  HANA_SCALE_UP_PERFORMANCE_SCENARIO,
-  HANA_SCALE_OUT,
-  ASCS_ERS,
-];
+export const clusterTypes = [HANA_SCALE_UP, HANA_SCALE_OUT, ASCS_ERS];
 export const hanaClusterScenarioTypes = [
-  HANA_SCALE_UP_PERFORMANCE_SCENARIO,
-  HANA_SCALE_UP_UNKNOWN_SCENARIO,
   HANA_SCALE_UP_COST_OPT_SCENARIO,
+  PERFORMANCE_SCENARIO,
 ];
 
 export const isValidClusterType = (clusterType) =>
@@ -33,7 +26,7 @@ export const getClusterTypeLabel = (type) =>
   clusterTypeLabels[type] || 'Unknown';
 
 const clusterTypeScenarioLabels = {
-  [HANA_SCALE_UP_PERFORMANCE_SCENARIO]: 'Perf. Opt.',
+  [PERFORMANCE_SCENARIO]: 'Perf. Opt.',
   [HANA_SCALE_UP_COST_OPT_SCENARIO]: 'Cost Opt.',
 };
 

--- a/assets/js/lib/model/clusters.js
+++ b/assets/js/lib/model/clusters.js
@@ -25,13 +25,13 @@ const clusterTypeLabels = {
 export const getClusterTypeLabel = (type) =>
   clusterTypeLabels[type] || 'Unknown';
 
-const clusterTypeScenarioLabels = {
+const clusterScenarioLabels = {
   [PERFORMANCE_SCENARIO]: 'Perf. Opt.',
   [COST_OPT_SCENARIO]: 'Cost Opt.',
 };
 
-export const getClusterTypeScenarioLabel = (type) =>
-  clusterTypeScenarioLabels[type] || '';
+export const getClusterScenarioLabel = (type) =>
+  clusterScenarioLabels[type] || '';
 
 export const ANGI_ARCHITECTURE = 'angi';
 export const CLASSIC_ARCHITECTURE = 'classic';

--- a/assets/js/lib/model/clusters.js
+++ b/assets/js/lib/model/clusters.js
@@ -33,8 +33,8 @@ export const getClusterTypeLabel = (type) =>
   clusterTypeLabels[type] || 'Unknown';
 
 const clusterTypeScenarioLabels = {
-  [HANA_SCALE_UP_PERFORMANCE_SCENARIO]: 'performance optimized',
-  [HANA_SCALE_UP_COST_OPT_SCENARIO]: 'cost optimized',
+  [HANA_SCALE_UP_PERFORMANCE_SCENARIO]: 'Perf. Opt.',
+  [HANA_SCALE_UP_COST_OPT_SCENARIO]: 'Cost Opt.',
 };
 
 export const getClusterTypeScenarioLabel = (type) =>

--- a/assets/js/lib/model/clusters.js
+++ b/assets/js/lib/model/clusters.js
@@ -4,12 +4,12 @@ export const HANA_SCALE_OUT = 'hana_scale_out';
 export const ASCS_ERS = 'ascs_ers';
 
 // Hana scale up scenarios
-export const HANA_SCALE_UP_COST_OPT_SCENARIO = 'cost_optimized';
+export const COST_OPT_SCENARIO = 'cost_optimized';
 export const PERFORMANCE_SCENARIO = 'performance_optimized';
 
 export const clusterTypes = [HANA_SCALE_UP, HANA_SCALE_OUT, ASCS_ERS];
 export const hanaClusterScenarioTypes = [
-  HANA_SCALE_UP_COST_OPT_SCENARIO,
+  COST_OPT_SCENARIO,
   PERFORMANCE_SCENARIO,
 ];
 
@@ -27,7 +27,7 @@ export const getClusterTypeLabel = (type) =>
 
 const clusterTypeScenarioLabels = {
   [PERFORMANCE_SCENARIO]: 'Perf. Opt.',
-  [HANA_SCALE_UP_COST_OPT_SCENARIO]: 'Cost Opt.',
+  [COST_OPT_SCENARIO]: 'Cost Opt.',
 };
 
 export const getClusterTypeScenarioLabel = (type) =>

--- a/assets/js/lib/test-utils/factories/clusters.js
+++ b/assets/js/lib/test-utils/factories/clusters.js
@@ -139,6 +139,7 @@ export const clusterFactory = Factory.define(({ sequence, params }) => {
     id: faker.string.uuid(),
     name: `${faker.person.firstName()}_${sequence}`,
     sid: generateSid(),
+    additional_sids: [],
     hosts_number: faker.number.int(),
     resources_number: faker.number.int(),
     type: clusterTypeEnum(),

--- a/assets/js/lib/test-utils/factories/clusters.js
+++ b/assets/js/lib/test-utils/factories/clusters.js
@@ -20,6 +20,13 @@ const ascsErsRole = () => faker.helpers.arrayElement(['ascs', 'ers']);
 const hanaArchitectureTypeEnum = () =>
   faker.helpers.arrayElement(['classic', 'angi']);
 
+const hanaScenarioTypeEnum = () =>
+  faker.helpers.arrayElement([
+    'performance_optimized',
+    'cost_optimized',
+    'unknown',
+  ]);
+
 export const sbdDevicesFactory = Factory.define(() => ({
   device: faker.system.filePath(),
   status: faker.helpers.arrayElement(['healthy', 'unhealthy']),
@@ -76,6 +83,7 @@ export const hanaClusterDetailsFactory = Factory.define(() => {
     system_replication_operation_mode: 'logreplay',
     maintenance_mode: false,
     architecture_type: hanaArchitectureTypeEnum(),
+    hana_scenario: hanaScenarioTypeEnum(),
   };
 });
 

--- a/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
@@ -79,6 +79,7 @@ export function ClusterDetailsPage() {
     case 'hana_scale_out':
       return (
         <HanaClusterDetails
+          additionalSids={cluster.additional_sids}
           clusterID={clusterID}
           userAbilities={abilities}
           clusterName={getClusterName(cluster)}
@@ -87,6 +88,7 @@ export function ClusterDetailsPage() {
           hosts={clusterHosts}
           clusterType={cluster.type}
           cibLastWritten={cluster.cib_last_written}
+          sid={cluster.sid}
           provider={cluster.provider}
           sapSystems={clusterSapSystems}
           details={cluster.details}

--- a/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
@@ -79,7 +79,6 @@ export function ClusterDetailsPage() {
     case 'hana_scale_out':
       return (
         <HanaClusterDetails
-          additionalSids={cluster.additional_sids}
           clusterID={clusterID}
           userAbilities={abilities}
           clusterName={getClusterName(cluster)}
@@ -89,6 +88,7 @@ export function ClusterDetailsPage() {
           clusterType={cluster.type}
           cibLastWritten={cluster.cib_last_written}
           sid={cluster.sid}
+          additionalSids={cluster.additional_sids}
           provider={cluster.provider}
           sapSystems={clusterSapSystems}
           details={cluster.details}

--- a/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
@@ -72,7 +72,6 @@ export function ClusterDetailsPage() {
   if (!cluster) {
     return <div>Loading...</div>;
   }
-
   const hasSelectedChecks = cluster.selected_checks.length > 0;
 
   switch (cluster.type) {
@@ -88,7 +87,6 @@ export function ClusterDetailsPage() {
           hosts={clusterHosts}
           clusterType={cluster.type}
           cibLastWritten={cluster.cib_last_written}
-          sid={cluster.sid}
           provider={cluster.provider}
           sapSystems={clusterSapSystems}
           details={cluster.details}

--- a/assets/js/pages/ClusterDetails/ClusterDetailsPage.test.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetailsPage.test.jsx
@@ -12,31 +12,27 @@ describe('ClusterDetails ClusterDetailsPage component', () => {
   it.each([
     {
       type: 'hana_scale_up',
-      label: 'HANA Scale Up',
-      clusterTypeScenarioLabel: 'Perf. Opt.',
+      label: 'HANA Scale Up Perf. Opt.',
       scenario: 'performance_optimized',
     },
     {
       type: 'hana_scale_up',
-      label: 'HANA Scale Up',
-      clusterTypeScenarioLabel: 'Cost Opt.',
+      label: 'HANA Scale Up Cost Opt.',
       scenario: 'cost_optimized',
     },
     {
       type: 'ascs_ers',
       label: 'ASCS/ERS',
-      clusterTypeScenarioLabel: '',
       scenario: 'unknwon',
     },
     {
       type: 'unknwon',
       label: 'Unknown cluster type',
-      clusterTypeScenarioLabel: '',
       scenario: 'unknwon',
     },
   ])(
     'should display the $type details based on cluster type',
-    ({ type, label, clusterTypeScenarioLabel, scenario }) => {
+    ({ type, label, scenario }) => {
       const cluster = clusterFactory.build({
         type,
         details: { hana_scenario: scenario },
@@ -64,11 +60,8 @@ describe('ClusterDetails ClusterDetailsPage component', () => {
         path: 'clusters/:clusterID',
         route: `/clusters/${cluster.id}`,
       });
-      const clusterTypeLabel =
-        clusterTypeScenarioLabel.length === 0
-          ? label
-          : `${label} ${clusterTypeScenarioLabel}`;
-      expect(screen.getByText(clusterTypeLabel)).toBeInTheDocument();
+
+      expect(screen.getByText(label)).toBeInTheDocument();
     }
   );
 });

--- a/assets/js/pages/ClusterDetails/ClusterDetailsPage.test.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetailsPage.test.jsx
@@ -22,11 +22,17 @@ describe('ClusterDetails ClusterDetailsPage component', () => {
       clusterTypeScenarioLabel: 'Cost Opt.',
       scenario: 'cost_optimized',
     },
-    { type: 'ascs_ers', label: 'ASCS/ERS', clusterTypeScenarioLabel: '' },
+    {
+      type: 'ascs_ers',
+      label: 'ASCS/ERS',
+      clusterTypeScenarioLabel: '',
+      scenario: 'unknwon',
+    },
     {
       type: 'unknwon',
       label: 'Unknown cluster type',
       clusterTypeScenarioLabel: '',
+      scenario: 'unknwon',
     },
   ])(
     'should display the $type details based on cluster type',

--- a/assets/js/pages/ClusterDetails/ClusterDetailsPage.test.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetailsPage.test.jsx
@@ -10,15 +10,30 @@ import { ClusterDetailsPage } from './ClusterDetailsPage';
 
 describe('ClusterDetails ClusterDetailsPage component', () => {
   it.each([
-    { type: 'hana_scale_up', label: 'HANA Scale Up', scneario: 'unknown' },
-    { type: 'ascs_ers', label: 'ASCS/ERS' },
-    { type: 'unknwon', label: 'Unknown cluster type' },
+    {
+      type: 'hana_scale_up',
+      label: 'HANA Scale Up',
+      clusterTypeScenarioLabel: 'Perf. Opt.',
+      scenario: 'performance_optimized',
+    },
+    {
+      type: 'hana_scale_up',
+      label: 'HANA Scale Up',
+      clusterTypeScenarioLabel: 'Cost Opt.',
+      scenario: 'cost_optimized',
+    },
+    { type: 'ascs_ers', label: 'ASCS/ERS', clusterTypeScenarioLabel: '' },
+    {
+      type: 'unknwon',
+      label: 'Unknown cluster type',
+      clusterTypeScenarioLabel: '',
+    },
   ])(
     'should display the $type details based on cluster type',
-    ({ type, label, scneario }) => {
+    ({ type, label, clusterTypeScenarioLabel, scenario }) => {
       const cluster = clusterFactory.build({
         type,
-        details: { hana_scenario: scneario },
+        details: { hana_scenario: scenario },
       });
       const initialState = {
         clustersList: { clusters: [cluster] },
@@ -43,8 +58,11 @@ describe('ClusterDetails ClusterDetailsPage component', () => {
         path: 'clusters/:clusterID',
         route: `/clusters/${cluster.id}`,
       });
-
-      expect(screen.getByText(label)).toBeInTheDocument();
+      const clusterTypeLabel =
+        clusterTypeScenarioLabel.length === 0
+          ? label
+          : `${label} ${clusterTypeScenarioLabel}`;
+      expect(screen.getByText(clusterTypeLabel)).toBeInTheDocument();
     }
   );
 });

--- a/assets/js/pages/ClusterDetails/ClusterDetailsPage.test.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetailsPage.test.jsx
@@ -10,13 +10,16 @@ import { ClusterDetailsPage } from './ClusterDetailsPage';
 
 describe('ClusterDetails ClusterDetailsPage component', () => {
   it.each([
-    { type: 'hana_scale_up', label: 'HANA Scale Up' },
+    { type: 'hana_scale_up', label: 'HANA Scale Up', scneario: 'unknown' },
     { type: 'ascs_ers', label: 'ASCS/ERS' },
     { type: 'unknwon', label: 'Unknown cluster type' },
   ])(
     'should display the $type details based on cluster type',
-    ({ type, label }) => {
-      const cluster = clusterFactory.build({ type });
+    ({ type, label, scneario }) => {
+      const cluster = clusterFactory.build({
+        type,
+        details: { hana_scenario: scneario },
+      });
       const initialState = {
         clustersList: { clusters: [cluster] },
         hostsList: { hosts: [] },

--- a/assets/js/pages/ClusterDetails/ClustersList.jsx
+++ b/assets/js/pages/ClusterDetails/ClustersList.jsx
@@ -79,7 +79,7 @@ function ClustersList() {
             const sapSystemData = getSapSystemBySID(allInstances, singleSid);
 
             return [
-              index > 0 && ', ',
+              index > 0 && <br />,
               <SapSystemLink
                 key={`${id}-${singleSid}`}
                 systemType={sapSystemData?.type}

--- a/assets/js/pages/ClusterDetails/ClustersList.jsx
+++ b/assets/js/pages/ClusterDetails/ClustersList.jsx
@@ -74,20 +74,21 @@ function ClustersList() {
         filterFromParams: true,
         filter: (filter, key) => (element) =>
           element[key].some((sid) => filter.includes(sid)),
-        render: (_, { sid, id }) => {
-          const sidsArray = sid.map((singleSid, index) => {
+        render: (_, { sid }) => {
+          const sidsArray = sid.map((singleSid) => {
             const sapSystemData = getSapSystemBySID(allInstances, singleSid);
 
-            return [
-              index > 0 && <br />,
-              <SapSystemLink
-                key={`${id}-${singleSid}`}
-                systemType={sapSystemData?.type}
-                sapSystemId={getInstanceID(sapSystemData)}
-              >
-                {singleSid}
-              </SapSystemLink>,
-            ];
+            return (
+              <span key={singleSid}>
+                <SapSystemLink
+                  systemType={sapSystemData?.type}
+                  sapSystemId={getInstanceID(sapSystemData)}
+                >
+                  {singleSid}
+                </SapSystemLink>
+                <br />
+              </span>
+            );
           });
 
           return sidsArray;

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
@@ -52,8 +52,8 @@ function HanaClusterDetails({
   navigate = () => {},
 }) {
   const enrichedNodes = enrichNodes(details?.nodes, hosts);
-  const sidsList = [sid, ...additionalSids];
-  const enrichedSapSystems = sidsList.map((sidItem) => ({
+  const sortedSidList = [sid, ...additionalSids].sort();
+  const enrichedSapSystems = sortedSidList.map((sidItem) => ({
     sid: sidItem,
     ...sapSystems.find(({ sid: currentSid }) => currentSid === sidItem),
   }));
@@ -172,7 +172,7 @@ function HanaClusterDetails({
                       ))}
                     </div>
                   ) : (
-                    <span>{sidsList.join(' ')}</span>
+                    <span>{sortedSidList.join(' ')}</span>
                   ),
               },
               {

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
@@ -32,10 +32,8 @@ export const enrichNodes = (clusterNodes, hosts) =>
     ...hosts.find(({ hostname }) => hostname === node.name),
   }));
 
-const generateEnrichedSapSystem = (systems) =>
-  systems.map((system) => ({ id: system.id, sid: system.sid }));
-
 function HanaClusterDetails({
+  additionalSids = [],
   clusterID,
   clusterName,
   selectedChecks,
@@ -45,6 +43,7 @@ function HanaClusterDetails({
   cibLastWritten,
   provider,
   sapSystems,
+  sid,
   details,
   catalog,
   userAbilities,
@@ -53,7 +52,12 @@ function HanaClusterDetails({
   navigate = () => {},
 }) {
   const enrichedNodes = enrichNodes(details?.nodes, hosts);
-  const enrichedSapSystems = generateEnrichedSapSystem(sapSystems);
+  const sidsList = [sid, ...additionalSids];
+
+  const enrichedSapSystems = sidsList.map((sidItem) => ({
+    sidItem,
+    ...sapSystems.find(({ sid: currentSid }) => currentSid === sidItem),
+  }));
 
   const unsitedNodes = enrichedNodes.filter(({ site }) => site === null);
 
@@ -153,13 +157,10 @@ function HanaClusterDetails({
                 content: enrichedSapSystems,
                 render: (content) => (
                   <div>
-                    {content.map((system) => (
-                      <span key={system.id}>
-                        <SapSystemLink
-                          sapSystemId={system.id}
-                          systemType="databases"
-                        >
-                          {system.sid}
+                    {content.map(({ id, sid: sapSystemSid }) => (
+                      <span key={sapSystemSid}>
+                        <SapSystemLink sapSystemId={id} systemType="databases">
+                          {sapSystemSid}
                         </SapSystemLink>{' '}
                       </span>
                     ))}

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
@@ -153,15 +153,14 @@ function HanaClusterDetails({
                 content: enrichedSapSystems,
                 render: (content) => (
                   <div>
-                    {content.map((system, index) => (
+                    {content.map((system) => (
                       <span key={system.id}>
                         <SapSystemLink
                           sapSystemId={system.id}
                           systemType="databases"
                         >
                           {system.sid}
-                        </SapSystemLink>
-                        {index < content.length - 1 && ', '}
+                        </SapSystemLink>{' '}
                       </span>
                     ))}
                   </div>

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
@@ -33,7 +33,6 @@ export const enrichNodes = (clusterNodes, hosts) =>
   }));
 
 function HanaClusterDetails({
-  additionalSids = [],
   clusterID,
   clusterName,
   selectedChecks,
@@ -44,6 +43,7 @@ function HanaClusterDetails({
   provider,
   sapSystems,
   sid,
+  additionalSids,
   details,
   catalog,
   userAbilities,
@@ -52,8 +52,8 @@ function HanaClusterDetails({
   navigate = () => {},
 }) {
   const enrichedNodes = enrichNodes(details?.nodes, hosts);
-  const sortedSidList = [sid, ...additionalSids].sort();
-  const enrichedSapSystems = sortedSidList.map((sidItem) => ({
+  const clusterSids = [sid, ...additionalSids];
+  const enrichedSapSystems = clusterSids.map((sidItem) => ({
     sid: sidItem,
     ...sapSystems.find(({ sid: currentSid }) => currentSid === sidItem),
   }));
@@ -172,7 +172,7 @@ function HanaClusterDetails({
                       ))}
                     </div>
                   ) : (
-                    <span>{sortedSidList.join(' ')}</span>
+                    <span>{clusterSids.join(' ')}</span>
                   ),
               },
               {

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
@@ -32,6 +32,9 @@ export const enrichNodes = (clusterNodes, hosts) =>
     ...hosts.find(({ hostname }) => hostname === node.name),
   }));
 
+const generateEnrichedSapSystem = (systems) =>
+  systems.map((system) => ({ id: system.id, sid: system.sid }));
+
 function HanaClusterDetails({
   clusterID,
   clusterName,
@@ -40,7 +43,6 @@ function HanaClusterDetails({
   hosts,
   clusterType,
   cibLastWritten,
-  sid,
   provider,
   sapSystems,
   details,
@@ -51,10 +53,8 @@ function HanaClusterDetails({
   navigate = () => {},
 }) {
   const enrichedNodes = enrichNodes(details?.nodes, hosts);
-  const enrichedSapSystem = {
-    sid,
-    ...sapSystems.find(({ sid: currentSid }) => currentSid === sid),
-  };
+  const enrichedSapSystems = generateEnrichedSapSystem(sapSystems);
+
   const unsitedNodes = enrichedNodes.filter(({ site }) => site === null);
 
   const {
@@ -150,14 +150,21 @@ function HanaClusterDetails({
               },
               {
                 title: 'SID',
-                content: enrichedSapSystem,
+                content: enrichedSapSystems,
                 render: (content) => (
-                  <SapSystemLink
-                    sapSystemId={content?.id}
-                    systemType="databases"
-                  >
-                    {content?.sid}
-                  </SapSystemLink>
+                  <div>
+                    {content.map((system, index) => (
+                      <span key={system.id}>
+                        <SapSystemLink
+                          sapSystemId={system.id}
+                          systemType="databases"
+                        >
+                          {system.sid}
+                        </SapSystemLink>
+                        {index < content.length - 1 && ', '}
+                      </span>
+                    ))}
+                  </div>
                 ),
               },
               {
@@ -170,6 +177,7 @@ function HanaClusterDetails({
                 render: (content) => (
                   <ClusterTypeLabel
                     clusterType={content}
+                    clusterScenario={details.hana_scenario}
                     architectureType={details.architecture_type}
                   />
                 ),

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
@@ -154,26 +154,17 @@ function HanaClusterDetails({
               {
                 title: 'SID',
                 content: enrichedSapSystems,
-                render: (content) =>
-                  content.every(
-                    (sapSystem) => sapSystem.id && sapSystem.sid
-                  ) ? (
-                    <div>
-                      {content.map(({ id, sid: sapSystemSid }) => (
-                        <span key={`${id}-${sapSystemSid}`}>
-                          <SapSystemLink
-                            key={id}
-                            sapSystemId={id}
-                            systemType="databases"
-                          >
-                            {sapSystemSid}
-                          </SapSystemLink>{' '}
-                        </span>
-                      ))}
-                    </div>
-                  ) : (
-                    <span>{clusterSids.join(' ')}</span>
-                  ),
+                render: (content) => (
+                  <div>
+                    {content.map(({ id, sid: sapSystemSid }) => (
+                      <span key={sapSystemSid}>
+                        <SapSystemLink sapSystemId={id} systemType="databases">
+                          {sapSystemSid}
+                        </SapSystemLink>{' '}
+                      </span>
+                    ))}
+                  </div>
+                ),
               },
               {
                 title: 'Fencing type',

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
@@ -53,9 +53,8 @@ function HanaClusterDetails({
 }) {
   const enrichedNodes = enrichNodes(details?.nodes, hosts);
   const sidsList = [sid, ...additionalSids];
-
   const enrichedSapSystems = sidsList.map((sidItem) => ({
-    sidItem,
+    sid: sidItem,
     ...sapSystems.find(({ sid: currentSid }) => currentSid === sidItem),
   }));
 
@@ -155,17 +154,26 @@ function HanaClusterDetails({
               {
                 title: 'SID',
                 content: enrichedSapSystems,
-                render: (content) => (
-                  <div>
-                    {content.map(({ id, sid: sapSystemSid }) => (
-                      <span key={sapSystemSid}>
-                        <SapSystemLink sapSystemId={id} systemType="databases">
-                          {sapSystemSid}
-                        </SapSystemLink>{' '}
-                      </span>
-                    ))}
-                  </div>
-                ),
+                render: (content) =>
+                  content.every(
+                    (sapSystem) => sapSystem.id && sapSystem.sid
+                  ) ? (
+                    <div>
+                      {content.map(({ id, sid: sapSystemSid }) => (
+                        <span key={`${id}-${sapSystemSid}`}>
+                          <SapSystemLink
+                            key={id}
+                            sapSystemId={id}
+                            systemType="databases"
+                          >
+                            {sapSystemSid}
+                          </SapSystemLink>{' '}
+                        </span>
+                      ))}
+                    </div>
+                  ) : (
+                    <span>{sidsList.join(' ')}</span>
+                  ),
               },
               {
                 title: 'Fencing type',

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.stories.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.stories.jsx
@@ -173,6 +173,23 @@ export const Hana = {
   },
 };
 
+export const HanaScaleUpCostOpt = {
+  args: {
+    ...Hana.args,
+    additionalSids: ['QAS', 'DEV'],
+    sapSystems: sapSystemList,
+    details: { ...Hana.args.details, hana_scenario: 'cost_optimized' },
+  },
+};
+
+export const HanaScaleUpCostOptWithoutEnrichedData = {
+  args: {
+    ...Hana.args,
+    additionalSids: ['QAS', 'DEV'],
+    details: { ...Hana.args.details, hana_scenario: 'cost_optimized' },
+  },
+};
+
 export const HanaScaleOut = {
   args: {
     ...Hana.args,

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.stories.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.stories.jsx
@@ -25,7 +25,7 @@ const {
   type: clusterType,
   selected_checks: selectedChecks,
   provider,
-  additional_sids,
+  additional_sids: additionalSids,
   cib_last_written: cibLastWritten,
   details,
 } = clusterFactory.build({
@@ -118,12 +118,10 @@ const sapSystems = sapSystemFactory.buildList(1, {
   hana_scenario: 'performance_optimized',
 });
 
-const additionalSids = additional_sids;
-
 const sapSystemList = [
-  sapSystemFactory.build({ sid, id: '123' }),
-  sapSystemFactory.build({ sid: 'QAS', id: '345' }),
-  sapSystemFactory.build({ sid: 'DEV', id: '678' }),
+  sapSystemFactory.build({ sid }),
+  sapSystemFactory.build({ sid: 'QAS' }),
+  sapSystemFactory.build({ sid: 'DEV' }),
 ];
 
 const catalog = catalogFactory.build();

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.stories.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.stories.jsx
@@ -25,6 +25,7 @@ const {
   type: clusterType,
   selected_checks: selectedChecks,
   provider,
+  additional_sids,
   cib_last_written: cibLastWritten,
   details,
 } = clusterFactory.build({
@@ -108,7 +109,17 @@ const scaleOutHosts = scaleOutDetails.nodes.map(({ name }) =>
   hostFactory.build({ hostname: name })
 );
 
-const sapSystems = sapSystemFactory.buildList(1, { sid });
+const sapSystems = sapSystemFactory.buildList(1, {
+  sid,
+  hana_scenario: 'performance_optimized',
+});
+
+const additionalSids = additional_sids;
+
+const sapSystemList = [
+  sapSystemFactory.build({ sid, hana_scenario: 'cost_optimized' }),
+  sapSystemFactory.build({ sid: 'QAS', hana_scenario: 'cost_optimized' }),
+];
 
 const catalog = catalogFactory.build();
 
@@ -145,6 +156,7 @@ export const Hana = {
     clusterType,
     cibLastWritten,
     sid,
+    additionalSids,
     provider,
     sapSystems,
     details,
@@ -224,6 +236,33 @@ export const AngiArchitecture = {
     details: {
       ...Hana.args.details,
       architecture_type: 'angi',
+      hana_scenario: 'unknown',
+    },
+  },
+};
+
+export const AngiArchitecturePerformanceScenario = {
+  args: {
+    ...Hana.args,
+    additionalSids: [],
+    details: {
+      ...Hana.args.details,
+      architecture_type: 'angi',
+      hana_scenario: 'performance_optimized',
+    },
+  },
+};
+
+export const AngiArchitectureCostOptScenario = {
+  args: {
+    ...Hana.args,
+    sid,
+    additionalSids: ['DEV', 'QAS'],
+    sap_systems: sapSystemList,
+    details: {
+      ...Hana.args.details,
+      architecture_type: 'angi',
+      hana_scenario: 'cost_optimized',
     },
   },
 };

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.stories.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.stories.jsx
@@ -30,13 +30,17 @@ const {
   details,
 } = clusterFactory.build({
   type: 'hana_scale_up',
-  details: { architecture_type: 'classic' },
+  details: {
+    architecture_type: 'classic',
+    hana_scenario: 'performance_optimized',
+  },
 });
 
 const scaleOutSites = hanaClusterSiteFactory.buildList(2);
 
 const scaleOutDetails = hanaClusterDetailsFactory.build({
   architecture_type: 'classic',
+  hana_scenario: 'unknown',
   sites: scaleOutSites,
   nodes: [
     hanaClusterDetailsNodesFactory.build({
@@ -117,8 +121,9 @@ const sapSystems = sapSystemFactory.buildList(1, {
 const additionalSids = additional_sids;
 
 const sapSystemList = [
-  sapSystemFactory.build({ sid, hana_scenario: 'cost_optimized' }),
-  sapSystemFactory.build({ sid: 'QAS', hana_scenario: 'cost_optimized' }),
+  sapSystemFactory.build({ sid, id: '123' }),
+  sapSystemFactory.build({ sid: 'QAS', id: '345' }),
+  sapSystemFactory.build({ sid: 'DEV', id: '678' }),
 ];
 
 const catalog = catalogFactory.build();
@@ -173,6 +178,7 @@ export const HanaScaleOut = {
     ...Hana.args,
     hosts: scaleOutHosts,
     details: scaleOutDetails,
+    clusterType: 'hana_scale_out',
   },
 };
 
@@ -230,21 +236,9 @@ export const WithNoSBDDevices = {
   },
 };
 
-export const AngiArchitecture = {
-  args: {
-    ...Hana.args,
-    details: {
-      ...Hana.args.details,
-      architecture_type: 'angi',
-      hana_scenario: 'unknown',
-    },
-  },
-};
-
 export const AngiArchitecturePerformanceScenario = {
   args: {
     ...Hana.args,
-    additionalSids: [],
     details: {
       ...Hana.args.details,
       architecture_type: 'angi',
@@ -257,8 +251,22 @@ export const AngiArchitectureCostOptScenario = {
   args: {
     ...Hana.args,
     sid,
-    additionalSids: ['DEV', 'QAS'],
-    sap_systems: sapSystemList,
+    additionalSids: ['QAS', 'DEV'],
+    sapSystems: sapSystemList,
+    details: {
+      ...Hana.args.details,
+      architecture_type: 'angi',
+      hana_scenario: 'cost_optimized',
+    },
+  },
+};
+
+export const AngiArchitectureCostOptScenarioWithoutEnrichedData = {
+  args: {
+    ...Hana.args,
+    sid,
+    additionalSids: ['QAS1', 'DEV1'],
+    sapSystems: sapSystemList,
     details: {
       ...Hana.args.details,
       architecture_type: 'angi',

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.test.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.test.jsx
@@ -95,6 +95,7 @@ describe('HanaClusterDetails component', () => {
           clusterType={clusterType}
           cibLastWritten={cibLastWritten}
           sid={sid}
+          additionalSids={[]}
           provider={provider}
           sapSystems={[]}
           details={details}
@@ -132,6 +133,7 @@ describe('HanaClusterDetails component', () => {
         clusterType={clusterType}
         cibLastWritten={cibLastWritten}
         sid={sid}
+        additionalSids={[]}
         provider={provider}
         sapSystems={sapSystems}
         details={details}
@@ -174,6 +176,7 @@ describe('HanaClusterDetails component', () => {
         provider={provider}
         sapSystems={[{ sid }]}
         sid={sid}
+        additionalSids={[]}
         details={details}
         lastExecution={null}
         userAbilities={userAbilities}
@@ -214,6 +217,7 @@ describe('HanaClusterDetails component', () => {
         clusterType={clusterType}
         cibLastWritten={cibLastWritten}
         sid={sid}
+        additionalSids={[]}
         provider={provider}
         sapSystems={[]}
         details={details}
@@ -255,6 +259,7 @@ describe('HanaClusterDetails component', () => {
         clusterType={clusterType}
         cibLastWritten={cibLastWritten}
         sid={sid}
+        additionalSids={[]}
         provider={provider}
         sapSystems={[]}
         details={details}
@@ -296,6 +301,7 @@ describe('HanaClusterDetails component', () => {
         clusterType={clusterType}
         cibLastWritten={cibLastWritten}
         sid={sid}
+        additionalSids={[]}
         provider={provider}
         sapSystems={[]}
         details={details}
@@ -338,6 +344,7 @@ describe('HanaClusterDetails component', () => {
         clusterType={clusterType}
         cibLastWritten={cibLastWritten}
         sid={sid}
+        additionalSids={[]}
         provider={provider}
         sapSystems={[]}
         details={updatedDetails}
@@ -380,6 +387,7 @@ describe('HanaClusterDetails component', () => {
         clusterType={clusterType}
         cibLastWritten={cibLastWritten}
         sid={sid}
+        additionalSids={[]}
         provider={provider}
         sapSystems={[]}
         details={details}
@@ -449,6 +457,7 @@ describe('HanaClusterDetails component', () => {
           clusterType={clusterType}
           cibLastWritten={cibLastWritten}
           sid={sid}
+          additionalSids={[]}
           provider={provider}
           sapSystems={[]}
           details={details}
@@ -470,21 +479,29 @@ describe('HanaClusterDetails component', () => {
       arch: 'angi',
       tooltip: 'Angi architecture',
       scenario: 'performance_optimized',
+      label: 'HANA Scale Up Perf. Opt.',
     },
     {
       arch: 'classic',
       tooltip: 'Classic architecture',
       scenario: 'performance_optimized',
+      label: 'HANA Scale Up Perf. Opt.',
     },
     {
       arch: 'classic',
       tooltip: 'Classic architecture',
       scenario: 'cost_optimized',
+      label: 'HANA Scale Up Cost Opt.',
     },
-    { arch: 'classic', tooltip: 'Classic architecture', scenario: 'unknown' },
+    {
+      arch: 'classic',
+      tooltip: 'Classic architecture',
+      scenario: 'unknown',
+      label: 'HANA Scale Up',
+    },
   ])(
     'should show cluster type with $arch architecture',
-    async ({ arch, tooltip, scenario }) => {
+    async ({ arch, tooltip, scenario, label }) => {
       const user = userEvent.setup();
 
       const {
@@ -512,6 +529,7 @@ describe('HanaClusterDetails component', () => {
           clusterType={clusterType}
           cibLastWritten={cibLastWritten}
           sid={sid}
+          additionalSids={[]}
           provider={provider}
           sapSystems={[]}
           details={details}
@@ -519,8 +537,7 @@ describe('HanaClusterDetails component', () => {
           userAbilities={userAbilities}
         />
       );
-
-      const icon = screen.getByText(/HANA Scale Up/i).children.item(0);
+      const icon = screen.getByText(label).children.item(0);
       await user.hover(icon);
       expect(screen.getByText(tooltip, { exact: false })).toBeInTheDocument();
     }
@@ -557,6 +574,7 @@ describe('HanaClusterDetails component', () => {
           clusterType={clusterType}
           cibLastWritten={cibLastWritten}
           sid={sid}
+          additionalSids={[]}
           provider={provider}
           sapSystems={[]}
           details={details}
@@ -603,6 +621,7 @@ describe('HanaClusterDetails component', () => {
           clusterType={clusterType}
           cibLastWritten={cibLastWritten}
           sid={sid}
+          additionalSids={[]}
           provider={provider}
           sapSystems={[]}
           details={details}

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.test.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.test.jsx
@@ -173,6 +173,7 @@ describe('HanaClusterDetails component', () => {
         cibLastWritten={cibLastWritten}
         provider={provider}
         sapSystems={[{ sid }]}
+        sid={sid}
         details={details}
         lastExecution={null}
         userAbilities={userAbilities}
@@ -180,7 +181,6 @@ describe('HanaClusterDetails component', () => {
     );
 
     const sidContainer = screen.getByText('SID').nextSibling;
-
     expect(sidContainer).toHaveTextContent(sid);
     expect(sidContainer.querySelector('a')).toBeNull();
   });

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.test.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.test.jsx
@@ -171,9 +171,8 @@ describe('HanaClusterDetails component', () => {
         hosts={hosts}
         clusterType={clusterType}
         cibLastWritten={cibLastWritten}
-        sid={sid}
         provider={provider}
-        sapSystems={[]}
+        sapSystems={[{ sid }]}
         details={details}
         lastExecution={null}
         userAbilities={userAbilities}
@@ -468,10 +467,20 @@ describe('HanaClusterDetails component', () => {
 
   it.each([
     { arch: 'angi', tooltip: 'Angi architecture' },
-    { arch: 'classic', tooltip: 'Classic architecture' },
+    {
+      arch: 'classic',
+      tooltip: 'Classic architecture',
+      scenario: 'performance_optimized',
+    },
+    {
+      arch: 'classic',
+      tooltip: 'Classic architecture',
+      scenario: 'cost_optimized',
+    },
+    { arch: 'classic', tooltip: 'Classic architecture', scenario: 'unknown' },
   ])(
     'should show cluster type with $arch architecture',
-    async ({ arch, tooltip }) => {
+    async ({ arch, tooltip, scenario }) => {
       const user = userEvent.setup();
 
       const {
@@ -484,7 +493,7 @@ describe('HanaClusterDetails component', () => {
         details,
       } = clusterFactory.build({
         type: 'hana_scale_up',
-        details: { architecture_type: arch },
+        details: { architecture_type: arch, hana_scenario: scenario },
       });
 
       const hosts = hostFactory.buildList(2, { cluster_id: clusterID });
@@ -507,7 +516,7 @@ describe('HanaClusterDetails component', () => {
         />
       );
 
-      const icon = screen.getByText('HANA Scale Up').children.item(0);
+      const icon = screen.getByText(/HANA Scale Up/i).children.item(0);
       await user.hover(icon);
       expect(screen.getByText(tooltip, { exact: false })).toBeInTheDocument();
     }

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.test.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.test.jsx
@@ -466,7 +466,11 @@ describe('HanaClusterDetails component', () => {
   );
 
   it.each([
-    { arch: 'angi', tooltip: 'Angi architecture' },
+    {
+      arch: 'angi',
+      tooltip: 'Angi architecture',
+      scenario: 'performance_optimized',
+    },
     {
       arch: 'classic',
       tooltip: 'Classic architecture',

--- a/assets/js/pages/HostsList/HostsList.jsx
+++ b/assets/js/pages/HostsList/HostsList.jsx
@@ -123,7 +123,7 @@ function HostsList() {
             (instance, index) => {
               const instanceID = getInstanceID(instance);
               return [
-                index > 0 && ', ',
+                index > 0 && <br />,
                 <SapSystemLink
                   key={`${instanceID}-${instance?.id}`}
                   systemType={instance?.type}

--- a/lib/trento/clusters/enums/hana_scenario.ex
+++ b/lib/trento/clusters/enums/hana_scenario.ex
@@ -1,6 +1,6 @@
 defmodule Trento.Clusters.Enums.HanaScenario do
   @moduledoc """
-  Type that represents the supported HANA architecture types.
+  Type that represents the supported HANA scenario types.
   """
 
   use Trento.Support.Enum, values: [:cost_optimized, :performance_optimized, :unknown]

--- a/lib/trento/clusters/enums/hana_scenario.ex
+++ b/lib/trento/clusters/enums/hana_scenario.ex
@@ -1,0 +1,7 @@
+defmodule Trento.Clusters.Enums.HanaScenario do
+  @moduledoc """
+  Type that represents the supported HANA architecture types.
+  """
+
+  use Trento.Support.Enum, values: [:cost_optimized, :performance_optimized, :unknown]
+end

--- a/lib/trento/clusters/value_objects/hana_cluster_details.ex
+++ b/lib/trento/clusters/value_objects/hana_cluster_details.ex
@@ -13,6 +13,7 @@ defmodule Trento.Clusters.ValueObjects.HanaClusterDetails do
   use Trento.Support.Type
 
   require Trento.Clusters.Enums.HanaArchitectureType, as: HanaArchitectureType
+  require Trento.Clusters.Enums.HanaScenario, as: HanaScenario
 
   alias Trento.Clusters.ValueObjects.{
     ClusterResource,
@@ -30,6 +31,7 @@ defmodule Trento.Clusters.ValueObjects.HanaClusterDetails do
     field :sr_health_state, :string
     field :fencing_type, :string
     field :maintenance_mode, :boolean
+    field :hana_scenario, Ecto.Enum, values: HanaScenario.values()
 
     embeds_many :stopped_resources, ClusterResource
     embeds_many :nodes, HanaClusterNode

--- a/lib/trento/clusters/value_objects/hana_cluster_details.ex
+++ b/lib/trento/clusters/value_objects/hana_cluster_details.ex
@@ -24,6 +24,7 @@ defmodule Trento.Clusters.ValueObjects.HanaClusterDetails do
 
   deftype do
     field :architecture_type, Ecto.Enum, values: HanaArchitectureType.values()
+    field :hana_scenario, Ecto.Enum, values: HanaScenario.values()
     field :system_replication_mode, :string
     field :system_replication_operation_mode, :string
     field :secondary_sync_state, :string
@@ -31,7 +32,6 @@ defmodule Trento.Clusters.ValueObjects.HanaClusterDetails do
     field :sr_health_state, :string
     field :fencing_type, :string
     field :maintenance_mode, :boolean
-    field :hana_scenario, Ecto.Enum, values: HanaScenario.values()
 
     embeds_many :stopped_resources, ClusterResource
     embeds_many :nodes, HanaClusterNode

--- a/lib/trento/discovery/payloads/cluster/cluster_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/cluster/cluster_discovery_payload.ex
@@ -180,7 +180,7 @@ defmodule Trento.Discovery.Payloads.Cluster.ClusterDiscoveryPayload do
          "cluster_type" => ClusterType.hana_scale_up(),
          "cib" => %{"configuration" => %{"resources" => %{"primitives" => primitives}}}
        }),
-       do: primitives |> get_sapinstance_sids()
+       do: get_sapinstance_sids(primitives)
 
   defp parse_cluster_additional_sids(%{
          "cib" => %{"configuration" => %{"resources" => %{"clones" => nil, "groups" => groups}}}

--- a/lib/trento/discovery/payloads/cluster/cluster_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/cluster/cluster_discovery_payload.ex
@@ -222,11 +222,6 @@ defmodule Trento.Discovery.Payloads.Cluster.ClusterDiscoveryPayload do
     |> Enum.uniq()
   end
 
-  defp parse_cluster_additional_sids(%{
-         "cib" => %{"configuration" => %{"resources" => %{"groups" => nil}}}
-       }),
-       do: []
-
   defp parse_cluster_additional_sids(_), do: []
 
   defp maybe_validate_required_fields(cluster, %{"cluster_type" => ClusterType.hana_scale_up()}),

--- a/lib/trento/discovery/policies/cluster_policy.ex
+++ b/lib/trento/discovery/policies/cluster_policy.ex
@@ -224,8 +224,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicy do
       fencing_type: parse_cluster_fencing_type(crmmon, sbd),
       stopped_resources: parse_cluster_stopped_resources(crmmon),
       sbd_devices: parse_sbd_devices(sbd),
-      maintenance_mode: parse_maintenance_mode(cib),
-      hana_scenario: parse_hana_scenario(additional_sids)
+      maintenance_mode: parse_maintenance_mode(cib)
     }
   end
 

--- a/lib/trento/discovery/policies/cluster_policy.ex
+++ b/lib/trento/discovery/policies/cluster_policy.ex
@@ -1036,10 +1036,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicy do
 
   defp parse_hana_scenario(_), do: HanaScenario.unknown()
 
-  defp validate_hana_scenario(crmmon) do
-    # clone_resources = Enum.map(crmmon.clones, fn clone -> clone.resources end)
-    resource = crmmon.resources
-
+  defp validate_hana_scenario(%{resources: resource}) do
     case extract_and_check_resource_id(resource) do
       true -> HanaScenario.cost_optimized()
       false -> HanaScenario.performance_optimized()

--- a/lib/trento/discovery/policies/cluster_policy.ex
+++ b/lib/trento/discovery/policies/cluster_policy.ex
@@ -1027,23 +1027,22 @@ defmodule Trento.Discovery.Policies.ClusterPolicy do
   defp parse_hana_cluster_health(%{sr_health_state: _, secondary_sync_state: _}),
     do: Health.critical()
 
-  defp parse_hana_scenario(crmmon, cluster_type) do
-    case cluster_type do
-      ClusterType.hana_scale_up() -> validate_hana_scenario(crmmon)
-      _ -> HanaScenario.unknown()
-    end
+  defp parse_hana_scenario(crmmon, ClusterType.hana_scale_up()) do
+    validate_hana_scenario(crmmon)
   end
+
+  defp parse_hana_scenario(_crmmon, _cluster_type), do: HanaScenario.unknown()
 
   defp parse_hana_scenario(_), do: HanaScenario.unknown()
 
   defp validate_hana_scenario(%{resources: resource}) do
-    case extract_and_check_resource_id(resource) do
+    case validate_resource_id_for_sap_system(resource) do
       true -> HanaScenario.cost_optimized()
       false -> HanaScenario.performance_optimized()
     end
   end
 
-  defp extract_and_check_resource_id(resource) do
+  defp validate_resource_id_for_sap_system(resource) do
     Enum.any?(resource, fn
       %{id: id} -> String.match?(id, ~r/rsc_SAP/)
     end)

--- a/lib/trento_web/controllers/v1/cluster_json.ex
+++ b/lib/trento_web/controllers/v1/cluster_json.ex
@@ -37,7 +37,7 @@ defmodule TrentoWeb.V1.ClusterJSON do
 
     adapted_details =
       details
-      |> Map.drop([:sites, :maintenance_mode, :architecture_type])
+      |> Map.drop([:sites, :maintenance_mode, :architecture_type, :hana_scenario])
       |> Map.put(:nodes, adapted_nodes)
       |> Map.put(:stopped_resources, adapted_stopped_resources)
 

--- a/lib/trento_web/openapi/v2/schema/cluster.ex
+++ b/lib/trento_web/openapi/v2/schema/cluster.ex
@@ -102,7 +102,7 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
           },
           hana_scenario: %Schema{
             type: :string,
-            description: "Detected hana scenario",
+            description: "Detected HANA scenario",
             enum: HanaScenario.values()
           },
           system_replication_mode: %Schema{type: :string, description: "System Replication Mode"},

--- a/lib/trento_web/openapi/v2/schema/cluster.ex
+++ b/lib/trento_web/openapi/v2/schema/cluster.ex
@@ -102,7 +102,7 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
           },
           hana_scenario: %Schema{
             type: :string,
-            description: "Detected HANA scenario",
+            description: "Detected HANA scenario type",
             enum: HanaScenario.values()
           },
           system_replication_mode: %Schema{type: :string, description: "System Replication Mode"},

--- a/lib/trento_web/openapi/v2/schema/cluster.ex
+++ b/lib/trento_web/openapi/v2/schema/cluster.ex
@@ -5,6 +5,7 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
   require Trento.Clusters.Enums.ClusterType, as: ClusterType
   require Trento.Clusters.Enums.AscsErsClusterRole, as: AscsErsClusterRole
   require Trento.Clusters.Enums.HanaArchitectureType, as: HanaArchitectureType
+  require Trento.Clusters.Enums.HanaScenario, as: HanaScenario
 
   alias OpenApiSpex.Schema
 
@@ -98,6 +99,11 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
             type: :string,
             description: "HANA architecture type.",
             enum: HanaArchitectureType.values()
+          },
+          hana_scenario: %Schema{
+            type: :string,
+            description: "Detected hana scenario",
+            enum: HanaScenario.values()
           },
           system_replication_mode: %Schema{type: :string, description: "System Replication Mode"},
           system_replication_operation_mode: %Schema{

--- a/lib/trento_web/openapi/v2/schema/cluster.ex
+++ b/lib/trento_web/openapi/v2/schema/cluster.ex
@@ -102,7 +102,7 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
           },
           hana_scenario: %Schema{
             type: :string,
-            description: "Detected HANA scenario type",
+            description: "HANA scenario type",
             enum: HanaScenario.values()
           },
           system_replication_mode: %Schema{type: :string, description: "System Replication Mode"},

--- a/test/fixtures/discovery/ha_cluster_discovery_hana_scale_up_cost_opt.json
+++ b/test/fixtures/discovery/ha_cluster_discovery_hana_scale_up_cost_opt.json
@@ -1,0 +1,786 @@
+{    
+    "agent_id": "2372b24f-3d7a-5d01-9b1a-a2c4c95c53d4",
+    "discovery_type": "ha_cluster_discovery",
+    "payload": {
+      "Cib": {
+        "Configuration": {
+          "CrmConfig": {
+            "ClusterProperties": [
+              {
+                "Id": "cib-bootstrap-options-have-watchdog",
+                "Name": "have-watchdog",
+                "Value": "true"
+              },
+              {
+                "Id": "cib-bootstrap-options-dc-version",
+                "Name": "dc-version",
+                "Value": "2.1.2+20211124.ada5c3b36-150400.4.9.2-2.1.2+20211124.ada5c3b36"
+              },
+              {
+                "Id": "cib-bootstrap-options-cluster-infrastructure",
+                "Name": "cluster-infrastructure",
+                "Value": "corosync"
+              },
+              {
+                "Id": "cib-bootstrap-options-cluster-name",
+                "Name": "cluster-name",
+                "Value": "hana_cluster"
+              },
+              {
+                "Id": "cib-bootstrap-options-last-lrm-refresh",
+                "Name": "last-lrm-refresh",
+                "Value": "1724668021"
+              },
+              {
+                "Id": "cib-bootstrap-options-maintenance-mode",
+                "Name": "maintenance-mode",
+                "Value": "false"
+              },
+              {
+                "Id": "cib-bootstrap-options-stonith-enabled",
+                "Name": "stonith-enabled",
+                "Value": "true"
+              },
+              {
+                "Id": "cib-bootstrap-options-stonith-timeout",
+                "Name": "stonith-timeout",
+                "Value": "144"
+              },
+              {
+                "Id": "SAPHanaSR-hana_hdq_site_srHook_SECONDARY_SITE_NAME",
+                "Name": "hana_hdq_site_srHook_SECONDARY_SITE_NAME",
+                "Value": "SOK"
+              },
+              {
+                "Id": "SAPHanaSR-hana_hdq_site_srHook_PRIMARY_SITE_NAME",
+                "Name": "hana_hdq_site_srHook_PRIMARY_SITE_NAME",
+                "Value": "PRIM"
+              }
+            ]
+          },
+          "Nodes": [
+            {
+              "Id": "1",
+              "Uname": "node01",
+              "InstanceAttributes": [
+                {
+                  "Id": "nodes-1-hana_hdq_vhost",
+                  "Name": "hana_hdq_vhost",
+                  "Value": "node01"
+                },
+                {
+                  "Id": "nodes-1-hana_hdq_site",
+                  "Name": "hana_hdq_site",
+                  "Value": "PRIMARY_SITE_NAME"
+                },
+                {
+                  "Id": "nodes-1-lpa_hdq_lpt",
+                  "Name": "lpa_hdq_lpt",
+                  "Value": "1724683939"
+                },
+                {
+                  "Id": "nodes-1-hana_hdq_op_mode",
+                  "Name": "hana_hdq_op_mode",
+                  "Value": "logreplay"
+                },
+                {
+                  "Id": "nodes-1-hana_hdq_srmode",
+                  "Name": "hana_hdq_srmode",
+                  "Value": "sync"
+                },
+                {
+                  "Id": "nodes-1-hana_hdq_remoteHost",
+                  "Name": "hana_hdq_remoteHost",
+                  "Value": "node02"
+                },
+                {
+                  "Id": "nodes-1-maintenance",
+                  "Name": "maintenance",
+                  "Value": "off"
+                }
+              ]
+            },
+            {
+              "Id": "2",
+              "Uname": "node02",
+              "InstanceAttributes": [
+                {
+                  "Id": "nodes-2-lpa_hdq_lpt",
+                  "Name": "lpa_hdq_lpt",
+                  "Value": "30"
+                },
+                {
+                  "Id": "nodes-2-hana_hdq_op_mode",
+                  "Name": "hana_hdq_op_mode",
+                  "Value": "logreplay"
+                },
+                {
+                  "Id": "nodes-2-hana_hdq_vhost",
+                  "Name": "hana_hdq_vhost",
+                  "Value": "node02"
+                },
+                {
+                  "Id": "nodes-2-hana_hdq_remoteHost",
+                  "Name": "hana_hdq_remoteHost",
+                  "Value": "node01"
+                },
+                {
+                  "Id": "nodes-2-hana_hdq_site",
+                  "Name": "hana_hdq_site",
+                  "Value": "SECONDARY_SITE_NAME"
+                },
+                {
+                  "Id": "nodes-2-hana_hdq_srmode",
+                  "Name": "hana_hdq_srmode",
+                  "Value": "sync"
+                }
+              ]
+
+            }
+          ],
+          "Resources": {
+            "Primitives": [
+              {
+                "Class": "stonith",
+                "Id": "stonith-sbd",
+                "InstanceAttributes": [
+                  {
+                    "Id": "stonith-sbd-instance_attributes-pcmk_delay_max",
+                    "Name": "pcmk_delay_max",
+                    "Value": "15"
+                  }
+                ],
+                "MetaAttributes": null,
+                "Operations": [
+                  {
+                    "Id": "stonith-sbd-monitor-15",
+                    "Interval": "15",
+                    "Name": "monitor",
+                    "Role": "",
+                    "Timeout": "15"
+                  }
+                ],
+                "Provider": "",
+                "Type": "external/sbd"
+              },
+              {
+                "Class": "ocf",
+                "Id": "rsc_SAP_QAS_HDB20",
+                "InstanceAttributes": [
+                  {
+                    "Id": "rsc_SAP_QAS_HDB20-instance_attributes-InstanceName",
+                    "Name": "InstanceName",
+                    "Value": "QAS_HDB20_node02"
+                  },
+                  {
+                    "Id": "rsc_SAP_QAS_HDB20-instance_attributes-MONITOR_SERVICES",
+                    "Name": "MONITOR_SERVICES",
+                    "Value": "hdbindexserver|hdbnameserver"
+                  },
+                  {
+                    "Id": "rsc_SAP_QAS_HDB20-instance_attributes-START_PROFILE",
+                    "Name": "START_PROFILE",
+                    "Value": "/usr/sap/QAS/SYS/profile/QAS_HDB20_node02"
+                  }
+                ],
+                "MetaAttributes": null,
+                "Operations": [
+                  {
+                    "Id": "rsc_SAP_QAS_HDB20-start-0",
+                    "Interval": "0",
+                    "Name": "start",
+                    "Role": "",
+                    "Timeout": "600"
+                  },
+                  {
+                    "Id": "rsc_SAP_QAS_HDB20-monitor-120",
+                    "Interval": "120",
+                    "Name": "monitor",
+                    "Role": "",
+                    "Timeout": "700"
+                  },
+                  {
+                    "Id": "rsc_SAP_QAS_HDB20-stop-0",
+                    "Interval": "0",
+                    "Name": "stop",
+                    "Role": "",
+                    "Timeout": "300"
+                  }
+                ],
+                "Provider": "heartbeat",
+                "Type": "SAPInstance"
+              }
+            ],
+            "Clones": [
+              {
+                "Id": "cln_SAPHanaTopology_HDQ_HDB10",
+                "MetaAttributes": [
+                  {
+                    "Id": "cln_SAPHanaTopology_HDQ_HDB10-meta_attributes-clone-node-max",
+                    "Name": "clone-node-max",
+                    "Value": "1"
+                  },
+                  {
+                    "Id": "cln_SAPHanaTopology_HDQ_HDB10-meta_attributes-interleave",
+                    "Name": "interleave",
+                    "Value": "true"
+                  }
+                ],
+                "Primitive": {
+                  "Class": "ocf",
+                  "Id": "rsc_SAPHanaTopology_HDQ_HDB10",
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_SAPHanaTopology_HDQ_HDB10-instance_attributes-SID",
+                      "Name": "SID",
+                      "Value": "HDQ"
+                    },
+                    {
+                      "Id": "rsc_SAPHanaTopology_HDQ_HDB10-instance_attributes-InstanceNumber",
+                      "Name": "InstanceNumber",
+                      "Value": "10"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "Operations": [
+                    {
+                      "Id": "rsc_SAPHanaTopology_HDQ_HDB10-monitor-10",
+                      "Interval": "10",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "600"
+                    },
+                    {
+                      "Id": "rsc_SAPHanaTopology_HDQ_HDB10-start-0",
+                      "Interval": "0",
+                      "Name": "start",
+                      "Role": "",
+                      "Timeout": "600"
+                    },
+                    {
+                      "Id": "rsc_SAPHanaTopology_HDQ_HDB10-stop-0",
+                      "Interval": "0",
+                      "Name": "stop",
+                      "Role": "",
+                      "Timeout": "300"
+                    }
+                  ],
+                  "Type": "SAPHanaTopology"
+                }
+              }
+            ],
+            "Groups": [
+              {
+                "Id": "g_ip_HDQ_HDB10",
+                "Primitives": [
+                  {
+                    "Class": "ocf",
+                    "Id": "rsc_ip_HDQ_HDB10",
+                    "InstanceAttributes": [
+                      {
+                        "Id": "rsc_ip_HDQ_HDB10-instance_attributes-ip",
+                        "Name": "ip",
+                        "Value": "192.168.100.122"
+                      },
+                      {
+                        "Id": "rsc_ip_HDQ_HDB10-instance_attributes-cidr_netmask",
+                        "Name": "cidr_netmask",
+                        "Value": "24"
+                      },
+                      {
+                        "Id": "rsc_ip_HDQ_HDB10-instance_attributes-nic",
+                        "Name": "nic",
+                        "Value": "eth0"
+                      }
+                    ],
+                    "MetaAttributes": [
+                      {
+                        "Id": "rsc_ip_HDQ_HDB10-meta_attributes-maintenance",
+                        "Name": "maintenance",
+                        "Value": "false"
+                      }
+                    ],
+                    "Operations": [
+                      {
+                        "Id": "rsc_ip_HDQ_HDB10-monitor-10s",
+                        "Interval": "10s",
+                        "Name": "monitor",
+                        "Role": "",
+                        "Timeout": "20s"
+                      }
+                    ],
+                    "Provider": "heartbeat",
+                    "Type": "IPaddr2"
+                  },
+                  {
+                    "Class": "ocf",
+                    "Id": "rsc_socat_HDQ_HDB10",
+                    "InstanceAttributes": [
+                      {
+                        "Id": "rsc_socat_HDQ_HDB10-instance_attributes-port",
+                        "Name": "port",
+                        "Value": "99999"
+                      }
+                    ],
+                    "MetaAttributes": [
+                      {
+                        "Id": "rsc_socat_HDQ_HDB10-meta_attributes-resource-stickiness",
+                        "Name": "resource-stickiness",
+                        "Value": "0"
+                      }
+                    ],
+                    "Operations": [
+                      {
+                        "Id": "rsc_socat_HDQ_HDB10-monitor-10",
+                        "Interval": "10",
+                        "Name": "monitor",
+                        "Role": "",
+                        "Timeout": "20"
+                      }
+                    ],
+                    "Provider": "heartbeat",
+                    "Type": "azure-lb"
+                  }
+                ]
+              }
+            ],
+            "Masters": [
+              {
+                "Id": "msl_SAPHana_HDQ_HDB10",
+                "MetaAttributes": [
+                  {
+                    "Id": "msl_SAPHana_HDQ_HDB10-meta_attributes-clone-max",
+                    "Name": "clone-max",
+                    "Value": "2"
+                  },
+                  {
+                    "Id": "msl_SAPHana_HDQ_HDB10-meta_attributes-clone-node-max",
+                    "Name": "clone-node-max",
+                    "Value": "1"
+                  },
+                  {
+                    "Id": "msl_SAPHana_HDQ_HDB10-meta_attributes-interleave",
+                    "Name": "interleave",
+                    "Value": "true"
+                  },
+                  {
+                    "Id": "msl_SAPHana_HDQ_HDB10-meta_attributes-maintenance",
+                    "Name": "maintenance",
+                    "Value": "false"
+                  }
+                ],
+                "Primitive": {
+                  "Class": "ocf",
+                  "Id": "rsc_SAPHana_HDQ_HDB10",
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_SAPHana_HDQ_HDB10-instance_attributes-SID",
+                      "Name": "SID",
+                      "Value": "HDQ"
+                    },
+                    {
+                      "Id": "rsc_SAPHana_HDQ_HDB10-instance_attributes-InstanceNumber",
+                      "Name": "InstanceNumber",
+                      "Value": "10"
+                    },
+                    {
+                      "Id": "rsc_SAPHana_HDQ_HDB10-instance_attributes-PREFER_SITE_TAKEOVER",
+                      "Name": "PREFER_SITE_TAKEOVER",
+                      "Value": "False"
+                    },
+                    {
+                      "Id": "rsc_SAPHana_HDQ_HDB10-instance_attributes-AUTOMATED_REGISTER",
+                      "Name": "AUTOMATED_REGISTER",
+                      "Value": "False"
+                    },
+                    {
+                      "Id": "rsc_SAPHana_HDQ_HDB10-instance_attributes-DUPLICATE_PRIMARY_TIMEOUT",
+                      "Name": "DUPLICATE_PRIMARY_TIMEOUT",
+                      "Value": "7200"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "Operations": [
+                    {
+                      "Id": "rsc_SAPHana_HDQ_HDB10-start-0",
+                      "Interval": "0",
+                      "Name": "start",
+                      "Role": "",
+                      "Timeout": "3600"
+                    },
+                    {
+                      "Id": "rsc_SAPHana_HDQ_HDB10-stop-0",
+                      "Interval": "0",
+                      "Name": "stop",
+                      "Role": "",
+                      "Timeout": "3600"
+                    },
+                    {
+                      "Id": "rsc_SAPHana_HDQ_HDB10-promote-0",
+                      "Interval": "0",
+                      "Name": "promote",
+                      "Role": "",
+                      "Timeout": "3600"
+                    },
+                    {
+                      "Id": "rsc_SAPHana_HDQ_HDB10-monitor-60",
+                      "Interval": "60",
+                      "Name": "monitor",
+                      "Role": "Master",
+                      "Timeout": "700"
+                    },
+                    {
+                      "Id": "rsc_SAPHana_HDQ_HDB10-monitor-61",
+                      "Interval": "61",
+                      "Name": "monitor",
+                      "Role": "Slave",
+                      "Timeout": "700"
+                    }
+                  ],
+                  "Provider": "suse",
+                  "Type": "SAPHana"
+                }
+              }
+            ]
+          },
+          "Constraints": {
+            "RscLocations": [
+              {
+                "Id": "loc_QAS_never_on_node01",
+                "Node": "node01",
+                "Resource": "rsc_SAP_QAS_HDB20",
+                "Role": "",
+                "Score": "-INFINITY"
+              }
+            ]
+          }
+        }
+      },
+      "Crmmon": {
+        "Clones": [
+          {
+            "Failed": false,
+            "FailureIgnored": false,
+            "Id": "msl_SAPHana_HDQ_HDB10",
+            "Managed": true,
+            "MultiState": true,
+            "Resources": [
+              {
+                "Active": true,
+                "Agent": "ocf::suse:SAPHana",
+                "Blocked": false,
+                "Failed": false,
+                "FailureIgnored": false,
+                "Id": "rsc_SAPHana_HDQ_HDB10",
+                "Managed": true,
+                "Node": { "Cached": true, "Id": "2", "Name": "node02" },
+                "NodesRunningOn": 1,
+                "Orphaned": false,
+                "Role": "Slave"
+              },
+              {
+                "Active": true,
+                "Agent": "ocf::suse:SAPHana",
+                "Blocked": false,
+                "Failed": false,
+                "FailureIgnored": false,
+                "Id": "rsc_SAPHana_HDQ_HDB10",
+                "Managed": true,
+                "Node": { "Cached": true, "Id": "1", "Name": "node01" },
+                "NodesRunningOn": 1,
+                "Orphaned": false,
+                "Role": "Master"
+              }
+            ],
+            "Unique": false
+          },
+          {
+            "Failed": false,
+            "FailureIgnored": false,
+            "Id": "cln_SAPHanaTopology_HDQ_HDB10",
+            "Managed": true,
+            "MultiState": false,
+            "Resources": [
+              {
+                "Active": true,
+                "Agent": "ocf::suse:SAPHanaTopology",
+                "Blocked": false,
+                "Failed": false,
+                "FailureIgnored": false,
+                "Id": "rsc_SAPHanaTopology_HDQ_HDB10",
+                "Managed": true,
+                "Node": { "Cached": true, "Id": "2", "Name": "node02" },
+                "NodesRunningOn": 1,
+                "Orphaned": false,
+                "Role": "Started"
+              },
+              {
+                "Active": true,
+                "Agent": "ocf::suse:SAPHanaTopology",
+                "Blocked": false,
+                "Failed": false,
+                "FailureIgnored": false,
+                "Id": "rsc_SAPHanaTopology_HDQ_HDB10",
+                "Managed": true,
+                "Node": { "Cached": true, "Id": "1", "Name": "node01" },
+                "NodesRunningOn": 1,
+                "Orphaned": false,
+                "Role": "Started"
+              }
+            ],
+            "Unique": false
+          }
+        ],
+        "Groups": [
+          {
+            "Id": "g_ip_HDQ_HDB10",
+            "Resources": [
+              {
+                "Active": true,
+                "Agent": "ocf::heartbeat:IPaddr2",
+                "Blocked": false,
+                "Failed": false,
+                "FailureIgnored": false,
+                "Id": "rsc_ip_HDQ_HDB10",
+                "Managed": true,
+                "Node": { "Cached": true, "Id": "1", "Name": "node01" },
+                "NodesRunningOn": 1,
+                "Orphaned": false,
+                "Role": "Started"
+              },
+              {
+                "Active": true,
+                "Agent": "ocf::heartbeat:azure-lb",
+                "Blocked": false,
+                "Failed": false,
+                "FailureIgnored": false,
+                "Id": "rsc_socat_HDQ_HDB10",
+                "Managed": true,
+                "Node": { "Cached": true, "Id": "1", "Name": "node01" },
+                "NodesRunningOn": 1,
+                "Orphaned": false,
+                "Role": "Started"
+              }
+            ]
+          }
+        ],
+        "NodeAttributes": {
+          "Nodes": [
+            {
+              "Attributes": [
+                { "Name": "hana_hdq_clone_state", "Value": "PROMOTED" },
+                { "Name": "hana_hdq_op_mode", "Value": "logreplay" },
+                { "Name": "hana_hdq_remoteHost", "Value": "node02" },
+                {
+                  "Name": "hana_hdq_roles",
+                  "Value": "4:P:master1:master:worker:master"
+                },
+                { "Name": "hana_hdq_site", "Value": "PRIMARY_SITE_NAME" },
+                { "Name": "hana_hdq_sra", "Value": "-" },
+                { "Name": "hana_hdq_srah", "Value": "-" },
+                { "Name": "hana_hdq_srmode", "Value": "sync" },
+                { "Name": "hana_hdq_sync_state", "Value": "PRIM" },
+                { "Name": "hana_hdq_version", "Value": "2.00.057.00" },
+                { "Name": "hana_hdq_vhost", "Value": "node01" },
+                { "Name": "lpa_hdq_lpt", "Value": "1724683939" },
+                { "Name": "maintenance", "Value": "off" },
+                { "Name": "master-rsc_SAPHana_HDQ_HDB10", "Value": "150" }
+              ],
+              "Name": "node01"
+            },
+            {
+              "Attributes": [
+                { "Name": "hana_hdq_clone_state", "Value": "DEMOTED" },
+                { "Name": "hana_hdq_op_mode", "Value": "logreplay" },
+                { "Name": "hana_hdq_remoteHost", "Value": "node01" },
+                {
+                  "Name": "hana_hdq_roles",
+                  "Value": "4:S:master1:master:worker:master"
+                },
+                { "Name": "hana_hdq_site", "Value": "SECONDARY_SITE_NAME" },
+                { "Name": "hana_hdq_srah", "Value": "-" },
+                { "Name": "hana_hdq_srmode", "Value": "sync" },
+                { "Name": "hana_hdq_sync_state", "Value": "SOK" },
+                { "Name": "hana_hdq_version", "Value": "2.00.057.00" },
+                { "Name": "hana_hdq_vhost", "Value": "node02" },
+                { "Name": "lpa_hdq_lpt", "Value": "30" },
+                { "Name": "master-rsc_SAPHana_HDQ_HDB10", "Value": "100" }
+              ],
+              "Name": "node02"
+            }
+          ]
+        },
+        "NodeHistory": {
+          "Nodes": [
+            {
+              "Name": "node02",
+              "ResourceHistory": [
+                {
+                  "FailCount": 0,
+                  "MigrationThreshold": 5000,
+                  "Name": "rsc_ip_HDQ_HDB10"
+                },
+                {
+                  "FailCount": 0,
+                  "MigrationThreshold": 5000,
+                  "Name": "rsc_socat_HDQ_HDB10"
+                },
+                {
+                  "FailCount": 0,
+                  "MigrationThreshold": 5000,
+                  "Name": "rsc_SAPHanaTopology_HDQ_HDB10"
+                },
+                {
+                  "FailCount": 0,
+                  "MigrationThreshold": 5000,
+                  "Name": "rsc_SAPHana_HDQ_HDB10"
+                },
+                {
+                  "FailCount": 0,
+                  "MigrationThreshold": 5000,
+                  "Name": "rsc_SAP_QAS_HDB20"
+                }
+              ]
+            },
+            {
+              "Name": "node01",
+              "ResourceHistory": [
+                {
+                  "FailCount": 0,
+                  "MigrationThreshold": 5000,
+                  "Name": "stonith-sbd"
+                },
+                {
+                  "FailCount": 0,
+                  "MigrationThreshold": 5000,
+                  "Name": "rsc_ip_HDQ_HDB10"
+                },
+                {
+                  "FailCount": 0,
+                  "MigrationThreshold": 5000,
+                  "Name": "rsc_socat_HDQ_HDB10"
+                },
+                {
+                  "FailCount": 0,
+                  "MigrationThreshold": 5000,
+                  "Name": "rsc_SAPHanaTopology_HDQ_HDB10"
+                },
+                {
+                  "FailCount": 0,
+                  "MigrationThreshold": 5000,
+                  "Name": "rsc_SAPHana_HDQ_HDB10"
+                }
+              ]
+            }
+          ]
+        },
+        "Nodes": [
+          {
+            "DC": false,
+            "ExpectedUp": true,
+            "Id": "1",
+            "Maintenance": false,
+            "Name": "node01",
+            "Online": true,
+            "Pending": false,
+            "ResourcesRunning": 5,
+            "Shutdown": false,
+            "Standby": false,
+            "StandbyOnFail": false,
+            "Type": "member",
+            "Unclean": false
+          },
+          {
+            "DC": true,
+            "ExpectedUp": true,
+            "Id": "2",
+            "Maintenance": false,
+            "Name": "node02",
+            "Online": true,
+            "Pending": false,
+            "ResourcesRunning": 3,
+            "Shutdown": false,
+            "Standby": false,
+            "StandbyOnFail": false,
+            "Type": "member",
+            "Unclean": false
+          }
+        ],
+        "Resources": [
+          {
+            "Active": true,
+            "Agent": "stonith:external/sbd",
+            "Blocked": false,
+            "Failed": false,
+            "FailureIgnored": false,
+            "Id": "stonith-sbd",
+            "Managed": true,
+            "Node": { "Cached": true, "Id": "1", "Name": "node01" },
+            "NodesRunningOn": 1,
+            "Orphaned": false,
+            "Role": "Started"
+          },
+          {
+            "Active": true,
+            "Agent": "ocf::heartbeat:SAPInstance",
+            "Blocked": false,
+            "Failed": false,
+            "FailureIgnored": false,
+            "Id": "rsc_SAP_QAS_HDB20",
+            "Managed": true,
+            "Node": { "Cached": true, "Id": "2", "Name": "node02" },
+            "NodesRunningOn": 1,
+            "Orphaned": false,
+            "Role": "Started"
+          }
+        ],
+        "Summary": {
+          "ClusterOptions": { "StonithEnabled": true },
+          "LastChange": { "Time": "Mon Aug 26 14:52:19 2024" },
+          "Nodes": { "Number": 2 },
+          "Resources": { "Blocked": 0, "Disabled": 0, "Number": 8 }
+        },
+        "Version": "2.1.2+20211124.ada5c3b36-150400.4.9.2"
+      },
+      "DC": true,
+      "Id": "81237d528fa520f993b5d6e1cd8e7138",
+      "Name": "hana_cluster",
+      "Provider": "azure",
+      "SBD": {
+        "Config": {
+          "SBD_DELAY_START": "216",
+          "SBD_DEVICE": "/dev/sdj",
+          "SBD_MOVE_TO_ROOT_CGROUP": "auto",
+          "SBD_OPTS": "",
+          "SBD_PACEMAKER": "yes",
+          "SBD_STARTMODE": "always",
+          "SBD_SYNC_RESOURCE_STARTUP": "yes",
+          "SBD_TIMEOUT_ACTION": "flush,reboot",
+          "SBD_WATCHDOG_DEV": "/dev/watchdog",
+          "SBD_WATCHDOG_TIMEOUT": "60"
+        },
+        "Devices": [
+          {
+            "Device": "/dev/sdj",
+            "Dump": {
+              "Header": "2.1",
+              "SectorSize": 512,
+              "Slots": 255,
+              "TimeoutAllocate": 2,
+              "TimeoutLoop": 1,
+              "TimeoutMsgwait": 120,
+              "TimeoutWatchdog": 60,
+              "Uuid": "8845d59a-1c6f-4b00-a575-3ce577805ea5"
+            },
+            "List": [
+              { "Id": 0, "Name": "node01", "Status": "clear" },
+              { "Id": 1, "Name": "node02", "Status": "clear" }
+            ],
+            "Status": "healthy"
+          }
+        ]
+      }
+    }
+
+  }
+  

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -11,6 +11,7 @@ defmodule Trento.Factory do
   require Trento.SoftwareUpdates.Enums.AdvisoryType, as: AdvisoryType
   require Trento.SoftwareUpdates.Enums.SoftwareUpdatesHealth, as: SoftwareUpdatesHealth
   require Trento.ActivityLog.RetentionPeriodUnit, as: RetentionPeriodUnit
+  require Trento.Clusters.Enums.HanaScenario, as: HanaScenario
 
   alias Faker.Random.Elixir, as: RandomElixir
 
@@ -547,6 +548,7 @@ defmodule Trento.Factory do
   def hana_cluster_details_factory do
     %HanaClusterDetails{
       architecture_type: HanaArchitectureType.classic(),
+      hana_scenario: HanaScenario.performance_optimized(),
       fencing_type: "external/sbd",
       maintenance_mode: false,
       nodes: build_list(1, :hana_cluster_node),

--- a/test/trento/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/discovery/policies/cluster_policy_test.exs
@@ -2015,7 +2015,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   cib_last_written: "Thu Feb 23 15:59:56 2023",
                   details: %HanaClusterDetails{
                     architecture_type: HanaArchitectureType.classic(),
-                    hana_scenario: HanaScenario.unknown(),
+                    hana_scenario: HanaScenario.performance_optimized(),
                     system_replication_mode: "syncmem",
                     system_replication_operation_mode: "delta_datashipping",
                     secondary_sync_state: "SOK",
@@ -2289,7 +2289,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   cib_last_written: "Tue Jan 23 12:49:07 2024",
                   details: %HanaClusterDetails{
                     architecture_type: HanaArchitectureType.classic(),
-                    hana_scenario: HanaScenario.unknown(),
+                    hana_scenario: HanaScenario.performance_optimized(),
                     system_replication_mode: "sync",
                     system_replication_operation_mode: "logreplay",
                     secondary_sync_state: "SOK",
@@ -2527,7 +2527,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   cib_last_written: "Thu Feb 23 15:59:56 2023",
                   details: %HanaClusterDetails{
                     architecture_type: HanaArchitectureType.classic(),
-                    hana_scenario: HanaScenario.unknown(),
+                    hana_scenario: HanaScenario.performance_optimized(),
                     system_replication_mode: "syncmem",
                     system_replication_operation_mode: "delta_datashipping",
                     secondary_sync_state: "SOK",
@@ -3035,7 +3035,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                     system_replication_mode: "sync",
                     system_replication_operation_mode: "logreplay",
                     architecture_type: HanaArchitectureType.classic(),
-                    hana_scenario: HanaScenario.unknown()
+                    hana_scenario: HanaScenario.performance_optimized()
                   },
                   discovered_health: :passing,
                   host_id: "6eabc497-6067-4de9-b583-e4c63334ff64",
@@ -3065,7 +3065,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                    designated_controller: true,
                    details: %HanaClusterDetails{
                      architecture_type: HanaArchitectureType.angi(),
-                     hana_scenario: HanaScenario.unknown(),
+                     hana_scenario: HanaScenario.performance_optimized(),
                      fencing_type: "external/sbd",
                      maintenance_mode: false,
                      nodes: [
@@ -3196,7 +3196,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                    designated_controller: true,
                    details: %HanaClusterDetails{
                      architecture_type: HanaArchitectureType.angi(),
-                     hana_scenario: HanaScenario.unknown(),
+                     hana_scenario: HanaScenario.performance_optimized(),
                      fencing_type: "external/sbd",
                      maintenance_mode: false,
                      nodes: [

--- a/test/trento/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/discovery/policies/cluster_policy_test.exs
@@ -284,7 +284,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                 details: %HanaClusterDetails{
                   fencing_type: "external/sbd",
                   maintenance_mode: true,
-                  hana_scenario: HanaScenario.unknown(),
                   nodes: [
                     %HanaClusterNode{
                       attributes: %{

--- a/test/trento/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/discovery/policies/cluster_policy_test.exs
@@ -9,6 +9,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
   require Trento.Enums.Provider, as: Provider
 
   require Trento.Clusters.Enums.HanaArchitectureType, as: HanaArchitectureType
+  require Trento.Clusters.Enums.HanaScenario, as: HanaScenario
 
   alias Trento.Discovery.Policies.ClusterPolicy
 
@@ -254,7 +255,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   ],
                   system_replication_mode: "sync",
                   system_replication_operation_mode: "logreplay",
-                  architecture_type: HanaArchitectureType.classic()
+                  architecture_type: HanaArchitectureType.classic(),
+                  hana_scenario: HanaScenario.performance_optimized()
                 },
                 host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
                 name: "hana_cluster",
@@ -282,6 +284,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                 details: %HanaClusterDetails{
                   fencing_type: "external/sbd",
                   maintenance_mode: true,
+                  hana_scenario: HanaScenario.unknown(),
                   nodes: [
                     %HanaClusterNode{
                       attributes: %{
@@ -504,7 +507,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   ],
                   system_replication_mode: "sync",
                   system_replication_operation_mode: "logreplay",
-                  architecture_type: HanaArchitectureType.classic()
+                  architecture_type: HanaArchitectureType.classic(),
+                  hana_scenario: HanaScenario.performance_optimized()
                 },
                 host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
                 name: "hana_cluster",
@@ -1393,7 +1397,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   stopped_resources: [],
                   system_replication_mode: "sync",
                   system_replication_operation_mode: "logreplay",
-                  architecture_type: HanaArchitectureType.classic()
+                  architecture_type: HanaArchitectureType.classic(),
+                  hana_scenario: HanaScenario.performance_optimized()
                 },
                 discovered_health: :passing,
                 host_id: "a3279fd0-0443-1234-9354-2d7909fd6bc6",
@@ -1562,7 +1567,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   ],
                   system_replication_mode: "sync",
                   system_replication_operation_mode: "logreplay",
-                  architecture_type: HanaArchitectureType.classic()
+                  architecture_type: HanaArchitectureType.classic(),
+                  hana_scenario: HanaScenario.performance_optimized()
                 },
                 discovered_health: :critical,
                 host_id: "1dc79771-0a96-1234-b5b6-cd4d0aef6acc",
@@ -1812,7 +1818,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   ],
                   system_replication_mode: "sync",
                   system_replication_operation_mode: "logreplay",
-                  architecture_type: HanaArchitectureType.classic()
+                  architecture_type: HanaArchitectureType.classic(),
+                  hana_scenario: HanaScenario.performance_optimized()
                 },
                 host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
                 name: nil,
@@ -1839,6 +1846,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                 designated_controller: true,
                 details: %HanaClusterDetails{
                   fencing_type: "Diskless SBD",
+                  hana_scenario: HanaScenario.performance_optimized(),
                   maintenance_mode: false,
                   nodes: [
                     %HanaClusterNode{
@@ -2008,6 +2016,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   cib_last_written: "Thu Feb 23 15:59:56 2023",
                   details: %HanaClusterDetails{
                     architecture_type: HanaArchitectureType.classic(),
+                    hana_scenario: HanaScenario.unknown(),
                     system_replication_mode: "syncmem",
                     system_replication_operation_mode: "delta_datashipping",
                     secondary_sync_state: "SOK",
@@ -2281,6 +2290,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   cib_last_written: "Tue Jan 23 12:49:07 2024",
                   details: %HanaClusterDetails{
                     architecture_type: HanaArchitectureType.classic(),
+                    hana_scenario: HanaScenario.unknown(),
                     system_replication_mode: "sync",
                     system_replication_operation_mode: "logreplay",
                     secondary_sync_state: "SOK",
@@ -2518,6 +2528,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   cib_last_written: "Thu Feb 23 15:59:56 2023",
                   details: %HanaClusterDetails{
                     architecture_type: HanaArchitectureType.classic(),
+                    hana_scenario: HanaScenario.unknown(),
                     system_replication_mode: "syncmem",
                     system_replication_operation_mode: "delta_datashipping",
                     secondary_sync_state: "SOK",
@@ -3024,7 +3035,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                     ],
                     system_replication_mode: "sync",
                     system_replication_operation_mode: "logreplay",
-                    architecture_type: HanaArchitectureType.classic()
+                    architecture_type: HanaArchitectureType.classic(),
+                    hana_scenario: HanaScenario.unknown()
                   },
                   discovered_health: :passing,
                   host_id: "6eabc497-6067-4de9-b583-e4c63334ff64",
@@ -3054,6 +3066,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                    designated_controller: true,
                    details: %HanaClusterDetails{
                      architecture_type: HanaArchitectureType.angi(),
+                     hana_scenario: HanaScenario.unknown(),
                      fencing_type: "external/sbd",
                      maintenance_mode: false,
                      nodes: [
@@ -3184,6 +3197,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                    designated_controller: true,
                    details: %HanaClusterDetails{
                      architecture_type: HanaArchitectureType.angi(),
+                     hana_scenario: HanaScenario.unknown(),
                      fencing_type: "external/sbd",
                      maintenance_mode: false,
                      nodes: [

--- a/test/trento/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/discovery/policies/cluster_policy_test.exs
@@ -525,6 +525,173 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
              |> ClusterPolicy.handle(nil)
   end
 
+  test "should return the expected commands when a ha_cluster_discovery payload of type hana_scale_up with cost optimized scenario is handled" do
+    assert {:ok,
+            [
+              %RegisterClusterHost{
+                cib_last_written: "Mon Aug 26 14:52:19 2024",
+                cluster_id: "ee7ea205-d5cc-5bbd-a345-10cad2aae2d7",
+                designated_controller: true,
+                details: %HanaClusterDetails{
+                  fencing_type: "external/sbd",
+                  maintenance_mode: false,
+                  hana_scenario: HanaScenario.cost_optimized(),
+                  nodes: [
+                    %HanaClusterNode{
+                      attributes: %{
+                        "hana_hdq_clone_state" => "PROMOTED",
+                        "hana_hdq_op_mode" => "logreplay",
+                        "hana_hdq_remoteHost" => "node02",
+                        "hana_hdq_roles" => "4:P:master1:master:worker:master",
+                        "hana_hdq_site" => "PRIMARY_SITE_NAME",
+                        "hana_hdq_sra" => "-",
+                        "hana_hdq_srah" => "-",
+                        "hana_hdq_srmode" => "sync",
+                        "hana_hdq_sync_state" => "PRIM",
+                        "hana_hdq_version" => "2.00.057.00",
+                        "hana_hdq_vhost" => "node01",
+                        "lpa_hdq_lpt" => "1724683939",
+                        "maintenance" => "off",
+                        "master-rsc_SAPHana_HDQ_HDB10" => "150"
+                      },
+                      hana_status: "Primary",
+                      status: "Online",
+                      name: "node01",
+                      nameserver_actual_role: "master",
+                      indexserver_actual_role: "master",
+                      resources: [
+                        %ClusterResource{
+                          fail_count: 0,
+                          id: "stonith-sbd",
+                          role: "Started",
+                          status: "Active",
+                          type: "stonith:external/sbd",
+                          managed: true
+                        },
+                        %ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_SAPHana_HDQ_HDB10",
+                          managed: true,
+                          role: "Master",
+                          status: "Active",
+                          type: "ocf::suse:SAPHana"
+                        },
+                        %ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_SAPHanaTopology_HDQ_HDB10",
+                          managed: true,
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::suse:SAPHanaTopology"
+                        },
+                        %ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_ip_HDQ_HDB10",
+                          managed: true,
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:IPaddr2"
+                        },
+                        %ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_socat_HDQ_HDB10",
+                          managed: true,
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:azure-lb"
+                        }
+                      ],
+                      site: "PRIMARY_SITE_NAME",
+                      virtual_ip: "192.168.100.122"
+                    },
+                    %HanaClusterNode{
+                      attributes: %{
+                        "hana_hdq_clone_state" => "DEMOTED",
+                        "hana_hdq_op_mode" => "logreplay",
+                        "hana_hdq_remoteHost" => "node01",
+                        "hana_hdq_roles" => "4:S:master1:master:worker:master",
+                        "hana_hdq_site" => "SECONDARY_SITE_NAME",
+                        "hana_hdq_srah" => "-",
+                        "hana_hdq_srmode" => "sync",
+                        "hana_hdq_sync_state" => "SOK",
+                        "hana_hdq_version" => "2.00.057.00",
+                        "hana_hdq_vhost" => "node02",
+                        "lpa_hdq_lpt" => "30",
+                        "master-rsc_SAPHana_HDQ_HDB10" => "100"
+                      },
+                      hana_status: "Secondary",
+                      status: "Online",
+                      name: "node02",
+                      indexserver_actual_role: "master",
+                      nameserver_actual_role: "master",
+                      resources: [
+                        %ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_SAP_QAS_HDB20",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::heartbeat:SAPInstance",
+                          managed: true
+                        },
+                        %ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_SAPHana_HDQ_HDB10",
+                          role: "Slave",
+                          status: "Active",
+                          type: "ocf::suse:SAPHana",
+                          managed: true
+                        },
+                        %ClusterResource{
+                          fail_count: 0,
+                          id: "rsc_SAPHanaTopology_HDQ_HDB10",
+                          role: "Started",
+                          status: "Active",
+                          type: "ocf::suse:SAPHanaTopology",
+                          managed: true
+                        }
+                      ],
+                      site: "SECONDARY_SITE_NAME",
+                      virtual_ip: nil
+                    }
+                  ],
+                  sites: [
+                    %HanaClusterSite{
+                      name: "PRIMARY_SITE_NAME",
+                      state: "Primary",
+                      sr_health_state: "4"
+                    },
+                    %HanaClusterSite{
+                      name: "SECONDARY_SITE_NAME",
+                      state: "Secondary",
+                      sr_health_state: "4"
+                    }
+                  ],
+                  sbd_devices: [
+                    %Trento.Clusters.ValueObjects.SbdDevice{device: "/dev/sdj", status: "healthy"}
+                  ],
+                  secondary_sync_state: "SOK",
+                  sr_health_state: "4",
+                  stopped_resources: [],
+                  system_replication_mode: "sync",
+                  system_replication_operation_mode: "logreplay",
+                  architecture_type: HanaArchitectureType.classic()
+                },
+                host_id: "2372b24f-3d7a-5d01-9b1a-a2c4c95c53d4",
+                name: "hana_cluster",
+                sid: "HDQ",
+                additional_sids: ["QAS"],
+                type: :hana_scale_up,
+                hosts_number: 2,
+                resources_number: 8,
+                discovered_health: :passing,
+                provider: Provider.azure()
+              }
+            ]} ==
+             "ha_cluster_discovery_hana_scale_up_cost_opt"
+             |> load_discovery_event_fixture()
+             |> ClusterPolicy.handle(nil)
+  end
+
   test "should return the expected commands when a ha_cluster_discovery payload of type ascs_ers is handled" do
     assert {:ok,
             [

--- a/test/trento_web/views/v1/cluster_view_json_test.exs
+++ b/test/trento_web/views/v1/cluster_view_json_test.exs
@@ -38,6 +38,7 @@ defmodule TrentoWeb.V1.ClusterJSONTest do
       refute Access.get(details, :sites)
       refute Access.get(details, :maintenance_mode)
       refute Access.get(details, :architecture_type)
+      refute Access.get(details, :hana_scenario)
       refute Access.get(node, :nameserver_actual_role)
       refute Access.get(node, :indexserver_actual_role)
       refute Access.get(node, :status)


### PR DESCRIPTION
# Description

This pr now adds a scenario discovery, with this, as a user I can see which HANA scale-up scenario I'm running on a cluster.

Main features.
- Multiple SID's are displayed in ClusterList, HostList, and ClusterDetails view. Links are redirecting to the correct sap database.
- Scenario discovery between Cost Opt. or Perf. Opt.
- Updated factory
- Additional sids in the overview are sorted by alphabet

Note: Scale out and ASCS/ERS untouched.


## Preview

ClusterList view:
![image](https://github.com/user-attachments/assets/1821c028-d5dc-497f-890a-a1a3585658a2)


HostList view: 
![image](https://github.com/user-attachments/assets/7573f5c4-55f3-4a4b-850e-6e10ddd60009)

ClusterDetails View  Cost Opt: 
![image](https://github.com/user-attachments/assets/c9a50511-54f1-4da5-b497-be11ff557217)

ClusterDetails View  Perf. Opt.
![image](https://github.com/user-attachments/assets/a09be3de-af84-43a9-9ef8-23a317cb3f1d)


## How was this tested?

- Fixed existing tests
- Added frontend tests
- Added backend test for scale up scenario with payload
- Fixed brocken storybook stories and added new scenarios