### PR TITLE
Table top margin

### DIFF
--- a/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
+++ b/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
@@ -112,6 +112,7 @@ function ActivityLogOverview({ activityLog, loading = false }) {
         config={activityLogTableConfig}
         data={activityLog.map(toRenderedEntry)}
         emptyStateText={loading ? 'Loading...' : 'No data available'}
+        roundedTop={false}
       />
     </>
   );

--- a/assets/js/common/PatchList/PatchList.jsx
+++ b/assets/js/common/PatchList/PatchList.jsx
@@ -148,6 +148,7 @@ export default function PatchList({ patches, onNavigate = noop }) {
 
   return (
     <Table
+      className="pt-2"
       config={patchListConfig}
       data={patches}
       sortBy={columnToSortingFunc[sortingColumn]}

--- a/assets/js/common/Table/Table.jsx
+++ b/assets/js/common/Table/Table.jsx
@@ -64,6 +64,7 @@ const getFilterFunction = (column, value) =>
 const itemsPerPageOptions = [10, 20, 50, 75, 100];
 
 function Table({
+  className,
   config,
   data = [],
   sortBy,
@@ -161,25 +162,23 @@ function Table({
 
   return (
     <div
-      className={classNames('container mx-auto', {
+      className={classNames(className, 'container mx-auto', {
         'px-4 sm:px-8': usePadding,
       })}
     >
-      <div
-        className={classNames('flex-row px-4 space-x-4', {
-          'pb-4': hasFilters,
-        })}
-      >
-        <TableFilters
-          config={config}
-          data={data}
-          filters={filters}
-          onChange={(newFilters) => {
-            setFilters(newFilters);
-            setCurrentPage(1);
-          }}
-        />
-      </div>
+      {hasFilters && (
+        <div className={classNames('flex-row px-4 space-x-4 pb-4')}>
+          <TableFilters
+            config={config}
+            data={data}
+            filters={filters}
+            onChange={(newFilters) => {
+              setFilters(newFilters);
+              setCurrentPage(1);
+            }}
+          />
+        </div>
+      )}
       <div className="">
         <div
           className={classNames('-mx-4 sm:-mx-8 px-4 sm:px-8', {
@@ -201,7 +200,7 @@ function Table({
                   {columns.map(
                     ({
                       title,
-                      className,
+                      columnClassName,
                       sortable = false,
                       sortDirection = undefined,
                       handleClick = () => {},
@@ -215,7 +214,7 @@ function Table({
                               ? 'cursor-pointer hover:text-gray-700 '
                               : ''
                           }px-5 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider bg-gray-100`,
-                          className
+                          columnClassName
                         )}
                         onClick={handleClick}
                       >

--- a/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.jsx
+++ b/assets/js/common/UpgradablePackagesList/UpgradablePackagesList.jsx
@@ -74,6 +74,7 @@ function UpgradablePackagesList({
 
   return (
     <Table
+      className="pt-2"
       config={config}
       data={upgradablePackages}
       sortBy={sortByLatestPackage}

--- a/assets/js/pages/ClusterDetails/AscsErsClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/AscsErsClusterDetails.jsx
@@ -189,7 +189,11 @@ function AscsErsClusterDetails({
       </div>
 
       <div className="mt-2">
-        <Table config={nodeDetailsConfig} data={currentSapSystem?.nodes} />
+        <Table
+          className="pt-2"
+          config={nodeDetailsConfig}
+          data={currentSapSystem?.nodes}
+        />
       </div>
     </>
   );

--- a/assets/js/pages/ClusterDetails/AttributesDetails.jsx
+++ b/assets/js/pages/ClusterDetails/AttributesDetails.jsx
@@ -66,6 +66,7 @@ function AttributesDetails({ attributes, resources, title }) {
       <Modal title={title} open={modalOpen} onClose={() => setModalOpen(false)}>
         <h3 className="font-medium mt-6">Attributes</h3>
         <Table
+          className="pt-2"
           config={attributesTableConfig}
           data={Object.keys(attributes).map((key) => ({
             attribute: key,
@@ -74,7 +75,11 @@ function AttributesDetails({ attributes, resources, title }) {
         />
 
         <h3 className="font-medium mt-6">Resources</h3>
-        <Table config={resourcesTableConfig} data={resources} />
+        <Table
+          className="pt-2"
+          config={resourcesTableConfig}
+          data={resources}
+        />
       </Modal>
     </>
   );

--- a/assets/js/pages/ExecutionResults/ExecutionResults.jsx
+++ b/assets/js/pages/ExecutionResults/ExecutionResults.jsx
@@ -209,6 +209,7 @@ function ExecutionResults({
             <Table
               config={resultsTableConfig}
               data={filterAndSortData(tableData, item)}
+              roundedTop={false}
             />
           </Accordion>
         ))}

--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -368,7 +368,11 @@ function HostDetails({
           <div>
             <h2 className="text-2xl font-bold">SAP instances</h2>
           </div>
-          <Table config={sapInstancesTableConfiguration} data={sapInstances} />
+          <Table
+            className="pt-2"
+            config={sapInstancesTableConfiguration}
+            data={sapInstances}
+          />
         </div>
 
         <div className="mt-16">
@@ -379,6 +383,7 @@ function HostDetails({
             </h2>
           </div>
           <Table
+            className="pt-2"
             config={subscriptionsTableConfiguration}
             data={slesSubscriptions}
           />

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
@@ -111,6 +111,7 @@ export function GenericSystemDetails({
           <h2 className="text-2xl font-bold self-center">Layout</h2>
         </div>
         <Table
+          className="pt-2"
           config={getSystemInstancesTableConfiguration({
             userAbilities,
             cleanUpPermittedFor,
@@ -125,6 +126,7 @@ export function GenericSystemDetails({
           <h2 className="text-2xl font-bold">Hosts</h2>
         </div>
         <Table
+          className="pt-2"
           config={systemHostsTableConfiguration}
           data={getUniqueHosts(system.hosts)}
         />

--- a/assets/js/pages/Users/Users.jsx
+++ b/assets/js/pages/Users/Users.jsx
@@ -151,6 +151,7 @@ function Users({
       </Modal>
 
       <Table
+        className="pt-2"
         config={usersTableConfig}
         data={loading ? defaultUsers : users}
         emptyStateText={loading ? 'Loading...' : 'No data available'}


### PR DESCRIPTION
# Description

The Table top margin usage was creating some issues. Depending on having filters or not it was different.

This PR changes the behaviour on that, only putting certain styles if the filters are available. Besides that, now the Table component accepts external class names. This means, that I have to pass the top margin to some tables.

These are all the tables we have. I have added the top margin in these ones:
**When I put top margin added, it means that I change the code to stay as it was until**
- ActivityLogOverview - Top margin added
- PatchList - Top margin added
- UpgradablePackagesList - Top margin added
- AscsErsClusterDetails  - Top margin added
- AttributeDetails (in cluster details) - Top margin added
- ClustersList - We don't need a margin, filters are used
- HanaClusterSite - Now, the error we have in the top is fixed - Check now if it is correct
- DatabasesOverview - We don't need a margin, filters are used
- ExecutionResults - Now, the error we have in the top is fixed - Check now if it is correct
- HomeHealthSummary - I don't think we need additional margin
- HostDetails - Top margin added in the 2 tables
- HostsList - We don't need a margin, filters are used
- SapSystemDetails/DatabaseDetails - Top margin added
- SapSystemOverview - We don't need a margin, filters are used
- Users - Top margin added

## How was this tested?

Visual inspection