### PR TITLE
Add cluster maintenance change modal

### DIFF
--- a/assets/js/common/OperationModals/ClusterMaintenanceChangeModal.jsx
+++ b/assets/js/common/OperationModals/ClusterMaintenanceChangeModal.jsx
@@ -6,7 +6,7 @@ import Switch from '@common/Switch';
 
 import OperationModal from './OperationModal';
 
-const NOT_SELECTED = 'Select a cluster resource';
+const NOT_SELECTED_LABEL = 'Select a cluster resource';
 const CLUSTER_LABEL = 'Cluster (full maintenance)';
 const NODE_MAINTENANCE_STATE = 'Maintenance';
 const CLUSTER_SCOPE = 'cluster';
@@ -15,7 +15,7 @@ const RESOURCE_SCOPE = 'resource';
 
 const NOT_SELECTED_OPTION = {
   value: {
-    id: NOT_SELECTED,
+    id: NOT_SELECTED_LABEL,
     maintenance: false,
   },
   key: 'not_selected',

--- a/assets/js/common/OperationModals/ClusterMaintenanceChangeModal.jsx
+++ b/assets/js/common/OperationModals/ClusterMaintenanceChangeModal.jsx
@@ -1,0 +1,128 @@
+import React, { useState } from 'react';
+import { concat, flatMap, flow, get, map, uniqBy } from 'lodash';
+import Label from '@common/Label';
+import Select from '@common/Select';
+import Switch from '@common/Switch';
+import OperationModal from './OperationModal';
+
+const NOT_SELECTED = 'Select a cluster resource';
+const CLUSTER_LABEL = 'Cluster (full maintenance)';
+const NODE_MAINTENANCE_STATE = 'Maintenance';
+const CLUSTER_SCOPE = 'cluster';
+const NODE_SCOPE = 'node';
+const RESOURCE_SCOPE = 'resource';
+
+const NOT_SELECTED_OPTION = {
+  value: {
+    id: NOT_SELECTED,
+    maintenance: false,
+  },
+  key: 'not_selected',
+};
+
+const renderOption = ({ value: { id } }) => id;
+
+function ClusterMaintenanceChangeModal({
+  clusterDetails,
+  isOpen = false,
+  onRequest,
+  onCancel,
+}) {
+  const [checked, setChecked] = useState(false);
+  const [resource, setResource] = useState(NOT_SELECTED_OPTION.value);
+  const [maintenanceState, setMaintenanceState] = useState(false);
+
+  const clusterMaintenance = get(clusterDetails, 'maintenance_mode', false);
+  const clusterNodes = get(clusterDetails, 'nodes', []);
+  const stoppedResource = get(clusterDetails, 'stopped_resources', []);
+
+  const clusterOption = {
+    value: {
+      id: CLUSTER_LABEL,
+      maintenance: clusterMaintenance,
+      scope: CLUSTER_SCOPE,
+    },
+    key: 'cluster',
+  };
+
+  const nodeOptions = map(clusterNodes, ({ name, status }) => ({
+    value: {
+      id: name,
+      maintenance: status === NODE_MAINTENANCE_STATE,
+      scope: NODE_SCOPE,
+    },
+    key: name,
+  }));
+
+  // flatMap all resources and parents from all nodes
+  // and concat stopped resources
+  const resourceOptions = flow([
+    (nodes) => flatMap(nodes, ({ resources }) => resources),
+    (resources) =>
+      flatMap(resources, (res) => (res.parent ? [res.parent, res] : [res])),
+    (resources) => concat(resources, stoppedResource),
+    (resources) => uniqBy(resources, 'id'),
+    (resources) =>
+      map(resources, ({ id, managed }) => ({
+        value: { id, maintenance: !managed, scope: RESOURCE_SCOPE },
+        key: id,
+      })),
+  ])(clusterNodes);
+
+  const allOptions = concat(
+    NOT_SELECTED_OPTION,
+    clusterOption,
+    nodeOptions,
+    resourceOptions
+  );
+
+  return (
+    <OperationModal
+      title="Cluster Maintenance"
+      description="Update cluster, node or resource maintenance state"
+      operationText="Maintenance"
+      applyDisabled={!checked || resource.maintenance === maintenanceState}
+      checked={checked}
+      isOpen={isOpen}
+      onChecked={() => setChecked((prev) => !prev)}
+      onRequest={() =>
+        // send node_id or resource_id only if the option is of that type
+        onRequest({
+          maintenance: maintenanceState,
+          ...(resource.scope === NODE_SCOPE && { node_id: resource.id }),
+          ...(resource.scope === RESOURCE_SCOPE && {
+            resource_id: resource.id,
+          }),
+        })
+      }
+      onCancel={onCancel}
+    >
+      <div className="grid grid-cols-3 gap-6">
+        <Label className="col-start-1 col-span-1">Resource</Label>
+        <div className="col-start-2 col-span-2">
+          <Select
+            optionsName="resources"
+            options={allOptions}
+            value={resource}
+            renderOption={renderOption}
+            onChange={(selectedValue) => {
+              setResource(selectedValue);
+              setMaintenanceState(selectedValue.maintenance);
+            }}
+            disabled={!checked}
+          />
+        </div>
+        <Label className="col-start-1 col-span-1">Maintenance state</Label>
+        <div className="col-start-2 col-span-2">
+          <Switch
+            selected={maintenanceState}
+            onChange={(value) => setMaintenanceState(value)}
+            disabled={!checked || resource === NOT_SELECTED_OPTION.value}
+          />
+        </div>
+      </div>
+    </OperationModal>
+  );
+}
+
+export default ClusterMaintenanceChangeModal;

--- a/assets/js/common/OperationModals/ClusterMaintenanceChangeModal.jsx
+++ b/assets/js/common/OperationModals/ClusterMaintenanceChangeModal.jsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
-import { concat, flatMap, flow, get, map, uniqBy } from 'lodash';
+import { concat, flatMap, flow, get, has, map, uniqBy } from 'lodash';
 import Label from '@common/Label';
 import Select from '@common/Select';
 import Switch from '@common/Switch';
+
 import OperationModal from './OperationModal';
 
 const NOT_SELECTED = 'Select a cluster resource';
@@ -33,8 +34,12 @@ function ClusterMaintenanceChangeModal({
   const [maintenanceState, setMaintenanceState] = useState(false);
 
   const clusterMaintenance = get(clusterDetails, 'maintenance_mode', false);
-  const clusterNodes = get(clusterDetails, 'nodes', []);
   const stoppedResource = get(clusterDetails, 'stopped_resources', []);
+
+  // in ASCS/ERS clusters the nodes are within SAP systems
+  const clusterNodes = has(clusterDetails, 'sap_systems')
+    ? flatMap(get(clusterDetails, 'sap_systems'), ({ nodes }) => nodes)
+    : get(clusterDetails, 'nodes', []);
 
   const clusterOption = {
     value: {

--- a/assets/js/common/OperationModals/ClusterMaintenanceChangeModal.stories.jsx
+++ b/assets/js/common/OperationModals/ClusterMaintenanceChangeModal.stories.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import { clusterFactory } from '@lib/test-utils/factories';
+
+import ClusterMaintenanceChangeModal from './ClusterMaintenanceChangeModal';
+
+const { details: clusterDetails } = clusterFactory.build();
+const { details: clusterMaintenanceDetails } = clusterFactory.build({
+  details: { maintenance_mode: true },
+});
+
+export default {
+  title: 'Components/ClusterMaintenanceChangeModal',
+  component: ClusterMaintenanceChangeModal,
+  argTypes: {
+    clusterDetails: {
+      description: 'Cluster details',
+      control: 'object',
+    },
+    isOpen: {
+      description: 'Modal is open',
+      control: 'boolean',
+    },
+    onRequest: {
+      description: 'Request cluster maintenance change operation',
+    },
+    onCancel: {
+      description: 'Closes the modal',
+    },
+  },
+  args: {
+    clusterDetails,
+    isOpen: true,
+  },
+};
+
+export function Default(args) {
+  return <ClusterMaintenanceChangeModal {...args} />;
+}
+
+export function ClusterMaintenance(args) {
+  return (
+    <ClusterMaintenanceChangeModal
+      {...args}
+      clusterDetails={clusterMaintenanceDetails}
+    />
+  );
+}

--- a/assets/js/common/OperationModals/ClusterMaintenanceChangeModal.stories.jsx
+++ b/assets/js/common/OperationModals/ClusterMaintenanceChangeModal.stories.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { clusterFactory } from '@lib/test-utils/factories';
 
 import ClusterMaintenanceChangeModal from './ClusterMaintenanceChangeModal';
@@ -34,15 +32,11 @@ export default {
   },
 };
 
-export function Default(args) {
-  return <ClusterMaintenanceChangeModal {...args} />;
-}
+export const Default = {};
 
-export function ClusterMaintenance(args) {
-  return (
-    <ClusterMaintenanceChangeModal
-      {...args}
-      clusterDetails={clusterMaintenanceDetails}
-    />
-  );
-}
+export const ClusterMaintenance = {
+  args: {
+    ...Default.args,
+    clusterDetails: clusterMaintenanceDetails,
+  },
+};

--- a/assets/js/common/OperationModals/ClusterMaintenanceChangeModal.test.jsx
+++ b/assets/js/common/OperationModals/ClusterMaintenanceChangeModal.test.jsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { concat } from 'lodash';
+import { act, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { clusterFactory } from '@lib/test-utils/factories';
+import ClusterMaintenanceChangeModal from './ClusterMaintenanceChangeModal';
+
+describe('ClusterMaintenanceChangeModal', () => {
+  it('should show correct title and description', async () => {
+    await act(async () => {
+      render(<ClusterMaintenanceChangeModal isOpen />);
+    });
+
+    expect(screen.getByText('Cluster Maintenance')).toBeInTheDocument();
+    expect(
+      screen.getByText('Update cluster, node or resource maintenance state')
+    ).toBeInTheDocument();
+  });
+
+  it('should forbid choosing and applying solution until accepting the checkbox', async () => {
+    await act(async () => {
+      render(<ClusterMaintenanceChangeModal isOpen />);
+    });
+
+    expect(screen.getByText('Apply')).toBeDisabled();
+    expect(screen.getByText('Select a cluster resource')).toBeDisabled();
+  });
+
+  it('should render available nodes and resources', async () => {
+    const user = userEvent.setup();
+    const { details } = clusterFactory.build();
+    const { nodes, stopped_resources: stoppedResources } = details;
+    const { resources: resources1 } = nodes[0];
+    const { resources: resources2 } = nodes[1];
+    const resources = concat(resources1, resources2, stoppedResources);
+
+    await act(async () => {
+      render(<ClusterMaintenanceChangeModal clusterDetails={details} isOpen />);
+    });
+
+    await user.click(screen.getByRole('checkbox'));
+    expect(screen.getByText('Apply')).toBeDisabled();
+
+    await user.click(screen.getByText('Select a cluster resource'));
+
+    expect(screen.getByText('Cluster (full maintenance)')).toBeInTheDocument();
+    nodes.forEach(({ name }) => {
+      expect(screen.getByText(name)).toBeInTheDocument();
+    });
+    resources.forEach(({ id }) => {
+      expect(screen.getByText(id)).toBeInTheDocument();
+    });
+  });
+
+  it.each([{ maintenance: true }, { maintenance: false }])(
+    'should set cluster maintenance initially as $maintenance',
+    async ({ maintenance }) => {
+      const user = userEvent.setup();
+      const { details } = clusterFactory.build({
+        details: { maintenance_mode: maintenance },
+      });
+
+      await act(async () => {
+        render(
+          <ClusterMaintenanceChangeModal clusterDetails={details} isOpen />
+        );
+      });
+
+      await user.click(screen.getByRole('checkbox'));
+      expect(screen.getByText('Apply')).toBeDisabled();
+      await user.click(screen.getByText('Select a cluster resource'));
+      await user.click(screen.getByText('Cluster (full maintenance)'));
+      if (maintenance) {
+        expect(screen.getByRole('switch')).toBeChecked();
+      } else {
+        expect(screen.getByRole('switch')).not.toBeChecked();
+      }
+    }
+  );
+
+  it.each([
+    { scope: 'cluster', optionIndex: 1, params: { maintenance: true } },
+    {
+      scope: 'node',
+      optionIndex: 2,
+      params: { maintenance: true, node_id: expect.anything() },
+    },
+    {
+      scope: 'resource',
+      optionIndex: 4,
+      params: {
+        maintenance: expect.anything(),
+        resource_id: expect.anything(),
+      },
+    },
+  ])('should request operation for $scope', async ({ optionIndex, params }) => {
+    const user = userEvent.setup();
+    const mockOnRequest = jest.fn();
+    const { details } = clusterFactory.build();
+
+    await act(async () => {
+      render(
+        <ClusterMaintenanceChangeModal
+          clusterDetails={details}
+          isOpen
+          onRequest={mockOnRequest}
+        />
+      );
+    });
+
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByText('Select a cluster resource'));
+    await user.click(screen.getAllByRole('option')[optionIndex]);
+    await user.click(screen.getByRole('switch'));
+    await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+    expect(mockOnRequest).toBeCalledWith(params);
+  });
+});

--- a/assets/js/common/OperationModals/ClusterMaintenanceChangeModal.test.jsx
+++ b/assets/js/common/OperationModals/ClusterMaintenanceChangeModal.test.jsx
@@ -27,10 +27,38 @@ describe('ClusterMaintenanceChangeModal', () => {
     expect(screen.getByText('Select a cluster resource')).toBeDisabled();
   });
 
-  it('should render available nodes and resources', async () => {
+  it('should render available nodes and resources in HANA clusters', async () => {
     const user = userEvent.setup();
     const { details } = clusterFactory.build();
     const { nodes, stopped_resources: stoppedResources } = details;
+    const { resources: resources1 } = nodes[0];
+    const { resources: resources2 } = nodes[1];
+    const resources = concat(resources1, resources2, stoppedResources);
+
+    await act(async () => {
+      render(<ClusterMaintenanceChangeModal clusterDetails={details} isOpen />);
+    });
+
+    await user.click(screen.getByRole('checkbox'));
+    expect(screen.getByText('Apply')).toBeDisabled();
+
+    await user.click(screen.getByText('Select a cluster resource'));
+
+    expect(screen.getByText('Cluster (full maintenance)')).toBeInTheDocument();
+    nodes.forEach(({ name }) => {
+      expect(screen.getByText(name)).toBeInTheDocument();
+    });
+    resources.forEach(({ id }) => {
+      expect(screen.getByText(id)).toBeInTheDocument();
+    });
+  });
+
+  it('should render available nodes and resources in ASCS/ERS clusters', async () => {
+    const user = userEvent.setup();
+    const { details } = clusterFactory.build({ type: 'ascs_ers' });
+    const { sap_systems: sapSystems, stopped_resources: stoppedResources } =
+      details;
+    const { nodes } = sapSystems[0];
     const { resources: resources1 } = nodes[0];
     const { resources: resources2 } = nodes[1];
     const resources = concat(resources1, resources2, stoppedResources);

--- a/assets/js/common/OperationModals/OperationForbiddenModal.stories.jsx
+++ b/assets/js/common/OperationModals/OperationForbiddenModal.stories.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import OperationForbiddenModal from './OperationForbiddenModal';
 
 export default {
@@ -32,10 +30,8 @@ export default {
   },
 };
 
-export function Default(args) {
-  return (
-    <OperationForbiddenModal {...args}>
-      My operation forbidden additional information
-    </OperationForbiddenModal>
-  );
-}
+export const Default = {
+  args: {
+    children: 'My operation forbidden additional information',
+  },
+};

--- a/assets/js/common/OperationModals/SaptuneSolutionApplyModal.stories.jsx
+++ b/assets/js/common/OperationModals/SaptuneSolutionApplyModal.stories.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import SaptuneSolutionApplyModal from './SaptuneSolutionApplyModal';
 
 export default {
@@ -32,14 +30,21 @@ export default {
   },
 };
 
-export function HanaRunning(args) {
-  return <SaptuneSolutionApplyModal {...args} isHanaRunning />;
-}
+export const HanaRunning = {
+  args: {
+    isHanaRunning: true,
+  },
+};
 
-export function AppRunning(args) {
-  return <SaptuneSolutionApplyModal {...args} isAppRunning />;
-}
+export const AppRunning = {
+  args: {
+    isAppRunning: true,
+  },
+};
 
-export function HanaAndAppRunning(args) {
-  return <SaptuneSolutionApplyModal {...args} isHanaRunning isAppRunning />;
-}
+export const HanaAndAppRunning = {
+  args: {
+    isHanaRunning: true,
+    isAppRunning: true,
+  },
+};


### PR DESCRIPTION
# Description

Add `ClusterMaintenanceChangeModal` component.
The components uses the cluster details to compose the list of nodes and resources to change the maintenance mode.
Depending on the type, the request we need to do is different, so I have added the `scope` concept here as well. Based on this value, we will send `node_id`, `resource_id` or neither of them in the request.

Find the entry in storybook.
![cluster_maintenance_change](https://github.com/user-attachments/assets/75c459ba-23d8-405a-970e-1f67068bb14e)
(we see 2 nodes entries as strings and resources as UUID)

## How was this tested?

UT and storybook
