### PR TITLE
Add transparent prop to operations button

### DIFF
--- a/assets/js/common/OperationsButton/OperationsButton.jsx
+++ b/assets/js/common/OperationsButton/OperationsButton.jsx
@@ -39,9 +39,11 @@ function CustomMenuButton({ value, running, disabled, onClick }) {
 }
 
 function OperationsButton({
+  text = 'Operations',
   operations,
   userAbilities,
   menuPosition = 'bottom start',
+  transparent = false,
 }) {
   const ref = useRef(null);
   const someRunning = some(operations, { running: true });
@@ -51,12 +53,16 @@ function OperationsButton({
       <MenuButton as={Fragment}>
         <div className="flex" ref={ref}>
           <Button
-            type="primary-white"
-            className="inline-block mx-0.5 border-green-500 border"
-            size="small"
+            type={transparent ? 'transparent' : 'primary-white'}
+            className={classNames(
+              'inline-block mx-0.5 border-green-500',
+              { 'border-none': transparent },
+              { border: !transparent }
+            )}
+            size={transparent ? 'fit' : 'small'}
           >
             <EOS_MORE_VERT className="inline-block fill-jungle-green-500" />{' '}
-            Operations
+            {text}
           </Button>
         </div>
       </MenuButton>

--- a/assets/js/common/OperationsButton/OperationsButton.stories.jsx
+++ b/assets/js/common/OperationsButton/OperationsButton.stories.jsx
@@ -64,6 +64,15 @@ export const Running = {
   },
 };
 
+export const Transparent = {
+  args: {
+    ...Default.args,
+    text: '',
+    transparent: true,
+    menuPosition: 'bottom',
+  },
+};
+
 export const Forbidden = {
   args: {
     ...Default.args,

--- a/assets/js/common/OperationsButton/OperationsButton.test.jsx
+++ b/assets/js/common/OperationsButton/OperationsButton.test.jsx
@@ -117,4 +117,22 @@ describe('OperationsButton', () => {
       screen.queryByText('You are not authorized for this action')
     ).toBeInTheDocument();
   });
+
+  it('should show a transparent operations button', () => {
+    const buttonText = 'test';
+    render(
+      <OperationsButton
+        text={buttonText}
+        transparent
+        operations={testOperations}
+        userAbilities={[]}
+      />
+    );
+
+    expect(screen.getByText(buttonText)).toBeInTheDocument();
+    const button = screen.getByRole('button', { value: buttonText });
+    expect(button).toHaveClass('border-none');
+    expect(button).toHaveClass('bg-transparent');
+    expect(button).toHaveClass('text-sm');
+  });
 });


### PR DESCRIPTION
# Description

Add `transparent` prop to `OperationsButton` to make it usable in contextual operation places.
I added just one prop and not all the class options as I don't expect the need to configure the component further, so fine grained classes don't look needed.

Example (not implemented in this PR, this is just a usage example):
![op-button-transparent](https://github.com/user-attachments/assets/373d7342-6176-4420-abff-fe7ba8946f42)

## How was this tested?

UT
