### PR TITLE
Fix cluster json view adapt_v1 function

### DIFF
--- a/lib/trento/support/struct_helper.ex
+++ b/lib/trento/support/struct_helper.ex
@@ -33,4 +33,41 @@ defmodule Trento.Support.StructHelper do
   def to_map(value) when is_nil(value), do: value
   def to_map(value) when is_atom(value), do: Atom.to_string(value)
   def to_map(value), do: value
+
+  @doc """
+  Converts the string keys of a map to existing atoms.
+  If the key does not exist as atom it continues being a string
+  """
+  @spec to_atomized_map(map | [map] | struct | [struct]) :: map | [map]
+  def to_atomized_map(%NaiveDateTime{} = value), do: value
+  def to_atomized_map(%DateTime{} = value), do: value
+  def to_atomized_map(%Date{} = value), do: value
+
+  def to_atomized_map(struct) when is_struct(struct) do
+    struct
+    |> Map.from_struct()
+    |> to_atomized_map()
+  end
+
+  def to_atomized_map(map) when is_map(map) do
+    map
+    |> Enum.reject(fn
+      {:__meta__, _} -> true
+      {_, %Ecto.Association.NotLoaded{}} -> true
+      _ -> false
+    end)
+    |> Map.new(fn {k, v} -> {atomize_key(k), to_atomized_map(v)} end)
+  end
+
+  def to_atomized_map(list) when is_list(list) do
+    Enum.map(list, &to_atomized_map/1)
+  end
+
+  def to_atomized_map(value), do: value
+
+  defp atomize_key(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError -> key
+  end
 end

--- a/lib/trento_web/controllers/v1/cluster_json.ex
+++ b/lib/trento_web/controllers/v1/cluster_json.ex
@@ -1,11 +1,13 @@
 defmodule TrentoWeb.V1.ClusterJSON do
+  alias Trento.Support.StructHelper
+
   def clusters(%{clusters: clusters}) do
     Enum.map(clusters, &cluster(%{cluster: &1}))
   end
 
   def cluster(%{cluster: cluster}) do
     cluster
-    |> Map.from_struct()
+    |> StructHelper.to_atomized_map()
     |> Map.delete(:deregistered_at)
     |> Map.delete(:__meta__)
     |> adapt_v1()

--- a/lib/trento_web/controllers/v1/cluster_json.ex
+++ b/lib/trento_web/controllers/v1/cluster_json.ex
@@ -9,7 +9,6 @@ defmodule TrentoWeb.V1.ClusterJSON do
     cluster
     |> StructHelper.to_atomized_map()
     |> Map.delete(:deregistered_at)
-    |> Map.delete(:__meta__)
     |> adapt_v1()
   end
 

--- a/lib/trento_web/controllers/v2/cluster_json.ex
+++ b/lib/trento_web/controllers/v2/cluster_json.ex
@@ -7,7 +7,6 @@ defmodule TrentoWeb.V2.ClusterJSON do
     cluster
     |> StructHelper.to_atomized_map()
     |> Map.delete(:deregistered_at)
-    |> Map.delete(:__meta__)
   end
 
   def cluster_registered(%{cluster: cluster}), do: Map.delete(cluster(%{cluster: cluster}), :tags)

--- a/lib/trento_web/controllers/v2/cluster_json.ex
+++ b/lib/trento_web/controllers/v2/cluster_json.ex
@@ -1,9 +1,11 @@
 defmodule TrentoWeb.V2.ClusterJSON do
+  alias Trento.Support.StructHelper
+
   def clusters(%{clusters: clusters}), do: Enum.map(clusters, &cluster(%{cluster: &1}))
 
   def cluster(%{cluster: cluster}) do
     cluster
-    |> Map.from_struct()
+    |> StructHelper.to_atomized_map()
     |> Map.delete(:deregistered_at)
     |> Map.delete(:__meta__)
   end

--- a/test/trento/clusters/projections/cluster_projector_test.exs
+++ b/test/trento/clusters/projections/cluster_projector_test.exs
@@ -7,13 +7,6 @@ defmodule Trento.Clusters.Projections.ClusterProjectorTest do
 
   import Trento.Factory
 
-  alias Trento.Clusters.ValueObjects.{
-    ClusterResource,
-    HanaClusterDetails,
-    HanaClusterNode,
-    SbdDevice
-  }
-
   alias Trento.Clusters.Events.{
     ClusterDeregistered,
     ClusterDetailsUpdated,
@@ -67,16 +60,16 @@ defmodule Trento.Clusters.Projections.ClusterProjectorTest do
       "cluster_registered",
       %{
         cib_last_written: nil,
-        details: %HanaClusterDetails{
+        details: %{
           architecture_type: :classic,
           fencing_type: "external/sbd",
           nodes: [
-            %HanaClusterNode{
+            %{
               attributes: _,
               hana_status: "Secondary",
               name: _,
               resources: [
-                %ClusterResource{
+                %{
                   fail_count: _,
                   id: _,
                   role: "Started",
@@ -89,12 +82,12 @@ defmodule Trento.Clusters.Projections.ClusterProjectorTest do
             }
           ],
           sbd_devices: [
-            %SbdDevice{device: "/dev/vdc", status: "healthy"}
+            %{device: "/dev/vdc", status: "healthy"}
           ],
           secondary_sync_state: "SOK",
           sr_health_state: "4",
           stopped_resources: [
-            %ClusterResource{
+            %{
               fail_count: _,
               id: _,
               role: "Stopped",
@@ -154,16 +147,16 @@ defmodule Trento.Clusters.Projections.ClusterProjectorTest do
     assert_broadcast(
       "cluster_details_updated",
       %{
-        details: %HanaClusterDetails{
+        details: %{
           architecture_type: :classic,
           fencing_type: "external/sbd",
           nodes: [
-            %HanaClusterNode{
+            %{
               attributes: _,
               hana_status: "Secondary",
               name: _,
               resources: [
-                %ClusterResource{
+                %{
                   fail_count: _,
                   id: _,
                   role: "Started",
@@ -176,12 +169,12 @@ defmodule Trento.Clusters.Projections.ClusterProjectorTest do
             }
           ],
           sbd_devices: [
-            %SbdDevice{device: "/dev/vdc", status: "healthy"}
+            %{device: "/dev/vdc", status: "healthy"}
           ],
           secondary_sync_state: "SOK",
           sr_health_state: "4",
           stopped_resources: [
-            %ClusterResource{
+            %{
               fail_count: _,
               id: _,
               role: "Stopped",
@@ -241,6 +234,7 @@ defmodule Trento.Clusters.Projections.ClusterProjectorTest do
       ClusterReadModel
       |> Repo.get!(event.cluster_id)
       |> Repo.preload([:tags])
+      |> StructHelper.to_atomized_map()
 
     assert nil == cluster_projection.deregistered_at
 

--- a/test/trento/support/struct_helper_test.exs
+++ b/test/trento/support/struct_helper_test.exs
@@ -1,0 +1,36 @@
+defmodule Trento.Support.StructHelperTest do
+  use ExUnit.Case
+
+  alias Trento.Support.StructHelper
+
+  describe "to_atomize_map/1" do
+    test "should map plain keys to atom keys" do
+      datetime = DateTime.utc_now()
+      date = Date.utc_today()
+      naive_datetime = NaiveDateTime.utc_now()
+
+      initial_map = %{
+        "id" => "some-id",
+        "not_existing_atom" => "some-value",
+        "not_loaded" => %Ecto.Association.NotLoaded{},
+        __meta__: nil,
+        __struct__: nil,
+        list: [
+          datetime,
+          date,
+          naive_datetime
+        ]
+      }
+
+      assert %{
+               "not_existing_atom" => "some-value",
+               id: "some-id",
+               list: [
+                 datetime,
+                 date,
+                 naive_datetime
+               ]
+             } == StructHelper.to_atomized_map(initial_map)
+    end
+  end
+end

--- a/test/trento_web/views/v2/cluster_view_json_test.exs
+++ b/test/trento_web/views/v2/cluster_view_json_test.exs
@@ -14,10 +14,7 @@ defmodule TrentoWeb.V2.ClusterJSONTest do
   end
 
   test "should render maintenance_mode field" do
-    details =
-      :hana_cluster_details
-      |> build()
-      |> Map.from_struct()
+    details = build(:hana_cluster_details)
 
     cluster = build(:cluster, details: details)
 


### PR DESCRIPTION
# Description

I have realized that the v1 adaption of the cluster view doesn't work as expected.
As the transformed data is loaded from the database, and the `details` field is a jsonb, it is loaded as plain maps.

The `to_atomized_map` function solves the issue and works when the `details` are loaded from the database and not. We need this as the transformation happens in 2 places:
- in the controller after loading the data from the db
- in the projection, where the details are coming from the ecto changeset as atom keys already

Other solution could be to change the `Trento.Support.Ecto.Payload` file to do this in the load, and set this type as the cluster `details` field in the read model. Like here: https://github.com/trento-project/wanda/pull/564
Just changing the `dump` function:

```
def dump(data) when is_list(data) or is_map(data), do: {:ok, to_atomized_map(data)}
```
I didn't do this, because we already use this `Payload` in other places and I'm not sure if we want to atomize all the keys.
We can postpone this decision as well and have some tech-debt task

## How was this tested?

UT
