### PR TITLE
remove unnecessary version field

### DIFF
--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -1,6 +1,5 @@
 {
   "name": "trento-e2e-tests",
-  "version": "2.4.0",
   "description": "E2E testing for Trento",
   "scripts": {
     "cypress:open": "cypress open",


### PR DESCRIPTION
This is not actually needed and we don't want to keep updating it at every release.