### PR TITLE
Deduplicate targets for ascs cluster checks executions

### DIFF
--- a/lib/trento/clusters.ex
+++ b/lib/trento/clusters.ex
@@ -211,6 +211,11 @@ defmodule Trento.Clusters do
        ) do
     sap_instance_sids = SapInstance.get_sap_instance_sids(sap_instances)
 
+    clustered_sap_instances =
+      sap_instances
+      |> Enum.map(& &1.instance_number)
+      |> Enum.uniq()
+
     hosts_data =
       Repo.all(
         from h in HostReadModel,
@@ -218,9 +223,8 @@ defmodule Trento.Clusters do
           on: h.id == a.host_id,
           where:
             h.cluster_id == ^cluster_id and is_nil(h.deregistered_at) and
-              a.sid in ^sap_instance_sids,
-          select: %{host_id: h.id, sap_system_id: a.sap_system_id},
-          distinct: true
+              a.sid in ^sap_instance_sids and a.instance_number in ^clustered_sap_instances,
+          select: %{host_id: h.id, sap_system_id: a.sap_system_id}
       )
 
     aggregated_ensa_version =

--- a/lib/trento/clusters.ex
+++ b/lib/trento/clusters.ex
@@ -219,7 +219,8 @@ defmodule Trento.Clusters do
           where:
             h.cluster_id == ^cluster_id and is_nil(h.deregistered_at) and
               a.sid in ^sap_instance_sids,
-          select: %{host_id: h.id, sap_system_id: a.sap_system_id}
+          select: %{host_id: h.id, sap_system_id: a.sap_system_id},
+          distinct: true
       )
 
     aggregated_ensa_version =

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -372,7 +372,8 @@ defmodule Trento.Factory do
       provider: Enum.random(Provider.values()),
       type: ClusterType.hana_scale_up(),
       health: Health.passing(),
-      selected_checks: Enum.map(0..4, fn _ -> Faker.StarWars.planet() end)
+      selected_checks: Enum.map(0..4, fn _ -> Faker.StarWars.planet() end),
+      details: %{}
     }
   end
 

--- a/test/trento/clusters/value_objects/sap_instance_test.exs
+++ b/test/trento/clusters/value_objects/sap_instance_test.exs
@@ -34,15 +34,22 @@ defmodule Trento.Clusters.ValueObjects.SapInstanceTest do
 
   describe "get_sap_instance_sids/1" do
     test "should return SAP instance sids" do
-      %{sid: sid_1} =
-        instance_1 =
-        build(:clustered_sap_instance, resource_type: SapInstanceResourceType.sap_instance())
+      sid_1 = Faker.Lorem.word()
+      sid_2 = Faker.StarWars.planet()
+
+      instance_1 =
+        build(:clustered_sap_instance,
+          sid: sid_1,
+          resource_type: SapInstanceResourceType.sap_instance()
+        )
 
       sap_instances = [
         instance_1,
         build(:clustered_sap_instance, resource_type: SapInstanceResourceType.sap_hana_topology()),
-        %{sid: sid_2} =
-          build(:clustered_sap_instance, resource_type: SapInstanceResourceType.sap_instance()),
+        build(:clustered_sap_instance,
+          sid: sid_2,
+          resource_type: SapInstanceResourceType.sap_instance()
+        ),
         build(:clustered_sap_instance,
           sid: sid_1,
           resource_type: SapInstanceResourceType.sap_instance()

--- a/test/trento/clusters_test.exs
+++ b/test/trento/clusters_test.exs
@@ -1002,22 +1002,34 @@ defmodule Trento.ClustersTest do
         )
 
       insert(:host, deregistered_at: DateTime.utc_now(), cluster_id: cluster_id)
-      hosts = insert_list(2, :host, cluster_id: cluster_id)
+      [%{id: host_id1}, %{id: host_id2}] = insert_list(2, :host, cluster_id: cluster_id)
 
-      Enum.each(
-        hosts,
-        &Enum.each(1..2, fn it ->
-          insert(:application_instance,
-            sap_system_id: sap_system_id,
-            host_id: &1.id,
-            sid: sid,
-            instance_number:
-              case it do
-                1 -> instance_number_1
-                2 -> Faker.Lorem.word()
-              end
-          )
-        end)
+      insert(:application_instance,
+        sap_system_id: sap_system_id,
+        host_id: host_id1,
+        sid: sid,
+        instance_number: instance_number_1
+      )
+
+      insert(:application_instance,
+        sap_system_id: sap_system_id,
+        host_id: host_id1,
+        sid: sid,
+        instance_number: "02"
+      )
+
+      insert(:application_instance,
+        sap_system_id: sap_system_id,
+        host_id: host_id2,
+        sid: sid,
+        instance_number: instance_number_2
+      )
+
+      insert(:application_instance,
+        sap_system_id: sap_system_id,
+        host_id: host_id2,
+        sid: sid,
+        instance_number: "03"
       )
 
       expect(Trento.Infrastructure.Messaging.Adapter.Mock, :publish, fn Publisher,


### PR DESCRIPTION
# Description

This fixes an issue where duplicated targets are sent during a checks execution when on the same host there are multiple application instances installed.

Added extra deduplication on wanda for broader robustness https://github.com/trento-project/wanda/pull/605