### PR TITLE
Operation policy messages

### DIFF
--- a/lib/trento/operations/database_instance_policy.ex
+++ b/lib/trento/operations/database_instance_policy.ex
@@ -7,6 +7,8 @@ defmodule Trento.Operations.DatabaseInstancePolicy do
 
   require Trento.Enums.Health, as: Health
 
+  alias Trento.Support.OperationsHelper
+
   alias Trento.Clusters.Projections.ClusterReadModel
   alias Trento.Databases.Projections.DatabaseInstanceReadModel
   alias Trento.Hosts.Projections.HostReadModel
@@ -16,26 +18,33 @@ defmodule Trento.Operations.DatabaseInstancePolicy do
   # - cluster is in maintenance
   def authorize_operation(
         :maintenance,
-        %DatabaseInstanceReadModel{health: health},
-        _
-      )
-      when health != Health.unknown(),
-      do: false
-
-  def authorize_operation(
-        :maintenance,
-        %DatabaseInstanceReadModel{host: %HostReadModel{cluster: nil}},
-        _
-      ),
-      do: true
-
-  def authorize_operation(
-        :maintenance,
-        %DatabaseInstanceReadModel{host: %HostReadModel{cluster: cluster}},
-        %{cluster_resource_id: _cluster_resource_id} = params
+        %DatabaseInstanceReadModel{} = application_instance,
+        params
       ) do
-    ClusterReadModel.authorize_operation(:maintenance, cluster, params)
+    OperationsHelper.reduce_operation_authorizations([
+      instance_running(application_instance),
+      cluster_maintenance(application_instance, params)
+    ])
   end
 
-  def authorize_operation(_, _, _), do: false
+  def authorize_operation(_, _, _), do: {:error, ["Unknown operation"]}
+
+  defp instance_running(%DatabaseInstanceReadModel{
+         sid: sid,
+         instance_number: instance_number,
+         health: health
+       })
+       when health != Health.unknown(),
+       do: {:error, ["Instance #{instance_number} of HANA database #{sid} is not stopped"]}
+
+  defp instance_running(_), do: :ok
+
+  defp cluster_maintenance(%DatabaseInstanceReadModel{host: %HostReadModel{cluster: nil}}, _),
+    do: :ok
+
+  defp cluster_maintenance(
+         %DatabaseInstanceReadModel{host: %HostReadModel{cluster: cluster}},
+         params
+       ),
+       do: ClusterReadModel.authorize_operation(:maintenance, cluster, params)
 end

--- a/lib/trento/operations/host_policy.ex
+++ b/lib/trento/operations/host_policy.ex
@@ -5,6 +5,8 @@ defmodule Trento.Operations.HostPolicy do
 
   @behaviour Trento.Operations.PolicyBehaviour
 
+  alias Trento.Support.OperationsHelper
+
   alias Trento.Clusters.Projections.ClusterReadModel
   alias Trento.Databases.Projections.DatabaseInstanceReadModel
   alias Trento.Hosts.Projections.HostReadModel
@@ -26,7 +28,7 @@ defmodule Trento.Operations.HostPolicy do
       |> Enum.map(fn application_instance ->
         %ApplicationInstanceReadModel{application_instance | host: host}
       end)
-      |> Enum.all?(fn application_instance ->
+      |> OperationsHelper.reduce_operation_authorizations(:ok, fn application_instance ->
         ApplicationInstanceReadModel.authorize_operation(:maintenance, application_instance, %{
           cluster_resource_id: nil
         })
@@ -35,21 +37,21 @@ defmodule Trento.Operations.HostPolicy do
     # Get SAPHana or SapHanaController master resource id
     cluster_resource_id = get_saptune_operation_resource_id(cluster)
 
-    databases_maintenance_authorized =
-      database_instances
-      |> Enum.map(fn database_instances ->
-        %DatabaseInstanceReadModel{database_instances | host: host}
-      end)
-      |> Enum.all?(fn database_instances ->
+    database_instances
+    |> Enum.map(fn database_instances ->
+      %DatabaseInstanceReadModel{database_instances | host: host}
+    end)
+    |> OperationsHelper.reduce_operation_authorizations(
+      applications_maintenance_authorized,
+      fn database_instances ->
         DatabaseInstanceReadModel.authorize_operation(:maintenance, database_instances, %{
           cluster_resource_id: cluster_resource_id
         })
-      end)
-
-    Enum.all?([applications_maintenance_authorized, databases_maintenance_authorized])
+      end
+    )
   end
 
-  def authorize_operation(_, _, _), do: false
+  def authorize_operation(_, _, _), do: {:error, ["Unknown operation"]}
 
   defp get_saptune_operation_resource_id(%ClusterReadModel{
          details: %{nodes: nodes}

--- a/lib/trento/operations/policy_behaviour.ex
+++ b/lib/trento/operations/policy_behaviour.ex
@@ -27,5 +27,5 @@ defmodule Trento.Operations.PolicyBehaviour do
                 | HostReadModel.t()
                 | SapSystemReadModel.t(),
               params :: map
-            ) :: boolean()
+            ) :: :ok | {:error, [String.t()]}
 end

--- a/lib/trento/support/operations_helper.ex
+++ b/lib/trento/support/operations_helper.ex
@@ -1,0 +1,38 @@
+defmodule Trento.Support.OperationsHelper do
+  @moduledoc """
+  Helper functions for operations
+  """
+
+  @spec reduce_operation_authorizations(
+          authorizations :: [Enumerable.t()],
+          acc :: :ok | {:error, [String.t()]}
+        ) ::
+          :ok | {:error, [String.t()]}
+  def reduce_operation_authorizations(authorizations, acc \\ :ok) do
+    Enum.reduce(authorizations, acc, fn
+      :ok, :ok ->
+        :ok
+
+      :ok, {:error, errors} ->
+        {:error, errors}
+
+      {:error, errors}, :ok ->
+        {:error, errors}
+
+      {:error, new_errors}, {:error, errors} ->
+        {:error, errors |> Enum.concat(new_errors) |> Enum.uniq()}
+    end)
+  end
+
+  @spec reduce_operation_authorizations(
+          authorizations :: [Enumerable.t()],
+          acc :: :ok | {:error, [String.t()]},
+          func :: function()
+        ) ::
+          :ok | {:error, [String.t()]}
+  def reduce_operation_authorizations(authorizations, acc, fun) do
+    authorizations
+    |> Enum.map(fn x -> fun.(x) end)
+    |> reduce_operation_authorizations(acc)
+  end
+end

--- a/lib/trento_web/controllers/error_json.ex
+++ b/lib/trento_web/controllers/error_json.ex
@@ -32,6 +32,29 @@ defmodule TrentoWeb.ErrorJSON do
     }
   end
 
+  def render("403.json", %{errors: errors}) do
+    %{
+      errors:
+        Enum.map(errors, fn error ->
+          %{
+            title: "Forbidden",
+            detail: error
+          }
+        end)
+    }
+  end
+
+  def render("403.json", _) do
+    %{
+      errors: [
+        %{
+          title: "Forbidden",
+          detail: "You can't perform the operation or access the resource."
+        }
+      ]
+    }
+  end
+
   def render("404.json", %{reason: reason}) do
     %{
       errors: [
@@ -104,17 +127,6 @@ defmodule TrentoWeb.ErrorJSON do
         %{
           title: "Not implemented",
           detail: reason
-        }
-      ]
-    }
-  end
-
-  def render("403.json", _) do
-    %{
-      errors: [
-        %{
-          title: "Forbidden",
-          detail: "You can't perform the operation or access the resource."
         }
       ]
     }

--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -214,6 +214,13 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"403")
   end
 
+  def call(conn, {:error, :forbidden, errors}) do
+    conn
+    |> put_status(:forbidden)
+    |> put_view(json: ErrorJSON)
+    |> render(:"403", errors: errors)
+  end
+
   def call(conn, {:error, :stale_entry}) do
     conn
     |> put_status(:precondition_failed)

--- a/lib/trento_web/plugs/operations_policy_plug.ex
+++ b/lib/trento_web/plugs/operations_policy_plug.ex
@@ -115,10 +115,9 @@ defmodule TrentoWeb.Plugs.OperationsPolicyPlug do
   end
 
   defp handle_permission(policy, operation, resource, params) do
-    if policy.authorize_operation(operation, resource, params) do
-      :ok
-    else
-      {:error, :forbidden}
+    case policy.authorize_operation(operation, resource, params) do
+      :ok -> :ok
+      {:error, errors} -> {:error, :forbidden, errors}
     end
   end
 end

--- a/test/trento/operations/application_instance_policy_test.exs
+++ b/test/trento/operations/application_instance_policy_test.exs
@@ -13,34 +13,54 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
   test "should forbid unknown operation" do
     instance = build(:application_instance)
 
-    refute ApplicationInstancePolicy.authorize_operation(:unknown, instance, %{})
+    assert {:error, ["Unknown operation"]} ==
+             ApplicationInstancePolicy.authorize_operation(:unknown, instance, %{})
   end
 
   describe "maintenance" do
     test "should forbid operation if the application instance is not stopped" do
-      instance = build(:application_instance, health: Health.passing())
+      cluster_details =
+        build(:hana_cluster_details, maintenance_mode: true, nodes: [])
 
-      refute ApplicationInstancePolicy.authorize_operation(:maintenance, instance, %{})
+      cluster = build(:cluster, details: cluster_details)
+
+      %{sid: sid, instance_number: instance_number} =
+        instance =
+        build(:application_instance,
+          health: Health.passing(),
+          host: %HostReadModel{cluster: cluster}
+        )
+
+      assert {:error, ["Instance #{instance_number} of SAP system #{sid} is not stopped"]} ==
+               ApplicationInstancePolicy.authorize_operation(:maintenance, instance, %{
+                 cluster_resource_id: nil
+               })
     end
 
     test "should authorize operation if the application instance is not clustered" do
       instance =
         build(:application_instance, health: Health.unknown(), host: %HostReadModel{cluster: nil})
 
-      assert ApplicationInstancePolicy.authorize_operation(:maintenance, instance, %{})
+      assert :ok == ApplicationInstancePolicy.authorize_operation(:maintenance, instance, %{})
     end
 
     test "should authorize operation if the cluster is in maintenance mode" do
+      cluster_name = Faker.StarWars.character()
+
       scenarios = [
-        %{maintenance_mode: true, authorized: true},
-        %{maintenance_mode: false, authorized: false}
+        %{maintenance_mode: true, result: :ok},
+        %{
+          maintenance_mode: false,
+          result:
+            {:error, ["Cluster #{cluster_name} operating this host is not in maintenance mode"]}
+        }
       ]
 
-      for %{maintenance_mode: maintenance_mode, authorized: authorized} <- scenarios do
+      for %{maintenance_mode: maintenance_mode, result: result} <- scenarios do
         cluster_details =
           build(:hana_cluster_details, maintenance_mode: maintenance_mode, nodes: [])
 
-        cluster = build(:cluster, details: cluster_details)
+        cluster = build(:cluster, name: cluster_name, details: cluster_details)
 
         instance =
           build(:application_instance,
@@ -48,11 +68,36 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
             host: %HostReadModel{cluster: cluster}
           )
 
-        assert authorized ==
+        assert result ==
                  ApplicationInstancePolicy.authorize_operation(:maintenance, instance, %{
                    cluster_resource_id: nil
                  })
       end
+    end
+
+    test "should forbid operation if the application instance is not stopped and cluster is not in maintenance" do
+      cluster_name = Faker.StarWars.character()
+
+      cluster_details =
+        build(:hana_cluster_details, maintenance_mode: false, nodes: [])
+
+      cluster = build(:cluster, name: cluster_name, details: cluster_details)
+
+      %{sid: sid, instance_number: instance_number} =
+        instance =
+        build(:application_instance,
+          health: Health.passing(),
+          host: %HostReadModel{cluster: cluster}
+        )
+
+      assert {:error,
+              [
+                "Instance #{instance_number} of SAP system #{sid} is not stopped",
+                "Cluster #{cluster_name} operating this host is not in maintenance mode"
+              ]} ==
+               ApplicationInstancePolicy.authorize_operation(:maintenance, instance, %{
+                 cluster_resource_id: nil
+               })
     end
   end
 end

--- a/test/trento/operations/cluster_policy_test.exs
+++ b/test/trento/operations/cluster_policy_test.exs
@@ -9,23 +9,30 @@ defmodule Trento.Operations.ClusterPolicyTest do
   test "should forbid unknown operation" do
     cluster = build(:cluster)
 
-    refute ClusterPolicy.authorize_operation(:unknown, cluster, %{})
+    assert {:error, ["Unknown operation"]} ==
+             ClusterPolicy.authorize_operation(:unknown, cluster, %{})
   end
 
   describe "maintenance" do
     test "should authorize operation depending on the cluster maintenance mode" do
+      cluster_name = Faker.StarWars.character()
+
       scenarios = [
-        %{maintenance_mode: true, authorized: true},
-        %{maintenance_mode: false, authorized: false}
+        %{maintenance_mode: true, result: :ok},
+        %{
+          maintenance_mode: false,
+          result:
+            {:error, ["Cluster #{cluster_name} operating this host is not in maintenance mode"]}
+        }
       ]
 
-      for %{maintenance_mode: maintenance_mode, authorized: authorized} <- scenarios do
+      for %{maintenance_mode: maintenance_mode, result: result} <- scenarios do
         cluster_details =
           build(:hana_cluster_details, maintenance_mode: maintenance_mode, nodes: [])
 
-        cluster = build(:cluster, details: cluster_details)
+        cluster = build(:cluster, name: cluster_name, details: cluster_details)
 
-        assert authorized ==
+        assert result ==
                  ClusterPolicy.authorize_operation(:maintenance, cluster, %{
                    cluster_resource_id: nil
                  })
@@ -33,18 +40,28 @@ defmodule Trento.Operations.ClusterPolicyTest do
     end
 
     test "should authorize operation depending on the given cluster resource managed state" do
+      cluster_name = Faker.StarWars.character()
+      cluster_resource_id = UUID.uuid4()
+
       scenarios = [
-        %{managed: true, authorized: false},
-        %{managed: false, authorized: true}
+        %{
+          managed: true,
+          result:
+            {:error,
+             [
+               "Cluster #{cluster_name} or resource #{cluster_resource_id} operating this host are not in maintenance mode"
+             ]}
+        },
+        %{managed: false, result: :ok}
       ]
 
-      for %{managed: managed, authorized: authorized} <- scenarios do
-        %{id: cluster_resource_id} = cluster_resource = build(:cluster_resource, managed: managed)
+      for %{managed: managed, result: result} <- scenarios do
+        cluster_resource = build(:cluster_resource, id: cluster_resource_id, managed: managed)
         nodes = build_list(1, :hana_cluster_node, resources: [cluster_resource])
         cluster_details = build(:hana_cluster_details, maintenance_mode: false, nodes: nodes)
-        cluster = build(:cluster, details: cluster_details)
+        cluster = build(:cluster, name: cluster_name, details: cluster_details)
 
-        assert authorized ==
+        assert result ==
                  ClusterPolicy.authorize_operation(:maintenance, cluster, %{
                    cluster_resource_id: cluster_resource_id
                  })

--- a/test/trento/operations/database_instance_policy_test.exs
+++ b/test/trento/operations/database_instance_policy_test.exs
@@ -13,34 +13,54 @@ defmodule Trento.Operations.DatabaseInstancePolicyTest do
   test "should forbid unknown operation" do
     instance = build(:database_instance)
 
-    refute DatabaseInstancePolicy.authorize_operation(:unknown, instance, %{})
+    assert {:error, ["Unknown operation"]} ==
+             DatabaseInstancePolicy.authorize_operation(:unknown, instance, %{})
   end
 
   describe "maintenance" do
     test "should forbid operation if the database instance is not stopped" do
-      instance = build(:database_instance, health: Health.passing())
+      cluster_details =
+        build(:hana_cluster_details, maintenance_mode: true, nodes: [])
 
-      refute DatabaseInstancePolicy.authorize_operation(:maintenance, instance, %{})
+      cluster = build(:cluster, details: cluster_details)
+
+      %{sid: sid, instance_number: instance_number} =
+        instance =
+        build(:database_instance,
+          health: Health.passing(),
+          host: %HostReadModel{cluster: cluster}
+        )
+
+      assert {:error, ["Instance #{instance_number} of HANA database #{sid} is not stopped"]} ==
+               DatabaseInstancePolicy.authorize_operation(:maintenance, instance, %{
+                 cluster_resource_id: nil
+               })
     end
 
     test "should authorize operation if the database instance is not clustered" do
       instance =
         build(:database_instance, health: Health.unknown(), host: %HostReadModel{cluster: nil})
 
-      assert DatabaseInstancePolicy.authorize_operation(:maintenance, instance, %{})
+      assert :ok == DatabaseInstancePolicy.authorize_operation(:maintenance, instance, %{})
     end
 
     test "should authorize operation if the cluster is in maintenance mode" do
+      cluster_name = Faker.StarWars.character()
+
       scenarios = [
-        %{maintenance_mode: true, authorized: true},
-        %{maintenance_mode: false, authorized: false}
+        %{maintenance_mode: true, result: :ok},
+        %{
+          maintenance_mode: false,
+          result:
+            {:error, ["Cluster #{cluster_name} operating this host is not in maintenance mode"]}
+        }
       ]
 
-      for %{maintenance_mode: maintenance_mode, authorized: authorized} <- scenarios do
+      for %{maintenance_mode: maintenance_mode, result: result} <- scenarios do
         cluster_details =
           build(:hana_cluster_details, maintenance_mode: maintenance_mode, nodes: [])
 
-        cluster = build(:cluster, details: cluster_details)
+        cluster = build(:cluster, name: cluster_name, details: cluster_details)
 
         instance =
           build(:database_instance,
@@ -48,11 +68,36 @@ defmodule Trento.Operations.DatabaseInstancePolicyTest do
             host: %HostReadModel{cluster: cluster}
           )
 
-        assert authorized ==
+        assert result ==
                  DatabaseInstancePolicy.authorize_operation(:maintenance, instance, %{
                    cluster_resource_id: nil
                  })
       end
+    end
+
+    test "should forbid operation if the database instance is not stopped and cluster is not in maintenance" do
+      cluster_name = Faker.StarWars.character()
+
+      cluster_details =
+        build(:hana_cluster_details, maintenance_mode: false, nodes: [])
+
+      cluster = build(:cluster, name: cluster_name, details: cluster_details)
+
+      %{sid: sid, instance_number: instance_number} =
+        instance =
+        build(:database_instance,
+          health: Health.passing(),
+          host: %HostReadModel{cluster: cluster}
+        )
+
+      assert {:error,
+              [
+                "Instance #{instance_number} of HANA database #{sid} is not stopped",
+                "Cluster #{cluster_name} operating this host is not in maintenance mode"
+              ]} ==
+               DatabaseInstancePolicy.authorize_operation(:maintenance, instance, %{
+                 cluster_resource_id: nil
+               })
     end
   end
 end

--- a/test/trento/support/operations_helper_test.exs
+++ b/test/trento/support/operations_helper_test.exs
@@ -1,0 +1,44 @@
+defmodule Trento.Support.OperationsHelperTest do
+  use ExUnit.Case
+
+  alias Trento.Support.OperationsHelper
+
+  describe "reduce_operation_authorizations" do
+    test "should reduce authorizations results" do
+      scenarios = [
+        %{
+          authorizations: [:ok, :ok],
+          acc: :ok,
+          result: :ok
+        },
+        %{
+          authorizations: [
+            :ok,
+            {:error, ["error2"]},
+            {:error, ["error3", "error4"]},
+            :ok,
+            {:error, ["error2"]}
+          ],
+          acc: {:error, ["error1"]},
+          result: {:error, ["error1", "error2", "error3", "error4"]}
+        }
+      ]
+
+      for %{authorizations: authorizations, acc: acc, result: result} <- scenarios do
+        assert result == OperationsHelper.reduce_operation_authorizations(authorizations, acc)
+      end
+    end
+
+    test "should reduce authorizations results with default acc" do
+      assert {:error, ["error1"]} ==
+               OperationsHelper.reduce_operation_authorizations([{:error, ["error1"]}, :ok])
+    end
+
+    test "should reduce authorizations results with functions" do
+      assert {:error, ["error1", "error2", "error3"]} ==
+               OperationsHelper.reduce_operation_authorizations([1, 2, 3], :ok, fn index ->
+                 {:error, ["error#{index}"]}
+               end)
+    end
+  end
+end


### PR DESCRIPTION
# Description

Talking with @abravosuse , we agreed that having detailed information about why the operation is not authorized is a really good thing to have. So instead of returning a boolean in the authorization, this PR changes the code to return a list of forbidden errors if the operation is forbidden.
So the return now is a `:ok | {:error, [errors}` thing instead of a boolean.
In order to accumulate all the errors, I have create the `OperationsHelper.reduce_operation_authorizations` function. It is a pretty simple reduce usage that accumulates the errors.

The pattern matching gets a bit more difficult, as we cannot simply return false the first forbidden scenario, and we need to accumulate the errors, but it is not that much.

Now in the request api forbidden error, we return the list of the forbidden messages as well, after changing the plug.

Now, we can have fancy things like this in the frontend:
![image](https://github.com/user-attachments/assets/c5bd0968-d9c5-4af8-af00-a1d870a3818d)

## How was this tested?

UT