### PR TITLE
Parse current instance field

### DIFF
--- a/lib/trento/discovery/payloads/sap_system_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/sap_system_discovery_payload.ex
@@ -233,14 +233,13 @@ defmodule Trento.Discovery.Payloads.SapSystemDiscoveryPayload do
       :httpPort,
       :dispstatus,
       :instanceNr,
-      :startPriority
+      :startPriority,
+      :runningLocally
     ]
 
     use Trento.Support.Type
 
     deftype do
-      # current_instance is a custom field to make data extraction easier
-      field :current_instance, :boolean, default: false
       field :features, :string
       field :hostname, :string
       field :httpPort, :integer
@@ -256,6 +255,7 @@ defmodule Trento.Discovery.Payloads.SapSystemDiscoveryPayload do
 
       field :instanceNr, :integer
       field :startPriority, :string
+      field :runningLocally, :boolean
     end
 
     def changeset(instance, attrs, hostname, instance_number) do
@@ -266,15 +266,17 @@ defmodule Trento.Discovery.Payloads.SapSystemDiscoveryPayload do
       |> validate_required_fields(@required_fields)
     end
 
+    defp enrich_current_instance(%{"runningLocally" => _} = attrs, _, _), do: attrs
+
+    # Keep backward compatibility for older agents that don't send runningLocally
     defp enrich_current_instance(
-           %{"hostname" => current_hostname, "instanceNr" => current_instance_number} = attrs,
+           %{"hostname" => hostname, "instanceNr" => instance_number} = attrs,
            hostname,
            instance_number
-         )
-         when hostname == current_hostname and instance_number == current_instance_number,
-         do: Map.put(attrs, "current_instance", true)
+         ),
+         do: Map.put(attrs, "runningLocally", true)
 
-    defp enrich_current_instance(attrs, _, _), do: attrs
+    defp enrich_current_instance(attrs, _, _), do: Map.put(attrs, "runningLocally", false)
   end
 
   defmodule SapControlProcess do

--- a/lib/trento/discovery/payloads/sap_system_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/sap_system_discovery_payload.ex
@@ -234,7 +234,7 @@ defmodule Trento.Discovery.Payloads.SapSystemDiscoveryPayload do
       :dispstatus,
       :instanceNr,
       :startPriority,
-      :runningLocally
+      :currentInstance
     ]
 
     use Trento.Support.Type
@@ -255,7 +255,7 @@ defmodule Trento.Discovery.Payloads.SapSystemDiscoveryPayload do
 
       field :instanceNr, :integer
       field :startPriority, :string
-      field :runningLocally, :boolean
+      field :currentInstance, :boolean
     end
 
     def changeset(instance, attrs, hostname, instance_number) do
@@ -266,17 +266,17 @@ defmodule Trento.Discovery.Payloads.SapSystemDiscoveryPayload do
       |> validate_required_fields(@required_fields)
     end
 
-    defp enrich_current_instance(%{"runningLocally" => _} = attrs, _, _), do: attrs
+    defp enrich_current_instance(%{"currentInstance" => _} = attrs, _, _), do: attrs
 
-    # Keep backward compatibility for older agents that don't send runningLocally
+    # Keep backward compatibility for older agents that don't send currentInstance
     defp enrich_current_instance(
            %{"hostname" => hostname, "instanceNr" => instance_number} = attrs,
            hostname,
            instance_number
          ),
-         do: Map.put(attrs, "runningLocally", true)
+         do: Map.put(attrs, "currentInstance", true)
 
-    defp enrich_current_instance(attrs, _, _), do: Map.put(attrs, "runningLocally", false)
+    defp enrich_current_instance(attrs, _, _), do: Map.put(attrs, "currentInstance", false)
   end
 
   defmodule SapControlProcess do

--- a/lib/trento/discovery/policies/sap_system_policy.ex
+++ b/lib/trento/discovery/policies/sap_system_policy.ex
@@ -213,7 +213,7 @@ defmodule Trento.Discovery.Policies.SapSystemPolicy do
          key
        ) do
     Enum.find_value(instances, fn
-      %{runningLocally: true} = current_instance -> Map.get(current_instance, key)
+      %{currentInstance: true} = current_instance -> Map.get(current_instance, key)
       _ -> nil
     end)
   end

--- a/lib/trento/discovery/policies/sap_system_policy.ex
+++ b/lib/trento/discovery/policies/sap_system_policy.ex
@@ -213,7 +213,7 @@ defmodule Trento.Discovery.Policies.SapSystemPolicy do
          key
        ) do
     Enum.find_value(instances, fn
-      %{current_instance: true} = current_instance -> Map.get(current_instance, key)
+      %{runningLocally: true} = current_instance -> Map.get(current_instance, key)
       _ -> nil
     end)
   end

--- a/test/fixtures/discovery/sap_system_discovery_application.json
+++ b/test/fixtures/discovery/sap_system_discovery_application.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/discovery/sap_system_discovery_application.json
+++ b/test/fixtures/discovery/sap_system_discovery_application.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/discovery/sap_system_discovery_application_diagnostics.json
+++ b/test/fixtures/discovery/sap_system_discovery_application_diagnostics.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [
@@ -267,7 +267,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 98,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/discovery/sap_system_discovery_application_diagnostics.json
+++ b/test/fixtures/discovery/sap_system_discovery_application_diagnostics.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               }
             ],
             "Processes": [
@@ -262,7 +266,8 @@
                 "httpPort": 59813,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 98,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/discovery/sap_system_discovery_database.json
+++ b/test/fixtures/discovery/sap_system_discovery_database.json
@@ -40,7 +40,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/discovery/sap_system_discovery_database.json
+++ b/test/fixtures/discovery/sap_system_discovery_database.json
@@ -41,7 +41,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/discovery/sap_system_discovery_database_multi_tenant.json
+++ b/test/fixtures/discovery/sap_system_discovery_database_multi_tenant.json
@@ -66,7 +66,8 @@
                 "httpPort": 55613,
                 "httpsPort": 55614,
                 "instanceNr": 56,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/discovery/sap_system_discovery_database_multi_tenant.json
+++ b/test/fixtures/discovery/sap_system_discovery_database_multi_tenant.json
@@ -67,7 +67,7 @@
                 "httpsPort": 55614,
                 "instanceNr": 56,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/discovery/sap_system_discovery_database_stopped_instance.json
+++ b/test/fixtures/discovery/sap_system_discovery_database_stopped_instance.json
@@ -38,7 +38,7 @@
                 "startPriority": "0.3",
                 "features": "HDB|HDB_WORKER",
                 "dispstatus": "SAPControl-GRAY",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Properties": [

--- a/test/fixtures/discovery/sap_system_discovery_database_stopped_instance.json
+++ b/test/fixtures/discovery/sap_system_discovery_database_stopped_instance.json
@@ -37,7 +37,8 @@
                 "httpsPort": 51014,
                 "startPriority": "0.3",
                 "features": "HDB|HDB_WORKER",
-                "dispstatus": "SAPControl-GRAY"
+                "dispstatus": "SAPControl-GRAY",
+                "runningLocally": true
               }
             ],
             "Properties": [

--- a/test/fixtures/scenarios/aws-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery.json
@@ -42,7 +42,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/aws-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery.json
@@ -41,7 +41,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/aws-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_sap_system_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_sap_system_discovery.json
@@ -42,7 +42,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/aws-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_sap_system_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_sap_system_discovery.json
@@ -41,7 +41,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/aws-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/aws-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/aws-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_sap_system_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_sap_system_discovery.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/aws-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_sap_system_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_sap_system_discovery.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": true
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/aws-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/aws-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/aws-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/aws-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/gcp-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery.json
@@ -42,7 +42,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/gcp-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery.json
@@ -41,7 +41,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/gcp-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_sap_system_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_sap_system_discovery.json
@@ -42,7 +42,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/gcp-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_sap_system_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_sap_system_discovery.json
@@ -41,7 +41,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/gcp-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/gcp-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/gcp-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_sap_system_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_sap_system_discovery.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/gcp-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_sap_system_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_sap_system_discovery.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": true
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/gcp-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/gcp-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/gcp-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/gcp-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_GRAY.json
+++ b/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_GRAY.json
@@ -42,7 +42,7 @@
                 "dispstatus": "SAPControl-GRAY",
                 "instanceNr": 10,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_GRAY.json
+++ b/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_GRAY.json
@@ -41,7 +41,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GRAY",
                 "instanceNr": 10,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_GREEN.json
+++ b/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_GREEN.json
@@ -42,7 +42,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_GREEN.json
+++ b/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_GREEN.json
@@ -41,7 +41,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_RED.json
+++ b/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_RED.json
@@ -42,7 +42,7 @@
                 "dispstatus": "SAPControl-RED",
                 "instanceNr": 10,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_RED.json
+++ b/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_RED.json
@@ -41,7 +41,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-RED",
                 "instanceNr": 10,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_YELLOW.json
+++ b/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_YELLOW.json
@@ -41,7 +41,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-YELLOW",
                 "instanceNr": 10,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_YELLOW.json
+++ b/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_YELLOW.json
@@ -42,7 +42,7 @@
                 "dispstatus": "SAPControl-YELLOW",
                 "instanceNr": 10,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_new.json
+++ b/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_new.json
@@ -42,7 +42,7 @@
                 "dispstatus": "SAPControl-GRAY",
                 "instanceNr": 11,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_new.json
+++ b/test/fixtures/scenarios/hana-database-details/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery_new.json
@@ -41,7 +41,8 @@
                 "httpsPort": 12345,
                 "dispstatus": "SAPControl-GRAY",
                 "instanceNr": 11,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-diskless-sbd/0f6e6491-21f2-495e-9f2d-bc50b872efaf_sap_system_discovery.json
+++ b/test/fixtures/scenarios/hana-diskless-sbd/0f6e6491-21f2-495e-9f2d-bc50b872efaf_sap_system_discovery.json
@@ -76,7 +76,7 @@
                 "httpsPort": 50014,
                 "instanceNr": 0,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-diskless-sbd/0f6e6491-21f2-495e-9f2d-bc50b872efaf_sap_system_discovery.json
+++ b/test/fixtures/scenarios/hana-diskless-sbd/0f6e6491-21f2-495e-9f2d-bc50b872efaf_sap_system_discovery.json
@@ -75,7 +75,8 @@
                 "httpPort": 50013,
                 "httpsPort": 50014,
                 "instanceNr": 0,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-diskless-sbd/5f2632a9-7b18-4c37-955a-fe16cadaaef4_sap_system_discovery.json
+++ b/test/fixtures/scenarios/hana-diskless-sbd/5f2632a9-7b18-4c37-955a-fe16cadaaef4_sap_system_discovery.json
@@ -80,7 +80,7 @@
                 "httpsPort": 50014,
                 "instanceNr": 0,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-diskless-sbd/5f2632a9-7b18-4c37-955a-fe16cadaaef4_sap_system_discovery.json
+++ b/test/fixtures/scenarios/hana-diskless-sbd/5f2632a9-7b18-4c37-955a-fe16cadaaef4_sap_system_discovery.json
@@ -79,7 +79,8 @@
                 "httpPort": 50013,
                 "httpsPort": 50014,
                 "instanceNr": 0,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-scale-out/12ab9a68-c047-4eda-81c8-1e24578d9973_sap_system_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-out/12ab9a68-c047-4eda-81c8-1e24578d9973_sap_system_discovery.json
@@ -96,7 +96,8 @@
                 "httpPort": 50013,
                 "httpsPort": 50014,
                 "instanceNr": 0,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": false
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -105,7 +106,8 @@
                 "httpPort": 50013,
                 "httpsPort": 50014,
                 "instanceNr": 0,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-scale-out/12ab9a68-c047-4eda-81c8-1e24578d9973_sap_system_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-out/12ab9a68-c047-4eda-81c8-1e24578d9973_sap_system_discovery.json
@@ -97,7 +97,7 @@
                 "httpsPort": 50014,
                 "instanceNr": 0,
                 "startPriority": "0.3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -107,7 +107,7 @@
                 "httpsPort": 50014,
                 "instanceNr": 0,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-scale-out/16bd3ed1-923d-46ff-b6d0-9bfed42e387b_sap_system_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-out/16bd3ed1-923d-46ff-b6d0-9bfed42e387b_sap_system_discovery.json
@@ -97,7 +97,7 @@
                 "httpsPort": 50014,
                 "instanceNr": 0,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -107,7 +107,7 @@
                 "httpsPort": 50014,
                 "instanceNr": 0,
                 "startPriority": "0.3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-scale-out/16bd3ed1-923d-46ff-b6d0-9bfed42e387b_sap_system_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-out/16bd3ed1-923d-46ff-b6d0-9bfed42e387b_sap_system_discovery.json
@@ -96,7 +96,8 @@
                 "httpPort": 50013,
                 "httpsPort": 50014,
                 "instanceNr": 0,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -105,7 +106,8 @@
                 "httpPort": 50013,
                 "httpsPort": 50014,
                 "instanceNr": 0,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-scale-out/33ec3a15-103b-453b-b6b2-f3f971582dc_sap_system_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-out/33ec3a15-103b-453b-b6b2-f3f971582dc_sap_system_discovery.json
@@ -101,7 +101,7 @@
                 "httpsPort": 50014,
                 "instanceNr": 0,
                 "startPriority": "0.3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -111,7 +111,7 @@
                 "httpsPort": 50014,
                 "instanceNr": 0,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-scale-out/33ec3a15-103b-453b-b6b2-f3f971582dc_sap_system_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-out/33ec3a15-103b-453b-b6b2-f3f971582dc_sap_system_discovery.json
@@ -100,7 +100,8 @@
                 "httpPort": 50013,
                 "httpsPort": 50014,
                 "instanceNr": 0,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": false
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -109,7 +110,8 @@
                 "httpPort": 50013,
                 "httpsPort": 50014,
                 "instanceNr": 0,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-scale-out/f3463fd1-004a-4214-afd4-b15160b0d521_sap_system_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-out/f3463fd1-004a-4214-afd4-b15160b0d521_sap_system_discovery.json
@@ -100,7 +100,8 @@
                 "httpPort": 50013,
                 "httpsPort": 50014,
                 "instanceNr": 0,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -109,7 +110,8 @@
                 "httpPort": 50013,
                 "httpsPort": 50014,
                 "instanceNr": 0,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-scale-out/f3463fd1-004a-4214-afd4-b15160b0d521_sap_system_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-out/f3463fd1-004a-4214-afd4-b15160b0d521_sap_system_discovery.json
@@ -101,7 +101,7 @@
                 "httpsPort": 50014,
                 "instanceNr": 0,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -111,7 +111,7 @@
                 "httpsPort": 50014,
                 "instanceNr": 0,
                 "startPriority": "0.3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-scale-up-angi/4b67842f-ccf7-46a4-a344-9e918648b117_sap_system_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-up-angi/4b67842f-ccf7-46a4-a344-9e918648b117_sap_system_discovery.json
@@ -79,7 +79,8 @@
                 "httpPort": 50913,
                 "httpsPort": 50914,
                 "instanceNr": 9,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-scale-up-angi/4b67842f-ccf7-46a4-a344-9e918648b117_sap_system_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-up-angi/4b67842f-ccf7-46a4-a344-9e918648b117_sap_system_discovery.json
@@ -80,7 +80,7 @@
                 "httpsPort": 50914,
                 "instanceNr": 9,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-scale-up-angi/851a4dd3-9693-44c3-a40b-b32d22872e74_sap_system_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-up-angi/851a4dd3-9693-44c3-a40b-b32d22872e74_sap_system_discovery.json
@@ -75,7 +75,8 @@
                 "httpPort": 50913,
                 "httpsPort": 50914,
                 "instanceNr": 9,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-scale-up-angi/851a4dd3-9693-44c3-a40b-b32d22872e74_sap_system_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-up-angi/851a4dd3-9693-44c3-a40b-b32d22872e74_sap_system_discovery.json
@@ -76,7 +76,7 @@
                 "httpsPort": 50914,
                 "instanceNr": 9,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-scale-up-cost-opt/2372b24f-3d7a-5d01-9b1a-a2c4c95c53d4_sap_system_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-up-cost-opt/2372b24f-3d7a-5d01-9b1a-a2c4c95c53d4_sap_system_discovery.json
@@ -277,7 +277,8 @@
                 "httpPort": 52013,
                 "httpsPort": 52014,
                 "instanceNr": 20,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-scale-up-cost-opt/2372b24f-3d7a-5d01-9b1a-a2c4c95c53d4_sap_system_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-up-cost-opt/2372b24f-3d7a-5d01-9b1a-a2c4c95c53d4_sap_system_discovery.json
@@ -278,7 +278,7 @@
                 "httpsPort": 52014,
                 "instanceNr": 20,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/hana-scale-up-cost-opt/fa7a5602-232b-5389-96a6-f5f5de6ff9a2_sap_system_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-up-cost-opt/fa7a5602-232b-5389-96a6-f5f5de6ff9a2_sap_system_discovery.json
@@ -74,7 +74,8 @@
                                 "httpPort": 51013,
                                 "httpsPort": 51014,
                                 "instanceNr": 10,
-                                "startPriority": "0.3"
+                                "startPriority": "0.3",
+                                "runningLocally": true
                             }
                         ],
                         "Processes": [

--- a/test/fixtures/scenarios/hana-scale-up-cost-opt/fa7a5602-232b-5389-96a6-f5f5de6ff9a2_sap_system_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-up-cost-opt/fa7a5602-232b-5389-96a6-f5f5de6ff9a2_sap_system_discovery.json
@@ -75,7 +75,7 @@
                                 "httpsPort": 51014,
                                 "instanceNr": 10,
                                 "startPriority": "0.3",
-                                "runningLocally": true
+                                "currentInstance": true
                             }
                         ],
                         "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/098fc159-3ed6-58e7-91be-38fda8a833ea_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/098fc159-3ed6-58e7-91be-38fda8a833ea_sap_system_discovery.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/098fc159-3ed6-58e7-91be-38fda8a833ea_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/098fc159-3ed6-58e7-91be-38fda8a833ea_sap_system_discovery.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery.json
@@ -42,7 +42,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_sap_system_discovery.json
@@ -41,7 +41,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0fc07435-7ee2-54ca-b0de-fb27ffdc5deb_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0fc07435-7ee2-54ca-b0de-fb27ffdc5deb_sap_system_discovery.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0fc07435-7ee2-54ca-b0de-fb27ffdc5deb_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0fc07435-7ee2-54ca-b0de-fb27ffdc5deb_sap_system_discovery.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/116d49bd-85e1-5e59-b820-83f66db8800c_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/116d49bd-85e1-5e59-b820-83f66db8800c_sap_system_discovery.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/116d49bd-85e1-5e59-b820-83f66db8800c_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/116d49bd-85e1-5e59-b820-83f66db8800c_sap_system_discovery.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": true
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_sap_system_discovery.json
@@ -42,7 +42,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_sap_system_discovery.json
@@ -41,7 +41,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/25677e37-fd33-5005-896c-9275b1284534_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/25677e37-fd33-5005-896c-9275b1284534_sap_system_discovery.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/25677e37-fd33-5005-896c-9275b1284534_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/25677e37-fd33-5005-896c-9275b1284534_sap_system_discovery.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": true
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/3711ea88-9ccc-5b07-8f9d-042be449d72b_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/3711ea88-9ccc-5b07-8f9d-042be449d72b_sap_system_discovery.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/3711ea88-9ccc-5b07-8f9d-042be449d72b_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/3711ea88-9ccc-5b07-8f9d-042be449d72b_sap_system_discovery.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/4b30a6af-4b52-5bda-bccb-f2248a12c992_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/4b30a6af-4b52-5bda-bccb-f2248a12c992_sap_system_discovery.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/4b30a6af-4b52-5bda-bccb-f2248a12c992_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/4b30a6af-4b52-5bda-bccb-f2248a12c992_sap_system_discovery.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_sap_system_discovery.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_sap_system_discovery.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": true
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/81e9b629-c1e7-538f-bff1-47d3a6580522_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/81e9b629-c1e7-538f-bff1-47d3a6580522_sap_system_discovery.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/81e9b629-c1e7-538f-bff1-47d3a6580522_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/81e9b629-c1e7-538f-bff1-47d3a6580522_sap_system_discovery.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/99cf8a3a-48d6-57a4-b302-6e4482227ab6_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/99cf8a3a-48d6-57a4-b302-6e4482227ab6_sap_system_discovery.json
@@ -42,7 +42,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/99cf8a3a-48d6-57a4-b302-6e4482227ab6_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/99cf8a3a-48d6-57a4-b302-6e4482227ab6_sap_system_discovery.json
@@ -41,7 +41,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9cd46919-5f19-59aa-993e-cf3736c71053_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9cd46919-5f19-59aa-993e-cf3736c71053_sap_system_discovery.json
@@ -42,7 +42,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9cd46919-5f19-59aa-993e-cf3736c71053_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9cd46919-5f19-59aa-993e-cf3736c71053_sap_system_discovery.json
@@ -41,7 +41,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a3297d85-5e8b-5ac5-b8a3-55eebc2b8d12_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a3297d85-5e8b-5ac5-b8a3-55eebc2b8d12_sap_system_discovery.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a3297d85-5e8b-5ac5-b8a3-55eebc2b8d12_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a3297d85-5e8b-5ac5-b8a3-55eebc2b8d12_sap_system_discovery.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_sap_system_discovery.json
@@ -42,7 +42,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_sap_system_discovery.json
@@ -41,7 +41,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/e0c182db-32ff-55c6-a9eb-2b82dd21bc8b_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/e0c182db-32ff-55c6-a9eb-2b82dd21bc8b_sap_system_discovery.json
@@ -42,7 +42,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/e0c182db-32ff-55c6-a9eb-2b82dd21bc8b_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/e0c182db-32ff-55c6-a9eb-2b82dd21bc8b_sap_system_discovery.json
@@ -41,7 +41,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/multi-tenant/544cbc99-c856-4b0a-88cf-e6b8db4606f6_sap_system_discovery.json
+++ b/test/fixtures/scenarios/multi-tenant/544cbc99-c856-4b0a-88cf-e6b8db4606f6_sap_system_discovery.json
@@ -111,7 +111,7 @@
                 "httpsPort": 50314,
                 "instanceNr": 3,
                 "startPriority": "0.3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -121,7 +121,7 @@
                 "httpsPort": 50314,
                 "instanceNr": 3,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -131,7 +131,7 @@
                 "httpsPort": 50314,
                 "instanceNr": 3,
                 "startPriority": "0.3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/multi-tenant/544cbc99-c856-4b0a-88cf-e6b8db4606f6_sap_system_discovery.json
+++ b/test/fixtures/scenarios/multi-tenant/544cbc99-c856-4b0a-88cf-e6b8db4606f6_sap_system_discovery.json
@@ -110,7 +110,8 @@
                 "httpPort": 50313,
                 "httpsPort": 50314,
                 "instanceNr": 3,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": false
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -119,7 +120,8 @@
                 "httpPort": 50313,
                 "httpsPort": 50314,
                 "instanceNr": 3,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -128,7 +130,8 @@
                 "httpPort": 50313,
                 "httpsPort": 50314,
                 "instanceNr": 3,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/multi-tenant/c0ecf7d1-bdd3-4c29-b768-cfb97efcc585_sap_system_discovery.json
+++ b/test/fixtures/scenarios/multi-tenant/c0ecf7d1-bdd3-4c29-b768-cfb97efcc585_sap_system_discovery.json
@@ -20,7 +20,7 @@
                 "httpsPort": 52114,
                 "instanceNr": 21,
                 "startPriority": "1",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -30,7 +30,7 @@
                 "httpsPort": 52014,
                 "instanceNr": 20,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [
@@ -154,7 +154,7 @@
                 "httpsPort": 52114,
                 "instanceNr": 21,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -164,7 +164,7 @@
                 "httpsPort": 52014,
                 "instanceNr": 20,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/multi-tenant/c0ecf7d1-bdd3-4c29-b768-cfb97efcc585_sap_system_discovery.json
+++ b/test/fixtures/scenarios/multi-tenant/c0ecf7d1-bdd3-4c29-b768-cfb97efcc585_sap_system_discovery.json
@@ -19,7 +19,8 @@
                 "httpPort": 52113,
                 "httpsPort": 52114,
                 "instanceNr": 21,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": true
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -28,7 +29,8 @@
                 "httpPort": 52013,
                 "httpsPort": 52014,
                 "instanceNr": 20,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [
@@ -151,7 +153,8 @@
                 "httpPort": 52113,
                 "httpsPort": 52114,
                 "instanceNr": 21,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -160,7 +163,8 @@
                 "httpPort": 52013,
                 "httpsPort": 52014,
                 "instanceNr": 20,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/multi-tenant/e0564d66-be9e-4763-9917-655af1bb4b58_sap_system_discovery.json
+++ b/test/fixtures/scenarios/multi-tenant/e0564d66-be9e-4763-9917-655af1bb4b58_sap_system_discovery.json
@@ -111,7 +111,7 @@
                 "httpsPort": 50314,
                 "instanceNr": 3,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -121,7 +121,7 @@
                 "httpsPort": 50314,
                 "instanceNr": 3,
                 "startPriority": "0.3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -131,7 +131,7 @@
                 "httpsPort": 50314,
                 "instanceNr": 3,
                 "startPriority": "0.3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/multi-tenant/e0564d66-be9e-4763-9917-655af1bb4b58_sap_system_discovery.json
+++ b/test/fixtures/scenarios/multi-tenant/e0564d66-be9e-4763-9917-655af1bb4b58_sap_system_discovery.json
@@ -110,7 +110,8 @@
                 "httpPort": 50313,
                 "httpsPort": 50314,
                 "instanceNr": 3,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -119,7 +120,8 @@
                 "httpPort": 50313,
                 "httpsPort": 50314,
                 "instanceNr": 3,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": false
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -128,7 +130,8 @@
                 "httpPort": 50313,
                 "httpsPort": 50314,
                 "instanceNr": 3,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/multi-tenant/edf755fd-abc7-4883-af81-8b06d836db37_sap_system_discovery.json
+++ b/test/fixtures/scenarios/multi-tenant/edf755fd-abc7-4883-af81-8b06d836db37_sap_system_discovery.json
@@ -19,7 +19,8 @@
                 "httpPort": 50113,
                 "httpsPort": 50114,
                 "instanceNr": 1,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": true
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -28,7 +29,8 @@
                 "httpPort": 50013,
                 "httpsPort": 50014,
                 "instanceNr": 0,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [
@@ -151,7 +153,8 @@
                 "httpPort": 50113,
                 "httpsPort": 50114,
                 "instanceNr": 1,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -160,7 +163,8 @@
                 "httpPort": 50013,
                 "httpsPort": 50014,
                 "instanceNr": 0,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/multi-tenant/edf755fd-abc7-4883-af81-8b06d836db37_sap_system_discovery.json
+++ b/test/fixtures/scenarios/multi-tenant/edf755fd-abc7-4883-af81-8b06d836db37_sap_system_discovery.json
@@ -20,7 +20,7 @@
                 "httpsPort": 50114,
                 "instanceNr": 1,
                 "startPriority": "1",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -30,7 +30,7 @@
                 "httpsPort": 50014,
                 "instanceNr": 0,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [
@@ -154,7 +154,7 @@
                 "httpsPort": 50114,
                 "instanceNr": 1,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -164,7 +164,7 @@
                 "httpsPort": 50014,
                 "instanceNr": 0,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/multi-tenant/f7a8969b-db9e-4162-b82a-d5cfafe1c4e9_sap_system_discovery.json
+++ b/test/fixtures/scenarios/multi-tenant/f7a8969b-db9e-4162-b82a-d5cfafe1c4e9_sap_system_discovery.json
@@ -111,7 +111,7 @@
                 "httpsPort": 50314,
                 "instanceNr": 3,
                 "startPriority": "0.3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -121,7 +121,7 @@
                 "httpsPort": 50314,
                 "instanceNr": 3,
                 "startPriority": "0.3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -131,7 +131,7 @@
                 "httpsPort": 50314,
                 "instanceNr": 3,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/multi-tenant/f7a8969b-db9e-4162-b82a-d5cfafe1c4e9_sap_system_discovery.json
+++ b/test/fixtures/scenarios/multi-tenant/f7a8969b-db9e-4162-b82a-d5cfafe1c4e9_sap_system_discovery.json
@@ -110,7 +110,8 @@
                 "httpPort": 50313,
                 "httpsPort": 50314,
                 "instanceNr": 3,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": false
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -119,7 +120,8 @@
                 "httpPort": 50313,
                 "httpsPort": 50314,
                 "instanceNr": 3,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": false
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -128,7 +130,8 @@
                 "httpPort": 50313,
                 "httpsPort": 50314,
                 "instanceNr": 3,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_GRAY.json
+++ b/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_GRAY.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GRAY",
                 "instanceNr": 2,
                 "startPriority": "5",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_GRAY.json
+++ b/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_GRAY.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50216,
                 "dispstatus": "SAPControl-GRAY",
                 "instanceNr": 2,
-                "startPriority": "5"
+                "startPriority": "5",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_GREEN.json
+++ b/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_GREEN.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "5",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_GREEN.json
+++ b/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_GREEN.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50216,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "5"
+                "startPriority": "5",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_RED.json
+++ b/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_RED.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-RED",
                 "instanceNr": 2,
                 "startPriority": "5",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_RED.json
+++ b/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_RED.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50216,
                 "dispstatus": "SAPControl-RED",
                 "instanceNr": 2,
-                "startPriority": "5"
+                "startPriority": "5",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_YELLOW.json
+++ b/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_YELLOW.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50216,
                 "dispstatus": "SAPControl-YELLOW",
                 "instanceNr": 2,
-                "startPriority": "5"
+                "startPriority": "5",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_YELLOW.json
+++ b/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_YELLOW.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-YELLOW",
                 "instanceNr": 2,
                 "startPriority": "5",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_new.json
+++ b/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_new.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50216,
                 "dispstatus": "SAPControl-GRAY",
                 "instanceNr": 2,
-                "startPriority": "5"
+                "startPriority": "5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -91,7 +95,8 @@
                 "httpsPort": 12345,
                 "dispstatus": "SAPControl-GRAY",
                 "instanceNr": 99,
-                "startPriority": "5"
+                "startPriority": "5",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_new.json
+++ b/test/fixtures/scenarios/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_new.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GRAY",
                 "instanceNr": 2,
                 "startPriority": "5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -96,7 +96,7 @@
                 "dispstatus": "SAPControl-GRAY",
                 "instanceNr": 99,
                 "startPriority": "5",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-system-java/a18a203d-4f2f-4d21-b9a5-e300a9c5eeee_sap_system_discovery.json
+++ b/test/fixtures/scenarios/sap-system-java/a18a203d-4f2f-4d21-b9a5-e300a9c5eeee_sap_system_discovery.json
@@ -22,7 +22,7 @@
                                 "httpsPort": 58114,
                                 "instanceNr": 81,
                                 "startPriority": "1",
-                                "runningLocally": false
+                                "currentInstance": false
                             },
                             {
                                 "dispstatus": "SAPControl-GREEN",
@@ -32,7 +32,7 @@
                                 "httpsPort": 58014,
                                 "instanceNr": 80,
                                 "startPriority": "3",
-                                "runningLocally": true
+                                "currentInstance": true
                             }
                         ],
                         "Processes": [
@@ -236,7 +236,7 @@
                                 "httpsPort": 58114,
                                 "instanceNr": 81,
                                 "startPriority": "1",
-                                "runningLocally": true
+                                "currentInstance": true
                             },
                             {
                                 "dispstatus": "SAPControl-GREEN",
@@ -246,7 +246,7 @@
                                 "httpsPort": 58014,
                                 "instanceNr": 80,
                                 "startPriority": "3",
-                                "runningLocally": false
+                                "currentInstance": false
                             }
                         ],
                         "Processes": [

--- a/test/fixtures/scenarios/sap-system-java/a18a203d-4f2f-4d21-b9a5-e300a9c5eeee_sap_system_discovery.json
+++ b/test/fixtures/scenarios/sap-system-java/a18a203d-4f2f-4d21-b9a5-e300a9c5eeee_sap_system_discovery.json
@@ -21,7 +21,8 @@
                                 "httpPort": 58113,
                                 "httpsPort": 58114,
                                 "instanceNr": 81,
-                                "startPriority": "1"
+                                "startPriority": "1",
+                                "runningLocally": false
                             },
                             {
                                 "dispstatus": "SAPControl-GREEN",
@@ -30,7 +31,8 @@
                                 "httpPort": 58013,
                                 "httpsPort": 58014,
                                 "instanceNr": 80,
-                                "startPriority": "3"
+                                "startPriority": "3",
+                                "runningLocally": true
                             }
                         ],
                         "Processes": [
@@ -233,7 +235,8 @@
                                 "httpPort": 58113,
                                 "httpsPort": 58114,
                                 "instanceNr": 81,
-                                "startPriority": "1"
+                                "startPriority": "1",
+                                "runningLocally": true
                             },
                             {
                                 "dispstatus": "SAPControl-GREEN",
@@ -242,7 +245,8 @@
                                 "httpPort": 58013,
                                 "httpsPort": 58014,
                                 "instanceNr": 80,
-                                "startPriority": "3"
+                                "startPriority": "3",
+                                "runningLocally": false
                             }
                         ],
                         "Processes": [

--- a/test/fixtures/scenarios/sap-systems-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_sap_system_discovery_RED.json
+++ b/test/fixtures/scenarios/sap-systems-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_sap_system_discovery_RED.json
@@ -42,7 +42,7 @@
                 "dispstatus": "SAPControl-RED",
                 "instanceNr": 10,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-systems-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_sap_system_discovery_RED.json
+++ b/test/fixtures/scenarios/sap-systems-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_sap_system_discovery_RED.json
@@ -41,7 +41,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-RED",
                 "instanceNr": 10,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-systems-overview/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_RED.json
+++ b/test/fixtures/scenarios/sap-systems-overview/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_RED.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GRAY",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-YELLOW",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50216,
                 "dispstatus": "SAPControl-RED",
                 "instanceNr": 2,
-                "startPriority": "5"
+                "startPriority": "5",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-systems-overview/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_RED.json
+++ b/test/fixtures/scenarios/sap-systems-overview/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_RED.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GRAY",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-YELLOW",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-RED",
                 "instanceNr": 2,
                 "startPriority": "5",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-systems-overview/2ace860d-38e9-55f4-b051-faf4336e71d6_sap_system_discovery_DAA.json
+++ b/test/fixtures/scenarios/sap-systems-overview/2ace860d-38e9-55f4-b051-faf4336e71d6_sap_system_discovery_DAA.json
@@ -21,7 +21,8 @@
                 "httpPort": 59813,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 98,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-systems-overview/2ace860d-38e9-55f4-b051-faf4336e71d6_sap_system_discovery_DAA.json
+++ b/test/fixtures/scenarios/sap-systems-overview/2ace860d-38e9-55f4-b051-faf4336e71d6_sap_system_discovery_DAA.json
@@ -22,7 +22,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 98,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-systems-overview/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery_NOT_MOVED.json
+++ b/test/fixtures/scenarios/sap-systems-overview/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery_NOT_MOVED.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [
@@ -310,7 +310,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -320,7 +320,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -330,7 +330,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -340,7 +340,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-systems-overview/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery_NOT_MOVED.json
+++ b/test/fixtures/scenarios/sap-systems-overview/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery_NOT_MOVED.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [
@@ -305,7 +309,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -314,7 +319,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -323,7 +329,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -332,7 +339,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-systems-overview/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery_YELLOW.json
+++ b/test/fixtures/scenarios/sap-systems-overview/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery_YELLOW.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GRAY",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-YELLOW",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50216,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "5"
+                "startPriority": "5",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-systems-overview/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery_YELLOW.json
+++ b/test/fixtures/scenarios/sap-systems-overview/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery_YELLOW.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GRAY",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-YELLOW",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "5",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-systems-overview/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery_GRAY.json
+++ b/test/fixtures/scenarios/sap-systems-overview/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery_GRAY.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GRAY",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-systems-overview/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery_GRAY.json
+++ b/test/fixtures/scenarios/sap-systems-overview/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery_GRAY.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GRAY",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-systems-overview/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery_MOVED.json
+++ b/test/fixtures/scenarios/sap-systems-overview/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery_MOVED.json
@@ -56,7 +56,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "features": "ENQREP",
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -86,7 +86,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [
@@ -252,7 +252,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ENQREP",
@@ -262,7 +262,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -272,7 +272,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -282,7 +282,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/sap-systems-overview/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery_MOVED.json
+++ b/test/fixtures/scenarios/sap-systems-overview/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery_MOVED.json
@@ -55,7 +55,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": true
               },
               {
                 "features": "ENQREP",
@@ -64,7 +65,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -73,7 +75,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -82,7 +85,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [
@@ -247,7 +251,8 @@
                 "httpsPort": 50014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "features": "ENQREP",
@@ -256,7 +261,8 @@
                 "httpsPort": 51014,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
-                "startPriority": "0.5"
+                "startPriority": "0.5",
+                "runningLocally": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -265,7 +271,8 @@
                 "httpsPort": 50114,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -274,7 +281,8 @@
                 "httpsPort": 50214,
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 2,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/single-hana-single-app/c4914bd4-efa3-553a-9a52-e9b562e210e5_sap_system_discovery.json
+++ b/test/fixtures/scenarios/single-hana-single-app/c4914bd4-efa3-553a-9a52-e9b562e210e5_sap_system_discovery.json
@@ -56,7 +56,7 @@
                 "httpsPort": 50014,
                 "instanceNr": 0,
                 "startPriority": "0.3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/single-hana-single-app/c4914bd4-efa3-553a-9a52-e9b562e210e5_sap_system_discovery.json
+++ b/test/fixtures/scenarios/single-hana-single-app/c4914bd4-efa3-553a-9a52-e9b562e210e5_sap_system_discovery.json
@@ -20,7 +20,10 @@
       "Id": "e058aaacf42f039937c4a43bf3df350b",
       "Instances": [
         {
-          "HdbnsutilSRstate": { "mode": "none", "online": "true" },
+          "HdbnsutilSRstate": {
+            "mode": "none",
+            "online": "true"
+          },
           "Host": "trento-hana01",
           "HostConfiguration": {
             "failoverActualGroup": "default",
@@ -52,7 +55,8 @@
                 "httpPort": 50013,
                 "httpsPort": 50014,
                 "instanceNr": 0,
-                "startPriority": "0.3"
+                "startPriority": "0.3",
+                "runningLocally": true
               }
             ],
             "Processes": [
@@ -210,7 +214,9 @@
               }
             ]
           },
-          "SystemReplication": { "local_site_id": "0" },
+          "SystemReplication": {
+            "local_site_id": "0"
+          },
           "Type": 1
         }
       ],

--- a/test/fixtures/scenarios/single-hana-single-app/e77ab524-c4e4-5381-bb59-5af8639d52a4_sap_system_discovery.json
+++ b/test/fixtures/scenarios/single-hana-single-app/e77ab524-c4e4-5381-bb59-5af8639d52a4_sap_system_discovery.json
@@ -21,7 +21,8 @@
                 "httpPort": 50013,
                 "httpsPort": 50014,
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": true
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -30,7 +31,8 @@
                 "httpPort": 50113,
                 "httpsPort": 50114,
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": false
               }
             ],
             "Processes": [
@@ -153,7 +155,8 @@
                 "httpPort": 50013,
                 "httpsPort": 50014,
                 "instanceNr": 0,
-                "startPriority": "1"
+                "startPriority": "1",
+                "runningLocally": false
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -162,7 +165,8 @@
                 "httpPort": 50113,
                 "httpsPort": 50114,
                 "instanceNr": 1,
-                "startPriority": "3"
+                "startPriority": "3",
+                "runningLocally": true
               }
             ],
             "Processes": [

--- a/test/fixtures/scenarios/single-hana-single-app/e77ab524-c4e4-5381-bb59-5af8639d52a4_sap_system_discovery.json
+++ b/test/fixtures/scenarios/single-hana-single-app/e77ab524-c4e4-5381-bb59-5af8639d52a4_sap_system_discovery.json
@@ -22,7 +22,7 @@
                 "httpsPort": 50014,
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": true
+                "currentInstance": true
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -32,7 +32,7 @@
                 "httpsPort": 50114,
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": false
+                "currentInstance": false
               }
             ],
             "Processes": [
@@ -156,7 +156,7 @@
                 "httpsPort": 50014,
                 "instanceNr": 0,
                 "startPriority": "1",
-                "runningLocally": false
+                "currentInstance": false
               },
               {
                 "dispstatus": "SAPControl-GREEN",
@@ -166,7 +166,7 @@
                 "httpsPort": 50114,
                 "instanceNr": 1,
                 "startPriority": "3",
-                "runningLocally": true
+                "currentInstance": true
               }
             ],
             "Processes": [

--- a/test/trento/discovery/policies/sap_system_policy_test.exs
+++ b/test/trento/discovery/policies/sap_system_policy_test.exs
@@ -258,6 +258,30 @@ defmodule Trento.Discovery.Policies.SapSystemPolicyTest do
              |> SapSystemPolicy.handle([], [])
   end
 
+  test "should parse runningLocally if it is not sent in the payload" do
+    assert {:ok,
+            [
+              %RegisterApplicationInstance{
+                features: "ABAP|GATEWAY|ICMAN|IGS",
+                instance_number: "02"
+              }
+            ]} =
+             "sap_system_discovery_application"
+             |> load_discovery_event_fixture()
+             |> pop_in([
+               "payload",
+               Access.all(),
+               "Instances",
+               Access.all(),
+               "SAPControl",
+               "Instances",
+               Access.all(),
+               "runningLocally"
+             ])
+             |> elem(1)
+             |> SapSystemPolicy.handle([], [])
+  end
+
   describe "delta deregistration" do
     test "should deregister the old instances and register the new ones" do
       database_sap_system_id = UUID.uuid4()

--- a/test/trento/discovery/policies/sap_system_policy_test.exs
+++ b/test/trento/discovery/policies/sap_system_policy_test.exs
@@ -258,7 +258,7 @@ defmodule Trento.Discovery.Policies.SapSystemPolicyTest do
              |> SapSystemPolicy.handle([], [])
   end
 
-  test "should parse runningLocally if it is not sent in the payload" do
+  test "should parse currentInstance if it is not sent in the payload" do
     assert {:ok,
             [
               %RegisterApplicationInstance{
@@ -276,7 +276,7 @@ defmodule Trento.Discovery.Policies.SapSystemPolicyTest do
                "SAPControl",
                "Instances",
                Access.all(),
-               "runningLocally"
+               "currentInstance"
              ])
              |> elem(1)
              |> SapSystemPolicy.handle([], [])


### PR DESCRIPTION
# Description
Parse `currentInstance` field coming in SAP payload.
Related to: https://github.com/trento-project/agent/pull/418/

Keeping backward compatibility for agents that don't send the new field.

## How was this tested?

UT and manual testing
