### PR TITLE
Analytics Eula Modal

### DIFF
--- a/assets/js/lib/test-utils/factories/users.js
+++ b/assets/js/lib/test-utils/factories/users.js
@@ -19,6 +19,7 @@ export const userFactory = Factory.define(() => ({
   password_change_requested_at: null,
   totp_enabled_at: formatISO(faker.date.past()),
   analytics_enabled: faker.datatype.boolean(),
+  analytics_eula_enabled: faker.datatype.boolean(),
   created_at: formatISO(faker.date.past()),
   updated_at: formatISO(faker.date.past()),
 }));
@@ -32,6 +33,7 @@ export const profileFactory = Factory.define(() => ({
   password_change_requested: false,
   totp_enabled: faker.datatype.boolean(),
   analytics_enabled: faker.datatype.boolean(),
+  analytics_eula_enabled: faker.datatype.boolean(),
   created_at: formatISO(faker.date.past()),
   updated_at: formatISO(faker.date.past()),
 }));

--- a/assets/js/pages/AnalyticsEula/AnalyticsEula.jsx
+++ b/assets/js/pages/AnalyticsEula/AnalyticsEula.jsx
@@ -15,13 +15,13 @@ export default function AnalyticsEula() {
     return null;
   }
 
-  const { analytics_eula_accepted, username } = useSelector(getUserProfile);
+  const user = useSelector(getUserProfile);
+  const { analytics_eula_accepted } = user;
   const [analyticsEulaModalOpen, setAnalyticsEulaModalOpen] = useState(
     !analytics_eula_accepted
   );
   const [checked, setChecked] = useState(false);
 
-  const user = { username };
   const isDefaultAdmin = isAdmin(user);
   const dispatch = useDispatch();
 

--- a/assets/js/pages/AnalyticsEula/AnalyticsEula.jsx
+++ b/assets/js/pages/AnalyticsEula/AnalyticsEula.jsx
@@ -20,7 +20,6 @@ export default function AnalyticsEula() {
   const [analyticsEulaModalOpen, setAnalyticsEulaModalOpen] = useState(
     !analytics_eula_accepted
   );
-  const [checked, setChecked] = useState(false);
 
   const isDefaultAdmin = isAdmin(user);
   const dispatch = useDispatch();
@@ -36,8 +35,6 @@ export default function AnalyticsEula() {
   return (
     <AnalyticsEulaModal
       isOpen={!isDefaultAdmin && analyticsEulaModalOpen}
-      checked={checked}
-      onChecked={() => setChecked((prev) => !prev)}
       onEnable={() => {
         setAnalyticsEulaModalOpen(false);
         updateAnalyticsEula({
@@ -45,7 +42,7 @@ export default function AnalyticsEula() {
           analytics_eula_accepted: true,
         });
       }}
-      onCancel={() => {
+      onCancel={(checked) => {
         setAnalyticsEulaModalOpen(false);
         if (checked) {
           updateAnalyticsEula({

--- a/assets/js/pages/AnalyticsEula/AnalyticsEula.jsx
+++ b/assets/js/pages/AnalyticsEula/AnalyticsEula.jsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+import { isAdmin } from '@lib/model/users';
+import { editUserProfile } from '@lib/api/users';
+import { getFromConfig } from '@lib/config/config';
+import { setUser } from '@state/user';
+import { getUserProfile } from '@state/selectors/user';
+import AnalyticsEulaModal from './AnalyticsEulaModal';
+
+const analyticsEnabledConfig = getFromConfig('analyticsEnabled');
+
+export default function AnalyticsEula() {
+  if (!analyticsEnabledConfig) {
+    return null;
+  }
+
+  const { analytics_eula_accepted, username } = useSelector(getUserProfile);
+  const [analyticsEulaModalOpen, setAnalyticsEulaModalOpen] = useState(
+    !analytics_eula_accepted
+  );
+  const [checked, setChecked] = useState(false);
+
+  const user = { username };
+  const isDefaultAdmin = isAdmin(user);
+  const dispatch = useDispatch();
+
+  const updateAnalyticsEula = (params) => {
+    editUserProfile(params)
+      .then(({ data: userData }) => {
+        dispatch(setUser(userData));
+      })
+      .catch(() => {});
+  };
+
+  return (
+    <AnalyticsEulaModal
+      isOpen={!isDefaultAdmin && analyticsEulaModalOpen}
+      checked={checked}
+      onChecked={() => setChecked((prev) => !prev)}
+      onEnable={() => {
+        setAnalyticsEulaModalOpen(false);
+        updateAnalyticsEula({
+          analytics_enabled: true,
+          analytics_eula_accepted: true,
+        });
+      }}
+      onCancel={() => {
+        setAnalyticsEulaModalOpen(false);
+        if (checked) {
+          updateAnalyticsEula({
+            analytics_eula_accepted: checked,
+          });
+        }
+      }}
+    />
+  );
+}

--- a/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.jsx
+++ b/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import Modal from '@common/Modal';
+import Button from '@common/Button';
+import Input from '@common/Input';
+
+function AnalyticsEulaModal({
+  isOpen = false,
+  checked = false,
+  onChecked,
+  onEnable,
+  onCancel,
+}) {
+  return (
+    <Modal
+      className="!w-1/2"
+      title="Collection of Anonymous Metrics"
+      open={isOpen}
+      onClose={() => null}
+    >
+      Allow the collection of{' '}
+      <a
+        className="text-jungle-green-500 hover:opacity-75"
+        href="https://trento-project.io/docs"
+        target="_blank"
+        rel="noreferrer"
+      >
+        anonymous metrics
+      </a>{' '}
+      to help improve Trento. This can also be managed in your Profile.
+      <div>
+        <Input
+          className="inline-block py-4 pr-2"
+          type="checkbox"
+          checked={checked}
+          onChange={onChecked}
+        />
+        Never show this message again.
+      </div>
+      <div className="flex flex-row space-x-2">
+        <Button type="default-fit" onClick={onEnable}>
+          Enable Analytics Collection
+        </Button>
+        <Button type="primary-white-fit" onClick={onCancel}>
+          Continue without Analytics
+        </Button>
+      </div>
+    </Modal>
+  );
+}
+
+export default AnalyticsEulaModal;

--- a/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.jsx
+++ b/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.jsx
@@ -1,16 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import Modal from '@common/Modal';
 import Button from '@common/Button';
 import Input from '@common/Input';
 
-function AnalyticsEulaModal({
-  isOpen = false,
-  checked = false,
-  onChecked,
-  onEnable,
-  onCancel,
-}) {
+function AnalyticsEulaModal({ isOpen = false, onEnable, onCancel }) {
+  const [checked, setChecked] = useState(false);
+
   return (
     <Modal
       className="!w-1/2"
@@ -33,15 +29,15 @@ function AnalyticsEulaModal({
           className="inline-block py-4 pr-2"
           type="checkbox"
           checked={checked}
-          onChange={onChecked}
+          onChange={() => setChecked((prev) => !prev)}
         />
         Never show this message again.
       </div>
       <div className="flex flex-row space-x-2">
-        <Button type="default-fit" onClick={onEnable}>
+        <Button type="default-fit" onClick={() => onEnable(checked)}>
           Enable Analytics Collection
         </Button>
-        <Button type="primary-white-fit" onClick={onCancel}>
+        <Button type="primary-white-fit" onClick={() => onCancel(checked)}>
           Continue without Analytics
         </Button>
       </div>

--- a/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.stories.jsx
+++ b/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.stories.jsx
@@ -1,48 +1,40 @@
-import React, { useState } from 'react';
+import React from 'react';
 
-import Button from '@common/Button/Button';
+import { action } from 'storybook/internal/actions';
 import AnalyticsEulaModal from './AnalyticsEulaModal';
 
 export default {
   title: 'Patterns/AnalyticsEulaModal',
   component: AnalyticsEulaModal,
-  argTypes: {
-    checked: {
-      type: 'boolean',
-      description: 'Checks checkbox',
+  parameters: {
+    docs: {
+      story: {
+        inline: false,
+        iframeHeight: 500,
+      },
     },
+  },
+  argTypes: {
     isOpen: {
       type: 'boolean',
       description: 'Sets the visibility of the modal',
     },
+    onEnable: {
+      description: 'Callback when the Enable button is clicked',
+      control: { type: 'function' },
+    },
+    onCancel: {
+      description: 'Callback when the Cancel button is clicked',
+      control: { type: 'function' },
+    },
+  },
+  args: {
+    isOpen: true,
+    onEnable: action('enable clicked'),
+    onCancel: action('cancel clicked'),
   },
 };
 
-function ButtonToOpenModal({ ...rest }) {
-  const [open, setOpen] = useState(false);
-  const [checked, setChecked] = useState(false);
-
-  return (
-    <>
-      <Button type="default-fit" onClick={() => setOpen(true)}>
-        Show Modal
-      </Button>
-
-      <AnalyticsEulaModal
-        isOpen={open}
-        checked={checked}
-        onEnable={() => {
-          setOpen(false);
-        }}
-        onCancel={() => setOpen(false)}
-        onChecked={() => setChecked((prev) => !prev)}
-        {...rest}
-      />
-    </>
-  );
+export function Default(args) {
+  return <AnalyticsEulaModal {...args} />;
 }
-
-export const Default = {
-  args: {},
-  render: (args) => <ButtonToOpenModal {...args} />,
-};

--- a/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.stories.jsx
+++ b/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.stories.jsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+
+import Button from '@common/Button/Button';
+import AnalyticsEulaModal from './AnalyticsEulaModal';
+
+export default {
+  title: 'Patterns/AnalyticsEulaModal',
+  component: AnalyticsEulaModal,
+  argTypes: {
+    checked: {
+      type: 'boolean',
+      description: 'Checks checkbox',
+    },
+    isOpen: {
+      type: 'boolean',
+      description: 'Sets the visibility of the modal',
+    },
+  },
+};
+
+function ButtonToOpenModal({ ...rest }) {
+  const [open, setOpen] = useState(false);
+  const [checked, setChecked] = useState(false);
+
+  return (
+    <>
+      <Button type="default-fit" onClick={() => setOpen(true)}>
+        Show Modal
+      </Button>
+
+      <AnalyticsEulaModal
+        isOpen={open}
+        checked={checked}
+        onEnable={() => {
+          setOpen(false);
+        }}
+        onCancel={() => setOpen(false)}
+        onChecked={() => setChecked((prev) => !prev)}
+        {...rest}
+      />
+    </>
+  );
+}
+
+export const Default = {
+  args: {},
+  render: (args) => <ButtonToOpenModal {...args} />,
+};

--- a/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.test.jsx
+++ b/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.test.jsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import AnalyticsEulaModal from './AnalyticsEulaModal';
 
 describe('Analytics Eula Modal component', () => {
   it('should render the Analytics Eula modal correctly', async () => {
-    render(
-      <AnalyticsEulaModal isOpen onEnable={() => {}} onCancel={() => {}} />
-    );
+    render(<AnalyticsEulaModal isOpen />);
 
     expect(
       await screen.findByText('Collection of Anonymous Metrics')
@@ -27,5 +26,45 @@ describe('Analytics Eula Modal component', () => {
     expect(
       await screen.findByRole('button', { name: 'Continue without Analytics' })
     ).toBeTruthy();
+  });
+
+  it('it should call onEnable when Enable button is clicked', async () => {
+    const user = userEvent.setup();
+    const mockOnEnable = jest.fn();
+
+    render(<AnalyticsEulaModal isOpen onEnable={mockOnEnable} />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Enable Analytics Collection' })
+    );
+
+    expect(mockOnEnable).toHaveBeenCalledWith(false);
+  });
+
+  it('it should call onCancel when Close button is clicked', async () => {
+    const user = userEvent.setup();
+    const mockOnCancel = jest.fn();
+
+    render(<AnalyticsEulaModal isOpen onCancel={mockOnCancel} />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Continue without Analytics' })
+    );
+
+    expect(mockOnCancel).toHaveBeenCalledWith(false);
+  });
+
+  it('it should return true when checkbox is checked and Close button is clicked ', async () => {
+    const user = userEvent.setup();
+    const mockOnCancel = jest.fn();
+
+    render(<AnalyticsEulaModal isOpen onCancel={mockOnCancel} />);
+
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(
+      screen.getByRole('button', { name: 'Continue without Analytics' })
+    );
+
+    expect(mockOnCancel).toHaveBeenCalledWith(true);
   });
 });

--- a/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.test.jsx
+++ b/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.test.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import AnalyticsEulaModal from './AnalyticsEulaModal';
+
+describe('Analytics Eula Modal component', () => {
+  it('should render the Analytics Eula modal correctly', async () => {
+    render(
+      <AnalyticsEulaModal isOpen onEnable={() => {}} onCancel={() => {}} />
+    );
+
+    expect(
+      await screen.findByText('Collection of Anonymous Metrics')
+    ).toBeTruthy();
+    expect(
+      await screen.findByText('Allow the collection of', { exact: false })
+    ).toBeTruthy();
+
+    expect(await screen.findByRole('checkbox')).toBeTruthy();
+    expect(
+      await screen.findByText('Never show this message again.')
+    ).toBeTruthy();
+
+    expect(
+      await screen.findByRole('button', { name: 'Enable Analytics Collection' })
+    ).toBeTruthy();
+    expect(
+      await screen.findByRole('button', { name: 'Continue without Analytics' })
+    ).toBeTruthy();
+  });
+});

--- a/assets/js/pages/AnalyticsEula/index.js
+++ b/assets/js/pages/AnalyticsEula/index.js
@@ -1,0 +1,3 @@
+import AnalyticsEula from './AnalyticsEula';
+
+export default AnalyticsEula;

--- a/assets/js/pages/Layout/Layout.jsx
+++ b/assets/js/pages/Layout/Layout.jsx
@@ -28,6 +28,7 @@ import TrentoLogo from '@static/trento-logo-stacked.svg';
 import classNames from 'classnames';
 import ProfileMenu from '@common/ProfileMenu';
 import ForbiddenGuard from '@common/ForbiddenGuard';
+import AnalyticsEula from '@pages/AnalyticsEula';
 
 const navigation = [
   { name: 'Dashboard', href: '/', icon: EOS_HOME_OUTLINED },
@@ -114,6 +115,7 @@ function Layout() {
 
   return (
     <main className="bg-gray-100 dark:bg-gray-800 relative">
+      <AnalyticsEula />
       <div className="flex flex-col h-screen items-start justify-between">
         <div
           className={classNames(

--- a/assets/js/state/sagas/user.js
+++ b/assets/js/state/sagas/user.js
@@ -46,6 +46,7 @@ export function* performLogin({ payload: { username, password, totpCode } }) {
       abilities,
       password_change_requested,
       analytics_enabled,
+      analytics_eula_accepted,
     } = yield call(profile, networkClient);
     yield put(
       setUser({
@@ -58,6 +59,7 @@ export function* performLogin({ payload: { username, password, totpCode } }) {
         abilities,
         password_change_requested,
         analytics_enabled,
+        analytics_eula_accepted,
       })
     );
     yield call(identify, analytics_enabled, id);

--- a/assets/js/state/user.js
+++ b/assets/js/state/user.js
@@ -14,6 +14,7 @@ export const initialState = {
   authError: null,
   authInProgress: false,
   analytics_enabled: undefined,
+  analytics_eula_accepted: undefined,
 };
 
 export const userSlice = createSlice({
@@ -46,6 +47,7 @@ export const userSlice = createSlice({
           abilities,
           password_change_requested,
           analytics_enabled,
+          analytics_eula_accepted,
         },
       }
     ) {
@@ -58,6 +60,7 @@ export const userSlice = createSlice({
       state.abilities = abilities;
       state.password_change_requested = password_change_requested;
       state.analytics_enabled = analytics_enabled;
+      state.analytics_eula_accepted = analytics_eula_accepted;
     },
   },
 });

--- a/assets/js/state/user.test.js
+++ b/assets/js/state/user.test.js
@@ -52,6 +52,7 @@ describe('user reducer', () => {
       created_at,
       updated_at,
       analytics_enabled,
+      analytics_eula_accepted,
     } = userFactory.build();
 
     const action = setUser({
@@ -63,6 +64,7 @@ describe('user reducer', () => {
       created_at,
       updated_at,
       analytics_enabled,
+      analytics_eula_accepted,
     });
 
     expect(userReducer(initialState, action)).toEqual({
@@ -75,6 +77,7 @@ describe('user reducer', () => {
       created_at,
       updated_at,
       analytics_enabled,
+      analytics_eula_accepted,
     });
   });
 });

--- a/lib/trento/users.ex
+++ b/lib/trento/users.ex
@@ -97,6 +97,7 @@ defmodule Trento.Users do
         attrs
         |> maybe_set_password_change_requested_at(true)
         |> maybe_enable_analytics()
+        |> maybe_accept_analytics_eula()
 
       user
       |> User.profile_update_changeset(updated_attrs)
@@ -259,6 +260,14 @@ defmodule Trento.Users do
 
   defp maybe_enable_analytics(attrs) do
     Map.put(attrs, :analytics_enabled_at, nil)
+  end
+
+  defp maybe_accept_analytics_eula(%{analytics_eula_accepted: true} = attrs) do
+    Map.put(attrs, :analytics_eula_accepted_at, DateTime.utc_now())
+  end
+
+  defp maybe_accept_analytics_eula(attrs) do
+    Map.put(attrs, :analytics_eula_accepted_at, nil)
   end
 
   defp insert_abilities_multi(multi, []), do: multi

--- a/lib/trento/users.ex
+++ b/lib/trento/users.ex
@@ -264,6 +264,8 @@ defmodule Trento.Users do
 
   defp maybe_enable_analytics(attrs), do: attrs
 
+  # The value for 'analytics_eula_accepted' can only be set
+  # to 'true' and not 'false', as this is a one time change.
   defp maybe_accept_analytics_eula(%{analytics_eula_accepted: true} = attrs) do
     Map.put(attrs, :analytics_eula_accepted_at, DateTime.utc_now())
   end

--- a/lib/trento/users.ex
+++ b/lib/trento/users.ex
@@ -258,17 +258,17 @@ defmodule Trento.Users do
     Map.put(attrs, :analytics_enabled_at, DateTime.utc_now())
   end
 
-  defp maybe_enable_analytics(attrs) do
+  defp maybe_enable_analytics(%{analytics_enabled: false} = attrs) do
     Map.put(attrs, :analytics_enabled_at, nil)
   end
+
+  defp maybe_enable_analytics(attrs), do: attrs
 
   defp maybe_accept_analytics_eula(%{analytics_eula_accepted: true} = attrs) do
     Map.put(attrs, :analytics_eula_accepted_at, DateTime.utc_now())
   end
 
-  defp maybe_accept_analytics_eula(attrs) do
-    Map.put(attrs, :analytics_eula_accepted_at, nil)
-  end
+  defp maybe_accept_analytics_eula(attrs), do: attrs
 
   defp insert_abilities_multi(multi, []), do: multi
 

--- a/lib/trento/users/user.ex
+++ b/lib/trento/users/user.ex
@@ -87,7 +87,11 @@ defmodule Trento.Users.User do
     |> pow_extension_changeset(attrs)
     |> validate_password()
     |> custom_fields_changeset(attrs)
-    |> cast(attrs, [:password_change_requested_at, :analytics_enabled_at, :analytics_eula_accepted_at])
+    |> cast(attrs, [
+      :password_change_requested_at,
+      :analytics_enabled_at,
+      :analytics_eula_accepted_at
+    ])
   end
 
   def totp_update_changeset(user, attrs) do

--- a/lib/trento/users/user.ex
+++ b/lib/trento/users/user.ex
@@ -41,6 +41,7 @@ defmodule Trento.Users.User do
     field :totp_secret, EncryptedBinary, redact: true
     field :totp_last_used_at, :utc_datetime_usec
     field :analytics_enabled_at, :utc_datetime_usec
+    field :analytics_eula_accepted_at, :utc_datetime_usec
     field :lock_version, :integer, default: 1
 
     many_to_many :abilities, Ability, join_through: UsersAbilities, unique: true
@@ -86,7 +87,7 @@ defmodule Trento.Users.User do
     |> pow_extension_changeset(attrs)
     |> validate_password()
     |> custom_fields_changeset(attrs)
-    |> cast(attrs, [:password_change_requested_at, :analytics_enabled_at])
+    |> cast(attrs, [:password_change_requested_at, :analytics_enabled_at, :analytics_eula_accepted_at])
   end
 
   def totp_update_changeset(user, attrs) do

--- a/lib/trento_web/controllers/v1/profile_json.ex
+++ b/lib/trento_web/controllers/v1/profile_json.ex
@@ -12,6 +12,7 @@ defmodule TrentoWeb.V1.ProfileJSON do
           totp_enabled_at: totp_enabled_at,
           user_identities: user_identities,
           analytics_enabled_at: analytics_enabled_at,
+          analytics_eula_accepted_at: analytics_eula_accepted_at,
           inserted_at: created_at,
           updated_at: updated_at
         }
@@ -26,6 +27,7 @@ defmodule TrentoWeb.V1.ProfileJSON do
         totp_enabled: totp_enabled_at != nil,
         created_at: created_at,
         analytics_enabled: analytics_enabled_at != nil,
+        analytics_eula_accepted: analytics_eula_accepted_at != nil,
         idp_user: length(user_identities) > 0,
         updated_at: updated_at
       }

--- a/lib/trento_web/openapi/v1/schema/user.ex
+++ b/lib/trento_web/openapi/v1/schema/user.ex
@@ -109,6 +109,11 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             description: "Whether user analytics collection is enabled",
             nullable: false
           },
+          analytics_eula_accepted: %Schema{
+            type: :boolean,
+            description: "Whether user analytics eula is accepted",
+            nullable: false
+          },
           totp_enabled: %Schema{
             type: :boolean,
             description: "TOTP is enabled",
@@ -165,7 +170,12 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             type: :boolean,
             description: "Whether user analytics collection is enabled",
             nullable: false
-          }
+          },
+          analytics_eula_accepted: %Schema{
+            type: :boolean,
+            description: "Whether user analytics eula is accepted",
+            nullable: false
+          },
         }
       },
       struct?: false

--- a/lib/trento_web/openapi/v1/schema/user.ex
+++ b/lib/trento_web/openapi/v1/schema/user.ex
@@ -173,7 +173,8 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
           },
           analytics_eula_accepted: %Schema{
             type: :boolean,
-            description: "Whether user analytics eula is accepted",
+            description:
+              "Whether user analytics eula is accepted. Setting this value to 'false' has no effect.",
             nullable: false
           }
         }

--- a/lib/trento_web/openapi/v1/schema/user.ex
+++ b/lib/trento_web/openapi/v1/schema/user.ex
@@ -175,7 +175,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             type: :boolean,
             description: "Whether user analytics eula is accepted",
             nullable: false
-          },
+          }
         }
       },
       struct?: false

--- a/priv/repo/migrations/20250728090509_add_analytics_eula_accepted_at_to_users.exs
+++ b/priv/repo/migrations/20250728090509_add_analytics_eula_accepted_at_to_users.exs
@@ -1,0 +1,9 @@
+defmodule Trento.Repo.Migrations.AddAnalyticsEulaAcceptedAtToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :analytics_eula_accepted_at, :utc_datetime_usec
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1292,7 +1292,8 @@ defmodule Trento.Factory do
       totp_enabled_at: nil,
       totp_secret: nil,
       totp_last_used_at: nil,
-      analytics_enabled_at: nil
+      analytics_enabled_at: nil,
+      analytics_eula_accepted_at: nil
     }
   end
 

--- a/test/trento/users/user_test.exs
+++ b/test/trento/users/user_test.exs
@@ -54,5 +54,12 @@ defmodule Trento.Users.UsersTest do
 
       assert changeset.changes[:analytics_enabled_at]
     end
+
+    test "changeset/2 validates analytics_eula_accepted_at field is cast properly" do
+      changeset =
+        User.profile_update_changeset(%User{}, %{"analytics_eula_accepted_at" => DateTime.utc_now()})
+
+      assert changeset.changes[:analytics_eula_accepted_at]
+    end
   end
 end

--- a/test/trento/users/user_test.exs
+++ b/test/trento/users/user_test.exs
@@ -57,7 +57,9 @@ defmodule Trento.Users.UsersTest do
 
     test "changeset/2 validates analytics_eula_accepted_at field is cast properly" do
       changeset =
-        User.profile_update_changeset(%User{}, %{"analytics_eula_accepted_at" => DateTime.utc_now()})
+        User.profile_update_changeset(%User{}, %{
+          "analytics_eula_accepted_at" => DateTime.utc_now()
+        })
 
       assert changeset.changes[:analytics_eula_accepted_at]
     end

--- a/test/trento/users_test.exs
+++ b/test/trento/users_test.exs
@@ -114,6 +114,26 @@ defmodule Trento.UsersTest do
 
       assert analytics_enabled_at == nil
     end
+
+    test "update user profile sets analytics eula value with current time" do
+      user = insert(:user)
+
+      assert {:ok,
+              %User{
+                analytics_eula_accepted_at: analytics_eula_accepted_at
+              }} =
+               Users.update_user_profile(user, %{analytics_eula_accepted: true})
+
+      refute analytics_eula_accepted_at == nil
+
+      assert {:ok,
+              %User{
+                analytics_eula_accepted_at: analytics_eula_accepted_at
+              }} =
+               Users.update_user_profile(user, %{analytics_eula_accepted: false})
+
+      assert analytics_eula_accepted_at == nil
+    end
   end
 
   describe "users" do

--- a/test/trento/users_test.exs
+++ b/test/trento/users_test.exs
@@ -133,6 +133,14 @@ defmodule Trento.UsersTest do
                Users.update_user_profile(user, %{analytics_eula_accepted: false})
 
       assert analytics_eula_accepted_at == nil
+
+      assert {:ok,
+              %User{
+                analytics_eula_accepted_at: analytics_eula_accepted_at
+              }} =
+               Users.update_user_profile(user, %{})
+
+      assert analytics_eula_accepted_at == nil
     end
   end
 

--- a/test/trento_web/views/v1/profile_view_json_test.exs
+++ b/test/trento_web/views/v1/profile_view_json_test.exs
@@ -33,7 +33,11 @@ defmodule TrentoWeb.V1.ProfileJSONTest do
 
     test "should correctly render a user profile when the user has accepted analytics eula" do
       user =
-        build(:user, abilities: [], user_identities: [], analytics_eula_accepted_at: DateTime.utc_now())
+        build(:user,
+          abilities: [],
+          user_identities: [],
+          analytics_eula_accepted_at: DateTime.utc_now()
+        )
 
       assert %{
                analytics_eula_accepted: true

--- a/test/trento_web/views/v1/profile_view_json_test.exs
+++ b/test/trento_web/views/v1/profile_view_json_test.exs
@@ -22,5 +22,22 @@ defmodule TrentoWeb.V1.ProfileJSONTest do
                analytics_enabled: true
              } = ProfileJSON.profile(%{user: user})
     end
+
+    test "should correctly render a user profile when the user has not accepted analytics eula" do
+      user = build(:user, abilities: [], user_identities: [], analytics_enabled_at: nil)
+
+      assert %{
+               analytics_eula_accepted: false
+             } = ProfileJSON.profile(%{user: user})
+    end
+
+    test "should correctly render a user profile when the user has accepted analytics eula" do
+      user =
+        build(:user, abilities: [], user_identities: [], analytics_eula_accepted_at: DateTime.utc_now())
+
+      assert %{
+               analytics_eula_accepted: true
+             } = ProfileJSON.profile(%{user: user})
+    end
   end
 end


### PR DESCRIPTION
# Description

This PR adds the **Analytics Eula Modal** which prompts the user to accept or decline to the collection of analytics. This is initiated once the user has logged and it is displayed on the Dashboard (Home) screen. The modal only displays for users that are **not** the default admin user. 

**Scenarios**
1. If the user, clicks the **Accept Analytics Collection** button then it stops showing the modal and analytics is enabled. 
2. If the user, clicks **Continue without Analytics** then it continues to show every time the user logs in or returns to the Dashboard (home) screen.
3. If the user, enables the checkbox (Never show this again) and clicks **Continue without Analytics** then the modal with not show again and the analytics will remain disabled. 
<img width="1440" height="901" alt="Screenshot 2025-08-18 at 12 48 25" src="https://github.com/user-attachments/assets/40046e1d-ccac-4565-be11-bd0e97a870e9" />

## How was this tested?

Describe the tests that have been added/changed for this new behaviour.
- [x] **DONE** Tests the presence of the `AnalyticEulaModal` component
- [x] **DONE**  Tests the value of the `analytics_eula_accepted` value in the backend

## Did you update the documentation?

Add a documentation PR or write that no changes are required for the documentation.
- [ ] **DONE** This will be done in a future PR
