### PR TITLE
Parse sap tenant

### DIFF
--- a/lib/trento/discovery/policies/sap_system_policy.ex
+++ b/lib/trento/discovery/policies/sap_system_policy.ex
@@ -23,7 +23,6 @@ defmodule Trento.Discovery.Policies.SapSystemPolicy do
 
   alias SapSystemDiscoveryPayload.{
     Instance,
-    Profile,
     SapControl,
     SystemReplication
   }
@@ -128,9 +127,7 @@ defmodule Trento.Discovery.Policies.SapSystemPolicy do
            Type: @application_type,
            Instances: instances,
            DBAddress: db_host,
-           Profile: %Profile{
-             "dbs/hdb/dbname": tenant
-           }
+           Tenant: tenant
          },
          host_id,
          sap_instances

--- a/lib/trento/sap_systems/commands/register_application_instance.ex
+++ b/lib/trento/sap_systems/commands/register_application_instance.ex
@@ -21,7 +21,6 @@ defmodule Trento.SapSystems.Commands.RegisterApplicationInstance do
     :instance_number,
     :sid,
     :db_host,
-    :tenant,
     :instance_hostname,
     :features,
     :http_port,

--- a/lib/trento/sap_systems/events/application_instance_registered.ex
+++ b/lib/trento/sap_systems/events/application_instance_registered.ex
@@ -10,6 +10,7 @@ defmodule Trento.SapSystems.Events.ApplicationInstanceRegistered do
   defevent do
     field :sap_system_id, Ecto.UUID
     field :sid, :string
+    field :tenant, :string
     field :host_id, Ecto.UUID
     field :instance_number, :string
     field :instance_hostname, :string

--- a/test/fixtures/discovery/sap_system_discovery_application.json
+++ b/test/fixtures/discovery/sap_system_discovery_application.json
@@ -7,6 +7,7 @@
       "SID": "HA1",
       "Type": 2,
       "DBAddress": "10.74.1.12",
+      "Tenant": "PRD",
       "Profile": {
         "SAPDBHOST": "10.74.1.12",
         "gw/acl_mode": "1",

--- a/test/fixtures/discovery/sap_system_discovery_application_diagnostics.json
+++ b/test/fixtures/discovery/sap_system_discovery_application_diagnostics.json
@@ -7,6 +7,7 @@
       "SID": "HA1",
       "Type": 2,
       "DBAddress": "10.74.1.12",
+      "Tenant": "PRD",
       "Profile": {
         "SAPDBHOST": "10.74.1.12",
         "gw/acl_mode": "1",
@@ -251,6 +252,7 @@
       "SID": "DAA",
       "Type": 3,
       "DBAddress": "",
+      "Tenant": "",
       "Profile": {},
       "Databases": null,
       "Instances": [

--- a/test/fixtures/discovery/sap_system_discovery_application_message_server.json
+++ b/test/fixtures/discovery/sap_system_discovery_application_message_server.json
@@ -1,0 +1,199 @@
+{
+  "agent_id": "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
+  "discovery_type": "sap_system_discovery",
+  "payload": [
+    {
+      "Id": "7b65dc281f9fae2c8e68e6cab669993e",
+      "SID": "HA1",
+      "Type": 2,
+      "DBAddress": "10.74.1.12",
+      "Tenant": "",
+      "Profile": {
+        "SAPDBHOST": "10.74.1.12",
+        "gw/acl_mode": "1",
+        "gw/sec_info": "$(DIR_GLOBAL)$(DIR_SEP)secinfo$(FT_DAT)",
+        "j2ee/dbhost": "10.74.1.12",
+        "j2ee/dbname": "PRD",
+        "j2ee/dbtype": "hdb",
+        "system/type": "ABAP",
+        "vmcj/enable": "off",
+        "rdisp/mshost": "sapha1as",
+        "rdisp/msserv": "sapmsHA1",
+        "SAPGLOBALHOST": "sapha1as",
+        "SAPSYSTEMNAME": "HA1",
+        "rdisp/btctime": "0",
+        "dbs/hdb/dbname": "PRD",
+        "dbs/hdb/schema": "SAPABAP1",
+        "enque/serverhost": "sapha1as",
+        "enque/serverinst": "00",
+        "icf/user_recheck": "1",
+        "rdisp/bufrefmode": "sendoff",
+        "rsdb/ssfs_connect": "0",
+        "rsec/ssfs_keypath": "$(DIR_GLOBAL)$(DIR_SEP)security$(DIR_SEP)rsecssfs$(DIR_SEP)key",
+        "rdisp/autoabaptime": "0",
+        "rsec/ssfs_datapath": "$(DIR_GLOBAL)$(DIR_SEP)security$(DIR_SEP)rsecssfs$(DIR_SEP)data",
+        "login/system_client": "001",
+        "rdisp/msserv_internal": "3900",
+        "enque/process_location": "REMOTESA",
+        "enque/deque_wait_answer": "TRUE",
+        "service/protectedwebmethods": "SDEFAULT",
+        "is/HTTP/show_detailed_errors": "FALSE",
+        "login/password_downwards_compatibility": "0",
+        "icm/HTTP/ASJava/disable_url_session_tracking": "TRUE"
+      },
+      "Databases": null,
+      "Instances": [
+        {
+          "Host": "vmnetweaver04",
+          "Name": "ASCS00",
+          "Type": 2,
+          "SAPControl": {
+            "Instances": [
+              {
+                "features": "MESSAGESERVER|ENQUE",
+                "hostname": "sapha1as",
+                "httpPort": 50013,
+                "httpsPort": 50014,
+                "dispstatus": "SAPControl-GREEN",
+                "instanceNr": 0,
+                "startPriority": "1"
+              },
+              {
+                "features": "ENQREP",
+                "hostname": "sapha1er",
+                "httpPort": 51013,
+                "httpsPort": 51014,
+                "dispstatus": "SAPControl-GREEN",
+                "instanceNr": 10,
+                "startPriority": "0.5"
+              },
+              {
+                "features": "ABAP|GATEWAY|ICMAN|IGS",
+                "hostname": "sapha1pas",
+                "httpPort": 50113,
+                "httpsPort": 50114,
+                "dispstatus": "SAPControl-GREEN",
+                "instanceNr": 1,
+                "startPriority": "3"
+              },
+              {
+                "features": "ABAP|GATEWAY|ICMAN|IGS",
+                "hostname": "sapha1aas1",
+                "httpPort": 50213,
+                "httpsPort": 50214,
+                "dispstatus": "SAPControl-GREEN",
+                "instanceNr": 2,
+                "startPriority": "3"
+              }
+            ],
+            "Processes": [
+              {
+                "pid": 7379,
+                "name": "enserver",
+                "starttime": "2022 01 11 12:55:17",
+                "dispstatus": "SAPControl-GREEN",
+                "textstatus": "Running",
+                "description": "EnqueueServer",
+                "elapsedtime": "151:56:46"
+              },
+              {
+                "pid": 7378,
+                "name": "msg_server",
+                "starttime": "2022 01 11 12:55:17",
+                "dispstatus": "SAPControl-GREEN",
+                "textstatus": "Running",
+                "description": "MessageServer",
+                "elapsedtime": "151:56:46"
+              }
+            ],
+            "Properties": [
+              {
+                "value": "ABAPReadSyslog",
+                "property": "Syslog",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "00",
+                "property": "SAPSYSTEM",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "Start,InstanceStart,StartBypassHA,Bootstrap,Stop,InstanceStop,StopBypassHA,Shutdown,ParameterValue,GetProcessList,GetStartProfile,GetTraceFile,GetAlertTree,GetAlerts,RestartService,StopService,GetEnvironment,ListDeveloperTraces,ReadDeveloperTrace,RestartInstance,SendSignal,GetVersionInfo,GetQueueStatistic,GetInstanceProperties,OSExecute,ReadLogFile,AnalyseLogFiles,ListLogFiles,GetAccessPointList,GetSystemInstanceList,GetSystemUpdateList,StartSystem,StopSystem,RestartSystem,UpdateSystem,UpdateSCSInstance,CheckUpdateSystem,AccessCheck,GetProcessParameter,SetProcessParameter,SetProcessParameter2,CheckParameter,ShmDetach,GetNetworkId,GetSecNetworkId,RequestLogonFile,CreateSnapshot,ReadSnapshot,ListSnapshots,DeleteSnapshots,GetCallstack,ABAPReadSyslog,ABAPReadRawSyslog,ABAPGetWPTable,ABAPAcknowledgeAlerts,ABAPGetComponentList,ABAPCheckRFCDestinations,ABAPGetSystemWPTable,ABAPSetServerInactive,J2EEGetProcessList,J2EEGetProcessList2,J2EEControlProcess,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadCallStack,J2EEGetThreadTaskStack,J2EEGetSessionList,J2EEGetWebSessionList,J2EEGetWebSessionList2,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetApplicationAliasList,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetEJBSessionList,J2EEGetRemoteObjectList,J2EEGetClusterMsgList,J2EEGetSharedTableInfo,J2EEGetComponentList,J2EEControlComponents,ICMGetThreadList,ICMGetConnectionList,ICMGetCacheEntries,ICMGetProxyConnectionList,WebDispGetServerList,WebDispGetGroupList,WebDispGetVirtHostList,WebDispGetUrlPrefixList,EnqGetLockTable,EnqRemoveLocks,EnqRemoveUserLocks,EnqGetStatistic,GWCancelConnections,GWDeleteClients,GWDeleteConnections,GWGetConnectionList,GWGetClientList,UpdateSystemPKI,UpdateInstancePSE,StorePSE,DeletePSE,CheckPSE,HACheckConfig,HACheckFailoverConfig,HAGetFailoverConfig,HAFailoverToNode,HASetMaintenanceMode,HACheckMaintenanceMode,ListConfigFiles,ReadConfigFile",
+                "property": "Webmethods",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "EnqGetLockTable",
+                "property": "Enque Locks",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "GetProcessList",
+                "property": "Process List",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "sapha1as",
+                "property": "SAPLOCALHOST",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "GetAccessPointList",
+                "property": "Access Points",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "ASCS00",
+                "property": "INSTANCE_NAME",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "https://launchpad.support.sap.com/#/softwarecenter/template/products/_APP=00200682500000001943&_EVENT=DISPHIER&HEADER=Y&FUNCTIONBAR=N&EVENT=TREE&NE=NAVIGATE&ENR=73554900100200005858&V=MAINT",
+                "property": "Kernel Update",
+                "propertytype": "NodeURL"
+              },
+              {
+                "value": "PRD",
+                "property": "SAPSYSTEMNAME",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "1",
+                "property": "StartPriority",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "YES",
+                "property": "CentralServices",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "EnqGetStatistic",
+                "property": "Enque Statistic",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "ABAPAcknowledgeAlerts,ABAPCheckRFCDestinations,ABAPGetComponentList,ABAPGetSystemWPTable,ABAPGetWPTable,ABAPReadRawSyslog,ABAPReadSyslog,ABAPSetServerInactive,AnalyseLogFiles,Bootstrap,CheckParameter,CheckPSE,CheckUpdateSystem,ConfigureLogFileList,CreatePSECredential,CreateSnapshot,DeletePSE,DeleteSnapshots,EnqGetLockTable,EnqGetStatistic,EnqRemoveLocks,EnqRemoveUserLocks,GetAccessPointList,GetAlerts,GetAlertTree,GetCallstack,GetEnvironment,GetLogFileList,GetProcessParameter,GetQueueStatistic,GetStartProfile,GetSystemUpdateList,GetTraceFile,GetVersionInfo,GWCancelConnections,GWDeleteClients,GWDeleteConnections,GWGetConnectionList,GWGetClientList,HACheckConfig,HACheckFailoverConfig,HACheckMaintenanceMode,HAFailoverToNode,HAGetFailoverConfig,HASetMaintenanceMode,ICMGetCacheEntries,ICMGetConnectionList,ICMGetProxyConnectionList,ICMGetThreadList,InstanceStart,InstanceStop,J2EEControlCluster,J2EEControlComponents,J2EEControlProcess,J2EEDisableDbgSession,J2EEEnableDbgSession,J2EEGetApplicationAliasList,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetClusterMsgList,J2EEGetComponentList,J2EEGetEJBSessionList,J2EEGetProcessList,J2EEGetProcessList2,J2EEGetRemoteObjectList,J2EEGetSessionList,J2EEGetSharedTableInfo,J2EEGetThreadCallStack,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadTaskStack,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetWebSessionList,J2EEGetWebSessionList2,ListConfigFiles,ListDeveloperTraces,ListLogFiles,ListSnapshots,OSExecute,ParameterValue,ReadConfigFile,ReadDeveloperTrace,ReadLogFile,ReadSnapshot,RestartInstance,RestartService,RestartSystem,SendSignal,SetProcessParameter,SetProcessParameter2,ShmDetach,Shutdown,Start,StartBypassHA,StartSystem,Stop,StopBypassHA,StopService,StopSystem,StorePSE,UpdateInstancePSE,UpdateSCSInstance,UpdateSystem,UpdateSystemPKI,WebDispGetServerList,WebDispGetGroupList,WebDispGetVirtHostList,WebDispGetUrlPrefixList,GetAgentConfig,GetListOfMaByCusGrp,GetMcInLocalMs,GetMtesByRequestTable,GetMtListByMtclass,InfoGetTree,MscCustomizeWrite,MscDeleteLines,MscReadCache,MsGetLocalMsInfo,MsGetMteclsInLocalMs,MtChangeStatus,MtCustomizeWrite,MtDbsetToWpsetByTid,MtDestroyMarkNTry,MteGetByToolRunstatus,MtGetAllToCust,MtGetAllToolsToSet,MtGetMteinfo,MtGetTidByName,MtRead,MtReset,PerfCustomizeWrite,PerfRead,PerfReadSmoothData,ReadDirectory,ReadFile,ReadProfileParameters,ReferenceRead,Register,RequestLogonFile,SnglmgsCustomizeWrite,SystemObjectSetValue,TextAttrRead,ToolGetEffective,ToolSet,ToolSetRuntimeStatus,TriggerDataCollection,Unregister,UtilAlChangeStatus,UtilMtGetAidByTid,UtilMtGetTreeLocal,UtilMtReadAll,UtilReadRawalertByAid,UtilSnglmsgReadRawdata",
+                "property": "Protected Webmethods",
+                "propertytype": "Attribute"
+              },
+              {
+                "value": "http://sapnwdas:50013/sapparamEN.html",
+                "property": "Parameter Documentation",
+                "propertytype": "NodeURL"
+              },
+              {
+                "value": "YES",
+                "property": "SupportsUpdateSCSInstance",
+                "propertytype": "Attribute"
+              }
+            ]
+          },
+          "HdbnsutilSRstate": null,
+          "HostConfiguration": null,
+          "SystemReplication": null
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/discovery/sap_system_discovery_database.json
+++ b/test/fixtures/discovery/sap_system_discovery_database.json
@@ -6,6 +6,7 @@
       "Id": "e06e328f8d6b0f46c1e66ffcd44d0dd7",
       "SID": "PRD",
       "Type": 1,
+      "Tenant": "",
       "Profile": {
         "SAPGLOBALHOST": "vmhana01",
         "SAPSYSTEMNAME": "PRD",

--- a/test/fixtures/discovery/sap_system_discovery_database_multi_tenant.json
+++ b/test/fixtures/discovery/sap_system_discovery_database_multi_tenant.json
@@ -4,6 +4,7 @@
   "payload": [
     {
       "DBAddress": "",
+      "Tenant": "",
       "Databases": [
         {
           "Active": "yes",

--- a/test/fixtures/discovery/sap_system_discovery_database_stopped_instance.json
+++ b/test/fixtures/discovery/sap_system_discovery_database_stopped_instance.json
@@ -143,7 +143,8 @@
           "Active": "yes"
         }
       ],
-      "DBAddress": ""
+      "DBAddress": "",
+      "Tenant": ""
     }
   ]
 }

--- a/test/fixtures/discovery/sap_system_discovery_empty_application_instances.json
+++ b/test/fixtures/discovery/sap_system_discovery_empty_application_instances.json
@@ -4,6 +4,7 @@
   "payload": [
     {
       "DBAddress": "",
+      "Tenant": "",
       "Databases": null,
       "Id": "-",
       "Instances": [],

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -466,6 +466,7 @@ defmodule Trento.Factory do
     %ApplicationInstanceRegistered{
       sap_system_id: Faker.UUID.v4(),
       sid: Faker.UUID.v4(),
+      tenant: Faker.Beer.style(),
       instance_number: "00",
       instance_hostname: "an-instance-name",
       features: Faker.Pokemon.name(),

--- a/test/trento/sap_systems/sap_system_test.exs
+++ b/test/trento/sap_systems/sap_system_test.exs
@@ -55,6 +55,7 @@ defmodule Trento.SapSystems.SapSystemTest do
         build(:application_instance_registered_event,
           sap_system_id: sap_system_id,
           sid: sid,
+          tenant: nil,
           features: "MESSAGESERVER",
           instance_number: "00"
         )
@@ -83,6 +84,7 @@ defmodule Trento.SapSystems.SapSystemTest do
           %ApplicationInstanceRegistered{
             sap_system_id: sap_system_id,
             sid: sid,
+            tenant: tenant,
             instance_number: "10",
             instance_hostname: instance_hostname,
             features: "ABAP",
@@ -105,6 +107,7 @@ defmodule Trento.SapSystems.SapSystemTest do
         fn state ->
           assert %SapSystem{
                    sid: ^sid,
+                   tenant: ^tenant,
                    ensa_version: ^ensa_version,
                    database_health: :passing,
                    instances: [
@@ -142,6 +145,7 @@ defmodule Trento.SapSystems.SapSystemTest do
         build(:application_instance_registered_event,
           sap_system_id: sap_system_id,
           sid: sid,
+          tenant: nil,
           features: "MESSAGESERVER",
           instance_number: "00"
         )
@@ -170,6 +174,7 @@ defmodule Trento.SapSystems.SapSystemTest do
           %ApplicationInstanceRegistered{
             sap_system_id: sap_system_id,
             sid: sid,
+            tenant: tenant,
             instance_number: "10",
             instance_hostname: instance_hostname,
             features: java_system_type,
@@ -192,6 +197,7 @@ defmodule Trento.SapSystems.SapSystemTest do
         fn state ->
           assert %SapSystem{
                    sid: ^sid,
+                   tenant: ^tenant,
                    ensa_version: ^ensa_version,
                    database_health: :passing,
                    instances: [
@@ -230,11 +236,13 @@ defmodule Trento.SapSystems.SapSystemTest do
         build(:application_instance_registered_event,
           sap_system_id: sap_system_id,
           sid: sid,
+          tenant: nil,
           features: "MESSAGESERVER"
         ),
         build(:application_instance_registered_event,
           sap_system_id: sap_system_id,
           sid: sid,
+          tenant: tenant,
           features: "ABAP",
           instance_number: instance_number,
           instance_hostname: instance_hostname,
@@ -312,6 +320,7 @@ defmodule Trento.SapSystems.SapSystemTest do
         build(:application_instance_registered_event,
           sap_system_id: sap_system_id,
           sid: sid,
+          tenant: nil,
           features: "MESSAGESERVER",
           host_id: message_server_host_id,
           instance_number: instance_number
@@ -319,6 +328,7 @@ defmodule Trento.SapSystems.SapSystemTest do
         build(:application_instance_registered_event,
           sap_system_id: sap_system_id,
           sid: sid,
+          tenant: tenant,
           features: "ABAP",
           instance_number: instance_number,
           instance_hostname: instance_hostname,
@@ -377,11 +387,13 @@ defmodule Trento.SapSystems.SapSystemTest do
         build(:application_instance_registered_event,
           sap_system_id: sap_system_id,
           sid: sid,
+          tenant: nil,
           features: "MESSAGESERVER"
         ),
         build(:application_instance_registered_event,
           sap_system_id: sap_system_id,
           sid: sid,
+          tenant: tenant,
           features: "ABAP",
           instance_number: instance_number,
           instance_hostname: instance_hostname,
@@ -422,6 +434,7 @@ defmodule Trento.SapSystems.SapSystemTest do
           %ApplicationInstanceRegistered{
             sap_system_id: sap_system_id,
             sid: sid,
+            tenant: tenant,
             instance_number: instance_number,
             instance_hostname: instance_hostname,
             features: "ABAP",
@@ -465,11 +478,13 @@ defmodule Trento.SapSystems.SapSystemTest do
         build(:application_instance_registered_event,
           sap_system_id: sap_system_id,
           sid: sid,
+          tenant: tenant,
           features: "MESSAGESERVER"
         ),
         build(:application_instance_registered_event,
           sap_system_id: sap_system_id,
           sid: sid,
+          tenant: tenant,
           features: "ABAP",
           instance_number: instance_number,
           instance_hostname: instance_hostname,
@@ -533,6 +548,7 @@ defmodule Trento.SapSystems.SapSystemTest do
         build(:application_instance_registered_event,
           sap_system_id: sap_system_id,
           sid: sid,
+          tenant: nil,
           features: "MESSAGESERVER",
           instance_number: instance_number,
           host_id: host_id
@@ -540,6 +556,7 @@ defmodule Trento.SapSystems.SapSystemTest do
         build(:application_instance_registered_event,
           sap_system_id: sap_system_id,
           sid: sid,
+          tenant: Faker.Beer.style(),
           features: "ABAP"
         ),
         build(
@@ -586,11 +603,13 @@ defmodule Trento.SapSystems.SapSystemTest do
         build(:application_instance_registered_event,
           sap_system_id: sap_system_id,
           sid: sid,
+          tenant: nil,
           features: "MESSAGESERVER"
         ),
         build(:application_instance_registered_event,
           sap_system_id: sap_system_id,
           sid: sid,
+          tenant: Faker.Beer.style(),
           features: "ABAP",
           instance_number: instance_number,
           host_id: host_id
@@ -687,6 +706,7 @@ defmodule Trento.SapSystems.SapSystemTest do
         build(:application_instance_registered_event,
           sap_system_id: sap_system_id,
           sid: sid,
+          tenant: tenant,
           features: "ABAP",
           instance_number: "10"
         )
@@ -698,7 +718,7 @@ defmodule Trento.SapSystems.SapSystemTest do
           sap_system_id: sap_system_id,
           sid: sid,
           db_host: db_host,
-          tenant: tenant,
+          tenant: nil,
           instance_number: "00",
           instance_hostname: instance_hostname,
           features: "MESSAGESERVER",
@@ -715,6 +735,7 @@ defmodule Trento.SapSystems.SapSystemTest do
           %ApplicationInstanceRegistered{
             sap_system_id: sap_system_id,
             sid: sid,
+            tenant: nil,
             instance_number: "00",
             instance_hostname: instance_hostname,
             features: "MESSAGESERVER",
@@ -737,6 +758,7 @@ defmodule Trento.SapSystems.SapSystemTest do
         fn state ->
           assert %SapSystem{
                    sid: ^sid,
+                   tenant: ^tenant,
                    instances: [
                      %Instance{
                        sid: ^sid,
@@ -790,6 +812,7 @@ defmodule Trento.SapSystems.SapSystemTest do
           %ApplicationInstanceRegistered{
             sap_system_id: sap_system_id,
             sid: sid,
+            tenant: tenant,
             instance_number: "00",
             instance_hostname: instance_hostname,
             features: "ABAP",
@@ -803,6 +826,7 @@ defmodule Trento.SapSystems.SapSystemTest do
         fn state ->
           assert %SapSystem{
                    sid: nil,
+                   tenant: ^tenant,
                    instances: [
                      %Instance{
                        sid: ^sid,
@@ -821,7 +845,6 @@ defmodule Trento.SapSystems.SapSystemTest do
       sap_system_id = Faker.UUID.v4()
       sid = Faker.StarWars.planet()
       db_host = Faker.Internet.ip_v4_address()
-      tenant = Faker.Beer.style()
       instance_hostname = Faker.Airports.iata()
       http_port = 80
       https_port = 443
@@ -837,7 +860,7 @@ defmodule Trento.SapSystems.SapSystemTest do
           sap_system_id: sap_system_id,
           sid: sid,
           db_host: db_host,
-          tenant: tenant,
+          tenant: nil,
           instance_number: "00",
           instance_hostname: instance_hostname,
           features: "MESSAGESERVER",
@@ -853,6 +876,7 @@ defmodule Trento.SapSystems.SapSystemTest do
           %ApplicationInstanceRegistered{
             sap_system_id: sap_system_id,
             sid: sid,
+            tenant: nil,
             instance_number: "00",
             instance_hostname: instance_hostname,
             features: "MESSAGESERVER",
@@ -866,6 +890,7 @@ defmodule Trento.SapSystems.SapSystemTest do
         fn state ->
           assert %SapSystem{
                    sid: nil,
+                   tenant: nil,
                    instances: [
                      %Instance{
                        sid: ^sid,
@@ -885,8 +910,12 @@ defmodule Trento.SapSystems.SapSystemTest do
       sid = Faker.StarWars.planet()
 
       initial_events = [
-        build(:application_instance_registered_event, sap_system_id: sap_system_id, sid: sid),
-        build(:sap_system_registered_event, sap_system_id: sap_system_id, sid: sid)
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          tenant: nil
+        ),
+        build(:sap_system_registered_event, sap_system_id: sap_system_id, sid: sid, tenant: nil)
       ]
 
       new_instance_db_host = Faker.Internet.ip_v4_address()
@@ -912,6 +941,7 @@ defmodule Trento.SapSystems.SapSystemTest do
           :application_instance_registered_event,
           sap_system_id: sap_system_id,
           sid: sid,
+          tenant: new_instance_tenant,
           instance_number: new_instance_number,
           features: new_instance_features,
           host_id: new_instance_host_id,
@@ -920,6 +950,7 @@ defmodule Trento.SapSystems.SapSystemTest do
         fn state ->
           assert %SapSystem{
                    sid: ^sid,
+                   tenant: ^new_instance_tenant,
                    instances: [
                      %Instance{
                        sid: ^sid,
@@ -980,7 +1011,8 @@ defmodule Trento.SapSystems.SapSystemTest do
           sap_system_id: sap_system_id,
           sid: sid,
           features: "ABAP",
-          instance_number: "10"
+          instance_number: "10",
+          tenant: tenant
         )
       ]
 
@@ -990,7 +1022,7 @@ defmodule Trento.SapSystems.SapSystemTest do
           :register_application_instance_command,
           sap_system_id: sap_system_id,
           sid: sid,
-          tenant: tenant,
+          tenant: nil,
           db_host: db_host,
           instance_number: instance_number,
           features: features,
@@ -1003,6 +1035,7 @@ defmodule Trento.SapSystems.SapSystemTest do
             :application_instance_registered_event,
             sap_system_id: sap_system_id,
             sid: sid,
+            tenant: nil,
             instance_number: instance_number,
             features: features,
             host_id: host_id,
@@ -1118,7 +1151,7 @@ defmodule Trento.SapSystems.SapSystemTest do
             :register_application_instance_command,
             sap_system_id: sap_system_id,
             sid: application_instance_registered_event.sid,
-            tenant: sap_system_registered_event.tenant,
+            tenant: nil,
             db_host: sap_system_registered_event.db_host,
             instance_number: application_instance_registered_event.instance_number,
             features: application_instance_registered_event.features,
@@ -1142,6 +1175,7 @@ defmodule Trento.SapSystems.SapSystemTest do
             :application_instance_registered_event,
             sap_system_id: sap_system_id,
             sid: application_instance_registered_event.sid,
+            tenant: sap_system_registered_event.tenant,
             instance_number: new_instance_number,
             features: new_instance_features,
             host_id: new_instance_host_id,
@@ -1231,7 +1265,7 @@ defmodule Trento.SapSystems.SapSystemTest do
 
       initial_events = [
         application_instance_registered_event,
-        %{ensa_version: ensa_version} =
+        %{tenant: tenant, ensa_version: ensa_version} =
           build(:sap_system_registered_event, sap_system_id: sap_system_id, sid: sid)
       ]
 
@@ -1243,6 +1277,7 @@ defmodule Trento.SapSystems.SapSystemTest do
           snapshot: %SapSystem{
             sap_system_id: sap_system_id,
             sid: sid,
+            tenant: tenant,
             health: :passing,
             database_health: :passing,
             ensa_version: ensa_version,
@@ -1448,6 +1483,7 @@ defmodule Trento.SapSystems.SapSystemTest do
       deregistered_at = DateTime.utc_now()
 
       application_sid = fake_sid()
+      tenant = Faker.Beer.style()
 
       message_server_host_id = UUID.uuid4()
       message_server_instance_number = "00"
@@ -1461,7 +1497,8 @@ defmodule Trento.SapSystems.SapSystemTest do
           features: "MESSAGESERVER|ENQUE",
           host_id: message_server_host_id,
           instance_number: message_server_instance_number,
-          sid: application_sid
+          sid: application_sid,
+          tenant: nil
         ),
         build(
           :application_instance_registered_event,
@@ -1469,12 +1506,14 @@ defmodule Trento.SapSystems.SapSystemTest do
           features: "ABAP|GATEWAY|ICMAN|IGS",
           host_id: abap_host_id,
           instance_number: abap_instance_number,
-          sid: application_sid
+          sid: application_sid,
+          tenant: tenant
         ),
         build(
           :sap_system_registered_event,
           sap_system_id: sap_system_id,
-          sid: application_sid
+          sid: application_sid,
+          tenant: tenant
         ),
         build(:sap_system_deregistered_event,
           sap_system_id: sap_system_id,
@@ -1504,6 +1543,7 @@ defmodule Trento.SapSystems.SapSystemTest do
           %ApplicationInstanceRegistered{
             sap_system_id: sap_system_id,
             sid: application_sid,
+            tenant: command.tenant,
             host_id: command.host_id,
             instance_number: command.instance_number,
             instance_hostname: command.instance_hostname,
@@ -1530,6 +1570,7 @@ defmodule Trento.SapSystems.SapSystemTest do
       deregistered_at = DateTime.utc_now()
 
       application_sid = fake_sid()
+      tenant = Faker.Beer.style()
 
       message_server_host_id = UUID.uuid4()
       message_server_instance_number = "00"
@@ -1543,7 +1584,8 @@ defmodule Trento.SapSystems.SapSystemTest do
           features: "MESSAGESERVER|ENQUE",
           host_id: message_server_host_id,
           instance_number: message_server_instance_number,
-          sid: application_sid
+          sid: application_sid,
+          tenant: nil
         ),
         build(
           :application_instance_registered_event,
@@ -1551,12 +1593,14 @@ defmodule Trento.SapSystems.SapSystemTest do
           features: "ABAP|GATEWAY|ICMAN|IGS",
           host_id: abap_host_id,
           instance_number: abap_instance_number,
-          sid: application_sid
+          sid: application_sid,
+          tenant: tenant
         ),
         build(
           :sap_system_registered_event,
           sap_system_id: sap_system_id,
-          sid: application_sid
+          sid: application_sid,
+          tenant: tenant
         ),
         build(:sap_system_deregistered_event,
           sap_system_id: sap_system_id,
@@ -1575,6 +1619,7 @@ defmodule Trento.SapSystems.SapSystemTest do
           :register_application_instance_command,
           sap_system_id: sap_system_id,
           sid: application_sid,
+          tenant: nil,
           db_host: database_host_id,
           features: "MESSAGESERVER",
           database_health: :critical
@@ -1587,6 +1632,7 @@ defmodule Trento.SapSystems.SapSystemTest do
           %ApplicationInstanceRegistered{
             sap_system_id: sap_system_id,
             sid: application_sid,
+            tenant: nil,
             host_id: command.host_id,
             instance_number: command.instance_number,
             instance_hostname: command.instance_hostname,
@@ -1598,7 +1644,7 @@ defmodule Trento.SapSystems.SapSystemTest do
           },
           %SapSystemRestored{
             sap_system_id: sap_system_id,
-            tenant: command.tenant,
+            tenant: tenant,
             db_host: command.db_host,
             health: command.health,
             database_health: command.database_health


### PR DESCRIPTION
# Description

Parse new SAP discovery field `Tenant`. 
Related to: https://github.com/trento-project/agent/pull/419

The old `dbs/hdb/dbname` is still used as fallback if the `Tenant` field is not sent like in old agent version.

The SAP system aggregate must be changed, as the tenant is not sent now in all instances. This means that we need to store it in the aggregate, and pick the first non nil tenant, as the remaining ones must have the same value.

## How was this tested?

UT and manual testing