### PR TITLE
Sap start stop operation modal

### DIFF
--- a/assets/js/common/OperationModals/SapStartStopOperationModal.jsx
+++ b/assets/js/common/OperationModals/SapStartStopOperationModal.jsx
@@ -1,0 +1,134 @@
+import React, { useState } from 'react';
+import { get, noop } from 'lodash';
+import {
+  DATABASE_START,
+  DATABASE_STOP,
+  SAP_SYSTEM_START,
+  SAP_SYSTEM_STOP,
+} from '@lib/operations';
+
+import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model/sapSystems';
+
+import { InputNumber } from '@common/Input';
+import Select from '@common/Select';
+
+import OperationModal from './OperationModal';
+
+const TITLES = {
+  [DATABASE_START]: 'Start database',
+  [DATABASE_STOP]: 'Stop database',
+  [SAP_SYSTEM_START]: 'Start SAP system',
+  [SAP_SYSTEM_STOP]: 'Stop SAP system',
+};
+
+const ALL_SELECTED = 'all';
+
+const instanceTypes = [
+  {
+    key: 'All instances',
+    value: ALL_SELECTED,
+  },
+  {
+    key: 'ABAP instances',
+    value: 'abap',
+  },
+  {
+    key: 'J2EE instances',
+    value: 'j2ee',
+  },
+  {
+    key: 'ASCS/SCS instances',
+    value: 'scs',
+  },
+  {
+    key: 'ENQREP instances',
+    value: 'enqrep',
+  },
+];
+
+const DEFAULT_TIMEOUT = 5;
+const MIN_TIMEOUT = 1;
+const MAX_TIMEOUT = 720; // 12 hours
+
+const getOperationTitle = (operation) =>
+  get(TITLES, operation, 'unknown operation');
+
+function SapStartStopOperationModal({
+  operation,
+  type,
+  sid,
+  site = null,
+  isOpen = false,
+  onRequest = noop,
+  onCancel = noop,
+}) {
+  const [checked, setChecked] = useState(false);
+  const [instanceType, setInstanceType] = useState(ALL_SELECTED);
+  const [timeout, setTimeout] = useState(DEFAULT_TIMEOUT);
+
+  const operationTitle = getOperationTitle(operation);
+
+  return (
+    <OperationModal
+      title={operationTitle}
+      description={`${operationTitle} ${sid}${site ? ` on ${site} site` : ''}`}
+      operationText={operationTitle}
+      applyDisabled={!checked}
+      checked={checked}
+      isOpen={isOpen}
+      onChecked={() => setChecked((prev) => !prev)}
+      onRequest={() => {
+        onRequest({
+          timeout: timeout * 60,
+          ...(type === APPLICATION_TYPE && { instance_type: instanceType }),
+          ...(type === DATABASE_TYPE && site && { site }),
+        });
+        setChecked(false);
+      }}
+      onCancel={() => {
+        onCancel();
+        setChecked(false);
+        setInstanceType(ALL_SELECTED);
+        setTimeout(DEFAULT_TIMEOUT);
+      }}
+    >
+      <div>
+        {type === APPLICATION_TYPE && (
+          <div className="flex items-center justify-start gap-2 mt-4">
+            <p className="font-semibold text-gray-900 tracking-wide">
+              Instance type
+            </p>
+            <Select
+              className="ml-auto !flex-none !w-2/3"
+              optionsName="instance_type"
+              options={instanceTypes}
+              value={instanceType}
+              onChange={(value) => setInstanceType(value)}
+              disabled={!checked}
+              renderOption={(item) => item.key}
+            />
+          </div>
+        )}
+        <div className="flex items-center justify-start gap-2 mt-4">
+          <p className="font-semibold text-gray-900 tracking-wide">
+            Timeout (minutes)
+          </p>
+          <InputNumber
+            id="timeout-input"
+            name="timeout-input"
+            className="ml-auto !w-2/3 h-8"
+            value={timeout}
+            min={MIN_TIMEOUT}
+            max={MAX_TIMEOUT}
+            onChange={(value) => {
+              setTimeout(value);
+            }}
+            disabled={!checked}
+          />
+        </div>
+      </div>
+    </OperationModal>
+  );
+}
+
+export default SapStartStopOperationModal;

--- a/assets/js/common/OperationModals/SapStartStopOperationModal.stories.jsx
+++ b/assets/js/common/OperationModals/SapStartStopOperationModal.stories.jsx
@@ -12,7 +12,7 @@ export default {
   argTypes: {
     operation: {
       description: 'Operation to request',
-      control: 'string',
+      control: 'text',
     },
     type: {
       description: 'System type',
@@ -21,11 +21,11 @@ export default {
     },
     sid: {
       description: 'SAP system or database sid',
-      control: 'string',
+      control: 'text',
     },
     site: {
       description: 'System replication site. Only applicable for database type',
-      control: 'string',
+      control: 'text',
     },
     isOpen: {
       description: 'Modal is open',

--- a/assets/js/common/OperationModals/SapStartStopOperationModal.stories.jsx
+++ b/assets/js/common/OperationModals/SapStartStopOperationModal.stories.jsx
@@ -1,0 +1,62 @@
+import { DATABASE_START, SAP_SYSTEM_START } from '@lib/operations';
+
+import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model/sapSystems';
+
+import { sapSystemFactory } from '@lib/test-utils/factories';
+
+import SapStartStopOperationModal from './SapStartStopOperationModal';
+
+export default {
+  title: 'Components/SapStartStopOperationModal',
+  component: SapStartStopOperationModal,
+  argTypes: {
+    operation: {
+      description: 'Operation to request',
+      control: 'string',
+    },
+    type: {
+      description: 'System type',
+      control: { type: 'radio' },
+      options: [APPLICATION_TYPE, DATABASE_TYPE],
+    },
+    sid: {
+      description: 'SAP system or database sid',
+      control: 'string',
+    },
+    site: {
+      description: 'System replication site. Only applicable for database type',
+      control: 'string',
+    },
+    isOpen: {
+      description: 'Modal is open',
+      control: 'boolean',
+    },
+    onRequest: {
+      description: 'Request start/stop operation',
+    },
+    onCancel: {
+      description: 'Closes the modal',
+    },
+  },
+  args: {
+    isOpen: true,
+  },
+};
+
+const { sid } = sapSystemFactory.build();
+
+export const SapSystem = {
+  args: {
+    operation: SAP_SYSTEM_START,
+    type: APPLICATION_TYPE,
+    sid,
+  },
+};
+
+export const Database = {
+  args: {
+    operation: DATABASE_START,
+    type: DATABASE_TYPE,
+    sid,
+  },
+};

--- a/assets/js/common/OperationModals/SapStartStopOperationModal.test.jsx
+++ b/assets/js/common/OperationModals/SapStartStopOperationModal.test.jsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { faker } from '@faker-js/faker';
+
+import { sapSystemFactory } from '@lib/test-utils/factories';
+import {
+  DATABASE_START,
+  DATABASE_STOP,
+  SAP_SYSTEM_START,
+  SAP_SYSTEM_STOP,
+} from '@lib/operations';
+
+import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model/sapSystems';
+
+import SapStartStopOperationModal from './SapStartStopOperationModal';
+
+const { sid } = sapSystemFactory.build();
+const systemReplicationSite = faker.animal.bear();
+
+describe('SapStartStopOperationModal', () => {
+  it.each([
+    {
+      operation: DATABASE_START,
+      title: 'Start database',
+      expectedDescription: `Start database ${sid}`,
+    },
+    {
+      operation: DATABASE_START,
+      title: 'Start database',
+      site: systemReplicationSite,
+      expectedDescription: `Start database ${sid} on ${systemReplicationSite} site`,
+    },
+    {
+      operation: DATABASE_STOP,
+      title: 'Stop database',
+      expectedDescription: `Stop database ${sid}`,
+    },
+    {
+      operation: SAP_SYSTEM_START,
+      title: 'Start SAP system',
+      expectedDescription: `Start SAP system ${sid}`,
+    },
+    {
+      operation: SAP_SYSTEM_STOP,
+      title: 'Stop SAP system',
+      expectedDescription: `Stop SAP system ${sid}`,
+    },
+  ])(
+    `should show correct title and description for $operation`,
+    async ({ operation, title, site, expectedDescription }) => {
+      await act(async () => {
+        render(
+          <SapStartStopOperationModal
+            operation={operation}
+            sid={sid}
+            site={site}
+            isOpen
+          />
+        );
+      });
+
+      expect(screen.getByText(title)).toBeInTheDocument();
+      expect(screen.getByText(expectedDescription)).toBeInTheDocument();
+    }
+  );
+
+  it.each([
+    {
+      option: 'All instances',
+      instanceType: 'all',
+    },
+    {
+      option: 'ABAP instances',
+      instanceType: 'abap',
+    },
+    {
+      option: 'J2EE instances',
+      instanceType: 'j2ee',
+    },
+    {
+      option: 'ASCS/SCS instances',
+      instanceType: 'scs',
+    },
+    {
+      option: 'ENQREP instances',
+      instanceType: 'enqrep',
+    },
+  ])(
+    'should request a SAP system operation with correct params for $instanceType instance type',
+    async ({ option, instanceType }) => {
+      const user = userEvent.setup();
+      const onRequest = jest.fn();
+
+      await act(async () => {
+        render(
+          <SapStartStopOperationModal
+            operation={SAP_SYSTEM_START}
+            sid={sid}
+            type={APPLICATION_TYPE}
+            isOpen
+            onRequest={onRequest}
+          />
+        );
+      });
+
+      expect(screen.getByText('Apply')).toBeDisabled();
+      await user.click(screen.getByRole('checkbox'));
+      await user.click(screen.getByText('All instances'));
+      await user.click(screen.getByRole('option', { name: option }));
+      await user.click(screen.getByText('Apply'));
+
+      expect(onRequest).toHaveBeenCalledWith({
+        instance_type: instanceType,
+        timeout: 300,
+      });
+    }
+  );
+
+  it('should request a database operation with correct params', async () => {
+    const user = userEvent.setup();
+    const onRequest = jest.fn();
+
+    await act(async () => {
+      render(
+        <SapStartStopOperationModal
+          operation={DATABASE_START}
+          sid={sid}
+          type={DATABASE_TYPE}
+          site={systemReplicationSite}
+          isOpen
+          onRequest={onRequest}
+        />
+      );
+    });
+
+    expect(screen.getByText('Apply')).toBeDisabled();
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByText('Apply'));
+
+    expect(onRequest).toHaveBeenCalledWith({
+      timeout: 300,
+      site: systemReplicationSite,
+    });
+  });
+
+  it('should call onCancel callback', async () => {
+    const user = userEvent.setup();
+    const onCancel = jest.fn();
+
+    await act(async () => {
+      render(
+        <SapStartStopOperationModal
+          operation={SAP_SYSTEM_START}
+          sid={sid}
+          isOpen
+          onCancel={onCancel}
+        />
+      );
+    });
+
+    await user.click(screen.getByText('Cancel'));
+
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/assets/js/common/OperationModals/index.js
+++ b/assets/js/common/OperationModals/index.js
@@ -1,9 +1,11 @@
 import SaptuneSolutionOperationModal from './SaptuneSolutionOperationModal';
 import OperationForbiddenModal from './OperationForbiddenModal';
 import SimpleAcceptanceOperationModal from './SimpleAcceptanceOperationModal';
+import SapStartStopOperationModal from './SapStartStopOperationModal';
 
 export {
   SaptuneSolutionOperationModal,
   SimpleAcceptanceOperationModal,
+  SapStartStopOperationModal,
   OperationForbiddenModal,
 };


### PR DESCRIPTION
# Description

Add SAP system and HANA database start/stop operation modal.
The modal has 2 optional inputs:
- Timeout (to start/stop)
- Instance type, only for SAP systems. 

SAP system:
![start_stop](https://github.com/user-attachments/assets/b40bb6d7-0793-4fdb-9ee6-396ff03abae0)

HANA database (site is optional, database without SR doesn't have it):
<img width="839" height="351" alt="image" src="https://github.com/user-attachments/assets/be55cbc9-5462-44ab-bb44-2c2ec858c01c" />


## How was this tested?

UT and storybbok
