### PR TITLE
Automate changelog generation

### DIFF
--- a/.github/release_drafter.yaml
+++ b/.github/release_drafter.yaml
@@ -1,0 +1,36 @@
+name-template: $RESOLVED_VERSION
+tag-template: $RESOLVED_VERSION
+categories:
+  - title: Features
+    labels:
+      - feature
+      - enhancement
+  - title: Bug Fixes
+    labels:
+      - fix
+      - bugfix
+      - bug
+  - title: Maintenance
+    labels:
+      - chore
+      - ci
+      - tech-debt
+  - title: Dependencies
+    label: dependencies
+    collapse-after: 3
+version-resolver:
+  major:
+    labels:
+      - major
+      - breaking
+  minor:
+    labels:
+      - feature
+      - minor
+  patch:
+    labels:
+      - patch
+      - bug
+  default: patch
+exclude-labels:
+  - skip-changelog

--- a/.github/release_drafter.yaml
+++ b/.github/release_drafter.yaml
@@ -35,4 +35,8 @@ version-resolver:
 exclude-labels:
   - skip-release-notes
 template: |
+  ## What's Changed
+
   $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION

--- a/.github/release_drafter.yaml
+++ b/.github/release_drafter.yaml
@@ -18,6 +18,8 @@ categories:
   - title: Dependencies
     label: dependencies
     collapse-after: 3
+category-template: |
+  ### $TITLE
 version-resolver:
   major:
     labels:

--- a/.github/release_drafter.yaml
+++ b/.github/release_drafter.yaml
@@ -34,3 +34,5 @@ version-resolver:
   default: patch
 exclude-labels:
   - skip-changelog
+template: |
+  $CHANGES

--- a/.github/release_drafter.yaml
+++ b/.github/release_drafter.yaml
@@ -33,6 +33,6 @@ version-resolver:
       - bug
   default: patch
 exclude-labels:
-  - skip-changelog
+  - skip-release-notes
 template: |
   $CHANGES

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,6 @@ on:
 env:
   MIX_ENV: test
   NODE_VERSION: "20"
-  MANTAINERS: '["cdimonaco", "dottorblaster", "janvhs", "nelsonkopliku", "arbulu89","jagabomb","emaksy", "balanza", "gagandeepb"]'
 
 jobs:
   elixir-deps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -353,7 +353,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [1,2,3,4,5,6,7,8]
+        containers: [1, 2, 3, 4, 5, 6, 7, 8]
     env:
       MIX_ENV: dev
     steps:
@@ -443,7 +443,7 @@ jobs:
   test-e2e:
     name: End to end tests
     runs-on: ubuntu-22.04
-    needs: test-e2e-parallel  
+    needs: test-e2e-parallel
     steps:
       - run: echo "E2E tests completed"
 

--- a/.github/workflows/post_release.yaml
+++ b/.github/workflows/post_release.yaml
@@ -25,9 +25,9 @@ jobs:
             CHANGELOG.md
           commit-message: update changelog
           title: Update changelog
-          body: This is an automatic pull request triggered by GitHub actions to keep CHANGELOG.md up to date.
+          body: |
+            This is an automatic pull request triggered by GitHub actions to keep `CHANGELOG.md` up to date.
           branch: update-changelog
           base: main
-          labels: |
-            changelog
+          labels: automated, skip-release-notes
           delete-branch: true

--- a/.github/workflows/post_release.yaml
+++ b/.github/workflows/post_release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update-changelog:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/post_release.yaml
+++ b/.github/workflows/post_release.yaml
@@ -27,6 +27,7 @@ jobs:
           title: Update changelog
           body: This is an automatic pull request triggered by GitHub actions to keep CHANGELOG.md up to date.
           branch: update-changelog
+          base: main
           labels: |
             changelog
           delete-branch: true

--- a/.github/workflows/post_release.yaml
+++ b/.github/workflows/post_release.yaml
@@ -1,0 +1,32 @@
+name: Post-release
+
+on:
+  release:
+    types:
+      - released
+
+jobs:
+  update-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-version: ${{ github.event.release.tag_name }}
+          release-notes: ${{ github.event.release.body }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          add-paths: |
+            CHANGELOG.md
+          commit-message: update changelog
+          title: Update changelog
+          body: This is an automatic pull request triggered by GitHub actions to keep CHANGELOG.md up to date.
+          branch: update-changelog
+          labels: |
+            changelog
+          delete-branch: true

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -1,0 +1,23 @@
+name: Pre-release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update-release-draft:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v6
+        with:
+          disable-autolabeler: true
+          config-name: release_drafter.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -12,7 +12,7 @@ jobs:
   update-release-draft:
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v6


### PR DESCRIPTION
# Description

This PR adds two new GHA workflows to ease the release process a little bit:
- **Pre-release**: runs every time `main` changes (i.e. when a PR is merged). It creates a draft release with automatically generated release notes and version, that only waits for the green "Publish" button to be clicked, to actually publish the release.
- **Post-release**: runs every time a release is actually published. It creates a Pull Request to keep the CHANGELOG.md file in sync with the content that gets automatically generated in the release notes in the above _Pre-release_ worfklow.

Coincidentally, this PR also includes a couple minor fixes to the existing CI workflow, namely the removal of an unused env var and some automatically applied stylistic changes.

## Did you add the right label?

Remember to add the right labels to this PR.
- [x] **DONE**

## How was this tested?

I tested manually in my own fork https://github.com/stefanotorresi/web

- [x] **DONE**

## Did you update the documentation?

Documentation changes will follow in the docs repo.

- [ ] **DONE**
