### PR TITLE
Omit an unnecessary query when requesting cluster checks execution

### DIFF
--- a/lib/trento/clusters.ex
+++ b/lib/trento/clusters.ex
@@ -148,23 +148,6 @@ defmodule Trento.Clusters do
     |> select_merge([c, e], %{cib_last_written: e.cib_last_written})
   end
 
-  defp get_filesystem_type(%ClusterReadModel{} = cluster) do
-    filesystems_list =
-      cluster
-      |> Map.get(:details, %{})
-      |> Map.get("sap_systems", [])
-      |> Enum.map(fn %{"filesystem_resource_based" => filesystem_resource_based} ->
-        filesystem_resource_based
-      end)
-      |> Enum.uniq()
-
-    case filesystems_list do
-      [true] -> FilesystemType.resource_managed()
-      [false] -> FilesystemType.simple_mount()
-      _ -> FilesystemType.mixed_fs_types()
-    end
-  end
-
   defp maybe_request_checks_execution(%ClusterReadModel{selected_checks: []}),
     do: {:error, :no_checks_selected}
 
@@ -242,6 +225,23 @@ defmodule Trento.Clusters do
   end
 
   defp maybe_request_checks_execution(error), do: error
+
+  defp get_filesystem_type(%ClusterReadModel{} = cluster) do
+    filesystems_list =
+      cluster
+      |> Map.get(:details, %{})
+      |> Map.get("sap_systems", [])
+      |> Enum.map(fn %{"filesystem_resource_based" => filesystem_resource_based} ->
+        filesystem_resource_based
+      end)
+      |> Enum.uniq()
+
+    case filesystems_list do
+      [true] -> FilesystemType.resource_managed()
+      [false] -> FilesystemType.simple_mount()
+      _ -> FilesystemType.mixed_fs_types()
+    end
+  end
 
   @spec get_cluster_ensa_version([String.t()]) :: ClusterEnsaVersion.t()
   defp get_cluster_ensa_version(sap_system_ids) do


### PR DESCRIPTION
# Description

Just a tiny adjustment removing an unnecessary query when requesting a checks execution for ascs/ers clusters.
