### PR TITLE
Log operation requested in activity log

### DIFF
--- a/assets/js/lib/model/activityLog.js
+++ b/assets/js/lib/model/activityLog.js
@@ -9,6 +9,7 @@ import {
   uniq,
   values,
 } from 'lodash/fp';
+import { getOperationResourceType } from '@lib/operations';
 import { isPermitted } from './users';
 
 export const LOGIN_ATTEMPT = 'login_attempt';
@@ -112,6 +113,9 @@ export const DATABASE_ROLL_UP_REQUESTED = 'database_roll_up_requested';
 export const DATABASE_TENANTS_UPDATED = 'database_tenants_updated';
 export const DATABASE_TOMBSTONED = 'database_tombstoned';
 
+// Operations
+export const OPERATION_REQUESTED = 'operation_requested';
+
 export const resourceTypes = ['host', 'cluster', 'database', 'sap_system'];
 
 export const resourceTypesToNameKeyMap = {
@@ -140,6 +144,15 @@ const taggingResourceType = (entry) =>
     database: databaseResourceType(entry),
     sap_system: sapSystemResourceType(entry),
   })[entry.metadata?.resource_type] ?? 'Unable to determine resource type';
+
+const operationResourceType = (entry) =>
+  ({
+    host: hostResourceType(entry),
+    cluster: clusterResourceType(entry),
+    database: databaseResourceType(entry),
+    sap_system: sapSystemResourceType(entry),
+  })[getOperationResourceType(entry.metadata?.operation)] ??
+  'Unable to determine operation type';
 
 export const resourceNameFromMetadata = (resourceType, metadata) =>
   pipe(
@@ -546,6 +559,12 @@ export const ACTIVITY_TYPES_CONFIG = {
     label: 'Database Tombstoned',
     message: (_entry) => `Database was tombstoned`,
     resource: databaseResourceType,
+  },
+  // Operations
+  [OPERATION_REQUESTED]: {
+    label: 'Operation Requested',
+    message: ({ metadata }) => `Operation "${metadata.operation}" requested`,
+    resource: operationResourceType,
   },
 };
 

--- a/assets/js/lib/model/activityLog.js
+++ b/assets/js/lib/model/activityLog.js
@@ -9,7 +9,7 @@ import {
   uniq,
   values,
 } from 'lodash/fp';
-import { getOperationResourceType } from '@lib/operations';
+import { getOperationLabel, getOperationResourceType } from '@lib/operations';
 import { isPermitted } from './users';
 
 export const LOGIN_ATTEMPT = 'login_attempt';
@@ -563,7 +563,8 @@ export const ACTIVITY_TYPES_CONFIG = {
   // Operations
   [OPERATION_REQUESTED]: {
     label: 'Operation Requested',
-    message: ({ metadata }) => `Operation "${metadata.operation}" requested`,
+    message: ({ metadata }) =>
+      `Operation ${getOperationLabel(metadata.operation)} requested`,
     resource: operationResourceType,
   },
 };

--- a/lib/trento/activity_logging/activity_catalog.ex
+++ b/lib/trento/activity_logging/activity_catalog.ex
@@ -143,7 +143,8 @@ defmodule Trento.ActivityLog.ActivityCatalog do
       {TrentoWeb.V1.HostController, :request_checks_execution} =>
         {:host_checks_execution_request, 202},
       {TrentoWeb.V1.SettingsController, :update_activity_log_settings} =>
-        {:activity_log_settings_update, 200}
+        {:activity_log_settings_update, 200},
+      {TrentoWeb.V1.HostController, :request_operation} => {:operation_requested, 202}
     }
   end
 end

--- a/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
+++ b/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
@@ -129,6 +129,22 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
       }),
       do: %{user_id: Map.get(params, :id)}
 
+  def get_activity_metadata(
+        :operation_requested,
+        %Plug.Conn{
+          params: params,
+          body_params: body_params,
+          resp_body: resp_body
+        }
+      ) do
+    %{
+      resource_id: Map.get(params, :id),
+      operation: Map.get(params, :operation),
+      operation_id: resp_body |> Jason.decode!() |> Map.get("operation_id"),
+      params: body_params
+    }
+  end
+
   def get_activity_metadata(_, _), do: %{}
 
   defp redact(request_body, key) do

--- a/lib/trento/activity_logging/severity_level.ex
+++ b/lib/trento/activity_logging/severity_level.ex
@@ -115,7 +115,8 @@ defmodule Trento.ActivityLog.SeverityLevel do
     "database_rolled_up" => :debug,
     "database_rollup_requested" => :info,
     "database_tenants_updated" => :info,
-    "database_tombstoned" => :debug
+    "database_tombstoned" => :debug,
+    "operation_requested" => :info
   }
 
   def map_severity_integer_to_text(n) when n >= 5 and n <= 8, do: "debug"

--- a/test/trento/activity_logging/activity_catalog_test.exs
+++ b/test/trento/activity_logging/activity_catalog_test.exs
@@ -25,7 +25,8 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
         :profile_update,
         :cluster_checks_execution_request,
         :host_checks_execution_request,
-        :activity_log_settings_update
+        :activity_log_settings_update,
+        :operation_requested
       ]
 
       connection_activity_catalog = ActivityCatalog.connection_activities()
@@ -204,6 +205,12 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
       %{
         activity: :cluster_checks_execution_request,
         connection_info: {TrentoWeb.V1.ClusterController, :request_checks_execution},
+        interesting_statuses: 202,
+        not_interesting_statuses: [400, 401, 403, 404, 500]
+      },
+      %{
+        activity: :operation_requested,
+        connection_info: {TrentoWeb.V1.HostController, :request_operation},
         interesting_statuses: 202,
         not_interesting_statuses: [400, 401, 403, 404, 500]
       }

--- a/test/trento/activity_logging/phoenix_conn_parser_test.exs
+++ b/test/trento/activity_logging/phoenix_conn_parser_test.exs
@@ -113,6 +113,26 @@ defmodule Trento.ActivityLog.PhoenixConnParserTest do
                  })
       end
     end
+
+    test "should extract operation metadata from requested operation", %{conn: conn} do
+      resource_id = Faker.UUID.v4()
+      operation_id = Faker.UUID.v4()
+      operation = Faker.Cat.name()
+      params = %{"key" => "value"}
+
+      assert %{
+               :resource_id => resource_id,
+               :operation => operation,
+               :operation_id => operation_id,
+               :params => params
+             } ==
+               PhoenixConnParser.get_activity_metadata(:operation_requested, %Plug.Conn{
+                 conn
+                 | params: %{id: resource_id, operation: operation},
+                   body_params: params,
+                   resp_body: Jason.encode!(%{operation_id: operation_id})
+               })
+    end
   end
 
   defp assert_for_relevant_activity(assertion_function) do


### PR DESCRIPTION
# Description

Log operation requested event in the activity log.
The `operation_id` comes in the response of the request, in raw format. That's why we need to decode the json. 

![image](https://github.com/user-attachments/assets/a3a9e8c7-b6f2-4784-aa87-863dd53020a5)

@abravosuse I'm putting the "internal" name of the operation here. Should we put something else? We could change the message to be `Operation Apply Saptune solution requested` for example. The value in the Data field is more annoying, as we would need to map the internal value to the "frontend label" which I don't want to do in the backend as well

## How was this tested?
UT

