### PR TITLE
Fix: Verify mocks in settings_test.ex

### DIFF
--- a/test/trento/settings_test.exs
+++ b/test/trento/settings_test.exs
@@ -30,6 +30,8 @@ defmodule Trento.SettingsTest do
     on_exit(fn -> Application.put_env(:trento, :flavor, "Community") end)
   end
 
+  setup :verify_on_exit!
+
   describe "installation_settings" do
     # TODO: remove InstallationSettings since premium does not exist anymore?
     test "should not create a new InstallationSettings if is already present" do


### PR DESCRIPTION
# Description

I've noticed that mocks are not verified in `settings_test.ex`. This is a one-liner fix for that.
I've double-checked that verify was *not* called from any of the `use` statements -- changing call count expectations in the mocks did not make a test to fail. After adding `verify_on_exit` and with modified expectations the tests start failing, so the fix is correct.