### PR TITLE
Use prometheus targets

### DIFF
--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { get, zipWith } from 'lodash';
+import { get, zipWith, startCase } from 'lodash';
 import classNames from 'classnames';
 import {
   EOS_CLEAR_ALL,
@@ -105,7 +105,7 @@ function HostDetails({
         className="self-center ml-4 shadow"
         heartbeat={exporterStatus}
       >
-        {exporterName}
+        {startCase(exporterName)}
       </StatusPill>
     )
   );

--- a/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
@@ -421,4 +421,31 @@ describe('HostDetails component', () => {
       expect(startExecutionButton).toBeEnabled();
     });
   });
+
+  describe('exporters', () => {
+    it.each([
+      {
+        state: 'passing',
+        label: 'running',
+      },
+      {
+        state: 'critical',
+        label: 'not running',
+      },
+    ])('should show exporters state as $state', ({ state, label }) => {
+      renderWithRouter(
+        <HostDetails
+          agentVersion="1.0.0"
+          userAbilities={userAbilities}
+          exportersStatus={{ node_exporter: state }}
+        />
+      );
+
+      expect(
+        screen.getByText(new RegExp(`Node Exporter:.*${label}`), {
+          exact: false,
+        })
+      ).toBeVisible();
+    });
+  });
 });

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,6 +50,8 @@ services:
       - "--web.enable-admin-api"
     ports:
       - 9090:9090
+    extra_hosts:
+      - host.docker.internal:host-gateway
   postgres:
     image: postgres:15
     environment:

--- a/lib/trento/discovery/payloads/host_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/host_discovery_payload.ex
@@ -25,7 +25,7 @@ defmodule Trento.Discovery.Payloads.HostDiscoveryPayload do
     field :socket_count, :integer
     field :os_version, :string
     field :fully_qualified_domain_name, :string
-    field :prometheus_targets, :map, default: %{}
+    field :prometheus_targets, :map
 
     field :installation_source, Ecto.Enum,
       values: [:community, :suse, :unknown],

--- a/lib/trento/discovery/payloads/host_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/host_discovery_payload.ex
@@ -25,6 +25,7 @@ defmodule Trento.Discovery.Payloads.HostDiscoveryPayload do
     field :socket_count, :integer
     field :os_version, :string
     field :fully_qualified_domain_name, :string
+    field :prometheus_targets, :map, default: %{}
 
     field :installation_source, Ecto.Enum,
       values: [:community, :suse, :unknown],

--- a/lib/trento/discovery/policies/host_policy.ex
+++ b/lib/trento/discovery/policies/host_policy.ex
@@ -138,7 +138,8 @@ defmodule Trento.Discovery.Policies.HostPolicy do
            socket_count: socket_count,
            os_version: os_version,
            installation_source: installation_source,
-           fully_qualified_domain_name: fqdn
+           fully_qualified_domain_name: fqdn,
+           prometheus_targets: prometheus_targets
          } = payload
        ),
        do:
@@ -152,7 +153,8 @@ defmodule Trento.Discovery.Policies.HostPolicy do
            socket_count: socket_count,
            os_version: os_version,
            installation_source: installation_source,
-           fully_qualified_domain_name: fqdn
+           fully_qualified_domain_name: fqdn,
+           prometheus_targets: prometheus_targets
          })
 
   defp build_ip_addresses(%{ip_addresses: ip_addresses, netmasks: nil}) do

--- a/lib/trento/hosts/commands/register_host.ex
+++ b/lib/trento/hosts/commands/register_host.ex
@@ -26,6 +26,7 @@ defmodule Trento.Hosts.Commands.RegisterHost do
     field :socket_count, :integer
     field :os_version, :string, default: "Unknown"
     field :fully_qualified_domain_name, :string
+    field :prometheus_targets, :map
 
     field :installation_source, Ecto.Enum, values: [:community, :suse, :unknown]
   end

--- a/lib/trento/hosts/events/host_details_updated.ex
+++ b/lib/trento/hosts/events/host_details_updated.ex
@@ -5,7 +5,7 @@ defmodule Trento.Hosts.Events.HostDetailsUpdated do
 
   use Trento.Support.Event
 
-  defevent version: 3 do
+  defevent version: 4 do
     field :host_id, Ecto.UUID
     field :hostname, :string
     field :fully_qualified_domain_name, :string
@@ -22,5 +22,5 @@ defmodule Trento.Hosts.Events.HostDetailsUpdated do
 
   def upcast(params, _, 2), do: Map.put(params, "installation_source", :unknown)
   def upcast(params, _, 3), do: Map.put(params, "fully_qualified_domain_name", nil)
-  def upcast(params, _, 4), do: Map.put(params, "prometheus_targets", %{})
+  def upcast(params, _, 4), do: Map.put(params, "prometheus_targets", nil)
 end

--- a/lib/trento/hosts/events/host_details_updated.ex
+++ b/lib/trento/hosts/events/host_details_updated.ex
@@ -15,10 +15,12 @@ defmodule Trento.Hosts.Events.HostDetailsUpdated do
     field :total_memory_mb, :integer
     field :socket_count, :integer
     field :os_version, :string
+    field :prometheus_targets, :map
 
     field :installation_source, Ecto.Enum, values: [:community, :suse, :unknown]
   end
 
   def upcast(params, _, 2), do: Map.put(params, "installation_source", :unknown)
   def upcast(params, _, 3), do: Map.put(params, "fully_qualified_domain_name", nil)
+  def upcast(params, _, 4), do: Map.put(params, "prometheus_targets", %{})
 end

--- a/lib/trento/hosts/events/host_registered.ex
+++ b/lib/trento/hosts/events/host_registered.ex
@@ -15,6 +15,7 @@ defmodule Trento.Hosts.Events.HostRegistered do
     field :socket_count, :integer
     field :os_version, :string
     field :fully_qualified_domain_name, :string
+    field :prometheus_targets, :map
 
     field :installation_source, Ecto.Enum, values: [:community, :suse, :unknown]
 
@@ -25,4 +26,5 @@ defmodule Trento.Hosts.Events.HostRegistered do
   def upcast(params, _, 2), do: Map.put(params, "installation_source", :unknown)
   def upcast(params, _, 3), do: Map.put(params, "health", :unknown)
   def upcast(params, _, 4), do: Map.put(params, "fully_qualified_domain_name", nil)
+  def upcast(params, _, 5), do: Map.put(params, "prometheus_targets", %{})
 end

--- a/lib/trento/hosts/events/host_registered.ex
+++ b/lib/trento/hosts/events/host_registered.ex
@@ -5,7 +5,7 @@ defmodule Trento.Hosts.Events.HostRegistered do
 
   use Trento.Support.Event
 
-  defevent version: 4 do
+  defevent version: 5 do
     field :host_id, Ecto.UUID
     field :hostname, :string
     field :ip_addresses, {:array, :string}
@@ -26,5 +26,5 @@ defmodule Trento.Hosts.Events.HostRegistered do
   def upcast(params, _, 2), do: Map.put(params, "installation_source", :unknown)
   def upcast(params, _, 3), do: Map.put(params, "health", :unknown)
   def upcast(params, _, 4), do: Map.put(params, "fully_qualified_domain_name", nil)
-  def upcast(params, _, 5), do: Map.put(params, "prometheus_targets", %{})
+  def upcast(params, _, 5), do: Map.put(params, "prometheus_targets", nil)
 end

--- a/lib/trento/hosts/host.ex
+++ b/lib/trento/hosts/host.ex
@@ -129,7 +129,7 @@ defmodule Trento.Hosts.Host do
     field :socket_count, :integer
     field :os_version, :string
     field :provider, Ecto.Enum, values: Provider.values()
-    field :prometheus_targets, :map, default: %{}
+    field :prometheus_targets, :map
     field :installation_source, Ecto.Enum, values: [:community, :suse, :unknown]
     field :heartbeat, Ecto.Enum, values: [:passing, :critical, :unknown]
     field :checks_health, Ecto.Enum, values: Health.values(), default: Health.unknown()

--- a/lib/trento/hosts/host.ex
+++ b/lib/trento/hosts/host.ex
@@ -129,6 +129,7 @@ defmodule Trento.Hosts.Host do
     field :socket_count, :integer
     field :os_version, :string
     field :provider, Ecto.Enum, values: Provider.values()
+    field :prometheus_targets, :map, default: %{}
     field :installation_source, Ecto.Enum, values: [:community, :suse, :unknown]
     field :heartbeat, Ecto.Enum, values: [:passing, :critical, :unknown]
     field :checks_health, Ecto.Enum, values: Health.values(), default: Health.unknown()
@@ -171,7 +172,8 @@ defmodule Trento.Hosts.Host do
           socket_count: socket_count,
           os_version: os_version,
           fully_qualified_domain_name: fully_qualified_domain_name,
-          installation_source: installation_source
+          installation_source: installation_source,
+          prometheus_targets: prometheus_targets
         }
       ) do
     [
@@ -186,6 +188,7 @@ defmodule Trento.Hosts.Host do
         os_version: os_version,
         installation_source: installation_source,
         fully_qualified_domain_name: fully_qualified_domain_name,
+        prometheus_targets: prometheus_targets,
         heartbeat: :unknown
       }
     ] ++ maybe_emit_software_updates_discovery_events(host_id, nil, fully_qualified_domain_name)
@@ -211,6 +214,7 @@ defmodule Trento.Hosts.Host do
           socket_count: socket_count,
           os_version: os_version,
           fully_qualified_domain_name: fully_qualified_domain_name,
+          prometheus_targets: prometheus_targets,
           installation_source: installation_source,
           deregistered_at: deregistered_at
         },
@@ -223,6 +227,7 @@ defmodule Trento.Hosts.Host do
           socket_count: socket_count,
           os_version: os_version,
           fully_qualified_domain_name: fully_qualified_domain_name,
+          prometheus_targets: prometheus_targets,
           installation_source: installation_source
         }
       )
@@ -246,7 +251,8 @@ defmodule Trento.Hosts.Host do
           socket_count: socket_count,
           os_version: os_version,
           fully_qualified_domain_name: new_fully_qualified_domain_name,
-          installation_source: installation_source
+          installation_source: installation_source,
+          prometheus_targets: prometheus_targets
         }
       )
       when not is_nil(deregistered_at) do
@@ -262,7 +268,8 @@ defmodule Trento.Hosts.Host do
         socket_count: socket_count,
         os_version: os_version,
         fully_qualified_domain_name: new_fully_qualified_domain_name,
-        installation_source: installation_source
+        installation_source: installation_source,
+        prometheus_targets: prometheus_targets
       }
     ] ++
       maybe_emit_software_updates_discovery_events(host_id, nil, new_fully_qualified_domain_name)
@@ -297,7 +304,8 @@ defmodule Trento.Hosts.Host do
           total_memory_mb: total_memory_mb,
           socket_count: socket_count,
           os_version: os_version,
-          installation_source: installation_source
+          installation_source: installation_source,
+          prometheus_targets: prometheus_targets
         },
         %RegisterHost{
           hostname: hostname,
@@ -308,7 +316,8 @@ defmodule Trento.Hosts.Host do
           total_memory_mb: total_memory_mb,
           socket_count: socket_count,
           os_version: os_version,
-          installation_source: installation_source
+          installation_source: installation_source,
+          prometheus_targets: prometheus_targets
         }
       ) do
     []
@@ -328,7 +337,8 @@ defmodule Trento.Hosts.Host do
           total_memory_mb: total_memory_mb,
           socket_count: socket_count,
           os_version: os_version,
-          installation_source: installation_source
+          installation_source: installation_source,
+          prometheus_targets: prometheus_targets
         }
       ) do
     [
@@ -342,7 +352,8 @@ defmodule Trento.Hosts.Host do
         total_memory_mb: total_memory_mb,
         socket_count: socket_count,
         os_version: os_version,
-        installation_source: installation_source
+        installation_source: installation_source,
+        prometheus_targets: prometheus_targets
       }
     ] ++
       maybe_emit_software_updates_discovery_events(
@@ -605,6 +616,7 @@ defmodule Trento.Hosts.Host do
           socket_count: socket_count,
           os_version: os_version,
           fully_qualified_domain_name: fully_qualified_domain_name,
+          prometheus_targets: prometheus_targets,
           installation_source: installation_source,
           heartbeat: heartbeat
         }
@@ -620,6 +632,7 @@ defmodule Trento.Hosts.Host do
         socket_count: socket_count,
         os_version: os_version,
         fully_qualified_domain_name: fully_qualified_domain_name,
+        prometheus_targets: prometheus_targets,
         installation_source: installation_source,
         heartbeat: heartbeat
     }
@@ -636,6 +649,7 @@ defmodule Trento.Hosts.Host do
           socket_count: socket_count,
           os_version: os_version,
           fully_qualified_domain_name: fully_qualified_domain_name,
+          prometheus_targets: prometheus_targets,
           installation_source: installation_source
         }
       ) do
@@ -649,6 +663,7 @@ defmodule Trento.Hosts.Host do
         socket_count: socket_count,
         os_version: os_version,
         fully_qualified_domain_name: fully_qualified_domain_name,
+        prometheus_targets: prometheus_targets,
         installation_source: installation_source
     }
   end

--- a/lib/trento/hosts/projections/host_projector.ex
+++ b/lib/trento/hosts/projections/host_projector.ex
@@ -39,7 +39,8 @@ defmodule Trento.Hosts.Projections.HostProjector do
       ip_addresses: ip_addresses,
       agent_version: agent_version,
       fully_qualified_domain_name: fully_qualified_domain_name,
-      heartbeat: heartbeat
+      heartbeat: heartbeat,
+      prometheus_targets: prometheus_targets
     },
     fn multi ->
       {addresses, netmasks} = parse_address_netmask(ip_addresses)
@@ -51,7 +52,8 @@ defmodule Trento.Hosts.Projections.HostProjector do
           netmasks: netmasks,
           agent_version: agent_version,
           fully_qualified_domain_name: fully_qualified_domain_name,
-          heartbeat: heartbeat
+          heartbeat: heartbeat,
+          prometheus_targets: prometheus_targets
         })
 
       Ecto.Multi.insert(multi, :host, changeset,
@@ -143,7 +145,8 @@ defmodule Trento.Hosts.Projections.HostProjector do
       hostname: hostname,
       ip_addresses: ip_addresses,
       fully_qualified_domain_name: fully_qualified_domain_name,
-      agent_version: agent_version
+      agent_version: agent_version,
+      prometheus_targets: prometheus_targets
     },
     fn multi ->
       {addresses, netmasks} = parse_address_netmask(ip_addresses)
@@ -156,7 +159,8 @@ defmodule Trento.Hosts.Projections.HostProjector do
           ip_addresses: addresses,
           netmasks: netmasks,
           fully_qualified_domain_name: fully_qualified_domain_name,
-          agent_version: agent_version
+          agent_version: agent_version,
+          prometheus_targets: prometheus_targets
         })
 
       Ecto.Multi.update(multi, :host, changeset)

--- a/lib/trento/hosts/projections/host_read_model.ex
+++ b/lib/trento/hosts/projections/host_read_model.ex
@@ -32,6 +32,7 @@ defmodule Trento.Hosts.Projections.HostReadModel do
     field :provider, Ecto.Enum, values: Provider.values()
     field :provider_data, :map
     field :saptune_status, :map
+    field :prometheus_targets, :map
 
     has_many :tags, Tag, foreign_key: :resource_id
 

--- a/lib/trento_web/controllers/v1/host_json.ex
+++ b/lib/trento_web/controllers/v1/host_json.ex
@@ -9,6 +9,7 @@ defmodule TrentoWeb.V1.HostJSON do
     |> Map.from_struct()
     |> Map.put(:sles_subscriptions, sles_subscriptions)
     |> Map.delete(:fully_qualified_domain_name)
+    |> Map.delete(:prometheus_targets)
     |> Map.delete(:__meta__)
   end
 

--- a/lib/trento_web/controllers/v1/prometheus_json.ex
+++ b/lib/trento_web/controllers/v1/prometheus_json.ex
@@ -1,7 +1,26 @@
 defmodule TrentoWeb.V1.PrometheusJSON do
+  @node_exporter_port 9100
+  @node_exporter_name "node_exporter"
+
   def exporters_status(%{status: status}), do: status
 
   def targets(%{targets: targets}), do: Enum.flat_map(targets, &target(%{target: &1}))
+
+  # Support backward compatibility with older agents that don't send prometheus_targets
+  def target(%{
+        target: %{id: id, hostname: hostname, ip_addresses: ip_addresses, prometheus_targets: nil}
+      }) do
+    [
+      %{
+        targets: ["#{List.first(ip_addresses, hostname)}:#{@node_exporter_port}"],
+        labels: %{
+          agentID: "#{id}",
+          hostname: "#{hostname}",
+          exporter_name: @node_exporter_name
+        }
+      }
+    ]
+  end
 
   def target(%{target: %{id: id, hostname: hostname, prometheus_targets: prometheus_targets}}) do
     Enum.map(prometheus_targets, fn {exporter, target} ->

--- a/lib/trento_web/controllers/v1/prometheus_json.ex
+++ b/lib/trento_web/controllers/v1/prometheus_json.ex
@@ -1,19 +1,18 @@
 defmodule TrentoWeb.V1.PrometheusJSON do
-  @node_exporter_port 9100
-  @node_exporter_name "Node Exporter"
-
   def exporters_status(%{status: status}), do: status
 
-  def targets(%{targets: targets}), do: Enum.map(targets, &target(%{target: &1}))
+  def targets(%{targets: targets}), do: Enum.flat_map(targets, &target(%{target: &1}))
 
-  def target(%{target: target}),
-    do: %{
-      targets: ["#{List.first(target.ip_addresses, target.hostname)}:#{@node_exporter_port}"],
-      labels: %{
-        # TODO: in the future renaeme this label which also is used by node_exporter json
-        agentID: "#{target.id}",
-        hostname: "#{target.hostname}",
-        exporter_name: @node_exporter_name
+  def target(%{target: %{id: id, hostname: hostname, prometheus_targets: prometheus_targets}}) do
+    Enum.map(prometheus_targets, fn {exporter, target} ->
+      %{
+        targets: [target],
+        labels: %{
+          agentID: id,
+          hostname: hostname,
+          exporter_name: exporter
+        }
       }
-    }
+    end)
+  end
 end

--- a/priv/repo/migrations/20241127140203_add_prometheus_targets_to_host_read_model.exs
+++ b/priv/repo/migrations/20241127140203_add_prometheus_targets_to_host_read_model.exs
@@ -1,0 +1,9 @@
+defmodule Trento.Repo.Migrations.AddPrometheusTargetsToHostReadModel do
+  use Ecto.Migration
+
+  def change do
+    alter table(:hosts) do
+      add :prometheus_targets, :map
+    end
+  end
+end

--- a/prometheus-dev-config.yml
+++ b/prometheus-dev-config.yml
@@ -13,3 +13,14 @@ scrape_configs:
         labels:
           agentID: "240f96b1-8d26-53b7-9e99-ffb0f2e735bf"
           exporter_name: "Node Exporter"
+
+  - job_name: "http_sd_hosts"
+    honor_timestamps: true
+    scrape_interval: 30s
+    scrape_timeout: 30s
+    scheme: http
+    follow_redirects: true
+    http_sd_configs:
+      - follow_redirects: true
+        refresh_interval: 1m
+        url: http://host.docker.internal:4000/api/prometheus/targets

--- a/test/fixtures/discovery/host_discovery_with_prometheus_targets.json
+++ b/test/fixtures/discovery/host_discovery_with_prometheus_targets.json
@@ -1,0 +1,20 @@
+{
+  "agent_id": "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
+  "discovery_type": "host_discovery",
+  "payload": {
+    "os_version": "15-SP2",
+    "ip_addresses": ["10.1.1.4", "10.1.1.5", "10.1.1.6"],
+    "netmasks": [16, 24, 32],
+    "hostname": "suse",
+    "cpu_count": 2,
+    "socket_count": 1,
+    "total_memory_mb": 4096,
+    "agent_version": "0.1.0",
+    "installation_source": "Community",
+    "fully_qualified_domain_name": "suse.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "prometheus_targets": {
+      "node_exporter": "10.0.0.1:9100",
+      "ha_cluster_exporter": "10.0.0.1:9664"
+    }
+  }
+}

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -163,6 +163,7 @@ defmodule Trento.Factory do
       os_version: Faker.App.semver(),
       fully_qualified_domain_name: Faker.Internet.domain_name(),
       installation_source: Enum.random([:community, :suse, :unknown]),
+      prometheus_targets: build(:host_prometheus_targets),
       heartbeat: :unknown
     }
   end
@@ -178,7 +179,8 @@ defmodule Trento.Factory do
       total_memory_mb: Enum.random(1..128),
       socket_count: Enum.random(1..16),
       os_version: Faker.App.semver(),
-      installation_source: Enum.random([:community, :suse, :unknown])
+      installation_source: Enum.random([:community, :suse, :unknown]),
+      prometheus_targets: build(:host_prometheus_targets)
     }
   end
 
@@ -197,7 +199,8 @@ defmodule Trento.Factory do
       provider_data: nil,
       deregistered_at: nil,
       selected_checks: Enum.map(0..4, fn _ -> Faker.StarWars.planet() end),
-      saptune_status: nil
+      saptune_status: nil,
+      prometheus_targets: build(:host_prometheus_targets)
     }
   end
 
@@ -868,7 +871,8 @@ defmodule Trento.Factory do
       socket_count: Enum.random(1..16),
       os_version: Faker.App.semver(),
       installation_source: Enum.random([:community, :suse, :unknown]),
-      fully_qualified_domain_name: Faker.Internet.domain_name()
+      fully_qualified_domain_name: Faker.Internet.domain_name(),
+      prometheus_targets: build(:host_prometheus_targets)
     })
   end
 
@@ -916,6 +920,12 @@ defmodule Trento.Factory do
       "os_version" => Faker.App.semver(),
       "installation_source" => Enum.random(["community", "suse", "unknown"]),
       "fully_qualified_domain_name" => Faker.Internet.domain_name()
+    }
+  end
+
+  def host_prometheus_targets_factory do
+    %{
+      "node_exporter" => "#{Faker.Internet.ip_v4_address()}:9100"
     }
   end
 

--- a/test/trento/discovery/policies/host_policy_test.exs
+++ b/test/trento/discovery/policies/host_policy_test.exs
@@ -37,7 +37,8 @@ defmodule Trento.Discovery.Policies.HostPolicyTest do
                host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
                hostname: "suse",
                ip_addresses: ["10.1.1.4/16", "10.1.1.5/24", "10.1.1.6/32"],
-               installation_source: :unknown
+               installation_source: :unknown,
+               prometheus_targets: %{}
              }
            } =
              "host_discovery"
@@ -72,6 +73,22 @@ defmodule Trento.Discovery.Policies.HostPolicyTest do
              |> load_discovery_event_fixture()
              |> pop_in(["payload", "netmasks"])
              |> elem(1)
+             |> HostPolicy.handle()
+  end
+
+  test "should return the expected commands when a host_discovery payload with prometheus_targets is handled" do
+    assert {
+             :ok,
+             %RegisterHost{
+               host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
+               prometheus_targets: %{
+                 "node_exporter" => "10.0.0.1:9100",
+                 "ha_cluster_exporter" => "10.0.0.1:9664"
+               }
+             }
+           } =
+             "host_discovery_with_prometheus_targets"
+             |> load_discovery_event_fixture()
              |> HostPolicy.handle()
   end
 

--- a/test/trento/discovery/policies/host_policy_test.exs
+++ b/test/trento/discovery/policies/host_policy_test.exs
@@ -38,7 +38,7 @@ defmodule Trento.Discovery.Policies.HostPolicyTest do
                hostname: "suse",
                ip_addresses: ["10.1.1.4/16", "10.1.1.5/24", "10.1.1.6/32"],
                installation_source: :unknown,
-               prometheus_targets: %{}
+               prometheus_targets: nil
              }
            } =
              "host_discovery"

--- a/test/trento/hosts/events/host_details_updated_test.exs
+++ b/test/trento/hosts/events/host_details_updated_test.exs
@@ -15,7 +15,7 @@ defmodule Trento.Hosts.Events.HostDetailsUpdatedTest do
       os_version = Faker.App.version()
 
       assert %HostDetailsUpdated{
-               version: 3,
+               version: 4,
                host_id: host_id,
                hostname: hostname,
                fully_qualified_domain_name: nil,
@@ -25,7 +25,8 @@ defmodule Trento.Hosts.Events.HostDetailsUpdatedTest do
                total_memory_mb: total_memory_mb,
                socket_count: socket_count,
                os_version: os_version,
-               installation_source: :unknown
+               installation_source: :unknown,
+               prometheus_targets: nil
              } ==
                %{
                  "host_id" => host_id,

--- a/test/trento/hosts/events/host_registered_test.exs
+++ b/test/trento/hosts/events/host_registered_test.exs
@@ -15,7 +15,7 @@ defmodule Trento.Hosts.Events.HostRegisteredTest do
       os_version = Faker.App.version()
 
       assert %HostRegistered{
-               version: 4,
+               version: 5,
                host_id: host_id,
                hostname: hostname,
                fully_qualified_domain_name: nil,
@@ -26,6 +26,7 @@ defmodule Trento.Hosts.Events.HostRegisteredTest do
                socket_count: socket_count,
                os_version: os_version,
                installation_source: :unknown,
+               prometheus_targets: nil,
                heartbeat: :unknown,
                health: :unknown
              } ==

--- a/test/trento/hosts/host_test.exs
+++ b/test/trento/hosts/host_test.exs
@@ -68,6 +68,7 @@ defmodule Trento.Hosts.HostTest do
       socket_count = Enum.random(1..16)
       os_version = Faker.App.version()
       installation_source = Enum.random([:community, :suse, :unknown])
+      prometheus_targets = build(:host_prometheus_targets)
 
       assert_events_and_state(
         [],
@@ -81,7 +82,8 @@ defmodule Trento.Hosts.HostTest do
           socket_count: socket_count,
           os_version: os_version,
           installation_source: installation_source,
-          fully_qualified_domain_name: nil
+          fully_qualified_domain_name: nil,
+          prometheus_targets: prometheus_targets
         }),
         %HostRegistered{
           host_id: host_id,
@@ -93,6 +95,7 @@ defmodule Trento.Hosts.HostTest do
           socket_count: socket_count,
           os_version: os_version,
           installation_source: installation_source,
+          prometheus_targets: prometheus_targets,
           heartbeat: :unknown
         },
         %Host{
@@ -106,6 +109,7 @@ defmodule Trento.Hosts.HostTest do
           socket_count: socket_count,
           os_version: os_version,
           installation_source: installation_source,
+          prometheus_targets: prometheus_targets,
           heartbeat: :unknown
         }
       )
@@ -122,6 +126,7 @@ defmodule Trento.Hosts.HostTest do
       socket_count = Enum.random(1..16)
       os_version = Faker.App.version()
       installation_source = Enum.random([:community, :suse, :unknown])
+      prometheus_targets = build(:host_prometheus_targets)
 
       assert_events_and_state(
         [],
@@ -135,7 +140,8 @@ defmodule Trento.Hosts.HostTest do
           total_memory_mb: total_memory_mb,
           socket_count: socket_count,
           os_version: os_version,
-          installation_source: installation_source
+          installation_source: installation_source,
+          prometheus_targets: prometheus_targets
         }),
         [
           %HostRegistered{
@@ -149,6 +155,7 @@ defmodule Trento.Hosts.HostTest do
             socket_count: socket_count,
             os_version: os_version,
             installation_source: installation_source,
+            prometheus_targets: prometheus_targets,
             heartbeat: :unknown
           },
           %SoftwareUpdatesDiscoveryRequested{
@@ -167,6 +174,7 @@ defmodule Trento.Hosts.HostTest do
           socket_count: socket_count,
           os_version: os_version,
           installation_source: installation_source,
+          prometheus_targets: prometheus_targets,
           heartbeat: :unknown
         }
       )
@@ -197,6 +205,7 @@ defmodule Trento.Hosts.HostTest do
         socket_count = Enum.random(1..16)
         os_version = Faker.App.version()
         installation_source = Enum.random([:community, :suse, :unknown])
+        prometheus_targets = build(:host_prometheus_targets)
 
         assert_events_and_state(
           build(:host_registered_event,
@@ -209,7 +218,8 @@ defmodule Trento.Hosts.HostTest do
             total_memory_mb: total_memory_mb,
             socket_count: socket_count,
             os_version: os_version,
-            installation_source: installation_source
+            installation_source: installation_source,
+            prometheus_targets: prometheus_targets
           ),
           RegisterHost.new!(%{
             host_id: host_id,
@@ -221,7 +231,8 @@ defmodule Trento.Hosts.HostTest do
             total_memory_mb: total_memory_mb,
             socket_count: socket_count,
             os_version: os_version,
-            installation_source: installation_source
+            installation_source: installation_source,
+            prometheus_targets: prometheus_targets
           }),
           [
             %HostDetailsUpdated{
@@ -234,7 +245,8 @@ defmodule Trento.Hosts.HostTest do
               total_memory_mb: total_memory_mb,
               socket_count: socket_count,
               os_version: os_version,
-              installation_source: installation_source
+              installation_source: installation_source,
+              prometheus_targets: prometheus_targets
             },
             %SoftwareUpdatesDiscoveryRequested{
               host_id: host_id,
@@ -252,6 +264,7 @@ defmodule Trento.Hosts.HostTest do
             socket_count: socket_count,
             os_version: os_version,
             installation_source: installation_source,
+            prometheus_targets: prometheus_targets,
             heartbeat: :unknown
           }
         )
@@ -273,6 +286,7 @@ defmodule Trento.Hosts.HostTest do
         socket_count = Enum.random(1..16)
         os_version = Faker.App.version()
         installation_source = Enum.random([:community, :suse, :unknown])
+        prometheus_targets = %{}
 
         initial_agent_version = Faker.Internet.slug()
         new_agent_version = Faker.StarWars.character()
@@ -288,7 +302,8 @@ defmodule Trento.Hosts.HostTest do
             total_memory_mb: total_memory_mb,
             socket_count: socket_count,
             os_version: os_version,
-            installation_source: installation_source
+            installation_source: installation_source,
+            prometheus_targets: prometheus_targets
           ),
           RegisterHost.new!(%{
             host_id: host_id,
@@ -300,7 +315,8 @@ defmodule Trento.Hosts.HostTest do
             total_memory_mb: total_memory_mb,
             socket_count: socket_count,
             os_version: os_version,
-            installation_source: installation_source
+            installation_source: installation_source,
+            prometheus_targets: prometheus_targets
           }),
           %HostDetailsUpdated{
             host_id: host_id,
@@ -312,7 +328,8 @@ defmodule Trento.Hosts.HostTest do
             total_memory_mb: total_memory_mb,
             socket_count: socket_count,
             os_version: os_version,
-            installation_source: installation_source
+            installation_source: installation_source,
+            prometheus_targets: prometheus_targets
           },
           %Host{
             host_id: host_id,
@@ -325,6 +342,7 @@ defmodule Trento.Hosts.HostTest do
             socket_count: socket_count,
             os_version: os_version,
             installation_source: installation_source,
+            prometheus_targets: prometheus_targets,
             heartbeat: :unknown
           }
         )
@@ -341,6 +359,7 @@ defmodule Trento.Hosts.HostTest do
       socket_count = Enum.random(1..16)
       os_version = Faker.App.version()
       installation_source = Enum.random([:community, :suse, :unknown])
+      prometheus_targets = build(:host_prometheus_targets)
 
       current_fully_qualified_domain_name = Faker.Internet.ip_v4_address()
       new_fully_qualified_domain_name = nil
@@ -356,7 +375,8 @@ defmodule Trento.Hosts.HostTest do
           total_memory_mb: total_memory_mb,
           socket_count: socket_count,
           os_version: os_version,
-          installation_source: installation_source
+          installation_source: installation_source,
+          prometheus_targets: prometheus_targets
         ),
         RegisterHost.new!(%{
           host_id: host_id,
@@ -368,7 +388,8 @@ defmodule Trento.Hosts.HostTest do
           total_memory_mb: total_memory_mb,
           socket_count: socket_count,
           os_version: os_version,
-          installation_source: installation_source
+          installation_source: installation_source,
+          prometheus_targets: prometheus_targets
         }),
         [
           %HostDetailsUpdated{
@@ -381,7 +402,8 @@ defmodule Trento.Hosts.HostTest do
             total_memory_mb: total_memory_mb,
             socket_count: socket_count,
             os_version: os_version,
-            installation_source: installation_source
+            installation_source: installation_source,
+            prometheus_targets: prometheus_targets
           },
           %SoftwareUpdatesDiscoveryCleared{
             host_id: host_id
@@ -398,6 +420,7 @@ defmodule Trento.Hosts.HostTest do
           socket_count: socket_count,
           os_version: os_version,
           installation_source: installation_source,
+          prometheus_targets: prometheus_targets,
           heartbeat: :unknown
         }
       )
@@ -413,6 +436,7 @@ defmodule Trento.Hosts.HostTest do
       new_socket_count = Enum.random(1..16)
       new_os_version = Faker.App.version()
       new_installation_source = Enum.random([:community, :suse, :unknown])
+      new_prometheus_targets = build(:host_prometheus_targets)
       fully_qualified_domain_name = Faker.Internet.domain_name()
 
       assert_events_and_state(
@@ -430,7 +454,8 @@ defmodule Trento.Hosts.HostTest do
           total_memory_mb: new_total_memory_mb,
           socket_count: new_socket_count,
           os_version: new_os_version,
-          installation_source: new_installation_source
+          installation_source: new_installation_source,
+          prometheus_targets: new_prometheus_targets
         }),
         %HostDetailsUpdated{
           host_id: host_id,
@@ -442,7 +467,8 @@ defmodule Trento.Hosts.HostTest do
           total_memory_mb: new_total_memory_mb,
           socket_count: new_socket_count,
           os_version: new_os_version,
-          installation_source: new_installation_source
+          installation_source: new_installation_source,
+          prometheus_targets: new_prometheus_targets
         },
         %Host{
           host_id: host_id,
@@ -455,6 +481,7 @@ defmodule Trento.Hosts.HostTest do
           socket_count: new_socket_count,
           os_version: new_os_version,
           installation_source: new_installation_source,
+          prometheus_targets: new_prometheus_targets,
           heartbeat: :unknown
         }
       )
@@ -475,7 +502,8 @@ defmodule Trento.Hosts.HostTest do
           total_memory_mb: host_registered_event.total_memory_mb,
           socket_count: host_registered_event.socket_count,
           os_version: host_registered_event.os_version,
-          installation_source: host_registered_event.installation_source
+          installation_source: host_registered_event.installation_source,
+          prometheus_targets: host_registered_event.prometheus_targets
         }),
         []
       )
@@ -1875,6 +1903,7 @@ defmodule Trento.Hosts.HostTest do
             socket_count: host_registered_event.socket_count,
             os_version: host_registered_event.os_version,
             installation_source: host_registered_event.installation_source,
+            prometheus_targets: host_registered_event.prometheus_targets,
             heartbeat: :unknown,
             rolling_up: false
           }
@@ -1994,7 +2023,8 @@ defmodule Trento.Hosts.HostTest do
           total_memory_mb: host_registered_event.total_memory_mb,
           socket_count: host_registered_event.socket_count,
           os_version: host_registered_event.os_version,
-          installation_source: host_registered_event.installation_source
+          installation_source: host_registered_event.installation_source,
+          prometheus_targets: host_registered_event.prometheus_targets
         )
 
       assert_events_and_state(
@@ -2042,7 +2072,8 @@ defmodule Trento.Hosts.HostTest do
             socket_count: restoration_command.socket_count,
             os_version: restoration_command.os_version,
             installation_source: restoration_command.installation_source,
-            fully_qualified_domain_name: restoration_command.fully_qualified_domain_name
+            fully_qualified_domain_name: restoration_command.fully_qualified_domain_name,
+            prometheus_targets: restoration_command.prometheus_targets
           }
         ],
         fn host ->
@@ -2074,7 +2105,8 @@ defmodule Trento.Hosts.HostTest do
           total_memory_mb: host_registered_event.total_memory_mb,
           socket_count: host_registered_event.socket_count,
           os_version: host_registered_event.os_version,
-          installation_source: host_registered_event.installation_source
+          installation_source: host_registered_event.installation_source,
+          prometheus_targets: host_registered_event.prometheus_targets
         )
 
       assert_events_and_state(
@@ -2141,7 +2173,8 @@ defmodule Trento.Hosts.HostTest do
               socket_count: restoration_command.socket_count,
               os_version: restoration_command.os_version,
               installation_source: restoration_command.installation_source,
-              fully_qualified_domain_name: restoration_command.fully_qualified_domain_name
+              fully_qualified_domain_name: restoration_command.fully_qualified_domain_name,
+              prometheus_targets: restoration_command.prometheus_targets
             },
             %SoftwareUpdatesDiscoveryRequested{
               host_id: host_id,
@@ -2201,7 +2234,8 @@ defmodule Trento.Hosts.HostTest do
               socket_count: restoration_command.socket_count,
               os_version: restoration_command.os_version,
               installation_source: restoration_command.installation_source,
-              fully_qualified_domain_name: restoration_command.fully_qualified_domain_name
+              fully_qualified_domain_name: restoration_command.fully_qualified_domain_name,
+              prometheus_targets: restoration_command.prometheus_targets
             }
           ],
           fn host ->

--- a/test/trento/hosts/projections/host_projector_test.exs
+++ b/test/trento/hosts/projections/host_projector_test.exs
@@ -78,6 +78,7 @@ defmodule Trento.Hosts.Projections.HostProjectorTest do
     assert event.host_id == host_projection.id
     assert event.hostname == host_projection.hostname
     assert event.fully_qualified_domain_name == host_projection.fully_qualified_domain_name
+    assert event.prometheus_targets == host_projection.prometheus_targets
 
     assert event.ip_addresses ==
              Enum.zip_with([ip_addresses, netmasks], fn [address, netmaks] ->
@@ -248,7 +249,8 @@ defmodule Trento.Hosts.Projections.HostProjectorTest do
         cpu_count: Enum.random(1..16),
         total_memory_mb: Enum.random(1..128),
         socket_count: Enum.random(1..16),
-        os_version: Faker.App.version()
+        os_version: Faker.App.version(),
+        prometheus_targets: build(:host_prometheus_targets)
       }
 
     ProjectorTestHelper.project(HostProjector, event, "host_projector")
@@ -259,6 +261,7 @@ defmodule Trento.Hosts.Projections.HostProjectorTest do
     assert [ip_address] == host_projection.ip_addresses
     assert [netmask] == host_projection.netmasks
     assert event.agent_version == host_projection.agent_version
+    assert event.prometheus_targets == host_projection.prometheus_targets
 
     assert_broadcast "host_details_updated",
                      %{

--- a/test/trento_web/controllers/v1/prometheus_controller_test.exs
+++ b/test/trento_web/controllers/v1/prometheus_controller_test.exs
@@ -24,26 +24,6 @@ defmodule TrentoWeb.V1.PrometheusControllerTest do
     assert_schema(response, "HttpSTDTargetList", api_spec)
   end
 
-  test "should return the expected targets when some host does not have any IP address", %{
-    conn: conn
-  } do
-    %{id: id, hostname: hostname} = insert(:host, ip_addresses: [])
-
-    response =
-      conn
-      |> get("/api/v1/prometheus/targets")
-      |> json_response(200)
-
-    %{
-      "targets" => ["#{hostname}:9100"],
-      "labels" => %{
-        "agentID" => "#{id}",
-        "hostname" => "#{hostname}",
-        "exporter_name" => "Node Exporter"
-      }
-    } in response
-  end
-
   test "should return the exporters status", %{conn: conn} do
     expect(Trento.Infrastructure.Prometheus.Mock, :get_exporters_status, fn _ ->
       {:ok, %{"Node Exporter" => :passing}}

--- a/test/trento_web/views/v1/host_view_json_test.exs
+++ b/test/trento_web/views/v1/host_view_json_test.exs
@@ -22,6 +22,7 @@ defmodule TrentoWeb.V1.HostJSONTest do
     rendered_host = HostJSON.host(%{host: host})
 
     refute Access.get(rendered_host, :fully_qualified_domain_name)
+    refute Access.get(rendered_host, :prometheus_targets)
     refute Access.get(rendered_host, :inserted_at)
   end
 

--- a/test/trento_web/views/v1/prometheus_json_test.exs
+++ b/test/trento_web/views/v1/prometheus_json_test.exs
@@ -14,6 +14,8 @@ defmodule TrentoWeb.V1.PrometheusJSONTest do
       )
 
     host2 = build(:host, prometheus_targets: %{"exporter_3" => "10.0.0.2:9100"})
+    # old agent, testing for backward compatibility
+    host3 = build(:host, prometheus_targets: nil, ip_addresses: ["10.0.0.3", "10.0.0.2"])
 
     expected_targets = [
       %{
@@ -39,10 +41,18 @@ defmodule TrentoWeb.V1.PrometheusJSONTest do
           hostname: host2.hostname,
           exporter_name: "exporter_3"
         }
+      },
+      %{
+        targets: ["10.0.0.3:9100"],
+        labels: %{
+          agentID: host3.id,
+          hostname: host3.hostname,
+          exporter_name: "node_exporter"
+        }
       }
     ]
 
     assert expected_targets ==
-             PrometheusJSON.targets(%{targets: [host1, host2]})
+             PrometheusJSON.targets(%{targets: [host1, host2, host3]})
   end
 end

--- a/test/trento_web/views/v1/prometheus_json_test.exs
+++ b/test/trento_web/views/v1/prometheus_json_test.exs
@@ -1,0 +1,48 @@
+defmodule TrentoWeb.V1.PrometheusJSONTest do
+  @moduledoc false
+
+  use TrentoWeb.ConnCase, async: true
+
+  import Trento.Factory
+
+  alias TrentoWeb.V1.PrometheusJSON
+
+  test "should render the targets of registered hosts" do
+    host1 =
+      build(:host,
+        prometheus_targets: %{"exporter_1" => "10.0.0.1:9100", "exporter_2" => "10.0.0.1:9101"}
+      )
+
+    host2 = build(:host, prometheus_targets: %{"exporter_3" => "10.0.0.2:9100"})
+
+    expected_targets = [
+      %{
+        targets: ["10.0.0.1:9100"],
+        labels: %{
+          agentID: host1.id,
+          hostname: host1.hostname,
+          exporter_name: "exporter_1"
+        }
+      },
+      %{
+        targets: ["10.0.0.1:9101"],
+        labels: %{
+          agentID: host1.id,
+          hostname: host1.hostname,
+          exporter_name: "exporter_2"
+        }
+      },
+      %{
+        targets: ["10.0.0.2:9100"],
+        labels: %{
+          agentID: host2.id,
+          hostname: host2.hostname,
+          exporter_name: "exporter_3"
+        }
+      }
+    ]
+
+    assert expected_targets ==
+             PrometheusJSON.targets(%{targets: [host1, host2]})
+  end
+end

--- a/test/trento_web/views/v1/prometheus_json_test.exs
+++ b/test/trento_web/views/v1/prometheus_json_test.exs
@@ -1,7 +1,5 @@
 defmodule TrentoWeb.V1.PrometheusJSONTest do
-  @moduledoc false
-
-  use TrentoWeb.ConnCase, async: true
+  use ExUnit.Case
 
   import Trento.Factory
 


### PR DESCRIPTION
# Description

Use new information about the prometheus targets to create the http service discovery data.
Pretty straightforward.

Related do: https://github.com/trento-project/agent/pull/356

PD:
I haven't updated the e2e and photofinish payloads to include the new field, because in reality we don't use them neither in the tests or in demo.
I think it is fine as is.
Otherwise, we could create other PR as well, to not bloat this one and make the review slightly simpler

## How was this tested?

UT added
