### PR TITLE
Add operations policy plug

### DIFF
--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -68,6 +68,13 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"404")
   end
 
+  def call(conn, {:error, :operation_not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(json: ErrorJSON)
+    |> render(:"404", reason: "Operation not found.")
+  end
+
   def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/lib/trento_web/plugs/operations_policy_plug.ex
+++ b/lib/trento_web/plugs/operations_policy_plug.ex
@@ -1,0 +1,124 @@
+defmodule TrentoWeb.Plugs.OperationsPolicyPlug do
+  @moduledoc """
+  This plug is responsible for authorizing operations. It falls back to `{:error, :forbidden}` if
+  the resource is not authorized.
+
+  Options:
+  - policy: Operations policy implementing Trento.Operations.PolicyBehaviour
+  - resource: Function returning the resource to be authorized. If it returns `nil` {:error, :not_found} is falled back
+  - operation: Function returning the operation to authorize. If it returns `nil` {:error, :operation_not_found} is falled back
+  - params: Function returning the operation params. It returns an empty map by default.
+  - assigns_to: Atom defining where the authorized resource is assigned in the conn once the plug finishes successfully.
+    It is available at `%{assings: %{authorized_resource: resource}}`. `authorized_resource` by default
+
+  The plug can be used like:
+  ```
+  plug TrentoWeb.Plugs.OperationsPolicyPlug,
+       [
+         policy: Trento.Operations.MyPolicy,
+         resource: &__MODULE__.get_resource/1,
+         operation: &__MODULE__.get_operation/1,
+         params: &__MODULE__.get_params/1
+         assigns_to: :resource
+       ]
+       when action == :request_operation
+
+  def get_resource(conn) do
+    # return the resource to be authorized
+  end
+
+  def get_operation(conn) do
+    # return the operation to authorize
+  end
+
+  def get_params(conn) do
+    # return the parameters
+  end
+  ```
+  """
+
+  import Plug.Conn
+
+  @spec init() :: %{
+          operation: fun(),
+          params: map(),
+          policy: module(),
+          resource: fun(),
+          assigns_to: atom()
+        }
+  def init(opts \\ []) do
+    policy = Keyword.get(opts, :policy)
+    operation = Keyword.get(opts, :operation)
+    resource = Keyword.get(opts, :resource)
+    params = Keyword.get(opts, :params, &get_params/1)
+    assigns_to = Keyword.get(opts, :assigns_to, :authorized_resource)
+
+    if is_nil(policy), do: raise(ArgumentError, "#{inspect(__MODULE__)} :policy option required")
+
+    if is_nil(operation),
+      do: raise(ArgumentError, "#{inspect(__MODULE__)} :operation option required")
+
+    if is_nil(resource),
+      do: raise(ArgumentError, "#{inspect(__MODULE__)} :resource option is required")
+
+    %{
+      policy: policy,
+      operation: operation,
+      resource: resource,
+      params: params,
+      assigns_to: assigns_to
+    }
+  end
+
+  def call(
+        conn,
+        %{
+          policy: policy,
+          params: params_fun,
+          assigns_to: assigns_to
+        } = opts
+      ) do
+    params = params_fun.(conn)
+
+    with {:ok, resource} <- handle_resource(conn, opts),
+         {:ok, operation} <- handle_operation(conn, opts),
+         :ok <- handle_permission(policy, operation, resource, params) do
+      assign(conn, assigns_to, resource)
+    else
+      error ->
+        conn
+        |> TrentoWeb.FallbackController.call(error)
+        |> Plug.Conn.halt()
+    end
+  end
+
+  defp get_params(_), do: %{}
+
+  defp handle_resource(conn, %{resource: resource_fun}) do
+    case resource_fun.(conn) do
+      nil ->
+        {:error, :not_found}
+
+      found_resource ->
+        {:ok, found_resource}
+    end
+  end
+
+  defp handle_operation(conn, %{operation: operation_fun}) do
+    case operation_fun.(conn) do
+      nil ->
+        {:error, :operation_not_found}
+
+      found_operation ->
+        {:ok, found_operation}
+    end
+  end
+
+  defp handle_permission(policy, operation, resource, params) do
+    if policy.authorize_operation(operation, resource, params) do
+      :ok
+    else
+      {:error, :forbidden}
+    end
+  end
+end

--- a/lib/trento_web/plugs/operations_policy_plug.ex
+++ b/lib/trento_web/plugs/operations_policy_plug.ex
@@ -5,11 +5,11 @@ defmodule TrentoWeb.Plugs.OperationsPolicyPlug do
 
   Options:
   - policy: Operations policy implementing Trento.Operations.PolicyBehaviour
-  - resource: Function returning the resource to be authorized. If it returns `nil` {:error, :not_found} is falled back
-  - operation: Function returning the operation to authorize. If it returns `nil` {:error, :operation_not_found} is falled back
+  - resource: Function returning the resource to be authorized. If it returns `nil` {:error, :not_found} is fallen back
+  - operation: Function returning the operation to authorize. If it returns `nil` {:error, :operation_not_found} is fallen back
   - params: Function returning the operation params. It returns an empty map by default.
   - assigns_to: Atom defining where the authorized resource is assigned in the conn once the plug finishes successfully.
-    It is available at `%{assings: %{authorized_resource: resource}}`. `authorized_resource` by default
+    It is available at `%{assigns: %{authorized_resource: resource}}`. `authorized_resource` by default
 
   The plug can be used like:
   ```

--- a/test/trento_web/plugs/operations_policy_plug_test.exs
+++ b/test/trento_web/plugs/operations_policy_plug_test.exs
@@ -1,0 +1,100 @@
+defmodule TrentoWeb.Plugs.OperationsPolicyPlugTest do
+  use TrentoWeb.ConnCase, async: true
+  use Plug.Test
+
+  alias TrentoWeb.Plugs.OperationsPolicyPlug
+
+  defmodule TestPolicy do
+    @behaviour Trento.Operations.PolicyBehaviour
+
+    def authorize_operation(:authorized, _, _), do: true
+    def authorize_operation(:forbidden, _, _), do: false
+  end
+
+  setup %{conn: conn} do
+    {:ok, conn: Phoenix.Controller.accepts(conn, ["json"])}
+  end
+
+  test "should return not found if the given resource is not found", %{conn: conn} do
+    opts = [
+      policy: TestPolicy,
+      operation: fn _ -> nil end,
+      resource: fn _ -> nil end
+    ]
+
+    init_opts = OperationsPolicyPlug.init(opts)
+    conn = OperationsPolicyPlug.call(conn, init_opts)
+
+    assert %{
+             "errors" => [
+               %{"detail" => "The requested resource cannot be found.", "title" => "Not Found"}
+             ]
+           } == json_response(conn, 404)
+  end
+
+  test "should return operation not found if the given operation is not found", %{conn: conn} do
+    opts = [
+      policy: TestPolicy,
+      operation: fn _ -> nil end,
+      resource: fn _ -> %{} end
+    ]
+
+    init_opts = OperationsPolicyPlug.init(opts)
+    conn = OperationsPolicyPlug.call(conn, init_opts)
+
+    assert %{
+             "errors" => [
+               %{"detail" => "Operation not found.", "title" => "Not Found"}
+             ]
+           } == json_response(conn, 404)
+  end
+
+  test "should forbid operation if the resourcec is not authorized", %{conn: conn} do
+    opts = [
+      policy: TestPolicy,
+      operation: fn _ -> :forbidden end,
+      resource: fn _ -> %{} end
+    ]
+
+    init_opts = OperationsPolicyPlug.init(opts)
+    conn = OperationsPolicyPlug.call(conn, init_opts)
+
+    assert %{
+             "errors" => [
+               %{
+                 "detail" => "You can't perform the operation or access the resource.",
+                 "title" => "Forbidden"
+               }
+             ]
+           } == json_response(conn, 403)
+  end
+
+  test "should authorize operation", %{conn: conn} do
+    resource = %{key: "value"}
+
+    opts = [
+      policy: TestPolicy,
+      operation: fn _ -> :authorized end,
+      resource: fn _ -> resource end
+    ]
+
+    init_opts = OperationsPolicyPlug.init(opts)
+
+    assert %{assigns: %{authorized_resource: ^resource}} =
+             OperationsPolicyPlug.call(conn, init_opts)
+  end
+
+  test "should authorize operation and assign to assigns_to", %{conn: conn} do
+    resource = %{key: "value"}
+
+    opts = [
+      policy: TestPolicy,
+      operation: fn _ -> :authorized end,
+      resource: fn _ -> resource end,
+      assigns_to: :my_resource
+    ]
+
+    init_opts = OperationsPolicyPlug.init(opts)
+    assert %{assigns: %{my_resource: ^resource}} = OperationsPolicyPlug.call(conn, init_opts)
+  end
+end


### PR DESCRIPTION
# Description
Add a pretty basic plug to standardize the way we authorize operations in the controllers.
This will help to avoid having the `with Policy.authorize(_) do` code in all the controller endpoints where we need to authorize things. It might look an overkill now, but once we more operations it will come handy.

To see a real implementation: https://github.com/trento-project/web/pull/3305

## How was this tested?
UT
