### PR TITLE
Relax timeouts

### DIFF
--- a/lib/trento/infrastructure/software_updates/adapter/suma_http_executor.ex
+++ b/lib/trento/infrastructure/software_updates/adapter/suma_http_executor.ex
@@ -97,7 +97,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor do
       "#{base_url}/auth/login",
       payload,
       [{"Content-type", "application/json"}],
-      ssl_options(ca_cert) ++ timeout_options()
+      ssl_options(ca_cert)
     )
   end
 
@@ -210,9 +210,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.Suma.HttpExecutor do
   end
 
   defp request_options(auth, ca_cert),
-    do: [hackney: [cookie: [auth]]] ++ ssl_options(ca_cert) ++ timeout_options()
-
-  defp timeout_options, do: [timeout: 1_000, recv_timeout: 5_000]
+    do: [hackney: [cookie: [auth]]] ++ ssl_options(ca_cert)
 
   defp ssl_options(nil), do: []
 

--- a/lib/trento/infrastructure/software_updates/suma_api.ex
+++ b/lib/trento/infrastructure/software_updates/suma_api.ex
@@ -229,6 +229,17 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
   defp decode_response({:error, :suma_authentication_error}, _),
     do: {:error, :suma_authentication_error}
 
+  defp decode_response({:error, %HTTPoison.Error{reason: :timeout}} = error,
+         error_atom: error_atom,
+         error_log: error_log
+       ) do
+    Logger.error(
+      "#{error_log} Request timed out: #{inspect(error)}. Propagating as #{error_atom}"
+    )
+
+    {:error, error_atom}
+  end
+
   defp decode_response({:error, _} = error, error_atom: error_atom, error_log: error_log) do
     Logger.error("#{error_log} Error: #{inspect(error)}")
 


### PR DESCRIPTION
Successor of #3472 . Description generally applies, but the TLDR is the default HTTPoison timeouts are more than enough for this out case and more restrictive lead to HTTP time-outs, even when SUMA would have responded. This PR addresses it