### PR TITLE
Use operation forbidden modal in host details

### DIFF
--- a/assets/js/lib/operations/ForbiddenMessages.jsx
+++ b/assets/js/lib/operations/ForbiddenMessages.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export const SAPTUNE_SOLUTION_APPLY_FORBIDDEN_MSG = (
+  <>
+    Find additional information in this{' '}
+    <a
+      className="text-jungle-green-500 hover:opacity-75"
+      href="https://documentation.suse.com/sbp/sap-15/html/SLES4SAP-hana-sr-guide-PerfOpt-15/index.html#id-updating-sap-hana-seamless-sap-hana-maintenance"
+      target="_blank"
+      rel="noreferrer"
+    >
+      link
+    </a>
+  </>
+);

--- a/assets/js/lib/operations/index.js
+++ b/assets/js/lib/operations/index.js
@@ -2,6 +2,8 @@ import { get, noop } from 'lodash';
 
 import { requestHostOperation } from '@lib/api/operations';
 
+import { SAPTUNE_SOLUTION_APPLY_FORBIDDEN_MSG } from './ForbiddenMessages';
+
 export const HOST_OPERATION = 'host';
 
 export const SAPTUNE_SOLUTION_APPLY = 'saptune_solution_apply';
@@ -22,6 +24,10 @@ const OPERATION_REQUEST_FUNCS = {
   [HOST_OPERATION]: requestHostOperation,
 };
 
+const OPERATION_FORBIDDEN_MESSAGES = {
+  [SAPTUNE_SOLUTION_APPLY]: SAPTUNE_SOLUTION_APPLY_FORBIDDEN_MSG,
+};
+
 export const getOperationLabel = (operation) =>
   get(OPERATION_LABELS, operation, 'unknown');
 
@@ -33,6 +39,9 @@ export const getOperationResourceType = (operation) =>
 
 export const getOperationRequestFunc = (resourceType) =>
   get(OPERATION_REQUEST_FUNCS, resourceType, noop);
+
+export const getOperationForbiddenMessage = (operation) =>
+  get(OPERATION_FORBIDDEN_MESSAGES, operation, null);
 
 export const operationSucceeded = (result) =>
   ['UPDATED', 'NOT_UPDATED'].includes(result);

--- a/assets/js/lib/operations/operations.test.js
+++ b/assets/js/lib/operations/operations.test.js
@@ -2,11 +2,14 @@ import { noop } from 'lodash';
 
 import { requestHostOperation } from '@lib/api/operations';
 
+import { SAPTUNE_SOLUTION_APPLY_FORBIDDEN_MSG } from './ForbiddenMessages';
+
 import {
   getOperationLabel,
   getOperationInternalName,
   getOperationResourceType,
   getOperationRequestFunc,
+  getOperationForbiddenMessage,
   operationSucceeded,
   operationRunning,
 } from '.';
@@ -70,6 +73,22 @@ describe('operations', () => {
     `should return the operation $operation request function`,
     ({ operation, func }) => {
       expect(getOperationRequestFunc(operation)).toBe(func);
+    }
+  );
+
+  it.each([
+    {
+      operation: 'unknown',
+      message: null,
+    },
+    {
+      operation: 'saptune_solution_apply',
+      message: SAPTUNE_SOLUTION_APPLY_FORBIDDEN_MSG,
+    },
+  ])(
+    `should return the operation $operation forbidden message`,
+    ({ operation, message }) => {
+      expect(getOperationForbiddenMessage(operation)).toBe(message);
     }
   );
 

--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -158,7 +158,7 @@ function HostDetails({
           <OperationForbiddenModal
             operation={getOperationLabel(runningOperationName)}
             isOpen={operationForbidden}
-            onCancel={() => cleanForbiddenOperation()}
+            onCancel={cleanForbiddenOperation}
             errors={operationForbiddenErrors}
           >
             {getOperationForbiddenMessage(runningOperationName)}

--- a/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
@@ -486,6 +486,40 @@ describe('HostDetails component', () => {
         })
       ).toBeDisabled();
     });
+
+    it('should show Saptune apply operation forbidden message', async () => {
+      const user = userEvent.setup();
+      const mockCleanForbiddenOperation = jest.fn();
+
+      renderWithRouter(
+        <HostDetails
+          agentVersion="2.0.0"
+          userAbilities={userAbilities}
+          operationsEnabled
+          runningOperation={{
+            operation: SAPTUNE_SOLUTION_APPLY,
+            forbidden: true,
+            errors: ['error1', 'error2'],
+          }}
+          cleanForbiddenOperation={mockCleanForbiddenOperation}
+        />
+      );
+
+      expect(screen.getByText('Operation Forbidden')).toBeInTheDocument();
+      expect(
+        screen.getByText('Unable to run Apply Saptune Solution operation', {
+          exact: false,
+        })
+      ).toBeInTheDocument();
+      expect(screen.getByText('error1')).toBeInTheDocument();
+      expect(screen.getByText('error2')).toBeInTheDocument();
+
+      const closeButton = screen.getByRole('button', {
+        name: 'Close',
+      });
+      await user.click(closeButton);
+      expect(mockCleanForbiddenOperation).toHaveBeenCalled();
+    });
   });
 
   describe('forbidden actions', () => {

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -31,6 +31,7 @@ import {
 import {
   operationRequested,
   updateRunningOperation,
+  removeRunningOperation,
 } from '@state/runningOperations';
 
 import { deregisterHost } from '@state/hosts';
@@ -158,6 +159,9 @@ function HostDetailsPage() {
       }}
       requestOperation={(operation, params) =>
         dispatch(operationRequested({ groupID: hostID, operation, params }))
+      }
+      cleanForbiddenOperation={() =>
+        dispatch(removeRunningOperation({ groupID: hostID }))
       }
       navigate={navigate}
     />

--- a/assets/js/state/runningOperations.js
+++ b/assets/js/state/runningOperations.js
@@ -28,6 +28,8 @@ const initialState = {};
 
 const initialOperationState = {
   operation: null,
+  forbidden: false,
+  errors: [],
 };
 
 export const runningOperationsSlice = createSlice({
@@ -38,6 +40,16 @@ export const runningOperationsSlice = createSlice({
       const { groupID } = payload;
 
       delete state[groupID];
+    },
+    setForbiddenOperation: (state, { payload }) => {
+      const { groupID, operation, errors } = payload;
+
+      state[groupID] = {
+        ...initialOperationState,
+        operation,
+        forbidden: true,
+        errors,
+      };
     },
     setRunningOperation: (state, { payload }) => {
       const { groupID, operation } = payload;
@@ -50,7 +62,10 @@ export const runningOperationsSlice = createSlice({
   },
 });
 
-export const { removeRunningOperation, setRunningOperation } =
-  runningOperationsSlice.actions;
+export const {
+  removeRunningOperation,
+  setForbiddenOperation,
+  setRunningOperation,
+} = runningOperationsSlice.actions;
 
 export default runningOperationsSlice.reducer;

--- a/assets/js/state/runningOperations.test.js
+++ b/assets/js/state/runningOperations.test.js
@@ -3,6 +3,7 @@ import { faker } from '@faker-js/faker';
 import runningOperationsReducer, {
   removeRunningOperation,
   setRunningOperation,
+  setForbiddenOperation,
 } from './runningOperations';
 
 describe('runningOperations reducer', () => {
@@ -22,10 +23,28 @@ describe('runningOperations reducer', () => {
     const operation = faker.lorem.word();
     const initialState = {};
     const expectedState = {
-      [groupID]: { operation },
+      [groupID]: { operation, forbidden: false, errors: [] },
     };
 
     const action = setRunningOperation({ groupID, operation });
+
+    expect(runningOperationsReducer(initialState, action)).toEqual(
+      expectedState
+    );
+  });
+
+  it('should set an operation as forbidden', () => {
+    const groupID = faker.string.uuid();
+    const operation = faker.lorem.word();
+    const errors = ['error1', 'error2'];
+    const initialState = {
+      [groupID]: { operation, forbidden: false, errors: [] },
+    };
+    const expectedState = {
+      [groupID]: { operation, forbidden: true, errors },
+    };
+
+    const action = setForbiddenOperation({ groupID, operation, errors });
 
     expect(runningOperationsReducer(initialState, action)).toEqual(
       expectedState


### PR DESCRIPTION
# Description

Final step to show the operation forbidden modal.
When the operation request api call returns 403 (forbidden), we set the operation as forbidden and show the modal.
Once the `Close` button is closed, the operation is removed from being running.

## How was this tested?

UT
