### PR TITLE
Log checks selected as connection activity

### DIFF
--- a/assets/js/lib/model/activityLog.js
+++ b/assets/js/lib/model/activityLog.js
@@ -54,7 +54,7 @@ export const SOFTWARE_UPDATES_HEALTH_CHANGED =
   'software_updates_health_changed';
 
 // Cluster events
-export const CHECKS_SELECTED = 'checks_selected';
+export const CLUSTER_CHECKS_SELECTED = 'cluster_checks_selected';
 export const CLUSTER_CHECKS_HEALTH_CHANGED = 'cluster_checks_health_changed';
 export const CLUSTER_DEREGISTERED = 'cluster_deregistered';
 export const CLUSTER_DETAILS_UPDATED = 'cluster_details_updated';
@@ -367,7 +367,7 @@ export const ACTIVITY_TYPES_CONFIG = {
     resource: hostResourceType,
   },
   // Cluster events
-  [CHECKS_SELECTED]: {
+  [CLUSTER_CHECKS_SELECTED]: {
     label: 'Cluster Checks Selected',
     message: (_entry) => `Checks were selected for cluster`,
     resource: clusterResourceType,

--- a/lib/trento/activity_logging/activity_catalog.ex
+++ b/lib/trento/activity_logging/activity_catalog.ex
@@ -12,6 +12,11 @@ defmodule Trento.ActivityLog.ActivityCatalog do
 
   alias Trento.Operations.V1.OperationCompleted
 
+  @excluded_events [
+    Trento.Hosts.Events.HostChecksSelected,
+    Trento.Clusters.Events.ChecksSelected
+  ]
+
   @type activity_type :: atom()
   @type connection_activity :: {controller :: module(), action :: atom()}
   @type domain_event_activity :: event_module :: module()
@@ -130,7 +135,7 @@ defmodule Trento.ActivityLog.ActivityCatalog do
             false
         end)
         |> Enum.map(&Module.concat/1)
-        |> Enum.filter(&(not &1.legacy?()))
+        |> Enum.filter(&(not &1.legacy?() and &1 not in @excluded_events))
         |> Map.new(fn event_module ->
           {event_module,
            {event_module
@@ -163,8 +168,10 @@ defmodule Trento.ActivityLog.ActivityCatalog do
       {TrentoWeb.V1.ProfileController, :update} => {:profile_update, 200},
       {TrentoWeb.V1.ClusterController, :request_checks_execution} =>
         {:cluster_checks_execution_request, 202},
+      {TrentoWeb.V1.ClusterController, :select_checks} => {:cluster_checks_selected, 202},
       {TrentoWeb.V1.HostController, :request_checks_execution} =>
         {:host_checks_execution_request, 202},
+      {TrentoWeb.V1.HostController, :select_checks} => {:host_checks_selected, 202},
       {TrentoWeb.V1.SettingsController, :update_activity_log_settings} =>
         {:activity_log_settings_update, 200},
       {TrentoWeb.V1.HostController, :request_operation} => {:operation_requested, 202}

--- a/lib/trento/activity_logging/activity_catalog.ex
+++ b/lib/trento/activity_logging/activity_catalog.ex
@@ -135,7 +135,7 @@ defmodule Trento.ActivityLog.ActivityCatalog do
             false
         end)
         |> Enum.map(&Module.concat/1)
-        |> Enum.filter(&(not &1.legacy?() and &1 not in @excluded_events))
+        |> Enum.reject(&(&1.legacy?() or &1 in @excluded_events))
         |> Map.new(fn event_module ->
           {event_module,
            {event_module

--- a/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
+++ b/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
@@ -109,20 +109,24 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
   end
 
   def get_activity_metadata(
-        :cluster_checks_execution_request,
+        activity,
         %Plug.Conn{
-          params: params
+          params: params,
+          body_params: request_body
         }
-      ),
-      do: %{cluster_id: Map.get(params, :cluster_id)}
+      )
+      when activity in [:cluster_checks_selected, :cluster_checks_execution_request],
+      do: Map.merge(request_body, %{cluster_id: Map.get(params, :cluster_id)})
 
   def get_activity_metadata(
-        :host_checks_execution_request,
+        activity,
         %Plug.Conn{
-          params: params
+          params: params,
+          body_params: request_body
         }
-      ),
-      do: %{host_id: Map.get(params, :id)}
+      )
+      when activity in [:host_checks_selected, :host_checks_execution_request],
+      do: Map.merge(request_body, %{host_id: Map.get(params, :id)})
 
   def get_activity_metadata(:user_deletion, %Plug.Conn{
         params: params

--- a/lib/trento/activity_logging/severity_level.ex
+++ b/lib/trento/activity_logging/severity_level.ex
@@ -23,7 +23,7 @@ defmodule Trento.ActivityLog.SeverityLevel do
       values: %{"critical" => :critical, "unknown" => :warning, "*" => :info},
       condition: :map_value_to_severity
     },
-    "host_checks_selected" => :info,
+    "host_checks_selected" => :warning,
     "host_checks_execution_request" => :info,
     "host_deregistered" => :warning,
     "host_deregistration_requested" => :debug,
@@ -61,7 +61,7 @@ defmodule Trento.ActivityLog.SeverityLevel do
       values: %{"critical" => :critical, "unknown" => :warning, "*" => :info},
       condition: :map_value_to_severity
     },
-    "checks_selected" => :warning,
+    "cluster_checks_selected" => :warning,
     "cluster_checks_health_changed" => %{
       type: :kv,
       key_suffix: "health",

--- a/test/support/commanded/commanded_case.ex
+++ b/test/support/commanded/commanded_case.ex
@@ -8,4 +8,19 @@ defmodule Trento.CommandedCase do
 
     :ok
   end
+
+  setup context do
+    mocked_commanded =
+      Map.get(context, :mocked_commanded, true)
+
+    if not mocked_commanded do
+      Application.put_env(:trento, Trento.Commanded, adapter: Trento.Commanded)
+
+      on_exit(fn ->
+        Application.put_env(:trento, Trento.Commanded, adapter: Trento.Commanded.Mock)
+      end)
+    end
+
+    {:ok, context}
+  end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -912,7 +912,7 @@ defmodule Trento.Factory do
     })
   end
 
-  def host_checks_selected_factory do
+  def host_checks_selected_event_factory do
     %HostChecksSelected{
       host_id: Faker.UUID.v4(),
       checks: Enum.map(0..4, fn _ -> Faker.UUID.v4() end)

--- a/test/trento/activity_logging/event_parser_test.exs
+++ b/test/trento/activity_logging/event_parser_test.exs
@@ -13,7 +13,7 @@ defmodule Trento.ActivityLog.EventParser do
     {:heartbeat_succeeded, build(:heartbeat_succeded)},
     {:heartbeat_failed, build(:heartbeat_failed)},
     {:host_checks_health_changed, build(:host_checks_health_changed)},
-    {:host_checks_selected, build(:host_checks_selected)},
+    {:host_checks_selected, build(:host_checks_selected_event)},
     {:software_updates_discovery_requested, build(:software_updates_discovery_requested_event)},
     {:foo_bar, TestEvent.new!(%{data: "some event"})}
   ]

--- a/test/trento/activity_logging/metadata_enricher_test.exs
+++ b/test/trento/activity_logging/metadata_enricher_test.exs
@@ -372,7 +372,7 @@ defmodule Trento.ActivityLog.MetadataEnricherTest do
         {:heartbeat_succeeded, build(:heartbeat_succeded, host_id: host_id)},
         {:heartbeat_failed, build(:heartbeat_failed, host_id: host_id)},
         {:host_checks_health_changed, build(:host_checks_health_changed, host_id: host_id)},
-        {:host_checks_selected, build(:host_checks_selected, host_id: host_id)},
+        {:host_checks_selected, build(:host_checks_selected_event, host_id: host_id)},
         {:host_health_changed, build(:host_health_changed_event, host_id: host_id)},
         {:saptune_status_updated, build(:saptune_status_updated_event, host_id: host_id)},
         {:software_updates_discovery_requested,
@@ -394,7 +394,7 @@ defmodule Trento.ActivityLog.MetadataEnricherTest do
       enrichable_events = [
         {:cluster_checks_health_changed,
          build(:cluster_checks_health_changed_event, cluster_id: cluster_id)},
-        {:checks_selected, build(:cluster_checks_selected_event, cluster_id: cluster_id)},
+        {:cluster_checks_selected, build(:cluster_checks_selected_event, cluster_id: cluster_id)},
         {:cluster_discovered_health_changed,
          build(:cluster_discovered_health_changed_event, cluster_id: cluster_id)},
         {:cluster_health_changed, build(:cluster_health_changed_event, cluster_id: cluster_id)}


### PR DESCRIPTION
# Description

This PR makes sure Checks selection activities are logged considering they're connection aspect so that the proper user is attached to the log entry.

Additionally both cluster and checks selections are now of warning severity.