### PR TITLE
Redact users in activity log

### DIFF
--- a/lib/trento/activity_logging/policy.ex
+++ b/lib/trento/activity_logging/policy.ex
@@ -1,0 +1,30 @@
+defmodule Trento.ActivityLog.Policy do
+  @moduledoc """
+  Policy for the Activity Log resource
+  """
+
+  alias Trento.Support.AbilitiesHelper
+  alias Trento.Users.User
+
+  def include_all_logs?(user),
+    do:
+      AbilitiesHelper.has_global_ability?(user) or
+        AbilitiesHelper.user_has_ability?(user, %{
+          name: "all",
+          resource: "users"
+        })
+
+  def has_access_to_users?(%User{} = user),
+    do:
+      AbilitiesHelper.has_global_ability?(user) ||
+        AbilitiesHelper.user_has_any_ability?(user, [
+          %{
+            name: "all",
+            resource: "users"
+          },
+          %{
+            name: "activity_log",
+            resource: "users"
+          }
+        ])
+end

--- a/lib/trento_web/channels/activity_log_channel.ex
+++ b/lib/trento_web/channels/activity_log_channel.ex
@@ -5,7 +5,7 @@ defmodule TrentoWeb.ActivityLogChannel do
   """
   require Logger
   use TrentoWeb, :channel
-  alias Trento.Support.AbilitiesHelper
+  alias Trento.ActivityLog.Policy
   alias Trento.Users
   alias Trento.Users.User
 
@@ -58,24 +58,10 @@ defmodule TrentoWeb.ActivityLogChannel do
   end
 
   defp detect_accessible_users(%User{username: current_username} = current_user) do
-    if has_access_to_users?(current_user) do
+    if Policy.has_access_to_users?(current_user) do
       Enum.map(Users.list_users(), & &1.username)
     else
       [current_username]
     end
   end
-
-  defp has_access_to_users?(%User{} = user),
-    do:
-      AbilitiesHelper.has_global_ability?(user) ||
-        AbilitiesHelper.user_has_any_ability?(user, [
-          %{
-            name: "all",
-            resource: "users"
-          },
-          %{
-            name: "activity_log",
-            resource: "users"
-          }
-        ])
 end

--- a/lib/trento_web/controllers/v1/activity_log_controller.ex
+++ b/lib/trento_web/controllers/v1/activity_log_controller.ex
@@ -3,7 +3,7 @@ defmodule TrentoWeb.V1.ActivityLogController do
   use OpenApiSpex.ControllerSpecs
 
   alias Trento.ActivityLog
-  alias Trento.Support.AbilitiesHelper
+  alias Trento.ActivityLog.Policy
   alias TrentoWeb.OpenApi.V1.Schema
 
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
@@ -68,22 +68,15 @@ defmodule TrentoWeb.V1.ActivityLogController do
 
   def get_activity_log(conn, params) do
     user = Pow.Plug.current_user(conn)
-    include_all_logs? = include_all_logs?(user)
+    include_all_logs? = Policy.include_all_logs?(user)
 
     with {:ok, activity_log_entries, meta} <-
            ActivityLog.list_activity_log(params, include_all_logs?) do
       render(conn, :activity_log, %{
         activity_log: activity_log_entries,
-        pagination: meta
+        pagination: meta,
+        current_user: user
       })
     end
   end
-
-  defp include_all_logs?(user),
-    do:
-      AbilitiesHelper.has_global_ability?(user) or
-        AbilitiesHelper.user_has_ability?(user, %{
-          name: "all",
-          resource: "users"
-        })
 end

--- a/lib/trento_web/controllers/v1/activity_log_controller.ex
+++ b/lib/trento_web/controllers/v1/activity_log_controller.ex
@@ -4,6 +4,7 @@ defmodule TrentoWeb.V1.ActivityLogController do
 
   alias Trento.ActivityLog
   alias Trento.ActivityLog.Policy
+  alias Trento.Users.User
   alias TrentoWeb.OpenApi.V1.Schema
 
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
@@ -70,13 +71,28 @@ defmodule TrentoWeb.V1.ActivityLogController do
     user = Pow.Plug.current_user(conn)
     include_all_logs? = Policy.include_all_logs?(user)
 
-    with {:ok, activity_log_entries, meta} <-
+    with :ok <- validate_incoming_filters(params, user),
+         {:ok, activity_log_entries, meta} <-
            ActivityLog.list_activity_log(params, include_all_logs?) do
       render(conn, :activity_log, %{
         activity_log: activity_log_entries,
         pagination: meta,
         current_user: user
       })
+    end
+  end
+
+  defp validate_incoming_filters(params, %User{username: username} = user) do
+    can_query_actor? =
+      Policy.has_access_to_users?(user) ||
+        params
+        |> Map.get(:actor, [])
+        |> Enum.all?(&(&1 == username || &1 == "system"))
+
+    if can_query_actor? do
+      :ok
+    else
+      {:error, :forbidden}
     end
   end
 end

--- a/lib/trento_web/controllers/v1/activity_log_json.ex
+++ b/lib/trento_web/controllers/v1/activity_log_json.ex
@@ -43,6 +43,8 @@ defmodule TrentoWeb.V1.ActivityLogJSON do
 
   defp maybe_redact_actor(actor, %User{username: actor}), do: actor
 
+  defp maybe_redact_actor("system" = actor, _), do: actor
+
   defp maybe_redact_actor(actor, user) do
     if Policy.has_access_to_users?(user) do
       actor

--- a/lib/trento_web/controllers/v1/activity_log_json.ex
+++ b/lib/trento_web/controllers/v1/activity_log_json.ex
@@ -1,15 +1,18 @@
 defmodule TrentoWeb.V1.ActivityLogJSON do
-  def activity_log(%{activity_log: entries, pagination: meta}),
+  alias Trento.ActivityLog.Policy
+  alias Trento.Users.User
+
+  def activity_log(%{activity_log: entries, pagination: meta, current_user: user}),
     do: %{
-      data: Enum.map(entries, &activity_log_entry(%{activity_log_entry: &1})),
+      data: Enum.map(entries, &activity_log_entry(%{activity_log_entry: &1, current_user: user})),
       pagination: pagination(%{pagination: meta})
     }
 
-  def activity_log_entry(%{activity_log_entry: entry}),
+  def activity_log_entry(%{activity_log_entry: entry, current_user: user}),
     do: %{
       id: entry.id,
       type: entry.type,
-      actor: entry.actor,
+      actor: maybe_redact_actor(entry.actor, user),
       metadata: entry.metadata,
       # Time of occurrence approximated by time of insertion in DB.
       occurred_on: entry.inserted_at
@@ -36,5 +39,15 @@ defmodule TrentoWeb.V1.ActivityLogJSON do
       has_next_page: has_next_page,
       has_previous_page: has_previous_page
     }
+  end
+
+  defp maybe_redact_actor(actor, %User{username: actor}), do: actor
+
+  defp maybe_redact_actor(actor, user) do
+    if Policy.has_access_to_users?(user) do
+      actor
+    else
+      "••••••••"
+    end
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1161,7 +1161,7 @@ defmodule Trento.Factory do
   def activity_log_entry_factory do
     %ActivityLogEntry{
       type: Faker.Pokemon.name(),
-      actor: Enum.random(["user", "system"]),
+      actor: Faker.Internet.user_name(),
       metadata: %{}
     }
   end

--- a/test/support/helpers/abilities_test_helper.ex
+++ b/test/support/helpers/abilities_test_helper.ex
@@ -24,14 +24,17 @@ defmodule Trento.Support.Helpers.AbilitiesTestHelper do
       |> Pow.Plug.put_config(otp_app: :trento)
 
     # Default inject all:all abilities user
-    %{id: user_id} = insert(:user)
+    %{id: user_id} = admin_user = insert(:user)
     %{id: ability_id} = insert(:ability, name: "all", resource: "all")
     insert(:users_abilities, user_id: user_id, ability_id: ability_id)
 
     conn =
       Pow.Plug.assign_current_user(conn, %{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
 
-    {:ok, conn: put_req_header(conn, "accept", "application/json"), api_spec: api_spec}
+    {:ok,
+     conn: put_req_header(conn, "accept", "application/json"),
+     api_spec: api_spec,
+     admin_user: admin_user}
   end
 
   def clear_default_abilities(_) do

--- a/test/trento/activity_logging/policy_test.exs
+++ b/test/trento/activity_logging/policy_test.exs
@@ -1,0 +1,90 @@
+defmodule Trento.ActivityLog.PolicyTest do
+  use ExUnit.Case
+
+  import Trento.Factory
+
+  alias Trento.ActivityLog.Policy
+
+  describe "Activity Log Policy" do
+    test "users with relevant permissions should be allowed to access all logs" do
+      scenarios = [
+        %{
+          abilities: [
+            %{name: "all", resource: "all"},
+            %{name: "foo", resource: "bar"}
+          ],
+          should_have_access_to_all_logs: true
+        },
+        %{
+          abilities: [
+            %{name: "all", resource: "users"},
+            %{name: "foo", resource: "bar"}
+          ],
+          should_have_access_to_all_logs: true
+        },
+        %{
+          abilities: [
+            %{name: "foo", resource: "bar"}
+          ],
+          should_have_access_to_all_logs: false
+        }
+      ]
+
+      for %{abilities: abilities, should_have_access_to_all_logs: should_have_access_to_all_logs} <-
+            scenarios do
+        assert should_have_access_to_all_logs ==
+                 abilities
+                 |> build_user_with_abilities()
+                 |> Policy.include_all_logs?()
+      end
+    end
+
+    test "users with relevant permissions should be allowed to access actor names in logs" do
+      scenarios = [
+        %{
+          abilities: [
+            %{name: "all", resource: "all"},
+            %{name: "foo", resource: "bar"}
+          ],
+          should_have_access_to_actor_names: true
+        },
+        %{
+          abilities: [
+            %{name: "all", resource: "users"},
+            %{name: "foo", resource: "bar"}
+          ],
+          should_have_access_to_actor_names: true
+        },
+        %{
+          abilities: [
+            %{name: "activity_log", resource: "users"},
+            %{name: "foo", resource: "bar"}
+          ],
+          should_have_access_to_actor_names: true
+        },
+        %{
+          abilities: [
+            %{name: "foo", resource: "bar"}
+          ],
+          should_have_access_to_actor_names: false
+        }
+      ]
+
+      for %{
+            abilities: abilities,
+            should_have_access_to_actor_names: should_have_access_to_actor_names
+          } <- scenarios do
+        assert should_have_access_to_actor_names ==
+                 abilities
+                 |> build_user_with_abilities()
+                 |> Policy.has_access_to_users?()
+      end
+    end
+  end
+
+  defp build_user_with_abilities(abilities),
+    do:
+      build(:user,
+        abilities: Enum.map(abilities, &build(:ability, name: &1.name, resource: &1.resource))
+      )
+end

--- a/test/trento_web/views/v1/activity_log_view_json_test.exs
+++ b/test/trento_web/views/v1/activity_log_view_json_test.exs
@@ -6,7 +6,7 @@ defmodule TrentoWeb.V1.ActivityLogJSONTest do
   alias Trento.ActivityLog.ActivityLog
   alias TrentoWeb.V1.ActivityLogJSON
 
-  test "should render activity_log_entry.json" do
+  test "should render plain activity_log_entry.json" do
     %ActivityLog{
       id: id,
       type: type,
@@ -23,7 +23,36 @@ defmodule TrentoWeb.V1.ActivityLogJSONTest do
              occurred_on: ^inserted_at
            } =
              ActivityLogJSON.activity_log_entry(%{
-               activity_log_entry: activity_log_entry
+               activity_log_entry: activity_log_entry,
+               current_user:
+                 build(:user,
+                   abilities: build_list(1, :ability, name: "activity_log", resource: "users")
+                 )
+             })
+  end
+
+  test "should render redacted activity_log_entry.json" do
+    %ActivityLog{
+      id: id,
+      type: type,
+      actor: _actor,
+      metadata: metadata,
+      inserted_at: inserted_at
+    } = activity_log_entry = build(:activity_log_entry)
+
+    assert %{
+             id: ^id,
+             type: ^type,
+             actor: "••••••••",
+             metadata: ^metadata,
+             occurred_on: ^inserted_at
+           } =
+             ActivityLogJSON.activity_log_entry(%{
+               activity_log_entry: activity_log_entry,
+               current_user:
+                 build(:user,
+                   abilities: build_list(1, :ability, name: "foo", resource: "bar")
+                 )
              })
   end
 end

--- a/test/trento_web/views/v1/activity_log_view_json_test.exs
+++ b/test/trento_web/views/v1/activity_log_view_json_test.exs
@@ -55,4 +55,29 @@ defmodule TrentoWeb.V1.ActivityLogJSONTest do
                  )
              })
   end
+
+  test "should render not redacted system activity as activity_log_entry.json" do
+    %ActivityLog{
+      id: id,
+      type: type,
+      actor: _system_actor,
+      metadata: metadata,
+      inserted_at: inserted_at
+    } = activity_log_entry = build(:activity_log_entry, actor: "system")
+
+    assert %{
+             id: ^id,
+             type: ^type,
+             actor: "system",
+             metadata: ^metadata,
+             occurred_on: ^inserted_at
+           } =
+             ActivityLogJSON.activity_log_entry(%{
+               activity_log_entry: activity_log_entry,
+               current_user:
+                 build(:user,
+                   abilities: build_list(1, :ability, name: "foo", resource: "bar")
+                 )
+             })
+  end
 end


### PR DESCRIPTION
# Description

With this PR we make sure that a user without necessary permissions receives redacted usernames in the activity log, except for own username and system.

In addition a check has been added that allows such users to only be able to query by their own username or by system.
