### PR TITLE
SAP instance start/stop user policy

### DIFF
--- a/assets/js/common/AbilitiesMultiSelect/AbilitiesMultiSelect.jsx
+++ b/assets/js/common/AbilitiesMultiSelect/AbilitiesMultiSelect.jsx
@@ -58,6 +58,8 @@ const groupedAbilities = [
       'maintenance_change:cluster',
       'pacemaker_enable:cluster',
       'pacemaker_disable:cluster',
+      'start:application_instance',
+      'stop:application_instance',
     ],
   },
 ];

--- a/assets/js/common/AbilitiesMultiSelect/AbilitiesMultiSelect.test.jsx
+++ b/assets/js/common/AbilitiesMultiSelect/AbilitiesMultiSelect.test.jsx
@@ -37,6 +37,8 @@ describe('AbilitiesMultiSelect Component', () => {
       { id: 17, name: 'maintenance_change', resource: 'cluster' },
       { id: 18, name: 'pacemaker_enable', resource: 'cluster' },
       { id: 19, name: 'pacemaker_disable', resource: 'cluster' },
+      { id: 20, name: 'start', resource: 'application_instance' },
+      { id: 21, name: 'stop', resource: 'application_instance' },
     ];
 
     render(
@@ -106,6 +108,8 @@ describe('AbilitiesMultiSelect Component', () => {
           { id: 6, name: 'maintenance_change', resource: 'cluster' },
           { id: 7, name: 'pacemaker_enable', resource: 'cluster' },
           { id: 8, name: 'pacemaker_disable', resource: 'cluster' },
+          { id: 9, name: 'start', resource: 'application_instance' },
+          { id: 10, name: 'stop', resource: 'application_instance' },
         ]}
         userAbilities={[
           { id: 1, name: 'all', resource: 'all' },
@@ -116,6 +120,8 @@ describe('AbilitiesMultiSelect Component', () => {
           { id: 6, name: 'maintenance_change', resource: 'cluster' },
           { id: 7, name: 'pacemaker_enable', resource: 'cluster' },
           { id: 8, name: 'pacemaker_disable', resource: 'cluster' },
+          { id: 9, name: 'start', resource: 'application_instance' },
+          { id: 10, name: 'stop', resource: 'application_instance' },
         ]}
         setAbilities={noop}
         operationsEnabled
@@ -145,6 +151,12 @@ describe('AbilitiesMultiSelect Component', () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByText('pacemaker_disable:cluster')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('start:application_instance')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('stop:application_instance')
     ).not.toBeInTheDocument();
 
     await user.click(screen.getByLabelText('permissions'));

--- a/assets/js/pages/SapSystemDetails/sapOperations.js
+++ b/assets/js/pages/SapSystemDetails/sapOperations.js
@@ -13,7 +13,7 @@ export const getSapInstanceOperations = curry(
       value: 'Start instance',
       running: false,
       disabled: instance.health === 'passing',
-      permitted: [],
+      permitted: ['start:application_instance'],
       onClick: () => {
         setCurrentOperationInstance(instance);
         setOperationModelOpen({ open: true, operation: SAP_INSTANCE_START });
@@ -23,7 +23,7 @@ export const getSapInstanceOperations = curry(
       value: 'Stop instance',
       running: false,
       disabled: instance.health === 'unknown',
-      permitted: [],
+      permitted: ['stop:application_instance'],
       onClick: () => {
         setCurrentOperationInstance(instance);
         setOperationModelOpen({ open: true, operation: SAP_INSTANCE_STOP });

--- a/lib/trento/sap_systems/policy.ex
+++ b/lib/trento/sap_systems/policy.ex
@@ -13,8 +13,20 @@ defmodule Trento.SapSystems.Policy do
   def authorize(:delete_application_instance, %User{} = user, SapSystemReadModel),
     do: has_global_ability?(user) or has_cleanup_ability?(user)
 
+  def authorize(:request_instance_operation, %User{} = user, %{operation: "sap_instance_start"}),
+    do: has_global_ability?(user) or has_app_instance_start_ability?(user)
+
+  def authorize(:request_instance_operation, %User{} = user, %{operation: "sap_instance_stop"}),
+    do: has_global_ability?(user) or has_app_instance_stop_ability?(user)
+
   def authorize(_, _, _), do: true
 
   defp has_cleanup_ability?(user),
     do: user_has_ability?(user, %{name: "cleanup", resource: "application_instance"})
+
+  defp has_app_instance_start_ability?(user),
+    do: user_has_ability?(user, %{name: "start", resource: "application_instance"})
+
+  defp has_app_instance_stop_ability?(user),
+    do: user_has_ability?(user, %{name: "stop", resource: "application_instance"})
 end

--- a/lib/trento_web/controllers/v1/sap_system_controller.ex
+++ b/lib/trento_web/controllers/v1/sap_system_controller.ex
@@ -150,6 +150,12 @@ defmodule TrentoWeb.V1.SapSystemController do
     end
   end
 
+  def get_policy_resource(%{
+        private: %{phoenix_action: :request_instance_operation},
+        path_params: %{"operation" => operation}
+      }),
+      do: %{operation: operation}
+
   def get_policy_resource(_), do: SapSystemReadModel
 
   def get_operation_instance(%{

--- a/priv/repo/migrations/20250617071552_add_sap_instance_start_stop_abilities.exs
+++ b/priv/repo/migrations/20250617071552_add_sap_instance_start_stop_abilities.exs
@@ -1,0 +1,14 @@
+defmodule Trento.Repo.Migrations.AddSapInstanceStartStopAbilities do
+  use Ecto.Migration
+
+  def up do
+    execute "INSERT INTO abilities(name, resource, label, inserted_at, updated_at) VALUES ('start', 'application_instance', 'Permits start operation on application instances', NOW(), NOW())"
+
+    execute "INSERT INTO abilities(name, resource, label, inserted_at, updated_at) VALUES ('stop', 'application_instance', 'Permits stop operation on application instances', NOW(), NOW())"
+  end
+
+  def down do
+    execute "DELETE FROM abilities WHERE name = 'start' AND resource = 'application_instance'"
+    execute "DELETE FROM abilities WHERE name = 'stop' AND resource = 'application_instance'"
+  end
+end

--- a/test/trento/sap_systems/policy_test.exs
+++ b/test/trento/sap_systems/policy_test.exs
@@ -24,6 +24,48 @@ defmodule Trento.SapSystems.PolicyTest do
     refute Policy.authorize(:delete_application_instance, user, SapSystemReadModel)
   end
 
+  describe "request_instance_operation" do
+    operations = [
+      %{
+        operation: "sap_instance_start",
+        ability: "start"
+      },
+      %{
+        operation: "sap_instance_stop",
+        ability: "stop"
+      }
+    ]
+
+    for %{operation: operation, ability: ability} <- operations do
+      @operation operation
+      @ability ability
+
+      test "should allow #{operation} operation if the user has #{ability}:application_instance ability" do
+        user = %User{abilities: [%Ability{name: @ability, resource: "application_instance"}]}
+
+        assert Policy.authorize(:request_instance_operation, user, %{
+                 operation: @operation
+               })
+      end
+
+      test "should allow #{operation} operation if the user has all:all ability" do
+        user = %User{abilities: [%Ability{name: "all", resource: "all"}]}
+
+        assert Policy.authorize(:request_instance_operation, user, %{
+                 operation: @operation
+               })
+      end
+
+      test "should disallow #{operation} operation if the user does not have #{ability}:application_instance ability" do
+        user = %User{abilities: [%Ability{name: "all", resource: "other_resource"}]}
+
+        refute Policy.authorize(:request_instance_operation, user, %{
+                 operation: @operation
+               })
+      end
+    end
+  end
+
   test "should allow unguarded actions" do
     user = %User{abilities: []}
 


### PR DESCRIPTION
# Description

Add `sap_instance_start` and `sap_instance_stop` user policies.
I have used `application_instance` as resource, as this resource already exists for the cleanup. 
If we use `sap_system`, the ability should be name `instance_start` or similar.
What do you think?

## How was this tested?

UT
