### PR TITLE
Add hostname field to activity log metadata for operation entries

### DIFF
--- a/lib/trento/activity_logging/parser/metadata_enricher.ex
+++ b/lib/trento/activity_logging/parser/metadata_enricher.ex
@@ -86,7 +86,7 @@ defmodule Trento.ActivityLog.Logger.Parser.MetadataEnricher do
        when activity in [:resource_tagging, :resource_untagging],
        do: {:ok, resource_id}
 
-  defp detect_enrichment(:host, {_, %{resource_id: id, operation: "saptune_solution_apply"}}),
+  defp detect_enrichment(:host, {_, %{resource_id: id, operation: :saptune_solution_apply}}),
     do: {:ok, id}
 
   defp detect_enrichment(_target_entity, {_activity, _metadata}),

--- a/lib/trento/activity_logging/parser/metadata_enricher.ex
+++ b/lib/trento/activity_logging/parser/metadata_enricher.ex
@@ -12,7 +12,11 @@ defmodule Trento.ActivityLog.Logger.Parser.MetadataEnricher do
   def enrich(activity, metadata) do
     case ActivityCatalog.detect_activity_category(activity) do
       supported_activities
-      when supported_activities in [:connection_activity, :domain_event_activity] ->
+      when supported_activities in [
+             :connection_activity,
+             :domain_event_activity,
+             :queue_event_activity
+           ] ->
         {:ok, enrich_metadata(activity, metadata)}
 
       _ ->
@@ -81,6 +85,9 @@ defmodule Trento.ActivityLog.Logger.Parser.MetadataEnricher do
        )
        when activity in [:resource_tagging, :resource_untagging],
        do: {:ok, resource_id}
+
+  defp detect_enrichment(:host, {_, %{resource_id: id, operation: "saptune_solution_apply"}}),
+    do: {:ok, id}
 
   defp detect_enrichment(_target_entity, {_activity, _metadata}),
     do: {:error, :no_enrichment_needed}

--- a/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
+++ b/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
@@ -139,7 +139,7 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
       ) do
     %{
       resource_id: Map.get(params, :id),
-      operation: Map.get(params, :operation),
+      operation: params |> Map.get(:operation) |> String.to_existing_atom(),
       operation_id: resp_body |> Jason.decode!() |> Map.get("operation_id"),
       params: body_params
     }

--- a/test/trento/activity_logging/metadata_enricher_test.exs
+++ b/test/trento/activity_logging/metadata_enricher_test.exs
@@ -224,7 +224,7 @@ defmodule Trento.ActivityLog.MetadataEnricherTest do
 
       initial_metadata = %{
         resource_id: host_id,
-        operation: "saptune_solution_apply"
+        operation: :saptune_solution_apply
       }
 
       assert {:ok, %{hostname: ^hostname}} =
@@ -236,7 +236,7 @@ defmodule Trento.ActivityLog.MetadataEnricherTest do
 
       initial_metadata = %{
         resource_id: host_id,
-        operation: "saptune_solution_apply"
+        operation: :saptune_solution_apply
       }
 
       assert {:ok, %{hostname: ^hostname}} =

--- a/test/trento/activity_logging/metadata_enricher_test.exs
+++ b/test/trento/activity_logging/metadata_enricher_test.exs
@@ -218,6 +218,32 @@ defmodule Trento.ActivityLog.MetadataEnricherTest do
     end
   end
 
+  describe "enriching operation activities" do
+    test "should enrich operation completed events in hosts" do
+      %{id: host_id, hostname: hostname} = insert(:host)
+
+      initial_metadata = %{
+        resource_id: host_id,
+        operation: "saptune_solution_apply"
+      }
+
+      assert {:ok, %{hostname: ^hostname}} =
+               MetadataEnricher.enrich(:operation_completed, initial_metadata)
+    end
+
+    test "should enrich operation requested events in hosts" do
+      %{id: host_id, hostname: hostname} = insert(:host)
+
+      initial_metadata = %{
+        resource_id: host_id,
+        operation: "saptune_solution_apply"
+      }
+
+      assert {:ok, %{hostname: ^hostname}} =
+               MetadataEnricher.enrich(:operation_requested, initial_metadata)
+    end
+  end
+
   describe "domain event activity log metadata enrichment" do
     test "should not enrich domain events related metadata already having required info" do
       not_enrichable_events = [

--- a/test/trento/activity_logging/phoenix_conn_parser_test.exs
+++ b/test/trento/activity_logging/phoenix_conn_parser_test.exs
@@ -117,12 +117,12 @@ defmodule Trento.ActivityLog.PhoenixConnParserTest do
     test "should extract operation metadata from requested operation", %{conn: conn} do
       resource_id = Faker.UUID.v4()
       operation_id = Faker.UUID.v4()
-      operation = Faker.Cat.name()
+      operation = "saptune_solution_apply"
       params = %{"key" => "value"}
 
       assert %{
                :resource_id => resource_id,
-               :operation => operation,
+               :operation => :saptune_solution_apply,
                :operation_id => operation_id,
                :params => params
              } ==


### PR DESCRIPTION
# Description

Add additional `hostname` field to host related operations (operation requested and completed).

![image](https://github.com/user-attachments/assets/cf74d5ee-cf7f-474f-a140-5d46f72abd0c)

## How was this tested?

UT