### PR TITLE
Add Architecture to HostInfoBox

### DIFF
--- a/assets/js/common/HostInfoBox/HostInfoBox.jsx
+++ b/assets/js/common/HostInfoBox/HostInfoBox.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import ListView from '@common/ListView';
 import ProviderLabel from '@common/ProviderLabel';
 
-function HostInfoBox({ provider, agentVersion }) {
+function HostInfoBox({ arch, provider, agentVersion }) {
   return (
     <div className="my-6 bg-white shadow rounded-lg px-8 py-4">
       <ListView
@@ -16,9 +16,8 @@ function HostInfoBox({ provider, agentVersion }) {
           },
           { title: 'Agent version', content: agentVersion },
           {
-            // This empty item in the list view is a hack to get the desired spacing rendered
-            title: '',
-            content: '',
+            title: 'Architecture',
+            content: arch,
           },
         ]}
       />

--- a/assets/js/common/HostInfoBox/HostInfoBox.test.jsx
+++ b/assets/js/common/HostInfoBox/HostInfoBox.test.jsx
@@ -9,45 +9,59 @@ describe('Host Info Box', () => {
       agentVersion: '1.1.0+git.dev17.1660137228.fe5ba8a',
       provider: 'aws',
       providerText: 'AWS',
+      arch: 'x86_64',
     },
     {
       agentVersion: '1.2.0+git.dev17.1660137228.fe5ba8a',
       provider: 'aws',
       providerText: 'AWS',
+      arch: 'ppc64le',
     },
     {
       agentVersion: '2.0.0+git.dev17.1660137228.fe5ba8a',
       provider: 'azure',
       providerText: 'Azure',
+      arch: 's390x',
     },
     {
       agentVersion: '1.1.0',
       provider: 'gcp',
       providerText: 'GCP',
+      arch: 'unknown',
     },
     {
       agentVersion: '1.2.0',
       provider: 'kvm',
       providerText: 'On-premises / KVM',
+      arch: 'x86_64',
     },
     {
       agentVersion: '2.0.0',
       provider: 'vmware',
       providerText: 'VMware',
+      arch: 'x86_64',
     },
     {
       agentVersion: '2.1.0',
       provider: 'nutanix',
       providerText: 'Nutanix',
+      arch: 'x86_64',
     },
   ];
 
   it.each(scenarios)(
     'should display host info box for $providerText',
-    ({ agentVersion, provider, providerText }) => {
-      render(<HostInfoBox provider={provider} agentVersion={agentVersion} />);
+    ({ agentVersion, provider, providerText, arch }) => {
+      render(
+        <HostInfoBox
+          arch={arch}
+          provider={provider}
+          agentVersion={agentVersion}
+        />
+      );
       expect(screen.getByText(providerText)).toBeTruthy();
       expect(screen.getByText(agentVersion)).toBeTruthy();
+      expect(screen.getByText(arch)).toBeTruthy();
     }
   );
 });

--- a/assets/js/pages/ExecutionResults/ExecutionHeader.test.jsx
+++ b/assets/js/pages/ExecutionResults/ExecutionHeader.test.jsx
@@ -49,6 +49,7 @@ describe('Checks results ExecutionHeader Component', () => {
         expect(screen.getByText(hanaScenarioLabel)).toBeTruthy();
         expect(screen.getByText('Checks Results for cluster')).toBeTruthy();
         expect(screen.getByText(clusterName)).toBeTruthy();
+        expect(screen.queryByText('Architecture')).not.toBeInTheDocument();
       }
     );
 
@@ -92,12 +93,14 @@ describe('Checks results ExecutionHeader Component', () => {
       const hostName = faker.animal.bear();
       const cloudProvider = 'aws';
       const agentVersion = '2.1.1';
+      const arch = 'x86_64';
 
       const target = hostFactory.build({
         id: hostID,
         name: hostName,
         provider: cloudProvider,
         agent_version: agentVersion,
+        arch,
       });
 
       renderWithRouter(
@@ -115,6 +118,8 @@ describe('Checks results ExecutionHeader Component', () => {
       expect(screen.getByText(hostName)).toBeTruthy();
       expect(screen.getByText('Agent version')).toBeTruthy();
       expect(screen.getByText(agentVersion)).toBeTruthy();
+      expect(screen.getByText('Architecture')).toBeTruthy();
+      expect(screen.getByText(arch)).toBeTruthy();
     });
 
     it('should not render a warning banner within the header on an unknown provider detection', () => {

--- a/assets/js/pages/ExecutionResults/ExecutionResults.test.jsx
+++ b/assets/js/pages/ExecutionResults/ExecutionResults.test.jsx
@@ -548,4 +548,95 @@ describe('ExecutionResults', () => {
     userEvent.click(screen.getByText(description));
     expect(screen.queryByText(remediation)).not.toBeInTheDocument();
   });
+
+  it('should render ExecutionResults with cluster data', async () => {
+    const {
+      clusterID,
+      clusterHosts,
+      loading,
+      catalog,
+      error,
+      executionLoading,
+      executionData,
+      executionError,
+      executionStarted,
+    } = prepareStateData('completed');
+
+    renderWithRouter(
+      <ExecutionResults
+        targetID={clusterID}
+        targetName="test-cluster"
+        targetType="cluster"
+        target={{
+          provider: 'azure',
+          type: 'hana_scale_up',
+        }}
+        targetHosts={clusterHosts}
+        catalogLoading={loading}
+        catalog={catalog}
+        executionStarted={executionStarted}
+        catalogError={error}
+        executionLoading={executionLoading}
+        executionData={executionData}
+        executionError={executionError}
+      />,
+      { route: `/clusters/${clusterID}/executions/last?health=passing` }
+    );
+
+    expect(screen.getAllByText('test-cluster')).toHaveLength(2);
+    expect(screen.getByText('HA Scenario')).toBeTruthy();
+    expect(screen.getByText('HANA Scale Up')).toBeTruthy();
+    expect(screen.getByText('Azure')).toBeTruthy();
+    expect(screen.getByText(clusterHosts[0].hostname)).toBeTruthy();
+    expect(screen.getByText(clusterHosts[1].hostname)).toBeTruthy();
+
+    expect(screen.queryByText('Architecture')).not.toBeInTheDocument();
+    expect(screen.queryByText('Agent version')).not.toBeInTheDocument();
+  });
+
+  it('should render ExecutionResults with host data', async () => {
+    const {
+      clusterID: hostID,
+      clusterHosts: [host1],
+      loading,
+      catalog,
+      error,
+      executionLoading,
+      executionData,
+      executionError,
+      executionStarted,
+    } = prepareStateData('completed');
+
+    const targetHost = {
+      ...host1,
+      arch: 'x86_64',
+      agent_version: '123.456',
+      provider: 'azure',
+    };
+
+    renderWithRouter(
+      <ExecutionResults
+        targetID={hostID}
+        targetName="test-host"
+        targetType="host"
+        target={targetHost}
+        targetHosts={[targetHost]}
+        catalogLoading={loading}
+        catalog={catalog}
+        executionStarted={executionStarted}
+        catalogError={error}
+        executionLoading={executionLoading}
+        executionData={executionData}
+        executionError={executionError}
+      />,
+      { route: `/clusters/${hostID}/executions/last` }
+    );
+
+    expect(screen.getByText('test-host')).toBeTruthy();
+    expect(screen.getByText('Azure')).toBeTruthy();
+    expect(screen.getByText('x86_64')).toBeTruthy();
+    expect(screen.getByText(targetHost.agent_version)).toBeTruthy();
+
+    expect(screen.queryByText('HA Scenario')).not.toBeInTheDocument();
+  });
 });

--- a/assets/js/pages/ExecutionResults/TargetInfoBox.jsx
+++ b/assets/js/pages/ExecutionResults/TargetInfoBox.jsx
@@ -22,6 +22,7 @@ function TargetInfoBox({ targetType, target }) {
     case TARGET_HOST:
       return (
         <HostInfoBox
+          arch={target.arch}
           provider={target.provider}
           agentVersion={target.agent_version}
         />

--- a/assets/js/pages/HostSettingsPage/HostSettingsPage.jsx
+++ b/assets/js/pages/HostSettingsPage/HostSettingsPage.jsx
@@ -49,7 +49,12 @@ function HostSettingsPage() {
   if (!host) {
     return <LoadingBox text="Loading..." />;
   }
-  const { hostname: hostName, provider, agent_version: agentVersion } = host;
+  const {
+    hostname: hostName,
+    provider,
+    agent_version: agentVersion,
+    arch,
+  } = host;
 
   const refreshChecksSelection = () =>
     fetchChecksSelection(hostID, {
@@ -94,7 +99,11 @@ function HostSettingsPage() {
         onSaveSelection={saveSelection}
         onStartExecution={requestChecksExecution}
       />
-      <HostInfoBox provider={provider} agentVersion={agentVersion} />
+      <HostInfoBox
+        arch={arch}
+        provider={provider}
+        agentVersion={agentVersion}
+      />
       <ChecksSelection
         groupID={hostID}
         catalog={checksSelection}

--- a/assets/js/pages/HostSettingsPage/HostSettingsPage.test.jsx
+++ b/assets/js/pages/HostSettingsPage/HostSettingsPage.test.jsx
@@ -39,6 +39,7 @@ describe('HostSettingsPage component', () => {
     expect(screen.getByText('Loading...')).toBeVisible();
     expect(screen.queryByText('Provider')).not.toBeTruthy();
     expect(screen.queryByText('Agent version')).not.toBeTruthy();
+    expect(screen.queryByText('Architecture')).not.toBeTruthy();
     expect(
       screen.queryByRole('button', { name: 'Save Check Selection' })
     ).not.toBeTruthy();
@@ -60,7 +61,7 @@ describe('HostSettingsPage component', () => {
       hostsList: { hosts },
       user: { abilities: [] },
     };
-    const { id: hostID, agent_version: agentVersion } = hosts[1];
+    const { id: hostID, agent_version: agentVersion, arch } = hosts[1];
 
     const [StatefulHostSettingsPage] = withState(<HostSettingsPage />, state);
 
@@ -79,6 +80,8 @@ describe('HostSettingsPage component', () => {
     expect(screen.getByText('Azure')).toBeVisible();
     expect(screen.getByText('Agent version')).toBeVisible();
     expect(screen.getByText(agentVersion)).toBeVisible();
+    expect(screen.getByText('Architecture')).toBeVisible();
+    expect(screen.getByText(arch)).toBeVisible();
     expect(screen.getByText(group0)).toBeVisible();
     expect(screen.getByText(group1)).toBeVisible();
     expect(screen.getByText(group2)).toBeVisible();


### PR DESCRIPTION
# Description

I think it might be a good addition to see the architecture of a host in both the checks-selection and checks-result page. We have space there anyway and by coincidentally it gets rid of the ugly 'just put an element here for the layout' hack  

## How was this tested?

Unit tests
