### PR TITLE
Fix start/stop AgentHeartbeat logic in before/after Each hooks in e2e tests

### DIFF
--- a/.github/workflows/e2e-flaky-tests-detection.yaml
+++ b/.github/workflows/e2e-flaky-tests-detection.yaml
@@ -144,7 +144,7 @@ jobs:
         container: ${{ fromJson(needs.generate-matrix.outputs.matrix).container }}
     env:
       MIX_ENV: dev
-    timeout-minutes: 120
+    timeout-minutes: 25
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/e2e-flaky-tests-detection.yaml
+++ b/.github/workflows/e2e-flaky-tests-detection.yaml
@@ -235,6 +235,7 @@ jobs:
     name: Flaky Tests Analysis
     needs: test-e2e
     runs-on: ubuntu-24.04
+    if: always()
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -46,9 +46,7 @@ context('Hosts Overview', () => {
 
   describe('Health Detection', () => {
     describe('Health Container shows the health overview of the deployed landscape', () => {
-      before(() => {
-        hostsOverviewPage.startAgentsHeartbeat();
-      });
+      beforeEach(() => hostsOverviewPage.startAgentsHeartbeat());
 
       it('should show health status of the entire cluster of 27 hosts with partial pagination', () => {
         hostsOverviewPage.expectedPassingHostsAreDisplayed(11);
@@ -61,7 +59,7 @@ context('Hosts Overview', () => {
         hostsOverviewPage.expectedAmountOfWarningsIsDisplayed(2);
       });
 
-      after(() => hostsOverviewPage.stopAgentsHeartbeat());
+      afterEach(() => hostsOverviewPage.stopAgentsHeartbeat());
     });
 
     describe('Health is changed based on saptune status', () => {
@@ -120,7 +118,7 @@ context('Hosts Overview', () => {
         hostsOverviewPage.expectedAmountOfCriticalsIsDisplayed(10);
       });
 
-      afterEach(() => hostsOverviewPage.stopAgentsHeartbeat());
+      after(() => hostsOverviewPage.stopAgentsHeartbeat());
     });
   });
 

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -46,7 +46,7 @@ context('Hosts Overview', () => {
 
   describe('Health Detection', () => {
     describe('Health Container shows the health overview of the deployed landscape', () => {
-      before(() => {
+      beforeEach(() => {
         hostsOverviewPage.startAgentsHeartbeat();
       });
 
@@ -61,11 +61,11 @@ context('Hosts Overview', () => {
         hostsOverviewPage.expectedAmountOfWarningsIsDisplayed(2);
       });
 
-      after(() => hostsOverviewPage.stopAgentsHeartbeat());
+      afterEach(() => hostsOverviewPage.stopAgentsHeartbeat());
     });
 
     describe('Health is changed based on saptune status', () => {
-      before(() => hostsOverviewPage.startAgentsHeartbeat());
+      beforeEach(() => hostsOverviewPage.startAgentsHeartbeat());
 
       it('should not change the health if saptune is not installed and a SAP workload is not running', () => {
         hostsOverviewPage.loadHostWithoutSaptune();
@@ -102,7 +102,7 @@ context('Hosts Overview', () => {
         hostsOverviewPage.hostWithSaptuneCompliantHasExpectedStatus();
       });
 
-      after(() => hostsOverviewPage.stopAgentsHeartbeat());
+      afterEach(() => hostsOverviewPage.stopAgentsHeartbeat());
     });
 
     describe('Health is changed to critical when the heartbeat is not sent', () => {
@@ -120,7 +120,7 @@ context('Hosts Overview', () => {
         hostsOverviewPage.expectedAmountOfCriticalsIsDisplayed(10);
       });
 
-      after(() => hostsOverviewPage.stopAgentsHeartbeat());
+      afterEach(() => hostsOverviewPage.stopAgentsHeartbeat());
     });
   });
 

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -46,7 +46,7 @@ context('Hosts Overview', () => {
 
   describe('Health Detection', () => {
     describe('Health Container shows the health overview of the deployed landscape', () => {
-      beforeEach(() => {
+      before(() => {
         hostsOverviewPage.startAgentsHeartbeat();
       });
 
@@ -61,11 +61,11 @@ context('Hosts Overview', () => {
         hostsOverviewPage.expectedAmountOfWarningsIsDisplayed(2);
       });
 
-      afterEach(() => hostsOverviewPage.stopAgentsHeartbeat());
+      after(() => hostsOverviewPage.stopAgentsHeartbeat());
     });
 
     describe('Health is changed based on saptune status', () => {
-      beforeEach(() => hostsOverviewPage.startAgentsHeartbeat());
+      before(() => hostsOverviewPage.startAgentsHeartbeat());
 
       it('should not change the health if saptune is not installed and a SAP workload is not running', () => {
         hostsOverviewPage.loadHostWithoutSaptune();
@@ -102,7 +102,7 @@ context('Hosts Overview', () => {
         hostsOverviewPage.hostWithSaptuneCompliantHasExpectedStatus();
       });
 
-      afterEach(() => hostsOverviewPage.stopAgentsHeartbeat());
+      after(() => hostsOverviewPage.stopAgentsHeartbeat());
     });
 
     describe('Health is changed to critical when the heartbeat is not sent', () => {

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -63,7 +63,7 @@ context('Hosts Overview', () => {
     });
 
     describe('Health is changed based on saptune status', () => {
-      before(() => hostsOverviewPage.startAgentsHeartbeat());
+      beforeEach(() => hostsOverviewPage.startAgentsHeartbeat());
 
       it('should not change the health if saptune is not installed and a SAP workload is not running', () => {
         hostsOverviewPage.loadHostWithoutSaptune();
@@ -100,7 +100,7 @@ context('Hosts Overview', () => {
         hostsOverviewPage.hostWithSaptuneCompliantHasExpectedStatus();
       });
 
-      after(() => hostsOverviewPage.stopAgentsHeartbeat());
+      afterEach(() => hostsOverviewPage.stopAgentsHeartbeat());
     });
 
     describe('Health is changed to critical when the heartbeat is not sent', () => {
@@ -118,7 +118,7 @@ context('Hosts Overview', () => {
         hostsOverviewPage.expectedAmountOfCriticalsIsDisplayed(10);
       });
 
-      after(() => hostsOverviewPage.stopAgentsHeartbeat());
+      afterEach(() => hostsOverviewPage.stopAgentsHeartbeat());
     });
   });
 


### PR DESCRIPTION
# Description

Use beforeEach instead of before so startAgentHeartbeat is called per every test, apply the same to afterEach and stopAgentHeartbeat. This fixes the issue with the cypress config crashing.

Bonus: Add always() to analyze step so it is executed even if some threads failed. Decrease timeout for every thread to 25 min (the whole test suite should take around 20 normally) 

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**
## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
- [Trento Web guides](https://github.com/trento-project/web/tree/main/guides)

Add a documentation PR or write that no changes are required for the documentation.
- [ ] **DONE**
