### PR TITLE
Refactor checkable warning message

### DIFF
--- a/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.jsx
+++ b/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.jsx
@@ -79,10 +79,11 @@ function CheckCustomizationModal({
       </p>
       <CheckableWarningMessage
         hideCheckbox={customized}
-        warningText={checkBoxWarningText}
         checked={checked}
         onChecked={() => setChecked((prev) => !prev)}
-      />
+      >
+        {checkBoxWarningText}
+      </CheckableWarningMessage>
       {values
         ?.filter(({ customizable }) => customizable)
         .map((value) => (

--- a/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.jsx
+++ b/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.jsx
@@ -5,9 +5,9 @@ import { EOS_WARNING_OUTLINED } from 'eos-icons-react';
 
 function CheckableWarningMessage({
   hideCheckbox = false,
-  warningText,
   checked,
   onChecked = noop,
+  children,
 }) {
   return (
     <div className="flex items-center border border-yellow-400 bg-yellow-50 p-4 rounded-md text-yellow-600 mb-4 text-sm font-normal">
@@ -18,7 +18,7 @@ function CheckableWarningMessage({
         size="l"
         className="centered fill-yellow-500 ml-4 mr-4"
       />
-      <span className="font-semibold">{warningText}</span>
+      <span className="font-semibold">{children}</span>
     </div>
   );
 }

--- a/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.stories.jsx
+++ b/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.stories.jsx
@@ -13,19 +13,19 @@ export default {
       description: 'Checkbox state',
       control: 'boolean',
     },
-    warningText: {
-      description: 'Text displayed inside the warning message',
-      control: 'text',
-    },
     onChecked: {
       description: 'Function to toggle the checkbox state',
       action: 'onChecked',
+    },
+    children: {
+      description: 'Content displayed inside the warning message',
+      control: 'text',
     },
   },
   args: {
     hideCheckbox: false,
     checked: false,
-    warningText:
+    children:
       'Trento & SUSE cannot be held liable for damages if system is unable to function due to custom check value.',
   },
 };

--- a/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.test.jsx
+++ b/assets/js/common/CheckableWarningMessage/CheckableWarningMessage.test.jsx
@@ -12,11 +12,9 @@ describe('CheckableWarningMessage', () => {
     const mockSetChecked = jest.fn();
 
     render(
-      <CheckableWarningMessage
-        warningText={warningMessage}
-        checked={false}
-        onChecked={mockSetChecked}
-      />
+      <CheckableWarningMessage checked={false} onChecked={mockSetChecked}>
+        {warningMessage}
+      </CheckableWarningMessage>
     );
 
     const checkbox = screen.getByRole('checkbox');
@@ -32,11 +30,9 @@ describe('CheckableWarningMessage', () => {
 
   it('should not render checkbox if hideCheckbox is true', () => {
     render(
-      <CheckableWarningMessage
-        hideCheckbox
-        warningText={warningMessage}
-        checked={false}
-      />
+      <CheckableWarningMessage hideCheckbox checked={false}>
+        {warningMessage}
+      </CheckableWarningMessage>
     );
 
     expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();

--- a/assets/js/common/OperationModals/OperationModal.jsx
+++ b/assets/js/common/OperationModals/OperationModal.jsx
@@ -27,12 +27,10 @@ function OperationModal({
       <p className="text-gray-500 text-sm font-normal tracking-wide pb-3">
         {description}
       </p>
-      <CheckableWarningMessage
-        warningText={`Trento & SUSE cannot be held liable for damages if system is unable to
-          function due applying ${operationText}.`}
-        checked={checked}
-        onChecked={onChecked}
-      />
+      <CheckableWarningMessage checked={checked} onChecked={onChecked}>
+        Trento & SUSE cannot be held liable for damages if system is unable to
+        function due applying {operationText}
+      </CheckableWarningMessage>
       {children}
       <div className="flex justify-start gap-2 mt-4">
         <Button


### PR DESCRIPTION
# Description

A small refactor of the CheckableWarningMessage component to make it more customizable by passing children instead of only text. With this we can reuse 

## How was this tested?

Updated existing test and storybook
