### PR TITLE
Add fixed witdh to relevant patches synopsis

### DIFF
--- a/assets/js/common/PatchList/PatchList.jsx
+++ b/assets/js/common/PatchList/PatchList.jsx
@@ -130,6 +130,7 @@ export default function PatchList({ patches, onNavigate = noop }) {
       {
         title: 'Synopsis',
         key: 'advisory_synopsis',
+        className: 'w-3/5 text-wrap',
         sortable: true,
         sortDirection:
           sortingColumn === 'advisory_synopsis' ? sortDirection : null,

--- a/assets/js/common/Table/Table.jsx
+++ b/assets/js/common/Table/Table.jsx
@@ -200,7 +200,7 @@ function Table({
                   {columns.map(
                     ({
                       title,
-                      columnClassName,
+                      className: columnClassName,
                       sortable = false,
                       sortDirection = undefined,
                       handleClick = () => {},

--- a/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.stories.jsx
+++ b/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.stories.jsx
@@ -6,11 +6,21 @@ import { hostFactory } from '@lib/test-utils/factories/hosts';
 
 import HostRelevantPatchesPage from './HostRelevantPatchesPage';
 
+function ContainerWrapper({ children }) {
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 md:px-8">{children}</div>
+  );
+}
+
 export default {
   title: 'Layouts/HostRelevantPatchesPage',
   components: HostRelevantPatchesPage,
   argTypes: {},
-  render: (args) => <HostRelevantPatchesPage {...args} />,
+  render: (args) => (
+    <ContainerWrapper>
+      <HostRelevantPatchesPage {...args} />
+    </ContainerWrapper>
+  ),
 };
 
 export const HasPatches = {


### PR DESCRIPTION
# Description

Add fixed width to relevant pacthes table synopsis. Without this, the table looks a bit jumpy.
Besides that, I have fixed the usage of row `className` that I have broke in my previous [PR](https://github.com/trento-project/web/pull/3517) :see_no_evil: 

You can play in storybook adding super long synopsis to see how it behaves now

Before:
![relevant_patches_fixed_width_before](https://github.com/user-attachments/assets/8f18ee63-d8a5-4371-bafc-f016679904f9)

After:
![relevant_patches_fixed_width](https://github.com/user-attachments/assets/a9e75b14-dcad-405e-bf33-4168d1c73f29)

## How was this tested?

Visual inspection
