### PR TITLE
Checks customization modal save

### DIFF
--- a/assets/js/common/CheckCustomizationModal/CheckCustomizationInput.jsx
+++ b/assets/js/common/CheckCustomizationModal/CheckCustomizationInput.jsx
@@ -85,7 +85,7 @@ function CheckCustomizationInput({
   return (
     <div
       key={`${name}_${currentValue}`}
-      className="flex items-center space-x-2 mb-8"
+      className="flex items-center space-x-2 mb-5"
     >
       <div className="flex-col w-1/3 min-w-[200px]">
         {renderLabel(name, defaultCheckValue)}

--- a/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.jsx
+++ b/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.jsx
@@ -15,14 +15,13 @@ import CheckCustomizationInput from './CheckCustomizationInput';
 const checkBoxWarningText =
   'Trento & SUSE cannot be held liable for damages if system is unable to function due to custom check value.';
 
-const buildCustomCheckPayload = (checkID, values) => {
-  const payload = {
-    checksID: checkID,
-    customValues: values,
-  };
-  return payload;
-};
-
+const buildCustomCheckPayload = (checksID, values) => ({
+  checksID,
+  customValues: Object.entries(values).map(([name, value]) => ({
+    name,
+    value,
+  })),
+});
 const appliedValue = (value) => value?.custom_value ?? value?.current_value;
 
 const detectType = (value) => {
@@ -115,8 +114,8 @@ function CheckCustomizationModal({
           className="w-1/2"
           disabled={!canSave}
           onClick={() => {
-            onSave(buildCustomCheckPayload(id, customValues));
             resetStateAndClose();
+            onSave(buildCustomCheckPayload(id, customValues));
           }}
         >
           Save

--- a/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.jsx
+++ b/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { noop, isBoolean, toNumber, isEmpty } from 'lodash';
+import { noop, isBoolean, toNumber, isEmpty, map } from 'lodash';
 
 import Modal from '@common/Modal';
 import Button from '@common/Button';
@@ -15,9 +15,10 @@ import CheckCustomizationInput from './CheckCustomizationInput';
 const checkBoxWarningText =
   'Trento & SUSE cannot be held liable for damages if system is unable to function due to custom check value.';
 
-const buildCustomCheckPayload = (checksID, values) => ({
-  checksID,
-  customValues: Object.entries(values).map(([name, value]) => ({
+const buildCustomCheckPayload = (checkID, groupID, values) => ({
+  checkID,
+  groupID,
+  customValues: map(values, (value, name) => ({
     name,
     value,
   })),
@@ -35,6 +36,7 @@ const detectType = (value) => {
 function CheckCustomizationModal({
   open = false,
   id,
+  groupID,
   values,
   description,
   provider = UNKNOWN_PROVIDER,
@@ -49,7 +51,6 @@ function CheckCustomizationModal({
   const canSave = !isEmpty(customValues) && canCustomize;
 
   const checkTitle = `Check: ${id}`;
-
   const resetStateAndClose = () => {
     setCustomValues({});
     setChecked(false);
@@ -115,7 +116,7 @@ function CheckCustomizationModal({
           disabled={!canSave}
           onClick={() => {
             resetStateAndClose();
-            onSave(buildCustomCheckPayload(id, customValues));
+            onSave(buildCustomCheckPayload(id, groupID, customValues));
           }}
         >
           Save

--- a/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.stories.jsx
+++ b/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.stories.jsx
@@ -89,6 +89,10 @@ export default {
       description: 'Check ID',
       control: 'text',
     },
+    groupID: {
+      description: 'Target ID',
+      control: 'text',
+    },
     values: {
       description: 'Check values',
       control: 'array',

--- a/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.test.jsx
+++ b/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.test.jsx
@@ -6,6 +6,14 @@ import {
   selectableCheckFactory,
   nonCustomizedValueFactory,
 } from '@lib/test-utils/factories';
+
+import {
+  READY,
+  ONGOING,
+  INVALID_VALUES,
+  GENERIC_FAILURE,
+} from '@pages/ChecksSelection/hooks';
+
 import CheckCustomizationModal from './CheckCustomizationModal';
 
 const mockOnClose = jest.fn();
@@ -44,6 +52,7 @@ const checkCustomizationModalProps = {
   onClose: mockOnClose,
   onSave: mockOnSave,
   onReset: mockOnReset,
+  customizationStatus: READY,
 };
 
 describe('CheckCustomizationModal', () => {
@@ -78,7 +87,7 @@ describe('CheckCustomizationModal', () => {
     expect(mockOnClose).toHaveBeenCalled();
   });
 
-  it('renders the modal  with multiple customizable values', async () => {
+  it('renders the modal with multiple customizable values', async () => {
     const user = userEvent.setup();
     const customCheckValue = ['999', 'veryImportantValue', false];
     const expectedCheckValues = [999, 'veryImportantValue', false];
@@ -112,15 +121,11 @@ describe('CheckCustomizationModal', () => {
     expect(inputElements[2]).toBeDisabled(); // Provider is always disabled
 
     await user.click(screen.getByText('Save'));
-    expect(onSave).toHaveBeenCalledWith({
-      checkID: '123',
-      customValues: [
-        { name: 'CheckIntValueName', value: expectedCheckValues[0] },
-        { name: 'CheckStringValueName', value: expectedCheckValues[1] },
-        { name: 'CheckBoolValueName', value: expectedCheckValues[2] },
-      ],
-      groupID: '123456789',
-    });
+    expect(onSave).toHaveBeenCalledWith('123', '123456789', [
+      { name: 'CheckIntValueName', value: expectedCheckValues[0] },
+      { name: 'CheckStringValueName', value: expectedCheckValues[1] },
+      { name: 'CheckBoolValueName', value: expectedCheckValues[2] },
+    ]);
   });
 
   it('renders the modal with partial customizable values', async () => {
@@ -162,13 +167,9 @@ describe('CheckCustomizationModal', () => {
     await user.type(inputElements[0], customCheckValue[0]);
 
     await user.click(screen.getByText('Save'));
-    expect(onSave).toHaveBeenCalledWith({
-      checkID: '123',
-      customValues: [
-        { name: customCheckNames[0], value: expectedCustomCheckValue },
-      ],
-      groupID: '123456789',
-    });
+    expect(onSave).toHaveBeenCalledWith('123', '123456789', [
+      { name: customCheckNames[0], value: expectedCustomCheckValue },
+    ]);
   });
 
   it('should disable reset customization button if check is not customized', async () => {
@@ -191,5 +192,42 @@ describe('CheckCustomizationModal', () => {
 
     await user.click(screen.getByText('Reset Check'));
     expect(onReset).toHaveBeenCalled();
+  });
+
+  it.each`
+    customizationStatus | expectedMessage
+    ${READY}            | ${null}
+    ${ONGOING}          | ${null}
+    ${INVALID_VALUES}   | ${'Some of the values are invalid. Please correct them and try again'}
+    ${GENERIC_FAILURE}  | ${'An error occurred while saving custom values'}
+  `(
+    'should show error message when customization status is failed',
+    async ({ customizationStatus, expectedMessage }) => {
+      await act(async () => {
+        render(
+          <CheckCustomizationModal
+            {...checkCustomizationModalProps}
+            customizationStatus={customizationStatus}
+          />
+        );
+      });
+
+      expectedMessage
+        ? expect(screen.getByText(expectedMessage)).toBeVisible()
+        : expect(screen.queryByTestId('error-message')).toBeNull();
+    }
+  );
+
+  it('should not allow saving customization while another one is ongoing', async () => {
+    await act(async () => {
+      render(
+        <CheckCustomizationModal
+          {...checkCustomizationModalProps}
+          customizationStatus={ONGOING}
+        />
+      );
+    });
+
+    expect(screen.getByText('Save')).toBeDisabled();
   });
 });

--- a/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.test.jsx
+++ b/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.test.jsx
@@ -40,6 +40,7 @@ const checkCustomizationModalProps = {
   ...check,
   open: true,
   provider: 'aws',
+  groupID: '123456789',
   onClose: mockOnClose,
   onSave: mockOnSave,
   onReset: mockOnReset,
@@ -112,12 +113,13 @@ describe('CheckCustomizationModal', () => {
 
     await user.click(screen.getByText('Save'));
     expect(onSave).toHaveBeenCalledWith({
-      checksID: '123',
-      customValues: {
-        CheckIntValueName: expectedCheckValues[0],
-        CheckStringValueName: expectedCheckValues[1],
-        CheckBoolValueName: expectedCheckValues[2],
-      },
+      checkID: '123',
+      customValues: [
+        { name: 'CheckIntValueName', value: expectedCheckValues[0] },
+        { name: 'CheckStringValueName', value: expectedCheckValues[1] },
+        { name: 'CheckBoolValueName', value: expectedCheckValues[2] },
+      ],
+      groupID: '123456789',
     });
   });
 
@@ -161,8 +163,11 @@ describe('CheckCustomizationModal', () => {
 
     await user.click(screen.getByText('Save'));
     expect(onSave).toHaveBeenCalledWith({
-      checksID: '123',
-      customValues: { [customCheckNames[0]]: expectedCustomCheckValue },
+      checkID: '123',
+      customValues: [
+        { name: customCheckNames[0], value: expectedCustomCheckValue },
+      ],
+      groupID: '123456789',
     });
   });
 

--- a/assets/js/lib/api/checks.js
+++ b/assets/js/lib/api/checks.js
@@ -26,7 +26,7 @@ export const getChecksSelection = (groupID, env) =>
     params: env,
   });
 
-export const saveCheckCustomization = ({ checkID, groupID, customValues }) =>
+export const saveCheckCustomization = (checkID, groupID, customValues) =>
   networkClient.post(
     `/api/v1/groups/${groupID}/checks/${checkID}/customization`,
     { values: customValues },

--- a/assets/js/lib/api/checks.js
+++ b/assets/js/lib/api/checks.js
@@ -26,16 +26,12 @@ export const getChecksSelection = (groupID, env) =>
     params: env,
   });
 
-export const saveCheckCustomization = (values) => {
-  const { checkID, groupID, customValues } = values;
-  const customValuesPayload = { values: customValues };
-
-  return networkClient.post(
+export const saveCheckCustomization = ({ checkID, groupID, customValues }) =>
+  networkClient.post(
     `/api/v1/groups/${groupID}/checks/${checkID}/customization`,
-    customValuesPayload,
+    { values: customValues },
     defaultConfig
   );
-};
 
 export const resetCheckCustomization = (groupID, checkID) =>
   networkClient.delete(

--- a/assets/js/lib/api/checks.js
+++ b/assets/js/lib/api/checks.js
@@ -26,6 +26,17 @@ export const getChecksSelection = (groupID, env) =>
     params: env,
   });
 
+export const saveCheckCustomization = (values) => {
+  const { checkID, groupID, customValues } = values;
+  const customValuesPayload = { values: customValues };
+
+  return networkClient.post(
+    `/api/v1/groups/${groupID}/checks/${checkID}/customization`,
+    customValuesPayload,
+    defaultConfig
+  );
+};
+
 export const resetCheckCustomization = (groupID, checkID) =>
   networkClient.delete(
     `/api/v1/groups/${groupID}/checks/${checkID}/customization`,

--- a/assets/js/pages/ChecksSelection/ChecksSelection.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelection.jsx
@@ -129,6 +129,7 @@ function ChecksSelection({
         <CheckCustomizationModal
           open={isCheckCustomizationModalOpen}
           id={selectedCheck?.id}
+          groupID={groupID}
           values={selectedCheck?.values}
           description={selectedCheck?.description}
           customized={selectedCheck?.customized}

--- a/assets/js/pages/ChecksSelection/ChecksSelection.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelection.jsx
@@ -27,20 +27,19 @@ const getGroupSelectedState = (checks, selectedChecks) => {
   return NONE_CHECKED;
 };
 
-const defaultSelectedChecks = [];
 const defaultAbilities = [];
 
 function ChecksSelection({
   groupID,
   catalog,
-  selectedChecks = defaultSelectedChecks,
+  selectedChecks = [],
   loading = false,
   catalogError,
   userAbilities = defaultAbilities,
   onUpdateCatalog,
   onChange,
   provider,
-  saveCustomCheck = () => {},
+  saveCustomCheck = noop,
   onResetCheckCustomization = noop,
 }) {
   const [isCheckCustomizationModalOpen, setIsCheckCustomizationModalOpen] =
@@ -76,7 +75,6 @@ function ChecksSelection({
       onChange(uniq([...selectedChecks, ...groupChecks]));
     }
   };
-
   return (
     <CatalogContainer
       onRefresh={onUpdateCatalog}
@@ -134,7 +132,6 @@ function ChecksSelection({
           values={selectedCheck?.values}
           description={selectedCheck?.description}
           customized={selectedCheck?.customized}
-          selectedCheck={selectedCheck}
           provider={provider}
           onClose={() => setIsCheckCustomizationModalOpen(false)}
           onSave={saveCustomCheck}

--- a/assets/js/pages/ChecksSelection/ChecksSelection.stories.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelection.stories.jsx
@@ -2,6 +2,7 @@ import { faker } from '@faker-js/faker';
 import { selectableCheckFactory } from '@lib/test-utils/factories';
 
 import ChecksSelection from './ChecksSelection';
+import { CUSTOMIZATION_STATUSES } from './hooks';
 
 const catalog = [
   selectableCheckFactory.build({ group: 'Corosync', customized: true }),
@@ -29,6 +30,10 @@ export default {
     groupID: {
       type: 'string',
       description: 'The ID of the group to which the selection refers to.',
+    },
+    provider: {
+      type: 'string',
+      description: 'Provider of the current checkable target',
     },
     catalog: {
       control: 'object',
@@ -72,6 +77,22 @@ export default {
       description:
         'Gets called when the selection changes. Used to propagate the new selected checks by the user.',
     },
+    onSaveCheckCustomization: {
+      action: 'Save check customization',
+      description: 'Gets called when the user saves a customization.',
+    },
+    onResetCheckCustomization: {
+      action: 'Reset check customization',
+      description: 'Gets called when the user resets a customization.',
+    },
+    customizationStatus: {
+      type: 'enum',
+      description: 'Current customization status',
+      options: CUSTOMIZATION_STATUSES,
+      control: {
+        type: 'radio',
+      },
+    },
   },
 };
 
@@ -80,6 +101,7 @@ export const Default = {
     groupID: faker.string.uuid(),
     catalog,
     userAbilities: [{ name: 'all', resource: 'check_customization' }],
+    provider: 'aws',
   },
 };
 

--- a/assets/js/pages/ChecksSelection/ChecksSelectionItem.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelectionItem.jsx
@@ -55,9 +55,7 @@ function ChecksSelectionItem({
               {canReset(userAbilities, customizable, customized) && (
                 <button
                   type="button"
-                  onClick={() => {
-                    onResetCustomization(checkID);
-                  }}
+                  onClick={onResetCustomization}
                   aria-label="reset-check-customization"
                   className="inline mr-2"
                 >
@@ -67,9 +65,7 @@ function ChecksSelectionItem({
               {canCustomize(userAbilities, customizable) && (
                 <button
                   type="button"
-                  onClick={() => {
-                    onCustomize(checkID);
-                  }}
+                  onClick={onCustomize}
                   aria-label="customize-check"
                   className="inline mr-4"
                 >

--- a/assets/js/pages/ChecksSelection/ChecksSelectionItem.test.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelectionItem.test.jsx
@@ -166,7 +166,7 @@ describe('Checks Customizability', () => {
     );
 
     await user.click(screen.getByLabelText('customize-check'));
-    expect(onCustomize).toHaveBeenCalledWith(check.id);
+    expect(onCustomize).toHaveBeenCalled();
   });
 
   it('should run the onResetCustomization function when the reset button is clicked', async () => {
@@ -190,6 +190,6 @@ describe('Checks Customizability', () => {
     );
 
     await user.click(screen.getByLabelText('reset-check-customization'));
-    expect(onResetCustomization).toHaveBeenCalledWith(check.id);
+    expect(onResetCustomization).toHaveBeenCalled();
   });
 });

--- a/assets/js/pages/ChecksSelection/hooks.js
+++ b/assets/js/pages/ChecksSelection/hooks.js
@@ -26,7 +26,6 @@ const saveValuesCustomizations = (check, customValues) => ({
   values: check.values.map((value, index) => ({
     ...value,
     custom_value: customValues[index].value,
-    customized: true,
   })),
 });
 

--- a/assets/js/pages/ChecksSelection/hooks.js
+++ b/assets/js/pages/ChecksSelection/hooks.js
@@ -67,10 +67,13 @@ export const useChecksSelection = () => {
     }
   };
 
-  const saveChecksCustomization = async (payload) => {
-    const { checkID, customValues } = payload;
+  const saveChecksCustomization = async ({
+    checkID,
+    groupID,
+    customValues,
+  }) => {
     try {
-      await saveCheckCustomization(payload);
+      await saveCheckCustomization(checkID, groupID, customValues);
       pipe(
         map(saveCheck(checkID, customValues)),
         setChecksSelection,

--- a/assets/js/pages/ChecksSelection/hooks.js
+++ b/assets/js/pages/ChecksSelection/hooks.js
@@ -11,22 +11,24 @@ import {
   saveCheckCustomization,
 } from '@lib/api/checks';
 
-const markCheckAsNotCustomized = (check) => ({
+const setCheckCustomized = (customized) => (check) => ({
   ...check,
-  customized: false,
+  customized,
 });
 
-const markCheckAsCustomized = (check) => ({
-  ...check,
-  customized: true,
+const applyValueCustomization = ({ value, customization }) =>
+  customization ? { ...value, custom_value: customization.value } : value;
+
+const findValueCustomization = (customValues) => (value) => ({
+  value,
+  customization: customValues.find(({ name }) => name === value.name),
 });
 
-const saveValuesCustomizations = (check, customValues) => ({
+const saveValuesCustomizations = (customValues) => (check) => ({
   ...check,
-  values: check.values.map((value, index) => ({
-    ...value,
-    custom_value: customValues[index].value,
-  })),
+  values: map(
+    pipe(findValueCustomization(customValues), applyValueCustomization)
+  )(check.values),
 });
 
 const resetValuesCustomizations = (check) => ({
@@ -36,21 +38,48 @@ const resetValuesCustomizations = (check) => ({
 
 const saveCheck = (checkID, customValues) => (check) =>
   check.id === checkID
-    ? pipe(markCheckAsCustomized, (c) =>
-        saveValuesCustomizations(c, customValues)
+    ? pipe(
+        setCheckCustomized(true),
+        saveValuesCustomizations(customValues)
       )(check)
     : check;
 
 const resetCheck = (checkId) => (check) =>
   check.id === checkId
-    ? pipe(markCheckAsNotCustomized, resetValuesCustomizations)(check)
+    ? pipe(setCheckCustomized(false), resetValuesCustomizations)(check)
     : check;
+
+export const READY = 'ready';
+export const ONGOING = 'ongoing';
+export const INVALID_VALUES = 'invalid_values';
+export const GENERIC_FAILURE = 'generic_failure';
+
+export const CUSTOMIZATION_STATUSES = [
+  READY,
+  ONGOING,
+  INVALID_VALUES,
+  GENERIC_FAILURE,
+];
+
+export const isReady = (status) => status === READY;
+export const isOngoing = (status) => status === ONGOING;
+export const isFailed = (status) =>
+  [GENERIC_FAILURE, INVALID_VALUES].includes(status);
+export const isInvalidValues = (status) => status === INVALID_VALUES;
+export const isGenericFailure = (status) => status === GENERIC_FAILURE;
 
 export const useChecksSelection = () => {
   const dispatch = useDispatch();
   const [loading, setLoading] = useState(false);
   const [checksSelection, setChecksSelection] = useState([]);
   const [fetchError, setFetchError] = useState(null);
+  const [customizationStatus, setCustomizationStatus] = useState(READY);
+
+  const notifySuccess = (successMsg) =>
+    pipe(() => ({ text: successMsg, icon: '✅' }), notify, dispatch);
+
+  const notifyError = (errorMsg) =>
+    pipe(() => ({ text: errorMsg, icon: '❌' }), notify, dispatch)();
 
   const fetchChecksSelection = async (groupId, env) => {
     setLoading(true);
@@ -67,26 +96,21 @@ export const useChecksSelection = () => {
     }
   };
 
-  const saveChecksCustomization = async ({
-    checkID,
-    groupID,
-    customValues,
-  }) => {
+  const saveChecksCustomization = async (checkID, groupID, customValues) => {
+    setCustomizationStatus(ONGOING);
     try {
-      await saveCheckCustomization(checkID, groupID, customValues);
+      const {
+        data: { values },
+      } = await saveCheckCustomization(checkID, groupID, customValues);
       pipe(
-        map(saveCheck(checkID, customValues)),
+        map(saveCheck(checkID, values)),
         setChecksSelection,
-        () => ({ text: `Check was customized successfully`, icon: '✅' }),
-        notify,
-        dispatch
+        notifySuccess('Check was customized successfully')
       )(checksSelection);
-    } catch (error) {
-      pipe(
-        () => ({ text: `Failed to customize check`, icon: '❌' }),
-        notify,
-        dispatch
-      )();
+      setCustomizationStatus(READY);
+    } catch ({ response: { status } }) {
+      notifyError('Failed to customize check');
+      setCustomizationStatus(status === 400 ? INVALID_VALUES : GENERIC_FAILURE);
     }
   };
 
@@ -96,16 +120,10 @@ export const useChecksSelection = () => {
       pipe(
         map(resetCheck(checkId)),
         setChecksSelection,
-        () => ({ text: `Customization was reset!`, icon: '✅' }),
-        notify,
-        dispatch
+        notifySuccess('Customization was reset!')
       )(checksSelection);
     } catch (error) {
-      pipe(
-        () => ({ text: `Unable to reset customization`, icon: '❌' }),
-        notify,
-        dispatch
-      )();
+      notifyError('Unable to reset customization');
     }
   };
 
@@ -116,5 +134,6 @@ export const useChecksSelection = () => {
     fetchChecksSelection,
     resetChecksCustomization,
     saveChecksCustomization,
+    customizationStatus,
   };
 };

--- a/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
+++ b/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
@@ -65,6 +65,7 @@ function ClusterSettingsPage() {
     checksSelection,
     checksSelectionLoading,
     checksSelectionFetchError,
+    saveChecksCustomization,
   } = useChecksSelection();
 
   const saving = useSelector(isSaving(TARGET_CLUSTER, clusterID));
@@ -109,16 +110,14 @@ function ClusterSettingsPage() {
     dispatch(executionRequested(clusterID, clusterHosts, selectedChecks));
   };
 
-  const saveCustomCheck = (values) => {
-    // ToDo for later when we hook up frontend and backend.
-    const { checksID, customValues } = values;
-    const payload = {
-      checkID: checksID,
-      groupID: clusterID,
-      customCheckValues: customValues,
-    };
-    // dispatch payload in future pr
-    return payload;
+  const saveCustomCheck = ({ checksID, customValues }) => {
+    dispatch(
+      saveChecksCustomization({
+        checkID: checksID,
+        groupID: clusterID,
+        customValues,
+      })
+    );
   };
 
   return (

--- a/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
+++ b/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
@@ -61,11 +61,12 @@ function ClusterSettingsPage() {
 
   const {
     fetchChecksSelection,
-    resetChecksCustomization,
     checksSelection,
     checksSelectionLoading,
     checksSelectionFetchError,
     saveChecksCustomization,
+    resetChecksCustomization,
+    customizationStatus,
   } = useChecksSelection();
 
   const saving = useSelector(isSaving(TARGET_CLUSTER, clusterID));
@@ -152,7 +153,8 @@ function ClusterSettingsPage() {
         onUpdateCatalog={refreshChecksSelection}
         onChange={setSelection}
         provider={provider}
-        saveCustomCheck={saveChecksCustomization}
+        onSaveCheckCustomization={saveChecksCustomization}
+        customizationStatus={customizationStatus}
         onResetCheckCustomization={resetChecksCustomization}
       />
     </>

--- a/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
+++ b/assets/js/pages/ClusterSettingsPage/ClusterSettingsPage.jsx
@@ -110,16 +110,6 @@ function ClusterSettingsPage() {
     dispatch(executionRequested(clusterID, clusterHosts, selectedChecks));
   };
 
-  const saveCustomCheck = ({ checksID, customValues }) => {
-    dispatch(
-      saveChecksCustomization({
-        checkID: checksID,
-        groupID: clusterID,
-        customValues,
-      })
-    );
-  };
-
   return (
     <>
       <ChecksSelectionHeader
@@ -162,7 +152,7 @@ function ClusterSettingsPage() {
         onUpdateCatalog={refreshChecksSelection}
         onChange={setSelection}
         provider={provider}
-        saveCustomCheck={saveCustomCheck}
+        saveCustomCheck={saveChecksCustomization}
         onResetCheckCustomization={resetChecksCustomization}
       />
     </>

--- a/assets/js/pages/HostSettingsPage/HostSettingsPage.jsx
+++ b/assets/js/pages/HostSettingsPage/HostSettingsPage.jsx
@@ -32,10 +32,12 @@ function HostSettingsPage() {
 
   const {
     fetchChecksSelection,
-    resetChecksCustomization,
     checksSelection,
     checksSelectionLoading,
     checksSelectionFetchError,
+    saveChecksCustomization,
+    resetChecksCustomization,
+    customizationStatus,
   } = useChecksSelection();
 
   const saving = useSelector(isSaving(TARGET_HOST, hostID));
@@ -63,18 +65,6 @@ function HostSettingsPage() {
         checks: newSelection,
       })
     );
-  };
-
-  const saveCustomCheck = (values) => {
-    // ToDo for later when we hook up frontend and backend.
-    const { checksID, customValues } = values;
-    const payload = {
-      checkID: checksID,
-      groupID: hostID,
-      customCheckValues: customValues,
-    };
-    // dispatch payload in future pr
-    return payload;
   };
 
   const requestChecksExecution = () => {
@@ -114,7 +104,8 @@ function HostSettingsPage() {
         onUpdateCatalog={refreshChecksSelection}
         onChange={setSelection}
         provider={provider}
-        saveCustomCheck={saveCustomCheck}
+        onSaveCheckCustomization={saveChecksCustomization}
+        customizationStatus={customizationStatus}
         onResetCheckCustomization={resetChecksCustomization}
       />
     </>


### PR DESCRIPTION
# Description

This pr wires up the web fronted save functionality for custom checks. The user now can save  custom checks values and also reset them from the frontend. 

## Demo: 

https://github.com/user-attachments/assets/048d8ddc-e4fa-4ef5-95cc-e84b8bce89b1


## How was this tested?

Updated old tests
Added hook test