### PR TITLE
Fix version usage in page_controller

### DIFF
--- a/lib/trento_web/controllers/page_controller.ex
+++ b/lib/trento_web/controllers/page_controller.ex
@@ -3,6 +3,8 @@ defmodule TrentoWeb.PageController do
 
   alias Trento.Settings
 
+  @version Mix.Project.config()[:version]
+
   def index(conn, _params) do
     check_service_base_url = Application.fetch_env!(:trento, :checks_service)[:base_url]
     charts_enabled = Application.fetch_env!(:trento, Trento.Charts)[:enabled]
@@ -13,7 +15,6 @@ defmodule TrentoWeb.PageController do
     analytics_key = Application.fetch_env!(:trento, :analytics)[:analytics_key]
     analytics_url = Application.fetch_env!(:trento, :analytics)[:analytics_url]
     operations_enabled = Application.fetch_env!(:trento, :operations_enabled)
-    version = Mix.Project.config()[:version]
 
     {sso_enabled, callback_url, login_url, enrollment_url} = sso_details(conn)
 
@@ -31,7 +32,7 @@ defmodule TrentoWeb.PageController do
       sso_callback_url: callback_url,
       sso_enrollment_url: enrollment_url,
       operations_enabled: operations_enabled,
-      version: version,
+      version: @version,
       layout: false
     )
   end


### PR DESCRIPTION
# Description

Fix version usage in page controller. The version must be retrieved in compile time.

The error is:

```
08:35:47.859 request_id=GFiDamVmcaGiWZEACbsS [debug] Converted error :undef to 500 response
08:35:47.860 [error] #PID<0.3581941.0> running TrentoWeb.Endpoint (connection #PID<0.3581952.0>, stream id 1) terminated
Server: demo.trento-project.io:80 (http)
Request: GET /
** (exit) an exception was raised:
    ** (UndefinedFunctionError) function Mix.Project.config/0 is undefined (module Mix.Project is not available)
        Mix.Project.config()
        (trento 2.5.0+git.163.1754037782.4fe42d770) lib/trento_web/controllers/page_controller.ex:16: TrentoWeb.PageController.index/2
        (trento 2.5.0+git.163.1754037782.4fe42d770) lib/trento_web/controllers/page_controller.ex:1: TrentoWeb.PageController.action/2
        (trento 2.5.0+git.163.1754037782.4fe42d770) lib/trento_web/controllers/page_controller.ex:1: TrentoWeb.PageController.phoenix_controller_pipeline/2
        (phoenix 1.7.14) lib/phoenix/router.ex:484: Phoenix.Router.__call__/5
        (trento 2.5.0+git.163.1754037782.4fe42d770) lib/trento_web/endpoint.ex:1: TrentoWeb.Endpoint.plug_builder_call/2
        (trento 2.5.0+git.163.1754037782.4fe42d770) lib/trento_web/endpoint.ex:1: TrentoWeb.Endpoint.call/2
```
