### PR TITLE
Fix Jest warnings on FE tests

### DIFF
--- a/assets/js/common/NotificationBox/NotificationBox.test.jsx
+++ b/assets/js/common/NotificationBox/NotificationBox.test.jsx
@@ -1,7 +1,6 @@
 import { faker } from '@faker-js/faker';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
-import { act } from 'react-dom/test-utils';
+import React, { act } from 'react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import NotificationBox from './NotificationBox';

--- a/assets/js/pages/ChecksCatalog/CatalogContainer.test.jsx
+++ b/assets/js/pages/ChecksCatalog/CatalogContainer.test.jsx
@@ -1,6 +1,5 @@
-import React from 'react';
+import React, { act } from 'react';
 
-import { act } from 'react-dom/test-utils';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';

--- a/assets/js/pages/ExecutionResults/CheckResultDetail/CheckDetailHeader.test.jsx
+++ b/assets/js/pages/ExecutionResults/CheckResultDetail/CheckDetailHeader.test.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { act } from 'react';
 import { screen } from '@testing-library/react';
 
 import { faker } from '@faker-js/faker';
@@ -6,7 +6,6 @@ import { renderWithRouter } from '@lib/test-utils';
 
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
-import { act } from 'react-dom/test-utils';
 import { cloudProviderEnum, resultEnum } from '@lib/test-utils/factories';
 import CheckDetailHeader from './CheckDetailHeader';
 

--- a/assets/js/pages/ExecutionResults/CheckResultOutline.test.jsx
+++ b/assets/js/pages/ExecutionResults/CheckResultOutline.test.jsx
@@ -1,7 +1,6 @@
-import React from 'react';
+import React, { act } from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { act } from 'react-dom/test-utils';
 
 import { faker } from '@faker-js/faker';
 

--- a/assets/js/pages/ExecutionResults/TargetResult.test.jsx
+++ b/assets/js/pages/ExecutionResults/TargetResult.test.jsx
@@ -1,7 +1,6 @@
-import React from 'react';
+import React, { act } from 'react';
 import { render, screen } from '@testing-library/react';
 
-import { act } from 'react-dom/test-utils';
 import userEvent from '@testing-library/user-event';
 
 import { faker } from '@faker-js/faker';

--- a/assets/js/pages/Guard/Guard.test.jsx
+++ b/assets/js/pages/Guard/Guard.test.jsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { act } from 'react';
 
 import { screen, waitFor } from '@testing-library/react';
 import 'intersection-observer';
 import '@testing-library/jest-dom';
-import { act } from 'react-dom/test-utils';
+
 import { Route, Routes } from 'react-router-dom';
 import { renderWithRouter, withState } from '@lib/test-utils';
 import Guard from './Guard';


### PR DESCRIPTION
# Description

Fix warning

```
console.error
      Warning: `ReactDOMTestUtils.act` is deprecated in favor of `React.act`. Import `act` from `react` instead of `react-dom/test-utils`. See https://react.dev/warnings/react-dom-test-utils for more info.
```

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [x] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [x] **DONE**
## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
- [Trento Web guides](https://github.com/trento-project/web/tree/main/guides)

Add a documentation PR or write that no changes are required for the documentation.
- [x] **DONE**
