### PR TITLE
Fix operation_completed activity log severity level

### DIFF
--- a/lib/trento/activity_logging/severity_level.ex
+++ b/lib/trento/activity_logging/severity_level.ex
@@ -120,7 +120,7 @@ defmodule Trento.ActivityLog.SeverityLevel do
     "operation_completed" => %{
       type: :kv,
       key_suffix: "result",
-      values: %{"UPDATED" => :info, "NOT_UPDATED" => :info, "*" => :critical},
+      values: %{"updated" => :info, "not_updated" => :info, "*" => :critical},
       condition: :map_value_to_severity
     }
   }


### PR DESCRIPTION
# Description
Fix `operation_completed` activity log severity level usage.
I didn't know the values were lower cased.
