### PR TITLE
Running operations redux

### DIFF
--- a/assets/js/lib/api/operations.js
+++ b/assets/js/lib/api/operations.js
@@ -1,0 +1,4 @@
+import { post } from '@lib/network';
+
+export const requestHostOperation = (hostID, operation, params) =>
+  post(`/hosts/${hostID}/operations/${operation}`, params);

--- a/assets/js/lib/operations/index.js
+++ b/assets/js/lib/operations/index.js
@@ -1,0 +1,31 @@
+import { get, noop } from 'lodash';
+
+import { requestHostOperation } from '@lib/api/operations';
+
+export const HOST_OPERATION = 'host';
+
+export const SAPTUNE_SOLUTION_APPLY = 'saptune_solution_apply';
+
+const OPERATION_LABELS = {
+  [SAPTUNE_SOLUTION_APPLY]: 'Apply Saptune solution',
+};
+
+const OPERATION_RESOURCE_TYPES = {
+  [SAPTUNE_SOLUTION_APPLY]: HOST_OPERATION,
+};
+
+const OPERATION_REQUEST_FUNCS = {
+  [HOST_OPERATION]: requestHostOperation,
+};
+
+export const getOperationLabel = (operation) =>
+  get(OPERATION_LABELS, operation, 'unknown');
+
+export const getOperationResourceType = (operation) =>
+  get(OPERATION_RESOURCE_TYPES, operation, 'unknown');
+
+export const getOperationRequestFunc = (resourceType) =>
+  get(OPERATION_REQUEST_FUNCS, resourceType, noop);
+
+export const operationSucceeded = (result) =>
+  ['UPDATED', 'NOT_UPDATED'].includes(result);

--- a/assets/js/lib/operations/operations.test.js
+++ b/assets/js/lib/operations/operations.test.js
@@ -1,0 +1,63 @@
+import { noop } from 'lodash';
+
+import { requestHostOperation } from '@lib/api/operations';
+
+import {
+  getOperationLabel,
+  getOperationResourceType,
+  getOperationRequestFunc,
+  operationSucceeded,
+} from '.';
+
+describe('operations', () => {
+  it.each([
+    {
+      operation: 'unknown',
+      label: 'unknown',
+    },
+    {
+      operation: 'saptune_solution_apply',
+      label: 'Apply Saptune solution',
+    },
+  ])(`should return the operation $operation label`, ({ operation, label }) => {
+    expect(getOperationLabel(operation)).toBe(label);
+  });
+
+  it.each([
+    {
+      operation: 'unknown',
+      resourceType: 'unknown',
+    },
+    {
+      operation: 'saptune_solution_apply',
+      resourceType: 'host',
+    },
+  ])(
+    `should return the operation $operation resource type`,
+    ({ operation, resourceType }) => {
+      expect(getOperationResourceType(operation)).toBe(resourceType);
+    }
+  );
+
+  it.each([
+    {
+      operation: 'unknown',
+      func: noop,
+    },
+    {
+      operation: 'host',
+      func: requestHostOperation,
+    },
+  ])(
+    `should return the operation $operation request function`,
+    ({ operation, func }) => {
+      expect(getOperationRequestFunc(operation)).toBe(func);
+    }
+  );
+
+  it('should check if an operation succeeded', () => {
+    expect(operationSucceeded('UPDATED')).toBeTruthy();
+    expect(operationSucceeded('NOT_UPDATED')).toBeTruthy();
+    expect(operationSucceeded('FAILED')).toBeFalsy();
+  });
+});

--- a/assets/js/state/index.js
+++ b/assets/js/state/index.js
@@ -14,6 +14,7 @@ import userReducer from './user';
 import softwareUpdatesReducer from './softwareUpdates';
 import activityLogsSettingsReducer from './activityLogsSettings';
 import activityLogReducer from './activityLog';
+import runningOperationsReducer from './runningOperations';
 import rootSaga from './sagas';
 
 export const createStore = (router) => {
@@ -38,6 +39,7 @@ export const createStore = (router) => {
       softwareUpdates: softwareUpdatesReducer,
       activityLogsSettings: activityLogsSettingsReducer,
       activityLog: activityLogReducer,
+      runningOperations: runningOperationsReducer,
     },
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware().concat(sagaMiddleware),

--- a/assets/js/state/runningOperations.js
+++ b/assets/js/state/runningOperations.js
@@ -1,0 +1,50 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+export const OPERATION_COMPLETED = 'OPERATION_COMPLETED';
+export const OPERATION_REQUESTED = 'OPERATION_REQUESTED';
+
+export const operationCompleted = ({
+  operationID,
+  groupID,
+  operation,
+  result,
+}) => ({
+  type: OPERATION_COMPLETED,
+  payload: { operationID, groupID, operation, result },
+});
+
+export const operationRequested = ({ groupID, operation, params }) => ({
+  type: OPERATION_REQUESTED,
+  payload: { groupID, operation, params },
+});
+
+const initialState = {};
+
+const initialOperationState = {
+  operation: null,
+};
+
+export const runningOperationsSlice = createSlice({
+  name: 'runningOperations',
+  initialState,
+  reducers: {
+    removeRunningOperation: (state, { payload }) => {
+      const { groupID } = payload;
+
+      delete state[groupID];
+    },
+    setRunningOperation: (state, { payload }) => {
+      const { groupID, operation } = payload;
+
+      state[groupID] = {
+        ...initialOperationState,
+        operation,
+      };
+    },
+  },
+});
+
+export const { removeRunningOperation, setRunningOperation } =
+  runningOperationsSlice.actions;
+
+export default runningOperationsSlice.reducer;

--- a/assets/js/state/runningOperations.test.js
+++ b/assets/js/state/runningOperations.test.js
@@ -1,0 +1,34 @@
+import { faker } from '@faker-js/faker';
+
+import runningOperationsReducer, {
+  removeRunningOperation,
+  setRunningOperation,
+} from './runningOperations';
+
+describe('runningOperations reducer', () => {
+  it('should remove a running operation', () => {
+    const groupID = faker.string.uuid();
+    const initialState = {
+      [groupID]: { operation: faker.lorem.word() },
+    };
+
+    const action = removeRunningOperation({ groupID });
+
+    expect(runningOperationsReducer(initialState, action)).toEqual({});
+  });
+
+  it('should set running an operation', () => {
+    const groupID = faker.string.uuid();
+    const operation = faker.lorem.word();
+    const initialState = {};
+    const expectedState = {
+      [groupID]: { operation },
+    };
+
+    const action = setRunningOperation({ groupID, operation });
+
+    expect(runningOperationsReducer(initialState, action)).toEqual(
+      expectedState
+    );
+  });
+});

--- a/assets/js/state/sagas/channels.js
+++ b/assets/js/state/sagas/channels.js
@@ -54,6 +54,8 @@ import {
   updateLastExecution,
 } from '@state/lastExecutions';
 
+import { operationCompleted } from '@state/runningOperations';
+
 import { userUpdated, userLocked, userDeleted } from '@state/user';
 import { activityLogUsersPushed } from '@state/activityLog';
 
@@ -222,6 +224,19 @@ const executionEvents = [
   },
 ];
 
+const operationEvents = [
+  {
+    name: 'operation_completed',
+    action: operationCompleted,
+    transform: ({
+      operation_id: operationID,
+      group_id: groupID,
+      operation_type: operation,
+      result,
+    }) => ({ operationID, groupID, operation, result }),
+  },
+];
+
 const userEvents = [
   {
     name: 'user_updated',
@@ -288,6 +303,7 @@ export function* watchSocketEvents(socket) {
     fork(watchChannelEvents, socket, 'monitoring:sap_systems', sapSystemEvents),
     fork(watchChannelEvents, socket, 'monitoring:databases', databaseEvents),
     fork(watchChannelEvents, socket, 'monitoring:executions', executionEvents),
+    fork(watchChannelEvents, socket, 'monitoring:operations', operationEvents),
     fork(watchChannelEvents, socket, `users:${userID}`, userEvents),
     fork(
       watchChannelEvents,

--- a/assets/js/state/sagas/index.js
+++ b/assets/js/state/sagas/index.js
@@ -80,6 +80,7 @@ import { watchSoftwareUpdates } from '@state/sagas/softwareUpdates';
 import { watchSocketEvents } from '@state/sagas/channels';
 import { watchActivityLogActions } from '@state/sagas/activityLog';
 import { checkApiKeyExpiration } from '@state/sagas/settings';
+import { watchOperationEvents } from '@state/sagas/operations';
 
 const RESET_STATE = 'RESET_STATE';
 
@@ -241,5 +242,6 @@ export default function* rootSaga() {
     watchActivityLogsSettings(),
     watchSoftwareUpdates(),
     watchActivityLogActions(),
+    watchOperationEvents(),
   ]);
 }

--- a/assets/js/state/sagas/operations.js
+++ b/assets/js/state/sagas/operations.js
@@ -1,0 +1,88 @@
+import { call, put, select, takeEvery } from 'redux-saga/effects';
+
+import {
+  HOST_OPERATION,
+  getOperationLabel,
+  getOperationResourceType,
+  getOperationRequestFunc,
+  operationSucceeded,
+} from '@lib/operations';
+import { notify } from '@state/notifications';
+import {
+  OPERATION_COMPLETED,
+  OPERATION_REQUESTED,
+  removeRunningOperation,
+  setRunningOperation,
+} from '@state/runningOperations';
+import { getHost } from '@state/selectors/host';
+
+function* getResourceName({ groupID, resourceType }) {
+  switch (resourceType) {
+    case HOST_OPERATION:
+      return (yield select(getHost(groupID)))?.hostname || 'unknown';
+    default:
+      return 'unknown';
+  }
+}
+
+export function* requestOperation({ payload }) {
+  const { groupID, operation, params } = payload;
+
+  const operationName = getOperationLabel(operation);
+  const operationResourceType = getOperationResourceType(operation);
+  const requestFunc = getOperationRequestFunc(operationResourceType);
+  const resourceName = yield call(getResourceName, {
+    groupID,
+    resourceType: operationResourceType,
+  });
+  yield put(setRunningOperation({ groupID, operation }));
+  try {
+    yield call(requestFunc, groupID, operation, params);
+    yield put(
+      notify({
+        text: `Operation ${operationName} requested for ${resourceName}`,
+        icon: '⚙️',
+      })
+    );
+  } catch {
+    yield put(removeRunningOperation({ groupID }));
+    yield put(
+      notify({
+        text: `Operation ${operationName} request for ${resourceName} failed`,
+        icon: '❌',
+      })
+    );
+  }
+}
+
+export function* completeOperation({ payload }) {
+  const { groupID, operation, result } = payload;
+
+  const operationName = getOperationLabel(operation);
+  const operationResourceType = getOperationResourceType(operation);
+  const resourceName = yield call(getResourceName, {
+    groupID,
+    resourceType: operationResourceType,
+  });
+  yield put(removeRunningOperation({ groupID }));
+  if (operationSucceeded(result)) {
+    yield put(
+      notify({
+        text: `Operation ${operationName} succeeded for ${resourceName}`,
+        icon: '✅',
+      })
+    );
+  } else {
+    yield put(
+      notify({
+        text: `Operation ${operationName} failed for  ${resourceName}`,
+        icon: '❌',
+      })
+    );
+  }
+}
+
+export function* watchOperationEvents() {
+  yield takeEvery(OPERATION_COMPLETED, completeOperation);
+  yield takeEvery(OPERATION_REQUESTED, requestOperation);
+}

--- a/assets/js/state/sagas/operations.test.js
+++ b/assets/js/state/sagas/operations.test.js
@@ -1,0 +1,122 @@
+import MockAdapter from 'axios-mock-adapter';
+import { faker } from '@faker-js/faker';
+
+import { recordSaga } from '@lib/test-utils';
+import { networkClient } from '@lib/network';
+
+import {
+  removeRunningOperation,
+  setRunningOperation,
+} from '@state/runningOperations';
+import { notify } from '@state/notifications';
+
+import { requestOperation, completeOperation } from './operations';
+
+const axiosMock = new MockAdapter(networkClient);
+const hostOperationRequestURL = (hostID, operation) =>
+  `/hosts/${hostID}/operations/${operation}`;
+
+describe('operations saga', () => {
+  beforeEach(() => {
+    axiosMock.reset();
+    jest.spyOn(console, 'error').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    /* eslint-disable-next-line */
+    console.error.mockRestore();
+  });
+
+  it('should request an operation', async () => {
+    const groupID = faker.string.uuid();
+    const operation = faker.lorem.word();
+    const hostname = faker.internet.displayName();
+
+    axiosMock.onGet(hostOperationRequestURL(groupID)).reply(202, {});
+
+    const dispatched = await recordSaga(
+      requestOperation,
+      {
+        payload: { groupID, operation },
+      },
+      { hostsList: [{ id: groupID, hostname }] }
+    );
+
+    expect(dispatched).toContainEqual(
+      setRunningOperation({ groupID, operation }),
+      notify({
+        text: `Operation ${operation} requested for ${hostname}`,
+        icon: '⚙️',
+      })
+    );
+  });
+
+  it('should fail requesting an operation if the api request fails', async () => {
+    const groupID = faker.string.uuid();
+    const operation = faker.lorem.word();
+    const hostname = faker.internet.displayName();
+
+    axiosMock.onGet(hostOperationRequestURL(groupID)).reply(404, {});
+
+    const dispatched = await recordSaga(
+      requestOperation,
+      {
+        payload: { groupID, operation },
+      },
+      { hostsList: [{ id: groupID, hostname }] }
+    );
+
+    expect(dispatched).toContainEqual(
+      setRunningOperation({ groupID, operation }),
+      removeRunningOperation({ groupID }),
+      notify({
+        text: `Operation ${operation} request for ${hostname} failed`,
+        icon: '❌',
+      })
+    );
+  });
+
+  it('should complete successfully an operation', async () => {
+    const groupID = faker.string.uuid();
+    const operation = faker.lorem.word();
+    const hostname = faker.internet.displayName();
+
+    const dispatched = await recordSaga(
+      completeOperation,
+      {
+        payload: { groupID, operation, result: 'UPDATED' },
+      },
+      { hostsList: [{ id: groupID, hostname }] }
+    );
+
+    expect(dispatched).toContainEqual(
+      removeRunningOperation({ groupID }),
+      notify({
+        text: `Operation ${operation} succeeded for ${hostname}`,
+        icon: '✅',
+      })
+    );
+  });
+
+  it('should complete an operation with a failed result', async () => {
+    const groupID = faker.string.uuid();
+    const operation = faker.lorem.word();
+    const hostname = faker.internet.displayName();
+
+    const dispatched = await recordSaga(
+      completeOperation,
+      {
+        payload: { groupID, operation, result: 'FAILED' },
+      },
+      { hostsList: [{ id: groupID, hostname }] }
+    );
+
+    expect(dispatched).toContainEqual(
+      removeRunningOperation({ groupID }),
+      notify({
+        text: `Operation ${operation} failed for ${hostname}`,
+        icon: '❌',
+      })
+    );
+  });
+});


### PR DESCRIPTION
# Description

Add redux logic to handle running operations. As the completion of operations is async, we need to keep the data in redux, so we can complete an operation once we receive the result from the backend in a websocket message.

The PR implements the redux state and saga code. Now, we can dispatch the operation from the frontend using these utils.

It doesn't handle yet the Forbidden operation use case. I'm still touching a bit that part, so I will send the code later on.

I will create other PR with components usage and redux selector.

## How was this tested?
UT
