### PR TITLE
Parameterized ecto payload

### DIFF
--- a/lib/trento/clusters.ex
+++ b/lib/trento/clusters.ex
@@ -262,8 +262,8 @@ defmodule Trento.Clusters do
     filesystems_list =
       cluster
       |> Map.get(:details, %{})
-      |> Map.get("sap_systems", [])
-      |> Enum.map(fn %{"filesystem_resource_based" => filesystem_resource_based} ->
+      |> Map.get(:sap_systems, [])
+      |> Enum.map(fn %{filesystem_resource_based: filesystem_resource_based} ->
         filesystem_resource_based
       end)
       |> Enum.uniq()
@@ -292,15 +292,15 @@ defmodule Trento.Clusters do
     end
   end
 
-  defp parse_architecture_type(%{"architecture_type" => "angi"}),
+  defp parse_architecture_type(%{architecture_type: "angi"}),
     do: HanaArchitectureType.angi()
 
   defp parse_architecture_type(_), do: HanaArchitectureType.classic()
 
-  defp parse_hana_scenario(%{"hana_scenario" => "performance_optimized"}),
+  defp parse_hana_scenario(%{hana_scenario: "performance_optimized"}),
     do: HanaScenario.performance_optimized()
 
-  defp parse_hana_scenario(%{"hana_scenario" => "cost_optimized"}),
+  defp parse_hana_scenario(%{hana_scenario: "cost_optimized"}),
     do: HanaScenario.cost_optimized()
 
   defp parse_hana_scenario(_), do: HanaScenario.unknown()

--- a/lib/trento/clusters/projections/cluster_read_model.ex
+++ b/lib/trento/clusters/projections/cluster_read_model.ex
@@ -31,7 +31,7 @@ defmodule Trento.Clusters.Projections.ClusterReadModel do
     field :health, Ecto.Enum, values: Health.values()
     field :resources_number, :integer
     field :hosts_number, :integer
-    field :details, :map
+    field :details, Trento.Support.Ecto.Payload, keys_as_atoms: true
 
     has_many :tags, Tag, foreign_key: :resource_id
 

--- a/lib/trento/support/ecto/payload.ex
+++ b/lib/trento/support/ecto/payload.ex
@@ -1,27 +1,60 @@
 defmodule Trento.Support.Ecto.Payload do
   @moduledoc """
   Ecto Type that represents a JSONB payload that contains an array or a map.
+
+  Opts:
+  - keys_as_atoms (boolean): Converts map keys to existing atoms
   """
 
-  use Ecto.Type
-  def type, do: :map
+  alias Trento.Support.StructHelper
+
+  use Ecto.ParameterizedType
+
+  def type(_params), do: :map
+
+  def init(opts) do
+    keys_as_atoms = Keyword.get(opts, :keys_as_atoms, false)
+
+    validate_opts(keys_as_atoms)
+
+    %{
+      keys_as_atoms: keys_as_atoms
+    }
+  end
 
   # Provide custom casting rules.
-  def cast(data) when is_list(data) or is_map(data) do
+  def cast(data, _params) when is_list(data) or is_map(data) do
     {:ok, data}
   end
+
+  def cast(nil, _), do: {:ok, nil}
 
   # Everything else is a failure though
-  def cast(_), do: :error
+  def cast(_, _), do: :error
 
   # When loading data from the database, we are guaranteed to
-  # receive a map or list
-  def load(data) when is_list(data) or is_map(data) do
+  # receive a map or list. It will convert keys to atoms if `keys_as_atoms` is set to true
+  def load(data, _loader, %{keys_as_atoms: false}) when is_list(data) or is_map(data) do
     {:ok, data}
   end
+
+  def load(data, _loader, %{keys_as_atoms: true}) when is_list(data) or is_map(data) do
+    {:ok, StructHelper.to_atomized_map(data)}
+  end
+
+  def load(nil, _, _), do: {:ok, nil}
 
   # When dumping data to the database, we *expect* a map or list
   # so we need to guard against them.
-  def dump(data) when is_list(data) or is_map(data), do: {:ok, data}
-  def dump(_), do: :error
+  def dump(data, _dumper, _params) when is_list(data) or is_map(data), do: {:ok, data}
+  def dump(nil, _, _), do: {:ok, nil}
+  def dump(_, _, _), do: :error
+
+  defp validate_opts(keys_as_atoms) when not is_boolean(keys_as_atoms),
+    do:
+      raise(ArgumentError, """
+      Trento.Support.Ecto.Payload type keys_as_atoms must be a boolean.
+      """)
+
+  defp validate_opts(_), do: nil
 end

--- a/lib/trento_web/controllers/v1/cluster_json.ex
+++ b/lib/trento_web/controllers/v1/cluster_json.ex
@@ -8,6 +8,7 @@ defmodule TrentoWeb.V1.ClusterJSON do
     |> Map.from_struct()
     |> Map.delete(:deregistered_at)
     |> Map.delete(:hosts)
+    |> Map.delete(:__meta__)
     |> adapt_v1()
   end
 

--- a/lib/trento_web/controllers/v1/cluster_json.ex
+++ b/lib/trento_web/controllers/v1/cluster_json.ex
@@ -1,13 +1,11 @@
 defmodule TrentoWeb.V1.ClusterJSON do
-  alias Trento.Support.StructHelper
-
   def clusters(%{clusters: clusters}) do
     Enum.map(clusters, &cluster(%{cluster: &1}))
   end
 
   def cluster(%{cluster: cluster}) do
     cluster
-    |> StructHelper.to_atomized_map()
+    |> Map.from_struct()
     |> Map.delete(:deregistered_at)
     |> Map.delete(:hosts)
     |> adapt_v1()

--- a/lib/trento_web/controllers/v2/cluster_json.ex
+++ b/lib/trento_web/controllers/v2/cluster_json.ex
@@ -1,11 +1,9 @@
 defmodule TrentoWeb.V2.ClusterJSON do
-  alias Trento.Support.StructHelper
-
   def clusters(%{clusters: clusters}), do: Enum.map(clusters, &cluster(%{cluster: &1}))
 
   def cluster(%{cluster: cluster}) do
     cluster
-    |> StructHelper.to_atomized_map()
+    |> Map.from_struct()
     |> Map.delete(:deregistered_at)
     |> Map.delete(:hosts)
     |> adapt_details()

--- a/lib/trento_web/controllers/v2/cluster_json.ex
+++ b/lib/trento_web/controllers/v2/cluster_json.ex
@@ -6,6 +6,7 @@ defmodule TrentoWeb.V2.ClusterJSON do
     |> Map.from_struct()
     |> Map.delete(:deregistered_at)
     |> Map.delete(:hosts)
+    |> Map.delete(:__meta__)
     |> adapt_details()
   end
 

--- a/test/trento/clusters/projections/cluster_projector_test.exs
+++ b/test/trento/clusters/projections/cluster_projector_test.exs
@@ -51,7 +51,7 @@ defmodule Trento.Clusters.Projections.ClusterProjectorTest do
     assert event.type == cluster_projection.type
     assert event.resources_number == cluster_projection.resources_number
     assert event.hosts_number == cluster_projection.hosts_number
-    assert StructHelper.to_map(event.details) == cluster_projection.details
+    assert StructHelper.to_map(event.details) == StructHelper.to_map(cluster_projection.details)
     assert event.health == cluster_projection.health
 
     cluster_id = event.cluster_id
@@ -142,7 +142,7 @@ defmodule Trento.Clusters.Projections.ClusterProjectorTest do
     assert event.type == cluster_projection.type
     assert event.resources_number == cluster_projection.resources_number
     assert event.hosts_number == cluster_projection.hosts_number
-    assert StructHelper.to_map(event.details) == cluster_projection.details
+    assert StructHelper.to_map(event.details) == StructHelper.to_map(cluster_projection.details)
 
     assert_broadcast(
       "cluster_details_updated",
@@ -234,7 +234,6 @@ defmodule Trento.Clusters.Projections.ClusterProjectorTest do
       ClusterReadModel
       |> Repo.get!(event.cluster_id)
       |> Repo.preload([:tags])
-      |> StructHelper.to_atomized_map()
 
     assert nil == cluster_projection.deregistered_at
 

--- a/test/trento_web/views/v1/cluster_view_json_test.exs
+++ b/test/trento_web/views/v1/cluster_view_json_test.exs
@@ -7,7 +7,12 @@ defmodule TrentoWeb.V1.ClusterJSONTest do
 
   describe "adapt to V1 version" do
     test "should remove the ascs/ers cluster type" do
-      cluster = build(:cluster, type: :ascs_ers, details: build(:ascs_ers_cluster_details))
+      cluster =
+        insert(
+          :cluster,
+          [type: :ascs_ers, details: build(:ascs_ers_cluster_details)],
+          returning: true
+        )
 
       assert %{type: :unknown, details: nil} =
                ClusterJSON.cluster(%{cluster: cluster})
@@ -24,20 +29,20 @@ defmodule TrentoWeb.V1.ClusterJSONTest do
 
       details = build(:hana_cluster_details, nodes: nodes)
 
-      cluster = build(:cluster, type: :hana_scale_up, details: details)
+      cluster = insert(:cluster, [type: :hana_scale_up, details: details], returning: true)
 
       %{
         details:
           %{
             nodes: [%{resources: resources} = node],
             stopped_resources: stopped_resources
-          } = details
+          } = updated_details
       } = ClusterJSON.cluster(%{cluster: cluster})
 
-      refute Access.get(details, :sites)
-      refute Access.get(details, :maintenance_mode)
-      refute Access.get(details, :architecture_type)
-      refute Access.get(details, :hana_scenario)
+      refute Access.get(updated_details, :sites)
+      refute Access.get(updated_details, :maintenance_mode)
+      refute Access.get(updated_details, :architecture_type)
+      refute Access.get(updated_details, :hana_scenario)
       refute Access.get(node, :nameserver_actual_role)
       refute Access.get(node, :indexserver_actual_role)
       refute Access.get(node, :status)

--- a/test/trento_web/views/v2/cluster_view_json_test.exs
+++ b/test/trento_web/views/v2/cluster_view_json_test.exs
@@ -16,7 +16,7 @@ defmodule TrentoWeb.V2.ClusterJSONTest do
   test "should render maintenance_mode field" do
     details = build(:hana_cluster_details)
 
-    cluster = build(:cluster, details: details)
+    cluster = insert(:cluster, [details: details], returning: true)
 
     assert %{details: %{maintenance_mode: false}} =
              ClusterJSON.cluster(%{cluster: cluster})


### PR DESCRIPTION
# Description

An experimental change to load custom jsonb payloads as maps with atoms as keys, instead of plain strings.
I have changed the `Ecto.Type` by `Ecto.ParameterizedType` to add the `keys_as_atoms` options. If this value is set to true, the field loads the map converting the keys to atoms (if possible, only if they are already existing entries).

This can handy to work with "uniformed" details entries, so we use atoms when we load from the database and in other parts of the code. Like the changes in the `clusters.ex` in this PR.

What do you think?

Refs:
- [ParmeterizedType](https://hexdocs.pm/ecto/Ecto.ParameterizedType.html)
- Example: [Ecto.Enum](https://hexdocs.pm/ecto/Ecto.Enum.html)

## How was this tested?

UT
