### PR TITLE
Checks customization e2e

### DIFF
--- a/test/e2e/cypress.config.js
+++ b/test/e2e/cypress.config.js
@@ -25,5 +25,6 @@ module.exports = defineConfig({
     },
     testIsolation: false,
     baseUrl: 'http://localhost:4000',
+    wandaUrl: 'http://localhost:4001',
   },
 });

--- a/test/e2e/cypress/e2e/checks_customization.cy.js
+++ b/test/e2e/cypress/e2e/checks_customization.cy.js
@@ -17,11 +17,10 @@ context('Checks customization', () => {
     beforeEach(() => {
       checksSelectionPage.visitChecksSelectionCluster();
       checksSelectionPage.clickOnCheckSelectionButton();
+      checksSelectionPage.corosyncCategoryClick();
     });
 
     it('should customize and reset a check through the modal successfully', () => {
-      // Open checks category
-      checksSelectionPage.corosyncCategoryClick();
       checksSelectionPage.openCustomizationModalFirstCheck();
       // Validate if initial check customization modal has the correct values
       checksSelectionPage.validateFirstCheckId();
@@ -33,12 +32,10 @@ context('Checks customization', () => {
       checksSelectionPage.validateProviderLabel();
       checksSelectionPage.validateProviderValue();
       checksSelectionPage.providerIconShouldBeDisplayed();
-
       // Check default button status of an non customized check
       checksSelectionPage.modalSaveButtonShouldBeDisabled();
       checksSelectionPage.modalResetCheckButtonShouldBeDisabled();
       checksSelectionPage.modalCloseButtonShouldBeEnabled();
-
       // User interacts with modal
       checksSelectionPage.userClickOnWarningCheckbox();
       checksSelectionPage.modalWarningCheckBoxShouldBeChecked();
@@ -46,8 +43,7 @@ context('Checks customization', () => {
       checksSelectionPage.modalSaveButtonShouldBeEnabled();
       checksSelectionPage.userClickModalSaveButton();
       checksSelectionPage.checkCustomizationSuccessToastIsShown();
-
-      // Validate check was modified
+      // Validate if check was customized
       checksSelectionPage.customizedCheckShouldHaveModifiedPill();
       checksSelectionPage.openCustomizationModalFirstCheck();
       checksSelectionPage.validateCustomizedValue();
@@ -64,8 +60,6 @@ context('Checks customization', () => {
     });
 
     it('should customize check values in the check customization modal and reset check in checks category overview', () => {
-      // Open checks category
-      checksSelectionPage.corosyncCategoryClick();
       checksSelectionPage.openCustomizationModalFirstCheck();
       // User interacts with modal
       checksSelectionPage.userClickOnWarningCheckbox();
@@ -82,8 +76,6 @@ context('Checks customization', () => {
     });
 
     it('should customize check values after fixing wrong user input', () => {
-      // Open checks category
-      checksSelectionPage.corosyncCategoryClick();
       checksSelectionPage.openCustomizationModalSecondCheck();
       // User interact with modal
       checksSelectionPage.validateSecondCheckId();
@@ -106,8 +98,6 @@ context('Checks customization', () => {
     });
 
     it('should not customize check values if the user input is invalid', () => {
-      // Open checks category
-      checksSelectionPage.corosyncCategoryClick();
       checksSelectionPage.openCustomizationModalSecondCheck();
       // User interact with modal
       checksSelectionPage.userClickOnWarningCheckbox();

--- a/test/e2e/cypress/e2e/checks_customization.cy.js
+++ b/test/e2e/cypress/e2e/checks_customization.cy.js
@@ -1,0 +1,135 @@
+import * as checksSelectionPage from '../pageObject/checks_customization_po';
+
+context('Checks customization', () => {
+  before(() => {
+    checksSelectionPage.preloadTestData();
+  });
+
+  beforeEach(() => {
+    checksSelectionPage.resetAllChecks();
+    checksSelectionPage.interceptCatalogRequest();
+    checksSelectionPage.interceptLastExecutionRequest();
+  });
+
+  after(() => {
+    checksSelectionPage.resetAllChecks();
+  });
+
+  describe('Checks customization should be possible for a cluster target', () => {
+    beforeEach(() => {
+      checksSelectionPage.visitChecksSelectionCluster();
+      checksSelectionPage.clickOnCheckSelectionButton();
+    });
+
+    it('should customize and reset a check successfully', () => {
+      // User opens check customization for Corosync Checks
+      checksSelectionPage.corosyncCategoryClick();
+      checksSelectionPage.openCustomizationModalFirstCheck();
+
+      // validate if inital check customization modal has the correct values
+      checksSelectionPage.validateFirstCheckId();
+      checksSelectionPage.validateFirstCheckDescription();
+      checksSelectionPage.modalWarningCheckBoxShouldNotBeChecked();
+      checksSelectionPage.validateWarningMessage();
+      checksSelectionPage.validateFirstCheckValueNameAndDefaultValue();
+      checksSelectionPage.validateCurrentValueFromWandaFirstCheck();
+      checksSelectionPage.validateProvider();
+      checksSelectionPage.providerIconShouldBeDisplayed();
+
+      // Check default button status of an non customized check
+      checksSelectionPage.modalSaveButtonShouldBeDisabled();
+      checksSelectionPage.modalResetCheckButtonShouldBeDisabled();
+      checksSelectionPage.modalCloseButtonShouldBeEnabled();
+
+      // User interacts with modal
+      checksSelectionPage.userClickOnWarningCheckbox();
+      checksSelectionPage.modalWarningCheckBoxShouldBeChecked();
+      checksSelectionPage.userInputCustomCheckValue();
+      checksSelectionPage.modalSaveButtonShouldBeEnabled();
+      checksSelectionPage.userClickModalSaveButton();
+      checksSelectionPage.checkCustomizationToastIsShown();
+      // check customization modal should close
+
+      // Validate check was modified
+      checksSelectionPage.customizedCheckShouldHaveModifiedPill();
+      checksSelectionPage.openCustomizationModalFirstCheckAfterCustomization();
+      checksSelectionPage.validateCustomizedValue();
+      // Reset check in the modal
+      checksSelectionPage.userClickResetModalButton();
+      checksSelectionPage.userClickResetButton();
+      // Validate if check was reset in overview
+      checksSelectionPage.checkCustomizationResetToastIsShown();
+      checksSelectionPage.customizedCheckShouldNotHaveModifiedPill();
+      checksSelectionPage.resetIconShouldNotExistInOverview();
+      // Great check was customized and reseted correctly
+    });
+
+    it('should customize check values in the check customization modal and reset check in checks category overview', () => {
+      // open checks category
+      checksSelectionPage.corosyncCategoryClick();
+      checksSelectionPage.openCustomizationModalFirstCheck();
+      // user interacts with modal
+      checksSelectionPage.userClickOnWarningCheckbox();
+      checksSelectionPage.userInputCustomCheckValue();
+      checksSelectionPage.userClickModalSaveButton();
+      // user resets check in overview
+      checksSelectionPage.userResetCustomizedCheck();
+      checksSelectionPage.userClickResetButton();
+      // validate if check was reset
+      checksSelectionPage.checkCustomizationResetToastIsShown();
+      checksSelectionPage.customizedCheckShouldNotHaveModifiedPill();
+      checksSelectionPage.resetIconShouldNotExistInOverview();
+    });
+
+    it('should customize check values after fixing wrong user input', () => {
+      // User opens check customization for Corosync Checks
+      checksSelectionPage.corosyncCategoryClick();
+      checksSelectionPage.openCustomizationModalSecondCheck();
+
+      // User interact with modal
+      checksSelectionPage.userClickOnWarningCheckbox();
+      checksSelectionPage.modalWarningCheckBoxShouldBeChecked();
+      checksSelectionPage.userInputInvalidCheckValue();
+      checksSelectionPage.modalSaveButtonShouldBeEnabled();
+      checksSelectionPage.userClickModalSaveButton();
+
+      // check that the modal is still open
+      checksSelectionPage.userInputValidationErrorShouldBeDisplayed();
+      checksSelectionPage.checkCustomizationErrorToastIsShown();
+      checksSelectionPage.modalSaveButtonShouldBeEnabled();
+      checksSelectionPage.modalResetCheckButtonShouldBeDisabled();
+      checksSelectionPage.modalCloseButtonShouldBeEnabled();
+
+      checksSelectionPage.userInputCustomCheckValue();
+      checksSelectionPage.modalSaveButtonShouldBeEnabled();
+      checksSelectionPage.userClickModalSaveButton();
+      checksSelectionPage.checkCustomizationToastIsShown();
+      checksSelectionPage.customizedCheckShouldHaveModifiedPill();
+    });
+
+    it('should not customize check values if the user input is invalid', () => {
+      // User opens check customization for Corosync Checks
+      checksSelectionPage.corosyncCategoryClick();
+      checksSelectionPage.openCustomizationModalSecondCheck();
+
+      // User interact with modal
+      checksSelectionPage.userClickOnWarningCheckbox();
+      checksSelectionPage.modalWarningCheckBoxShouldBeChecked();
+      checksSelectionPage.userInputInvalidCheckValue();
+      checksSelectionPage.modalSaveButtonShouldBeEnabled();
+      checksSelectionPage.userClickModalSaveButton();
+      // Check if input was validated
+      checksSelectionPage.userInputValidationErrorShouldBeDisplayed();
+      checksSelectionPage.checkCustomizationErrorToastIsShown();
+      checksSelectionPage.modalSaveButtonShouldBeDisabled();
+      checksSelectionPage.modalResetCheckButtonShouldBeDisabled();
+
+      // User closes modal
+      checksSelectionPage.userClickCloseButton();
+
+      // Check that the overview does not show any modified elements
+      checksSelectionPage.secondCustomizedCheckShouldNotHaveModifiedPill();
+      checksSelectionPage.resetIconShouldNotExistInOverview();
+    });
+  });
+});

--- a/test/e2e/cypress/e2e/checks_customization.cy.js
+++ b/test/e2e/cypress/e2e/checks_customization.cy.js
@@ -7,8 +7,6 @@ context('Checks customization', () => {
 
   beforeEach(() => {
     checksSelectionPage.resetAllChecks();
-    checksSelectionPage.interceptCatalogRequest();
-    checksSelectionPage.interceptLastExecutionRequest();
   });
 
   after(() => {
@@ -21,8 +19,8 @@ context('Checks customization', () => {
       checksSelectionPage.clickOnCheckSelectionButton();
     });
 
-    it('should customize and reset a check successfully', () => {
-      // User opens check customization for Corosync Checks
+    it('should customize and reset a check through the modal successfully', () => {
+      // User opens check customization for corosync checks
       checksSelectionPage.corosyncCategoryClick();
       checksSelectionPage.openCustomizationModalFirstCheck();
 
@@ -47,8 +45,7 @@ context('Checks customization', () => {
       checksSelectionPage.userInputCustomCheckValue();
       checksSelectionPage.modalSaveButtonShouldBeEnabled();
       checksSelectionPage.userClickModalSaveButton();
-      checksSelectionPage.checkCustomizationToastIsShown();
-      // check customization modal should close
+      checksSelectionPage.checkCustomizationSuccessToastIsShown();
 
       // Validate check was modified
       checksSelectionPage.customizedCheckShouldHaveModifiedPill();
@@ -56,6 +53,7 @@ context('Checks customization', () => {
       checksSelectionPage.validateCustomizedValue();
       // Reset check in the modal
       checksSelectionPage.userClickResetModalButton();
+      checksSelectionPage.validateResetWarningText();
       checksSelectionPage.userClickResetButton();
       // Validate if check was reset in overview
       checksSelectionPage.checkCustomizationResetToastIsShown();
@@ -72,8 +70,9 @@ context('Checks customization', () => {
       checksSelectionPage.userClickOnWarningCheckbox();
       checksSelectionPage.userInputCustomCheckValue();
       checksSelectionPage.userClickModalSaveButton();
+      checksSelectionPage.checkCustomizationSuccessToastIsShown();
       // user resets check in overview
-      checksSelectionPage.userResetCustomizedCheck();
+      checksSelectionPage.userClickResetCustomizedCheck();
       checksSelectionPage.userClickResetButton();
       // validate if check was reset
       checksSelectionPage.checkCustomizationResetToastIsShown();
@@ -87,23 +86,22 @@ context('Checks customization', () => {
       checksSelectionPage.openCustomizationModalSecondCheck();
 
       // User interact with modal
+      checksSelectionPage.validateSecondCheckId();
       checksSelectionPage.userClickOnWarningCheckbox();
       checksSelectionPage.modalWarningCheckBoxShouldBeChecked();
       checksSelectionPage.userInputInvalidCheckValue();
       checksSelectionPage.modalSaveButtonShouldBeEnabled();
       checksSelectionPage.userClickModalSaveButton();
-
-      // check that the modal is still open
       checksSelectionPage.userInputValidationErrorShouldBeDisplayed();
       checksSelectionPage.checkCustomizationErrorToastIsShown();
-      checksSelectionPage.modalSaveButtonShouldBeEnabled();
+      checksSelectionPage.modalSaveButtonShouldBeDisabled();
       checksSelectionPage.modalResetCheckButtonShouldBeDisabled();
       checksSelectionPage.modalCloseButtonShouldBeEnabled();
 
       checksSelectionPage.userInputCustomCheckValue();
       checksSelectionPage.modalSaveButtonShouldBeEnabled();
       checksSelectionPage.userClickModalSaveButton();
-      checksSelectionPage.checkCustomizationToastIsShown();
+      checksSelectionPage.checkCustomizationSuccessToastIsShown();
       checksSelectionPage.customizedCheckShouldHaveModifiedPill();
     });
 
@@ -118,15 +116,12 @@ context('Checks customization', () => {
       checksSelectionPage.userInputInvalidCheckValue();
       checksSelectionPage.modalSaveButtonShouldBeEnabled();
       checksSelectionPage.userClickModalSaveButton();
-      // Check if input was validated
       checksSelectionPage.userInputValidationErrorShouldBeDisplayed();
       checksSelectionPage.checkCustomizationErrorToastIsShown();
       checksSelectionPage.modalSaveButtonShouldBeDisabled();
       checksSelectionPage.modalResetCheckButtonShouldBeDisabled();
-
       // User closes modal
       checksSelectionPage.userClickCloseButton();
-
       // Check that the overview does not show any modified elements
       checksSelectionPage.secondCustomizedCheckShouldNotHaveModifiedPill();
       checksSelectionPage.resetIconShouldNotExistInOverview();

--- a/test/e2e/cypress/e2e/checks_customization.cy.js
+++ b/test/e2e/cypress/e2e/checks_customization.cy.js
@@ -24,7 +24,7 @@ context('Checks customization', () => {
       checksSelectionPage.corosyncCategoryClick();
       checksSelectionPage.openCustomizationModalFirstCheck();
 
-      // validate if inital check customization modal has the correct values
+      // validate if initial check customization modal has the correct values
       checksSelectionPage.validateFirstCheckId();
       checksSelectionPage.validateFirstCheckDescription();
       checksSelectionPage.modalWarningCheckBoxShouldNotBeChecked();
@@ -59,7 +59,7 @@ context('Checks customization', () => {
       checksSelectionPage.checkCustomizationResetToastIsShown();
       checksSelectionPage.customizedCheckShouldNotHaveModifiedPill();
       checksSelectionPage.resetIconShouldNotExistInOverview();
-      // Great check was customized and reseted correctly
+      // Great check was customized and reset correctly
     });
 
     it('should customize check values in the check customization modal and reset check in checks category overview', () => {

--- a/test/e2e/cypress/e2e/checks_customization.cy.js
+++ b/test/e2e/cypress/e2e/checks_customization.cy.js
@@ -17,7 +17,7 @@ context('Checks customization', () => {
     beforeEach(() => {
       checksSelectionPage.visitChecksSelectionCluster();
       checksSelectionPage.clickOnCheckSelectionButton();
-      checksSelectionPage.corosyncCategoryClick();
+      checksSelectionPage.clickCorosyncCategory();
     });
 
     it('should customize and reset a check through the modal successfully', () => {
@@ -37,38 +37,37 @@ context('Checks customization', () => {
       checksSelectionPage.modalResetCheckButtonShouldBeDisabled();
       checksSelectionPage.modalCloseButtonShouldBeEnabled();
       // User interacts with modal
-      checksSelectionPage.userClickOnWarningCheckbox();
+      checksSelectionPage.clickOnWarningCheckbox();
       checksSelectionPage.modalWarningCheckBoxShouldBeChecked();
-      checksSelectionPage.userInputCustomCheckValue();
+      checksSelectionPage.inputCustomCheckValue();
       checksSelectionPage.modalSaveButtonShouldBeEnabled();
-      checksSelectionPage.userClickModalSaveButton();
+      checksSelectionPage.clickModalSaveButton();
       checksSelectionPage.checkCustomizationSuccessToastIsShown();
       // Validate if check was customized
       checksSelectionPage.customizedCheckShouldHaveModifiedPill();
       checksSelectionPage.openCustomizationModalFirstCheck();
       checksSelectionPage.validateCustomizedValue();
       // Reset check in the modal
-      checksSelectionPage.userClickResetCheckModalButton();
+      checksSelectionPage.clickResetCheckModalButton();
       checksSelectionPage.validateResetModalTitle();
       checksSelectionPage.validateResetModalWarningText();
-      checksSelectionPage.userClickResetModalButton();
+      checksSelectionPage.clickResetModalButton();
       // Validate if check was reset in overview
       checksSelectionPage.checkCustomizationResetToastIsShown();
       checksSelectionPage.customizedCheckShouldNotHaveModifiedPill();
       checksSelectionPage.resetIconShouldNotExistInOverview();
-      // Great check was customized and reset correctly
     });
 
     it('should customize check values in the check customization modal and reset check in checks category overview', () => {
       checksSelectionPage.openCustomizationModalFirstCheck();
       // User interacts with modal
-      checksSelectionPage.userClickOnWarningCheckbox();
-      checksSelectionPage.userInputCustomCheckValue();
-      checksSelectionPage.userClickModalSaveButton();
+      checksSelectionPage.clickOnWarningCheckbox();
+      checksSelectionPage.inputCustomCheckValue();
+      checksSelectionPage.clickModalSaveButton();
       checksSelectionPage.checkCustomizationSuccessToastIsShown();
       // User resets check in overview
-      checksSelectionPage.userClickResetCustomizedCheck();
-      checksSelectionPage.userClickResetButton();
+      checksSelectionPage.clickResetCustomizedCheck();
+      checksSelectionPage.clickResetButton();
       // Validate if check was reset
       checksSelectionPage.checkCustomizationResetToastIsShown();
       checksSelectionPage.customizedCheckShouldNotHaveModifiedPill();
@@ -79,19 +78,19 @@ context('Checks customization', () => {
       checksSelectionPage.openCustomizationModalSecondCheck();
       // User interact with modal
       checksSelectionPage.validateSecondCheckId();
-      checksSelectionPage.userClickOnWarningCheckbox();
+      checksSelectionPage.clickOnWarningCheckbox();
       checksSelectionPage.modalWarningCheckBoxShouldBeChecked();
-      checksSelectionPage.userInputInvalidCheckValue();
+      checksSelectionPage.inputInvalidCheckValue();
       checksSelectionPage.modalSaveButtonShouldBeEnabled();
-      checksSelectionPage.userClickModalSaveButton();
-      checksSelectionPage.userInputValidationErrorShouldBeDisplayed();
+      checksSelectionPage.clickModalSaveButton();
+      checksSelectionPage.inputValidationErrorShouldBeDisplayed();
       checksSelectionPage.checkCustomizationErrorToastIsShown();
       checksSelectionPage.modalSaveButtonShouldBeDisabled();
       checksSelectionPage.modalResetCheckButtonShouldBeDisabled();
       checksSelectionPage.modalCloseButtonShouldBeEnabled();
-      checksSelectionPage.userInputCustomCheckValue();
+      checksSelectionPage.inputCustomCheckValue();
       checksSelectionPage.modalSaveButtonShouldBeEnabled();
-      checksSelectionPage.userClickModalSaveButton();
+      checksSelectionPage.clickModalSaveButton();
       // Validate overview
       checksSelectionPage.checkCustomizationSuccessToastIsShown();
       checksSelectionPage.customizedCheckShouldHaveModifiedPill();
@@ -100,17 +99,17 @@ context('Checks customization', () => {
     it('should not customize check values if the user input is invalid', () => {
       checksSelectionPage.openCustomizationModalSecondCheck();
       // User interact with modal
-      checksSelectionPage.userClickOnWarningCheckbox();
+      checksSelectionPage.clickOnWarningCheckbox();
       checksSelectionPage.modalWarningCheckBoxShouldBeChecked();
-      checksSelectionPage.userInputInvalidCheckValue();
+      checksSelectionPage.inputInvalidCheckValue();
       checksSelectionPage.modalSaveButtonShouldBeEnabled();
-      checksSelectionPage.userClickModalSaveButton();
-      checksSelectionPage.userInputValidationErrorShouldBeDisplayed();
+      checksSelectionPage.clickModalSaveButton();
+      checksSelectionPage.inputValidationErrorShouldBeDisplayed();
       checksSelectionPage.checkCustomizationErrorToastIsShown();
       checksSelectionPage.modalSaveButtonShouldBeDisabled();
       checksSelectionPage.modalResetCheckButtonShouldBeDisabled();
       // User closes modal
-      checksSelectionPage.userClickCloseButton();
+      checksSelectionPage.clickCloseButton();
       // Check that the overview does not show any modified elements
       checksSelectionPage.secondCustomizedCheckShouldNotHaveModifiedPill();
       checksSelectionPage.resetIconShouldNotExistInOverview();

--- a/test/e2e/cypress/e2e/checks_customization.cy.js
+++ b/test/e2e/cypress/e2e/checks_customization.cy.js
@@ -6,11 +6,11 @@ context('Checks customization', () => {
   });
 
   beforeEach(() => {
-    checksSelectionPage.resetAllChecks();
+    checksSelectionPage.apiResetAllChecks();
   });
 
   after(() => {
-    checksSelectionPage.resetAllChecks();
+    checksSelectionPage.apiResetAllChecks();
   });
 
   describe('Checks customization should be possible for a cluster target', () => {

--- a/test/e2e/cypress/e2e/checks_customization.cy.js
+++ b/test/e2e/cypress/e2e/checks_customization.cy.js
@@ -20,18 +20,18 @@ context('Checks customization', () => {
     });
 
     it('should customize and reset a check through the modal successfully', () => {
-      // User opens check customization for corosync checks
+      // Open checks category
       checksSelectionPage.corosyncCategoryClick();
       checksSelectionPage.openCustomizationModalFirstCheck();
-
-      // validate if initial check customization modal has the correct values
+      // Validate if initial check customization modal has the correct values
       checksSelectionPage.validateFirstCheckId();
       checksSelectionPage.validateFirstCheckDescription();
       checksSelectionPage.modalWarningCheckBoxShouldNotBeChecked();
       checksSelectionPage.validateWarningMessage();
       checksSelectionPage.validateFirstCheckValueNameAndDefaultValue();
       checksSelectionPage.validateCurrentValueFromWandaFirstCheck();
-      checksSelectionPage.validateProvider();
+      checksSelectionPage.validateProviderLabel();
+      checksSelectionPage.validateProviderValue();
       checksSelectionPage.providerIconShouldBeDisplayed();
 
       // Check default button status of an non customized check
@@ -49,12 +49,13 @@ context('Checks customization', () => {
 
       // Validate check was modified
       checksSelectionPage.customizedCheckShouldHaveModifiedPill();
-      checksSelectionPage.openCustomizationModalFirstCheckAfterCustomization();
+      checksSelectionPage.openCustomizationModalFirstCheck();
       checksSelectionPage.validateCustomizedValue();
       // Reset check in the modal
+      checksSelectionPage.userClickResetCheckModalButton();
+      checksSelectionPage.validateResetModalTitle();
+      checksSelectionPage.validateResetModalWarningText();
       checksSelectionPage.userClickResetModalButton();
-      checksSelectionPage.validateResetWarningText();
-      checksSelectionPage.userClickResetButton();
       // Validate if check was reset in overview
       checksSelectionPage.checkCustomizationResetToastIsShown();
       checksSelectionPage.customizedCheckShouldNotHaveModifiedPill();
@@ -63,28 +64,27 @@ context('Checks customization', () => {
     });
 
     it('should customize check values in the check customization modal and reset check in checks category overview', () => {
-      // open checks category
+      // Open checks category
       checksSelectionPage.corosyncCategoryClick();
       checksSelectionPage.openCustomizationModalFirstCheck();
-      // user interacts with modal
+      // User interacts with modal
       checksSelectionPage.userClickOnWarningCheckbox();
       checksSelectionPage.userInputCustomCheckValue();
       checksSelectionPage.userClickModalSaveButton();
       checksSelectionPage.checkCustomizationSuccessToastIsShown();
-      // user resets check in overview
+      // User resets check in overview
       checksSelectionPage.userClickResetCustomizedCheck();
       checksSelectionPage.userClickResetButton();
-      // validate if check was reset
+      // Validate if check was reset
       checksSelectionPage.checkCustomizationResetToastIsShown();
       checksSelectionPage.customizedCheckShouldNotHaveModifiedPill();
       checksSelectionPage.resetIconShouldNotExistInOverview();
     });
 
     it('should customize check values after fixing wrong user input', () => {
-      // User opens check customization for Corosync Checks
+      // Open checks category
       checksSelectionPage.corosyncCategoryClick();
       checksSelectionPage.openCustomizationModalSecondCheck();
-
       // User interact with modal
       checksSelectionPage.validateSecondCheckId();
       checksSelectionPage.userClickOnWarningCheckbox();
@@ -97,19 +97,18 @@ context('Checks customization', () => {
       checksSelectionPage.modalSaveButtonShouldBeDisabled();
       checksSelectionPage.modalResetCheckButtonShouldBeDisabled();
       checksSelectionPage.modalCloseButtonShouldBeEnabled();
-
       checksSelectionPage.userInputCustomCheckValue();
       checksSelectionPage.modalSaveButtonShouldBeEnabled();
       checksSelectionPage.userClickModalSaveButton();
+      // Validate overview
       checksSelectionPage.checkCustomizationSuccessToastIsShown();
       checksSelectionPage.customizedCheckShouldHaveModifiedPill();
     });
 
     it('should not customize check values if the user input is invalid', () => {
-      // User opens check customization for Corosync Checks
+      // Open checks category
       checksSelectionPage.corosyncCategoryClick();
       checksSelectionPage.openCustomizationModalSecondCheck();
-
       // User interact with modal
       checksSelectionPage.userClickOnWarningCheckbox();
       checksSelectionPage.modalWarningCheckBoxShouldBeChecked();

--- a/test/e2e/cypress/pageObject/checks_customization_po.js
+++ b/test/e2e/cypress/pageObject/checks_customization_po.js
@@ -65,10 +65,9 @@ const resetCustomizedCheckIcon =
   'a[class*="block"] button[aria-label="reset-check-customization"] svg';
 const modifiedPill = `a[class*="block"] span:contains("${modifiedPillLabel}")`;
 const modalDescrition = 'div[class="mt-2"] p';
-const modalWarningText = 'div[class="mt-2"] span';
+const modalSpan = 'div[class="mt-2"] span';
 const modalInput = 'div[class="mt-2"] input';
 const modalValueDefault = 'div[class="mt-2"] label';
-const modalInputValue = 'div[class="mt-2"] span';
 const modalProviderSvg = 'div[class="mt-2"] span img';
 const resetModalTitle = 'div[class*="space-y-4"] h2';
 const resetModalWarning = 'div[class="mt-2"] div[class*="text-gray"]';
@@ -131,7 +130,7 @@ export const modalWarningCheckBoxShouldNotBeChecked = () =>
 export const modalWarningCheckBoxShouldBeChecked = () =>
   cy.get(modalInput).eq(0).should('be.checked');
 export const validateWarningMessage = () =>
-  cy.get(modalWarningText).should('contain', modalWarningCheckboxLabel);
+  cy.get(modalSpan).should('contain', modalWarningCheckboxLabel);
 const validateValueNameAndDefaultValue = (valueName, defaultValue) => {
   cy.get(modalValueDefault)
     .should('contain', valueName)
@@ -155,7 +154,7 @@ export const validateCustomizedValue = () => {
 export const validateProviderLabel = () =>
   cy.get(modalValueDefault).eq(1).should('contain', modalProviderLabel);
 export const validateProviderValue = () =>
-  cy.get(modalInputValue).eq(1).should('contain', modalProviderValue);
+  cy.get(modalSpan).eq(1).should('contain', modalProviderValue);
 export const providerIconShouldBeDisplayed = () => {
   cy.get(modalProviderSvg)
     .should('be.visible')

--- a/test/e2e/cypress/pageObject/checks_customization_po.js
+++ b/test/e2e/cypress/pageObject/checks_customization_po.js
@@ -58,15 +58,14 @@ const customMixedValue = '30000a';
 //Checks overview
 const checksCategorySwitch = '.tn-check-switch';
 const corosyncLabel = 'Corosync';
-const checkCustomModalSettingsIconFirstCheck =
-  ':nth-child(1) > .block > .px-4 > .mt-2 > .flex > .inline > [data-testid="eos-svg-component"] > path';
+const checkCustomModalSettingsIconFirstCheck ='a[class*="block"]:contains("Corosync is running with max_messages") svg'
+
 const checkCustomModalSettingsIconFirstCheckAfterCustomization =
-  ':nth-child(1) > .block > .px-4 > .mt-2 > .flex > .mr-4 > [data-testid="eos-svg-component"]';
-const checkCustomModalSettingsIconSecondCheck =
-  ':nth-child(2) > .block > .px-4 > .mt-2 > .flex > .mr-4 > [data-testid="eos-svg-component"]';
-const resetCustomizedCheckIcon = '.mr-2 > [data-testid="eos-svg-component"]';
+  'a[class*="block"] button[aria-label="customize-check"] svg';
+const checkCustomModalSettingsIconSecondCheck ='a[class*="block"] button[aria-label="customize-check"] svg';
+const resetCustomizedCheckIcon =   'a[class*="block"] button[aria-label="reset-check-customization"] svg';
 const modifiedPillLabel = 'MODIFIED';
-const modifiedPill = '.block > .px-4 > :nth-child(1) > .bg-white';
+const modifiedPill=`a[class*="block"] span:contains("${modifiedPillLabel}")`
 
 // Modal elements and values
 const modalDescrition = '.mt-2 > .text-gray-500';
@@ -74,10 +73,10 @@ const modalWarningText = '.border-yellow-400 > .font-semibold';
 const modalWarningCheckbox = '.border-yellow-400 > div > .rc-input';
 const modalValueDefault = '.flex-col > .font-bold';
 const modalValueCurrentValue = '.space-x-4 > div.w-full > .rc-input';
-const modalProvider = ':nth-child(4) > .w-1\\/3';
 const modalProviderLabel = 'Provider';
-const modalProviderInput = 'div.relative > div.w-full > .rc-input';
+const modalProvider = `div[class="mt-2"] label[class="font-bold"]:contains("${modalProviderLabel}")`;
 const modalProviderValue = 'Azure';
+const modalProviderInput = `div[class="mt-2"]  div[class="flex items-center space-x-2 mb-5"] div[class="relative w-full"] span:contains("${modalProviderValue}")`
 const modalProviderIcon = '.absolute > .flex > .mr-2';
 const resetModalText =
   'You are about to reset custom checks values. Would you like to continue?';
@@ -104,16 +103,13 @@ export const openCustomizationModalFirstCheck = () => {
   cy.get(checkCustomModalSettingsIconFirstCheck).first().click({ force: true });
 };
 
-export const openCustomizationModalFirstCheckAfterCustomization = () => {
-  cy.get(checkCustomModalSettingsIconFirstCheckAfterCustomization)
-    .first()
-    .click({ force: true });
-};
+export const openCustomizationModalFirstCheckAfterCustomization = () => cy.get(checkCustomModalSettingsIconFirstCheckAfterCustomization).first().click();
+
 
 export const openCustomizationModalSecondCheck = () => {
   cy.get(checkCustomModalSettingsIconSecondCheck)
-    .first()
-    .click({ force: true });
+    .eq(1)
+    .click();
 };
 
 // User clicks on element

--- a/test/e2e/cypress/pageObject/checks_customization_po.js
+++ b/test/e2e/cypress/pageObject/checks_customization_po.js
@@ -42,7 +42,7 @@ const secondCheckDefaultValue = `${secondCheck.values[0].default}:`;
 const firstCurrentCheckValue = `${firstCheck.values[0].default}`;
 const modalWarningCheckboxLabel =
   'Trento and SUSE are not responsible for cluster operation failure due to deviation from Best Practices.';
-const userInputValidationErrorLabel =
+const inputValidationErrorLabel =
   'Some of the values are invalid. Please correct them and try again';
 const customValue = '100';
 const customMixedValue = '30000a';
@@ -71,7 +71,7 @@ const modalValueDefault = 'div[class="mt-2"] label';
 const modalProviderSvg = 'div[class="mt-2"] span img';
 const resetModalTitle = 'div[class*="space-y-4"] h2';
 const resetModalWarning = 'div[class="mt-2"] div[class*="text-gray"]';
-const userValidationError = 'div[class="mt-2"] div p[class*="text-red"]';
+const validationError = 'div[class="mt-2"] div p[class*="text-red"]';
 const saveButtonModal = 'button:contains("Save")';
 const resetCheckButtonModal = 'button:contains("Reset Check")';
 const closeCheckButtonModal = 'button:contains("Close")';
@@ -80,24 +80,21 @@ const checkCustomizationToastSuccess = `p:contains(${checkCustomizationToastSucc
 const checkCustomizationToastReset = `p:contains(${checkCustomizationToastResetLabel})`;
 
 //UI interactions
-export const corosyncCategoryClick = () => cy.get(corosyncCategory).click();
+export const clickCorosyncCategory = () => cy.get(corosyncCategory).click();
 export const openCustomizationModalFirstCheck = () =>
   cy.get(checksCustomizationSettingsIcon).eq(0).click();
 export const openCustomizationModalSecondCheck = () =>
   cy.get(checksCustomizationSettingsIcon).eq(1).click();
-export const userClickOnWarningCheckbox = () =>
-  cy.get(modalInput).eq(0).click();
-export const userClickResetCheckModalButton = () =>
+export const clickOnWarningCheckbox = () => cy.get(modalInput).eq(0).click();
+export const clickResetCheckModalButton = () =>
   cy.get(resetCheckButtonModal).click();
-export const userClickCloseButton = () => cy.get(closeCheckButtonModal).click();
-export const userClickResetButton = () => cy.get(resetButton).click();
-export const userClickResetModalButton = () =>
-  cy.get(resetButton).eq(1).click();
-export const userClickResetCustomizedCheck = () =>
+export const clickCloseButton = () => cy.get(closeCheckButtonModal).click();
+export const clickResetButton = () => cy.get(resetButton).click();
+export const clickResetModalButton = () => cy.get(resetButton).eq(1).click();
+export const clickResetCustomizedCheck = () =>
   cy.get(resetCustomizedCheckIcon).click();
-export const userClickModalSaveButton = () =>
-  cy.get(saveButtonModal).eq(1).click();
-const setInputValue = (element, index, value) => {
+export const clickModalSaveButton = () => cy.get(saveButtonModal).eq(1).click();
+const _setInputValue = (element, index, value) => {
   cy.get(element)
     .eq(index)
     .should('be.visible')
@@ -105,10 +102,10 @@ const setInputValue = (element, index, value) => {
     .type(value)
     .should('have.value', value);
 };
-export const userInputCustomCheckValue = () =>
-  setInputValue(modalInput, 1, customValue);
-export const userInputInvalidCheckValue = () =>
-  setInputValue(modalInput, 1, customMixedValue);
+export const inputCustomCheckValue = () =>
+  _setInputValue(modalInput, 1, customValue);
+export const inputInvalidCheckValue = () =>
+  _setInputValue(modalInput, 1, customMixedValue);
 
 // UI validations
 export const resetIconShouldNotExistInOverview = () =>
@@ -119,10 +116,10 @@ export const customizedCheckShouldNotHaveModifiedPill = () =>
   cy.get(modifiedPill).should('not.exist');
 export const secondCustomizedCheckShouldNotHaveModifiedPill = () =>
   cy.get(modifiedPill).should('not.exist');
-const validateCheckId = (value) =>
+const _validateCheckId = (value) =>
   cy.contains(`Check: ${value}`).should('contain', value);
-export const validateFirstCheckId = () => validateCheckId(firstCheck.id);
-export const validateSecondCheckId = () => validateCheckId(secondCheck.id);
+export const validateFirstCheckId = () => _validateCheckId(firstCheck.id);
+export const validateSecondCheckId = () => _validateCheckId(secondCheck.id);
 export const validateFirstCheckDescription = () =>
   cy.get(modalDescrition).should('contain', firstCheck.description);
 export const modalWarningCheckBoxShouldNotBeChecked = () =>
@@ -131,30 +128,33 @@ export const modalWarningCheckBoxShouldBeChecked = () =>
   cy.get(modalInput).eq(0).should('be.checked');
 export const validateWarningMessage = () =>
   cy.get(modalSpan).should('contain', modalWarningCheckboxLabel);
-const validateValueNameAndDefaultValue = (valueName, defaultValue) => {
+const _validateValueNameAndDefaultValue = (valueName, defaultValue) => {
   cy.get(modalValueDefault)
     .should('contain', valueName)
     .and('contain', defaultValue);
 };
 export const validateFirstCheckValueNameAndDefaultValue = () =>
-  validateValueNameAndDefaultValue(firstCheckValueName, firstCheckDefaultValue);
+  _validateValueNameAndDefaultValue(
+    firstCheckValueName,
+    firstCheckDefaultValue
+  );
 export const validateSecondCheckValueNameAndDefaultValue = () => {
-  validateValueNameAndDefaultValue(
+  _validateValueNameAndDefaultValue(
     secondCheckValueName,
     secondCheckDefaultValue
   );
 };
-const validateModalInputValue = (input, index, value) =>
+const _validateModalInputValue = (input, index, value) =>
   cy.get(input).eq(index).should('have.value', value);
 export const validateCurrentValueFromWandaFirstCheck = () =>
-  validateModalInputValue(modalInput, 1, firstCurrentCheckValue);
+  _validateModalInputValue(modalInput, 1, firstCurrentCheckValue);
 export const validateCustomizedValue = () => {
-  validateModalInputValue(modalInput, 0, customValue);
+  _validateModalInputValue(modalInput, 0, customValue);
 };
 export const validateProviderLabel = () =>
-  cy.get(modalValueDefault).eq(1).should('contain', modalProviderLabel);
+  cy.get(modalValueDefault).eq(1).should('have.text', modalProviderLabel);
 export const validateProviderValue = () =>
-  cy.get(modalSpan).eq(1).should('contain', modalProviderValue);
+  cy.get(modalSpan).eq(1).should('have.text', modalProviderValue);
 export const providerIconShouldBeDisplayed = () => {
   cy.get(modalProviderSvg)
     .should('be.visible')
@@ -163,35 +163,35 @@ export const providerIconShouldBeDisplayed = () => {
 export const validateResetModalTitle = () =>
   cy.get(resetModalTitle).should('contain', resetModalTitleLabel);
 export const validateResetModalWarningText = () =>
-  cy.get(resetModalWarning).eq(1).should('contain', resetModalText);
-export const userInputValidationErrorShouldBeDisplayed = () =>
-  cy.get(userValidationError).should('contain', userInputValidationErrorLabel);
-const toastShouldBeVisible = (label) => cy.get(label).should('be.visible');
+  cy.get(resetModalWarning).eq(1).should('have.text', resetModalText);
+export const inputValidationErrorShouldBeDisplayed = () =>
+  cy.get(validationError).should('contain', inputValidationErrorLabel);
+const _toastShouldBeVisible = (label) => cy.get(label).should('be.visible');
 export const checkCustomizationSuccessToastIsShown = () =>
-  toastShouldBeVisible(checkCustomizationToastSuccess);
+  _toastShouldBeVisible(checkCustomizationToastSuccess);
 export const checkCustomizationResetToastIsShown = () =>
-  toastShouldBeVisible(checkCustomizationToastReset);
+  _toastShouldBeVisible(checkCustomizationToastReset);
 export const checkCustomizationErrorToastIsShown = () =>
   cy.get('body').should('contain', checkCustomizationToastErrorLabel);
-const buttonEnabled = (button) => cy.get(button).should('be.enabled');
-const buttonDisabled = (button) => cy.get(button).should('be.disabled');
+const _buttonEnabled = (button) => cy.get(button).should('be.enabled');
+const _buttonDisabled = (button) => cy.get(button).should('be.disabled');
 export const modalSaveButtonShouldBeEnabled = () =>
-  buttonEnabled(saveButtonModal);
+  _buttonEnabled(saveButtonModal);
 export const modalSaveButtonShouldBeDisabled = () =>
-  buttonDisabled(saveButtonModal);
-export const resetCheckButtonEnabled = () =>
-  buttonEnabled(resetCheckButtonModal);
+  _buttonDisabled(saveButtonModal);
+export const resetCheck_buttonEnabled = () =>
+  _buttonEnabled(resetCheckButtonModal);
 export const modalResetCheckButtonShouldBeDisabled = () =>
-  buttonDisabled(resetCheckButtonModal);
+  _buttonDisabled(resetCheckButtonModal);
 export const modalCloseButtonShouldBeEnabled = () =>
-  buttonEnabled(closeCheckButtonModal);
+  _buttonEnabled(closeCheckButtonModal);
 
 // Api
 export const visit = (clusterId = '') => basePage.visit(`${url}/${clusterId}`);
 export const visitChecksSelectionCluster = () => visit(availableHanaCluster.id);
 export const clickOnCheckSelectionButton = () =>
   cy.get('button').contains('Check Selection').click();
-const resetCheck = (groupId, checkId) =>
+const _resetCheck = (groupId, checkId) =>
   basePage.apiLogin().then(({ accessToken }) =>
     cy.request({
       method: 'DELETE',
@@ -202,9 +202,9 @@ const resetCheck = (groupId, checkId) =>
       failOnStatusCode: false,
     })
   );
-const resetChecks = (checks) => {
+const _resetChecks = (checks) => {
   checks.forEach(({ id }) => {
-    resetCheck(availableHanaCluster.id, id);
+    _resetCheck(availableHanaCluster.id, id);
   });
 };
-export const apiResetAllChecks = () => resetChecks(checkList);
+export const apiResetAllChecks = () => _resetChecks(checkList);

--- a/test/e2e/cypress/pageObject/checks_customization_po.js
+++ b/test/e2e/cypress/pageObject/checks_customization_po.js
@@ -2,19 +2,11 @@ export * from './base_po.js';
 import * as basePage from './base_po.js';
 
 import {
-  checksExecutionCompletedFactory,
   catalogCheckFactory,
   catalogValueFactory,
 } from '@lib/test-utils/factories';
 
 import { availableHanaCluster } from '../fixtures/hana-cluster-details/available_hana_cluster.js';
-
-const lastExecution = checksExecutionCompletedFactory.build({
-  group_id: availableHanaCluster.id,
-  passing_count: 5,
-  warning_count: 3,
-  critical_count: 1,
-});
 
 const firstCheck = catalogCheckFactory.build({
   id: '00081D',
@@ -43,6 +35,9 @@ const secondCheck = catalogCheckFactory.build({
 
 const checkList = [firstCheck, secondCheck];
 
+const url = '/clusters';
+
+// Reset checks
 const resetCheck = (groupId, checkId) =>
   basePage.apiLogin().then(({ accessToken }) =>
     cy.request({
@@ -63,74 +58,62 @@ const resetChecks = (checks) => {
 
 export const resetAllChecks = () => resetChecks(checkList);
 
-const catalog = catalogCheckFactory.buildList(5);
-
-// Attributes
-const url = '/clusters';
-const catalogEndpointAlias = 'catalog';
-const lastExecutionEndpointAlias = 'lastExecution';
-
+// Page navigation
 export const visit = (clusterId = '') => {
   basePage.visit(`${url}/${clusterId}`);
-  if (clusterId !== '') {
-    basePage.waitForRequest(lastExecutionEndpointAlias);
-    basePage.waitForRequest(catalogEndpointAlias);
-  }
 };
-
 export const visitChecksSelectionCluster = () => visit(availableHanaCluster.id);
+
 export const clickOnCheckSelectionButton = () =>
   cy.get('button').contains('Check Selection').click();
 
-// API
-export const interceptLastExecutionRequest = () => {
-  const lastExecutionURL = '/api/v2/checks/groups/**/executions/last';
-  cy.intercept(lastExecutionURL, {
-    body: lastExecution,
-  }).as(lastExecutionEndpointAlias);
-};
-
-export const interceptCatalogRequest = () => {
-  const catalogURL = '/api/v3/checks/catalog*';
-  cy.intercept(catalogURL, { body: { items: catalog } }).as(
-    catalogEndpointAlias
-  );
-};
-
-export const expectedClusterNameIsDisplayedInHeader = () =>
-  basePage.pageTitleIsCorrectlyDisplayed(availableHanaCluster.name);
+//Checks overview
 
 const checksCategorySwitch = '.tn-check-switch';
 const corosyncLabel = 'Corosync';
 
+const checkCustomModalSettingsIconFirstCheck =
+  ':nth-child(1) > .block > .px-4 > .mt-2 > .flex > .inline > [data-testid="eos-svg-component"] > path';
+const checkCustomModalSettingsIconFirstCheckAfterCustomization =
+  ':nth-child(1) > .block > .px-4 > .mt-2 > .flex > .mr-4 > [data-testid="eos-svg-component"]';
+const checkCustomModalSettingsIconSecondCheck =
+  ':nth-child(2) > .block > .px-4 > .mt-2 > .flex > .mr-4 > [data-testid="eos-svg-component"]';
+
+const resetCustomizedCheckIcon = '.mr-2 > [data-testid="eos-svg-component"]';
+
+const modifiedPillLabel = 'MODIFIED';
+const modifiedPill = '.block > .px-4 > :nth-child(1) > .bg-white';
+
 export const corosyncCategoryClick = () =>
   cy.get(checksCategorySwitch).contains(corosyncLabel).click();
 
-const checkCustomModalSettingsIconFirstCheck =
-  ':nth-child(1) > .block > .px-4 > .mt-2 > .flex > .inline > [data-testid="eos-svg-component"] > path';
 export const openCustomizationModalFirstCheck = () => {
   cy.get(checkCustomModalSettingsIconFirstCheck).first().click({ force: true });
 };
-const checkCustomModalSettingsIconFirstCheckAfterCustomization =
-  ':nth-child(1) > .block > .px-4 > .mt-2 > .flex > .mr-4 > [data-testid="eos-svg-component"]';
+
 export const openCustomizationModalFirstCheckAfterCustomization = () => {
   cy.get(checkCustomModalSettingsIconFirstCheckAfterCustomization)
     .first()
     .click({ force: true });
 };
 
-const checkCustomModalSettingsIconSecondCheck =
-  ':nth-child(2) > .block > .px-4 > .mt-2 > .flex > .mr-4 > [data-testid="eos-svg-component"]';
 export const openCustomizationModalSecondCheck = () => {
   cy.get(checkCustomModalSettingsIconSecondCheck)
     .first()
     .click({ force: true });
 };
 
-// Modal elements and values
+export const resetIconShouldNotExistInOverview = () =>
+  cy.get(resetCustomizedCheckIcon).should('not.exist');
 
-const modalTitle = '#headlessui-dialog-title-\\:r1m\\:';
-const modalTitleSecondCheck = '#headlessui-dialog-title-\\:r21\\:';
+export const customizedCheckShouldHaveModifiedPill = () =>
+  cy.get(modifiedPill).should('contain', modifiedPillLabel);
+export const customizedCheckShouldNotHaveModifiedPill = () =>
+  cy.get(modifiedPill).should('not.exist');
+export const secondCustomizedCheckShouldNotHaveModifiedPill = () =>
+  cy.get(modifiedPill).should('not.exist');
+
+// Modal elements and values
 const modalDescrition = '.mt-2 > .text-gray-500';
 const modalWarningText = '.border-yellow-400 > .font-semibold';
 const modalWarningCheckbox = '.border-yellow-400 > div > .rc-input';
@@ -144,26 +127,16 @@ const modalProviderInput = 'div.relative > div.w-full > .rc-input';
 const modalProviderValue = 'Azure';
 const modalProviderIcon = '.absolute > .flex > .mr-2';
 
-const resetCustomizedCheckIcon = '.mr-2 > [data-testid="eos-svg-component"]';
 const resetModalText =
   'You are about to reset custom checks values. Would you like to continue?';
 const resetModalWarning = '.mt-2 > .text-gray-500';
 
+// Modal check values
 const firstCheckValueName = `${firstCheck.values[0].name}:`;
 const firstCheckDefaultValue = `(Default: ${firstCheck.values[0].default})`;
 const secondCheckValueName = `${secondCheck.values[0].name}:`;
 const secondCheckDefaultValue = `${secondCheck.values[0].default}:`;
 const firstCurrentCheckValue = `${firstCheck.values[0].default}`;
-
-const modifiedPillLabel = 'MODIFIED';
-const modifiedPill = '.block > .px-4 > :nth-child(1) > .bg-white';
-
-// Toast messages for checks customization
-const checkCustomizationToastSuccessLabel = 'Check was customized successfully';
-const checkCustomizationToastSuccess = `p:contains(${checkCustomizationToastSuccessLabel})`;
-const checkCustomizationToastResetLabel = 'Customization was reset!';
-const checkCustomizationToastReset = `p:contains(${checkCustomizationToastResetLabel})`;
-const checkCustomizationToastErrorLabel = 'Failed to customize check';
 
 // Input validation
 const userInputValidationErrorLabel =
@@ -174,102 +147,12 @@ const userValidationError = '.text-red-500';
 const customValue = '100';
 const customMixedValue = '30000a';
 
-// Button status
+// Button in modal
 const saveButtonModal = 'button:contains("Save")';
 const resetCheckButtonModal = 'button:contains("Reset Check")';
 const closeCheckButtonModal = 'button:contains("Close")';
 const resetModalLabel = 'Reset';
 const resetModalButton = '.mt-2 > .flex > .bg-jungle-green-500';
-
-export const providerIconShouldBeDisplayed = () => {
-  cy.get(modalProviderIcon)
-    .should('be.visible')
-    .and('have.attr', 'alt', 'azure');
-};
-
-// Validation of values
-
-export const validateFirstCheckValueNameAndDefaultValue = () => {
-  validateValueNameAndDefaultValue(firstCheckValueName, firstCheckDefaultValue);
-};
-
-export const validateSecondCheckValueNameAndDefaultValue = () => {
-  validateValueNameAndDefaultValue(
-    secondCheckValueName,
-    secondCheckDefaultValue
-  );
-};
-
-export const validateCustomizedValue = () => {
-  validateValue(modalValueCurrentValue, customValue);
-};
-
-const validateValueNameAndDefaultValue = (valueName, defaultValue) => {
-  cy.get(modalValueDefault)
-    .should('contain', valueName)
-    .and('contain', defaultValue);
-};
-
-const validateCheckId = (element, value) =>
-  cy.get(element).should('contain', `Check: ${value}`);
-export const validateFirstCheckId = () =>
-  validateCheckId(modalTitle, firstCheck.id);
-export const validateSecondCheckId = () =>
-  validateCheckId(modalTitleSecondCheck, secondCheck.id);
-
-export const validateFirstCheckDescription = () =>
-  cy.get(modalDescrition).should('contain', firstCheck.description);
-export const validateWarningMessage = () =>
-  cy.get(modalWarningText).should('contain', modalWarningCheckboxLabel);
-
-const validateValue = (element, value) =>
-  cy.get(element).should('have.value', value);
-export const validateCurrentValueFromWandaFirstCheck = () =>
-  validateValue(modalValueCurrentValue, firstCurrentCheckValue);
-
-export const validateProvider = () =>
-  cy.get(modalProvider).should('contain', modalProviderLabel);
-export const validateProviderValue = () =>
-  cy.get(modalProviderInput).should('contain', modalProviderValue);
-
-export const modalWarningCheckBoxShouldNotBeChecked = () =>
-  cy.get(modalWarningCheckbox).should('not.be.checked');
-export const modalWarningCheckBoxShouldBeChecked = () =>
-  cy.get(modalWarningCheckbox).should('be.checked');
-
-export const userInputValidationErrorShouldBeDisplayed = () =>
-  cy.get(userValidationError).should('contain', userInputValidationErrorLabel);
-
-export const validateResetWarningText = () =>
-  cy.get(resetModalWarning).should('contain', resetModalText);
-
-export const resetIconShouldNotExistInOverview = () =>
-  cy.get(resetCustomizedCheckIcon).should('not.exist');
-
-// User clicks on element
-export const userClickOnWarningCheckbox = () =>
-  cy.get(modalWarningCheckbox).click();
-
-export const userClickResetModalButton = () =>
-  cy.get(resetCheckButtonModal).click();
-export const userClickCloseButton = () => cy.get(closeCheckButtonModal).click();
-
-export const userClickResetButton = () =>
-  cy.get(resetModalButton).contains(resetModalLabel).click();
-
-export const userResetCustomizedCheck = () =>
-  cy.get(resetCustomizedCheckIcon).click();
-
-//  Check if Element is in View
-
-export const customizedCheckShouldHaveModifiedPill = () =>
-  cy.get(modifiedPill).should('contain', modifiedPillLabel);
-export const customizedCheckShouldNotHaveModifiedPill = () =>
-  cy.get(modifiedPill).should('not.exist');
-export const secondCustomizedCheckShouldNotHaveModifiedPill = () =>
-  cy.get(modifiedPill).should('not.exist');
-
-// Modal Buttons
 
 const buttonEnabled = (button) => cy.get(button).should('be.enabled');
 const buttonDisabled = (button) => cy.get(button).should('be.disabled');
@@ -291,7 +174,78 @@ export const closeButtonDisabled = () => {
   buttonDisabled(closeCheckButtonModal);
 };
 
-// user Value input
+// Validation of values
+const validateCheckId = (value) =>
+  cy.contains(`Check: ${value}`).should('contain', value);
+export const validateFirstCheckId = () => validateCheckId(firstCheck.id);
+export const validateSecondCheckId = () => validateCheckId(secondCheck.id);
+
+const validateValueNameAndDefaultValue = (valueName, defaultValue) => {
+  cy.get(modalValueDefault)
+    .should('contain', valueName)
+    .and('contain', defaultValue);
+};
+export const validateFirstCheckDescription = () =>
+  cy.get(modalDescrition).should('contain', firstCheck.description);
+
+export const modalWarningCheckBoxShouldNotBeChecked = () =>
+  cy.get(modalWarningCheckbox).should('not.be.checked');
+export const modalWarningCheckBoxShouldBeChecked = () =>
+  cy.get(modalWarningCheckbox).should('be.checked');
+
+export const validateWarningMessage = () =>
+  cy.get(modalWarningText).should('contain', modalWarningCheckboxLabel);
+export const validateFirstCheckValueNameAndDefaultValue = () => {
+  validateValueNameAndDefaultValue(firstCheckValueName, firstCheckDefaultValue);
+};
+export const validateSecondCheckValueNameAndDefaultValue = () => {
+  validateValueNameAndDefaultValue(
+    secondCheckValueName,
+    secondCheckDefaultValue
+  );
+};
+const validateValue = (element, value) =>
+  cy.get(element).should('have.value', value);
+export const validateCurrentValueFromWandaFirstCheck = () =>
+  validateValue(modalValueCurrentValue, firstCurrentCheckValue);
+
+export const validateCustomizedValue = () => {
+  validateValue(modalValueCurrentValue, customValue);
+};
+
+export const validateProvider = () =>
+  cy.get(modalProvider).should('contain', modalProviderLabel);
+export const validateProviderValue = () =>
+  cy.get(modalProviderInput).should('contain', modalProviderValue);
+export const providerIconShouldBeDisplayed = () => {
+  cy.get(modalProviderIcon)
+    .should('be.visible')
+    .and('have.attr', 'alt', 'azure');
+};
+export const validateResetWarningText = () =>
+  cy.get(resetModalWarning).should('contain', resetModalText);
+
+export const userInputValidationErrorShouldBeDisplayed = () =>
+  cy.get(userValidationError).should('contain', userInputValidationErrorLabel);
+
+// User clicks on element
+export const userClickOnWarningCheckbox = () =>
+  cy.get(modalWarningCheckbox).click();
+
+export const userClickResetModalButton = () =>
+  cy.get(resetCheckButtonModal).click();
+export const userClickCloseButton = () => cy.get(closeCheckButtonModal).click();
+
+export const userClickResetButton = () =>
+  cy.get(resetModalButton).contains(resetModalLabel).click();
+
+export const userClickResetCustomizedCheck = () =>
+  cy.get(resetCustomizedCheckIcon).click();
+
+export const userClickModalSaveButton = () =>
+  cy.get('.w-80 > .bg-jungle-green-500').click();
+
+// User input
 const setInputValue = (element, value) => {
   cy.get(element)
     .should('be.visible')
@@ -306,13 +260,21 @@ export const userInputCustomCheckValue = () => {
 export const userInputInvalidCheckValue = () => {
   setInputValue(modalValueCurrentValue, customMixedValue);
 };
-export const userClickModalSaveButton = () =>
-  cy.get('.w-80 > .bg-jungle-green-500').click();
 
 // Toast messages for checks customization
-export const checkCustomizationToastIsShown = () =>
-  cy.get(checkCustomizationToastSuccess).should('be.visible');
+const checkCustomizationToastSuccessLabel = 'Check was customized successfully';
+const checkCustomizationToastSuccess = `p:contains(${checkCustomizationToastSuccessLabel})`;
+const checkCustomizationToastResetLabel = 'Customization was reset!';
+const checkCustomizationToastReset = `p:contains(${checkCustomizationToastResetLabel})`;
+const checkCustomizationToastErrorLabel = 'Failed to customize check';
+
+// Toast messages for checks customization
+const toastShouldBeVisible = (label) => {
+  cy.get(label).should('be.visible');
+};
+export const checkCustomizationSuccessToastIsShown = () =>
+  toastShouldBeVisible(checkCustomizationToastSuccess);
 export const checkCustomizationResetToastIsShown = () =>
-  cy.get(checkCustomizationToastReset).should('be.visible');
+  toastShouldBeVisible(checkCustomizationToastReset);
 export const checkCustomizationErrorToastIsShown = () =>
   cy.get('body').should('contain', checkCustomizationToastErrorLabel);

--- a/test/e2e/cypress/pageObject/checks_customization_po.js
+++ b/test/e2e/cypress/pageObject/checks_customization_po.js
@@ -1,0 +1,318 @@
+export * from './base_po.js';
+import * as basePage from './base_po.js';
+
+import {
+  checksExecutionCompletedFactory,
+  catalogCheckFactory,
+  catalogValueFactory,
+} from '@lib/test-utils/factories';
+
+import { availableHanaCluster } from '../fixtures/hana-cluster-details/available_hana_cluster.js';
+
+const lastExecution = checksExecutionCompletedFactory.build({
+  group_id: availableHanaCluster.id,
+  passing_count: 5,
+  warning_count: 3,
+  critical_count: 1,
+});
+
+const firstCheck = catalogCheckFactory.build({
+  id: '00081D',
+  description:
+    'Corosync is running with max_messages set to the recommended value',
+  values: [
+    catalogValueFactory.build({
+      name: 'expected_max_messages',
+      default: '20',
+      customizable: true,
+    }),
+  ],
+});
+
+const secondCheck = catalogCheckFactory.build({
+  id: '156F64',
+  description: 'Corosync `token` timeout is set to expected value',
+  values: [
+    catalogValueFactory.build({
+      name: 'expected_token_timeout',
+      default: '30000',
+      customizable: true,
+    }),
+  ],
+});
+
+const checkList = [firstCheck, secondCheck];
+
+const resetCheck = (groupId, checkId) =>
+  basePage.apiLogin().then(({ accessToken }) =>
+    cy.request({
+      method: 'DELETE',
+      url: `${Cypress.config(
+        'wandaUrl'
+      )}/api/v1/groups/${groupId}/checks/${checkId}/customization`,
+      auth: { bearer: accessToken },
+      failOnStatusCode: false,
+    })
+  );
+
+const resetChecks = (checks) => {
+  checks.forEach(({ id }) => {
+    resetCheck(availableHanaCluster.id, id);
+  });
+};
+
+export const resetAllChecks = () => resetChecks(checkList);
+
+const catalog = catalogCheckFactory.buildList(5);
+
+// Attributes
+const url = '/clusters';
+const catalogEndpointAlias = 'catalog';
+const lastExecutionEndpointAlias = 'lastExecution';
+
+export const visit = (clusterId = '') => {
+  basePage.visit(`${url}/${clusterId}`);
+  if (clusterId !== '') {
+    basePage.waitForRequest(lastExecutionEndpointAlias);
+    basePage.waitForRequest(catalogEndpointAlias);
+  }
+};
+
+export const visitChecksSelectionCluster = () => visit(availableHanaCluster.id);
+export const clickOnCheckSelectionButton = () =>
+  cy.get('button').contains('Check Selection').click();
+
+// API
+export const interceptLastExecutionRequest = () => {
+  const lastExecutionURL = '/api/v2/checks/groups/**/executions/last';
+  cy.intercept(lastExecutionURL, {
+    body: lastExecution,
+  }).as(lastExecutionEndpointAlias);
+};
+
+export const interceptCatalogRequest = () => {
+  const catalogURL = '/api/v3/checks/catalog*';
+  cy.intercept(catalogURL, { body: { items: catalog } }).as(
+    catalogEndpointAlias
+  );
+};
+
+export const expectedClusterNameIsDisplayedInHeader = () =>
+  basePage.pageTitleIsCorrectlyDisplayed(availableHanaCluster.name);
+
+const checksCategorySwitch = '.tn-check-switch';
+const corosyncLabel = 'Corosync';
+
+export const corosyncCategoryClick = () =>
+  cy.get(checksCategorySwitch).contains(corosyncLabel).click();
+
+const checkCustomModalSettingsIconFirstCheck =
+  ':nth-child(1) > .block > .px-4 > .mt-2 > .flex > .inline > [data-testid="eos-svg-component"] > path';
+export const openCustomizationModalFirstCheck = () => {
+  cy.get(checkCustomModalSettingsIconFirstCheck).first().click({ force: true });
+};
+const checkCustomModalSettingsIconFirstCheckAfterCustomization =
+  ':nth-child(1) > .block > .px-4 > .mt-2 > .flex > .mr-4 > [data-testid="eos-svg-component"]';
+export const openCustomizationModalFirstCheckAfterCustomization = () => {
+  cy.get(checkCustomModalSettingsIconFirstCheckAfterCustomization)
+    .first()
+    .click({ force: true });
+};
+
+const checkCustomModalSettingsIconSecondCheck =
+  ':nth-child(2) > .block > .px-4 > .mt-2 > .flex > .mr-4 > [data-testid="eos-svg-component"]';
+export const openCustomizationModalSecondCheck = () => {
+  cy.get(checkCustomModalSettingsIconSecondCheck)
+    .first()
+    .click({ force: true });
+};
+
+// Modal elements and values
+
+const modalTitle = '#headlessui-dialog-title-\\:r1m\\:';
+const modalTitleSecondCheck = '#headlessui-dialog-title-\\:r21\\:';
+const modalDescrition = '.mt-2 > .text-gray-500';
+const modalWarningText = '.border-yellow-400 > .font-semibold';
+const modalWarningCheckbox = '.border-yellow-400 > div > .rc-input';
+const modalWarningCheckboxLabel =
+  'Trento and SUSE are not responsible for cluster operation failure due to deviation from Best Practices.';
+const modalValueDefault = '.flex-col > .font-bold';
+const modalValueCurrentValue = '.space-x-4 > div.w-full > .rc-input';
+const modalProvider = ':nth-child(4) > .w-1\\/3';
+const modalProviderLabel = 'Provider';
+const modalProviderInput = 'div.relative > div.w-full > .rc-input';
+const modalProviderValue = 'Azure';
+const modalProviderIcon = '.absolute > .flex > .mr-2';
+
+const resetCustomizedCheckIcon = '.mr-2 > [data-testid="eos-svg-component"]';
+const resetModalText =
+  'You are about to reset custom checks values. Would you like to continue?';
+const resetModalWarning = '.mt-2 > .text-gray-500';
+
+const firstCheckValueName = `${firstCheck.values[0].name}:`;
+const firstCheckDefaultValue = `(Default: ${firstCheck.values[0].default})`;
+const secondCheckValueName = `${secondCheck.values[0].name}:`;
+const secondCheckDefaultValue = `${secondCheck.values[0].default}:`;
+const firstCurrentCheckValue = `${firstCheck.values[0].default}`;
+
+const modifiedPillLabel = 'MODIFIED';
+const modifiedPill = '.block > .px-4 > :nth-child(1) > .bg-white';
+
+// Toast messages for checks customization
+const checkCustomizationToastSuccessLabel = 'Check was customized successfully';
+const checkCustomizationToastSuccess = `p:contains(${checkCustomizationToastSuccessLabel})`;
+const checkCustomizationToastResetLabel = 'Customization was reset!';
+const checkCustomizationToastReset = `p:contains(${checkCustomizationToastResetLabel})`;
+const checkCustomizationToastErrorLabel = 'Failed to customize check';
+
+// Input validation
+const userInputValidationErrorLabel =
+  'Some of the values are invalid. Please correct them and try again';
+const userValidationError = '.text-red-500';
+
+// user Value input
+const customValue = '100';
+const customMixedValue = '30000a';
+
+// Button status
+const saveButtonModal = 'button:contains("Save")';
+const resetCheckButtonModal = 'button:contains("Reset Check")';
+const closeCheckButtonModal = 'button:contains("Close")';
+const resetModalLabel = 'Reset';
+const resetModalButton = '.mt-2 > .flex > .bg-jungle-green-500';
+
+export const providerIconShouldBeDisplayed = () => {
+  cy.get(modalProviderIcon)
+    .should('be.visible')
+    .and('have.attr', 'alt', 'azure');
+};
+
+// Validation of values
+
+export const validateFirstCheckValueNameAndDefaultValue = () => {
+  validateValueNameAndDefaultValue(firstCheckValueName, firstCheckDefaultValue);
+};
+
+export const validateSecondCheckValueNameAndDefaultValue = () => {
+  validateValueNameAndDefaultValue(
+    secondCheckValueName,
+    secondCheckDefaultValue
+  );
+};
+
+export const validateCustomizedValue = () => {
+  validateValue(modalValueCurrentValue, customValue);
+};
+
+const validateValueNameAndDefaultValue = (valueName, defaultValue) => {
+  cy.get(modalValueDefault)
+    .should('contain', valueName)
+    .and('contain', defaultValue);
+};
+
+const validateCheckId = (element, value) =>
+  cy.get(element).should('contain', `Check: ${value}`);
+export const validateFirstCheckId = () =>
+  validateCheckId(modalTitle, firstCheck.id);
+export const validateSecondCheckId = () =>
+  validateCheckId(modalTitleSecondCheck, secondCheck.id);
+
+export const validateFirstCheckDescription = () =>
+  cy.get(modalDescrition).should('contain', firstCheck.description);
+export const validateWarningMessage = () =>
+  cy.get(modalWarningText).should('contain', modalWarningCheckboxLabel);
+
+const validateValue = (element, value) =>
+  cy.get(element).should('have.value', value);
+export const validateCurrentValueFromWandaFirstCheck = () =>
+  validateValue(modalValueCurrentValue, firstCurrentCheckValue);
+
+export const validateProvider = () =>
+  cy.get(modalProvider).should('contain', modalProviderLabel);
+export const validateProviderValue = () =>
+  cy.get(modalProviderInput).should('contain', modalProviderValue);
+
+export const modalWarningCheckBoxShouldNotBeChecked = () =>
+  cy.get(modalWarningCheckbox).should('not.be.checked');
+export const modalWarningCheckBoxShouldBeChecked = () =>
+  cy.get(modalWarningCheckbox).should('be.checked');
+
+export const userInputValidationErrorShouldBeDisplayed = () =>
+  cy.get(userValidationError).should('contain', userInputValidationErrorLabel);
+
+export const validateResetWarningText = () =>
+  cy.get(resetModalWarning).should('contain', resetModalText);
+
+export const resetIconShouldNotExistInOverview = () =>
+  cy.get(resetCustomizedCheckIcon).should('not.exist');
+
+// User clicks on element
+export const userClickOnWarningCheckbox = () =>
+  cy.get(modalWarningCheckbox).click();
+
+export const userClickResetModalButton = () =>
+  cy.get(resetCheckButtonModal).click();
+export const userClickCloseButton = () => cy.get(closeCheckButtonModal).click();
+
+export const userClickResetButton = () =>
+  cy.get(resetModalButton).contains(resetModalLabel).click();
+
+export const userResetCustomizedCheck = () =>
+  cy.get(resetCustomizedCheckIcon).click();
+
+//  Check if Element is in View
+
+export const customizedCheckShouldHaveModifiedPill = () =>
+  cy.get(modifiedPill).should('contain', modifiedPillLabel);
+export const customizedCheckShouldNotHaveModifiedPill = () =>
+  cy.get(modifiedPill).should('not.exist');
+export const secondCustomizedCheckShouldNotHaveModifiedPill = () =>
+  cy.get(modifiedPill).should('not.exist');
+
+// Modal Buttons
+
+const buttonEnabled = (button) => cy.get(button).should('be.enabled');
+const buttonDisabled = (button) => cy.get(button).should('be.disabled');
+
+export const modalSaveButtonShouldBeEnabled = () =>
+  buttonEnabled(saveButtonModal);
+export const modalSaveButtonShouldBeDisabled = () =>
+  buttonDisabled(saveButtonModal);
+export const resetCheckButtonEnabled = () =>
+  buttonEnabled(resetCheckButtonModal);
+
+export const modalResetCheckButtonShouldBeDisabled = () => {
+  buttonDisabled(resetCheckButtonModal);
+};
+export const modalCloseButtonShouldBeEnabled = () => {
+  buttonEnabled(closeCheckButtonModal);
+};
+export const closeButtonDisabled = () => {
+  buttonDisabled(closeCheckButtonModal);
+};
+
+// user Value input
+const setInputValue = (element, value) => {
+  cy.get(element)
+    .should('be.visible')
+    .clear()
+    .type(value)
+    .should('have.value', value);
+};
+
+export const userInputCustomCheckValue = () => {
+  setInputValue(modalValueCurrentValue, customValue);
+};
+export const userInputInvalidCheckValue = () => {
+  setInputValue(modalValueCurrentValue, customMixedValue);
+};
+export const userClickModalSaveButton = () =>
+  cy.get('.w-80 > .bg-jungle-green-500').click();
+
+// Toast messages for checks customization
+export const checkCustomizationToastIsShown = () =>
+  cy.get(checkCustomizationToastSuccess).should('be.visible');
+export const checkCustomizationResetToastIsShown = () =>
+  cy.get(checkCustomizationToastReset).should('be.visible');
+export const checkCustomizationErrorToastIsShown = () =>
+  cy.get('body').should('contain', checkCustomizationToastErrorLabel);

--- a/test/e2e/cypress/pageObject/checks_customization_po.js
+++ b/test/e2e/cypress/pageObject/checks_customization_po.js
@@ -8,6 +8,9 @@ import {
 
 import { availableHanaCluster } from '../fixtures/hana-cluster-details/available_hana_cluster.js';
 
+const url = '/clusters';
+
+// Test data
 const firstCheck = catalogCheckFactory.build({
   id: '00081D',
   description:
@@ -32,58 +35,68 @@ const secondCheck = catalogCheckFactory.build({
     }),
   ],
 });
-
 const checkList = [firstCheck, secondCheck];
 
-const url = '/clusters';
+// Modal check values
+const firstCheckValueName = `${firstCheck.values[0].name}:`;
+const firstCheckDefaultValue = `(Default: ${firstCheck.values[0].default})`;
+const secondCheckValueName = `${secondCheck.values[0].name}:`;
+const secondCheckDefaultValue = `${secondCheck.values[0].default}:`;
+const firstCurrentCheckValue = `${firstCheck.values[0].default}`;
+const modalWarningCheckboxLabel =
+  'Trento and SUSE are not responsible for cluster operation failure due to deviation from Best Practices.';
+const userInputValidationErrorLabel =
+  'Some of the values are invalid. Please correct them and try again';
+const userValidationError = '.text-red-500';
 
-// Reset checks
-const resetCheck = (groupId, checkId) =>
-  basePage.apiLogin().then(({ accessToken }) =>
-    cy.request({
-      method: 'DELETE',
-      url: `${Cypress.config(
-        'wandaUrl'
-      )}/api/v1/groups/${groupId}/checks/${checkId}/customization`,
-      auth: { bearer: accessToken },
-      failOnStatusCode: false,
-    })
-  );
+// User input data
+const customValue = '100';
+const customMixedValue = '30000a';
 
-const resetChecks = (checks) => {
-  checks.forEach(({ id }) => {
-    resetCheck(availableHanaCluster.id, id);
-  });
-};
-
-export const resetAllChecks = () => resetChecks(checkList);
-
-// Page navigation
-export const visit = (clusterId = '') => {
-  basePage.visit(`${url}/${clusterId}`);
-};
-export const visitChecksSelectionCluster = () => visit(availableHanaCluster.id);
-
-export const clickOnCheckSelectionButton = () =>
-  cy.get('button').contains('Check Selection').click();
+// Selectors
 
 //Checks overview
-
 const checksCategorySwitch = '.tn-check-switch';
 const corosyncLabel = 'Corosync';
-
 const checkCustomModalSettingsIconFirstCheck =
   ':nth-child(1) > .block > .px-4 > .mt-2 > .flex > .inline > [data-testid="eos-svg-component"] > path';
 const checkCustomModalSettingsIconFirstCheckAfterCustomization =
   ':nth-child(1) > .block > .px-4 > .mt-2 > .flex > .mr-4 > [data-testid="eos-svg-component"]';
 const checkCustomModalSettingsIconSecondCheck =
   ':nth-child(2) > .block > .px-4 > .mt-2 > .flex > .mr-4 > [data-testid="eos-svg-component"]';
-
 const resetCustomizedCheckIcon = '.mr-2 > [data-testid="eos-svg-component"]';
-
 const modifiedPillLabel = 'MODIFIED';
 const modifiedPill = '.block > .px-4 > :nth-child(1) > .bg-white';
 
+// Modal elements and values
+const modalDescrition = '.mt-2 > .text-gray-500';
+const modalWarningText = '.border-yellow-400 > .font-semibold';
+const modalWarningCheckbox = '.border-yellow-400 > div > .rc-input';
+const modalValueDefault = '.flex-col > .font-bold';
+const modalValueCurrentValue = '.space-x-4 > div.w-full > .rc-input';
+const modalProvider = ':nth-child(4) > .w-1\\/3';
+const modalProviderLabel = 'Provider';
+const modalProviderInput = 'div.relative > div.w-full > .rc-input';
+const modalProviderValue = 'Azure';
+const modalProviderIcon = '.absolute > .flex > .mr-2';
+const resetModalText =
+  'You are about to reset custom checks values. Would you like to continue?';
+const resetModalWarning = '.mt-2 > .text-gray-500';
+// Button in modal
+const saveButtonModal = 'button:contains("Save")';
+const resetCheckButtonModal = 'button:contains("Reset Check")';
+const closeCheckButtonModal = 'button:contains("Close")';
+const resetModalLabel = 'Reset';
+const resetModalButton = '.mt-2 > .flex > .bg-jungle-green-500';
+
+// Toast messages for checks customization
+const checkCustomizationToastSuccessLabel = 'Check was customized successfully';
+const checkCustomizationToastSuccess = `p:contains(${checkCustomizationToastSuccessLabel})`;
+const checkCustomizationToastResetLabel = 'Customization was reset!';
+const checkCustomizationToastReset = `p:contains(${checkCustomizationToastResetLabel})`;
+const checkCustomizationToastErrorLabel = 'Failed to customize check';
+
+//UI interactions
 export const corosyncCategoryClick = () =>
   cy.get(checksCategorySwitch).contains(corosyncLabel).click();
 
@@ -102,131 +115,6 @@ export const openCustomizationModalSecondCheck = () => {
     .first()
     .click({ force: true });
 };
-
-export const resetIconShouldNotExistInOverview = () =>
-  cy.get(resetCustomizedCheckIcon).should('not.exist');
-
-export const customizedCheckShouldHaveModifiedPill = () =>
-  cy.get(modifiedPill).should('contain', modifiedPillLabel);
-export const customizedCheckShouldNotHaveModifiedPill = () =>
-  cy.get(modifiedPill).should('not.exist');
-export const secondCustomizedCheckShouldNotHaveModifiedPill = () =>
-  cy.get(modifiedPill).should('not.exist');
-
-// Modal elements and values
-const modalDescrition = '.mt-2 > .text-gray-500';
-const modalWarningText = '.border-yellow-400 > .font-semibold';
-const modalWarningCheckbox = '.border-yellow-400 > div > .rc-input';
-const modalWarningCheckboxLabel =
-  'Trento and SUSE are not responsible for cluster operation failure due to deviation from Best Practices.';
-const modalValueDefault = '.flex-col > .font-bold';
-const modalValueCurrentValue = '.space-x-4 > div.w-full > .rc-input';
-const modalProvider = ':nth-child(4) > .w-1\\/3';
-const modalProviderLabel = 'Provider';
-const modalProviderInput = 'div.relative > div.w-full > .rc-input';
-const modalProviderValue = 'Azure';
-const modalProviderIcon = '.absolute > .flex > .mr-2';
-
-const resetModalText =
-  'You are about to reset custom checks values. Would you like to continue?';
-const resetModalWarning = '.mt-2 > .text-gray-500';
-
-// Modal check values
-const firstCheckValueName = `${firstCheck.values[0].name}:`;
-const firstCheckDefaultValue = `(Default: ${firstCheck.values[0].default})`;
-const secondCheckValueName = `${secondCheck.values[0].name}:`;
-const secondCheckDefaultValue = `${secondCheck.values[0].default}:`;
-const firstCurrentCheckValue = `${firstCheck.values[0].default}`;
-
-// Input validation
-const userInputValidationErrorLabel =
-  'Some of the values are invalid. Please correct them and try again';
-const userValidationError = '.text-red-500';
-
-// user Value input
-const customValue = '100';
-const customMixedValue = '30000a';
-
-// Button in modal
-const saveButtonModal = 'button:contains("Save")';
-const resetCheckButtonModal = 'button:contains("Reset Check")';
-const closeCheckButtonModal = 'button:contains("Close")';
-const resetModalLabel = 'Reset';
-const resetModalButton = '.mt-2 > .flex > .bg-jungle-green-500';
-
-const buttonEnabled = (button) => cy.get(button).should('be.enabled');
-const buttonDisabled = (button) => cy.get(button).should('be.disabled');
-
-export const modalSaveButtonShouldBeEnabled = () =>
-  buttonEnabled(saveButtonModal);
-export const modalSaveButtonShouldBeDisabled = () =>
-  buttonDisabled(saveButtonModal);
-export const resetCheckButtonEnabled = () =>
-  buttonEnabled(resetCheckButtonModal);
-
-export const modalResetCheckButtonShouldBeDisabled = () => {
-  buttonDisabled(resetCheckButtonModal);
-};
-export const modalCloseButtonShouldBeEnabled = () => {
-  buttonEnabled(closeCheckButtonModal);
-};
-export const closeButtonDisabled = () => {
-  buttonDisabled(closeCheckButtonModal);
-};
-
-// Validation of values
-const validateCheckId = (value) =>
-  cy.contains(`Check: ${value}`).should('contain', value);
-export const validateFirstCheckId = () => validateCheckId(firstCheck.id);
-export const validateSecondCheckId = () => validateCheckId(secondCheck.id);
-
-const validateValueNameAndDefaultValue = (valueName, defaultValue) => {
-  cy.get(modalValueDefault)
-    .should('contain', valueName)
-    .and('contain', defaultValue);
-};
-export const validateFirstCheckDescription = () =>
-  cy.get(modalDescrition).should('contain', firstCheck.description);
-
-export const modalWarningCheckBoxShouldNotBeChecked = () =>
-  cy.get(modalWarningCheckbox).should('not.be.checked');
-export const modalWarningCheckBoxShouldBeChecked = () =>
-  cy.get(modalWarningCheckbox).should('be.checked');
-
-export const validateWarningMessage = () =>
-  cy.get(modalWarningText).should('contain', modalWarningCheckboxLabel);
-export const validateFirstCheckValueNameAndDefaultValue = () => {
-  validateValueNameAndDefaultValue(firstCheckValueName, firstCheckDefaultValue);
-};
-export const validateSecondCheckValueNameAndDefaultValue = () => {
-  validateValueNameAndDefaultValue(
-    secondCheckValueName,
-    secondCheckDefaultValue
-  );
-};
-const validateValue = (element, value) =>
-  cy.get(element).should('have.value', value);
-export const validateCurrentValueFromWandaFirstCheck = () =>
-  validateValue(modalValueCurrentValue, firstCurrentCheckValue);
-
-export const validateCustomizedValue = () => {
-  validateValue(modalValueCurrentValue, customValue);
-};
-
-export const validateProvider = () =>
-  cy.get(modalProvider).should('contain', modalProviderLabel);
-export const validateProviderValue = () =>
-  cy.get(modalProviderInput).should('contain', modalProviderValue);
-export const providerIconShouldBeDisplayed = () => {
-  cy.get(modalProviderIcon)
-    .should('be.visible')
-    .and('have.attr', 'alt', 'azure');
-};
-export const validateResetWarningText = () =>
-  cy.get(resetModalWarning).should('contain', resetModalText);
-
-export const userInputValidationErrorShouldBeDisplayed = () =>
-  cy.get(userValidationError).should('contain', userInputValidationErrorLabel);
 
 // User clicks on element
 export const userClickOnWarningCheckbox = () =>
@@ -261,12 +149,88 @@ export const userInputInvalidCheckValue = () => {
   setInputValue(modalValueCurrentValue, customMixedValue);
 };
 
-// Toast messages for checks customization
-const checkCustomizationToastSuccessLabel = 'Check was customized successfully';
-const checkCustomizationToastSuccess = `p:contains(${checkCustomizationToastSuccessLabel})`;
-const checkCustomizationToastResetLabel = 'Customization was reset!';
-const checkCustomizationToastReset = `p:contains(${checkCustomizationToastResetLabel})`;
-const checkCustomizationToastErrorLabel = 'Failed to customize check';
+// UI validations
+
+// Checks overview
+export const resetIconShouldNotExistInOverview = () =>
+  cy.get(resetCustomizedCheckIcon).should('not.exist');
+export const customizedCheckShouldHaveModifiedPill = () =>
+  cy.get(modifiedPill).should('contain', modifiedPillLabel);
+export const customizedCheckShouldNotHaveModifiedPill = () =>
+  cy.get(modifiedPill).should('not.exist');
+export const secondCustomizedCheckShouldNotHaveModifiedPill = () =>
+  cy.get(modifiedPill).should('not.exist');
+
+// buttons
+const buttonEnabled = (button) => cy.get(button).should('be.enabled');
+const buttonDisabled = (button) => cy.get(button).should('be.disabled');
+export const modalSaveButtonShouldBeEnabled = () =>
+  buttonEnabled(saveButtonModal);
+export const modalSaveButtonShouldBeDisabled = () =>
+  buttonDisabled(saveButtonModal);
+export const resetCheckButtonEnabled = () =>
+  buttonEnabled(resetCheckButtonModal);
+export const modalResetCheckButtonShouldBeDisabled = () => {
+  buttonDisabled(resetCheckButtonModal);
+};
+export const modalCloseButtonShouldBeEnabled = () => {
+  buttonEnabled(closeCheckButtonModal);
+};
+export const closeButtonDisabled = () => {
+  buttonDisabled(closeCheckButtonModal);
+};
+
+// Validation of values
+const validateCheckId = (value) =>
+  cy.contains(`Check: ${value}`).should('contain', value);
+export const validateFirstCheckId = () => validateCheckId(firstCheck.id);
+export const validateSecondCheckId = () => validateCheckId(secondCheck.id);
+export const validateFirstCheckDescription = () =>
+  cy.get(modalDescrition).should('contain', firstCheck.description);
+export const modalWarningCheckBoxShouldNotBeChecked = () =>
+  cy.get(modalWarningCheckbox).should('not.be.checked');
+export const modalWarningCheckBoxShouldBeChecked = () =>
+  cy.get(modalWarningCheckbox).should('be.checked');
+export const validateWarningMessage = () =>
+  cy.get(modalWarningText).should('contain', modalWarningCheckboxLabel);
+
+const validateValueNameAndDefaultValue = (valueName, defaultValue) => {
+  cy.get(modalValueDefault)
+    .should('contain', valueName)
+    .and('contain', defaultValue);
+};
+export const validateFirstCheckValueNameAndDefaultValue = () => {
+  validateValueNameAndDefaultValue(firstCheckValueName, firstCheckDefaultValue);
+};
+export const validateSecondCheckValueNameAndDefaultValue = () => {
+  validateValueNameAndDefaultValue(
+    secondCheckValueName,
+    secondCheckDefaultValue
+  );
+};
+const validateValue = (element, value) =>
+  cy.get(element).should('have.value', value);
+export const validateCurrentValueFromWandaFirstCheck = () =>
+  validateValue(modalValueCurrentValue, firstCurrentCheckValue);
+
+export const validateCustomizedValue = () => {
+  validateValue(modalValueCurrentValue, customValue);
+};
+
+export const validateProvider = () =>
+  cy.get(modalProvider).should('contain', modalProviderLabel);
+export const validateProviderValue = () =>
+  cy.get(modalProviderInput).should('contain', modalProviderValue);
+export const providerIconShouldBeDisplayed = () => {
+  cy.get(modalProviderIcon)
+    .should('be.visible')
+    .and('have.attr', 'alt', 'azure');
+};
+export const validateResetWarningText = () =>
+  cy.get(resetModalWarning).should('contain', resetModalText);
+
+export const userInputValidationErrorShouldBeDisplayed = () =>
+  cy.get(userValidationError).should('contain', userInputValidationErrorLabel);
 
 // Toast messages for checks customization
 const toastShouldBeVisible = (label) => {
@@ -278,3 +242,35 @@ export const checkCustomizationResetToastIsShown = () =>
   toastShouldBeVisible(checkCustomizationToastReset);
 export const checkCustomizationErrorToastIsShown = () =>
   cy.get('body').should('contain', checkCustomizationToastErrorLabel);
+
+// Api
+
+// Page navigation
+export const visit = (clusterId = '') => {
+  basePage.visit(`${url}/${clusterId}`);
+};
+export const visitChecksSelectionCluster = () => visit(availableHanaCluster.id);
+
+export const clickOnCheckSelectionButton = () =>
+  cy.get('button').contains('Check Selection').click();
+
+// Reset checks
+const resetCheck = (groupId, checkId) =>
+  basePage.apiLogin().then(({ accessToken }) =>
+    cy.request({
+      method: 'DELETE',
+      url: `${Cypress.config(
+        'wandaUrl'
+      )}/api/v1/groups/${groupId}/checks/${checkId}/customization`,
+      auth: { bearer: accessToken },
+      failOnStatusCode: false,
+    })
+  );
+
+const resetChecks = (checks) => {
+  checks.forEach(({ id }) => {
+    resetCheck(availableHanaCluster.id, id);
+  });
+};
+
+export const resetAllChecks = () => resetChecks(checkList);

--- a/test/e2e/cypress/pageObject/checks_customization_po.js
+++ b/test/e2e/cypress/pageObject/checks_customization_po.js
@@ -273,4 +273,4 @@ const resetChecks = (checks) => {
   });
 };
 
-export const resetAllChecks = () => resetChecks(checkList);
+export const apiResetAllChecks = () => resetChecks(checkList);

--- a/test/e2e/cypress/pageObject/checks_customization_po.js
+++ b/test/e2e/cypress/pageObject/checks_customization_po.js
@@ -167,7 +167,6 @@ export const validateResetModalWarningText = () =>
   cy.get(resetModalWarning).eq(1).should('contain', resetModalText);
 export const userInputValidationErrorShouldBeDisplayed = () =>
   cy.get(userValidationError).should('contain', userInputValidationErrorLabel);
-// Toast messages for checks customization
 const toastShouldBeVisible = (label) => cy.get(label).should('be.visible');
 export const checkCustomizationSuccessToastIsShown = () =>
   toastShouldBeVisible(checkCustomizationToastSuccess);

--- a/test/e2e/cypress/pageObject/checks_customization_po.js
+++ b/test/e2e/cypress/pageObject/checks_customization_po.js
@@ -23,7 +23,6 @@ const firstCheck = catalogCheckFactory.build({
     }),
   ],
 });
-
 const secondCheck = catalogCheckFactory.build({
   id: '156F64',
   description: 'Corosync `token` timeout is set to expected value',
@@ -36,8 +35,6 @@ const secondCheck = catalogCheckFactory.build({
   ],
 });
 const checkList = [firstCheck, secondCheck];
-
-// Modal check values
 const firstCheckValueName = `${firstCheck.values[0].name}:`;
 const firstCheckDefaultValue = `(Default: ${firstCheck.values[0].default})`;
 const secondCheckValueName = `${secondCheck.values[0].name}:`;
@@ -47,107 +44,74 @@ const modalWarningCheckboxLabel =
   'Trento and SUSE are not responsible for cluster operation failure due to deviation from Best Practices.';
 const userInputValidationErrorLabel =
   'Some of the values are invalid. Please correct them and try again';
-const userValidationError = '.text-red-500';
-
-// User input data
 const customValue = '100';
 const customMixedValue = '30000a';
-
-// Selectors
-
-//Checks overview
-const checksCategorySwitch = '.tn-check-switch';
 const corosyncLabel = 'Corosync';
-const checkCustomModalSettingsIconFirstCheck ='a[class*="block"]:contains("Corosync is running with max_messages") svg'
-
-const checkCustomModalSettingsIconFirstCheckAfterCustomization =
-  'a[class*="block"] button[aria-label="customize-check"] svg';
-const checkCustomModalSettingsIconSecondCheck ='a[class*="block"] button[aria-label="customize-check"] svg';
-const resetCustomizedCheckIcon =   'a[class*="block"] button[aria-label="reset-check-customization"] svg';
 const modifiedPillLabel = 'MODIFIED';
-const modifiedPill=`a[class*="block"] span:contains("${modifiedPillLabel}")`
-
-// Modal elements and values
-const modalDescrition = '.mt-2 > .text-gray-500';
-const modalWarningText = '.border-yellow-400 > .font-semibold';
-const modalWarningCheckbox = '.border-yellow-400 > div > .rc-input';
-const modalValueDefault = '.flex-col > .font-bold';
-const modalValueCurrentValue = '.space-x-4 > div.w-full > .rc-input';
 const modalProviderLabel = 'Provider';
-const modalProvider = `div[class="mt-2"] label[class="font-bold"]:contains("${modalProviderLabel}")`;
 const modalProviderValue = 'Azure';
-const modalProviderInput = `div[class="mt-2"]  div[class="flex items-center space-x-2 mb-5"] div[class="relative w-full"] span:contains("${modalProviderValue}")`
-const modalProviderIcon = '.absolute > .flex > .mr-2';
+const resetModalTitleLabel = 'Reset check: 00081D';
 const resetModalText =
   'You are about to reset custom checks values. Would you like to continue?';
-const resetModalWarning = '.mt-2 > .text-gray-500';
-// Button in modal
+const checkCustomizationToastSuccessLabel = 'Check was customized successfully';
+const checkCustomizationToastResetLabel = 'Customization was reset!';
+const checkCustomizationToastErrorLabel = 'Failed to customize check';
+
+// Selectors
+const corosyncCategory = `div[class="pb-4"] h3.tn-check-switch:contains("${corosyncLabel}")`;
+const checksCustomizationSettingsIcon =
+  'a[class*="block"] button[aria-label="customize-check"] svg';
+const resetCustomizedCheckIcon =
+  'a[class*="block"] button[aria-label="reset-check-customization"] svg';
+const modifiedPill = `a[class*="block"] span:contains("${modifiedPillLabel}")`;
+const modalDescrition = 'div[class="mt-2"] p';
+const modalWarningText = 'div[class="mt-2"] span';
+const modalInput = 'div[class="mt-2"] input';
+const modalValueDefault = 'div[class="mt-2"] label';
+const modalInputValue = 'div[class="mt-2"] span';
+const modalProviderSvg = 'div[class="mt-2"] span img';
+const resetModalTitle = 'div[class*="space-y-4"] h2';
+const resetModalWarning = 'div[class="mt-2"] div[class*="text-gray"]';
+const userValidationError = 'div[class="mt-2"] div p[class*="text-red"]';
 const saveButtonModal = 'button:contains("Save")';
 const resetCheckButtonModal = 'button:contains("Reset Check")';
 const closeCheckButtonModal = 'button:contains("Close")';
-const resetModalLabel = 'Reset';
-const resetModalButton = '.mt-2 > .flex > .bg-jungle-green-500';
-
-// Toast messages for checks customization
-const checkCustomizationToastSuccessLabel = 'Check was customized successfully';
+const resetButton = 'button:contains("Reset")';
 const checkCustomizationToastSuccess = `p:contains(${checkCustomizationToastSuccessLabel})`;
-const checkCustomizationToastResetLabel = 'Customization was reset!';
 const checkCustomizationToastReset = `p:contains(${checkCustomizationToastResetLabel})`;
-const checkCustomizationToastErrorLabel = 'Failed to customize check';
 
 //UI interactions
-export const corosyncCategoryClick = () =>
-  cy.get(checksCategorySwitch).contains(corosyncLabel).click();
-
-export const openCustomizationModalFirstCheck = () => {
-  cy.get(checkCustomModalSettingsIconFirstCheck).first().click({ force: true });
-};
-
-export const openCustomizationModalFirstCheckAfterCustomization = () => cy.get(checkCustomModalSettingsIconFirstCheckAfterCustomization).first().click();
-
-
-export const openCustomizationModalSecondCheck = () => {
-  cy.get(checkCustomModalSettingsIconSecondCheck)
-    .eq(1)
-    .click();
-};
-
-// User clicks on element
+export const corosyncCategoryClick = () => cy.get(corosyncCategory).click();
+export const openCustomizationModalFirstCheck = () =>
+  cy.get(checksCustomizationSettingsIcon).eq(0).click();
+export const openCustomizationModalSecondCheck = () =>
+  cy.get(checksCustomizationSettingsIcon).eq(1).click();
 export const userClickOnWarningCheckbox = () =>
-  cy.get(modalWarningCheckbox).click();
-
-export const userClickResetModalButton = () =>
+  cy.get(modalInput).eq(0).click();
+export const userClickResetCheckModalButton = () =>
   cy.get(resetCheckButtonModal).click();
 export const userClickCloseButton = () => cy.get(closeCheckButtonModal).click();
-
-export const userClickResetButton = () =>
-  cy.get(resetModalButton).contains(resetModalLabel).click();
-
+export const userClickResetButton = () => cy.get(resetButton).click();
+export const userClickResetModalButton = () =>
+  cy.get(resetButton).eq(1).click();
 export const userClickResetCustomizedCheck = () =>
   cy.get(resetCustomizedCheckIcon).click();
-
 export const userClickModalSaveButton = () =>
-  cy.get('.w-80 > .bg-jungle-green-500').click();
-
-// User input
-const setInputValue = (element, value) => {
+  cy.get(saveButtonModal).eq(1).click();
+const setInputValue = (element, index, value) => {
   cy.get(element)
+    .eq(index)
     .should('be.visible')
     .clear()
     .type(value)
     .should('have.value', value);
 };
-
-export const userInputCustomCheckValue = () => {
-  setInputValue(modalValueCurrentValue, customValue);
-};
-export const userInputInvalidCheckValue = () => {
-  setInputValue(modalValueCurrentValue, customMixedValue);
-};
+export const userInputCustomCheckValue = () =>
+  setInputValue(modalInput, 1, customValue);
+export const userInputInvalidCheckValue = () =>
+  setInputValue(modalInput, 1, customMixedValue);
 
 // UI validations
-
-// Checks overview
 export const resetIconShouldNotExistInOverview = () =>
   cy.get(resetCustomizedCheckIcon).should('not.exist');
 export const customizedCheckShouldHaveModifiedPill = () =>
@@ -156,8 +120,61 @@ export const customizedCheckShouldNotHaveModifiedPill = () =>
   cy.get(modifiedPill).should('not.exist');
 export const secondCustomizedCheckShouldNotHaveModifiedPill = () =>
   cy.get(modifiedPill).should('not.exist');
-
-// buttons
+const validateCheckId = (value) =>
+  cy.contains(`Check: ${value}`).should('contain', value);
+export const validateFirstCheckId = () => validateCheckId(firstCheck.id);
+export const validateSecondCheckId = () => validateCheckId(secondCheck.id);
+export const validateFirstCheckDescription = () =>
+  cy.get(modalDescrition).should('contain', firstCheck.description);
+export const modalWarningCheckBoxShouldNotBeChecked = () =>
+  cy.get(modalInput).eq(0).should('not.be.checked');
+export const modalWarningCheckBoxShouldBeChecked = () =>
+  cy.get(modalInput).eq(0).should('be.checked');
+export const validateWarningMessage = () =>
+  cy.get(modalWarningText).should('contain', modalWarningCheckboxLabel);
+const validateValueNameAndDefaultValue = (valueName, defaultValue) => {
+  cy.get(modalValueDefault)
+    .should('contain', valueName)
+    .and('contain', defaultValue);
+};
+export const validateFirstCheckValueNameAndDefaultValue = () =>
+  validateValueNameAndDefaultValue(firstCheckValueName, firstCheckDefaultValue);
+export const validateSecondCheckValueNameAndDefaultValue = () => {
+  validateValueNameAndDefaultValue(
+    secondCheckValueName,
+    secondCheckDefaultValue
+  );
+};
+const validateModalInputValue = (input, index, value) =>
+  cy.get(input).eq(index).should('have.value', value);
+export const validateCurrentValueFromWandaFirstCheck = () =>
+  validateModalInputValue(modalInput, 1, firstCurrentCheckValue);
+export const validateCustomizedValue = () => {
+  validateModalInputValue(modalInput, 0, customValue);
+};
+export const validateProviderLabel = () =>
+  cy.get(modalValueDefault).eq(1).should('contain', modalProviderLabel);
+export const validateProviderValue = () =>
+  cy.get(modalInputValue).eq(1).should('contain', modalProviderValue);
+export const providerIconShouldBeDisplayed = () => {
+  cy.get(modalProviderSvg)
+    .should('be.visible')
+    .and('have.attr', 'alt', 'azure');
+};
+export const validateResetModalTitle = () =>
+  cy.get(resetModalTitle).should('contain', resetModalTitleLabel);
+export const validateResetModalWarningText = () =>
+  cy.get(resetModalWarning).eq(1).should('contain', resetModalText);
+export const userInputValidationErrorShouldBeDisplayed = () =>
+  cy.get(userValidationError).should('contain', userInputValidationErrorLabel);
+// Toast messages for checks customization
+const toastShouldBeVisible = (label) => cy.get(label).should('be.visible');
+export const checkCustomizationSuccessToastIsShown = () =>
+  toastShouldBeVisible(checkCustomizationToastSuccess);
+export const checkCustomizationResetToastIsShown = () =>
+  toastShouldBeVisible(checkCustomizationToastReset);
+export const checkCustomizationErrorToastIsShown = () =>
+  cy.get('body').should('contain', checkCustomizationToastErrorLabel);
 const buttonEnabled = (button) => cy.get(button).should('be.enabled');
 const buttonDisabled = (button) => cy.get(button).should('be.disabled');
 export const modalSaveButtonShouldBeEnabled = () =>
@@ -166,91 +183,16 @@ export const modalSaveButtonShouldBeDisabled = () =>
   buttonDisabled(saveButtonModal);
 export const resetCheckButtonEnabled = () =>
   buttonEnabled(resetCheckButtonModal);
-export const modalResetCheckButtonShouldBeDisabled = () => {
+export const modalResetCheckButtonShouldBeDisabled = () =>
   buttonDisabled(resetCheckButtonModal);
-};
-export const modalCloseButtonShouldBeEnabled = () => {
+export const modalCloseButtonShouldBeEnabled = () =>
   buttonEnabled(closeCheckButtonModal);
-};
-export const closeButtonDisabled = () => {
-  buttonDisabled(closeCheckButtonModal);
-};
-
-// Validation of values
-const validateCheckId = (value) =>
-  cy.contains(`Check: ${value}`).should('contain', value);
-export const validateFirstCheckId = () => validateCheckId(firstCheck.id);
-export const validateSecondCheckId = () => validateCheckId(secondCheck.id);
-export const validateFirstCheckDescription = () =>
-  cy.get(modalDescrition).should('contain', firstCheck.description);
-export const modalWarningCheckBoxShouldNotBeChecked = () =>
-  cy.get(modalWarningCheckbox).should('not.be.checked');
-export const modalWarningCheckBoxShouldBeChecked = () =>
-  cy.get(modalWarningCheckbox).should('be.checked');
-export const validateWarningMessage = () =>
-  cy.get(modalWarningText).should('contain', modalWarningCheckboxLabel);
-
-const validateValueNameAndDefaultValue = (valueName, defaultValue) => {
-  cy.get(modalValueDefault)
-    .should('contain', valueName)
-    .and('contain', defaultValue);
-};
-export const validateFirstCheckValueNameAndDefaultValue = () => {
-  validateValueNameAndDefaultValue(firstCheckValueName, firstCheckDefaultValue);
-};
-export const validateSecondCheckValueNameAndDefaultValue = () => {
-  validateValueNameAndDefaultValue(
-    secondCheckValueName,
-    secondCheckDefaultValue
-  );
-};
-const validateValue = (element, value) =>
-  cy.get(element).should('have.value', value);
-export const validateCurrentValueFromWandaFirstCheck = () =>
-  validateValue(modalValueCurrentValue, firstCurrentCheckValue);
-
-export const validateCustomizedValue = () => {
-  validateValue(modalValueCurrentValue, customValue);
-};
-
-export const validateProvider = () =>
-  cy.get(modalProvider).should('contain', modalProviderLabel);
-export const validateProviderValue = () =>
-  cy.get(modalProviderInput).should('contain', modalProviderValue);
-export const providerIconShouldBeDisplayed = () => {
-  cy.get(modalProviderIcon)
-    .should('be.visible')
-    .and('have.attr', 'alt', 'azure');
-};
-export const validateResetWarningText = () =>
-  cy.get(resetModalWarning).should('contain', resetModalText);
-
-export const userInputValidationErrorShouldBeDisplayed = () =>
-  cy.get(userValidationError).should('contain', userInputValidationErrorLabel);
-
-// Toast messages for checks customization
-const toastShouldBeVisible = (label) => {
-  cy.get(label).should('be.visible');
-};
-export const checkCustomizationSuccessToastIsShown = () =>
-  toastShouldBeVisible(checkCustomizationToastSuccess);
-export const checkCustomizationResetToastIsShown = () =>
-  toastShouldBeVisible(checkCustomizationToastReset);
-export const checkCustomizationErrorToastIsShown = () =>
-  cy.get('body').should('contain', checkCustomizationToastErrorLabel);
 
 // Api
-
-// Page navigation
-export const visit = (clusterId = '') => {
-  basePage.visit(`${url}/${clusterId}`);
-};
+export const visit = (clusterId = '') => basePage.visit(`${url}/${clusterId}`);
 export const visitChecksSelectionCluster = () => visit(availableHanaCluster.id);
-
 export const clickOnCheckSelectionButton = () =>
   cy.get('button').contains('Check Selection').click();
-
-// Reset checks
 const resetCheck = (groupId, checkId) =>
   basePage.apiLogin().then(({ accessToken }) =>
     cy.request({
@@ -262,11 +204,9 @@ const resetCheck = (groupId, checkId) =>
       failOnStatusCode: false,
     })
   );
-
 const resetChecks = (checks) => {
   checks.forEach(({ id }) => {
     resetCheck(availableHanaCluster.id, id);
   });
 };
-
 export const apiResetAllChecks = () => resetChecks(checkList);


### PR DESCRIPTION
# Description

This pr adds first e2e tests for checks customization feature. With the addition of wanda in demo mode in https://github.com/trento-project/web/pull/3455 we are able to test api communication between web and wanda. With this we don't require a mocked catalog anymore. As wanda runs in demo mode we receive even mocked agent data, which can be used in a follow up test  for modified checks execution.

## How was this tested?

Added e2e test with po