### PR TITLE
Alerting settings from env coerced correcly

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -153,9 +153,18 @@ if config_env() in [:prod, :demo] do
   # See https://hexdocs.pm/swoosh/Swoosh.html#module-installation for details.
 
   config :trento, :alerting,
-    enabled: System.get_env("ENABLE_ALERTING"),
+    enabled:
+      (case System.get_env("ENABLE_ALERTING") do
+         nil -> nil
+         "true" -> true
+         _ -> false
+       end),
     smtp_server: System.get_env("SMTP_SERVER"),
-    smtp_port: System.get_env("SMTP_PORT"),
+    smtp_port:
+      (case Integer.parse(System.get_env("SMTP_PORT", "")) do
+         :error -> nil
+         {number, _} -> number
+       end),
     smtp_username: System.get_env("SMTP_USER"),
     smtp_password: System.get_env("SMTP_PASSWORD"),
     sender_email: System.get_env("ALERT_SENDER"),

--- a/lib/trento/settings.ex
+++ b/lib/trento/settings.ex
@@ -242,9 +242,7 @@ defmodule Trento.Settings do
 
   defp get_alerting_settings_from_app_env do
     explicitly_set =
-      Application.get_env(:trento, :alerting)
-      |> Enum.filter(fn {_key, value} -> value != nil end)
-      |> Enum.map(&coerce_alerting_env_value/1)
+      Enum.filter(Application.get_env(:trento, :alerting), fn {_key, value} -> value != nil end)
 
     settings =
       struct!(
@@ -254,31 +252,6 @@ defmodule Trento.Settings do
 
     {:ok, settings}
   end
-
-  defp coerce_alerting_env_value({:enabled, value}) when value in [true, "true"],
-    do: {:enabled, true}
-
-  defp coerce_alerting_env_value({:enabled, _}), do: {:enabled, false}
-
-  defp coerce_alerting_env_value({:smtp_port, value}) when is_binary(value) do
-    port =
-      case Integer.parse(value) do
-        {port, _} -> port
-        :error -> Keyword.fetch!(@alerting_settings_default_env, :smtp_port)
-      end
-
-    {:smtp_port, port}
-  end
-
-  defp coerce_alerting_env_value({:smtp_port, value}) when not is_integer(value),
-    do: {:smtp_port, Keyword.fetch!(@alerting_settings_default_env, :smtp_port)}
-
-  defp coerce_alerting_env_value({key, value})
-       when key in [:smtp_server, :smtp_username, :smtp_password, :sender_email, :recipient_email] and
-              not is_binary(value),
-       do: {key, Keyword.fetch!(@alerting_settings_default_env, key)}
-
-  defp coerce_alerting_env_value(pair), do: pair
 
   defp get_alerting_settings_from_db do
     case Repo.one(AlertingSettings.base_query()) do

--- a/lib/trento/settings.ex
+++ b/lib/trento/settings.ex
@@ -61,7 +61,8 @@ defmodule Trento.Settings do
     smtp_username: "",
     smtp_password: "",
     sender_email: "alerts@trento-project.io",
-    recipient_email: "admin@trento-project.io"
+    recipient_email: "admin@trento-project.io",
+    enforced_from_env: true
   ]
 
   @spec get_installation_id :: String.t()
@@ -241,7 +242,9 @@ defmodule Trento.Settings do
 
   defp get_alerting_settings_from_app_env do
     explicitly_set =
-      Enum.filter(Application.get_env(:trento, :alerting), fn {_key, value} -> value != nil end)
+      Application.get_env(:trento, :alerting)
+      |> Enum.filter(fn {_key, value} -> value != nil end)
+      |> Enum.map(&coerce_alerting_env_value/1)
 
     settings =
       struct!(
@@ -251,6 +254,31 @@ defmodule Trento.Settings do
 
     {:ok, settings}
   end
+
+  defp coerce_alerting_env_value({:enabled, value}) when value in [true, "true"],
+    do: {:enabled, true}
+
+  defp coerce_alerting_env_value({:enabled, _}), do: {:enabled, false}
+
+  defp coerce_alerting_env_value({:smtp_port, value}) when is_binary(value) do
+    port =
+      case Integer.parse(value) do
+        {port, _} -> port
+        :error -> Keyword.fetch!(@alerting_settings_default_env, :smtp_port)
+      end
+
+    {:smtp_port, port}
+  end
+
+  defp coerce_alerting_env_value({:smtp_port, value}) when not is_integer(value),
+    do: {:smtp_port, Keyword.fetch!(@alerting_settings_default_env, :smtp_port)}
+
+  defp coerce_alerting_env_value({key, value})
+       when key in [:smtp_server, :smtp_username, :smtp_password, :sender_email, :recipient_email] and
+              not is_binary(value),
+       do: {key, Keyword.fetch!(@alerting_settings_default_env, key)}
+
+  defp coerce_alerting_env_value(pair), do: pair
 
   defp get_alerting_settings_from_db do
     case Repo.one(AlertingSettings.base_query()) do

--- a/test/trento/settings_test.exs
+++ b/test/trento/settings_test.exs
@@ -975,26 +975,41 @@ defmodule Trento.SettingsTest do
       smtp_username: "",
       smtp_password: "",
       sender_email: "alerts@trento-project.io",
-      recipient_email: "admin@trento-project.io"
+      recipient_email: "admin@trento-project.io",
+      enforced_from_env: true
     }
 
-    for {case_name, _pair} = scenario <- [
-          {"enabled", [enabled: true]},
-          {"SMTP server", [smtp_server: "test.com"]},
-          {"SMTP port", [smtp_port: "587"]},
-          {"SMTP username", [smtp_username: "testuser"]},
-          {"SMTP password", [smtp_password: "testpass}"]},
-          {"sender email", [sender_email: "sender@trento.com"]},
-          {"recipient email", [recipient_email: "recipient@trento.com"]},
-          {"enabled and SMTP server", [enabled: true, smtp_server: "testserver.com"]}
+    for {case_name, _env_params, _exp_overrides} = scenario <- [
+          {"enabled", [enabled: true], []},
+          {"enabled as string", [enabled: "true"], [enabled: true]},
+          {"enabled as empty string", [enabled: ""], [enabled: false]},
+          {"SMTP server", [smtp_server: "test.com"], []},
+          {"SMTP server as non-string", [smtp_server: 111], [smtp_server: ""]},
+          {"SMTP port", [smtp_port: 587], []},
+          {"SMTP port as string", [smtp_port: "587"], [smtp_port: 587]},
+          {"SMTP port as empty string", [smtp_port: ""], [smtp_port: 587]},
+          {"SMTP port as non-parsable string", [smtp_port: "not-an-int"], [smtp_port: 587]},
+          {"SMTP username", [smtp_username: "testuser"], []},
+          {"SMTP password", [smtp_password: "testpass}"], []},
+          {"sender email", [sender_email: "sender@trento.com"], []},
+          {"recipient email", [recipient_email: "recipient@trento.com"], []},
+          {"enabled and SMTP server", [enabled: true, smtp_server: "testserver.com"], []}
         ] do
       @scenario scenario
 
-      test "return complete settings with default values when only #{case_name} is set" do
-        {_, settings} = @scenario
-        expected_settings = struct!(@default_alerting_settings, settings)
+      test "return complete settings with default values when only '#{case_name}' is set" do
+        {_, env_params, exp_overrides} = @scenario
 
-        Application.put_env(:trento, :alerting, settings)
+        expected_params =
+          if exp_overrides == [], do: env_params, else: exp_overrides
+
+        expected_settings =
+          struct!(
+            @default_alerting_settings,
+            expected_params
+          )
+
+        Application.put_env(:trento, :alerting, env_params)
         assert {:ok, expected_settings} == Settings.get_alerting_settings()
       end
     end

--- a/test/trento/settings_test.exs
+++ b/test/trento/settings_test.exs
@@ -979,35 +979,21 @@ defmodule Trento.SettingsTest do
       enforced_from_env: true
     }
 
-    for {case_name, _env_params, _exp_overrides} = scenario <- [
-          {"enabled", [enabled: true], []},
-          {"enabled as string", [enabled: "true"], [enabled: true]},
-          {"enabled as empty string", [enabled: ""], [enabled: false]},
-          {"SMTP server", [smtp_server: "test.com"], []},
-          {"SMTP server as non-string", [smtp_server: 111], [smtp_server: ""]},
-          {"SMTP port", [smtp_port: 587], []},
-          {"SMTP port as string", [smtp_port: "587"], [smtp_port: 587]},
-          {"SMTP port as empty string", [smtp_port: ""], [smtp_port: 587]},
-          {"SMTP port as non-parsable string", [smtp_port: "not-an-int"], [smtp_port: 587]},
-          {"SMTP username", [smtp_username: "testuser"], []},
-          {"SMTP password", [smtp_password: "testpass}"], []},
-          {"sender email", [sender_email: "sender@trento.com"], []},
-          {"recipient email", [recipient_email: "recipient@trento.com"], []},
-          {"enabled and SMTP server", [enabled: true, smtp_server: "testserver.com"], []}
+    for {case_name, _env_params} = scenario <- [
+          {"enabled", [enabled: true]},
+          {"SMTP server", [smtp_server: "test.com"]},
+          {"SMTP port", [smtp_port: 587]},
+          {"SMTP username", [smtp_username: "testuser"]},
+          {"SMTP password", [smtp_password: "testpass}"]},
+          {"sender email", [sender_email: "sender@trento.com"]},
+          {"recipient email", [recipient_email: "recipient@trento.com"]},
+          {"enabled and SMTP server", [enabled: true, smtp_server: "testserver.com"]}
         ] do
       @scenario scenario
 
       test "return complete settings with default values when only '#{case_name}' is set" do
-        {_, env_params, exp_overrides} = @scenario
-
-        expected_params =
-          if exp_overrides == [], do: env_params, else: exp_overrides
-
-        expected_settings =
-          struct!(
-            @default_alerting_settings,
-            expected_params
-          )
+        {_, env_params} = @scenario
+        expected_settings = struct!(@default_alerting_settings, env_params)
 
         Application.put_env(:trento, :alerting, env_params)
         assert {:ok, expected_settings} == Settings.get_alerting_settings()


### PR DESCRIPTION
# Description

Fixes a bug where we don't coerce values coming from OS env-vars to proper types for the AlertingSettings struct.


## How was this tested?

Added new UT covering this case.
