### PR TITLE
Limit user access in activity log filters

### DIFF
--- a/lib/trento/support/abilities_helper.ex
+++ b/lib/trento/support/abilities_helper.ex
@@ -9,4 +9,7 @@ defmodule Trento.Support.AbilitiesHelper do
 
   def has_global_ability?(%User{} = user),
     do: user_has_ability?(user, %{name: "all", resource: "all"})
+
+  def user_has_any_ability?(%User{} = user, abilities),
+    do: Enum.any?(abilities, &user_has_ability?(user, &1))
 end

--- a/test/support/helpers/abilities_test_helper.ex
+++ b/test/support/helpers/abilities_test_helper.ex
@@ -34,6 +34,11 @@ defmodule Trento.Support.Helpers.AbilitiesTestHelper do
     {:ok, conn: put_req_header(conn, "accept", "application/json"), api_spec: api_spec}
   end
 
+  def clear_default_abilities(_) do
+    delete_default_abilities()
+    {:ok, %{}}
+  end
+
   defp delete_default_abilities do
     Trento.Repo.delete_all(Trento.Abilities.Ability)
   end

--- a/test/trento/support/abilities_helper_test.exs
+++ b/test/trento/support/abilities_helper_test.exs
@@ -31,4 +31,39 @@ defmodule Trento.Support.AbilitiesHelperTest do
 
     assert true == AbilitiesHelper.has_global_ability?(user)
   end
+
+  test "has_global_ability/2 returns false if user does not have the global ability" do
+    first_ability = build(:ability, name: "manage", resource: "things")
+    second_ability = build(:ability, name: "read", resource: "things")
+
+    user = build(:user, abilities: [first_ability, second_ability])
+
+    refute AbilitiesHelper.has_global_ability?(user)
+  end
+
+  test "user_has_any_ability/2 returns true if user does have any of the required abilities" do
+    first_ability = build(:ability, name: "manage", resource: "things")
+    second_ability = build(:ability, name: "read", resource: "things")
+    third_ability = build(:ability, name: "delete", resource: "things")
+
+    user = build(:user, abilities: [first_ability, second_ability, third_ability])
+
+    assert true ==
+             AbilitiesHelper.user_has_any_ability?(user, [
+               %{name: "manage", resource: "things"},
+               %{name: "foo", resource: "bar"}
+             ])
+  end
+
+  test "user_has_any_ability/2 returns false if user does not have any of the required abilities" do
+    first_ability = build(:ability, name: "manage", resource: "things")
+    second_ability = build(:ability, name: "read", resource: "things")
+
+    user = build(:user, abilities: [first_ability, second_ability])
+
+    refute AbilitiesHelper.user_has_any_ability?(user, [
+             %{name: "foo", resource: "bar"},
+             %{name: "baz", resource: "qux"}
+           ])
+  end
 end

--- a/test/trento_web/channels/activity_log_channel_test.exs
+++ b/test/trento_web/channels/activity_log_channel_test.exs
@@ -1,28 +1,136 @@
 defmodule TrentoWeb.ActivityLogChannelTest do
-  use TrentoWeb.ChannelCase
+  use TrentoWeb.ChannelCase, async: true
 
-  test "Socket users can only join the activity log channel" do
-    assert {:ok, _, _socket} =
-             TrentoWeb.UserSocket
-             |> socket("user_id", %{current_user_id: 876})
-             |> join(TrentoWeb.ActivityLogChannel, "activity_log:876")
+  import Trento.Factory
+  import Trento.Support.Helpers.AbilitiesTestHelper, only: [clear_default_abilities: 1]
 
-    assert_push("al_users_pushed", %{users: _})
-    assert_push("al_users_pushed", %{users: _})
-    assert_push("al_users_pushed", %{users: _})
+  setup :clear_default_abilities
+
+  describe "joining activity log users channel" do
+    test "users can join the activity log channel" do
+      %{id: user_id} = insert(:user)
+
+      assert {:ok, _, _socket} =
+               TrentoWeb.UserSocket
+               |> socket("user_id", %{current_user_id: user_id})
+               |> join(
+                 TrentoWeb.ActivityLogChannel,
+                 "activity_log:" <> Integer.to_string(user_id)
+               )
+    end
+
+    test "Unauthorized users cannot join the activity log channel" do
+      %{id: user_id} = insert(:user)
+
+      non_matching_user_id = user_id + 1
+
+      assert {:error, :unauthorized} =
+               TrentoWeb.UserSocket
+               |> socket("user_id", %{current_user_id: user_id})
+               |> join(
+                 TrentoWeb.ActivityLogChannel,
+                 "activity_log:" <> Integer.to_string(non_matching_user_id)
+               )
+    end
+
+    test "Non logged users cannot join an activity log channel" do
+      assert {:error, :user_not_logged} =
+               TrentoWeb.UserSocket
+               |> socket("user_id", %{})
+               |> join(TrentoWeb.ActivityLogChannel, "activity_log:8989")
+    end
   end
 
-  test "Unauthorized users cannot join the activity log channel" do
-    assert {:error, :unauthorized} =
-             TrentoWeb.UserSocket
-             |> socket("user_id", %{current_user_id: 788})
-             |> join(TrentoWeb.ActivityLogChannel, "activity_log:876")
-  end
+  describe "publishing activity log users" do
+    scenarios = [
+      %{
+        name: "all:all",
+        users: ["foo", "bar", "baz", "qux", "quux"],
+        current_user: %{
+          username: "foo",
+          abilities: [
+            %{name: "all", resource: "all"},
+            %{name: "foo", resource: "bar"}
+          ]
+        },
+        expected_users: ["system", "foo", "bar", "baz", "qux", "quux"]
+      },
+      %{
+        name: "all:users",
+        users: ["foo", "bar", "baz", "qux", "quux"],
+        current_user: %{
+          username: "foo",
+          abilities: [
+            %{name: "all", resource: "users"},
+            %{name: "foo", resource: "bar"}
+          ]
+        },
+        expected_users: ["system", "foo", "bar", "baz", "qux", "quux"]
+      },
+      %{
+        name: "no special permissions",
+        users: ["foo", "bar", "baz", "qux", "quux"],
+        current_user: %{
+          username: "foo",
+          abilities: [
+            %{name: "foo", resource: "bar"}
+          ]
+        },
+        expected_users: ["system", "foo"]
+      },
+      %{
+        name: "activity_log:users",
+        users: ["foo", "bar", "baz", "qux", "quux"],
+        current_user: %{
+          username: "foo",
+          abilities: [
+            %{name: "activity_log", resource: "users"}
+          ]
+        },
+        expected_users: ["system", "foo", "bar", "baz", "qux", "quux"]
+      }
+    ]
 
-  test "Non logged users cannot join an activity log channel" do
-    assert {:error, :user_not_logged} =
-             TrentoWeb.UserSocket
-             |> socket("user_id", %{})
-             |> join(TrentoWeb.ActivityLogChannel, "activity_log:8989")
+    for %{name: name} = scenario <- scenarios do
+      @scenario scenario
+
+      test "relevant users are pushed based on permission: #{name}" do
+        %{
+          users: users,
+          current_user: %{
+            username: username,
+            abilities: abilities
+          },
+          expected_users: expected_users
+        } = @scenario
+
+        current_user_id =
+          users
+          |> Enum.map(&insert(:user, username: &1))
+          |> Enum.find(&(&1.username == username))
+          |> Map.get(:id)
+
+        Enum.each(abilities, fn %{name: name, resource: resource} ->
+          ability_id =
+            :ability
+            |> insert(name: name, resource: resource)
+            |> Map.get(:id)
+
+          insert(:users_abilities, user_id: current_user_id, ability_id: ability_id)
+        end)
+
+        assert {:ok, _, _socket} =
+                 TrentoWeb.UserSocket
+                 |> socket("user_id", %{current_user_id: current_user_id})
+                 |> join(
+                   TrentoWeb.ActivityLogChannel,
+                   "activity_log:" <> Integer.to_string(current_user_id)
+                 )
+
+        assert_push("al_users_pushed", %{users: ^expected_users})
+        assert_push("al_users_pushed", %{users: ^expected_users})
+        assert_push("al_users_pushed", %{users: ^expected_users})
+      end
+    end
   end
 end


### PR DESCRIPTION
# Description

This PR makes sure that only relevant users are exposed as in activity log filter by user, based on the currently logged user's permissions.

A user with any of `all:all`, `all:users`, `activity_log:users` permissions can access all users in the activity log filters, otherwise only self and `system` are available.

Following up also the activity log API output and related view are going to be restricted based on caller permissions.

## How was this tested?

Automated tests.