### PR TITLE
Increase timeout for Cypress tests execution flaky tests analysis

### DIFF
--- a/.github/workflows/e2e-flaky-tests-detection.yaml
+++ b/.github/workflows/e2e-flaky-tests-detection.yaml
@@ -144,7 +144,7 @@ jobs:
         container: ${{ fromJson(needs.generate-matrix.outputs.matrix).container }}
     env:
       MIX_ENV: dev
-    timeout-minutes: 25
+    timeout-minutes: 30
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1


### PR DESCRIPTION
# Description

Timeout for cypress test execution in flaky test analysis was [too tight](https://github.com/trento-project/web/actions/runs/15671363607/job/44142981317), so I just increased it by 5 minutes to be sure it gets executed.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**
## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
- [Trento Web guides](https://github.com/trento-project/web/tree/main/guides)

Add a documentation PR or write that no changes are required for the documentation.
- [ ] **DONE**
