### PR TITLE
Add pacemaker ops to activity log

### DIFF
--- a/assets/js/lib/model/activityLog.js
+++ b/assets/js/lib/model/activityLog.js
@@ -123,6 +123,8 @@ export const APPLICATION_INSTANCE_OPERATION_REQUESTED =
   'application_instance_operation_requested';
 export const CLUSTER_OPERATION_REQUESTED = 'cluster_operation_requested';
 export const HOST_OPERATION_REQUESTED = 'host_operation_requested';
+export const CLUSTER_HOST_OPERATION_REQUESTED =
+  'cluster_host_operation_requested';
 export const OPERATION_COMPLETED = 'operation_completed';
 
 // Check Customization
@@ -634,6 +636,12 @@ export const ACTIVITY_TYPES_CONFIG = {
     message: ({ metadata }) =>
       `Operation ${getOperationLabel(metadata.operation)} requested`,
     resource: hostResourceType,
+  },
+  [CLUSTER_HOST_OPERATION_REQUESTED]: {
+    label: 'Operation Requested on a cluster host',
+    message: ({ metadata }) =>
+      `Operation ${getOperationLabel(metadata.operation)} requested`,
+    resource: clusterResourceType,
   },
   [OPERATION_COMPLETED]: {
     label: 'Operation Completed',

--- a/lib/trento/activity_logging/activity_catalog.ex
+++ b/lib/trento/activity_logging/activity_catalog.ex
@@ -180,6 +180,8 @@ defmodule Trento.ActivityLog.ActivityCatalog do
         {:activity_log_settings_update, 200},
       {TrentoWeb.V1.HostController, :request_operation} => {:host_operation_requested, 202},
       {TrentoWeb.V1.ClusterController, :request_operation} => {:cluster_operation_requested, 202},
+      {TrentoWeb.V1.ClusterController, :request_host_operation} =>
+        {:cluster_host_operation_requested, 202},
       {TrentoWeb.V1.SapSystemController, :request_instance_operation} =>
         {:application_instance_operation_requested, 202},
       {TrentoWeb.V1.HostController, :delete} => {:host_cleanup_requested, 204},

--- a/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
+++ b/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
@@ -189,7 +189,8 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
       when activity in [
              :application_instance_operation_requested,
              :cluster_operation_requested,
-             :host_operation_requested
+             :host_operation_requested,
+             :cluster_host_operation_requested
            ] do
     %{
       operation: params |> Map.get(:operation) |> String.to_existing_atom(),
@@ -212,7 +213,10 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
   defp get_operation_resource_id_field(:application_instance_operation_requested),
     do: :sap_system_id
 
-  defp get_operation_resource_id_field(:cluster_operation_requested), do: :cluster_id
+  defp get_operation_resource_id_field(activity)
+       when activity in [:cluster_operation_requested, :cluster_host_operation_requested],
+       do: :cluster_id
+
   defp get_operation_resource_id_field(:host_operation_requested), do: :host_id
 
   defp maybe_add_additional_fields(
@@ -228,6 +232,18 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
     metadata
     |> Map.put(:host_id, host_id)
     |> Map.put(:instance_number, instance_number)
+  end
+
+  defp maybe_add_additional_fields(
+         metadata,
+         :cluster_host_operation_requested,
+         %Plug.Conn{
+           params: %{
+             host_id: host_id
+           }
+         }
+       ) do
+    Map.put(metadata, :host_id, host_id)
   end
 
   defp maybe_add_additional_fields(metadata, _, _), do: metadata

--- a/test/trento/activity_logging/activity_catalog_test.exs
+++ b/test/trento/activity_logging/activity_catalog_test.exs
@@ -35,6 +35,7 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
         :activity_log_settings_update,
         :host_operation_requested,
         :cluster_operation_requested,
+        :cluster_host_operation_requested,
         :application_instance_operation_requested
       ]
 
@@ -270,6 +271,12 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
       %{
         activity: :cluster_operation_requested,
         connection_info: {TrentoWeb.V1.ClusterController, :request_operation},
+        interesting_statuses: 202,
+        not_interesting_statuses: [400, 401, 403, 404, 500]
+      },
+      %{
+        activity: :cluster_host_operation_requested,
+        connection_info: {TrentoWeb.V1.ClusterController, :request_host_operation},
         interesting_statuses: 202,
         not_interesting_statuses: [400, 401, 403, 404, 500]
       },

--- a/test/trento/activity_logging/phoenix_conn_parser_test.exs
+++ b/test/trento/activity_logging/phoenix_conn_parser_test.exs
@@ -249,6 +249,24 @@ defmodule Trento.ActivityLog.PhoenixConnParserTest do
           atom_operation: :saptune_solution_apply,
           resource_field: :host_id,
           additional_params: %{}
+        },
+        %{
+          action: :cluster_host_operation_requested,
+          operation: "pacemaker_enable",
+          atom_operation: :pacemaker_enable,
+          resource_field: :cluster_id,
+          additional_params: %{
+            host_id: host_id
+          }
+        },
+        %{
+          action: :cluster_host_operation_requested,
+          operation: "pacemaker_disable",
+          atom_operation: :pacemaker_disable,
+          resource_field: :cluster_id,
+          additional_params: %{
+            host_id: host_id
+          }
         }
       ]
 


### PR DESCRIPTION
# Description

Adding pacemaker enable/disable - and more generally cluster host - operations to the activity log
