### PR TITLE
Add cluster status for host

### DIFF
--- a/lib/trento/hosts/projections/host_read_model.ex
+++ b/lib/trento/hosts/projections/host_read_model.ex
@@ -95,5 +95,4 @@ defmodule Trento.Hosts.Projections.HostReadModel do
       true -> changeset
     end
   end
-
 end

--- a/lib/trento/hosts/projections/host_read_model.ex
+++ b/lib/trento/hosts/projections/host_read_model.ex
@@ -55,8 +55,7 @@ defmodule Trento.Hosts.Projections.HostReadModel do
       type: Ecto.UUID,
       where: [deregistered_at: nil]
 
-    field :cluster_status, Ecto.Enum,
-      values: [:online, :offline]
+    field :cluster_status, Ecto.Enum, values: [:online, :offline]
 
     has_many :database_instances, DatabaseInstanceReadModel,
       references: :id,

--- a/lib/trento/hosts/projections/host_read_model.ex
+++ b/lib/trento/hosts/projections/host_read_model.ex
@@ -92,7 +92,7 @@ defmodule Trento.Hosts.Projections.HostReadModel do
       # TODO: when we will handle the status explicitly, we can remove this line
       # so far we stick to the old behavior that considers the host online in the cluster if the cluster_id is set
       cluster_status == nil -> put_change(changeset, :cluster_status, :online)
-      true ->  changeset
+      true -> changeset
     end
 
   end

--- a/lib/trento/hosts/projections/host_read_model.ex
+++ b/lib/trento/hosts/projections/host_read_model.ex
@@ -94,7 +94,6 @@ defmodule Trento.Hosts.Projections.HostReadModel do
       cluster_status == nil -> put_change(changeset, :cluster_status, :online)
       true -> changeset
     end
-
   end
 
 end

--- a/lib/trento_web/openapi/v1/schema/host.ex
+++ b/lib/trento_web/openapi/v1/schema/host.ex
@@ -105,6 +105,11 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Host do
             description: "Identifier of the cluster this host is part of",
             format: :uuid
           },
+          cluster_status: %Schema{
+            type: :string,
+            description: "Status of the cluster this host is part of",
+            nullable: true
+          },
           heartbeat: %Schema{
             type: :string,
             description: "Host's last heartbeat status",

--- a/priv/repo/migrations/20250707075129_add_host_cluster_status.exs
+++ b/priv/repo/migrations/20250707075129_add_host_cluster_status.exs
@@ -1,0 +1,16 @@
+defmodule Trento.Repo.Migrations.AddHostClusterStatus do
+  use Ecto.Migration
+
+  def change do
+
+    alter table(:hosts) do
+      add :cluster_status, :string
+    end
+
+    execute(
+      "UPDATE hosts SET cluster_status = 'online' WHERE cluster_status IS NOT NULL",
+      "UPDATE hosts SET cluster_status = NULL"
+    )
+
+  end
+end

--- a/priv/repo/migrations/20250707075129_add_host_cluster_status.exs
+++ b/priv/repo/migrations/20250707075129_add_host_cluster_status.exs
@@ -10,6 +10,5 @@ defmodule Trento.Repo.Migrations.AddHostClusterStatus do
       "UPDATE hosts SET cluster_status = 'online' WHERE cluster_status IS NOT NULL",
       "UPDATE hosts SET cluster_status = NULL"
     )
-
   end
 end

--- a/priv/repo/migrations/20250707075129_add_host_cluster_status.exs
+++ b/priv/repo/migrations/20250707075129_add_host_cluster_status.exs
@@ -2,7 +2,6 @@ defmodule Trento.Repo.Migrations.AddHostClusterStatus do
   use Ecto.Migration
 
   def change do
-
     alter table(:hosts) do
       add :cluster_status, :string
     end


### PR DESCRIPTION
Add `cluster_status` field to the host read model to map whether a host is online or offline in the cluster.

The field is set as `online` for every host that belongs to a cluster, to mimic the actual behaviour.