### PR TITLE
Operation user authorization

### DIFF
--- a/lib/trento/hosts/policy.ex
+++ b/lib/trento/hosts/policy.ex
@@ -22,6 +22,9 @@ defmodule Trento.Hosts.Policy do
   def authorize(:delete, %User{} = user, HostReadModel),
     do: has_global_ability?(user) or has_cleanup_ability?(user)
 
+  def authorize(:request_operation, %User{} = user, %{operation: "saptune_solution_apply"}),
+    do: has_global_ability?(user) or has_saptune_solution_apply_ability?(user)
+
   def authorize(_, _, _), do: true
 
   defp has_select_checks_ability?(user),
@@ -32,4 +35,7 @@ defmodule Trento.Hosts.Policy do
 
   defp has_cleanup_ability?(user),
     do: user_has_ability?(user, %{name: "cleanup", resource: "host"})
+
+  defp has_saptune_solution_apply_ability?(user),
+    do: user_has_ability?(user, %{name: "saptune_solution_apply", resource: "host"})
 end

--- a/lib/trento_web/controllers/v1/host_controller.ex
+++ b/lib/trento_web/controllers/v1/host_controller.ex
@@ -202,7 +202,7 @@ defmodule TrentoWeb.V1.HostController do
 
   def get_policy_resource(%{
         private: %{phoenix_action: :request_operation},
-        params: %{"operation" => operation}
+        path_params: %{"operation" => operation}
       }),
       do: %{operation: operation}
 

--- a/lib/trento_web/controllers/v1/host_controller.ex
+++ b/lib/trento_web/controllers/v1/host_controller.ex
@@ -200,6 +200,12 @@ defmodule TrentoWeb.V1.HostController do
     end
   end
 
+  def get_policy_resource(%{
+        private: %{phoenix_action: :request_operation},
+        params: %{"operation" => operation}
+      }),
+      do: %{operation: operation}
+
   def get_policy_resource(_), do: HostReadModel
 
   def get_operation_host(%{params: %{id: id}}) do

--- a/priv/repo/migrations/20250306083321_add_saptune_solution_apply_abilities.exs
+++ b/priv/repo/migrations/20250306083321_add_saptune_solution_apply_abilities.exs
@@ -1,0 +1,11 @@
+defmodule Trento.Repo.Migrations.AddSaptuneSolutionApplyAbilities do
+  use Ecto.Migration
+
+  def up do
+    execute "INSERT INTO abilities(name, resource, label, inserted_at, updated_at) VALUES ('saptune_solution_apply', 'host', 'Permits Saptune solution apply operation on host', NOW(), NOW())"
+  end
+
+  def down do
+    execute "DELETE FROM abilities WHERE name = 'saptune_solution_apply' AND resource = 'host'"
+  end
+end

--- a/test/trento/hosts/policy_test.exs
+++ b/test/trento/hosts/policy_test.exs
@@ -54,6 +54,26 @@ defmodule Trento.Hosts.PolicyTest do
     refute Policy.authorize(:delete, user, HostReadModel)
   end
 
+  describe "request_operation" do
+    test "should allow saptune_solution_apply operation if the user has saptune_solution_apply:host ability" do
+      user = %User{abilities: [%Ability{name: "saptune_solution_apply", resource: "host"}]}
+
+      assert Policy.authorize(:request_operation, user, %{operation: "saptune_solution_apply"})
+    end
+
+    test "should allow saptune_solution_apply operation if the user has all:all ability" do
+      user = %User{abilities: [%Ability{name: "all", resource: "all"}]}
+
+      assert Policy.authorize(:request_operation, user, %{operation: "saptune_solution_apply"})
+    end
+
+    test "should disallow saptune_solution_apply operation if the user does not have saptune_solution_apply:host ability" do
+      user = %User{abilities: []}
+
+      refute Policy.authorize(:request_operation, user, %{operation: "saptune_solution_apply"})
+    end
+  end
+
   test "should allow unguarded actions" do
     user = %User{abilities: []}
 


### PR DESCRIPTION
# Description
Authorize `request_operation` specific operations, `saptune_solution_apply` in this case.
It includes a new ability `saptune_solution_apply`.
We will have individual abilities always. Future examples `start:application_instance`, `stop:application_instance`, etc.
We will group them in the frontend by now as we do with other similar things.

I will remove the ability from the frontend temporarily in the next PR, based on frontend changes.

## How was this tested?

UT
