### PR TITLE
Fix PR env pre-flight check for forks

### DIFF
--- a/.github/workflows/pr_env.yaml
+++ b/.github/workflows/pr_env.yaml
@@ -14,6 +14,7 @@ jobs:
   check_env_creation_privilege:
     name: Check if the environment creation criteria are met, store in the job output
     runs-on: ubuntu-24.04
+    if: vars.PR_ENV_ALLOW_LIST != '' && vars.PR_ENV_LABEL != ''
     outputs:
       create_env: ${{ steps.check.outputs.create_env }}
     steps:


### PR DESCRIPTION
# Description

Skip the pr_env workflow if variables are not set in GHA settings. This avoids red runs triggered by forks, which likely don't have those settings.
