### PR TITLE
Order users query

### DIFF
--- a/lib/trento/users.ex
+++ b/lib/trento/users.ex
@@ -42,6 +42,7 @@ defmodule Trento.Users do
     |> where([u], is_nil(u.deleted_at))
     |> preload(:abilities)
     |> preload(:user_identities)
+    |> order_by(asc: :id)
     |> Repo.all()
   end
 

--- a/test/trento_web/controllers/v1/users_controller_test.exs
+++ b/test/trento_web/controllers/v1/users_controller_test.exs
@@ -67,7 +67,12 @@ defmodule TrentoWeb.V1.UsersControllerTest do
         |> json_response(200)
         |> assert_schema("UserCollection", api_spec)
 
-      assert [_, %{id: ^user_one_id}, %{id: ^user_two_id}] = resp
+      Enum.each([user_one_id, user_two_id], fn id ->
+        assert Enum.find_value(resp, fn
+                 %{id: ^id} -> true
+                 _ -> false
+               end)
+      end)
     end
   end
 


### PR DESCRIPTION
# Description

Sometimes test at `test/trento_web/controllers/v1/users_controller_test.exs:59` fails.

Seems to be related to ordering of the entries returned, see [this failing pipeline](https://github.com/trento-project/web/actions/runs/12252134618/job/34178144423#step:8:203).

By adding an order by clause to the query we get a deterministic result and the test should not fail.