### PR TITLE
Fix operation resource type mapping

### DIFF
--- a/assets/js/lib/model/activityLog.js
+++ b/assets/js/lib/model/activityLog.js
@@ -160,6 +160,7 @@ const resourceTypeMapping = (entry) => ({
   database: databaseResourceType(entry),
   sap_system: sapSystemResourceType(entry),
   application_instance: applicationInstaceResourceType(entry),
+  cluster_host: hostResourceType(entry),
 });
 
 const resolveResourceType = (entry, key, defaultValue) =>


### PR DESCRIPTION
# Description

Adds a missing mapping for cluster host operation resource type on completion.
Without this change we see `unknown resource type`.

Even though it does not make me super happy, I mapped it to cluster, for consistency with the rest.