### PR TITLE
Operation user authorization frontend

### DIFF
--- a/assets/js/common/AbilitiesMultiSelect/AbilitiesMultiSelect.jsx
+++ b/assets/js/common/AbilitiesMultiSelect/AbilitiesMultiSelect.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { assign, find } from 'lodash';
+import { getFromConfig } from '@lib/config';
 
 import MultiSelect from '@common/MultiSelect';
 
@@ -48,9 +49,14 @@ const groupedAbilities = [
       'all:activity_logs_settings',
     ],
   },
+  {
+    ability: 'operation:all',
+    tooltip: 'Permits running operations in all resources',
+    groupAbilities: ['saptune_solution_apply:host'],
+  },
 ];
 
-const mapAbilities = (abilities) =>
+const mapAbilities = (abilities, operationsEnabled) =>
   abilities.reduce((acc, { id, name, resource, label }) => {
     const valueLabel = `${name}:${resource}`;
     const groupedAbility = find(groupedAbilities, ({ groupAbilities }) =>
@@ -59,6 +65,11 @@ const mapAbilities = (abilities) =>
 
     if (!groupedAbility) {
       return acc.concat({ value: id, label: valueLabel, tooltip: label });
+    }
+
+    // remove operations abilities by now
+    if (!operationsEnabled && groupedAbility.ability === 'operation:all') {
+      return acc;
     }
 
     const currentOption = find(acc, { label: groupedAbility.ability });
@@ -82,14 +93,15 @@ function AbilitiesMultiSelect({
   userAbilities,
   placeholder,
   setAbilities,
+  operationsEnabled = getFromConfig('operationsEnabled'),
   ...props
 }) {
   return (
     <MultiSelect
       aria-label="permissions"
       placeholder={placeholder}
-      values={mapAbilities(userAbilities)}
-      options={mapAbilities(abilities)}
+      values={mapAbilities(userAbilities, operationsEnabled)}
+      options={mapAbilities(abilities, operationsEnabled)}
       onChange={(values) => setAbilities(unmapAbilities(values))}
       getOptionValue={(option) => option.value.toString()}
       {...props}

--- a/assets/js/common/AbilitiesMultiSelect/AbilitiesMultiSelect.test.jsx
+++ b/assets/js/common/AbilitiesMultiSelect/AbilitiesMultiSelect.test.jsx
@@ -15,6 +15,7 @@ describe('AbilitiesMultiSelect Component', () => {
       'all:checks_selection',
       'all:checks_execution',
       'cleanup:all',
+      'operation:all',
     ];
     const abilities = [
       { id: 1, name: 'all', resource: 'host_checks_selection' },
@@ -31,6 +32,7 @@ describe('AbilitiesMultiSelect Component', () => {
       { id: 12, name: 'all', resource: 'api_key_settings' },
       { id: 13, name: 'all', resource: 'suma_settings' },
       { id: 14, name: 'all', resource: 'activity_logs_settings' },
+      { id: 15, name: 'saptune_solution_apply', resource: 'host' },
     ];
 
     render(
@@ -38,6 +40,7 @@ describe('AbilitiesMultiSelect Component', () => {
         abilities={abilities}
         userAbilities={[]}
         setAbilities={noop}
+        operationsEnabled
       />
     );
 
@@ -59,6 +62,8 @@ describe('AbilitiesMultiSelect Component', () => {
     await user.click(screen.getByText('all:tags'));
     await user.click(screen.getByLabelText('permissions'));
     await user.click(screen.getByText('all:settings'));
+    await user.click(screen.getByLabelText('permissions'));
+    await user.click(screen.getByText('operation:all'));
     await user.click(screen.getByLabelText('permissions'));
 
     expect(screen.getByText('No options')).toBeVisible();
@@ -92,23 +97,30 @@ describe('AbilitiesMultiSelect Component', () => {
           { id: 1, name: 'all', resource: 'all' },
           { id: 2, name: 'all', resource: 'host_checks_selection' },
           { id: 3, name: 'all', resource: 'cluster_checks_selection' },
+          { id: 4, name: 'saptune_solution_apply', resource: 'host' },
         ]}
         userAbilities={[
           { id: 1, name: 'all', resource: 'all' },
           { id: 2, name: 'all', resource: 'host_checks_selection' },
           { id: 3, name: 'all', resource: 'cluster_checks_selection' },
+          { id: 4, name: 'saptune_solution_apply', resource: 'host' },
         ]}
         setAbilities={noop}
+        operationsEnabled
       />
     );
 
     screen.getByText('all:checks_selection');
     screen.getByText('all:all');
+    screen.getByText('operation:all');
     expect(
       screen.queryByText('all:host_checks_selection')
     ).not.toBeInTheDocument();
     expect(
       screen.queryByText('all:cluster_checks_selection')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('saptune_solution_apply:host')
     ).not.toBeInTheDocument();
 
     await user.click(screen.getByLabelText('permissions'));

--- a/assets/js/common/OperationsButton/OperationsButton.jsx
+++ b/assets/js/common/OperationsButton/OperationsButton.jsx
@@ -11,8 +11,34 @@ import {
 import { EOS_MORE_VERT, EOS_LOADING_ANIMATED } from 'eos-icons-react';
 
 import Button from '@common/Button';
+import DisabledGuard from '@common/DisabledGuard';
 
-function OperationsButton({ operations }) {
+// The custom component is required to wrap in the DisabledGuard component
+// and pass the disabled value to the child
+function CustomMenuButton({ value, running, disabled, onClick }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      role="menuitem"
+      className={classNames(
+        'w-full rounded-md text-left block px-4 py-2 text-sm',
+        {
+          'text-gray-700 hover:bg-gray-100': !disabled,
+        },
+        { 'text-gray-400': disabled }
+      )}
+      disabled={disabled}
+    >
+      {running && (
+        <EOS_LOADING_ANIMATED className="inline-block fill-jungle-green-500 mr-1" />
+      )}
+      {value}
+    </button>
+  );
+}
+
+function OperationsButton({ operations, userAbilities }) {
   const ref = useRef(null);
   const someRunning = some(operations, { running: true });
 
@@ -35,28 +61,23 @@ function OperationsButton({ operations }) {
         as="div"
         className="w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 px-3 py-3 focus:outline-none"
       >
-        {operations.map(({ value, running, disabled, onClick }) => (
+        {operations.map(({ value, running, disabled, permitted, onClick }) => (
           <Fragment key={value}>
             <MenuItem>
-              <button
-                type="button"
-                onClick={onClick}
-                className={classNames(
-                  'w-full rounded-md text-left block px-4 py-2 text-sm',
-                  {
-                    'text-gray-700 hover:bg-gray-100':
-                      !disabled && !someRunning,
-                  },
-                  { 'text-gray-400': disabled || someRunning }
-                )}
-                disabled={disabled || someRunning}
+              <DisabledGuard
+                userAbilities={userAbilities}
+                permitted={permitted}
+                tooltipWrap
               >
-                {running && (
-                  <EOS_LOADING_ANIMATED className="inline-block fill-jungle-green-500 mr-1" />
-                )}
-                {value}
-              </button>
+                <CustomMenuButton
+                  value={value}
+                  running={running}
+                  disabled={disabled || someRunning}
+                  onClick={onClick}
+                />
+              </DisabledGuard>
             </MenuItem>
+
             <MenuSeparator className="my-1" />
           </Fragment>
         ))}

--- a/assets/js/common/OperationsButton/OperationsButton.stories.jsx
+++ b/assets/js/common/OperationsButton/OperationsButton.stories.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { noop } from 'lodash';
 
 import OperationsButton from './OperationsButton';
@@ -11,45 +10,56 @@ export default {
       description: 'Operations to be displayed in the operations button menu',
       control: 'array',
     },
+    userAbilities: {
+      control: 'array',
+      description: 'Current user abilities',
+    },
   },
+};
+
+export const Default = {
   args: {
     operations: [
       {
         value: 'Operation 1',
         running: false,
         disabled: false,
+        permitted: ['foo:resource'],
         onClick: noop,
       },
       {
         value: 'Operation 2',
         running: false,
         disabled: false,
+        permitted: ['bar:resource'],
         onClick: noop,
       },
     ],
+    userAbilities: [{ name: 'all', resource: 'all' }],
   },
 };
 
-export function Default(args) {
-  return <OperationsButton {...args} />;
-}
+export const Disabled = {
+  args: {
+    ...Default.args,
+    operations: Object.assign([], Default.args.operations, {
+      0: { ...Default.args.operations[0], disabled: true },
+    }),
+  },
+};
 
-export function Disabled({ operations }) {
-  return (
-    <OperationsButton
-      operations={Object.assign([], operations, {
-        0: { ...operations[0], disabled: true },
-      })}
-    />
-  );
-}
+export const Running = {
+  args: {
+    ...Default.args,
+    operations: Object.assign([], Default.args.operations, {
+      0: { ...Default.args.operations[0], running: true },
+    }),
+  },
+};
 
-export function Running({ operations }) {
-  return (
-    <OperationsButton
-      operations={Object.assign([], operations, {
-        0: { ...operations[0], running: true },
-      })}
-    />
-  );
-}
+export const Forbidden = {
+  args: {
+    ...Default.args,
+    userAbilities: [{ name: 'foo', resource: 'resource' }],
+  },
+};

--- a/assets/js/common/OperationsButton/OperationsButton.test.jsx
+++ b/assets/js/common/OperationsButton/OperationsButton.test.jsx
@@ -10,22 +10,30 @@ const testOperations = [
     value: 'Operation 1',
     running: false,
     disabled: false,
+    permitted: ['foo:resource'],
     onClick: mockOnClick,
   },
   {
     value: 'Operation 2',
     running: false,
     disabled: false,
+    permitted: ['bar:resource'],
     onClick: mockOnClick,
   },
 ];
+const userAbilities = [{ name: 'all', resource: 'all' }];
 
 describe('OperationsButton', () => {
   it('should show correct operations', async () => {
     const user = userEvent.setup();
 
     await act(async () => {
-      render(<OperationsButton operations={testOperations} />);
+      render(
+        <OperationsButton
+          operations={testOperations}
+          userAbilities={userAbilities}
+        />
+      );
     });
 
     expect(screen.getByText('Operations')).toBeInTheDocument();
@@ -47,7 +55,12 @@ describe('OperationsButton', () => {
     });
 
     await act(async () => {
-      render(<OperationsButton operations={disabledOperations} />);
+      render(
+        <OperationsButton
+          operations={disabledOperations}
+          userAbilities={userAbilities}
+        />
+      );
     });
 
     await user.click(screen.getByText('Operations'));
@@ -63,7 +76,12 @@ describe('OperationsButton', () => {
     });
 
     await act(async () => {
-      render(<OperationsButton operations={runningOperations} />);
+      render(
+        <OperationsButton
+          operations={runningOperations}
+          userAbilities={userAbilities}
+        />
+      );
     });
 
     await user.click(screen.getByText('Operations'));
@@ -75,5 +93,23 @@ describe('OperationsButton', () => {
       .getByRole('menuitem', { name: 'Operation 1' })
       .querySelector("[data-testid='eos-svg-component']");
     expect(svgEl).toBeInTheDocument();
+  });
+
+  it('should forbid operation is the user does not have the correct abilities', async () => {
+    const user = userEvent.setup();
+
+    await act(async () => {
+      render(
+        <OperationsButton
+          operations={testOperations}
+          userAbilities={[{ name: 'foo', resource: 'resource' }]}
+        />
+      );
+    });
+
+    await user.click(screen.getByText('Operations'));
+
+    expect(screen.getByText('Operation 1')).toBeEnabled();
+    expect(screen.getByText('Operation 2')).toBeDisabled();
   });
 });

--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -169,12 +169,14 @@ function HostDetails({
             <div className="flex w-fit whitespace-nowrap">
               {operationsEnabled && (
                 <OperationsButton
+                  userAbilities={userAbilities}
                   operations={[
                     {
                       value: 'Apply Saptune Solution',
                       running: runningOperationName === SAPTUNE_SOLUTION_APPLY,
                       disabled:
                         !sapPresent || get(saptuneStatus, 'enabled_solution'),
+                      permitted: ['saptune_solution_apply:host'],
                       onClick: () => {
                         setSaptuneSolutionApplyModalOpen(true);
                       },

--- a/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
@@ -344,3 +344,10 @@ export const WithDisabledOperation = {
     },
   },
 };
+
+export const WithForbiddenOperation = {
+  args: {
+    ...Default.args,
+    userAbilities: [],
+  },
+};

--- a/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
@@ -524,6 +524,58 @@ describe('HostDetails component', () => {
       const startExecutionButton = screen.getByText('Start Execution');
       expect(startExecutionButton).toBeEnabled();
     });
+
+    it('should disable Saptune apply operation button when the user abilities are not compatible', async () => {
+      const user = userEvent.setup();
+
+      renderWithRouter(
+        <HostDetails
+          agentVersion="2.0.0"
+          userAbilities={[]}
+          operationsEnabled
+        />
+      );
+
+      const operationsButton = screen.getByRole('button', {
+        name: 'Operations',
+      });
+      await user.click(operationsButton);
+
+      const menuButton = screen.getByRole('menuitem', {
+        name: 'Apply Saptune Solution',
+      });
+
+      expect(menuButton).toBeDisabled();
+
+      await user.hover(menuButton);
+      expect(
+        screen.queryByText('You are not authorized for this action')
+      ).toBeInTheDocument();
+    });
+
+    it('should enable Saptune apply operation button when the user abilities are compatible', async () => {
+      const user = userEvent.setup();
+
+      renderWithRouter(
+        <HostDetails
+          agentVersion="2.0.0"
+          userAbilities={[{ name: 'saptune_solution_apply', resource: 'host' }]}
+          operationsEnabled
+        />
+      );
+
+      await user.click(
+        screen.getByRole('button', {
+          name: 'Operations',
+        })
+      );
+
+      expect(
+        screen.getByRole('menuitem', {
+          name: 'Apply Saptune Solution',
+        })
+      ).Enabled();
+    });
   });
 
   describe('exporters', () => {


### PR DESCRIPTION
# Description
Guard operations authorizations based on user abilities.
@abravosuse I have grouped the currently existing `saptune_solution_apply:host` ability to `operation:all`.
So we will display only the 2nd when we need to select the abilities. 
It is the same we do for others like cleanup. Otherwise, we would overflow the options when we have more abilities. In the future we can decide to remove the grouping, it is just a visualization thing. The abilities are still stored one by one.

Related to: https://github.com/trento-project/web/pull/3368

![image](https://github.com/user-attachments/assets/4fcb9097-103e-45bf-b2d9-f20ffe920e6a)

![image](https://github.com/user-attachments/assets/9ffdf75d-88ac-4fbd-b697-eb35b441bc8b)

## How was this tested?

UT and storybook
