### PR TITLE
Fetch running operation on page load

### DIFF
--- a/assets/js/lib/api/operations.js
+++ b/assets/js/lib/api/operations.js
@@ -8,7 +8,7 @@ const defaultConfig = { baseURL };
 export const requestHostOperation = (hostID, operation, params) =>
   post(`/hosts/${hostID}/operations/${operation}`, params);
 
-export const getOperations = (params) =>
+export const getOperationExecutions = (params) =>
   networkClient.get('/api/v1/operations/executions', {
     ...defaultConfig,
     params,

--- a/assets/js/lib/api/operations.js
+++ b/assets/js/lib/api/operations.js
@@ -1,4 +1,15 @@
-import { post } from '@lib/network';
+import { networkClient, post } from '@lib/network';
+
+// eslint-disable-next-line no-undef
+const baseURL = config.checksServiceBaseUrl;
+
+const defaultConfig = { baseURL };
 
 export const requestHostOperation = (hostID, operation, params) =>
   post(`/hosts/${hostID}/operations/${operation}`, params);
+
+export const getOperations = (params) =>
+  networkClient.get('/api/v1/operations/executions', {
+    ...defaultConfig,
+    params,
+  });

--- a/assets/js/lib/operations/index.js
+++ b/assets/js/lib/operations/index.js
@@ -10,6 +10,10 @@ const OPERATION_LABELS = {
   [SAPTUNE_SOLUTION_APPLY]: 'Apply Saptune solution',
 };
 
+const OPERATIONS_INTERNAL_MAP = {
+  'saptuneapplysolution@v1': SAPTUNE_SOLUTION_APPLY,
+};
+
 const OPERATION_RESOURCE_TYPES = {
   [SAPTUNE_SOLUTION_APPLY]: HOST_OPERATION,
 };
@@ -21,6 +25,9 @@ const OPERATION_REQUEST_FUNCS = {
 export const getOperationLabel = (operation) =>
   get(OPERATION_LABELS, operation, 'unknown');
 
+export const getOperationInternalName = (operation) =>
+  get(OPERATIONS_INTERNAL_MAP, operation, 'unknown');
+
 export const getOperationResourceType = (operation) =>
   get(OPERATION_RESOURCE_TYPES, operation, 'unknown');
 
@@ -29,3 +36,5 @@ export const getOperationRequestFunc = (resourceType) =>
 
 export const operationSucceeded = (result) =>
   ['UPDATED', 'NOT_UPDATED'].includes(result);
+
+export const operationRunning = ({ status }) => status === 'running';

--- a/assets/js/lib/operations/index.js
+++ b/assets/js/lib/operations/index.js
@@ -10,7 +10,7 @@ const OPERATION_LABELS = {
   [SAPTUNE_SOLUTION_APPLY]: 'Apply Saptune solution',
 };
 
-const OPERATIONS_INTERNAL_MAP = {
+const OPERATION_INTERNAL_NAMES = {
   'saptuneapplysolution@v1': SAPTUNE_SOLUTION_APPLY,
 };
 
@@ -26,7 +26,7 @@ export const getOperationLabel = (operation) =>
   get(OPERATION_LABELS, operation, 'unknown');
 
 export const getOperationInternalName = (operation) =>
-  get(OPERATIONS_INTERNAL_MAP, operation, 'unknown');
+  get(OPERATION_INTERNAL_NAMES, operation, 'unknown');
 
 export const getOperationResourceType = (operation) =>
   get(OPERATION_RESOURCE_TYPES, operation, 'unknown');

--- a/assets/js/lib/operations/operations.test.js
+++ b/assets/js/lib/operations/operations.test.js
@@ -4,9 +4,11 @@ import { requestHostOperation } from '@lib/api/operations';
 
 import {
   getOperationLabel,
+  getOperationInternalName,
   getOperationResourceType,
   getOperationRequestFunc,
   operationSucceeded,
+  operationRunning,
 } from '.';
 
 describe('operations', () => {
@@ -22,6 +24,22 @@ describe('operations', () => {
   ])(`should return the operation $operation label`, ({ operation, label }) => {
     expect(getOperationLabel(operation)).toBe(label);
   });
+
+  it.each([
+    {
+      operation: 'unknown',
+      name: 'unknown',
+    },
+    {
+      operation: 'saptuneapplysolution@v1',
+      name: 'saptune_solution_apply',
+    },
+  ])(
+    `should return the operation $operation internal name`,
+    ({ operation, name }) => {
+      expect(getOperationInternalName(operation)).toBe(name);
+    }
+  );
 
   it.each([
     {
@@ -59,5 +77,10 @@ describe('operations', () => {
     expect(operationSucceeded('UPDATED')).toBeTruthy();
     expect(operationSucceeded('NOT_UPDATED')).toBeTruthy();
     expect(operationSucceeded('FAILED')).toBeFalsy();
+  });
+
+  it('should check if an operation is running', () => {
+    expect(operationRunning({ status: 'running' })).toBeTruthy();
+    expect(operationRunning({ status: 'completed' })).toBeFalsy();
   });
 });

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -28,7 +28,10 @@ import {
   updateLastExecution,
   hostExecutionRequested,
 } from '@state/lastExecutions';
-import { operationRequested } from '@state/runningOperations';
+import {
+  operationRequested,
+  updateRunningOperation,
+} from '@state/runningOperations';
 
 import { deregisterHost } from '@state/hosts';
 import { fetchSoftwareUpdates } from '@state/softwareUpdates';
@@ -109,6 +112,7 @@ function HostDetailsPage() {
     getExportersStatus();
     refreshCatalog();
     dispatch(updateLastExecution(hostID));
+    operationsEnabled && dispatch(updateRunningOperation(hostID));
   }, []);
 
   if (!host) {

--- a/assets/js/state/runningOperations.js
+++ b/assets/js/state/runningOperations.js
@@ -2,6 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 
 export const OPERATION_COMPLETED = 'OPERATION_COMPLETED';
 export const OPERATION_REQUESTED = 'OPERATION_REQUESTED';
+export const UPDATE_RUNNING_OPERATION = 'UPDATE_RUNNING_OPERATION';
 
 export const operationCompleted = ({
   operationID,
@@ -16,6 +17,11 @@ export const operationCompleted = ({
 export const operationRequested = ({ groupID, operation, params }) => ({
   type: OPERATION_REQUESTED,
   payload: { groupID, operation, params },
+});
+
+export const updateRunningOperation = (groupID) => ({
+  type: UPDATE_RUNNING_OPERATION,
+  payload: { groupID },
 });
 
 const initialState = {};

--- a/assets/js/state/sagas/operations.js
+++ b/assets/js/state/sagas/operations.js
@@ -9,7 +9,7 @@ import {
   operationRunning,
   operationSucceeded,
 } from '@lib/operations';
-import { getOperations } from '@lib/api/operations';
+import { getOperationExecutions } from '@lib/api/operations';
 import { notify } from '@state/notifications';
 import {
   OPERATION_COMPLETED,
@@ -92,7 +92,10 @@ export function* updateRunningOperation({ payload }) {
   try {
     const {
       data: { items: operations, total_count: totalCount },
-    } = yield call(getOperations, { group_id: groupID, items_per_page: 1 });
+    } = yield call(getOperationExecutions, {
+      group_id: groupID,
+      items_per_page: 1,
+    });
     if (totalCount === 1 && operationRunning(operations[0])) {
       const operation = getOperationInternalName(operations[0].operation);
       yield put(setRunningOperation({ groupID, operation }));

--- a/assets/js/state/sagas/operations.js
+++ b/assets/js/state/sagas/operations.js
@@ -91,13 +91,16 @@ export function* updateRunningOperation({ payload }) {
 
   try {
     const {
-      data: { items: operations, total_count: totalCount },
+      data: {
+        items: [operationItem],
+        total_count: totalCount,
+      },
     } = yield call(getOperationExecutions, {
       group_id: groupID,
       items_per_page: 1,
     });
-    if (totalCount === 1 && operationRunning(operations[0])) {
-      const operation = getOperationInternalName(operations[0].operation);
+    if (totalCount === 1 && operationRunning(operationItem)) {
+      const operation = getOperationInternalName(operationItem.operation);
       yield put(setRunningOperation({ groupID, operation }));
     }
   } catch {

--- a/assets/js/state/sagas/operations.js
+++ b/assets/js/state/sagas/operations.js
@@ -3,14 +3,18 @@ import { call, put, select, takeEvery } from 'redux-saga/effects';
 import {
   HOST_OPERATION,
   getOperationLabel,
+  getOperationInternalName,
   getOperationResourceType,
   getOperationRequestFunc,
+  operationRunning,
   operationSucceeded,
 } from '@lib/operations';
+import { getOperations } from '@lib/api/operations';
 import { notify } from '@state/notifications';
 import {
   OPERATION_COMPLETED,
   OPERATION_REQUESTED,
+  UPDATE_RUNNING_OPERATION,
   removeRunningOperation,
   setRunningOperation,
 } from '@state/runningOperations';
@@ -82,7 +86,24 @@ export function* completeOperation({ payload }) {
   }
 }
 
+export function* updateRunningOperation({ payload }) {
+  const { groupID } = payload;
+
+  try {
+    const {
+      data: { items: operations, total_count: totalCount },
+    } = yield call(getOperations, { group_id: groupID, items_per_page: 1 });
+    if (totalCount === 1 && operationRunning(operations[0])) {
+      const operation = getOperationInternalName(operations[0].operation);
+      yield put(setRunningOperation({ groupID, operation }));
+    }
+  } catch {
+    /* empty */
+  }
+}
+
 export function* watchOperationEvents() {
   yield takeEvery(OPERATION_COMPLETED, completeOperation);
   yield takeEvery(OPERATION_REQUESTED, requestOperation);
+  yield takeEvery(UPDATE_RUNNING_OPERATION, updateRunningOperation);
 }

--- a/assets/js/state/sagas/operations.test.js
+++ b/assets/js/state/sagas/operations.test.js
@@ -4,17 +4,24 @@ import { faker } from '@faker-js/faker';
 import { recordSaga } from '@lib/test-utils';
 import { networkClient } from '@lib/network';
 
+import { SAPTUNE_SOLUTION_APPLY } from '@lib/operations';
 import {
   removeRunningOperation,
   setRunningOperation,
 } from '@state/runningOperations';
 import { notify } from '@state/notifications';
 
-import { requestOperation, completeOperation } from './operations';
+import {
+  requestOperation,
+  completeOperation,
+  updateRunningOperation,
+} from './operations';
 
 const axiosMock = new MockAdapter(networkClient);
 const hostOperationRequestURL = (hostID, operation) =>
   `/hosts/${hostID}/operations/${operation}`;
+
+const getOperationsURL = () => `/api/v1/operations/executions`;
 
 describe('operations saga', () => {
   beforeEach(() => {
@@ -27,96 +34,163 @@ describe('operations saga', () => {
     console.error.mockRestore();
   });
 
-  it('should request an operation', async () => {
-    const groupID = faker.string.uuid();
-    const operation = faker.lorem.word();
-    const hostname = faker.internet.displayName();
+  describe('request operation', () => {
+    it('should request an operation', async () => {
+      const groupID = faker.string.uuid();
+      const operation = faker.lorem.word();
+      const hostname = faker.internet.displayName();
 
-    axiosMock.onGet(hostOperationRequestURL(groupID)).reply(202, {});
+      axiosMock.onGet(hostOperationRequestURL(groupID)).reply(202, {});
 
-    const dispatched = await recordSaga(
-      requestOperation,
-      {
-        payload: { groupID, operation },
-      },
-      { hostsList: [{ id: groupID, hostname }] }
-    );
+      const dispatched = await recordSaga(
+        requestOperation,
+        {
+          payload: { groupID, operation },
+        },
+        { hostsList: [{ id: groupID, hostname }] }
+      );
 
-    expect(dispatched).toContainEqual(
-      setRunningOperation({ groupID, operation }),
-      notify({
-        text: `Operation ${operation} requested for ${hostname}`,
-        icon: '⚙️',
-      })
-    );
+      expect(dispatched).toContainEqual(
+        setRunningOperation({ groupID, operation }),
+        notify({
+          text: `Operation ${operation} requested for ${hostname}`,
+          icon: '⚙️',
+        })
+      );
+    });
+
+    it('should fail requesting an operation if the api request fails', async () => {
+      const groupID = faker.string.uuid();
+      const operation = faker.lorem.word();
+      const hostname = faker.internet.displayName();
+
+      axiosMock.onGet(hostOperationRequestURL(groupID)).reply(404, {});
+
+      const dispatched = await recordSaga(
+        requestOperation,
+        {
+          payload: { groupID, operation },
+        },
+        { hostsList: [{ id: groupID, hostname }] }
+      );
+
+      expect(dispatched).toContainEqual(
+        setRunningOperation({ groupID, operation }),
+        removeRunningOperation({ groupID }),
+        notify({
+          text: `Operation ${operation} request for ${hostname} failed`,
+          icon: '❌',
+        })
+      );
+    });
   });
 
-  it('should fail requesting an operation if the api request fails', async () => {
-    const groupID = faker.string.uuid();
-    const operation = faker.lorem.word();
-    const hostname = faker.internet.displayName();
+  describe('complete operation', () => {
+    it('should complete successfully an operation', async () => {
+      const groupID = faker.string.uuid();
+      const operation = faker.lorem.word();
+      const hostname = faker.internet.displayName();
 
-    axiosMock.onGet(hostOperationRequestURL(groupID)).reply(404, {});
+      const dispatched = await recordSaga(
+        completeOperation,
+        {
+          payload: { groupID, operation, result: 'UPDATED' },
+        },
+        { hostsList: [{ id: groupID, hostname }] }
+      );
 
-    const dispatched = await recordSaga(
-      requestOperation,
-      {
-        payload: { groupID, operation },
-      },
-      { hostsList: [{ id: groupID, hostname }] }
-    );
+      expect(dispatched).toContainEqual(
+        removeRunningOperation({ groupID }),
+        notify({
+          text: `Operation ${operation} succeeded for ${hostname}`,
+          icon: '✅',
+        })
+      );
+    });
 
-    expect(dispatched).toContainEqual(
-      setRunningOperation({ groupID, operation }),
-      removeRunningOperation({ groupID }),
-      notify({
-        text: `Operation ${operation} request for ${hostname} failed`,
-        icon: '❌',
-      })
-    );
+    it('should complete an operation with a failed result', async () => {
+      const groupID = faker.string.uuid();
+      const operation = faker.lorem.word();
+      const hostname = faker.internet.displayName();
+
+      const dispatched = await recordSaga(
+        completeOperation,
+        {
+          payload: { groupID, operation, result: 'FAILED' },
+        },
+        { hostsList: [{ id: groupID, hostname }] }
+      );
+
+      expect(dispatched).toContainEqual(
+        removeRunningOperation({ groupID }),
+        notify({
+          text: `Operation ${operation} failed for ${hostname}`,
+          icon: '❌',
+        })
+      );
+    });
   });
 
-  it('should complete successfully an operation', async () => {
-    const groupID = faker.string.uuid();
-    const operation = faker.lorem.word();
-    const hostname = faker.internet.displayName();
+  describe('update running operation', () => {
+    it('should update running operations state for a group when the operation is running', async () => {
+      const groupID = faker.string.uuid();
+      const operation = 'saptuneapplysolution@v1';
 
-    const dispatched = await recordSaga(
-      completeOperation,
-      {
-        payload: { groupID, operation, result: 'UPDATED' },
-      },
-      { hostsList: [{ id: groupID, hostname }] }
-    );
+      axiosMock.onGet(getOperationsURL(groupID)).reply(200, {
+        items: [{ operation, status: 'running' }],
+        total_count: 1,
+      });
 
-    expect(dispatched).toContainEqual(
-      removeRunningOperation({ groupID }),
-      notify({
-        text: `Operation ${operation} succeeded for ${hostname}`,
-        icon: '✅',
-      })
-    );
-  });
+      const dispatched = await recordSaga(updateRunningOperation, {
+        payload: { groupID },
+      });
 
-  it('should complete an operation with a failed result', async () => {
-    const groupID = faker.string.uuid();
-    const operation = faker.lorem.word();
-    const hostname = faker.internet.displayName();
+      expect(dispatched).toContainEqual(
+        setRunningOperation({ groupID, operation: SAPTUNE_SOLUTION_APPLY })
+      );
+    });
 
-    const dispatched = await recordSaga(
-      completeOperation,
-      {
-        payload: { groupID, operation, result: 'FAILED' },
-      },
-      { hostsList: [{ id: groupID, hostname }] }
-    );
+    it('should not update running operations state for a group when the operation is completed', async () => {
+      const groupID = faker.string.uuid();
+      const operation = faker.lorem.word();
 
-    expect(dispatched).toContainEqual(
-      removeRunningOperation({ groupID }),
-      notify({
-        text: `Operation ${operation} failed for ${hostname}`,
-        icon: '❌',
-      })
-    );
+      axiosMock.onGet(getOperationsURL(groupID)).reply(200, {
+        items: [{ operation, status: 'completed' }],
+        total_count: 1,
+      });
+
+      const dispatched = await recordSaga(updateRunningOperation, {
+        payload: { groupID },
+      });
+
+      expect(dispatched).toEqual([]);
+    });
+
+    it('should not update running operations state for a group when there is not any operation', async () => {
+      const groupID = faker.string.uuid();
+
+      axiosMock.onGet(getOperationsURL(groupID)).reply(200, {
+        items: [],
+        total_count: 0,
+      });
+
+      const dispatched = await recordSaga(updateRunningOperation, {
+        payload: { groupID },
+      });
+
+      expect(dispatched).toEqual([]);
+    });
+
+    it('should not update running operations state for a group when the api call fails', async () => {
+      const groupID = faker.string.uuid();
+
+      axiosMock.onGet(getOperationsURL(groupID)).reply(400, {});
+
+      const dispatched = await recordSaga(updateRunningOperation, {
+        payload: { groupID },
+      });
+
+      expect(dispatched).toEqual([]);
+    });
   });
 });

--- a/assets/js/state/sagas/operations.test.js
+++ b/assets/js/state/sagas/operations.test.js
@@ -21,7 +21,7 @@ const axiosMock = new MockAdapter(networkClient);
 const hostOperationRequestURL = (hostID, operation) =>
   `/hosts/${hostID}/operations/${operation}`;
 
-const getOperationsURL = () => `/api/v1/operations/executions`;
+const getOperationExecutionsURL = () => `/api/v1/operations/executions`;
 
 describe('operations saga', () => {
   beforeEach(() => {
@@ -136,7 +136,7 @@ describe('operations saga', () => {
       const groupID = faker.string.uuid();
       const operation = 'saptuneapplysolution@v1';
 
-      axiosMock.onGet(getOperationsURL(groupID)).reply(200, {
+      axiosMock.onGet(getOperationExecutionsURL(groupID)).reply(200, {
         items: [{ operation, status: 'running' }],
         total_count: 1,
       });
@@ -154,7 +154,7 @@ describe('operations saga', () => {
       const groupID = faker.string.uuid();
       const operation = faker.lorem.word();
 
-      axiosMock.onGet(getOperationsURL(groupID)).reply(200, {
+      axiosMock.onGet(getOperationExecutionsURL(groupID)).reply(200, {
         items: [{ operation, status: 'completed' }],
         total_count: 1,
       });
@@ -169,7 +169,7 @@ describe('operations saga', () => {
     it('should not update running operations state for a group when there is not any operation', async () => {
       const groupID = faker.string.uuid();
 
-      axiosMock.onGet(getOperationsURL(groupID)).reply(200, {
+      axiosMock.onGet(getOperationExecutionsURL(groupID)).reply(200, {
         items: [],
         total_count: 0,
       });
@@ -184,7 +184,7 @@ describe('operations saga', () => {
     it('should not update running operations state for a group when the api call fails', async () => {
       const groupID = faker.string.uuid();
 
-      axiosMock.onGet(getOperationsURL(groupID)).reply(400, {});
+      axiosMock.onGet(getOperationExecutionsURL(groupID)).reply(400, {});
 
       const dispatched = await recordSaga(updateRunningOperation, {
         payload: { groupID },


### PR DESCRIPTION
# Description

Update running operation state on page arrival. If we load trento in a moment when an operation was already running, this saga dispatch will query wanda to see if some operation is in running state for this group. If that's the case, it will set the operation in running, so we cannot request the operation again.

## How was this tested?
UT
