### PR TITLE
Fix demo helm deployment name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -834,7 +834,7 @@ jobs:
         run: |
           cd helm-charts-rolling/charts/trento-server
           helm dependency update
-          helm upgrade -i trento --wait . \
+          helm upgrade -i trento-server --wait . \
             --set trento-web.adminUser.password="${{ secrets.DEMO_PASSWORD }}" \
             --set trento-web.image.pullPolicy=Always \
             --set trento-web.image.repository="${IMAGE_REPOSITORY}/trento-web" \


### PR DESCRIPTION
# Description

This change makes sure our demo deployment succeeds by providing the deployment name that would match 

```yaml
extraEnvVarsCM: trento-server-rabbitmq-configmap
```
See [here](https://github.com/trento-project/helm-charts/blob/f6c2521be32065fa61a8af85e5a07cb925a18500/charts/trento-server/values.yaml#L80)

Unless we make `trento-server` the mandatory deployment name, helm installation would fail as long as the deployment name is different.

Specifically rabbitmq pod would fail with `CreateContainerConfigError` because `Error: configmap "trento-server-rabbitmq-configmap" not found`