### PR TITLE
Expose cluster resource parent api

### DIFF
--- a/lib/trento_web/controllers/v2/cluster_json.ex
+++ b/lib/trento_web/controllers/v2/cluster_json.ex
@@ -9,7 +9,6 @@ defmodule TrentoWeb.V2.ClusterJSON do
     |> Map.delete(:deregistered_at)
     |> Map.delete(:hosts)
     |> Map.delete(:__meta__)
-    |> adapt_details()
     |> adapt_sids()
   end
 
@@ -27,58 +26,6 @@ defmodule TrentoWeb.V2.ClusterJSON do
 
   def cluster_health_changed(%{cluster: %{id: id, name: name, health: health}}),
     do: %{cluster_id: id, name: name, health: health}
-
-  defp adapt_details(
-         %{
-           details: %{nodes: nodes, stopped_resources: stopped_resources} = details
-         } =
-           cluster
-       ) do
-    adapted_nodes = Enum.map(nodes, &adapt_node/1)
-    adapted_stopped_resources = adapt_resources(stopped_resources)
-
-    adapted_details =
-      details
-      |> Map.put(:nodes, adapted_nodes)
-      |> Map.put(:stopped_resources, adapted_stopped_resources)
-
-    %{cluster | details: adapted_details}
-  end
-
-  defp adapt_details(
-         %{
-           details: %{sap_systems: nodes, stopped_resources: stopped_resources} = details
-         } =
-           cluster
-       ) do
-    adapted_sap_systems = Enum.map(nodes, &adapt_sap_system/1)
-    adapted_stopped_resources = adapt_resources(stopped_resources)
-
-    adapted_details =
-      details
-      |> Map.put(:sap_systems, adapted_sap_systems)
-      |> Map.put(:stopped_resources, adapted_stopped_resources)
-
-    %{cluster | details: adapted_details}
-  end
-
-  defp adapt_details(cluster), do: cluster
-
-  defp adapt_sap_system(%{nodes: nodes} = sap_system) do
-    adapted_nodes = Enum.map(nodes, &adapt_node/1)
-
-    Map.put(sap_system, :nodes, adapted_nodes)
-  end
-
-  defp adapt_node(%{resources: resources} = node) do
-    adapted_resources = adapt_resources(resources)
-
-    Map.put(node, :resources, adapted_resources)
-  end
-
-  defp adapt_resources(resources) do
-    Enum.map(resources, &Map.drop(&1, [:parent]))
-  end
 
   defp adapt_sids(%{sap_instances: sap_instances} = cluster) do
     adapted_sap_instances =

--- a/lib/trento_web/openapi/v2/schema/cluster.ex
+++ b/lib/trento_web/openapi/v2/schema/cluster.ex
@@ -33,7 +33,11 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
             nullable: true,
             properties: %{
               id: %Schema{type: :string},
-              managed: %Schema{type: :boolean},
+              managed: %Schema{
+                type: :boolean,
+                nullable: true,
+                description: "Resource is managed. null for standard groups"
+              },
               multi_state: %Schema{
                 type: :boolean,
                 nullable: true,

--- a/lib/trento_web/openapi/v2/schema/cluster.ex
+++ b/lib/trento_web/openapi/v2/schema/cluster.ex
@@ -26,7 +26,26 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
           role: %Schema{type: :string},
           status: %Schema{type: :string},
           fail_count: %Schema{type: :integer},
-          managed: %Schema{type: :boolean}
+          managed: %Schema{type: :boolean},
+          parent: %Schema{
+            type: :object,
+            additionalProperties: false,
+            nullable: true,
+            properties: %{
+              id: %Schema{type: :string},
+              managed: %Schema{type: :boolean},
+              multi_state: %Schema{
+                type: :boolean,
+                nullable: true,
+                description: """
+                Represents the type of the group.
+                - true: promotable group
+                - false: cloned group
+                - null: standard group
+                """
+              }
+            }
+          }
         }
       },
       struct?: false

--- a/test/trento_web/views/v2/cluster_view_json_test.exs
+++ b/test/trento_web/views/v2/cluster_view_json_test.exs
@@ -24,50 +24,6 @@ defmodule TrentoWeb.V2.ClusterJSONTest do
              ClusterJSON.cluster(%{cluster: cluster})
   end
 
-  test "should remove parent field from HANA clusters" do
-    details = build(:hana_cluster_details)
-
-    cluster = insert(:cluster, [type: :hana_scale_up, details: details], returning: true)
-
-    %{
-      details: %{
-        nodes: [%{resources: resources}],
-        stopped_resources: stopped_resources
-      }
-    } =
-      ClusterJSON.cluster(%{cluster: cluster})
-
-    Enum.each(stopped_resources, fn stopped_resource ->
-      refute Map.has_key?(stopped_resource, :parent)
-    end)
-
-    Enum.each(resources, fn resource ->
-      refute Map.has_key?(resource, :parent)
-    end)
-  end
-
-  test "should remove parent field from ASCS/ERS clusters" do
-    details = build(:ascs_ers_cluster_details)
-
-    cluster = insert(:cluster, [type: :ascs_ers, details: details], returning: true)
-
-    %{
-      details: %{
-        sap_systems: [%{nodes: [%{resources: resources} | _]} | _],
-        stopped_resources: stopped_resources
-      }
-    } =
-      ClusterJSON.cluster(%{cluster: cluster})
-
-    Enum.each(stopped_resources, fn stopped_resource ->
-      refute Map.has_key?(stopped_resource, :parent)
-    end)
-
-    Enum.each(resources, fn resource ->
-      refute Map.has_key?(resource, :parent)
-    end)
-  end
-
   test "should render sap instances and deprecated sids properly" do
     sap_instances = [
       %{sid: sid_1, instance_number: inr_1} =


### PR DESCRIPTION
# Description

Expose cluster resource `parent` field in the clusters api. It is only exposed in the `v2` of the `/clusters` endpoint.
This field is needed in order to put parent cluster resources in maintenance, as it is a pretty common thing.
I don't aim to display the value anywhere else, even though we could do it, in the same place where we show other cluster resources.

## How was this tested?

UT
