### PR TITLE
Reorder start ordering

### DIFF
--- a/lib/trento/application.ex
+++ b/lib/trento/application.ex
@@ -15,6 +15,7 @@ defmodule Trento.Application do
         TrentoWeb.Telemetry,
         # Start the PubSub system
         {Phoenix.PubSub, name: Trento.PubSub},
+        {Task.Supervisor, name: Trento.TasksSupervisor},
         # Start the Endpoint (http/https)
         TrentoWeb.Endpoint,
         Trento.Commanded,
@@ -30,7 +31,6 @@ defmodule Trento.Application do
         Trento.Infrastructure.Discovery.AMQP.Publisher,
         Trento.Vault,
         Trento.Infrastructure.SoftwareUpdates.Auth.SumaAuth,
-        {Task.Supervisor, name: Trento.TasksSupervisor},
         {Samly.Provider, []}
         # Start a worker by calling: Trento.Worker.start_link(arg)
         # {Trento.Worker, arg}


### PR DESCRIPTION
Start the `Task.Supervisor` before the endpoint since the ActivityLogging plug is dependent on this and the plug relies on the endpoint for logging.

