### PR TITLE
Hana Scale up cost opt checks in the trento console

### DIFF
--- a/assets/js/common/ClusterInfoBox/ClusterInfoBox.jsx
+++ b/assets/js/common/ClusterInfoBox/ClusterInfoBox.jsx
@@ -4,7 +4,12 @@ import ListView from '@common/ListView';
 import ProviderLabel from '@common/ProviderLabel';
 import ClusterTypeLabel from '@common/ClusterTypeLabel';
 
-function ClusterInfoBox({ haScenario, provider, architectureType }) {
+function ClusterInfoBox({
+  clusterType,
+  provider,
+  architectureType,
+  scaleUpScenario,
+}) {
   return (
     <div className="tn-cluster-details w-full my-6 mr-4 bg-white shadow rounded-lg px-8 py-4">
       <ListView
@@ -14,10 +19,11 @@ function ClusterInfoBox({ haScenario, provider, architectureType }) {
         data={[
           {
             title: 'HA Scenario',
-            content: haScenario,
+            content: clusterType,
             render: (content) => (
               <ClusterTypeLabel
                 clusterType={content}
+                clusterScenario={scaleUpScenario}
                 architectureType={architectureType}
               />
             ),

--- a/assets/js/common/ClusterInfoBox/ClusterInfoBox.test.jsx
+++ b/assets/js/common/ClusterInfoBox/ClusterInfoBox.test.jsx
@@ -10,62 +10,110 @@ import ClusterInfoBox from './ClusterInfoBox';
 describe('Cluster Info Box', () => {
   [
     {
-      haScenario: 'hana_scale_up',
-      haScenarioText: 'HANA Scale Up',
+      clusterType: 'hana_scale_up',
+      haScenarioText: 'HANA Scale Up Perf. Opt.',
+      scaleUpScenario: 'performance_optimized',
       provider: 'aws',
       providerText: 'AWS',
     },
     {
-      haScenario: 'hana_scale_out',
+      clusterType: 'hana_scale_up',
+      haScenarioText: 'HANA Scale Up Cost Opt.',
+      scaleUpScenario: 'cost_optimized',
+      provider: 'aws',
+      providerText: 'AWS',
+    },
+    {
+      clusterType: 'hana_scale_out',
       haScenarioText: 'HANA Scale Out',
+      scaleUpScenario: '',
       provider: 'aws',
       providerText: 'AWS',
     },
     {
-      haScenario: 'hana_scale_up',
+      clusterType: 'hana_scale_up',
       haScenarioText: 'HANA Scale Up',
+      scaleUpScenario: '',
       provider: 'azure',
       providerText: 'Azure',
     },
     {
-      haScenario: 'ascs_ers',
+      clusterType: 'hana_scale_up',
+      haScenarioText: 'HANA Scale Up Perf. Opt.',
+      scaleUpScenario: 'performance_optimized',
+      provider: 'azure',
+      providerText: 'Azure',
+    },
+    {
+      clusterType: 'hana_scale_up',
+      haScenarioText: 'HANA Scale Up Cost Opt.',
+      scaleUpScenario: 'cost_optimized',
+      provider: 'azure',
+      providerText: 'Azure',
+    },
+    {
+      clusterType: 'ascs_ers',
       haScenarioText: 'ASCS/ERS',
+      scaleUpScenario: '',
       provider: 'azure',
       providerText: 'Azure',
     },
     {
-      haScenario: '',
+      clusterType: '',
       haScenarioText: 'Unknown',
+      scaleUpScenario: '',
       provider: 'gcp',
       providerText: 'GCP',
     },
     {
-      haScenario: 'unknown',
+      clusterType: 'unknown',
       haScenarioText: 'Unknown',
+      scaleUpScenario: '',
       provider: 'kvm',
       providerText: 'On-premises / KVM',
     },
     {
-      haScenario: 'unknown',
+      clusterType: 'unknown',
       haScenarioText: 'Unknown',
+      scaleUpScenario: '',
       provider: 'vmware',
       providerText: 'VMware',
     },
     {
-      haScenario: 'hana_scale_up',
-      haScenarioText: 'HANA Scale Up',
+      clusterType: 'hana_scale_up',
+      haScenarioText: 'HANA Scale Up Perf. Opt.',
+      scaleUpScenario: 'performance_optimized',
       provider: 'nutanix',
       providerText: 'Nutanix',
     },
-  ].forEach(({ haScenario, haScenarioText, provider, providerText }) => {
-    it(`should display ${providerText} as the provider and HA Scenario: ${haScenarioText}`, () => {
-      const { getByText } = render(
-        <ClusterInfoBox haScenario={haScenario} provider={provider} />
-      );
-      expect(getByText(providerText)).toBeTruthy();
-      expect(getByText(haScenarioText)).toBeTruthy();
-    });
-  });
+    {
+      clusterType: 'hana_scale_up',
+      haScenarioText: 'HANA Scale Up Cost Opt.',
+      scaleUpScenario: 'cost_optimized',
+      provider: 'nutanix',
+      providerText: 'Nutanix',
+    },
+  ].forEach(
+    ({
+      clusterType,
+      scaleUpScenario,
+      haScenarioText,
+      provider,
+      providerText,
+    }) => {
+      it(`should display ${providerText} as the provider and HA Scenario: ${haScenarioText}`, () => {
+        const { getByText } = render(
+          <ClusterInfoBox
+            clusterType={clusterType}
+            scaleUpScenario={scaleUpScenario}
+            provider={provider}
+          />
+        );
+        expect(getByText(providerText)).toBeTruthy();
+        expect(getByText(haScenarioText)).toBeTruthy();
+      });
+    }
+  );
 
   it.each([
     { architectureType: 'classic', tooltip: 'Classic architecture' },
@@ -77,7 +125,7 @@ describe('Cluster Info Box', () => {
 
       renderWithRouter(
         <ClusterInfoBox
-          haScenario="hana_scale_up"
+          clusterType="hana_scale_up"
           provider="azure"
           architectureType={architectureType}
         />
@@ -91,7 +139,7 @@ describe('Cluster Info Box', () => {
   );
 
   it('should not display architecture type icon if architecture is unknown', () => {
-    render(<ClusterInfoBox haScenario="ascs_ers" provider="azure" />);
+    render(<ClusterInfoBox clusterType="ascs_ers" provider="azure" />);
     expect(screen.queryByTestId('eos-svg-component')).not.toBeInTheDocument();
   });
 });

--- a/assets/js/lib/checks/env.js
+++ b/assets/js/lib/checks/env.js
@@ -1,4 +1,4 @@
-import { ASCS_ERS } from '@lib/model/clusters';
+import { ASCS_ERS, HANA_SCALE_UP } from '@lib/model/clusters';
 
 export const buildEnv = ({
   provider,
@@ -7,6 +7,7 @@ export const buildEnv = ({
   ensa_version,
   filesystem_type,
   architecture_type,
+  hana_scenario,
 }) => {
   switch (cluster_type) {
     case ASCS_ERS: {
@@ -16,6 +17,15 @@ export const buildEnv = ({
         cluster_type,
         ensa_version,
         filesystem_type,
+      };
+    }
+    case HANA_SCALE_UP: {
+      return {
+        provider,
+        target_type,
+        cluster_type,
+        architecture_type,
+        hana_scenario,
       };
     }
     default: {

--- a/assets/js/lib/checks/env.test.js
+++ b/assets/js/lib/checks/env.test.js
@@ -1,7 +1,12 @@
 import { faker } from '@faker-js/faker';
 import { pick } from 'lodash';
 
-import { ASCS_ERS, HANA_SCALE_UP } from '@lib/model/clusters';
+import {
+  ASCS_ERS,
+  HANA_SCALE_UP,
+  COST_OPT_SCENARIO,
+  PERFORMANCE_SCENARIO,
+} from '@lib/model/clusters';
 
 import { buildEnv } from '.';
 
@@ -29,9 +34,10 @@ describe('buildEnv', () => {
     expect(env).toEqual(expectedPayload);
   });
 
-  it('should build and env for HANA clusters', () => {
+  it('should build and env for HANA sclae up performance clusters', () => {
     const payload = {
       cluster_type: HANA_SCALE_UP,
+      hana_scenario: PERFORMANCE_SCENARIO,
       provider: faker.color.rgb(),
       target_type: faker.hacker.noun(),
       ensa_version: faker.number.int(),
@@ -41,6 +47,31 @@ describe('buildEnv', () => {
 
     const expectedPayload = pick(payload, [
       'cluster_type',
+      'hana_scenario',
+      'provider',
+      'target_type',
+      'architecture_type',
+    ]);
+
+    const env = buildEnv(payload);
+
+    expect(env).toEqual(expectedPayload);
+  });
+
+  it('should build and env for HANA scale up cost opt clusters', () => {
+    const payload = {
+      cluster_type: HANA_SCALE_UP,
+      hana_scenario: COST_OPT_SCENARIO,
+      provider: faker.color.rgb(),
+      target_type: faker.hacker.noun(),
+      ensa_version: faker.number.int(),
+      filesystem_type: faker.animal.dog(),
+      architecture_type: faker.hacker.noun(),
+    };
+
+    const expectedPayload = pick(payload, [
+      'cluster_type',
+      'hana_scenario',
       'provider',
       'target_type',
       'architecture_type',

--- a/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
@@ -33,6 +33,7 @@ export function ClusterDetailsPage() {
   const provider = get(cluster, 'provider');
   const type = get(cluster, 'type');
   const architectureType = get(cluster, 'details.architecture_type');
+  const hanaScenario = get(cluster, 'details.hana_scenario');
 
   const catalog = useSelector(getCatalog());
 
@@ -50,6 +51,7 @@ export function ClusterDetailsPage() {
       provider,
       target_type: TARGET_CLUSTER,
       cluster_type: type,
+      hana_scenario: hanaScenario,
       ensa_version: ensaVersion,
       filesystem_type: filesystemType,
       architecture_type: architectureType,

--- a/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
+++ b/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
@@ -48,6 +48,7 @@ function ClusterSettingsPage() {
 
   const { abilities } = useSelector(getUserProfile);
   const cluster = useSelector(getCluster(clusterID));
+
   const clusterHosts = useSelector((state) =>
     getClusterHosts(state, clusterID)
   );
@@ -78,6 +79,7 @@ function ClusterSettingsPage() {
 
   const provider = get(cluster, 'provider');
   const type = get(cluster, 'type');
+  const hanaScenario = get(cluster, 'details.hana_scenario');
   const architectureType = get(cluster, 'details.architecture_type');
 
   const refreshCatalog = () => {
@@ -85,6 +87,7 @@ function ClusterSettingsPage() {
       provider,
       target_type: TARGET_CLUSTER,
       cluster_type: type,
+      hana_scenario: hanaScenario,
       ensa_version: ensaVersion,
       filesystem_type: filesystemType,
       architecture_type: architectureType,
@@ -133,7 +136,8 @@ function ClusterSettingsPage() {
       />
       {catalogBanner[provider]}
       <ClusterInfoBox
-        haScenario={type}
+        clusterType={type}
+        scaleUpScenario={hanaScenario}
         provider={provider}
         architectureType={architectureType}
       />

--- a/assets/js/pages/ExecutionResults/ExecutionHeader.test.jsx
+++ b/assets/js/pages/ExecutionResults/ExecutionHeader.test.jsx
@@ -10,34 +10,47 @@ import ExecutionHeader from './ExecutionHeader';
 
 describe('Checks results ExecutionHeader Component', () => {
   describe('With target Cluster', () => {
-    it('should render a header with expected cluster information', () => {
-      const clusterID = faker.string.uuid();
-      const clusterName = faker.animal.bear();
-      const cloudProvider = 'azure';
-      const clusterScenario = 'hana_scale_up';
+    it.each([
+      {
+        hanaScenario: 'performance_optimized',
+        hanaScenarioLabel: 'HANA Scale Up Perf. Opt.',
+      },
+      {
+        hanaScenario: 'cost_optimized',
+        hanaScenarioLabel: 'HANA Scale Up Cost Opt.',
+      },
+    ])(
+      'should render a header with expected cluster information for correct scale up scenario',
+      ({ hanaScenario, hanaScenarioLabel }) => {
+        const clusterID = faker.string.uuid();
+        const clusterName = faker.animal.bear();
+        const cloudProvider = 'azure';
+        const clusterScenario = 'hana_scale_up';
 
-      const target = clusterFactory.build({
-        id: clusterID,
-        name: clusterName,
-        provider: cloudProvider,
-        type: clusterScenario,
-      });
+        const target = clusterFactory.build({
+          id: clusterID,
+          name: clusterName,
+          provider: cloudProvider,
+          type: clusterScenario,
+          details: { hana_scenario: hanaScenario },
+        });
 
-      renderWithRouter(
-        <ExecutionHeader
-          targetID={clusterID}
-          targetName={clusterName}
-          targetType="cluster"
-          target={target}
-        />
-      );
+        renderWithRouter(
+          <ExecutionHeader
+            targetID={clusterID}
+            targetName={clusterName}
+            targetType="cluster"
+            target={target}
+          />
+        );
 
-      expect(screen.getByText('Back to Cluster Details')).toBeTruthy();
-      expect(screen.getByText('Azure')).toBeTruthy();
-      expect(screen.getByText('HANA Scale Up')).toBeTruthy();
-      expect(screen.getByText('Checks Results for cluster')).toBeTruthy();
-      expect(screen.getByText(clusterName)).toBeTruthy();
-    });
+        expect(screen.getByText('Back to Cluster Details')).toBeTruthy();
+        expect(screen.getByText('Azure')).toBeTruthy();
+        expect(screen.getByText(hanaScenarioLabel)).toBeTruthy();
+        expect(screen.getByText('Checks Results for cluster')).toBeTruthy();
+        expect(screen.getByText(clusterName)).toBeTruthy();
+      }
+    );
 
     it('should render a header with a warning banner on an unknown provider detection', () => {
       const clusterID = faker.string.uuid();
@@ -50,6 +63,7 @@ describe('Checks results ExecutionHeader Component', () => {
         name: clusterName,
         provider: cloudProvider,
         type: clusterScenario,
+        details: { hana_scenario: 'performance_optimized' },
       });
 
       renderWithRouter(
@@ -62,7 +76,7 @@ describe('Checks results ExecutionHeader Component', () => {
       );
 
       expect(screen.getByText('Provider not recognized')).toBeTruthy();
-      expect(screen.getByText('HANA Scale Up')).toBeTruthy();
+      expect(screen.getByText('HANA Scale Up Perf. Opt.')).toBeTruthy();
       expect(screen.getByText('Checks Results for cluster')).toBeTruthy();
       expect(
         screen.getByText(

--- a/assets/js/pages/ExecutionResults/ExecutionResults.stories.jsx
+++ b/assets/js/pages/ExecutionResults/ExecutionResults.stories.jsx
@@ -34,7 +34,11 @@ const checkRemediation = [
 const groupID = '02acea9d-9658-4902-9806-0eef2bfbbf5d';
 const cloudProvider = 'azure';
 
-const { name: clusterName, type: clusterScenario, details: clusterDetails } = clusterFactory.build({
+const {
+  name: clusterName,
+  type: clusterScenario,
+  details: clusterDetails,
+} = clusterFactory.build({
   id: groupID,
   type: 'hana_scale_up',
   details: { hana_scenario: 'performance_optimized' },

--- a/assets/js/pages/ExecutionResults/ExecutionResults.stories.jsx
+++ b/assets/js/pages/ExecutionResults/ExecutionResults.stories.jsx
@@ -34,9 +34,10 @@ const checkRemediation = [
 const groupID = '02acea9d-9658-4902-9806-0eef2bfbbf5d';
 const cloudProvider = 'azure';
 
-const { name: clusterName, type: clusterScenario } = clusterFactory.build({
+const { name: clusterName, type: clusterScenario, details: clusterDetails } = clusterFactory.build({
   id: groupID,
   type: 'hana_scale_up',
+  details: { hana_scenario: 'performance_optimized' },
 });
 
 const clusterHosts = [
@@ -349,6 +350,7 @@ export const Running = {
     target: {
       type: clusterScenario,
       provider: cloudProvider,
+      details: clusterDetails,
     },
     onLastExecutionUpdate: fetchRunning,
     onCatalogRefresh: fetchCatalog,
@@ -366,6 +368,7 @@ export const Completed = {
     target: {
       type: clusterScenario,
       provider: cloudProvider,
+      details: clusterDetails,
     },
     onLastExecutionUpdate: fetchCompleted,
     onCatalogRefresh: fetchCatalog,

--- a/assets/js/pages/ExecutionResults/TargetInfoBox.jsx
+++ b/assets/js/pages/ExecutionResults/TargetInfoBox.jsx
@@ -8,13 +8,14 @@ import HostInfoBox from '@common/HostInfoBox';
 
 function TargetInfoBox({ targetType, target }) {
   const architectureType = get(target, 'details.architecture_type');
-
+  const hanaScaleUpScenario = get(target, 'details.hana_scenario');
   switch (targetType) {
     case TARGET_CLUSTER:
       return (
         <ClusterInfoBox
-          haScenario={target.type}
+          clusterType={target.type}
           provider={target.provider}
+          scaleUpScenario={hanaScaleUpScenario}
           architectureType={architectureType}
         />
       );

--- a/lib/trento/infrastructure/checks/checks.ex
+++ b/lib/trento/infrastructure/checks/checks.ex
@@ -109,14 +109,28 @@ defmodule Trento.Infrastructure.Checks do
   end
 
   defp build_env(%ClusterExecutionEnv{
-         cluster_type: cluster_type,
+         cluster_type: :hana_scale_up,
          provider: provider,
-         architecture_type: architecture_type
+         architecture_type: architecture_type,
+         hana_scenario: hana_scenario
        }) do
     %{
-      "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
+      "cluster_type" => %{kind: {:string_value, Atom.to_string(ClusterType.hana_scale_up())}},
       "provider" => %{kind: {:string_value, Atom.to_string(provider)}},
-      "architecture_type" => %{kind: {:string_value, Atom.to_string(architecture_type)}}
+      "architecture_type" => %{kind: {:string_value, Atom.to_string(architecture_type)}},
+      "hana_scenario" => %{kind: {:string_value, Atom.to_string(hana_scenario)}}
+    }
+  end
+
+  defp build_env(%ClusterExecutionEnv{
+         cluster_type: :hana_scale_out,
+         architecture_type: architecture_type,
+         provider: provider
+       }) do
+    %{
+      "cluster_type" => %{kind: {:string_value, Atom.to_string(ClusterType.hana_scale_out())}},
+      "architecture_type" => %{kind: {:string_value, Atom.to_string(architecture_type)}},
+      "provider" => %{kind: {:string_value, Atom.to_string(provider)}}
     }
   end
 

--- a/lib/trento/infrastructure/checks/cluster_execution_env.ex
+++ b/lib/trento/infrastructure/checks/cluster_execution_env.ex
@@ -11,6 +11,7 @@ defmodule Trento.Infrastructure.Checks.ClusterExecutionEnv do
   require Trento.Clusters.Enums.FilesystemType, as: FilesystemType
   require Trento.Clusters.Enums.ClusterEnsaVersion, as: ClusterEnsaVersion
   require Trento.Clusters.Enums.HanaArchitectureType, as: HanaArchitectureType
+  require Trento.Clusters.Enums.HanaScenario, as: HanaScenario
 
   deftype do
     field :cluster_type, Ecto.Enum, values: ClusterType.values()
@@ -18,5 +19,6 @@ defmodule Trento.Infrastructure.Checks.ClusterExecutionEnv do
     field :filesystem_type, Ecto.Enum, values: FilesystemType.values()
     field :ensa_version, Ecto.Enum, values: ClusterEnsaVersion.values()
     field :architecture_type, Ecto.Enum, values: HanaArchitectureType.values()
+    field :hana_scenario, Ecto.Enum, values: HanaScenario.values()
   end
 end


### PR DESCRIPTION
# Description

This pr will enrich the communication between web and wanda required for the  hana scale up  cost opt and performance opt scenario. By updating the env which is send to wanda, web receives the correct checks related to the hana scale up scenario. 
Additionally, updated the internal env building on the backend to inform about the correct hana scale up scenario and update the checks execution properly. 
Visually, the frontend displays the cluster type correctly according to the scenario in the ClusterDetailsPage and ChecksResultDetails view.

Additionally to this, the pr requires an addition to all existing checks:
https://github.com/trento-project/checks/pull/23
The existing checks require the new hana_scenario
and a small update to wanda docs
https://github.com/trento-project/wanda/pull/538

## How was this tested?

- updated and added frontend tests
- updated and added backend tests


