### PR TITLE
Fix selected cluster type ui in Checks catalog view

### DIFF
--- a/assets/js/common/Select/Select.jsx
+++ b/assets/js/common/Select/Select.jsx
@@ -11,7 +11,8 @@ export const OPTION_ALL = 'all';
 const defaultOnChange = () => {};
 const defaultRenderOption = (item) => item.value;
 
-const deepCompareSelection=(optionValue, value) => isEqual(optionValue, value);
+const deepCompareSelection = (optionValue, value) =>
+  isEqual(optionValue, value);
 
 function Select({
   optionsName,

--- a/assets/js/common/Select/Select.jsx
+++ b/assets/js/common/Select/Select.jsx
@@ -4,12 +4,14 @@ import { Listbox, Transition } from '@headlessui/react';
 import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/20/solid';
 
 import classNames from 'classnames';
-import { find, get } from 'lodash';
+import { find, get, isEqual } from 'lodash';
 
 export const OPTION_ALL = 'all';
 
 const defaultOnChange = () => {};
 const defaultRenderOption = (item) => item.value;
+
+const deepCompareSelection=(optionValue, value) => isEqual(optionValue, value);
 
 function Select({
   optionsName,
@@ -42,6 +44,7 @@ function Select({
       disabled={disabled}
       value={value}
       onChange={onChange}
+      by={deepCompareSelection}
     >
       <div className="relative">
         <Listbox.Button

--- a/test/e2e/cypress/e2e/checks_catalog.cy.js
+++ b/test/e2e/cypress/e2e/checks_catalog.cy.js
@@ -93,12 +93,15 @@ context('Checks catalog', () => {
   });
 
   describe('Filtering', () => {
+    const selectedIconSelector =
+      '.absolute.inset-y-0.right-2.end-1.flex.items-center.pl-3.text-green-600';
     const filteringScenarios = [
       {
         selectedFilters: [
           {
             dropdown: 'providers-selection-dropdown',
             option: 'AWS',
+            selectedIcon: selectedIconSelector,
           },
         ],
         expectedRequest: `${checksCatalogURL}?provider=aws`,
@@ -108,10 +111,12 @@ context('Checks catalog', () => {
           {
             dropdown: 'providers-selection-dropdown',
             option: 'AWS',
+            selectedIcon: selectedIconSelector,
           },
           {
             dropdown: 'targets-selection-dropdown',
             option: 'Clusters',
+            selectedIcon: selectedIconSelector,
           },
         ],
         expectedRequest: `${checksCatalogURL}?provider=aws&target_type=cluster`,
@@ -121,14 +126,17 @@ context('Checks catalog', () => {
           {
             dropdown: 'providers-selection-dropdown',
             option: 'AWS',
+            selectedIcon: selectedIconSelector,
           },
           {
             dropdown: 'targets-selection-dropdown',
             option: 'Clusters',
+            selectedIcon: selectedIconSelector,
           },
           {
             dropdown: 'cluster-types-selection-dropdown',
             option: 'HANA Scale Up Perf. Opt.',
+            selectedIcon: selectedIconSelector,
           },
         ],
         expectedRequest: `${checksCatalogURL}?provider=aws&target_type=cluster&cluster_type=hana_scale_up&hana_scenario=performance_optimized`,
@@ -138,14 +146,17 @@ context('Checks catalog', () => {
           {
             dropdown: 'providers-selection-dropdown',
             option: 'AWS',
+            selectedIcon: selectedIconSelector,
           },
           {
             dropdown: 'targets-selection-dropdown',
             option: 'Clusters',
+            selectedIcon: selectedIconSelector,
           },
           {
             dropdown: 'cluster-types-selection-dropdown',
             option: 'HANA Scale Up Cost Opt.',
+            selectedIcon: selectedIconSelector,
           },
         ],
         expectedRequest: `${checksCatalogURL}?provider=aws&target_type=cluster&cluster_type=hana_scale_up&hana_scenario=cost_optimized`,
@@ -157,8 +168,10 @@ context('Checks catalog', () => {
         cy.intercept(expectedRequest, {
           body: { items: catalog },
         }).as('request');
-        selectedFilters.forEach(({ dropdown, option }) => {
+        selectedFilters.forEach(({ dropdown, option, selectedIcon }) => {
           cy.get(`.${dropdown}`).click();
+          // test if the selected item has the green SVG icon rendered which shows the current selection
+          cy.get(selectedIcon).should('be.visible');
           cy.get(`.${dropdown}`).get('span').contains(option).click();
         });
         cy.wait('@request');


### PR DESCRIPTION
# Description
This pr will restore the previous ui behaviour in the checks catalog view. When selecting a cluster type in the checks catalog the green svg icon is not rendered.
With the latest changes in #3210 we now not only pass a string as value, which was handled by the built in headless ui `selected` boolean, but also an object `{ type, hanaScenario }` . Check out the official docs https://headlessui.com/v1/react/listbox#listbox-option
With using the lodash isEqual we now  use a "deep comparison"  to ensure accurate evaluation of selected options.

For this we use the "by" value provided by Listbox: 
```You can also pass your own comparison function to the by prop if you'd like complete control over how objects are compared```
Source: https://headlessui.com/v1/react/listbox#binding-objects-as-values

## Demo: 

https://github.com/user-attachments/assets/4d2fc8dc-e50a-47cb-9ebd-22ee862b4ae1

## Test

Enriched existing e2e test to test that the SVG is rendered 
