### PR TITLE
Add `forwardRef` to button component

### DIFF
--- a/assets/js/common/Button/Button.jsx
+++ b/assets/js/common/Button/Button.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import classNames from 'classnames';
 
 const getSizeClasses = (size) => {
@@ -35,7 +35,7 @@ const getButtonClasses = (type) => {
   }
 };
 
-function Button({ children, className, type, size, disabled, ...props }) {
+function Button({ children, className, type, size, disabled, ...props }, ref) {
   const buttonClasses = classNames(
     getButtonClasses(type),
     getSizeClasses(size),
@@ -48,6 +48,7 @@ function Button({ children, className, type, size, disabled, ...props }) {
       type="button"
       className={buttonClasses}
       disabled={disabled}
+      ref={ref}
       {...props}
     >
       {children}
@@ -55,4 +56,6 @@ function Button({ children, className, type, size, disabled, ...props }) {
   );
 }
 
-export default Button;
+// forwardRef will be deprecated in React 19
+// https://react.dev/blog/2024/12/05/react-19#ref-as-a-prop
+export default forwardRef(Button);

--- a/assets/js/common/Tooltip/Tooltip.jsx
+++ b/assets/js/common/Tooltip/Tooltip.jsx
@@ -25,7 +25,7 @@ function Tooltip({
   children,
   place = 'top',
   isEnabled = true,
-  // we careful using wrap={false}. The children element must receive the `ref` property.
+  // be careful using wrap={false}. The children element must receive the `ref` property.
   // Check Button component
   // Otherwise findDom deprecated warning is raised
   wrap = true,

--- a/assets/js/common/Tooltip/Tooltip.jsx
+++ b/assets/js/common/Tooltip/Tooltip.jsx
@@ -25,6 +25,9 @@ function Tooltip({
   children,
   place = 'top',
   isEnabled = true,
+  // we careful using wrap={false}. The children element must receive the `ref` property.
+  // Check Button component
+  // Otherwise findDom deprecated warning is raised
   wrap = true,
   // The visible ternary flag forces the tooltip to show/hide
   // regardless of the user interaction.


### PR DESCRIPTION
# Description

Add `forwardRef` to button component.
This change aims to fix the `findDom is deprecated` warning message when a the `Tooltip` component with `wrap={false}` is used. The `rc-tooltip` needs to pass the `ref` to the children elements, specifically to a native react tag (`<a>`, `<button>`, etc).

By coincidence, the `forwardRef` usage will be deprecated in React 19 (we are in React 18 now). So the solution might change a bit (not much) when we upgrade. I'm leaving a comment behind.

We will need to be careful now on when we use the `Tooltip` with the wrap property.

The fixed message:
![image](https://github.com/user-attachments/assets/74d31d94-da4c-4615-a4bf-8e254be7aac8)


## How was this tested?
Tested that the warning goes away
