### PR TITLE
Add cluster host start/stop ops to activity log

### DIFF
--- a/test/trento/activity_logging/phoenix_conn_parser_test.exs
+++ b/test/trento/activity_logging/phoenix_conn_parser_test.exs
@@ -294,6 +294,24 @@ defmodule Trento.ActivityLog.PhoenixConnParserTest do
           }
         },
         %{
+          action: :cluster_host_operation_requested,
+          operation: "cluster_host_start",
+          atom_operation: :cluster_host_start,
+          resource_field: :cluster_id,
+          additional_params: %{
+            host_id: host_id
+          }
+        },
+        %{
+          action: :cluster_host_operation_requested,
+          operation: "cluster_host_stop",
+          atom_operation: :cluster_host_stop,
+          resource_field: :cluster_id,
+          additional_params: %{
+            host_id: host_id
+          }
+        },
+        %{
           action: :sap_system_operation_requested,
           operation: "sap_system_start",
           atom_operation: :sap_system_start,


### PR DESCRIPTION
The job is done already by https://github.com/trento-project/web/pull/3602

Adding tests to confim