### PR TITLE
Fix for nil values in severity

### DIFF
--- a/lib/trento/activity_logging/severity_level.ex
+++ b/lib/trento/activity_logging/severity_level.ex
@@ -158,15 +158,21 @@ defmodule Trento.ActivityLog.SeverityLevel do
       :map_value_to_severity ->
         health_key_suffix = mapping.key_suffix
 
-        health_key =
+        maybe_health_key =
           keys
           |> Enum.map(&Atom.to_string/1)
           |> Enum.find(fn e -> String.ends_with?(e, health_key_suffix) end)
 
-        health_value = metadata[String.to_existing_atom(health_key)]
-        health_value_downcased = health_value |> Atom.to_string() |> String.downcase()
-        severity_default = Map.get(mapping.values, "*")
-        Map.get(mapping.values, health_value_downcased, severity_default)
+        case maybe_health_key do
+          nil ->
+            :info
+
+          health_key when is_binary(health_key) ->
+            health_value = metadata[String.to_existing_atom(health_key)]
+            health_value_downcased = health_value |> Atom.to_string() |> String.downcase()
+            severity_default = Map.get(mapping.values, "*")
+            Map.get(mapping.values, health_value_downcased, severity_default)
+        end
 
       :key_exists ->
         key = mapping.key

--- a/test/trento/activity_logging/severity_level_test.exs
+++ b/test/trento/activity_logging/severity_level_test.exs
@@ -16,7 +16,17 @@ defmodule Trento.ActivityLog.SeverityLevelTest do
       },
       condition: :map_value_to_severity
     },
-    "activity_type_5" => %{type: :key, key: :reason, condition: :key_exists}
+    "activity_type_5" => %{type: :key, key: :reason, condition: :key_exists},
+    "activity_type_6" => %{
+      type: :kv,
+      key_suffix: "some_health_suffix",
+      values: %{
+        "critical" => :critical,
+        "unknown" => :warning,
+        "*" => :debug
+      },
+      condition: :map_value_to_severity
+    }
   }
   describe "map_severity_level/3" do
     test "should map unmapped activity type to info" do
@@ -89,6 +99,16 @@ defmodule Trento.ActivityLog.SeverityLevelTest do
     test "should map key exists activity types appropriately in the info case" do
       activity_type = "activity_type_5"
 
+      metadata = %{}
+
+      severity =
+        SeverityLevel.map_severity_level(activity_type, metadata, @severity_level_mapping)
+
+      assert severity == :info
+    end
+
+    test "should may conditional key suffix types with no metadata correctly" do
+      activity_type = "activity_type_6"
       metadata = %{}
 
       severity =


### PR DESCRIPTION
Sometimes in the metadata to severity mapping, the health key in metadata is not found, since the metadata is an empty map. Here we handle this nil appropriately, by mapping it to the info level.
Added a unit test to cover the observed case.

