### PR TITLE
Bugfix for web as it fails to start when no IPV6 is available

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -69,12 +69,14 @@ if config_env() in [:prod, :demo] do
       For example: yourdomain.example.com
       """
 
-  defp determine_ip() do
+  # Returns an IP address to bind the HTTP server, based on IPv6 support.
+  # This prevents startup failures on systems without IPv6 where the app would crash
+  # Falls back to IPv4 `{0, 0, 0, 0}` if IPv6 is not available.
+  ip =
     case :inet.getaddr(~c"localhost", :inet6) do
       {:ok, _addr} -> {0, 0, 0, 0, 0, 0, 0, 0}
       {:error, _} -> {0, 0, 0, 0}
     end
-  end
 
   config :trento, TrentoWeb.Endpoint,
     http: [
@@ -82,7 +84,7 @@ if config_env() in [:prod, :demo] do
       # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.
       # See the documentation on https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html
       # for details about using IPv6 vs IPv4 and loopback vs public addresses.
-      ip: determine_ip(),
+      ip: ip,
       port: String.to_integer(System.get_env("PORT") || "4000")
     ],
     check_origin: true,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -69,13 +69,20 @@ if config_env() in [:prod, :demo] do
       For example: yourdomain.example.com
       """
 
+  defp determine_ip() do
+    case :inet.getaddr(~c"localhost", :inet6) do
+      {:ok, _addr} -> {0, 0, 0, 0, 0, 0, 0, 0}
+      {:error, _} -> {0, 0, 0, 0}
+    end
+  end
+
   config :trento, TrentoWeb.Endpoint,
     http: [
       # Enable IPv6 and bind on all interfaces.
       # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.
       # See the documentation on https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html
       # for details about using IPv6 vs IPv4 and loopback vs public addresses.
-      ip: {0, 0, 0, 0, 0, 0, 0, 0},
+      ip: determine_ip(),
       port: String.to_integer(System.get_env("PORT") || "4000")
     ],
     check_origin: true,


### PR DESCRIPTION
# Description

This pr provides a fix for web, currently when web is started and the machine does not have ipv6 the app fails to start.
This happens because the [Cowboy webserver Plug](https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html) requires either an ipv4 or ipv6 address.  For this we can use the [erlang inet getaddr function ](https://www.erlang.org/docs/23/man/inet#getaddr-2)

Same change will be done in wanda

## How was this tested?
Tested locally by disabling ipv6