### PR TITLE
Improve e2e tests on Activity log

### DIFF
--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -305,7 +305,7 @@ context('Activity Log page', () => {
 
       cy.wait('@data20').its('response.body.pagination.first').should('eq', 20);
 
-      cy.get('button').contains('20').click();
+      cy.get('[data-testid="pagination"]').contains('20').click();
       cy.get('[data-testid="pagination"]').contains('50').click();
 
       cy.wait('@data50').its('response.body.pagination.first').should('eq', 50);
@@ -328,8 +328,8 @@ context('Activity Log page', () => {
 
       cy.wait('@data20').its('response.body.pagination.first').should('eq', 20);
 
-      cy.get('button').contains('20').click();
-      cy.get('span').contains('10').click();
+      cy.get('[data-testid="pagination"]').contains('20').click();
+      cy.get('[data-testid="pagination"]').contains('10').click();
 
       cy.wait('@data10').its('response.body.pagination.first').should('eq', 10);
 


### PR DESCRIPTION
# Description

Narrow down the selection of pagination elements on Activity Log e2e tests using the dedicated test ID.

By selecting only by text, being the text to query for just a number, sometimes the wrong element is clicked hence the script doesn't work ([example](https://github.com/trento-project/web/actions/runs/12122807801/job/33796890089?pr=3155#step:15:133)).