### PR TITLE
Start/stop SAP system user policy

### DIFF
--- a/assets/js/common/AbilitiesMultiSelect/AbilitiesMultiSelect.jsx
+++ b/assets/js/common/AbilitiesMultiSelect/AbilitiesMultiSelect.jsx
@@ -61,6 +61,8 @@ const groupedAbilities = [
       'pacemaker_disable:cluster',
       'start:application_instance',
       'stop:application_instance',
+      'start:sap_system',
+      'stop:sap_system',
     ],
   },
 ];

--- a/assets/js/common/AbilitiesMultiSelect/AbilitiesMultiSelect.test.jsx
+++ b/assets/js/common/AbilitiesMultiSelect/AbilitiesMultiSelect.test.jsx
@@ -39,6 +39,8 @@ describe('AbilitiesMultiSelect Component', () => {
       { id: 19, name: 'pacemaker_disable', resource: 'cluster' },
       { id: 20, name: 'start', resource: 'application_instance' },
       { id: 21, name: 'stop', resource: 'application_instance' },
+      { id: 22, name: 'start', resource: 'sap_system' },
+      { id: 23, name: 'stop', resource: 'sap_system' },
     ];
 
     render(
@@ -110,6 +112,8 @@ describe('AbilitiesMultiSelect Component', () => {
           { id: 8, name: 'pacemaker_disable', resource: 'cluster' },
           { id: 9, name: 'start', resource: 'application_instance' },
           { id: 10, name: 'stop', resource: 'application_instance' },
+          { id: 11, name: 'start', resource: 'sap_system' },
+          { id: 12, name: 'stop', resource: 'sap_system' },
         ]}
         userAbilities={[
           { id: 1, name: 'all', resource: 'all' },
@@ -122,6 +126,8 @@ describe('AbilitiesMultiSelect Component', () => {
           { id: 8, name: 'pacemaker_disable', resource: 'cluster' },
           { id: 9, name: 'start', resource: 'application_instance' },
           { id: 10, name: 'stop', resource: 'application_instance' },
+          { id: 11, name: 'start', resource: 'sap_system' },
+          { id: 12, name: 'stop', resource: 'sap_system' },
         ]}
         setAbilities={noop}
         operationsEnabled
@@ -158,6 +164,8 @@ describe('AbilitiesMultiSelect Component', () => {
     expect(
       screen.queryByText('stop:application_instance')
     ).not.toBeInTheDocument();
+    expect(screen.queryByText('start:sap_system')).not.toBeInTheDocument();
+    expect(screen.queryByText('stop:sap_system')).not.toBeInTheDocument();
 
     await user.click(screen.getByLabelText('permissions'));
     expect(screen.getByText('No options')).toBeVisible();

--- a/lib/trento/sap_systems/policy.ex
+++ b/lib/trento/sap_systems/policy.ex
@@ -20,10 +20,10 @@ defmodule Trento.SapSystems.Policy do
     do: has_global_ability?(user) or has_app_instance_stop_ability?(user)
 
   def authorize(:request_operation, %User{} = user, %{operation: "sap_system_start"}),
-    do: has_global_ability?(user) or has_system_start_ability?(user)
+    do: has_global_ability?(user) or has_sap_system_start_ability?(user)
 
   def authorize(:request_operation, %User{} = user, %{operation: "sap_system_stop"}),
-    do: has_global_ability?(user) or has_system_stop_ability?(user)
+    do: has_global_ability?(user) or has_sap_system_stop_ability?(user)
 
   def authorize(_, _, _), do: true
 
@@ -36,9 +36,9 @@ defmodule Trento.SapSystems.Policy do
   defp has_app_instance_stop_ability?(user),
     do: user_has_ability?(user, %{name: "stop", resource: "application_instance"})
 
-  defp has_system_start_ability?(user),
+  defp has_sap_system_start_ability?(user),
     do: user_has_ability?(user, %{name: "start", resource: "sap_system"})
 
-  defp has_system_stop_ability?(user),
+  defp has_sap_system_stop_ability?(user),
     do: user_has_ability?(user, %{name: "stop", resource: "sap_system"})
 end

--- a/lib/trento/sap_systems/policy.ex
+++ b/lib/trento/sap_systems/policy.ex
@@ -19,6 +19,12 @@ defmodule Trento.SapSystems.Policy do
   def authorize(:request_instance_operation, %User{} = user, %{operation: "sap_instance_stop"}),
     do: has_global_ability?(user) or has_app_instance_stop_ability?(user)
 
+  def authorize(:request_operation, %User{} = user, %{operation: "sap_system_start"}),
+    do: has_global_ability?(user) or has_system_start_ability?(user)
+
+  def authorize(:request_operation, %User{} = user, %{operation: "sap_system_stop"}),
+    do: has_global_ability?(user) or has_system_stop_ability?(user)
+
   def authorize(_, _, _), do: true
 
   defp has_cleanup_ability?(user),
@@ -29,4 +35,10 @@ defmodule Trento.SapSystems.Policy do
 
   defp has_app_instance_stop_ability?(user),
     do: user_has_ability?(user, %{name: "stop", resource: "application_instance"})
+
+  defp has_system_start_ability?(user),
+    do: user_has_ability?(user, %{name: "start", resource: "sap_system"})
+
+  defp has_system_stop_ability?(user),
+    do: user_has_ability?(user, %{name: "stop", resource: "sap_system"})
 end

--- a/priv/repo/migrations/20250717085841_add_sap_system_start_stop_abilities.exs
+++ b/priv/repo/migrations/20250717085841_add_sap_system_start_stop_abilities.exs
@@ -1,0 +1,14 @@
+defmodule Trento.Repo.Migrations.AddSapSystemStartStopAbilities do
+  use Ecto.Migration
+
+  def up do
+    execute "INSERT INTO abilities(name, resource, label, inserted_at, updated_at) VALUES ('start', 'sap_system', 'Permits start operation on SAP systems', NOW(), NOW())"
+
+    execute "INSERT INTO abilities(name, resource, label, inserted_at, updated_at) VALUES ('stop', 'sap_system', 'Permits stop operation on SAP systems', NOW(), NOW())"
+  end
+
+  def down do
+    execute "DELETE FROM abilities WHERE name = 'start' AND resource = 'sap_system'"
+    execute "DELETE FROM abilities WHERE name = 'stop' AND resource = 'sap_system'"
+  end
+end

--- a/test/trento/sap_systems/policy_test.exs
+++ b/test/trento/sap_systems/policy_test.exs
@@ -66,6 +66,48 @@ defmodule Trento.SapSystems.PolicyTest do
     end
   end
 
+  describe "request_operation" do
+    operations = [
+      %{
+        operation: "sap_system_start",
+        ability: "start"
+      },
+      %{
+        operation: "sap_system_stop",
+        ability: "stop"
+      }
+    ]
+
+    for %{operation: operation, ability: ability} <- operations do
+      @operation operation
+      @ability ability
+
+      test "should allow #{operation} operation if the user has #{ability}:sap_system ability" do
+        user = %User{abilities: [%Ability{name: @ability, resource: "sap_system"}]}
+
+        assert Policy.authorize(:request_operation, user, %{
+                 operation: @operation
+               })
+      end
+
+      test "should allow #{operation} operation if the user has all:all ability" do
+        user = %User{abilities: [%Ability{name: "all", resource: "all"}]}
+
+        assert Policy.authorize(:request_operation, user, %{
+                 operation: @operation
+               })
+      end
+
+      test "should disallow #{operation} operation if the user does not have #{ability}:sap_system ability" do
+        user = %User{abilities: [%Ability{name: "all", resource: "other_resource"}]}
+
+        refute Policy.authorize(:request_operation, user, %{
+                 operation: @operation
+               })
+      end
+    end
+  end
+
   test "should allow unguarded actions" do
     user = %User{abilities: []}
 

--- a/test/trento_web/controllers/v1/sap_system_controller_test.exs
+++ b/test/trento_web/controllers/v1/sap_system_controller_test.exs
@@ -287,46 +287,16 @@ defmodule TrentoWeb.V1.SapSystemControllerTest do
                } = resp
       end
 
-      test "should authorize operation #{operation} when the user has #{ability} ability",
+      test "should perform operation #{operation} properly with authorized #{ability} ability",
            %{
-             conn: conn
+             conn: conn,
+             api_spec: api_spec
            } do
         %{id: user_id} = insert(:user)
 
         %{id: ability_id} = insert(:ability, name: @ability, resource: "application_instance")
         insert(:users_abilities, user_id: user_id, ability_id: ability_id)
 
-        %{id: host_id} = insert(:host)
-
-        %{sap_system_id: sap_system_id, instance_number: inst_number} =
-          insert(:application_instance, features: "MESSAGESERVER|ENQUE", host_id: host_id)
-
-        %{id: database_id} = insert(:database, health: :passing)
-        insert(:sap_system, id: sap_system_id, database_id: database_id)
-
-        expect(
-          Trento.Infrastructure.Messaging.Adapter.Mock,
-          :publish,
-          fn OperationsPublisher, _, _ ->
-            :ok
-          end
-        )
-
-        conn
-        |> Pow.Plug.assign_current_user(%{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
-        |> put_req_header("content-type", "application/json")
-        |> post(
-          "/api/v1/sap_systems/#{sap_system_id}/hosts/#{host_id}/instances/#{inst_number}/operations/#{@operation}",
-          %{}
-        )
-        |> json_response(:accepted)
-      end
-
-      test "should perform operation #{operation} properly",
-           %{
-             conn: conn,
-             api_spec: api_spec
-           } do
         %{id: cluster_id} =
           insert(:cluster,
             details:
@@ -354,6 +324,7 @@ defmodule TrentoWeb.V1.SapSystemControllerTest do
 
         posted_conn =
           conn
+          |> Pow.Plug.assign_current_user(%{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
           |> put_req_header("content-type", "application/json")
           |> post(
             "/api/v1/sap_systems/#{sap_system_id}/hosts/#{host_id}/instances/#{inst_number}/operations/#{@operation}",
@@ -479,45 +450,16 @@ defmodule TrentoWeb.V1.SapSystemControllerTest do
                } = resp
       end
 
-      test "should authorize operation #{operation} when the user has #{ability} ability",
+      test "should perform operation #{operation} properly with authorized #{ability} ability",
            %{
-             conn: conn
+             conn: conn,
+             api_spec: api_spec
            } do
         %{id: user_id} = insert(:user)
 
         %{id: ability_id} = insert(:ability, name: @ability, resource: "sap_system")
         insert(:users_abilities, user_id: user_id, ability_id: ability_id)
 
-        %{id: database_id} = insert(:database)
-        %{id: sap_system_id} = insert(:sap_system, database_id: database_id)
-
-        %{id: host_id} = insert(:host, heartbeat: :passing)
-
-        insert(:application_instance, sap_system_id: sap_system_id, host_id: host_id)
-
-        expect(
-          Trento.Infrastructure.Messaging.Adapter.Mock,
-          :publish,
-          fn OperationsPublisher, _, _ ->
-            :ok
-          end
-        )
-
-        conn
-        |> Pow.Plug.assign_current_user(%{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
-        |> put_req_header("content-type", "application/json")
-        |> post(
-          "/api/v1/sap_systems/#{sap_system_id}/operations/#{@operation}",
-          %{}
-        )
-        |> json_response(:accepted)
-      end
-
-      test "should perform operation #{operation} properly",
-           %{
-             conn: conn,
-             api_spec: api_spec
-           } do
         %{id: database_id} = insert(:database)
         %{id: sap_system_id} = insert(:sap_system, database_id: database_id)
 
@@ -547,6 +489,7 @@ defmodule TrentoWeb.V1.SapSystemControllerTest do
 
         posted_conn =
           conn
+          |> Pow.Plug.assign_current_user(%{"user_id" => user_id}, Pow.Plug.fetch_config(conn))
           |> put_req_header("content-type", "application/json")
           |> post(
             "/api/v1/sap_systems/#{sap_system_id}/operations/#{@operation}",


### PR DESCRIPTION
# Description

Add SAP system start/stop user abilities. The `start/stop` abilities for the `sap_system` resource specifically.
The frontend usage will be applied once we have the operation buttons in place

## How was this tested?

UT
