### PR TITLE
Enable reset customization when check is customized

### DIFF
--- a/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.jsx
+++ b/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.jsx
@@ -132,7 +132,12 @@ function CheckCustomizationModal({
         >
           Save
         </Button>
-        <Button type="primary-white-fit" className="w-1/2" onClick={onReset}>
+        <Button
+          type="primary-white-fit"
+          className="w-1/2"
+          onClick={onReset}
+          disabled={!customized}
+        >
           Reset Check
         </Button>
         <Button

--- a/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.test.jsx
+++ b/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.test.jsx
@@ -183,12 +183,22 @@ describe('CheckCustomizationModal', () => {
     });
   });
 
+  it('should disable reset customization button if check is not customized', async () => {
+    await act(async () => {
+      render(<CheckCustomizationModal open customized={false} />);
+    });
+
+    expect(screen.getByText('Reset Check')).toBeDisabled();
+  });
+
   it('should call onReset when reset button is clicked', async () => {
     const user = userEvent.setup();
     const { onReset } = checkCustomizationModalProps;
 
     await act(async () => {
-      render(<CheckCustomizationModal {...checkCustomizationModalProps} />);
+      render(
+        <CheckCustomizationModal {...checkCustomizationModalProps} customized />
+      );
     });
 
     await user.click(screen.getByText('Reset Check'));


### PR DESCRIPTION
# Description

Allows to click the reset customization button if the check is customized.