### PR TITLE
Alerting Settings web API

### DIFF
--- a/lib/trento/settings/policy.ex
+++ b/lib/trento/settings/policy.ex
@@ -19,6 +19,18 @@ defmodule Trento.Settings.Policy do
 
   alias Trento.Users.User
 
+  @action_to_resource %{
+    update_api_key_settings: Trento.Settings.ApiKeySettings,
+    update_activity_log_settings: Trento.Settings.ActivityLogSettings,
+    save_suse_manager_settings: Trento.Settings.SuseManagerSettings,
+    update_suse_manager_settings: Trento.Settings.SuseManagerSettings,
+    delete_suse_manager_settings: Trento.Settings.SuseManagerSettings,
+    test_suse_manager_settings: Trento.Settings.SuseManagerSettings,
+    get_alerting_settings: Trento.Settings.AlertingSettings,
+    create_alerting_settings: Trento.Settings.AlertingSettings,
+    update_alerting_settings: Trento.Settings.AlertingSettings
+  }
+
   def authorize(:update_api_key_settings, %User{} = user, ApiKeySettings),
     do: has_global_ability?(user) or has_api_key_settings_change_ability?(user)
 
@@ -40,6 +52,9 @@ defmodule Trento.Settings.Policy do
   end
 
   def authorize(_, _, _), do: true
+
+  @spec get_resource(atom()) :: atom() | nil
+  def get_resource(action), do: Map.get(@action_to_resource, action, nil)
 
   defp has_api_key_settings_change_ability?(user),
     do: user_has_ability?(user, %{name: "all", resource: "api_key_settings"})

--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -24,6 +24,13 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"404", reason: "SUSE Manager settings not configured.")
   end
 
+  def call(conn, {:error, :alerting_settings_not_configured}) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(json: ErrorJSON)
+    |> render(:"404", reason: "Alerting settings not configured.")
+  end
+
   def call(conn, {:error, :suma_authentication_error}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/lib/trento_web/controllers/v1/settings_controller.ex
+++ b/lib/trento_web/controllers/v1/settings_controller.ex
@@ -260,6 +260,78 @@ defmodule TrentoWeb.V1.SettingsController do
     render(conn, :public_keys, %{public_keys: [certificates]})
   end
 
+  operation :get_alerting_settings,
+    summary: "Get alerting settings",
+    tags: ["Platform"],
+    description: "Get the saved settings for alerting in Trento",
+    responses: [
+      ok: {"Alerting settings retrieved", "application/json", Schema.Platform.AlertingSettings},
+      unauthorized: Schema.Unauthorized.response(),
+      not_found: Schema.NotFound.response()
+    ]
+
+  def get_alerting_settings(conn, _params) do
+    with {:ok, settings} <- Settings.get_alerting_settings() do
+      conn
+      |> put_status(:ok)
+      |> render(:alerting_settings, alerting_settings: settings)
+    end
+  end
+
+  operation :create_alerting_settings,
+    summary: "Set alerting settings",
+    description: "Set persisted settings for alerting in Trento",
+    tags: ["Platform"],
+    request_body:
+      {"Request body for setting alerting settings", "application/json",
+       Schema.Platform.AlertingSettings},
+    responses: [
+      ok:
+        {"Alerting settings successfully modified", "application/json",
+         Schema.Platform.AlertingSettings},
+      unauthorized: Schema.Unauthorized.response(),
+      forbidden: Schema.Forbidden.response(),
+      unprocessable_entity: Schema.UnprocessableEntity.response()
+    ]
+
+  def create_alerting_settings(conn, _params) do
+    alerting_body = OpenApiSpex.body_params(conn)
+
+    with {:ok, settings} <- Settings.create_alerting_settings(alerting_body) do
+      conn
+      |> put_status(:ok)
+      |> render(:alerting_settings, alerting_settings: settings)
+    end
+  end
+
+  operation :update_alerting_settings,
+    summary: "Update alerting settings",
+    description: "Update persisted settings for alerting in Trento",
+    tags: ["Platform"],
+    request_body:
+      {"Request body for updating alerting settings", "application/json",
+       Schema.Platform.UpdateAlertingSettings},
+    responses: [
+      ok:
+        {"Alerting settings successfully modified", "application/json",
+         Schema.Platform.AlertingSettings},
+      unauthorized: Schema.Unauthorized.response(),
+      forbidden: Schema.Forbidden.response(),
+      not_found: Schema.NotFound.response(),
+      unprocessable_entity: Schema.UnprocessableEntity.response()
+    ]
+
+  def update_alerting_settings(conn, _params) do
+    alerting_body = OpenApiSpex.body_params(conn)
+
+    with {:ok, settings} <- Settings.update_alerting_settings(alerting_body) do
+      conn
+      |> put_status(:ok)
+      |> render(:alerting_settings, alerting_settings: settings)
+    end
+  end
+
+  # credo:disable-for-next-line
   def get_policy_resource(conn) do
     case Phoenix.Controller.action_name(conn) do
       :update_api_key_settings -> Trento.Settings.ApiKeySettings
@@ -268,6 +340,9 @@ defmodule TrentoWeb.V1.SettingsController do
       :update_suse_manager_settings -> Trento.Settings.SuseManagerSettings
       :delete_suse_manager_settings -> Trento.Settings.SuseManagerSettings
       :test_suse_manager_settings -> Trento.Settings.SuseManagerSettings
+      :get_alerting_settings -> Trento.Settings.AlertingSettings
+      :create_alerting_settings -> Trento.Settings.AlertingSettings
+      :update_alerting_settings -> Trento.Settings.AlertingSettings
       _ -> nil
     end
   end

--- a/lib/trento_web/controllers/v1/settings_controller.ex
+++ b/lib/trento_web/controllers/v1/settings_controller.ex
@@ -284,7 +284,7 @@ defmodule TrentoWeb.V1.SettingsController do
     tags: ["Platform"],
     request_body:
       {"Request body for setting alerting settings", "application/json",
-       Schema.Platform.AlertingSettings},
+       Schema.Platform.CreateAlertingSettings},
     responses: [
       ok:
         {"Alerting settings successfully modified", "application/json",

--- a/lib/trento_web/controllers/v1/settings_controller.ex
+++ b/lib/trento_web/controllers/v1/settings_controller.ex
@@ -331,19 +331,9 @@ defmodule TrentoWeb.V1.SettingsController do
     end
   end
 
-  # credo:disable-for-next-line
   def get_policy_resource(conn) do
-    case Phoenix.Controller.action_name(conn) do
-      :update_api_key_settings -> Trento.Settings.ApiKeySettings
-      :update_activity_log_settings -> Trento.Settings.ActivityLogSettings
-      :save_suse_manager_settings -> Trento.Settings.SuseManagerSettings
-      :update_suse_manager_settings -> Trento.Settings.SuseManagerSettings
-      :delete_suse_manager_settings -> Trento.Settings.SuseManagerSettings
-      :test_suse_manager_settings -> Trento.Settings.SuseManagerSettings
-      :get_alerting_settings -> Trento.Settings.AlertingSettings
-      :create_alerting_settings -> Trento.Settings.AlertingSettings
-      :update_alerting_settings -> Trento.Settings.AlertingSettings
-      _ -> nil
-    end
+    conn
+    |> Phoenix.Controller.action_name()
+    |> Trento.Settings.Policy.get_resource()
   end
 end

--- a/lib/trento_web/controllers/v1/settings_json.ex
+++ b/lib/trento_web/controllers/v1/settings_json.ex
@@ -50,4 +50,23 @@ defmodule TrentoWeb.V1.SettingsJSON do
 
   def public_key(%{public_key: %{name: name, certificate_file: cert_file}}),
     do: %{name: name, content: cert_file}
+
+  def alerting_settings(%{
+        alerting_settings: %{
+          enabled: enabled,
+          sender_email: sender_email,
+          recipient_email: recipient_email,
+          smtp_server: smtp_server,
+          smtp_port: smtp_port,
+          smtp_username: smtp_username
+        }
+      }),
+      do: %{
+        enabled: enabled,
+        sender_email: sender_email,
+        recipient_email: recipient_email,
+        smtp_server: smtp_server,
+        smtp_port: smtp_port,
+        smtp_username: smtp_username
+      }
 end

--- a/lib/trento_web/openapi/v1/schema/platform.ex
+++ b/lib/trento_web/openapi/v1/schema/platform.ex
@@ -286,8 +286,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Platform do
           recipient_email: %Schema{type: :string},
           smtp_server: %Schema{type: :string},
           smtp_port: %Schema{
-            title: "Port",
-            anyOf: [%Schema{type: :integer}, %Schema{type: :string}],
+            type: :integer,
             example: 587
           },
           smtp_username: %Schema{type: :string}

--- a/lib/trento_web/openapi/v1/schema/platform.ex
+++ b/lib/trento_web/openapi/v1/schema/platform.ex
@@ -290,9 +290,41 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Platform do
             anyOf: [%Schema{type: :integer}, %Schema{type: :string}],
             example: 587
           },
+          smtp_username: %Schema{type: :string}
+        },
+        required: [
+          :enabled,
+          :sender_email,
+          :recipient_email,
+          :smtp_server,
+          :smtp_port,
+          :smtp_username
+        ]
+      },
+      struct?: false
+    )
+  end
+
+  defmodule CreateAlertingSettings do
+    @moduledoc false
+
+    OpenApiSpex.schema(
+      %{
+        title: "CreateAlertingSettings",
+        description: "Request body for creating Alerting Settings",
+        type: :object,
+        properties: %{
+          enabled: %Schema{type: :boolean},
+          sender_email: %Schema{type: :string},
+          recipient_email: %Schema{type: :string},
+          smtp_server: %Schema{type: :string},
+          smtp_port: %Schema{
+            title: "Port",
+            anyOf: [%Schema{type: :integer}, %Schema{type: :string}],
+            example: 587
+          },
           smtp_username: %Schema{type: :string},
-          smtp_password: %Schema{type: :string, format: :password, writeOnly: true},
-          enforced_from_env: %Schema{type: :boolean, readOnly: true}
+          smtp_password: %Schema{type: :string, format: :password}
         },
         required: [
           :enabled,
@@ -302,9 +334,6 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Platform do
           :smtp_port,
           :smtp_username,
           :smtp_password
-          # `open_api_spex` has a bug with required readOnly fields:
-          # https://github.com/open-api-spex/open_api_spex/issues/662
-          # :enforced_from_env,
         ]
       },
       struct?: false

--- a/lib/trento_web/openapi/v1/schema/platform.ex
+++ b/lib/trento_web/openapi/v1/schema/platform.ex
@@ -271,4 +271,69 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Platform do
       struct?: false
     )
   end
+
+  defmodule AlertingSettings do
+    @moduledoc false
+
+    OpenApiSpex.schema(
+      %{
+        title: "AlertingSettings",
+        description: "Settings for the alerting sub-system",
+        type: :object,
+        properties: %{
+          enabled: %Schema{type: :boolean},
+          sender_email: %Schema{type: :string},
+          recipient_email: %Schema{type: :string},
+          smtp_server: %Schema{type: :string},
+          smtp_port: %Schema{
+            title: "Port",
+            anyOf: [%Schema{type: :integer}, %Schema{type: :string}],
+            example: 587
+          },
+          smtp_username: %Schema{type: :string},
+          smtp_password: %Schema{type: :string, format: :password, writeOnly: true},
+          enforced_from_env: %Schema{type: :boolean, readOnly: true}
+        },
+        required: [
+          :enabled,
+          :sender_email,
+          :recipient_email,
+          :smtp_server,
+          :smtp_port,
+          :smtp_username,
+          :smtp_password
+          # `open_api_spex` has a bug with required readOnly fields:
+          # https://github.com/open-api-spex/open_api_spex/issues/662
+          # :enforced_from_env,
+        ]
+      },
+      struct?: false
+    )
+  end
+
+  defmodule UpdateAlertingSettings do
+    @moduledoc false
+
+    OpenApiSpex.schema(
+      %{
+        title: "UpdateAlertingSettings",
+        description: "Request body for updating Alerting Settings.",
+        type: :object,
+        properties: %{
+          enabled: %Schema{type: :boolean},
+          sender_email: %Schema{type: :string},
+          recipient_email: %Schema{type: :string},
+          smtp_server: %Schema{type: :string},
+          smtp_port: %Schema{
+            title: "Port",
+            anyOf: [%Schema{type: :integer}, %Schema{type: :string}],
+            example: 587
+          },
+          smtp_username: %Schema{type: :string},
+          smtp_password: %Schema{type: :string, format: :password}
+        }
+      },
+      struct?: false
+    )
+  end
 end

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -215,6 +215,10 @@ defmodule TrentoWeb.Router do
           delete "/", SettingsController, :delete_suse_manager_settings
           post "/test", SettingsController, :test_suse_manager_settings
         end
+
+        get "/alerting", SettingsController, :get_alerting_settings
+        post "/alerting", SettingsController, :create_alerting_settings
+        patch "/alerting", SettingsController, :update_alerting_settings
       end
 
       # Deprecated

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -216,9 +216,11 @@ defmodule TrentoWeb.Router do
           post "/test", SettingsController, :test_suse_manager_settings
         end
 
-        get "/alerting", SettingsController, :get_alerting_settings
-        post "/alerting", SettingsController, :create_alerting_settings
-        patch "/alerting", SettingsController, :update_alerting_settings
+        scope "/alerting" do
+          get "/", SettingsController, :get_alerting_settings
+          post "/", SettingsController, :create_alerting_settings
+          patch "/", SettingsController, :update_alerting_settings
+        end
       end
 
       # Deprecated

--- a/test/trento/settings/policy_test.exs
+++ b/test/trento/settings/policy_test.exs
@@ -140,4 +140,14 @@ defmodule Trento.Settings.PolicyTest do
       refute Policy.authorize(:update_alerting_settings, user, AlertingSettings)
     end
   end
+
+  describe "Action to resource mapping" do
+    test "should return correct resource for a mapped action" do
+      assert Policy.get_resource(:update_api_key_settings) == ApiKeySettings
+    end
+
+    test "should return nil for unmapped actions" do
+      assert Policy.get_resource(:unmapped_action) == nil
+    end
+  end
 end

--- a/test/trento_web/controllers/v1/settings_controller_test.exs
+++ b/test/trento_web/controllers/v1/settings_controller_test.exs
@@ -7,14 +7,10 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
   import Trento.Support.Helpers.AbilitiesTestHelper
   import Mox
 
-  alias TrentoWeb.OpenApi.V1.ApiSpec
-
-  setup :setup_api_spec_v1
+  setup_all :setup_api_spec_v1
   setup :setup_user
 
-  test "should return the settings according to the schema", %{conn: conn} do
-    api_spec = ApiSpec.spec()
-
+  test "should return the settings according to the schema", %{conn: conn, api_spec: api_spec} do
     conn = get(conn, "/api/v1/settings")
 
     conn
@@ -23,10 +19,6 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
   end
 
   describe "ApiKeySettings" do
-    setup do
-      %{api_spec: ApiSpec.spec()}
-    end
-
     test "should return not found when api key settings are not configured", %{
       conn: conn,
       api_spec: api_spec
@@ -118,10 +110,6 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
   end
 
   describe "ActivityLogSettings" do
-    setup do
-      %{api_spec: ApiSpec.spec()}
-    end
-
     test "should return activity retention settings after setting up", %{
       conn: conn,
       api_spec: api_spec
@@ -176,13 +164,11 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
   end
 
   describe "SuseManagerSettings" do
-    test "should return user settings", %{conn: conn} do
+    test "should return user settings", %{conn: conn, api_spec: api_spec} do
       insert_software_updates_settings(
         ca_cert: build(:self_signed_certificate),
         ca_uploaded_at: DateTime.utc_now()
       )
-
-      api_spec = ApiSpec.spec()
 
       conn
       |> get("/api/v1/settings/suse_manager")
@@ -190,9 +176,10 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
       |> assert_schema("SuseManagerSettings", api_spec)
     end
 
-    test "should return forbidden if no user settings have been saved", %{conn: conn} do
-      api_spec = ApiSpec.spec()
-
+    test "should return forbidden if no user settings have been saved", %{
+      conn: conn,
+      api_spec: api_spec
+    } do
       conn
       |> get("/api/v1/settings/suse_manager")
       |> json_response(:not_found)
@@ -638,10 +625,6 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
   end
 
   describe "SSOCertificatesSettings" do
-    setup do
-      %{api_spec: ApiSpec.spec()}
-    end
-
     test "should return uploaded certificates public content in the public_keys route", %{
       conn: conn,
       api_spec: api_spec
@@ -658,46 +641,221 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
     end
   end
 
-  describe "forbidden response" do
-    test "should return forbidden if the user does not have the permission to update the api key",
-         %{conn: conn, api_spec: api_spec} do
-      insert(:api_key_settings)
-      %{id: user_id} = insert(:user)
+  describe "AlertingSettings" do
+    @alerting_settings_get_fields ~w(enabled sender_email recipient_email smtp_server smtp_port smtp_username)a
+    @alerting_settings_set_fields ~w(enabled sender_email recipient_email smtp_server smtp_port smtp_username smtp_password)a
+
+    test "returning successful response on get request", %{conn: conn, api_spec: api_spec} do
+      exp_settings =
+        :alerting_settings
+        |> insert()
+        |> Map.take(@alerting_settings_get_fields)
+
+      resp =
+        conn
+        |> get(~p"/api/v1/settings/alerting")
+        |> json_response(:ok)
+        |> assert_response_schema("AlertingSettings", api_spec)
+
+      assert exp_settings == resp
+    end
+
+    test "successfully creates settings and returns expected response", %{
+      conn: conn,
+      api_spec: api_spec
+    } do
+      settings = build(:alerting_settings)
+      set_params = Map.take(settings, @alerting_settings_set_fields)
+      exp_params = Map.take(settings, @alerting_settings_get_fields)
+
+      resp =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post(~p"/api/v1/settings/alerting", set_params)
+        |> json_response(:ok)
+        |> assert_response_schema("AlertingSettings", api_spec)
+
+      assert exp_params == resp
+    end
+
+    for field <-
+          ~w(enabled sender_email recipient_email smtp_server smtp_port smtp_username smtp_password)a do
+      test "fails to create settings if missing required field (#{field}) in the OpeApi spec", %{
+        conn: conn,
+        api_spec: api_spec
+      } do
+        settings =
+          :alerting_settings
+          |> build()
+          |> Map.take(@alerting_settings_set_fields)
+          |> Map.delete(unquote(field))
+
+        conn =
+          conn
+          |> put_req_header("content-type", "application/json")
+          |> post(~p"/api/v1/settings/alerting", settings)
+          |> json_response(:unprocessable_entity)
+
+        assert_response_schema(conn, "UnprocessableEntity", api_spec)
+
+        assert %{
+                 "errors" => [
+                   %{
+                     "detail" => "Missing field: " <> to_string(unquote(field)),
+                     "source" => %{"pointer" => "/" <> to_string(unquote(field))},
+                     "title" => "Invalid value"
+                   }
+                 ]
+               } == conn
+      end
+    end
+
+    test "fails to create settings if validation (changeset) fails", %{
+      conn: conn,
+      api_spec: api_spec
+    } do
+      # We check a whole class of errors by checking for only one
+      # field. The rest of the fields should act the same.
+      settings =
+        :alerting_settings
+        |> build(sender_email: "not_an_email.com")
+        |> Map.take(@alerting_settings_set_fields)
 
       conn =
         conn
-        |> Pow.Plug.assign_current_user(%{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
         |> put_req_header("content-type", "application/json")
+        |> post(~p"/api/v1/settings/alerting", settings)
+        |> json_response(:unprocessable_entity)
+
+      assert_response_schema(conn, "UnprocessableEntity", api_spec)
+
+      assert %{
+               "errors" => [
+                 %{
+                   "detail" => "Invalid e-mail address.",
+                   "source" => %{"pointer" => "/sender_email"},
+                   "title" => "Invalid value"
+                 }
+               ]
+             } == conn
+    end
+
+    test "successfully updates settings and returns expected response", %{
+      conn: conn,
+      api_spec: api_spec
+    } do
+      %{
+        sender_email: sender_email,
+        recipient_email: recipient_email,
+        smtp_server: smtp_server,
+        smtp_port: smtp_port,
+        smtp_username: smtp_username
+      } = insert(:alerting_settings, enabled: true)
+
+      resp =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> patch(~p"/api/v1/settings/alerting", %{enabled: false})
+        |> json_response(:ok)
+        |> assert_response_schema("AlertingSettings", api_spec)
+
+      assert %{
+               enabled: false,
+               sender_email: sender_email,
+               recipient_email: recipient_email,
+               smtp_server: smtp_server,
+               smtp_port: smtp_port,
+               smtp_username: smtp_username
+             } == resp
+    end
+
+    test "fails to update settings if validation (changeset) fails", %{
+      conn: conn,
+      api_spec: api_spec
+    } do
+      insert(:alerting_settings)
+
+      # We check a whole class of errors by checking for only one
+      # field. The rest of the fields should act the same.
+      settings = %{sender_email: "not_an_email.com"}
 
       conn =
-        patch(conn, "/api/v1/settings/api_key", %{
-          "expire_at" => DateTime.to_iso8601(DateTime.utc_now())
-        })
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> patch(~p"/api/v1/settings/alerting", settings)
+        |> json_response(:unprocessable_entity)
+
+      assert_response_schema(conn, "UnprocessableEntity", api_spec)
+
+      assert %{
+               "errors" => [
+                 %{
+                   "detail" => "Invalid e-mail address.",
+                   "source" => %{"pointer" => "/sender_email"},
+                   "title" => "Invalid value"
+                 }
+               ]
+             } == conn
+    end
+
+    test "returns error when trying to update settings without previously saved ones", %{
+      conn: conn,
+      api_spec: api_spec
+    } do
+      resp =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> patch(~p"/api/v1/settings/alerting", %{enabled: false})
+        |> json_response(:not_found)
+        |> assert_response_schema("NotFound", api_spec)
+
+      assert %{
+               errors: [
+                 %{title: "Not Found", detail: "Alerting settings not configured."}
+               ]
+             } == resp
+    end
+  end
+
+  describe "forbidden response" do
+    setup %{conn: conn} do
+      %{id: unpriv_user_id} = insert(:user)
+
+      conn =
+        Pow.Plug.assign_current_user(
+          conn,
+          %{"user_id" => unpriv_user_id},
+          Pow.Plug.fetch_config(conn)
+        )
+
+      {:ok, conn: conn, unpriv_user: unpriv_user_id}
+    end
+
+    test "should return forbidden if the user does not have the permission to update the api key",
+         %{conn: conn, api_spec: api_spec} do
+      insert(:api_key_settings)
 
       conn
+      |> put_req_header("content-type", "application/json")
+      |> patch("/api/v1/settings/api_key", %{
+        "expire_at" => DateTime.to_iso8601(DateTime.utc_now())
+      })
       |> json_response(:forbidden)
       |> assert_schema("Forbidden", api_spec)
     end
 
     test "should return forbidden if the user does not have the permission to edit activity logs settings",
          %{conn: conn, api_spec: api_spec} do
-      %{id: user_id} = insert(:user)
       insert(:activity_log_settings)
 
-      conn =
-        conn
-        |> Pow.Plug.assign_current_user(%{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
-        |> put_req_header("content-type", "application/json")
-
-      conn =
-        put(conn, "/api/v1/settings/activity_log", %{
-          retention_time: %{
-            value: 42,
-            unit: :year
-          }
-        })
-
       conn
+      |> put_req_header("content-type", "application/json")
+      |> put("/api/v1/settings/activity_log", %{
+        retention_time: %{
+          value: 42,
+          unit: :year
+        }
+      })
       |> json_response(:forbidden)
       |> assert_schema("Forbidden", api_spec)
     end
@@ -713,14 +871,8 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
         ca_cert: build(:self_signed_certificate)
       }
 
-      %{id: user_id} = insert(:user)
-
-      conn =
-        conn
-        |> Pow.Plug.assign_current_user(%{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
-        |> put_req_header("content-type", "application/json")
-
       conn
+      |> put_req_header("content-type", "application/json")
       |> post("/api/v1/settings/suse_manager", settings)
       |> json_response(:forbidden)
       |> assert_schema("Forbidden", api_spec)
@@ -731,36 +883,60 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
       api_spec: api_spec
     } do
       insert_software_updates_settings()
-      %{id: user_id} = insert(:user)
 
       change_submission = %{}
 
-      conn =
-        conn
-        |> Pow.Plug.assign_current_user(%{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
-        |> put_req_header("content-type", "application/json")
-
       conn
+      |> put_req_header("content-type", "application/json")
       |> patch("/api/v1/settings/suse_manager", change_submission)
       |> json_response(:forbidden)
       |> assert_schema("Forbidden", api_spec)
     end
-  end
 
-  test "should return forbidden when user tries to delete settings without right abilities", %{
-    conn: conn,
-    api_spec: api_spec
-  } do
-    %{id: user_id} = insert(:user)
-
-    conn =
+    test "should return forbidden when user tries to delete settings without right abilities", %{
+      conn: conn,
+      api_spec: api_spec
+    } do
       conn
-      |> Pow.Plug.assign_current_user(%{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
       |> put_req_header("content-type", "application/json")
+      |> delete("/api/v1/settings/suse_manager")
+      |> json_response(:forbidden)
+      |> assert_schema("Forbidden", api_spec)
+    end
 
-    conn
-    |> delete("/api/v1/settings/suse_manager")
-    |> json_response(:forbidden)
-    |> assert_schema("Forbidden", api_spec)
+    test "should return forbidden when user ties to create alerting settings without right abilities",
+         %{
+           conn: conn,
+           api_spec: api_spec
+         } do
+      settings =
+        :alerting_settings
+        |> build()
+        |> Map.take(@alerting_settings_set_fields)
+
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> post(~p"/api/v1/settings/alerting", settings)
+      |> json_response(:forbidden)
+      |> assert_schema("Forbidden", api_spec)
+    end
+
+    test "should return forbidden when user ties to update alerting settings without right abilities",
+         %{
+           conn: conn,
+           api_spec: api_spec
+         } do
+      settings =
+        :alerting_settings
+        |> build()
+        |> Map.take(@alerting_settings_set_fields)
+        |> Map.delete(:smtp_password)
+
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> patch(~p"/api/v1/settings/alerting", settings)
+      |> json_response(:forbidden)
+      |> assert_schema("Forbidden", api_spec)
+    end
   end
 end

--- a/test/trento_web/controllers/v1/settings_controller_test.exs
+++ b/test/trento_web/controllers/v1/settings_controller_test.exs
@@ -696,10 +696,11 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
           ~w(enabled sender_email recipient_email smtp_server smtp_port smtp_username smtp_password)a do
       @field field
 
-      test "should fail to create settings if missing required field (#{@field}) in the OpeApi spec", %{
-        conn: conn,
-        api_spec: api_spec
-      } do
+      test "should fail to create settings if missing required field (#{@field}) in the OpeApi spec",
+           %{
+             conn: conn,
+             api_spec: api_spec
+           } do
         settings =
           :alerting_settings
           |> build()

--- a/test/trento_web/views/v1/settings_view_json_test.exs
+++ b/test/trento_web/views/v1/settings_view_json_test.exs
@@ -1,6 +1,8 @@
 defmodule TrentoWeb.V1.SettingsJSONTest do
   use TrentoWeb.ConnCase, async: true
 
+  import Trento.Factory
+
   alias TrentoWeb.V1.SettingsJSON
 
   describe "renders suse_manager.json" do
@@ -16,6 +18,18 @@ defmodule TrentoWeb.V1.SettingsJSONTest do
 
       assert %{url: url, username: username, ca_uploaded_at: ca_uploaded_at} ==
                SettingsJSON.suse_manager(%{settings: settings})
+    end
+  end
+
+  describe "Alerting Settings template/view" do
+    @alerting_allowed_fields ~w(enabled sender_email recipient_email smtp_server smtp_port smtp_username)a
+
+    test "filters only correct fileds" do
+      settings = build(:alerting_settings)
+      expected = Map.take(settings, @alerting_allowed_fields)
+
+      assert expected ==
+               SettingsJSON.alerting_settings(%{alerting_settings: settings})
     end
   end
 end

--- a/test/trento_web/views/v1/settings_view_json_test.exs
+++ b/test/trento_web/views/v1/settings_view_json_test.exs
@@ -24,7 +24,7 @@ defmodule TrentoWeb.V1.SettingsJSONTest do
   describe "Alerting Settings template/view" do
     @alerting_allowed_fields ~w(enabled sender_email recipient_email smtp_server smtp_port smtp_username)a
 
-    test "filters only correct fileds" do
+    test "filters only correct fields" do
       settings = build(:alerting_settings)
       expected = Map.take(settings, @alerting_allowed_fields)
 


### PR DESCRIPTION
# Description
THIS IS DEPENDENT ON #3461.

Adding web API for getting/settings/updating alerting settings. Full OpenAPI schema descriptions are added as well.

Adds fixes towards [TRNT-2711](https://jira.suse.com/browse/TRNT-2711)

## How was this tested?

Unit tests:
- Added tests for getting/setting/updating settings through the API (controller test)
- Added tests for authorization requirements in alerting settings API.