### PR TITLE
Recreate and not remove checks container in PR env ci

### DIFF
--- a/.github/workflows/pr_env.yaml
+++ b/.github/workflows/pr_env.yaml
@@ -127,6 +127,7 @@ jobs:
             nginx_vhost_listen_port='443' \
             force_recreate_wanda_container='true' \
             force_recreate_web_container='true' \
+            force_recreate_checks_container='true' \
             force_pull_images='true' \
             web_upstream_name='${{ env.PR_NUMBER }}web' \
             wanda_upstream_name='${{ env.PR_NUMBER }}wanda' \

--- a/.github/workflows/pr_env_close.yaml
+++ b/.github/workflows/pr_env_close.yaml
@@ -130,4 +130,5 @@ jobs:
             rabbitmq_password='trento' \
             rabbitmq_username='${{ env.PR_NUMBER }}rabbitusr' \
             remove_wanda_container_image='false' \
+            remove_checks_container_image='false' \
             install_method='docker'"


### PR DESCRIPTION
# Description

Recreate checks container in every update and keep it in cleanup. Other PR environments depends on it.
Otherwise we can get errors like this one: https://github.com/trento-project/web/actions/runs/14493729333/attempts/1
