### PR TITLE
Operation completed activity log

### DIFF
--- a/assets/js/lib/model/activityLog.js
+++ b/assets/js/lib/model/activityLog.js
@@ -115,6 +115,7 @@ export const DATABASE_TOMBSTONED = 'database_tombstoned';
 
 // Operations
 export const OPERATION_REQUESTED = 'operation_requested';
+export const OPERATION_COMPLETED = 'operation_completed';
 
 export const resourceTypes = ['host', 'cluster', 'database', 'sap_system'];
 
@@ -565,6 +566,12 @@ export const ACTIVITY_TYPES_CONFIG = {
     label: 'Operation Requested',
     message: ({ metadata }) =>
       `Operation ${getOperationLabel(metadata.operation)} requested`,
+    resource: operationResourceType,
+  },
+  [OPERATION_COMPLETED]: {
+    label: 'Operation Completed',
+    message: ({ metadata }) =>
+      `Operation ${getOperationLabel(metadata.operation)} completed`,
     resource: operationResourceType,
   },
 };

--- a/lib/trento/activity_logging/parser/activity_parser.ex
+++ b/lib/trento/activity_logging/parser/activity_parser.ex
@@ -5,7 +5,13 @@ defmodule Trento.ActivityLog.Parser.ActivityParser do
 
   alias Trento.ActivityLog.ActivityCatalog
   alias Trento.ActivityLog.SeverityLevel
-  alias Trento.ActivityLog.Logger.Parser.{EventParser, MetadataEnricher, PhoenixConnParser}
+
+  alias Trento.ActivityLog.Logger.Parser.{
+    EventParser,
+    MetadataEnricher,
+    PhoenixConnParser,
+    QueueEventParser
+  }
 
   @type activity_log :: %{
           type: String.t(),
@@ -48,6 +54,9 @@ defmodule Trento.ActivityLog.Parser.ActivityParser do
       :domain_event_activity ->
         {:ok, parse_domain_event_activity_info(info, activity, activity_context)}
 
+      :queue_event_activity ->
+        {:ok, parse_queue_event_activity_info(info, activity, activity_context)}
+
       :unsupported_activity ->
         {:error, :unsupported_activity}
     end
@@ -64,4 +73,10 @@ defmodule Trento.ActivityLog.Parser.ActivityParser do
 
   defp parse_domain_event_activity_info(:metadata, activity, activity_context),
     do: EventParser.get_activity_metadata(activity, activity_context)
+
+  defp parse_queue_event_activity_info(:actor, activity, %{queue_event: activity_context}),
+    do: QueueEventParser.get_activity_actor(activity, activity_context)
+
+  defp parse_queue_event_activity_info(:metadata, activity, %{queue_event: activity_context}),
+    do: QueueEventParser.get_activity_metadata(activity, activity_context)
 end

--- a/lib/trento/activity_logging/parser/queue_event_parser.ex
+++ b/lib/trento/activity_logging/parser/queue_event_parser.ex
@@ -1,0 +1,39 @@
+defmodule Trento.ActivityLog.Logger.Parser.QueueEventParser do
+  @moduledoc """
+  Queue event activity parser
+  """
+
+  alias Trento.Operations.V1.OperationCompleted
+
+  alias Trento.Infrastructure.Operations
+
+  alias Trento.ActivityLog
+
+  def get_activity_actor(:operation_completed, %OperationCompleted{operation_id: operation_id}) do
+    case ActivityLog.list_activity_log(%{type: "operation_requested", search: operation_id}) do
+      {:ok, [%{actor: actor}], _meta} -> actor
+      _ -> "system"
+    end
+  end
+
+  def get_activity_actor(_, _), do: nil
+
+  def get_activity_metadata(
+        :operation_completed,
+        %OperationCompleted{
+          operation_id: operation_id,
+          group_id: group_id,
+          operation_type: operation_type,
+          result: result
+        }
+      ) do
+    %{
+      resource_id: group_id,
+      operation: Operations.map_operation_type(operation_type),
+      operation_id: operation_id,
+      result: result
+    }
+  end
+
+  def get_activity_metadata(_, _), do: %{}
+end

--- a/lib/trento/activity_logging/severity_level.ex
+++ b/lib/trento/activity_logging/severity_level.ex
@@ -116,7 +116,13 @@ defmodule Trento.ActivityLog.SeverityLevel do
     "database_rollup_requested" => :info,
     "database_tenants_updated" => :info,
     "database_tombstoned" => :debug,
-    "operation_requested" => :info
+    "operation_requested" => :info,
+    "operation_completed" => %{
+      type: :kv,
+      key_suffix: "result",
+      values: %{"UPDATED" => :info, "NOT_UPDATED" => :info, "*" => :critical},
+      condition: :map_value_to_severity
+    }
   }
 
   def map_severity_integer_to_text(n) when n >= 5 and n <= 8, do: "debug"

--- a/lib/trento/infrastructure/operations/operations.ex
+++ b/lib/trento/infrastructure/operations/operations.ex
@@ -44,4 +44,7 @@ defmodule Trento.Infrastructure.Operations do
         error
     end
   end
+
+  def map_operation_type("saptuneapplysolution@v1"), do: :saptune_solution_apply
+  def map_operation_type(_), do: :unknown
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -157,6 +157,8 @@ defmodule Trento.Factory do
   alias Trento.UserIdentities.UserIdentity
   alias Trento.Users.User
 
+  alias Trento.Operations.V1.OperationCompleted
+
   use ExMachina.Ecto, repo: Trento.Repo
 
   def host_registered_event_factory do
@@ -1222,6 +1224,15 @@ defmodule Trento.Factory do
       user_id: 1,
       uid: Faker.UUID.v4(),
       provider: Faker.Pokemon.name()
+    }
+  end
+
+  def operation_completed_v1_factory do
+    %OperationCompleted{
+      operation_id: Faker.UUID.v4(),
+      group_id: Faker.UUID.v4(),
+      operation_type: Faker.Pokemon.name(),
+      result: Enum.random([:UPDATED, :NOT_UPDATED, :FAILED])
     }
   end
 end

--- a/test/trento/activity_logging/activity_catalog_test.exs
+++ b/test/trento/activity_logging/activity_catalog_test.exs
@@ -112,6 +112,20 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
         assert event_module in events_activities_catalog
       end
     end
+
+    test "should expose queue event related activities" do
+      queue_events = [
+        :operation_completed
+      ]
+
+      queue_activity_catalog = ActivityCatalog.queue_event_activities()
+
+      assert length(queue_events) == length(queue_activity_catalog)
+
+      for queue_event <- queue_events do
+        assert queue_event in queue_activity_catalog
+      end
+    end
   end
 
   describe "activity detection" do
@@ -290,6 +304,17 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
 
       assert {:ok, :database_deregistered} =
                ActivityCatalog.detect_activity(%{event: current_event})
+    end
+
+    test "should detect activity from queue events" do
+      events = [
+        {build(:operation_completed_v1), :operation_completed}
+      ]
+
+      for {event, expected_activity_type} <- events do
+        assert {:ok, expected_activity_type} ==
+                 ActivityCatalog.detect_activity(%{queue_event: event, metadata: %{}})
+      end
     end
   end
 end

--- a/test/trento/activity_logging/activity_logger_test.exs
+++ b/test/trento/activity_logging/activity_logger_test.exs
@@ -453,4 +453,32 @@ defmodule Trento.ActivityLog.ActivityLoggerTest do
                Enum.find(activity_log, &(&1.type == expected_activity_type))
     end
   end
+
+  test "queue event activity logging" do
+    operation_completed = build(:operation_completed_v1)
+
+    events = [
+      {operation_completed, "operation_completed"}
+    ]
+
+    Enum.each(events, fn {event, _} ->
+      assert :ok ==
+               ActivityLogger.log_activity(%{
+                 queue_event: event,
+                 metadata: %{}
+               })
+    end)
+
+    activity_log = Trento.Repo.all(ActivityLog)
+
+    assert Enum.count(activity_log) == length(events)
+
+    for {event, expected_activity_type} <- events do
+      assert %ActivityLog{
+               type: ^expected_activity_type,
+               actor: "system"
+             } =
+               Enum.find(activity_log, &(&1.type == expected_activity_type))
+    end
+  end
 end

--- a/test/trento/activity_logging/activity_logger_test.exs
+++ b/test/trento/activity_logging/activity_logger_test.exs
@@ -473,7 +473,7 @@ defmodule Trento.ActivityLog.ActivityLoggerTest do
 
     assert Enum.count(activity_log) == length(events)
 
-    for {event, expected_activity_type} <- events do
+    for {_event, expected_activity_type} <- events do
       assert %ActivityLog{
                type: ^expected_activity_type,
                actor: "system"

--- a/test/trento/activity_logging/queue_event_parser_test.exs
+++ b/test/trento/activity_logging/queue_event_parser_test.exs
@@ -1,0 +1,58 @@
+defmodule Trento.ActivityLog.QueueEventParserTest do
+  @moduledoc false
+
+  use TrentoWeb.ConnCase, async: false
+  use Plug.Test
+
+  import Trento.Factory
+
+  alias Trento.ActivityLog.Logger.Parser.QueueEventParser
+
+  describe "operation completed" do
+    test "should get actor if operation requested is logged" do
+      %{operation_id: operation_id} = operation_completed = build(:operation_completed_v1)
+
+      %{actor: actor} =
+        insert(:activity_log_entry,
+          type: "operation_requested",
+          metadata: %{"operation_id" => operation_id}
+        )
+
+      assert actor ==
+               QueueEventParser.get_activity_actor(:operation_completed, operation_completed)
+    end
+
+    test "should get default system actor if operation requested is not logged" do
+      operation_completed = build(:operation_completed_v1)
+
+      assert "system" ==
+               QueueEventParser.get_activity_actor(:operation_completed, operation_completed)
+    end
+
+    test "should get operation completed metadata" do
+      %{
+        operation_id: operation_id,
+        group_id: group_id,
+        result: result
+      } =
+        operation_completed =
+        build(:operation_completed_v1, operation_type: "saptuneapplysolution@v1")
+
+      assert %{
+               operation_id: operation_id,
+               resource_id: group_id,
+               operation: :saptune_solution_apply,
+               result: result
+             } ==
+               QueueEventParser.get_activity_metadata(:operation_completed, operation_completed)
+    end
+  end
+
+  test "should return a nil actor in unknown event" do
+    assert nil == QueueEventParser.get_activity_actor(:unknown, %{})
+  end
+
+  test "should return empty metadata in unknown event" do
+    assert %{} == QueueEventParser.get_activity_metadata(:unknown, %{})
+  end
+end

--- a/test/trento/activity_logging/queue_event_parser_test.exs
+++ b/test/trento/activity_logging/queue_event_parser_test.exs
@@ -1,8 +1,8 @@
 defmodule Trento.ActivityLog.QueueEventParserTest do
   @moduledoc false
 
-  use TrentoWeb.ConnCase, async: false
-  use Plug.Test
+  use ExUnit.Case, async: true
+  use Trento.DataCase, async: true
 
   import Trento.Factory
 

--- a/test/trento/infrastructure/operations/operations_test.exs
+++ b/test/trento/infrastructure/operations/operations_test.exs
@@ -99,4 +99,23 @@ defmodule Trento.Infrastructure.Operations.OperationsTest do
                )
     end
   end
+
+  describe "map operation type" do
+    test "should map the internal operation type to a known name" do
+      operations = [
+        %{
+          operation_type: :unknown,
+          internal_type: "unknown"
+        },
+        %{
+          operation_type: :saptune_solution_apply,
+          internal_type: "saptuneapplysolution@v1"
+        }
+      ]
+
+      for %{operation_type: operation_type, internal_type: internal_type} <- operations do
+        assert operation_type == Operations.map_operation_type(internal_type)
+      end
+    end
+  end
 end

--- a/test/trento/infrastructure/operations/processor_test.exs
+++ b/test/trento/infrastructure/operations/processor_test.exs
@@ -10,7 +10,11 @@ defmodule Trento.Infrastructure.Operations.AMQP.ProcessorTest do
     OperationStarted
   }
 
+  alias Trento.ActivityLog.ActivityLog
+
   alias Trento.Contracts
+
+  alias Trento.Repo
 
   describe "process" do
     setup do
@@ -63,6 +67,8 @@ defmodule Trento.Infrastructure.Operations.AMQP.ProcessorTest do
 
       assert :ok = Processor.process(message)
 
+      assert 1 == ActivityLog |> Repo.all() |> length()
+
       assert_broadcast "operation_completed",
                        %{
                          operation_id: ^operation_id,
@@ -71,31 +77,6 @@ defmodule Trento.Infrastructure.Operations.AMQP.ProcessorTest do
                          result: :UPDATED
                        },
                        1000
-    end
-
-    test "should map operation_type properly do" do
-      operations = [
-        %{
-          incoming_operation: "saptuneapplysolution@v1",
-          outgoing_operation: :saptune_solution_apply
-        }
-      ]
-
-      for %{incoming_operation: incoming, outgoing_operation: outgoing} <- operations do
-        operation_completed =
-          Contracts.to_event(%OperationCompleted{
-            operation_id: UUID.uuid4(),
-            group_id: UUID.uuid4(),
-            operation_type: incoming,
-            result: :UPDATED
-          })
-
-        message = %GenRMQ.Message{payload: operation_completed, attributes: %{}, channel: nil}
-
-        assert :ok = Processor.process(message)
-
-        assert_broadcast "operation_completed", %{operation_type: ^outgoing}, 1000
-      end
     end
 
     test "should return error if the event cannot be decoded" do


### PR DESCRIPTION
# Description

Add `operation_completed` event activity log entry.
This is a new event type for the activity log. I have named it `queue_event`, as the event is received in the rabbitmq queue.
Basically it replicates what we do with connection and domain events.
It includes its own parser.

In this particular case, and to avoid sending the user/actor to wanda (it doesn't really need it), I'm simply querying the `operation_requested` activity log to get the actor. The both share the same operation id, and this is a UUID, so the unique possible return will be the request for this operation.
If for some reason, the request to wanda doesn't go through web, we return `system` as actor. At the end, we are logging `web` things.

![image](https://github.com/user-attachments/assets/fea45aba-9a04-43b1-b481-5d39de2bf917)

## How was this tested?
UT