### PR TITLE
Request cluster discovery on operation complete event

### DIFF
--- a/lib/trento/discovery.ex
+++ b/lib/trento/discovery.ex
@@ -115,6 +115,19 @@ defmodule Trento.Discovery do
   @spec request_saptune_discovery(String.t()) :: :ok | {:error, any}
   def request_saptune_discovery(host_id), do: request_discovery("saptune_discovery", [host_id])
 
+  @doc """
+  Request cluster discovery
+  """
+  @spec request_cluster_discovery(String.t()) :: :ok | {:error, any}
+  def request_cluster_discovery(cluster_id) do
+    targets =
+      cluster_id
+      |> Clusters.get_cluster_hosts()
+      |> Enum.map(& &1.id)
+
+    request_discovery("ha_cluster_discovery", targets)
+  end
+
   @spec store_discovery_event(map) :: {:ok, DiscoveryEvent.t()} | {:error, any}
   defp store_discovery_event(%{
          "agent_id" => agent_id,

--- a/lib/trento/infrastructure/operations/amqp/processor.ex
+++ b/lib/trento/infrastructure/operations/amqp/processor.ex
@@ -20,6 +20,8 @@ defmodule Trento.Infrastructure.Operations.AMQP.Processor do
 
   require Logger
 
+  require Trento.Operations.Enums.ClusterOperations, as: ClusterOperations
+
   def process(%GenRMQ.Message{payload: payload} = message) do
     Logger.debug("Received message: #{inspect(message)}")
 
@@ -77,6 +79,11 @@ defmodule Trento.Infrastructure.Operations.AMQP.Processor do
   defp maybe_request_discovery(operation, :UPDATED, group_id)
        when operation in [:saptune_solution_apply, :saptune_solution_change] do
     Discovery.request_saptune_discovery(group_id)
+  end
+
+  defp maybe_request_discovery(operation, :UPDATED, group_id)
+       when operation in ClusterOperations.values() do
+    Discovery.request_cluster_discovery(group_id)
   end
 
   defp maybe_request_discovery(_, _, _), do: :ok


### PR DESCRIPTION
# Description

Request `ha_cluster_discovery` when a cluster related operation is completed.
It requests a cluster discovery in all the host of the cluster. Again, this is suboptimal, as asking only the DC would be enough. But let's go with this by now.
If at some point we implement the DC discovery properly, we can change this

## How was this tested?

UT
