### PR TITLE
Add operations button to SAP instance in table

### DIFF
--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
@@ -1,15 +1,20 @@
 import React, { useState } from 'react';
 
+import { noop } from 'lodash';
+
 import {
   EOS_APPLICATION_OUTLINED,
   EOS_DATABASE_OUTLINED,
 } from 'eos-icons-react';
 
+import { SAP_INSTANCE_START, SAP_INSTANCE_STOP } from '@lib/operations';
 import { APPLICATION_TYPE, getEnsaVersionLabel } from '@lib/model/sapSystems';
 
 import ListView from '@common/ListView';
 import Table from '@common/Table';
 import PageHeader from '@common/PageHeader';
+import { SapInstanceStartStopModal } from '@common/OperationModals';
+
 import DeregistrationModal from '@pages/DeregistrationModal';
 
 import {
@@ -30,6 +35,13 @@ const getUniqueHosts = (hosts) =>
       .values()
   );
 
+// it includes SAP and HANA instance operations
+const instanceStartStopOperations = [SAP_INSTANCE_START, SAP_INSTANCE_STOP];
+
+const modalInitialState = { open: false, operation: '' };
+
+const closeInstanceModal = (prevState) => ({ ...prevState, open: false });
+
 export function GenericSystemDetails({
   title,
   type,
@@ -37,21 +49,32 @@ export function GenericSystemDetails({
   userAbilities,
   cleanUpPermittedFor,
   onInstanceCleanUp,
+  operationsEnabled = false,
+  getInstanceOperations = noop,
 }) {
   if (!system) {
     return <div>Not Found</div>;
   }
   const [cleanUpModalOpen, setCleanUpModalOpen] = useState(false);
   const [instanceToDeregister, setInstanceToDeregister] = useState(undefined);
+  const [operationModalOpen, setOperationModelOpen] =
+    useState(modalInitialState);
+  const [currentOperationInstance, setCurrentOperationInstance] =
+    useState(undefined);
 
   const onCleanUpClick = (instance) => {
     setCleanUpModalOpen(true);
     setInstanceToDeregister(instance);
   };
 
+  const curriedGetInstanceOperations = getInstanceOperations(
+    null, // placeholder for runningOperations to be used at some point
+    setOperationModelOpen,
+    setCurrentOperationInstance
+  );
+
   return (
     <div>
-      <PageHeader className="font-bold">{title}</PageHeader>
       <DeregistrationModal
         contentType={type}
         instanceNumber={instanceToDeregister?.instance_number}
@@ -65,6 +88,26 @@ export function GenericSystemDetails({
           setCleanUpModalOpen(false);
         }}
       />
+      <SapInstanceStartStopModal
+        operation={operationModalOpen.operation}
+        instanceNumber={currentOperationInstance?.instance_number}
+        sid={currentOperationInstance?.sid}
+        isOpen={
+          operationModalOpen.open &&
+          instanceStartStopOperations.includes(operationModalOpen.operation)
+        }
+        onRequest={(_params) => {
+          setOperationModelOpen(closeInstanceModal);
+        }}
+        onCancel={() => {
+          setOperationModelOpen(closeInstanceModal);
+        }}
+      />
+      <div className="flex flex-wrap">
+        <div className="flex w-1/2 h-auto overflow-hidden overflow-ellipsis break-words">
+          <PageHeader className="font-bold">{title}</PageHeader>
+        </div>
+      </div>
       <div className="mt-4 bg-white shadow rounded-lg py-4 px-8">
         <ListView
           orientation="vertical"
@@ -116,6 +159,8 @@ export function GenericSystemDetails({
             userAbilities,
             cleanUpPermittedFor,
             onCleanUpClick,
+            operationsEnabled,
+            getOperations: curriedGetInstanceOperations,
           })}
           data={system.instances}
         />

--- a/assets/js/pages/SapSystemDetails/SapSystemDetails.jsx
+++ b/assets/js/pages/SapSystemDetails/SapSystemDetails.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 
+import { getFromConfig } from '@lib/config';
 import { APPLICATION_TYPE } from '@lib/model/sapSystems';
 import { getEnrichedSapSystemDetails } from '@state/selectors/sapSystem';
 import { getUserProfile } from '@state/selectors/user';
@@ -9,6 +10,10 @@ import { deregisterApplicationInstance } from '@state/sapSystems';
 
 import BackButton from '@common/BackButton';
 import { GenericSystemDetails } from '@pages/SapSystemDetails';
+
+import { getSapInstanceOperations } from './sapOperations';
+
+const operationsEnabled = getFromConfig('operationsEnabled');
 
 function SapSystemDetails() {
   const { id } = useParams();
@@ -31,6 +36,8 @@ function SapSystemDetails() {
         system={sapSystem}
         userAbilities={abilities}
         cleanUpPermittedFor={['cleanup:application_instance']}
+        operationsEnabled={operationsEnabled}
+        getInstanceOperations={getSapInstanceOperations}
         onInstanceCleanUp={(instance) => {
           dispatch(deregisterApplicationInstance(instance));
         }}

--- a/assets/js/pages/SapSystemDetails/SapSystemDetails.stories.jsx
+++ b/assets/js/pages/SapSystemDetails/SapSystemDetails.stories.jsx
@@ -12,6 +12,8 @@ import { APPLICATION_TYPE } from '@lib/model/sapSystems';
 
 import { GenericSystemDetails } from './GenericSystemDetails';
 
+import { getSapInstanceOperations } from './sapOperations';
+
 const system = {
   ...sapSystemFactory.build({
     instances: sapSystemApplicationInstanceFactory.buildList(2),
@@ -52,6 +54,10 @@ export default {
       control: 'array',
       description: 'Abilities that allow instance clean up',
     },
+    getInstanceOperations: {
+      action: 'Get instance operations function',
+      description: 'Function to get instance operations',
+    },
     onInstanceCleanUp: {
       action: 'Clean up instance',
       description: 'Deregister and clean up an absent instance',
@@ -78,6 +84,8 @@ export const SapSystem = {
     system,
     userAbilities: [{ name: 'all', resource: 'all' }],
     cleanUpPermittedFor: ['cleanup:application_instance'],
+    getInstanceOperations: getSapInstanceOperations,
+    operationsEnabled: true,
   },
 };
 

--- a/assets/js/pages/SapSystemDetails/sapOperations.js
+++ b/assets/js/pages/SapSystemDetails/sapOperations.js
@@ -1,0 +1,33 @@
+import { curry } from 'lodash';
+
+import { SAP_INSTANCE_START, SAP_INSTANCE_STOP } from '@lib/operations';
+
+export const getSapInstanceOperations = curry(
+  (
+    _runningOperations,
+    setOperationModelOpen,
+    setCurrentOperationInstance,
+    instance
+  ) => [
+    {
+      value: 'Start instance',
+      running: false,
+      disabled: instance.health === 'passing',
+      permitted: [],
+      onClick: () => {
+        setCurrentOperationInstance(instance);
+        setOperationModelOpen({ open: true, operation: SAP_INSTANCE_START });
+      },
+    },
+    {
+      value: 'Stop instance',
+      running: false,
+      disabled: instance.health === 'unknown',
+      permitted: [],
+      onClick: () => {
+        setCurrentOperationInstance(instance);
+        setOperationModelOpen({ open: true, operation: SAP_INSTANCE_STOP });
+      },
+    },
+  ]
+);

--- a/assets/js/pages/SapSystemDetails/tableConfigs.jsx
+++ b/assets/js/pages/SapSystemDetails/tableConfigs.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import classNames from 'classnames';
+import { isEmpty } from 'lodash';
 
 import HostLink from '@common/HostLink';
 import ProviderLabel from '@common/ProviderLabel';
 import CleanUpButton from '@common/CleanUpButton';
 import Tooltip from '@common/Tooltip';
 import HealthIcon from '@common/HealthIcon';
+
+import OperationsButton from '@common/OperationsButton';
 
 import Features from './Features';
 import InstanceStatus from './InstanceStatus';
@@ -20,6 +23,8 @@ export const getSystemInstancesTableConfiguration = ({
   userAbilities,
   cleanUpPermittedFor,
   onCleanUpClick,
+  operationsEnabled = false,
+  getOperations = () => [],
 }) => ({
   usePadding: false,
   columns: [
@@ -73,22 +78,42 @@ export const getSystemInstancesTableConfiguration = ({
     },
     {
       title: '',
-      key: 'absent_at',
+      key: 'actions',
       className: 'w-40',
-      render: (content, item) =>
-        content && (
-          <CleanUpButton
-            size="fit"
-            type="transparent"
-            className="jungle-green-500 border-none shadow-none"
-            cleaning={item.deregistering}
-            userAbilities={userAbilities}
-            permittedFor={cleanUpPermittedFor}
-            onClick={() => {
-              onCleanUpClick(item);
-            }}
-          />
-        ),
+      render: (_content, item) => {
+        if (item.absent_at) {
+          return (
+            <CleanUpButton
+              size="fit"
+              type="transparent"
+              className="jungle-green-500 border-none shadow-none"
+              cleaning={item.deregistering}
+              userAbilities={userAbilities}
+              permittedFor={cleanUpPermittedFor}
+              onClick={() => {
+                onCleanUpClick(item);
+              }}
+            />
+          );
+        }
+
+        const operations = getOperations(item);
+        if (operationsEnabled && !isEmpty(operations)) {
+          return (
+            <div className="flex items-center justify-center">
+              <OperationsButton
+                text=""
+                userAbilities={userAbilities}
+                menuPosition="bottom"
+                transparent
+                operations={operations}
+              />
+            </div>
+          );
+        }
+
+        return null;
+      },
     },
   ],
 });


### PR DESCRIPTION
# Description

Add operations button to the SAP instance in table.

I continue adding things step by step, instead of a big change in one PR. The request and the running operation display are not that trivial.

As the `GenericSystemDetails` is a shared component between SAP systems and HANA databases, I have added a new prop` (`getInstanceOperations`), so we can pass the operations for each of the independently.
This way, we don't need to touch the table thing and do different things for each of both types.

I think it gets pretty clean and easy to use.

![image](https://github.com/user-attachments/assets/fa1b2d7b-380d-4c9d-bb05-bb4537faa04f)

![image](https://github.com/user-attachments/assets/c2dfd818-ff4a-495d-a3dd-03dda22539b9)

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
UT.
As in previous tests of operations button, I have tried to test the `onClick` action, but it is extremely flaky and it doesn't work often...
I think we will test this modals better once we add e2e tests