### PR TITLE
Correlation of operations activity log entries

### DIFF
--- a/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
+++ b/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
@@ -191,9 +191,12 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
              :cluster_operation_requested,
              :host_operation_requested
            ] do
+    operation_id = resp_body |> Jason.decode!() |> Map.get("operation_id")
+
     %{
+      correlation_id: operation_id,
       operation: params |> Map.get(:operation) |> String.to_existing_atom(),
-      operation_id: resp_body |> Jason.decode!() |> Map.get("operation_id"),
+      operation_id: operation_id,
       params: body_params
     }
     |> Map.put(get_operation_resource_id_field(activity), Map.get(params, :id))

--- a/lib/trento/activity_logging/parser/queue_event_parser.ex
+++ b/lib/trento/activity_logging/parser/queue_event_parser.ex
@@ -62,9 +62,11 @@ defmodule Trento.ActivityLog.Logger.Parser.QueueEventParser do
         |> StructHelper.to_atomized_map()
         |> Map.put(:operation, operation)
         |> Map.put(:result, result)
+        |> Map.put(:correlation_id, operation_id)
 
       _ ->
         %{
+          correlation_id: operation_id,
           resource_id: group_id,
           operation: operation,
           operation_id: operation_id,

--- a/test/trento/activity_logging/phoenix_conn_parser_test.exs
+++ b/test/trento/activity_logging/phoenix_conn_parser_test.exs
@@ -267,7 +267,8 @@ defmodule Trento.ActivityLog.PhoenixConnParserTest do
               resource_field => resource_id,
               :operation => atom_operation,
               :operation_id => operation_id,
-              :params => body_params
+              :params => body_params,
+              :correlation_id => operation_id
             },
             additional_params
           )

--- a/test/trento/activity_logging/queue_event_parser_test.exs
+++ b/test/trento/activity_logging/queue_event_parser_test.exs
@@ -45,6 +45,7 @@ defmodule Trento.ActivityLog.QueueEventParserTest do
         build(:operation_completed_v1, operation_type: "saptuneapplysolution@v1")
 
       assert %{
+               correlation_id: operation_id,
                operation_id: operation_id,
                resource_id: group_id,
                operation: :saptune_solution_apply,
@@ -75,6 +76,7 @@ defmodule Trento.ActivityLog.QueueEventParserTest do
       )
 
       assert %{
+               correlation_id: operation_id,
                operation_id: operation_id,
                host_id: group_id,
                operation: :saptune_solution_apply,


### PR DESCRIPTION
# Description

Implements correlation of operations related activity log entries. Makes use of/re-uses the operation id as a correlation id. This leaves client/FE code agnostic to correlated activity log entry type.

## How was this tested?

UT 

