### PR TITLE
Operation policies

### DIFF
--- a/lib/trento/clusters.ex
+++ b/lib/trento/clusters.ex
@@ -145,17 +145,21 @@ defmodule Trento.Clusters do
   end
 
   @spec resource_managed?(ClusterReadModel.t(), String.t()) :: boolean()
-  def resource_managed?(%ClusterReadModel{details: details}, resource_id) do
-    has_resource_maintenance?(details, resource_id)
+  def resource_managed?(%ClusterReadModel{type: type, details: details}, resource_id)
+      when type in [ClusterType.hana_scale_up(), ClusterType.hana_scale_out()] do
+    has_resource_managed?(details, resource_id)
   end
 
-  # ASCS/ERS cluster type
-  defp has_resource_maintenance?(%{sap_systems: sap_systems}, resource_id) do
-    Enum.any?(sap_systems, &has_resource_maintenance?(&1, resource_id))
+  def resource_managed?(
+        %ClusterReadModel{type: ClusterType.ascs_ers(), details: %{sap_systems: sap_systems}},
+        resource_id
+      ) do
+    Enum.any?(sap_systems, &has_resource_managed?(&1, resource_id))
   end
 
-  # HANA cluster type or specific ASCS/ERS system
-  defp has_resource_maintenance?(%{nodes: nodes}, resource_id) do
+  def resource_managed?(_, _), do: false
+
+  defp has_resource_managed?(%{nodes: nodes}, resource_id) do
     Enum.any?(nodes, fn %{resources: resources} ->
       Enum.find_value(resources, false, fn %{parent: parent} = resource ->
         managed?(resource, resource_id) or managed?(parent, resource_id)

--- a/lib/trento/clusters.ex
+++ b/lib/trento/clusters.ex
@@ -146,16 +146,16 @@ defmodule Trento.Clusters do
 
   @spec resource_managed?(ClusterReadModel.t(), String.t()) :: boolean()
   def resource_managed?(%ClusterReadModel{details: details}, resource_id) do
-    do_resource_maintenance?(details, resource_id)
+    has_resource_maintenance?(details, resource_id)
   end
 
   # ASCS/ERS cluster type
-  defp do_resource_maintenance?(%{sap_systems: sap_systems}, resource_id) do
-    Enum.any?(sap_systems, &do_resource_maintenance?(&1, resource_id))
+  defp has_resource_maintenance?(%{sap_systems: sap_systems}, resource_id) do
+    Enum.any?(sap_systems, &has_resource_maintenance?(&1, resource_id))
   end
 
   # HANA cluster type or specific ASCS/ERS system
-  defp do_resource_maintenance?(%{nodes: nodes}, resource_id) do
+  defp has_resource_maintenance?(%{nodes: nodes}, resource_id) do
     Enum.any?(nodes, fn %{resources: resources} ->
       Enum.find_value(resources, false, fn %{parent: parent} = resource ->
         managed?(resource, resource_id) or managed?(parent, resource_id)

--- a/lib/trento/clusters/projections/cluster_read_model.ex
+++ b/lib/trento/clusters/projections/cluster_read_model.ex
@@ -17,6 +17,9 @@ defmodule Trento.Clusters.Projections.ClusterReadModel do
 
   defdelegate authorize(action, user, params), to: Trento.Clusters.Policy
 
+  defdelegate authorize_operation(action, application_instance, params),
+    to: Trento.Operations.ClusterPolicy
+
   @type t :: %__MODULE__{}
 
   @derive {Jason.Encoder, except: [:__meta__, :__struct__]}

--- a/lib/trento/databases/projections/database_instance_read_model.ex
+++ b/lib/trento/databases/projections/database_instance_read_model.ex
@@ -13,6 +13,9 @@ defmodule Trento.Databases.Projections.DatabaseInstanceReadModel do
 
   alias Trento.Hosts.Projections.HostReadModel
 
+  defdelegate authorize_operation(action, application_instance, params),
+    to: Trento.Operations.DatabaseInstancePolicy
+
   @derive {Jason.Encoder, except: [:__meta__, :__struct__]}
   @primary_key false
   schema "database_instances" do

--- a/lib/trento/hosts/projections/host_read_model.ex
+++ b/lib/trento/hosts/projections/host_read_model.ex
@@ -18,6 +18,9 @@ defmodule Trento.Hosts.Projections.HostReadModel do
 
   defdelegate authorize(action, user, params), to: Trento.Hosts.Policy
 
+  defdelegate authorize_operation(action, host, params),
+    to: Trento.Operations.HostPolicy
+
   @type t :: %__MODULE__{}
 
   @derive {Jason.Encoder, except: [:__meta__, :__struct__]}

--- a/lib/trento/operations/application_instance_policy.ex
+++ b/lib/trento/operations/application_instance_policy.ex
@@ -1,0 +1,41 @@
+defmodule Trento.Operations.ApplicationInstancePolicy do
+  @moduledoc """
+  ApplicationInstanceReadModel operation policies
+  """
+
+  @behaviour Trento.Operations.PolicyBehaviour
+
+  require Trento.Enums.Health, as: Health
+
+  alias Trento.Clusters.Projections.ClusterReadModel
+  alias Trento.Hosts.Projections.HostReadModel
+  alias Trento.SapSystems.Projections.ApplicationInstanceReadModel
+
+  # maintenance operation authorized when:
+  # - instance is not running
+  # - cluster is in maintenance
+  def authorize_operation(
+        :maintenance,
+        %ApplicationInstanceReadModel{health: health},
+        _
+      )
+      when health != Health.unknown(),
+      do: false
+
+  def authorize_operation(
+        :maintenance,
+        %ApplicationInstanceReadModel{host: %HostReadModel{cluster: nil}},
+        _
+      ),
+      do: true
+
+  def authorize_operation(
+        :maintenance,
+        %ApplicationInstanceReadModel{host: %HostReadModel{cluster: cluster}},
+        %{cluster_resource_id: _cluster_resource_id} = params
+      ) do
+    ClusterReadModel.authorize_operation(:maintenance, cluster, params)
+  end
+
+  def authorize_operation(_, _, _), do: false
+end

--- a/lib/trento/operations/cluster_policy.ex
+++ b/lib/trento/operations/cluster_policy.ex
@@ -1,0 +1,34 @@
+defmodule Trento.Operations.ClusterPolicy do
+  @moduledoc """
+  ClusterReadModel operation policies
+  """
+
+  @behaviour Trento.Operations.PolicyBehaviour
+
+  alias Trento.Clusters
+
+  alias Trento.Clusters.Projections.ClusterReadModel
+
+  # maintenance operation authorized when:
+  # - cluster is in maintenance
+  # - cluster resource is not managed
+  def authorize_operation(
+        :maintenance,
+        %ClusterReadModel{} = cluster,
+        %{cluster_resource_id: nil}
+      ),
+      do: Clusters.maintenance?(cluster)
+
+  def authorize_operation(
+        :maintenance,
+        %ClusterReadModel{} = cluster,
+        %{cluster_resource_id: cluster_resource_id}
+      ) do
+    Enum.any?([
+      Clusters.maintenance?(cluster),
+      not Clusters.resource_managed?(cluster, cluster_resource_id)
+    ])
+  end
+
+  def authorize_operation(_, _, _), do: false
+end

--- a/lib/trento/operations/database_instance_policy.ex
+++ b/lib/trento/operations/database_instance_policy.ex
@@ -1,0 +1,41 @@
+defmodule Trento.Operations.DatabaseInstancePolicy do
+  @moduledoc """
+  DatabaseInstanceReadModel operation policies
+  """
+
+  @behaviour Trento.Operations.PolicyBehaviour
+
+  require Trento.Enums.Health, as: Health
+
+  alias Trento.Clusters.Projections.ClusterReadModel
+  alias Trento.Databases.Projections.DatabaseInstanceReadModel
+  alias Trento.Hosts.Projections.HostReadModel
+
+  # maintenance operation authorized when:
+  # - instance is not running
+  # - cluster is in maintenance
+  def authorize_operation(
+        :maintenance,
+        %DatabaseInstanceReadModel{health: health},
+        _
+      )
+      when health != Health.unknown(),
+      do: false
+
+  def authorize_operation(
+        :maintenance,
+        %DatabaseInstanceReadModel{host: %HostReadModel{cluster: nil}},
+        _
+      ),
+      do: true
+
+  def authorize_operation(
+        :maintenance,
+        %DatabaseInstanceReadModel{host: %HostReadModel{cluster: cluster}},
+        %{cluster_resource_id: _cluster_resource_id} = params
+      ) do
+    ClusterReadModel.authorize_operation(:maintenance, cluster, params)
+  end
+
+  def authorize_operation(_, _, _), do: false
+end

--- a/lib/trento/operations/host_policy.ex
+++ b/lib/trento/operations/host_policy.ex
@@ -1,0 +1,69 @@
+defmodule Trento.Operations.HostPolicy do
+  @moduledoc """
+  HostReadModel operation policies
+  """
+
+  @behaviour Trento.Operations.PolicyBehaviour
+
+  alias Trento.Clusters.Projections.ClusterReadModel
+  alias Trento.Databases.Projections.DatabaseInstanceReadModel
+  alias Trento.Hosts.Projections.HostReadModel
+  alias Trento.SapSystems.Projections.ApplicationInstanceReadModel
+
+  # saptune_solution_apply operation authorized when:
+  # - all SAP instances are authorized for maintenance
+  def authorize_operation(
+        :saptune_solution_apply,
+        %HostReadModel{
+          cluster: cluster,
+          application_instances: application_instances,
+          database_instances: database_instances
+        } = host,
+        _
+      ) do
+    applications_maintenance_authorized =
+      application_instances
+      |> Enum.map(fn application_instance ->
+        %ApplicationInstanceReadModel{application_instance | host: host}
+      end)
+      |> Enum.all?(fn application_instance ->
+        ApplicationInstanceReadModel.authorize_operation(:maintenance, application_instance, %{
+          cluster_resource_id: nil
+        })
+      end)
+
+    # Get SAPHana or SapHanaController master resource id
+    cluster_resource_id = get_saptune_operation_resource_id(cluster)
+
+    databases_maintenance_authroized =
+      database_instances
+      |> Enum.map(fn database_instancec ->
+        %DatabaseInstanceReadModel{database_instancec | host: host}
+      end)
+      |> Enum.all?(fn database_instancec ->
+        DatabaseInstanceReadModel.authorize_operation(:maintenance, database_instancec, %{
+          cluster_resource_id: cluster_resource_id
+        })
+      end)
+
+    Enum.all?([applications_maintenance_authorized, databases_maintenance_authroized])
+  end
+
+  def authorize_operation(_, _, _), do: false
+
+  defp get_saptune_operation_resource_id(%ClusterReadModel{
+         details: %{nodes: nodes}
+       }) do
+    Enum.find_value(nodes, nil, fn %{resources: resources} ->
+      Enum.find_value(resources, nil, &find_resource_id/1)
+    end)
+  end
+
+  defp get_saptune_operation_resource_id(_), do: nil
+
+  # Classic SAP HANA setup
+  defp find_resource_id(%{type: "ocf::suse:SAPHana", parent: %{id: id}}), do: id
+  # Angi SAP HANA setup
+  defp find_resource_id(%{type: "ocf::suse:SAPHanaController", parent: %{id: id}}), do: id
+  defp find_resource_id(_), do: nil
+end

--- a/lib/trento/operations/host_policy.ex
+++ b/lib/trento/operations/host_policy.ex
@@ -35,18 +35,18 @@ defmodule Trento.Operations.HostPolicy do
     # Get SAPHana or SapHanaController master resource id
     cluster_resource_id = get_saptune_operation_resource_id(cluster)
 
-    databases_maintenance_authroized =
+    databases_maintenance_authorized =
       database_instances
-      |> Enum.map(fn database_instancec ->
-        %DatabaseInstanceReadModel{database_instancec | host: host}
+      |> Enum.map(fn database_instances ->
+        %DatabaseInstanceReadModel{database_instances | host: host}
       end)
-      |> Enum.all?(fn database_instancec ->
-        DatabaseInstanceReadModel.authorize_operation(:maintenance, database_instancec, %{
+      |> Enum.all?(fn database_instances ->
+        DatabaseInstanceReadModel.authorize_operation(:maintenance, database_instances, %{
           cluster_resource_id: cluster_resource_id
         })
       end)
 
-    Enum.all?([applications_maintenance_authorized, databases_maintenance_authroized])
+    Enum.all?([applications_maintenance_authorized, databases_maintenance_authorized])
   end
 
   def authorize_operation(_, _, _), do: false

--- a/lib/trento/operations/policy_behaviour.ex
+++ b/lib/trento/operations/policy_behaviour.ex
@@ -1,0 +1,31 @@
+defmodule Trento.Operations.PolicyBehaviour do
+  @moduledoc """
+  Behaviour of the operations policies.
+  """
+
+  alias Trento.Clusters.Projections.ClusterReadModel
+
+  alias Trento.Databases.Projections.{
+    DatabaseInstanceReadModel,
+    DatabaseReadModel
+  }
+
+  alias Trento.Hosts.Projections.HostReadModel
+
+  alias Trento.SapSystems.Projections.{
+    ApplicationInstanceReadModel,
+    SapSystemReadModel
+  }
+
+  @callback authorize_operation(
+              operation :: atom,
+              read_model ::
+                ApplicationInstanceReadModel.t()
+                | ClusterReadModel.t()
+                | DatabaseInstanceReadModel.t()
+                | DatabaseReadModel.t()
+                | HostReadModel.t()
+                | SapSystemReadModel.t(),
+              params :: map
+            ) :: boolean()
+end

--- a/lib/trento/sap_systems/projections/application_instance_read_model.ex
+++ b/lib/trento/sap_systems/projections/application_instance_read_model.ex
@@ -13,6 +13,9 @@ defmodule Trento.SapSystems.Projections.ApplicationInstanceReadModel do
 
   alias Trento.Hosts.Projections.HostReadModel
 
+  defdelegate authorize_operation(action, application_instance, params),
+    to: Trento.Operations.ApplicationInstancePolicy
+
   @derive {Jason.Encoder, except: [:__meta__, :__struct__]}
   @primary_key false
   schema "application_instances" do

--- a/test/trento/clusters_test.exs
+++ b/test/trento/clusters_test.exs
@@ -852,4 +852,43 @@ defmodule Trento.ClustersTest do
       assert :ok = Clusters.request_checks_execution(cluster_id)
     end
   end
+
+  describe "maintenance?/1" do
+    test "should return cluster maintenance mode" do
+      cluster = build(:cluster, details: build(:hana_cluster_details, maintenance_mode: true))
+
+      assert Clusters.maintenance?(cluster)
+
+      cluster = build(:cluster, details: build(:hana_cluster_details, maintenance_mode: false))
+
+      refute Clusters.maintenance?(cluster)
+    end
+  end
+
+  describe "resource_managed?/2" do
+    test "should return the managed state of a resource" do
+      %{id: cluster_resource_id, managed: managed} = cluster_resource = build(:cluster_resource)
+      nodes = build_list(1, :hana_cluster_node, resources: [cluster_resource])
+      cluster_details = build(:hana_cluster_details, maintenance_mode: false, nodes: nodes)
+      cluster = build(:cluster, details: cluster_details)
+
+      assert managed == Clusters.resource_managed?(cluster, cluster_resource_id)
+    end
+
+    test "should return the managed state of a grouped resource" do
+      %{id: cluster_resource_id, managed: managed} = parent = build(:cluster_resource_parent)
+      cluster_resource = build(:cluster_resource, managed: not managed, parent: parent)
+      nodes = build_list(1, :hana_cluster_node, resources: [cluster_resource])
+      cluster_details = build(:hana_cluster_details, maintenance_mode: false, nodes: nodes)
+      cluster = build(:cluster, details: cluster_details)
+
+      assert managed == Clusters.resource_managed?(cluster, cluster_resource_id)
+    end
+
+    test "should return false if the resource if not found" do
+      cluster = build(:cluster, details: build(:hana_cluster_details))
+
+      refute Clusters.resource_managed?(cluster, "unknown")
+    end
+  end
 end

--- a/test/trento/operations/application_instance_policy_test.exs
+++ b/test/trento/operations/application_instance_policy_test.exs
@@ -1,0 +1,58 @@
+defmodule Trento.Operations.ApplicationInstancePolicyTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  require Trento.Enums.Health, as: Health
+
+  alias Trento.Hosts.Projections.HostReadModel
+
+  alias Trento.Operations.ApplicationInstancePolicy
+
+  import Trento.Factory
+
+  test "should forbid unknown operation" do
+    instance = build(:application_instance)
+
+    refute ApplicationInstancePolicy.authorize_operation(:unknown, instance, %{})
+  end
+
+  describe "maintenance" do
+    test "should forbid operation if the application instance is not stopped" do
+      instance = build(:application_instance, health: Health.passing())
+
+      refute ApplicationInstancePolicy.authorize_operation(:maintenance, instance, %{})
+    end
+
+    test "should authorize operation if the application instance is not clustered" do
+      instance =
+        build(:application_instance, health: Health.unknown(), host: %HostReadModel{cluster: nil})
+
+      assert ApplicationInstancePolicy.authorize_operation(:maintenance, instance, %{})
+    end
+
+    test "should authorize operation if the cluster is in maintenance mode" do
+      scenarios = [
+        %{maintenance_mode: true, authorized: true},
+        %{maintenance_mode: false, authorized: false}
+      ]
+
+      for %{maintenance_mode: maintenance_mode, authorized: authorized} <- scenarios do
+        cluster_details =
+          build(:hana_cluster_details, maintenance_mode: maintenance_mode, nodes: [])
+
+        cluster = build(:cluster, details: cluster_details)
+
+        instance =
+          build(:application_instance,
+            health: Health.unknown(),
+            host: %HostReadModel{cluster: cluster}
+          )
+
+        assert authorized ==
+                 ApplicationInstancePolicy.authorize_operation(:maintenance, instance, %{
+                   cluster_resource_id: nil
+                 })
+      end
+    end
+  end
+end

--- a/test/trento/operations/cluster_policy_test.exs
+++ b/test/trento/operations/cluster_policy_test.exs
@@ -1,0 +1,54 @@
+defmodule Trento.Operations.ClusterPolicyTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Trento.Operations.ClusterPolicy
+
+  import Trento.Factory
+
+  test "should forbid unknown operation" do
+    cluster = build(:cluster)
+
+    refute ClusterPolicy.authorize_operation(:unknown, cluster, %{})
+  end
+
+  describe "maintenance" do
+    test "should authorize operation depending on the cluster maintenance mode" do
+      scenarios = [
+        %{maintenance_mode: true, authorized: true},
+        %{maintenance_mode: false, authorized: false}
+      ]
+
+      for %{maintenance_mode: maintenance_mode, authorized: authorized} <- scenarios do
+        cluster_details =
+          build(:hana_cluster_details, maintenance_mode: maintenance_mode, nodes: [])
+
+        cluster = build(:cluster, details: cluster_details)
+
+        assert authorized ==
+                 ClusterPolicy.authorize_operation(:maintenance, cluster, %{
+                   cluster_resource_id: nil
+                 })
+      end
+    end
+
+    test "should authorize operation depending on the given cluster resource managed state" do
+      scenarios = [
+        %{managed: true, authorized: false},
+        %{managed: false, authorized: true}
+      ]
+
+      for %{managed: managed, authorized: authorized} <- scenarios do
+        %{id: cluster_resource_id} = cluster_resource = build(:cluster_resource, managed: managed)
+        nodes = build_list(1, :hana_cluster_node, resources: [cluster_resource])
+        cluster_details = build(:hana_cluster_details, maintenance_mode: false, nodes: nodes)
+        cluster = build(:cluster, details: cluster_details)
+
+        assert authorized ==
+                 ClusterPolicy.authorize_operation(:maintenance, cluster, %{
+                   cluster_resource_id: cluster_resource_id
+                 })
+      end
+    end
+  end
+end

--- a/test/trento/operations/database_instance_policy_test.exs
+++ b/test/trento/operations/database_instance_policy_test.exs
@@ -1,0 +1,58 @@
+defmodule Trento.Operations.DatabaseInstancePolicyTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  require Trento.Enums.Health, as: Health
+
+  alias Trento.Hosts.Projections.HostReadModel
+
+  alias Trento.Operations.DatabaseInstancePolicy
+
+  import Trento.Factory
+
+  test "should forbid unknown operation" do
+    instance = build(:database_instance)
+
+    refute DatabaseInstancePolicy.authorize_operation(:unknown, instance, %{})
+  end
+
+  describe "maintenance" do
+    test "should forbid operation if the database instance is not stopped" do
+      instance = build(:database_instance, health: Health.passing())
+
+      refute DatabaseInstancePolicy.authorize_operation(:maintenance, instance, %{})
+    end
+
+    test "should authorize operation if the database instance is not clustered" do
+      instance =
+        build(:database_instance, health: Health.unknown(), host: %HostReadModel{cluster: nil})
+
+      assert DatabaseInstancePolicy.authorize_operation(:maintenance, instance, %{})
+    end
+
+    test "should authorize operation if the cluster is in maintenance mode" do
+      scenarios = [
+        %{maintenance_mode: true, authorized: true},
+        %{maintenance_mode: false, authorized: false}
+      ]
+
+      for %{maintenance_mode: maintenance_mode, authorized: authorized} <- scenarios do
+        cluster_details =
+          build(:hana_cluster_details, maintenance_mode: maintenance_mode, nodes: [])
+
+        cluster = build(:cluster, details: cluster_details)
+
+        instance =
+          build(:database_instance,
+            health: Health.unknown(),
+            host: %HostReadModel{cluster: cluster}
+          )
+
+        assert authorized ==
+                 DatabaseInstancePolicy.authorize_operation(:maintenance, instance, %{
+                   cluster_resource_id: nil
+                 })
+      end
+    end
+  end
+end

--- a/test/trento/operations/host_policy_test.exs
+++ b/test/trento/operations/host_policy_test.exs
@@ -1,0 +1,127 @@
+defmodule Trento.Operations.HostPolicyTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  require Trento.Enums.Health, as: Health
+
+  alias Trento.Operations.HostPolicy
+
+  import Trento.Factory
+
+  test "should forbid unknown operation" do
+    host = build(:host)
+
+    refute HostPolicy.authorize_operation(:unknown, host, %{})
+  end
+
+  describe "saptune_solution_apply" do
+    test "should forbid operation if an application instance is not stopped" do
+      application_instances = [
+        build(:application_instance, health: Health.unknown()),
+        build(:application_instance, health: Health.passing())
+      ]
+
+      database_instancess = build_list(2, :database_instance, health: Health.unknown())
+
+      cluster = build(:cluster, details: build(:hana_cluster_details))
+
+      host =
+        build(:host,
+          application_instances: application_instances,
+          database_instances: database_instancess,
+          cluster: cluster
+        )
+
+      refute HostPolicy.authorize_operation(:saptune_solution_apply, host, %{})
+    end
+
+    test "should forbid operation if an database instance is not stopped" do
+      application_instances = build_list(2, :application_instance, health: Health.unknown())
+
+      database_instancess = [
+        build(:database_instance, health: Health.unknown()),
+        build(:database_instance, health: Health.passing())
+      ]
+
+      cluster = build(:cluster, details: build(:hana_cluster_details))
+
+      host =
+        build(:host,
+          application_instances: application_instances,
+          database_instances: database_instancess,
+          cluster: cluster
+        )
+
+      refute HostPolicy.authorize_operation(:saptune_solution_apply, host, %{})
+    end
+
+    test "should authorize operation if there is not any SAP instance running" do
+      host =
+        build(:host,
+          application_instances: [],
+          database_instances: [],
+          cluster: nil
+        )
+
+      assert HostPolicy.authorize_operation(:saptune_solution_apply, host, %{})
+    end
+
+    test "should authorize operation if all instances are stopped and the host is not clustered" do
+      application_instances = build_list(2, :application_instance, health: Health.unknown())
+      database_instancess = build_list(2, :database_instance, health: Health.unknown())
+
+      host =
+        build(:host,
+          application_instances: application_instances,
+          database_instances: database_instancess,
+          cluster: nil
+        )
+
+      assert HostPolicy.authorize_operation(:saptune_solution_apply, host, %{})
+    end
+
+    test "should authorize operation if all instances are stopped and cluster is in maintenance" do
+      application_instances = build_list(2, :application_instance, health: Health.unknown())
+      database_instancess = build_list(2, :database_instance, health: Health.unknown())
+      cluster = build(:cluster, details: build(:hana_cluster_details, maintenance_mode: true))
+
+      host =
+        build(:host,
+          application_instances: application_instances,
+          database_instances: database_instancess,
+          cluster: cluster
+        )
+
+      assert HostPolicy.authorize_operation(:saptune_solution_apply, host, %{})
+    end
+
+    test "should authorize operation if all instances are stopped and HANA resources are not managed" do
+      scenarios = [
+        %{cluster_resource_type: "ocf::suse:SAPHana"},
+        %{cluster_resource_type: "ocf::suse:SAPHanaController"}
+      ]
+
+      database_instancess = build_list(2, :database_instance, health: Health.unknown())
+
+      for %{cluster_resource_type: cluster_resource_type} <- scenarios do
+        parent = build(:cluster_resource_parent, managed: false)
+
+        cluster_resource =
+          build(:cluster_resource, type: cluster_resource_type, managed: true, parent: parent)
+
+        nodes = build_list(1, :hana_cluster_node, resources: [cluster_resource])
+        cluster_details = build(:hana_cluster_details, maintenance_mode: false, nodes: nodes)
+        cluster = build(:cluster, details: cluster_details)
+
+        host =
+          build(:host,
+            application_instances: [],
+            database_instances: database_instancess,
+            cluster: cluster
+          )
+
+        assert HostPolicy.authorize_operation(:saptune_solution_apply, host, %{})
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description

Add operations framework policy. It tries to replicate what we do with `Bodyguard` for the user authorizations.

The operations that will be executed in the trento agents are really sensitive, so this policies guard them against incorrect usage. They will protect the operation new endpoints, so the users cannot run the operations if the resources are not in good state.

This is just the first model. We can add more conditions, and of course, more operations.

By now I have included the `saptune_solution_apply` main operation, which depends on having the SAP instances in a maintainable state:
- Cluster:
. The cluster can have maintenance operations if it is actually in maintenance mode
. Or the resource that will be changed is not managed
- Application and database instances
. The instances are not running
. Cluster is in maintenance
- Host
. All the SAP instances running on this host are in maintenance mode

PD:
Here a ref with SUSE docs explaining a general way of doing SAP maintenance (like applying saptune) in clustered nodes: https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-maintenance

## How was this tested?

UT
