### PR TITLE
Fix Flaky test in activity log page when selecting every different refresh rate.

### DIFF
--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -4,7 +4,7 @@ import * as basePage from '../pageObject/base_po';
 const defaultSeverity = 'severity=info&severity=warning&severity=critical';
 
 context('Activity Log page', () => {
-  before(() => activityLogPage.preloadTestData());
+  // before(() => activityLogPage.preloadTestData());
   beforeEach(() => activityLogPage.interceptActivityLogEndpoint());
 
   describe('Navigation', () => {
@@ -287,12 +287,12 @@ context('Activity Log page', () => {
       const changingRefreshRateScenarios =
         activityLogPage.buildChangingRefreshRateScenarios();
 
-      changingRefreshRateScenarios.forEach(
-        ({ currentRefreshRate, expectedRefreshRate }) => {
+      cy.wrap(changingRefreshRateScenarios).each(
+        ({ currentRefreshRate, newRefreshRate, expectedRefreshRate }) => {
           activityLogPage.autoRefreshIntervalButtonHasTheExpectedValue(
             currentRefreshRate
           );
-          activityLogPage.selectNextRefreshRate();
+          activityLogPage.selectRefreshRate(newRefreshRate);
           const expectedUrl = `/activity_log${
             expectedRefreshRate ? `?refreshRate=${expectedRefreshRate}` : ''
           }`;

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -280,13 +280,16 @@ context('Activity Log page', () => {
       activityLogPage.validateUrl(expectedUrl);
     });
 
+    it('should have all expected refresh rates available', () => {
+      activityLogPage.visit();
+      activityLogPage.expectedRefreshRatesAreAvailable();
+    });
+
     // eslint-disable-next-line mocha/no-exclusive-tests
     it.only('should change refresh rate', () => {
       activityLogPage.visit();
-      activityLogPage.expectedRefreshRatesAreAvailable();
       const changingRefreshRateScenarios =
         activityLogPage.buildChangingRefreshRateScenarios();
-
       cy.wrap(changingRefreshRateScenarios).each(
         ({ currentRefreshRate, newRefreshRate, expectedRefreshRate }) => {
           activityLogPage.autoRefreshIntervalButtonHasTheExpectedValue(

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -286,12 +286,13 @@ context('Activity Log page', () => {
       activityLogPage.expectedRefreshRatesAreAvailable();
       const changingRefreshRateScenarios =
         activityLogPage.buildChangingRefreshRateScenarios();
+
       changingRefreshRateScenarios.forEach(
-        ({ currentRefreshRate, newRefreshRate, expectedRefreshRate }) => {
+        ({ currentRefreshRate, expectedRefreshRate }) => {
           activityLogPage.autoRefreshIntervalButtonHasTheExpectedValue(
             currentRefreshRate
           );
-          activityLogPage.selectRefreshRate(newRefreshRate);
+          activityLogPage.selectNextRefreshRate();
           const expectedUrl = `/activity_log${
             expectedRefreshRate ? `?refreshRate=${expectedRefreshRate}` : ''
           }`;

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -280,7 +280,8 @@ context('Activity Log page', () => {
       activityLogPage.validateUrl(expectedUrl);
     });
 
-    it('should change refresh rate', () => {
+    // eslint-disable-next-line mocha/no-exclusive-tests
+    it.only('should change refresh rate', () => {
       activityLogPage.visit();
       activityLogPage.expectedRefreshRatesAreAvailable();
       const changingRefreshRateScenarios =

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -4,7 +4,7 @@ import * as basePage from '../pageObject/base_po';
 const defaultSeverity = 'severity=info&severity=warning&severity=critical';
 
 context('Activity Log page', () => {
-  // before(() => activityLogPage.preloadTestData());
+  before(() => activityLogPage.preloadTestData());
   beforeEach(() => activityLogPage.interceptActivityLogEndpoint());
 
   describe('Navigation', () => {

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -280,17 +280,12 @@ context('Activity Log page', () => {
       activityLogPage.validateUrl(expectedUrl);
     });
 
-    it('should have all expected refresh rates available', () => {
+    it('should change refresh rate', () => {
       activityLogPage.visit();
       activityLogPage.expectedRefreshRatesAreAvailable();
-    });
-
-    // eslint-disable-next-line mocha/no-exclusive-tests
-    it.only('should change refresh rate', () => {
-      activityLogPage.visit();
       const changingRefreshRateScenarios =
         activityLogPage.buildChangingRefreshRateScenarios();
-      cy.wrap(changingRefreshRateScenarios).each(
+      changingRefreshRateScenarios.forEach(
         ({ currentRefreshRate, newRefreshRate, expectedRefreshRate }) => {
           activityLogPage.autoRefreshIntervalButtonHasTheExpectedValue(
             currentRefreshRate

--- a/test/e2e/cypress/pageObject/activity_log_po.js
+++ b/test/e2e/cypress/pageObject/activity_log_po.js
@@ -104,15 +104,8 @@ export const selectPagination = (amountOfItems) => {
 };
 
 export const selectRefreshRate = (refreshRate) => {
-  cy.get(autoRefreshIntervalButton).click();
-  // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(1000); // couldn't really find a way to reduce flakiness here
+  clickAutoRefreshRateButton();
   return cy.contains(refreshRate).click();
-};
-
-export const selectNextRefreshRate = (refreshRate) => {
-  cy.get('div[class="relative flex-1"]').type('{downarrow}');
-  cy.contains(refreshRate).click();
 };
 
 // UI Validations

--- a/test/e2e/cypress/pageObject/activity_log_po.js
+++ b/test/e2e/cypress/pageObject/activity_log_po.js
@@ -32,15 +32,7 @@ const autoRefreshIntervalButton = 'button[class*="refresh-rate"]';
 const availableRefreshRates = 'button[class*="refresh-rate"] + div div';
 
 //Test data
-export const expectedRefreshRates = [
-  'Off',
-  '5s',
-  '10s',
-  '30s',
-  '1m',
-  '5m',
-  '30m',
-];
+const expectedRefreshRates = ['Off', '5s', '10s', '30s', '1m', '5m', '30m'];
 
 export const visit = (queryString = '') =>
   basePage.visit(`/activity_log${queryString}`);
@@ -116,6 +108,19 @@ export const selectRefreshRate = (refreshRate) => {
   // eslint-disable-next-line cypress/no-unnecessary-waiting
   cy.wait(1000); // couldn't really find a way to reduce flakiness here
   return cy.contains(refreshRate).click();
+};
+
+export const selectNextRefreshRate = () => {
+  cy.get('button[class*="refresh-rate-selection-dropdown"]').click();
+  cy.get('button[class*="refresh-rate-selection-dropdown"]')
+    .invoke('text')
+    .then(($text) => {
+      if ($text === '30m') {
+        cy.get('div[role="listbox"]').type(
+          '{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{enter}'
+        );
+      } else cy.get('div[role="listbox"]').type('{downarrow}{enter}');
+    });
 };
 
 // UI Validations

--- a/test/e2e/cypress/pageObject/activity_log_po.js
+++ b/test/e2e/cypress/pageObject/activity_log_po.js
@@ -62,7 +62,6 @@ export const waitForActivityLogRequest = () =>
 export const clickFilterTypeButton = () =>
   cy.get(filterTypeButton).click({ force: true });
 
-
 export const clickAutoRefreshRateButton = () => {
   basePage.clickOutside();
   cy.get(autoRefreshIntervalButton).click();

--- a/test/e2e/cypress/pageObject/activity_log_po.js
+++ b/test/e2e/cypress/pageObject/activity_log_po.js
@@ -63,8 +63,8 @@ export const clickFilterTypeButton = () =>
   cy.get(filterTypeButton).click({ force: true });
 
 export const clickAutoRefreshRateButton = () => {
+  cy.get('body').click();
   cy.get(autoRefreshIntervalButton).click();
-  cy.get('div[role="option"]').should('have.length', 7);
 };
 
 export const clickFilterNewerThanButton = () =>

--- a/test/e2e/cypress/pageObject/activity_log_po.js
+++ b/test/e2e/cypress/pageObject/activity_log_po.js
@@ -62,8 +62,10 @@ export const waitForActivityLogRequest = () =>
 export const clickFilterTypeButton = () =>
   cy.get(filterTypeButton).click({ force: true });
 
+const clickOutside = () => cy.get('body').click();
+
 export const clickAutoRefreshRateButton = () => {
-  cy.get('body').click();
+  clickOutside();
   cy.get(autoRefreshIntervalButton).click();
 };
 

--- a/test/e2e/cypress/pageObject/activity_log_po.js
+++ b/test/e2e/cypress/pageObject/activity_log_po.js
@@ -110,17 +110,9 @@ export const selectRefreshRate = (refreshRate) => {
   return cy.contains(refreshRate).click();
 };
 
-export const selectNextRefreshRate = () => {
-  cy.get('button[class*="refresh-rate-selection-dropdown"]').click();
-  cy.get('button[class*="refresh-rate-selection-dropdown"]')
-    .invoke('text')
-    .then(($text) => {
-      if ($text === '30m') {
-        cy.get('div[role="listbox"]').type(
-          '{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{enter}'
-        );
-      } else cy.get('div[role="listbox"]').type('{downarrow}{enter}');
-    });
+export const selectNextRefreshRate = (refreshRate) => {
+  cy.get('div[class="relative flex-1"]').type('{downarrow}');
+  cy.contains(refreshRate).click();
 };
 
 // UI Validations

--- a/test/e2e/cypress/pageObject/activity_log_po.js
+++ b/test/e2e/cypress/pageObject/activity_log_po.js
@@ -62,8 +62,10 @@ export const waitForActivityLogRequest = () =>
 export const clickFilterTypeButton = () =>
   cy.get(filterTypeButton).click({ force: true });
 
-export const clickAutoRefreshRateButton = () =>
+export const clickAutoRefreshRateButton = () => {
   cy.get(autoRefreshIntervalButton).click();
+  cy.get('div[role="option"]').should('have.length', 7);
+};
 
 export const clickFilterNewerThanButton = () =>
   cy.get(filterNewerThanButton).click();

--- a/test/e2e/cypress/pageObject/activity_log_po.js
+++ b/test/e2e/cypress/pageObject/activity_log_po.js
@@ -114,7 +114,7 @@ export const selectPagination = (amountOfItems) => {
 export const selectRefreshRate = (refreshRate) => {
   cy.get(autoRefreshIntervalButton).click();
   // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(250); // couldn't really find a way to reduce flakiness here
+  cy.wait(500); // couldn't really find a way to reduce flakiness here
   return cy.contains(refreshRate).click();
 };
 

--- a/test/e2e/cypress/pageObject/activity_log_po.js
+++ b/test/e2e/cypress/pageObject/activity_log_po.js
@@ -62,10 +62,9 @@ export const waitForActivityLogRequest = () =>
 export const clickFilterTypeButton = () =>
   cy.get(filterTypeButton).click({ force: true });
 
-const clickOutside = () => cy.get('body').click();
 
 export const clickAutoRefreshRateButton = () => {
-  clickOutside();
+  basePage.clickOutside();
   cy.get(autoRefreshIntervalButton).click();
 };
 

--- a/test/e2e/cypress/pageObject/activity_log_po.js
+++ b/test/e2e/cypress/pageObject/activity_log_po.js
@@ -114,7 +114,7 @@ export const selectPagination = (amountOfItems) => {
 export const selectRefreshRate = (refreshRate) => {
   cy.get(autoRefreshIntervalButton).click();
   // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(500); // couldn't really find a way to reduce flakiness here
+  cy.wait(1000); // couldn't really find a way to reduce flakiness here
   return cy.contains(refreshRate).click();
 };
 

--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -119,6 +119,8 @@ export const selectFromDropdown = (selector, choice) => {
   return cy.get(`${selector} + div div:contains("${choice}")`).click();
 };
 
+export const clickOutside = () => cy.get('body').click();
+
 // UI Validations
 
 export const shouldRedirectToIdpUrl = () =>


### PR DESCRIPTION
### Overview

This pull request resolves flakiness in the end-to-end (E2E) test for the activity log page when selecting different refresh rates. 

### Key Changes

- Refactored test utilities for the activity log page:
  - The refresh rate dropdown interaction is now more robust, with an explicit click outside the menu before opening it.
  - Consolidated the list of expected refresh rates into a local constant.
  - Removed explicit wait as it wasn't helping a lot
- Added a new helper (`clickOutside`) in the base page object to improve interaction reliability.

P.S: This scenario is a bit tricky and you may think it could actually be a bug, but I haven't been able to reproduce it manually, so I understand that this trick to test all the possible refresh rates selected is perfectly valid.