### PR TITLE
Use custom function to check if data is loaded

### DIFF
--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -217,14 +217,16 @@ export const selectFromDropdown = (selector, choice) => {
   return cy.get(`${selector} + div div:contains("${choice}")`).click();
 };
 
-export const preloadTestData = () => {
+export const preloadTestData = ({
+  isDataLoadedFunc = isTestDataLoaded,
+} = {}) => {
   /**
    * Preload required test data.
    * It must run photofinish scenario twice as the order of sent payloads is relevant
    * and the tests require a fully loaded scenario which only happens when the
    * scenario is sent in the second time.
    */
-  isTestDataLoaded().then((isLoaded) => {
+  isDataLoadedFunc().then((isLoaded) => {
     if (!isLoaded) loadScenario('healthy-27-node-SAP-cluster');
   });
   loadScenario('healthy-27-node-SAP-cluster');

--- a/test/e2e/cypress/pageObject/databases_overview_po.js
+++ b/test/e2e/cypress/pageObject/databases_overview_po.js
@@ -133,6 +133,22 @@ export const clickModalCleanUpButton = () => cy.get(cleanUpButtonModal).click();
 
 // API Interactions
 
+export const preloadTestData = () =>
+  basePage.preloadTestData({ isDataLoadedFunc: isTestDataLoaded });
+
+const isTestDataLoaded = () =>
+  basePage.apiLogin().then(({ accessToken }) =>
+    cy
+      .request({
+        url: '/api/v1/sap_systems',
+        method: 'GET',
+        auth: {
+          bearer: accessToken,
+        },
+      })
+      .then(({ body }) => body.length !== 0)
+  );
+
 export const deregisterHdqDatabasePrimaryInstance = () =>
   basePage.apiDeregisterHost(hdqDatabase.instances[0].id);
 


### PR DESCRIPTION
# Description

The regression suite was broken. Most probably since we change photofinish behaviour.
This change give the option to decide if we need to load photofinish data twice or not before the test for each suite.

For example, for the databases suite, we check if sap systems are present or not.