### PR TITLE
Reduce wss updates based on cib last written

### DIFF
--- a/test/trento/clusters_test.exs
+++ b/test/trento/clusters_test.exs
@@ -499,6 +499,15 @@ defmodule Trento.ClustersTest do
       {:ok, %ClusterEnrichmentData{cib_last_written: ^cib_last_written}} =
         Clusters.update_cib_last_written(cluster.id, cib_last_written)
     end
+
+    test "should not update a not changed cib_last_written" do
+      %{id: cluster_id} = insert(:cluster)
+      cib_last_written = Date.to_string(Faker.Date.forward(0))
+      insert(:cluster_enrichment_data, cluster_id: cluster_id, cib_last_written: cib_last_written)
+
+      {:error, :unchanged_cib_last_written} =
+        Clusters.update_cib_last_written(cluster_id, cib_last_written)
+    end
   end
 
   describe "ASCS/ERS cluster checks execution" do

--- a/test/trento/infrastructure/commanded/middleware/enrich_register_cluster_host_test.exs
+++ b/test/trento/infrastructure/commanded/middleware/enrich_register_cluster_host_test.exs
@@ -53,6 +53,23 @@ defmodule Trento.Infrastructure.Commanded.Middleware.EnrichRegisterClusterHostTe
                      1000
   end
 
+  test "should not broadcast cluster_cib_last_written_updated message when cib last written is unchanged" do
+    %{id: cluster_id} = insert(:cluster)
+    cib_last_written = Date.to_string(Faker.Date.forward(0))
+    insert(:cluster_enrichment_data, cluster_id: cluster_id, cib_last_written: cib_last_written)
+
+    command =
+      build(
+        :register_cluster_host,
+        cluster_id: cluster_id,
+        cib_last_written: cib_last_written
+      )
+
+    Enrichable.enrich(command, %{})
+
+    refute_broadcast "cluster_cib_last_written_updated", _
+  end
+
   describe "stripping irrelevant cluster node attributes" do
     test "should strip irrelevant lpt attributes from hana-scale-up cluster nodes" do
       sid = String.upcase(Faker.Lorem.word())


### PR DESCRIPTION
# Description

This change reduces the amount of non strictly necessary updates caused by unchanged `cib_last_written` information.

Why is this useful? 
Besides reducing the amount of unnecessary network traffic it reduces the amount of the consequent rerenders of a cluster detail mitigating undesired side effect like the inability to properly use cluster host operations (ie enable/disable pacemaker).