### PR TITLE
requiring target's selectable checks

### DIFF
--- a/lib/trento_web/controllers/v1/cluster_controller.ex
+++ b/lib/trento_web/controllers/v1/cluster_controller.ex
@@ -89,5 +89,25 @@ defmodule TrentoWeb.V1.ClusterController do
     end
   end
 
+  operation :list_selectable_checks,
+    summary: "List Selectable Checks for a Cluster",
+    tags: ["Checks"],
+    description: "List the Checks that can be selected for the cluster",
+    parameters: [
+      cluster_id: [
+        in: :path,
+        required: true,
+        type: %OpenApiSpex.Schema{type: :string, format: :uuid}
+      ]
+    ]
+
+  def list_selectable_checks(conn, %{cluster_id: cluster_id}) do
+    with {:ok, checks} <- Clusters.list_selectable_checks(cluster_id) do
+      conn
+      |> put_status(:ok)
+      |> json(checks)
+    end
+  end
+
   def get_policy_resource(_), do: Trento.Clusters.Projections.ClusterReadModel
 end

--- a/lib/trento_web/controllers/v1/host_controller.ex
+++ b/lib/trento_web/controllers/v1/host_controller.ex
@@ -143,5 +143,25 @@ defmodule TrentoWeb.V1.HostController do
     end
   end
 
+  operation :list_selectable_checks,
+    summary: "List Selectable Checks for a Host",
+    tags: ["Checks"],
+    description: "List the Checks that can be selected for the host",
+    parameters: [
+      id: [
+        in: :path,
+        required: true,
+        type: %OpenApiSpex.Schema{type: :string, format: :uuid}
+      ]
+    ]
+
+  def list_selectable_checks(conn, %{id: host_id}) do
+    with {:ok, checks} <- Hosts.list_selectable_checks(host_id) do
+      conn
+      |> put_status(:ok)
+      |> json(checks)
+    end
+  end
+
   def get_policy_resource(_), do: Trento.Hosts.Projections.HostReadModel
 end

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -113,9 +113,17 @@ defmodule TrentoWeb.Router do
       post "/clusters/:cluster_id/checks", ClusterController, :select_checks
       post "/hosts/:id/checks", HostController, :select_checks
 
+      get "/clusters/:cluster_id/available_checks",
+          ClusterController,
+          :list_selectable_checks
+
       post "/clusters/:cluster_id/checks/request_execution",
            ClusterController,
            :request_checks_execution
+
+      get "/hosts/:id/available_checks",
+          HostController,
+          :list_selectable_checks
 
       post "/hosts/:id/checks/request_execution",
            HostController,


### PR DESCRIPTION
# Description

During hackweek I attempted implementing a TUI (`trentoctl`) to interact with Trento.

I wanted to be able to:
- list hosts/clusters
- select an entry
- show selectable checks for such entry
- select desired checks
- issue a checks execution

Now, besides the fanciness and challenges of implementing a tui in rust and https://ratatui.rs/, it is mainly a matter of integrating with Trento APIs: serialize/deserialize json, making http requests, checking responses... pretty common things.

---

Let's focus on: **showing selectable checks for a target**

In order to answer the question _which are the selectable checks for a given target (cluster/host)?_ we need to query Wanda's catalog API with a specific set of parameters based on the target for which we are querying selectable checks.

For a host we need just a provider, while for a cluster we need its type, the architecture type if hana scale up or hana scale out, while we need ensa version and filesystem type when talking about an ascs/ers cluster...

This sounds like delegating too much to integrating clients (logic leakage), and leads to a lot of boilerplate code to achieve a well known outcome like _the selectable checks for a given target (cluster/host/maybemorecomingnext)_.

As someone integrating with trento I'd find it useful having something more straightforward to interact with in order to get that information.

Here is where I was considering the option of having two endpoints in trento doing this
- GET `/clusters/:cluster_id/available_checks`
- GET `/hosts/:id/available_checks`

What I like about this option:
- simplifies integrating with checks execution process within trento context
- reduces cognitive overhead of who integrates
- reduces logic duplication and possibility for errors
- allows for frontend code simplification

What I don't like much:
- proxy controller towards wanda (which anyway is what we do with SUMA integration)

Note that wanda as such remains untouched in it's agnosticism.

Happy to hear thoughts. If the team agrees on this approach the implementation will be finalized.