### PR TITLE
Handle unmounted clustered sap instance

### DIFF
--- a/lib/trento/clusters/value_objects/sap_instance.ex
+++ b/lib/trento/clusters/value_objects/sap_instance.ex
@@ -14,6 +14,7 @@ defmodule Trento.Clusters.ValueObjects.SapInstance do
     field :instance_number, :string
     field :hostname, :string
     field :resource_type, Ecto.Enum, values: SapInstanceResourceType.values()
+    field :mounted, :boolean
   end
 
   @spec get_hana_instance_sid([__MODULE__.t()]) :: String.t()

--- a/lib/trento/discovery/policies/sap_system_policy.ex
+++ b/lib/trento/discovery/policies/sap_system_policy.ex
@@ -139,8 +139,12 @@ defmodule Trento.Discovery.Policies.SapSystemPolicy do
       instance_number = parse_instance_number(instance)
 
       clustered =
-        Enum.any?(sap_instances, fn %{instance_number: inst_number, sid: inst_sid} ->
-          inst_number == instance_number && inst_sid == sid
+        Enum.any?(sap_instances, fn %{
+                                      instance_number: inst_number,
+                                      sid: inst_sid,
+                                      mounted: mounted
+                                    } ->
+          inst_number == instance_number && inst_sid == sid && mounted
         end)
 
       RegisterApplicationInstance.new(%{

--- a/test/fixtures/discovery/ha_cluster_discovery_ascs_ers_simple_mount.json
+++ b/test/fixtures/discovery/ha_cluster_discovery_ascs_ers_simple_mount.json
@@ -1,0 +1,672 @@
+{
+  "agent_id": "4b30a6af-4b52-5bda-bccb-f2248a12c992",
+  "discovery_type": "ha_cluster_discovery",
+  "payload": {
+    "DC": false,
+    "Provider": "azure",
+    "Id": "8bca366a6cb7816555538092a1ddd5aa",
+    "Cib": {
+      "Configuration": {
+        "Nodes": [
+          {
+            "Id": "1",
+            "Uname": "vmnwprd01",
+            "InstanceAttributes": null
+          },
+          {
+            "Id": "2",
+            "Uname": "vmnwprd02",
+            "InstanceAttributes": null
+          }
+        ],
+        "CrmConfig": {
+          "ClusterProperties": [
+            {
+              "Id": "cib-bootstrap-options-have-watchdog",
+              "Name": "have-watchdog",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-dc-version",
+              "Name": "dc-version",
+              "Value": "2.0.5+20201202.ba59be712-4.13.1-2.0.5+20201202.ba59be712"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-infrastructure",
+              "Name": "cluster-infrastructure",
+              "Value": "corosync"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-name",
+              "Name": "cluster-name",
+              "Value": "netweaver_cluster"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-enabled",
+              "Name": "stonith-enabled",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-timeout",
+              "Name": "stonith-timeout",
+              "Value": "144s"
+            },
+            {
+              "Id": "cib-bootstrap-options-maintenance-mode",
+              "Name": "maintenance-mode",
+              "Value": "false"
+            }
+          ]
+        },
+        "Resources": {
+          "Clones": null,
+          "Groups": [
+            {
+              "Id": "grp_NWP_ASCS00",
+              "Primitives": [
+                {
+                  "Id": "rsc_ip_NWP_ASCS00",
+                  "Type": "IPaddr2",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_ip_NWP_ASCS00-monitor-10s",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "20s",
+                      "Interval": "10s"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_ip_NWP_ASCS00-instance_attributes-ip",
+                      "Name": "ip",
+                      "Value": "10.80.1.25"
+                    }
+                  ]
+                },
+                {
+                  "Id": "rsc_SAPStartSrv_NWP_ASCS00",
+                  "Type": "SAPStartSrv",
+                  "Class": "ocf",
+                  "Provider": "suse",
+                  "Operations": [],
+                  "MetaAttributes": null,
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_SAPStartSrv_NWP_ASCS00-instance_attributes-InstanceName",
+                      "Name": "InstanceName",
+                      "Value": "NWP_ASCS00_sapnwpas"
+                    }
+                  ]
+                },
+                {
+                  "Id": "rsc_sap_NWP_ASCS00",
+                  "Type": "SAPInstance",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_sap_NWP_ASCS00-operations-monitor-120",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "60",
+                      "Interval": "120"
+                    }
+                  ],
+                  "MetaAttributes": [
+                    {
+                      "Id": "rsc_sap_NWP_ASCS00-meta_attributes-resource-stickiness",
+                      "Name": "resource-stickiness",
+                      "Value": "5000"
+                    },
+                    {
+                      "Id": "rsc_sap_NWP_ASCS00-meta_attributes-failure-timeout",
+                      "Name": "failure-timeout",
+                      "Value": "60"
+                    },
+                    {
+                      "Id": "rsc_sap_NWP_ASCS00-meta_attributes-migration-threshold",
+                      "Name": "migration-threshold",
+                      "Value": "1"
+                    },
+                    {
+                      "Id": "rsc_sap_NWP_ASCS00-meta_attributes-priority",
+                      "Name": "priority",
+                      "Value": "10"
+                    }
+                  ],
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_sap_NWP_ASCS00-instance_attributes-InstanceName",
+                      "Name": "InstanceName",
+                      "Value": "NWP_ASCS00_sapnwpas"
+                    },
+                    {
+                      "Id": "rsc_sap_NWP_ASCS00-instance_attributes-START_PROFILE",
+                      "Name": "START_PROFILE",
+                      "Value": "/sapmnt/NWP/profile/NWP_ASCS00_sapnwpas"
+                    },
+                    {
+                      "Id": "rsc_sap_NWP_ASCS00-instance_attributes-AUTOMATIC_RECOVER",
+                      "Name": "AUTOMATIC_RECOVER",
+                      "Value": "false"
+                    },
+                    {
+                      "Id": "rsc_sap_NWP_ASCS00-instance_attributes-MINIMAL_PROBE",
+                      "Name": "MINIMAL_PROBE",
+                      "Value": "true"
+                    }
+                  ]
+                },
+                {
+                  "Id": "rsc_socat_NWP_ASCS00",
+                  "Type": "azure-lb",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_socat_NWP_ASCS00-monitor-10",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "20s",
+                      "Interval": "10"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_socat_NWP_ASCS00-instance_attributes-port",
+                      "Name": "port",
+                      "Value": "62000"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Id": "grp_NWP_ERS10",
+              "Primitives": [
+                {
+                  "Id": "rsc_ip_NWP_ERS10",
+                  "Type": "IPaddr2",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_ip_NWP_ERS10-monitor-10s",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "20s",
+                      "Interval": "10s"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_ip_NWP_ERS10-instance_attributes-ip",
+                      "Name": "ip",
+                      "Value": "10.80.1.26"
+                    }
+                  ]
+                },
+                {
+                  "Id": "rsc_SAPStartSrv_NWP_ERS10",
+                  "Type": "SAPStartSrv",
+                  "Class": "ocf",
+                  "Provider": "suse",
+                  "Operations": [],
+                  "MetaAttributes": null,
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_SAPStartSrv_NWP_ERS10-instance_attributes-InstanceName",
+                      "Name": "InstanceName",
+                      "Value": "NWP_ERS10_sapnwper"
+                    }
+                  ]
+                },
+                {
+                  "Id": "rsc_sap_NWP_ERS10",
+                  "Type": "SAPInstance",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_sap_NWP_ERS10-operations-monitor-120",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "60",
+                      "Interval": "120"
+                    }
+                  ],
+                  "MetaAttributes": [
+                    {
+                      "Id": "rsc_sap_NWP_ERS10-meta_attributes-priority",
+                      "Name": "priority",
+                      "Value": "1000"
+                    }
+                  ],
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_sap_NWP_ERS10-instance_attributes-InstanceName",
+                      "Name": "InstanceName",
+                      "Value": "NWP_ERS10_sapnwper"
+                    },
+                    {
+                      "Id": "rsc_sap_NWP_ERS10-instance_attributes-START_PROFILE",
+                      "Name": "START_PROFILE",
+                      "Value": "/sapmnt/NWP/profile/NWP_ERS10_sapnwper"
+                    },
+                    {
+                      "Id": "rsc_sap_NWP_ERS10-instance_attributes-AUTOMATIC_RECOVER",
+                      "Name": "AUTOMATIC_RECOVER",
+                      "Value": "false"
+                    },
+                    {
+                      "Id": "rsc_sap_NWP_ERS10-instance_attributes-IS_ERS",
+                      "Name": "IS_ERS",
+                      "Value": "true"
+                    },
+                    {
+                      "Id": "rsc_sap_NWP_ERS10-instance_attributes-MINIMAL_PROBE",
+                      "Name": "MINIMAL_PROBE",
+                      "Value": "true"
+                    }
+                  ]
+                },
+                {
+                  "Id": "rsc_socat_NWP_ERS10",
+                  "Type": "azure-lb",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_socat_NWP_ERS10-monitor-10",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "20s",
+                      "Interval": "10"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_socat_NWP_ERS10-instance_attributes-port",
+                      "Name": "port",
+                      "Value": "62110"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "Masters": null,
+          "Primitives": [
+            {
+              "Id": "stonith-sbd",
+              "Type": "external/sbd",
+              "Class": "stonith",
+              "Provider": "",
+              "Operations": null,
+              "MetaAttributes": null,
+              "InstanceAttributes": [
+                {
+                  "Id": "stonith-sbd-instance_attributes-pcmk_delay_max",
+                  "Name": "pcmk_delay_max",
+                  "Value": "30s"
+                }
+              ]
+            }
+          ]
+        },
+        "Constraints": {
+          "RscLocations": [
+            {
+              "Id": "loc_sap_NWP_failover_to_ers",
+              "Node": "",
+              "Role": "",
+              "Score": "",
+              "Resource": "rsc_sap_NWP_ASCS00"
+            }
+          ]
+        }
+      }
+    },
+    "SBD": {
+      "Config": {
+        "SBD_OPTS": "",
+        "SBD_DEVICE": "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_e34218cd-0d9a-4b21-b6d5-a313980baa82",
+        "SBD_PACEMAKER": "yes",
+        "SBD_STARTMODE": "always",
+        "SBD_DELAY_START": "yes",
+        "SBD_WATCHDOG_DEV": "/dev/watchdog",
+        "SBD_TIMEOUT_ACTION": "flush,reboot",
+        "SBD_WATCHDOG_TIMEOUT": "5",
+        "SBD_MOVE_TO_ROOT_CGROUP": "auto",
+        "SBD_SYNC_RESOURCE_STARTUP": "no"
+      },
+      "Devices": [
+        {
+          "Dump": {
+            "Uuid": "e0c97fe2-f63a-4fd1-83df-9a736a03b49b",
+            "Slots": 255,
+            "Header": "2.1",
+            "SectorSize": 512,
+            "TimeoutLoop": 1,
+            "TimeoutMsgwait": 10,
+            "TimeoutAllocate": 2,
+            "TimeoutWatchdog": 5
+          },
+          "List": [
+            {
+              "Id": 0,
+              "Name": "vmnwprd01",
+              "Status": "clear"
+            },
+            {
+              "Id": 1,
+              "Name": "vmnwprd02",
+              "Status": "clear"
+            }
+          ],
+          "Device": "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_e34218cd-0d9a-4b21-b6d5-a313980baa82",
+          "Status": "healthy"
+        }
+      ]
+    },
+    "Name": "netweaver_cluster",
+    "Crmmon": {
+      "Nodes": [
+        {
+          "DC": true,
+          "Id": "1",
+          "Name": "vmnwprd01",
+          "Type": "member",
+          "Online": true,
+          "Pending": false,
+          "Standby": false,
+          "Unclean": false,
+          "Shutdown": false,
+          "ExpectedUp": true,
+          "Maintenance": false,
+          "StandbyOnFail": false,
+          "ResourcesRunning": 5
+        },
+        {
+          "DC": false,
+          "Id": "2",
+          "Name": "vmnwprd02",
+          "Type": "member",
+          "Online": true,
+          "Pending": false,
+          "Standby": false,
+          "Unclean": false,
+          "Shutdown": false,
+          "ExpectedUp": true,
+          "Maintenance": false,
+          "StandbyOnFail": false,
+          "ResourcesRunning": 4
+        }
+      ],
+      "Clones": null,
+      "Groups": [
+        {
+          "Id": "grp_NWP_ASCS00",
+          "Resources": [
+            {
+              "Id": "rsc_ip_NWP_ASCS00",
+              "Node": {
+                "Id": "1",
+                "Name": "vmnwprd01",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:IPaddr2",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_SAPStartSrv_NWP_ASCS00",
+              "Node": {
+                "Id": "1",
+                "Name": "vmnwprd01",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::suse:SAPStartSrv",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_sap_NWP_ASCS00",
+              "Node": {
+                "Id": "1",
+                "Name": "vmnwprd01",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:SAPInstance",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_socat_NWP_ASCS00",
+              "Node": {
+                "Id": "1",
+                "Name": "vmnwprd01",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:azure-lb",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            }
+          ]
+        },
+        {
+          "Id": "grp_NWP_ERS10",
+          "Resources": [
+            {
+              "Id": "rsc_ip_NWP_ERS10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmnwprd02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:IPaddr2",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_SAPStartSrv_NWP_ERS10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmnwprd02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:SAPStartSrv",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_sap_NWP_ERS10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmnwprd02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:SAPInstance",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_socat_NWP_ERS10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmnwprd02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:azure-lb",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            }
+          ]
+        }
+      ],
+      "Summary": {
+        "Nodes": {
+          "Number": 2
+        },
+        "Resources": {
+          "Number": 9,
+          "Blocked": 0,
+          "Disabled": 0
+        },
+        "LastChange": {
+          "Time": "Tue Jan 11 13:43:06 2022"
+        },
+        "ClusterOptions": {
+          "StonithEnabled": true
+        }
+      },
+      "Version": "2.0.5",
+      "Resources": [
+        {
+          "Id": "stonith-sbd",
+          "Node": {
+            "Id": "1",
+            "Name": "vmnwprd01",
+            "Cached": true
+          },
+          "Role": "Started",
+          "Agent": "stonith:external/sbd",
+          "Active": true,
+          "Failed": false,
+          "Blocked": false,
+          "Managed": true,
+          "Orphaned": false,
+          "FailureIgnored": false,
+          "NodesRunningOn": 1
+        }
+      ],
+      "NodeHistory": {
+        "Nodes": [
+          {
+            "Name": "vmnwprd01",
+            "ResourceHistory": [
+              {
+                "Name": "rsc_ip_NWP_ASCS00",
+                "FailCount": 0,
+                "MigrationThreshold": 3
+              },
+              {
+                "Name": "stonith-sbd",
+                "FailCount": 0,
+                "MigrationThreshold": 3
+              },
+              {
+                "Name": "rsc_socat_NWP_ASCS00",
+                "FailCount": 0,
+                "MigrationThreshold": 3
+              },
+              {
+                "Name": "rsc_SAPStartSrv_NWP_ASCS00",
+                "FailCount": 0,
+                "MigrationThreshold": 3
+              },
+              {
+                "Name": "rsc_sap_NWP_ASCS00",
+                "FailCount": 0,
+                "MigrationThreshold": 1
+              }
+            ]
+          },
+          {
+            "Name": "vmnwprd02",
+            "ResourceHistory": [
+              {
+                "Name": "rsc_ip_NWP_ERS10",
+                "FailCount": 0,
+                "MigrationThreshold": 3
+              },
+              {
+                "Name": "rsc_SAPStartSrv_NWP_ERS10",
+                "FailCount": 0,
+                "MigrationThreshold": 3
+              },
+              {
+                "Name": "rsc_sap_NWP_ERS10",
+                "FailCount": 0,
+                "MigrationThreshold": 3
+              },
+              {
+                "Name": "rsc_socat_NWP_ERS10",
+                "FailCount": 0,
+                "MigrationThreshold": 3
+              }
+            ]
+          }
+        ]
+      },
+      "NodeAttributes": {
+        "Nodes": [
+          {
+            "Name": "vmnwprd02",
+            "Attributes": [
+              {
+                "Name": "runs_ers_NWP",
+                "Value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/discovery/ha_cluster_discovery_ascs_ers_unmounted.json
+++ b/test/fixtures/discovery/ha_cluster_discovery_ascs_ers_unmounted.json
@@ -1,0 +1,635 @@
+{
+  "agent_id": "4b30a6af-4b52-5bda-bccb-f2248a12c992",
+  "discovery_type": "ha_cluster_discovery",
+  "payload": {
+    "DC": false,
+    "Provider": "azure",
+    "Id": "8bca366a6cb7816555538092a1ddd5aa",
+    "Cib": {
+      "Configuration": {
+        "Nodes": [
+          {
+            "Id": "1",
+            "Uname": "vmnwprd01",
+            "InstanceAttributes": null
+          },
+          {
+            "Id": "2",
+            "Uname": "vmnwprd02",
+            "InstanceAttributes": null
+          }
+        ],
+        "CrmConfig": {
+          "ClusterProperties": [
+            {
+              "Id": "cib-bootstrap-options-have-watchdog",
+              "Name": "have-watchdog",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-dc-version",
+              "Name": "dc-version",
+              "Value": "2.0.5+20201202.ba59be712-4.13.1-2.0.5+20201202.ba59be712"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-infrastructure",
+              "Name": "cluster-infrastructure",
+              "Value": "corosync"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-name",
+              "Name": "cluster-name",
+              "Value": "netweaver_cluster"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-enabled",
+              "Name": "stonith-enabled",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-timeout",
+              "Name": "stonith-timeout",
+              "Value": "144s"
+            },
+            {
+              "Id": "cib-bootstrap-options-maintenance-mode",
+              "Name": "maintenance-mode",
+              "Value": "false"
+            }
+          ]
+        },
+        "Resources": {
+          "Clones": null,
+          "Groups": [
+            {
+              "Id": "grp_NWP_ASCS00",
+              "Primitives": [
+                {
+                  "Id": "rsc_ip_NWP_ASCS00",
+                  "Type": "IPaddr2",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_ip_NWP_ASCS00-monitor-10s",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "20s",
+                      "Interval": "10s"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_ip_NWP_ASCS00-instance_attributes-ip",
+                      "Name": "ip",
+                      "Value": "10.80.1.25"
+                    }
+                  ]
+                },
+                {
+                  "Id": "rsc_SAPStartSrv_NWP_ASCS00",
+                  "Type": "SAPStartSrv",
+                  "Class": "ocf",
+                  "Provider": "suse",
+                  "Operations": [],
+                  "MetaAttributes": null,
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_SAPStartSrv_NWP_ASCS00-instance_attributes-InstanceName",
+                      "Name": "InstanceName",
+                      "Value": "NWP_ASCS00_sapnwpas"
+                    }
+                  ]
+                },
+                {
+                  "Id": "rsc_sap_NWP_ASCS00",
+                  "Type": "SAPInstance",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_sap_NWP_ASCS00-operations-monitor-120",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "60",
+                      "Interval": "120"
+                    }
+                  ],
+                  "MetaAttributes": [
+                    {
+                      "Id": "rsc_sap_NWP_ASCS00-meta_attributes-resource-stickiness",
+                      "Name": "resource-stickiness",
+                      "Value": "5000"
+                    },
+                    {
+                      "Id": "rsc_sap_NWP_ASCS00-meta_attributes-failure-timeout",
+                      "Name": "failure-timeout",
+                      "Value": "60"
+                    },
+                    {
+                      "Id": "rsc_sap_NWP_ASCS00-meta_attributes-migration-threshold",
+                      "Name": "migration-threshold",
+                      "Value": "1"
+                    },
+                    {
+                      "Id": "rsc_sap_NWP_ASCS00-meta_attributes-priority",
+                      "Name": "priority",
+                      "Value": "10"
+                    }
+                  ],
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_sap_NWP_ASCS00-instance_attributes-InstanceName",
+                      "Name": "InstanceName",
+                      "Value": "NWP_ASCS00_sapnwpas"
+                    },
+                    {
+                      "Id": "rsc_sap_NWP_ASCS00-instance_attributes-START_PROFILE",
+                      "Name": "START_PROFILE",
+                      "Value": "/sapmnt/NWP/profile/NWP_ASCS00_sapnwpas"
+                    },
+                    {
+                      "Id": "rsc_sap_NWP_ASCS00-instance_attributes-AUTOMATIC_RECOVER",
+                      "Name": "AUTOMATIC_RECOVER",
+                      "Value": "false"
+                    },
+                    {
+                      "Id": "rsc_sap_NWP_ASCS00-instance_attributes-MINIMAL_PROBE",
+                      "Name": "MINIMAL_PROBE",
+                      "Value": "true"
+                    }
+                  ]
+                },
+                {
+                  "Id": "rsc_socat_NWP_ASCS00",
+                  "Type": "azure-lb",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_socat_NWP_ASCS00-monitor-10",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "20s",
+                      "Interval": "10"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_socat_NWP_ASCS00-instance_attributes-port",
+                      "Name": "port",
+                      "Value": "62000"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "Id": "grp_NWP_ERS10",
+              "Primitives": [
+                {
+                  "Id": "rsc_ip_NWP_ERS10",
+                  "Type": "IPaddr2",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_ip_NWP_ERS10-monitor-10s",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "20s",
+                      "Interval": "10s"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_ip_NWP_ERS10-instance_attributes-ip",
+                      "Name": "ip",
+                      "Value": "10.80.1.26"
+                    }
+                  ]
+                },
+                {
+                  "Id": "rsc_sap_NWP_ERS10",
+                  "Type": "SAPInstance",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_sap_NWP_ERS10-operations-monitor-120",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "60",
+                      "Interval": "120"
+                    }
+                  ],
+                  "MetaAttributes": [
+                    {
+                      "Id": "rsc_sap_NWP_ERS10-meta_attributes-priority",
+                      "Name": "priority",
+                      "Value": "1000"
+                    }
+                  ],
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_sap_NWP_ERS10-instance_attributes-InstanceName",
+                      "Name": "InstanceName",
+                      "Value": "NWP_ERS10_sapnwper"
+                    },
+                    {
+                      "Id": "rsc_sap_NWP_ERS10-instance_attributes-START_PROFILE",
+                      "Name": "START_PROFILE",
+                      "Value": "/sapmnt/NWP/profile/NWP_ERS10_sapnwper"
+                    },
+                    {
+                      "Id": "rsc_sap_NWP_ERS10-instance_attributes-AUTOMATIC_RECOVER",
+                      "Name": "AUTOMATIC_RECOVER",
+                      "Value": "false"
+                    },
+                    {
+                      "Id": "rsc_sap_NWP_ERS10-instance_attributes-IS_ERS",
+                      "Name": "IS_ERS",
+                      "Value": "true"
+                    },
+                    {
+                      "Id": "rsc_sap_NWP_ERS10-instance_attributes-MINIMAL_PROBE",
+                      "Name": "MINIMAL_PROBE",
+                      "Value": "true"
+                    }
+                  ]
+                },
+                {
+                  "Id": "rsc_socat_NWP_ERS10",
+                  "Type": "azure-lb",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_socat_NWP_ERS10-monitor-10",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "20s",
+                      "Interval": "10"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_socat_NWP_ERS10-instance_attributes-port",
+                      "Name": "port",
+                      "Value": "62110"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "Masters": null,
+          "Primitives": [
+            {
+              "Id": "stonith-sbd",
+              "Type": "external/sbd",
+              "Class": "stonith",
+              "Provider": "",
+              "Operations": null,
+              "MetaAttributes": null,
+              "InstanceAttributes": [
+                {
+                  "Id": "stonith-sbd-instance_attributes-pcmk_delay_max",
+                  "Name": "pcmk_delay_max",
+                  "Value": "30s"
+                }
+              ]
+            }
+          ]
+        },
+        "Constraints": {
+          "RscLocations": [
+            {
+              "Id": "loc_sap_NWP_failover_to_ers",
+              "Node": "",
+              "Role": "",
+              "Score": "",
+              "Resource": "rsc_sap_NWP_ASCS00"
+            }
+          ]
+        }
+      }
+    },
+    "SBD": {
+      "Config": {
+        "SBD_OPTS": "",
+        "SBD_DEVICE": "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_e34218cd-0d9a-4b21-b6d5-a313980baa82",
+        "SBD_PACEMAKER": "yes",
+        "SBD_STARTMODE": "always",
+        "SBD_DELAY_START": "yes",
+        "SBD_WATCHDOG_DEV": "/dev/watchdog",
+        "SBD_TIMEOUT_ACTION": "flush,reboot",
+        "SBD_WATCHDOG_TIMEOUT": "5",
+        "SBD_MOVE_TO_ROOT_CGROUP": "auto",
+        "SBD_SYNC_RESOURCE_STARTUP": "no"
+      },
+      "Devices": [
+        {
+          "Dump": {
+            "Uuid": "e0c97fe2-f63a-4fd1-83df-9a736a03b49b",
+            "Slots": 255,
+            "Header": "2.1",
+            "SectorSize": 512,
+            "TimeoutLoop": 1,
+            "TimeoutMsgwait": 10,
+            "TimeoutAllocate": 2,
+            "TimeoutWatchdog": 5
+          },
+          "List": [
+            {
+              "Id": 0,
+              "Name": "vmnwprd01",
+              "Status": "clear"
+            },
+            {
+              "Id": 1,
+              "Name": "vmnwprd02",
+              "Status": "clear"
+            }
+          ],
+          "Device": "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_e34218cd-0d9a-4b21-b6d5-a313980baa82",
+          "Status": "healthy"
+        }
+      ]
+    },
+    "Name": "netweaver_cluster",
+    "Crmmon": {
+      "Nodes": [
+        {
+          "DC": true,
+          "Id": "1",
+          "Name": "vmnwprd01",
+          "Type": "member",
+          "Online": true,
+          "Pending": false,
+          "Standby": false,
+          "Unclean": false,
+          "Shutdown": false,
+          "ExpectedUp": true,
+          "Maintenance": false,
+          "StandbyOnFail": false,
+          "ResourcesRunning": 5
+        },
+        {
+          "DC": false,
+          "Id": "2",
+          "Name": "vmnwprd02",
+          "Type": "member",
+          "Online": true,
+          "Pending": false,
+          "Standby": false,
+          "Unclean": false,
+          "Shutdown": false,
+          "ExpectedUp": true,
+          "Maintenance": false,
+          "StandbyOnFail": false,
+          "ResourcesRunning": 4
+        }
+      ],
+      "Clones": null,
+      "Groups": [
+        {
+          "Id": "grp_NWP_ASCS00",
+          "Resources": [
+            {
+              "Id": "rsc_ip_NWP_ASCS00",
+              "Node": {
+                "Id": "1",
+                "Name": "vmnwprd01",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:IPaddr2",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_SAPStartSrv_NWP_ASCS00",
+              "Node": {
+                "Id": "1",
+                "Name": "vmnwprd01",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::suse:SAPStartSrv",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_sap_NWP_ASCS00",
+              "Node": {
+                "Id": "1",
+                "Name": "vmnwprd01",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:SAPInstance",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_socat_NWP_ASCS00",
+              "Node": {
+                "Id": "1",
+                "Name": "vmnwprd01",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:azure-lb",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            }
+          ]
+        },
+        {
+          "Id": "grp_NWP_ERS10",
+          "Resources": [
+            {
+              "Id": "rsc_ip_NWP_ERS10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmnwprd02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:IPaddr2",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_sap_NWP_ERS10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmnwprd02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:SAPInstance",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_socat_NWP_ERS10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmnwprd02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:azure-lb",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            }
+          ]
+        }
+      ],
+      "Summary": {
+        "Nodes": {
+          "Number": 2
+        },
+        "Resources": {
+          "Number": 9,
+          "Blocked": 0,
+          "Disabled": 0
+        },
+        "LastChange": {
+          "Time": "Tue Jan 11 13:43:06 2022"
+        },
+        "ClusterOptions": {
+          "StonithEnabled": true
+        }
+      },
+      "Version": "2.0.5",
+      "Resources": [
+        {
+          "Id": "stonith-sbd",
+          "Node": {
+            "Id": "1",
+            "Name": "vmnwprd01",
+            "Cached": true
+          },
+          "Role": "Started",
+          "Agent": "stonith:external/sbd",
+          "Active": true,
+          "Failed": false,
+          "Blocked": false,
+          "Managed": true,
+          "Orphaned": false,
+          "FailureIgnored": false,
+          "NodesRunningOn": 1
+        }
+      ],
+      "NodeHistory": {
+        "Nodes": [
+          {
+            "Name": "vmnwprd01",
+            "ResourceHistory": [
+              {
+                "Name": "rsc_ip_NWP_ASCS00",
+                "FailCount": 0,
+                "MigrationThreshold": 3
+              },
+              {
+                "Name": "stonith-sbd",
+                "FailCount": 0,
+                "MigrationThreshold": 3
+              },
+              {
+                "Name": "rsc_socat_NWP_ASCS00",
+                "FailCount": 0,
+                "MigrationThreshold": 3
+              },
+              {
+                "Name": "rsc_SAPStartSrv_NWP_ASCS00",
+                "FailCount": 0,
+                "MigrationThreshold": 3
+              },
+              {
+                "Name": "rsc_sap_NWP_ASCS00",
+                "FailCount": 0,
+                "MigrationThreshold": 1
+              }
+            ]
+          },
+          {
+            "Name": "vmnwprd02",
+            "ResourceHistory": [
+              {
+                "Name": "rsc_ip_NWP_ERS10",
+                "FailCount": 0,
+                "MigrationThreshold": 3
+              },
+              {
+                "Name": "rsc_sap_NWP_ERS10",
+                "FailCount": 0,
+                "MigrationThreshold": 3
+              },
+              {
+                "Name": "rsc_socat_NWP_ERS10",
+                "FailCount": 0,
+                "MigrationThreshold": 3
+              }
+            ]
+          }
+        ]
+      },
+      "NodeAttributes": {
+        "Nodes": [
+          {
+            "Name": "vmnwprd02",
+            "Attributes": [
+              {
+                "Name": "runs_ers_NWP",
+                "Value": "1"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -248,7 +248,8 @@ defmodule Trento.Factory do
       sid: Faker.StarWars.planet(),
       instance_number: instance_number,
       hostname: Faker.StarWars.character(),
-      resource_type: Enum.random(SapInstanceResourceType.values())
+      resource_type: Enum.random(SapInstanceResourceType.values()),
+      mounted: true
     }
   end
 

--- a/test/trento/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/discovery/policies/cluster_policy_test.exs
@@ -716,7 +716,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                     sid: "QAS",
                     instance_number: "20",
                     hostname: "node02",
-                    resource_type: SapInstanceResourceType.sap_instance()
+                    resource_type: SapInstanceResourceType.sap_instance(),
+                    mounted: false
                   }
                 ],
                 type: :hana_scale_up,
@@ -891,14 +892,16 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                     sid: "NWP",
                     instance_number: "00",
                     hostname: "sapnwpas",
-                    resource_type: SapInstanceResourceType.sap_instance()
+                    resource_type: SapInstanceResourceType.sap_instance(),
+                    mounted: true
                   },
                   %SapInstance{
                     name: "ERS10",
                     sid: "NWP",
                     instance_number: "10",
                     hostname: "sapnwper",
-                    resource_type: SapInstanceResourceType.sap_instance()
+                    resource_type: SapInstanceResourceType.sap_instance(),
+                    mounted: true
                   }
                 ],
                 type: :ascs_ers,
@@ -1073,14 +1076,16 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                     sid: "NWP",
                     instance_number: "00",
                     hostname: "sapnwpas",
-                    resource_type: SapInstanceResourceType.sap_instance()
+                    resource_type: SapInstanceResourceType.sap_instance(),
+                    mounted: true
                   },
                   %SapInstance{
                     name: "ERS10",
                     sid: "NWP",
                     instance_number: "10",
                     hostname: "sapnwper",
-                    resource_type: SapInstanceResourceType.sap_instance()
+                    resource_type: SapInstanceResourceType.sap_instance(),
+                    mounted: true
                   }
                 ],
                 type: :ascs_ers,
@@ -1162,7 +1167,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                     sid: "NWP",
                     instance_number: "00",
                     hostname: "sapnwpas",
-                    resource_type: SapInstanceResourceType.sap_instance()
+                    resource_type: SapInstanceResourceType.sap_instance(),
+                    mounted: true
                   }
                 ],
                 type: :unknown,
@@ -1468,28 +1474,32 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                     sid: "NWP",
                     instance_number: "00",
                     hostname: "sapnwpas",
-                    resource_type: SapInstanceResourceType.sap_instance()
+                    resource_type: SapInstanceResourceType.sap_instance(),
+                    mounted: true
                   },
                   %SapInstance{
                     name: "ERS10",
                     sid: "NWP",
                     instance_number: "10",
                     hostname: "sapnwper",
-                    resource_type: SapInstanceResourceType.sap_instance()
+                    resource_type: SapInstanceResourceType.sap_instance(),
+                    mounted: true
                   },
                   %SapInstance{
                     name: "ASCS01",
                     sid: "NWD",
                     instance_number: "01",
                     hostname: "sapnwpas",
-                    resource_type: SapInstanceResourceType.sap_instance()
+                    resource_type: SapInstanceResourceType.sap_instance(),
+                    mounted: true
                   },
                   %SapInstance{
                     name: "ERS11",
                     sid: "NWD",
                     instance_number: "11",
                     hostname: "sapnwper",
-                    resource_type: SapInstanceResourceType.sap_instance()
+                    resource_type: SapInstanceResourceType.sap_instance(),
+                    mounted: true
                   }
                 ],
                 type: :ascs_ers,
@@ -1552,6 +1562,64 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                group_1,
                group_2
              ])
+             |> ClusterPolicy.handle(nil)
+  end
+
+  test "should return the expected commands when simple mount configured cluster payload is received" do
+    assert {:ok,
+            [
+              %RegisterClusterHost{
+                sap_instances: [
+                  %SapInstance{
+                    name: "ASCS00",
+                    sid: "NWP",
+                    instance_number: "00",
+                    hostname: "sapnwpas",
+                    resource_type: SapInstanceResourceType.sap_instance(),
+                    mounted: true
+                  },
+                  %SapInstance{
+                    name: "ERS10",
+                    sid: "NWP",
+                    instance_number: "10",
+                    hostname: "sapnwper",
+                    resource_type: SapInstanceResourceType.sap_instance(),
+                    mounted: true
+                  }
+                ]
+              }
+            ]} =
+             "ha_cluster_discovery_ascs_ers_simple_mount"
+             |> load_discovery_event_fixture()
+             |> ClusterPolicy.handle(nil)
+  end
+
+  test "should return the expected commands when ERS is not mounted in a filesystem" do
+    assert {:ok,
+            [
+              %RegisterClusterHost{
+                sap_instances: [
+                  %SapInstance{
+                    name: "ASCS00",
+                    sid: "NWP",
+                    instance_number: "00",
+                    hostname: "sapnwpas",
+                    resource_type: SapInstanceResourceType.sap_instance(),
+                    mounted: true
+                  },
+                  %SapInstance{
+                    name: "ERS10",
+                    sid: "NWP",
+                    instance_number: "10",
+                    hostname: "sapnwper",
+                    resource_type: SapInstanceResourceType.sap_instance(),
+                    mounted: false
+                  }
+                ]
+              }
+            ]} =
+             "ha_cluster_discovery_ascs_ers_unmounted"
+             |> load_discovery_event_fixture()
              |> ClusterPolicy.handle(nil)
   end
 
@@ -4200,14 +4268,16 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                        sid: "NWP",
                        instance_number: "00",
                        hostname: "sapnwpas",
-                       resource_type: SapInstanceResourceType.sap_instance()
+                       resource_type: SapInstanceResourceType.sap_instance(),
+                       mounted: true
                      },
                      %SapInstance{
                        name: "ERS10",
                        sid: "NWP",
                        instance_number: "10",
                        hostname: "sapnwper",
-                       resource_type: SapInstanceResourceType.sap_instance()
+                       resource_type: SapInstanceResourceType.sap_instance(),
+                       mounted: true
                      }
                    ],
                    type: :hana_ascs_ers


### PR DESCRIPTION
# Description

Some customers use a pacemaker setup where the ERS resource is not mounted using a Filesystem or SAPStartSrv cluster resource.

This means that they have the ERS installed in both nodes of the cluster, and the cluster starts and stops it instead of moving it.

In this case, we need to avoid emitting the `ApplicationInstanceMoved` event.
To check that, we need to know if the SAP instance is mounted checking if the `Filesystem` or `SAPStartSrv` resources are managed by the cluster. 

Some info about simple mount configuration: https://documentation.suse.com/sbp/sap-15/html/SAP-S4HA10-setupguide-simplemount-sle15/index.html

## How was this tested?

UT
- `simple_mount` fixture includes a cluster configuration using the Simple mount setup. There we have the `SAPStartSrv` resource instead of the traditional `Filesystem` one
- `unmounted` fixture includes a cluster configuration where the ERS is not mounted with `Filesystem` nor `SAPStartSrv` resources. This means that the ERS is not moved as it is installed in both cluster nodes.