### PR TITLE
Activity log autorefresh

### DIFF
--- a/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.jsx
+++ b/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.jsx
@@ -29,7 +29,7 @@ function TimeSpan({ time: initialTime, error = false, onChange = noop }) {
 
   return (
     <div className="flex items-center space-x-2">
-      <div className="w-1/4 pt-1">
+      <div className="w-1/4">
         <InputNumber
           value={time.value}
           className="!h-8"

--- a/assets/js/common/ApiKeySettingsModal/ApiKeySettingsModal.jsx
+++ b/assets/js/common/ApiKeySettingsModal/ApiKeySettingsModal.jsx
@@ -136,7 +136,7 @@ function ApiKeySettingsModal({
                 <Label>Key Expiration</Label>
               </div>
 
-              <div className="w-2/4 pt-1">
+              <div className="w-2/4">
                 <InputNumber
                   value={timeQuantity}
                   className="!h-8"

--- a/assets/js/common/ComposedFilter/ComposedFilter.jsx
+++ b/assets/js/common/ComposedFilter/ComposedFilter.jsx
@@ -92,7 +92,7 @@ function ComposedFilter({
                 onChange(value);
               }}
             >
-              Apply Filter
+              Apply Filters
             </Button>
             <Button
               type="primary-white"

--- a/assets/js/common/ComposedFilter/ComposedFilter.jsx
+++ b/assets/js/common/ComposedFilter/ComposedFilter.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import classNames from 'classnames';
 import { EOS_SEARCH } from 'eos-icons-react';
 import Button from '@common/Button';
 import Input from '@common/Input';
@@ -40,6 +41,7 @@ const renderFilter = (key, { type, ...filterProps }, value, onChange) => {
  * Filters are specified through a list of objects, each containing the filter properties.
  * The value of the composed filter is an object with the filter key as key and the selected value as value.
  *
+ * @param {String} props.className - Additional classes to apply to the component
  * @param {Array} props.filters - List of filters to be composed. Filters are displayed in order.
  * @param {Object} props.value - Key/value pairs of selected filters, where key is the filter key
  * @param {Function} props.onChange - Function to call when the composed value changes. If autoApply is true, this function is called on every filter change
@@ -47,6 +49,7 @@ const renderFilter = (key, { type, ...filterProps }, value, onChange) => {
  * @param {ReactNode} props.children - Additional elements to display after the filters
  */
 function ComposedFilter({
+  className,
   filters = [],
   onChange,
   value: initialValue = {},
@@ -70,35 +73,39 @@ function ComposedFilter({
   }, [JSON.stringify(initialValue)]);
 
   return (
-    <div className="grid grid-flow-col gap-4">
+    <div className={classNames('grid grid-flow-col gap-4', className)}>
       {filters
         .map(({ key, ...rest }) => [key, rest, value[key], onFilterChange(key)])
         .map((args) => renderFilter(...args))}
       {!autoApply && (
-        <div className="grid grid-rows-subgrid gap-4 row-span-2">
-          <Button
-            className="col-span-1"
-            disabled={!isChanged}
-            onClick={() => {
-              setIsChanged(false);
-              onChange(value);
-            }}
-          >
-            Apply
-          </Button>
-          <Button
-            className="col-span-1"
-            type="primary-white"
-            onClick={() => {
-              setValue({});
-              setIsChanged(false);
-              onChange({});
-            }}
-          >
-            Reset
-          </Button>
-          {children}
-        </div>
+        <>
+          {children && (
+            <div className="grid grid-rows-subgrid gap-4 grid-flow-col grid-cols-2">
+              {children}
+            </div>
+          )}
+          <div className="grid grid-rows-subgrid gap-4 grid-flow-col grid-cols-2">
+            <Button
+              disabled={!isChanged}
+              onClick={() => {
+                setIsChanged(false);
+                onChange(value);
+              }}
+            >
+              Apply Filter
+            </Button>
+            <Button
+              type="primary-white"
+              onClick={() => {
+                setValue({});
+                setIsChanged(false);
+                onChange({});
+              }}
+            >
+              Reset Filters
+            </Button>
+          </div>
+        </>
       )}
     </div>
   );

--- a/assets/js/common/ComposedFilter/ComposedFilter.test.jsx
+++ b/assets/js/common/ComposedFilter/ComposedFilter.test.jsx
@@ -245,7 +245,7 @@ describe('ComposedFilter component', () => {
     expect(mockOnChange).not.toHaveBeenCalled();
 
     // apply
-    await act(() => userEvent.click(screen.getByText('Apply')));
+    await act(() => userEvent.click(screen.getByText('Apply Filter')));
 
     // after apply
     expect(mockOnChange).toHaveBeenCalledTimes(1);
@@ -300,7 +300,7 @@ describe('ComposedFilter component', () => {
       )
     );
 
-    await act(() => userEvent.click(screen.getByText('Reset')));
+    await act(() => userEvent.click(screen.getByText('Reset Filters')));
 
     expect(mockOnChange).toHaveBeenCalledTimes(1);
     expect(mockOnChange).toHaveBeenCalledWith({});

--- a/assets/js/common/ComposedFilter/ComposedFilter.test.jsx
+++ b/assets/js/common/ComposedFilter/ComposedFilter.test.jsx
@@ -245,7 +245,7 @@ describe('ComposedFilter component', () => {
     expect(mockOnChange).not.toHaveBeenCalled();
 
     // apply
-    await act(() => userEvent.click(screen.getByText('Apply Filter')));
+    await act(() => userEvent.click(screen.getByText('Apply Filters')));
 
     // after apply
     expect(mockOnChange).toHaveBeenCalledTimes(1);

--- a/assets/js/common/Select/Select.jsx
+++ b/assets/js/common/Select/Select.jsx
@@ -20,6 +20,7 @@ function Select({
   className,
   disabled = false,
   optionsListPosition = '',
+  selectedItemPrefix = null,
 }) {
   const enrichedOptions = options.map((option) => ({
     value: get(option, 'value', option),
@@ -32,77 +33,78 @@ function Select({
   )}-selection-dropdown`;
 
   return (
-    <div className={classNames('flex-2', className)}>
-      <Listbox disabled={disabled} value={value} onChange={onChange}>
-        <div className="relative mt-1">
-          <Listbox.Button
+    <Listbox
+      className={classNames('flex-2', className)}
+      disabled={disabled}
+      value={value}
+      onChange={onChange}
+    >
+      <div className="relative">
+        <Listbox.Button
+          className={classNames(
+            dropdownSelector,
+            'relative w-full py-2 px-3 text-left bg-white rounded cursor-default border border-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-opacity-75 focus-visible:ring-white focus-visible:ring-offset-orange-300 focus-visible:ring-offset-2 focus-visible:border-indigo-500 sm:text-sm disabled:bg-gray-50 disabled:text-gray-400 h-full'
+          )}
+        >
+          {selectedItemPrefix}
+          {renderOption(selectedOption)}
+          <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
+            <ChevronUpDownIcon
+              className="w-5 h-5 text-gray-400"
+              aria-hidden="true"
+            />
+          </span>
+        </Listbox.Button>
+        <Transition
+          as={Fragment}
+          leave="transition ease-in duration-100"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <Listbox.Options
             className={classNames(
-              dropdownSelector,
-              'relative w-full py-2 px-3 text-left bg-white rounded-lg cursor-default border border-gray-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-opacity-75 focus-visible:ring-white focus-visible:ring-offset-orange-300 focus-visible:ring-offset-2 focus-visible:border-indigo-500 sm:text-sm disabled:bg-gray-50 disabled:text-gray-400'
+              'absolute w-full py-1 mt-1 overflow-auto text-base bg-white rounded-md shadow-lg max-h-60 ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm z-40',
+              {
+                'bottom-11': optionsListPosition === 'top',
+              }
             )}
           >
-            {renderOption(selectedOption)}
-            <span className="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
-              <ChevronUpDownIcon
-                className="w-5 h-5 text-gray-400"
-                aria-hidden="true"
-              />
-            </span>
-          </Listbox.Button>
-          <Transition
-            as={Fragment}
-            leave="transition ease-in duration-100"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-          >
-            <Listbox.Options
-              className={classNames(
-                'absolute w-full py-1 mt-1 overflow-auto text-base bg-white rounded-md shadow-lg max-h-60 ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm z-40',
-                {
-                  'bottom-11': optionsListPosition === 'top',
+            {enrichedOptions.map((option) => (
+              <Listbox.Option
+                key={option.value}
+                className={({ active, disabled: optionDisabled }) =>
+                  classNames('cursor-default select-none relative py-2 px-3', {
+                    'text-gray-400': optionDisabled,
+                    'text-green-900 bg-green-100': active,
+                    'text-gray-900': !optionDisabled && !active,
+                  })
                 }
-              )}
-            >
-              {enrichedOptions.map((option) => (
-                <Listbox.Option
-                  key={option.value}
-                  className={({ active, disabled: optionDisabled }) =>
-                    classNames(
-                      'cursor-default select-none relative py-2 px-3',
-                      {
-                        'text-gray-400': optionDisabled,
-                        'text-green-900 bg-green-100': active,
-                        'text-gray-900': !optionDisabled && !active,
-                      }
-                    )
-                  }
-                  value={option.value}
-                  disabled={option.disabled}
-                >
-                  {({ selected: isSelected }) => (
-                    <>
-                      <span
-                        className={classNames('block', 'truncate', {
-                          'font-medium': isSelected,
-                          'font-normal': !isSelected,
-                        })}
-                      >
-                        {renderOption(option)}
+                value={option.value}
+                disabled={option.disabled}
+              >
+                {({ selected: isSelected }) => (
+                  <>
+                    <span
+                      className={classNames('block', 'truncate', {
+                        'font-medium': isSelected,
+                        'font-normal': !isSelected,
+                      })}
+                    >
+                      {renderOption(option)}
+                    </span>
+                    {isSelected ? (
+                      <span className="absolute inset-y-0 right-2 end-1 flex items-center pl-3 text-green-600">
+                        <CheckIcon className="w-5 h-5" aria-hidden="true" />
                       </span>
-                      {isSelected ? (
-                        <span className="absolute inset-y-0 right-2 end-1 flex items-center pl-3 text-green-600">
-                          <CheckIcon className="w-5 h-5" aria-hidden="true" />
-                        </span>
-                      ) : null}
-                    </>
-                  )}
-                </Listbox.Option>
-              ))}
-            </Listbox.Options>
-          </Transition>
-        </div>
-      </Listbox>
-    </div>
+                    ) : null}
+                  </>
+                )}
+              </Listbox.Option>
+            ))}
+          </Listbox.Options>
+        </Transition>
+      </div>
+    </Listbox>
   );
 }
 

--- a/assets/js/common/Select/Select.stories.jsx
+++ b/assets/js/common/Select/Select.stories.jsx
@@ -139,3 +139,10 @@ export const Disabled = {
     disabled: true,
   },
 };
+
+export const WithSelectedItemPrefix = {
+  args: {
+    ...Default.args,
+    selectedItemPrefix: '👉 ',
+  },
+};

--- a/assets/js/pages/ActivityLogPage/ActivityLogPage.test.jsx
+++ b/assets/js/pages/ActivityLogPage/ActivityLogPage.test.jsx
@@ -42,7 +42,7 @@ describe('ActivityLogPage', () => {
   it('should render actions', async () => {
     const [StatefulActivityLogPage, _] = withDefaultState(<ActivityLogPage />);
     await act(() => renderWithRouter(StatefulActivityLogPage));
-    expect(screen.getByText('Apply Filter')).toBeVisible();
+    expect(screen.getByText('Apply Filters')).toBeVisible();
     expect(screen.getByText('Reset Filters')).toBeVisible();
     expect(screen.getByText('Refresh')).toBeVisible();
     // Autorefresh is off by default

--- a/assets/js/pages/ActivityLogPage/ActivityLogPage.test.jsx
+++ b/assets/js/pages/ActivityLogPage/ActivityLogPage.test.jsx
@@ -42,8 +42,8 @@ describe('ActivityLogPage', () => {
   it('should render filter actions', async () => {
     const [StatefulActivityLogPage, _] = withDefaultState(<ActivityLogPage />);
     await act(() => renderWithRouter(StatefulActivityLogPage));
-    expect(screen.getByText('Apply')).toBeVisible();
-    expect(screen.getByText('Reset')).toBeVisible();
+    expect(screen.getByText('Apply Filter')).toBeVisible();
+    expect(screen.getByText('Reset Filters')).toBeVisible();
     expect(screen.getByText('Refresh')).toBeVisible();
   });
 

--- a/assets/js/pages/ActivityLogPage/autorefresh.js
+++ b/assets/js/pages/ActivityLogPage/autorefresh.js
@@ -1,0 +1,50 @@
+const second = 1 * 1000;
+const minute = 60 * second;
+
+export const refreshRateOptions = [
+  'off',
+  5 * second,
+  10 * second,
+  30 * second,
+  1 * minute,
+  5 * minute,
+  30 * minute,
+];
+
+export const refreshRateOptionsToLabel = {
+  off: `Off`,
+  [5 * second]: '5s',
+  [10 * second]: '10s',
+  [30 * second]: '30s',
+  [1 * minute]: '1m',
+  [5 * minute]: '5m',
+  [30 * minute]: '30m',
+};
+
+export const detectRefreshRate = (number) =>
+  refreshRateOptions.includes(Number(number))
+    ? Number(number)
+    : refreshRateOptions[0];
+
+export const addRefreshRateToSearchParams = (searchParams, refreshRate) => {
+  searchParams.set('refreshRate', refreshRate);
+  return searchParams;
+};
+
+export const removeRefreshRateFromSearchParams = (searchParams) => {
+  searchParams.delete('refreshRate');
+  return searchParams;
+};
+
+export const resetAutorefresh = (currentInterval, operation, refreshRate) => {
+  clearInterval(currentInterval);
+
+  const detectedRefreshRate = detectRefreshRate(refreshRate);
+
+  const interval =
+    detectedRefreshRate !== 'off'
+      ? setInterval(operation, detectedRefreshRate)
+      : null;
+
+  return { interval, cleanup: () => clearInterval(interval) };
+};

--- a/assets/js/pages/ActivityLogPage/autorefresh.test.js
+++ b/assets/js/pages/ActivityLogPage/autorefresh.test.js
@@ -1,0 +1,120 @@
+import { noop } from 'lodash';
+import {
+  addRefreshRateToSearchParams,
+  detectRefreshRate,
+  removeRefreshRateFromSearchParams,
+  resetAutorefresh,
+} from './autorefresh';
+
+jest.useFakeTimers();
+
+describe('Autorefresh', () => {
+  it.each`
+    input        | expectedDetection
+    ${1}         | ${'off'}
+    ${null}      | ${'off'}
+    ${undefined} | ${'off'}
+    ${'off'}     | ${'off'}
+    ${5000}      | ${5000}
+    ${10000}     | ${10000}
+    ${30000}     | ${30000}
+    ${60000}     | ${60000}
+    ${300000}    | ${300000}
+    ${1800000}   | ${1800000}
+    ${'5000'}    | ${5000}
+    ${'10000'}   | ${10000}
+    ${'30000'}   | ${30000}
+    ${'60000'}   | ${60000}
+    ${'300000'}  | ${300000}
+    ${'1800000'} | ${1800000}
+  `('should detect refresh rate', ({ input, expectedDetection }) => {
+    const detectedRefreshRate = detectRefreshRate(input);
+    expect(detectedRefreshRate).toEqual(expectedDetection);
+  });
+
+  it.each`
+    initialParams                 | expectation
+    ${{ foo: 'bar', baz: 'qux' }} | ${[['foo', 'bar'], ['baz', 'qux'], ['refreshRate', '10']]}
+    ${{}}                         | ${[['refreshRate', '10']]}
+  `(
+    'should add the autorefresh rate to the search params',
+    ({ initialParams, expectation }) => {
+      const sp = new URLSearchParams(initialParams);
+
+      const result = addRefreshRateToSearchParams(sp, '10');
+
+      expect(Array.from(result)).toEqual(expectation);
+    }
+  );
+
+  it.each`
+    initialParams                                    | expectation
+    ${{ foo: 'bar', baz: 'qux' }}                    | ${[['foo', 'bar'], ['baz', 'qux']]}
+    ${{ foo: 'bar', baz: 'qux', refreshRate: '10' }} | ${[['foo', 'bar'], ['baz', 'qux']]}
+    ${{}}                                            | ${[]}
+  `(
+    'should remove the autorefresh rate to the search params',
+    ({ initialParams, expectation }) => {
+      const sp = new URLSearchParams(initialParams);
+
+      const result = removeRefreshRateFromSearchParams(sp);
+
+      expect(Array.from(result)).toEqual(expectation);
+    }
+  );
+
+  describe('resetting autorefresh interval', () => {
+    it('should return null when refresh rate is unsupported', () => {
+      const operation = jest.fn();
+
+      const { interval } = resetAutorefresh(null, operation, '50');
+
+      expect(interval).toBeNull();
+
+      jest.advanceTimersByTime(5000 * 6);
+      expect(operation).not.toHaveBeenCalled();
+    });
+
+    it('should clear a previously set inteval', () => {
+      const operation = jest.fn();
+
+      const previousInterval = setInterval(operation, 5000);
+      expect(previousInterval).not.toBeNull();
+
+      jest.advanceTimersByTime(5000 * 4);
+      expect(operation).toHaveBeenCalledTimes(4);
+
+      resetAutorefresh(previousInterval, noop, '5000');
+
+      // with time passing by the operation should not be called, except for the initial 4 times
+      jest.advanceTimersByTime(5000 * 6);
+      expect(operation).toHaveBeenCalledTimes(4);
+    });
+
+    it('should reset autorefresh interval', () => {
+      const operation = jest.fn();
+
+      resetAutorefresh(null, operation, '5000');
+
+      expect(operation).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(5000 * 6);
+      expect(operation).toHaveBeenCalledTimes(6);
+    });
+
+    it('should return a cleanup function for the autorefresh interval', () => {
+      const operation = jest.fn();
+
+      const { cleanup } = resetAutorefresh(null, operation, '5000');
+
+      jest.advanceTimersByTime(5000 * 6);
+      expect(operation).toHaveBeenCalledTimes(6);
+
+      cleanup();
+
+      jest.advanceTimersByTime(5000 * 10);
+      // operation should not be called after cleanup
+      expect(operation).toHaveBeenCalledTimes(6);
+    });
+  });
+});

--- a/assets/js/pages/ActivityLogPage/searchParams.js
+++ b/assets/js/pages/ActivityLogPage/searchParams.js
@@ -15,6 +15,7 @@ const omitUndefined = (obj) =>
 
 const paginationFields = ['after', 'before', 'first', 'last'];
 const scalarKeys = [...paginationFields, 'search'];
+const ignoreKeys = ['refreshRate'];
 
 const searchParamsToEntries = (searchParams) =>
   pipe(Array.from, uniq, (keys) =>
@@ -36,12 +37,19 @@ const entriesToSearchParams = (entries) =>
       }, new URLSearchParams())
     : new URLSearchParams();
 
+const ignoreIrrelevantEntries = pipe(
+  Object.fromEntries,
+  omit(ignoreKeys),
+  Object.entries
+);
+
 /**
  * Convert a search params object to an API params object as expected by the API client
  * Make the necessary transformations to the values before setting them in the search params
  */
 export const searchParamsToAPIParams = pipe(
   searchParamsToEntries,
+  ignoreIrrelevantEntries,
   map(([key, value]) => {
     switch (key) {
       case 'from_date':

--- a/assets/js/pages/ActivityLogPage/searchParams.test.js
+++ b/assets/js/pages/ActivityLogPage/searchParams.test.js
@@ -25,6 +25,16 @@ describe('searchParams helpers', () => {
         search: 'foo+bar',
       });
     });
+
+    it('should ignore irrelevant entries', () => {
+      const sp = new URLSearchParams();
+      sp.append('search', 'foo+bar');
+      sp.append('refreshRate', '5000');
+
+      const result = searchParamsToAPIParams(sp);
+
+      expect(result).toEqual({ search: 'foo+bar' });
+    });
   });
 
   describe('searchParamsToFilterValue', () => {

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -103,7 +103,7 @@ context('Activity Log page', () => {
 
       cy.get('input[name="metadata-search"]').type('foo bar');
 
-      cy.contains('Apply').click();
+      cy.contains('Apply Filter').click();
 
       cy.url().should(
         'eq',
@@ -122,7 +122,7 @@ context('Activity Log page', () => {
         '/activity_log?from_date=custom&from_date=2024-08-14T10%3A21%3A00.000Z&type=login_attempt&type=resource_tagging&search=foo+bar'
       );
 
-      cy.contains('Reset').click();
+      cy.contains('Reset Filters').click();
 
       cy.contains('Filter Type', { matchCase: false }).should('be.visible');
       cy.contains('Filter older than', { matchCase: false }).should(
@@ -256,7 +256,7 @@ context('Activity Log page', () => {
 
       cy.contains('Filter Type').click();
       cy.contains('Login Attempt').click();
-      cy.contains('Apply').click();
+      cy.contains('Apply Filter').click();
 
       cy.url().should(
         'eq',

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -103,7 +103,7 @@ context('Activity Log page', () => {
 
       cy.get('input[name="metadata-search"]').type('foo bar');
 
-      cy.contains('Apply Filter').click();
+      cy.contains('Apply Filters').click();
 
       cy.url().should(
         'eq',
@@ -256,7 +256,7 @@ context('Activity Log page', () => {
 
       cy.contains('Filter Type').click();
       cy.contains('Login Attempt').click();
-      cy.contains('Apply Filter').click();
+      cy.contains('Apply Filters').click();
 
       cy.url().should(
         'eq',


### PR DESCRIPTION
# Description

Adds polling-based autorefresh capabilities to the Activity log.

Some side effects required:
- Select component support for a prefix in the selected item c4dfcd2652656d22fe594b22d26772fcf8fad337
- Enhanced ComposedFilter css composability + copy adjustments 45f298aa047342be2166034014a737058ea39b72

The following piece of doc were helpful:
- https://react.dev/reference/react/useEffect#usage
- https://jestjs.io/docs/timer-mocks

## How was this tested?

Automated tests.