### PR TITLE
Review & fix users e2e tests flakiness

### DIFF
--- a/.github/workflows/e2e-flaky-tests-detection.yaml
+++ b/.github/workflows/e2e-flaky-tests-detection.yaml
@@ -232,6 +232,12 @@ jobs:
         with:
           name: e2e-junit-reports-${{ matrix.container }}
           path: /tmp/*.xml
+      - name: Upload cypress test screenshots
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: e2e-screenshots-${{ matrix.container }}
+          path: test/e2e/cypress/screenshots/
 
 
   flaky-tests-analysis:

--- a/.github/workflows/e2e-flaky-tests-detection.yaml
+++ b/.github/workflows/e2e-flaky-tests-detection.yaml
@@ -228,11 +228,6 @@ jobs:
         with:
           name: e2e-junit-reports-${{ matrix.container }}
           path: /tmp/*.xml
-      - name: Upload cypress test screenshots
-        uses: actions/upload-artifact@v4
-        with:
-          name: e2e-screenshots-${{ matrix.container }}
-          path: test/e2e/cypress/screenshots/
 
 
   flaky-tests-analysis:
@@ -261,7 +256,7 @@ jobs:
           make install-deps
           make PATH-TO-JUNIT-FILES=../../junit-reports analyze-files 2>&1 | tail -n +2 >> $GITHUB_STEP_SUMMARY
         working-directory: hack/flaky_tests_analysis
-      # - name: Delete Artifacts
-      #   uses: geekyeggo/delete-artifact@v5
-      #   with:
-      #     name: e2e-junit-reports-*
+      - name: Delete Artifacts
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: e2e-junit-reports-*

--- a/.github/workflows/e2e-flaky-tests-detection.yaml
+++ b/.github/workflows/e2e-flaky-tests-detection.yaml
@@ -260,7 +260,7 @@ jobs:
           make install-deps
           make PATH-TO-JUNIT-FILES=../../junit-reports analyze-files 2>&1 | tail -n +2 >> $GITHUB_STEP_SUMMARY
         working-directory: hack/flaky_tests_analysis
-      - name: Delete Artifacts
-        uses: geekyeggo/delete-artifact@v5
-        with:
-          name: e2e-junit-reports-*
+      # - name: Delete Artifacts
+      #   uses: geekyeggo/delete-artifact@v5
+      #   with:
+      #     name: e2e-junit-reports-*

--- a/.github/workflows/e2e-flaky-tests-detection.yaml
+++ b/.github/workflows/e2e-flaky-tests-detection.yaml
@@ -164,10 +164,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-      # - name: Set up Python
-      #   uses: actions/setup-python@v5
-      #   with:
-      #     python-version: ${{ env.PYTHON_VERSION }}
       - name: Retrieve Cached Dependencies
         uses: actions/cache@v4
         id: mix-cache

--- a/.github/workflows/e2e-flaky-tests-detection.yaml
+++ b/.github/workflows/e2e-flaky-tests-detection.yaml
@@ -164,10 +164,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
+      # - name: Set up Python
+      #   uses: actions/setup-python@v5
+      #   with:
+      #     python-version: ${{ env.PYTHON_VERSION }}
       - name: Retrieve Cached Dependencies
         uses: actions/cache@v4
         id: mix-cache

--- a/.github/workflows/e2e-flaky-tests-detection.yaml
+++ b/.github/workflows/e2e-flaky-tests-detection.yaml
@@ -234,7 +234,6 @@ jobs:
           path: /tmp/*.xml
       - name: Upload cypress test screenshots
         uses: actions/upload-artifact@v4
-        if: failure()
         with:
           name: e2e-screenshots-${{ matrix.container }}
           path: test/e2e/cypress/screenshots/

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -1,3 +1,4 @@
+/* eslint-disable cypress/no-unnecessary-waiting */
 import { userFactory } from '@lib/test-utils/factories/users';
 
 import * as usersPage from '../pageObject/users_po';
@@ -254,20 +255,28 @@ describe('Users', () => {
     // eslint-disable-next-line mocha/no-exclusive-tests
     it.only('should reconfigure TOTP and validate login cases', () => {
       cy.intercept('/api/v1/profile/totp_enrollment').as('totpEnrollment');
+      cy.intercept('/api/v1/profile').as('profile');
       usersPage.clickAuthenticatorAppSwitch();
+      cy.wait(1000);
       cy.wait('@totpEnrollment');
       usersPage
         .typeUserTotpCode()
         .then(() => usersPage.clickVerifyTotpButton());
+      cy.wait(1000);
       cy.wait('@totpEnrollment');
       usersPage.clickAuthenticatorAppSwitch();
+      cy.wait(1000);
       usersPage.clickDisableTotpButton();
+      cy.wait(1000);
       cy.wait('@totpEnrollment');
+      cy.wait('@profile');
       usersPage.clickAuthenticatorAppSwitch();
+      cy.wait(1000);
+
       cy.wait('@totpEnrollment');
       usersPage.typeUserTotpCode().then((totpSecret) => {
-        cy.intercept('api/v1/profile').as('profile');
         usersPage.clickVerifyTotpButton();
+        cy.wait(1000);
         cy.wait('@profile');
         usersPage.authenticatorAppSwitchIsEnabled();
         usersPage.clickSignOutButton();

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -275,7 +275,6 @@ describe('Users', () => {
 
       cy.wait('@totpEnrollment');
       usersPage.typeUserTotpCode().then((totpSecret) => {
-        cy.wait(1000);
         usersPage.clickVerifyTotpButton();
         cy.wait(1000);
         cy.wait('@profile');
@@ -294,7 +293,6 @@ describe('Users', () => {
         loginPage.invalidCredentialsErrorIsDisplayed();
         loginPage.waitForNewTotpCodeAndTypeIt(totpSecret);
         cy.intercept('api/v1/hosts').as('hosts');
-        cy.wait(1000);
         loginPage.clickSubmitLoginButton();
         cy.wait('@hosts');
         dashboardPage.dashboardPageIsDisplayed();

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -257,26 +257,26 @@ describe('Users', () => {
       cy.intercept('/api/v1/profile/totp_enrollment').as('totpEnrollment');
       cy.intercept('/api/v1/profile').as('profile');
       usersPage.clickAuthenticatorAppSwitch();
-      cy.wait(1000);
+      cy.wait(500);
       cy.wait('@totpEnrollment');
       usersPage
         .typeUserTotpCode()
         .then(() => usersPage.clickVerifyTotpButton());
-      cy.wait(1000);
+      cy.wait(500);
       cy.wait('@totpEnrollment');
       usersPage.clickAuthenticatorAppSwitch();
-      cy.wait(1000);
+      cy.wait(500);
       usersPage.clickDisableTotpButton();
-      cy.wait(1000);
+      cy.wait(500);
       cy.wait('@totpEnrollment');
       cy.wait('@profile');
       usersPage.clickAuthenticatorAppSwitch();
-      cy.wait(1000);
-
+      cy.wait(500);
       cy.wait('@totpEnrollment');
       usersPage.typeUserTotpCode().then((totpSecret) => {
+        cy.wait(500);
         usersPage.clickVerifyTotpButton();
-        cy.wait(1000);
+        cy.wait(500);
         cy.wait('@profile');
         usersPage.authenticatorAppSwitchIsEnabled();
         usersPage.clickSignOutButton();

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -275,6 +275,7 @@ describe('Users', () => {
 
       cy.wait('@totpEnrollment');
       usersPage.typeUserTotpCode().then((totpSecret) => {
+        cy.wait(1000);
         usersPage.clickVerifyTotpButton();
         cy.wait(1000);
         cy.wait('@profile');
@@ -293,6 +294,7 @@ describe('Users', () => {
         loginPage.invalidCredentialsErrorIsDisplayed();
         loginPage.waitForNewTotpCodeAndTypeIt(totpSecret);
         cy.intercept('api/v1/hosts').as('hosts');
+        cy.wait(1000);
         loginPage.clickSubmitLoginButton();
         cy.wait('@hosts');
         dashboardPage.dashboardPageIsDisplayed();

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -253,12 +253,14 @@ describe('Users', () => {
 
     // eslint-disable-next-line mocha/no-exclusive-tests
     it.only('should reconfigure TOTP and validate login cases', () => {
+      cy.intercept('/api/v1/profile/totp_enrollment').as('totpEnrollment');
       usersPage.clickAuthenticatorAppSwitch();
       usersPage.typeUserTotpCode();
       usersPage.clickVerifyTotpButton();
       usersPage.clickAuthenticatorAppSwitch();
       usersPage.clickDisableTotpButton();
       usersPage.clickAuthenticatorAppSwitch();
+      cy.wait('@totpEnrollment');
       usersPage.typeUserTotpCode().then((totpSecret) => {
         usersPage.clickVerifyTotpButton();
         usersPage.authenticatorAppSwitchIsEnabled();

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -275,10 +275,11 @@ describe('Users', () => {
       cy.wait('@totpEnrollment');
       usersPage.typeUserTotpCode().then((totpSecret) => {
         cy.wait(1000);
-        usersPage.clickVerifyTotpButton();
-        cy.wait(1000);
-        cy.wait('@profile');
-        usersPage.authenticatorAppSwitchIsEnabled();
+        usersPage.clickVerifyTotpButton().then(() => {
+          cy.wait(1000);
+          cy.wait('@profile');
+          usersPage.authenticatorAppSwitchIsEnabled();
+        });
         usersPage.clickSignOutButton();
         cy.intercept('/api/session').as('session');
         loginPage.login(usersPage.USER.username, usersPage.PASSWORD);

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -256,6 +256,7 @@ describe('Users', () => {
     it.only('should reconfigure TOTP and validate login cases', () => {
       cy.intercept('/api/v1/profile/totp_enrollment').as('totpEnrollment');
       cy.intercept('/api/v1/profile').as('profile');
+      cy.intercept('/api/v1/hosts').as('hosts');
       usersPage.clickAuthenticatorAppSwitch();
       cy.wait(1000);
       cy.wait('@totpEnrollment');
@@ -292,11 +293,11 @@ describe('Users', () => {
         loginPage.clickSubmitLoginButton();
         cy.wait('@session');
         loginPage.invalidCredentialsErrorIsDisplayed();
-        loginPage.waitForNewTotpCodeAndTypeIt(totpSecret);
-        cy.intercept('api/v1/hosts').as('hosts');
-        loginPage.clickSubmitLoginButton();
-        cy.wait('@hosts');
-        dashboardPage.dashboardPageIsDisplayed();
+        loginPage.waitForNewTotpCodeAndTypeIt(totpSecret).then(() => {
+          loginPage.clickSubmitLoginButton();
+          cy.wait('@hosts');
+          dashboardPage.dashboardPageIsDisplayed();
+        });
       });
     });
 

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -251,7 +251,8 @@ describe('Users', () => {
       loginPage.loginShouldSucceed(usersPage.USER.username, usersPage.PASSWORD);
     });
 
-    it('should configure TOTP and validate login cases, then disable it', () => {
+    // eslint-disable-next-line mocha/no-exclusive-tests
+    it.only('should configure TOTP and validate login cases, then disable it', () => {
       usersPage.clickAuthenticatorAppSwitch();
       usersPage.getTotpSecret().then((totpSecret) => {
         usersPage.typeUserTotpCode(totpSecret).then((code) => {

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -256,18 +256,19 @@ describe('Users', () => {
       cy.intercept('/api/v1/profile/totp_enrollment').as('totpEnrollment');
       usersPage.clickAuthenticatorAppSwitch();
       cy.wait('@totpEnrollment');
-      usersPage.typeUserTotpCode();
-      usersPage.clickVerifyTotpButton();
+      usersPage
+        .typeUserTotpCode()
+        .then(() => usersPage.clickVerifyTotpButton());
       cy.wait('@totpEnrollment');
       usersPage.clickAuthenticatorAppSwitch();
       usersPage.clickDisableTotpButton();
       cy.wait('@totpEnrollment');
       usersPage.clickAuthenticatorAppSwitch();
       cy.wait('@totpEnrollment');
-
       usersPage.typeUserTotpCode().then((totpSecret) => {
+        cy.intercept('api/v1/profile').as('profile');
         usersPage.clickVerifyTotpButton();
-        cy.wait('@totpEnrollment');
+        cy.wait('@profile');
         usersPage.authenticatorAppSwitchIsEnabled();
         usersPage.clickSignOutButton();
         cy.intercept('/api/session').as('session');
@@ -282,8 +283,9 @@ describe('Users', () => {
         cy.wait('@session');
         loginPage.invalidCredentialsErrorIsDisplayed();
         loginPage.waitForNewTotpCodeAndTypeIt(totpSecret);
+        cy.intercept('api/v1/hosts').as('hosts');
         loginPage.clickSubmitLoginButton();
-        cy.wait('@session');
+        cy.wait('@hosts');
         dashboardPage.dashboardPageIsDisplayed();
       });
     });

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -226,7 +226,7 @@ describe('Users', () => {
 
     it('should complete TOTP enrollment properly', () => {
       usersPage.clickAuthenticatorAppSwitch();
-      usersPage.typeUserTotpCode();
+      usersPage.getSecretAndTypeTotpCode();
       usersPage.clickVerifyTotpButton();
       usersPage.authenticatorAppSwitchIsEnabled();
       usersPage.totpEnabledToasterIsDisplayed();
@@ -234,7 +234,7 @@ describe('Users', () => {
 
     it('should fail to login if TOTP code is not given', () => {
       usersPage.clickAuthenticatorAppSwitch();
-      usersPage.typeUserTotpCode();
+      usersPage.getSecretAndTypeTotpCode();
       usersPage.clickVerifyTotpButton();
       loginPage.loginFailsIfOtpNotProvided(
         usersPage.USER.username,
@@ -244,15 +244,14 @@ describe('Users', () => {
 
     it('should disable TOTP authentication and check login works without TOTP', () => {
       usersPage.clickAuthenticatorAppSwitch();
-      usersPage.typeUserTotpCode();
+      usersPage.getSecretAndTypeTotpCode();
       usersPage.clickVerifyTotpButton();
       usersPage.clickAuthenticatorAppSwitch();
       usersPage.clickDisableTotpButton();
       loginPage.loginShouldSucceed(usersPage.USER.username, usersPage.PASSWORD);
     });
 
-    // eslint-disable-next-line mocha/no-exclusive-tests
-    it.only('should configure TOTP and validate login cases, then disable it', () => {
+    it('should configure TOTP and validate login cases, then disable it', () => {
       usersPage.clickAuthenticatorAppSwitch();
       usersPage.getTotpSecret().then((totpSecret) => {
         usersPage.typeUserTotpCode(totpSecret).then((code) => {
@@ -280,7 +279,7 @@ describe('Users', () => {
 
     it('should be disabled by admin user', () => {
       usersPage.clickAuthenticatorAppSwitch();
-      usersPage.typeUserTotpCode();
+      usersPage.getSecretAndTypeTotpCode();
       usersPage.clickVerifyTotpButton();
       usersPage.clickSignOutButton();
       usersPage.apiLoginAndCreateSession();

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -253,25 +253,37 @@ describe('Users', () => {
 
     // eslint-disable-next-line mocha/no-exclusive-tests
     it.only('should reconfigure TOTP and validate login cases', () => {
+      cy.intercept('/api/v1/profile/totp_enrollment').as('totpEnrollment');
       usersPage.clickAuthenticatorAppSwitch();
+      cy.wait('@totpEnrollment');
       usersPage.typeUserTotpCode();
       usersPage.clickVerifyTotpButton();
+      cy.wait('@totpEnrollment');
       usersPage.clickAuthenticatorAppSwitch();
       usersPage.clickDisableTotpButton();
+      cy.wait('@totpEnrollment');
       usersPage.clickAuthenticatorAppSwitch();
+      cy.wait('@totpEnrollment');
+
       usersPage.typeUserTotpCode().then((totpSecret) => {
         usersPage.clickVerifyTotpButton();
+        cy.wait('@totpEnrollment');
         usersPage.authenticatorAppSwitchIsEnabled();
         usersPage.clickSignOutButton();
+        cy.intercept('/api/session').as('session');
         loginPage.login(usersPage.USER.username, usersPage.PASSWORD);
+        cy.wait('@session');
         loginPage.typeInvalidLoginTotpCode();
         loginPage.clickSubmitLoginButton();
+        cy.wait('@session');
         loginPage.invalidCredentialsErrorIsDisplayed();
         loginPage.typeAlreadyUsedTotpCode(totpSecret);
         loginPage.clickSubmitLoginButton();
+        cy.wait('@session');
         loginPage.invalidCredentialsErrorIsDisplayed();
         loginPage.waitForNewTotpCodeAndTypeIt(totpSecret);
         loginPage.clickSubmitLoginButton();
+        cy.wait('@session');
         dashboardPage.dashboardPageIsDisplayed();
       });
     });

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -252,29 +252,29 @@ describe('Users', () => {
     });
 
     // eslint-disable-next-line mocha/no-exclusive-tests
-    it.only('should reconfigure TOTP and validate login cases', () => {
-      cy.intercept('/api/v1/profile/totp_enrollment').as('totpEnrollment');
+    it.only('should configure TOTP and validate login cases, then disable it', () => {
       usersPage.clickAuthenticatorAppSwitch();
-      usersPage.typeUserTotpCode();
-      usersPage.clickVerifyTotpButton();
-      usersPage.clickAuthenticatorAppSwitch();
-      usersPage.clickDisableTotpButton();
-      usersPage.clickAuthenticatorAppSwitch();
-      cy.wait('@totpEnrollment');
-      usersPage.typeUserTotpCode().then((totpSecret) => {
-        usersPage.clickVerifyTotpButton();
-        usersPage.authenticatorAppSwitchIsEnabled();
-        usersPage.clickSignOutButton();
-        loginPage.login(usersPage.USER.username, usersPage.PASSWORD);
-        loginPage.typeInvalidLoginTotpCode();
-        loginPage.clickSubmitLoginButton();
-        loginPage.invalidCredentialsErrorIsDisplayed();
-        loginPage.typeAlreadyUsedTotpCode(totpSecret);
-        loginPage.clickSubmitLoginButton();
-        loginPage.invalidCredentialsErrorIsDisplayed();
-        loginPage.waitForNewTotpCodeAndTypeIt(totpSecret);
-        loginPage.clickSubmitLoginButton();
-        dashboardPage.dashboardPageIsDisplayed();
+      usersPage.getTotpSecret().then((totpSecret) => {
+        usersPage.typeUserTotpCode(totpSecret).then((code) => {
+          usersPage.clickVerifyTotpButton();
+          usersPage.authenticatorAppSwitchIsEnabled();
+          usersPage.clickSignOutButton();
+          loginPage.login(usersPage.USER.username, usersPage.PASSWORD);
+          loginPage.typeInvalidLoginTotpCode();
+          loginPage.clickSubmitLoginButton();
+          loginPage.invalidCredentialsErrorIsDisplayed();
+          loginPage.typeAlreadyUsedTotpCode(code);
+          loginPage.clickSubmitLoginButton();
+          loginPage.invalidCredentialsErrorIsDisplayed();
+          loginPage.typeLoginTotpCode(totpSecret);
+          loginPage.clickSubmitLoginButton();
+          dashboardPage.dashboardPageIsDisplayed();
+          usersPage.visit('/profile');
+          usersPage.clickAuthenticatorAppSwitch();
+          usersPage.clickDisableTotpButton();
+          usersPage.clickAuthenticatorAppSwitch();
+          usersPage.newIssuedTotpSecretIsDifferent();
+        });
       });
     });
 

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -1,4 +1,3 @@
-/* eslint-disable cypress/no-unnecessary-waiting */
 import { userFactory } from '@lib/test-utils/factories/users';
 
 import * as usersPage from '../pageObject/users_po';
@@ -254,50 +253,26 @@ describe('Users', () => {
 
     // eslint-disable-next-line mocha/no-exclusive-tests
     it.only('should reconfigure TOTP and validate login cases', () => {
-      cy.intercept('/api/v1/profile/totp_enrollment').as('totpEnrollment');
-      cy.intercept('/api/v1/profile').as('profile');
-      cy.intercept('/api/v1/hosts').as('hosts');
       usersPage.clickAuthenticatorAppSwitch();
-      cy.wait(1000);
-      cy.wait('@totpEnrollment');
-      usersPage
-        .typeUserTotpCode()
-        .then(() => usersPage.clickVerifyTotpButton());
-      cy.wait(1000);
-      cy.wait('@totpEnrollment');
+      usersPage.typeUserTotpCode();
+      usersPage.clickVerifyTotpButton();
       usersPage.clickAuthenticatorAppSwitch();
-      cy.wait(1000);
       usersPage.clickDisableTotpButton();
-      cy.wait(1000);
-      cy.wait('@totpEnrollment');
-      cy.wait('@profile');
       usersPage.clickAuthenticatorAppSwitch();
-      cy.wait(1000);
-      cy.wait('@totpEnrollment');
       usersPage.typeUserTotpCode().then((totpSecret) => {
-        cy.wait(1000);
-        usersPage.clickVerifyTotpButton().then(() => {
-          cy.wait(1000);
-          cy.wait('@profile');
-          usersPage.authenticatorAppSwitchIsEnabled();
-        });
+        usersPage.clickVerifyTotpButton();
+        usersPage.authenticatorAppSwitchIsEnabled();
         usersPage.clickSignOutButton();
-        cy.intercept('/api/session').as('session');
         loginPage.login(usersPage.USER.username, usersPage.PASSWORD);
-        cy.wait('@session');
         loginPage.typeInvalidLoginTotpCode();
         loginPage.clickSubmitLoginButton();
-        cy.wait('@session');
         loginPage.invalidCredentialsErrorIsDisplayed();
         loginPage.typeAlreadyUsedTotpCode(totpSecret);
         loginPage.clickSubmitLoginButton();
-        cy.wait('@session');
         loginPage.invalidCredentialsErrorIsDisplayed();
-        loginPage.waitForNewTotpCodeAndTypeIt(totpSecret).then(() => {
-          loginPage.clickSubmitLoginButton();
-          cy.wait('@hosts');
-          dashboardPage.dashboardPageIsDisplayed();
-        });
+        loginPage.waitForNewTotpCodeAndTypeIt(totpSecret);
+        loginPage.clickSubmitLoginButton();
+        dashboardPage.dashboardPageIsDisplayed();
       });
     });
 

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -251,8 +251,7 @@ describe('Users', () => {
       loginPage.loginShouldSucceed(usersPage.USER.username, usersPage.PASSWORD);
     });
 
-    // eslint-disable-next-line mocha/no-exclusive-tests
-    it.only('should configure TOTP and validate login cases, then disable it', () => {
+    it('should configure TOTP and validate login cases, then disable it', () => {
       usersPage.clickAuthenticatorAppSwitch();
       usersPage.getTotpSecret().then((totpSecret) => {
         usersPage.typeUserTotpCode(totpSecret).then((code) => {

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -251,7 +251,8 @@ describe('Users', () => {
       loginPage.loginShouldSucceed(usersPage.USER.username, usersPage.PASSWORD);
     });
 
-    it('should reconfigure TOTP and validate login cases', () => {
+    // eslint-disable-next-line mocha/no-exclusive-tests
+    it.only('should reconfigure TOTP and validate login cases', () => {
       usersPage.clickAuthenticatorAppSwitch();
       usersPage.typeUserTotpCode();
       usersPage.clickVerifyTotpButton();

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -257,26 +257,26 @@ describe('Users', () => {
       cy.intercept('/api/v1/profile/totp_enrollment').as('totpEnrollment');
       cy.intercept('/api/v1/profile').as('profile');
       usersPage.clickAuthenticatorAppSwitch();
-      cy.wait(500);
+      cy.wait(1000);
       cy.wait('@totpEnrollment');
       usersPage
         .typeUserTotpCode()
         .then(() => usersPage.clickVerifyTotpButton());
-      cy.wait(500);
+      cy.wait(1000);
       cy.wait('@totpEnrollment');
       usersPage.clickAuthenticatorAppSwitch();
-      cy.wait(500);
+      cy.wait(1000);
       usersPage.clickDisableTotpButton();
-      cy.wait(500);
+      cy.wait(1000);
       cy.wait('@totpEnrollment');
       cy.wait('@profile');
       usersPage.clickAuthenticatorAppSwitch();
-      cy.wait(500);
+      cy.wait(1000);
       cy.wait('@totpEnrollment');
       usersPage.typeUserTotpCode().then((totpSecret) => {
-        cy.wait(500);
+        cy.wait(1000);
         usersPage.clickVerifyTotpButton();
-        cy.wait(500);
+        cy.wait(1000);
         cy.wait('@profile');
         usersPage.authenticatorAppSwitchIsEnabled();
         usersPage.clickSignOutButton();

--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -71,13 +71,22 @@ export const clickUserDropdownProfileButton = () => {
   return cy.get(userDropdownProfileButton).click();
 };
 
-export const typeTotpCode = (totpSecret, inputField) => {
-  const { otp } = TOTP.generate(totpSecret);
-  return cy
-    .get(inputField)
-    .clear()
-    .type(otp)
-    .then(() => totpSecret);
+export const typeTotpCode = (totpSecret, inputField, valid = true) => {
+  const currentTime = Date.now();
+  const totpDuration = 30000;
+  const expirationTime = Math.ceil(currentTime / totpDuration) * totpDuration;
+  const remainingTime = Math.floor(expirationTime - currentTime);
+  const invalidOtp = TOTP.generate(totpSecret);
+  cy.wait(remainingTime).then(() => {
+    const validOtp = TOTP.generate(totpSecret);
+    cy.log(invalidOtp, validOtp);
+    const otp = valid ? validOtp.otp : invalidOtp.otp;
+    return cy
+      .get(inputField)
+      .clear()
+      .type(otp)
+      .then(() => totpSecret);
+  });
 };
 
 // UI Validations

--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -71,21 +71,24 @@ export const clickUserDropdownProfileButton = () => {
   return cy.get(userDropdownProfileButton).click();
 };
 
-export const typeTotpCode = (totpSecret, inputField, valid = true) => {
+export const typeNextGeneratedTotpCode = (
+  totpSecret,
+  inputField,
+  forceNext = false
+) => {
   const currentTime = Date.now();
   const totpDuration = 30000;
   const expirationTime = Math.ceil(currentTime / totpDuration) * totpDuration;
   const remainingTime = Math.floor(expirationTime - currentTime);
-  const invalidOtp = TOTP.generate(totpSecret);
-  cy.wait(remainingTime).then(() => {
-    const validOtp = TOTP.generate(totpSecret);
-    cy.log(invalidOtp, validOtp);
-    const otp = valid ? validOtp.otp : invalidOtp.otp;
+  const timeToWait =
+    forceNext === false && remainingTime > 10000 ? 0 : remainingTime;
+  return cy.wait(timeToWait).then(() => {
+    const { otp } = TOTP.generate(totpSecret);
     return cy
       .get(inputField)
       .clear()
       .type(otp)
-      .then(() => totpSecret);
+      .then(() => otp);
   });
 };
 

--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -71,17 +71,28 @@ export const clickUserDropdownProfileButton = () => {
   return cy.get(userDropdownProfileButton).click();
 };
 
+const _getTotpWaitTime = (forceNext) => {
+  const currentTime = Date.now();
+  const totpDuration = 30000;
+  const minimumRemainingTimeToReuse = 10000;
+  const expirationTime = Math.ceil(currentTime / totpDuration) * totpDuration;
+  const remainingTime = Math.floor(expirationTime - currentTime);
+
+  const totpWaitingTime =
+    forceNext === false && remainingTime > minimumRemainingTimeToReuse
+      ? 0
+      : remainingTime;
+
+  return totpWaitingTime;
+};
+
 export const typeNextGeneratedTotpCode = (
   totpSecret,
   inputField,
   forceNext = false
 ) => {
-  const currentTime = Date.now();
-  const totpDuration = 30000;
-  const expirationTime = Math.ceil(currentTime / totpDuration) * totpDuration;
-  const remainingTime = Math.floor(expirationTime - currentTime);
-  const timeToWait =
-    forceNext === false && remainingTime > 10000 ? 0 : remainingTime;
+  const timeToWait = _getTotpWaitTime(forceNext);
+
   return cy.wait(timeToWait).then(() => {
     const { otp } = TOTP.generate(totpSecret);
     return cy

--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -112,17 +112,8 @@ export const validateItemNotPresentInNavigationMenu = (itemName) => {
   });
 };
 
-export const validateItemPresentInNavigationMenu = (navigationMenuItem) => {
-  return cy.get(navigation.navigationItems).then(($elements) => {
-    const itemFound = Array.from($elements).some((element) =>
-      element.innerText.includes(navigationMenuItem)
-    );
-    expect(
-      itemFound,
-      `"${navigationMenuItem}" navigation item should be present`
-    ).to.be.true;
-  });
-};
+export const validateItemPresentInNavigationMenu = (navigationMenuItem) =>
+  cy.get(`a:contains("${navigationMenuItem}")`).should('be.visible');
 
 export const addTagButtonsAreDisabled = () =>
   cy.get(addTagButtons).should('have.class', 'opacity-50');

--- a/test/e2e/cypress/pageObject/login_po.js
+++ b/test/e2e/cypress/pageObject/login_po.js
@@ -61,12 +61,11 @@ export const clickSubmitLoginButton = () => {
   return cy.get(submitLoginButton).click();
 };
 
-export const typeLoginTotpCode = (totpSecret) => {
-  basePage.typeTotpCode(totpSecret, totpCodeInput);
-};
+export const typeLoginTotpCode = (totpSecret) =>
+  basePage.typeNextGeneratedTotpCode(totpSecret, totpCodeInput, true);
 
-export const typeAlreadyUsedTotpCode = (totpSecret) => {
-  return basePage.typeTotpCode(totpSecret, totpCodeInput, false);
+export const typeAlreadyUsedTotpCode = (code) => {
+  cy.get(totpCodeInput).clear().type(code);
 };
 
 export const typeInvalidLoginTotpCode = () => {

--- a/test/e2e/cypress/pageObject/login_po.js
+++ b/test/e2e/cypress/pageObject/login_po.js
@@ -75,5 +75,5 @@ export const typeInvalidLoginTotpCode = () => {
 
 export const waitForNewTotpCodeAndTypeIt = (totpSecret) => {
   // eslint-disable-next-line cypress/no-unnecessary-waiting
-  return cy.wait(30000).then(() => typeLoginTotpCode(totpSecret));
+  return cy.wait(31000).then(() => typeLoginTotpCode(totpSecret));
 };

--- a/test/e2e/cypress/pageObject/login_po.js
+++ b/test/e2e/cypress/pageObject/login_po.js
@@ -66,7 +66,7 @@ export const typeLoginTotpCode = (totpSecret) => {
 };
 
 export const typeAlreadyUsedTotpCode = (totpSecret) => {
-  return typeLoginTotpCode(totpSecret);
+  return basePage.typeTotpCode(totpSecret, totpCodeInput, false);
 };
 
 export const typeInvalidLoginTotpCode = () => {
@@ -74,12 +74,5 @@ export const typeInvalidLoginTotpCode = () => {
 };
 
 export const waitForNewTotpCodeAndTypeIt = (totpSecret) => {
-  const currentTime = Date.now();
-  const totpDuration = 30000;
-  const expirationTime = Math.ceil(currentTime / totpDuration) * totpDuration;
-  const remainingTimeInSeconds = Math.floor(expirationTime - currentTime);
-  // eslint-disable-next-line cypress/no-unnecessary-waiting
-  return cy
-    .wait(remainingTimeInSeconds)
-    .then(() => typeLoginTotpCode(totpSecret));
+  typeLoginTotpCode(totpSecret);
 };

--- a/test/e2e/cypress/pageObject/login_po.js
+++ b/test/e2e/cypress/pageObject/login_po.js
@@ -74,6 +74,12 @@ export const typeInvalidLoginTotpCode = () => {
 };
 
 export const waitForNewTotpCodeAndTypeIt = (totpSecret) => {
+  const currentTime = Date.now();
+  const totpDuration = 30000;
+  const expirationTime = Math.ceil(currentTime / totpDuration) * totpDuration;
+  const remainingTimeInSeconds = Math.floor(expirationTime - currentTime);
   // eslint-disable-next-line cypress/no-unnecessary-waiting
-  return cy.wait(31000).then(() => typeLoginTotpCode(totpSecret));
+  return cy
+    .wait(remainingTimeInSeconds)
+    .then(() => typeLoginTotpCode(totpSecret));
 };

--- a/test/e2e/cypress/pageObject/users_po.js
+++ b/test/e2e/cypress/pageObject/users_po.js
@@ -35,7 +35,8 @@ const newTotpCodeIssuedMessage = 'div:contains("Your new TOTP secret is:")';
 const totpSecret = `${newTotpCodeIssuedMessage} + div[class*="bold"]`;
 const newTotpCodeInputField = 'input[placeholder="TOTP code"]';
 const verifyTotpButton = 'button:contains("Verify")';
-const confirmDisableTotpButton = 'button:contains("Disable")';
+const confirmDisableTotpButton =
+  'div[id*="headlessui-dialog-panel"] button:contains("Disable")';
 const editUserTotpDropdown = 'button.totp-selection-dropdown';
 const enableUserTotpOption = `${editUserTotpDropdown} + div div:contains("Enabled")`;
 

--- a/test/e2e/cypress/pageObject/users_po.js
+++ b/test/e2e/cypress/pageObject/users_po.js
@@ -153,15 +153,12 @@ export const selectFromTotpDropdown = (choice) => {
   return basePage.selectFromDropdown(editUserTotpDropdown, choice);
 };
 
-const getTotpSecret = () => {
+export const getTotpSecret = () => {
   return cy.get(totpSecret).then((element) => element.text());
 };
 
-export const typeUserTotpCode = () => {
-  return getTotpSecret().then((totpSecret) =>
-    basePage.typeTotpCode(totpSecret, newTotpCodeInputField)
-  );
-};
+export const typeUserTotpCode = (totpSecret) =>
+  basePage.typeNextGeneratedTotpCode(totpSecret, newTotpCodeInputField);
 
 export const typeInvalidUserTotpCode = () => {
   return cy.get(newTotpCodeInputField).clear().type('invalid');
@@ -358,4 +355,13 @@ export const enableTotpOptionIsDisabled = () => {
     .get(enableUserTotpOption)
     .invoke('attr', 'aria-disabled')
     .should('eq', 'true');
+};
+
+export const newIssuedTotpSecretIsDifferent = (originalTotpSecret) => {
+  getTotpSecret().then((newTotpSecret) => {
+    expect(
+      newTotpSecret === originalTotpSecret,
+      'New issued TOTP secret is different'
+    ).to.be.false;
+  });
 };

--- a/test/e2e/cypress/pageObject/users_po.js
+++ b/test/e2e/cypress/pageObject/users_po.js
@@ -160,6 +160,12 @@ export const getTotpSecret = () => {
 export const typeUserTotpCode = (totpSecret) =>
   basePage.typeNextGeneratedTotpCode(totpSecret, newTotpCodeInputField);
 
+export const getSecretAndTypeTotpCode = () => {
+  getTotpSecret().then((totpSecret) => {
+    typeUserTotpCode(totpSecret);
+  });
+};
+
 export const typeInvalidUserTotpCode = () => {
   return cy.get(newTotpCodeInputField).clear().type('invalid');
 };


### PR DESCRIPTION
# Description

**Improve users e2e tests as the totp was causing intermittent failures. This was because sometimes the remaining time for some codes was so little that in a future point of the test the totp code was no longer valid. Now I introduced some logic to wait for the next code when the remaining time is less than 10s, to make sure that the rest of the test is not affected.**

**To verify this, I've executed the flaky test analysis job at every change. With the last [execution](https://github.com/trento-project/web/actions/runs/13787556630), there was no failure with 100 runs.**

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**
## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
- [Trento Web guides](https://github.com/trento-project/web/tree/main/guides)

Add a documentation PR or write that no changes are required for the documentation.
- [ ] **DONE**
