### PR TITLE
Support AWS without metadata scenarios

### DIFF
--- a/.photofinish.toml
+++ b/.photofinish.toml
@@ -248,6 +248,12 @@ files = [
     "./test/fixtures/scenarios/host-details/9cd46919-5f19-59aa-993e-cf3736c71053_cloud_discovery_aws.json",
 ]
 
+[host-details-aws-no-metadata]
+
+files = [
+    "./test/fixtures/scenarios/host-details/9cd46919-5f19-59aa-993e-cf3736c71053_cloud_discovery_aws_no_metadata.json",
+]
+
 [host-details-gcp]
 
 files = [

--- a/assets/js/lib/test-utils/factories/hosts.js
+++ b/assets/js/lib/test-utils/factories/hosts.js
@@ -100,6 +100,7 @@ export const saptuneStatusFactory = Factory.define(() => {
     tuning_state: saptuneTuningStateEnum(),
   };
 });
+
 export const hostFactory = Factory.define(({ params, sequence }) => {
   const id = params.id || faker.string.uuid();
 
@@ -129,3 +130,14 @@ export const hostFactory = Factory.define(({ params, sequence }) => {
     saptune_status: saptuneStatusFactory.build(),
   };
 });
+
+export const awsMetadataFactory = Factory.define(() => ({
+  account_id: faker.string.uuid(),
+  ami_id: `ami-${faker.string.uuid()}`,
+  availability_zone: 'eu-west-1a',
+  data_disk_number: 1,
+  instance_id: 'i-44444',
+  instance_type: 't3.micro',
+  region: 'eu-west-1',
+  vpc_id: 'vpc-99999',
+}));

--- a/assets/js/pages/HostDetailsPage/ProviderDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/ProviderDetails.jsx
@@ -4,6 +4,31 @@ import Pill from '@common/Pill';
 import ListView from '@common/ListView';
 import ProviderLabel from '@common/ProviderLabel';
 
+const awsMetadataRenderSpec = (provider_data) => {
+  if (!provider_data) {
+    return [];
+  }
+
+  return [
+    { title: 'Instance type', content: provider_data?.instance_type },
+    { title: 'Instance ID', content: provider_data?.instance_id },
+    {
+      title: 'Data disk number',
+      content: provider_data?.data_disk_number,
+    },
+    {
+      title: 'Account ID',
+      content: provider_data?.account_id,
+    },
+    { title: 'AMI ID', content: provider_data?.ami_id },
+    {
+      title: 'Region',
+      content: `${provider_data?.region} (${provider_data?.availability_zone})`,
+    },
+    { title: 'VPC ID', content: provider_data?.vpc_id },
+  ];
+};
+
 function ProviderDetails({ provider, provider_data }) {
   const data = {
     azure: [
@@ -32,22 +57,7 @@ function ProviderDetails({ provider, provider_data }) {
         content: provider,
         render: (content) => <ProviderLabel provider={content} />,
       },
-      { title: 'Instance type', content: provider_data?.instance_type },
-      { title: 'Instance ID', content: provider_data?.instance_id },
-      {
-        title: 'Data disk number',
-        content: provider_data?.data_disk_number,
-      },
-      {
-        title: 'Account ID',
-        content: provider_data?.account_id,
-      },
-      { title: 'AMI ID', content: provider_data?.ami_id },
-      {
-        title: 'Region',
-        content: `${provider_data?.region} (${provider_data?.availability_zone})`,
-      },
-      { title: 'VPC ID', content: provider_data?.vpc_id },
+      ...awsMetadataRenderSpec(provider_data),
     ],
     gcp: [
       {

--- a/assets/js/pages/HostDetailsPage/ProviderDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/ProviderDetails.test.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+
+import { AWS_PROVIDER } from '@lib/model';
 import ProviderDetails from './ProviderDetails';
 
 describe('Provider Details', () => {
@@ -42,5 +44,81 @@ describe('Provider Details', () => {
     expect(document.querySelector('span')).toHaveTextContent(
       'Provider not recognized'
     );
+  });
+
+  describe('AWS', () => {
+    const metadataLabels = [
+      {
+        key: 'account_id',
+        label: 'Account ID',
+      },
+      {
+        key: 'ami_id',
+        label: 'AMI ID',
+      },
+      // availability_zone is not displayed on its own but as part of the region
+      // {
+      //   key: 'availability_zone',
+      //   label: null,
+      // },
+      {
+        key: 'data_disk_number',
+        label: 'Data disk number',
+      },
+      {
+        key: 'instance_id',
+        label: 'Instance ID',
+      },
+      {
+        key: 'instance_type',
+        label: 'Instance type',
+      },
+      {
+        key: 'region',
+        label: 'Region',
+      },
+      {
+        key: 'vpc_id',
+        label: 'VPC ID',
+      },
+    ];
+
+    it('should render with AWS metadata', () => {
+      const awsMetadata = {
+        account_id: '123456',
+        ami_id: 'ami-67890',
+        availability_zone: 'eu-west-1a',
+        data_disk_number: 1,
+        instance_id: 'i-44444',
+        instance_type: 't3.micro',
+        region: 'eu-west-1',
+        vpc_id: 'vpc-99999',
+      };
+
+      render(
+        <ProviderDetails provider={AWS_PROVIDER} provider_data={awsMetadata} />
+      );
+
+      expect(screen.getByText('AWS')).toBeVisible();
+
+      metadataLabels.forEach(({ key, label }) => {
+        expect(screen.queryByText(label)).toBeVisible();
+
+        expect(screen.queryByText(label).nextSibling).toHaveTextContent(
+          awsMetadata[key],
+          { exact: false }
+        );
+      });
+    });
+
+    it('should render without AWS', () => {
+      render(<ProviderDetails provider={AWS_PROVIDER} provider_data={null} />);
+
+      expect(screen.getByText('AWS')).toBeVisible();
+
+      metadataLabels.forEach(({ _, label }) => {
+        expect(screen.queryByText(label)).toBeNull();
+      });
+    });
   });
 });

--- a/assets/js/pages/HostDetailsPage/ProviderDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/ProviderDetails.test.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
+import { awsMetadataFactory } from '@lib/test-utils/factories';
+
 import { AWS_PROVIDER } from '@lib/model';
 import ProviderDetails from './ProviderDetails';
 
@@ -84,16 +86,7 @@ describe('Provider Details', () => {
     ];
 
     it('should render with AWS metadata', () => {
-      const awsMetadata = {
-        account_id: '123456',
-        ami_id: 'ami-67890',
-        availability_zone: 'eu-west-1a',
-        data_disk_number: 1,
-        instance_id: 'i-44444',
-        instance_type: 't3.micro',
-        region: 'eu-west-1',
-        vpc_id: 'vpc-99999',
-      };
+      const awsMetadata = awsMetadataFactory.build();
 
       render(
         <ProviderDetails provider={AWS_PROVIDER} provider_data={awsMetadata} />
@@ -117,7 +110,7 @@ describe('Provider Details', () => {
       expect(screen.getByText('AWS')).toBeVisible();
 
       metadataLabels.forEach(({ _, label }) => {
-        expect(screen.queryByText(label)).toBeNull();
+        expect(screen.queryByText(label)).not.toBeInTheDocument();
       });
     });
   });

--- a/test/e2e/cypress/e2e/host_details.cy.js
+++ b/test/e2e/cypress/e2e/host_details.cy.js
@@ -82,6 +82,11 @@ context('Host Details', () => {
       hostDetailsPage.expectedVpcIdIsDisplayed('aws');
     });
 
+    it('should show AWS cloud details correctly when no metadata are available', () => {
+      hostDetailsPage.loadScenario('host-details-aws-no-metadata');
+      hostDetailsPage.expectedProviderIsDisplayed('aws');
+    });
+
     it('should show GCP cloud details correctly', () => {
       hostDetailsPage.loadScenario('host-details-gcp');
       hostDetailsPage.expectedProviderIsDisplayed('gcp');

--- a/test/fixtures/discovery/cloud_discovery_kvm.json
+++ b/test/fixtures/discovery/cloud_discovery_kvm.json
@@ -3,6 +3,6 @@
   "agent_id": "0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4",
   "payload": {
     "Provider": "kvm",
-    "Metadata": {}
+    "Metadata": null
   }
 }

--- a/test/fixtures/discovery/cloud_discovery_nutanix.json
+++ b/test/fixtures/discovery/cloud_discovery_nutanix.json
@@ -3,6 +3,6 @@
   "agent_id": "0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4",
   "payload": {
     "Provider": "nutanix",
-    "Metadata": {}
+    "Metadata": null
   }
 }

--- a/test/fixtures/discovery/cloud_discovery_vmware.json
+++ b/test/fixtures/discovery/cloud_discovery_vmware.json
@@ -3,7 +3,7 @@
     "agent_id": "0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4",
     "payload": {
       "Provider": "vmware",
-      "Metadata": {}
+      "Metadata": null
     }
   }
   

--- a/test/fixtures/scenarios/host-details/9cd46919-5f19-59aa-993e-cf3736c71053_cloud_discovery_aws_no_metadata.json
+++ b/test/fixtures/scenarios/host-details/9cd46919-5f19-59aa-993e-cf3736c71053_cloud_discovery_aws_no_metadata.json
@@ -2,7 +2,7 @@
   "discovery_type": "cloud_discovery",
   "agent_id": "9cd46919-5f19-59aa-993e-cf3736c71053",
   "payload": {
-    "Provider": "unknown",
+    "Provider": "aws",
     "Metadata": null
   }
 }

--- a/test/fixtures/scenarios/host-details/9cd46919-5f19-59aa-993e-cf3736c71053_cloud_discovery_kvm.json
+++ b/test/fixtures/scenarios/host-details/9cd46919-5f19-59aa-993e-cf3736c71053_cloud_discovery_kvm.json
@@ -3,6 +3,6 @@
   "agent_id": "9cd46919-5f19-59aa-993e-cf3736c71053",
   "payload": {
     "Provider": "kvm",
-    "Metadata": {}
+    "Metadata": null
   }
 }

--- a/test/fixtures/scenarios/host-details/9cd46919-5f19-59aa-993e-cf3736c71053_cloud_discovery_nutanix.json
+++ b/test/fixtures/scenarios/host-details/9cd46919-5f19-59aa-993e-cf3736c71053_cloud_discovery_nutanix.json
@@ -3,6 +3,6 @@
   "agent_id": "9cd46919-5f19-59aa-993e-cf3736c71053",
   "payload": {
     "Provider": "nutanix",
-    "Metadata": {}
+    "Metadata": null
   }
 }

--- a/test/fixtures/scenarios/host-details/9cd46919-5f19-59aa-993e-cf3736c71053_cloud_discovery_vmware.json
+++ b/test/fixtures/scenarios/host-details/9cd46919-5f19-59aa-993e-cf3736c71053_cloud_discovery_vmware.json
@@ -3,6 +3,6 @@
   "agent_id": "9cd46919-5f19-59aa-993e-cf3736c71053",
   "payload": {
     "Provider": "vmware",
-    "Metadata": {}
+    "Metadata": null
   }
 }


### PR DESCRIPTION
# Description

This PR makes sure scenarios where AWS metadata is missing is properly handled.
Related to https://github.com/trento-project/agent/pull/414

Some of the cloud discovery fixtures with `"Metadata": {}` have been adjusted to what the agent actually returns in those cases `"Metadata": null`