### PR TITLE
Add check customization ability

### DIFF
--- a/assets/js/pages/ChecksSelection/ChecksSelection.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelection.jsx
@@ -26,12 +26,14 @@ const getGroupSelectedState = (checks, selectedChecks) => {
 };
 
 const defaultSelectedChecks = [];
+const defaultAbilities = [];
 
 function ChecksSelection({
   catalog,
   selectedChecks = defaultSelectedChecks,
   loading = false,
   catalogError,
+  userAbilities = defaultAbilities,
   onUpdateCatalog,
   onChange,
 }) {
@@ -85,6 +87,7 @@ function ChecksSelection({
                 name={check.name}
                 description={check.description}
                 selected={check.selected}
+                userAbilities={userAbilities}
                 customizable={check.customizable}
                 onChange={() => {
                   onChange(toggle(check.id, selectedChecks));

--- a/assets/js/pages/ChecksSelection/ChecksSelection.stories.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelection.stories.jsx
@@ -54,6 +54,10 @@ export default {
         type: { summary: 'string' },
       },
     },
+    userAbilities: {
+      control: 'array',
+      description: 'Current user abilities',
+    },
     onUpdateCatalog: {
       action: 'Update catalog',
       description: 'Gets called to refresh the catalog.',
@@ -69,6 +73,7 @@ export default {
 export const Default = {
   args: {
     catalog,
+    userAbilities: [{ name: 'all', resource: 'check_customization' }],
   },
 };
 

--- a/assets/js/pages/ChecksSelection/ChecksSelectionItem.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelectionItem.jsx
@@ -8,12 +8,22 @@ import classNames from 'classnames';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
+import { isPermitted } from '@lib/model/users';
+
+const defaultAbilities = [];
+
+const CUSTOMIZATION_ALLOWED_FOR = ['all:all', 'all:check_customization'];
+
+const isCustomizable = (abilities, customizable) =>
+  isPermitted(abilities, CUSTOMIZATION_ALLOWED_FOR) && customizable;
+
 function ChecksSelectionItem({
   checkID,
   name,
   description,
   customizable = false,
   selected,
+  userAbilities = defaultAbilities,
   onChange = () => {},
   onCustomize = () => {},
 }) {
@@ -34,7 +44,7 @@ function ChecksSelectionItem({
               </ReactMarkdown>
             </div>
             <Switch.Group as="div" className="flex items-center">
-              {customizable && (
+              {isCustomizable(userAbilities, customizable) && (
                 <button
                   type="button"
                   onClick={() => {

--- a/assets/js/pages/ChecksSelection/ChecksSelectionItem.test.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelectionItem.test.jsx
@@ -66,33 +66,50 @@ describe('ChecksSelectionItem component', () => {
 });
 
 describe('Checks Customizability', () => {
+  const fooBarAbility = { name: 'foo', resource: 'bar' };
+  const allAbility = { name: 'all', resource: 'all' };
+  const checkCustomizationAbility = {
+    name: 'all',
+    resource: 'check_customization',
+  };
+
   it.each`
-    customizable
-    ${true}
-    ${false}
-  `('should show check customization call to action', ({ customizable }) => {
-    const check = catalogCheckFactory.build({ customizable });
+    customizable | abilities                                     | expectedCallToAction
+    ${true}      | ${[]}                                         | ${false}
+    ${true}      | ${[fooBarAbility]}                            | ${false}
+    ${true}      | ${[allAbility, fooBarAbility]}                | ${true}
+    ${true}      | ${[checkCustomizationAbility, fooBarAbility]} | ${true}
+    ${false}     | ${[]}                                         | ${false}
+    ${false}     | ${[allAbility]}                               | ${false}
+    ${false}     | ${[checkCustomizationAbility]}                | ${false}
+    ${false}     | ${[fooBarAbility]}                            | ${false}
+  `(
+    'should show check customization call to action',
+    ({ customizable, abilities, expectedCallToAction }) => {
+      const check = catalogCheckFactory.build({ customizable });
 
-    render(
-      <ChecksSelectionItem
-        key={check.id}
-        checkID={check.id}
-        name={check.name}
-        description={check.description}
-        selected
-        customizable={check.customizable}
-      />
-    );
+      render(
+        <ChecksSelectionItem
+          key={check.id}
+          checkID={check.id}
+          name={check.name}
+          description={check.description}
+          selected
+          userAbilities={abilities}
+          customizable={check.customizable}
+        />
+      );
 
-    const customizationCallToAction =
-      screen.queryByLabelText('customize-check');
+      const customizationCallToAction =
+        screen.queryByLabelText('customize-check');
 
-    if (customizable) {
-      expect(customizationCallToAction).toBeVisible();
-    } else {
-      expect(customizationCallToAction).toBeNull();
+      if (expectedCallToAction) {
+        expect(customizationCallToAction).toBeVisible();
+      } else {
+        expect(customizationCallToAction).toBeNull();
+      }
     }
-  });
+  );
 
   it('should run the onCustomize function when the customize button is clicked', async () => {
     const user = userEvent.setup();
@@ -106,6 +123,7 @@ describe('Checks Customizability', () => {
         name={check.name}
         description={check.description}
         selected
+        userAbilities={[checkCustomizationAbility]}
         customizable={check.customizable}
         onCustomize={onCustomize}
       />

--- a/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
+++ b/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
@@ -146,6 +146,7 @@ function ClusterSettingsPage() {
         catalogError={catalogError}
         loading={catalogLoading}
         selectedChecks={selection}
+        userAbilities={abilities}
         onUpdateCatalog={refreshCatalog}
         onChange={setSelection}
       />

--- a/assets/js/pages/HostSettingsPage/HostSettingsPage.jsx
+++ b/assets/js/pages/HostSettingsPage/HostSettingsPage.jsx
@@ -99,6 +99,7 @@ function HostSettingsPage() {
         catalogError={catalogError}
         loading={catalogLoading}
         selectedChecks={selection}
+        userAbilities={abilities}
         onUpdateCatalog={refreshCatalog}
         onChange={setSelection}
       />

--- a/priv/repo/migrations/20250120105043_add_check_customization_abilities.exs
+++ b/priv/repo/migrations/20250120105043_add_check_customization_abilities.exs
@@ -1,0 +1,11 @@
+defmodule Trento.Repo.Migrations.AddChecksCustomizationAbilities do
+  use Ecto.Migration
+
+  def up do
+    execute "INSERT INTO abilities(id, name, resource, label, inserted_at, updated_at) VALUES (DEFAULT, 'all', 'check_customization', 'Permits customizing checks values', NOW(), NOW())"
+  end
+
+  def down do
+    execute "DELETE FROM abilities WHERE name = 'all' and resource = 'check_customization'"
+  end
+end


### PR DESCRIPTION
# Description

This PR introduces a new ability called `all:check_customization` which allows to customize checks.

Additionally the call to action in the UI is not provided when the logged user does not have sufficient permissions.