### PR TITLE
Split host and cluster operation requested activity logging

### DIFF
--- a/assets/js/lib/model/activityLog.js
+++ b/assets/js/lib/model/activityLog.js
@@ -114,7 +114,8 @@ export const DATABASE_TENANTS_UPDATED = 'database_tenants_updated';
 export const DATABASE_TOMBSTONED = 'database_tombstoned';
 
 // Operations
-export const OPERATION_REQUESTED = 'operation_requested';
+export const CLUSTER_OPERATION_REQUESTED = 'cluster_operation_requested';
+export const HOST_OPERATION_REQUESTED = 'host_operation_requested';
 export const OPERATION_COMPLETED = 'operation_completed';
 
 // Check Customization
@@ -580,11 +581,17 @@ export const ACTIVITY_TYPES_CONFIG = {
     resource: databaseResourceType,
   },
   // Operations
-  [OPERATION_REQUESTED]: {
-    label: 'Operation Requested',
+  [CLUSTER_OPERATION_REQUESTED]: {
+    label: 'Cluster Operation Requested',
     message: ({ metadata }) =>
       `Operation ${getOperationLabel(metadata.operation)} requested`,
-    resource: operationResourceType,
+    resource: clusterResourceType,
+  },
+  [HOST_OPERATION_REQUESTED]: {
+    label: 'Host Operation Requested',
+    message: ({ metadata }) =>
+      `Operation ${getOperationLabel(metadata.operation)} requested`,
+    resource: hostResourceType,
   },
   [OPERATION_COMPLETED]: {
     label: 'Operation Completed',

--- a/lib/trento/activity_logging/activity_catalog.ex
+++ b/lib/trento/activity_logging/activity_catalog.ex
@@ -174,8 +174,8 @@ defmodule Trento.ActivityLog.ActivityCatalog do
       {TrentoWeb.V1.HostController, :select_checks} => {:host_checks_selected, 202},
       {TrentoWeb.V1.SettingsController, :update_activity_log_settings} =>
         {:activity_log_settings_update, 200},
-      {TrentoWeb.V1.HostController, :request_operation} => {:operation_requested, 202},
-      {TrentoWeb.V1.ClusterController, :request_operation} => {:operation_requested, 202}
+      {TrentoWeb.V1.HostController, :request_operation} => {:host_operation_requested, 202},
+      {TrentoWeb.V1.ClusterController, :request_operation} => {:cluster_operation_requested, 202}
     }
   end
 

--- a/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
+++ b/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
@@ -134,13 +134,14 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
       do: %{user_id: Map.get(params, :id)}
 
   def get_activity_metadata(
-        :operation_requested,
+        activity,
         %Plug.Conn{
           params: params,
           body_params: body_params,
           resp_body: resp_body
         }
-      ) do
+      )
+      when activity in [:cluster_operation_requested, :host_operation_requested] do
     %{
       resource_id: Map.get(params, :id),
       operation: params |> Map.get(:operation) |> String.to_existing_atom(),

--- a/lib/trento/activity_logging/severity_level.ex
+++ b/lib/trento/activity_logging/severity_level.ex
@@ -151,7 +151,8 @@ defmodule Trento.ActivityLog.SeverityLevel do
     "database_rollup_requested" => :info,
     "database_tenants_updated" => :info,
     "database_tombstoned" => :debug,
-    "operation_requested" => :info,
+    "cluster_operation_requested" => :info,
+    "host_operation_requested" => :info,
     "operation_completed" => %{
       type: :kv,
       key_suffix: "result",

--- a/test/trento/activity_logging/activity_catalog_test.exs
+++ b/test/trento/activity_logging/activity_catalog_test.exs
@@ -28,10 +28,8 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
         :host_checks_selected,
         :host_checks_execution_request,
         :activity_log_settings_update,
-        # operation_requested for hosts
-        :operation_requested,
-        # operation_requested for clusters
-        :operation_requested
+        :host_operation_requested,
+        :cluster_operation_requested
       ]
 
       connection_activity_catalog = ActivityCatalog.connection_activities()
@@ -246,8 +244,14 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
         not_interesting_statuses: [400, 401, 403, 404, 500]
       },
       %{
-        activity: :operation_requested,
+        activity: :host_operation_requested,
         connection_info: {TrentoWeb.V1.HostController, :request_operation},
+        interesting_statuses: 202,
+        not_interesting_statuses: [400, 401, 403, 404, 500]
+      },
+      %{
+        activity: :cluster_operation_requested,
+        connection_info: {TrentoWeb.V1.ClusterController, :request_operation},
         interesting_statuses: 202,
         not_interesting_statuses: [400, 401, 403, 404, 500]
       }

--- a/test/trento/activity_logging/metadata_enricher_test.exs
+++ b/test/trento/activity_logging/metadata_enricher_test.exs
@@ -243,7 +243,35 @@ defmodule Trento.ActivityLog.MetadataEnricherTest do
         }
 
         assert {:ok, %{hostname: ^hostname}} =
-                 MetadataEnricher.enrich(:operation_requested, initial_metadata)
+                 MetadataEnricher.enrich(:host_operation_requested, initial_metadata)
+      end
+    end
+
+    for current_operation <- [:cluster_maintenance_change] do
+      @current_operation current_operation
+
+      test "should enrich operation '#{current_operation}' completed events in clusters" do
+        %{id: cluster_id, name: name} = insert(:cluster)
+
+        initial_metadata = %{
+          resource_id: cluster_id,
+          operation: @current_operation
+        }
+
+        assert {:ok, %{name: ^name}} =
+                 MetadataEnricher.enrich(:operation_completed, initial_metadata)
+      end
+
+      test "should enrich operation '#{current_operation}' requested events in clusters" do
+        %{id: cluster_id, name: name} = insert(:cluster)
+
+        initial_metadata = %{
+          resource_id: cluster_id,
+          operation: @current_operation
+        }
+
+        assert {:ok, %{name: ^name}} =
+                 MetadataEnricher.enrich(:cluster_operation_requested, initial_metadata)
       end
     end
   end

--- a/test/trento/activity_logging/queue_event_parser_test.exs
+++ b/test/trento/activity_logging/queue_event_parser_test.exs
@@ -16,7 +16,7 @@ defmodule Trento.ActivityLog.QueueEventParserTest do
 
       %{actor: actor} =
         insert(:activity_log_entry,
-          type: "operation_requested",
+          type: "someresource_operation_requested",
           metadata: %{"operation_id" => operation_id}
         )
 


### PR DESCRIPTION
# Description

Follow up for: https://github.com/trento-project/web/pull/3532#discussion_r2112276586

**Disclaimer: the current code, before this PR, already manages the host and cluster operation requested activity log entries properly. So the end result is practically the same**

Split host and cluster activity logging logic. It gives more granularity in expense of having more code.

Let me know what do you think. If it is worth it or not, because we will need duplicate the code for sap systems and databases as well, or keep a "generic" `operation_requested` usage.

The bad thing is that we cannot identify the operation completed resource so easily, without making more changes in the activity logging framework.

## How was this tested?

UT
