### PR TITLE
Create checkable warning messages

### DIFF
--- a/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.jsx
+++ b/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.jsx
@@ -80,7 +80,7 @@ function CheckCustomizationModal({
         hideCheckbox={customized}
         warningText={checkBoxWarningText}
         checked={checked}
-        setChecked={setChecked}
+        onChecked={setChecked}
       />
       {values
         ?.filter(({ customizable }) => customizable)

--- a/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.jsx
+++ b/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.jsx
@@ -80,7 +80,7 @@ function CheckCustomizationModal({
         hideCheckbox={customized}
         warningText={checkBoxWarningText}
         checked={checked}
-        onChecked={setChecked}
+        onChecked={() => setChecked((prev) => !prev)}
       />
       {values
         ?.filter(({ customizable }) => customizable)

--- a/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.jsx
+++ b/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { noop } from 'lodash';
-import { EOS_WARNING_OUTLINED } from 'eos-icons-react';
 
 import Modal from '@common/Modal';
 import Button from '@common/Button';
@@ -8,6 +7,7 @@ import Input from '@common/Input';
 import Label from '@common/Label';
 import ProviderLabel from '@common/ProviderLabel';
 import Tooltip from '@common/Tooltip';
+import CheckableWarningMessage from '@common/CheckableWarningMessage';
 import { UNKNOWN_PROVIDER } from '@lib/model';
 
 const checkBoxWarningText =
@@ -76,22 +76,12 @@ function CheckCustomizationModal({
       <p className="text-gray-500 text-sm font-normal tracking-wide pb-2">
         {description}
       </p>
-
-      <div className="flex items-center border border-yellow-400 bg-yellow-50 p-4 rounded-md text-yellow-600 mb-4">
-        {!customized && (
-          <Input
-            type="checkbox"
-            checked={checked}
-            onChange={() => setChecked((prev) => !prev)}
-          />
-        )}
-
-        <EOS_WARNING_OUTLINED
-          size="xxl"
-          className="centered fill-yellow-500 ml-4 mr-4"
-        />
-        <span className="font-semibold">{checkBoxWarningText}</span>
-      </div>
+      <CheckableWarningMessage
+        hideCheckbox={customized}
+        warningText={checkBoxWarningText}
+        checked={checked}
+        setChecked={setChecked}
+      />
       {values
         ?.filter(({ customizable }) => customizable)
         .map((value) => (

--- a/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.jsx
+++ b/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.jsx
@@ -12,12 +12,7 @@ function CheckableWarningMessage({
   return (
     <div className="flex items-center border border-yellow-400 bg-yellow-50 p-4 rounded-md text-yellow-600 mb-4">
       {!hideCheckbox && (
-        <Input
-          type="checkbox"
-          checked={checked}
-          onChange={() => onChecked((prev) => !prev)}
-          className="w-5 h-5 border-2 border-yellow-400 rounded-md focus:ring-yellow-400"
-        />
+        <Input type="checkbox" checked={checked} onChange={onChecked} />
       )}
       <EOS_WARNING_OUTLINED
         size="l"

--- a/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.jsx
+++ b/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.jsx
@@ -7,7 +7,7 @@ function CheckableWarningMessage({
   hideCheckbox = false,
   warningText,
   checked,
-  setChecked = noop,
+  onChecked = noop,
 }) {
   return (
     <div className="flex items-center border border-yellow-400 bg-yellow-50 p-4 rounded-md text-yellow-600 mb-4">
@@ -15,11 +15,12 @@ function CheckableWarningMessage({
         <Input
           type="checkbox"
           checked={checked}
-          onChange={() => setChecked((prev) => !prev)}
+          onChange={() => onChecked((prev) => !prev)}
+          className="w-5 h-5 border-2 border-yellow-400 rounded-md focus:ring-yellow-400"
         />
       )}
       <EOS_WARNING_OUTLINED
-        size="xxl"
+        size="l"
         className="centered fill-yellow-500 ml-4 mr-4"
       />
       <span className="font-semibold">{warningText}</span>

--- a/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.jsx
+++ b/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.jsx
@@ -10,7 +10,7 @@ function CheckableWarningMessage({
   onChecked = noop,
 }) {
   return (
-    <div className="flex items-center border border-yellow-400 bg-yellow-50 p-4 rounded-md text-yellow-600 mb-4">
+    <div className="flex items-center border border-yellow-400 bg-yellow-50 p-4 rounded-md text-yellow-600 mb-4 text-sm font-normal">
       {!hideCheckbox && (
         <Input type="checkbox" checked={checked} onChange={onChecked} />
       )}

--- a/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.jsx
+++ b/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import Input from '@common/Input';
+import { noop } from 'lodash';
+import { EOS_WARNING_OUTLINED } from 'eos-icons-react';
+
+function CheckableWarningMessage({
+  hideCheckbox = false,
+  warningText,
+  checked,
+  setChecked = noop,
+}) {
+  return (
+    <div className="flex items-center border border-yellow-400 bg-yellow-50 p-4 rounded-md text-yellow-600 mb-4">
+      {!hideCheckbox && (
+        <Input
+          type="checkbox"
+          checked={checked}
+          onChange={() => setChecked((prev) => !prev)}
+        />
+      )}
+      <EOS_WARNING_OUTLINED
+        size="xxl"
+        className="centered fill-yellow-500 ml-4 mr-4"
+      />
+      <span className="font-semibold">{warningText}</span>
+    </div>
+  );
+}
+
+export default CheckableWarningMessage;

--- a/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.stories.jsx
+++ b/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.stories.jsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import CheckableWarningMessage from '.';
+
+export default {
+  title: 'Components/CheckableWarningMessage',
+  component: CheckableWarningMessage,
+  argTypes: {
+    hideCheckbox: {
+      description: 'Hides the checkbox when set to true',
+      control: 'boolean',
+    },
+    checked: {
+      description: 'Checkbox state',
+      control: 'boolean',
+    },
+    warningText: {
+      description: 'Text displayed inside the warning message',
+      control: 'text',
+    },
+    setChecked: {
+      description: 'Function to toggle the checkbox state',
+      action: 'setChecked',
+    },
+  },
+  args: {
+    hideCheckbox: false,
+    checked: false,
+    warningText:
+      'Trento & SUSE cannot be held liable for damages if system is unable to function due to custom check value.',
+  },
+};
+
+export function Default(args) {
+  const [warningChecked, setWarningChecked] = useState(false);
+  return (
+    <CheckableWarningMessage
+      {...args}
+      checked={warningChecked}
+      setChecked={setWarningChecked}
+    />
+  );
+}
+
+export function Checked(args) {
+  const [checked, setChecked] = useState(true);
+  return (
+    <CheckableWarningMessage
+      {...args}
+      checked={checked}
+      setChecked={setChecked}
+    />
+  );
+}
+
+export function WithoutCheckbox(args) {
+  const [checked, setChecked] = useState(true);
+  return (
+    <CheckableWarningMessage
+      {...args}
+      checked={checked}
+      setChecked={setChecked}
+      hideCheckbox
+    />
+  );
+}

--- a/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.stories.jsx
+++ b/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.stories.jsx
@@ -17,9 +17,9 @@ export default {
       description: 'Text displayed inside the warning message',
       control: 'text',
     },
-    setChecked: {
+    onChecked: {
       description: 'Function to toggle the checkbox state',
-      action: 'setChecked',
+      action: 'onChecked',
     },
   },
   args: {

--- a/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.stories.jsx
+++ b/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.stories.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import CheckableWarningMessage from '.';
 
 export default {
@@ -31,35 +31,13 @@ export default {
 };
 
 export function Default(args) {
-  const [warningChecked, setWarningChecked] = useState(false);
-  return (
-    <CheckableWarningMessage
-      {...args}
-      checked={warningChecked}
-      setChecked={setWarningChecked}
-    />
-  );
+  return <CheckableWarningMessage {...args} />;
 }
 
 export function Checked(args) {
-  const [checked, setChecked] = useState(true);
-  return (
-    <CheckableWarningMessage
-      {...args}
-      checked={checked}
-      setChecked={setChecked}
-    />
-  );
+  return <CheckableWarningMessage {...args} checked />;
 }
 
 export function WithoutCheckbox(args) {
-  const [checked, setChecked] = useState(true);
-  return (
-    <CheckableWarningMessage
-      {...args}
-      checked={checked}
-      setChecked={setChecked}
-      hideCheckbox
-    />
-  );
+  return <CheckableWarningMessage {...args} hideCheckbox />;
 }

--- a/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.test.jsx
+++ b/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.test.jsx
@@ -5,7 +5,7 @@ import CheckableWarningMessage from './CheckableWarningMessage';
 
 const warningMessage = 'A default warning test';
 describe('CheckableWarningMessage', () => {
-  it('should render warning text and the checkbox if hideCheckbox is false', () => {
+  it('should render a clickable checkbox, svg warning icon, warning text.', () => {
     const mockSetChecked = jest.fn();
     render(
       <CheckableWarningMessage

--- a/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.test.jsx
+++ b/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.test.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CheckableWarningMessage from './CheckableWarningMessage';
+
+const warningMessage = 'A default warning test';
+describe('CheckableWarningMessage', () => {
+  it('should render warning text and the checkbox if hideCheckbox is false', () => {
+    const mockSetChecked = jest.fn();
+    render(
+      <CheckableWarningMessage
+        warningText={warningMessage}
+        checked={false}
+        setChecked={mockSetChecked}
+      />
+    );
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toBeInTheDocument();
+    expect(screen.getByText(warningMessage)).toBeInTheDocument();
+    const icon = screen.getByTestId('eos-svg-component');
+    expect(icon).toBeInTheDocument();
+    fireEvent.click(checkbox);
+    expect(mockSetChecked).toHaveBeenCalled();
+  });
+
+  it('should not render checkbox if hideCheckbox is true', () => {
+    render(
+      <CheckableWarningMessage
+        hideCheckbox
+        warningText={warningMessage}
+        checked={false}
+      />
+    );
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+});

--- a/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.test.jsx
+++ b/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.test.jsx
@@ -1,25 +1,32 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import CheckableWarningMessage from './CheckableWarningMessage';
 
 const warningMessage = 'A default warning test';
+
 describe('CheckableWarningMessage', () => {
-  it('should render a clickable checkbox, svg warning icon, warning text.', () => {
+  it('should render a clickable checkbox, svg warning icon, warning text.', async () => {
+    const user = userEvent.setup();
     const mockSetChecked = jest.fn();
+
     render(
       <CheckableWarningMessage
         warningText={warningMessage}
         checked={false}
-        setChecked={mockSetChecked}
+        onChecked={mockSetChecked}
       />
     );
+
     const checkbox = screen.getByRole('checkbox');
     expect(checkbox).toBeInTheDocument();
     expect(screen.getByText(warningMessage)).toBeInTheDocument();
+
     const icon = screen.getByTestId('eos-svg-component');
     expect(icon).toBeInTheDocument();
-    fireEvent.click(checkbox);
+
+    await user.click(checkbox);
     expect(mockSetChecked).toHaveBeenCalled();
   });
 
@@ -31,6 +38,7 @@ describe('CheckableWarningMessage', () => {
         checked={false}
       />
     );
+
     expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
   });
 });

--- a/assets/js/common/CheckableWarningMessage/index.js
+++ b/assets/js/common/CheckableWarningMessage/index.js
@@ -1,0 +1,3 @@
+import CheckableWarningMessage from './CheckableWarningMessage';
+
+export default CheckableWarningMessage;


### PR DESCRIPTION
# Description

This pr refactors the CheckCustomizationModal by exporting the warning banner to an own common component. With this it can be reused through the application if needed.

Checkout storybook to see how the component behaves


## How was this tested? 

Added unit test


