### PR TITLE
Rescue on discovery exceptions

### DIFF
--- a/lib/trento/discovery.ex
+++ b/lib/trento/discovery.ex
@@ -49,7 +49,7 @@ defmodule Trento.Discovery do
     end
   rescue
     error ->
-      IO.inspect(error, label: "Error handling discovery event")
+      Logger.error("Error handling discovery event: #{inspect(error)}")
       store_discarded_discovery_event(event, inspect(error))
       {:error, :discovery_exception}
   end

--- a/lib/trento/discovery.ex
+++ b/lib/trento/discovery.ex
@@ -47,6 +47,11 @@ defmodule Trento.Discovery do
 
         error
     end
+  rescue
+    error ->
+      IO.inspect(error, label: "Error handling discovery event")
+      store_discarded_discovery_event(event, inspect(error))
+      {:error, :discovery_exception}
   end
 
   @doc """

--- a/lib/trento/discovery.ex
+++ b/lib/trento/discovery.ex
@@ -49,7 +49,11 @@ defmodule Trento.Discovery do
     end
   rescue
     error ->
-      Logger.error("Error handling discovery event: #{inspect(error)}")
+      Logger.error(
+        "Error handling discovery event: #{inspect(error)}" <>
+          "\n" <> "#{Exception.format_stacktrace()}"
+      )
+
       store_discarded_discovery_event(event, inspect(error))
       {:error, :discovery_exception}
   end

--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -116,6 +116,13 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"422", reason: "Unknown discovery type.")
   end
 
+  def call(conn, {:error, :discovery_exception}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(json: ErrorJSON)
+    |> render(:"422", reason: "Unable to handle discovery.")
+  end
+
   def call(conn, {:error, :host_alive}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/test/trento_web/controllers/v1/discovery_controller_test.exs
+++ b/test/trento_web/controllers/v1/discovery_controller_test.exs
@@ -84,5 +84,30 @@ defmodule TrentoWeb.V1.DiscoveryControllerTest do
       assert %DiscardedDiscoveryEvent{payload: ^body, reason: "[:associated_database_not_found]"} =
                discarded_event
     end
+
+    test "collect action returns error when unexpected error has happened during event processing",
+         %{conn: conn} do
+      body =
+        load_discovery_event_fixture("sap_system_discovery_application")
+
+      expect(Trento.Commanded.Mock, :dispatch, fn _ ->
+        raise "Test Exception"
+      end)
+
+      %{status: status} =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/v1/collect", body)
+
+      assert status == 422
+
+      [discarded_event] = Discovery.get_discarded_discovery_events(1)
+
+      assert %DiscardedDiscoveryEvent{
+               payload: ^body,
+               reason: "%RuntimeError{message: \"Test Exception\"}"
+             } =
+               discarded_event
+    end
   end
 end


### PR DESCRIPTION
# Description

If there are cluster discovery events that fail in an unexpected way, the saving of the offending request logic didn't trigger and thus the events were not saved in the discarded table. This PR fixes this. 

It uses `rescue` early in the Commanded handler for discovery events and if error/exit/trow is encountered during processing it logs the error with stack trace and saves the offending event.

## How was this tested?
Manually and with UTs.
