### PR TITLE
Fix discovery dispatch accumulating errors

### DIFF
--- a/lib/trento/discovery.ex
+++ b/lib/trento/discovery.ex
@@ -171,6 +171,9 @@ defmodule Trento.Discovery do
         {:ok, :ok} ->
           :ok
 
+        {:ok, {:error, errors}} ->
+          {:error, errors}
+
         {{:error, error}, :ok} ->
           {:error, [error]}
 


### PR DESCRIPTION
# Description

The `dispatch` function was failing in some circumstances if the 1st command failed but the 2nd worked.
I saw this behaviour running the `hana-scale-up-cost-opt` photofinish scenario.
In reality, we don't have any flagrant error, as by coincidence the correct command is the 2nd and last, so the commands are properly dispatched to the domain code. The failure was that we were returning 500 error in the collect endpoint (and we had more SAP instances in the payload, they wouldn't be handled).

This was the error log in web:
```
14:16:33.482 [error] #PID<0.1014.0> running Phoenix.Endpoint.SyncCodeReloadPlug (connection #PID<0.1004.0>, stream id 2) terminated
Server: localhost:4000 (http)
Request: POST /api/v1/collect
** (exit) an exception was raised:
    ** (CaseClauseError) no case clause matching: {:ok, {:error, [:database_not_registered]}}
        (trento 2.4.0+git.dev88.1738570035.d87bd8166) lib/trento/discovery.ex:170: anonymous fn/2 in Trento.Discovery.dispatch/1
        (elixir 1.15.7) lib/enum.ex:2510: Enum."-reduce/3-lists^foldl/2-0-"/3

```

## How was this tested?

UT
