### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@trento-project/maintainers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,17 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "trento-project/maintainers"
   - package-ecosystem: "mix"
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "trento-project/maintainers"
   - package-ecosystem: "npm"
     directory: "/assets"
     schedule:
       interval: "daily"
-    reviewers:
-      - "trento-project/maintainers"


### PR DESCRIPTION
# Description

Dependabot complains about a config deprecation https://github.com/trento-project/web/pull/3512#issuecomment-2889686161

`CODEOWNERS` is the way https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/