### PR TITLE
SAP instance start/stop policy

### DIFF
--- a/lib/trento/operations/application_instance_policy.ex
+++ b/lib/trento/operations/application_instance_policy.ex
@@ -19,17 +19,42 @@ defmodule Trento.Operations.ApplicationInstancePolicy do
   def authorize_operation(
         :maintenance,
         %ApplicationInstanceReadModel{} = application_instance,
-        params
+        _params
       ) do
     OperationsHelper.reduce_operation_authorizations([
       instance_running(application_instance),
-      cluster_maintenance(application_instance, params)
+      cluster_maintenance(application_instance)
     ])
   end
 
-  def authorize_operation(operation, %ApplicationInstanceReadModel{}, _)
-      when operation in [:sap_instance_start, :sap_instance_stop] do
-    :ok
+  # instance start operation authorized when:
+  # - other instances in the system are started
+  # - database is started
+  # - cluster is in maintenance
+  def authorize_operation(
+        :sap_instance_start,
+        %ApplicationInstanceReadModel{} = application_instance,
+        _params
+      ) do
+    OperationsHelper.reduce_operation_authorizations([
+      other_instances_started(application_instance),
+      database_started(application_instance),
+      cluster_maintenance(application_instance)
+    ])
+  end
+
+  # stop instance operation authorized when:
+  # - other instances in the system are stopped
+  # - cluster is in maintenance
+  def authorize_operation(
+        :sap_instance_stop,
+        %ApplicationInstanceReadModel{} = application_instance,
+        _params
+      ) do
+    OperationsHelper.reduce_operation_authorizations([
+      other_instances_stopped(application_instance),
+      cluster_maintenance(application_instance)
+    ])
   end
 
   def authorize_operation(_, _, _), do: {:error, ["Unknown operation"]}
@@ -44,12 +69,136 @@ defmodule Trento.Operations.ApplicationInstancePolicy do
 
   defp instance_running(_), do: :ok
 
-  defp cluster_maintenance(%ApplicationInstanceReadModel{host: %HostReadModel{cluster: nil}}, _),
+  # Message Server, start without depending on other instances
+  defp other_instances_started(%ApplicationInstanceReadModel{
+         features: "MESSAGESERVER" <> _
+       }) do
+    :ok
+  end
+
+  # Enq rep and App servers, start only if Message server is started
+  defp other_instances_started(%ApplicationInstanceReadModel{
+         host_id: host_id,
+         sid: sid,
+         instance_number: instance_number,
+         sap_system: %{
+           application_instances: instances
+         }
+       }) do
+    message_server_instance =
+      instances
+      |> reject_current_instance(host_id, instance_number)
+      |> Enum.find(fn %{features: features} ->
+        features =~ "MESSAGESERVER"
+      end)
+
+    case message_server_instance do
+      %{health: :passing} ->
+        :ok
+
+      %{instance_number: msg_instance_number} ->
+        {:error, ["Message server #{msg_instance_number} of SAP system #{sid} is not started"]}
+
+      nil ->
+        {:error, ["Message server not found in SAP system #{sid}"]}
+    end
+  end
+
+  # Message Server and Enq rep, start without depending on database
+  defp database_started(%ApplicationInstanceReadModel{features: "MESSAGESERVER" <> _}), do: :ok
+  defp database_started(%ApplicationInstanceReadModel{features: "ENQREP"}), do: :ok
+
+  # ABAP and JAVA servers, start only if database is started
+  defp database_started(%ApplicationInstanceReadModel{
+         sap_system: %{
+           database: %{
+             health: :passing
+           }
+         }
+       }),
+       do: :ok
+
+  defp database_started(%ApplicationInstanceReadModel{
+         sap_system: %{
+           database: %{
+             sid: sid
+           }
+         }
+       }),
+       do: {:error, ["Database #{sid} is not started"]}
+
+  # Message server, stop only if the other instances are stopped
+  defp other_instances_stopped(%ApplicationInstanceReadModel{
+         features: "MESSAGESERVER" <> _,
+         host_id: host_id,
+         sid: sid,
+         instance_number: instance_number,
+         sap_system: %{
+           application_instances: instances
+         }
+       }) do
+    instances
+    |> reject_current_instance(host_id, instance_number)
+    |> Enum.filter(fn %{health: health} ->
+      health != :unknown
+    end)
+    |> case do
+      [] ->
+        :ok
+
+      running_instances ->
+        {:error,
+         Enum.map(running_instances, fn %{instance_number: inst_number} ->
+           "Instance #{inst_number} of SAP system #{sid} is not stopped"
+         end)}
+    end
+  end
+
+  # Other instances, stop without depending on other instances
+  defp other_instances_stopped(_), do: :ok
+
+  defp cluster_maintenance(%ApplicationInstanceReadModel{host: %HostReadModel{cluster: nil}}),
     do: :ok
 
-  defp cluster_maintenance(
-         %ApplicationInstanceReadModel{host: %HostReadModel{cluster: cluster}},
-         params
-       ),
-       do: ClusterReadModel.authorize_operation(:maintenance, cluster, params)
+  defp cluster_maintenance(%ApplicationInstanceReadModel{
+         sid: sid,
+         instance_number: instance_number,
+         host: %{hostname: hostname, cluster: %{sap_instances: sap_instances} = cluster}
+       }) do
+    is_clustered =
+      Enum.any?(sap_instances, fn
+        %{sid: ^sid, instance_number: ^instance_number} -> true
+        _ -> false
+      end)
+
+    resource_id = get_cluster_resource_id(is_clustered, sid, hostname, cluster)
+
+    ClusterReadModel.authorize_operation(:maintenance, cluster, %{
+      cluster_resource_id: resource_id
+    })
+  end
+
+  defp get_cluster_resource_id(false, _, _, _), do: nil
+
+  defp get_cluster_resource_id(true, sid, hostname, %{details: %{sap_systems: sap_systems}}) do
+    sap_systems
+    |> Enum.find_value([], fn
+      %{nodes: nodes, sid: ^sid} -> nodes
+      _ -> nil
+    end)
+    |> Enum.find_value([], fn
+      %{resources: resources, name: ^hostname} -> resources
+      _ -> nil
+    end)
+    |> Enum.find_value(fn
+      %{id: id, type: "ocf::heartbeat:SAPInstance"} -> id
+      _ -> nil
+    end)
+  end
+
+  defp reject_current_instance(instances, host_id, instance_number) do
+    Enum.reject(instances, fn %{instance_number: inst_number, host_id: h_id} ->
+      instance_number == inst_number && host_id == h_id
+    end)
+  end
 end

--- a/lib/trento/sap_systems/projections/application_instance_read_model.ex
+++ b/lib/trento/sap_systems/projections/application_instance_read_model.ex
@@ -12,6 +12,7 @@ defmodule Trento.SapSystems.Projections.ApplicationInstanceReadModel do
   @type t :: %__MODULE__{}
 
   alias Trento.Hosts.Projections.HostReadModel
+  alias Trento.SapSystems.Projections.SapSystemReadModel
 
   defdelegate authorize_operation(action, application_instance, params),
     to: Trento.Operations.ApplicationInstancePolicy
@@ -19,7 +20,6 @@ defmodule Trento.SapSystems.Projections.ApplicationInstanceReadModel do
   @derive {Jason.Encoder, except: [:__meta__, :__struct__]}
   @primary_key false
   schema "application_instances" do
-    field :sap_system_id, Ecto.UUID, primary_key: true
     field :sid, :string
     field :instance_number, :string, primary_key: true
     field :instance_hostname, :string
@@ -33,6 +33,13 @@ defmodule Trento.SapSystems.Projections.ApplicationInstanceReadModel do
     belongs_to :host, HostReadModel,
       references: :id,
       foreign_key: :host_id,
+      primary_key: true,
+      type: Ecto.UUID,
+      where: [deregistered_at: nil]
+
+    belongs_to :sap_system, SapSystemReadModel,
+      references: :id,
+      foreign_key: :sap_system_id,
       primary_key: true,
       type: Ecto.UUID,
       where: [deregistered_at: nil]

--- a/lib/trento_web/controllers/v1/sap_system_controller.ex
+++ b/lib/trento_web/controllers/v1/sap_system_controller.ex
@@ -159,13 +159,17 @@ defmodule TrentoWeb.V1.SapSystemController do
           instance_number: inst_number
         }
       }) do
-    sap_system_id
-    |> SapSystems.get_application_instances_by_id()
+    instances = SapSystems.get_application_instances_by_id(sap_system_id)
+
+    instances
     |> Enum.find(fn
       %{host_id: ^host_id, instance_number: ^inst_number} -> true
       _ -> false
     end)
-    |> Repo.preload(sap_system: [:application_instances, :database], host: :cluster)
+    |> Repo.preload(
+      sap_system: [:database, application_instances: fn _ -> instances end],
+      host: :cluster
+    )
   end
 
   def get_operation_instance(_), do: nil

--- a/lib/trento_web/controllers/v1/sap_system_controller.ex
+++ b/lib/trento_web/controllers/v1/sap_system_controller.ex
@@ -165,7 +165,7 @@ defmodule TrentoWeb.V1.SapSystemController do
       %{host_id: ^host_id, instance_number: ^inst_number} -> true
       _ -> false
     end)
-    |> Repo.preload(host: :cluster)
+    |> Repo.preload(sap_system: [:application_instances, :database], host: :cluster)
   end
 
   def get_operation_instance(_), do: nil

--- a/lib/trento_web/controllers/v1/sap_system_json.ex
+++ b/lib/trento_web/controllers/v1/sap_system_json.ex
@@ -7,6 +7,7 @@ defmodule TrentoWeb.V1.SapSystemJSON do
     |> Map.from_struct()
     |> Map.delete(:__meta__)
     |> Map.delete(:host)
+    |> Map.delete(:sap_system)
   end
 
   def application_instance_moved(%{instance_moved: instance_moved}), do: instance_moved

--- a/test/trento/operations/application_instance_policy_test.exs
+++ b/test/trento/operations/application_instance_policy_test.exs
@@ -4,11 +4,17 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
 
   require Trento.Enums.Health, as: Health
 
-  alias Trento.Hosts.Projections.HostReadModel
-
   alias Trento.Operations.ApplicationInstancePolicy
 
   import Trento.Factory
+
+  @empty_ascs_ers_cluster build(:cluster,
+                            details:
+                              build(:ascs_ers_cluster_details,
+                                maintenance_mode: true,
+                                sap_systems: []
+                              )
+                          )
 
   test "should forbid unknown operation" do
     instance = build(:application_instance)
@@ -28,7 +34,7 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
         instance =
         build(:application_instance,
           health: Health.passing(),
-          host: %HostReadModel{cluster: cluster}
+          host: build(:host, cluster: cluster)
         )
 
       assert {:error, ["Instance #{instance_number} of SAP system #{sid} is not stopped"]} ==
@@ -39,7 +45,7 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
 
     test "should authorize operation if the application instance is not clustered" do
       instance =
-        build(:application_instance, health: Health.unknown(), host: %HostReadModel{cluster: nil})
+        build(:application_instance, health: Health.unknown(), host: build(:host, cluster: nil))
 
       assert :ok == ApplicationInstancePolicy.authorize_operation(:maintenance, instance, %{})
     end
@@ -65,13 +71,73 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
         instance =
           build(:application_instance,
             health: Health.unknown(),
-            host: %HostReadModel{cluster: cluster}
+            host: build(:host, cluster: cluster)
           )
 
         assert result ==
                  ApplicationInstancePolicy.authorize_operation(:maintenance, instance, %{
                    cluster_resource_id: nil
                  })
+      end
+    end
+
+    test "should authorize operation if the cluster SAPInstance resource is unmanaged" do
+      cluster_name = Faker.StarWars.character()
+      resource_id = Faker.UUID.v4()
+
+      scenarios = [
+        %{managed: false, result: :ok},
+        %{
+          managed: true,
+          result:
+            {:error,
+             [
+               "Cluster #{cluster_name} or resource #{resource_id} operating this host are not in maintenance mode"
+             ]}
+        }
+      ]
+
+      for %{managed: managed, result: result} <- scenarios do
+        [%{name: hostname}] =
+          nodes =
+          build_list(1, :ascs_ers_cluster_node,
+            resources:
+              build_list(1, :cluster_resource,
+                id: resource_id,
+                type: "ocf::heartbeat:SAPInstance",
+                managed: managed
+              )
+          )
+
+        [%{sid: sid}] = sap_systems = build_list(1, :ascs_ers_cluster_sap_system, nodes: nodes)
+
+        cluster_details =
+          build(:ascs_ers_cluster_details, maintenance_mode: false, sap_systems: sap_systems)
+
+        [%{instance_number: instance_number}] =
+          clustered_sap_instances =
+          build_list(1, :clustered_sap_instance, hostname: hostname, sid: sid)
+
+        cluster =
+          build(:cluster,
+            name: cluster_name,
+            type: :ascs_ers,
+            details: cluster_details,
+            sap_instances: clustered_sap_instances
+          )
+
+        host = build(:host, hostname: hostname, cluster: cluster)
+
+        instance =
+          build(:application_instance,
+            health: Health.unknown(),
+            host: host,
+            sid: sid,
+            instance_number: instance_number
+          )
+
+        assert result ==
+                 ApplicationInstancePolicy.authorize_operation(:maintenance, instance, %{})
       end
     end
 
@@ -87,7 +153,7 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
         instance =
         build(:application_instance,
           health: Health.passing(),
-          host: %HostReadModel{cluster: cluster}
+          host: build(:host, cluster: cluster)
         )
 
       assert {:error,
@@ -101,21 +167,217 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
     end
   end
 
-  describe "SAP instance start" do
-    test "should authorize SAP instance start operation" do
-      instance = build(:application_instance)
+  describe "sap_instance_start" do
+    test "should authorize Message server start always" do
+      instance =
+        build(:application_instance,
+          features: "MESSAGESERVER|ENQUE",
+          host: build(:host, cluster: @empty_ascs_ers_cluster)
+        )
 
       assert :ok ==
                ApplicationInstancePolicy.authorize_operation(:sap_instance_start, instance, %{})
     end
+
+    test "should authorize other instances start depending on Message server running status" do
+      instance_number = "00"
+      sid = "PRD"
+
+      scenarios = [
+        %{health: :passing, result: :ok},
+        %{
+          health: :unknown,
+          result:
+            {:error, ["Message server #{instance_number} of SAP system #{sid} is not started"]}
+        }
+      ]
+
+      for %{health: health, result: result} <- scenarios do
+        message_server_instance =
+          build(:application_instance,
+            instance_number: instance_number,
+            health: health,
+            features: "MESSAGESERVER|ENQUE"
+          )
+
+        instance =
+          build(:application_instance,
+            sid: sid,
+            host: build(:host, cluster: @empty_ascs_ers_cluster)
+          )
+
+        sap_system =
+          build(:sap_system,
+            application_instances: [message_server_instance, instance],
+            database: build(:database, health: :passing)
+          )
+
+        assert result ==
+                 ApplicationInstancePolicy.authorize_operation(
+                   :sap_instance_start,
+                   %{instance | sap_system: sap_system},
+                   %{}
+                 )
+      end
+    end
+
+    test "should forbid other instances start if Message server is not found" do
+      %{sid: sid} =
+        instance =
+        build(:application_instance, host: build(:host, cluster: @empty_ascs_ers_cluster))
+
+      sap_system =
+        build(:sap_system,
+          application_instances: [instance],
+          database: build(:database, health: :passing)
+        )
+
+      assert {:error, ["Message server not found in SAP system #{sid}"]} ==
+               ApplicationInstancePolicy.authorize_operation(
+                 :sap_instance_start,
+                 %{instance | sap_system: sap_system},
+                 %{}
+               )
+    end
+
+    test "should authorize Enque replication start if Message server is running and no matter the database state" do
+      for database_health <- [:unknown, :passing] do
+        message_server_instance =
+          build(:application_instance,
+            health: :passing,
+            features: "MESSAGESERVER|ENQUE"
+          )
+
+        instance =
+          build(:application_instance,
+            features: "ENQREP",
+            host: build(:host, cluster: @empty_ascs_ers_cluster)
+          )
+
+        sap_system =
+          build(:sap_system,
+            application_instances: [message_server_instance, instance],
+            database: build(:database, health: database_health)
+          )
+
+        assert :ok ==
+                 ApplicationInstancePolicy.authorize_operation(
+                   :sap_instance_start,
+                   %{instance | sap_system: sap_system},
+                   %{}
+                 )
+      end
+    end
+
+    test "should authorize other instances start depending on database running state" do
+      sid = "PRD"
+
+      scenarios = [
+        %{database_health: :passing, result: :ok},
+        %{
+          database_health: :unknown,
+          result: {:error, ["Database #{sid} is not started"]}
+        }
+      ]
+
+      for %{database_health: database_health, result: result} <- scenarios do
+        message_server_instance =
+          build(:application_instance,
+            health: :passing,
+            features: "MESSAGESERVER|ENQUE"
+          )
+
+        instance =
+          build(:application_instance,
+            host: build(:host, cluster: @empty_ascs_ers_cluster)
+          )
+
+        sap_system =
+          build(:sap_system,
+            application_instances: [message_server_instance, instance],
+            database: build(:database, sid: sid, health: database_health)
+          )
+
+        assert result ==
+                 ApplicationInstancePolicy.authorize_operation(
+                   :sap_instance_start,
+                   %{instance | sap_system: sap_system},
+                   %{}
+                 )
+      end
+    end
   end
 
-  describe "SAP instance stop" do
-    test "should authorize SAP instance stop operation" do
-      instance = build(:application_instance)
+  describe "sap_instance_stop" do
+    test "should authorize Message server stop if the other instances are stopped" do
+      instance =
+        build(:application_instance,
+          features: "MESSAGESERVER|ENQUE",
+          host: build(:host, cluster: @empty_ascs_ers_cluster)
+        )
+
+      other_instances = build_list(2, :application_instance, health: :unknown)
+
+      sap_system =
+        build(:sap_system,
+          application_instances: [instance | other_instances]
+        )
 
       assert :ok ==
-               ApplicationInstancePolicy.authorize_operation(:sap_instance_stop, instance, %{})
+               ApplicationInstancePolicy.authorize_operation(
+                 :sap_instance_stop,
+                 %{instance | sap_system: sap_system},
+                 %{}
+               )
     end
+
+    test "should forbid Message server stop if the other instances are running" do
+      %{sid: sid} =
+        instance =
+        build(:application_instance,
+          features: "MESSAGESERVER|ENQUE",
+          host: build(:host, cluster: @empty_ascs_ers_cluster)
+        )
+
+      [%{instance_number: inst_number_1}, %{instance_number: inst_number_2}] =
+        other_instances = build_list(2, :application_instance, health: :passing)
+
+      sap_system =
+        build(:sap_system,
+          application_instances: [instance | other_instances]
+        )
+
+      assert {:error,
+              [
+                "Instance #{inst_number_1} of SAP system #{sid} is not stopped",
+                "Instance #{inst_number_2} of SAP system #{sid} is not stopped"
+              ]} ==
+               ApplicationInstancePolicy.authorize_operation(
+                 :sap_instance_stop,
+                 %{instance | sap_system: sap_system},
+                 %{}
+               )
+    end
+  end
+
+  test "should authorize other instances stop" do
+    instance =
+      build(:application_instance,
+        host: build(:host, cluster: @empty_ascs_ers_cluster)
+      )
+
+    other_instances = build_list(2, :application_instance, health: :unknown)
+
+    sap_system =
+      build(:sap_system,
+        application_instances: [instance | other_instances]
+      )
+
+    assert :ok ==
+             ApplicationInstancePolicy.authorize_operation(
+               :sap_instance_stop,
+               %{instance | sap_system: sap_system},
+               %{}
+             )
   end
 end

--- a/test/trento/sap_systems/projections/sap_system_projector_test.exs
+++ b/test/trento/sap_systems/projections/sap_system_projector_test.exs
@@ -314,7 +314,6 @@ defmodule Trento.SapSystems.Projections.SapSystemProjectorTest do
       |> Map.from_struct()
       |> Map.delete(:__meta__)
       |> Map.delete(:host)
-      |> Map.delete(:sap_system)
 
     application_instance =
       insert(:application_instance, sap_system_id: sap_system_id)

--- a/test/trento/sap_systems/projections/sap_system_projector_test.exs
+++ b/test/trento/sap_systems/projections/sap_system_projector_test.exs
@@ -314,12 +314,14 @@ defmodule Trento.SapSystems.Projections.SapSystemProjectorTest do
       |> Map.from_struct()
       |> Map.delete(:__meta__)
       |> Map.delete(:host)
+      |> Map.delete(:sap_system)
 
     application_instance =
       insert(:application_instance, sap_system_id: sap_system_id)
       |> Map.from_struct()
       |> Map.delete(:__meta__)
       |> Map.delete(:host)
+      |> Map.delete(:sap_system)
 
     insert_list(5, :tag, resource_id: sap_system_id)
 

--- a/test/trento_web/controllers/v1/sap_system_controller_test.exs
+++ b/test/trento_web/controllers/v1/sap_system_controller_test.exs
@@ -239,7 +239,10 @@ defmodule TrentoWeb.V1.SapSystemControllerTest do
         %{id: host_id} = insert(:host)
 
         %{sap_system_id: sap_system_id, instance_number: inst_number} =
-          insert(:application_instance, host_id: host_id)
+          insert(:application_instance, features: "MESSAGESERVER|ENQUE", host_id: host_id)
+
+        %{id: database_id} = insert(:database, health: :passing)
+        insert(:sap_system, id: sap_system_id, database_id: database_id)
 
         expect(
           Trento.Infrastructure.Messaging.Adapter.Mock,
@@ -273,11 +276,22 @@ defmodule TrentoWeb.V1.SapSystemControllerTest do
              conn: conn,
              api_spec: api_spec
            } do
-        %{id: cluster_id} = insert(:cluster)
+        %{id: cluster_id} =
+          insert(:cluster,
+            details:
+              build(:ascs_ers_cluster_details,
+                maintenance_mode: true,
+                sap_systems: []
+              )
+          )
+
         %{id: host_id} = insert(:host, cluster_id: cluster_id)
 
         %{sap_system_id: sap_system_id, instance_number: inst_number} =
-          insert(:application_instance, host_id: host_id)
+          insert(:application_instance, features: "MESSAGESERVER|ENQUE", host_id: host_id)
+
+        %{id: database_id} = insert(:database, health: :passing)
+        insert(:sap_system, id: sap_system_id, database_id: database_id)
 
         expect(
           Trento.Infrastructure.Messaging.Adapter.Mock,

--- a/test/trento_web/controllers/v1/sap_system_controller_test.exs
+++ b/test/trento_web/controllers/v1/sap_system_controller_test.exs
@@ -317,6 +317,11 @@ defmodule TrentoWeb.V1.SapSystemControllerTest do
                  assigns: %{
                    instance: %{
                      sap_system_id: ^sap_system_id,
+                     sap_system: %{
+                       id: ^sap_system_id,
+                       application_instances: [%{sap_system_id: ^sap_system_id}],
+                       database: %{id: ^database_id}
+                     },
                      host: %{id: ^host_id, cluster: %{id: ^cluster_id}}
                    }
                  }

--- a/test/trento_web/views/v1/sap_system_view_json_test.exs
+++ b/test/trento_web/views/v1/sap_system_view_json_test.exs
@@ -35,6 +35,7 @@ defmodule TrentoWeb.V1.SapSystemJSONTest do
             |> Map.from_struct()
             |> Map.delete(:__meta__)
             |> Map.delete(:host)
+            |> Map.delete(:sap_system)
           end)
         )
         |> Map.put(
@@ -44,6 +45,7 @@ defmodule TrentoWeb.V1.SapSystemJSONTest do
             |> Map.from_struct()
             |> Map.delete(:__meta__)
             |> Map.delete(:host)
+            |> Map.delete(:sap_system)
             |> Map.put(:sap_system_id, database_id)
           end)
         )

--- a/test/trento_web/views/v1/sap_system_view_json_test.exs
+++ b/test/trento_web/views/v1/sap_system_view_json_test.exs
@@ -45,7 +45,6 @@ defmodule TrentoWeb.V1.SapSystemJSONTest do
             |> Map.from_struct()
             |> Map.delete(:__meta__)
             |> Map.delete(:host)
-            |> Map.delete(:sap_system)
             |> Map.put(:sap_system_id, database_id)
           end)
         )


### PR DESCRIPTION
# Description

**Spoiler alert: This is a pretty complex implementation**

Add SAP instance start/stop operations policies.
Some instance depend on others and the database to start/stop.
In our trento internal usage: `passing` means `running` and `uknown` means `stopped/gray`.
These are the conditions:

`sap_instance_start`:
- Message server instance `MESSAGESERVER|ENQUE` (or ASCS): it can start without any dependency
- Enque replicator `ENQREP` (or ERS):  it needs the Message server running
- Other instances (`ABAP|...`, `J2EE|...`): they need the Message server and the database associated to the system running

`sap_instance_stop`:
- Message server instance: all the remaining instances must be stopped
- Other instances: they can stop without any dependency
- **the stop operation doesn't have any dependency with the database)**

`cluster_maintenance`:
For both start/stop, the `cluster_maintenance` policy must be changed (which impacts and improves other operations, like `saptune_solution_apply`, which have the same need).
Now, instead of just looking for the whole cluster maintenance value, we check for the `SAPInstance` resource managed state as well.
As `ASCS/ERS` clusters have at least 2 of this resources, we need to match with the current application instances `sid/instance_number` to find the resource.

## How was this tested?

UT
