### PR TITLE
Apply PageObject pattern Clusters Overview tests.

### DIFF
--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -1,14 +1,5 @@
 import * as clustersOverviewPage from '../pageObject/clusters-overview-po.js';
 
-import {
-  availableClusters,
-  healthyClusterScenario,
-  unhealthyClusterScenario,
-} from '../fixtures/clusters-overview/available_clusters';
-
-const clusterIdByName = (clusterName) =>
-  availableClusters.find(({ name }) => name === clusterName).id;
-
 context('Clusters Overview', () => {
   before(() => clustersOverviewPage.preloadTestData());
 
@@ -44,55 +35,26 @@ context('Clusters Overview', () => {
     // eslint-disable-next-line mocha/no-skipped-tests
     describe.skip('Health status for each cluster is correct', () => {
       before(() => {
-        cy.selectChecks(
-          clusterIdByName(healthyClusterScenario.clusterName),
-          healthyClusterScenario.checks
-        );
+        clustersOverviewPage.selectChecksForHealthyCluster();
         // wip: set expected results
-        cy.requestChecksExecution(
-          clusterIdByName(healthyClusterScenario.clusterName)
-        );
+        clustersOverviewPage.requestChecksForHealthyCluster();
 
-        cy.selectChecks(
-          clusterIdByName(unhealthyClusterScenario.clusterName),
-          healthyClusterScenario.checks
-        );
+        clustersOverviewPage.selectChecksForUnhealthyCluster();
         // wip: set expected results
-        cy.requestChecksExecution(
-          clusterIdByName(unhealthyClusterScenario.clusterName)
-        );
+        clustersOverviewPage.requestChecksForUnhealthyCluster();
       });
 
       after(() => {
-        cy.selectChecks(
-          clusterIdByName(healthyClusterScenario.clusterName),
-          []
-        );
-
-        cy.selectChecks(
-          clusterIdByName(unhealthyClusterScenario.clusterName),
-          []
-        );
+        clustersOverviewPage.removeHealthyClusterChecks();
+        clustersOverviewPage.removeUnhealthyClusterChecks();
       });
 
-      it(`should have ${healthyClusterScenario.clusterName} displaying healthy state`, () => {
-        cy.get('td')
-          .contains(healthyClusterScenario.clusterName)
-          .parent()
-          .parent()
-          .prev()
-          .get('div > svg')
-          .should('have.class', 'fill-jungle-green-500');
+      it(`should have ${clustersOverviewPage.healthyClusterName} displaying healthy state`, () => {
+        clustersOverviewPage.healthyClusterNameDisplaysHealthyState();
       });
 
-      it(`should have ${unhealthyClusterScenario.clusterName} displaying unhealthy state`, () => {
-        cy.get('td')
-          .contains(unhealthyClusterScenario.clusterName)
-          .parent()
-          .parent()
-          .prev()
-          .get('div > svg')
-          .should('have.class', 'fill-red-500');
+      it(`should have ${clustersOverviewPage.unhealthyClusterName} displaying unhealthy state`, () => {
+        clustersOverviewPage.unhealthyClusterNameDisplaysUnhealthyState();
       });
     });
   });

--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -6,6 +6,7 @@ import {
   unhealthyClusterScenario,
 } from '../fixtures/clusters-overview/available_clusters';
 
+
 const clusterIdByName = (clusterName) =>
   availableClusters.find(({ name }) => name === clusterName).id;
 

--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -1,7 +1,7 @@
 import * as clustersOverviewPage from '../pageObject/clusters-overview-po.js';
 
 context('Clusters Overview', () => {
-  before(() => clustersOverviewPage.preloadTestData());
+  // before(() => clustersOverviewPage.preloadTestData());
 
   beforeEach(() => {
     clustersOverviewPage.interceptClustersEndpoint();
@@ -33,7 +33,7 @@ context('Clusters Overview', () => {
     });
 
     // eslint-disable-next-line mocha/no-skipped-tests
-    describe.skip('Health status for each cluster is correct', () => {
+    describe('Health status for each cluster is correct', () => {
       before(() => {
         clustersOverviewPage.selectChecksForHealthyCluster();
         // wip: set expected results

--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -17,9 +17,10 @@ const clusterTags = {
 };
 
 context('Clusters Overview', () => {
-  // before(() => clustersOverviewPage.preloadTestData());
+  before(() => clustersOverviewPage.preloadTestData());
 
   beforeEach(() => {
+    clustersOverviewPage.interceptClustersEndpoint();
     clustersOverviewPage.visit();
     clustersOverviewPage.validateUrl();
   });
@@ -33,7 +34,7 @@ context('Clusters Overview', () => {
       clustersOverviewPage.paginationButtonsAreDisabled();
     });
 
-    it.only('should show the expected clusters data', () => {
+    it('should show the expected clusters data', () => {
       clustersOverviewPage.clustersDataIsDisplayedAsExpected();
     });
 

--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -35,18 +35,18 @@ context('Clusters Overview', () => {
     // eslint-disable-next-line mocha/no-skipped-tests
     describe.skip('Health status for each cluster is correct', () => {
       before(() => {
-        clustersOverviewPage.selectChecksForHealthyCluster();
+        clustersOverviewPage.apiSelectChecksForHealthyCluster();
         // wip: set expected results
-        clustersOverviewPage.requestChecksForHealthyCluster();
+        clustersOverviewPage.apiRequestChecksForHealthyCluster();
 
-        clustersOverviewPage.selectChecksForUnhealthyCluster();
+        clustersOverviewPage.apiSelectChecksForUnhealthyCluster();
         // wip: set expected results
-        clustersOverviewPage.requestChecksForUnhealthyCluster();
+        clustersOverviewPage.apiRequestChecksForUnhealthyCluster();
       });
 
       after(() => {
-        clustersOverviewPage.removeHealthyClusterChecks();
-        clustersOverviewPage.removeUnhealthyClusterChecks();
+        clustersOverviewPage.apiRemoveHealthyClusterChecks();
+        clustersOverviewPage.apiRemoveUnhealthyClusterChecks();
       });
 
       it(`should have ${clustersOverviewPage.healthyClusterName} displaying healthy state`, () => {
@@ -75,7 +75,7 @@ context('Clusters Overview', () => {
     before(() => {
       clustersOverviewPage.apiRemoveAllTags();
       clustersOverviewPage.apiSetTagsHanaCluster1();
-      clustersOverviewPage.deregisterAllClusterHosts();
+      clustersOverviewPage.apiDeregisterAllClusterHosts();
     });
 
     it(`should not display '${clustersOverviewPage.hanaCluster1.name}' after deregistering all its nodes`, () => {
@@ -83,7 +83,7 @@ context('Clusters Overview', () => {
     });
 
     it(`should show cluster '${clustersOverviewPage.hanaCluster1.name}' after registering it again with the previous tags`, () => {
-      clustersOverviewPage.restoreClusterHosts();
+      clustersOverviewPage.apiRestoreClusterHosts();
       clustersOverviewPage.clusterNameIsDisplayed();
       clustersOverviewPage.hanaCluster1TagsAreDisplayed();
     });
@@ -99,7 +99,7 @@ context('Clusters Overview', () => {
       });
 
       it('should prevent a tag update when the user abilities are not compliant', () => {
-        clustersOverviewPage.createUserWithoutAbilities();
+        clustersOverviewPage.apiCreateUserWithoutAbilities();
         clustersOverviewPage.loginWithoutTagAbilities();
         clustersOverviewPage.visit();
         clustersOverviewPage.addTagButtonsAreDisabled();
@@ -107,7 +107,7 @@ context('Clusters Overview', () => {
       });
 
       it('should allow a tag update when the user abilities are compliant', () => {
-        clustersOverviewPage.createUserWithClusterTagsAbilities();
+        clustersOverviewPage.apiCreateUserWithClusterTagsAbilities();
         clustersOverviewPage.loginWithTagAbilities();
         clustersOverviewPage.visit();
         clustersOverviewPage.addTagButtonsAreNotDisabled();

--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -1,7 +1,7 @@
 import * as clustersOverviewPage from '../pageObject/clusters-overview-po.js';
 
 context('Clusters Overview', () => {
-  // before(() => clustersOverviewPage.preloadTestData());
+  before(() => clustersOverviewPage.preloadTestData());
 
   beforeEach(() => {
     clustersOverviewPage.interceptClustersEndpoint();

--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -1,3 +1,4 @@
+import * as clustersOverviewPage from '../pageObject/clusters-overview-po.js';
 import { createUserRequestFactory } from '@lib/test-utils/factories';
 
 import {
@@ -5,7 +6,6 @@ import {
   healthyClusterScenario,
   unhealthyClusterScenario,
 } from '../fixtures/clusters-overview/available_clusters';
-
 
 const clusterIdByName = (clusterName) =>
   availableClusters.find(({ name }) => name === clusterName).id;
@@ -17,54 +17,24 @@ const clusterTags = {
 };
 
 context('Clusters Overview', () => {
-  before(() => {
-    cy.preloadTestData();
-    cy.visit('/clusters');
-    cy.url().should('include', '/clusters');
+  // before(() => clustersOverviewPage.preloadTestData());
+
+  beforeEach(() => {
+    clustersOverviewPage.visit();
+    clustersOverviewPage.validateUrl();
   });
 
   describe('Registered Clusters should be available in the overview', () => {
     it('should show all of the registered clusters', () => {
-      cy.get('.tn-clustername')
-        .its('length')
-        .should('eq', availableClusters.length);
+      clustersOverviewPage.allRegisteredClustersAreDisplayed();
     });
 
     it('should have 1 pages', () => {
-      cy.get(`[data-testid="pagination"]`).should('include.text', '1');
-      cy.get(`[data-testid="pagination"]`).should('not.include.text', '2');
+      clustersOverviewPage.paginationButtonsAreDisabled();
     });
 
-    it('should show the expected clusters data', () => {
-      cy.get('.container').eq(0).as('clustersTable');
-      availableClusters.forEach((cluster, index) => {
-        cy.get('@clustersTable')
-          .find('tr')
-          .eq(index + 1)
-          .find('td')
-          .as('clusterRow');
-
-        cy.get('@clustersTable')
-          .contains('th', 'Name')
-          .invoke('index')
-          .then((i) => {
-            cy.get('@clusterRow').eq(i).should('contain', cluster.name);
-          });
-
-        cy.get('@clustersTable')
-          .contains('th', 'SID')
-          .invoke('index')
-          .then((i) => {
-            cy.get('@clusterRow').eq(i).should('contain', cluster.sid);
-          });
-
-        cy.get('@clustersTable')
-          .contains('th', 'Type')
-          .invoke('index')
-          .then((i) => {
-            cy.get('@clusterRow').eq(i).should('contain', cluster.type);
-          });
-      });
+    it.only('should show the expected clusters data', () => {
+      clustersOverviewPage.clustersDataIsDisplayedAsExpected();
     });
 
     describe('Unnamed cluster', () => {

--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -33,7 +33,7 @@ context('Clusters Overview', () => {
     });
 
     // eslint-disable-next-line mocha/no-skipped-tests
-    describe('Health status for each cluster is correct', () => {
+    describe.skip('Health status for each cluster is correct', () => {
       before(() => {
         clustersOverviewPage.selectChecksForHealthyCluster();
         // wip: set expected results
@@ -69,12 +69,11 @@ context('Clusters Overview', () => {
       clustersOverviewPage.setClusterTags();
       clustersOverviewPage.eachClusterTagsIsCorrectlyDisplayed();
     });
-
-    after(() => clustersOverviewPage.apiRemoveAllTags());
   });
 
   describe('Deregistration', () => {
     before(() => {
+      clustersOverviewPage.apiRemoveAllTags();
       clustersOverviewPage.apiSetTagsHanaCluster1();
       clustersOverviewPage.deregisterAllClusterHosts();
     });
@@ -88,19 +87,18 @@ context('Clusters Overview', () => {
       clustersOverviewPage.clusterNameIsDisplayed();
       clustersOverviewPage.hanaCluster1TagsAreDisplayed();
     });
-
-    after(() => clustersOverviewPage.apiRemoveAllTags());
   });
 
   describe('Forbidden action', () => {
     describe('Tag operations', () => {
       beforeEach(() => {
+        clustersOverviewPage.apiRemoveAllTags();
         clustersOverviewPage.apiSetTagsHanaCluster1();
         clustersOverviewPage.apiDeleteAllUsers();
+        clustersOverviewPage.logout();
       });
 
       it('should prevent a tag update when the user abilities are not compliant', () => {
-        clustersOverviewPage.logout();
         clustersOverviewPage.createUserWithoutAbilities();
         clustersOverviewPage.loginWithoutTagAbilities();
         clustersOverviewPage.visit();
@@ -109,15 +107,12 @@ context('Clusters Overview', () => {
       });
 
       it('should allow a tag update when the user abilities are compliant', () => {
-        clustersOverviewPage.logout();
         clustersOverviewPage.createUserWithClusterTagsAbilities();
         clustersOverviewPage.loginWithTagAbilities();
         clustersOverviewPage.visit();
-        clustersOverviewPage.addTagButtonsAreNotsDisabled();
+        clustersOverviewPage.addTagButtonsAreNotDisabled();
         clustersOverviewPage.removeTagButtonIsEnabled();
       });
-
-      after(() => clustersOverviewPage.apiRemoveAllTags());
     });
   });
 });

--- a/test/e2e/cypress/pageObject/about-po.js
+++ b/test/e2e/cypress/pageObject/about-po.js
@@ -9,9 +9,7 @@ const githubRepositoryLabel = 'div:contains("GitHub repository") + div a';
 const amountOfSlesForSapSubscriptionsLabel =
   'div:contains("SLES for SAP subscriptions") + div span';
 
-export const visit = (_url = url) => {
-  return basePage.visit(_url);
-};
+export const visit = () => basePage.visit(url);
 
 export const pageTitleIsDisplayed = () => {
   return cy.get(pageTitle).should('have.text', 'About Trento Console');

--- a/test/e2e/cypress/pageObject/base-po.js
+++ b/test/e2e/cypress/pageObject/base-po.js
@@ -170,12 +170,12 @@ export const preloadTestData = () => {
    * scenario is sent in the second time.
    */
   isTestDataLoaded().then((isLoaded) => {
-    if (!isLoaded) cy.loadScenario('healthy-27-node-SAP-cluster');
+    if (!isLoaded) loadScenario('healthy-27-node-SAP-cluster');
   });
   loadScenario('healthy-27-node-SAP-cluster');
 };
 
-const loadScenario = (scenario) => {
+export const loadScenario = (scenario) => {
   const [projectRoot, photofinishBinary, webAPIHost, webAPIPort] = [
     Cypress.env('project_root'),
     Cypress.env('photofinish_binary'),

--- a/test/e2e/cypress/pageObject/base-po.js
+++ b/test/e2e/cypress/pageObject/base-po.js
@@ -102,8 +102,10 @@ export const apiLoginAndCreateSession = (
 };
 
 export const logout = () => {
-  window.localStorage.removeItem('access_token');
-  window.localStorage.removeItem('refresh_token');
+  cy.window().then((win) => {
+    win.localStorage.removeItem('access_token');
+    win.localStorage.removeItem('refresh_token');
+  });
   Cypress.session.clearAllSavedSessions();
 };
 

--- a/test/e2e/cypress/pageObject/base-po.js
+++ b/test/e2e/cypress/pageObject/base-po.js
@@ -204,3 +204,29 @@ const isTestDataLoaded = () =>
       })
       .then(({ body }) => body.length !== 0)
   );
+
+export const createUserWithAbilities = (payload, abilities) =>
+  apiLogin().then(({ accessToken }) =>
+    cy
+      .request({
+        url: '/api/v1/abilities',
+        method: 'GET',
+        auth: { bearer: accessToken },
+        body: {},
+      })
+      .then(({ body }) => {
+        const abilitiesWithID = abilities.map((ability) => ({
+          ...body.find(
+            ({ name, resource }) =>
+              ability.name === name && ability.resource === resource
+          ),
+        }));
+
+        cy.request({
+          url: '/api/v1/users',
+          method: 'POST',
+          auth: { bearer: accessToken },
+          body: { ...payload, abilities: abilitiesWithID },
+        });
+      })
+  );

--- a/test/e2e/cypress/pageObject/checks-catalog-po.js
+++ b/test/e2e/cypress/pageObject/checks-catalog-po.js
@@ -13,8 +13,7 @@ const groupNames = '.check-group > div > div > h3';
 const checkRows = '.check-row';
 const checkPanels = '.check-panel';
 
-const clusterTargetTypeIcon = '[data-testid="target-icon-cluster"]';
-const hostTargetTypeIcon = '[data-testid="target-icon-host"]';
+const targetIcon = 'div[aria-label="accordion-panel"] span span:nth-child(1)';
 
 const providersSelectionDropdown = 'button.providers-selection-dropdown';
 const targetsSelectionDropdown = 'button.targets-selection-dropdown';
@@ -65,9 +64,7 @@ const selectFromCatalogDropdown = (dropdownElementSelector, choice) => {
     .click();
 };
 
-export const visit = (_url = url) => {
-  return basePage.visit(_url);
-};
+export const visit = () => basePage.visit(url);
 
 export const interceptChecksCatalogEndpoint = (forceError = false) => {
   let interceptArgument;
@@ -172,11 +169,16 @@ export const eachGroupHasExpectedCheckIds = () => {
 };
 
 export const expectedTargetTypeClusterIconsAreDisplayed = () => {
-  return cy.get(clusterTargetTypeIcon).should('have.length', group1Checks);
+  return cy
+    .get(`h3:contains("${clusterChecksGroup}")`)
+    .parents(checkGroups)
+    .within(() => cy.get(targetIcon).should('have.length', group1Checks));
 };
 
 export const expectedTargetTypeHostIconsAreDisplayed = () => {
-  return cy.get(hostTargetTypeIcon).should('have.length', group2Checks);
+  cy.get(`h3:contains("${hostChecksGroup}")`)
+    .parents(checkGroups)
+    .within(() => cy.get(targetIcon).should('have.length', group2Checks));
 };
 
 export const checkPanelIsNotVisible = () => {

--- a/test/e2e/cypress/pageObject/clusters-overview-po.js
+++ b/test/e2e/cypress/pageObject/clusters-overview-po.js
@@ -1,12 +1,12 @@
+export * from './base-po.js';
+import * as basePage from './base-po.js';
+
 import { createUserRequestFactory } from '@lib/test-utils/factories';
 import {
   availableClusters,
   healthyClusterScenario,
   unhealthyClusterScenario,
 } from '../fixtures/clusters-overview/available_clusters';
-
-export * from './base-po.js';
-import * as basePage from './base-po.js';
 
 const url = '/clusters';
 const clustersEndpoint = '/api/v2/clusters';
@@ -16,6 +16,29 @@ const clustersEndpointAlias = 'clustersEndpoint';
 const clusterNames = '.tn-clustername';
 const paginationNavigationButtons = 'div[class*="bg-gray-50"] ul button';
 const tableRows = 'tbody tr';
+const rowCells = 'td';
+const addTagButtons = 'span span:contains("Add Tag")';
+
+//Test data
+export const hanaCluster1 = {
+  name: 'hana_cluster_1',
+  hosts: [
+    '13e8c25c-3180-5a9a-95c8-51ec38e50cfc',
+    '0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4',
+  ],
+};
+
+const clusterTags = {
+  hana_cluster_1: 'env1',
+  hana_cluster_2: 'env2',
+  hana_cluster_3: 'env3',
+};
+
+const taggingRules = [
+  ['hana_cluster_1', clusterTags.hana_cluster_1],
+  ['hana_cluster_2', clusterTags.hana_cluster_2],
+  ['hana_cluster_3', clusterTags.hana_cluster_3],
+];
 
 export const visit = () => basePage.visit(url);
 
@@ -46,4 +69,152 @@ export const clustersDataIsDisplayedAsExpected = () => {
       return cy.wrap($row).find('td').eq(5).should('have.text', cluster.type);
     });
   });
+};
+
+export const restoreClusterName = () => basePage.loadScenario('cluster-4-SOK');
+
+const clusterIdByName = (clusterName) =>
+  availableClusters.find(({ name }) => name === clusterName).id;
+
+export const clusterNameLinkIsDisplayedAsId = (clusterName) => {
+  const clusterID = clusterIdByName(clusterName);
+  return waitForClustersEndpoint().then(() =>
+    cy.get(tableRows).eq(8).find(rowCells).eq(1).should('have.text', clusterID)
+  );
+};
+
+export const apiRemoveTagByClusterId = (clusterId, tagId) => {
+  return basePage.apiLogin().then(({ accessToken }) =>
+    cy.request({
+      url: `api/v1/clusters/${clusterId}/tags/${tagId}`,
+      method: 'DELETE',
+      auth: { bearer: accessToken },
+    })
+  );
+};
+
+const apiGetClusters = () => {
+  return basePage.apiLogin().then(({ accessToken }) => {
+    const url = '/api/v2/clusters/';
+    return cy
+      .request({
+        method: 'GET',
+        url: url,
+        auth: {
+          bearer: accessToken,
+        },
+      })
+      .then((response) => response);
+  });
+};
+
+export const apiRemoveAllTags = () => {
+  apiGetClusters().then((response) => {
+    const clusterTags = getClusterTags(response.body);
+    Object.entries(clusterTags).forEach(([clusterId, tags]) => {
+      tags.forEach((tag) => apiRemoveTagByClusterId(clusterId, tag));
+    });
+  });
+  return basePage.refresh();
+};
+
+const getClusterTags = (jsonData) => {
+  const clusterTags = {};
+  jsonData.forEach((cluster) => {
+    if (cluster.tags && cluster.tags.length > 0) {
+      clusterTags[cluster.id] = cluster.tags.map((tag) => tag.value);
+    }
+  });
+
+  return clusterTags;
+};
+
+const addTagByColumnValue = (columnValue, tagValue) => {
+  cy.get(`td:contains(${columnValue})`)
+    .parents('tr')
+    .within(() => {
+      cy.get(addTagButtons).type(`${tagValue}{enter}`);
+    });
+};
+
+export const setClusterTags = () => {
+  taggingRules.forEach(([clusterName, tag]) => {
+    addTagByColumnValue(clusterName, tag);
+  });
+};
+
+export const eachClusterTagsIsCorrectlyDisplayed = () => {
+  taggingRules.forEach(([tag]) =>
+    cy.get(`span span:contains(${tag})`).should('be.visible')
+  );
+};
+
+export const deregisterHost = (hostId) => {
+  const [webAPIHost, webAPIPort] = [
+    Cypress.env('web_api_host'),
+    Cypress.env('web_api_port'),
+  ];
+
+  const headers = {
+    'Content-Type': 'application/json;charset=UTF-8',
+  };
+
+  return basePage.apiLogin().then(({ accessToken }) => {
+    const url = `http://${webAPIHost}:${webAPIPort}/api/v1/hosts/${hostId}`;
+    cy.request({
+      method: 'DELETE',
+      url: url,
+      headers: headers,
+      auth: {
+        bearer: accessToken,
+      },
+    });
+  });
+};
+
+export const deregisterAllClusterHosts = () => {
+  hanaCluster1.hosts.forEach((hostId) => deregisterHost(hostId));
+};
+
+export const restoreClusterHosts = () =>
+  basePage.loadScenario(`cluster-${hanaCluster1.name}-restore`);
+
+export const clusterIsNotDisplayedWhenNodesAreDeregistered = () =>
+  cy.get(`span span:contains("${hanaCluster1.name}")`).should('not.exist');
+
+export const clusterNameIsDisplayed = () => {
+  cy.get(`span span:contains("${hanaCluster1.name}")`).should('be.visible');
+};
+
+const apiSetTag = (clusterName, tag) => {
+  const [webAPIHost, webAPIPort] = [
+    Cypress.env('web_api_host'),
+    Cypress.env('web_api_port'),
+  ];
+  const clusterID = clusterIdByName(clusterName);
+  return basePage.apiLogin().then(({ accessToken }) =>
+    cy.request({
+      url: `http://${webAPIHost}:${webAPIPort}/api/v1/clusters/${clusterID}/tags/`,
+      method: 'POST',
+      auth: { bearer: accessToken },
+      body: { value: tag },
+    })
+  );
+};
+
+export const apiSetTagsHanaCluster1 = () => {
+  const tagsForCluster1 = taggingRules
+    .filter(([cluster]) => cluster === 'hana_cluster_1') // Filter for hana_cluster_1
+    .map(([, tag]) => tag); // Extract the tag
+  tagsForCluster1.forEach((tag) => apiSetTag('hana_cluster_1', tag));
+};
+
+export const hanaCluster1TagsAreDisplayed = () => {
+  return cy
+    .get(`tr:contains("${hanaCluster1.name}")`)
+    .within(() =>
+      cy
+        .get(`span span:contains("${clusterTags[hanaCluster1.name]}")`)
+        .should('be.visible')
+    );
 };

--- a/test/e2e/cypress/pageObject/clusters-overview-po.js
+++ b/test/e2e/cypress/pageObject/clusters-overview-po.js
@@ -92,7 +92,7 @@ export const hanaCluster1TagsAreDisplayed = () => {
 export const addTagButtonsAreDisabled = () =>
   cy.get(addTagButtons).should('have.class', 'opacity-50');
 
-export const addTagButtonsAreNotsDisabled = () =>
+export const addTagButtonsAreNotDisabled = () =>
   cy.get(addTagButtons).should('not.have.class', 'opacity-50');
 
 export const removeTagButtonIsDisabled = () =>

--- a/test/e2e/cypress/pageObject/clusters-overview-po.js
+++ b/test/e2e/cypress/pageObject/clusters-overview-po.js
@@ -18,8 +18,16 @@ const paginationNavigationButtons = 'div[class*="bg-gray-50"] ul button';
 const tableRows = 'tbody tr';
 const rowCells = 'td';
 const addTagButtons = 'span span:contains("Add Tag")';
+const removeEnv1TagButton = 'span span:contains("env1") span';
 
 //Test data
+const password = 'password';
+
+const user = createUserRequestFactory.build({
+  password,
+  password_confirmation: password,
+});
+
 export const hanaCluster1 = {
   name: 'hana_cluster_1',
   hosts: [
@@ -204,8 +212,8 @@ const apiSetTag = (clusterName, tag) => {
 
 export const apiSetTagsHanaCluster1 = () => {
   const tagsForCluster1 = taggingRules
-    .filter(([cluster]) => cluster === 'hana_cluster_1') // Filter for hana_cluster_1
-    .map(([, tag]) => tag); // Extract the tag
+    .filter(([cluster]) => cluster === 'hana_cluster_1')
+    .map(([, tag]) => tag);
   tagsForCluster1.forEach((tag) => apiSetTag('hana_cluster_1', tag));
 };
 
@@ -217,4 +225,36 @@ export const hanaCluster1TagsAreDisplayed = () => {
         .get(`span span:contains("${clusterTags[hanaCluster1.name]}")`)
         .should('be.visible')
     );
+};
+
+export const createUserWithoutAbilities = () => {
+  return basePage.createUserWithAbilities(user, []);
+};
+
+export const createUserWithClusterTagsAbilities = () => {
+  return basePage.createUserWithAbilities(user, [
+    { name: 'all', resource: 'cluster_tags' },
+  ]);
+};
+
+export const loginWithoutTagAbilities = () =>
+  basePage.apiLoginAndCreateSession(user.username, password);
+
+export const loginWithTagAbilities = () =>
+  basePage.apiLoginAndCreateSession(user.username, password);
+
+export const addTagButtonsAreDisabled = () => {
+  cy.get(addTagButtons).should('have.class', 'opacity-50');
+};
+
+export const addTagButtonsAreNotsDisabled = () => {
+  cy.get(addTagButtons).should('not.have.class', 'opacity-50');
+};
+
+export const removeTagButtonIsDisabled = () => {
+  cy.get(removeEnv1TagButton).should('have.class', 'opacity-50');
+};
+
+export const removeTagButtonIsEnabled = () => {
+  cy.get(removeEnv1TagButton).should('not.have.class', 'opacity-50');
 };

--- a/test/e2e/cypress/pageObject/clusters-overview-po.js
+++ b/test/e2e/cypress/pageObject/clusters-overview-po.js
@@ -1,0 +1,49 @@
+import { createUserRequestFactory } from '@lib/test-utils/factories';
+import {
+  availableClusters,
+  healthyClusterScenario,
+  unhealthyClusterScenario,
+} from '../fixtures/clusters-overview/available_clusters';
+
+export * from './base-po.js';
+import * as basePage from './base-po.js';
+
+const url = '/clusters';
+const clustersEndpoint = '/api/v2/clusters';
+const clustersEndpointAlias = 'clustersEndpoint';
+
+//Selectors
+const clusterNames = '.tn-clustername';
+const paginationNavigationButtons = 'div[class*="bg-gray-50"] ul button';
+const tableRows = 'tbody tr';
+
+export const visit = () => basePage.visit(url);
+
+export const validateUrl = () => basePage.validateUrl(url);
+
+export const interceptClustersEndpoint = () => {
+  cy.intercept(clustersEndpoint).as(clustersEndpointAlias);
+};
+
+export const waitForClustersEndpoint = () => {
+  return basePage.waitForRequest(clustersEndpointAlias);
+};
+
+export const allRegisteredClustersAreDisplayed = () => {
+  cy.get(clusterNames).its('length').should('eq', availableClusters.length);
+};
+
+export const paginationButtonsAreDisabled = () => {
+  cy.get(paginationNavigationButtons).should('be.disabled');
+};
+
+export const clustersDataIsDisplayedAsExpected = () => {
+  interceptClustersEndpoint();
+  waitForClustersEndpoint();
+  cy.get(tableRows).each(($row, index) => {
+    const cluster = availableClusters[index];
+    cy.wrap($row).find('td').eq(1).should('have.text', cluster.name);
+    cy.wrap($row).find('td').eq(2).should('have.text', cluster.sid);
+    cy.wrap($row).find('td').eq(5).should('have.text', cluster.type);
+  });
+};

--- a/test/e2e/cypress/pageObject/clusters-overview-po.js
+++ b/test/e2e/cypress/pageObject/clusters-overview-po.js
@@ -109,7 +109,7 @@ export const clusterNameLinkIsDisplayedAsId = (clusterName) => {
 };
 
 export const allRegisteredClustersAreDisplayed = () =>
-  cy.get(clusterNames).its('length').should('eq', availableClusters.length);
+  cy.get(clusterNames).should('have.length', availableClusters.length);
 
 export const paginationButtonsAreDisabled = () =>
   cy.get(paginationNavigationButtons).should('be.disabled');
@@ -212,7 +212,7 @@ const getClusterTags = (jsonData) => {
   return clusterTags;
 };
 
-export const deregisterHost = (hostId) => {
+const apiDeregisterHost = (hostId) => {
   return basePage.apiLogin().then(({ accessToken }) => {
     const url = `/api/v1/hosts/${hostId}`;
     cy.request({
@@ -225,11 +225,10 @@ export const deregisterHost = (hostId) => {
   });
 };
 
-export const deregisterAllClusterHosts = () => {
-  hanaCluster1.hosts.forEach((hostId) => deregisterHost(hostId));
-};
+export const apiDeregisterAllClusterHosts = () =>
+  hanaCluster1.hosts.forEach((hostId) => apiDeregisterHost(hostId));
 
-export const restoreClusterHosts = () =>
+export const apiRestoreClusterHosts = () =>
   basePage.loadScenario(`cluster-${hanaCluster1.name}-restore`);
 
 const apiSetTag = (clusterName, tag) => {
@@ -248,18 +247,16 @@ export const apiSetTagsHanaCluster1 = () => {
   const tagsForCluster1 = taggingRules
     .filter(([cluster]) => cluster === 'hana_cluster_1')
     .map(([, tag]) => tag);
-  tagsForCluster1.forEach((tag) => apiSetTag('hana_cluster_1', tag));
+  return tagsForCluster1.forEach((tag) => apiSetTag('hana_cluster_1', tag));
 };
 
-export const createUserWithoutAbilities = () => {
-  return basePage.createUserWithAbilities(user, []);
-};
+export const apiCreateUserWithoutAbilities = () =>
+  basePage.createUserWithAbilities(user, []);
 
-export const createUserWithClusterTagsAbilities = () => {
-  return basePage.createUserWithAbilities(user, [
+export const apiCreateUserWithClusterTagsAbilities = () =>
+  basePage.createUserWithAbilities(user, [
     { name: 'all', resource: 'cluster_tags' },
   ]);
-};
 
 export const loginWithoutTagAbilities = () =>
   basePage.apiLoginAndCreateSession(user.username, password);
@@ -267,7 +264,7 @@ export const loginWithoutTagAbilities = () =>
 export const loginWithTagAbilities = () =>
   basePage.apiLoginAndCreateSession(user.username, password);
 
-const selectChecks = (clusterId, checks) => {
+const apiSelectChecks = (clusterId, checks) => {
   const checksBody = JSON.stringify({
     checks: checks,
   });
@@ -290,7 +287,7 @@ const selectChecks = (clusterId, checks) => {
   });
 };
 
-const requestChecksExecution = (clusterId) => {
+const apiRequestChecksExecution = (clusterId) => {
   return basePage.apiLogin().then(({ accessToken }) => {
     const url = `/api/clusters/${clusterId}/checks/request_execution`;
     cy.request({
@@ -303,28 +300,32 @@ const requestChecksExecution = (clusterId) => {
   });
 };
 
-export const selectChecksForHealthyCluster = () =>
-  selectChecks(
+export const apiSelectChecksForHealthyCluster = () =>
+  apiSelectChecks(
     clusterIdByName(healthyClusterScenario.clusterName),
     healthyClusterScenario.checks
   );
 
-export const requestChecksForHealthyCluster = () =>
-  requestChecksExecution(clusterIdByName(healthyClusterScenario.clusterName));
+export const apiRequestChecksForHealthyCluster = () =>
+  apiRequestChecksExecution(
+    clusterIdByName(healthyClusterScenario.clusterName)
+  );
 
-export const selectChecksForUnhealthyCluster = () =>
-  selectChecks(
+export const apiSelectChecksForUnhealthyCluster = () =>
+  apiSelectChecks(
     clusterIdByName(unhealthyClusterScenario.clusterName),
     healthyClusterScenario.checks
   );
 
-export const requestChecksForUnhealthyCluster = () =>
-  requestChecksExecution(clusterIdByName(unhealthyClusterScenario.clusterName));
+export const apiRequestChecksForUnhealthyCluster = () =>
+  apiRequestChecksExecution(
+    clusterIdByName(unhealthyClusterScenario.clusterName)
+  );
 
-export const removeHealthyClusterChecks = () =>
-  selectChecks(clusterIdByName(healthyClusterScenario.clusterName), []);
+export const apiRemoveHealthyClusterChecks = () =>
+  apiSelectChecks(clusterIdByName(healthyClusterScenario.clusterName), []);
 
-export const removeUnhealthyClusterChecks = () =>
-  selectChecks(clusterIdByName(unhealthyClusterScenario.clusterName), []);
+export const apiRemoveUnhealthyClusterChecks = () =>
+  apiSelectChecks(clusterIdByName(unhealthyClusterScenario.clusterName), []);
 
 export const restoreClusterName = () => basePage.loadScenario('cluster-4-SOK');

--- a/test/e2e/cypress/pageObject/clusters-overview-po.js
+++ b/test/e2e/cypress/pageObject/clusters-overview-po.js
@@ -38,12 +38,12 @@ export const paginationButtonsAreDisabled = () => {
 };
 
 export const clustersDataIsDisplayedAsExpected = () => {
-  interceptClustersEndpoint();
-  waitForClustersEndpoint();
-  cy.get(tableRows).each(($row, index) => {
-    const cluster = availableClusters[index];
-    cy.wrap($row).find('td').eq(1).should('have.text', cluster.name);
-    cy.wrap($row).find('td').eq(2).should('have.text', cluster.sid);
-    cy.wrap($row).find('td').eq(5).should('have.text', cluster.type);
+  return waitForClustersEndpoint().then(() => {
+    return cy.get(tableRows).each(($row, index) => {
+      const cluster = availableClusters[index];
+      cy.wrap($row).find('td').eq(1).should('have.text', cluster.name);
+      cy.wrap($row).find('td').eq(2).should('have.text', cluster.sid);
+      return cy.wrap($row).find('td').eq(5).should('have.text', cluster.type);
+    });
   });
 };

--- a/test/e2e/cypress/pageObject/clusters-overview-po.js
+++ b/test/e2e/cypress/pageObject/clusters-overview-po.js
@@ -178,7 +178,7 @@ export const apiRemoveTagByClusterId = (clusterId, tagId) => {
 
 const apiGetClusters = () => {
   return basePage.apiLogin().then(({ accessToken }) => {
-    const url = '/api/v2/clusters/';
+    const url = '/api/v2/clusters';
     return cy
       .request({
         method: 'GET',
@@ -235,7 +235,7 @@ const apiSetTag = (clusterName, tag) => {
   const clusterID = clusterIdByName(clusterName);
   return basePage.apiLogin().then(({ accessToken }) =>
     cy.request({
-      url: `/api/v1/clusters/${clusterID}/tags/`,
+      url: `/api/v1/clusters/${clusterID}/tags`,
       method: 'POST',
       auth: { bearer: accessToken },
       body: { value: tag },

--- a/test/e2e/cypress/support/commands.js
+++ b/test/e2e/cypress/support/commands.js
@@ -125,33 +125,6 @@ Cypress.Commands.add('clickOutside', () => {
   return cy.get('body').click(0, 0); //0,0 here are the x and y coordinates
 });
 
-Cypress.Commands.add('selectChecks', (clusterId, checks) => {
-  const [webAPIHost, webAPIPort] = [
-    Cypress.env('web_api_host'),
-    Cypress.env('web_api_port'),
-  ];
-  const checksBody = JSON.stringify({
-    checks: checks,
-  });
-
-  const headers = {
-    'Content-Type': 'application/json;charset=UTF-8',
-  };
-
-  cy.apiLogin().then(({ accessToken }) => {
-    const url = `http://${webAPIHost}:${webAPIPort}/api/clusters/${clusterId}/checks`;
-    cy.request({
-      method: 'POST',
-      url: url,
-      body: checksBody,
-      headers: headers,
-      auth: {
-        bearer: accessToken,
-      },
-    });
-  });
-});
-
 const isTestDataLoaded = () =>
   cy.apiLogin().then(({ accessToken }) =>
     cy
@@ -196,29 +169,6 @@ Cypress.Commands.add('resetFilterSelection', (filterName) => {
         cy.get(resetButton).click();
       }
     });
-});
-
-Cypress.Commands.add('requestChecksExecution', (clusterId) => {
-  const [webAPIHost, webAPIPort] = [
-    Cypress.env('web_api_host'),
-    Cypress.env('web_api_port'),
-  ];
-
-  const headers = {
-    'Content-Type': 'application/json;charset=UTF-8',
-  };
-
-  cy.apiLogin().then(({ accessToken }) => {
-    const url = `http://${webAPIHost}:${webAPIPort}/api/clusters/${clusterId}/checks/request_execution`;
-    cy.request({
-      method: 'POST',
-      url: url,
-      headers: headers,
-      auth: {
-        bearer: accessToken,
-      },
-    });
-  });
 });
 
 Cypress.Commands.add('deregisterHost', (hostId) => {


### PR DESCRIPTION
# Description

Apply page object pattern to clusters overview tests
Key points:
- Some methods from commands file have been removed and now they are in po files
- Skipped & WIP test has been refactored but still left as WIP as the scope of this task was different

Bonus track:
- I removed a couple of unused parameters in visit methods from two page objects as required by @nelsonkopliku in a previus pr review
- I also removed a validation that was done with data-testid for consistency and to end up not using them after the refactor finishes.

No changes required in docs.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [X] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [X] **DONE**
## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
- [Trento Web guides](https://github.com/trento-project/web/tree/main/guides)

Add a documentation PR or write that no changes are required for the documentation.
- [X] **DONE**
