### PR TITLE
Activity log severity levels filter

### DIFF
--- a/assets/js/pages/ActivityLogPage/searchParams.js
+++ b/assets/js/pages/ActivityLogPage/searchParams.js
@@ -14,7 +14,7 @@ const omitUndefined = (obj) =>
   );
 
 const paginationFields = ['after', 'before', 'first', 'last'];
-const scalarKeys = [...paginationFields, 'search'];
+const scalarKeys = [...paginationFields, 'search', 'severity'];
 const ignoreKeys = ['refreshRate'];
 
 const searchParamsToEntries = (searchParams) =>

--- a/lib/trento/activity_log.ex
+++ b/lib/trento/activity_log.ex
@@ -49,6 +49,8 @@ defmodule Trento.ActivityLog do
     end
   end
 
+  defdelegate map_severity_integer_to_text(int), to: Trento.ActivityLog.SeverityLevel
+
   defp maybe_exclude_user_logs(ActivityLog = q, true = _include_all_log_types?), do: q
 
   defp maybe_exclude_user_logs(ActivityLog = q, false = _include_all_log_types?) do

--- a/lib/trento/activity_log.ex
+++ b/lib/trento/activity_log.ex
@@ -131,9 +131,8 @@ defmodule Trento.ActivityLog do
            op: :>=,
            value:
              v
-             |> Enum.map(&String.to_existing_atom/1)
-             |> Enum.map(&SeverityLevel.severity_level_to_integer/1)
-             |> Enum.min()
+             |> (&String.to_existing_atom/1).()
+             |> (&SeverityLevel.severity_level_to_integer/1).()
          }}
 
       param ->

--- a/lib/trento/activity_log.ex
+++ b/lib/trento/activity_log.ex
@@ -10,6 +10,7 @@ defmodule Trento.ActivityLog do
   alias Trento.ActivityLog.ActivityLog
   alias Trento.ActivityLog.MetadataQueryParser
   alias Trento.ActivityLog.RetentionTime
+  alias Trento.ActivityLog.SeverityLevel
   alias Trento.Repo
   alias Trento.Settings
 
@@ -66,6 +67,7 @@ defmodule Trento.ActivityLog do
             m0: fragment("jsonb_path_query(?, ?)", q.metadata, ^jsonpath_expr),
             type: q.type,
             actor: q.actor,
+            severity: q.severity,
             inserted_at: q.inserted_at,
             updated_at: q.updated_at
           }
@@ -119,6 +121,18 @@ defmodule Trento.ActivityLog do
 
       {:type, v} ->
         {:filters, %{field: :type, op: :ilike_or, value: v}}
+
+      {:severity, v} ->
+        {:filters,
+         %{
+           field: :severity,
+           op: :>=,
+           value:
+             v
+             |> Enum.map(&String.to_existing_atom/1)
+             |> Enum.map(&SeverityLevel.severity_level_to_integer/1)
+             |> Enum.min()
+         }}
 
       param ->
         param

--- a/lib/trento/activity_log.ex
+++ b/lib/trento/activity_log.ex
@@ -131,8 +131,8 @@ defmodule Trento.ActivityLog do
            op: :>=,
            value:
              v
-             |> (&String.to_existing_atom/1).()
-             |> (&SeverityLevel.severity_level_to_integer/1).()
+             |> String.to_existing_atom()
+             |> SeverityLevel.severity_level_to_integer()
          }}
 
       param ->

--- a/lib/trento/activity_logging/severity_level.ex
+++ b/lib/trento/activity_logging/severity_level.ex
@@ -118,6 +118,12 @@ defmodule Trento.ActivityLog.SeverityLevel do
     "database_tombstoned" => :debug
   }
 
+  def map_severity_integer_to_text(n) when n >= 5 and n <= 8, do: "debug"
+  def map_severity_integer_to_text(n) when n >= 9 and n <= 12, do: "info"
+  def map_severity_integer_to_text(n) when n >= 13 and n <= 16, do: "warning"
+  def map_severity_integer_to_text(n) when n >= 17 and n <= 20, do: "error"
+  def map_severity_integer_to_text(n) when n >= 21 and n <= 24, do: "critical"
+
   def severity_level_to_integer(:debug), do: 5
   def severity_level_to_integer(:info), do: 9
   def severity_level_to_integer(:warning), do: 13

--- a/lib/trento_web/controllers/v1/activity_log_controller.ex
+++ b/lib/trento_web/controllers/v1/activity_log_controller.ex
@@ -59,6 +59,14 @@ defmodule TrentoWeb.V1.ActivityLogController do
         in: :query,
         schema: %OpenApiSpex.Schema{type: :array},
         required: false
+      ],
+      severity: [
+        in: :query,
+        schema: %OpenApiSpex.Schema{
+          type: :array,
+          default: ["info", "warning", "error", "critical"]
+        },
+        required: false
       ]
     ],
     responses: [

--- a/lib/trento_web/controllers/v1/activity_log_controller.ex
+++ b/lib/trento_web/controllers/v1/activity_log_controller.ex
@@ -63,8 +63,9 @@ defmodule TrentoWeb.V1.ActivityLogController do
       severity: [
         in: :query,
         schema: %OpenApiSpex.Schema{
-          type: :array,
-          default: ["info", "warning", "error", "critical"]
+          type: :string,
+          enum: ["debug", "info", "warning", "error", "critical"],
+          default: "info"
         },
         required: false
       ]

--- a/lib/trento_web/controllers/v1/activity_log_json.ex
+++ b/lib/trento_web/controllers/v1/activity_log_json.ex
@@ -1,5 +1,6 @@
 defmodule TrentoWeb.V1.ActivityLogJSON do
   alias Trento.ActivityLog.Policy
+  alias Trento.ActivityLog
   alias Trento.Users.User
 
   def activity_log(%{activity_log: entries, pagination: meta, current_user: user}),
@@ -14,7 +15,7 @@ defmodule TrentoWeb.V1.ActivityLogJSON do
       type: entry.type,
       actor: maybe_redact_actor(entry.actor, user),
       metadata: entry.metadata,
-      severity: map_severity_integer_to_text(entry.severity),
+      severity: ActivityLog.map_severity_integer_to_text(entry.severity),
       # Time of occurrence approximated by time of insertion in DB.
       occurred_on: entry.inserted_at
     }
@@ -41,12 +42,6 @@ defmodule TrentoWeb.V1.ActivityLogJSON do
       has_previous_page: has_previous_page
     }
   end
-
-  defp map_severity_integer_to_text(n) when n >= 5 and n <= 8, do: "debug"
-  defp map_severity_integer_to_text(n) when n >= 9 and n <= 12, do: "info"
-  defp map_severity_integer_to_text(n) when n >= 13 and n <= 16, do: "warning"
-  defp map_severity_integer_to_text(n) when n >= 17 and n <= 20, do: "error"
-  defp map_severity_integer_to_text(n) when n >= 21 and n <= 24, do: "critical"
 
   defp maybe_redact_actor(actor, %User{username: actor}), do: actor
 

--- a/lib/trento_web/controllers/v1/activity_log_json.ex
+++ b/lib/trento_web/controllers/v1/activity_log_json.ex
@@ -1,6 +1,6 @@
 defmodule TrentoWeb.V1.ActivityLogJSON do
-  alias Trento.ActivityLog.Policy
   alias Trento.ActivityLog
+  alias Trento.ActivityLog.Policy
   alias Trento.Users.User
 
   def activity_log(%{activity_log: entries, pagination: meta, current_user: user}),

--- a/lib/trento_web/controllers/v1/activity_log_json.ex
+++ b/lib/trento_web/controllers/v1/activity_log_json.ex
@@ -14,6 +14,7 @@ defmodule TrentoWeb.V1.ActivityLogJSON do
       type: entry.type,
       actor: maybe_redact_actor(entry.actor, user),
       metadata: entry.metadata,
+      severity: map_severity_integer_to_text(entry.severity),
       # Time of occurrence approximated by time of insertion in DB.
       occurred_on: entry.inserted_at
     }
@@ -40,6 +41,12 @@ defmodule TrentoWeb.V1.ActivityLogJSON do
       has_previous_page: has_previous_page
     }
   end
+
+  defp map_severity_integer_to_text(n) when n >= 5 and n <= 8, do: "debug"
+  defp map_severity_integer_to_text(n) when n >= 9 and n <= 12, do: "info"
+  defp map_severity_integer_to_text(n) when n >= 13 and n <= 16, do: "warning"
+  defp map_severity_integer_to_text(n) when n >= 17 and n <= 20, do: "error"
+  defp map_severity_integer_to_text(n) when n >= 21 and n <= 24, do: "critical"
 
   defp maybe_redact_actor(actor, %User{username: actor}), do: actor
 

--- a/lib/trento_web/openapi/v1/schema/activity_log.ex
+++ b/lib/trento_web/openapi/v1/schema/activity_log.ex
@@ -29,6 +29,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.ActivityLog do
             },
             severity: %Schema{
               type: :string,
+              enum: [:debug, :info, :warning, :error, :critical],
               description: "Severity level of an Activity Log entry. E.g. info, warning etc."
             },
             metadata: %Schema{

--- a/lib/trento_web/openapi/v1/schema/activity_log.ex
+++ b/lib/trento_web/openapi/v1/schema/activity_log.ex
@@ -27,6 +27,10 @@ defmodule TrentoWeb.OpenApi.V1.Schema.ActivityLog do
               type: :string,
               description: "Actor causing an Activity Log entry. E.g. System or a specific user."
             },
+            severity: %Schema{
+              type: :string,
+              description: "Severity level of an Activity Log entry. E.g. info, warning etc."
+            },
             metadata: %Schema{
               type: :object
             },

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -125,7 +125,8 @@ context('Activity Log page', () => {
     });
 
     it('should paginate data with filters', () => {
-      const queryString = '?type=sles_subscriptions_updated&search=x86_64&severity=debug';
+      const queryString =
+        '?type=sles_subscriptions_updated&search=x86_64&severity=debug';
       activityLogPage.visit(queryString);
       activityLogPage.waitForActivityLogRequest().then(({ response }) => {
         activityLogPage.paginationPropertiesAreTheExpected(response);

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -125,15 +125,15 @@ context('Activity Log page', () => {
     });
 
     it('should paginate data with filters', () => {
-      const queryString = '?type=sles_subscriptions_updated&search=x86_64';
+      const queryString = '?type=sles_subscriptions_updated&search=x86_64&severity=debug';
       activityLogPage.visit(queryString);
       activityLogPage.waitForActivityLogRequest().then(({ response }) => {
         activityLogPage.paginationPropertiesAreTheExpected(response);
-        let expectedUrl = `/activity_log?type=sles_subscriptions_updated&search=x86_64`;
+        let expectedUrl = `/activity_log?type=sles_subscriptions_updated&search=x86_64&severity=debug`;
         activityLogPage.validateUrl(expectedUrl);
         activityLogPage.clickNextPageButton();
         activityLogPage.activityLogRequestHasExpectedStatusCode(200);
-        expectedUrl = `/activity_log?first=20&after=${response.body.pagination.end_cursor}&type=sles_subscriptions_updated&search=x86_64`;
+        expectedUrl = `/activity_log?first=20&after=${response.body.pagination.end_cursor}&type=sles_subscriptions_updated&search=x86_64&severity=debug`;
         activityLogPage.validateUrl(expectedUrl);
       });
     });

--- a/test/trento/activity_log_test.exs
+++ b/test/trento/activity_log_test.exs
@@ -161,6 +161,47 @@ defmodule Trento.ActivityLogTest do
     end
   end
 
+  describe "Filtering by severity levels" do
+    test "should return all entries severity level entries when no param provided" do
+      _inserted_records = insert_list(4, :activity_log_entry, %{severity: 5})
+      _inserted_records = insert_list(4, :activity_log_entry, %{severity: 9})
+      _inserted_records = insert_list(4, :activity_log_entry, %{severity: 13})
+      _inserted_records = insert_list(4, :activity_log_entry, %{severity: 17})
+      _inserted_records = insert_list(4, :activity_log_entry, %{severity: 21})
+
+      {:ok, entries, _} = ActivityLog.list_activity_log(%{})
+
+      severity_levels =
+        entries
+        |> Enum.map(fn entry -> entry.severity end)
+        |> Enum.uniq()
+        |> Enum.map(&ActivityLog.map_severity_integer_to_text/1)
+        |> Enum.sort()
+
+      assert severity_levels == Enum.sort(["debug", "info", "warning", "error", "critical"])
+    end
+
+    test "should return error and above severity level entries when queried with appropriate param" do
+      _inserted_records = insert_list(4, :activity_log_entry, %{severity: 5})
+      _inserted_records = insert_list(4, :activity_log_entry, %{severity: 9})
+      _inserted_records = insert_list(4, :activity_log_entry, %{severity: 13})
+      _inserted_records = insert_list(4, :activity_log_entry, %{severity: 17})
+      _inserted_records = insert_list(4, :activity_log_entry, %{severity: 21})
+
+      assert {:ok, entries, _} = ActivityLog.list_activity_log(%{severity: "error"})
+
+      severity_levels =
+        entries
+        |> Enum.map(fn entry -> entry.severity end)
+        |> Enum.uniq()
+        |> Enum.map(&ActivityLog.map_severity_integer_to_text/1)
+        |> Enum.sort()
+
+      assert severity_levels == Enum.sort(["error", "critical"])
+      assert length(entries) == 8
+    end
+  end
+
   describe "Search by metadata tests" do
     test "Single keyword" do
       keyword = "Foo-4_2/:2.4"

--- a/test/trento_web/controllers/v1/activity_log_controller_test.exs
+++ b/test/trento_web/controllers/v1/activity_log_controller_test.exs
@@ -317,7 +317,7 @@ defmodule TrentoWeb.V1.ActivityLogControllerTest do
 
       resp =
         conn
-        |> get("/api/v1/activity_log?severity[]=error")
+        |> get("/api/v1/activity_log?severity=error")
         |> json_response(200)
 
       severity_levels =

--- a/test/trento_web/views/v1/activity_log_view_json_test.exs
+++ b/test/trento_web/views/v1/activity_log_view_json_test.exs
@@ -15,20 +15,32 @@ defmodule TrentoWeb.V1.ActivityLogJSONTest do
       inserted_at: inserted_at
     } = activity_log_entry = build(:activity_log_entry)
 
+    json_entry =
+      ActivityLogJSON.activity_log_entry(%{
+        activity_log_entry: activity_log_entry,
+        current_user:
+          build(:user,
+            abilities: build_list(1, :ability, name: "activity_log", resource: "users")
+          )
+      })
+
     assert %{
              id: ^id,
              type: ^type,
              actor: ^actor,
              metadata: ^metadata,
              occurred_on: ^inserted_at
-           } =
-             ActivityLogJSON.activity_log_entry(%{
-               activity_log_entry: activity_log_entry,
-               current_user:
-                 build(:user,
-                   abilities: build_list(1, :ability, name: "activity_log", resource: "users")
-                 )
-             })
+           } = json_entry
+
+    assert Enum.sort(Map.keys(json_entry)) ==
+             Enum.sort([
+               :actor,
+               :id,
+               :metadata,
+               :occurred_on,
+               :severity,
+               :type
+             ])
   end
 
   test "should render redacted activity_log_entry.json" do


### PR DESCRIPTION
Adds new query parameter for filtering by severity level to the activity log endpoint. 

## How was this tested?

UT
