### PR TITLE
Harden saptune operation policy

### DIFF
--- a/lib/trento/infrastructure/commanded/event_handlers/saptune_status_update_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/saptune_status_update_event_handler.ex
@@ -148,13 +148,15 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SaptuneStatusUpdateEvent
          },
          sap_running
        ) do
-    commanded().dispatch(%UpdateSaptuneStatus{
+    %{
       host_id: host_id,
       package_version: version,
       saptune_installed: true,
       sap_running: sap_running,
       status: status
-    })
+    }
+    |> UpdateSaptuneStatus.new!()
+    |> commanded().dispatch()
   end
 
   # instance_numbers variable is used to reject the instance with that number from the check

--- a/lib/trento/operations/host_policy.ex
+++ b/lib/trento/operations/host_policy.ex
@@ -71,38 +71,28 @@ defmodule Trento.Operations.HostPolicy do
 
   defp get_saptune_operation_resource_id(_), do: nil
 
-  defp authorize_saptune_solution_operation(
-         :saptune_solution_apply,
-         saptune_status
-       ) do
-    case saptune_status do
-      nil ->
-        :ok
+  defp authorize_saptune_solution_operation(:saptune_solution_apply, nil), do: :ok
 
-      %{applied_solution: nil} ->
-        :ok
+  defp authorize_saptune_solution_operation(:saptune_solution_apply, %{applied_solution: nil}),
+    do: :ok
 
-      _ ->
-        {:error,
-         ["Cannot apply the requested solution because there is an already applied on this host"]}
-    end
-  end
+  defp authorize_saptune_solution_operation(:saptune_solution_apply, _),
+    do:
+      {:error,
+       ["Cannot apply the requested solution because there is an already applied on this host"]}
 
-  defp authorize_saptune_solution_operation(
-         :saptune_solution_change,
-         saptune_status
-       ) do
-    case saptune_status do
-      %{applied_solution: applied_solution} when not is_nil(applied_solution) ->
-        :ok
+  defp authorize_saptune_solution_operation(:saptune_solution_change, %{
+         applied_solution: applied_solution
+       })
+       when not is_nil(applied_solution),
+       do: :ok
 
-      _ ->
-        {:error,
-         [
-           "Cannot change the requested solution because there is no currently applied one on this host"
-         ]}
-    end
-  end
+  defp authorize_saptune_solution_operation(:saptune_solution_change, _),
+    do:
+      {:error,
+       [
+         "Cannot change the requested solution because there is no currently applied one on this host"
+       ]}
 
   # Classic SAP HANA setup
   defp find_resource_id(%{type: "ocf::suse:SAPHana", parent: %{id: id}}), do: id

--- a/lib/trento_web/controllers/v1/host_json.ex
+++ b/lib/trento_web/controllers/v1/host_json.ex
@@ -1,6 +1,4 @@
 defmodule TrentoWeb.V1.HostJSON do
-  alias Trento.Support.StructHelper
-
   def hosts(%{hosts: hosts}), do: Enum.map(hosts, &host(%{host: &1}))
 
   def host(%{host: %{sles_subscriptions: sles_subscriptions} = host}) do
@@ -62,7 +60,7 @@ defmodule TrentoWeb.V1.HostJSON do
   def saptune_status_updated(%{
         host: %{id: id, saptune_status: status, hostname: hostname}
       }),
-      do: %{id: id, status: StructHelper.to_atomized_map(status), hostname: hostname}
+      do: %{id: id, status: status, hostname: hostname}
 
   def host_health_changed(%{host: %{id: id, hostname: hostname, health: health}}),
     do: %{id: id, hostname: hostname, health: health}

--- a/lib/trento_web/controllers/v1/host_json.ex
+++ b/lib/trento_web/controllers/v1/host_json.ex
@@ -1,4 +1,6 @@
 defmodule TrentoWeb.V1.HostJSON do
+  alias Trento.Support.StructHelper
+
   def hosts(%{hosts: hosts}), do: Enum.map(hosts, &host(%{host: &1}))
 
   def host(%{host: %{sles_subscriptions: sles_subscriptions} = host}) do
@@ -60,7 +62,7 @@ defmodule TrentoWeb.V1.HostJSON do
   def saptune_status_updated(%{
         host: %{id: id, saptune_status: status, hostname: hostname}
       }),
-      do: %{id: id, status: status, hostname: hostname}
+      do: %{id: id, status: StructHelper.to_atomized_map(status), hostname: hostname}
 
   def host_health_changed(%{host: %{id: id, hostname: hostname, health: health}}),
     do: %{id: id, hostname: hostname, health: health}

--- a/lib/trento_web/openapi/v1/schema/saptune_status.ex
+++ b/lib/trento_web/openapi/v1/schema/saptune_status.ex
@@ -68,7 +68,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.SaptuneStatus do
         additionalProperties: false,
         properties: %{
           id: %Schema{
-            type: :boolean,
+            type: :string,
             description: "Saptune solution ID"
           },
           notes: %Schema{
@@ -133,7 +133,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.SaptuneStatus do
           type: :array,
           items: Service
         },
-        enabled_nodes: %Schema{
+        enabled_notes: %Schema{
           title: "Enabled notes",
           description: "A list of enabled notes",
           type: :array,

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -30,6 +30,8 @@ defmodule Trento.Factory do
   }
 
   alias Trento.Hosts.ValueObjects.{
+    SaptuneSolution,
+    SaptuneStaging,
     SaptuneStatus,
     SlesSubscription
   }
@@ -349,11 +351,30 @@ defmodule Trento.Factory do
     }
   end
 
+  def saptune_solution_factory do
+    %SaptuneSolution{
+      id: Faker.UUID.v4(),
+      notes: ["foo", "bar", "baz"],
+      partial: Enum.random([true, false])
+    }
+  end
+
+  def saptune_staging_factory do
+    %SaptuneStaging{
+      enabled: Enum.random([true, false]),
+      notes: ["foo", "bar", "baz"],
+      solutions_ids: [Faker.UUID.v4(), Faker.UUID.v4()]
+    }
+  end
+
   def saptune_status_factory do
     %SaptuneStatus{
       package_version: Faker.App.semver(),
       configured_version: Enum.random(["1", "2", "3"]),
-      tuning_state: Enum.random(["compliant", "not compliant", "not tuned"])
+      tuning_state: Enum.random(["compliant", "not compliant", "not tuned"]),
+      applied_solution: build(:saptune_solution),
+      enabled_solution: build(:saptune_solution),
+      staging: build(:saptune_staging)
     }
   end
 

--- a/test/trento/hosts/host_test.exs
+++ b/test/trento/hosts/host_test.exs
@@ -3,6 +3,8 @@ defmodule Trento.Hosts.HostTest do
 
   import Trento.Factory
 
+  alias Trento.Support.StructHelper
+
   alias Trento.Hosts.Commands.{
     ClearSoftwareUpdatesDiscovery,
     CompleteHostChecksExecution,
@@ -1295,7 +1297,7 @@ defmodule Trento.Hosts.HostTest do
           saptune_installed: true,
           package_version: "3.2.0",
           sap_running: false,
-          status: Map.from_struct(new_saptune_status)
+          status: StructHelper.to_atomized_map(new_saptune_status)
         }),
         %SaptuneStatusUpdated{
           host_id: host_id,
@@ -1329,7 +1331,7 @@ defmodule Trento.Hosts.HostTest do
           saptune_installed: true,
           package_version: Faker.App.semver(),
           sap_running: false,
-          status: Map.from_struct(saptune_status)
+          status: StructHelper.to_atomized_map(saptune_status)
         }),
         [],
         fn state ->
@@ -1507,7 +1509,7 @@ defmodule Trento.Hosts.HostTest do
             saptune_installed: true,
             package_version: suppported_version,
             sap_running: true,
-            status: Map.from_struct(saptune_status)
+            status: StructHelper.to_atomized_map(saptune_status)
           }),
           [
             %SaptuneStatusUpdated{

--- a/test/trento/hosts/projections/host_projector_test.exs
+++ b/test/trento/hosts/projections/host_projector_test.exs
@@ -39,6 +39,8 @@ defmodule Trento.Hosts.Projections.HostProjectorTest do
   alias Trento.ProjectorTestHelper
   alias Trento.Repo
 
+  alias Trento.Support.StructHelper
+
   @moduletag :integration
 
   @endpoint TrentoWeb.Endpoint
@@ -563,7 +565,7 @@ defmodule Trento.Hosts.Projections.HostProjectorTest do
       status: saptune_status
     }
 
-    expected_status = Map.from_struct(saptune_status)
+    expected_status = StructHelper.to_atomized_map(saptune_status)
 
     ProjectorTestHelper.project(HostProjector, event, "host_projector")
     host_projection = Repo.get!(HostReadModel, host_id)

--- a/test/trento/hosts/projections/host_projector_test.exs
+++ b/test/trento/hosts/projections/host_projector_test.exs
@@ -559,6 +559,7 @@ defmodule Trento.Hosts.Projections.HostProjectorTest do
          hostname: hostname
        } do
     saptune_status = build(:saptune_status)
+    map_saptune_status = Map.from_struct(saptune_status)
 
     event = %SaptuneStatusUpdated{
       host_id: host_id,
@@ -576,7 +577,7 @@ defmodule Trento.Hosts.Projections.HostProjectorTest do
                      %{
                        id: ^host_id,
                        hostname: ^hostname,
-                       status: ^expected_status
+                       status: ^map_saptune_status
                      },
                      1000
   end

--- a/test/trento/infrastructure/commanded/event_handlers/saptune_status_update_event_handler_test.exs
+++ b/test/trento/infrastructure/commanded/event_handlers/saptune_status_update_event_handler_test.exs
@@ -49,7 +49,6 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SaptuneStatusUpdateEvent
     test "should update saptune status when saptune is installed" do
       %{package_version: version} = saptune_status = build(:saptune_status)
       %{id: host_id} = insert(:host, saptune_status: saptune_status)
-      saptune_as_map = Map.from_struct(saptune_status)
 
       events = [
         build(:database_instance_registered_event, host_id: host_id),
@@ -62,7 +61,7 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SaptuneStatusUpdateEvent
                                                       package_version: ^version,
                                                       saptune_installed: true,
                                                       sap_running: true,
-                                                      status: ^saptune_as_map
+                                                      status: ^saptune_status
                                                     } ->
           :ok
         end)

--- a/test/trento/operations/host_policy_test.exs
+++ b/test/trento/operations/host_policy_test.exs
@@ -14,9 +14,6 @@ defmodule Trento.Operations.HostPolicyTest do
     assert {:error, ["Unknown operation"]} == HostPolicy.authorize_operation(:unknown, host, %{})
   end
 
-  describe "Forbidding saptune operations" do
-  end
-
   describe "Saptune operations" do
     scenarios = [
       %{

--- a/test/trento/operations/host_policy_test.exs
+++ b/test/trento/operations/host_policy_test.exs
@@ -14,11 +14,33 @@ defmodule Trento.Operations.HostPolicyTest do
     assert {:error, ["Unknown operation"]} == HostPolicy.authorize_operation(:unknown, host, %{})
   end
 
-  describe "Saptune operations" do
-    for operation <- [:saptune_solution_apply, :saptune_solution_change] do
-      @saptune_operation operation
+  describe "Forbidding saptune operations" do
+  end
 
-      test "should forbid operation '#{operation}' if an application instance is not stopped" do
+  describe "Saptune operations" do
+    scenarios = [
+      %{
+        name: "applying solution when there is no saptune status",
+        operation: :saptune_solution_apply,
+        saptune_status: nil
+      },
+      %{
+        name: "applying solution when there is no applied solution in saptune status",
+        operation: :saptune_solution_apply,
+        saptune_status: build(:saptune_status, applied_solution: nil)
+      },
+      %{
+        name: "changing solution when there is an already applied solution",
+        operation: :saptune_solution_change,
+        saptune_status: build(:saptune_status)
+      }
+    ]
+
+    for %{name: name, operation: operation, saptune_status: saptune_status} <- scenarios do
+      @saptune_operation operation
+      @saptune_status saptune_status
+
+      test "should forbid operation '#{operation}' if an application instance is not stopped. Scenario: #{name}" do
         application_instances = [
           build(:application_instance, health: Health.unknown()),
           %{sid: sid, instance_number: instance_number} =
@@ -33,7 +55,8 @@ defmodule Trento.Operations.HostPolicyTest do
           build(:host,
             application_instances: application_instances,
             database_instances: database_instancess,
-            cluster: cluster
+            cluster: cluster,
+            saptune_status: @saptune_status
           )
 
         assert {:error,
@@ -43,7 +66,7 @@ defmodule Trento.Operations.HostPolicyTest do
                 ]} == HostPolicy.authorize_operation(@saptune_operation, host, %{})
       end
 
-      test "should forbid operation '#{operation}' if an database instance is not stopped" do
+      test "should forbid operation '#{operation}' if an database instance is not stopped. Scenario: #{name}" do
         application_instances = build_list(2, :application_instance, health: Health.unknown())
 
         database_instancess = [
@@ -58,7 +81,8 @@ defmodule Trento.Operations.HostPolicyTest do
           build(:host,
             application_instances: application_instances,
             database_instances: database_instancess,
-            cluster: cluster
+            cluster: cluster,
+            saptune_status: @saptune_status
           )
 
         assert {:error,
@@ -68,7 +92,7 @@ defmodule Trento.Operations.HostPolicyTest do
                 ]} == HostPolicy.authorize_operation(@saptune_operation, host, %{})
       end
 
-      test "should forbid operation '#{operation}' if an application and database instances are not stopped" do
+      test "should forbid operation '#{operation}' if an application and database instances are not stopped. Scenario: #{name}" do
         application_instances = [
           build(:application_instance, health: Health.unknown()),
           %{sid: app_sid, instance_number: app_instance_number} =
@@ -87,7 +111,8 @@ defmodule Trento.Operations.HostPolicyTest do
           build(:host,
             application_instances: application_instances,
             database_instances: database_instancess,
-            cluster: cluster
+            cluster: cluster,
+            saptune_status: @saptune_status
           )
 
         assert {:error,
@@ -98,18 +123,19 @@ defmodule Trento.Operations.HostPolicyTest do
                 ]} == HostPolicy.authorize_operation(@saptune_operation, host, %{})
       end
 
-      test "should authorize operation '#{operation}' if there is not any SAP instance running" do
+      test "should authorize operation '#{operation}' if there is not any SAP instance running. Scenario: #{name}" do
         host =
           build(:host,
             application_instances: [],
             database_instances: [],
-            cluster: nil
+            cluster: nil,
+            saptune_status: @saptune_status
           )
 
         assert :ok == HostPolicy.authorize_operation(@saptune_operation, host, %{})
       end
 
-      test "should authorize operation '#{operation}' if all instances are stopped and the host is not clustered" do
+      test "should authorize operation '#{operation}' if all instances are stopped and the host is not clustered. Scenario: #{name}" do
         application_instances = build_list(2, :application_instance, health: Health.unknown())
         database_instancess = build_list(2, :database_instance, health: Health.unknown())
 
@@ -117,13 +143,14 @@ defmodule Trento.Operations.HostPolicyTest do
           build(:host,
             application_instances: application_instances,
             database_instances: database_instancess,
-            cluster: nil
+            cluster: nil,
+            saptune_status: @saptune_status
           )
 
         assert :ok == HostPolicy.authorize_operation(@saptune_operation, host, %{})
       end
 
-      test "should authorize operation '#{operation}' if all instances are stopped and cluster is in maintenance" do
+      test "should authorize operation '#{operation}' if all instances are stopped and cluster is in maintenance. Scenario: #{name}" do
         application_instances = build_list(2, :application_instance, health: Health.unknown())
         database_instancess = build_list(2, :database_instance, health: Health.unknown())
         cluster = build(:cluster, details: build(:hana_cluster_details, maintenance_mode: true))
@@ -132,13 +159,14 @@ defmodule Trento.Operations.HostPolicyTest do
           build(:host,
             application_instances: application_instances,
             database_instances: database_instancess,
-            cluster: cluster
+            cluster: cluster,
+            saptune_status: @saptune_status
           )
 
         assert :ok == HostPolicy.authorize_operation(@saptune_operation, host, %{})
       end
 
-      test "should authorize operation '#{operation}' if all instances are stopped and HANA resources are not managed" do
+      test "should authorize operation '#{operation}' if all instances are stopped and HANA resources are not managed. Scenario: #{name}" do
         scenarios = [
           %{cluster_resource_type: "ocf::suse:SAPHana"},
           %{cluster_resource_type: "ocf::suse:SAPHanaController"}
@@ -160,11 +188,47 @@ defmodule Trento.Operations.HostPolicyTest do
             build(:host,
               application_instances: [],
               database_instances: database_instancess,
-              cluster: cluster
+              cluster: cluster,
+              saptune_status: @saptune_status
             )
 
           assert :ok == HostPolicy.authorize_operation(@saptune_operation, host, %{})
         end
+      end
+    end
+
+    test "should forbid applying a saptune solution when there is an already applied one" do
+      host =
+        build(:host,
+          application_instances: [],
+          database_instances: [],
+          cluster: nil,
+          saptune_status: build(:saptune_status)
+        )
+
+      assert {:error,
+              [
+                "Cannot apply the requested solution because there is an already applied on this host"
+              ]} == HostPolicy.authorize_operation(:saptune_solution_apply, host, %{})
+    end
+
+    test "should forbid changing saptune solution when there is not an already applied one" do
+      for saptune_status <- [
+            nil,
+            build(:saptune_status, applied_solution: nil)
+          ] do
+        host =
+          build(:host,
+            application_instances: [],
+            database_instances: [],
+            cluster: nil,
+            saptune_status: saptune_status
+          )
+
+        assert {:error,
+                [
+                  "Cannot change the requested solution because there is no currently applied one on this host"
+                ]} == HostPolicy.authorize_operation(:saptune_solution_change, host, %{})
       end
     end
   end


### PR DESCRIPTION
# Description

This PR hardens the host policy with regards to saptune operations.

Makes sure to not issue operations when the current state does not allow it
- it is not possible to apply a solution when there is an already applied one
- it is not possible to change a solution when there isn't another one applied

Checking whether the requested solution matches or not the one in the host is left to the operator.

EDIT:
the main change is in the first commit ddd7ed5ce6002c5435b6b8291b1169c452edf677
The secon commit fd1ab5d046cdf492fca8d6d4352f6d3c78f622c6 is mainly side effect required adjustments

Of course there is an API bc break https://github.com/trento-project/web/actions/runs/15303383262/job/43049718634?pr=3535 but since the previous state was just wrong, not sure it is worth a bump