### PR TITLE
Fix database profile payload validation

### DIFF
--- a/lib/trento/discovery/payloads/sap_system_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/sap_system_discovery_payload.ex
@@ -36,7 +36,9 @@ defmodule Trento.Discovery.Payloads.SapSystemDiscoveryPayload do
     sap_system
     |> cast(modified_attrs, fields())
     |> cast_embed(:Profile,
-      with: fn profile, attrs -> Profile.changeset(profile, attrs, parse_system_type(attrs)) end,
+      with: fn profile, profile_attrs ->
+        Profile.changeset(profile, profile_attrs, parse_system_type(modified_attrs))
+      end,
       required: true
     )
     |> cast_embed(:Databases)

--- a/test/trento/discovery/policies/sap_system_policy_test.exs
+++ b/test/trento/discovery/policies/sap_system_policy_test.exs
@@ -350,4 +350,19 @@ defmodule Trento.Discovery.Policies.SapSystemPolicyTest do
                |> SapSystemPolicy.handle([application_instance, database_instance], nil)
     end
   end
+
+  describe "validation" do
+    test "should fail if an application instance payload does not have a dbname entry in the profile" do
+      assert {:error, {:validation, [%{Profile: %{"dbs/hdb/dbname": ["can't be blank"]}}]}} =
+               "sap_system_discovery_application"
+               |> load_discovery_event_fixture()
+               |> update_in(
+                 ["payload"],
+                 &Enum.map(&1, fn sap_system ->
+                   sap_system |> pop_in(["Profile", "dbs/hdb/dbname"]) |> elem(1)
+                 end)
+               )
+               |> SapSystemPolicy.handle([], nil)
+    end
+  end
 end


### PR DESCRIPTION
# Description

Fix database payload profile validation. The `dbname` field was not being validated properly, as the application type was passed always incorrectly as `nil`.
It doesn't have major relevance than returning an easier error in the payload validation and hence, in the discarded message. Without this, we got `{:validation, %{tenant: [\"can't be blank\"]}}`, which well, it was OK as at least it was failing, but in one step ahead.

@abravosuse Related to the last scenario with the `DVEBMGS00` instance. It doesn't fix the issue itself, but it improves the debugging.

## How was this tested?

UT and some manual testing
