### PR TITLE
Update community container image to use fixed versions from leap15.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM opensuse/tumbleweed AS elixir-build
+FROM opensuse/leap:15.6 AS elixir-build
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
-RUN zypper -n in make gcc git-core elixir elixir-hex erlang-rebar3
+RUN zypper ar https://download.opensuse.org/repositories/devel:sap:trento:builddeps/15.6 buildeps
+RUN zypper -n --gpg-auto-import-keys ref
+RUN zypper -n in make gcc git-core elixir115 elixir-hex erlang26 erlang-rebar3
 COPY . /build
 WORKDIR /build
 ARG MIX_ENV=prod
@@ -24,10 +26,13 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 ARG MIX_ENV=prod
 ENV MIX_ENV=$MIX_ENV
+ENV MIX_HOME=/usr/bin
+ENV MIX_REBAR3=/usr/bin/rebar3
+ENV MIX_PATH=/usr/lib/elixir/lib/hex/ebin
 RUN mix phx.digest
 RUN mix release
 
-FROM opensuse/tumbleweed AS trento
+FROM opensuse/leap:15.6 AS trento
 LABEL org.opencontainers.image.source="https://github.com/trento-project/web"
 ARG MIX_ENV=prod
 ENV LANG en_US.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM opensuse/leap:15.6 AS elixir-build
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 RUN zypper ar https://download.opensuse.org/repositories/devel:sap:trento:builddeps/15.6 buildeps
 RUN zypper -n --gpg-auto-import-keys ref
 RUN zypper -n in make gcc git-core elixir==1.15 elixir-hex erlang==26 erlang-rebar3
@@ -21,9 +21,9 @@ RUN npm run build
 FROM elixir-build AS release
 COPY --from=assets-build /build /build
 WORKDIR /build
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 ARG MIX_ENV=prod
 ENV MIX_ENV=$MIX_ENV
 ENV MIX_HOME=/usr/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 RUN zypper ar https://download.opensuse.org/repositories/devel:sap:trento:builddeps/15.6 buildeps
 RUN zypper -n --gpg-auto-import-keys ref
-RUN zypper -n in make gcc git-core elixir115 elixir-hex erlang26 erlang-rebar3
+RUN zypper -n in make gcc git-core elixir==1.15 elixir-hex erlang==26 erlang-rebar3
 COPY . /build
 WORKDIR /build
 ARG MIX_ENV=prod
@@ -32,7 +32,7 @@ ENV MIX_PATH=/usr/lib/elixir/lib/hex/ebin
 RUN mix phx.digest
 RUN mix release
 
-FROM opensuse/leap:15.6 AS trento
+FROM opensuse/leap:15.6
 LABEL org.opencontainers.image.source="https://github.com/trento-project/web"
 ARG MIX_ENV=prod
 ENV LANG en_US.UTF-8

--- a/packaging/suse/container/Dockerfile
+++ b/packaging/suse/container/Dockerfile
@@ -5,16 +5,14 @@
 #!UseOBSRepositories
 #!ExclusiveArch: x86_64
 
-FROM bci/nodejs:20 AS assets-build
+FROM registry.suse.com/bci/nodejs:20 AS assets-build
 ADD web.tar.gz /build/
 WORKDIR /build/web/assets
 RUN npm run tailwind:build
 RUN npm run build
 
-FROM bci/bci-base:15.6 AS release
-# Workaround for https://github.com/openSUSE/obs-build/issues/487
-RUN zypper --non-interactive in sles-release
-RUN zypper -n in make gcc git-core elixir115 elixir-hex erlang26 erlang-rebar3
+FROM registry.suse.com/bci/bci-base:15.6 AS release
+RUN zypper -n in make gcc git-core elixir==1.15 elixir-hex erlang==26 erlang-rebar3
 COPY --from=assets-build /build /build
 WORKDIR /build/web/
 ENV LANG en_US.UTF-8
@@ -28,7 +26,7 @@ ENV VERSION=%%VERSION%%
 RUN mix phx.digest
 RUN mix release
 
-FROM bci/bci-base:15.6 AS trento
+FROM registry.suse.com/bci/bci-base:15.6
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.suse.trento
 LABEL org.opencontainers.image.source="https://github.com/trento-project/web"

--- a/packaging/suse/container/Dockerfile
+++ b/packaging/suse/container/Dockerfile
@@ -15,9 +15,9 @@ FROM registry.suse.com/bci/bci-base:15.6 AS release
 RUN zypper -n in make gcc git-core elixir==1.15 elixir-hex erlang==26 erlang-rebar3
 COPY --from=assets-build /build /build
 WORKDIR /build/web/
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 ENV MIX_ENV=prod
 ENV MIX_HOME=/usr/bin
 ENV MIX_REBAR3=/usr/bin/rebar3
@@ -30,9 +30,9 @@ FROM registry.suse.com/bci/bci-base:15.6
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.suse.trento
 LABEL org.opencontainers.image.source="https://github.com/trento-project/web"
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 # tar is required by kubectl cp
 RUN zypper -n in tar
 WORKDIR /app

--- a/packaging/suse/container/Dockerfile
+++ b/packaging/suse/container/Dockerfile
@@ -11,10 +11,10 @@ WORKDIR /build/web/assets
 RUN npm run tailwind:build
 RUN npm run build
 
-FROM bci/bci-base:15.4 AS release
+FROM bci/bci-base:15.6 AS release
 # Workaround for https://github.com/openSUSE/obs-build/issues/487
 RUN zypper --non-interactive in sles-release
-RUN zypper -n in make gcc git-core elixir>=1.15 elixir-hex erlang-rebar3
+RUN zypper -n in make gcc git-core elixir115 elixir-hex erlang26 erlang-rebar3
 COPY --from=assets-build /build /build
 WORKDIR /build/web/
 ENV LANG en_US.UTF-8
@@ -28,7 +28,7 @@ ENV VERSION=%%VERSION%%
 RUN mix phx.digest
 RUN mix release
 
-FROM bci/bci-base:15.4 AS trento
+FROM bci/bci-base:15.6 AS trento
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=com.suse.trento
 LABEL org.opencontainers.image.source="https://github.com/trento-project/web"


### PR DESCRIPTION
# Description
The build of the community image is failing since `tumbleweed` erlang version has been upgraded to `otp-27` and some our dependencies don't build with that version (something to be fixed at some point).

This PR simply sets opensuse Leap 15.6 as baseline and sets fixed versions of elixir and erlang.

Fixes https://github.com/trento-project/web/actions/runs/12560125083/job/35017432246