### PR TITLE
Expose cluster resources

### DIFF
--- a/lib/trento/clusters/value_objects/ascs_ers_cluster_details.ex
+++ b/lib/trento/clusters/value_objects/ascs_ers_cluster_details.ex
@@ -21,7 +21,9 @@ defmodule Trento.Clusters.ValueObjects.AscsErsClusterDetails do
     field :maintenance_mode, :boolean
 
     embeds_many :sap_systems, AscsErsClusterSapSystem
+    # stopped_resources attribute is deprecated, moved to main details
     embeds_many :stopped_resources, ClusterResource
     embeds_many :sbd_devices, SbdDevice
+    embeds_many :resources, ClusterResource
   end
 end

--- a/lib/trento/clusters/value_objects/ascs_ers_cluster_node.ex
+++ b/lib/trento/clusters/value_objects/ascs_ers_cluster_node.ex
@@ -21,6 +21,7 @@ defmodule Trento.Clusters.ValueObjects.AscsErsClusterNode do
     field :attributes, {:map, :string}
     field :status, :string
 
+    # resources attribute is deprecated, moved to main details
     embeds_many :resources, ClusterResource
   end
 end

--- a/lib/trento/clusters/value_objects/cluster_resource.ex
+++ b/lib/trento/clusters/value_objects/cluster_resource.ex
@@ -20,6 +20,8 @@ defmodule Trento.Clusters.ValueObjects.ClusterResource do
     field :status, :string
     field :fail_count, :integer
     field :managed, :boolean
+    field :node, :string
+    field :sid, :string
 
     embeds_one :parent, ClusterResourceParent
   end

--- a/lib/trento/clusters/value_objects/hana_cluster_details.ex
+++ b/lib/trento/clusters/value_objects/hana_cluster_details.ex
@@ -33,9 +33,11 @@ defmodule Trento.Clusters.ValueObjects.HanaClusterDetails do
     field :fencing_type, :string
     field :maintenance_mode, :boolean
 
+    # stopped_resources attribute is deprecated, moved to main details
     embeds_many :stopped_resources, ClusterResource
     embeds_many :nodes, HanaClusterNode
     embeds_many :sbd_devices, SbdDevice
     embeds_many :sites, HanaClusterSite
+    embeds_many :resources, ClusterResource
   end
 end

--- a/lib/trento/clusters/value_objects/hana_cluster_node.ex
+++ b/lib/trento/clusters/value_objects/hana_cluster_node.ex
@@ -24,6 +24,7 @@ defmodule Trento.Clusters.ValueObjects.HanaClusterNode do
     field :indexserver_actual_role, :string
     field :status, :string
 
+    # resources attribute is deprecated, moved to main details
     embeds_many :resources, ClusterResource
   end
 end

--- a/lib/trento/discovery/payloads/cluster/cib_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/cluster/cib_discovery_payload.ex
@@ -83,6 +83,12 @@ defmodule Trento.Discovery.Payloads.Cluster.CibDiscoveryPayload do
         embeds_one :primitive, Primitive
       end
 
+      embeds_many :masters, Master, primary_key: false do
+        field :id, :string
+
+        embeds_one :primitive, Primitive
+      end
+
       embeds_many :groups, Group, primary_key: false do
         field :id, :string
 
@@ -96,12 +102,13 @@ defmodule Trento.Discovery.Payloads.Cluster.CibDiscoveryPayload do
       cib_resources
       |> cast(transformed_attrs, [])
       |> cast_embed(:primitives)
-      |> cast_embed(:clones, with: &clones_changeset/2)
+      |> cast_embed(:clones, with: &clones_masters_changeset/2)
+      |> cast_embed(:masters, with: &clones_masters_changeset/2)
       |> cast_embed(:groups, with: &groups_changeset/2)
       |> validate_required_fields(@required_fields)
     end
 
-    defp clones_changeset(clones, attrs) do
+    defp clones_masters_changeset(clones, attrs) do
       clones
       |> cast(attrs, [:id])
       |> cast_embed(:primitive)
@@ -116,12 +123,18 @@ defmodule Trento.Discovery.Payloads.Cluster.CibDiscoveryPayload do
     end
 
     defp transform_nil_lists(
-           %{"groups" => groups, "primitives" => primitives, "clones" => clones} = attrs
+           %{
+             "groups" => groups,
+             "primitives" => primitives,
+             "clones" => clones,
+             "masters" => masters
+           } = attrs
          ) do
       attrs
       |> Map.put("groups", ListHelper.to_list(groups))
       |> Map.put("primitives", ListHelper.to_list(primitives))
       |> Map.put("clones", ListHelper.to_list(clones))
+      |> Map.put("masters", ListHelper.to_list(masters))
     end
 
     defp transform_nil_lists(attrs), do: attrs

--- a/lib/trento/discovery/policies/cluster_policy.ex
+++ b/lib/trento/discovery/policies/cluster_policy.ex
@@ -212,7 +212,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicy do
       stopped_resources: parse_cluster_stopped_resources(crmmon),
       nodes: nodes,
       sbd_devices: parse_sbd_devices(sbd),
-      sites: parse_hana_scale_up_sites(nodes, hana_sid)
+      sites: parse_hana_scale_up_sites(nodes, hana_sid),
+      resources: parse_cluster_resources(crmmon, cib)
     }
   end
 
@@ -240,7 +241,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicy do
       stopped_resources: parse_cluster_stopped_resources(crmmon),
       nodes: parse_cluster_nodes(payload, hana_sid),
       sbd_devices: parse_sbd_devices(sbd),
-      sites: parse_hana_scale_out_sites(HanaArchitectureType.classic(), cib, hana_sid)
+      sites: parse_hana_scale_out_sites(HanaArchitectureType.classic(), cib, hana_sid),
+      resources: parse_cluster_resources(crmmon, cib)
     }
   end
 
@@ -269,7 +271,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicy do
       stopped_resources: parse_cluster_stopped_resources(crmmon),
       nodes: parse_cluster_nodes(payload, hana_sid),
       sbd_devices: parse_sbd_devices(sbd),
-      sites: parse_hana_scale_out_sites(HanaArchitectureType.angi(), cib, hana_sid)
+      sites: parse_hana_scale_out_sites(HanaArchitectureType.angi(), cib, hana_sid),
+      resources: parse_cluster_resources(crmmon, cib)
     }
   end
 
@@ -288,7 +291,8 @@ defmodule Trento.Discovery.Policies.ClusterPolicy do
       fencing_type: parse_cluster_fencing_type(crmmon, sbd),
       stopped_resources: parse_cluster_stopped_resources(crmmon),
       sbd_devices: parse_sbd_devices(sbd),
-      maintenance_mode: parse_maintenance_mode(cib)
+      maintenance_mode: parse_maintenance_mode(cib),
+      resources: parse_cluster_resources(crmmon, cib)
     }
   end
 
@@ -723,11 +727,13 @@ defmodule Trento.Discovery.Policies.ClusterPolicy do
   defp extract_cluster_primitives_from_cib(%{
          primitives: primitives,
          groups: groups,
-         clones: clones
+         clones: clones,
+         masters: masters
        }) do
     Enum.concat(
       primitives,
       Enum.flat_map(clones, &(&1 |> Map.get(:primitive, []) |> List.wrap())) ++
+        Enum.flat_map(masters, &(&1 |> Map.get(:primitive, []) |> List.wrap())) ++
         Enum.flat_map(groups, &Map.get(&1, :primitives, []))
     )
   end
@@ -1120,4 +1126,62 @@ defmodule Trento.Discovery.Policies.ClusterPolicy do
   defp parse_hana_scenario([]), do: HanaScenario.performance_optimized()
 
   defp parse_hana_scenario(_), do: HanaScenario.cost_optimized()
+
+  defp parse_cluster_resources(crmmon, cib) do
+    crmmon
+    |> extract_cluster_resources()
+    |> Enum.map(fn %{id: id, agent: type, role: role, parent: parent, node: node} = resource ->
+      nodename = parse_resource_node(node)
+
+      %{
+        id: id,
+        type: type,
+        role: role,
+        status: parse_resource_status(resource),
+        fail_count: parse_fail_count(nodename, id, crmmon),
+        managed: parse_managed(resource),
+        parent: parent,
+        node: nodename,
+        sid: parse_sid_for_resource(id, type, cib)
+      }
+    end)
+  end
+
+  defp parse_resource_node(%{name: name}), do: name
+  defp parse_resource_node(_), do: nil
+
+  defp parse_sid_for_resource(resource_id, type, %{
+         configuration: %{resources: resources}
+       })
+       when type in [
+              "ocf::suse:SAPHana",
+              "ocf::suse:SAPHanaTopology",
+              "ocf::suse:SAPHanaController"
+            ] do
+    resources
+    |> extract_cluster_primitives_from_cib()
+    |> Enum.find_value([], fn %{id: id, instance_attributes: instance_attributes} ->
+      if id == resource_id, do: instance_attributes
+    end)
+    |> Enum.find_value(nil, fn
+      %{name: "SID", value: value} -> value
+      _ -> false
+    end)
+  end
+
+  defp parse_sid_for_resource(resource_id, "ocf::heartbeat:SAPInstance", %{
+         configuration: %{resources: resources}
+       }) do
+    resources
+    |> extract_cluster_primitives_from_cib()
+    |> Enum.find_value([], fn %{id: id, instance_attributes: instance_attributes} ->
+      if id == resource_id, do: instance_attributes
+    end)
+    |> Enum.find_value(nil, fn
+      %{name: "InstanceName", value: value} -> value |> String.split("_") |> Enum.at(0)
+      _ -> false
+    end)
+  end
+
+  defp parse_sid_for_resource(_, _, _), do: nil
 end

--- a/lib/trento/operations/database_instance_policy.ex
+++ b/lib/trento/operations/database_instance_policy.ex
@@ -65,11 +65,9 @@ defmodule Trento.Operations.DatabaseInstancePolicy do
   end
 
   defp get_cluster_resource_id(%ClusterReadModel{
-         details: %{nodes: nodes}
+         details: %{resources: resources}
        }) do
-    Enum.find_value(nodes, nil, fn %{resources: resources} ->
-      Enum.find_value(resources, nil, &find_resource_id/1)
-    end)
+    Enum.find_value(resources, nil, &find_resource_id/1)
   end
 
   defp get_cluster_resource_id(_), do: nil

--- a/lib/trento_web/controllers/v1/cluster_json.ex
+++ b/lib/trento_web/controllers/v1/cluster_json.ex
@@ -38,7 +38,7 @@ defmodule TrentoWeb.V1.ClusterJSON do
 
     adapted_details =
       details
-      |> Map.drop([:sites, :maintenance_mode, :architecture_type, :hana_scenario])
+      |> Map.drop([:sites, :maintenance_mode, :architecture_type, :hana_scenario, :resources])
       |> Map.put(:nodes, adapted_nodes)
       |> Map.put(:stopped_resources, adapted_stopped_resources)
 
@@ -60,6 +60,6 @@ defmodule TrentoWeb.V1.ClusterJSON do
   end
 
   defp adapt_resources(resources) do
-    Enum.map(resources, &Map.drop(&1, [:managed, :parent]))
+    Enum.map(resources, &Map.drop(&1, [:managed, :parent, :node, :sid]))
   end
 end

--- a/lib/trento_web/openapi/v2/schema/cluster.ex
+++ b/lib/trento_web/openapi/v2/schema/cluster.ex
@@ -27,6 +27,7 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
           status: %Schema{type: :string},
           fail_count: %Schema{type: :integer},
           managed: %Schema{type: :boolean},
+          node: %Schema{type: :string, nullable: true},
           parent: %Schema{
             type: :object,
             additionalProperties: false,
@@ -81,7 +82,8 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
           resources: %Schema{
             description: "A list of Cluster resources",
             type: :array,
-            items: ClusterResource
+            items: ClusterResource,
+            deprecated: true
           }
         }
       },
@@ -147,7 +149,8 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
           stopped_resources: %Schema{
             description: "A list of the stopped resources on this HANA Cluster",
             type: :array,
-            items: ClusterResource
+            items: ClusterResource,
+            deprecated: true
           },
           nodes: %Schema{
             type: :array,
@@ -161,6 +164,10 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
           sbd_devices: %Schema{
             type: :array,
             items: Cluster.SbdDevice
+          },
+          resources: %Schema{
+            description: "A list of cluster resources",
+            items: ClusterResource
           }
         },
         required: [:nodes]
@@ -200,7 +207,8 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
           resources: %Schema{
             type: :array,
             items: ClusterResource,
-            description: "A list of Cluster resources"
+            description: "A list of Cluster resources",
+            deprecated: true
           },
           roles: %Schema{
             type: :array,
@@ -281,7 +289,12 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
           stopped_resources: %Schema{
             type: :array,
             items: ClusterResource,
-            description: "List of the stopped resources on this HANA Cluster"
+            description: "List of the stopped resources on this HANA Cluster",
+            deprecated: true
+          },
+          resources: %Schema{
+            description: "A list of cluster resources",
+            items: ClusterResource
           }
         },
         required: [:sap_systems]

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -627,7 +627,8 @@ defmodule Trento.Factory do
           type: "ocf::heartbeat:Dummy"
         ),
       system_replication_mode: "sync",
-      system_replication_operation_mode: "logreplay"
+      system_replication_operation_mode: "logreplay",
+      resources: build_list(5, :cluster_resource)
     }
   end
 
@@ -689,7 +690,9 @@ defmodule Trento.Factory do
       status: Faker.Pokemon.name(),
       fail_count: Enum.random(0..100),
       managed: Enum.random([false, true]),
-      parent: build(:cluster_resource_parent)
+      parent: build(:cluster_resource_parent),
+      node: Faker.StarWars.character(),
+      sid: nil
     }
   end
 
@@ -707,7 +710,8 @@ defmodule Trento.Factory do
       maintenance_mode: false,
       sap_systems: build_list(2, :ascs_ers_cluster_sap_system),
       sbd_devices: build_list(2, :sbd_device),
-      stopped_resources: build_list(2, :cluster_resource)
+      stopped_resources: build_list(2, :cluster_resource),
+      resources: build_list(5, :cluster_resource)
     }
   end
 

--- a/test/trento/clusters_test.exs
+++ b/test/trento/clusters_test.exs
@@ -1065,8 +1065,10 @@ defmodule Trento.ClustersTest do
   describe "resource_managed?/2" do
     test "should return the managed state of a resource in HANA cluster" do
       %{id: cluster_resource_id, managed: managed} = cluster_resource = build(:cluster_resource)
-      nodes = build_list(1, :hana_cluster_node, resources: [cluster_resource])
-      cluster_details = build(:hana_cluster_details, maintenance_mode: false, nodes: nodes)
+
+      cluster_details =
+        build(:hana_cluster_details, maintenance_mode: false, resources: [cluster_resource])
+
       cluster = build(:cluster, type: ClusterType.hana_scale_up(), details: cluster_details)
 
       assert managed == Clusters.resource_managed?(cluster, cluster_resource_id)
@@ -1074,11 +1076,9 @@ defmodule Trento.ClustersTest do
 
     test "should return the managed state of a resource in ASCS/ERS cluster" do
       %{id: cluster_resource_id, managed: managed} = cluster_resource = build(:cluster_resource)
-      nodes = build_list(1, :hana_cluster_node, resources: [cluster_resource])
-      sap_systems = build_list(1, :ascs_ers_cluster_sap_system, nodes: nodes)
 
       cluster_details =
-        build(:ascs_ers_cluster_details, maintenance_mode: false, sap_systems: sap_systems)
+        build(:ascs_ers_cluster_details, maintenance_mode: false, resources: [cluster_resource])
 
       cluster = build(:cluster, type: ClusterType.ascs_ers(), details: cluster_details)
 
@@ -1088,8 +1088,10 @@ defmodule Trento.ClustersTest do
     test "should return the managed state of a grouped resource" do
       %{id: cluster_resource_id, managed: managed} = parent = build(:cluster_resource_parent)
       cluster_resource = build(:cluster_resource, managed: not managed, parent: parent)
-      nodes = build_list(1, :hana_cluster_node, resources: [cluster_resource])
-      cluster_details = build(:hana_cluster_details, maintenance_mode: false, nodes: nodes)
+
+      cluster_details =
+        build(:hana_cluster_details, maintenance_mode: false, resources: [cluster_resource])
+
       cluster = build(:cluster, type: ClusterType.hana_scale_up(), details: cluster_details)
 
       assert managed == Clusters.resource_managed?(cluster, cluster_resource_id)

--- a/test/trento/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/discovery/policies/cluster_policy_test.exs
@@ -247,7 +247,173 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   system_replication_mode: "sync",
                   system_replication_operation_mode: "logreplay",
                   architecture_type: HanaArchitectureType.classic(),
-                  hana_scenario: HanaScenario.performance_optimized()
+                  hana_scenario: HanaScenario.performance_optimized(),
+                  resources: [
+                    %ClusterResource{
+                      id: "test-stop",
+                      type: "ocf::heartbeat:Dummy",
+                      role: "Stopped",
+                      status: nil,
+                      fail_count: nil,
+                      managed: true,
+                      node: nil,
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "test",
+                      type: "ocf::heartbeat:Dummy",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node02",
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "stonith-sbd",
+                      type: "stonith:external/sbd",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node01",
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "rsc_ip_PRD_HDB00",
+                      type: "ocf::heartbeat:IPaddr2",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 2,
+                      managed: true,
+                      node: "node01",
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHana_PRD_HDB00",
+                      type: "ocf::suse:SAPHana",
+                      role: "Master",
+                      status: "Active",
+                      fail_count: 1_000_000,
+                      managed: true,
+                      node: "node01",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "msl_SAPHana_PRD_HDB00",
+                        managed: true,
+                        multi_state: true
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHana_PRD_HDB00",
+                      type: "ocf::suse:SAPHana",
+                      role: "Slave",
+                      status: "Active",
+                      fail_count: 300,
+                      managed: true,
+                      node: "node02",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "msl_SAPHana_PRD_HDB00",
+                        managed: true,
+                        multi_state: true
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHanaTopology_PRD_HDB00",
+                      type: "ocf::suse:SAPHanaTopology",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node01",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "cln_SAPHanaTopology_PRD_HDB00",
+                        managed: true,
+                        multi_state: false
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHanaTopology_PRD_HDB00",
+                      type: "ocf::suse:SAPHanaTopology",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node02",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "cln_SAPHanaTopology_PRD_HDB00",
+                        managed: true,
+                        multi_state: false
+                      }
+                    },
+                    %ClusterResource{
+                      id: "clusterfs",
+                      type: "ocf::heartbeat:Filesystem",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: nil,
+                      managed: true,
+                      node: "node01",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "c-clusterfs",
+                        managed: true,
+                        multi_state: false
+                      }
+                    },
+                    %ClusterResource{
+                      id: "clusterfs",
+                      type: "ocf::heartbeat:Filesystem",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: nil,
+                      managed: true,
+                      node: "node02",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "c-clusterfs",
+                        managed: true,
+                        multi_state: false
+                      }
+                    },
+                    %ClusterResource{
+                      id: "clusterfs",
+                      type: "ocf::heartbeat:Filesystem",
+                      role: "Stopped",
+                      status: nil,
+                      fail_count: nil,
+                      managed: true,
+                      node: nil,
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "c-clusterfs",
+                        managed: true,
+                        multi_state: false
+                      }
+                    },
+                    %ClusterResource{
+                      id: "clusterfs",
+                      type: "ocf::heartbeat:Filesystem",
+                      role: "Stopped",
+                      status: nil,
+                      fail_count: nil,
+                      managed: true,
+                      node: nil,
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "c-clusterfs",
+                        managed: true,
+                        multi_state: false
+                      }
+                    }
+                  ]
                 },
                 host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
                 name: "hana_cluster",
@@ -493,7 +659,173 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   system_replication_mode: "sync",
                   system_replication_operation_mode: "logreplay",
                   architecture_type: HanaArchitectureType.classic(),
-                  hana_scenario: HanaScenario.performance_optimized()
+                  hana_scenario: HanaScenario.performance_optimized(),
+                  resources: [
+                    %ClusterResource{
+                      id: "test-stop",
+                      type: "ocf::heartbeat:Dummy",
+                      role: "Stopped",
+                      status: nil,
+                      fail_count: nil,
+                      managed: true,
+                      node: nil,
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "test",
+                      type: "ocf::heartbeat:Dummy",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node02",
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "stonith-sbd",
+                      type: "stonith:external/sbd",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node01",
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "rsc_ip_PRD_HDB00",
+                      type: "ocf::heartbeat:IPaddr2",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 2,
+                      managed: true,
+                      node: "node01",
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHana_PRD_HDB00",
+                      type: "ocf::suse:SAPHana",
+                      role: "Master",
+                      status: "Active",
+                      fail_count: 1_000_000,
+                      managed: true,
+                      node: "node01",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "msl_SAPHana_PRD_HDB00",
+                        managed: true,
+                        multi_state: true
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHana_PRD_HDB00",
+                      type: "ocf::suse:SAPHana",
+                      role: "Slave",
+                      status: "Active",
+                      fail_count: 300,
+                      managed: true,
+                      node: "node02",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "msl_SAPHana_PRD_HDB00",
+                        managed: true,
+                        multi_state: true
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHanaTopology_PRD_HDB00",
+                      type: "ocf::suse:SAPHanaTopology",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node01",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "cln_SAPHanaTopology_PRD_HDB00",
+                        managed: true,
+                        multi_state: false
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHanaTopology_PRD_HDB00",
+                      type: "ocf::suse:SAPHanaTopology",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node02",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "cln_SAPHanaTopology_PRD_HDB00",
+                        managed: true,
+                        multi_state: false
+                      }
+                    },
+                    %ClusterResource{
+                      id: "clusterfs",
+                      type: "ocf::heartbeat:Filesystem",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: nil,
+                      managed: true,
+                      node: "node01",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "c-clusterfs",
+                        managed: true,
+                        multi_state: false
+                      }
+                    },
+                    %ClusterResource{
+                      id: "clusterfs",
+                      type: "ocf::heartbeat:Filesystem",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: nil,
+                      managed: true,
+                      node: "node02",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "c-clusterfs",
+                        managed: true,
+                        multi_state: false
+                      }
+                    },
+                    %ClusterResource{
+                      id: "clusterfs",
+                      type: "ocf::heartbeat:Filesystem",
+                      role: "Stopped",
+                      status: nil,
+                      fail_count: nil,
+                      managed: true,
+                      node: nil,
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "c-clusterfs",
+                        managed: true,
+                        multi_state: false
+                      }
+                    },
+                    %ClusterResource{
+                      id: "clusterfs",
+                      type: "ocf::heartbeat:Filesystem",
+                      role: "Stopped",
+                      status: nil,
+                      fail_count: nil,
+                      managed: true,
+                      node: nil,
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "c-clusterfs",
+                        managed: true,
+                        multi_state: false
+                      }
+                    }
+                  ]
                 },
                 host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
                 name: "hana_cluster",
@@ -699,7 +1031,121 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   stopped_resources: [],
                   system_replication_mode: "sync",
                   system_replication_operation_mode: "logreplay",
-                  architecture_type: HanaArchitectureType.classic()
+                  architecture_type: HanaArchitectureType.classic(),
+                  resources: [
+                    %ClusterResource{
+                      id: "stonith-sbd",
+                      type: "stonith:external/sbd",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node01",
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAP_QAS_HDB20",
+                      type: "ocf::heartbeat:SAPInstance",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node02",
+                      sid: "QAS",
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHana_HDQ_HDB10",
+                      type: "ocf::suse:SAPHana",
+                      role: "Slave",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node02",
+                      sid: "HDQ",
+                      parent: %ClusterResourceParent{
+                        id: "msl_SAPHana_HDQ_HDB10",
+                        managed: true,
+                        multi_state: true
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHana_HDQ_HDB10",
+                      type: "ocf::suse:SAPHana",
+                      role: "Master",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node01",
+                      sid: "HDQ",
+                      parent: %ClusterResourceParent{
+                        id: "msl_SAPHana_HDQ_HDB10",
+                        managed: true,
+                        multi_state: true
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHanaTopology_HDQ_HDB10",
+                      type: "ocf::suse:SAPHanaTopology",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node02",
+                      sid: "HDQ",
+                      parent: %ClusterResourceParent{
+                        id: "cln_SAPHanaTopology_HDQ_HDB10",
+                        managed: true,
+                        multi_state: false
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHanaTopology_HDQ_HDB10",
+                      type: "ocf::suse:SAPHanaTopology",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node01",
+                      sid: "HDQ",
+                      parent: %ClusterResourceParent{
+                        id: "cln_SAPHanaTopology_HDQ_HDB10",
+                        managed: true,
+                        multi_state: false
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_ip_HDQ_HDB10",
+                      type: "ocf::heartbeat:IPaddr2",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node01",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "g_ip_HDQ_HDB10",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_socat_HDQ_HDB10",
+                      type: "ocf::heartbeat:azure-lb",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node01",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "g_ip_HDQ_HDB10",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    }
+                  ]
                 },
                 host_id: "2372b24f-3d7a-5d01-9b1a-a2c4c95c53d4",
                 name: "hana_cluster",
@@ -881,6 +1327,139 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       device:
                         "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_e34218cd-0d9a-4b21-b6d5-a313980baa82",
                       status: "healthy"
+                    }
+                  ],
+                  resources: [
+                    %ClusterResource{
+                      id: "stonith-sbd",
+                      type: "stonith:external/sbd",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd01",
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "rsc_ip_NWP_ASCS00",
+                      type: "ocf::heartbeat:IPaddr2",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd01",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ASCS00",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_fs_NWP_ASCS00",
+                      type: "ocf::heartbeat:Filesystem",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd01",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ASCS00",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_sap_NWP_ASCS00",
+                      type: "ocf::heartbeat:SAPInstance",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd01",
+                      sid: "NWP",
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ASCS00",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_socat_NWP_ASCS00",
+                      type: "ocf::heartbeat:azure-lb",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd01",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ASCS00",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_ip_NWP_ERS10",
+                      type: "ocf::heartbeat:IPaddr2",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd02",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ERS10",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_fs_NWP_ERS10",
+                      type: "ocf::heartbeat:Filesystem",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd02",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ERS10",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_sap_NWP_ERS10",
+                      type: "ocf::heartbeat:SAPInstance",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd02",
+                      sid: "NWP",
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ERS10",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_socat_NWP_ERS10",
+                      type: "ocf::heartbeat:azure-lb",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd02",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ERS10",
+                        managed: nil,
+                        multi_state: nil
+                      }
                     }
                   ]
                 },
@@ -1065,6 +1644,139 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       device:
                         "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_e34218cd-0d9a-4b21-b6d5-a313980baa82",
                       status: "healthy"
+                    }
+                  ],
+                  resources: [
+                    %ClusterResource{
+                      id: "stonith-sbd",
+                      type: "stonith:external/sbd",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd01",
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "rsc_ip_NWP_ASCS00",
+                      type: "ocf::heartbeat:IPaddr2",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd01",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ASCS00",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_fs_NWP_ASCS00",
+                      type: "ocf::heartbeat:Filesystem",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd01",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ASCS00",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_sap_NWP_ASCS00",
+                      type: "ocf::heartbeat:SAPInstance",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd01",
+                      sid: "NWP",
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ASCS00",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_socat_NWP_ASCS00",
+                      type: "ocf::heartbeat:azure-lb",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd01",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ASCS00",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_ip_NWP_ERS10",
+                      type: "ocf::heartbeat:IPaddr2",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd02",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ERS10",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_fs_NWP_ERS10",
+                      type: "ocf::heartbeat:Filesystem",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd02",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ERS10",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_sap_NWP_ERS10",
+                      type: "ocf::heartbeat:SAPInstance",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd02",
+                      sid: "NWP",
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ERS10",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_socat_NWP_ERS10",
+                      type: "ocf::heartbeat:azure-lb",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd02",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ERS10",
+                        managed: nil,
+                        multi_state: nil
+                      }
                     }
                   ]
                 },
@@ -1463,6 +2175,259 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       device:
                         "/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_e34218cd-0d9a-4b21-b6d5-a313980baa82",
                       status: "healthy"
+                    }
+                  ],
+                  resources: [
+                    %ClusterResource{
+                      id: "stonith-sbd",
+                      type: "stonith:external/sbd",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd01",
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "rsc_ip_NWP_ASCS00",
+                      type: "ocf::heartbeat:IPaddr2",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd01",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ASCS00",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_fs_NWP_ASCS00",
+                      type: "ocf::heartbeat:Filesystem",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd01",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ASCS00",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_sap_NWP_ASCS00",
+                      type: "ocf::heartbeat:SAPInstance",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd01",
+                      sid: "NWP",
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ASCS00",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_socat_NWP_ASCS00",
+                      type: "ocf::heartbeat:azure-lb",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd01",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ASCS00",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_ip_NWP_ERS10",
+                      type: "ocf::heartbeat:IPaddr2",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd02",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ERS10",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_fs_NWP_ERS10",
+                      type: "ocf::heartbeat:Filesystem",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd02",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ERS10",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_sap_NWP_ERS10",
+                      type: "ocf::heartbeat:SAPInstance",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd02",
+                      sid: "NWP",
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ERS10",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_socat_NWP_ERS10",
+                      type: "ocf::heartbeat:azure-lb",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd02",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWP_ERS10",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_ip_NWD_ASCS01",
+                      type: "ocf::heartbeat:IPaddr2",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd01",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWD_ASCS01",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_fs_NWD_ASCS01",
+                      type: "ocf::heartbeat:Filesystem",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd01",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWD_ASCS01",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_sap_NWD_ASCS01",
+                      type: "ocf::heartbeat:SAPInstance",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd01",
+                      sid: "NWD",
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWD_ASCS01",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_socat_NWD_ASCS01",
+                      type: "ocf::heartbeat:azure-lb",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd01",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWD_ASCS01",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_ip_NWD_ERS11",
+                      type: "ocf::heartbeat:IPaddr2",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd02",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWD_ERS11",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_fs_NWD_ERS11",
+                      type: "ocf::heartbeat:Filesystem",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd02",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWD_ERS11",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_sap_NWD_ERS11",
+                      type: "ocf::heartbeat:SAPInstance",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd02",
+                      sid: "NWD",
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWD_ERS11",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_socat_NWD_ERS11",
+                      type: "ocf::heartbeat:azure-lb",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmnwprd02",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "grp_NWD_ERS11",
+                        managed: nil,
+                        multi_state: nil
+                      }
                     }
                   ]
                 },
@@ -1917,7 +2882,102 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   system_replication_mode: "sync",
                   system_replication_operation_mode: "logreplay",
                   architecture_type: HanaArchitectureType.classic(),
-                  hana_scenario: HanaScenario.performance_optimized()
+                  hana_scenario: HanaScenario.performance_optimized(),
+                  resources: [
+                    %ClusterResource{
+                      id: "rsc_aws_stonith_PRD_HDB00",
+                      type: "stonith:external/ec2",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmhana01",
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "rsc_ip_PRD_HDB00",
+                      type: "ocf::suse:aws-vpc-move-ip",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmhana01",
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "rsc_exporter_PRD_HDB00",
+                      type: "systemd:prometheus-hanadb_exporter@PRD_HDB00",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmhana01",
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHana_PRD_HDB00",
+                      type: "ocf::suse:SAPHana",
+                      role: "Master",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmhana01",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "msl_SAPHana_PRD_HDB00",
+                        managed: true,
+                        multi_state: true
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHana_PRD_HDB00",
+                      type: "ocf::suse:SAPHana",
+                      role: "Slave",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmhana02",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "msl_SAPHana_PRD_HDB00",
+                        managed: true,
+                        multi_state: true
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHanaTopology_PRD_HDB00",
+                      type: "ocf::suse:SAPHanaTopology",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmhana01",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "cln_SAPHanaTopology_PRD_HDB00",
+                        managed: true,
+                        multi_state: false
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHanaTopology_PRD_HDB00",
+                      type: "ocf::suse:SAPHanaTopology",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmhana02",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "cln_SAPHanaTopology_PRD_HDB00",
+                        managed: true,
+                        multi_state: false
+                      }
+                    }
+                  ]
                 },
                 discovered_health: :passing,
                 host_id: "a3279fd0-0443-1234-9354-2d7909fd6bc6",
@@ -2123,7 +3183,132 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   system_replication_mode: "sync",
                   system_replication_operation_mode: "logreplay",
                   architecture_type: HanaArchitectureType.classic(),
-                  hana_scenario: HanaScenario.performance_optimized()
+                  hana_scenario: HanaScenario.performance_optimized(),
+                  resources: [
+                    %ClusterResource{
+                      id: "rsc_gcp_stonith_PRD_HDB00_vmhana01",
+                      type: "stonith:fence_gce",
+                      role: "Stopped",
+                      status: nil,
+                      fail_count: nil,
+                      managed: true,
+                      node: nil,
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "rsc_exporter_PRD_HDB00",
+                      type: "systemd:prometheus-hanadb_exporter@PRD_HDB00",
+                      role: "Stopped",
+                      status: nil,
+                      fail_count: nil,
+                      managed: true,
+                      node: nil,
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "rsc_gcp_stonith_PRD_HDB00_vmhana02",
+                      type: "stonith:fence_gce",
+                      role: "Stopped",
+                      status: nil,
+                      fail_count: nil,
+                      managed: true,
+                      node: nil,
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHana_PRD_HDB00",
+                      type: "ocf::suse:SAPHana",
+                      role: "Slave",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmhana02",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "msl_SAPHana_PRD_HDB00",
+                        managed: true,
+                        multi_state: true
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHana_PRD_HDB00",
+                      type: "ocf::suse:SAPHana",
+                      role: "Stopped",
+                      status: nil,
+                      fail_count: nil,
+                      managed: true,
+                      node: nil,
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "msl_SAPHana_PRD_HDB00",
+                        managed: true,
+                        multi_state: true
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHanaTopology_PRD_HDB00",
+                      type: "ocf::suse:SAPHanaTopology",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmhana01",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "cln_SAPHanaTopology_PRD_HDB00",
+                        managed: true,
+                        multi_state: false
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHanaTopology_PRD_HDB00",
+                      type: "ocf::suse:SAPHanaTopology",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmhana02",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "cln_SAPHanaTopology_PRD_HDB00",
+                        managed: true,
+                        multi_state: false
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_ip_PRD_HDB00",
+                      type: "ocf::heartbeat:IPaddr2",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmhana01",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "g_ip_PRD_HDB00",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_socat_PRD_HDB00",
+                      type: "ocf::heartbeat:anything",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "vmhana01",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "g_ip_PRD_HDB00",
+                        managed: nil,
+                        multi_state: nil
+                      }
+                    }
+                  ]
                 },
                 discovered_health: :critical,
                 host_id: "1dc79771-0a96-1234-b5b6-cd4d0aef6acc",
@@ -2369,7 +3554,173 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   system_replication_mode: "sync",
                   system_replication_operation_mode: "logreplay",
                   architecture_type: HanaArchitectureType.classic(),
-                  hana_scenario: HanaScenario.performance_optimized()
+                  hana_scenario: HanaScenario.performance_optimized(),
+                  resources: [
+                    %ClusterResource{
+                      id: "test-stop",
+                      type: "ocf::heartbeat:Dummy",
+                      role: "Stopped",
+                      status: nil,
+                      fail_count: nil,
+                      managed: true,
+                      node: nil,
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "test",
+                      type: "ocf::heartbeat:Dummy",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node02",
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "stonith-sbd",
+                      type: "stonith:external/sbd",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node01",
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "rsc_ip_PRD_HDB00",
+                      type: "ocf::heartbeat:IPaddr2",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 2,
+                      managed: true,
+                      node: "node01",
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHana_PRD_HDB00",
+                      type: "ocf::suse:SAPHana",
+                      role: "Master",
+                      status: "Active",
+                      fail_count: 1_000_000,
+                      managed: true,
+                      node: "node01",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "msl_SAPHana_PRD_HDB00",
+                        managed: true,
+                        multi_state: true
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHana_PRD_HDB00",
+                      type: "ocf::suse:SAPHana",
+                      role: "Slave",
+                      status: "Active",
+                      fail_count: 300,
+                      managed: true,
+                      node: "node02",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "msl_SAPHana_PRD_HDB00",
+                        managed: true,
+                        multi_state: true
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHanaTopology_PRD_HDB00",
+                      type: "ocf::suse:SAPHanaTopology",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node01",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "cln_SAPHanaTopology_PRD_HDB00",
+                        managed: true,
+                        multi_state: false
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHanaTopology_PRD_HDB00",
+                      type: "ocf::suse:SAPHanaTopology",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node02",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "cln_SAPHanaTopology_PRD_HDB00",
+                        managed: true,
+                        multi_state: false
+                      }
+                    },
+                    %ClusterResource{
+                      id: "clusterfs",
+                      type: "ocf::heartbeat:Filesystem",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: nil,
+                      managed: true,
+                      node: "node01",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "c-clusterfs",
+                        managed: true,
+                        multi_state: false
+                      }
+                    },
+                    %ClusterResource{
+                      id: "clusterfs",
+                      type: "ocf::heartbeat:Filesystem",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: nil,
+                      managed: true,
+                      node: "node02",
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "c-clusterfs",
+                        managed: true,
+                        multi_state: false
+                      }
+                    },
+                    %ClusterResource{
+                      id: "clusterfs",
+                      type: "ocf::heartbeat:Filesystem",
+                      role: "Stopped",
+                      status: nil,
+                      fail_count: nil,
+                      managed: true,
+                      node: nil,
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "c-clusterfs",
+                        managed: true,
+                        multi_state: false
+                      }
+                    },
+                    %ClusterResource{
+                      id: "clusterfs",
+                      type: "ocf::heartbeat:Filesystem",
+                      role: "Stopped",
+                      status: nil,
+                      fail_count: nil,
+                      managed: true,
+                      node: nil,
+                      sid: nil,
+                      parent: %ClusterResourceParent{
+                        id: "c-clusterfs",
+                        managed: true,
+                        multi_state: false
+                      }
+                    }
+                  ]
                 },
                 host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
                 name: nil,
@@ -2534,7 +3885,80 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   stopped_resources: [],
                   system_replication_mode: "sync",
                   system_replication_operation_mode: "logreplay",
-                  architecture_type: HanaArchitectureType.classic()
+                  architecture_type: HanaArchitectureType.classic(),
+                  resources: [
+                    %ClusterResource{
+                      id: "rsc_ip_PRD_HDB00",
+                      type: "ocf::heartbeat:IPaddr2",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 2,
+                      managed: true,
+                      node: "node01",
+                      sid: nil,
+                      parent: nil
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHana_PRD_HDB00",
+                      type: "ocf::suse:SAPHana",
+                      role: "Master",
+                      status: "Active",
+                      fail_count: 1_000_000,
+                      managed: true,
+                      node: "node01",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "msl_SAPHana_PRD_HDB00",
+                        managed: true,
+                        multi_state: true
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHana_PRD_HDB00",
+                      type: "ocf::suse:SAPHana",
+                      role: "Slave",
+                      status: "Active",
+                      fail_count: 300,
+                      managed: true,
+                      node: "node02",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "msl_SAPHana_PRD_HDB00",
+                        managed: true,
+                        multi_state: true
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHanaTopology_PRD_HDB00",
+                      type: "ocf::suse:SAPHanaTopology",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node01",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "cln_SAPHanaTopology_PRD_HDB00",
+                        managed: true,
+                        multi_state: false
+                      }
+                    },
+                    %ClusterResource{
+                      id: "rsc_SAPHanaTopology_PRD_HDB00",
+                      type: "ocf::suse:SAPHanaTopology",
+                      role: "Started",
+                      status: "Active",
+                      fail_count: 0,
+                      managed: true,
+                      node: "node02",
+                      sid: "PRD",
+                      parent: %ClusterResourceParent{
+                        id: "cln_SAPHanaTopology_PRD_HDB00",
+                        managed: true,
+                        multi_state: false
+                      }
+                    }
+                  ]
                 },
                 host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
                 name: "hana_cluster",
@@ -2918,6 +4342,221 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                         device: "/dev/vdb",
                         status: "healthy"
                       }
+                    ],
+                    resources: [
+                      %ClusterResource{
+                        id: "stonith-sbd",
+                        type: "stonith:external/sbd",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana01",
+                        sid: nil,
+                        parent: nil
+                      },
+                      %ClusterResource{
+                        id: "rsc_ip_PRD_HDB00",
+                        type: "ocf::heartbeat:IPaddr2",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana01",
+                        sid: nil,
+                        parent: nil
+                      },
+                      %ClusterResource{
+                        id: "rsc_exporter_PRD_HDB00",
+                        type: "systemd:prometheus-hanadb_exporter@PRD_HDB00",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana01",
+                        sid: nil,
+                        parent: nil
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaController_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Master",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana01",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHanaController_PRD_HDB00",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaController_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Slave",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana02",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHanaController_PRD_HDB00",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaController_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Slave",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana03",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHanaController_PRD_HDB00",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaController_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Slave",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana04",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHanaController_PRD_HDB00",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaController_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Slave",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana05",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHanaController_PRD_HDB00",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaController_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Slave",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana06",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHanaController_PRD_HDB00",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTopology_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana01",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTopology_PRD_HDB00",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTopology_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana02",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTopology_PRD_HDB00",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTopology_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana03",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTopology_PRD_HDB00",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTopology_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana04",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTopology_PRD_HDB00",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTopology_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana05",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTopology_PRD_HDB00",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTopology_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana06",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTopology_PRD_HDB00",
+                          managed: true,
+                          multi_state: false
+                        }
+                      }
                     ]
                   }
                 }
@@ -3215,6 +4854,199 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                         device:
                           "/dev/disk/by-id/scsi-1LIO-ORG_sbdnfs:01144514-24f0-4386-83c2-321e6b1af8b0",
                         status: "healthy"
+                      }
+                    ],
+                    resources: [
+                      %ClusterResource{
+                        id: "stonith-sbd",
+                        type: "stonith:external/sbd",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhanamm",
+                        sid: nil,
+                        parent: nil
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTop_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana11",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTop_PRD_HDB00",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTop_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana12",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTop_PRD_HDB00",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTop_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana22",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTop_PRD_HDB00",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTop_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana21",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTop_PRD_HDB00",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTop_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Stopped",
+                        status: nil,
+                        fail_count: nil,
+                        managed: true,
+                        node: nil,
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTop_PRD_HDB00",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaCon_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Slave",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana11",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHanaCon_PRD_HDB00",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaCon_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Slave",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana12",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHanaCon_PRD_HDB00",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaCon_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Slave",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana22",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHanaCon_PRD_HDB00",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaCon_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Master",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana21",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHanaCon_PRD_HDB00",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaCon_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Stopped",
+                        status: nil,
+                        fail_count: nil,
+                        managed: true,
+                        node: nil,
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHanaCon_PRD_HDB00",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_ip_PRD_HDB00",
+                        type: "ocf::heartbeat:IPaddr2",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana21",
+                        sid: nil,
+                        parent: %ClusterResourceParent{
+                          id: "g_ip_PRD_HDB00",
+                          managed: nil,
+                          multi_state: nil
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_nc_PRD_HDB00",
+                        type: "ocf::heartbeat:azure-lb",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana21",
+                        sid: nil,
+                        parent: %ClusterResourceParent{
+                          id: "g_ip_PRD_HDB00",
+                          managed: nil,
+                          multi_state: nil
+                        }
                       }
                     ]
                   }
@@ -3560,6 +5392,221 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                         device: "/dev/vdb",
                         status: "healthy"
                       }
+                    ],
+                    resources: [
+                      %ClusterResource{
+                        id: "stonith-sbd",
+                        type: "stonith:external/sbd",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana01",
+                        sid: nil,
+                        parent: nil
+                      },
+                      %ClusterResource{
+                        id: "rsc_ip_PRD_HDB00",
+                        type: "ocf::heartbeat:IPaddr2",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana01",
+                        sid: nil,
+                        parent: nil
+                      },
+                      %ClusterResource{
+                        id: "rsc_exporter_PRD_HDB00",
+                        type: "systemd:prometheus-hanadb_exporter@PRD_HDB00",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana01",
+                        sid: nil,
+                        parent: nil
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaController_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Master",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana01",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHanaController_PRD_HDB00",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaController_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Slave",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana02",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHanaController_PRD_HDB00",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaController_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Slave",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana03",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHanaController_PRD_HDB00",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaController_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Slave",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana04",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHanaController_PRD_HDB00",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaController_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Slave",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana05",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHanaController_PRD_HDB00",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaController_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Slave",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana06",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHanaController_PRD_HDB00",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTopology_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana01",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTopology_PRD_HDB00",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTopology_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana02",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTopology_PRD_HDB00",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTopology_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana03",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTopology_PRD_HDB00",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTopology_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana04",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTopology_PRD_HDB00",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTopology_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana05",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTopology_PRD_HDB00",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTopology_PRD_HDB00",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "vmhana06",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTopology_PRD_HDB00",
+                          managed: true,
+                          multi_state: false
+                        }
+                      }
                     ]
                   }
                 }
@@ -3893,7 +5940,264 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                     system_replication_mode: "sync",
                     system_replication_operation_mode: "logreplay",
                     architecture_type: HanaArchitectureType.classic(),
-                    hana_scenario: HanaScenario.performance_optimized()
+                    hana_scenario: HanaScenario.performance_optimized(),
+                    resources: [
+                      %ClusterResource{
+                        id: "fs_PRD_HDB01_fscheck",
+                        type: "ocf::heartbeat:Filesystem",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "hana-s2-db2",
+                        sid: nil,
+                        parent: %ClusterResourceParent{
+                          id: "cln_fs_PRD_HDB01_fscheck",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "fs_PRD_HDB01_fscheck",
+                        type: "ocf::heartbeat:Filesystem",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "hana-s1-db1",
+                        sid: nil,
+                        parent: %ClusterResourceParent{
+                          id: "cln_fs_PRD_HDB01_fscheck",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "fs_PRD_HDB01_fscheck",
+                        type: "ocf::heartbeat:Filesystem",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "hana-s2-db1",
+                        sid: nil,
+                        parent: %ClusterResourceParent{
+                          id: "cln_fs_PRD_HDB01_fscheck",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "fs_PRD_HDB01_fscheck",
+                        type: "ocf::heartbeat:Filesystem",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "hana-s1-db2",
+                        sid: nil,
+                        parent: %ClusterResourceParent{
+                          id: "cln_fs_PRD_HDB01_fscheck",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "fs_PRD_HDB01_fscheck",
+                        type: "ocf::heartbeat:Filesystem",
+                        role: "Stopped",
+                        status: nil,
+                        fail_count: nil,
+                        managed: true,
+                        node: nil,
+                        sid: nil,
+                        parent: %ClusterResourceParent{
+                          id: "cln_fs_PRD_HDB01_fscheck",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTopology_PRD_HDB01",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "hana-s2-db2",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTopology_PRD_HDB01",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTopology_PRD_HDB01",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "hana-s1-db1",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTopology_PRD_HDB01",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTopology_PRD_HDB01",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "hana-s2-db1",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTopology_PRD_HDB01",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTopology_PRD_HDB01",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "hana-s1-db2",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTopology_PRD_HDB01",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHanaTopology_PRD_HDB01",
+                        type: "ocf::suse:SAPHanaTopology",
+                        role: "Stopped",
+                        status: nil,
+                        fail_count: nil,
+                        managed: true,
+                        node: nil,
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "cln_SAPHanaTopology_PRD_HDB01",
+                          managed: true,
+                          multi_state: false
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHana_PRD_HDB01",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Slave",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "hana-s2-db2",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHana_PRD_HDB01",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHana_PRD_HDB01",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Master",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "hana-s1-db1",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHana_PRD_HDB01",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHana_PRD_HDB01",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Slave",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "hana-s2-db1",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHana_PRD_HDB01",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHana_PRD_HDB01",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Slave",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "hana-s1-db2",
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHana_PRD_HDB01",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_SAPHana_PRD_HDB01",
+                        type: "ocf::suse:SAPHanaController",
+                        role: "Stopped",
+                        status: nil,
+                        fail_count: nil,
+                        managed: true,
+                        node: nil,
+                        sid: "PRD",
+                        parent: %ClusterResourceParent{
+                          id: "msl_SAPHana_PRD_HDB01",
+                          managed: true,
+                          multi_state: true
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_ip_PRD_HDB01",
+                        type: "ocf::heartbeat:IPaddr2",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "hana-s1-db1",
+                        sid: nil,
+                        parent: %ClusterResourceParent{
+                          id: "g_ip_PRD_HDB01",
+                          managed: nil,
+                          multi_state: nil
+                        }
+                      },
+                      %ClusterResource{
+                        id: "rsc_nc_PRD_HDB01",
+                        type: "ocf::heartbeat:azure-lb",
+                        role: "Started",
+                        status: "Active",
+                        fail_count: 0,
+                        managed: true,
+                        node: "hana-s1-db1",
+                        sid: nil,
+                        parent: %ClusterResourceParent{
+                          id: "g_ip_PRD_HDB01",
+                          managed: nil,
+                          multi_state: nil
+                        }
+                      }
+                    ]
                   },
                   discovered_health: :passing,
                   host_id: "6eabc497-6067-4de9-b583-e4c63334ff64",
@@ -4054,7 +6358,91 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                      sr_health_state: "4",
                      stopped_resources: [],
                      system_replication_mode: "sync",
-                     system_replication_operation_mode: "logreplay"
+                     system_replication_operation_mode: "logreplay",
+                     resources: [
+                       %ClusterResource{
+                         id: "stonith-sbd",
+                         type: "stonith:external/sbd",
+                         role: "Started",
+                         status: "Active",
+                         fail_count: 0,
+                         managed: true,
+                         node: "vmhana01",
+                         sid: nil,
+                         parent: nil
+                       },
+                       %ClusterResource{
+                         id: "rsc_ip_HN9_HDB09",
+                         type: "ocf::heartbeat:IPaddr2",
+                         role: "Started",
+                         status: "Active",
+                         fail_count: 0,
+                         managed: true,
+                         node: "vmhana01",
+                         sid: nil,
+                         parent: nil
+                       },
+                       %ClusterResource{
+                         id: "rsc_SAPHanaTop_HN9_HDB09",
+                         type: "ocf::suse:SAPHanaTopology",
+                         role: "Started",
+                         status: "Active",
+                         fail_count: 0,
+                         managed: true,
+                         node: "vmhana01",
+                         sid: "HN9",
+                         parent: %ClusterResourceParent{
+                           id: "cln_SAPHanaTop_HN9_HDB09",
+                           managed: true,
+                           multi_state: false
+                         }
+                       },
+                       %ClusterResource{
+                         id: "rsc_SAPHanaTop_HN9_HDB09",
+                         type: "ocf::suse:SAPHanaTopology",
+                         role: "Started",
+                         status: "Active",
+                         fail_count: 0,
+                         managed: true,
+                         node: "vmhana02",
+                         sid: "HN9",
+                         parent: %ClusterResourceParent{
+                           id: "cln_SAPHanaTop_HN9_HDB09",
+                           managed: true,
+                           multi_state: false
+                         }
+                       },
+                       %ClusterResource{
+                         id: "rsc_SAPHanaCon_HN9_HDB09",
+                         type: "ocf::suse:SAPHanaController",
+                         role: "Master",
+                         status: "Active",
+                         fail_count: 0,
+                         managed: true,
+                         node: "vmhana01",
+                         sid: "HN9",
+                         parent: %ClusterResourceParent{
+                           id: "mst_SAPHanacon_HN9_HDB09",
+                           managed: true,
+                           multi_state: true
+                         }
+                       },
+                       %ClusterResource{
+                         id: "rsc_SAPHanaCon_HN9_HDB09",
+                         type: "ocf::suse:SAPHanaController",
+                         role: "Slave",
+                         status: "Active",
+                         fail_count: 0,
+                         managed: true,
+                         node: "vmhana02",
+                         sid: "HN9",
+                         parent: %ClusterResourceParent{
+                           id: "mst_SAPHanacon_HN9_HDB09",
+                           managed: true,
+                           multi_state: true
+                         }
+                       }
+                     ]
                    },
                    discovered_health: :passing,
                    host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
@@ -4212,7 +6600,91 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                        }
                      ],
                      system_replication_mode: "sync",
-                     system_replication_operation_mode: "logreplay"
+                     system_replication_operation_mode: "logreplay",
+                     resources: [
+                       %ClusterResource{
+                         id: "stonith-sbd",
+                         type: "stonith:external/sbd",
+                         role: "Started",
+                         status: "Active",
+                         fail_count: 0,
+                         managed: true,
+                         node: "vmhana01",
+                         sid: nil,
+                         parent: nil
+                       },
+                       %ClusterResource{
+                         id: "rsc_ip_HN9_HDB09",
+                         type: "ocf::heartbeat:IPaddr2",
+                         role: "Started",
+                         status: "Active",
+                         fail_count: 0,
+                         managed: true,
+                         node: "vmhana02",
+                         sid: nil,
+                         parent: nil
+                       },
+                       %ClusterResource{
+                         id: "rsc_SAPHanaTop_HN9_HDB09",
+                         type: "ocf::suse:SAPHanaTopology",
+                         role: "Started",
+                         status: "Active",
+                         fail_count: 0,
+                         managed: true,
+                         node: "vmhana01",
+                         sid: "HN9",
+                         parent: %ClusterResourceParent{
+                           id: "cln_SAPHanaTop_HN9_HDB09",
+                           managed: true,
+                           multi_state: false
+                         }
+                       },
+                       %ClusterResource{
+                         id: "rsc_SAPHanaTop_HN9_HDB09",
+                         type: "ocf::suse:SAPHanaTopology",
+                         role: "Started",
+                         status: "Active",
+                         fail_count: 0,
+                         managed: true,
+                         node: "vmhana02",
+                         sid: "HN9",
+                         parent: %ClusterResourceParent{
+                           id: "cln_SAPHanaTop_HN9_HDB09",
+                           managed: true,
+                           multi_state: false
+                         }
+                       },
+                       %ClusterResource{
+                         id: "rsc_SAPHanaCon_HN9_HDB09",
+                         type: "ocf::suse:SAPHanaController",
+                         role: "Stopped",
+                         status: nil,
+                         fail_count: nil,
+                         managed: true,
+                         node: nil,
+                         sid: "HN9",
+                         parent: %ClusterResourceParent{
+                           id: "mst_SAPHanacon_HN9_HDB09",
+                           managed: true,
+                           multi_state: true
+                         }
+                       },
+                       %ClusterResource{
+                         id: "rsc_SAPHanaCon_HN9_HDB09",
+                         type: "ocf::suse:SAPHanaController",
+                         role: "Master",
+                         status: "Active",
+                         fail_count: 0,
+                         managed: true,
+                         node: "vmhana02",
+                         sid: "HN9",
+                         parent: %ClusterResourceParent{
+                           id: "mst_SAPHanacon_HN9_HDB09",
+                           managed: true,
+                           multi_state: true
+                         }
+                       }
+                     ]
                    },
                    discovered_health: :critical,
                    host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",

--- a/test/trento/operations/cluster_policy_test.exs
+++ b/test/trento/operations/cluster_policy_test.exs
@@ -57,8 +57,10 @@ defmodule Trento.Operations.ClusterPolicyTest do
 
       for %{managed: managed, result: result} <- scenarios do
         cluster_resource = build(:cluster_resource, id: cluster_resource_id, managed: managed)
-        nodes = build_list(1, :hana_cluster_node, resources: [cluster_resource])
-        cluster_details = build(:hana_cluster_details, maintenance_mode: false, nodes: nodes)
+
+        cluster_details =
+          build(:hana_cluster_details, maintenance_mode: false, resources: [cluster_resource])
+
         cluster = build(:cluster, name: cluster_name, details: cluster_details)
 
         assert result ==

--- a/test/trento/operations/database_instance_policy_test.exs
+++ b/test/trento/operations/database_instance_policy_test.exs
@@ -190,8 +190,8 @@ defmodule Trento.Operations.DatabaseInstancePolicyTest do
         clustered_sap_instances =
         build_list(1, :clustered_sap_instance)
 
-      nodes = build_list(1, :hana_cluster_node, resources: [cluster_resource])
-      cluster_details = build(:hana_cluster_details, maintenance_mode: false, nodes: nodes)
+      cluster_details =
+        build(:hana_cluster_details, maintenance_mode: false, resources: [cluster_resource])
 
       cluster =
         build(:cluster,

--- a/test/trento/operations/host_policy_test.exs
+++ b/test/trento/operations/host_policy_test.exs
@@ -155,21 +155,16 @@ defmodule Trento.Operations.HostPolicyTest do
 
         database_instances = build_list(2, :database_instance, health: Health.unknown())
 
-        [%{name: hostname}] =
-          nodes =
-          build_list(1, :ascs_ers_cluster_node,
-            resources:
-              [%{id: resource_id}] =
-                build_list(1, :cluster_resource,
-                  type: "ocf::heartbeat:SAPInstance",
-                  managed: true
-                )
+        resources =
+          [%{id: resource_id}] =
+          build_list(1, :cluster_resource,
+            type: "ocf::heartbeat:SAPInstance",
+            managed: true,
+            sid: sid
           )
 
-        sap_systems = build_list(1, :ascs_ers_cluster_sap_system, sid: sid, nodes: nodes)
-
         cluster_details =
-          build(:ascs_ers_cluster_details, maintenance_mode: false, sap_systems: sap_systems)
+          build(:ascs_ers_cluster_details, maintenance_mode: false, resources: resources)
 
         clustered_sap_instances =
           build_list(1, :clustered_sap_instance,
@@ -187,7 +182,6 @@ defmodule Trento.Operations.HostPolicyTest do
 
         host =
           build(:host,
-            hostname: hostname,
             application_instances: application_instances,
             database_instances: database_instances,
             cluster: cluster,
@@ -225,8 +219,8 @@ defmodule Trento.Operations.HostPolicyTest do
           cluster_resource =
             build(:cluster_resource, type: cluster_resource_type, parent: parent)
 
-          nodes = build_list(1, :hana_cluster_node, resources: [cluster_resource])
-          cluster_details = build(:hana_cluster_details, maintenance_mode: false, nodes: nodes)
+          cluster_details =
+            build(:hana_cluster_details, maintenance_mode: false, resources: [cluster_resource])
 
           %{name: cluster_name} =
             cluster =

--- a/test/trento/operations/host_policy_test.exs
+++ b/test/trento/operations/host_policy_test.exs
@@ -289,37 +289,6 @@ defmodule Trento.Operations.HostPolicyTest do
 
         assert :ok == HostPolicy.authorize_operation(@saptune_operation, host, %{})
       end
-
-      test "should authorize operation '#{operation}' if all instances are stopped and HANA resources are not managed. Scenario: #{name}" do
-        scenarios = [
-          %{cluster_resource_type: "ocf::suse:SAPHana"},
-          %{cluster_resource_type: "ocf::suse:SAPHanaController"}
-        ]
-
-        database_instancess = build_list(2, :database_instance, health: Health.unknown())
-
-        for %{cluster_resource_type: cluster_resource_type} <- scenarios do
-          parent = build(:cluster_resource_parent, managed: false)
-
-          cluster_resource =
-            build(:cluster_resource, type: cluster_resource_type, managed: true, parent: parent)
-
-          cluster_details =
-            build(:hana_cluster_details, maintenance_mode: false, resources: [cluster_resource])
-
-          cluster = build(:cluster, details: cluster_details)
-
-          host =
-            build(:host,
-              application_instances: [],
-              database_instances: database_instancess,
-              cluster: cluster,
-              saptune_status: @saptune_status
-            )
-
-          assert :ok == HostPolicy.authorize_operation(@saptune_operation, host, %{})
-        end
-      end
     end
 
     test "should forbid applying a saptune solution when there is an already applied one" do

--- a/test/trento_web/views/v1/cluster_view_json_test.exs
+++ b/test/trento_web/views/v1/cluster_view_json_test.exs
@@ -44,6 +44,7 @@ defmodule TrentoWeb.V1.ClusterJSONTest do
       refute Access.get(updated_details, :architecture_type)
       refute Access.get(updated_details, :hana_scenario)
       refute Access.get(updated_details, :sap_instances)
+      refute Access.get(updated_details, :resources)
       refute Access.get(node, :nameserver_actual_role)
       refute Access.get(node, :indexserver_actual_role)
       refute Access.get(node, :status)
@@ -51,11 +52,15 @@ defmodule TrentoWeb.V1.ClusterJSONTest do
       Enum.each(stopped_resources, fn stopped_resource ->
         refute Map.has_key?(stopped_resource, :managed)
         refute Map.has_key?(stopped_resource, :parent)
+        refute Map.has_key?(stopped_resource, :sid)
+        refute Map.has_key?(stopped_resource, :node)
       end)
 
       Enum.each(resources, fn resource ->
         refute Map.has_key?(resource, :managed)
         refute Map.has_key?(resource, :parent)
+        refute Map.has_key?(resource, :sid)
+        refute Map.has_key?(resource, :node)
       end)
     end
   end

--- a/test/trento_web/views/v2/cluster_view_json_test.exs
+++ b/test/trento_web/views/v2/cluster_view_json_test.exs
@@ -36,11 +36,7 @@ defmodule TrentoWeb.V2.ClusterJSONTest do
 
     cluster = build(:cluster, sap_instances: sap_instances)
 
-    %{
-      sap_instances: view_sap_instances,
-      sid: sid,
-      additional_sids: additional_sids
-    } =
+    %{sap_instances: view_sap_instances, sid: sid, additional_sids: additional_sids} =
       ClusterJSON.cluster(%{cluster: cluster})
 
     assert sid_2 == sid

--- a/test/trento_web/views/v2/cluster_view_json_test.exs
+++ b/test/trento_web/views/v2/cluster_view_json_test.exs
@@ -36,7 +36,11 @@ defmodule TrentoWeb.V2.ClusterJSONTest do
 
     cluster = build(:cluster, sap_instances: sap_instances)
 
-    %{sap_instances: view_sap_instances, sid: sid, additional_sids: additional_sids} =
+    %{
+      sap_instances: view_sap_instances,
+      sid: sid,
+      additional_sids: additional_sids
+    } =
       ClusterJSON.cluster(%{cluster: cluster})
 
     assert sid_2 == sid
@@ -47,5 +51,19 @@ defmodule TrentoWeb.V2.ClusterJSONTest do
              %{sid: sid_2, instance_number: inr_2},
              %{sid: sid_3, instance_number: inr_3}
            ] == view_sap_instances
+  end
+
+  test "should remove sid from resources" do
+    details = build(:hana_cluster_details)
+    cluster = build(:cluster, details: details)
+
+    %{
+      details: %{resources: resources}
+    } =
+      ClusterJSON.cluster(%{cluster: cluster})
+
+    Enum.each(resources, fn resource ->
+      refute Map.has_key?(resource, :sid)
+    end)
   end
 end


### PR DESCRIPTION
# Description

**Spoiler**: Don't worry about the code changes added. 99% of them are just tests. This change actually simplifies things, and if we were to remove the deprecated fields it would have less code than before.

In order to properly display the new resources table, rellocate the resources entries in the read models so they are flat-mapped directly in `details`. We don't need anymore `stopped_resources` nor `resources` inside `nodes/sap_systems`. These fields are now deprecated (i hope we can remove them before release 3.x.x, as deprecated fields number is increasing).

At the end, the plan is to have something like this in the Frontend (not included in this PR):

![image](https://github.com/user-attachments/assets/05c6d32b-160b-4b5e-9e2f-9526debe8c42)


## How was this tested?

UT
