### PR TITLE
Handle crmmon group managed

### DIFF
--- a/lib/trento/discovery/payloads/cluster/crmmon_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/cluster/crmmon_discovery_payload.ex
@@ -174,8 +174,8 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
 
     embeds_many :groups, CrmmonGroup, primary_key: false do
       field :id, :string
+      field :managed, :boolean, default: true
 
-      embeds_many :primitives, Primitive
       embeds_many :resources, CrmmonResource
     end
 
@@ -237,9 +237,8 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
 
   defp groups_changeset(groups, attrs) do
     groups
-    |> cast(attrs, [:id])
+    |> cast(attrs, [:id, :managed])
     |> cast_embed(:resources)
-    |> cast_embed(:primitives)
     |> validate_required([:id])
   end
 

--- a/lib/trento/discovery/policies/cluster_policy.ex
+++ b/lib/trento/discovery/policies/cluster_policy.ex
@@ -878,9 +878,9 @@ defmodule Trento.Discovery.Policies.ClusterPolicy do
           put_parent(resource, %{id: id, managed: managed, multi_state: multi_state})
         end)
 
-      %CrmmonGroup{id: id, resources: resources} ->
+      %CrmmonGroup{id: id, managed: managed, resources: resources} ->
         Enum.map(resources, fn resource ->
-          put_parent(resource, %{id: id, managed: nil, multi_state: nil})
+          put_parent(resource, %{id: id, managed: managed, multi_state: nil})
         end)
 
       %CrmmonResource{} = resource ->

--- a/lib/trento_web/openapi/v2/schema/cluster.ex
+++ b/lib/trento_web/openapi/v2/schema/cluster.ex
@@ -34,11 +34,7 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
             nullable: true,
             properties: %{
               id: %Schema{type: :string},
-              managed: %Schema{
-                type: :boolean,
-                nullable: true,
-                description: "Resource is managed. null for standard groups"
-              },
+              managed: %Schema{type: :boolean, description: "Resource is managed"},
               multi_state: %Schema{
                 type: :boolean,
                 nullable: true,

--- a/test/e2e/cypress/fixtures/hana-cluster-details/available_hana_cluster.js
+++ b/test/e2e/cypress/fixtures/hana-cluster-details/available_hana_cluster.js
@@ -208,7 +208,7 @@ export const availableHanaCluster = {
       type: 'Group',
       role: '',
       status: '',
-      managed: '',
+      managed: 'True',
       failCount: '',
       node: '',
     },

--- a/test/fixtures/discovery/ha_cluster_discovery_ascs_ers.json
+++ b/test/fixtures/discovery/ha_cluster_discovery_ascs_ers.json
@@ -468,6 +468,7 @@
       "Groups": [
         {
           "Id": "grp_NWP_ASCS00",
+          "Managed": true,
           "Resources": [
             {
               "Id": "rsc_ip_NWP_ASCS00",
@@ -541,6 +542,7 @@
         },
         {
           "Id": "grp_NWP_ERS10",
+          "Managed": false,
           "Resources": [
             {
               "Id": "rsc_ip_NWP_ERS10",

--- a/test/trento/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/discovery/policies/cluster_policy_test.exs
@@ -926,7 +926,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                           managed: true,
                           parent: %ClusterResourceParent{
                             id: "g_ip_HDQ_HDB10",
-                            managed: nil,
+                            managed: true,
                             multi_state: nil
                           },
                           role: "Started",
@@ -939,7 +939,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                           managed: true,
                           parent: %ClusterResourceParent{
                             id: "g_ip_HDQ_HDB10",
-                            managed: nil,
+                            managed: true,
                             multi_state: nil
                           },
                           role: "Started",
@@ -1126,7 +1126,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "g_ip_HDQ_HDB10",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -1141,7 +1141,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "g_ip_HDQ_HDB10",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     }
@@ -1211,7 +1211,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ASCS00",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             },
@@ -1224,7 +1224,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ASCS00",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             },
@@ -1237,7 +1237,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ASCS00",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             },
@@ -1250,7 +1250,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ASCS00",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             }
@@ -1273,7 +1273,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ERS10",
-                                managed: nil,
+                                managed: false,
                                 multi_state: nil
                               }
                             },
@@ -1286,7 +1286,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ERS10",
-                                managed: nil,
+                                managed: false,
                                 multi_state: nil
                               }
                             },
@@ -1299,7 +1299,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ERS10",
-                                managed: nil,
+                                managed: false,
                                 multi_state: nil
                               }
                             },
@@ -1312,7 +1312,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ERS10",
-                                managed: nil,
+                                managed: false,
                                 multi_state: nil
                               }
                             }
@@ -1352,7 +1352,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ASCS00",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -1367,7 +1367,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ASCS00",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -1382,7 +1382,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: "NWP",
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ASCS00",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -1397,7 +1397,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ASCS00",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -1412,7 +1412,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ERS10",
-                        managed: nil,
+                        managed: false,
                         multi_state: nil
                       }
                     },
@@ -1427,7 +1427,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ERS10",
-                        managed: nil,
+                        managed: false,
                         multi_state: nil
                       }
                     },
@@ -1442,7 +1442,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: "NWP",
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ERS10",
-                        managed: nil,
+                        managed: false,
                         multi_state: nil
                       }
                     },
@@ -1457,7 +1457,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ERS10",
-                        managed: nil,
+                        managed: false,
                         multi_state: nil
                       }
                     }
@@ -1528,7 +1528,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ASCS00",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             },
@@ -1541,7 +1541,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ASCS00",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             },
@@ -1554,7 +1554,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ASCS00",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             },
@@ -1567,7 +1567,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ASCS00",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             }
@@ -1590,7 +1590,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ERS10",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             },
@@ -1603,7 +1603,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ERS10",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             },
@@ -1616,7 +1616,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ERS10",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             },
@@ -1629,7 +1629,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ERS10",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             }
@@ -1669,7 +1669,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ASCS00",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -1684,7 +1684,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ASCS00",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -1699,7 +1699,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: "NWP",
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ASCS00",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -1714,7 +1714,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ASCS00",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -1729,7 +1729,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ERS10",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -1744,7 +1744,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ERS10",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -1759,7 +1759,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: "NWP",
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ERS10",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -1774,7 +1774,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ERS10",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     }
@@ -1928,7 +1928,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ASCS00",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             },
@@ -1941,7 +1941,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ASCS00",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             },
@@ -1954,7 +1954,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ASCS00",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             },
@@ -1967,7 +1967,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ASCS00",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             }
@@ -1990,7 +1990,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ERS10",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             },
@@ -2003,7 +2003,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ERS10",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             },
@@ -2016,7 +2016,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ERS10",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             },
@@ -2029,7 +2029,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWP_ERS10",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             }
@@ -2059,7 +2059,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWD_ASCS01",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             },
@@ -2072,7 +2072,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWD_ASCS01",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             },
@@ -2085,7 +2085,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWD_ASCS01",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             },
@@ -2098,7 +2098,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWD_ASCS01",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             }
@@ -2121,7 +2121,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWD_ERS11",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             },
@@ -2134,7 +2134,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWD_ERS11",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             },
@@ -2147,7 +2147,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWD_ERS11",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             },
@@ -2160,7 +2160,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                               managed: true,
                               parent: %ClusterResourceParent{
                                 id: "grp_NWD_ERS11",
-                                managed: nil,
+                                managed: true,
                                 multi_state: nil
                               }
                             }
@@ -2200,7 +2200,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ASCS00",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -2215,7 +2215,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ASCS00",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -2230,7 +2230,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: "NWP",
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ASCS00",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -2245,7 +2245,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ASCS00",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -2260,7 +2260,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ERS10",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -2275,7 +2275,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ERS10",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -2290,7 +2290,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: "NWP",
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ERS10",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -2305,7 +2305,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWP_ERS10",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -2320,7 +2320,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWD_ASCS01",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -2335,7 +2335,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWD_ASCS01",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -2350,7 +2350,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: "NWD",
                       parent: %ClusterResourceParent{
                         id: "grp_NWD_ASCS01",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -2365,7 +2365,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWD_ASCS01",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -2380,7 +2380,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWD_ERS11",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -2395,7 +2395,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWD_ERS11",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -2410,7 +2410,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: "NWD",
                       parent: %ClusterResourceParent{
                         id: "grp_NWD_ERS11",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -2425,7 +2425,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "grp_NWD_ERS11",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     }
@@ -3055,7 +3055,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                           managed: true,
                           parent: %ClusterResourceParent{
                             id: "g_ip_PRD_HDB00",
-                            managed: nil,
+                            managed: true,
                             multi_state: nil
                           }
                         },
@@ -3068,7 +3068,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                           managed: true,
                           parent: %ClusterResourceParent{
                             id: "g_ip_PRD_HDB00",
-                            managed: nil,
+                            managed: true,
                             multi_state: nil
                           }
                         }
@@ -3289,7 +3289,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "g_ip_PRD_HDB00",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     },
@@ -3304,7 +3304,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       sid: nil,
                       parent: %ClusterResourceParent{
                         id: "g_ip_PRD_HDB00",
-                        managed: nil,
+                        managed: true,
                         multi_state: nil
                       }
                     }
@@ -4761,7 +4761,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                             managed: true,
                             parent: %ClusterResourceParent{
                               id: "g_ip_PRD_HDB00",
-                              managed: nil,
+                              managed: true,
                               multi_state: nil
                             }
                           },
@@ -4774,7 +4774,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                             managed: true,
                             parent: %ClusterResourceParent{
                               id: "g_ip_PRD_HDB00",
-                              managed: nil,
+                              managed: true,
                               multi_state: nil
                             }
                           }
@@ -5029,7 +5029,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                         sid: nil,
                         parent: %ClusterResourceParent{
                           id: "g_ip_PRD_HDB00",
-                          managed: nil,
+                          managed: true,
                           multi_state: nil
                         }
                       },
@@ -5044,7 +5044,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                         sid: nil,
                         parent: %ClusterResourceParent{
                           id: "g_ip_PRD_HDB00",
-                          managed: nil,
+                          managed: true,
                           multi_state: nil
                         }
                       }
@@ -5699,7 +5699,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                             managed: true,
                             parent: %ClusterResourceParent{
                               id: "g_ip_PRD_HDB01",
-                              managed: nil,
+                              managed: true,
                               multi_state: nil
                             }
                           },
@@ -5712,7 +5712,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                             managed: true,
                             parent: %ClusterResourceParent{
                               id: "g_ip_PRD_HDB01",
-                              managed: nil,
+                              managed: true,
                               multi_state: nil
                             }
                           }
@@ -6178,7 +6178,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                         sid: nil,
                         parent: %ClusterResourceParent{
                           id: "g_ip_PRD_HDB01",
-                          managed: nil,
+                          managed: true,
                           multi_state: nil
                         }
                       },
@@ -6193,7 +6193,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                         sid: nil,
                         parent: %ClusterResourceParent{
                           id: "g_ip_PRD_HDB01",
-                          managed: nil,
+                          managed: true,
                           multi_state: nil
                         }
                       }


### PR DESCRIPTION
# Description

Handle `crm_mon` group `managed` field.
Putting default value to `true` for agents that don't send the field.

Related to: https://github.com/trento-project/agent/pull/457

## How was this tested?
UT and e2e
