### PR TITLE
Add reset customization cta inside modal

### DIFF
--- a/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.jsx
+++ b/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.jsx
@@ -46,6 +46,7 @@ function CheckCustomizationModal({
   customized = false,
   onClose = noop,
   onSave = noop,
+  onReset = noop,
 }) {
   const [checked, setChecked] = useState(customized);
   const [customValues, setCustomValues] = useState({});
@@ -119,29 +120,28 @@ function CheckCustomizationModal({
         </div>
       </div>
 
-      <div className="flex flex-row w-80">
-        <div className="flex flex-row w-24 mt-3 rounded-md">
-          <Button
-            type="default-fit"
-            className="w-1/2"
-            disabled={!canCustomize}
-            onClick={() => {
-              onSave(buildCustomCheckPayload(id, customValues));
-              resetStateAndClose();
-            }}
-          >
-            Save
-          </Button>
-        </div>
-        <div className="flex flex-row w-24 mt-3 rounded-md">
-          <Button
-            type="primary-white"
-            className="w-1/2"
-            onClick={resetStateAndClose}
-          >
-            Close
-          </Button>
-        </div>
+      <div className="flex w-80 flex-row space-x-2">
+        <Button
+          type="default-fit"
+          className="w-1/2"
+          disabled={!canCustomize}
+          onClick={() => {
+            onSave(buildCustomCheckPayload(id, customValues));
+            resetStateAndClose();
+          }}
+        >
+          Save
+        </Button>
+        <Button type="primary-white-fit" className="w-1/2" onClick={onReset}>
+          Reset Check
+        </Button>
+        <Button
+          type="primary-white-fit"
+          className="w-1/2"
+          onClick={resetStateAndClose}
+        >
+          Close
+        </Button>
       </div>
     </Modal>
   );

--- a/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.stories.jsx
+++ b/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.stories.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { action } from '@storybook/addon-actions';
 import CheckCustomizationModal from '.';
 
 const singleValue = [
@@ -76,35 +76,44 @@ export default {
       control: 'text',
     },
     onClose: {
+      type: 'function',
       description: 'Closes the modal',
     },
     onSave: {
+      type: 'function',
       description: 'Saves the customized checks values and closes the modal',
     },
+    onReset: {
+      type: 'function',
+      description: 'Resets the customized checks values and closes the modal',
+    },
   },
+};
+
+export const SingleValue = {
   args: {
     open: false,
     id: defaultCheck.id,
     values: defaultCheck.values,
     description: defaultCheck.description,
     provider: defaultProvider,
+    onClose: action('onClose'),
+    onSave: action('onSave'),
+    onReset: action('onReset'),
   },
 };
 
-export function SingleValue(args) {
-  return <CheckCustomizationModal {...args} />;
-}
+export const MultipleValues = {
+  args: {
+    ...SingleValue.args,
+    values: multipleValues,
+  },
+};
 
-export function MultipleValues(args) {
-  return <CheckCustomizationModal {...args} values={multipleValues} />;
-}
-
-export function PartialNonCustomizableValues(args) {
-  return (
-    <CheckCustomizationModal
-      {...args}
-      isChecked
-      values={partialCustomizableValues}
-    />
-  );
-}
+export const PartialNonCustomizableValues = {
+  args: {
+    ...SingleValue.args,
+    isChecked: true,
+    values: partialCustomizableValues,
+  },
+};

--- a/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.test.jsx
+++ b/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.test.jsx
@@ -10,6 +10,7 @@ import CheckCustomizationModal from './CheckCustomizationModal';
 
 const mockOnClose = jest.fn();
 const mockOnSave = jest.fn();
+const mockOnReset = jest.fn();
 
 const check = selectableCheckFactory.build({
   id: '123',
@@ -25,28 +26,29 @@ const check = selectableCheckFactory.build({
   customizable: false,
 });
 
-const expectedCheckModalValues = {
+const checkCustomizationModalProps = {
   ...check,
   open: true,
   provider: 'aws',
   onClose: mockOnClose,
   onSave: mockOnSave,
+  onReset: mockOnReset,
 };
 
 describe('CheckCustomizationModal', () => {
   it('renders modal with correct title, description, warning, disabled input field and a disabled save button', async () => {
-    const expectedModalTitle = `Check: ${expectedCheckModalValues.id}`;
+    const expectedModalTitle = `Check: ${checkCustomizationModalProps.id}`;
     const expectedWarningBannerText =
       'Trento & SUSE cannot be held liable for damages if system is unable to function due to custom check value.';
     const user = userEvent.setup();
 
     await act(async () => {
-      render(<CheckCustomizationModal {...expectedCheckModalValues} />);
+      render(<CheckCustomizationModal {...checkCustomizationModalProps} />);
     });
 
     expect(screen.getByText(expectedModalTitle)).toBeInTheDocument();
     expect(
-      screen.getByText(expectedCheckModalValues.description)
+      screen.getByText(checkCustomizationModalProps.description)
     ).toBeInTheDocument();
     expect(screen.getByText(expectedWarningBannerText)).toBeInTheDocument();
     const warningBannerCheckbox = screen.getByRole('checkbox');
@@ -64,10 +66,10 @@ describe('CheckCustomizationModal', () => {
   it('renders the modal  with a single customizable values', async () => {
     const user = userEvent.setup();
     const customCheckValue = '999';
-    const { onSave } = expectedCheckModalValues;
+    const { onSave } = checkCustomizationModalProps;
 
     await act(async () => {
-      render(<CheckCustomizationModal {...expectedCheckModalValues} />);
+      render(<CheckCustomizationModal {...checkCustomizationModalProps} />);
     });
 
     const warningBannerCheckbox = screen.getByRole('checkbox');
@@ -89,7 +91,7 @@ describe('CheckCustomizationModal', () => {
 
   it('renders the modal with multiple customizable values', async () => {
     const user = userEvent.setup();
-    const { onSave } = expectedCheckModalValues;
+    const { onSave } = checkCustomizationModalProps;
     const customCheckValue = ['123', '456', '789'];
     const customCheckNames = ['abc', 'def', 'xxx'];
 
@@ -101,7 +103,7 @@ describe('CheckCustomizationModal', () => {
         name: customCheckNames[index],
       }));
     const checkWithMultipleValues = {
-      ...expectedCheckModalValues,
+      ...checkCustomizationModalProps,
       values: checkValues,
     };
 
@@ -139,7 +141,7 @@ describe('CheckCustomizationModal', () => {
 
   it('renders the modal with partial customizable values', async () => {
     const user = userEvent.setup();
-    const { onSave } = expectedCheckModalValues;
+    const { onSave } = checkCustomizationModalProps;
     const customCheckValue = ['123', '456'];
     const customCheckNames = ['abc', 'def'];
 
@@ -154,7 +156,7 @@ describe('CheckCustomizationModal', () => {
       }),
     ];
     const checkWithMultipleValues = {
-      ...expectedCheckModalValues,
+      ...checkCustomizationModalProps,
       values: checkValueList,
     };
 
@@ -179,5 +181,17 @@ describe('CheckCustomizationModal', () => {
       checksID: '123',
       customValues: { [customCheckNames[0]]: customCheckValue[0] },
     });
+  });
+
+  it('should call onReset when reset button is clicked', async () => {
+    const user = userEvent.setup();
+    const { onReset } = checkCustomizationModalProps;
+
+    await act(async () => {
+      render(<CheckCustomizationModal {...checkCustomizationModalProps} />);
+    });
+
+    await user.click(screen.getByText('Reset Check'));
+    expect(onReset).toHaveBeenCalled();
   });
 });

--- a/assets/js/pages/ChecksSelection/ChecksSelection.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelection.jsx
@@ -92,11 +92,9 @@ function ChecksSelection({
           onReset={() => {
             onResetCheckCustomization(groupID, selectedCheck?.id);
             setResetConfirmationModalOpen(false);
+            setIsCheckCustomizationModalOpen(false);
           }}
-          onCancel={() => {
-            setResetConfirmationModalOpen(false);
-            setSelectedCheck(null);
-          }}
+          onCancel={() => setResetConfirmationModalOpen(false)}
         />
         {groupedChecks?.map(({ group, checks, groupSelected }) => (
           <ChecksSelectionGroup
@@ -138,11 +136,9 @@ function ChecksSelection({
           customized={selectedCheck?.customized}
           selectedCheck={selectedCheck}
           provider={provider}
-          onClose={() => {
-            setIsCheckCustomizationModalOpen(false);
-            setSelectedCheck(null);
-          }}
+          onClose={() => setIsCheckCustomizationModalOpen(false)}
           onSave={saveCustomCheck}
+          onReset={() => setResetConfirmationModalOpen(true)}
         />
       </div>
     </CatalogContainer>

--- a/assets/js/pages/ChecksSelection/ChecksSelection.stories.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelection.stories.jsx
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 import { selectableCheckFactory } from '@lib/test-utils/factories';
 
 import ChecksSelection from './ChecksSelection';
@@ -76,6 +77,7 @@ export default {
 
 export const Default = {
   args: {
+    groupID: faker.string.uuid(),
     catalog,
     userAbilities: [{ name: 'all', resource: 'check_customization' }],
   },

--- a/assets/js/pages/ChecksSelection/hooks.test.jsx
+++ b/assets/js/pages/ChecksSelection/hooks.test.jsx
@@ -1,8 +1,10 @@
-import { networkClient } from '@lib/network';
-import MockAdapter from 'axios-mock-adapter';
-import { faker } from '@faker-js/faker';
 import { act, renderHook } from '@testing-library/react';
+import { faker } from '@faker-js/faker';
+import MockAdapter from 'axios-mock-adapter';
+import { every, has } from 'lodash';
 import { hookWrapperWithState } from '@lib/test-utils';
+
+import { networkClient } from '@lib/network';
 import { selectableCheckFactory } from '@lib/test-utils/factories';
 import { useChecksSelection } from './hooks';
 
@@ -159,9 +161,11 @@ describe('useChecksSelection', () => {
 
     const updatedChecksSelection = hookResult.current.checksSelection;
 
-    updatedChecksSelection.forEach(({ id, customized }) => {
+    const doesNotHaveCustomValue = (value) => !has(value, 'custom_value');
+    updatedChecksSelection.forEach(({ id, customized, values }) => {
       if (id === checkId) {
         expect(customized).toBe(false);
+        expect(every(values, doesNotHaveCustomValue)).toBe(true);
       } else {
         expect(customized).toBe(true);
       }


### PR DESCRIPTION
# Description

This PR:
- adds a `Reset Button` in the check customization modal actions
- properly updated the state so that non customized values are shown
- adds minor improvements