### PR TITLE
Saptune solution apply modal

### DIFF
--- a/assets/js/common/OperationModals/OperationModal.jsx
+++ b/assets/js/common/OperationModals/OperationModal.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { EOS_WARNING_OUTLINED } from 'eos-icons-react';
+import { noop } from 'lodash';
 
 import Modal from '@common/Modal';
 import Button from '@common/Button';
@@ -12,9 +13,9 @@ function OperationModal({
   applyDisabled = true,
   checked = false,
   isOpen = false,
-  onChecked,
-  onRequest,
-  onCancel,
+  onChecked = noop,
+  onRequest = noop,
+  onCancel = noop,
   children,
 }) {
   return (

--- a/assets/js/common/OperationModals/OperationModal.jsx
+++ b/assets/js/common/OperationModals/OperationModal.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { EOS_WARNING_OUTLINED } from 'eos-icons-react';
 import { noop } from 'lodash';
 
 import Modal from '@common/Modal';
 import Button from '@common/Button';
-import Input from '@common/Input';
+import CheckableWarningMessage from '@common/CheckableWarningMessage';
 
 function OperationModal({
   title,
@@ -28,23 +27,12 @@ function OperationModal({
       <p className="text-gray-500 text-sm font-normal tracking-wide pb-3">
         {description}
       </p>
-      <div className="flex items-center text-sm font-normal border border-yellow-400 bg-yellow-50 p-4 rounded-md text-yellow-600 mb-4">
-        <Input
-          type="checkbox"
-          checked={checked}
-          className="border-yellow-400"
-          onChange={onChecked}
-        />
-
-        <EOS_WARNING_OUTLINED
-          size="l"
-          className="centered fill-yellow-500 ml-4 mr-4"
-        />
-        <span className="font-semibold">
-          Trento & SUSE cannot be held liable for damages if system is unable to
-          function due applying {operationText}.
-        </span>
-      </div>
+      <CheckableWarningMessage
+        warningText={`Trento & SUSE cannot be held liable for damages if system is unable to
+          function due applying ${operationText}.`}
+        checked={checked}
+        onChecked={onChecked}
+      />
       {children}
       <div className="flex justify-start gap-2 mt-4">
         <Button

--- a/assets/js/common/OperationModals/OperationModal.jsx
+++ b/assets/js/common/OperationModals/OperationModal.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { EOS_WARNING_OUTLINED } from 'eos-icons-react';
+
+import Modal from '@common/Modal';
+import Button from '@common/Button';
+import Input from '@common/Input';
+
+function OperationModal({
+  title,
+  description,
+  operationText,
+  applyDisabled = true,
+  checked = false,
+  isOpen = false,
+  onChecked,
+  onRequest,
+  onCancel,
+  children,
+}) {
+  return (
+    <Modal
+      className="!w-3/4 !max-w-3xl"
+      title={title}
+      open={isOpen}
+      onClose={onCancel}
+    >
+      <p className="text-gray-500 text-sm font-normal tracking-wide pb-3">
+        {description}
+      </p>
+      <div className="flex items-center text-sm font-normal border border-yellow-400 bg-yellow-50 p-4 rounded-md text-yellow-600 mb-4">
+        <Input
+          type="checkbox"
+          checked={checked}
+          className="border-yellow-400"
+          onChange={onChecked}
+        />
+
+        <EOS_WARNING_OUTLINED
+          size="l"
+          className="centered fill-yellow-500 ml-4 mr-4"
+        />
+        <span className="font-semibold">
+          Trento & SUSE cannot be held liable for damages if system is unable to
+          function due applying {operationText}.
+        </span>
+      </div>
+      {children}
+      <div className="flex justify-start gap-2 mt-4">
+        <Button
+          type="default-fit"
+          className="inline-block mx-0.5 border-green-500 border w-fit"
+          size="small"
+          disabled={applyDisabled}
+          onClick={onRequest}
+        >
+          Apply
+        </Button>
+        <Button
+          type="primary-white-fit"
+          className="inline-block mx-0.5 border-green-500 border"
+          size="small"
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
+export default OperationModal;

--- a/assets/js/common/OperationModals/SaptuneSolutionApplyModal.jsx
+++ b/assets/js/common/OperationModals/SaptuneSolutionApplyModal.jsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import { filter } from 'lodash';
+import Select from '@common/Select';
+import OperationModal from './OperationModal';
+
+const NOT_SELECTED = 'Select a saptune solution';
+
+const solutions = [
+  {
+    value: NOT_SELECTED,
+    key: NOT_SELECTED,
+    available: () => true,
+  },
+  {
+    value: 'HANA',
+    key: 'hana',
+    available: (isHanaRunning, isAppRunning) => isHanaRunning && !isAppRunning,
+  },
+  {
+    value: 'NETWEAVER',
+    key: 'netweaver',
+    available: (isHanaRunning, isAppRunning) => !isHanaRunning && isAppRunning,
+  },
+  {
+    value: 'S4HANA-APPSERVER',
+    key: 's4hana-appserver',
+    available: (isHanaRunning, isAppRunning) => !isHanaRunning && isAppRunning,
+  },
+  {
+    value: 'S4HANA-APP+DB',
+    key: 's4hana-app-db',
+    available: (isHanaRunning, isAppRunning) => isHanaRunning && isAppRunning,
+  },
+  {
+    value: 'S4HANA-DBSERVER',
+    key: 's4hana-dbserver',
+    available: (isHanaRunning, isAppRunning) => isHanaRunning && !isAppRunning,
+  },
+  {
+    value: 'NETWEAVER+HANA',
+    key: 'netweaver-hana',
+    available: (isHanaRunning, isAppRunning) => isHanaRunning && isAppRunning,
+  },
+];
+
+function SaptuneSolutionApplyModal({
+  isHanaRunning,
+  isAppRunning,
+  isOpen = false,
+  onRequest,
+  onCancel,
+}) {
+  const [checked, setChecked] = useState(false);
+  const [solution, setSolution] = useState(NOT_SELECTED);
+
+  const availableSolutions = filter(solutions, ({ available }) =>
+    available(isHanaRunning, isAppRunning)
+  );
+
+  return (
+    <OperationModal
+      title="Apply Saptune Solution"
+      description="Select Saptune tuning solution"
+      operationText="Saptune solution"
+      applyDisabled={!checked || solution === NOT_SELECTED}
+      checked={checked}
+      isOpen={isOpen}
+      onChecked={() => setChecked((prev) => !prev)}
+      onRequest={() => onRequest(solution)}
+      onCancel={onCancel}
+    >
+      <div className="flex items-center justify-start gap-2 mt-4">
+        <p className="font-semibold text-gray-900 tracking-wide">
+          Saptune Solution
+        </p>
+        <Select
+          className="ml-auto !w-2/3"
+          optionsName="solutions"
+          options={availableSolutions}
+          value={solution}
+          onChange={(value) => setSolution(value)}
+          disabled={!checked}
+        />
+      </div>
+    </OperationModal>
+  );
+}
+
+export default SaptuneSolutionApplyModal;

--- a/assets/js/common/OperationModals/SaptuneSolutionApplyModal.jsx
+++ b/assets/js/common/OperationModals/SaptuneSolutionApplyModal.jsx
@@ -8,7 +8,7 @@ const NOT_SELECTED = 'Select a saptune solution';
 const solutions = [
   {
     value: NOT_SELECTED,
-    key: NOT_SELECTED,
+    key: 'not_selected',
     available: () => true,
   },
   {

--- a/assets/js/common/OperationModals/SaptuneSolutionApplyModal.stories.jsx
+++ b/assets/js/common/OperationModals/SaptuneSolutionApplyModal.stories.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import SaptuneSolutionApplyModal from './SaptuneSolutionApplyModal';
+
+export default {
+  title: 'Components/SaptuneSolutionApplyModal',
+  component: SaptuneSolutionApplyModal,
+  argTypes: {
+    isHanaRunning: {
+      description: 'HANA instance is running on host',
+      control: 'boolean',
+    },
+    isAppRunning: {
+      description: 'Application instance is running on host',
+      control: 'boolean',
+    },
+    isOpen: {
+      description: 'Model is open',
+      control: 'boolean',
+    },
+    onRequest: {
+      description: 'Request saptune solution apply operation',
+    },
+    onCancel: {
+      description: 'Closes the modal',
+    },
+  },
+  args: {
+    isHanaRunning: false,
+    isAppRunning: false,
+    isOpen: true,
+  },
+};
+
+export function HanaRunning(args) {
+  return <SaptuneSolutionApplyModal {...args} isHanaRunning />;
+}
+
+export function AppRunning(args) {
+  return <SaptuneSolutionApplyModal {...args} isAppRunning />;
+}
+
+export function HanaAndAppRunning(args) {
+  return <SaptuneSolutionApplyModal {...args} isHanaRunning isAppRunning />;
+}

--- a/assets/js/common/OperationModals/SaptuneSolutionApplyModal.test.jsx
+++ b/assets/js/common/OperationModals/SaptuneSolutionApplyModal.test.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { noop } from 'lodash';
+import SaptuneSolutionApplyModal from './SaptuneSolutionApplyModal';
+
+describe('SaptuneSolutionApplyModal', () => {
+  it('should show correct title and description', async () => {
+    await act(async () => {
+      render(<SaptuneSolutionApplyModal isOpen onCancel={noop} />);
+    });
+
+    expect(screen.getByText('Apply Saptune Solution')).toBeInTheDocument();
+    expect(
+      screen.getByText('Select Saptune tuning solution')
+    ).toBeInTheDocument();
+  });
+
+  it('should forbid choosing and applying solution until accepting the checkbox', async () => {
+    await act(async () => {
+      render(<SaptuneSolutionApplyModal isOpen onCancel={noop} />);
+    });
+
+    expect(screen.getByText('Apply')).toBeDisabled();
+    expect(screen.getByText('Select a saptune solution')).toBeDisabled();
+  });
+
+  it('should render HANA solutions', async () => {
+    const user = userEvent.setup();
+    const mockOnRequest = jest.fn();
+
+    await act(async () => {
+      render(
+        <SaptuneSolutionApplyModal
+          isOpen
+          isHanaRunning
+          onCancel={noop}
+          onRequest={mockOnRequest}
+        />
+      );
+    });
+
+    await user.click(screen.getByRole('checkbox'));
+    expect(screen.getByText('Apply')).toBeDisabled();
+
+    await user.click(screen.getByText('Select a saptune solution'));
+
+    expect(screen.getByText('HANA')).toBeInTheDocument();
+    expect(screen.getByText('S4HANA-DBSERVER')).toBeInTheDocument();
+
+    await user.click(screen.getByText('HANA'));
+    await user.click(screen.getByText('Apply'));
+
+    expect(mockOnRequest).toBeCalledWith('HANA');
+  });
+
+  it('should render Application solutions', async () => {
+    const user = userEvent.setup();
+
+    await act(async () => {
+      render(
+        <SaptuneSolutionApplyModal
+          isOpen
+          isAppRunning
+          onCancel={noop}
+          onRequest={noop}
+        />
+      );
+    });
+
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByText('Select a saptune solution'));
+
+    expect(screen.getByText('NETWEAVER')).toBeInTheDocument();
+    expect(screen.getByText('S4HANA-APPSERVER')).toBeInTheDocument();
+  });
+
+  it('should render HANA and Application solutions', async () => {
+    const user = userEvent.setup();
+
+    await act(async () => {
+      render(
+        <SaptuneSolutionApplyModal
+          isOpen
+          isHanaRunning
+          isAppRunning
+          onCancel={noop}
+          onRequest={noop}
+        />
+      );
+    });
+
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByText('Select a saptune solution'));
+
+    expect(screen.getByText('S4HANA-APP+DB')).toBeInTheDocument();
+    expect(screen.getByText('NETWEAVER+HANA')).toBeInTheDocument();
+  });
+});

--- a/assets/js/common/OperationModals/SaptuneSolutionApplyModal.test.jsx
+++ b/assets/js/common/OperationModals/SaptuneSolutionApplyModal.test.jsx
@@ -2,13 +2,12 @@ import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
-import { noop } from 'lodash';
 import SaptuneSolutionApplyModal from './SaptuneSolutionApplyModal';
 
 describe('SaptuneSolutionApplyModal', () => {
   it('should show correct title and description', async () => {
     await act(async () => {
-      render(<SaptuneSolutionApplyModal isOpen onCancel={noop} />);
+      render(<SaptuneSolutionApplyModal isOpen />);
     });
 
     expect(screen.getByText('Apply Saptune Solution')).toBeInTheDocument();
@@ -19,7 +18,7 @@ describe('SaptuneSolutionApplyModal', () => {
 
   it('should forbid choosing and applying solution until accepting the checkbox', async () => {
     await act(async () => {
-      render(<SaptuneSolutionApplyModal isOpen onCancel={noop} />);
+      render(<SaptuneSolutionApplyModal isOpen />);
     });
 
     expect(screen.getByText('Apply')).toBeDisabled();
@@ -35,7 +34,6 @@ describe('SaptuneSolutionApplyModal', () => {
         <SaptuneSolutionApplyModal
           isOpen
           isHanaRunning
-          onCancel={noop}
           onRequest={mockOnRequest}
         />
       );
@@ -59,14 +57,7 @@ describe('SaptuneSolutionApplyModal', () => {
     const user = userEvent.setup();
 
     await act(async () => {
-      render(
-        <SaptuneSolutionApplyModal
-          isOpen
-          isAppRunning
-          onCancel={noop}
-          onRequest={noop}
-        />
-      );
+      render(<SaptuneSolutionApplyModal isOpen isAppRunning />);
     });
 
     await user.click(screen.getByRole('checkbox'));
@@ -80,15 +71,7 @@ describe('SaptuneSolutionApplyModal', () => {
     const user = userEvent.setup();
 
     await act(async () => {
-      render(
-        <SaptuneSolutionApplyModal
-          isOpen
-          isHanaRunning
-          isAppRunning
-          onCancel={noop}
-          onRequest={noop}
-        />
-      );
+      render(<SaptuneSolutionApplyModal isOpen isHanaRunning isAppRunning />);
     });
 
     await user.click(screen.getByRole('checkbox'));

--- a/assets/js/common/OperationModals/index.js
+++ b/assets/js/common/OperationModals/index.js
@@ -1,0 +1,3 @@
+import SaptuneSolutionApplyModal from './SaptuneSolutionApplyModal';
+
+export { SaptuneSolutionApplyModal };


### PR DESCRIPTION
# Description

Add Saptune solution apply modal to the frontend.
The solutions per each host are based on having HANA or Application instances running. More details here: https://documentation.suse.com/sles-sap/15-SP5/html/SLES-SAP-guide/cha-tune.html#sec-saptune-configure-tuning

The `OperationModal` is a generic template to be used internally to create specific modals

![image](https://github.com/user-attachments/assets/29ecf568-386e-43b5-bd60-d4dbb1ecc9ad)

PD: Once we have the warning box with the checkbox component we can replace it

## How was this tested?

UT and storybook
