### PR TITLE
Apply PageObject pattern to databases overview tests.

### DIFF
--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -108,7 +108,7 @@ context('Clusters Overview', () => {
 
       it('should allow a tag update when the user abilities are compliant', () => {
         clustersOverviewPage.apiCreateUserWithClusterTagsAbilities();
-        clustersOverviewPage.loginWithTagAbilities();
+        clustersOverviewPage.loginWithAbilities();
         clustersOverviewPage.visit();
         clustersOverviewPage.addTagButtonsAreNotDisabled();
         clustersOverviewPage.removeTagButtonIsEnabled();

--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -62,7 +62,7 @@ context('Clusters Overview', () => {
   describe('Clusters Tagging', () => {
     beforeEach(() => {
       clustersOverviewPage.restoreClusterName();
-      clustersOverviewPage.apiRemoveAllTags();
+      clustersOverviewPage.apiRemoveAllClusterTags();
     });
 
     it('should tag each cluster with the corresponding tag', () => {
@@ -73,7 +73,7 @@ context('Clusters Overview', () => {
 
   describe('Deregistration', () => {
     before(() => {
-      clustersOverviewPage.apiRemoveAllTags();
+      clustersOverviewPage.apiRemoveAllClusterTags();
       clustersOverviewPage.apiSetTagsHanaCluster1();
       clustersOverviewPage.apiDeregisterAllClusterHosts();
     });
@@ -92,7 +92,7 @@ context('Clusters Overview', () => {
   describe('Forbidden action', () => {
     describe('Tag operations', () => {
       beforeEach(() => {
-        clustersOverviewPage.apiRemoveAllTags();
+        clustersOverviewPage.apiRemoveAllClusterTags();
         clustersOverviewPage.apiSetTagsHanaCluster1();
         clustersOverviewPage.apiDeleteAllUsers();
         clustersOverviewPage.logout();

--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -100,7 +100,7 @@ context('Clusters Overview', () => {
 
       it('should prevent a tag update when the user abilities are not compliant', () => {
         clustersOverviewPage.apiCreateUserWithoutAbilities();
-        clustersOverviewPage.loginWithoutTagAbilities();
+        clustersOverviewPage.loginWithoutAbilities();
         clustersOverviewPage.visit();
         clustersOverviewPage.addTagButtonsAreDisabled();
         clustersOverviewPage.removeTagButtonIsDisabled();

--- a/test/e2e/cypress/e2e/databases_overview.cy.js
+++ b/test/e2e/cypress/e2e/databases_overview.cy.js
@@ -68,7 +68,7 @@ context('Databases Overview', () => {
 
     describe('Tag creation', () => {
       before(() => {
-        databasesOverviewPage.apiRemoveAllTags();
+        databasesOverviewPage.apiRemoveAllDatabaseTags();
         databasesOverviewPage.addTagByColumnValue('HDQ', 'env1');
       });
 

--- a/test/e2e/cypress/e2e/databases_overview.cy.js
+++ b/test/e2e/cypress/e2e/databases_overview.cy.js
@@ -82,7 +82,7 @@ context('Databases Overview', () => {
 
       it('it should allow a tag update when the user abilities are compliant', () => {
         databasesOverviewPage.apiCreateUserWithDatabaseTagsAbilities();
-        databasesOverviewPage.loginWithTagAbilities();
+        databasesOverviewPage.loginWithAbilities();
         databasesOverviewPage.visit();
         databasesOverviewPage.addTagButtonsAreNotDisabled();
         databasesOverviewPage.removeTagButtonIsEnabled();
@@ -104,7 +104,7 @@ context('Databases Overview', () => {
 
       it('should allow database instance clean up', () => {
         databasesOverviewPage.apiCreateUserWithCleanupAbilities();
-        databasesOverviewPage.loginWithTagAbilities();
+        databasesOverviewPage.loginWithAbilities();
         databasesOverviewPage.visit();
         databasesOverviewPage.cleanUpButtonIsEnabled();
       });

--- a/test/e2e/cypress/e2e/databases_overview.cy.js
+++ b/test/e2e/cypress/e2e/databases_overview.cy.js
@@ -12,6 +12,11 @@ context('Databases Overview', () => {
   });
 
   describe('Deregistration', () => {
+    beforeEach(() => {
+      databasesOverviewPage.refresh();
+      databasesOverviewPage.clickHdqDatabaseRow();
+    });
+
     it(`should not display DB ${databasesOverviewPage.hdqDatabase.sid} after deregistering the primary instance`, () => {
       databasesOverviewPage.deregisterHdqDatabasePrimaryInstance();
       databasesOverviewPage.hdqDatabaseIsNotDisplayed();
@@ -22,12 +27,10 @@ context('Databases Overview', () => {
     });
 
     it(`should include both instances in DB ${databasesOverviewPage.hdqDatabase.sid} after restoring the primary instance`, () => {
-      databasesOverviewPage.clickHdqDatabaseRow();
       databasesOverviewPage.bothDatabaseInstancesAreDisplayed();
     });
 
     it('should show the ACTIVE pill in the right host', () => {
-      databasesOverviewPage.clickHdqDatabaseRow();
       databasesOverviewPage.activePillIsDisplayedInTheRightHost();
     });
 

--- a/test/e2e/cypress/e2e/databases_overview.cy.js
+++ b/test/e2e/cypress/e2e/databases_overview.cy.js
@@ -74,7 +74,7 @@ context('Databases Overview', () => {
 
       it('it should prevent a tag update when the user abilities are not compliant', () => {
         databasesOverviewPage.apiCreateUserWithoutAbilities();
-        databasesOverviewPage.loginWithoutTagAbilities();
+        databasesOverviewPage.loginWithoutAbilities();
         databasesOverviewPage.visit();
         databasesOverviewPage.addTagButtonsAreDisabled();
         databasesOverviewPage.removeTagButtonIsDisabled();
@@ -97,13 +97,13 @@ context('Databases Overview', () => {
 
       it('should forbid database instance cleanup', () => {
         databasesOverviewPage.apiCreateUserWithoutAbilities();
-        databasesOverviewPage.loginWithoutTagAbilities();
+        databasesOverviewPage.loginWithoutAbilities();
         databasesOverviewPage.visit();
         databasesOverviewPage.cleanUpButtonIsDisabled();
       });
 
       it('should allow database instance clean up', () => {
-        databasesOverviewPage.apiCreateUserWithDatabaseTagsAbilities();
+        databasesOverviewPage.apiCreateUserWithCleanupAbilities();
         databasesOverviewPage.loginWithTagAbilities();
         databasesOverviewPage.visit();
         databasesOverviewPage.cleanUpButtonIsEnabled();

--- a/test/e2e/cypress/pageObject/base-po.js
+++ b/test/e2e/cypress/pageObject/base-po.js
@@ -232,3 +232,35 @@ export const createUserWithAbilities = (payload, abilities) =>
         });
       })
   );
+
+export const apiDeregisterHost = (hostId) => {
+  return isHostRegistered(hostId).then((isRegistered) => {
+    if (isRegistered) {
+      return apiLogin().then(({ accessToken }) => {
+        const url = `/api/v1/hosts/${hostId}`;
+        return cy.request({
+          method: 'DELETE',
+          url: url,
+          auth: {
+            bearer: accessToken,
+          },
+        });
+      });
+    } else return;
+  });
+};
+
+export const isHostRegistered = (hostId) => {
+  return apiLogin()
+    .then(({ accessToken }) => {
+      const url = '/api/v1/hosts/';
+      cy.request({
+        method: 'GET',
+        url: url,
+        auth: {
+          bearer: accessToken,
+        },
+      });
+    })
+    .then(({ body }) => body.some((host) => host.id === hostId));
+};

--- a/test/e2e/cypress/pageObject/base-po.js
+++ b/test/e2e/cypress/pageObject/base-po.js
@@ -307,7 +307,7 @@ export const isHostRegistered = (hostId) => {
 export const loginWithoutAbilities = () =>
   apiLoginAndCreateSession(user.username, password);
 
-export const loginWithTagAbilities = () =>
+export const loginWithAbilities = () =>
   apiLoginAndCreateSession(user.username, password);
 
 export const apiCreateUserWithoutAbilities = () => createUserWithAbilities([]);

--- a/test/e2e/cypress/pageObject/base-po.js
+++ b/test/e2e/cypress/pageObject/base-po.js
@@ -286,7 +286,7 @@ export const addTagByColumnValue = (columnValue, tagValue) => {
     });
 };
 
-export const loginWithoutTagAbilities = () =>
+export const loginWithoutAbilities = () =>
   apiLoginAndCreateSession(user.username, password);
 
 export const loginWithTagAbilities = () =>

--- a/test/e2e/cypress/pageObject/clusters-overview-po.js
+++ b/test/e2e/cypress/pageObject/clusters-overview-po.js
@@ -1,7 +1,6 @@
 export * from './base-po.js';
 import * as basePage from './base-po.js';
 
-import { createUserRequestFactory } from '@lib/test-utils/factories';
 import {
   availableClusters,
   healthyClusterScenario,
@@ -17,19 +16,10 @@ const clusterNames = '.tn-clustername';
 const paginationNavigationButtons = 'div[class*="bg-gray-50"] ul button';
 const tableRows = 'tbody tr';
 const rowCells = 'td';
-const addTagButtons = 'span span:contains("Add Tag")';
-const removeEnv1TagButton = 'span span:contains("env1") span';
 
 //Test data
 export const healthyClusterName = healthyClusterScenario.clusterName;
 export const unhealthyClusterName = unhealthyClusterScenario.clusterName;
-
-const password = 'password';
-
-const user = createUserRequestFactory.build({
-  password,
-  password_confirmation: password,
-});
 
 export const hanaCluster1 = {
   name: 'hana_cluster_1',
@@ -65,16 +55,8 @@ export const waitForClustersEndpoint = () =>
 
 export const setClusterTags = () => {
   taggingRules.forEach(([clusterName, tag]) => {
-    addTagByColumnValue(clusterName, tag);
+    basePage.addTagByColumnValue(clusterName, tag);
   });
-};
-
-const addTagByColumnValue = (columnValue, tagValue) => {
-  cy.get(`td:contains(${columnValue})`)
-    .parents('tr')
-    .within(() => {
-      cy.get(addTagButtons).type(`${tagValue}{enter}`);
-    });
 };
 
 // Validations
@@ -88,18 +70,6 @@ export const hanaCluster1TagsAreDisplayed = () => {
         .should('be.visible')
     );
 };
-
-export const addTagButtonsAreDisabled = () =>
-  cy.get(addTagButtons).should('have.class', 'opacity-50');
-
-export const addTagButtonsAreNotDisabled = () =>
-  cy.get(addTagButtons).should('not.have.class', 'opacity-50');
-
-export const removeTagButtonIsDisabled = () =>
-  cy.get(removeEnv1TagButton).should('have.class', 'opacity-50');
-
-export const removeTagButtonIsEnabled = () =>
-  cy.get(removeEnv1TagButton).should('not.have.class', 'opacity-50');
 
 export const clusterNameLinkIsDisplayedAsId = (clusterName) => {
   const clusterID = clusterIdByName(clusterName);
@@ -237,20 +207,6 @@ export const apiSetTagsHanaCluster1 = () => {
   return tagsForCluster1.forEach((tag) => apiSetTag('hana_cluster_1', tag));
 };
 
-export const apiCreateUserWithoutAbilities = () =>
-  basePage.createUserWithAbilities(user, []);
-
-export const apiCreateUserWithClusterTagsAbilities = () =>
-  basePage.createUserWithAbilities(user, [
-    { name: 'all', resource: 'cluster_tags' },
-  ]);
-
-export const loginWithoutTagAbilities = () =>
-  basePage.apiLoginAndCreateSession(user.username, password);
-
-export const loginWithTagAbilities = () =>
-  basePage.apiLoginAndCreateSession(user.username, password);
-
 const apiSelectChecks = (clusterId, checks) => {
   const checksBody = JSON.stringify({
     checks: checks,
@@ -316,3 +272,6 @@ export const apiRemoveUnhealthyClusterChecks = () =>
   apiSelectChecks(clusterIdByName(unhealthyClusterScenario.clusterName), []);
 
 export const restoreClusterName = () => basePage.loadScenario('cluster-4-SOK');
+
+export const apiCreateUserWithClusterTagsAbilities = () =>
+  basePage.createUserWithAbilities([{ name: 'all', resource: 'cluster_tags' }]);

--- a/test/e2e/cypress/pageObject/clusters-overview-po.js
+++ b/test/e2e/cypress/pageObject/clusters-overview-po.js
@@ -136,7 +136,7 @@ const clusterIdByName = (clusterName) =>
 
 // API Interactions
 
-export const apiRemoveTagByClusterId = (clusterId, tagId) => {
+const apiRemoveTagByClusterId = (clusterId, tagId) => {
   return basePage.apiLogin().then(({ accessToken }) =>
     cy.request({
       url: `/api/v1/clusters/${clusterId}/tags/${tagId}`,
@@ -161,7 +161,7 @@ const apiGetClusters = () => {
   });
 };
 
-export const apiRemoveAllTags = () => {
+export const apiRemoveAllClusterTags = () => {
   apiGetClusters().then((response) => {
     const clusterTags = getClusterTags(response.body);
     Object.entries(clusterTags).forEach(([clusterId, tags]) => {

--- a/test/e2e/cypress/pageObject/clusters-overview-po.js
+++ b/test/e2e/cypress/pageObject/clusters-overview-po.js
@@ -212,21 +212,8 @@ const getClusterTags = (jsonData) => {
   return clusterTags;
 };
 
-const apiDeregisterHost = (hostId) => {
-  return basePage.apiLogin().then(({ accessToken }) => {
-    const url = `/api/v1/hosts/${hostId}`;
-    cy.request({
-      method: 'DELETE',
-      url: url,
-      auth: {
-        bearer: accessToken,
-      },
-    });
-  });
-};
-
 export const apiDeregisterAllClusterHosts = () =>
-  hanaCluster1.hosts.forEach((hostId) => apiDeregisterHost(hostId));
+  hanaCluster1.hosts.forEach((hostId) => basePage.apiDeregisterHost(hostId));
 
 export const apiRestoreClusterHosts = () =>
   basePage.loadScenario(`cluster-${hanaCluster1.name}-restore`);

--- a/test/e2e/cypress/pageObject/databases-overview-po.js
+++ b/test/e2e/cypress/pageObject/databases-overview-po.js
@@ -147,6 +147,11 @@ export const apiCreateUserWithDatabaseTagsAbilities = () =>
     { name: 'all', resource: 'database_tags' },
   ]);
 
+export const apiCreateUserWithCleanupAbilities = () =>
+  basePage.createUserWithAbilities([
+    { name: 'cleanup', resource: 'database_instance' },
+  ]);
+
 export const cleanUpButtonIsEnabled = () =>
   cy.get(cleanUpButtons).should('be.enabled');
 

--- a/test/e2e/cypress/pageObject/databases-overview-po.js
+++ b/test/e2e/cypress/pageObject/databases-overview-po.js
@@ -39,8 +39,8 @@ const hdqDatabaseCell = `tr:contains("${hdqDatabase.sid}")`;
 
 const hddDatabaseCell = `tr:contains("${hddDatabase.sid}")`;
 
-const databaseInstace1 = `a:contains("${hdqDatabase.instances[0].name}")`;
-const databaseInstace2 = `a:contains("${hdqDatabase.instances[1].name}")`;
+const databaseInstance1 = `a:contains("${hdqDatabase.instances[0].name}")`;
+const databaseInstance2 = `a:contains("${hdqDatabase.instances[1].name}")`;
 
 const deletedSapSystemToaster = `p:contains("The SAP System ${nwqSystem.sid} has been deregistered.")`;
 
@@ -72,17 +72,15 @@ export const hddDatabaseIsNotDisplayed = () =>
   cy.get(hddDatabaseCell).should('not.exist');
 
 export const bothDatabaseInstancesAreDisplayed = () => {
-  cy.get(databaseInstace1).should('be.visible');
-  return cy.get(databaseInstace2).should('be.visible');
+  cy.get(databaseInstance1).should('be.visible');
+  return cy.get(databaseInstance2).should('be.visible');
 };
 
 export const activePillIsDisplayedInTheRightHost = () => {
-  return hdqDatabase.instances.forEach((instance) => {
-    return cy.get(`div.table-row:contains("${instance.name}")`).within(() => {
+  return cy.wrap(hdqDatabase.instances).each((instance) => {
+    cy.get(`div.table-row:contains("${instance.name}")`).within(() => {
       const isHostActive = instance.state === 'ACTIVE';
-      return cy
-        .get(activePill)
-        .should(isHostActive ? 'be.visible' : 'not.exist');
+      cy.get(activePill).should(isHostActive ? 'be.visible' : 'not.exist');
     });
   });
 };

--- a/test/e2e/cypress/pageObject/databases-overview-po.js
+++ b/test/e2e/cypress/pageObject/databases-overview-po.js
@@ -1,0 +1,78 @@
+export * from './base-po.js';
+import * as basePage from './base-po.js';
+
+// Test Data
+export const hdqDatabase = {
+  sid: 'HDQ',
+  instances: [
+    {
+      name: 'vmhdbqas01',
+      id: '99cf8a3a-48d6-57a4-b302-6e4482227ab6',
+      state: '',
+    },
+    {
+      name: 'vmhdbqas02',
+      id: 'e0c182db-32ff-55c6-a9eb-2b82dd21bc8b',
+      state: 'ACTIVE',
+    },
+  ],
+};
+
+const nwqSystem = {
+  sid: 'NWQ',
+  ascsInstance: {
+    id: '25677e37-fd33-5005-896c-9275b1284534',
+  },
+};
+
+// Selectors
+const hdqDatabaseCell = `tr:contains("${hdqDatabase.sid}")`;
+
+const databaseInstace1 = `a:contains("${hdqDatabase.instances[0].name}")`;
+const databaseInstace2 = `a:contains("${hdqDatabase.instances[1].name}")`;
+
+const deletedSapSystemToaster = `p:contains("The SAP System ${nwqSystem.sid} has been deregistered.")`;
+
+const tableGroupRows = '.table-row-group > div.table-row';
+
+export const visit = () => basePage.visit('/databases');
+
+export const deregisterHdqDatabasePrimaryInstance = () =>
+  basePage.apiDeregisterHost(hdqDatabase.instances[0].id);
+
+export const deregisterNwqSystemAscsInstance = () =>
+  basePage.apiDeregisterHost(nwqSystem.ascsInstance.id);
+
+export const restoreHdqDatabasePrimaryInstance = () =>
+  basePage.loadScenario(`host-${hdqDatabase.instances[0].name}-restore`);
+
+export const hdqDatabaseIsNotDisplayed = () =>
+  cy.get(hdqDatabaseCell).should('not.exist');
+
+export const hdqDatabaseIsDisplayed = () =>
+  cy.get(hdqDatabaseCell).should('be.visible');
+
+export const clickHdqDatabaseRow = () => cy.get(hdqDatabaseCell).click();
+
+export const bothDatabaseInstancesAreDisplayed = () => {
+  cy.get(databaseInstace1).should('be.visible');
+  return cy.get(databaseInstace2).should('be.visible');
+};
+
+export const activePillIsDisplayedInTheRightHost = () => {
+  hdqDatabase.instances.forEach((instance) => {
+    cy.get(`div.table-row:contains("${instance.name}")`).within(() => {
+      if (instance.state === 'ACTIVE') {
+        cy.contains('ACTIVE').should('exist');
+      } else {
+        cy.contains('ACTIVE').should('not.exist');
+      }
+    });
+  });
+};
+
+export const deletedSapSystemToasterIsDisplayed = () =>
+  cy.get(deletedSapSystemToaster).should('be.visible');
+
+export const databaseInstancesAreStillTheSame = () =>
+  cy.get(tableGroupRows).should('have.length', 6);

--- a/test/e2e/cypress/pageObject/databases-overview-po.js
+++ b/test/e2e/cypress/pageObject/databases-overview-po.js
@@ -51,6 +51,8 @@ const cleanUpButtonModal =
 
 const cleanUpButtons = 'button:contains("Clean up")';
 
+const activePill = 'span:contains("ACTIVE")';
+
 const getCleanUpButtonByIdAndInstanceIndex = (id, index) =>
   `tbody tr:contains("${id}") + tr div[class="table-row-group"] div[class*="table-row border-b"]:nth-child(${
     index + 1
@@ -75,13 +77,12 @@ export const bothDatabaseInstancesAreDisplayed = () => {
 };
 
 export const activePillIsDisplayedInTheRightHost = () => {
-  hdqDatabase.instances.forEach((instance) => {
-    cy.get(`div.table-row:contains("${instance.name}")`).within(() => {
-      if (instance.state === 'ACTIVE') {
-        cy.contains('ACTIVE').should('exist');
-      } else {
-        cy.contains('ACTIVE').should('not.exist');
-      }
+  return hdqDatabase.instances.forEach((instance) => {
+    return cy.get(`div.table-row:contains("${instance.name}")`).within(() => {
+      const isHostActive = instance.state === 'ACTIVE';
+      return cy
+        .get(activePill)
+        .should(isHostActive ? 'be.visible' : 'not.exist');
     });
   });
 };

--- a/test/e2e/cypress/pageObject/databases-overview-po.js
+++ b/test/e2e/cypress/pageObject/databases-overview-po.js
@@ -25,8 +25,18 @@ const nwqSystem = {
   },
 };
 
+const hddDatabase = {
+  sid: 'HDD',
+  instance: {
+    instanceNumber: '10',
+    row: 1,
+  },
+};
+
 // Selectors
 const hdqDatabaseCell = `tr:contains("${hdqDatabase.sid}")`;
+
+const hddDatabaseCell = `tr:contains("${hddDatabase.sid}")`;
 
 const databaseInstace1 = `a:contains("${hdqDatabase.instances[0].name}")`;
 const databaseInstace2 = `a:contains("${hdqDatabase.instances[1].name}")`;
@@ -34,6 +44,11 @@ const databaseInstace2 = `a:contains("${hdqDatabase.instances[1].name}")`;
 const deletedSapSystemToaster = `p:contains("The SAP System ${nwqSystem.sid} has been deregistered.")`;
 
 const tableGroupRows = '.table-row-group > div.table-row';
+
+const cleanUpButtonModal =
+  '#headlessui-portal-root button:contains("Clean up")';
+
+const cleanUpButtons = 'button:contains("Clean up")';
 
 export const visit = () => basePage.visit('/databases');
 
@@ -53,6 +68,11 @@ export const hdqDatabaseIsDisplayed = () =>
   cy.get(hdqDatabaseCell).should('be.visible');
 
 export const clickHdqDatabaseRow = () => cy.get(hdqDatabaseCell).click();
+
+export const clickHddDatabaseRow = () => cy.get(hddDatabaseCell).click();
+
+export const hddDatabaseIsNotDisplayed = () =>
+  cy.get(hddDatabaseCell).should('not.exist');
 
 export const bothDatabaseInstancesAreDisplayed = () => {
   cy.get(databaseInstace1).should('be.visible');
@@ -76,3 +96,94 @@ export const deletedSapSystemToasterIsDisplayed = () =>
 
 export const databaseInstancesAreStillTheSame = () =>
   cy.get(tableGroupRows).should('have.length', 6);
+
+export const markHddDatabaseAsAbsent = () => {
+  basePage.loadScenario(
+    `sap-systems-overview-${hddDatabase.sid}-${hddDatabase.instance.instanceNumber}-absent`
+  );
+};
+
+export const markHddDatabaseAsPresent = () => {
+  basePage.loadScenario(
+    `sap-systems-overview-${hddDatabase.sid}-${hddDatabase.instance.instanceNumber}-present`
+  );
+};
+
+const getCleanUpButtonByIdAndInstanceIndex = (id, index) =>
+  `tbody tr:contains("${id}") + tr div[class="table-row-group"] div[class*="table-row border-b"]:nth-child(${
+    index + 1
+  }) span:contains("Clean up")`;
+
+export const cleanUpButtonIsDisplayed = () => {
+  const cleanUpButtonSelector = getCleanUpButtonByIdAndInstanceIndex(
+    hddDatabase.sid,
+    hddDatabase.instance.row
+  );
+
+  return cy.get(cleanUpButtonSelector).should('be.visible', { timeout: 15000 });
+};
+
+export const cleanUpButtonIsNotDisplayed = () => {
+  const cleanUpButtonSelector = getCleanUpButtonByIdAndInstanceIndex(
+    hddDatabase.sid,
+    hddDatabase.instance.row
+  );
+
+  return cy.get(cleanUpButtonSelector).should('not.exist', { timeout: 15000 });
+};
+
+export const clickCleanUpButton = () => {
+  const cleanUpButtonSelector = getCleanUpButtonByIdAndInstanceIndex(
+    hddDatabase.sid,
+    hddDatabase.instance.row
+  );
+  return cy.get(cleanUpButtonSelector).click({ timeout: 15000 });
+};
+
+export const clickModalCleanUpButton = () => cy.get(cleanUpButtonModal).click();
+
+export const apiCreateUserWithDatabaseTagsAbilities = () =>
+  basePage.createUserWithAbilities([
+    { name: 'all', resource: 'database_tags' },
+  ]);
+
+export const cleanUpButtonIsEnabled = () =>
+  cy.get(cleanUpButtons).should('be.enabled');
+
+export const cleanUpButtonIsDisabled = () =>
+  cy.get(cleanUpButtons).should('be.disabled');
+
+export const apiRemoveTagByDatabaseId = (databaseId, tagId) => {
+  return basePage.apiLogin().then(({ accessToken }) =>
+    cy.request({
+      url: `/api/v1/databases/${databaseId}/tags/${tagId}`,
+      method: 'DELETE',
+      auth: { bearer: accessToken },
+    })
+  );
+};
+
+const apiGetDatabases = () => {
+  return basePage.apiLogin().then(({ accessToken }) => {
+    const url = '/api/v1/databases';
+    return cy
+      .request({
+        method: 'GET',
+        url: url,
+        auth: {
+          bearer: accessToken,
+        },
+      })
+      .then((response) => response);
+  });
+};
+
+export const apiRemoveAllTags = () => {
+  apiGetDatabases().then((response) => {
+    const databaseTags = basePage.getResourceTags(response.body);
+    Object.entries(databaseTags).forEach(([databaseId, tags]) => {
+      tags.forEach((tag) => apiRemoveTagByDatabaseId(databaseId, tag));
+    });
+  });
+  return basePage.refresh();
+};


### PR DESCRIPTION
# Description

Apply page object pattern to databases overview tests.

Key points:
- Moved some code related to remove tags as it is a common thing across different views in trento
- Renamed some existing functions to be more descriptive
- As usual, tests are now decoupled and can be run independently.

PD: no need to update docs.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [X] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [X] **DONE**
## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
- [Trento Web guides](https://github.com/trento-project/web/tree/main/guides)

Add a documentation PR or write that no changes are required for the documentation.
- [X] **DONE**
