### PR TITLE
Handle systemd units host discovery

### DIFF
--- a/lib/trento/discovery/payloads/host_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/host_discovery_payload.ex
@@ -28,6 +28,7 @@ defmodule Trento.Discovery.Payloads.HostDiscoveryPayload do
     field :os_version, :string
     field :fully_qualified_domain_name, :string
     field :prometheus_targets, :map
+    field :systemd_units, {:array, :map}, default: []
 
     field :installation_source, Ecto.Enum,
       values: [:community, :suse, :unknown],
@@ -43,6 +44,7 @@ defmodule Trento.Discovery.Payloads.HostDiscoveryPayload do
       attrs
       |> installation_source_to_downcase()
       |> arch_to_downcase()
+      |> handle_systemd_units()
 
     host
     |> cast(modified_attrs, fields())
@@ -58,4 +60,9 @@ defmodule Trento.Discovery.Payloads.HostDiscoveryPayload do
     do: %{attrs | "arch" => String.downcase(arch)}
 
   defp arch_to_downcase(attrs), do: attrs
+
+  defp handle_systemd_units(%{"systemd_units" => nil} = attrs),
+    do: %{attrs | "systemd_units" => []}
+
+  defp handle_systemd_units(attrs), do: attrs
 end

--- a/lib/trento/discovery/policies/host_policy.ex
+++ b/lib/trento/discovery/policies/host_policy.ex
@@ -140,7 +140,8 @@ defmodule Trento.Discovery.Policies.HostPolicy do
            os_version: os_version,
            installation_source: installation_source,
            fully_qualified_domain_name: fqdn,
-           prometheus_targets: prometheus_targets
+           prometheus_targets: prometheus_targets,
+           systemd_units: systemd_units
          } = payload
        ),
        do:
@@ -156,7 +157,8 @@ defmodule Trento.Discovery.Policies.HostPolicy do
            os_version: os_version,
            installation_source: installation_source,
            fully_qualified_domain_name: fqdn,
-           prometheus_targets: prometheus_targets
+           prometheus_targets: prometheus_targets,
+           systemd_units: systemd_units
          })
 
   defp build_ip_addresses(%{ip_addresses: ip_addresses, netmasks: nil}) do

--- a/lib/trento/hosts/commands/register_host.ex
+++ b/lib/trento/hosts/commands/register_host.ex
@@ -2,6 +2,7 @@ defmodule Trento.Hosts.Commands.RegisterHost do
   @moduledoc """
   Register a host to the monitoring system.
   """
+  alias Trento.Hosts.ValueObjects.SystemdUnit
 
   @required_fields [
     :host_id,
@@ -29,6 +30,7 @@ defmodule Trento.Hosts.Commands.RegisterHost do
     field :os_version, :string, default: "Unknown"
     field :fully_qualified_domain_name, :string
     field :prometheus_targets, :map
+    embeds_many :systemd_units, SystemdUnit
 
     field :installation_source, Ecto.Enum, values: [:community, :suse, :unknown]
     field :arch, Ecto.Enum, values: Architecture.values()

--- a/lib/trento/hosts/commands/register_host.ex
+++ b/lib/trento/hosts/commands/register_host.ex
@@ -30,9 +30,10 @@ defmodule Trento.Hosts.Commands.RegisterHost do
     field :os_version, :string, default: "Unknown"
     field :fully_qualified_domain_name, :string
     field :prometheus_targets, :map
-    embeds_many :systemd_units, SystemdUnit
 
     field :installation_source, Ecto.Enum, values: [:community, :suse, :unknown]
     field :arch, Ecto.Enum, values: Architecture.values()
+
+    embeds_many :systemd_units, SystemdUnit
   end
 end

--- a/lib/trento/hosts/events/host_details_updated.ex
+++ b/lib/trento/hosts/events/host_details_updated.ex
@@ -7,6 +7,8 @@ defmodule Trento.Hosts.Events.HostDetailsUpdated do
 
   require Trento.Hosts.Enums.Architecture, as: Architecture
 
+  alias Trento.Hosts.ValueObjects.SystemdUnit
+
   defevent version: 5 do
     field :host_id, Ecto.UUID
     field :hostname, :string
@@ -18,6 +20,7 @@ defmodule Trento.Hosts.Events.HostDetailsUpdated do
     field :socket_count, :integer
     field :os_version, :string
     field :prometheus_targets, :map
+    embeds_many :systemd_units, SystemdUnit
 
     field :installation_source, Ecto.Enum, values: [:community, :suse, :unknown]
     field :arch, Ecto.Enum, values: Architecture.values()
@@ -27,4 +30,5 @@ defmodule Trento.Hosts.Events.HostDetailsUpdated do
   def upcast(params, _, 3), do: Map.put(params, "fully_qualified_domain_name", nil)
   def upcast(params, _, 4), do: Map.put(params, "prometheus_targets", nil)
   def upcast(params, _, 5), do: Map.put(params, "arch", Architecture.unknown())
+  def upcast(params, _, 6), do: Map.put(params, "systemd_units", [])
 end

--- a/lib/trento/hosts/events/host_details_updated.ex
+++ b/lib/trento/hosts/events/host_details_updated.ex
@@ -9,7 +9,7 @@ defmodule Trento.Hosts.Events.HostDetailsUpdated do
 
   alias Trento.Hosts.ValueObjects.SystemdUnit
 
-  defevent version: 5 do
+  defevent version: 6 do
     field :host_id, Ecto.UUID
     field :hostname, :string
     field :fully_qualified_domain_name, :string
@@ -20,10 +20,11 @@ defmodule Trento.Hosts.Events.HostDetailsUpdated do
     field :socket_count, :integer
     field :os_version, :string
     field :prometheus_targets, :map
-    embeds_many :systemd_units, SystemdUnit
 
     field :installation_source, Ecto.Enum, values: [:community, :suse, :unknown]
     field :arch, Ecto.Enum, values: Architecture.values()
+
+    embeds_many :systemd_units, SystemdUnit
   end
 
   def upcast(params, _, 2), do: Map.put(params, "installation_source", :unknown)

--- a/lib/trento/hosts/events/host_registered.ex
+++ b/lib/trento/hosts/events/host_registered.ex
@@ -7,6 +7,8 @@ defmodule Trento.Hosts.Events.HostRegistered do
 
   require Trento.Hosts.Enums.Architecture, as: Architecture
 
+  alias Trento.Hosts.ValueObjects.SystemdUnit
+
   defevent version: 6 do
     field :host_id, Ecto.UUID
     field :hostname, :string
@@ -18,6 +20,7 @@ defmodule Trento.Hosts.Events.HostRegistered do
     field :os_version, :string
     field :fully_qualified_domain_name, :string
     field :prometheus_targets, :map
+    embeds_many :systemd_units, SystemdUnit
 
     field :installation_source, Ecto.Enum, values: [:community, :suse, :unknown]
     field :arch, Ecto.Enum, values: Architecture.values()
@@ -31,4 +34,5 @@ defmodule Trento.Hosts.Events.HostRegistered do
   def upcast(params, _, 4), do: Map.put(params, "fully_qualified_domain_name", nil)
   def upcast(params, _, 5), do: Map.put(params, "prometheus_targets", nil)
   def upcast(params, _, 6), do: Map.put(params, "arch", Architecture.unknown())
+  def upcast(params, _, 7), do: Map.put(params, "systemd_units", [])
 end

--- a/lib/trento/hosts/events/host_registered.ex
+++ b/lib/trento/hosts/events/host_registered.ex
@@ -9,7 +9,7 @@ defmodule Trento.Hosts.Events.HostRegistered do
 
   alias Trento.Hosts.ValueObjects.SystemdUnit
 
-  defevent version: 6 do
+  defevent version: 7 do
     field :host_id, Ecto.UUID
     field :hostname, :string
     field :ip_addresses, {:array, :string}

--- a/lib/trento/hosts/host.ex
+++ b/lib/trento/hosts/host.ex
@@ -72,7 +72,8 @@ defmodule Trento.Hosts.Host do
     AzureProvider,
     GcpProvider,
     SaptuneStatus,
-    SlesSubscription
+    SlesSubscription,
+    SystemdUnit
   }
 
   alias Trento.Hosts.Commands.{
@@ -156,6 +157,8 @@ defmodule Trento.Hosts.Host do
         gcp: [module: GcpProvider, identify_by_fields: [:project_id]]
       ],
       on_replace: :update
+
+    embeds_many :systemd_units, SystemdUnit
   end
 
   # Stop everything during the rollup process
@@ -176,7 +179,8 @@ defmodule Trento.Hosts.Host do
           os_version: os_version,
           fully_qualified_domain_name: fully_qualified_domain_name,
           installation_source: installation_source,
-          prometheus_targets: prometheus_targets
+          prometheus_targets: prometheus_targets,
+          systemd_units: systemd_units
         }
       ) do
     [
@@ -193,7 +197,8 @@ defmodule Trento.Hosts.Host do
         installation_source: installation_source,
         fully_qualified_domain_name: fully_qualified_domain_name,
         prometheus_targets: prometheus_targets,
-        heartbeat: :unknown
+        heartbeat: :unknown,
+        systemd_units: systemd_units
       }
     ] ++ maybe_emit_software_updates_discovery_events(host_id, nil, fully_qualified_domain_name)
   end
@@ -221,7 +226,8 @@ defmodule Trento.Hosts.Host do
           fully_qualified_domain_name: fully_qualified_domain_name,
           prometheus_targets: prometheus_targets,
           installation_source: installation_source,
-          deregistered_at: deregistered_at
+          deregistered_at: deregistered_at,
+          systemd_units: systemd_units
         },
         %RegisterHost{
           hostname: hostname,
@@ -234,7 +240,8 @@ defmodule Trento.Hosts.Host do
           os_version: os_version,
           fully_qualified_domain_name: fully_qualified_domain_name,
           prometheus_targets: prometheus_targets,
-          installation_source: installation_source
+          installation_source: installation_source,
+          systemd_units: systemd_units
         }
       )
       when not is_nil(deregistered_at) do
@@ -259,7 +266,8 @@ defmodule Trento.Hosts.Host do
           os_version: os_version,
           fully_qualified_domain_name: new_fully_qualified_domain_name,
           installation_source: installation_source,
-          prometheus_targets: prometheus_targets
+          prometheus_targets: prometheus_targets,
+          systemd_units: systemd_units
         }
       )
       when not is_nil(deregistered_at) do
@@ -277,7 +285,8 @@ defmodule Trento.Hosts.Host do
         os_version: os_version,
         fully_qualified_domain_name: new_fully_qualified_domain_name,
         installation_source: installation_source,
-        prometheus_targets: prometheus_targets
+        prometheus_targets: prometheus_targets,
+        systemd_units: systemd_units
       }
     ] ++
       maybe_emit_software_updates_discovery_events(host_id, nil, new_fully_qualified_domain_name)
@@ -314,7 +323,8 @@ defmodule Trento.Hosts.Host do
           socket_count: socket_count,
           os_version: os_version,
           installation_source: installation_source,
-          prometheus_targets: prometheus_targets
+          prometheus_targets: prometheus_targets,
+          systemd_units: systemd_units
         },
         %RegisterHost{
           hostname: hostname,
@@ -327,7 +337,8 @@ defmodule Trento.Hosts.Host do
           socket_count: socket_count,
           os_version: os_version,
           installation_source: installation_source,
-          prometheus_targets: prometheus_targets
+          prometheus_targets: prometheus_targets,
+          systemd_units: systemd_units
         }
       ) do
     []
@@ -349,7 +360,8 @@ defmodule Trento.Hosts.Host do
           socket_count: socket_count,
           os_version: os_version,
           installation_source: installation_source,
-          prometheus_targets: prometheus_targets
+          prometheus_targets: prometheus_targets,
+          systemd_units: systemd_units
         }
       ) do
     [
@@ -365,7 +377,8 @@ defmodule Trento.Hosts.Host do
         socket_count: socket_count,
         os_version: os_version,
         installation_source: installation_source,
-        prometheus_targets: prometheus_targets
+        prometheus_targets: prometheus_targets,
+        systemd_units: systemd_units
       }
     ] ++
       maybe_emit_software_updates_discovery_events(
@@ -631,7 +644,8 @@ defmodule Trento.Hosts.Host do
           fully_qualified_domain_name: fully_qualified_domain_name,
           prometheus_targets: prometheus_targets,
           installation_source: installation_source,
-          heartbeat: heartbeat
+          heartbeat: heartbeat,
+          systemd_units: systemd_units
         }
       ) do
     %Host{
@@ -648,7 +662,8 @@ defmodule Trento.Hosts.Host do
         fully_qualified_domain_name: fully_qualified_domain_name,
         prometheus_targets: prometheus_targets,
         installation_source: installation_source,
-        heartbeat: heartbeat
+        heartbeat: heartbeat,
+        systemd_units: systemd_units
     }
   end
 
@@ -665,7 +680,8 @@ defmodule Trento.Hosts.Host do
           os_version: os_version,
           fully_qualified_domain_name: fully_qualified_domain_name,
           prometheus_targets: prometheus_targets,
-          installation_source: installation_source
+          installation_source: installation_source,
+          systemd_units: systemd_units
         }
       ) do
     %Host{
@@ -680,7 +696,8 @@ defmodule Trento.Hosts.Host do
         os_version: os_version,
         fully_qualified_domain_name: fully_qualified_domain_name,
         prometheus_targets: prometheus_targets,
-        installation_source: installation_source
+        installation_source: installation_source,
+        systemd_units: systemd_units
     }
   end
 

--- a/lib/trento/hosts/projections/host_projector.ex
+++ b/lib/trento/hosts/projections/host_projector.ex
@@ -57,7 +57,7 @@ defmodule Trento.Hosts.Projections.HostProjector do
           fully_qualified_domain_name: fully_qualified_domain_name,
           heartbeat: heartbeat,
           prometheus_targets: prometheus_targets,
-          systemd_units: struct_list_to_map_list(systemd_units)
+          systemd_units: map_list_from_struct_list(systemd_units)
         })
 
       Ecto.Multi.insert(multi, :host, changeset,
@@ -168,7 +168,7 @@ defmodule Trento.Hosts.Projections.HostProjector do
           agent_version: agent_version,
           arch: arch,
           prometheus_targets: prometheus_targets,
-          systemd_units: struct_list_to_map_list(systemd_units)
+          systemd_units: map_list_from_struct_list(systemd_units)
         })
 
       Ecto.Multi.update(multi, :host, changeset)
@@ -429,9 +429,11 @@ defmodule Trento.Hosts.Projections.HostProjector do
 
   def after_update(_, _, _), do: :ok
 
-  defp struct_list_to_map_list(structs) when is_list(structs) do
+  defp map_list_from_struct_list(structs) when is_list(structs) do
     Enum.map(structs, &map_from_struct/1)
   end
+
+  defp map_list_from_struct_list(structs), do: structs
 
   defp map_from_struct(struct) when is_struct(struct) do
     Map.from_struct(struct)

--- a/lib/trento/hosts/projections/host_projector.ex
+++ b/lib/trento/hosts/projections/host_projector.ex
@@ -41,7 +41,8 @@ defmodule Trento.Hosts.Projections.HostProjector do
       arch: arch,
       fully_qualified_domain_name: fully_qualified_domain_name,
       heartbeat: heartbeat,
-      prometheus_targets: prometheus_targets
+      prometheus_targets: prometheus_targets,
+      systemd_units: systemd_units
     },
     fn multi ->
       {addresses, netmasks} = parse_address_netmask(ip_addresses)
@@ -55,7 +56,8 @@ defmodule Trento.Hosts.Projections.HostProjector do
           arch: arch,
           fully_qualified_domain_name: fully_qualified_domain_name,
           heartbeat: heartbeat,
-          prometheus_targets: prometheus_targets
+          prometheus_targets: prometheus_targets,
+          systemd_units: struct_list_to_map_list(systemd_units)
         })
 
       Ecto.Multi.insert(multi, :host, changeset,
@@ -149,7 +151,8 @@ defmodule Trento.Hosts.Projections.HostProjector do
       fully_qualified_domain_name: fully_qualified_domain_name,
       agent_version: agent_version,
       arch: arch,
-      prometheus_targets: prometheus_targets
+      prometheus_targets: prometheus_targets,
+      systemd_units: systemd_units
     },
     fn multi ->
       {addresses, netmasks} = parse_address_netmask(ip_addresses)
@@ -164,7 +167,8 @@ defmodule Trento.Hosts.Projections.HostProjector do
           fully_qualified_domain_name: fully_qualified_domain_name,
           agent_version: agent_version,
           arch: arch,
-          prometheus_targets: prometheus_targets
+          prometheus_targets: prometheus_targets,
+          systemd_units: struct_list_to_map_list(systemd_units)
         })
 
       Ecto.Multi.update(multi, :host, changeset)
@@ -256,12 +260,6 @@ defmodule Trento.Hosts.Projections.HostProjector do
       Ecto.Multi.update(multi, :host, changeset)
     end
   )
-
-  def map_from_struct(struct) when is_struct(struct) do
-    Map.from_struct(struct)
-  end
-
-  def map_from_struct(_), do: nil
 
   @impl true
   @spec after_update(any, any, any) :: :ok | {:error, any}
@@ -430,6 +428,16 @@ defmodule Trento.Hosts.Projections.HostProjector do
   end
 
   def after_update(_, _, _), do: :ok
+
+  defp struct_list_to_map_list(structs) when is_list(structs) do
+    Enum.map(structs, &map_from_struct/1)
+  end
+
+  defp map_from_struct(struct) when is_struct(struct) do
+    Map.from_struct(struct)
+  end
+
+  defp map_from_struct(_), do: nil
 
   defp parse_address_netmask(ip_addresses) do
     ip_addresses

--- a/lib/trento/hosts/projections/host_read_model.ex
+++ b/lib/trento/hosts/projections/host_read_model.ex
@@ -42,8 +42,6 @@ defmodule Trento.Hosts.Projections.HostReadModel do
     field :saptune_status, Trento.Support.Ecto.Payload, keys_as_atoms: true
     field :prometheus_targets, :map
 
-    embeds_many :systemd_units, SystemdUnit, on_replace: :delete
-
     has_many :tags, Tag, foreign_key: :resource_id
 
     has_many :sles_subscriptions, SlesSubscriptionReadModel,
@@ -69,6 +67,8 @@ defmodule Trento.Hosts.Projections.HostReadModel do
 
     field :deregistered_at, :utc_datetime_usec
     timestamps(type: :utc_datetime_usec)
+
+    embeds_many :systemd_units, SystemdUnit, on_replace: :delete
   end
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()

--- a/lib/trento/hosts/projections/host_read_model.ex
+++ b/lib/trento/hosts/projections/host_read_model.ex
@@ -14,6 +14,7 @@ defmodule Trento.Hosts.Projections.HostReadModel do
   alias Trento.Clusters.Projections.ClusterReadModel
   alias Trento.Databases.Projections.DatabaseInstanceReadModel
   alias Trento.Hosts.Projections.SlesSubscriptionReadModel
+  alias Trento.Hosts.ValueObjects.SystemdUnit
   alias Trento.SapSystems.Projections.ApplicationInstanceReadModel
   alias Trento.Tags.Tag
 
@@ -40,6 +41,8 @@ defmodule Trento.Hosts.Projections.HostReadModel do
     field :provider_data, :map
     field :saptune_status, Trento.Support.Ecto.Payload, keys_as_atoms: true
     field :prometheus_targets, :map
+
+    embeds_many :systemd_units, SystemdUnit, on_replace: :delete
 
     has_many :tags, Tag, foreign_key: :resource_id
 
@@ -70,6 +73,8 @@ defmodule Trento.Hosts.Projections.HostReadModel do
 
   @spec changeset(t() | Ecto.Changeset.t(), map) :: Ecto.Changeset.t()
   def changeset(host, attrs) do
-    cast(host, attrs, __MODULE__.__schema__(:fields))
+    host
+    |> cast(attrs, __MODULE__.__schema__(:fields) -- [:systemd_units])
+    |> cast_embed(:systemd_units)
   end
 end

--- a/lib/trento/hosts/value_objects/systemd_unit.ex
+++ b/lib/trento/hosts/value_objects/systemd_unit.ex
@@ -1,0 +1,13 @@
+defmodule Trento.Hosts.ValueObjects.SystemdUnit do
+  @moduledoc """
+  Systemd unit value object
+  """
+  @required_fields :all
+
+  use Trento.Support.Type
+
+  deftype do
+    field :name, :string
+    field :unit_file_state, :string
+  end
+end

--- a/lib/trento_web/openapi/v1/schema/host.ex
+++ b/lib/trento_web/openapi/v1/schema/host.ex
@@ -39,6 +39,26 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Host do
     )
   end
 
+  defmodule SystemdUnit do
+    @moduledoc false
+
+    OpenApiSpex.schema(
+      %{
+        title: "SystemdUnit",
+        type: :object,
+        additionalProperties: false,
+        properties: %{
+          name: %Schema{type: :string, description: "Name of the systemd unit"},
+          unit_file_state: %Schema{
+            type: :string,
+            description: "State of the systemd unit. Whether it is enabled or disabled"
+          }
+        }
+      },
+      struct?: false
+    )
+  end
+
   defmodule HostItem do
     @moduledoc false
 
@@ -71,6 +91,12 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Host do
           agent_version: %Schema{
             type: :string,
             description: "Version of the agent installed on the host"
+          },
+          systemd_units: %Schema{
+            title: "SystemdUnits",
+            description: "A list of systemd units on the host",
+            type: :array,
+            items: SystemdUnit
           },
           arch: HostArchitecture,
           health: ResourceHealth,

--- a/priv/repo/migrations/20250702154303_add_systemd_units_to_host_read_model.exs
+++ b/priv/repo/migrations/20250702154303_add_systemd_units_to_host_read_model.exs
@@ -1,0 +1,9 @@
+defmodule Trento.Repo.Migrations.AddSystemdUnitsToHostReadModel do
+  use Ecto.Migration
+
+  def change do
+    alter table(:hosts) do
+      add :systemd_units, :map
+    end
+  end
+end

--- a/test/fixtures/discovery/host_discovery.json
+++ b/test/fixtures/discovery/host_discovery.json
@@ -11,6 +11,12 @@
     "socket_count": 1,
     "total_memory_mb": 4096,
     "agent_version": "0.1.0",
-    "fully_qualified_domain_name": "suse.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "suse.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/aws-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_host_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_host_discovery.json
@@ -21,6 +21,12 @@
     "agent_version": "2.1.0",
     "total_memory_mb": 32107,
     "fully_qualified_domain_name": "vmhdbdev02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/aws-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_host_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_host_discovery.json
@@ -23,6 +23,12 @@
     "agent_version": "2.1.0",
     "total_memory_mb": 32107,
     "fully_qualified_domain_name": "vmhdbdev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/aws-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_host_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_host_discovery.json
@@ -23,6 +23,12 @@
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
     "fully_qualified_domain_name": "vmnwdev04.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/aws-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_host_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_host_discovery.json
@@ -23,6 +23,12 @@
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
     "fully_qualified_domain_name": "vmnwdev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/aws-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_host_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_host_discovery.json
@@ -23,6 +23,12 @@
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
     "fully_qualified_domain_name": "vmnwdev03.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/aws-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_host_discovery.json
+++ b/test/fixtures/scenarios/aws-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_host_discovery.json
@@ -23,6 +23,12 @@
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
     "fully_qualified_domain_name": "vmnwdev02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/gcp-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_host_discovery.json
@@ -21,6 +21,12 @@
     "agent_version": "2.1.0",
     "total_memory_mb": 32107,
     "fully_qualified_domain_name": "vmhdbdev02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/gcp-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_host_discovery.json
@@ -23,6 +23,12 @@
     "agent_version": "2.1.0",
     "total_memory_mb": 32107,
     "fully_qualified_domain_name": "vmhdbdev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/gcp-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_host_discovery.json
@@ -23,6 +23,12 @@
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
     "fully_qualified_domain_name": "vmnwdev04.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/gcp-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_host_discovery.json
@@ -23,6 +23,12 @@
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
     "fully_qualified_domain_name": "vmnwdev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/gcp-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_host_discovery.json
@@ -23,6 +23,12 @@
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
     "fully_qualified_domain_name": "vmnwdev03.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/gcp-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_host_discovery.json
@@ -23,6 +23,12 @@
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
     "fully_qualified_domain_name": "vmnwdev02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/hana-diskless-sbd/0f6e6491-21f2-495e-9f2d-bc50b872efaf_host_discovery.json
+++ b/test/fixtures/scenarios/hana-diskless-sbd/0f6e6491-21f2-495e-9f2d-bc50b872efaf_host_discovery.json
@@ -26,6 +26,12 @@
     "socket_count": 2,
     "total_memory_mb": 1547378,
     "fully_qualified_domain_name": "vmh3shdb01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/hana-diskless-sbd/43dcb497-2652-4254-b53a-3ff1d3b2a0ff_host_discovery.json
+++ b/test/fixtures/scenarios/hana-diskless-sbd/43dcb497-2652-4254-b53a-3ff1d3b2a0ff_host_discovery.json
@@ -22,6 +22,12 @@
     "socket_count": 1,
     "total_memory_mb": 128418,
     "fully_qualified_domain_name": "vmh3shdb03.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/hana-diskless-sbd/5f2632a9-7b18-4c37-955a-fe16cadaaef4_host_discovery.json
+++ b/test/fixtures/scenarios/hana-diskless-sbd/5f2632a9-7b18-4c37-955a-fe16cadaaef4_host_discovery.json
@@ -24,6 +24,12 @@
     "socket_count": 1,
     "total_memory_mb": 1547378,
     "fully_qualified_domain_name": "vmh3shdb02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/hana-scale-out/1109be4b-54fb-4796-b073-f4cc04d2ca55_host_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-out/1109be4b-54fb-4796-b073-f4cc04d2ca55_host_discovery.json
@@ -22,6 +22,12 @@
     "socket_count": 1,
     "total_memory_mb": 7888,
     "fully_qualified_domain_name": "vms4prdiscsi.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/hana-scale-out/12ab9a68-c047-4eda-81c8-1e24578d9973_host_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-out/12ab9a68-c047-4eda-81c8-1e24578d9973_host_discovery.json
@@ -22,6 +22,12 @@
     "socket_count": 1,
     "total_memory_mb": 32043,
     "fully_qualified_domain_name": "vms4prdhdb04.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/hana-scale-out/16bd3ed1-923d-46ff-b6d0-9bfed42e387b_host_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-out/16bd3ed1-923d-46ff-b6d0-9bfed42e387b_host_discovery.json
@@ -24,6 +24,12 @@
     "socket_count": 1,
     "total_memory_mb": 32043,
     "fully_qualified_domain_name": "vms4prdhdb03.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/hana-scale-out/28edd956-2155-487e-a4eb-f3d4cf7c9543_host_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-out/28edd956-2155-487e-a4eb-f3d4cf7c9543_host_discovery.json
@@ -22,6 +22,12 @@
     "socket_count": 1,
     "total_memory_mb": 3862,
     "fully_qualified_domain_name": "vms4prdmm.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/hana-scale-out/33ec3a15-103b-453b-b6b2-f3f971582dc_host_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-out/33ec3a15-103b-453b-b6b2-f3f971582dc_host_discovery.json
@@ -22,6 +22,12 @@
     "socket_count": 1,
     "total_memory_mb": 32043,
     "fully_qualified_domain_name": "vms4prdhdb02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/hana-scale-out/f3463fd1-004a-4214-afd4-b15160b0d521_host_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-out/f3463fd1-004a-4214-afd4-b15160b0d521_host_discovery.json
@@ -22,6 +22,12 @@
     "socket_count": 1,
     "total_memory_mb": 32043,
     "fully_qualified_domain_name": "vms4prdhdb01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/hana-scale-up-angi/4b67842f-ccf7-46a4-a344-9e918648b117_host_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-up-angi/4b67842f-ccf7-46a4-a344-9e918648b117_host_discovery.json
@@ -22,6 +22,12 @@
     "os_version": "15-SP5",
     "socket_count": 1,
     "total_memory_mb": 32043,
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/hana-scale-up-angi/851a4dd3-9693-44c3-a40b-b32d22872e74_host_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-up-angi/851a4dd3-9693-44c3-a40b-b32d22872e74_host_discovery.json
@@ -24,6 +24,12 @@
     "os_version": "15-SP5",
     "socket_count": 1,
     "total_memory_mb": 32043,
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/hana-scale-up-cost-opt/2372b24f-3d7a-5d01-9b1a-a2c4c95c53d4_host_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-up-cost-opt/2372b24f-3d7a-5d01-9b1a-a2c4c95c53d4_host_discovery.json
@@ -22,6 +22,12 @@
     "os_version": "15-SP4",
     "socket_count": 1,
     "total_memory_mb": 32097,
-    "arch": "ppc64le"
+    "arch": "ppc64le",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/hana-scale-up-cost-opt/fa7a5602-232b-5389-96a6-f5f5de6ff9a2_host_discovery.json
+++ b/test/fixtures/scenarios/hana-scale-up-cost-opt/fa7a5602-232b-5389-96a6-f5f5de6ff9a2_host_discovery.json
@@ -24,6 +24,12 @@
     "os_version": "15-SP4",
     "socket_count": 1,
     "total_memory_mb": 32097,
-    "arch": "ppc64le"
+    "arch": "ppc64le",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/098fc159-3ed6-58e7-91be-38fda8a833ea_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/098fc159-3ed6-58e7-91be-38fda8a833ea_host_discovery.json
@@ -23,6 +23,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
-    "fully_qualified_domain_name": "vmnwqas03.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmnwqas03.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4_host_discovery.json
@@ -21,6 +21,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 32107,
-    "fully_qualified_domain_name": "vmhdbdev02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmhdbdev02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0fc07435-7ee2-54ca-b0de-fb27ffdc5deb_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/0fc07435-7ee2-54ca-b0de-fb27ffdc5deb_host_discovery.json
@@ -23,6 +23,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
-    "fully_qualified_domain_name": "vmnwprd04.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmnwprd04.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/116d49bd-85e1-5e59-b820-83f66db8800c_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/116d49bd-85e1-5e59-b820-83f66db8800c_host_discovery.json
@@ -23,6 +23,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
-    "fully_qualified_domain_name": "vmnwprd01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmnwprd01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_host_discovery.json
@@ -23,6 +23,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 32107,
-    "fully_qualified_domain_name": "vmhdbdev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmhdbdev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/1b0e9297-97dd-55d6-9874-8efde4d84c90_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/1b0e9297-97dd-55d6-9874-8efde4d84c90_host_discovery.json
@@ -23,6 +23,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
-    "fully_qualified_domain_name": "vmnwdev04.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmnwdev04.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/21de186a-e38f-5804-b643-7f4ef22fecfd_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/21de186a-e38f-5804-b643-7f4ef22fecfd_host_discovery.json
@@ -20,6 +20,12 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951
+    "total_memory_mb": 7951,
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/240f96b1-8d26-53b7-9e99-ffb0f2e735bf_host_discovery.json
@@ -23,6 +23,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
-    "fully_qualified_domain_name": "vmdrbddev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmdrbddev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/25677e37-fd33-5005-896c-9275b1284534_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/25677e37-fd33-5005-896c-9275b1284534_host_discovery.json
@@ -23,6 +23,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
-    "fully_qualified_domain_name": "vmnwqas01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmnwqas01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/3711ea88-9ccc-5b07-8f9d-042be449d72b_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/3711ea88-9ccc-5b07-8f9d-042be449d72b_host_discovery.json
@@ -23,6 +23,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
-    "fully_qualified_domain_name": "vmnwqas02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmnwqas02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/422686d6-b2d1-5092-93e8-a744854f5085_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/422686d6-b2d1-5092-93e8-a744854f5085_host_discovery.json
@@ -21,6 +21,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
-    "fully_qualified_domain_name": "vmdrbdqas02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmdrbdqas02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/4b30a6af-4b52-5bda-bccb-f2248a12c992_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/4b30a6af-4b52-5bda-bccb-f2248a12c992_host_discovery.json
@@ -23,6 +23,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
-    "fully_qualified_domain_name": "vmnwprd02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmnwprd02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/69f4dcbb-efa2-5a16-8bc8-01df7dbb7384_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/69f4dcbb-efa2-5a16-8bc8-01df7dbb7384_host_discovery.json
@@ -21,6 +21,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 3421,
-    "fully_qualified_domain_name": "vmiscsi01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmiscsi01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_host_discovery.json
@@ -23,6 +23,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
-    "fully_qualified_domain_name": "vmnwdev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmnwdev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/81e9b629-c1e7-538f-bff1-47d3a6580522_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/81e9b629-c1e7-538f-bff1-47d3a6580522_host_discovery.json
@@ -23,6 +23,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
-    "fully_qualified_domain_name": "vmnwqas04.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmnwqas04.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/927901fa-2c87-524e-b18c-3ef5187f504f_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/927901fa-2c87-524e-b18c-3ef5187f504f_host_discovery.json
@@ -21,6 +21,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
-    "fully_qualified_domain_name": "vmdrbdprd02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmdrbdprd02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/99cf8a3a-48d6-57a4-b302-6e4482227ab6_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/99cf8a3a-48d6-57a4-b302-6e4482227ab6_host_discovery.json
@@ -23,6 +23,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 32107,
-    "fully_qualified_domain_name": "vmhdbqas01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmhdbqas01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a26b6d0-6e72-597c-9fe5-152a6875f214_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a26b6d0-6e72-597c-9fe5-152a6875f214_host_discovery.json
@@ -21,6 +21,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 3421,
-    "fully_qualified_domain_name": "vmiscsi01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmiscsi01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_host_discovery.json
@@ -23,6 +23,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
-    "fully_qualified_domain_name": "vmnwdev03.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmnwdev03.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9cd46919-5f19-59aa-993e-cf3736c71053_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/9cd46919-5f19-59aa-993e-cf3736c71053_host_discovery.json
@@ -23,6 +23,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 32107,
-    "fully_qualified_domain_name": "vmhdbprd01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmhdbprd01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a09d9cf3-46c1-505c-8fb8-4b0a71a9114e_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a09d9cf3-46c1-505c-8fb8-4b0a71a9114e_host_discovery.json
@@ -23,6 +23,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
-    "fully_qualified_domain_name": "vmdrbdprd01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmdrbdprd01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a3297d85-5e8b-5ac5-b8a3-55eebc2b8d12_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/a3297d85-5e8b-5ac5-b8a3-55eebc2b8d12_host_discovery.json
@@ -23,6 +23,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
-    "fully_qualified_domain_name": "vmnwprd03.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmnwprd03.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/b767b3e9-e802-587e-a442-541d093b86b9_host_discovery.json
@@ -21,6 +21,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 32107,
-    "fully_qualified_domain_name": "vmhdbprd02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmhdbprd02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/ddcb7992-2ffb-5c10-8b39-80685f6eaaba_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/ddcb7992-2ffb-5c10-8b39-80685f6eaaba_host_discovery.json
@@ -23,6 +23,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
-    "fully_qualified_domain_name": "vmdrbdqas01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmdrbdqas01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/e0c182db-32ff-55c6-a9eb-2b82dd21bc8b_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/e0c182db-32ff-55c6-a9eb-2b82dd21bc8b_host_discovery.json
@@ -21,6 +21,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 32107,
-    "fully_qualified_domain_name": "vmhdbqas02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmhdbqas02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/f0c808b3-d869-5192-a944-20f66a6a8449_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/f0c808b3-d869-5192-a944-20f66a6a8449_host_discovery.json
@@ -21,6 +21,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 3422,
-    "fully_qualified_domain_name": "vmiscsi01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmiscsi01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_host_discovery.json
+++ b/test/fixtures/scenarios/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_host_discovery.json
@@ -23,6 +23,12 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
-    "fully_qualified_domain_name": "vmnwdev02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net"
+    "fully_qualified_domain_name": "vmnwdev02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/multi-tenant/544cbc99-c856-4b0a-88cf-e6b8db4606f6_host_discovery.json
+++ b/test/fixtures/scenarios/multi-tenant/544cbc99-c856-4b0a-88cf-e6b8db4606f6_host_discovery.json
@@ -22,7 +22,13 @@
     "os_version": "15-SP4",
     "socket_count": 1,
     "total_memory_mb": 64240,
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   },
   "discovery_type": "host_discovery",
   "agent_id": "544cbc99-c856-4b0a-88cf-e6b8db4606f6"

--- a/test/fixtures/scenarios/multi-tenant/c0ecf7d1-bdd3-4c29-b768-cfb97efcc585_host_discovery.json
+++ b/test/fixtures/scenarios/multi-tenant/c0ecf7d1-bdd3-4c29-b768-cfb97efcc585_host_discovery.json
@@ -20,7 +20,13 @@
     "os_version": "15-SP4",
     "socket_count": 1,
     "total_memory_mb": 7880,
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   },
   "discovery_type": "host_discovery",
   "agent_id": "c0ecf7d1-bdd3-4c29-b768-cfb97efcc585"

--- a/test/fixtures/scenarios/multi-tenant/e0564d66-be9e-4763-9917-655af1bb4b58_host_discovery.json
+++ b/test/fixtures/scenarios/multi-tenant/e0564d66-be9e-4763-9917-655af1bb4b58_host_discovery.json
@@ -22,7 +22,13 @@
     "os_version": "15-SP4",
     "socket_count": 1,
     "total_memory_mb": 64240,
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   },
   "discovery_type": "host_discovery",
   "agent_id": "e0564d66-be9e-4763-9917-655af1bb4b58"

--- a/test/fixtures/scenarios/multi-tenant/edf755fd-abc7-4883-af81-8b06d836db37_host_discovery.json
+++ b/test/fixtures/scenarios/multi-tenant/edf755fd-abc7-4883-af81-8b06d836db37_host_discovery.json
@@ -20,7 +20,13 @@
     "os_version": "15-SP4",
     "socket_count": 1,
     "total_memory_mb": 7880,
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   },
   "discovery_type": "host_discovery",
   "agent_id": "edf755fd-abc7-4883-af81-8b06d836db37"

--- a/test/fixtures/scenarios/multi-tenant/f7a8969b-db9e-4162-b82a-d5cfafe1c4e9_host_discovery.json
+++ b/test/fixtures/scenarios/multi-tenant/f7a8969b-db9e-4162-b82a-d5cfafe1c4e9_host_discovery.json
@@ -22,7 +22,13 @@
     "os_version": "15-SP5",
     "socket_count": 1,
     "total_memory_mb": 64248,
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   },
   "discovery_type": "host_discovery",
   "agent_id": "f7a8969b-db9e-4162-b82a-d5cfafe1c4e9"

--- a/test/fixtures/scenarios/sap-system-java/a18a203d-4f2f-4d21-b9a5-e300a9c5eeee_host_discovery.json
+++ b/test/fixtures/scenarios/sap-system-java/a18a203d-4f2f-4d21-b9a5-e300a9c5eeee_host_discovery.json
@@ -22,6 +22,12 @@
     "os_version": "15-SP5",
     "socket_count": 1,
     "total_memory_mb": 7888,
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/single-hana-single-app/c4914bd4-efa3-553a-9a52-e9b562e210e5_host_discovery.json
+++ b/test/fixtures/scenarios/single-hana-single-app/c4914bd4-efa3-553a-9a52-e9b562e210e5_host_discovery.json
@@ -22,6 +22,12 @@
     "socket_count": 1,
     "total_memory_mb": 31578,
     "fully_qualified_domain_name": "trento-hana01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/fixtures/scenarios/single-hana-single-app/e77ab524-c4e4-5381-bb59-5af8639d52a4_host_discovery.json
+++ b/test/fixtures/scenarios/single-hana-single-app/e77ab524-c4e4-5381-bb59-5af8639d52a4_host_discovery.json
@@ -36,6 +36,12 @@
     "socket_count": 1,
     "total_memory_mb": 15699,
     "fully_qualified_domain_name": "trento-vmnetweaver01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
-    "arch": "x86_64"
+    "arch": "x86_64",
+    "systemd_units": [
+      {
+        "name": "pacemaker.service",
+        "unit_file_state": "enabled"
+      }
+    ]
   }
 }

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -223,7 +223,8 @@ defmodule Trento.Factory do
       deregistered_at: nil,
       selected_checks: Enum.map(0..4, fn _ -> Faker.StarWars.planet() end),
       saptune_status: nil,
-      prometheus_targets: build(:host_prometheus_targets)
+      prometheus_targets: build(:host_prometheus_targets),
+      systemd_units: build_list(2, :host_systemd_unit)
     }
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -34,7 +34,8 @@ defmodule Trento.Factory do
     SaptuneSolution,
     SaptuneStaging,
     SaptuneStatus,
-    SlesSubscription
+    SlesSubscription,
+    SystemdUnit
   }
 
   alias Trento.SapSystems.Instance
@@ -183,7 +184,8 @@ defmodule Trento.Factory do
       fully_qualified_domain_name: Faker.Internet.domain_name(),
       installation_source: Enum.random([:community, :suse, :unknown]),
       prometheus_targets: build(:host_prometheus_targets),
-      heartbeat: :unknown
+      heartbeat: :unknown,
+      systemd_units: build_list(2, :host_systemd_unit)
     }
   end
 
@@ -982,6 +984,13 @@ defmodule Trento.Factory do
   def host_prometheus_targets_factory do
     %{
       "node_exporter" => "#{Faker.Internet.ip_v4_address()}:9100"
+    }
+  end
+
+  def host_systemd_unit_factory do
+    %SystemdUnit{
+      name: Faker.UUID.v4(),
+      unit_file_state: Enum.random(["enabled", "disabled", "unknown"])
     }
   end
 

--- a/test/trento/discovery/policies/host_policy_test.exs
+++ b/test/trento/discovery/policies/host_policy_test.exs
@@ -119,7 +119,7 @@ defmodule Trento.Discovery.Policies.HostPolicyTest do
              |> HostPolicy.handle()
   end
 
-  test "should return the expected commands when a host_discovery payload with empty//incorrect systemd_units is handled" do
+  test "should return the expected commands when a host_discovery payload with empty/incorrect systemd_units is handled" do
     scenarios = [
       %{
         name: "without systemd_units",

--- a/test/trento/hosts/events/host_details_updated_test.exs
+++ b/test/trento/hosts/events/host_details_updated_test.exs
@@ -17,7 +17,7 @@ defmodule Trento.Hosts.Events.HostDetailsUpdatedTest do
       os_version = Faker.App.version()
 
       assert %HostDetailsUpdated{
-               version: 5,
+               version: 6,
                host_id: host_id,
                hostname: hostname,
                fully_qualified_domain_name: nil,
@@ -29,7 +29,8 @@ defmodule Trento.Hosts.Events.HostDetailsUpdatedTest do
                os_version: os_version,
                arch: Architecture.unknown(),
                installation_source: :unknown,
-               prometheus_targets: nil
+               prometheus_targets: nil,
+               systemd_units: []
              } ==
                %{
                  "host_id" => host_id,

--- a/test/trento/hosts/events/host_registered_test.exs
+++ b/test/trento/hosts/events/host_registered_test.exs
@@ -15,7 +15,7 @@ defmodule Trento.Hosts.Events.HostRegisteredTest do
       os_version = Faker.App.version()
 
       assert %HostRegistered{
-               version: 6,
+               version: 7,
                host_id: host_id,
                hostname: hostname,
                fully_qualified_domain_name: nil,
@@ -29,7 +29,8 @@ defmodule Trento.Hosts.Events.HostRegisteredTest do
                installation_source: :unknown,
                prometheus_targets: nil,
                heartbeat: :unknown,
-               health: :unknown
+               health: :unknown,
+               systemd_units: []
              } ==
                %{
                  "host_id" => host_id,

--- a/test/trento/hosts/host_test.exs
+++ b/test/trento/hosts/host_test.exs
@@ -73,6 +73,7 @@ defmodule Trento.Hosts.HostTest do
       arch = Enum.random(Architecture.values())
       installation_source = Enum.random([:community, :suse, :unknown])
       prometheus_targets = build(:host_prometheus_targets)
+      systemd_units = build_list(2, :host_systemd_unit)
 
       assert_events_and_state(
         [],
@@ -88,7 +89,8 @@ defmodule Trento.Hosts.HostTest do
           arch: arch,
           installation_source: installation_source,
           fully_qualified_domain_name: nil,
-          prometheus_targets: prometheus_targets
+          prometheus_targets: prometheus_targets,
+          systemd_units: Enum.map(systemd_units, &Map.from_struct/1)
         }),
         %HostRegistered{
           host_id: host_id,
@@ -102,7 +104,8 @@ defmodule Trento.Hosts.HostTest do
           arch: arch,
           installation_source: installation_source,
           prometheus_targets: prometheus_targets,
-          heartbeat: :unknown
+          heartbeat: :unknown,
+          systemd_units: systemd_units
         },
         %Host{
           host_id: host_id,
@@ -117,7 +120,8 @@ defmodule Trento.Hosts.HostTest do
           arch: arch,
           installation_source: installation_source,
           prometheus_targets: prometheus_targets,
-          heartbeat: :unknown
+          heartbeat: :unknown,
+          systemd_units: systemd_units
         }
       )
     end
@@ -166,7 +170,8 @@ defmodule Trento.Hosts.HostTest do
             arch: arch,
             installation_source: installation_source,
             prometheus_targets: prometheus_targets,
-            heartbeat: :unknown
+            heartbeat: :unknown,
+            systemd_units: []
           },
           %SoftwareUpdatesDiscoveryRequested{
             host_id: host_id,
@@ -186,7 +191,8 @@ defmodule Trento.Hosts.HostTest do
           arch: arch,
           installation_source: installation_source,
           prometheus_targets: prometheus_targets,
-          heartbeat: :unknown
+          heartbeat: :unknown,
+          systemd_units: []
         }
       )
     end
@@ -218,6 +224,7 @@ defmodule Trento.Hosts.HostTest do
         arch = Enum.random(Architecture.values())
         installation_source = Enum.random([:community, :suse, :unknown])
         prometheus_targets = build(:host_prometheus_targets)
+        systemd_units = build_list(2, :host_systemd_unit)
 
         assert_events_and_state(
           build(:host_registered_event,
@@ -232,7 +239,8 @@ defmodule Trento.Hosts.HostTest do
             os_version: os_version,
             arch: arch,
             installation_source: installation_source,
-            prometheus_targets: prometheus_targets
+            prometheus_targets: prometheus_targets,
+            systemd_units: systemd_units
           ),
           RegisterHost.new!(%{
             host_id: host_id,
@@ -246,7 +254,8 @@ defmodule Trento.Hosts.HostTest do
             os_version: os_version,
             arch: arch,
             installation_source: installation_source,
-            prometheus_targets: prometheus_targets
+            prometheus_targets: prometheus_targets,
+            systemd_units: Enum.map(systemd_units, &Map.from_struct/1)
           }),
           [
             %HostDetailsUpdated{
@@ -261,7 +270,8 @@ defmodule Trento.Hosts.HostTest do
               os_version: os_version,
               arch: arch,
               installation_source: installation_source,
-              prometheus_targets: prometheus_targets
+              prometheus_targets: prometheus_targets,
+              systemd_units: systemd_units
             },
             %SoftwareUpdatesDiscoveryRequested{
               host_id: host_id,
@@ -281,7 +291,8 @@ defmodule Trento.Hosts.HostTest do
             arch: arch,
             installation_source: installation_source,
             prometheus_targets: prometheus_targets,
-            heartbeat: :unknown
+            heartbeat: :unknown,
+            systemd_units: systemd_units
           }
         )
       end
@@ -304,6 +315,7 @@ defmodule Trento.Hosts.HostTest do
         arch = Enum.random(Architecture.values())
         installation_source = Enum.random([:community, :suse, :unknown])
         prometheus_targets = %{}
+        systemd_units = build_list(2, :host_systemd_unit)
 
         initial_agent_version = Faker.Internet.slug()
         new_agent_version = Faker.StarWars.character()
@@ -321,7 +333,8 @@ defmodule Trento.Hosts.HostTest do
             os_version: os_version,
             arch: arch,
             installation_source: installation_source,
-            prometheus_targets: prometheus_targets
+            prometheus_targets: prometheus_targets,
+            systemd_units: systemd_units
           ),
           RegisterHost.new!(%{
             host_id: host_id,
@@ -335,7 +348,8 @@ defmodule Trento.Hosts.HostTest do
             os_version: os_version,
             arch: arch,
             installation_source: installation_source,
-            prometheus_targets: prometheus_targets
+            prometheus_targets: prometheus_targets,
+            systemd_units: Enum.map(systemd_units, &Map.from_struct/1)
           }),
           %HostDetailsUpdated{
             host_id: host_id,
@@ -349,7 +363,8 @@ defmodule Trento.Hosts.HostTest do
             os_version: os_version,
             arch: arch,
             installation_source: installation_source,
-            prometheus_targets: prometheus_targets
+            prometheus_targets: prometheus_targets,
+            systemd_units: systemd_units
           },
           %Host{
             host_id: host_id,
@@ -364,7 +379,8 @@ defmodule Trento.Hosts.HostTest do
             arch: arch,
             installation_source: installation_source,
             prometheus_targets: prometheus_targets,
-            heartbeat: :unknown
+            heartbeat: :unknown,
+            systemd_units: systemd_units
           }
         )
       end
@@ -382,6 +398,7 @@ defmodule Trento.Hosts.HostTest do
       arch = Enum.random(Architecture.values())
       installation_source = Enum.random([:community, :suse, :unknown])
       prometheus_targets = build(:host_prometheus_targets)
+      systemd_units = build_list(2, :host_systemd_unit)
 
       current_fully_qualified_domain_name = Faker.Internet.ip_v4_address()
       new_fully_qualified_domain_name = nil
@@ -399,7 +416,8 @@ defmodule Trento.Hosts.HostTest do
           os_version: os_version,
           arch: arch,
           installation_source: installation_source,
-          prometheus_targets: prometheus_targets
+          prometheus_targets: prometheus_targets,
+          systemd_units: systemd_units
         ),
         RegisterHost.new!(%{
           host_id: host_id,
@@ -413,7 +431,8 @@ defmodule Trento.Hosts.HostTest do
           os_version: os_version,
           arch: arch,
           installation_source: installation_source,
-          prometheus_targets: prometheus_targets
+          prometheus_targets: prometheus_targets,
+          systemd_units: Enum.map(systemd_units, &Map.from_struct/1)
         }),
         [
           %HostDetailsUpdated{
@@ -428,7 +447,8 @@ defmodule Trento.Hosts.HostTest do
             os_version: os_version,
             arch: arch,
             installation_source: installation_source,
-            prometheus_targets: prometheus_targets
+            prometheus_targets: prometheus_targets,
+            systemd_units: systemd_units
           },
           %SoftwareUpdatesDiscoveryCleared{
             host_id: host_id
@@ -447,7 +467,8 @@ defmodule Trento.Hosts.HostTest do
           arch: arch,
           installation_source: installation_source,
           prometheus_targets: prometheus_targets,
-          heartbeat: :unknown
+          heartbeat: :unknown,
+          systemd_units: systemd_units
         }
       )
     end
@@ -465,6 +486,7 @@ defmodule Trento.Hosts.HostTest do
       new_installation_source = Enum.random([:community, :suse, :unknown])
       new_prometheus_targets = build(:host_prometheus_targets)
       fully_qualified_domain_name = Faker.Internet.domain_name()
+      new_systemd_units = build_list(2, :host_systemd_unit)
 
       assert_events_and_state(
         build(:host_registered_event,
@@ -484,7 +506,8 @@ defmodule Trento.Hosts.HostTest do
           os_version: new_os_version,
           arch: new_arch,
           installation_source: new_installation_source,
-          prometheus_targets: new_prometheus_targets
+          prometheus_targets: new_prometheus_targets,
+          systemd_units: Enum.map(new_systemd_units, &Map.from_struct/1)
         }),
         %HostDetailsUpdated{
           host_id: host_id,
@@ -498,7 +521,8 @@ defmodule Trento.Hosts.HostTest do
           os_version: new_os_version,
           arch: new_arch,
           installation_source: new_installation_source,
-          prometheus_targets: new_prometheus_targets
+          prometheus_targets: new_prometheus_targets,
+          systemd_units: new_systemd_units
         },
         %Host{
           host_id: host_id,
@@ -513,7 +537,8 @@ defmodule Trento.Hosts.HostTest do
           arch: new_arch,
           installation_source: new_installation_source,
           prometheus_targets: new_prometheus_targets,
-          heartbeat: :unknown
+          heartbeat: :unknown,
+          systemd_units: new_systemd_units
         }
       )
     end
@@ -535,7 +560,8 @@ defmodule Trento.Hosts.HostTest do
           os_version: host_registered_event.os_version,
           arch: host_registered_event.arch,
           installation_source: host_registered_event.installation_source,
-          prometheus_targets: host_registered_event.prometheus_targets
+          prometheus_targets: host_registered_event.prometheus_targets,
+          systemd_units: Enum.map(host_registered_event.systemd_units, &Map.from_struct/1)
         }),
         []
       )
@@ -1937,6 +1963,7 @@ defmodule Trento.Hosts.HostTest do
             arch: host_registered_event.arch,
             installation_source: host_registered_event.installation_source,
             prometheus_targets: host_registered_event.prometheus_targets,
+            systemd_units: host_registered_event.systemd_units,
             heartbeat: :unknown,
             rolling_up: false
           }
@@ -2005,6 +2032,7 @@ defmodule Trento.Hosts.HostTest do
               os_version: host_registered_event.os_version,
               arch: host_registered_event.arch,
               installation_source: host_registered_event.installation_source,
+              systemd_units: host_registered_event.systemd_units,
               heartbeat: :unknown,
               rolling_up: false
             }
@@ -2027,6 +2055,7 @@ defmodule Trento.Hosts.HostTest do
           assert host.os_version == host_registered_event.os_version
           assert host.arch == host_registered_event.arch
           assert host.installation_source == host_registered_event.installation_source
+          assert host.systemd_units == host_registered_event.systemd_units
           assert host.heartbeat == :unknown
         end
       )
@@ -2060,7 +2089,8 @@ defmodule Trento.Hosts.HostTest do
           os_version: host_registered_event.os_version,
           arch: host_registered_event.arch,
           installation_source: host_registered_event.installation_source,
-          prometheus_targets: host_registered_event.prometheus_targets
+          prometheus_targets: host_registered_event.prometheus_targets,
+          systemd_units: host_registered_event.systemd_units
         )
 
       assert_events_and_state(
@@ -2110,7 +2140,8 @@ defmodule Trento.Hosts.HostTest do
             arch: restoration_command.arch,
             installation_source: restoration_command.installation_source,
             fully_qualified_domain_name: restoration_command.fully_qualified_domain_name,
-            prometheus_targets: restoration_command.prometheus_targets
+            prometheus_targets: restoration_command.prometheus_targets,
+            systemd_units: restoration_command.systemd_units
           }
         ],
         fn host ->
@@ -2144,7 +2175,8 @@ defmodule Trento.Hosts.HostTest do
           os_version: host_registered_event.os_version,
           arch: host_registered_event.arch,
           installation_source: host_registered_event.installation_source,
-          prometheus_targets: host_registered_event.prometheus_targets
+          prometheus_targets: host_registered_event.prometheus_targets,
+          systemd_units: host_registered_event.systemd_units
         )
 
       assert_events_and_state(
@@ -2213,7 +2245,8 @@ defmodule Trento.Hosts.HostTest do
               arch: restoration_command.arch,
               installation_source: restoration_command.installation_source,
               fully_qualified_domain_name: restoration_command.fully_qualified_domain_name,
-              prometheus_targets: restoration_command.prometheus_targets
+              prometheus_targets: restoration_command.prometheus_targets,
+              systemd_units: restoration_command.systemd_units
             },
             %SoftwareUpdatesDiscoveryRequested{
               host_id: host_id,
@@ -2275,7 +2308,8 @@ defmodule Trento.Hosts.HostTest do
               arch: restoration_command.arch,
               installation_source: restoration_command.installation_source,
               fully_qualified_domain_name: restoration_command.fully_qualified_domain_name,
-              prometheus_targets: restoration_command.prometheus_targets
+              prometheus_targets: restoration_command.prometheus_targets,
+              systemd_units: restoration_command.systemd_units
             }
           ],
           fn host ->

--- a/test/trento/hosts/projections/host_projector_test.exs
+++ b/test/trento/hosts/projections/host_projector_test.exs
@@ -75,7 +75,8 @@ defmodule Trento.Hosts.Projections.HostProjectorTest do
       ip_addresses: ip_addresses,
       netmasks: netmasks,
       provider: provider,
-      provider_data: provider_data
+      provider_data: provider_data,
+      systemd_units: systemd_units
     } = host_projection = Repo.get!(HostReadModel, event.host_id)
 
     assert event.host_id == host_projection.id
@@ -91,6 +92,7 @@ defmodule Trento.Hosts.Projections.HostProjectorTest do
 
     assert event.agent_version == host_projection.agent_version
     assert event.heartbeat == host_projection.heartbeat
+    assert event.systemd_units == host_projection.systemd_units
 
     assert_broadcast "host_registered",
                      %{
@@ -103,7 +105,8 @@ defmodule Trento.Hosts.Projections.HostProjectorTest do
                        ip_addresses: ^ip_addresses,
                        netmasks: ^netmasks,
                        provider: ^provider,
-                       provider_data: ^provider_data
+                       provider_data: ^provider_data,
+                       systemd_units: ^systemd_units
                      },
                      1000
   end
@@ -245,7 +248,8 @@ defmodule Trento.Hosts.Projections.HostProjectorTest do
     %{
       agent_version: agent_version,
       arch: arch,
-      hostname: hostname
+      hostname: hostname,
+      systemd_units: systemd_units
     } =
       event = %HostDetailsUpdated{
         host_id: host_id,
@@ -257,7 +261,8 @@ defmodule Trento.Hosts.Projections.HostProjectorTest do
         socket_count: Enum.random(1..16),
         os_version: Faker.App.version(),
         arch: Enum.random(Architecture.values()),
-        prometheus_targets: build(:host_prometheus_targets)
+        prometheus_targets: build(:host_prometheus_targets),
+        systemd_units: build_list(2, :host_systemd_unit)
       }
 
     ProjectorTestHelper.project(HostProjector, event, "host_projector")
@@ -270,6 +275,7 @@ defmodule Trento.Hosts.Projections.HostProjectorTest do
     assert event.agent_version == host_projection.agent_version
     assert event.prometheus_targets == host_projection.prometheus_targets
     assert event.arch == host_projection.arch
+    assert event.systemd_units == host_projection.systemd_units
 
     assert_broadcast "host_details_updated",
                      %{
@@ -279,7 +285,8 @@ defmodule Trento.Hosts.Projections.HostProjectorTest do
                        id: ^host_id,
                        ip_addresses: [^ip_address],
                        netmasks: [^netmask],
-                       provider_data: nil
+                       provider_data: nil,
+                       systemd_units: ^systemd_units
                      },
                      1000
   end
@@ -512,7 +519,8 @@ defmodule Trento.Hosts.Projections.HostProjectorTest do
       provider_data: provider_data,
       deregistered_at: deregistered_at,
       sles_subscriptions: sles_subscriptions,
-      tags: tags
+      tags: tags,
+      systemd_units: systemd_units
     } =
       HostReadModel
       |> Repo.get!(host_id)
@@ -531,7 +539,8 @@ defmodule Trento.Hosts.Projections.HostProjectorTest do
                        provider: ^provider,
                        provider_data: ^provider_data,
                        sles_subscriptions: ^sles_subscriptions,
-                       tags: ^tags
+                       tags: ^tags,
+                       systemd_units: ^systemd_units
                      },
                      1000
   end


### PR DESCRIPTION
# Description

This PR handles systemd units info added in https://github.com/trento-project/agent/pull/455

It makes sure it is compatible in case the data is missing from the discovery.

## How was this tested?

Automated tests.