### PR TITLE
add job conditional to ensure secret availability

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -276,7 +276,7 @@ jobs:
     name: Chromatic deployment
     needs: [elixir-deps, npm-deps]
     runs-on: ubuntu-20.04
-    if: github.event_name != 'repository_dispatch'
+    if: github.event_name != 'repository_dispatch' && github.secret_source != 'None'
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1


### PR DESCRIPTION
this way the job is skipped, instead of failing, if it's triggered by a pull request coming from a fork.
(see https://github.com/trento-project/web/actions/runs/12770300460/job/35594873099?pr=3225)