### PR TITLE
Alerting Settings handling and access

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -35,6 +35,10 @@ config :swoosh, :api_client, false
 # configure the recipient for alert notifications
 config :trento, :alerting,
   enabled: nil,
+  smtp_server: nil,
+  smtp_port: nil,
+  smtp_username: nil,
+  smtp_password: nil,
   sender: nil,
   recipient: nil
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -34,9 +34,9 @@ config :swoosh, :api_client, false
 
 # configure the recipient for alert notifications
 config :trento, :alerting,
-  enabled: true,
-  sender: "alerts@trento-project.io",
-  recipient: "admin@trento.io"
+  enabled: nil,
+  sender: nil,
+  recipient: nil
 
 # Configure esbuild (the version is required)
 config :esbuild,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -154,25 +154,30 @@ if config_env() in [:prod, :demo] do
 
   config :trento, :alerting,
     enabled: System.get_env("ENABLE_ALERTING"),
-    sender: System.get_env("ALERT_SENDER"),
-    recipient: System.get_env("ALERT_RECIPIENT")
+    smtp_server: System.get_env("SMTP_SERVER"),
+    smtp_port: System.get_env("SMTP_PORT"),
+    smtp_username: System.get_env("SMTP_USER"),
+    smtp_password: System.get_env("SMTP_PASSWORD"),
+    sender_email: System.get_env("ALERT_SENDER"),
+    recipient_email: System.get_env("ALERT_RECIPIENT")
 
   :ok = :public_key.cacerts_load()
   [_ | _] = cacerts = :public_key.cacerts_get()
 
   config :trento, Trento.Mailer,
     adapter: Swoosh.Adapters.SMTP,
-    relay: System.get_env("SMTP_SERVER"),
-    port: System.get_env("SMTP_PORT"),
-    username: System.get_env("SMTP_USER"),
-    password: System.get_env("SMTP_PASSWORD"),
+    # `relay`, `port`, `username` and `password` would be supplied
+    # dynamically during runtime and would be derived from values
+    # specified in the :alerting key.
     auth: :always,
     ssl: false,
     tls: :if_available,
     tls_options: [
       versions: [:"tlsv1.2", :"tlsv1.3"],
       cacerts: cacerts,
-      server_name_indication: String.to_charlist(System.get_env("SMTP_SERVER", "")),
+      # `server_name_indication` would be supplied dynamically during
+      # runtime and would be derived from values
+      # specified in the :alerting key.
       depth: 99
     ]
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -153,19 +153,19 @@ if config_env() in [:prod, :demo] do
   # See https://hexdocs.pm/swoosh/Swoosh.html#module-installation for details.
 
   config :trento, :alerting,
-    enabled: System.get_env("ENABLE_ALERTING", "false") == "true",
-    sender: System.get_env("ALERT_SENDER", "alerts@trento-project.io"),
-    recipient: System.get_env("ALERT_RECIPIENT", "admin@trento-project.io")
+    enabled: System.get_env("ENABLE_ALERTING"),
+    sender: System.get_env("ALERT_SENDER"),
+    recipient: System.get_env("ALERT_RECIPIENT")
 
   :ok = :public_key.cacerts_load()
   [_ | _] = cacerts = :public_key.cacerts_get()
 
   config :trento, Trento.Mailer,
     adapter: Swoosh.Adapters.SMTP,
-    relay: System.get_env("SMTP_SERVER") || "",
-    port: System.get_env("SMTP_PORT") || "",
-    username: System.get_env("SMTP_USER") || "",
-    password: System.get_env("SMTP_PASSWORD") || "",
+    relay: System.get_env("SMTP_SERVER"),
+    port: System.get_env("SMTP_PORT"),
+    username: System.get_env("SMTP_USER"),
+    password: System.get_env("SMTP_PASSWORD"),
     auth: :always,
     ssl: false,
     tls: :if_available,

--- a/lib/trento/infrastructure/alerting/alerting.ex
+++ b/lib/trento/infrastructure/alerting/alerting.ex
@@ -17,69 +17,79 @@ defmodule Trento.Infrastructure.Alerting.Alerting do
   require Logger
 
   @spec notify_critical_host_health(String.t()) :: :ok
-  def notify_critical_host_health(host_id),
-    do: maybe_notify_critical_host_health(enabled?(), host_id)
+  def notify_critical_host_health(host_id) do
+    construct_email = fn %{sender: sender, recipient: recipient} ->
+      %HostReadModel{hostname: hostname} = Trento.Repo.get!(HostReadModel, host_id)
+
+      EmailAlert.alert(
+        "Host",
+        "hostname",
+        hostname,
+        "health is now in critical state",
+        sender: sender,
+        recipient: recipient
+      )
+    end
+
+    deliver_notification(construct_email)
+  end
 
   @spec notify_critical_cluster_health(String.t()) :: :ok
-  def notify_critical_cluster_health(cluster_id),
-    do: maybe_notify_critical_cluster_health(enabled?(), cluster_id)
+  def notify_critical_cluster_health(cluster_id) do
+    construct_email = fn %{sender: sender, recipient: recipient} ->
+      %ClusterReadModel{name: name} = Trento.Repo.get!(ClusterReadModel, cluster_id)
+
+      EmailAlert.alert(
+        "Cluster",
+        "name",
+        name,
+        "health is now in critical state",
+        sender: sender,
+        recipient: recipient
+      )
+    end
+
+    deliver_notification(construct_email)
+  end
 
   @spec notify_critical_database_health(String.t()) :: :ok
-  def notify_critical_database_health(id),
-    do: maybe_notify_critical_database_health(enabled?(), id)
+  def notify_critical_database_health(id) do
+    construct_email = fn %{sender: sender, recipient: recipient} ->
+      %DatabaseReadModel{sid: sid} = Trento.Repo.get!(DatabaseReadModel, id)
+
+      EmailAlert.alert(
+        "Database",
+        "SID",
+        sid,
+        "health is now in critical state",
+        sender: sender,
+        recipient: recipient
+      )
+    end
+
+    deliver_notification(construct_email)
+  end
 
   @spec notify_critical_sap_system_health(String.t()) :: :ok
-  def notify_critical_sap_system_health(id),
-    do: maybe_notify_critical_sap_system_health(enabled?(), id)
+  def notify_critical_sap_system_health(id) do
+    construct_email = fn %{sender: sender, recipient: recipient} ->
+      %SapSystemReadModel{sid: sid} = Trento.Repo.get!(SapSystemReadModel, id)
+
+      EmailAlert.alert(
+        "Sap System",
+        "SID",
+        sid,
+        "health is now in critical state",
+        sender: sender,
+        recipient: recipient
+      )
+    end
+
+    deliver_notification(construct_email)
+  end
 
   @spec notify_api_key_expiration() :: :ok
-  def notify_api_key_expiration, do: maybe_notify_api_key_expiration(enabled?())
-
-  defp enabled?, do: Application.fetch_env!(:trento, :alerting)[:enabled]
-
-  defp maybe_notify_critical_host_health(false, _), do: :ok
-
-  defp maybe_notify_critical_host_health(true, host_id) do
-    %HostReadModel{hostname: hostname} = Trento.Repo.get!(HostReadModel, host_id)
-
-    deliver_notification(
-      EmailAlert.alert("Host", "hostname", hostname, "health is now in critical state")
-    )
-  end
-
-  defp maybe_notify_critical_cluster_health(false, _), do: :ok
-
-  defp maybe_notify_critical_cluster_health(true, cluster_id) do
-    %ClusterReadModel{name: name} = Trento.Repo.get!(ClusterReadModel, cluster_id)
-
-    deliver_notification(
-      EmailAlert.alert("Cluster", "name", name, "health is now in critical state")
-    )
-  end
-
-  defp maybe_notify_critical_database_health(false, _), do: :ok
-
-  defp maybe_notify_critical_database_health(true, id) do
-    %DatabaseReadModel{sid: sid} = Trento.Repo.get!(DatabaseReadModel, id)
-
-    deliver_notification(
-      EmailAlert.alert("Database", "SID", sid, "health is now in critical state")
-    )
-  end
-
-  defp maybe_notify_critical_sap_system_health(false, _), do: :ok
-
-  defp maybe_notify_critical_sap_system_health(true, id) do
-    %SapSystemReadModel{sid: sid} = Trento.Repo.get!(SapSystemReadModel, id)
-
-    deliver_notification(
-      EmailAlert.alert("Sap System", "SID", sid, "health is now in critical state")
-    )
-  end
-
-  defp maybe_notify_api_key_expiration(false), do: :ok
-
-  defp maybe_notify_api_key_expiration(true) do
+  def notify_api_key_expiration do
     case Settings.get_api_key_settings() do
       {:ok, %ApiKeySettings{expire_at: nil}} ->
         :ok
@@ -98,21 +108,78 @@ defmodule Trento.Infrastructure.Alerting.Alerting do
     do: DateTime.diff(expire_at, DateTime.utc_now(), :day)
 
   defp maybe_send_api_key_notification(days) when days < 0 do
-    deliver_notification(EmailAlert.api_key_expired())
+    construct_email = fn %{sender: sender, recipient: recipient} ->
+      EmailAlert.api_key_expired(
+        sender: sender,
+        recipient: recipient
+      )
+    end
+
+    deliver_notification(construct_email)
   end
 
   defp maybe_send_api_key_notification(days) when days < 30 do
-    days
-    |> EmailAlert.api_key_will_expire()
-    |> deliver_notification()
+    construct_email = fn %{sender: sender, recipient: recipient} ->
+      EmailAlert.api_key_will_expire(
+        days,
+        sender: sender,
+        recipient: recipient
+      )
+    end
+
+    deliver_notification(construct_email)
   end
 
   defp maybe_send_api_key_notification(_), do: :ok
 
-  @spec deliver_notification(Swoosh.Email.t()) :: :ok
-  defp deliver_notification(%Swoosh.Email{subject: subject} = notification) do
+  defp prepare_mailer_config(%{
+         smtp_server: server,
+         smtp_port: port,
+         smtp_username: username,
+         smtp_password: password
+       }) do
+    tls_options =
+      Application.get_env(:trento, Trento.Mailer)
+      |> Keyword.get(:tls_options, [])
+      |> Keyword.put(:server_name_indication, String.to_charlist(server))
+
+    [
+      relay: server,
+      port: port,
+      username: username,
+      password: password,
+      tls_options: tls_options
+    ]
+  end
+
+  defp deliver_notification(construct_email) do
+    case Settings.get_alerting_settings() do
+      {:ok, settings} ->
+        deliver_notification(construct_email, settings)
+
+      {:error, :alerting_settings_not_configured} ->
+        Logger.warning("Trying to send email but alerting settings are not configured")
+        :ok
+    end
+  end
+
+  defp deliver_notification(_, %{enabled: false}), do: :ok
+
+  defp deliver_notification(
+         construct_email,
+         %{
+           sender_email: sender,
+           recipient_email: recipient
+         } = alerting_settings
+       )
+       when is_function(construct_email) do
+    %Swoosh.Email{subject: subject} =
+      notification = construct_email.(%{sender: sender, recipient: recipient})
+
+    mailer_config = prepare_mailer_config(alerting_settings)
+
     notification
-    |> Mailer.deliver()
+    |> Mailer.deliver(mailer_config)
     |> case do
       {:ok, _} ->
         :ok

--- a/lib/trento/infrastructure/alerting/emails/email_alert.ex
+++ b/lib/trento/infrastructure/alerting/emails/email_alert.ex
@@ -5,20 +5,20 @@ defmodule Trento.Infrastructure.Alerting.Emails.EmailAlert do
 
   use Phoenix.Swoosh, view: Trento.Infrastructure.Alerting.Emails.EmailView
 
-  def api_key_expired do
+  def api_key_expired(sender: sender, recipient: recipient) do
     new()
-    |> from({"Trento Alerts", Application.fetch_env!(:trento, :alerting)[:sender]})
-    |> to({"Trento Admin", Application.fetch_env!(:trento, :alerting)[:recipient]})
+    |> from({"Trento Alerts", sender})
+    |> to({"Trento Admin", recipient})
     |> subject("Trento Alert: Api key expired")
     |> render_body("api_key_expiration.html", %{
       api_key_expired: true
     })
   end
 
-  def api_key_will_expire(days) do
+  def api_key_will_expire(days, sender: sender, recipient: recipient) do
     new()
-    |> from({"Trento Alerts", Application.fetch_env!(:trento, :alerting)[:sender]})
-    |> to({"Trento Admin", Application.fetch_env!(:trento, :alerting)[:recipient]})
+    |> from({"Trento Alerts", sender})
+    |> to({"Trento Admin", recipient})
     |> subject("Trento Alert: Api key will expire in #{days} days")
     |> render_body("api_key_expiration.html", %{
       api_key_expired: false,
@@ -26,10 +26,10 @@ defmodule Trento.Infrastructure.Alerting.Emails.EmailAlert do
     })
   end
 
-  def alert(component, identified_by, identifier, reason) do
+  def alert(component, identified_by, identifier, reason, sender: sender, recipient: recipient) do
     new()
-    |> from({"Trento Alerts", Application.fetch_env!(:trento, :alerting)[:sender]})
-    |> to({"Trento Admin", Application.fetch_env!(:trento, :alerting)[:recipient]})
+    |> from({"Trento Alerts", sender})
+    |> to({"Trento Admin", recipient})
     |> subject("Trento Alert: #{component} #{identifier} needs attention.")
     |> render_body("critical.html", %{
       component: component,

--- a/lib/trento/settings.ex
+++ b/lib/trento/settings.ex
@@ -192,13 +192,6 @@ defmodule Trento.Settings do
 
   # Alerting Settings
 
-  @spec alerting_settings_enforced_from_env? :: boolean()
-  def alerting_settings_enforced_from_env? do
-    Application.get_env(:trento, :alerting)
-    |> Enum.map(fn {_key, val} -> val != nil end)
-    |> Enum.any?()
-  end
-
   @spec get_alerting_settings ::
           {:ok, AlertingSettings.t()} | {:error, :alerting_settings_not_configured}
   def get_alerting_settings do
@@ -238,6 +231,12 @@ defmodule Trento.Settings do
         |> Repo.update()
       end
     end
+  end
+
+  defp alerting_settings_enforced_from_env? do
+    Application.get_env(:trento, :alerting)
+    |> Enum.map(fn {_key, val} -> val != nil end)
+    |> Enum.any?()
   end
 
   defp get_alerting_settings_from_app_env do

--- a/lib/trento/settings/alerting_settings.ex
+++ b/lib/trento/settings/alerting_settings.ex
@@ -25,6 +25,7 @@ defmodule Trento.Settings.AlertingSettings do
       source: :alerting_smtp_password,
       redact: true
 
+    field :enforced_from_env, :boolean, virtual: true, default: false
     timestamps(type: :utc_datetime_usec)
     sti_fields()
   end

--- a/lib/trento_web/controllers/error_json.ex
+++ b/lib/trento_web/controllers/error_json.ex
@@ -77,6 +77,17 @@ defmodule TrentoWeb.ErrorJSON do
     }
   end
 
+  def render("409.json", %{reason: reason}) do
+    %{
+      errors: [
+        %{
+          title: "Conflict has occurred",
+          detail: reason
+        }
+      ]
+    }
+  end
+
   def render("422.json", %{changeset: changeset}) do
     error =
       Ecto.Changeset.traverse_errors(

--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -31,6 +31,13 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"404", reason: "Alerting settings not configured.")
   end
 
+  def call(conn, {:error, :alerting_settings_enforced}) do
+    conn
+    |> put_status(:conflict)
+    |> put_view(json: ErrorJSON)
+    |> render(:"409", reason: "Alerting settings can not be set, enforced by ENV.")
+  end
+
   def call(conn, {:error, :suma_authentication_error}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/lib/trento_web/controllers/v1/settings_controller.ex
+++ b/lib/trento_web/controllers/v1/settings_controller.ex
@@ -291,6 +291,7 @@ defmodule TrentoWeb.V1.SettingsController do
          Schema.Platform.AlertingSettings},
       unauthorized: Schema.Unauthorized.response(),
       forbidden: Schema.Forbidden.response(),
+      conflict: Schema.Conflict.response(),
       unprocessable_entity: Schema.UnprocessableEntity.response()
     ]
 
@@ -318,6 +319,7 @@ defmodule TrentoWeb.V1.SettingsController do
       unauthorized: Schema.Unauthorized.response(),
       forbidden: Schema.Forbidden.response(),
       not_found: Schema.NotFound.response(),
+      conflict: Schema.Conflict.response(),
       unprocessable_entity: Schema.UnprocessableEntity.response()
     ]
 

--- a/lib/trento_web/controllers/v1/settings_json.ex
+++ b/lib/trento_web/controllers/v1/settings_json.ex
@@ -58,7 +58,8 @@ defmodule TrentoWeb.V1.SettingsJSON do
           recipient_email: recipient_email,
           smtp_server: smtp_server,
           smtp_port: smtp_port,
-          smtp_username: smtp_username
+          smtp_username: smtp_username,
+          enforced_from_env: enforced_from_env
         }
       }),
       do: %{
@@ -67,6 +68,7 @@ defmodule TrentoWeb.V1.SettingsJSON do
         recipient_email: recipient_email,
         smtp_server: smtp_server,
         smtp_port: smtp_port,
-        smtp_username: smtp_username
+        smtp_username: smtp_username,
+        enforced_from_env: enforced_from_env
       }
 end

--- a/lib/trento_web/openapi/v1/schema/conflict.ex
+++ b/lib/trento_web/openapi/v1/schema/conflict.ex
@@ -1,0 +1,38 @@
+defmodule TrentoWeb.OpenApi.V1.Schema.Conflict do
+  @moduledoc """
+  409 - Conflict
+  """
+  require OpenApiSpex
+
+  alias OpenApiSpex.Operation
+  alias OpenApiSpex.Schema
+
+  OpenApiSpex.schema(
+    %{
+      title: "Conflict",
+      type: :object,
+      additionalProperties: false,
+      properties: %{
+        errors: %Schema{
+          type: :array,
+          items: %Schema{
+            type: :object,
+            properties: %{
+              detail: %Schema{type: :string, example: "Conflicting state."},
+              title: %Schema{type: :string, example: "Conflict has occured"}
+            }
+          }
+        }
+      }
+    },
+    struct?: false
+  )
+
+  def response do
+    Operation.response(
+      "Conflict",
+      "application/json",
+      __MODULE__
+    )
+  end
+end

--- a/lib/trento_web/openapi/v1/schema/conflict.ex
+++ b/lib/trento_web/openapi/v1/schema/conflict.ex
@@ -19,7 +19,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Conflict do
             type: :object,
             properties: %{
               detail: %Schema{type: :string, example: "Conflicting state."},
-              title: %Schema{type: :string, example: "Conflict has occured"}
+              title: %Schema{type: :string, example: "Conflict has occurred"}
             }
           }
         }

--- a/lib/trento_web/openapi/v1/schema/platform.ex
+++ b/lib/trento_web/openapi/v1/schema/platform.ex
@@ -289,7 +289,8 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Platform do
             type: :integer,
             example: 587
           },
-          smtp_username: %Schema{type: :string}
+          smtp_username: %Schema{type: :string},
+          enforced_from_env: %Schema{type: :boolean}
         },
         required: [
           :enabled,
@@ -297,7 +298,8 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Platform do
           :recipient_email,
           :smtp_server,
           :smtp_port,
-          :smtp_username
+          :smtp_username,
+          :enforced_from_env
         ]
       },
       struct?: false

--- a/test/support/helpers/alerting_settings_helper.ex
+++ b/test/support/helpers/alerting_settings_helper.ex
@@ -8,15 +8,12 @@ defmodule Trento.Support.Helpers.AlertingSettingsHelper do
   def nil_alerting_app_env do
     Application.put_env(:trento, :alerting,
       enabled: nil,
-      sender: nil,
-      recipient: nil
-    )
-
-    Application.put_env(:trento, Trento.Mailer,
-      relay: nil,
-      port: nil,
-      username: nil,
-      password: nil
+      smtp_server: nil,
+      smtp_port: nil,
+      smtp_username: nil,
+      smtp_password: nil,
+      sender_email: nil,
+      recipient_email: nil
     )
   end
 
@@ -24,11 +21,9 @@ defmodule Trento.Support.Helpers.AlertingSettingsHelper do
 
   def restore_alerting_app_env(_context) do
     default_alerting_config = Application.get_env(:trento, :alerting)
-    default_mailer_config = Application.get_env(:trento, Trento.Mailer)
 
     on_exit(fn ->
       Application.put_env(:trento, :alerting, default_alerting_config)
-      Application.put_env(:trento, Trento.Mailer, default_mailer_config)
     end)
   end
 end

--- a/test/support/helpers/alerting_settings_helper.ex
+++ b/test/support/helpers/alerting_settings_helper.ex
@@ -5,6 +5,9 @@ defmodule Trento.Support.Helpers.AlertingSettingsHelper do
 
   import ExUnit.Callbacks
 
+  @alerting_settings_get_fields ~w(enabled sender_email recipient_email smtp_server smtp_port smtp_username enforced_from_env)a
+  @alerting_settings_set_fields ~w(enabled sender_email recipient_email smtp_server smtp_port smtp_username smtp_password)a
+
   def clear_alerting_app_env do
     Application.put_env(:trento, :alerting,
       enabled: nil,
@@ -15,6 +18,14 @@ defmodule Trento.Support.Helpers.AlertingSettingsHelper do
       sender_email: nil,
       recipient_email: nil
     )
+  end
+
+  def alerting_settings_get_fields do
+    @alerting_settings_get_fields
+  end
+
+  def alerting_settings_set_fields do
+    @alerting_settings_set_fields
   end
 
   # Setup helpers

--- a/test/support/helpers/alerting_settings_helper.ex
+++ b/test/support/helpers/alerting_settings_helper.ex
@@ -5,7 +5,7 @@ defmodule Trento.Support.Helpers.AlertingSettingsHelper do
 
   import ExUnit.Callbacks
 
-  def nil_alerting_app_env do
+  def clear_alerting_app_env do
     Application.put_env(:trento, :alerting,
       enabled: nil,
       smtp_server: nil,

--- a/test/support/helpers/alerting_settings_helper.ex
+++ b/test/support/helpers/alerting_settings_helper.ex
@@ -1,0 +1,34 @@
+defmodule Trento.Support.Helpers.AlertingSettingsHelper do
+  @moduledoc """
+  Test helper functions for alerting settings.
+  """
+
+  import ExUnit.Callbacks
+
+  def nil_alerting_app_env do
+    Application.put_env(:trento, :alerting,
+      enabled: nil,
+      sender: nil,
+      recipient: nil
+    )
+
+    Application.put_env(:trento, Trento.Mailer,
+      relay: nil,
+      port: nil,
+      username: nil,
+      password: nil
+    )
+  end
+
+  # Setup helpers
+
+  def restore_alerting_app_env(_context) do
+    default_alerting_config = Application.get_env(:trento, :alerting)
+    default_mailer_config = Application.get_env(:trento, Trento.Mailer)
+
+    on_exit(fn ->
+      Application.put_env(:trento, :alerting, default_alerting_config)
+      Application.put_env(:trento, Trento.Mailer, default_mailer_config)
+    end)
+  end
+end

--- a/test/trento/infrastructure/alerting/alerting_test.exs
+++ b/test/trento/infrastructure/alerting/alerting_test.exs
@@ -109,12 +109,14 @@ defmodule Trento.Infrastructure.Alerting.AlertingTest do
     test "should be caught if SMTP server is wrongly set up" do
       relay_ip_address = Faker.Internet.ip_v4_address()
 
-      Application.put_env(:trento, :alerting, enabled: true)
-
-      Application.put_env(:trento, Trento.Mailer,
-        adapter: Swoosh.Adapters.SMTP,
-        relay: "smtp://#{relay_ip_address}"
+      Application.put_env(
+        :trento,
+        :alerting,
+        enabled: true,
+        smtp_server: "smtp://#{relay_ip_address}"
       )
+
+      Application.put_env(:trento, Trento.Mailer, adapter: Swoosh.Adapters.SMTP)
 
       host_id = Faker.UUID.v4()
       insert(:host, id: host_id)

--- a/test/trento/infrastructure/alerting/alerting_test.exs
+++ b/test/trento/infrastructure/alerting/alerting_test.exs
@@ -18,7 +18,7 @@ defmodule Trento.Infrastructure.Alerting.AlertingTest do
 
   describe "When alerting is disabled or not configured" do
     test "no email is sent and error is returned when alerting is not configured" do
-      nil_alerting_app_env()
+      clear_alerting_app_env()
 
       host_id = Faker.UUID.v4()
 

--- a/test/trento/settings_test.exs
+++ b/test/trento/settings_test.exs
@@ -983,7 +983,7 @@ defmodule Trento.SettingsTest do
           {"SMTP server", [smtp_server: "test.com"]},
           {"SMTP port", [smtp_port: "587"]},
           {"SMTP username", [smtp_username: "testuser"]},
-          {"SMPT password", [smtp_password: "testpass}"]},
+          {"SMTP password", [smtp_password: "testpass}"]},
           {"sender email", [sender_email: "sender@trento.com"]},
           {"recipient email", [recipient_email: "recipient@trento.com"]},
           {"enabled and SMTP server", [enabled: true, smtp_server: "testserver.com"]}

--- a/test/trento/settings_test.exs
+++ b/test/trento/settings_test.exs
@@ -805,17 +805,20 @@ defmodule Trento.SettingsTest do
       assert Settings.alerting_settings_enforced_from_env?() == false
     end
 
-    for {key, value, subkey} <- [
+    for {key, _value} = scenario <- [
           {:enabled, false, :alerting},
-          {:sender, "sender@trento.com", :alerting},
-          {:recipient, "recipient@trento.com", :alerting},
-          {:relay, "test.com", Trento.Mailer},
-          {:port, 587, Trento.Mailer},
-          {:username, "testuser", Trento.Mailer},
-          {:password, "testpass}", Trento.Mailer}
+          {:smtp_server, "test.com"},
+          {:smtp_port, "587"},
+          {:smtp_username, "testuser"},
+          {:smtp_password, "testpass}"},
+          {:sender_email, "sender@trento.com"},
+          {:recipient_email, "recipient@trento.com"}
         ] do
+      @scenario scenario
+
       test "returns TRUE if `#{key}` is configured via env" do
-        Application.put_env(:trento, unquote(subkey), [{unquote(key), unquote(value)}])
+        {key, value} = @scenario
+        Application.put_env(:trento, :alerting, [{key, value}])
         assert Settings.alerting_settings_enforced_from_env?() == true
       end
     end

--- a/test/trento_web/controllers/v1/settings_controller_test.exs
+++ b/test/trento_web/controllers/v1/settings_controller_test.exs
@@ -5,6 +5,7 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
   import Trento.Factory
   import OpenApiSpex.TestAssertions
   import Trento.Support.Helpers.AbilitiesTestHelper
+  import Trento.Support.Helpers.AlertingSettingsHelper
   import Mox
 
   setup_all :setup_api_spec_v1
@@ -645,6 +646,8 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
     @alerting_settings_get_fields ~w(enabled sender_email recipient_email smtp_server smtp_port smtp_username enforced_from_env)a
     @alerting_settings_set_fields ~w(enabled sender_email recipient_email smtp_server smtp_port smtp_username smtp_password)a
 
+    setup :restore_alerting_app_env
+
     test "should successfully return settings", %{conn: conn, api_spec: api_spec} do
       exp_settings =
         :alerting_settings
@@ -824,6 +827,40 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
                  %{title: "Not Found", detail: "Alerting settings not configured."}
                ]
              } == resp
+    end
+
+    for {case_name, _} = scenario <- [{"create", "post"}, {"update", "patch"}] do
+      @scenario scenario
+
+      test "should fail when trying to #{case_name} settings when they enforced from env", %{
+        conn: conn,
+        api_spec: api_spec
+      } do
+        {_, http_method} = @scenario
+
+        Application.put_env(:trento, :alerting, enabled: true)
+
+        params =
+          :alerting_settings
+          |> build()
+          |> Map.take(@alerting_settings_set_fields)
+
+        resp =
+          conn
+          |> put_req_header("content-type", "application/json")
+          |> dispatch(@endpoint, http_method, ~p"/api/v1/settings/alerting", params)
+          |> json_response(:conflict)
+          |> assert_response_schema("Conflict", api_spec)
+
+        assert %{
+                 errors: [
+                   %{
+                     title: "Conflict has occurred",
+                     detail: "Alerting settings can not be set, enforced by ENV."
+                   }
+                 ]
+               } == resp
+      end
     end
   end
 

--- a/test/trento_web/controllers/v1/settings_controller_test.exs
+++ b/test/trento_web/controllers/v1/settings_controller_test.exs
@@ -5,6 +5,7 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
   import Trento.Factory
   import OpenApiSpex.TestAssertions
   import Trento.Support.Helpers.AbilitiesTestHelper
+  import Trento.Support.Helpers.AlertingSettingsHelper
   import Mox
 
   setup_all :setup_api_spec_v1
@@ -642,14 +643,11 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
   end
 
   describe "AlertingSettings" do
-    @alerting_settings_get_fields ~w(enabled sender_email recipient_email smtp_server smtp_port smtp_username enforced_from_env)a
-    @alerting_settings_set_fields ~w(enabled sender_email recipient_email smtp_server smtp_port smtp_username smtp_password)a
-
     test "should successfully return settings", %{conn: conn, api_spec: api_spec} do
       exp_settings =
         :alerting_settings
         |> insert()
-        |> Map.take(@alerting_settings_get_fields)
+        |> Map.take(alerting_settings_get_fields())
 
       resp =
         conn
@@ -679,8 +677,8 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
       api_spec: api_spec
     } do
       settings = build(:alerting_settings)
-      create_params = Map.take(settings, @alerting_settings_set_fields)
-      exp_params = Map.take(settings, @alerting_settings_get_fields)
+      create_params = Map.take(settings, alerting_settings_set_fields())
+      exp_params = Map.take(settings, alerting_settings_get_fields())
 
       resp =
         conn
@@ -704,7 +702,7 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
         settings =
           :alerting_settings
           |> build()
-          |> Map.take(@alerting_settings_set_fields)
+          |> Map.take(alerting_settings_set_fields())
           |> Map.delete(@field)
 
         conn =
@@ -736,7 +734,7 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
       settings =
         :alerting_settings
         |> build(sender_email: "not_an_email.com")
-        |> Map.take(@alerting_settings_set_fields)
+        |> Map.take(alerting_settings_set_fields())
 
       conn =
         conn
@@ -766,7 +764,7 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
 
       exp_params =
         inserted_settings
-        |> Map.take(@alerting_settings_get_fields)
+        |> Map.take(alerting_settings_get_fields())
         |> Map.merge(update_params)
 
       resp =
@@ -922,7 +920,7 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
       settings =
         :alerting_settings
         |> build()
-        |> Map.take(@alerting_settings_set_fields)
+        |> Map.take(alerting_settings_set_fields())
 
       conn
       |> put_req_header("content-type", "application/json")
@@ -939,7 +937,7 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
       settings =
         :alerting_settings
         |> build()
-        |> Map.take(@alerting_settings_set_fields)
+        |> Map.take(alerting_settings_set_fields())
         |> Map.delete(:smtp_password)
 
       conn
@@ -967,8 +965,6 @@ defmodule TrentoWeb.V1.SettingsControllerSequentialTest do
   setup :setup_user
 
   describe "Alerting Settings" do
-    @alerting_settings_set_fields ~w(enabled sender_email recipient_email smtp_server smtp_port smtp_username smtp_password)a
-
     setup :restore_alerting_app_env
 
     for {case_name, _} = scenario <- [{"create", "post"}, {"update", "patch"}] do
@@ -985,7 +981,7 @@ defmodule TrentoWeb.V1.SettingsControllerSequentialTest do
         params =
           :alerting_settings
           |> build()
-          |> Map.take(@alerting_settings_set_fields)
+          |> Map.take(alerting_settings_set_fields())
 
         resp =
           conn

--- a/test/trento_web/views/error_view_json_test.exs
+++ b/test/trento_web/views/error_view_json_test.exs
@@ -58,6 +58,17 @@ defmodule TrentoWeb.ErrorJSONTest do
            } == ErrorJSON.render("422.json", %{reason: "Invalid values."})
   end
 
+  test "should render a 409 error" do
+    assert %{
+             errors: [
+               %{
+                 title: "Conflict has occurred",
+                 detail: "Generic conflicting state"
+               }
+             ]
+           } == ErrorJSON.render("409.json", %{reason: "Generic conflicting state"})
+  end
+
   test "should render a 422 error (validation error)" do
     {:error, validation_error} = TestData.new(%{embedded: %{id: "invalid", name: 0}})
 

--- a/test/trento_web/views/v1/settings_view_json_test.exs
+++ b/test/trento_web/views/v1/settings_view_json_test.exs
@@ -22,7 +22,7 @@ defmodule TrentoWeb.V1.SettingsJSONTest do
   end
 
   describe "Alerting Settings template/view" do
-    @alerting_allowed_fields ~w(enabled sender_email recipient_email smtp_server smtp_port smtp_username)a
+    @alerting_allowed_fields ~w(enabled sender_email recipient_email smtp_server smtp_port smtp_username enforced_from_env)a
 
     test "filters only correct fields" do
       settings = build(:alerting_settings)


### PR DESCRIPTION
# Description

THIS IS DEPENDENT ON https://github.com/trento-project/web/pull/3462

This PR introduces changes on how alerting configuration is made and how this configuration is later accessed. 

Up  until now, configuration of the alerting and mailer settings were only supplied by a combination of compile-time (per-build target) parameters and runtime-supplied environment variables. Now, it's possible to get, set and partially update the these settings over the a web API. The alerting infrastructure is updated to get the settings from a centralized AlertingSettings model/module and configure the mail templates, as well as mailer configuration with these settings (as opposed to directly getting them from the Application environment). To keep backwards-compatibility and to support "declarative configuration" the possibility to configure via Application environment (env-vars) is preserved, but the following precedence scheme is implemented:

1. If _any_ of the following env-vars is set, their values take precedence: `ENABLE_ALERTING`, `ALERTING_SENDER`, `ALERTING_RECIPIENT`, `SMTP_SERVER`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`. If user didn't specify some of the env-vars, trento provides default values.

2. If all of the previously specified env-vars are not set, then configuration will be made with settings get from the DB. These settings can be changed (idempotent set or partially updated) on demand via a web API. In a next PR, a web-ui will be provided.

Note: Settings returned by the GET API call would always return the values that are currently in effect (if any). Changes to the settings requested over the API would be accepted only when no env-var configuration is in place.

Adds fixes towards [TRNT-2711](https://jira.suse.com/browse/TRNT-2711)

## How was this tested?

Modified unit tests that depend on the newly added model fields `enforced_from_env`. 
Split test for alerting settings coming from the DB from the ones that check alerting configuration from the app env.

## Did you update the documentation?

Will be updated with another PR.
