### PR TITLE
Enable operations in production

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -10,7 +10,7 @@ config :trento, Trento.SoftwareUpdates.Discovery,
   adapter: Trento.Infrastructure.SoftwareUpdates.Suma
 
 config :trento,
-  operations_enabled: false
+  operations_enabled: true
 
 # Do not print debug messages in production
 # config :logger, level: :info


### PR DESCRIPTION
# Description
Enable operation in production.
Keeping the flag as it is so we still have the chance to disable.