### PR TITLE
Add reset customization cta

### DIFF
--- a/assets/js/common/ResetCheckCustomizationModal/ResetCheckCustomizationModal.jsx
+++ b/assets/js/common/ResetCheckCustomizationModal/ResetCheckCustomizationModal.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { noop } from 'lodash';
+
+import Modal from '@common/Modal';
+import Button from '@common/Button';
+
+function ResetCheckCustomizationModal({
+  checkId,
+  open = false,
+  onReset = noop,
+  onCancel = noop,
+}) {
+  return (
+    <Modal
+      className="!w-3/4 !max-w-3xl"
+      title={`Reset check: ${checkId}`}
+      open={open}
+      onClose={onCancel}
+    >
+      <div className="text-gray-500">
+        You are about to reset custom checks values. Would you like to continue?
+      </div>
+      <div className="flex justify-start gap-2 mt-4">
+        <Button
+          type="default-fit"
+          className="inline-block mx-0.5 border-green-500 border w-fit"
+          size="small"
+          onClick={onReset}
+        >
+          Reset
+        </Button>
+        <Button
+          type="primary-white-fit"
+          className="inline-block mx-0.5 border-green-500 border"
+          size="small"
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
+export default ResetCheckCustomizationModal;

--- a/assets/js/common/ResetCheckCustomizationModal/ResetCheckCustomizationModal.stories.jsx
+++ b/assets/js/common/ResetCheckCustomizationModal/ResetCheckCustomizationModal.stories.jsx
@@ -1,0 +1,35 @@
+import { action } from '@storybook/addon-actions';
+import { faker } from '@faker-js/faker';
+
+import ResetCheckCustomizationModal from '.';
+
+export default {
+  title: 'Patterns/ResetCheckCustomizationModal',
+  component: ResetCheckCustomizationModal,
+  argTypes: {
+    checkId: {
+      type: 'string',
+      description: 'The check ID for which the customization will be reset',
+    },
+    open: {
+      type: 'boolean',
+      description: 'Sets the visibility of the modal',
+    },
+    onReset: {
+      type: 'function',
+      description: 'Callback when the Reset button is clicked',
+    },
+    onCancel: {
+      type: 'function',
+      description: 'Callback when the Cancel button is clicked',
+    },
+  },
+};
+
+export const Default = {
+  args: {
+    checkId: faker.lorem.word(),
+    onReset: action('reset clicked'),
+    onCancel: action('cancel clicked'),
+  },
+};

--- a/assets/js/common/ResetCheckCustomizationModal/ResetCheckCustomizationModal.test.jsx
+++ b/assets/js/common/ResetCheckCustomizationModal/ResetCheckCustomizationModal.test.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import { faker } from '@faker-js/faker';
+
+import ResetCheckCustomizationModal from '.';
+
+describe('ResetCheckCustomizationModal component', () => {
+  it('should render the reset check customization confirmation modal correctly', async () => {
+    const checkId = faker.string.uuid();
+
+    await act(async () => {
+      render(<ResetCheckCustomizationModal checkId={checkId} open />);
+    });
+
+    expect(screen.getByText(`Reset check: ${checkId}`)).toBeVisible();
+    expect(
+      screen.getByText(
+        'You are about to reset custom checks values. Would you like to continue?'
+      )
+    ).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Reset' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeVisible();
+  });
+
+  it.each`
+    scenario                                          | button      | callbackName
+    ${'should confirm resetting check customization'} | ${'Reset'}  | ${'onReset'}
+    ${'should cancel reset confirmation'}             | ${'Cancel'} | ${'onCancel'}
+  `('$scenario', async ({ button, callbackName }) => {
+    const callback = jest.fn();
+
+    await act(async () => {
+      render(
+        <ResetCheckCustomizationModal
+          checkId={faker.string.uuid()}
+          open
+          {...{ [callbackName]: callback }}
+        />
+      );
+    });
+
+    await userEvent.click(screen.getByText(button));
+    expect(callback).toHaveBeenCalled();
+  });
+});

--- a/assets/js/common/ResetCheckCustomizationModal/index.js
+++ b/assets/js/common/ResetCheckCustomizationModal/index.js
@@ -1,0 +1,3 @@
+import ResetCheckCustomizationModal from './ResetCheckCustomizationModal';
+
+export default ResetCheckCustomizationModal;

--- a/assets/js/pages/ChecksSelection/ChecksSelection.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelection.jsx
@@ -4,6 +4,7 @@ import { without, uniq, groupBy } from 'lodash';
 import { toggle } from '@lib/lists';
 
 import CheckCustomizationModal from '@common/CheckCustomizationModal';
+import ResetCheckCustomizationModal from '@common/ResetCheckCustomizationModal';
 import CatalogContainer from '@pages/ChecksCatalog/CatalogContainer';
 import ChecksSelectionGroup, {
   NONE_CHECKED,
@@ -41,6 +42,8 @@ function ChecksSelection({
   saveCustomCheck = () => {},
 }) {
   const [isCheckCustomizationModalOpen, setIsCheckCustomizationModalOpen] =
+    useState(false);
+  const [isResetConfirmationModalOpen, setResetConfirmationModalOpen] =
     useState(false);
   const [selectedCheck, setSelectedCheck] = useState(null);
 
@@ -80,6 +83,18 @@ function ChecksSelection({
       loading={loading}
     >
       <div className="pb-4">
+        <ResetCheckCustomizationModal
+          key={selectedCheck?.id}
+          checkId={selectedCheck?.id}
+          open={!!isResetConfirmationModalOpen}
+          onReset={() => {
+            setResetConfirmationModalOpen(false);
+          }}
+          onCancel={() => {
+            setResetConfirmationModalOpen(false);
+            setSelectedCheck(null);
+          }}
+        />
         {groupedChecks?.map(({ group, checks, groupSelected }) => (
           <ChecksSelectionGroup
             key={group}
@@ -103,6 +118,10 @@ function ChecksSelection({
                 onCustomize={() => {
                   setSelectedCheck(check);
                   setIsCheckCustomizationModalOpen(true);
+                }}
+                onResetCustomization={() => {
+                  setSelectedCheck(check);
+                  setResetConfirmationModalOpen(true);
                 }}
               />
             ))}

--- a/assets/js/pages/ChecksSelection/ChecksSelectionItem.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelectionItem.jsx
@@ -1,7 +1,8 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React from 'react';
+import { noop } from 'lodash';
 
-import { EOS_SETTINGS_OUTLINED } from 'eos-icons-react';
+import { EOS_RESTART_ALT, EOS_SETTINGS_OUTLINED } from 'eos-icons-react';
 import { Switch } from '@headlessui/react';
 
 import classNames from 'classnames';
@@ -15,8 +16,11 @@ const defaultAbilities = [];
 
 const CUSTOMIZATION_ALLOWED_FOR = ['all:all', 'all:check_customization'];
 
-const isCustomizable = (abilities, customizable) =>
+const canCustomize = (abilities, customizable) =>
   isPermitted(abilities, CUSTOMIZATION_ALLOWED_FOR) && customizable;
+
+const canReset = (abilities, customizable, customized) =>
+  canCustomize(abilities, customizable) && customized;
 
 function ChecksSelectionItem({
   checkID,
@@ -26,8 +30,9 @@ function ChecksSelectionItem({
   customized = false,
   selected,
   userAbilities = defaultAbilities,
-  onChange = () => {},
-  onCustomize = () => {},
+  onChange = noop,
+  onCustomize = noop,
+  onResetCustomization = noop,
 }) {
   return (
     <li>
@@ -54,7 +59,19 @@ function ChecksSelectionItem({
               </ReactMarkdown>
             </div>
             <Switch.Group as="div" className="flex items-center">
-              {isCustomizable(userAbilities, customizable) && (
+              {canReset(userAbilities, customizable, customized) && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    onResetCustomization(checkID);
+                  }}
+                  aria-label="reset-check-customization"
+                  className="inline mr-2"
+                >
+                  <EOS_RESTART_ALT className="fill-jungle-green-500" />
+                </button>
+              )}
+              {canCustomize(userAbilities, customizable) && (
                 <button
                   type="button"
                   onClick={() => {


### PR DESCRIPTION
# Description

This PR adds the reset check customization confirmation modal.

API call will be wired up via a custom hook as a follow up.
