### PR TITLE
Database start/stop activity logging

### DIFF
--- a/assets/js/lib/model/activityLog.js
+++ b/assets/js/lib/model/activityLog.js
@@ -126,6 +126,7 @@ export const HOST_OPERATION_REQUESTED = 'host_operation_requested';
 export const CLUSTER_HOST_OPERATION_REQUESTED =
   'cluster_host_operation_requested';
 export const SAP_SYSTEM_OPERATION_REQUESTED = 'sap_system_operation_requested';
+export const DATABASE_OPERATION_REQUESTED = 'database_operation_requested';
 export const OPERATION_COMPLETED = 'operation_completed';
 
 // Check Customization
@@ -650,6 +651,12 @@ export const ACTIVITY_TYPES_CONFIG = {
     message: ({ metadata }) =>
       `Operation ${getOperationLabel(metadata.operation)} requested`,
     resource: sapSystemResourceType,
+  },
+  [DATABASE_OPERATION_REQUESTED]: {
+    label: 'Database Operation Requested',
+    message: ({ metadata }) =>
+      `Operation ${getOperationLabel(metadata.operation)} requested`,
+    resource: databaseResourceType,
   },
   [OPERATION_COMPLETED]: {
     label: 'Operation Completed',

--- a/lib/trento/activity_logging/activity_catalog.ex
+++ b/lib/trento/activity_logging/activity_catalog.ex
@@ -186,6 +186,8 @@ defmodule Trento.ActivityLog.ActivityCatalog do
         {:sap_system_operation_requested, 202},
       {TrentoWeb.V1.SapSystemController, :request_instance_operation} =>
         {:application_instance_operation_requested, 202},
+      {TrentoWeb.V1.DatabaseController, :request_operation} =>
+        {:database_operation_requested, 202},
       {TrentoWeb.V1.HostController, :delete} => {:host_cleanup_requested, 204},
       {TrentoWeb.V1.SapSystemController, :delete_application_instance} =>
         {:sap_system_cleanup_requested, 204},

--- a/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
+++ b/lib/trento/activity_logging/parser/phoenix_conn_parser.ex
@@ -206,7 +206,8 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
              :cluster_operation_requested,
              :host_operation_requested,
              :cluster_host_operation_requested,
-             :sap_system_operation_requested
+             :sap_system_operation_requested,
+             :database_operation_requested
            ] do
     operation_id = resp_body |> Jason.decode!() |> Map.get("operation_id")
 
@@ -241,6 +242,8 @@ defmodule Trento.ActivityLog.Logger.Parser.PhoenixConnParser do
        do: :cluster_id
 
   defp get_operation_resource_id_field(:host_operation_requested), do: :host_id
+
+  defp get_operation_resource_id_field(:database_operation_requested), do: :database_id
 
   defp maybe_add_additional_fields(
          metadata,

--- a/lib/trento/activity_logging/severity_level.ex
+++ b/lib/trento/activity_logging/severity_level.ex
@@ -160,6 +160,7 @@ defmodule Trento.ActivityLog.SeverityLevel do
     "host_operation_requested" => :info,
     "application_instance_operation_requested" => :info,
     "sap_system_operation_requested" => :info,
+    "database_operation_requested" => :info,
     "operation_completed" => %{
       type: :kv,
       key_suffix: "result",

--- a/test/trento/activity_logging/activity_catalog_test.exs
+++ b/test/trento/activity_logging/activity_catalog_test.exs
@@ -37,7 +37,8 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
         :cluster_operation_requested,
         :cluster_host_operation_requested,
         :application_instance_operation_requested,
-        :sap_system_operation_requested
+        :sap_system_operation_requested,
+        :database_operation_requested
       ]
 
       connection_activity_catalog = ActivityCatalog.connection_activities()
@@ -290,6 +291,12 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
       %{
         activity: :sap_system_operation_requested,
         connection_info: {TrentoWeb.V1.SapSystemController, :request_operation},
+        interesting_statuses: 202,
+        not_interesting_statuses: [400, 401, 403, 404, 500]
+      },
+      %{
+        activity: :database_operation_requested,
+        connection_info: {TrentoWeb.V1.DatabaseController, :request_operation},
         interesting_statuses: 202,
         not_interesting_statuses: [400, 401, 403, 404, 500]
       }

--- a/test/trento/activity_logging/phoenix_conn_parser_test.exs
+++ b/test/trento/activity_logging/phoenix_conn_parser_test.exs
@@ -299,6 +299,13 @@ defmodule Trento.ActivityLog.PhoenixConnParserTest do
           atom_operation: :sap_system_start,
           resource_field: :sap_system_id,
           additional_params: %{}
+        },
+        %{
+          action: :database_operation_requested,
+          operation: "database_start",
+          atom_operation: :database_start,
+          resource_field: :database_id,
+          additional_params: %{}
         }
       ]
 


### PR DESCRIPTION
# Description

Add database start/stop operation to activity logging entries.

<img width="1291" height="255" alt="image" src="https://github.com/user-attachments/assets/896a071c-a859-4cd4-933f-a41fa295caa1" />

<img width="783" height="701" alt="image" src="https://github.com/user-attachments/assets/b1468d38-8b1e-4b17-ab68-9eb93a0ca419" />

## How was this tested?

UT
