### PR TITLE
Add system replication details

### DIFF
--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
@@ -285,6 +285,7 @@ export function GenericSystemDetails({
                           <SystemReplicationDataPill
                             label="Replicating"
                             data={instances[0].system_replication_source_site}
+                            className="bg-gray-200 text-gray-500 max-w-32 truncate !inline self-center !py-0.5"
                           />
                           <SystemReplicationDataPill
                             label="Replication Mode"

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
@@ -1,6 +1,18 @@
 import React, { useState } from 'react';
 
-import { find, get, noop } from 'lodash';
+import {
+  find,
+  get,
+  noop,
+  capitalize,
+  some,
+  groupBy,
+  sortBy,
+  map,
+  upperCase,
+} from 'lodash';
+
+import classNames from 'classnames';
 
 import {
   EOS_APPLICATION_OUTLINED,
@@ -13,7 +25,11 @@ import {
   getOperationLabel,
   getOperationForbiddenMessage,
 } from '@lib/operations';
-import { APPLICATION_TYPE, getEnsaVersionLabel } from '@lib/model/sapSystems';
+import {
+  APPLICATION_TYPE,
+  DATABASE_TYPE,
+  getEnsaVersionLabel,
+} from '@lib/model/sapSystems';
 
 import ListView from '@common/ListView';
 import Table from '@common/Table';
@@ -24,6 +40,9 @@ import {
 } from '@common/OperationModals';
 
 import DeregistrationModal from '@pages/DeregistrationModal';
+
+import Pill from '@common/Pill';
+import { getReplicationStatusClasses } from '@pages/InstanceOverview/InstanceOverview';
 
 import {
   systemHostsTableConfiguration,
@@ -49,6 +68,21 @@ const instanceStartStopOperations = [SAP_INSTANCE_START, SAP_INSTANCE_STOP];
 const modalInitialState = { open: false, operation: '' };
 
 const closeInstanceModal = (prevState) => ({ ...prevState, open: false });
+
+function SystemReplicationDataPill({
+  label,
+  data,
+  className = 'bg-gray-200 text-gray-500',
+}) {
+  return (
+    <div className="flex space-x-1">
+      <span className="text-gray-500 font-bold">{label}</span>
+      <Pill className={classNames(className, '!py-0 items-center')}>
+        {data}
+      </Pill>
+    </div>
+  );
+}
 
 export function GenericSystemDetails({
   title,
@@ -90,6 +124,16 @@ export function GenericSystemDetails({
   const forbiddenOperationName = get(forbiddenOperation, 'operation', null);
   const isForbidden = get(forbiddenOperation, 'forbidden', false);
   const forbiddenErrors = get(forbiddenOperation, 'errors', []);
+
+  const sortedInstances = sortBy(system.instances, ['system_replication_tier']);
+  const sitedInstances = groupBy(
+    sortedInstances,
+    ({ system_replication_site: site }) => site
+  );
+  const hasSystemReplication = some(
+    system.instances,
+    (instance) => instance.system_replication
+  );
 
   return (
     <div>
@@ -164,11 +208,20 @@ export function GenericSystemDetails({
                   },
                 ]
               : []),
+            ...(type === DATABASE_TYPE
+              ? [
+                  {
+                    title: 'System Replication',
+                    content: hasSystemReplication,
+                    render: (content) => capitalize(content),
+                  },
+                ]
+              : []),
             {
               title: '',
               content: type,
               render: (content) => (
-                <div className="float-right">
+                <div className="justify-end float-right">
                   {content === APPLICATION_TYPE ? (
                     <EOS_APPLICATION_OUTLINED
                       size={25}
@@ -191,17 +244,67 @@ export function GenericSystemDetails({
         <div className="flex flex-direction-row">
           <h2 className="text-2xl font-bold self-center">Layout</h2>
         </div>
-        <Table
-          className="pt-2"
-          config={getSystemInstancesTableConfiguration({
-            userAbilities,
-            cleanUpPermittedFor,
-            onCleanUpClick,
-            operationsEnabled,
-            getOperations: curriedGetInstanceOperations,
-          })}
-          data={system.instances}
-        />
+        {map(sitedInstances, (instances, site) => (
+          <div key={site} className="mt-4 bg-white rounded-lg">
+            <Table
+              config={getSystemInstancesTableConfiguration({
+                type,
+                userAbilities,
+                cleanUpPermittedFor,
+                onCleanUpClick,
+                operationsEnabled,
+                getOperations: curriedGetInstanceOperations,
+              })}
+              data={instances}
+              header={
+                hasSystemReplication && (
+                  <div className="flex py-4 px-5">
+                    <div className="flex w-3/4 space-x-3">
+                      <div className="flex space-x-2 mr-3">
+                        <h3 className="text-l font-bold">{site}</h3>
+                        <Pill className="bg-green-100 text-green-800 !py-0 items-center">
+                          {upperCase(instances[0].system_replication)}
+                        </Pill>
+                      </div>
+                      <SystemReplicationDataPill
+                        label="Tier"
+                        data={instances[0].system_replication_tier}
+                      />
+
+                      {instances[0].system_replication === 'Primary' && (
+                        <SystemReplicationDataPill
+                          label="Status"
+                          data={instances[0].system_replication_status}
+                          className={getReplicationStatusClasses(
+                            instances[0].system_replication_status
+                          )}
+                        />
+                      )}
+                      {instances[0].system_replication === 'Secondary' && (
+                        <>
+                          <SystemReplicationDataPill
+                            label="Replicating"
+                            data={instances[0].system_replication_source_site}
+                          />
+                          <SystemReplicationDataPill
+                            label="Replication Mode"
+                            data={instances[0].system_replication_mode}
+                          />
+                          <SystemReplicationDataPill
+                            label="Operation Mode"
+                            data={
+                              instances[0].system_replication_operation_mode
+                            }
+                          />
+                        </>
+                      )}
+                    </div>
+                  </div>
+                )
+              }
+            />
+          </div>
+        ))}
       </div>
 
       <div className="mt-8">

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
@@ -259,7 +259,7 @@ export function GenericSystemDetails({
               header={
                 hasSystemReplication && (
                   <div className="flex py-4 px-5">
-                    <div className="flex w-3/4 space-x-3">
+                    <div className="flex w-11/12 space-x-3">
                       <div className="flex space-x-2 mr-3">
                         <h3 className="text-l font-bold">{site}</h3>
                         <Pill className="bg-green-100 text-green-800 !py-0 items-center">

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
@@ -149,24 +149,36 @@ describe('GenericSystemDetails', () => {
 
     const siteTables = screen.getAllByRole('table');
 
+    const instance1 = database.instances[0];
     const { getByText: getByTextSite1 } = within(siteTables[0].previousSibling);
-    expect(getByTextSite1('Site1')).toBeTruthy();
-    expect(getByTextSite1('PRIMARY')).toBeTruthy();
-    expect(getByTextSite1('Tier').nextSibling).toHaveTextContent('1');
-    expect(getByTextSite1('Status').nextSibling).toHaveTextContent('ACTIVE');
+    expect(getByTextSite1(instance1.system_replication_site)).toBeTruthy();
+    expect(
+      getByTextSite1(instance1.system_replication.toUpperCase())
+    ).toBeTruthy();
+    expect(getByTextSite1('Tier').nextSibling).toHaveTextContent(
+      instance1.system_replication_tier.toString()
+    );
+    expect(getByTextSite1('Status').nextSibling).toHaveTextContent(
+      instance1.system_replication_status
+    );
 
+    const instance2 = database.instances[1];
     const { getByText: getByTextSite2 } = within(siteTables[1].previousSibling);
-    expect(getByTextSite2('Site2')).toBeTruthy();
-    expect(getByTextSite2('SECONDARY')).toBeTruthy();
-    expect(getByTextSite2('Tier').nextSibling).toHaveTextContent('2');
+    expect(getByTextSite2(instance2.system_replication_site)).toBeTruthy();
+    expect(
+      getByTextSite2(instance2.system_replication.toUpperCase())
+    ).toBeTruthy();
+    expect(getByTextSite2('Tier').nextSibling).toHaveTextContent(
+      instance2.system_replication_tier.toString()
+    );
     expect(getByTextSite2('Replicating').nextSibling).toHaveTextContent(
-      'Site1'
+      instance2.system_replication_source_site
     );
     expect(getByTextSite2('Replication Mode').nextSibling).toHaveTextContent(
-      'sync'
+      instance2.system_replication_mode
     );
     expect(getByTextSite2('Operation Mode').nextSibling).toHaveTextContent(
-      'logreplay'
+      instance2.system_replication_operation_mode
     );
   });
 

--- a/test/e2e/cypress/e2e/hana_database_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_database_details.cy.js
@@ -19,6 +19,10 @@ context('HANA database details', () => {
       hanaDbDetailsPage.databaseHasExpectedType();
     });
 
+    it('should display system replication enablement status', () => {
+      hanaDbDetailsPage.databaseHasExpectedSystemReplication();
+    });
+
     it(`should display "Not found" page when HANA database doesn't exist`, () => {
       hanaDbDetailsPage.visitNonExistentDatabase();
       hanaDbDetailsPage.validateNonExistentDatabaseUrl();
@@ -37,6 +41,10 @@ context('HANA database details', () => {
 
     it(`should show each hostname with the expected values`, () => {
       hanaDbDetailsPage.eachHostNameHasExpectedValues();
+    });
+
+    it('should show each site with the expected system replication values', () => {
+      hanaDbDetailsPage.eachSiteHasExpectedValues();
     });
 
     it('should show Green badge in instance when SAPControl-GREEN state is received', () => {

--- a/test/e2e/cypress/fixtures/hana-database-details/selected_database.js
+++ b/test/e2e/cypress/fixtures/hana-database-details/selected_database.js
@@ -2,6 +2,27 @@ export const selectedDatabase = {
   Id: 'f534a4ad-cef7-5234-b196-e67082ffb50c',
   Sid: 'HDD',
   Type: 'HANA Database',
+  SystemReplication: 'True',
+  Sites: [
+    {
+      Name: 'NBG',
+      SystemReplication: 'PRIMARY',
+      Tier: '1',
+      Status: 'ACTIVE',
+      Replicating: null,
+      ReplicationMode: null,
+      OperationMode: null,
+    },
+    {
+      Name: 'WDF',
+      SystemReplication: 'SECONDARY',
+      Tier: '2',
+      Status: null,
+      Replicating: 'NBG',
+      ReplicationMode: 'sync',
+      OperationMode: 'logreplay',
+    },
+  ],
   Hosts: [
     {
       Hostname: 'vmhdbdev02',

--- a/test/e2e/cypress/pageObject/hana_database_details_po.js
+++ b/test/e2e/cypress/pageObject/hana_database_details_po.js
@@ -16,6 +16,8 @@ const databaseNameLabel =
   'div[class*="grid-flow-row"]:contains("Name") div span';
 const databaseTypeLabel =
   'div[class*="grid-flow-row"]:contains("Type") div span';
+const systemReplicationLabel =
+  'div[class*="grid-flow-row"]:contains("System Replication") div:nth-child(2)';
 const pageNotFoundLabel = 'div:contains("Not Found")';
 const attachedHostsTableRows = 'div[class="mt-16"]:contains("Layout") tbody tr';
 const newRegisteredHost = `div[class="mt-8"]:contains("Hosts") td:contains("${attachedHosts[0].Name}")`;
@@ -23,6 +25,7 @@ const layoutTableHostNameCell = (hostName) =>
   `div[class="mt-16"]:contains("Layout") td:contains("${hostName}")`;
 const hostsTableHostNameCell = (hostName) =>
   `div[class="mt-8"]:contains("Hosts") td:contains("${hostName}")`;
+const siteHeader = (site) => `h3:contains("${site}")`;
 
 //UI Interactions
 
@@ -44,6 +47,11 @@ export const databaseHasExpectedName = () =>
 
 export const databaseHasExpectedType = () =>
   cy.get(databaseTypeLabel).should('have.text', selectedDatabase.Type);
+
+export const databaseHasExpectedSystemReplication = () =>
+  cy
+    .get(systemReplicationLabel)
+    .should('have.text', selectedDatabase.SystemReplication);
 
 export const pageNotFoundLabelIsDisplayed = () =>
   cy.get(pageNotFoundLabel).should('be.visible');
@@ -90,6 +98,39 @@ const hostStatusHasExpectedClass = (hostName) => {
   validateHostClass(hostName, status);
 };
 
+const getSiteContainer = (site) => {
+  const header = siteHeader(site);
+  return cy.get(header).parent().parent();
+};
+
+const siteHasExpectedName = (site) => {
+  getSiteContainer(site).should('include.text', site);
+};
+
+const siteHasExpectedSystemReplication = (site, systemReplication) => {
+  getSiteContainer(site).should('include.text', systemReplication);
+};
+
+const siteHasExpectedTier = (site, tier) => {
+  getSiteContainer(site).should('include.text', tier);
+};
+
+const siteHasExpectedStatus = (site, status) => {
+  getSiteContainer(site).should('include.text', status);
+};
+
+const siteHasExpectedReplicating = (site, replicating) => {
+  getSiteContainer(site).should('include.text', replicating);
+};
+
+const siteHasExpectedReplicationMode = (site, replicationMode) => {
+  getSiteContainer(site).should('include.text', replicationMode);
+};
+
+const siteHasExpectedOperationMode = (site, operationMode) => {
+  getSiteContainer(site).should('include.text', operationMode);
+};
+
 const validateHostClass = (hostName, status) => {
   const hostNameCellSelector = layoutTableHostNameCell(hostName);
   cy.get(hostNameCellSelector)
@@ -128,6 +169,20 @@ export const eachHostNameHasExpectedValues = () => {
     hostHasExpectedStartPriority(hostName);
     hostHasExpectedStatus(hostName);
     hostStatusHasExpectedClass(hostName);
+  });
+};
+
+export const eachSiteHasExpectedValues = () => {
+  selectedDatabase.Sites.forEach((site) => {
+    siteHasExpectedName(site.Name);
+    siteHasExpectedSystemReplication(site.Name, site.SystemReplication);
+    siteHasExpectedTier(site.Name, site.Tier);
+    site.Status && siteHasExpectedStatus(site.Name, site.Status);
+    site.Replicating && siteHasExpectedReplicating(site.Name, site.Replicating);
+    site.ReplicationMode &&
+      siteHasExpectedReplicationMode(site.Name, site.ReplicationMode);
+    site.OperationMode &&
+      siteHasExpectedOperationMode(site.Name, site.OperationMode);
   });
 };
 

--- a/test/e2e/cypress/pageObject/hana_database_details_po.js
+++ b/test/e2e/cypress/pageObject/hana_database_details_po.js
@@ -25,7 +25,7 @@ const layoutTableHostNameCell = (hostName) =>
   `div[class="mt-16"]:contains("Layout") td:contains("${hostName}")`;
 const hostsTableHostNameCell = (hostName) =>
   `div[class="mt-8"]:contains("Hosts") td:contains("${hostName}")`;
-const siteHeader = (site) => `h3:contains("${site}")`;
+const siteHeader = (site) => `div:has(div > h3:contains("${site}"))`;
 
 //UI Interactions
 
@@ -99,8 +99,7 @@ const hostStatusHasExpectedClass = (hostName) => {
 };
 
 const getSiteContainer = (site) => {
-  const header = siteHeader(site);
-  return cy.get(header).parent().parent();
+  return cy.get(siteHeader(site));
 };
 
 const siteHasExpectedName = (site) => {


### PR DESCRIPTION
# Description

Add system replication details to the HANA database details view.
The instances are grouped by sites.
If the database doesn't have system replication, the table header is not added.

With SR:
<img width="1286" height="626" alt="image" src="https://github.com/user-attachments/assets/41dfab21-8fb6-4b89-9743-7584b8c0f6b6" />

Without SR:
<img width="1302" height="399" alt="image" src="https://github.com/user-attachments/assets/32823f26-9a34-43ef-9aac-ff88146627dc" />


## How was this tested?
UT and e2e
