### PR TITLE
Expose cluster sap instances frontend

### DIFF
--- a/assets/js/lib/model/clusters.js
+++ b/assets/js/lib/model/clusters.js
@@ -1,3 +1,5 @@
+import { map, uniq } from 'lodash';
+
 // Cluster types
 export const HANA_SCALE_UP = 'hana_scale_up';
 export const HANA_SCALE_OUT = 'hana_scale_out';
@@ -48,3 +50,6 @@ export const CLASSIC_ARCHITECTURE = 'classic';
 export const FS_TYPE_RESOURCE_MANAGED = 'resource_managed';
 export const FS_TYPE_SIMPLE_MOUNT = 'simple_mount';
 export const FS_TYPE_MIXED = 'mixed_fs_types';
+
+export const getClusterSids = ({ sap_instances: sapInstances }) =>
+  uniq(map(sapInstances, 'sid'));

--- a/assets/js/lib/model/clusters.test.js
+++ b/assets/js/lib/model/clusters.test.js
@@ -1,4 +1,13 @@
-import { getClusterTypeLabel, isValidClusterType } from './clusters';
+import {
+  clusterFactory,
+  clusteredSapInstanceFactory,
+} from '@lib/test-utils/factories';
+
+import {
+  getClusterTypeLabel,
+  isValidClusterType,
+  getClusterSids,
+} from './clusters';
 
 describe('clusters', () => {
   it('should check if a cluster type is valid', () => {
@@ -19,5 +28,15 @@ describe('clusters', () => {
     });
 
     expect(getClusterTypeLabel('other')).toBe('Unknown');
+  });
+
+  it('should get SAP instances SIDs from cluster', () => {
+    const instance1 = clusteredSapInstanceFactory.build();
+    const instance2 = clusteredSapInstanceFactory.build();
+    const instance3 = clusteredSapInstanceFactory.build({ sid: instance1.sid });
+    const cluster = clusterFactory.build({
+      sap_instances: [instance1, instance2, instance3],
+    });
+    expect(getClusterSids(cluster)).toEqual([instance1.sid, instance2.sid]);
   });
 });

--- a/assets/js/lib/test-utils/factories/clusters.js
+++ b/assets/js/lib/test-utils/factories/clusters.js
@@ -121,6 +121,11 @@ export const ascsErsClusterDetailsFactory = Factory.define(({ params }) => {
   };
 });
 
+export const clusteredSapInstanceFactory = Factory.define(() => ({
+  sid: generateSid(),
+  instance_number: faker.number.int({ min: 10, max: 99 }).toString(),
+}));
+
 export const clusterFactory = Factory.define(({ sequence, params }) => {
   const { type = 'hana_scale_up' } = params;
 
@@ -138,8 +143,7 @@ export const clusterFactory = Factory.define(({ sequence, params }) => {
   return {
     id: faker.string.uuid(),
     name: `${faker.person.firstName()}_${sequence}`,
-    sid: generateSid(),
-    additional_sids: [],
+    sap_instances: clusteredSapInstanceFactory.buildList(1),
     hosts_number: faker.number.int(),
     resources_number: faker.number.int(),
     type: clusterTypeEnum(),

--- a/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
@@ -17,6 +17,7 @@ import { updateCatalog } from '@state/catalog';
 import { executionRequested, updateLastExecution } from '@state/lastExecutions';
 import { buildEnv } from '@lib/checks';
 import { TARGET_CLUSTER } from '@lib/model';
+import { getClusterSids } from '@lib/model/clusters';
 
 import AscsErsClusterDetails from './AscsErsClusterDetails';
 import HanaClusterDetails from './HanaClusterDetails';
@@ -89,8 +90,7 @@ export function ClusterDetailsPage() {
           hosts={clusterHosts}
           clusterType={cluster.type}
           cibLastWritten={cluster.cib_last_written}
-          sid={cluster.sid}
-          additionalSids={cluster.additional_sids}
+          clusterSids={getClusterSids(cluster)}
           provider={cluster.provider}
           sapSystems={clusterSapSystems}
           details={cluster.details}

--- a/assets/js/pages/ClusterDetails/ClustersList.jsx
+++ b/assets/js/pages/ClusterDetails/ClustersList.jsx
@@ -3,7 +3,11 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useSearchParams } from 'react-router-dom';
 
 import { post, del } from '@lib/network';
-import { HANA_ASCS_ERS, getClusterTypeLabel } from '@lib/model/clusters';
+import {
+  HANA_ASCS_ERS,
+  getClusterTypeLabel,
+  getClusterSids,
+} from '@lib/model/clusters';
 
 import { addTagToCluster, removeTagFromCluster } from '@state/clusters';
 import { getAllSAPInstances } from '@state/selectors/sapSystem';
@@ -158,7 +162,7 @@ function ClustersList() {
     health: cluster.health,
     name: cluster.name,
     id: cluster.id,
-    sid: (cluster.sid ? [cluster.sid] : []).concat(cluster.additional_sids),
+    sid: getClusterSids(cluster),
     type: cluster.type,
     hosts_number: cluster.hosts_number,
     resources_number: cluster.resources_number,

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
@@ -42,8 +42,7 @@ function HanaClusterDetails({
   cibLastWritten,
   provider,
   sapSystems,
-  sid,
-  additionalSids,
+  clusterSids,
   details,
   catalog,
   userAbilities,
@@ -52,7 +51,6 @@ function HanaClusterDetails({
   navigate = () => {},
 }) {
   const enrichedNodes = enrichNodes(details?.nodes, hosts);
-  const clusterSids = [sid, ...additionalSids];
   const enrichedSapSystems = clusterSids.map((sidItem) => ({
     sid: sidItem,
     ...sapSystems.find(({ sid: currentSid }) => currentSid === sidItem),

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.stories.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.stories.jsx
@@ -21,11 +21,10 @@ const userAbilities = [{ name: 'all', resource: 'all' }];
 const {
   id: clusterID,
   name: clusterName,
-  sid,
   type: clusterType,
   selected_checks: selectedChecks,
   provider,
-  additional_sids: additionalSids,
+  sap_instances: [{ sid }],
   cib_last_written: cibLastWritten,
   details,
 } = clusterFactory.build({
@@ -158,8 +157,7 @@ export const Hana = {
     hosts,
     clusterType,
     cibLastWritten,
-    sid,
-    additionalSids,
+    clusterSids: [sid],
     provider,
     sapSystems,
     details,
@@ -174,7 +172,7 @@ export const Hana = {
 export const HanaScaleUpCostOpt = {
   args: {
     ...Hana.args,
-    additionalSids: ['QAS', 'DEV'],
+    clusterSids: [sid, 'QAS', 'DEV'],
     sapSystems: sapSystemList,
     details: { ...Hana.args.details, hana_scenario: 'cost_optimized' },
   },
@@ -183,7 +181,7 @@ export const HanaScaleUpCostOpt = {
 export const HanaScaleUpCostOptWithoutEnrichedData = {
   args: {
     ...Hana.args,
-    additionalSids: ['QAS', 'DEV'],
+    clusterSids: [sid, 'QAS', 'DEV'],
     details: { ...Hana.args.details, hana_scenario: 'cost_optimized' },
   },
 };
@@ -265,8 +263,7 @@ export const AngiArchitecturePerformanceScenario = {
 export const AngiArchitectureCostOptScenario = {
   args: {
     ...Hana.args,
-    sid,
-    additionalSids: ['QAS', 'DEV'],
+    clusterSids: [sid, 'QAS', 'DEV'],
     sapSystems: sapSystemList,
     details: {
       ...Hana.args.details,
@@ -279,8 +276,7 @@ export const AngiArchitectureCostOptScenario = {
 export const AngiArchitectureCostOptScenarioWithoutEnrichedData = {
   args: {
     ...Hana.args,
-    sid,
-    additionalSids: ['QAS1', 'DEV1'],
+    clusterSids: [sid, 'QAS1', 'DEV1'],
     sapSystems: sapSystemList,
     details: {
       ...Hana.args.details,

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.test.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.test.jsx
@@ -78,7 +78,7 @@ describe('HanaClusterDetails component', () => {
         clusterName,
         cib_last_written: cibLastWritten,
         type: clusterType,
-        sid,
+        sap_instances: [{ sid }],
         provider,
         details,
       } = hanaCluster;
@@ -94,8 +94,7 @@ describe('HanaClusterDetails component', () => {
           hosts={hosts}
           clusterType={clusterType}
           cibLastWritten={cibLastWritten}
-          sid={sid}
-          additionalSids={[]}
+          clusterSids={[sid]}
           provider={provider}
           sapSystems={[]}
           details={details}
@@ -114,7 +113,7 @@ describe('HanaClusterDetails component', () => {
       clusterName,
       cib_last_written: cibLastWritten,
       type: clusterType,
-      sid,
+      sap_instances: [{ sid }],
       provider,
       details,
     } = clusterFactory.build();
@@ -132,8 +131,7 @@ describe('HanaClusterDetails component', () => {
         hosts={hosts}
         clusterType={clusterType}
         cibLastWritten={cibLastWritten}
-        sid={sid}
-        additionalSids={[]}
+        clusterSids={[sid]}
         provider={provider}
         sapSystems={sapSystems}
         details={details}
@@ -157,7 +155,7 @@ describe('HanaClusterDetails component', () => {
       clusterName,
       cib_last_written: cibLastWritten,
       type: clusterType,
-      sid,
+      sap_instances: [{ sid }],
       provider,
       details,
     } = clusterFactory.build();
@@ -175,8 +173,7 @@ describe('HanaClusterDetails component', () => {
         cibLastWritten={cibLastWritten}
         provider={provider}
         sapSystems={[{ sid }]}
-        sid={sid}
-        additionalSids={[]}
+        clusterSids={[sid]}
         details={details}
         lastExecution={null}
         userAbilities={userAbilities}
@@ -194,7 +191,7 @@ describe('HanaClusterDetails component', () => {
       clusterName,
       cib_last_written: cibLastWritten,
       type: clusterType,
-      sid,
+      sap_instances: [{ sid }],
       provider,
       details,
     } = clusterFactory.build();
@@ -216,8 +213,7 @@ describe('HanaClusterDetails component', () => {
         hosts={[host]}
         clusterType={clusterType}
         cibLastWritten={cibLastWritten}
-        sid={sid}
-        additionalSids={[]}
+        clusterSids={[sid]}
         provider={provider}
         sapSystems={[]}
         details={details}
@@ -242,7 +238,7 @@ describe('HanaClusterDetails component', () => {
       clusterName,
       cib_last_written: cibLastWritten,
       type: clusterType,
-      sid,
+      sap_instances: [{ sid }],
       provider,
       details,
     } = clusterFactory.build({ details: { maintenance_mode: true } });
@@ -258,8 +254,7 @@ describe('HanaClusterDetails component', () => {
         hosts={hosts}
         clusterType={clusterType}
         cibLastWritten={cibLastWritten}
-        sid={sid}
-        additionalSids={[]}
+        clusterSids={[sid]}
         provider={provider}
         sapSystems={[]}
         details={details}
@@ -280,7 +275,7 @@ describe('HanaClusterDetails component', () => {
       clusterName,
       cib_last_written: cibLastWritten,
       type: clusterType,
-      sid,
+      sap_instances: [{ sid }],
       provider,
       details,
     } = clusterFactory.build();
@@ -300,8 +295,7 @@ describe('HanaClusterDetails component', () => {
         hosts={hosts}
         clusterType={clusterType}
         cibLastWritten={cibLastWritten}
-        sid={sid}
-        additionalSids={[]}
+        clusterSids={[sid]}
         provider={provider}
         sapSystems={[]}
         details={details}
@@ -321,7 +315,7 @@ describe('HanaClusterDetails component', () => {
       clusterName,
       cib_last_written: cibLastWritten,
       type: clusterType,
-      sid,
+      sap_instances: [{ sid }],
       provider,
       details,
     } = clusterFactory.build();
@@ -343,8 +337,7 @@ describe('HanaClusterDetails component', () => {
         hosts={hosts}
         clusterType={clusterType}
         cibLastWritten={cibLastWritten}
-        sid={sid}
-        additionalSids={[]}
+        clusterSids={[sid]}
         provider={provider}
         sapSystems={[]}
         details={updatedDetails}
@@ -366,7 +359,7 @@ describe('HanaClusterDetails component', () => {
       clusterName,
       cib_last_written: cibLastWritten,
       type: clusterType,
-      sid,
+      sap_instances: [{ sid }],
       provider,
       details,
     } = clusterFactory.build();
@@ -386,8 +379,7 @@ describe('HanaClusterDetails component', () => {
         hosts={hosts}
         clusterType={clusterType}
         cibLastWritten={cibLastWritten}
-        sid={sid}
-        additionalSids={[]}
+        clusterSids={[sid]}
         provider={provider}
         sapSystems={[]}
         details={details}
@@ -440,7 +432,7 @@ describe('HanaClusterDetails component', () => {
         clusterName,
         cib_last_written: cibLastWritten,
         type: clusterType,
-        sid,
+        sap_instances: [{ sid }],
         provider,
         details,
       } = clusterFactory.build();
@@ -456,8 +448,7 @@ describe('HanaClusterDetails component', () => {
           hosts={hosts}
           clusterType={clusterType}
           cibLastWritten={cibLastWritten}
-          sid={sid}
-          additionalSids={[]}
+          clusterSids={[sid]}
           provider={provider}
           sapSystems={[]}
           details={details}
@@ -509,7 +500,7 @@ describe('HanaClusterDetails component', () => {
         clusterName,
         cib_last_written: cibLastWritten,
         type: clusterType,
-        sid,
+        sap_instances: [{ sid }],
         provider,
         details,
       } = clusterFactory.build({
@@ -528,8 +519,7 @@ describe('HanaClusterDetails component', () => {
           hosts={hosts}
           clusterType={clusterType}
           cibLastWritten={cibLastWritten}
-          sid={sid}
-          additionalSids={[]}
+          clusterSids={[sid]}
           provider={provider}
           sapSystems={[]}
           details={details}
@@ -557,7 +547,7 @@ describe('HanaClusterDetails component', () => {
         clusterName,
         cib_last_written: cibLastWritten,
         type: clusterType,
-        sid,
+        sap_instances: [{ sid }],
         provider,
         details,
       } = clusterFactory.build();
@@ -573,8 +563,7 @@ describe('HanaClusterDetails component', () => {
           hosts={hosts}
           clusterType={clusterType}
           cibLastWritten={cibLastWritten}
-          sid={sid}
-          additionalSids={[]}
+          clusterSids={[sid]}
           provider={provider}
           sapSystems={[]}
           details={details}
@@ -604,7 +593,7 @@ describe('HanaClusterDetails component', () => {
         clusterName,
         cib_last_written: cibLastWritten,
         type: clusterType,
-        sid,
+        sap_instances: [{ sid }],
         provider,
         details,
       } = clusterFactory.build();
@@ -620,8 +609,7 @@ describe('HanaClusterDetails component', () => {
           hosts={hosts}
           clusterType={clusterType}
           cibLastWritten={cibLastWritten}
-          sid={sid}
-          additionalSids={[]}
+          clusterSids={[sid]}
           provider={provider}
           sapSystems={[]}
           details={details}

--- a/assets/js/pages/InstanceOverview/InstanceOverview.jsx
+++ b/assets/js/pages/InstanceOverview/InstanceOverview.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
+import { get, some } from 'lodash';
 
 import { DATABASE_TYPE } from '@lib/model/sapSystems';
 
@@ -16,6 +17,7 @@ function InstanceOverview({
   instanceType,
   instance,
   instance: {
+    sid,
     health,
     system_replication: systemReplication,
     system_replication_status: systemReplicationStatus,
@@ -30,6 +32,10 @@ function InstanceOverview({
   cleanUpPermittedFor,
   onCleanUpClick,
 }) {
+  const hostname = get(host, 'hostname', '');
+  const cluster = get(host, 'cluster', null);
+  const sapInstances = get(host, 'cluster.sap_instances', []);
+
   const isDatabase = DATABASE_TYPE === instanceType;
   const rowClasses = classNames(
     { 'bg-gray-100': absentAt },
@@ -61,8 +67,8 @@ function InstanceOverview({
         </div>
       )}
       <div className="table-cell p-2">
-        {host?.cluster ? (
-          <ClusterLink cluster={host.cluster} />
+        {some(sapInstances, { sid, instance_number: instanceNumber }) ? (
+          <ClusterLink cluster={cluster} />
         ) : (
           <p className="text-gray-500 dark:text-gray-300 text-sm">
             not available
@@ -70,7 +76,7 @@ function InstanceOverview({
         )}
       </div>
       <div className="table-cell p-2">
-        <HostLink hostId={hostID}>{host && host.hostname}</HostLink>
+        <HostLink hostId={hostID}>{hostname}</HostLink>
       </div>
       {absentAt && (
         <div className="table-cell p-2">

--- a/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.test.jsx
+++ b/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.test.jsx
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event';
 
 import {
   clusterFactory,
+  clusteredSapInstanceFactory,
   hostFactory,
   sapSystemApplicationInstanceFactory,
   sapSystemFactory,
@@ -189,6 +190,7 @@ describe('SapSystemsOverviews component', () => {
       const enrichedApplicationInstances = applicationInstances.map(
         (instance) => {
           const host = hostFactory.build({ id: instance.host_id });
+          const { sid, instance_number } = instance;
           return {
             ...instance,
             host: {
@@ -196,6 +198,10 @@ describe('SapSystemsOverviews component', () => {
               cluster: clusterFactory.build({
                 id: host.cluster_id,
                 type: 'hana_scale_up',
+                sap_instances: clusteredSapInstanceFactory.buildList(1, {
+                  sid,
+                  instance_number,
+                }),
               }),
             },
           };
@@ -204,6 +210,7 @@ describe('SapSystemsOverviews component', () => {
 
       const enrichedDatabaseInstances = databaseInstances.map((instance) => {
         const host = hostFactory.build({ id: instance.host_id });
+        const { sid, instance_number } = instance;
 
         return {
           ...instance,
@@ -212,6 +219,10 @@ describe('SapSystemsOverviews component', () => {
             cluster: clusterFactory.build({
               id: host.cluster_id,
               type: 'hana_scale_up',
+              sap_instances: clusteredSapInstanceFactory.buildList(1, {
+                sid,
+                instance_number,
+              }),
             }),
           },
         };

--- a/lib/trento_web/controllers/v1/cluster_json.ex
+++ b/lib/trento_web/controllers/v1/cluster_json.ex
@@ -9,6 +9,7 @@ defmodule TrentoWeb.V1.ClusterJSON do
     %{cluster: cluster}
     |> V2.ClusterJSON.cluster()
     |> adapt_v1()
+    |> Map.delete(:sap_instances)
   end
 
   def cluster_registered(%{cluster: cluster}) do

--- a/lib/trento_web/controllers/v2/cluster_json.ex
+++ b/lib/trento_web/controllers/v2/cluster_json.ex
@@ -81,9 +81,14 @@ defmodule TrentoWeb.V2.ClusterJSON do
   end
 
   defp adapt_sids(%{sap_instances: sap_instances} = cluster) do
+    adapted_sap_instances =
+      Enum.map(sap_instances, fn %{sid: sid, instance_number: instance_number} ->
+        %{sid: sid, instance_number: instance_number}
+      end)
+
     cluster
     |> Map.put(:sid, SapInstance.get_hana_instance_sid(sap_instances))
     |> Map.put(:additional_sids, SapInstance.get_sap_instance_sids(sap_instances))
-    |> Map.delete(:sap_instances)
+    |> Map.put(:sap_instances, adapted_sap_instances)
   end
 end

--- a/lib/trento_web/openapi/v2/schema/cluster.ex
+++ b/lib/trento_web/openapi/v2/schema/cluster.ex
@@ -296,11 +296,30 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
         properties: %{
           id: %Schema{type: :string, description: "Cluster ID", format: :uuid},
           name: %Schema{type: :string, description: "Cluster name"},
-          sid: %Schema{type: :string, description: "SID"},
+          sid: %Schema{
+            type: :string,
+            description: "SID. Deprecated: use sap_instances instead",
+            deprecated: true
+          },
           additional_sids: %Schema{
             type: :array,
             items: %Schema{type: :string},
-            description: "Additionally discovered SIDs, such as ASCS/ERS cluster SIDs"
+            description:
+              "Additionally discovered SIDs, such as ASCS/ERS cluster SIDs. Deprecated: use sap_instances instead",
+            deprecated: true
+          },
+          sap_instances: %Schema{
+            description: "Cluster SAP instances with their SID and additional information",
+            type: :array,
+            items: %Schema{
+              type: :object,
+              properties: %{
+                sid: %Schema{type: :string, description: "SAP instance SID"},
+                instance_number: %Schema{type: :string, description: "SAP instance number"}
+              },
+              additionalProperties: false,
+              required: [:sid, :instance_number]
+            }
           },
           provider: Provider.SupportedProviders,
           type: %Schema{

--- a/test/trento_web/views/v1/cluster_view_json_test.exs
+++ b/test/trento_web/views/v1/cluster_view_json_test.exs
@@ -43,6 +43,7 @@ defmodule TrentoWeb.V1.ClusterJSONTest do
       refute Access.get(updated_details, :maintenance_mode)
       refute Access.get(updated_details, :architecture_type)
       refute Access.get(updated_details, :hana_scenario)
+      refute Access.get(updated_details, :sap_instances)
       refute Access.get(node, :nameserver_actual_role)
       refute Access.get(node, :indexserver_actual_role)
       refute Access.get(node, :status)

--- a/test/trento_web/views/v2/cluster_view_json_test.exs
+++ b/test/trento_web/views/v2/cluster_view_json_test.exs
@@ -2,6 +2,8 @@ defmodule TrentoWeb.V2.ClusterJSONTest do
   use TrentoWeb.ConnCase, async: true
   import Trento.Factory
 
+  require Trento.Clusters.Enums.SapInstanceResourceType, as: SapInstanceResourceType
+
   alias TrentoWeb.V2.ClusterJSON
 
   alias Trento.Clusters.Projections.ClusterReadModel
@@ -64,5 +66,30 @@ defmodule TrentoWeb.V2.ClusterJSONTest do
     Enum.each(resources, fn resource ->
       refute Map.has_key?(resource, :parent)
     end)
+  end
+
+  test "should render sap instances and deprecated sids properly" do
+    sap_instances = [
+      %{sid: sid_1, instance_number: inr_1} =
+        build(:clustered_sap_instance, resource_type: SapInstanceResourceType.sap_instance()),
+      %{sid: sid_2, instance_number: inr_2} =
+        build(:clustered_sap_instance, resource_type: SapInstanceResourceType.sap_hana_topology()),
+      %{sid: sid_3, instance_number: inr_3} =
+        build(:clustered_sap_instance, resource_type: SapInstanceResourceType.sap_instance())
+    ]
+
+    cluster = build(:cluster, sap_instances: sap_instances)
+
+    %{sap_instances: view_sap_instances, sid: sid, additional_sids: additional_sids} =
+      ClusterJSON.cluster(%{cluster: cluster})
+
+    assert sid_2 == sid
+    assert [sid_1, sid_3] == additional_sids
+
+    assert [
+             %{sid: sid_1, instance_number: inr_1},
+             %{sid: sid_2, instance_number: inr_2},
+             %{sid: sid_3, instance_number: inr_3}
+           ] == view_sap_instances
   end
 end


### PR DESCRIPTION
# Description

Follow up of: https://github.com/trento-project/web/pull/3397
Expose the new cluster field `sap_instances` to the frontend in the clusters API and replace the usage of sid and additional_sids with it. Now `sid` and `additional_sids` are marked as deprecated in the API openapi schema.
In the `InstanceOverview` the cluster link is created if the instance is only clustered.

## How was this tested?

UT and storybook
