### PR TITLE
Add hana scale up scenario as selection in checks catalog

### DIFF
--- a/assets/js/common/Select/Select.jsx
+++ b/assets/js/common/Select/Select.jsx
@@ -22,10 +22,14 @@ function Select({
   optionsListPosition = '',
   selectedItemPrefix = null,
 }) {
-  const enrichedOptions = options.map((option) => ({
-    value: get(option, 'value', option),
-    disabled: get(option, 'disabled', false),
-  }));
+  const enrichedOptions = options.map((option) => {
+    const optionValue = get(option, 'value', option);
+    return {
+      value: optionValue,
+      disabled: get(option, 'disabled', false),
+      key: get(option, 'key', optionValue),
+    };
+  });
   const selectedOption = find(enrichedOptions, { value });
   const dropdownSelector = `${optionsName.replace(
     /\s+/g,
@@ -71,7 +75,7 @@ function Select({
           >
             {enrichedOptions.map((option) => (
               <Listbox.Option
-                key={option.value}
+                key={option.key}
                 className={({ active, disabled: optionDisabled }) =>
                   classNames('cursor-default select-none relative py-2 px-3', {
                     'text-gray-400': optionDisabled,

--- a/assets/js/lib/model/checks.js
+++ b/assets/js/lib/model/checks.js
@@ -14,6 +14,14 @@ const supportsClusterType =
       (metadataClusterType) => metadataClusterType === clusterType
     );
 
+const supportsHanaScenario =
+  (hanaScenario) =>
+  ({ metadata }) =>
+    !metadata?.hana_scenario ||
+    castArray(metadata.hana_scenario).some(
+      (metadataHanaScenario) => metadataHanaScenario === hanaScenario
+    );
+
 export const hasChecksForTarget = (catalog, targetType) =>
   catalog.some(isCheckForTarget(targetType));
 
@@ -21,3 +29,8 @@ export const hasChecksForClusterType = (catalog, clusterType) =>
   catalog
     .filter(isCheckForTarget(TARGET_CLUSTER))
     .some(supportsClusterType(clusterType));
+
+export const hasChecksForHanaScenario = (catalog, hanaScenario) =>
+  catalog
+    .filter(isCheckForTarget(TARGET_CLUSTER))
+    .some(supportsHanaScenario(hanaScenario));

--- a/assets/js/lib/model/clusters.js
+++ b/assets/js/lib/model/clusters.js
@@ -7,10 +7,6 @@ export const ASCS_ERS = 'ascs_ers';
 export const COST_OPT_SCENARIO = 'cost_optimized';
 export const PERFORMANCE_SCENARIO = 'performance_optimized';
 
-// Hana scale up  with scenario
-export const HANA_SCALE_UP_PERF_OPT = `${HANA_SCALE_UP}-${PERFORMANCE_SCENARIO}`;
-export const HANA_SCALE_UP_COST_OPT = `${HANA_SCALE_UP}-${COST_OPT_SCENARIO}`;
-
 export const clusterTypes = [HANA_SCALE_UP, HANA_SCALE_OUT, ASCS_ERS];
 
 const clusterTypeLabels = {
@@ -37,22 +33,12 @@ const clusterScenarioLabels = {
 export const getClusterScenarioLabel = (type) =>
   clusterScenarioLabels[type] || '';
 
-export const clusterTypesCatalog = [
-  HANA_SCALE_UP_PERF_OPT,
-  HANA_SCALE_UP_COST_OPT,
-  HANA_SCALE_OUT,
-  ASCS_ERS,
+export const clusterCatalogFilters = [
+  { type: HANA_SCALE_UP, hanaScenario: PERFORMANCE_SCENARIO },
+  { type: HANA_SCALE_UP, hanaScenario: COST_OPT_SCENARIO },
+  { type: HANA_SCALE_OUT, hanaScenario: null },
+  { type: ASCS_ERS, hanaScenario: null },
 ];
-
-export const clusterTypeLabelsChecksCatalog = {
-  [HANA_SCALE_UP_PERF_OPT]: 'HANA Scale Up Perf. Opt.',
-  [HANA_SCALE_UP_COST_OPT]: 'HANA Scale Up Cost Opt.',
-  [HANA_SCALE_OUT]: 'HANA Scale Out',
-  [ASCS_ERS]: 'ASCS/ERS',
-};
-
-export const getClusterTypeLabelChecksCatalog = (type) =>
-  clusterTypeLabelsChecksCatalog[type] || 'Unknown';
 
 export const ANGI_ARCHITECTURE = 'angi';
 export const CLASSIC_ARCHITECTURE = 'classic';

--- a/assets/js/lib/model/clusters.js
+++ b/assets/js/lib/model/clusters.js
@@ -7,23 +7,27 @@ export const ASCS_ERS = 'ascs_ers';
 export const COST_OPT_SCENARIO = 'cost_optimized';
 export const PERFORMANCE_SCENARIO = 'performance_optimized';
 
-export const clusterTypes = [HANA_SCALE_UP, HANA_SCALE_OUT, ASCS_ERS];
-export const hanaClusterScenarioTypes = [
-  COST_OPT_SCENARIO,
-  PERFORMANCE_SCENARIO,
-];
+// Hana scale up  with scenarios
+export const HANA_SCALE_UP_PERF_OPT = `${HANA_SCALE_UP}-${PERFORMANCE_SCENARIO}`;
+export const HANA_SCALE_UP_COST_OPT = `${HANA_SCALE_UP}-${COST_OPT_SCENARIO}`;
 
-export const isValidClusterType = (clusterType) =>
-  clusterTypes.includes(clusterType);
+export const clusterTypes = [HANA_SCALE_UP, HANA_SCALE_OUT, ASCS_ERS];
 
 const clusterTypeLabels = {
   [HANA_SCALE_UP]: 'HANA Scale Up',
   [HANA_SCALE_OUT]: 'HANA Scale Out',
   [ASCS_ERS]: 'ASCS/ERS',
 };
+export const isValidClusterType = (clusterType) =>
+  clusterTypes.includes(clusterType);
 
 export const getClusterTypeLabel = (type) =>
   clusterTypeLabels[type] || 'Unknown';
+
+export const hanaClusterScenarioTypes = [
+  COST_OPT_SCENARIO,
+  PERFORMANCE_SCENARIO,
+];
 
 const clusterScenarioLabels = {
   [PERFORMANCE_SCENARIO]: 'Perf. Opt.',
@@ -32,6 +36,23 @@ const clusterScenarioLabels = {
 
 export const getClusterScenarioLabel = (type) =>
   clusterScenarioLabels[type] || '';
+
+export const clusterTypesCatalog = [
+  HANA_SCALE_UP_PERF_OPT,
+  HANA_SCALE_UP_COST_OPT,
+  HANA_SCALE_OUT,
+  ASCS_ERS,
+];
+
+export const clusterTypeLabelsChecksCatalog = {
+  [HANA_SCALE_UP_PERF_OPT]: 'HANA Scale Up Perf. Opt.',
+  [HANA_SCALE_UP_COST_OPT]: 'HANA Scale Up Cost Opt.',
+  [HANA_SCALE_OUT]: 'HANA Scale Out',
+  [ASCS_ERS]: 'ASCS/ERS',
+};
+
+export const getClusterTypeLabelChecksCatalog = (type) =>
+  clusterTypeLabelsChecksCatalog[type] || 'Unknown';
 
 export const ANGI_ARCHITECTURE = 'angi';
 export const CLASSIC_ARCHITECTURE = 'classic';

--- a/assets/js/lib/model/clusters.js
+++ b/assets/js/lib/model/clusters.js
@@ -7,7 +7,7 @@ export const ASCS_ERS = 'ascs_ers';
 export const COST_OPT_SCENARIO = 'cost_optimized';
 export const PERFORMANCE_SCENARIO = 'performance_optimized';
 
-// Hana scale up  with scenarios
+// Hana scale up  with scenario
 export const HANA_SCALE_UP_PERF_OPT = `${HANA_SCALE_UP}-${PERFORMANCE_SCENARIO}`;
 export const HANA_SCALE_UP_COST_OPT = `${HANA_SCALE_UP}-${COST_OPT_SCENARIO}`;
 

--- a/assets/js/pages/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/pages/ChecksCatalog/ChecksCatalog.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import classNames from 'classnames';
-import { get, groupBy } from 'lodash';
+import { get, groupBy, trim } from 'lodash';
 
 import {
   providers,
@@ -34,27 +34,21 @@ const providerOptionRenderer = createOptionRenderer(
 
 const clusterTypeRenderer = createOptionRenderer(
   'All cluster types',
-  ({ type, hanaScenario }, disabled) => {
-    const clusterTypeLabel = [
-      getClusterTypeLabel(type),
-      getClusterScenarioLabel(hanaScenario),
-    ]
-      .filter((label) => label !== null && label !== undefined && label !== '')
-      .join(' ');
-    return (
-      <>
-        {clusterTypeLabel}
-        {disabled && (
-          <Pill
-            size="xs"
-            className="absolute right-2 bg-green-100 text-green-800"
-          >
-            Coming Soon
-          </Pill>
-        )}
-      </>
-    );
-  }
+  ({ type, hanaScenario }, disabled) => (
+    <>
+      {trim(
+        `${getClusterTypeLabel(type)} ${getClusterScenarioLabel(hanaScenario)}`
+      )}
+      {disabled && (
+        <Pill
+          size="xs"
+          className="absolute right-2 bg-green-100 text-green-800"
+        >
+          Coming Soon
+        </Pill>
+      )}
+    </>
+  )
 );
 
 const targetTypeOptionRenderer = createOptionRenderer(

--- a/assets/js/pages/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/pages/ChecksCatalog/ChecksCatalog.jsx
@@ -154,12 +154,6 @@ function ChecksCatalog({
   ];
 
   useEffect(() => {
-    console.log('Selected Filters:', {
-      selectedProvider,
-      selectedTargetType,
-      selectedClusterType,
-      selectedHanaScaleUpScenario,
-    });
     updateCatalog({
       selectedProvider,
       selectedTargetType,

--- a/assets/js/pages/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/pages/ChecksCatalog/ChecksCatalog.jsx
@@ -8,7 +8,15 @@ import {
   TARGET_HOST,
   TARGET_CLUSTER,
 } from '@lib/model';
-import { clusterTypes, getClusterTypeLabel } from '@lib/model/clusters';
+import {
+  clusterTypesCatalog,
+  getClusterTypeLabelChecksCatalog,
+  COST_OPT_SCENARIO,
+  HANA_SCALE_UP,
+  PERFORMANCE_SCENARIO,
+  HANA_SCALE_UP_PERF_OPT,
+  HANA_SCALE_UP_COST_OPT,
+} from '@lib/model/clusters';
 import { hasChecksForClusterType, hasChecksForTarget } from '@lib/model/checks';
 import Accordion from '@common/Accordion';
 import PageHeader from '@common/PageHeader';
@@ -24,11 +32,21 @@ const providerOptionRenderer = createOptionRenderer(
   (provider) => <ProviderLabel provider={provider} />
 );
 
+const mapClusterType = (type) => {
+  switch (type) {
+    case HANA_SCALE_UP_PERF_OPT:
+    case HANA_SCALE_UP_COST_OPT:
+      return HANA_SCALE_UP;
+    default:
+      return type;
+  }
+};
+
 const clusterTypeRenderer = createOptionRenderer(
   'All cluster types',
   (clusterType, disabled) => (
     <>
-      {getClusterTypeLabel(clusterType)}
+      {getClusterTypeLabelChecksCatalog(clusterType)}
       {disabled && (
         <Pill
           size="xs"
@@ -74,11 +92,30 @@ function ChecksCatalog({
   const [selectedProvider, setProviderSelected] = useState(OPTION_ALL);
   const [selectedTargetType, setSelectedTargetType] = useState(OPTION_ALL);
   const [selectedClusterType, setSelectedClusterType] = useState(OPTION_ALL);
+  const [selectedHanaScaleUpScenario, setSelectedHanaScaleUpScenario] =
+    useState(OPTION_ALL);
+
+  const onClusterTypeChange = (type) => {
+    switch (type) {
+      case HANA_SCALE_UP_PERF_OPT:
+        setSelectedHanaScaleUpScenario(PERFORMANCE_SCENARIO);
+        break;
+      case HANA_SCALE_UP_COST_OPT:
+        setSelectedHanaScaleUpScenario(COST_OPT_SCENARIO);
+        break;
+      default:
+        setSelectedHanaScaleUpScenario(OPTION_ALL);
+    }
+
+    setSelectedClusterType(type);
+  };
 
   const onTargetTypeChange = (targetType) => {
     if (targetType !== TARGET_CLUSTER) {
       setSelectedClusterType(OPTION_ALL);
+      setSelectedHanaScaleUpScenario(OPTION_ALL);
     }
+    setSelectedHanaScaleUpScenario(OPTION_ALL);
     setSelectedTargetType(targetType);
   };
 
@@ -95,13 +132,16 @@ function ChecksCatalog({
     },
     {
       optionsName: 'cluster-types',
-      options: clusterTypes.map((clusterType) => ({
+      options: clusterTypesCatalog.map((clusterType) => ({
         value: clusterType,
-        disabled: !hasChecksForClusterType(completeCatalog, clusterType),
+        disabled: !hasChecksForClusterType(
+          completeCatalog,
+          mapClusterType(clusterType)
+        ),
       })),
       renderOption: clusterTypeRenderer,
       value: selectedClusterType,
-      onChange: setSelectedClusterType,
+      onChange: onClusterTypeChange,
       disabled: selectedTargetType !== TARGET_CLUSTER,
     },
     {
@@ -114,17 +154,30 @@ function ChecksCatalog({
   ];
 
   useEffect(() => {
+    console.log('Selected Filters:', {
+      selectedProvider,
+      selectedTargetType,
+      selectedClusterType,
+      selectedHanaScaleUpScenario,
+    });
     updateCatalog({
       selectedProvider,
       selectedTargetType,
       selectedClusterType,
+      selectedHanaScaleUpScenario,
     });
-  }, [selectedProvider, selectedTargetType, selectedClusterType]);
+  }, [
+    selectedProvider,
+    selectedTargetType,
+    selectedClusterType,
+    selectedHanaScaleUpScenario,
+  ]);
 
   const clearFilters = () => {
     setProviderSelected(OPTION_ALL);
     setSelectedTargetType(OPTION_ALL);
     setSelectedClusterType(OPTION_ALL);
+    setSelectedHanaScaleUpScenario(OPTION_ALL);
   };
 
   return (

--- a/assets/js/pages/ChecksCatalog/ChecksCatalog.jsx
+++ b/assets/js/pages/ChecksCatalog/ChecksCatalog.jsx
@@ -111,11 +111,10 @@ function ChecksCatalog({
   };
 
   const onTargetTypeChange = (targetType) => {
+    setSelectedHanaScaleUpScenario(OPTION_ALL);
     if (targetType !== TARGET_CLUSTER) {
       setSelectedClusterType(OPTION_ALL);
-      setSelectedHanaScaleUpScenario(OPTION_ALL);
     }
-    setSelectedHanaScaleUpScenario(OPTION_ALL);
     setSelectedTargetType(targetType);
   };
 

--- a/assets/js/pages/ChecksCatalog/ChecksCatalog.test.jsx
+++ b/assets/js/pages/ChecksCatalog/ChecksCatalog.test.jsx
@@ -43,7 +43,7 @@ describe('ChecksCatalog ChecksCatalog component', () => {
       selectedClusterType: 'all',
       selectedProvider: 'all',
       selectedTargetType: 'all',
-      selectedHanaScaleUpScenario: 'all',
+      selectedHanaScenario: 'all',
     });
   });
 
@@ -177,6 +177,12 @@ describe('ChecksCatalog ChecksCatalog component', () => {
       catalogCheckFactory.build({
         metadata: {
           target_type: 'cluster',
+          cluster_type: 'hana_scale_out',
+        },
+      }),
+      catalogCheckFactory.build({
+        metadata: {
+          target_type: 'cluster',
           cluster_type: 'ascs_ers',
         },
       }),
@@ -195,30 +201,58 @@ describe('ChecksCatalog ChecksCatalog component', () => {
     await user.click(screen.getByText('Clusters'));
 
     await user.click(screen.getByText('All cluster types'));
+    await user.click(screen.getByText('HANA Scale Up Perf. Opt.'));
+
+    await user.click(screen.getAllByText('HANA Scale Up Perf. Opt.')[0]);
+    await user.click(screen.getByText('HANA Scale Up Cost Opt.'));
+
+    await user.click(screen.getAllByText('HANA Scale Up Cost Opt.')[0]);
+    await user.click(screen.getByText('HANA Scale Out'));
+
+    await user.click(screen.getAllByText('HANA Scale Out')[0]);
     await user.click(screen.getByText('ASCS/ERS'));
+
     expect(mockUpdateCatalog).toHaveBeenNthCalledWith(1, {
       selectedClusterType: 'all',
+      selectedHanaScenario: 'all',
       selectedProvider: 'all',
       selectedTargetType: 'all',
-      selectedHanaScaleUpScenario: 'all',
     });
     expect(mockUpdateCatalog).toHaveBeenNthCalledWith(2, {
       selectedClusterType: 'all',
+      selectedHanaScenario: 'all',
       selectedProvider: 'aws',
       selectedTargetType: 'all',
-      selectedHanaScaleUpScenario: 'all',
     });
     expect(mockUpdateCatalog).toHaveBeenNthCalledWith(3, {
       selectedClusterType: 'all',
+      selectedHanaScenario: 'all',
       selectedProvider: 'aws',
       selectedTargetType: 'cluster',
-      selectedHanaScaleUpScenario: 'all',
     });
     expect(mockUpdateCatalog).toHaveBeenNthCalledWith(4, {
-      selectedClusterType: 'ascs_ers',
+      selectedClusterType: 'hana_scale_up',
+      selectedHanaScenario: 'performance_optimized',
       selectedProvider: 'aws',
       selectedTargetType: 'cluster',
-      selectedHanaScaleUpScenario: 'all',
+    });
+    expect(mockUpdateCatalog).toHaveBeenNthCalledWith(5, {
+      selectedClusterType: 'hana_scale_up',
+      selectedHanaScenario: 'cost_optimized',
+      selectedProvider: 'aws',
+      selectedTargetType: 'cluster',
+    });
+    expect(mockUpdateCatalog).toHaveBeenNthCalledWith(6, {
+      selectedClusterType: 'hana_scale_out',
+      selectedHanaScenario: null,
+      selectedProvider: 'aws',
+      selectedTargetType: 'cluster',
+    });
+    expect(mockUpdateCatalog).toHaveBeenNthCalledWith(7, {
+      selectedClusterType: 'ascs_ers',
+      selectedHanaScenario: null,
+      selectedProvider: 'aws',
+      selectedTargetType: 'cluster',
     });
   });
 });

--- a/assets/js/pages/ChecksCatalog/ChecksCatalog.test.jsx
+++ b/assets/js/pages/ChecksCatalog/ChecksCatalog.test.jsx
@@ -43,6 +43,7 @@ describe('ChecksCatalog ChecksCatalog component', () => {
       selectedClusterType: 'all',
       selectedProvider: 'all',
       selectedTargetType: 'all',
+      selectedHanaScaleUpScenario: 'all',
     });
   });
 
@@ -72,6 +73,16 @@ describe('ChecksCatalog ChecksCatalog component', () => {
           metadata: {
             target_type: 'cluster',
             cluster_type: 'hana_scale_up',
+            hana_scenario: 'performance_optimized',
+            architecture_type: 'classic',
+          },
+        }),
+        catalogCheckFactory.build({
+          metadata: {
+            target_type: 'cluster',
+            cluster_type: 'hana_scale_up',
+            hana_scenario: 'cost_optimized',
+            architecture_type: 'classic',
           },
         }),
         catalogCheckFactory.build({
@@ -89,7 +100,11 @@ describe('ChecksCatalog ChecksCatalog component', () => {
       initialTargetType: 'Clusters',
       filter: 'All cluster types',
       expectDisabled: 'HANA Scale Out',
-      expectAllEnabled: ['HANA Scale Up', 'ASCS/ERS'],
+      expectAllEnabled: [
+        'HANA Scale Up Perf. Opt.',
+        'HANA Scale Up Cost Opt.',
+        'ASCS/ERS',
+      ],
     },
   ];
 
@@ -120,11 +135,9 @@ describe('ChecksCatalog ChecksCatalog component', () => {
       }
 
       await user.click(screen.getByText(filter));
-
       expect(
         screen.getByText(expectDisabled, { exact: false }).closest('div')
       ).toHaveAttribute('aria-disabled', 'true');
-
       const expectItemEnabled = (itemExpectedEnabled) =>
         expect(
           screen.getByText(itemExpectedEnabled).closest('div')
@@ -151,6 +164,14 @@ describe('ChecksCatalog ChecksCatalog component', () => {
         metadata: {
           target_type: 'cluster',
           cluster_type: 'hana_scale_up',
+          hana_scenario: 'performance_optimized',
+        },
+      }),
+      catalogCheckFactory.build({
+        metadata: {
+          target_type: 'cluster',
+          cluster_type: 'hana_scale_up',
+          hana_scenario: 'cost_optimized',
         },
       }),
       catalogCheckFactory.build({
@@ -179,21 +200,25 @@ describe('ChecksCatalog ChecksCatalog component', () => {
       selectedClusterType: 'all',
       selectedProvider: 'all',
       selectedTargetType: 'all',
+      selectedHanaScaleUpScenario: 'all',
     });
     expect(mockUpdateCatalog).toHaveBeenNthCalledWith(2, {
       selectedClusterType: 'all',
       selectedProvider: 'aws',
       selectedTargetType: 'all',
+      selectedHanaScaleUpScenario: 'all',
     });
     expect(mockUpdateCatalog).toHaveBeenNthCalledWith(3, {
       selectedClusterType: 'all',
       selectedProvider: 'aws',
       selectedTargetType: 'cluster',
+      selectedHanaScaleUpScenario: 'all',
     });
     expect(mockUpdateCatalog).toHaveBeenNthCalledWith(4, {
       selectedClusterType: 'ascs_ers',
       selectedProvider: 'aws',
       selectedTargetType: 'cluster',
+      selectedHanaScaleUpScenario: 'all',
     });
   });
 });

--- a/assets/js/pages/ChecksCatalog/ChecksCatalogPage.jsx
+++ b/assets/js/pages/ChecksCatalog/ChecksCatalogPage.jsx
@@ -1,12 +1,8 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import {
-  HANA_SCALE_UP,
-  HANA_SCALE_UP_PERF_OPT,
-  HANA_SCALE_UP_COST_OPT,
-} from '@lib/model/clusters';
 
 import { pickBy, values } from 'lodash';
+
 import { getCatalog } from '@state/selectors/catalog';
 import { updateCatalog } from '@state/catalog';
 import { OPTION_ALL } from '@common/Select';
@@ -15,25 +11,10 @@ import ChecksCatalog from './ChecksCatalog';
 
 const isSomeFilter = (value) => value !== OPTION_ALL;
 
-const modifyHanaScaleUpClusterType = (clusterType) => {
-  switch (clusterType) {
-    case HANA_SCALE_UP_PERF_OPT:
-    case HANA_SCALE_UP_COST_OPT:
-      return HANA_SCALE_UP;
-    default:
-      return clusterType;
-  }
-};
-
 const buildUpdateCatalogAction = (selectedFilters) => {
   const hasFilters = values(selectedFilters).some(isSomeFilter);
-  const modifiedSelectedFilters = {
-    ...selectedFilters,
-    cluster_type: modifyHanaScaleUpClusterType(selectedFilters.cluster_type),
-  };
-
   const payload = {
-    ...pickBy(modifiedSelectedFilters, isSomeFilter),
+    ...pickBy(selectedFilters, isSomeFilter),
     ...(hasFilters ? { filteredCatalog: true } : {}),
   };
   return updateCatalog(payload);
@@ -59,14 +40,14 @@ function ChecksCatalogPage() {
         selectedProvider,
         selectedTargetType,
         selectedClusterType,
-        selectedHanaScaleUpScenario,
+        selectedHanaScenario,
       }) =>
         dispatch(
           buildUpdateCatalogAction({
             provider: selectedProvider,
             target_type: selectedTargetType,
             cluster_type: selectedClusterType,
-            hana_scenario: selectedHanaScaleUpScenario,
+            hana_scenario: selectedHanaScenario,
           })
         )
       }

--- a/assets/js/pages/ChecksCatalog/ChecksCatalogPage.jsx
+++ b/assets/js/pages/ChecksCatalog/ChecksCatalogPage.jsx
@@ -32,8 +32,6 @@ const buildUpdateCatalogAction = (selectedFilters) => {
     cluster_type: modifyHanaScaleUpClusterType(selectedFilters.cluster_type),
   };
 
-  console.log('selectedFilters', selectedFilters);
-
   const payload = {
     ...pickBy(modifiedSelectedFilters, isSomeFilter),
     ...(hasFilters ? { filteredCatalog: true } : {}),

--- a/assets/js/pages/ChecksCatalog/ChecksCatalogPage.jsx
+++ b/assets/js/pages/ChecksCatalog/ChecksCatalogPage.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import {
+  HANA_SCALE_UP,
+  HANA_SCALE_UP_PERF_OPT,
+  HANA_SCALE_UP_COST_OPT,
+} from '@lib/model/clusters';
 
 import { pickBy, values } from 'lodash';
-
 import { getCatalog } from '@state/selectors/catalog';
 import { updateCatalog } from '@state/catalog';
 import { OPTION_ALL } from '@common/Select';
@@ -11,10 +15,27 @@ import ChecksCatalog from './ChecksCatalog';
 
 const isSomeFilter = (value) => value !== OPTION_ALL;
 
+const modifyHanaScaleUpClusterType = (clusterType) => {
+  switch (clusterType) {
+    case HANA_SCALE_UP_PERF_OPT:
+    case HANA_SCALE_UP_COST_OPT:
+      return HANA_SCALE_UP;
+    default:
+      return clusterType;
+  }
+};
+
 const buildUpdateCatalogAction = (selectedFilters) => {
   const hasFilters = values(selectedFilters).some(isSomeFilter);
+  const modifiedSelectedFilters = {
+    ...selectedFilters,
+    cluster_type: modifyHanaScaleUpClusterType(selectedFilters.cluster_type),
+  };
+
+  console.log('selectedFilters', selectedFilters);
+
   const payload = {
-    ...pickBy(selectedFilters, isSomeFilter),
+    ...pickBy(modifiedSelectedFilters, isSomeFilter),
     ...(hasFilters ? { filteredCatalog: true } : {}),
   };
   return updateCatalog(payload);
@@ -40,12 +61,14 @@ function ChecksCatalogPage() {
         selectedProvider,
         selectedTargetType,
         selectedClusterType,
+        selectedHanaScaleUpScenario,
       }) =>
         dispatch(
           buildUpdateCatalogAction({
             provider: selectedProvider,
             target_type: selectedTargetType,
             cluster_type: selectedClusterType,
+            hana_scenario: selectedHanaScaleUpScenario,
           })
         )
       }

--- a/test/e2e/cypress/e2e/checks_catalog.cy.js
+++ b/test/e2e/cypress/e2e/checks_catalog.cy.js
@@ -128,10 +128,27 @@ context('Checks catalog', () => {
           },
           {
             dropdown: 'cluster-types-selection-dropdown',
-            option: 'HANA Scale Up',
+            option: 'HANA Scale Up Perf. Opt.',
           },
         ],
-        expectedRequest: `${checksCatalogURL}?provider=aws&target_type=cluster&cluster_type=hana_scale_up`,
+        expectedRequest: `${checksCatalogURL}?provider=aws&target_type=cluster&cluster_type=hana_scale_up&hana_scenario=performance_optimized`,
+      },
+      {
+        selectedFilters: [
+          {
+            dropdown: 'providers-selection-dropdown',
+            option: 'AWS',
+          },
+          {
+            dropdown: 'targets-selection-dropdown',
+            option: 'Clusters',
+          },
+          {
+            dropdown: 'cluster-types-selection-dropdown',
+            option: 'HANA Scale Up Cost Opt.',
+          },
+        ],
+        expectedRequest: `${checksCatalogURL}?provider=aws&target_type=cluster&cluster_type=hana_scale_up&hana_scenario=cost_optimized`,
       },
     ];
 


### PR DESCRIPTION
# Description
This pr enriches the checks catalog view by changing the Hana Scale Up filter to Perf Opt and adding a new filter with cost optimized scenario.  


## Demo *before* PR
![image](https://github.com/user-attachments/assets/ef1ead01-340f-4330-971d-ec6eb7c15adb)


## Demo *after* PR
![image](https://github.com/user-attachments/assets/e44c7714-7ddb-409c-8a3e-d633a1f939b5)


New features:
- Rename "HANA Scale Up" as "HANA Scale Up Perf. Opt." in Cluster Types filter in Checks Catalog view
when selected, checks applicable to "HANA Scale Up Perf. Opt." clusters will be displayed in the view
- Add "HANA Scale Up Cost Opt." in Cluster Types filter in Checks Catalog view
when selected, checks applicable to "HANA Scale Up Cost Opt." clusters will be displayed in the view
Fixes # (issue)

## How was this tested?
- Fixed existing tests
