### PR TITLE
Add cluster start and stop operations to the controller

### DIFF
--- a/lib/trento/infrastructure/operations/operations.ex
+++ b/lib/trento/infrastructure/operations/operations.ex
@@ -54,6 +54,8 @@ defmodule Trento.Infrastructure.Operations do
   def map_operation_type("sapsystemstop@v1"), do: :sap_system_stop
   def map_operation_type("pacemakerenable@v1"), do: :pacemaker_enable
   def map_operation_type("pacemakerdisable@v1"), do: :pacemaker_disable
+  def map_operation_type("crmclusterstart@v1"), do: :cluster_host_start
+  def map_operation_type("crmclusterstop@v1"), do: :cluster_host_stop
   def map_operation_type("databasestart@v1"), do: :database_start
   def map_operation_type("databasestop@v1"), do: :database_stop
   def map_operation_type(_), do: :unknown
@@ -61,6 +63,8 @@ defmodule Trento.Infrastructure.Operations do
   def map_operation(:saptune_solution_apply), do: "saptuneapplysolution@v1"
   def map_operation(:saptune_solution_change), do: "saptunechangesolution@v1"
   def map_operation(:cluster_maintenance_change), do: "clustermaintenancechange@v1"
+  def map_operation(:cluster_host_start), do: "crmclusterstart@v1"
+  def map_operation(:cluster_host_stop), do: "crmclusterstop@v1"
   def map_operation(:sap_instance_start), do: "sapinstancestart@v1"
   def map_operation(:sap_instance_stop), do: "sapinstancestop@v1"
   def map_operation(:sap_system_start), do: "sapsystemstart@v1"

--- a/lib/trento/operations/cluster_policy.ex
+++ b/lib/trento/operations/cluster_policy.ex
@@ -46,6 +46,9 @@ defmodule Trento.Operations.ClusterPolicy do
 
   def authorize_operation(:cluster_maintenance_change, _, _), do: :ok
 
+  def authorize_operation(:cluster_host_start, _, _), do: :ok
+  def authorize_operation(:cluster_host_stop, _, _), do: :ok
+
   def authorize_operation(
         operation,
         %ClusterReadModel{hosts: hosts},

--- a/lib/trento/operations/enums/cluster_host_operations.ex
+++ b/lib/trento/operations/enums/cluster_host_operations.ex
@@ -2,5 +2,6 @@ defmodule Trento.Operations.Enums.ClusterHostOperations do
   @moduledoc """
   Cluster host operations
   """
-  use Trento.Support.Enum, values: [:pacemaker_enable, :pacemaker_disable]
+  use Trento.Support.Enum,
+    values: [:pacemaker_enable, :pacemaker_disable, :cluster_host_start, :cluster_host_stop]
 end

--- a/lib/trento_web/controllers/v1/cluster_controller.ex
+++ b/lib/trento_web/controllers/v1/cluster_controller.ex
@@ -209,10 +209,9 @@ defmodule TrentoWeb.V1.ClusterController do
       do: Clusters.get_cluster_by_id(id)
 
   def get_operation_cluster(%{
-        assigns: %{operation: operation},
+        assigns: %{operation: _},
         params: %{id: id, host_id: host_id}
-      })
-      when operation in [:pacemaker_enable, :pacemaker_disable] do
+      }) do
     id
     |> Clusters.get_cluster_by_id()
     |> Repo.preload(:hosts)
@@ -231,6 +230,8 @@ defmodule TrentoWeb.V1.ClusterController do
     end
   end
 
+  def get_operation_cluster(_), do: nil
+
   def get_operation(%{params: %{operation: "cluster_maintenance_change"}}),
     do: :cluster_maintenance_change
 
@@ -239,6 +240,12 @@ defmodule TrentoWeb.V1.ClusterController do
 
   def get_operation(%{params: %{operation: "pacemaker_disable"}}),
     do: :pacemaker_disable
+
+  def get_operation(%{params: %{operation: "cluster_host_start"}}),
+    do: :cluster_host_start
+
+  def get_operation(%{params: %{operation: "cluster_host_stop"}}),
+    do: :cluster_host_stop
 
   def get_operation(_), do: nil
 

--- a/test/trento/clusters_test.exs
+++ b/test/trento/clusters_test.exs
@@ -1213,7 +1213,7 @@ defmodule Trento.ClustersTest do
       end
     end
 
-    pacemaker_enablement_scenarios = [
+    host_operation_scenarios = [
       %{
         operation: :pacemaker_enable,
         expected_operator: "pacemakerenable@v1"
@@ -1221,17 +1221,25 @@ defmodule Trento.ClustersTest do
       %{
         operation: :pacemaker_disable,
         expected_operator: "pacemakerdisable@v1"
+      },
+      %{
+        operation: :cluster_host_start,
+        expected_operator: "crmclusterstart@v1"
+      },
+      %{
+        operation: :cluster_host_stop,
+        expected_operator: "crmclusterstop@v1"
       }
     ]
 
-    for %{operation: operation} = scenario <- pacemaker_enablement_scenarios do
-      @pacemaker_enablement_scenario scenario
+    for %{operation: operation} = scenario <- host_operation_scenarios do
+      @host_operation_scenarios scenario
 
       test "should request #{operation} operation" do
         %{
           operation: pacemaker_operation,
           expected_operator: expected_operator
-        } = @pacemaker_enablement_scenario
+        } = @host_operation_scenarios
 
         cluster_id = Faker.UUID.v4()
         host_id = Faker.UUID.v4()
@@ -1261,7 +1269,7 @@ defmodule Trento.ClustersTest do
       end
 
       test "should handle #{operation} messagging error" do
-        %{operation: pacemaker_operation} = @pacemaker_enablement_scenario
+        %{operation: host_operation} = @host_operation_scenarios
 
         expect(
           Trento.Infrastructure.Messaging.Adapter.Mock,
@@ -1274,7 +1282,7 @@ defmodule Trento.ClustersTest do
 
         assert {:error, :amqp_error} =
                  Clusters.request_host_operation(
-                   pacemaker_operation,
+                   host_operation,
                    Faker.UUID.v4(),
                    Faker.UUID.v4()
                  )


### PR DESCRIPTION
Following https://github.com/trento-project/wanda/pull/633

This PR exposes the `cluster_host_start` and `cluster_host_stop` operations as cluster host operations