### PR TITLE
Add OperationForbiddenModal

### DIFF
--- a/assets/js/common/OperationModals/OperationForbiddenModal.jsx
+++ b/assets/js/common/OperationModals/OperationForbiddenModal.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { noop } from 'lodash';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+import Modal from '@common/Modal';
+import Button from '@common/Button';
+import Banner from '@common/Banners/Banner';
+
+function OperationForbiddenModal({
+  operation,
+  isOpen = false,
+  onCancel = noop,
+  children,
+}) {
+  return (
+    <Modal
+      className="!w-3/4 !max-w-3xl"
+      title="Operation Forbidden"
+      open={isOpen}
+      onClose={onCancel}
+    >
+      <Banner type="error">
+        Unable to run {operation} operation. Some of the conditions are not met.
+      </Banner>
+      <ReactMarkdown className="markdown text-sm" remarkPlugins={[remarkGfm]}>
+        {children}
+      </ReactMarkdown>
+      <div className="flex justify-start gap-2 mt-4">
+        <Button
+          type="primary-white-fit"
+          className="inline-block mx-0.5 border-green-500 border"
+          size="small"
+          onClick={onCancel}
+        >
+          Close
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
+export default OperationForbiddenModal;

--- a/assets/js/common/OperationModals/OperationForbiddenModal.jsx
+++ b/assets/js/common/OperationModals/OperationForbiddenModal.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { noop } from 'lodash';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
 
 import Modal from '@common/Modal';
 import Button from '@common/Button';
@@ -9,6 +7,7 @@ import Banner from '@common/Banners/Banner';
 
 function OperationForbiddenModal({
   operation,
+  errors,
   isOpen = false,
   onCancel = noop,
   children,
@@ -23,9 +22,15 @@ function OperationForbiddenModal({
       <Banner type="error">
         Unable to run {operation} operation. Some of the conditions are not met.
       </Banner>
-      <ReactMarkdown className="markdown text-sm" remarkPlugins={[remarkGfm]}>
-        {children}
-      </ReactMarkdown>
+      <p className="text-sm mb-1">Some of the next conditions are not met:</p>
+      <ul className="list-disc list-inside space-y-1 mb-1">
+        {errors.map((error) => (
+          <li key={error} className="text-sm">
+            {error}
+          </li>
+        ))}
+      </ul>
+      <p className="text-sm mb-1">{children}</p>
       <div className="flex justify-start gap-2 mt-4">
         <Button
           type="primary-white-fit"

--- a/assets/js/common/OperationModals/OperationForbiddenModal.stories.jsx
+++ b/assets/js/common/OperationModals/OperationForbiddenModal.stories.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import OperationForbiddenModal from './OperationForbiddenModal';
+
+export default {
+  title: 'Components/OperationForbiddenModal',
+  component: OperationForbiddenModal,
+  argTypes: {
+    operation: {
+      type: 'string',
+      description: 'Operation name',
+      control: {
+        type: 'text',
+      },
+    },
+    isOpen: {
+      description: 'Modal is open',
+      control: 'boolean',
+    },
+    onCancel: {
+      description: 'Closes the modal',
+    },
+  },
+  args: {
+    operation: 'My operation',
+    isOpen: true,
+  },
+};
+
+export function Default(args) {
+  return (
+    <OperationForbiddenModal {...args}>
+      My operation forbidden description
+    </OperationForbiddenModal>
+  );
+}
+
+export function WithMarkdown(args) {
+  return (
+    <OperationForbiddenModal {...args} operation="With markdown">{`
+The **OperationForbiddenModal** renders markdown. A list for example:
+- Value 1
+- Value 2`}</OperationForbiddenModal>
+  );
+}

--- a/assets/js/common/OperationModals/OperationForbiddenModal.stories.jsx
+++ b/assets/js/common/OperationModals/OperationForbiddenModal.stories.jsx
@@ -13,6 +13,10 @@ export default {
         type: 'text',
       },
     },
+    errors: {
+      description: 'Authorization errors as string',
+      control: 'array',
+    },
     isOpen: {
       description: 'Modal is open',
       control: 'boolean',
@@ -23,6 +27,7 @@ export default {
   },
   args: {
     operation: 'My operation',
+    errors: ['Authorization error 1', 'Authorization error 2'],
     isOpen: true,
   },
 };
@@ -30,16 +35,7 @@ export default {
 export function Default(args) {
   return (
     <OperationForbiddenModal {...args}>
-      My operation forbidden description
+      My operation forbidden additional information
     </OperationForbiddenModal>
-  );
-}
-
-export function WithMarkdown(args) {
-  return (
-    <OperationForbiddenModal {...args} operation="With markdown">{`
-The **OperationForbiddenModal** renders markdown. A list for example:
-- Value 1
-- Value 2`}</OperationForbiddenModal>
   );
 }

--- a/assets/js/common/OperationModals/OperationForbiddenModal.test.jsx
+++ b/assets/js/common/OperationModals/OperationForbiddenModal.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import OperationForbiddenModal from './OperationForbiddenModal';
@@ -8,7 +8,11 @@ describe('OperationForbiddenModal', () => {
   it('should show forbidden operation modal', async () => {
     await act(async () => {
       render(
-        <OperationForbiddenModal operation="My operation" isOpen>
+        <OperationForbiddenModal
+          operation="My operation"
+          errors={['error1', 'error2']}
+          isOpen
+        >
           Some children
         </OperationForbiddenModal>
       );
@@ -20,6 +24,13 @@ describe('OperationForbiddenModal', () => {
         'Unable to run My operation operation. Some of the conditions are not met.'
       )
     ).toBeInTheDocument();
+
+    const list = screen.getByRole('list');
+    const { getAllByRole } = within(list);
+    const items = getAllByRole('listitem');
+    expect(items[0].textContent).toBe('error1');
+    expect(items[1].textContent).toBe('error2');
+
     expect(screen.getByText('Some children')).toBeInTheDocument();
   });
 
@@ -30,6 +41,7 @@ describe('OperationForbiddenModal', () => {
       render(
         <OperationForbiddenModal
           operation="My operation"
+          errors={[]}
           isOpen
           onCancel={mockOnCancel}
         >

--- a/assets/js/common/OperationModals/OperationForbiddenModal.test.jsx
+++ b/assets/js/common/OperationModals/OperationForbiddenModal.test.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import OperationForbiddenModal from './OperationForbiddenModal';
+
+describe('OperationForbiddenModal', () => {
+  it('should show forbidden operation modal', async () => {
+    await act(async () => {
+      render(
+        <OperationForbiddenModal operation="My operation" isOpen>
+          Some children
+        </OperationForbiddenModal>
+      );
+    });
+
+    expect(screen.getByText('Operation Forbidden')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Unable to run My operation operation. Some of the conditions are not met.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText('Some children')).toBeInTheDocument();
+  });
+
+  it('should run onCancel when the close button is clicked', async () => {
+    const user = userEvent.setup();
+    const mockOnCancel = jest.fn();
+    await act(async () => {
+      render(
+        <OperationForbiddenModal
+          operation="My operation"
+          isOpen
+          onCancel={mockOnCancel}
+        >
+          Some children
+        </OperationForbiddenModal>
+      );
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    expect(mockOnCancel).toBeCalled();
+  });
+});

--- a/assets/js/common/OperationModals/SaptuneSolutionApplyModal.stories.jsx
+++ b/assets/js/common/OperationModals/SaptuneSolutionApplyModal.stories.jsx
@@ -15,7 +15,7 @@ export default {
       control: 'boolean',
     },
     isOpen: {
-      description: 'Model is open',
+      description: 'Modal is open',
       control: 'boolean',
     },
     onRequest: {

--- a/assets/js/common/OperationModals/index.js
+++ b/assets/js/common/OperationModals/index.js
@@ -1,3 +1,4 @@
 import SaptuneSolutionApplyModal from './SaptuneSolutionApplyModal';
+import OperationForbiddenModal from './OperationForbiddenModal';
 
-export { SaptuneSolutionApplyModal };
+export { SaptuneSolutionApplyModal, OperationForbiddenModal };


### PR DESCRIPTION
# Description

Add operation forbidden modal. We can render any kind of markdown and have specific description messages for each operation. For example:

![image](https://github.com/user-attachments/assets/78ea88da-9715-4df5-a25a-124e73f8074f)

PD: Don't check too much the text after the banner. We will review that in other PRs, when it is really implemented. This was just an example

## How was this tested?

UT
