### PR TITLE
Expose abilities as jwt claims

### DIFF
--- a/lib/trento_web/plugs/app_jwt_auth_plug.ex
+++ b/lib/trento_web/plugs/app_jwt_auth_plug.ex
@@ -24,10 +24,7 @@ defmodule TrentoWeb.Plugs.AppJWTAuthPlug do
   """
   def fetch(conn, _config) do
     with {:ok, jwt_token} <- read_token(conn),
-         {:ok, claims} <- validate_access_token(jwt_token) do
-      sub = claims["sub"]
-      abilities = claims["abilities"]
-
+         {:ok, %{"sub" => sub, "abilities" => abilities}} <- validate_access_token(jwt_token) do
       conn =
         conn
         |> Conn.put_private(:api_access_token, jwt_token)

--- a/lib/trento_web/plugs/app_jwt_auth_plug.ex
+++ b/lib/trento_web/plugs/app_jwt_auth_plug.ex
@@ -29,7 +29,6 @@ defmodule TrentoWeb.Plugs.AppJWTAuthPlug do
         conn
         |> Conn.put_private(:api_access_token, jwt_token)
         |> Conn.put_private(:user_id, sub)
-        |> Conn.put_private(:abilities, abilities)
 
       {conn,
        %{

--- a/lib/trento_web/plugs/app_jwt_auth_plug.ex
+++ b/lib/trento_web/plugs/app_jwt_auth_plug.ex
@@ -49,13 +49,19 @@ defmodule TrentoWeb.Plugs.AppJWTAuthPlug do
   def create(conn, user, _config) do
     {:ok, user} = Users.get_user(user.id)
 
-    claims = %{
-      "sub" => user.id,
-      "abilities" => Enum.map(user.abilities, &%{name: &1.name, resource: &1.resource})
+    default_claims = %{
+      "sub" => user.id
     }
 
-    access_token = AccessToken.generate_access_token!(claims)
-    refresh_token = RefreshToken.generate_refresh_token!(claims)
+    access_token_claims =
+      Map.put(
+        default_claims,
+        "abilities",
+        Enum.map(user.abilities, &%{name: &1.name, resource: &1.resource})
+      )
+
+    access_token = AccessToken.generate_access_token!(access_token_claims)
+    refresh_token = RefreshToken.generate_refresh_token!(default_claims)
 
     conn =
       conn

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1199,6 +1199,17 @@ defmodule Trento.Factory do
     }
   end
 
+  def user_with_abilities_factory do
+    user = build(:user)
+    ability = build(:ability)
+    build(:users_abilities, user_id: user.id, ability_id: ability.id)
+
+    %User{
+      user
+      | abilities: [ability]
+    }
+  end
+
   def user_identity_factory do
     %UserIdentity{
       user_id: 1,

--- a/test/trento/activity_logging/activity_logger_test.exs
+++ b/test/trento/activity_logging/activity_logger_test.exs
@@ -41,7 +41,7 @@ defmodule Trento.ActivityLog.ActivityLoggerTest do
   end
 
   defp with_token(conn, user_id) do
-    jwt = AccessToken.generate_access_token!(%{"sub" => user_id})
+    jwt = AccessToken.generate_access_token!(%{"sub" => user_id, "abilities" => []})
 
     Plug.Conn.put_req_header(conn, "authorization", "Bearer " <> jwt)
   end

--- a/test/trento_web/controllers/session_controller_test.exs
+++ b/test/trento_web/controllers/session_controller_test.exs
@@ -204,7 +204,8 @@ defmodule TrentoWeb.SessionControllerTest do
         end
       )
 
-      good_jwt = TrentoWeb.Auth.AccessToken.generate_access_token!(%{"sub" => user.id})
+      good_jwt =
+        TrentoWeb.Auth.AccessToken.generate_access_token!(%{"sub" => user.id, "abilities" => []})
 
       resp =
         conn

--- a/test/trento_web/plugs/app_jwt_auth_plug_test.exs
+++ b/test/trento_web/plugs/app_jwt_auth_plug_test.exs
@@ -167,8 +167,7 @@ defmodule TrentoWeb.Plugs.AppJWTAuthPlugTest do
       assert %{
                private: %{
                  api_access_token: ^jwt,
-                 user_id: 1,
-                 abilities: [%{"name" => "foo", "resource" => "bar"}]
+                 user_id: 1
                }
              } = res_conn
     end

--- a/test/trento_web/plugs/app_jwt_auth_plug_test.exs
+++ b/test/trento_web/plugs/app_jwt_auth_plug_test.exs
@@ -14,6 +14,7 @@ defmodule TrentoWeb.Plugs.AppJWTAuthPlugTest do
   alias TrentoWeb.Plugs.AppJWTAuthPlug
 
   import Mox
+  import Trento.Factory
 
   @pow_config [otp_app: :trento]
 
@@ -132,9 +133,9 @@ defmodule TrentoWeb.Plugs.AppJWTAuthPlugTest do
 
   describe "create/3" do
     test "should add to the conn the access/refresh token pair and the expiration", %{conn: conn} do
-      user = %{id: 1}
+      %{id: user_id} = user = insert(:user_with_abilities)
 
-      assert {res_conn, ^user} = AppJWTAuthPlug.create(conn, user, @pow_config)
+      assert {res_conn, %{id: ^user_id}} = AppJWTAuthPlug.create(conn, user, @pow_config)
 
       assert %{
                private: %{
@@ -148,17 +149,28 @@ defmodule TrentoWeb.Plugs.AppJWTAuthPlugTest do
 
   describe "fetch/2" do
     test "should fetch a user when the jwt is valid", %{conn: conn} do
-      jwt = AccessToken.generate_access_token!(%{"sub" => 1})
+      jwt =
+        AccessToken.generate_access_token!(%{
+          "sub" => 1,
+          "abilities" => [%{name: "foo", resource: "bar"}]
+        })
 
       conn = Plug.Conn.put_req_header(conn, "authorization", "Bearer " <> jwt)
 
       assert {res_conn,
               %{
                 "access_token" => ^jwt,
-                "user_id" => 1
+                "user_id" => 1,
+                "abilities" => [%{"name" => "foo", "resource" => "bar"}]
               }} = AppJWTAuthPlug.fetch(conn, @pow_config)
 
-      assert %{private: %{api_access_token: ^jwt, user_id: 1}} = res_conn
+      assert %{
+               private: %{
+                 api_access_token: ^jwt,
+                 user_id: 1,
+                 abilities: [%{"name" => "foo", "resource" => "bar"}]
+               }
+             } = res_conn
     end
 
     test "should not fetch a user when the jwt signature is invalid", %{conn: conn} do

--- a/test/trento_web/plugs/app_jwt_auth_plug_test.exs
+++ b/test/trento_web/plugs/app_jwt_auth_plug_test.exs
@@ -136,7 +136,13 @@ defmodule TrentoWeb.Plugs.AppJWTAuthPlugTest do
       %{id: user_id, abilities: [%{name: name, resource: resource} | _]} =
         user = insert(:user_with_abilities)
 
-      assert {res_conn, %{id: ^user_id}} = AppJWTAuthPlug.create(conn, user, @pow_config)
+      assert {
+               res_conn,
+               %{
+                 id: ^user_id,
+                 abilities: [%{name: ^name, resource: ^resource}]
+               }
+             } = AppJWTAuthPlug.create(conn, user, @pow_config)
 
       assert %{
                private: %{


### PR DESCRIPTION
# Description

In order to allow service providers like wanda to do proper role based authorization, we expose abilities as part of the JWT claims.