### PR TITLE
Fix Save button after saving a check in the checks customization modal

### DIFF
--- a/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.jsx
+++ b/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.jsx
@@ -133,13 +133,14 @@ function CheckCustomizationModal({
           type="default-fit"
           className="w-1/2"
           disabled={!canSave}
-          onClick={() =>
+          onClick={() => {
             pipe(
               entries,
               map(([name, value]) => ({ name, value })),
               (payload) => onSave(id, groupID, payload)
-            )(customValues)
-          }
+            )(customValues);
+            setCustomValues({});
+          }}
         >
           Save
         </Button>


### PR DESCRIPTION
# Description

This pr is just a small fix for the save button in the checks customization modal. When a user marks the warning and inputs a new custom value. Pressing the save button will close the modal. If the user opens the modal again  the save button is still enabled. 

This is a bug as it should be disabled.

## Demo before fix

https://github.com/user-attachments/assets/7a243fd0-cf81-4bf0-8015-16ffeb0bca74

## Demo after fix


https://github.com/user-attachments/assets/e6f0d8c8-7623-4373-b15f-54af37d02a0c

## How was this tested ? 

Manual testing --> E2e tests in a future pr

