### PR TITLE
Analytics Add Version Code

### DIFF
--- a/assets/js/lib/analytics/pageview.js
+++ b/assets/js/lib/analytics/pageview.js
@@ -1,17 +1,20 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { capture } from '@lib/analytics';
+import { getFromConfig } from '@lib/config';
 import { useSelector } from 'react-redux';
 import { getUserProfile } from '@state/selectors/user';
 
 export default function PostHogPageView() {
   const location = useLocation();
   const { analytics_enabled } = useSelector(getUserProfile);
+  const webversion = getFromConfig('webversion');
 
   // Track pageviews
   useEffect(() => {
     capture(analytics_enabled, '$pageview', {
       $current_url: window.location.href,
+      webversion,
     });
   }, [location]);
 

--- a/lib/trento_web/controllers/page_controller.ex
+++ b/lib/trento_web/controllers/page_controller.ex
@@ -13,6 +13,7 @@ defmodule TrentoWeb.PageController do
     analytics_key = Application.fetch_env!(:trento, :analytics)[:analytics_key]
     analytics_url = Application.fetch_env!(:trento, :analytics)[:analytics_url]
     operations_enabled = Application.fetch_env!(:trento, :operations_enabled)
+    version = Mix.Project.config()[:version]
 
     {sso_enabled, callback_url, login_url, enrollment_url} = sso_details(conn)
 
@@ -30,6 +31,7 @@ defmodule TrentoWeb.PageController do
       sso_callback_url: callback_url,
       sso_enrollment_url: enrollment_url,
       operations_enabled: operations_enabled,
+      version: version,
       layout: false
     )
   end

--- a/lib/trento_web/controllers/page_html/index.html.heex
+++ b/lib/trento_web/controllers/page_html/index.html.heex
@@ -14,7 +14,8 @@
       ssoLoginUrl: '<%= raw @sso_login_url %>',
       ssoCallbackUrl: '<%= raw @sso_callback_url %>',
       ssoEnrollmentUrl: '<%= raw @sso_enrollment_url %>',
-      operationsEnabled: <%= @operations_enabled %>
+      operationsEnabled: <%= @operations_enabled %>,
+      webversion: '<%= @version %>'
   };
 </script>
 

--- a/lib/trento_web/controllers/page_html/index.html.heex
+++ b/lib/trento_web/controllers/page_html/index.html.heex
@@ -1,4 +1,4 @@
-<div id="trento" />
+<div id="trento" data-ph-capture-attribute-webversion={@version} />
 
 <script>
   const config = {


### PR DESCRIPTION
# Description

This PR adds the `version` code of **Trento Web** ~~and an environment value~~ for each Autocapture and PageView event. The purpose of these addition is to help detect which version of **Trento Web** is in use. ~~Then the environment value helps us to cross check that development, demo and production events are clearly distinguishable. See below for visual reference.~~

**Assumptions:**
1. Every official build of Trento Web will have the **production** `environment` value.
2. Every demo build will have either **demo** `environment` value.
3. Project source will use the **dev** `environment` value.
4. Official **production** Posthog instance will be for **production events only**.
5. Dev/Demo events will use a separate or private instance of Posthog for development purposes.

## How was this tested?

Describe the tests that have been added/changed for this new behaviour.
- [x] **Manually** (Need to find an automated solution) 😅 


<img width="1210" height="419" alt="Screenshot 2025-07-23 at 10 58 35" src="https://github.com/user-attachments/assets/5c2435c6-c3b6-41ea-9442-258d8b5380f4" />