### PR TITLE
Add operations button host view

### DIFF
--- a/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { faker } from '@faker-js/faker';
 import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model/sapSystems';
+import { SAPTUNE_SOLUTION_APPLY } from '@lib/operations';
 
 import {
   clusterFactory,
@@ -142,6 +143,15 @@ export default {
       control: 'array',
       description: 'Current user abilities',
     },
+    operationsEnabled: {
+      control: { type: 'boolean' },
+      description:
+        'Operations framework enabled. Remove once it is ready to release',
+    },
+    runningOperation: {
+      control: 'object',
+      description: 'Currently running operation data',
+    },
     cleanUpHost: {
       action: 'Deregister host',
       description: 'Deregister host',
@@ -149,6 +159,10 @@ export default {
     requestHostChecksExecution: {
       action: 'Request host execution',
       description: 'Request checks execution',
+    },
+    requestOperation: {
+      action: 'Request operation',
+      description: 'Request operation',
     },
     navigate: {
       description: 'Navigate function',
@@ -206,6 +220,8 @@ export const Default = {
     selectedChecks: [],
     slesSubscriptions: host.sles_subscriptions,
     userAbilities: [{ name: 'all', resource: 'all' }],
+    operationsEnabled: true,
+    runningOperations: {},
   },
 };
 
@@ -309,5 +325,22 @@ export const WithSoftwareUpdatesFailed = {
     upgradablePackages: undefined,
     softwareUpdatesErrorMessage: 'Connection to SUMA not working',
     softwareUpdatesTooltip: 'Please review SUSE Manager settings',
+  },
+};
+
+export const WithRunningOperation = {
+  args: {
+    ...Default.args,
+    runningOperation: { operation: SAPTUNE_SOLUTION_APPLY },
+  },
+};
+
+export const WithDisabledOperation = {
+  args: {
+    ...Default.args,
+    saptuneStatus: {
+      package_version: '3.0.0',
+      enabled_solution: 'HANA',
+    },
   },
 };

--- a/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { act, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import 'intersection-observer';
 import '@testing-library/jest-dom';
@@ -8,8 +8,14 @@ import { networkClient } from '@lib/network';
 import MockAdapter from 'axios-mock-adapter';
 
 import { renderWithRouter } from '@lib/test-utils';
-import { hostFactory, saptuneStatusFactory } from '@lib/test-utils/factories';
+import {
+  hostFactory,
+  saptuneStatusFactory,
+  databaseInstanceFactory,
+} from '@lib/test-utils/factories';
 import { TUNING_VALUES } from '@pages/SaptuneDetails/SaptuneDetails.test';
+import { DATABASE_TYPE } from '@lib/model/sapSystems';
+import { SAPTUNE_SOLUTION_APPLY } from '@lib/operations';
 
 import HostDetails from './HostDetails';
 
@@ -378,6 +384,107 @@ describe('HostDetails component', () => {
       expect(
         screen.getByText('No check results available.')
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('operations', () => {
+    it('should run Saptune apply operation when clicking apply button in modal', async () => {
+      const user = userEvent.setup();
+      const mockRequestSolution = jest.fn();
+      const sapInstances = databaseInstanceFactory
+        .buildList(1)
+        .map((instance) => ({ ...instance, type: DATABASE_TYPE }));
+
+      renderWithRouter(
+        <HostDetails
+          agentVersion="2.0.0"
+          userAbilities={userAbilities}
+          operationsEnabled
+          requestOperation={mockRequestSolution}
+          sapInstances={sapInstances}
+        />
+      );
+
+      const operationsButton = screen.getByRole('button', {
+        name: 'Operations',
+      });
+      await user.click(operationsButton);
+
+      const menuItem = screen.getByRole('menuitem', {
+        name: 'Apply Saptune Solution',
+      });
+      await user.click(menuItem);
+
+      const selectSolution = screen.getByText('Select a saptune solution');
+      expect(selectSolution).toBeDisabled();
+
+      const checkbox = screen.getByRole('checkbox');
+      await user.click(checkbox);
+
+      const selectSolutionEnabled = screen.getByText(
+        'Select a saptune solution'
+      );
+      expect(selectSolutionEnabled).toBeEnabled();
+
+      await user.click(selectSolutionEnabled);
+
+      const hanaSolution = screen.getByRole('option', { name: 'HANA'});
+      await user.click(hanaSolution);
+
+      const apply = screen.getByRole('button', { name: 'Apply' });
+      await user.click(apply);
+
+      expect(mockRequestSolution).toHaveBeenCalledWith({ solution: 'HANA' });
+    });
+
+    it('should show Saptune apply operation running', async () => {
+      const user = userEvent.setup();
+
+      renderWithRouter(
+        <HostDetails
+          agentVersion="2.0.0"
+          userAbilities={userAbilities}
+          operationsEnabled
+          runningOperation={{ operation: SAPTUNE_SOLUTION_APPLY }}
+        />
+      );
+
+      const operationsButton = screen.getByRole('button', {
+        name: 'Operations',
+      });
+      await user.click(operationsButton);
+
+      const menuItem = screen.getByRole('menuitem', {
+        name: 'Apply Saptune Solution',
+      });
+      expect(menuItem).toBeDisabled();
+
+      const { getByTestId } = within(menuItem);
+
+      expect(getByTestId('eos-svg-component')).toBeInTheDocument();
+    });
+
+    it('should show Saptune apply operation disabled', async () => {
+      const user = userEvent.setup();
+
+      renderWithRouter(
+        <HostDetails
+          agentVersion="2.0.0"
+          userAbilities={userAbilities}
+          operationsEnabled
+        />
+      );
+
+      const operationsButton = screen.getByRole('button', {
+        name: 'Operations',
+      });
+      await user.click(operationsButton);
+
+      expect(
+        screen.getByRole('menuitem', {
+          name: 'Apply Saptune Solution',
+        })
+      ).toBeDisabled();
     });
   });
 

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -19,6 +19,7 @@ import {
   getSoftwareUpdatesStats,
   getSoftwareUpdatesErrors,
 } from '@state/selectors/softwareUpdates';
+import { getRunningOperation } from '@state/selectors/runningOperations';
 
 import { getHost, getHostSelectedChecks } from '@state/selectors/host';
 import { isSaving } from '@state/selectors/checksSelection';
@@ -27,6 +28,7 @@ import {
   updateLastExecution,
   hostExecutionRequested,
 } from '@state/lastExecutions';
+import { operationRequested } from '@state/runningOperations';
 
 import { deregisterHost } from '@state/hosts';
 import { fetchSoftwareUpdates } from '@state/softwareUpdates';
@@ -38,6 +40,7 @@ import {
 import HostDetails from './HostDetails';
 
 const chartsEnabled = getFromConfig('chartsEnabled');
+const operationsEnabled = getFromConfig('operationsEnabled');
 
 function HostDetailsPage() {
   const { hostID } = useParams();
@@ -83,6 +86,8 @@ function HostDetailsPage() {
   const softwareUpdatesTooltip = getSoftwareUpdatesErrorTooltip(
     softwareUpdatesErrors
   );
+
+  const runningOperation = useSelector(getRunningOperation(hostID));
 
   const getExportersStatus = async () => {
     const { data } = await networkClient.get(
@@ -139,12 +144,17 @@ function HostDetailsPage() {
       softwareUpdatesErrorMessage={softwareUpdatesErrorMessage}
       softwareUpdatesTooltip={softwareUpdatesTooltip}
       userAbilities={abilities}
+      operationsEnabled={operationsEnabled}
+      runningOperation={runningOperation}
       cleanUpHost={() => {
         dispatch(deregisterHost({ id: hostID, hostname: host.hostname }));
       }}
       requestHostChecksExecution={() => {
         dispatch(hostExecutionRequested(host, hostSelectedChecks, navigate));
       }}
+      requestOperation={(operation, params) =>
+        dispatch(operationRequested({ groupID: hostID, operation, params }))
+      }
       navigate={navigate}
     />
   );

--- a/assets/js/state/selectors/runningOperations.js
+++ b/assets/js/state/selectors/runningOperations.js
@@ -1,0 +1,9 @@
+import { createSelector } from '@reduxjs/toolkit';
+import { get } from 'lodash';
+
+const getRunningOperations = ({ runningOperations }) => runningOperations;
+
+export const getRunningOperation = (groupID) =>
+  createSelector([getRunningOperations], (runningOperations) =>
+    get(runningOperations, groupID, {})
+  );

--- a/assets/js/state/selectors/runningOperations.test.js
+++ b/assets/js/state/selectors/runningOperations.test.js
@@ -1,0 +1,25 @@
+import { faker } from '@faker-js/faker';
+
+import { getRunningOperation } from './runningOperations';
+
+describe('runningOperations selector', () => {
+  it('should return the running operation by group ID', () => {
+    const groupID = faker.string.uuid();
+    const operation = faker.animal.bear();
+
+    const state = {
+      runningOperations: {
+        [groupID]: {
+          operation,
+        },
+      },
+    };
+
+    const expectedState = {
+      operation,
+    };
+
+    expect(getRunningOperation(groupID)(state)).toEqual(expectedState);
+    expect(getRunningOperation(faker.string.uuid())(state)).toEqual({});
+  });
+});

--- a/lib/trento_web/controllers/page_controller.ex
+++ b/lib/trento_web/controllers/page_controller.ex
@@ -12,6 +12,7 @@ defmodule TrentoWeb.PageController do
     analytics_enabled = Application.fetch_env!(:trento, :analytics)[:enabled]
     analytics_key = Application.fetch_env!(:trento, :analytics)[:analytics_key]
     analytics_url = Application.fetch_env!(:trento, :analytics)[:analytics_url]
+    operations_enabled = Application.fetch_env!(:trento, :operations_enabled)
 
     {sso_enabled, callback_url, login_url, enrollment_url} = sso_details(conn)
 
@@ -28,6 +29,7 @@ defmodule TrentoWeb.PageController do
       sso_login_url: login_url,
       sso_callback_url: callback_url,
       sso_enrollment_url: enrollment_url,
+      operations_enabled: operations_enabled,
       layout: false
     )
   end

--- a/lib/trento_web/controllers/page_html/index.html.heex
+++ b/lib/trento_web/controllers/page_html/index.html.heex
@@ -14,7 +14,7 @@
       ssoLoginUrl: '<%= raw @sso_login_url %>',
       ssoCallbackUrl: '<%= raw @sso_callback_url %>',
       ssoEnrollmentUrl: '<%= raw @sso_enrollment_url %>',
-      operationsEnabled: '<%= @operations_enabled %>'
+      operationsEnabled: <%= @operations_enabled %>
   };
 </script>
 

--- a/lib/trento_web/controllers/page_html/index.html.heex
+++ b/lib/trento_web/controllers/page_html/index.html.heex
@@ -13,7 +13,8 @@
       ssoEnabled: <%= @sso_enabled %>,
       ssoLoginUrl: '<%= raw @sso_login_url %>',
       ssoCallbackUrl: '<%= raw @sso_callback_url %>',
-      ssoEnrollmentUrl: '<%= raw @sso_enrollment_url %>'
+      ssoEnrollmentUrl: '<%= raw @sso_enrollment_url %>',
+      operationsEnabled: '<%= @operations_enabled %>'
   };
 </script>
 


### PR DESCRIPTION
# Description

Add operations buttion and Saptune solution apply modal to the host details view.
I added a selector function to get the data from redux, so we can put the solution in running state from there.
The disabled option is simple function checking if saptune is not set and the host has SAP instances.

I have passed the `operationsEnabled` from the backend, so we only display the operations button in dev.

## How was this tested?

UT and storybook
