### PR TITLE
Fix Host OpenApi spec

### DIFF
--- a/lib/trento_web/openapi/v1/schema/host.ex
+++ b/lib/trento_web/openapi/v1/schema/host.ex
@@ -103,7 +103,8 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Host do
           cluster_id: %Schema{
             type: :string,
             description: "Identifier of the cluster this host is part of",
-            format: :uuid
+            format: :uuid,
+            nullable: true
           },
           heartbeat: %Schema{
             type: :string,

--- a/test/trento_web/controllers/v1/host_controller_test.exs
+++ b/test/trento_web/controllers/v1/host_controller_test.exs
@@ -30,6 +30,14 @@ defmodule TrentoWeb.V1.HostControllerTest do
       |> json_response(200)
       |> assert_schema("HostsCollection", api_spec)
     end
+
+    test "should handle null cluster_id", %{conn: conn, api_spec: api_spec} do
+      insert(:host, cluster_id: nil)
+
+      get(conn, "/api/v1/hosts")
+      |> json_response(200)
+      |> assert_schema("HostsCollection", api_spec)
+    end
   end
 
   describe "heartbeat" do


### PR DESCRIPTION
`cluster_id` is, in fact, nullable for hosts, as they do not always belong to a cluster. 