### PR TITLE
Pin k3s version in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -900,7 +900,7 @@ jobs:
       - name: Start a local k8s cluster
         uses: jupyterhub/action-k3s-helm@v4
         with:
-          k3s-channel: latest
+          k3s-version: v1.31.2+k3s1
       - name: Add bitnami & jetstack(cert-manager) helm deps
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami


### PR DESCRIPTION
# Description

Pin the k3s version to `v1.31.2+k3s1` (the latest non-pre-release currently advertised on https://github.com/k3s-io/k3s/releases) to avoid intermittent failures due to upstream release issues (e.g. missing assets, see https://github.com/trento-project/web/actions/runs/12176389647/job/33963860549).
