### PR TITLE
Increase timeout for SUSE Multi Linux Manager API

### DIFF
--- a/lib/trento/infrastructure/software_updates/adapter/suma_http_executor.ex
+++ b/lib/trento/infrastructure/software_updates/adapter/suma_http_executor.ex
@@ -212,7 +212,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor do
   defp request_options(auth, ca_cert),
     do: [hackney: [cookie: [auth]]] ++ ssl_options(ca_cert) ++ timeout_options()
 
-  defp timeout_options, do: [timeout: 1_000, recv_timeout: 1_500]
+  defp timeout_options, do: [timeout: 1_000, recv_timeout: 5_000]
 
   defp ssl_options(nil), do: []
 


### PR DESCRIPTION
Some report from SMLM comes with a big payload which takes more than 1s to be transferred. This PR set the limit to a more relaxed 5s period. Please note that the connection timeout is kept unchanged, thus this change won't affect Trento in case of SMLM API is not available.