### PR TITLE
Apply page object pattern to hosts overview tests

### DIFF
--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -126,7 +126,7 @@ context('Hosts Overview', () => {
 
   describe('Deregistration', () => {
     describe('Clean-up buttons should be visible only when needed', () => {
-      it('should not display a clean-up button when hearbeat is sent', () => {
+      it('should not display a clean-up button when heartbeat is sent', () => {
         hostsOverviewPage.cleanupButtonIsDisplayedForHostSendingHeartbeat();
         hostsOverviewPage.startAgentHeartbeat();
         hostsOverviewPage.cleanupButtonIsNotDisplayedForHostSendingHeartbeat();

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -1,3 +1,5 @@
+import * as hostsOverviewPage from '../pageObject/hosts_overview_po';
+
 import { createUserRequestFactory } from '@lib/test-utils/factories';
 
 import {
@@ -10,148 +12,47 @@ const availableHosts1stPage = availableHosts.slice(0, 10);
 const NEXT_PAGE_SELECTOR = '[aria-label="next-page"]';
 
 context('Hosts Overview', () => {
-  before(() => {
-    cy.preloadTestData();
-    cy.visit('/hosts');
-    cy.url().should('include', '/hosts');
+  beforeEach(() => {
+    // hostsOverviewPage.preloadTestData();
+    hostsOverviewPage.visit();
+  });
+
+  it('should have expected url', () => {
+    hostsOverviewPage.validateUrl();
   });
 
   describe('Registered Hosts are shown in the list', () => {
     it('should highlight the hosts sidebar entry', () => {
-      cy.get('.tn-menu-item[href="/hosts"]')
-        .invoke('attr', 'aria-current')
-        .should('eq', 'page');
+      hostsOverviewPage.hostsIsHighglightedInSidebar();
     });
 
     it('should show 10 of the 27 registered hosts', () => {
-      cy.get('.tn-hostname').its('length').should('eq', 10);
+      hostsOverviewPage.tenHostsAreListed();
     });
 
     it('should have 3 pages', () => {
-      cy.get(`[data-testid="pagination"]`).as('pagination');
-      cy.get(`@pagination`).contains('Showing 1–10 of 27').should('exist');
-
-      cy.get(NEXT_PAGE_SELECTOR).click();
-      cy.get(`@pagination`).contains('Showing 11–20 of 27').should('exist');
-
-      cy.get(NEXT_PAGE_SELECTOR).click();
-      cy.get(`@pagination`).contains('Showing 21–27 of 27').should('exist');
-
-      cy.get(NEXT_PAGE_SELECTOR).should('be.disabled');
+      hostsOverviewPage.expectedPaginationIsDisplayed('Showing 1–10 of 27');
+      hostsOverviewPage.clickNextPageButton();
+      hostsOverviewPage.expectedPaginationIsDisplayed('Showing 11–20 of 27');
+      hostsOverviewPage.clickNextPageButton();
+      hostsOverviewPage.expectedPaginationIsDisplayed('Showing 21–27 of 27');
+      hostsOverviewPage.nextPageButtonIsDisabled();
     });
 
     it('should show the ip addresses, provider and agent version data for the hosts in the 1st page', () => {
-      cy.reload();
-      cy.get('.container').eq(0).as('hostsTable');
-      availableHosts1stPage.forEach((host, index) => {
-        cy.get('@hostsTable')
-          .find('tr')
-          .eq(index + 1)
-          .find('td')
-          .as('hostRow');
-
-        cy.get('@hostsTable')
-          .contains('th', 'IP')
-          .invoke('index')
-          .then((i) => {
-            host.ipAddresses.forEach((ipAddress) => {
-              cy.get('@hostRow').eq(i).should('contain', ipAddress);
-            });
-          });
-
-        cy.get('@hostsTable')
-          .contains('th', 'Provider')
-          .invoke('index')
-          .then((i) => {
-            cy.get('@hostRow').eq(i).should('contain', host.provider);
-          });
-
-        cy.get('@hostsTable')
-          .contains('th', 'Agent version')
-          .invoke('index')
-          .then((i) => {
-            cy.get('@hostRow')
-              .eq(i)
-              .should('contain', host.agentVersion.slice(0, 15));
-          });
-      });
+      hostsOverviewPage.hostsTableContentsAreTheExpected();
     });
 
     it('should link to the correct host details page clicking in the host name', () => {
-      cy.get('.container').eq(0).as('hostsTable');
-      availableHosts1stPage.forEach((host, index) => {
-        cy.get('@hostsTable')
-          .find('tr')
-          .eq(index + 1)
-          .find('td')
-          .as('hostRow');
-
-        cy.get('@hostsTable')
-          .contains('th', 'Hostname')
-          .invoke('index')
-          .then((i) => {
-            cy.get('@hostRow').eq(i).should('contain', host.name);
-            cy.get('@hostRow').eq(i).click();
-            cy.location('pathname').should('eq', `/hosts/${host.id}`);
-            cy.go('back');
-          });
-      });
+      hostsOverviewPage.everyLinkGoesToExpectedHostDetailsPage();
     });
 
     it('should link to the correct cluster details page clicking in the cluster name', () => {
-      cy.get('.container').eq(0).as('hostsTable');
-      availableHosts1stPage.forEach((host, index) => {
-        cy.get('@hostsTable')
-          .find('tr')
-          .eq(index + 1)
-          .find('td')
-          .as('hostRow');
-
-        cy.get('@hostsTable')
-          .contains('th', 'Cluster')
-          .invoke('index')
-          .then((i) => {
-            if (host.clusterId) {
-              cy.get('@hostRow').eq(i).should('contain', host.clusterName);
-              cy.get('@hostRow').eq(i).click();
-              cy.location('pathname').should(
-                'eq',
-                `/clusters/${host.clusterId}`
-              );
-              cy.go('back');
-            } else {
-              cy.get('@hostRow').eq(i).find('a').should('not.exist');
-            }
-          });
-      });
+      hostsOverviewPage.everyClusterLinkGoesToExpectedClusterDetailsPage();
     });
 
     it('should link to the correct sap system details page clicking in the sap system name', () => {
-      cy.get('.container').eq(0).as('hostsTable');
-      availableHosts1stPage.forEach((host, index) => {
-        cy.get('@hostsTable')
-          .find('tr')
-          .eq(index + 1)
-          .find('td')
-          .as('hostRow');
-
-        cy.get('@hostsTable')
-          .contains('th', 'SID')
-          .invoke('index')
-          .then((i) => {
-            if (host.clusterId) {
-              cy.get('@hostRow').eq(i).should('contain', host.sapSystemSid);
-              cy.get('@hostRow').eq(i).click();
-              cy.location('pathname').should(
-                'eq',
-                `/databases/${host.sapSystemId}`
-              );
-              cy.go('back');
-            } else {
-              cy.get('@hostRow').eq(i).find('a').should('not.exist');
-            }
-          });
-      });
+      hostsOverviewPage.everySapSystemLinkGoesToExpectedSapSystemDetailsPage();
     });
   });
 

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -1,7 +1,5 @@
 import * as hostsOverviewPage from '../pageObject/hosts_overview_po';
 
-import { createUserRequestFactory } from '@lib/test-utils/factories';
-
 context('Hosts Overview', () => {
   before(() => hostsOverviewPage.preloadTestData());
 
@@ -199,70 +197,44 @@ context('Hosts Overview', () => {
   });
 
   describe('Forbidden actions', () => {
-    const password = 'password';
-
     beforeEach(() => {
-      cy.deleteAllUsers();
-      cy.logout();
-      const user = createUserRequestFactory.build({
-        password,
-        password_confirmation: password,
-      });
-      cy.wrap(user).as('user');
+      hostsOverviewPage.apiDeleteAllHostsTags();
+      hostsOverviewPage.apiSetTag();
+      hostsOverviewPage.apiDeleteAllUsers();
+      hostsOverviewPage.logout();
     });
 
     describe('Tag creation', () => {
       it('it should prevent a tag update when the user abilities are not compliant', () => {
-        cy.get('@user').then((user) => {
-          cy.createUserWithAbilities(user, []);
-          cy.login(user.username, password);
-        });
-
-        cy.visit('/hosts');
-
-        cy.contains('span', 'Add Tag').should('have.class', 'opacity-50');
-        cy.get('[data-test-id="tag-tag1"]').should('have.class', 'opacity-50');
+        hostsOverviewPage.apiCreateUserWithoutAbilities();
+        hostsOverviewPage.loginWithoutAbilities();
+        hostsOverviewPage.visit();
+        hostsOverviewPage.addTagButtonIsDisabled();
+        hostsOverviewPage.removeTag1ButtonIsDisabled();
       });
 
       it('it should allow a tag update when the user abilities are compliant', () => {
-        cy.get('@user').then((user) => {
-          cy.createUserWithAbilities(user, [
-            { name: 'all', resource: 'host_tags' },
-          ]);
-          cy.login(user.username, password);
-        });
-
-        cy.visit('/hosts');
-
-        cy.contains('span', 'Add Tag').should('not.have.class', 'opacity-50');
-        cy.get('[data-test-id="tag-tag1"]').should(
-          'not.have.class',
-          'opacity-50'
-        );
+        hostsOverviewPage.apiCreateUserWithHostTagsAbility();
+        hostsOverviewPage.loginWithAbilities();
+        hostsOverviewPage.visit();
+        hostsOverviewPage.addTagButtonIsEnabled();
+        hostsOverviewPage.removeTag1ButtonIsEnabled();
       });
     });
 
     describe('Clean up', () => {
       it('should forbid host clean up', () => {
-        cy.get('@user').then((user) => {
-          cy.createUserWithAbilities(user, []);
-          cy.login(user.username, password);
-        });
-        cy.visit(`/hosts`);
-
-        cy.contains('button', 'Clean up').should('be.disabled');
+        hostsOverviewPage.apiCreateUserWithoutAbilities();
+        hostsOverviewPage.loginWithoutAbilities();
+        hostsOverviewPage.visit();
+        hostsOverviewPage.cleanupButtonsAreDisabled();
       });
 
       it('should allow host clean up', () => {
-        cy.get('@user').then((user) => {
-          cy.createUserWithAbilities(user, [
-            { name: 'cleanup', resource: 'host' },
-          ]);
-          cy.login(user.username, password);
-        });
-        cy.visit(`/hosts`);
-
-        cy.contains('button', 'Clean up').should('be.enabled');
+        hostsOverviewPage.apiCreateUserWithHostCleanupAbility();
+        hostsOverviewPage.loginWithAbilities();
+        hostsOverviewPage.visit();
+        hostsOverviewPage.cleanupButtonsAreEnabled();
       });
     });
   });

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -129,30 +129,20 @@ context('Hosts Overview', () => {
   });
 
   describe('Deregistration', () => {
-    const hostToDeregister = {
-      name: 'vmhdbdev01',
-      id: '13e8c25c-3180-5a9a-95c8-51ec38e50cfc',
-      tag: 'tag1',
-    };
-
     describe('Clean-up buttons should be visible only when needed', () => {
-      before(() => {
-        cy.url().should('include', '/hosts');
-        cy.task('startAgentHeartbeat', [hostToDeregister.id]);
-      });
-
-      it.only(`should not display a clean-up button for host ${hostToDeregister.name}`, () => {
-        cy.contains(hostToDeregister.name).within(() => {
-          cy.get('td:nth-child(9)').should('not.exist');
-        });
+      it('should not display a clean-up button when hearbeat is sent', () => {
+        hostsOverviewPage.cleanupButtonIsDisplayedForHostSendingHeartbeat();
+        hostsOverviewPage.startAgentHeartbeat();
+        hostsOverviewPage.cleanupButtonIsNotDisplayedForHostSendingHeartbeat();
       });
 
       it('should show all other cleanup buttons', () => {
-        cy.get('tbody tr')
-          .find('button')
-          .should('have.length', 9)
-          .contains('Clean up');
+        hostsOverviewPage.expectedAmountOfCleanupButtonsIsDisplayed(10);
+        hostsOverviewPage.startAgentHeartbeat();
+        hostsOverviewPage.expectedAmountOfCleanupButtonsIsDisplayed(9);
       });
+
+      afterEach(() => hostsOverviewPage.stopAgentsHeartbeat());
     });
 
     describe('Clean-up button should deregister a host', () => {
@@ -160,42 +150,42 @@ context('Hosts Overview', () => {
         cy.visit('/hosts');
         cy.url().should('include', '/hosts');
         cy.task('stopAgentsHeartbeat');
-        cy.addTagByColumnValue(hostToDeregister.name, hostToDeregister.tag);
+        // cy.addTagByColumnValue(hostToDeregister.name, hostToDeregister.tag);
       });
 
       it('should allow to deregister a host after clean up confirmation', () => {
-        cy.contains(
-          `The host ${hostToDeregister.name} heartbeat is failing`
-        ).should('exist');
+        // cy.contains(
+        //   `The host ${hostToDeregister.name} heartbeat is failing`
+        // ).should('exist');
 
-        cy.contains('tr', hostToDeregister.name).within(() => {
-          cy.get('td:nth-child(9)')
-            .contains('Clean up', { timeout: 15000 })
-            .click();
-        });
+        // cy.contains('tr', hostToDeregister.name).within(() => {
+        //   cy.get('td:nth-child(9)')
+        //     .contains('Clean up', { timeout: 15000 })
+        //     .click();
+        // });
 
         cy.get('#headlessui-portal-root').as('modal');
 
-        cy.get('@modal')
-          .find('.w-full')
-          .should(
-            'contain.text',
-            `Clean up data discovered by agent on host ${hostToDeregister.name}`
-          );
+        // cy.get('@modal')
+        //   .find('.w-full')
+        //   .should(
+        //     'contain.text',
+        //     `Clean up data discovered by agent on host ${hostToDeregister.name}`
+        //   );
 
-        cy.get('@modal').contains('button', 'Clean up').click();
+        // cy.get('@modal').contains('button', 'Clean up').click();
 
-        cy.get(`#host-${hostToDeregister.id}`).should('not.exist');
+        // cy.get(`#host-${hostToDeregister.id}`).should('not.exist');
       });
 
       describe('Restoration', () => {
-        it(`should show host ${hostToDeregister.name} registered again after restoring the host with the tag`, () => {
-          cy.loadScenario(`host-${hostToDeregister.name}-restore`);
-          cy.contains(hostToDeregister.name).should('exist');
-          cy.contains('tr', hostToDeregister.name).within(() => {
-            cy.contains(hostToDeregister.tag).should('exist');
-          });
-        });
+        // it(`should show host ${hostToDeregister.name} registered again after restoring the host with the tag`, () => {
+        //   cy.loadScenario(`host-${hostToDeregister.name}-restore`);
+        //   cy.contains(hostToDeregister.name).should('exist');
+        //   cy.contains('tr', hostToDeregister.name).within(() => {
+        //     cy.contains(hostToDeregister.tag).should('exist');
+        //   });
+        // });
       });
 
       describe('Deregistration of hosts should update remaining hosts data', () => {

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -146,36 +146,18 @@ context('Hosts Overview', () => {
     });
 
     describe('Clean-up button should deregister a host', () => {
-      before(() => {
-        cy.visit('/hosts');
-        cy.url().should('include', '/hosts');
-        cy.task('stopAgentsHeartbeat');
-        // cy.addTagByColumnValue(hostToDeregister.name, hostToDeregister.tag);
+      beforeEach(() => {
+        hostsOverviewPage.startAgentHeartbeat();
+        // hostsOverviewPage.addTagToHost();
       });
 
-      it('should allow to deregister a host after clean up confirmation', () => {
-        // cy.contains(
-        //   `The host ${hostToDeregister.name} heartbeat is failing`
-        // ).should('exist');
-
-        // cy.contains('tr', hostToDeregister.name).within(() => {
-        //   cy.get('td:nth-child(9)')
-        //     .contains('Clean up', { timeout: 15000 })
-        //     .click();
-        // });
-
-        cy.get('#headlessui-portal-root').as('modal');
-
-        // cy.get('@modal')
-        //   .find('.w-full')
-        //   .should(
-        //     'contain.text',
-        //     `Clean up data discovered by agent on host ${hostToDeregister.name}`
-        //   );
-
-        // cy.get('@modal').contains('button', 'Clean up').click();
-
-        // cy.get(`#host-${hostToDeregister.id}`).should('not.exist');
+      it.only('should allow to deregister a host after clean up confirmation', () => {
+        hostsOverviewPage.stopAgentsHeartbeat();
+        hostsOverviewPage.heartbeatFailingToasterIsDisplayed();
+        hostsOverviewPage.clickCleanupOnHostToDeregister();
+        hostsOverviewPage.deregisterModalTitleIsDisplayed();
+        hostsOverviewPage.clickCleanupConfirmationButton();
+        hostsOverviewPage.deregisteredHostIsNotVisible();
       });
 
       describe('Restoration', () => {

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -272,7 +272,7 @@ describe('Users', () => {
           usersPage.clickAuthenticatorAppSwitch();
           usersPage.clickDisableTotpButton();
           usersPage.clickAuthenticatorAppSwitch();
-          usersPage.newIssuedTotpSecretIsDifferent();
+          usersPage.newIssuedTotpSecretIsDifferent(totpSecret);
         });
       });
     });

--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -304,6 +304,8 @@ export const apiDeregisterHost = (hostId) => {
   });
 };
 
+export const stopAgentsHeartbeat = () => cy.task('stopAgentsHeartbeat');
+
 export const isHostRegistered = (hostId) => {
   return apiLogin()
     .then(({ accessToken }) => {

--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -9,9 +9,10 @@ const userDropdownMenuButton = 'header button[id*="menu"]';
 const userDropdownProfileButton = 'a:contains("Profile")';
 const accessForbiddenMessage =
   'div:contains("Access to this page is forbidden")';
-const navigation = {
+export const navigation = {
   navigationItems: 'nav a',
   activityLog: 'a:contains("Activity Log")',
+  hosts: 'a:contains("Hosts")',
 };
 const signOutButton = 'button:contains("Sign out")';
 const removeEnv1TagButton = 'span span:contains("env1") span';

--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -338,3 +338,14 @@ export const getResourceTags = (resourceResponse) => {
   });
   return resourceTags;
 };
+
+export const apiSetTag = (resource, resourceId, tag) => {
+  return apiLogin().then(({ accessToken }) =>
+    cy.request({
+      url: `/api/v1/${resource}/${resourceId}/tags`,
+      method: 'POST',
+      auth: { bearer: accessToken },
+      body: { value: tag },
+    })
+  );
+};

--- a/test/e2e/cypress/pageObject/clusters_overview_po.js
+++ b/test/e2e/cypress/pageObject/clusters_overview_po.js
@@ -190,14 +190,7 @@ export const apiRestoreClusterHosts = () =>
 
 const apiSetTag = (clusterName, tag) => {
   const clusterID = clusterIdByName(clusterName);
-  return basePage.apiLogin().then(({ accessToken }) =>
-    cy.request({
-      url: `/api/v1/clusters/${clusterID}/tags`,
-      method: 'POST',
-      auth: { bearer: accessToken },
-      body: { value: tag },
-    })
-  );
+  return basePage.apiSetTag('clusters', clusterID, tag);
 };
 
 export const apiSetTagsHanaCluster1 = () => {

--- a/test/e2e/cypress/pageObject/host_details_po.js
+++ b/test/e2e/cypress/pageObject/host_details_po.js
@@ -440,13 +440,12 @@ export const loadSaptuneScenario = (state) => {
 
 export const loadAwsHostDetails = () =>
   basePage.loadScenario('host-details-aws');
+
 export const startAgentHeartbeat = () =>
   cy.task('startAgentHeartbeat', [selectedHost.agentId]);
 
 export const restoreHost = () =>
   basePage.loadScenario(`host-details-${selectedHost.hostName}`);
-
-export const stopAgentsHeartbeat = () => cy.task('stopAgentsHeartbeat');
 
 export const apiCreateUserWithHostChecksExecutionAbilities = () =>
   basePage.createUserWithAbilities([

--- a/test/e2e/cypress/pageObject/hosts_overview_po.js
+++ b/test/e2e/cypress/pageObject/hosts_overview_po.js
@@ -31,6 +31,9 @@ const warningHostBadge = 'svg.fill-yellow-500';
 const criticalHostBadge = 'svg.fill-red-500';
 const hostToDeregisterCleanupButton = `tr:contains("${hostToDeregister}") td:contains("Clean up")`;
 const cleanupButtons = 'tbody tr button:contains("Clean up")';
+const heartbeatFailingToaster = `p:contains("The host ${hostToDeregister} heartbeat is failing.")`;
+const deregisterHostModalTitle = `div:contains("Clean up data discovered by agent on host ${hostToDeregister}")`;
+const cleanupConfirmationButton = `${deregisterHostModalTitle} button:contains("Clean up")`;
 
 // UI Interactions
 
@@ -39,6 +42,11 @@ export const visit = () => basePage.visit(url);
 export const validateUrl = () => basePage.validateUrl(url);
 
 export const clickNextPageButton = () => cy.get(nextPageSelector).click();
+
+export const addTagToHost = () => {
+  const host = _getHostToDeregisterData(hostToDeregister);
+  basePage.addTagByColumnValue(host.name, host.tag);
+};
 
 // UI Validations
 
@@ -141,6 +149,9 @@ export const cleanupButtonIsNotDisplayedForHostSendingHeartbeat = () => {
   cy.get(hostToDeregisterCleanupButton, { timeout: 15000 }).should('not.exist');
 };
 
+export const clickCleanupOnHostToDeregister = () =>
+  cy.get(hostToDeregisterCleanupButton).click();
+
 export const cleanupButtonIsDisplayedForHostSendingHeartbeat = () =>
   cy.get(hostToDeregisterCleanupButton).should('be.visible');
 
@@ -151,7 +162,20 @@ export const expectedAmountOfCleanupButtonsIsDisplayed = (amount) =>
     })
     .should('have.length', amount);
 
-// API)
+export const heartbeatFailingToasterIsDisplayed = () =>
+  cy.get(heartbeatFailingToaster, { timeout: 15000 }).should('be.visible');
+
+export const deregisterModalTitleIsDisplayed = () =>
+  cy.get(deregisterHostModalTitle).should('be.visible');
+
+export const clickCleanupConfirmationButton = () =>
+  cy.get(cleanupConfirmationButton).click();
+
+export const deregisteredHostIsNotVisible = () => {
+  const host = _getHostToDeregisterData();
+  cy.get(`#host-${host.id}`).should('not.exist');
+};
+// API
 
 // Table Validation
 

--- a/test/e2e/cypress/pageObject/hosts_overview_po.js
+++ b/test/e2e/cypress/pageObject/hosts_overview_po.js
@@ -4,21 +4,7 @@ import * as basePage from './base_po';
 import { capitalize } from 'lodash';
 
 // Test data
-const saptuneScenarios = [
-  {
-    scenario: 'not-compliant',
-    icon: 'fill-red-500',
-  },
-  {
-    scenario: 'not-tuned',
-    icon: 'fill-yellow-500',
-  },
-  {
-    scenario: 'compliant',
-    icon: 'fill-jungle-green-500',
-  },
-];
-
+const hostToDeregister = 'vmhdbdev01';
 const hostWithoutSap = 'vmdrbddev01';
 const hostWithSap = 'vmhdbprd01';
 
@@ -43,6 +29,8 @@ const hostsWithPassing = 'p:contains("Passing") + p';
 const passingHostBadge = 'svg.fill-jungle-green-500';
 const warningHostBadge = 'svg.fill-yellow-500';
 const criticalHostBadge = 'svg.fill-red-500';
+const hostToDeregisterCleanupButton = `tr:contains("${hostToDeregister}") td:contains("Clean up")`;
+const cleanupButtons = 'tbody tr button:contains("Clean up")';
 
 // UI Interactions
 
@@ -149,6 +137,22 @@ export const hostWithSaptuneNotTunedHasExpectedStatus = () =>
 export const hostWithSaptuneCompliantHasExpectedStatus = () =>
   _hostHasExpectedStatus(hostWithSap, 'fill-jungle-green-500');
 
+export const cleanupButtonIsNotDisplayedForHostSendingHeartbeat = () => {
+  cy.get(hostToDeregisterCleanupButton, { timeout: 15000 }).should('not.exist');
+};
+
+export const cleanupButtonIsDisplayedForHostSendingHeartbeat = () =>
+  cy.get(hostToDeregisterCleanupButton).should('be.visible');
+
+export const expectedAmountOfCleanupButtonsIsDisplayed = (amount) =>
+  cy
+    .get(cleanupButtons, {
+      timeout: 15000,
+    })
+    .should('have.length', amount);
+
+// API)
+
 // Table Validation
 
 export const hostsTableContentsAreTheExpected = () => {
@@ -207,7 +211,25 @@ const _validateCell = (header, rowIndex, expectedValue) => {
     });
 };
 
+// Helpers
+
+const _getHostToDeregisterData = () => {
+  const foundHost = availableHosts.find(
+    (host) => host.name === hostToDeregister
+  );
+  return {
+    name: foundHost.name,
+    id: foundHost.id,
+    tag: 'tag1',
+  };
+};
+
 // API
+export const startAgentHeartbeat = () => {
+  const hostToDeregister = _getHostToDeregisterData();
+  cy.task('startAgentHeartbeat', [hostToDeregister.id]);
+};
+
 export const startAgentsHeartbeat = () =>
   cy.task('startAgentHeartbeat', agents());
 

--- a/test/e2e/cypress/pageObject/hosts_overview_po.js
+++ b/test/e2e/cypress/pageObject/hosts_overview_po.js
@@ -4,6 +4,24 @@ import * as basePage from './base_po';
 import { capitalize } from 'lodash';
 
 // Test data
+const saptuneScenarios = [
+  {
+    scenario: 'not-compliant',
+    icon: 'fill-red-500',
+  },
+  {
+    scenario: 'not-tuned',
+    icon: 'fill-yellow-500',
+  },
+  {
+    scenario: 'compliant',
+    icon: 'fill-jungle-green-500',
+  },
+];
+
+const hostWithoutSap = 'vmdrbddev01';
+const hostWithSap = 'vmhdbprd01';
+
 import {
   availableHosts,
   agents,
@@ -17,6 +35,13 @@ const hostNameCell = '.tn-hostname';
 const currentPaginationDetails =
   'div[data-testid="pagination"] span:contains("Showing")';
 const nextPageSelector = '[aria-label="next-page"]';
+
+const hostsWithWarning = 'p:contains("Warning") + p';
+const hostsWithCritical = 'p:contains("Critical") + p';
+const hostsWithPassing = 'p:contains("Passing") + p';
+
+const passingHostBadge = 'svg.fill-jungle-green-500';
+const warningHostBadge = 'svg.fill-yellow-500';
 
 // UI Interactions
 
@@ -81,6 +106,41 @@ export const everySapSystemLinkGoesToExpectedSapSystemDetailsPage = () => {
   });
 };
 
+export const expectedWarningHostsAreDisplayed = (amount) =>
+  cy.get(hostsWithWarning).should('have.text', amount);
+
+export const expectedCriticalHostsAreDisplayed = (amount) =>
+  cy.get(hostsWithCritical).should('have.text', amount);
+
+export const expectedPassingHostsAreDisplayed = (amount) =>
+  cy.get(hostsWithPassing).should('have.text', amount);
+
+export const expectedAmountOfWarningsIsDisplayed = (amount) =>
+  cy.get(warningHostBadge).should('have.length', amount);
+
+export const expectedAmountOfPassingIsDisplayed = (amount) =>
+  cy.get(passingHostBadge).should('have.length', amount);
+
+const _hostHasExpectedStatus = (host, status) =>
+  cy
+    .get(`tr:contains("${host}") td:nth-child(1) svg`)
+    .should('have.class', status);
+
+export const hostWithSapHasExpectedStatus = () =>
+  _hostHasExpectedStatus(hostWithoutSap, 'fill-jungle-green-500');
+
+export const hostWithoutSapHasExpectedStatus = () =>
+  _hostHasExpectedStatus(hostWithSap, 'fill-yellow-500');
+
+export const hostWithSaptuneNotCompliantHasExpectedStatus = () =>
+  _hostHasExpectedStatus(hostWithSap, 'fill-red-500');
+
+export const hostWithSaptuneNotTunedHasExpectedStatus = () =>
+  _hostHasExpectedStatus(hostWithSap, 'fill-yellow-500');
+
+export const hostWithSaptuneCompliantHasExpectedStatus = () =>
+  _hostHasExpectedStatus(hostWithSap, 'fill-jungle-green-500');
+
 // Table Validation
 
 export const hostsTableContentsAreTheExpected = () => {
@@ -138,3 +198,22 @@ const _validateCell = (header, rowIndex, expectedValue) => {
       }
     });
 };
+
+// API
+export const startAgentsHeartbeat = () =>
+  cy.task('startAgentHeartbeat', agents());
+
+export const loadHostWithoutSaptune = () =>
+  basePage.loadScenario(`host-${hostWithoutSap}-saptune-uninstalled`);
+
+export const loadHostWithSaptuneNotTuned = () =>
+  basePage.loadScenario(`host-${hostWithoutSap}-saptune-not-tuned`);
+
+export const loadHostWithSapWithoutSaptune = () =>
+  basePage.loadScenario(`host-${hostWithSap}-saptune-uninstalled`);
+
+export const loadHostWithSapWithSaptuneUnsupported = () =>
+  basePage.loadScenario(`host-${hostWithSap}-saptune-unsupported`);
+
+export const loadHostWithSaptuneScenario = (scenario) =>
+  basePage.loadScenario(`host-${hostWithSap}-saptune-${scenario}`);

--- a/test/e2e/cypress/pageObject/hosts_overview_po.js
+++ b/test/e2e/cypress/pageObject/hosts_overview_po.js
@@ -48,6 +48,9 @@ const deregisterHostModalTitle = `div:contains("Clean up data discovered by agen
 const cleanupConfirmationButton = `${deregisterHostModalTitle} button:contains("Clean up")`;
 const sapSystemToDeregister = `a:contains("${sapSystemHostToDeregister.sid}")`;
 const initialHostName = `a:contains("${sapSystemHostsToDeregister.initialHostname}")`;
+const addTagButton = 'span:contains("Add Tag")';
+const removeTag1Button =
+  'span[class*="leading-5"]:contains("tag1") span[aria-hidden="true"]';
 
 // UI Interactions
 
@@ -213,6 +216,24 @@ export const initialHostNameIsDisplayed = () =>
 
 export const initialHostNameIsNotDisplayed = () =>
   cy.get(initialHostName).should('not.exist');
+
+export const addTagButtonIsDisabled = () =>
+  cy.get(addTagButton).should('have.class', 'opacity-50');
+
+export const removeTag1ButtonIsDisabled = () =>
+  cy.get(removeTag1Button).should('have.class', 'opacity-50');
+
+export const addTagButtonIsEnabled = () =>
+  cy.get(addTagButton).should('not.have.class', 'opacity-50');
+
+export const removeTag1ButtonIsEnabled = () =>
+  cy.get(removeTag1Button).should('not.have.class', 'opacity-50');
+
+export const cleanupButtonsAreDisabled = () =>
+  cy.get(cleanupButtons).should('be.disabled');
+
+export const cleanupButtonsAreEnabled = () =>
+  cy.get(cleanupButtons).should('not.be.disabled');
 
 // API
 
@@ -381,3 +402,22 @@ export const apiDeregisterMovedHost = () =>
 
 export const apiDeregisterInitialHostId = () =>
   basePage.apiDeregisterHost(sapSystemHostsToDeregister.initialHostId);
+
+export const apiSetTag = () => {
+  const host = _getHostToDeregisterData(hostToDeregister);
+  return basePage.apiLogin().then(({ accessToken }) =>
+    cy.request({
+      url: `/api/v1/hosts/${host.id}/tags`,
+      method: 'POST',
+      auth: { bearer: accessToken },
+      body: { value: host.tag },
+    })
+  );
+};
+
+export const apiCreateUserWithHostTagsAbility = () => {
+  basePage.createUserWithAbilities([{ name: 'all', resource: 'host_tags' }]);
+};
+
+export const apiCreateUserWithHostCleanupAbility = () =>
+  basePage.createUserWithAbilities([{ name: 'cleanup', resource: 'host' }]);

--- a/test/e2e/cypress/pageObject/hosts_overview_po.js
+++ b/test/e2e/cypress/pageObject/hosts_overview_po.js
@@ -103,7 +103,11 @@ export const everyClusterLinkGoesToExpectedClusterDetailsPage = () => {
       .invoke('index')
       .then((i) => {
         if (host.clusterId !== '') {
+          cy.intercept('/api/v2/checks/groups/*/executions/last').as(
+            'checkExecutions'
+          );
           cy.get('tbody tr').eq(index).find('td').eq(i).click();
+          cy.wait('@checkExecutions', { timeout: 10000 });
           basePage.validateUrl(`/clusters/${host.clusterId}`);
           cy.go('back');
         }

--- a/test/e2e/cypress/pageObject/hosts_overview_po.js
+++ b/test/e2e/cypress/pageObject/hosts_overview_po.js
@@ -42,6 +42,7 @@ const hostsWithPassing = 'p:contains("Passing") + p';
 
 const passingHostBadge = 'svg.fill-jungle-green-500';
 const warningHostBadge = 'svg.fill-yellow-500';
+const criticalHostBadge = 'svg.fill-red-500';
 
 // UI Interactions
 
@@ -110,13 +111,20 @@ export const expectedWarningHostsAreDisplayed = (amount) =>
   cy.get(hostsWithWarning).should('have.text', amount);
 
 export const expectedCriticalHostsAreDisplayed = (amount) =>
-  cy.get(hostsWithCritical).should('have.text', amount);
+  cy.get(hostsWithCritical, { timeout: 20000 }).should('have.text', amount);
 
 export const expectedPassingHostsAreDisplayed = (amount) =>
   cy.get(hostsWithPassing).should('have.text', amount);
 
 export const expectedAmountOfWarningsIsDisplayed = (amount) =>
   cy.get(warningHostBadge).should('have.length', amount);
+
+export const expectedAmountOfCriticalsIsDisplayed = (amount) => {
+  if (amount === 0) cy.get(criticalHostBadge).should('not.exist');
+  else {
+    cy.get(criticalHostBadge, { timeout: 20000 }).should('have.length', amount);
+  }
+};
 
 export const expectedAmountOfPassingIsDisplayed = (amount) =>
   cy.get(passingHostBadge).should('have.length', amount);

--- a/test/e2e/cypress/pageObject/hosts_overview_po.js
+++ b/test/e2e/cypress/pageObject/hosts_overview_po.js
@@ -28,7 +28,6 @@ import {
 const url = '/hosts';
 
 // Selectors
-
 const hostNameCell = '.tn-hostname';
 const currentPaginationDetails =
   'div[data-testid="pagination"] span:contains("Showing")';
@@ -51,6 +50,7 @@ const initialHostName = `a:contains("${sapSystemHostsToDeregister.initialHostnam
 const addTagButton = 'span:contains("Add Tag")';
 const removeTag1Button =
   'span[class*="leading-5"]:contains("tag1") span[aria-hidden="true"]';
+const sidTableHeader = 'thead th:contains("SID")';
 
 // UI Interactions
 
@@ -64,6 +64,12 @@ export const addTagToHost = () => {
   const host = _getHostToDeregisterData(hostToDeregister);
   basePage.addTagByColumnValue(host.name, host.tag);
 };
+
+export const clickCleanupOnHostToDeregister = () =>
+  cy.get(hostToDeregisterCleanupButton).click();
+
+export const clickCleanupConfirmationButton = () =>
+  cy.get(cleanupConfirmationButton).click();
 
 // UI Validations
 
@@ -107,7 +113,7 @@ export const everyClusterLinkGoesToExpectedClusterDetailsPage = () => {
 
 export const everySapSystemLinkGoesToExpectedSapSystemDetailsPage = () => {
   availableHosts.slice(0, 10).forEach((host, index) => {
-    cy.get('thead th:contains("SID")')
+    cy.get(sidTableHeader)
       .invoke('index')
       .then((i) => {
         if (host.sapSystemSid !== '') {
@@ -166,9 +172,6 @@ export const cleanupButtonIsNotDisplayedForHostSendingHeartbeat = () => {
   cy.get(hostToDeregisterCleanupButton, { timeout: 20000 }).should('not.exist');
 };
 
-export const clickCleanupOnHostToDeregister = () =>
-  cy.get(hostToDeregisterCleanupButton).click();
-
 export const cleanupButtonIsDisplayedForHostSendingHeartbeat = () =>
   cy.get(hostToDeregisterCleanupButton).should('be.visible');
 
@@ -184,9 +187,6 @@ export const heartbeatFailingToasterIsDisplayed = () =>
 
 export const deregisterModalTitleIsDisplayed = () =>
   cy.get(deregisterHostModalTitle).should('be.visible');
-
-export const clickCleanupConfirmationButton = () =>
-  cy.get(cleanupConfirmationButton).click();
 
 export const deregisteredHostIsNotVisible = () => {
   const host = _getHostToDeregisterData();
@@ -234,8 +234,6 @@ export const cleanupButtonsAreDisabled = () =>
 
 export const cleanupButtonsAreEnabled = () =>
   cy.get(cleanupButtons).should('not.be.disabled');
-
-// API
 
 // Table Validation
 
@@ -352,8 +350,8 @@ const apiRemoveTagByHostId = (hostId, tagId) => {
 
 export const apiDeleteAllHostsTags = () => {
   apiGetHosts().then((response) => {
-    const clusterTags = getHostTags(response.body);
-    Object.entries(clusterTags).forEach(([clusterId, tags]) => {
+    const hostsTags = getHostTags(response.body);
+    Object.entries(hostsTags).forEach(([clusterId, tags]) => {
       tags.forEach((tag) => apiRemoveTagByHostId(clusterId, tag));
     });
   });
@@ -405,14 +403,7 @@ export const apiDeregisterInitialHostId = () =>
 
 export const apiSetTag = () => {
   const host = _getHostToDeregisterData(hostToDeregister);
-  return basePage.apiLogin().then(({ accessToken }) =>
-    cy.request({
-      url: `/api/v1/hosts/${host.id}/tags`,
-      method: 'POST',
-      auth: { bearer: accessToken },
-      body: { value: host.tag },
-    })
-  );
+  return basePage.apiSetTag('hosts', host.id, host.tag);
 };
 
 export const apiCreateUserWithHostTagsAbility = () => {

--- a/test/e2e/cypress/pageObject/hosts_overview_po.js
+++ b/test/e2e/cypress/pageObject/hosts_overview_po.js
@@ -1,0 +1,140 @@
+export * from './base_po';
+import * as basePage from './base_po';
+
+import { capitalize } from 'lodash';
+
+// Test data
+import {
+  availableHosts,
+  agents,
+} from '../fixtures/hosts-overview/available_hosts';
+
+const url = '/hosts';
+
+// Selectors
+
+const hostNameCell = '.tn-hostname';
+const currentPaginationDetails =
+  'div[data-testid="pagination"] span:contains("Showing")';
+const nextPageSelector = '[aria-label="next-page"]';
+
+// UI Interactions
+
+export const visit = () => basePage.visit(url);
+
+export const validateUrl = () => basePage.validateUrl(url);
+
+export const clickNextPageButton = () => cy.get(nextPageSelector).click();
+
+// UI Validations
+
+export const hostsIsHighglightedInSidebar = () => {
+  cy.get(basePage.navigation.hosts).should('have.attr', 'aria-current', 'page');
+};
+
+export const tenHostsAreListed = () => {
+  cy.get(hostNameCell).should('have.length', 10);
+};
+
+export const expectedPaginationIsDisplayed = (expectedPaginationDetails) =>
+  cy
+    .get(currentPaginationDetails)
+    .should('have.text', expectedPaginationDetails);
+
+export const nextPageButtonIsDisabled = () =>
+  cy.get(nextPageSelector).should('be.disabled');
+
+export const everyLinkGoesToExpectedHostDetailsPage = () => {
+  availableHosts.slice(0, 10).forEach((host) => {
+    cy.get(`a[href*="${host.id}"]`).click();
+    basePage.validateUrl(`${url}/${host.id}`);
+    cy.go('back');
+  });
+};
+
+export const everyClusterLinkGoesToExpectedClusterDetailsPage = () => {
+  availableHosts.slice(0, 10).forEach((host, index) => {
+    cy.get('thead th:contains("Cluster")')
+      .invoke('index')
+      .then((i) => {
+        if (host.clusterId !== '') {
+          cy.get('tbody tr').eq(index).find('td').eq(i).click();
+          basePage.validateUrl(`/clusters/${host.clusterId}`);
+          cy.go('back');
+        }
+      });
+  });
+};
+
+export const everySapSystemLinkGoesToExpectedSapSystemDetailsPage = () => {
+  availableHosts.slice(0, 10).forEach((host, index) => {
+    cy.get('thead th:contains("SID")')
+      .invoke('index')
+      .then((i) => {
+        if (host.sapSystemSid !== '') {
+          cy.get(`td:contains("${host.sapSystemSid}")`).should('be.visible');
+          cy.get('tbody tr').eq(index).find('td').eq(i).click();
+          basePage.validateUrl(`/databases/${host.sapSystemId}`);
+          cy.go('back');
+        }
+      });
+  });
+};
+
+// Table Validation
+
+export const hostsTableContentsAreTheExpected = () => {
+  const expectedValuesArray = availableHosts.slice(0, 10);
+  expectedValuesArray.forEach((rowExpectedValues, rowIndex) => {
+    _getTableHeaders().then((headers) => {
+      headers.slice(3, 7).forEach((header) => {
+        const attributeName = _processAttributeName(header);
+        let expectedValue = rowExpectedValues[attributeName];
+        _validateCell(header, rowIndex, expectedValue);
+      });
+    });
+  });
+};
+
+const _getTableHeaders = () => {
+  return cy.get('thead th').then((headers) => {
+    const headerTexts = [...headers].map((header) => header.textContent.trim());
+    return cy.wrap(headerTexts);
+  });
+};
+
+const _processAttributeName = (attributeHeaderName) => {
+  const splittedAttribute = attributeHeaderName.toLowerCase().split(' ');
+  if (splittedAttribute.length === 2)
+    return splittedAttribute[0] + capitalize(splittedAttribute[1]);
+  else if (splittedAttribute[0] === 'ip') return 'ipAddresses';
+  else if (splittedAttribute[0] === 'cluster') return 'clusterName';
+  else if (splittedAttribute[0] === 'sid') return 'sapSystemSid';
+  else return splittedAttribute;
+};
+
+const _validateCell = (header, rowIndex, expectedValue) => {
+  const tableHeaderSelector = `thead th:contains("${header}")`;
+  const tableRowSelector = `tbody tr`;
+
+  cy.get(tableHeaderSelector)
+    .invoke('index')
+    .then((i) => {
+      const isPropertyArray = Array.isArray(expectedValue);
+      if (isPropertyArray) {
+        cy.wrap(expectedValue).each((value) => {
+          cy.get(tableRowSelector)
+            .eq(rowIndex)
+            .find('td')
+            .eq(i)
+            .should('contain', value);
+        });
+      } else {
+        cy.get(tableRowSelector)
+          .eq(rowIndex)
+          .find('td')
+          .eq(i)
+          .should('contain', expectedValue);
+      }
+    });
+};

--- a/test/e2e/cypress/pageObject/users_po.js
+++ b/test/e2e/cypress/pageObject/users_po.js
@@ -366,9 +366,6 @@ export const enableTotpOptionIsDisabled = () => {
 
 export const newIssuedTotpSecretIsDifferent = (originalTotpSecret) => {
   getTotpSecret().then((newTotpSecret) => {
-    expect(
-      newTotpSecret === originalTotpSecret,
-      'New issued TOTP secret is different'
-    ).to.be.false;
+    cy.wrap(newTotpSecret).should('not.equal', originalTotpSecret);
   });
 };


### PR DESCRIPTION
# Description

apply page object pattern to hosts overview tests

add missing parameter to validate totp secret, that was missed in last pr about reviewing users test suite flakiness.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**
## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
- [Trento Web guides](https://github.com/trento-project/web/tree/main/guides)

Add a documentation PR or write that no changes are required for the documentation.
- [ ] **DONE**
