### PR TITLE
Update running operations refresh

### DIFF
--- a/assets/js/lib/operations/index.js
+++ b/assets/js/lib/operations/index.js
@@ -55,5 +55,3 @@ export const getOperationForbiddenMessage = (operation) =>
 
 export const operationSucceeded = (result) =>
   ['UPDATED', 'NOT_UPDATED'].includes(result);
-
-export const operationRunning = ({ status }) => status === 'running';

--- a/assets/js/lib/operations/operations.test.js
+++ b/assets/js/lib/operations/operations.test.js
@@ -6,7 +6,6 @@ import {
   getOperationResourceType,
   getOperationForbiddenMessage,
   operationSucceeded,
-  operationRunning,
 } from '.';
 
 describe('operations', () => {
@@ -127,10 +126,5 @@ describe('operations', () => {
     expect(operationSucceeded('UPDATED')).toBeTruthy();
     expect(operationSucceeded('NOT_UPDATED')).toBeTruthy();
     expect(operationSucceeded('FAILED')).toBeFalsy();
-  });
-
-  it('should check if an operation is running', () => {
-    expect(operationRunning({ status: 'running' })).toBeTruthy();
-    expect(operationRunning({ status: 'completed' })).toBeFalsy();
   });
 });

--- a/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
@@ -19,7 +19,7 @@ import { updateCatalog } from '@state/catalog';
 import { executionRequested, updateLastExecution } from '@state/lastExecutions';
 import {
   operationRequested,
-  updateRunningOperation,
+  updateRunningOperations,
   removeRunningOperation,
 } from '@state/runningOperations';
 import { getRunningOperation } from '@state/selectors/runningOperations';
@@ -74,7 +74,7 @@ export function ClusterDetailsPage() {
       dispatch(updateCatalog(env));
       dispatch(updateLastExecution(clusterID));
     }
-    dispatch(updateRunningOperation(clusterID));
+    operationsEnabled && dispatch(updateRunningOperations());
   }, [dispatch, provider, type, ensaVersion, filesystemType, architectureType]);
 
   const clusterHosts = useSelector((state) =>

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -30,7 +30,7 @@ import {
 } from '@state/lastExecutions';
 import {
   operationRequested,
-  updateRunningOperation,
+  updateRunningOperations,
   removeRunningOperation,
 } from '@state/runningOperations';
 
@@ -113,7 +113,7 @@ function HostDetailsPage() {
     getExportersStatus();
     refreshCatalog();
     dispatch(updateLastExecution(hostID));
-    operationsEnabled && dispatch(updateRunningOperation(hostID));
+    operationsEnabled && dispatch(updateRunningOperations());
   }, []);
 
   if (!host) {

--- a/assets/js/pages/SapSystemDetails/SapSystemDetails.jsx
+++ b/assets/js/pages/SapSystemDetails/SapSystemDetails.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 
@@ -10,6 +10,7 @@ import { getUserProfile } from '@state/selectors/user';
 import { deregisterApplicationInstance } from '@state/sapSystems';
 import {
   operationRequested,
+  updateRunningOperations,
   removeRunningOperation,
 } from '@state/runningOperations';
 
@@ -29,6 +30,10 @@ function SapSystemDetails() {
   const dispatch = useDispatch();
 
   const runningOperations = useSelector(getRunningOperationsList());
+
+  useEffect(() => {
+    operationsEnabled && dispatch(updateRunningOperations());
+  }, [dispatch]);
 
   if (!sapSystem) {
     return <div>Not Found</div>;

--- a/assets/js/state/runningOperations.js
+++ b/assets/js/state/runningOperations.js
@@ -2,7 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 
 export const OPERATION_COMPLETED = 'OPERATION_COMPLETED';
 export const OPERATION_REQUESTED = 'OPERATION_REQUESTED';
-export const UPDATE_RUNNING_OPERATION = 'UPDATE_RUNNING_OPERATION';
+export const UPDATE_RUNNING_OPERATIONS = 'UPDATE_RUNNING_OPERATIONS';
 
 export const operationCompleted = ({
   operationID,
@@ -19,9 +19,9 @@ export const operationRequested = ({ groupID, operation, requestParams }) => ({
   payload: { groupID, operation, requestParams },
 });
 
-export const updateRunningOperation = (groupID) => ({
-  type: UPDATE_RUNNING_OPERATION,
-  payload: { groupID },
+export const updateRunningOperations = () => ({
+  type: UPDATE_RUNNING_OPERATIONS,
+  payload: {},
 });
 
 const initialState = {};


### PR DESCRIPTION
# Description

Update running operations on page refresh.
Now, instead of updating the running operations by group ID, we need to update multiple resources at once (for example, the SAP instance can have multiple on-going operations, by per instance).

It simply uses the new way to filter by status and put the running operations in the state.

Related to: https://github.com/trento-project/wanda/pull/626

## How was this tested?
UT
