### PR TITLE
Add check customization call to action in checks selection

### DIFF
--- a/assets/js/lib/test-utils/factories/index.js
+++ b/assets/js/lib/test-utils/factories/index.js
@@ -95,6 +95,18 @@ export const catalogExpectEnumExpectationFactory = Factory.define(
   })
 );
 
+export const catalogConditionFactory = Factory.define(() => ({
+  value: faker.lorem.word(),
+  expression: faker.lorem.sentence(),
+}));
+
+export const catalogValueFactory = Factory.define(() => ({
+  name: faker.string.uuid(),
+  default: faker.lorem.word(),
+  customizable: faker.datatype.boolean(),
+  conditions: catalogConditionFactory.buildList(2),
+}));
+
 export const catalogCheckFactory = Factory.define(() => ({
   id: faker.string.uuid(),
   name: faker.animal.cat(),
@@ -102,7 +114,9 @@ export const catalogCheckFactory = Factory.define(() => ({
   description: faker.lorem.paragraph(),
   remediation: faker.lorem.paragraph(),
   metadata: null,
+  values: catalogValueFactory.buildList(3),
   expectations: catalogExpectExpectationFactory.buildList(3),
+  customizable: faker.datatype.boolean(),
 }));
 
 export const catalogFactory = Factory.define(() => ({

--- a/assets/js/pages/ChecksSelection/ChecksSelection.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelection.jsx
@@ -85,8 +85,12 @@ function ChecksSelection({
                 name={check.name}
                 description={check.description}
                 selected={check.selected}
+                customizable={check.customizable}
                 onChange={() => {
                   onChange(toggle(check.id, selectedChecks));
+                }}
+                onCustomize={() => {
+                  alert('Coming Soon!');
                 }}
               />
             ))}

--- a/assets/js/pages/ChecksSelection/ChecksSelectionItem.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelectionItem.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React from 'react';
 
+import { EOS_SETTINGS_OUTLINED } from 'eos-icons-react';
 import { Switch } from '@headlessui/react';
 
 import classNames from 'classnames';
@@ -11,8 +12,10 @@ function ChecksSelectionItem({
   checkID,
   name,
   description,
+  customizable = false,
   selected,
   onChange = () => {},
+  onCustomize = () => {},
 }) {
   return (
     <li>
@@ -31,6 +34,18 @@ function ChecksSelectionItem({
               </ReactMarkdown>
             </div>
             <Switch.Group as="div" className="flex items-center">
+              {customizable && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    onCustomize(checkID);
+                  }}
+                  aria-label="customize-check"
+                  className="inline mr-4"
+                >
+                  <EOS_SETTINGS_OUTLINED className="fill-jungle-green-500" />
+                </button>
+              )}
               <Switch
                 checked={selected}
                 className={classNames(

--- a/assets/js/pages/ChecksSelection/ChecksSelectionItem.test.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelectionItem.test.jsx
@@ -8,7 +8,7 @@ import { catalogCheckFactory } from '@lib/test-utils/factories';
 
 import ChecksSelectionItem from './ChecksSelectionItem';
 
-describe('ClusterDetails ChecksSelectionItem component', () => {
+describe('ChecksSelectionItem component', () => {
   it('should show check with selected state', () => {
     const check = catalogCheckFactory.build();
 
@@ -62,5 +62,56 @@ describe('ClusterDetails ChecksSelectionItem component', () => {
 
     await user.click(screen.getByRole('switch'));
     expect(onChangeMock).toBeCalled();
+  });
+});
+
+describe('Checks Customizability', () => {
+  it.each`
+    customizable
+    ${true}
+    ${false}
+  `('should show check customization call to action', ({ customizable }) => {
+    const check = catalogCheckFactory.build({ customizable });
+
+    render(
+      <ChecksSelectionItem
+        key={check.id}
+        checkID={check.id}
+        name={check.name}
+        description={check.description}
+        selected
+        customizable={check.customizable}
+      />
+    );
+
+    const customizationCallToAction =
+      screen.queryByLabelText('customize-check');
+
+    if (customizable) {
+      expect(customizationCallToAction).toBeVisible();
+    } else {
+      expect(customizationCallToAction).toBeNull();
+    }
+  });
+
+  it('should run the onCustomize function when the customize button is clicked', async () => {
+    const user = userEvent.setup();
+    const check = catalogCheckFactory.build({ customizable: true });
+    const onCustomize = jest.fn();
+
+    render(
+      <ChecksSelectionItem
+        key={check.id}
+        checkID={check.id}
+        name={check.name}
+        description={check.description}
+        selected
+        customizable={check.customizable}
+        onCustomize={onCustomize}
+      />
+    );
+
+    await user.click(screen.getByLabelText('customize-check'));
+    expect(onCustomize).toHaveBeenCalledWith(check.id);
   });
 });


### PR DESCRIPTION
# Description

This PR adds an icon to start check customization in checks selection.

Notes:
- action is available only when a check is marked as customizable
- a `Coming Soon!` alert is shown currently

Unfortunately the PR env is not deploying checks, so can't really use it.

Here's a screenshot
![image](https://github.com/user-attachments/assets/6dbf27ac-386b-4089-9895-73ea40b27389)
