### PR TITLE
Backend for User Analytics Settings

### DIFF
--- a/lib/trento/users.ex
+++ b/lib/trento/users.ex
@@ -93,7 +93,10 @@ defmodule Trento.Users do
     if username == admin_username() do
       {:error, :forbidden}
     else
-      updated_attrs = maybe_set_password_change_requested_at(attrs, true)
+      updated_attrs =
+        attrs
+        |> maybe_set_password_change_requested_at(true)
+        |> maybe_enable_analytics()
 
       user
       |> User.profile_update_changeset(updated_attrs)
@@ -249,6 +252,14 @@ defmodule Trento.Users do
   end
 
   defp maybe_set_password_change_requested_at(attrs, _), do: attrs
+
+  defp maybe_enable_analytics(%{analytics_enabled: true} = attrs) do
+    Map.put(attrs, :analytics_enabled_at, DateTime.utc_now())
+  end
+
+  defp maybe_enable_analytics(attrs) do
+    Map.put(attrs, :analytics_enabled_at, nil)
+  end
 
   defp insert_abilities_multi(multi, []), do: multi
 

--- a/lib/trento/users/user.ex
+++ b/lib/trento/users/user.ex
@@ -40,6 +40,7 @@ defmodule Trento.Users.User do
     field :totp_enabled_at, :utc_datetime_usec
     field :totp_secret, EncryptedBinary, redact: true
     field :totp_last_used_at, :utc_datetime_usec
+    field :analytics_enabled_at, :utc_datetime_usec
     field :lock_version, :integer, default: 1
 
     many_to_many :abilities, Ability, join_through: UsersAbilities, unique: true
@@ -85,7 +86,7 @@ defmodule Trento.Users.User do
     |> pow_extension_changeset(attrs)
     |> validate_password()
     |> custom_fields_changeset(attrs)
-    |> cast(attrs, [:password_change_requested_at])
+    |> cast(attrs, [:password_change_requested_at, :analytics_enabled_at])
   end
 
   def totp_update_changeset(user, attrs) do

--- a/lib/trento_web/controllers/v1/profile_json.ex
+++ b/lib/trento_web/controllers/v1/profile_json.ex
@@ -11,6 +11,7 @@ defmodule TrentoWeb.V1.ProfileJSON do
           password_change_requested_at: password_change_requested_at,
           totp_enabled_at: totp_enabled_at,
           user_identities: user_identities,
+          analytics_enabled_at: analytics_enabled_at,
           inserted_at: created_at,
           updated_at: updated_at
         }
@@ -24,6 +25,7 @@ defmodule TrentoWeb.V1.ProfileJSON do
         password_change_requested: password_change_requested_at != nil,
         totp_enabled: totp_enabled_at != nil,
         created_at: created_at,
+        analytics_enabled: analytics_enabled_at != nil,
         idp_user: length(user_identities) > 0,
         updated_at: updated_at
       }

--- a/lib/trento_web/controllers/v1/users_json.ex
+++ b/lib/trento_web/controllers/v1/users_json.ex
@@ -16,6 +16,7 @@ defmodule TrentoWeb.V1.UsersJSON do
           password_change_requested_at: password_change_requested_at,
           user_identities: user_identities,
           totp_enabled_at: totp_enabled_at,
+          analytics_enabled_at: analytics_enabled_at,
           inserted_at: created_at,
           updated_at: updated_at
         }
@@ -30,6 +31,7 @@ defmodule TrentoWeb.V1.UsersJSON do
         idp_user: length(user_identities) > 0,
         password_change_requested_at: password_change_requested_at,
         totp_enabled_at: totp_enabled_at,
+        analytics_enabled_at: analytics_enabled_at,
         created_at: created_at,
         updated_at: updated_at
       }

--- a/lib/trento_web/controllers/v1/users_json.ex
+++ b/lib/trento_web/controllers/v1/users_json.ex
@@ -31,7 +31,7 @@ defmodule TrentoWeb.V1.UsersJSON do
         idp_user: length(user_identities) > 0,
         password_change_requested_at: password_change_requested_at,
         totp_enabled_at: totp_enabled_at,
-        analytics_enabled_at: analytics_enabled_at,
+        analytics_enabled: analytics_enabled_at != nil,
         created_at: created_at,
         updated_at: updated_at
       }

--- a/lib/trento_web/openapi/v1/schema/user.ex
+++ b/lib/trento_web/openapi/v1/schema/user.ex
@@ -164,7 +164,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
           analytics_enabled: %Schema{
             type: :boolean,
             description: "Whether user analytics collection is enabled",
-            nullable: true
+            nullable: false
           }
         }
       },
@@ -199,6 +199,11 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
           password_confirmation: %Schema{
             type: :string,
             description: "User new password, should be the same as password field",
+            nullable: false
+          },
+          analytics_enabled: %Schema{
+            type: :boolean,
+            description: "Whether user analytics collection is enabled",
             nullable: false
           },
           abilities: AbilityCollection
@@ -238,6 +243,11 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             nullable: false
           },
           abilities: AbilityCollection,
+          analytics_enabled: %Schema{
+            type: :boolean,
+            description: "Whether user analytics collection is enabled",
+            nullable: false
+          },
           totp_disabled: %Schema{
             type: :boolean,
             description:
@@ -309,10 +319,9 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             description: "Date of user last update",
             nullable: true
           },
-          analytics_enabled_at: %Schema{
-            type: :string,
-            format: :"date-time",
-            description: "Date of analytics collection opt-in",
+          analytics_enabled: %Schema{
+            type: :boolean,
+            description: "Whether user analytics collection is enabled",
             nullable: false
           },
           totp_enabled_at: %OpenApiSpex.Schema{

--- a/lib/trento_web/openapi/v1/schema/user.ex
+++ b/lib/trento_web/openapi/v1/schema/user.ex
@@ -104,6 +104,11 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             description: "Password change is requested",
             nullable: false
           },
+          analytics_enabled: %Schema{
+            type: :boolean,
+            description: "Whether user analytics collection is enabled",
+            nullable: false
+          },
           totp_enabled: %Schema{
             type: :boolean,
             description: "TOTP is enabled",
@@ -155,6 +160,11 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             type: :string,
             description: "User new password, should be the same as password field",
             nullable: false
+          },
+          analytics_enabled: %Schema{
+            type: :boolean,
+            description: "Whether user analytics collection is enabled",
+            nullable: true
           }
         }
       },
@@ -298,6 +308,12 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             format: :"date-time",
             description: "Date of user last update",
             nullable: true
+          },
+          analytics_enabled_at: %Schema{
+            type: :string,
+            format: :"date-time",
+            description: "Date of analytics collection opt-in",
+            nullable: false
           },
           totp_enabled_at: %OpenApiSpex.Schema{
             type: :string,

--- a/lib/trento_web/openapi/v1/schema/user.ex
+++ b/lib/trento_web/openapi/v1/schema/user.ex
@@ -201,11 +201,6 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             description: "User new password, should be the same as password field",
             nullable: false
           },
-          analytics_enabled: %Schema{
-            type: :boolean,
-            description: "Whether user analytics collection is enabled",
-            nullable: false
-          },
           abilities: AbilityCollection
         },
         required: [:fullname, :email, :enabled, :password, :password_confirmation, :username]
@@ -243,11 +238,6 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             nullable: false
           },
           abilities: AbilityCollection,
-          analytics_enabled: %Schema{
-            type: :boolean,
-            description: "Whether user analytics collection is enabled",
-            nullable: false
-          },
           totp_disabled: %Schema{
             type: :boolean,
             description:

--- a/priv/repo/migrations/20250327095737_add_analytics_enabled_at_to_users.exs
+++ b/priv/repo/migrations/20250327095737_add_analytics_enabled_at_to_users.exs
@@ -1,0 +1,9 @@
+defmodule Trento.Repo.Migrations.AddAnalyticsEnabledAtToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :analytics_enabled_at, :utc_datetime_usec
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1203,7 +1203,8 @@ defmodule Trento.Factory do
       password_change_requested_at: nil,
       totp_enabled_at: nil,
       totp_secret: nil,
-      totp_last_used_at: nil
+      totp_last_used_at: nil,
+      analytics_enabled_at: nil
     }
   end
 

--- a/test/trento/users/user_test.exs
+++ b/test/trento/users/user_test.exs
@@ -47,5 +47,12 @@ defmodule Trento.Users.UsersTest do
       assert changeset.errors[:totp_enabled_at] ==
                {"is invalid", [validation: :inclusion, enum: [nil]]}
     end
+
+    test "changeset/2 validates analytics_enabled_at field is cast properly" do
+      changeset =
+        User.profile_update_changeset(%User{}, %{"analytics_enabled_at" => DateTime.utc_now()})
+
+      assert changeset.changes[:analytics_enabled_at]
+    end
   end
 end

--- a/test/trento/users_test.exs
+++ b/test/trento/users_test.exs
@@ -94,6 +94,26 @@ defmodule Trento.UsersTest do
 
       assert user.password_change_requested_at == nil
     end
+
+    test "update user profile sets analytics enabled value with current time" do
+      user = insert(:user)
+
+      assert {:ok,
+              %User{
+                analytics_enabled_at: analytics_enabled_at
+              }} =
+               Users.update_user_profile(user, %{analytics_enabled: true})
+
+      refute analytics_enabled_at == nil
+
+      assert {:ok,
+              %User{
+                analytics_enabled_at: analytics_enabled_at
+              }} =
+               Users.update_user_profile(user, %{analytics_enabled: false})
+
+      assert analytics_enabled_at == nil
+    end
   end
 
   describe "users" do

--- a/test/trento_web/views/v1/profile_view_json_test.exs
+++ b/test/trento_web/views/v1/profile_view_json_test.exs
@@ -1,0 +1,26 @@
+defmodule TrentoWeb.V1.ProfileJSONTest do
+  use ExUnit.Case
+
+  import Trento.Factory
+
+  alias TrentoWeb.V1.ProfileJSON
+
+  describe "renders profile.json" do
+    test "should correctly render a user profile when the user has no analytics preference" do
+      user = build(:user, abilities: [], user_identities: [], analytics_enabled_at: nil)
+
+      assert %{
+               analytics_enabled: false
+             } = ProfileJSON.profile(%{user: user})
+    end
+
+    test "should correctly render a user profile when the user has an analytics preference" do
+      user =
+        build(:user, abilities: [], user_identities: [], analytics_enabled_at: DateTime.utc_now())
+
+      assert %{
+               analytics_enabled: true
+             } = ProfileJSON.profile(%{user: user})
+    end
+  end
+end

--- a/test/trento_web/views/v1/users_view_json_test.exs
+++ b/test/trento_web/views/v1/users_view_json_test.exs
@@ -42,5 +42,22 @@ defmodule TrentoWeb.V1.UsersJSONTest do
                idp_user: false
              } = UsersJSON.user(%{user: user})
     end
+
+    test "should correctly render a user when the user has no analytics preference" do
+      user = build(:user, abilities: [], user_identities: [], analytics_enabled_at: nil)
+
+      assert %{
+               analytics_enabled: false
+             } = UsersJSON.user(%{user: user})
+    end
+
+    test "should correctly render a user when the user has an analytics preference" do
+      user =
+        build(:user, abilities: [], user_identities: [], analytics_enabled_at: DateTime.utc_now())
+
+      assert %{
+               analytics_enabled: true
+             } = UsersJSON.user(%{user: user})
+    end
   end
 end


### PR DESCRIPTION
# Description

**Update 28 March 2025**
This PR adds the capability to access and store an `analytics_opt_in` value in the db that retains the consent from each user for their preference regarding the collection of analytics data. This will then be configurable in the frontend in the next PR.

**Update 12 March 2025**
This PR will focus on the backend mostly with regards to feedback. A separate PR will be created for the frontend feedback.

~~This PR attempts to allow collection of Analytics when users have opted in on the Settings screen. This was the most logical starting point to enable Analytics since it gives the user the ability to opt-in or opt-out.~~

~~**Outstanding items for this PR**~~

~~1. Link to our Analytics Policy (Settings Modal)
2. Tests
3. Storybook for Analytics Settings Component
4. Potential Documentation?~~

~~**Future PRs**~~

~~1. Analytics Optin Modal on Home or After Initial Login
2. Adding variables like `installation_id`, `environment` and `version`  to the tracking events.
3. Using the correct Production vs Dev/Demo Posthog codes based on deployment.~~

## How was this tested?
- [ ] **TODO**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
- [Trento Web guides](https://github.com/trento-project/web/tree/main/guides)

Add a documentation PR or write that no changes are required for the documentation.
- [ ] **TODO?**
