### PR TITLE
Fix operations policy get_params usage

### DIFF
--- a/lib/trento_web/plugs/operations_policy_plug.ex
+++ b/lib/trento_web/plugs/operations_policy_plug.ex
@@ -40,17 +40,17 @@ defmodule TrentoWeb.Plugs.OperationsPolicyPlug do
   import Plug.Conn
 
   @spec init() :: %{
-          operation: fun(),
-          params: map(),
           policy: module(),
+          operation: fun(),
           resource: fun(),
+          params: fun(),
           assigns_to: atom()
         }
   def init(opts \\ []) do
     policy = Keyword.get(opts, :policy)
     operation = Keyword.get(opts, :operation)
     resource = Keyword.get(opts, :resource)
-    params = Keyword.get(opts, :params, &get_params/1)
+    params = Keyword.get(opts, :params, &__MODULE__.get_params/1)
     assigns_to = Keyword.get(opts, :assigns_to, :authorized_resource)
 
     if is_nil(policy), do: raise(ArgumentError, "#{inspect(__MODULE__)} :policy option required")
@@ -92,7 +92,7 @@ defmodule TrentoWeb.Plugs.OperationsPolicyPlug do
     end
   end
 
-  defp get_params(_), do: %{}
+  def get_params(_), do: %{}
 
   defp handle_resource(conn, %{resource: resource_fun}) do
     case resource_fun.(conn) do


### PR DESCRIPTION
# Description
The `OperationsPolicyPlug` incorrect usage has caused an error that I was only reproduced when generating the release. I didn't see it running locally.

This is the error: https://github.com/trento-project/web/actions/runs/13430969298/job/37522721412

The `Keyword.get` function/macro cannot find a private function apparently.

I'm setting the `env` label to check if everything works fine

## How was this tested?

Creating the docker file locally and with the `env` label
