### PR TITLE
Request host discovery on pacemaker ops

### DIFF
--- a/lib/trento/discovery.ex
+++ b/lib/trento/discovery.ex
@@ -128,6 +128,19 @@ defmodule Trento.Discovery do
     request_discovery("ha_cluster_discovery", targets)
   end
 
+  @doc """
+  Request cluster hosts discovery
+  """
+  @spec request_cluster_hosts_discovery(String.t()) :: :ok | {:error, any}
+  def request_cluster_hosts_discovery(cluster_id) do
+    targets =
+      cluster_id
+      |> Clusters.get_cluster_hosts()
+      |> Enum.map(& &1.id)
+
+    request_discovery("host_discovery", targets)
+  end
+
   @spec store_discovery_event(map) :: {:ok, DiscoveryEvent.t()} | {:error, any}
   defp store_discovery_event(%{
          "agent_id" => agent_id,

--- a/lib/trento/infrastructure/operations/amqp/processor.ex
+++ b/lib/trento/infrastructure/operations/amqp/processor.ex
@@ -5,12 +5,15 @@ defmodule Trento.Infrastructure.Operations.AMQP.Processor do
 
   @behaviour GenRMQ.Processor
 
+  require Trento.Operations.Enums.ClusterHostOperations
   alias Trento.Contracts
 
   alias Trento.Operations.V1.{
     OperationCompleted,
     OperationStarted
   }
+
+  alias Trento.Operations.Enums.ClusterHostOperations
 
   alias Trento.Infrastructure.Operations
 
@@ -84,6 +87,11 @@ defmodule Trento.Infrastructure.Operations.AMQP.Processor do
   defp maybe_request_discovery(operation, :UPDATED, group_id)
        when operation in ClusterOperations.values() do
     Discovery.request_cluster_discovery(group_id)
+  end
+
+  defp maybe_request_discovery(operation, :UPDATED, group_id)
+       when operation in ClusterHostOperations.values() do
+    Discovery.request_cluster_hosts_discovery(group_id)
   end
 
   defp maybe_request_discovery(_, _, _), do: :ok

--- a/test/trento/discovery_test.exs
+++ b/test/trento/discovery_test.exs
@@ -237,6 +237,26 @@ defmodule Trento.DiscoveryTest do
       assert :ok == Discovery.request_cluster_discovery(cluster_id)
     end
 
+    test "should request cluster hosts discovery" do
+      %{id: cluster_id} = insert(:cluster)
+      [%{id: host_id_1}, %{id: host_id_2}] = insert_list(2, :host, cluster_id: cluster_id)
+
+      discovery_requested = %DiscoveryRequested{
+        discovery_type: "host_discovery",
+        targets: [host_id_1, host_id_2]
+      }
+
+      expect(
+        Trento.Infrastructure.Messaging.Adapter.Mock,
+        :publish,
+        fn Publisher, "agents", ^discovery_requested ->
+          :ok
+        end
+      )
+
+      assert :ok == Discovery.request_cluster_hosts_discovery(cluster_id)
+    end
+
     test "should handle publishing error on cluster discovery request" do
       %{id: cluster_id} = build(:cluster)
 


### PR DESCRIPTION
# Description

Requesting host discovery for cluster hosts on pacemaker enable/disable operation completion.

We cannot specify for which specific host we want to run the discovery, so all the hosts of the cluster are involved.