### PR TITLE
Request and process operation events

### DIFF
--- a/lib/trento/hosts.ex
+++ b/lib/trento/hosts.ex
@@ -139,14 +139,19 @@ defmodule Trento.Hosts do
     end
   end
 
-  @spec request_operation(atom(), String.t(), map()) :: :ok | {:error, any}
+  @spec request_operation(atom(), String.t(), map()) :: {:ok, String.t()} | {:error, any}
   def request_operation(:saptune_solution_apply, host_id, params) do
-    Operations.request_operation(
-      UUID.uuid4(),
-      host_id,
-      "saptuneapplysolution@v1",
-      [%{agent_id: host_id, arguments: params}]
-    )
+    operation_id = UUID.uuid4()
+
+    with :ok <-
+           Operations.request_operation(
+             operation_id,
+             host_id,
+             "saptuneapplysolution@v1",
+             [%{agent_id: host_id, arguments: params}]
+           ) do
+      {:ok, operation_id}
+    end
   end
 
   def request_operation(_, _, _), do: {:error, :operation_not_found}

--- a/lib/trento/hosts.ex
+++ b/lib/trento/hosts.ex
@@ -23,7 +23,10 @@ defmodule Trento.Hosts do
     SelectHostChecks
   }
 
-  alias Trento.Infrastructure.Checks
+  alias Trento.Infrastructure.{
+    Checks,
+    Operations
+  }
 
   alias Trento.Repo
 
@@ -135,6 +138,18 @@ defmodule Trento.Hosts do
       host -> {:ok, host}
     end
   end
+
+  @spec request_operation(atom(), String.t(), map()) :: :ok | {:error, any}
+  def request_operation(:saptune_solution_apply, host_id, params) do
+    Operations.request_operation(
+      UUID.uuid4(),
+      host_id,
+      "saptuneapplysolution@v1",
+      [%{agent_id: host_id, arguments: params}]
+    )
+  end
+
+  def request_operation(_, _, _), do: {:error, :operation_not_found}
 
   @spec enrich_host_read_model_query(Ecto.Query.t()) :: Ecto.Query.t()
   defp enrich_host_read_model_query(query) do

--- a/lib/trento/hosts.ex
+++ b/lib/trento/hosts.ex
@@ -143,14 +143,14 @@ defmodule Trento.Hosts do
   def request_operation(:saptune_solution_apply, host_id, params) do
     operation_id = UUID.uuid4()
 
-    with :ok <-
-           Operations.request_operation(
-             operation_id,
-             host_id,
-             "saptuneapplysolution@v1",
-             [%{agent_id: host_id, arguments: params}]
-           ) do
-      {:ok, operation_id}
+    case Operations.request_operation(
+           operation_id,
+           host_id,
+           "saptuneapplysolution@v1",
+           [%{agent_id: host_id, arguments: params}]
+         ) do
+      :ok -> {:ok, operation_id}
+      error -> error
     end
   end
 

--- a/lib/trento/infrastructure/checks/checks.ex
+++ b/lib/trento/infrastructure/checks/checks.ex
@@ -21,6 +21,8 @@ defmodule Trento.Infrastructure.Checks do
     HostExecutionEnv
   }
 
+  alias Trento.Support.Protobuf
+
   require Logger
   require Trento.Clusters.Enums.ClusterType, as: ClusterType
   require Trento.Infrastructure.Checks.TargetType, as: TargetType
@@ -102,7 +104,7 @@ defmodule Trento.Infrastructure.Checks do
          provider: provider,
          filesystem_type: filesystem_type
        }) do
-    build_protobuf_env(%{
+    Protobuf.from_map(%{
       cluster_type: ClusterType.ascs_ers(),
       ensa_version: ensa_version,
       provider: provider,
@@ -116,7 +118,7 @@ defmodule Trento.Infrastructure.Checks do
          architecture_type: architecture_type,
          hana_scenario: hana_scenario
        }) do
-    build_protobuf_env(%{
+    Protobuf.from_map(%{
       cluster_type: ClusterType.hana_scale_up(),
       provider: provider,
       architecture_type: architecture_type,
@@ -129,7 +131,7 @@ defmodule Trento.Infrastructure.Checks do
          architecture_type: architecture_type,
          provider: provider
        }) do
-    build_protobuf_env(%{
+    Protobuf.from_map(%{
       cluster_type: ClusterType.hana_scale_out(),
       architecture_type: architecture_type,
       provider: provider
@@ -137,22 +139,10 @@ defmodule Trento.Infrastructure.Checks do
   end
 
   defp build_env(%HostExecutionEnv{provider: provider}) do
-    build_protobuf_env(%{
+    Protobuf.from_map(%{
       provider: provider
     })
   end
-
-  defp build_protobuf_env(env) do
-    %{fields: protobuf_env} =
-      env
-      |> Enum.into(%{}, fn {key, value} -> {key, map_value(value)} end)
-      |> Google.Protobuf.from_map()
-
-    protobuf_env
-  end
-
-  defp map_value(value) when is_atom(value), do: Atom.to_string(value)
-  defp map_value(value), do: value
 
   defp commanded,
     do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]

--- a/lib/trento/infrastructure/checks/checks.ex
+++ b/lib/trento/infrastructure/checks/checks.ex
@@ -97,50 +97,62 @@ defmodule Trento.Infrastructure.Checks do
   end
 
   defp build_env(%ClusterExecutionEnv{
-         cluster_type: :ascs_ers,
+         cluster_type: ClusterType.ascs_ers(),
          ensa_version: ensa_version,
          provider: provider,
          filesystem_type: filesystem_type
        }) do
-    %{
-      "cluster_type" => %{kind: {:string_value, Atom.to_string(ClusterType.ascs_ers())}},
-      "ensa_version" => %{kind: {:string_value, Atom.to_string(ensa_version)}},
-      "provider" => %{kind: {:string_value, Atom.to_string(provider)}},
-      "filesystem_type" => %{kind: {:string_value, Atom.to_string(filesystem_type)}}
-    }
+    build_protobuf_env(%{
+      cluster_type: ClusterType.ascs_ers(),
+      ensa_version: ensa_version,
+      provider: provider,
+      filesystem_type: filesystem_type
+    })
   end
 
   defp build_env(%ClusterExecutionEnv{
-         cluster_type: :hana_scale_up,
+         cluster_type: ClusterType.hana_scale_up(),
          provider: provider,
          architecture_type: architecture_type,
          hana_scenario: hana_scenario
        }) do
-    %{
-      "cluster_type" => %{kind: {:string_value, Atom.to_string(ClusterType.hana_scale_up())}},
-      "provider" => %{kind: {:string_value, Atom.to_string(provider)}},
-      "architecture_type" => %{kind: {:string_value, Atom.to_string(architecture_type)}},
-      "hana_scenario" => %{kind: {:string_value, Atom.to_string(hana_scenario)}}
-    }
+    build_protobuf_env(%{
+      cluster_type: ClusterType.hana_scale_up(),
+      provider: provider,
+      architecture_type: architecture_type,
+      hana_scenario: hana_scenario
+    })
   end
 
   defp build_env(%ClusterExecutionEnv{
-         cluster_type: :hana_scale_out,
+         cluster_type: ClusterType.hana_scale_out(),
          architecture_type: architecture_type,
          provider: provider
        }) do
-    %{
-      "cluster_type" => %{kind: {:string_value, Atom.to_string(ClusterType.hana_scale_out())}},
-      "architecture_type" => %{kind: {:string_value, Atom.to_string(architecture_type)}},
-      "provider" => %{kind: {:string_value, Atom.to_string(provider)}}
-    }
+    build_protobuf_env(%{
+      cluster_type: ClusterType.hana_scale_out(),
+      architecture_type: architecture_type,
+      provider: provider
+    })
   end
 
   defp build_env(%HostExecutionEnv{provider: provider}) do
-    %{
-      "provider" => %{kind: {:string_value, Atom.to_string(provider)}}
-    }
+    build_protobuf_env(%{
+      provider: provider
+    })
   end
+
+  defp build_protobuf_env(env) do
+    %{fields: protobuf_env} =
+      env
+      |> Enum.into(%{}, fn {key, value} -> {key, map_value(value)} end)
+      |> Google.Protobuf.from_map()
+
+    protobuf_env
+  end
+
+  defp map_value(value) when is_atom(value), do: Atom.to_string(value)
+  defp map_value(value), do: value
 
   defp commanded,
     do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]

--- a/lib/trento/infrastructure/operations/operations.ex
+++ b/lib/trento/infrastructure/operations/operations.ex
@@ -28,7 +28,7 @@ defmodule Trento.Infrastructure.Operations do
       operation_type: operation,
       targets:
         Enum.map(targets, fn %{agent_id: agent_id, arguments: arguments} ->
-          %OperationTarget{agent_id: agent_id, arguments: map_value(arguments)}
+          %OperationTarget{agent_id: agent_id, arguments: map_arguments(arguments)}
         end)
     }
 
@@ -43,16 +43,8 @@ defmodule Trento.Infrastructure.Operations do
     end
   end
 
-  defp map_value(map) when is_map(map) do
-    Enum.into(map, %{}, fn {key, value} -> {map_key(key), map_value(value)} end)
+  defp map_arguments(arguments) do
+    %{fields: protobuf_arguments} = Google.Protobuf.from_map(arguments)
+    protobuf_arguments
   end
-
-  defp map_value(value) when is_number(value), do: %{kind: {:number_value, value}}
-  defp map_value(value) when is_boolean(value), do: %{kind: {:bool_value, value}}
-  defp map_value(value) when is_nil(value), do: %{kind: {:null_value}}
-  defp map_value(value) when is_atom(value), do: %{kind: {:string_value, Atom.to_string(value)}}
-  defp map_value(value), do: %{kind: {:string_value, value}}
-
-  defp map_key(key) when is_atom(key), do: Atom.to_string(key)
-  defp map_key(key), do: key
 end

--- a/lib/trento/infrastructure/operations/operations.ex
+++ b/lib/trento/infrastructure/operations/operations.ex
@@ -1,0 +1,58 @@
+defmodule Trento.Infrastructure.Operations do
+  @moduledoc """
+  Operations integration
+  """
+
+  alias Trento.Operations.V1.{
+    OperationRequested,
+    OperationTarget
+  }
+
+  alias Trento.Infrastructure.Messaging
+
+  alias Trento.Infrastructure.Operations.AMQP.Publisher
+
+  require Logger
+
+  @type operation_target :: %{
+          agent_id: String.t(),
+          arguments: map()
+        }
+
+  @spec request_operation(String.t(), String.t(), String.t(), [operation_target()]) ::
+          :ok | {:error, any}
+  def request_operation(operation_id, group_id, operation, targets) do
+    operation_requested = %OperationRequested{
+      operation_id: operation_id,
+      group_id: group_id,
+      operation_type: operation,
+      targets:
+        Enum.map(targets, fn %{agent_id: agent_id, arguments: arguments} ->
+          %OperationTarget{agent_id: agent_id, arguments: map_value(arguments)}
+        end)
+    }
+
+    case Messaging.publish(Publisher, "requests", operation_requested) do
+      :ok ->
+        :ok
+
+      {:error, reason} = error ->
+        Logger.error("Failed to publish message to topic operations: #{inspect(reason)}")
+
+        error
+    end
+  end
+
+  defp map_value(map) when is_map(map) do
+    Enum.into(map, %{}, fn {key, value} -> {map_key(key), map_value(value)} end)
+  end
+
+  defp map_value(value) when is_number(value), do: %{kind: {:number_value, value}}
+  defp map_value(value) when is_boolean(value), do: %{kind: {:bool_value, value}}
+  defp map_value(value) when is_nil(value), do: %{kind: {:null_value}}
+  defp map_value(value) when is_atom(value), do: %{kind: {:string_value, Atom.to_string(value)}}
+  defp map_value(value), do: %{kind: {:string_value, value}}
+
+  defp map_key(key) when is_atom(key), do: Atom.to_string(key)
+  defp map_key(key), do: key
+end

--- a/lib/trento/infrastructure/operations/operations.ex
+++ b/lib/trento/infrastructure/operations/operations.ex
@@ -12,6 +12,8 @@ defmodule Trento.Infrastructure.Operations do
 
   alias Trento.Infrastructure.Operations.AMQP.Publisher
 
+  alias Trento.Support.Protobuf
+
   require Logger
 
   @type operation_target :: %{
@@ -28,7 +30,7 @@ defmodule Trento.Infrastructure.Operations do
       operation_type: operation,
       targets:
         Enum.map(targets, fn %{agent_id: agent_id, arguments: arguments} ->
-          %OperationTarget{agent_id: agent_id, arguments: map_arguments(arguments)}
+          %OperationTarget{agent_id: agent_id, arguments: Protobuf.from_map(arguments)}
         end)
     }
 
@@ -41,10 +43,5 @@ defmodule Trento.Infrastructure.Operations do
 
         error
     end
-  end
-
-  defp map_arguments(arguments) do
-    %{fields: protobuf_arguments} = Google.Protobuf.from_map(arguments)
-    protobuf_arguments
   end
 end

--- a/lib/trento/support/protobuf.ex
+++ b/lib/trento/support/protobuf.ex
@@ -1,0 +1,21 @@
+defmodule Trento.Support.Protobuf do
+  @moduledoc """
+  Helper functions to use Protobuf mapping
+  """
+  def from_map(map) do
+    %{fields: protobuf_map} =
+      map
+      |> Enum.into(%{}, fn {key, value} -> {from_key(key), from_value(value)} end)
+      |> Google.Protobuf.from_map()
+
+    protobuf_map
+  end
+
+  defp from_key(key) when is_atom(key), do: Atom.to_string(key)
+  defp from_key(key), do: key
+
+  defp from_value(nil), do: nil
+  defp from_value(value) when is_boolean(value), do: value
+  defp from_value(value) when is_atom(value), do: Atom.to_string(value)
+  defp from_value(value), do: value
+end

--- a/lib/trento_web/controllers/v1/host_controller.ex
+++ b/lib/trento_web/controllers/v1/host_controller.ex
@@ -191,15 +191,11 @@ defmodule TrentoWeb.V1.HostController do
     %{solution: solution} = OpenApiSpex.body_params(conn)
     %{id: host_id} = host
 
-    Logger.info(
-      "Operation authorized. Send real saptune_solution_apply with #{solution} to #{host_id}"
-    )
-
-    # Request operation, get operation id when created and return in json
-
-    conn
-    |> put_status(:accepted)
-    |> json(%{operation_id: UUID.uuid4()})
+    with :ok <- Hosts.request_operation(:saptune_solution_apply, host_id, %{solution: solution}) do
+      conn
+      |> put_status(:accepted)
+      |> json(%{})
+    end
   end
 
   def get_policy_resource(_), do: HostReadModel

--- a/lib/trento_web/controllers/v1/host_controller.ex
+++ b/lib/trento_web/controllers/v1/host_controller.ex
@@ -19,6 +19,7 @@ defmodule TrentoWeb.V1.HostController do
     BadRequest,
     Forbidden,
     NotFound,
+    OperationAccepted,
     OperationParams,
     UnprocessableEntity
   }
@@ -179,7 +180,7 @@ defmodule TrentoWeb.V1.HostController do
     ],
     request_body: {"Params", "application/json", OperationParams},
     responses: [
-      accepted: "The operation has been authorized and requested",
+      accepted: OperationAccepted.response(),
       not_found: NotFound.response(),
       forbidden: Forbidden.response(),
       unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
@@ -191,10 +192,11 @@ defmodule TrentoWeb.V1.HostController do
     %{solution: solution} = OpenApiSpex.body_params(conn)
     %{id: host_id} = host
 
-    with :ok <- Hosts.request_operation(:saptune_solution_apply, host_id, %{solution: solution}) do
+    with {:ok, operation_id} <-
+           Hosts.request_operation(:saptune_solution_apply, host_id, %{solution: solution}) do
       conn
       |> put_status(:accepted)
-      |> json(%{})
+      |> json(%{operation_id: operation_id})
     end
   end
 

--- a/lib/trento_web/openapi/v1/schema/operation_accepted.ex
+++ b/lib/trento_web/openapi/v1/schema/operation_accepted.ex
@@ -1,0 +1,29 @@
+defmodule TrentoWeb.OpenApi.V1.Schema.OperationAccepted do
+  @moduledoc false
+  require OpenApiSpex
+
+  alias OpenApiSpex.Operation
+  alias OpenApiSpex.Schema
+
+  OpenApiSpex.schema(
+    %{
+      title: "OperationAccepted",
+      description: "The operation has been authorized and requested",
+      type: :object,
+      additionalProperties: false,
+      properties: %{
+        operation_id: %Schema{type: :string, format: :uuid}
+      },
+      required: [:operation_id]
+    },
+    struct?: false
+  )
+
+  def response do
+    Operation.response(
+      "Operation Accepted",
+      "application/json",
+      __MODULE__
+    )
+  end
+end

--- a/test/trento/clusters_test.exs
+++ b/test/trento/clusters_test.exs
@@ -22,6 +22,8 @@ defmodule Trento.ClustersTest do
 
   alias Trento.Infrastructure.Checks.AMQP.Publisher
 
+  alias Google.Protobuf.Value, as: ProtobufValue
+
   require Trento.Clusters.Enums.ClusterType, as: ClusterType
   require Trento.Clusters.Enums.ClusterEnsaVersion, as: ClusterEnsaVersion
   require Trento.Clusters.Enums.FilesystemType, as: FilesystemType
@@ -74,10 +76,14 @@ defmodule Trento.ClustersTest do
         assert length(message.targets) == 2
 
         assert message.env == %{
-                 "provider" => %{kind: {:string_value, Atom.to_string(provider)}},
-                 "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
-                 "ensa_version" => %{kind: {:string_value, Atom.to_string(ensa_version)}},
-                 "filesystem_type" => %{
+                 "provider" => %ProtobufValue{kind: {:string_value, Atom.to_string(provider)}},
+                 "cluster_type" => %ProtobufValue{
+                   kind: {:string_value, Atom.to_string(cluster_type)}
+                 },
+                 "ensa_version" => %ProtobufValue{
+                   kind: {:string_value, Atom.to_string(ensa_version)}
+                 },
+                 "filesystem_type" => %ProtobufValue{
                    kind: {:string_value, Atom.to_string(FilesystemType.resource_managed())}
                  }
                }
@@ -116,12 +122,14 @@ defmodule Trento.ClustersTest do
           assert length(message.targets) == 2
 
           assert message.env == %{
-                   "provider" => %{kind: {:string_value, Atom.to_string(provider)}},
-                   "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
-                   "architecture_type" => %{
+                   "provider" => %ProtobufValue{kind: {:string_value, Atom.to_string(provider)}},
+                   "cluster_type" => %ProtobufValue{
+                     kind: {:string_value, Atom.to_string(cluster_type)}
+                   },
+                   "architecture_type" => %ProtobufValue{
                      kind: {:string_value, Atom.to_string(architecture_type)}
                    },
-                   "hana_scenario" => %{
+                   "hana_scenario" => %ProtobufValue{
                      kind: {:string_value, Atom.to_string(HanaScenario.performance_optimized())}
                    }
                  }
@@ -161,12 +169,14 @@ defmodule Trento.ClustersTest do
           assert length(message.targets) == 2
 
           assert message.env == %{
-                   "provider" => %{kind: {:string_value, Atom.to_string(provider)}},
-                   "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
-                   "architecture_type" => %{
+                   "provider" => %ProtobufValue{kind: {:string_value, Atom.to_string(provider)}},
+                   "cluster_type" => %ProtobufValue{
+                     kind: {:string_value, Atom.to_string(cluster_type)}
+                   },
+                   "architecture_type" => %ProtobufValue{
                      kind: {:string_value, Atom.to_string(architecture_type)}
                    },
-                   "hana_scenario" => %{
+                   "hana_scenario" => %ProtobufValue{
                      kind: {:string_value, Atom.to_string(HanaScenario.cost_optimized())}
                    }
                  }
@@ -506,10 +516,14 @@ defmodule Trento.ClustersTest do
         assert length(message.targets) == 2
 
         assert message.env == %{
-                 "provider" => %{kind: {:string_value, Atom.to_string(provider)}},
-                 "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
-                 "filesystem_type" => %{kind: {:string_value, Atom.to_string(:resource_managed)}},
-                 "ensa_version" => %{
+                 "provider" => %ProtobufValue{kind: {:string_value, Atom.to_string(provider)}},
+                 "cluster_type" => %ProtobufValue{
+                   kind: {:string_value, Atom.to_string(cluster_type)}
+                 },
+                 "filesystem_type" => %ProtobufValue{
+                   kind: {:string_value, Atom.to_string(:resource_managed)}
+                 },
+                 "ensa_version" => %ProtobufValue{
                    kind: {:string_value, Atom.to_string(ClusterEnsaVersion.ensa1())}
                  }
                }
@@ -558,10 +572,14 @@ defmodule Trento.ClustersTest do
         assert length(message.targets) == 2
 
         assert message.env == %{
-                 "provider" => %{kind: {:string_value, Atom.to_string(provider)}},
-                 "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
-                 "filesystem_type" => %{kind: {:string_value, Atom.to_string(:simple_mount)}},
-                 "ensa_version" => %{
+                 "provider" => %ProtobufValue{kind: {:string_value, Atom.to_string(provider)}},
+                 "cluster_type" => %ProtobufValue{
+                   kind: {:string_value, Atom.to_string(cluster_type)}
+                 },
+                 "filesystem_type" => %ProtobufValue{
+                   kind: {:string_value, Atom.to_string(:simple_mount)}
+                 },
+                 "ensa_version" => %ProtobufValue{
                    kind: {:string_value, Atom.to_string(ClusterEnsaVersion.ensa2())}
                  }
                }
@@ -612,10 +630,14 @@ defmodule Trento.ClustersTest do
         assert length(message.targets) == 2
 
         assert message.env == %{
-                 "provider" => %{kind: {:string_value, Atom.to_string(provider)}},
-                 "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
-                 "filesystem_type" => %{kind: {:string_value, Atom.to_string(:mixed_fs_types)}},
-                 "ensa_version" => %{
+                 "provider" => %ProtobufValue{kind: {:string_value, Atom.to_string(provider)}},
+                 "cluster_type" => %ProtobufValue{
+                   kind: {:string_value, Atom.to_string(cluster_type)}
+                 },
+                 "filesystem_type" => %ProtobufValue{
+                   kind: {:string_value, Atom.to_string(:mixed_fs_types)}
+                 },
+                 "ensa_version" => %ProtobufValue{
                    kind: {:string_value, Atom.to_string(ClusterEnsaVersion.ensa2())}
                  }
                }
@@ -695,10 +717,14 @@ defmodule Trento.ClustersTest do
         assert length(message.targets) == 2
 
         assert message.env == %{
-                 "provider" => %{kind: {:string_value, Atom.to_string(provider)}},
-                 "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
-                 "filesystem_type" => %{kind: {:string_value, Atom.to_string(:simple_mount)}},
-                 "ensa_version" => %{
+                 "provider" => %ProtobufValue{kind: {:string_value, Atom.to_string(provider)}},
+                 "cluster_type" => %ProtobufValue{
+                   kind: {:string_value, Atom.to_string(cluster_type)}
+                 },
+                 "filesystem_type" => %ProtobufValue{
+                   kind: {:string_value, Atom.to_string(:simple_mount)}
+                 },
+                 "ensa_version" => %ProtobufValue{
                    kind: {:string_value, Atom.to_string(ClusterEnsaVersion.ensa1())}
                  }
                }
@@ -778,10 +804,14 @@ defmodule Trento.ClustersTest do
         assert length(message.targets) == 2
 
         assert message.env == %{
-                 "provider" => %{kind: {:string_value, Atom.to_string(provider)}},
-                 "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
-                 "filesystem_type" => %{kind: {:string_value, Atom.to_string(:simple_mount)}},
-                 "ensa_version" => %{
+                 "provider" => %ProtobufValue{kind: {:string_value, Atom.to_string(provider)}},
+                 "cluster_type" => %ProtobufValue{
+                   kind: {:string_value, Atom.to_string(cluster_type)}
+                 },
+                 "filesystem_type" => %ProtobufValue{
+                   kind: {:string_value, Atom.to_string(:simple_mount)}
+                 },
+                 "ensa_version" => %ProtobufValue{
                    kind: {:string_value, Atom.to_string(ClusterEnsaVersion.ensa2())}
                  }
                }
@@ -861,10 +891,14 @@ defmodule Trento.ClustersTest do
         assert length(message.targets) == 2
 
         assert message.env == %{
-                 "provider" => %{kind: {:string_value, Atom.to_string(provider)}},
-                 "cluster_type" => %{kind: {:string_value, Atom.to_string(cluster_type)}},
-                 "filesystem_type" => %{kind: {:string_value, Atom.to_string(:simple_mount)}},
-                 "ensa_version" => %{
+                 "provider" => %ProtobufValue{kind: {:string_value, Atom.to_string(provider)}},
+                 "cluster_type" => %ProtobufValue{
+                   kind: {:string_value, Atom.to_string(cluster_type)}
+                 },
+                 "filesystem_type" => %ProtobufValue{
+                   kind: {:string_value, Atom.to_string(:simple_mount)}
+                 },
+                 "ensa_version" => %ProtobufValue{
                    kind: {:string_value, Atom.to_string(ClusterEnsaVersion.mixed_versions())}
                  }
                }

--- a/test/trento/hosts_test.exs
+++ b/test/trento/hosts_test.exs
@@ -21,7 +21,13 @@ defmodule Trento.HostsTest do
     Target
   }
 
+  alias Trento.Operations.V1.{
+    OperationRequested,
+    OperationTarget
+  }
+
   alias Trento.Infrastructure.Checks.AMQP.Publisher
+  alias Trento.Infrastructure.Operations.AMQP.Publisher, as: OperationsPublisher
 
   require Logger
 
@@ -253,6 +259,39 @@ defmodule Trento.HostsTest do
 
       assert capture_log(fn -> Hosts.request_hosts_checks_execution() end) =~
                expected_logger_message
+    end
+  end
+
+  describe "request operation" do
+    test "should request saptune_solution_apply operation" do
+      host_id = UUID.uuid4()
+
+      expect(
+        Trento.Infrastructure.Messaging.Adapter.Mock,
+        :publish,
+        1,
+        fn OperationsPublisher,
+           "requests",
+           %OperationRequested{
+             group_id: ^host_id,
+             operation_type: "saptuneapplysolution@v1",
+             targets: [
+               %OperationTarget{
+                 agent_id: ^host_id,
+                 arguments: %{"solution" => %{kind: {:string_value, "HANA"}}}
+               }
+             ]
+           } ->
+          :ok
+        end
+      )
+
+      assert :ok =
+               Hosts.request_operation(:saptune_solution_apply, host_id, %{solution: "HANA"})
+    end
+
+    test "should return operation_not_found if the given operation does not exist" do
+      assert {:error, :operation_not_found} = Hosts.request_operation(:unknown, UUID.uuid4(), %{})
     end
   end
 end

--- a/test/trento/hosts_test.exs
+++ b/test/trento/hosts_test.exs
@@ -286,7 +286,7 @@ defmodule Trento.HostsTest do
         end
       )
 
-      assert :ok =
+      assert {:ok, _} =
                Hosts.request_operation(:saptune_solution_apply, host_id, %{solution: "HANA"})
     end
 

--- a/test/trento/hosts_test.exs
+++ b/test/trento/hosts_test.exs
@@ -29,6 +29,8 @@ defmodule Trento.HostsTest do
   alias Trento.Infrastructure.Checks.AMQP.Publisher
   alias Trento.Infrastructure.Operations.AMQP.Publisher, as: OperationsPublisher
 
+  alias Google.Protobuf.Value, as: ProtobufValue
+
   require Logger
 
   @moduletag :integration
@@ -165,7 +167,7 @@ defmodule Trento.HostsTest do
         assert length(message.targets) == 1
 
         assert message.env == %{
-                 "provider" => %{kind: {:string_value, Atom.to_string(provider)}}
+                 "provider" => %ProtobufValue{kind: {:string_value, Atom.to_string(provider)}}
                }
 
         assert message.target_type == "host"
@@ -278,7 +280,7 @@ defmodule Trento.HostsTest do
              targets: [
                %OperationTarget{
                  agent_id: ^host_id,
-                 arguments: %{"solution" => %{kind: {:string_value, "HANA"}}}
+                 arguments: %{"solution" => %ProtobufValue{kind: {:string_value, "HANA"}}}
                }
              ]
            } ->

--- a/test/trento/infrastructure/operations/operations_test.exs
+++ b/test/trento/infrastructure/operations/operations_test.exs
@@ -61,7 +61,7 @@ defmodule Trento.Infrastructure.Operations.OperationsTest do
                      arguments: %{
                        "integer" => %{kind: {:number_value, 10}},
                        "boolean" => %{kind: {:bool_value, true}},
-                       "nil" => %{kind: {:null_value}}
+                       "nil" => %{kind: {:null_value, :NULL_VALUE}}
                      }
                    }
                  ]

--- a/test/trento/infrastructure/operations/operations_test.exs
+++ b/test/trento/infrastructure/operations/operations_test.exs
@@ -1,0 +1,102 @@
+defmodule Trento.Infrastructure.Operations.OperationsTest do
+  @moduledoc false
+
+  use ExUnit.Case
+
+  import Mox
+
+  alias Trento.Infrastructure.Operations
+
+  alias Trento.Operations.V1.{
+    OperationRequested,
+    OperationTarget
+  }
+
+  alias Trento.Infrastructure.Operations.AMQP.Publisher
+
+  describe "request operation" do
+    test "should publish an OperationRequested event" do
+      operation_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+      operation = "testoperation"
+
+      agent_id_1 = UUID.uuid4()
+      agent_id_2 = UUID.uuid4()
+
+      targets = [
+        %{
+          agent_id: agent_id_1,
+          arguments: %{
+            "string" => "some_string",
+            :some_atom => :some_value
+          }
+        },
+        %{
+          agent_id: agent_id_2,
+          arguments: %{
+            "integer" => 10,
+            "boolean" => true,
+            "nil" => nil
+          }
+        }
+      ]
+
+      expect(Trento.Infrastructure.Messaging.Adapter.Mock, :publish, fn Publisher,
+                                                                        "requests",
+                                                                        event ->
+        assert %OperationRequested{
+                 operation_id: ^operation_id,
+                 group_id: ^group_id,
+                 operation_type: ^operation,
+                 targets: [
+                   %OperationTarget{
+                     agent_id: ^agent_id_1,
+                     arguments: %{
+                       "string" => %{kind: {:string_value, "some_string"}},
+                       "some_atom" => %{kind: {:string_value, "some_value"}}
+                     }
+                   },
+                   %OperationTarget{
+                     agent_id: ^agent_id_2,
+                     arguments: %{
+                       "integer" => %{kind: {:number_value, 10}},
+                       "boolean" => %{kind: {:bool_value, true}},
+                       "nil" => %{kind: {:null_value}}
+                     }
+                   }
+                 ]
+               } = event
+
+        :ok
+      end)
+
+      assert :ok =
+               Operations.request_operation(
+                 operation_id,
+                 group_id,
+                 operation,
+                 targets
+               )
+    end
+
+    test "should return messaging error" do
+      operation_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+      operation = "testoperation"
+
+      expect(Trento.Infrastructure.Messaging.Adapter.Mock, :publish, fn Publisher,
+                                                                        "requests",
+                                                                        _ ->
+        {:error, :amqp_error}
+      end)
+
+      assert {:error, :amqp_error} =
+               Operations.request_operation(
+                 operation_id,
+                 group_id,
+                 operation,
+                 []
+               )
+    end
+  end
+end

--- a/test/trento/infrastructure/operations/processor_test.exs
+++ b/test/trento/infrastructure/operations/processor_test.exs
@@ -1,0 +1,106 @@
+defmodule Trento.Infrastructure.Operations.AMQP.ProcessorTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  use TrentoWeb.ChannelCase
+
+  alias Trento.Infrastructure.Operations.AMQP.Processor
+
+  alias Trento.Operations.V1.{
+    OperationCompleted,
+    OperationStarted
+  }
+
+  alias Trento.Contracts
+
+  describe "process" do
+    setup do
+      {:ok, _, _} =
+        TrentoWeb.UserSocket
+        |> socket("user_id", %{some: :assign})
+        |> subscribe_and_join(TrentoWeb.MonitoringChannel, "monitoring:operations")
+
+      :ok
+    end
+
+    test "should process OperationStarted and broadcast to the socket" do
+      operation_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+
+      operation_started =
+        Contracts.to_event(%OperationStarted{
+          operation_id: operation_id,
+          group_id: group_id,
+          operation_type: Faker.Lorem.word(),
+          targets: []
+        })
+
+      message = %GenRMQ.Message{payload: operation_started, attributes: %{}, channel: nil}
+
+      assert :ok = Processor.process(message)
+
+      assert_broadcast "operation_started",
+                       %{
+                         operation_id: ^operation_id,
+                         group_id: ^group_id,
+                         operation_type: :unknown
+                       },
+                       1000
+    end
+
+    test "should process OperationCompleted and broadcast to the socket" do
+      operation_id = UUID.uuid4()
+      group_id = UUID.uuid4()
+
+      operation_completed =
+        Contracts.to_event(%OperationCompleted{
+          operation_id: operation_id,
+          group_id: group_id,
+          operation_type: Faker.Lorem.word(),
+          result: :UPDATED
+        })
+
+      message = %GenRMQ.Message{payload: operation_completed, attributes: %{}, channel: nil}
+
+      assert :ok = Processor.process(message)
+
+      assert_broadcast "operation_completed",
+                       %{
+                         operation_id: ^operation_id,
+                         group_id: ^group_id,
+                         operation_type: :unknown,
+                         result: :UPDATED
+                       },
+                       1000
+    end
+
+    test "should map operation_type properly do" do
+      operations = [
+        %{
+          incoming_operation: "saptuneapplysolution@v1",
+          outgoing_operation: :saptune_solution_apply
+        }
+      ]
+
+      for %{incoming_operation: incoming, outgoing_operation: outgoing} <- operations do
+        operation_completed =
+          Contracts.to_event(%OperationCompleted{
+            operation_id: UUID.uuid4(),
+            group_id: UUID.uuid4(),
+            operation_type: incoming,
+            result: :UPDATED
+          })
+
+        message = %GenRMQ.Message{payload: operation_completed, attributes: %{}, channel: nil}
+
+        assert :ok = Processor.process(message)
+
+        assert_broadcast "operation_completed", %{operation_type: ^outgoing}, 1000
+      end
+    end
+
+    test "should return error if the event cannot be decoded" do
+      message = %GenRMQ.Message{payload: "bad-payload", attributes: %{}, channel: nil}
+      assert {:error, :decoding_error} = Processor.process(message)
+    end
+  end
+end

--- a/test/trento/support/protobuf_test.exs
+++ b/test/trento/support/protobuf_test.exs
@@ -1,0 +1,63 @@
+defmodule Trento.Support.Test do
+  @moduledoc false
+  use ExUnit.Case
+
+  alias Trento.Support.Protobuf
+
+  alias Google.Protobuf.{
+    ListValue,
+    Struct,
+    Value
+  }
+
+  test "from_map" do
+    assert %{
+             "boolean" => %Value{kind: {:bool_value, true}},
+             "integer" => %Value{kind: {:number_value, 10}},
+             "list" => %Value{
+               kind:
+                 {:list_value,
+                  %ListValue{
+                    values: [
+                      %Value{kind: {:string_value, "string"}},
+                      %Value{kind: {:number_value, 15}}
+                    ]
+                  }}
+             },
+             "map" => %Value{
+               kind:
+                 {:struct_value,
+                  %Struct{
+                    fields: %{
+                      "integer" => %Value{kind: {:number_value, 10}},
+                      "list" => %Value{
+                        kind:
+                          {:list_value,
+                           %ListValue{
+                             values: [
+                               %Value{kind: {:bool_value, true}},
+                               %Value{kind: {:null_value, :NULL_VALUE}}
+                             ]
+                           }}
+                      }
+                    }
+                  }}
+             },
+             "nil" => %Value{kind: {:null_value, :NULL_VALUE}},
+             "some_atom" => %Value{kind: {:string_value, "some_value"}},
+             "string" => %Value{kind: {:string_value, "some_string"}}
+           } ==
+             Protobuf.from_map(%{
+               "string" => "some_string",
+               :some_atom => :some_value,
+               "integer" => 10,
+               "boolean" => true,
+               "nil" => nil,
+               "list" => ["string", 15],
+               "map" => %{
+                 "list" => [true, nil],
+                 "integer" => 10
+               }
+             })
+  end
+end

--- a/test/trento_web/controllers/v1/host_controller_test.exs
+++ b/test/trento_web/controllers/v1/host_controller_test.exs
@@ -456,7 +456,7 @@ defmodule TrentoWeb.V1.HostControllerTest do
              } = resp
     end
 
-    test "should request saptune solution apply operation", %{conn: conn} do
+    test "should request saptune solution apply operation", %{conn: conn, api_spec: api_spec} do
       %{id: host_id} = insert(:host)
 
       expect(
@@ -473,6 +473,7 @@ defmodule TrentoWeb.V1.HostControllerTest do
         "solution" => "HANA"
       })
       |> json_response(:accepted)
+      |> assert_schema("OperationAccepted", api_spec)
     end
   end
 

--- a/test/trento_web/controllers/v1/host_controller_test.exs
+++ b/test/trento_web/controllers/v1/host_controller_test.exs
@@ -11,6 +11,7 @@ defmodule TrentoWeb.V1.HostControllerTest do
   alias Trento.Hosts.Commands.RequestHostDeregistration
 
   alias Trento.Infrastructure.Checks.AMQP.Publisher
+  alias Trento.Infrastructure.Operations.AMQP.Publisher, as: OperationsPublisher
 
   setup [:set_mox_from_context, :verify_on_exit!]
 
@@ -426,8 +427,45 @@ defmodule TrentoWeb.V1.HostControllerTest do
              } == resp
     end
 
+    test "should respond with 500 on messaging error", %{conn: conn} do
+      %{id: host_id} = insert(:host)
+
+      expect(
+        Trento.Infrastructure.Messaging.Adapter.Mock,
+        :publish,
+        fn OperationsPublisher, _, _ ->
+          {:error, :amqp_error}
+        end
+      )
+
+      resp =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/v1/hosts/#{host_id}/operations/saptune_solution_apply", %{
+          "solution" => "HANA"
+        })
+        |> json_response(:internal_server_error)
+
+      assert %{
+               "errors" => [
+                 %{
+                   "detail" => "Something went wrong.",
+                   "title" => "Internal Server Error"
+                 }
+               ]
+             } = resp
+    end
+
     test "should request saptune solution apply operation", %{conn: conn} do
       %{id: host_id} = insert(:host)
+
+      expect(
+        Trento.Infrastructure.Messaging.Adapter.Mock,
+        :publish,
+        fn OperationsPublisher, _, _ ->
+          :ok
+        end
+      )
 
       conn
       |> put_req_header("content-type", "application/json")


### PR DESCRIPTION
# Description

 - Request operation and send the event to wanda.
 - Process incoming operation events from wanda.

Wanda implementation: https://github.com/trento-project/wanda/pull/577

PD: forget about the API BC check. I just used a more appropriate response schema

## How was this tested?

UT
