### PR TITLE
Handle null node attributes nodes list

### DIFF
--- a/lib/trento/discovery/payloads/cluster/crmmon_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/cluster/crmmon_discovery_payload.ex
@@ -281,5 +281,6 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
     |> Map.update("clones", [], &ListHelper.to_list/1)
     |> update_in(["clones", Access.all(), "resources"], &ListHelper.to_list/1)
     |> Map.update("resources", [], &ListHelper.to_list/1)
+    |> update_in(["node_attributes", "nodes"], &ListHelper.to_list/1)
   end
 end

--- a/lib/trento/discovery/payloads/cluster/crmmon_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/cluster/crmmon_discovery_payload.ex
@@ -281,6 +281,11 @@ defmodule Trento.Discovery.Payloads.Cluster.CrmmonDiscoveryPayload do
     |> Map.update("clones", [], &ListHelper.to_list/1)
     |> update_in(["clones", Access.all(), "resources"], &ListHelper.to_list/1)
     |> Map.update("resources", [], &ListHelper.to_list/1)
-    |> update_in(["node_attributes", "nodes"], &ListHelper.to_list/1)
+    |> maybe_node_attributes_to_list()
   end
+
+  defp maybe_node_attributes_to_list(%{"node_attributes" => _} = attrs),
+    do: update_in(attrs, ["node_attributes", "nodes"], &ListHelper.to_list/1)
+
+  defp maybe_node_attributes_to_list(attrs), do: attrs
 end

--- a/test/trento/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/discovery/policies/cluster_policy_test.exs
@@ -2605,6 +2605,34 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
              |> ClusterPolicy.handle(nil)
   end
 
+  test "should handle ascs/ers cluster when node attributes nodes list is null" do
+    assert {
+             :ok,
+             [
+               %RegisterOnlineClusterHost{
+                 details: %AscsErsClusterDetails{
+                   sap_systems: [
+                     %AscsErsClusterSapSystem{
+                       nodes: [
+                         %AscsErsClusterNode{
+                           attributes: %{}
+                         },
+                         %AscsErsClusterNode{
+                           attributes: %{}
+                         }
+                       ]
+                     }
+                   ]
+                 }
+               }
+             ]
+           } =
+             "ha_cluster_discovery_ascs_ers"
+             |> load_discovery_event_fixture()
+             |> put_in(["payload", "Crmmon", "NodeAttributes", "Nodes"], nil)
+             |> ClusterPolicy.handle(nil)
+  end
+
   describe "ascs/ers clusters health" do
     test "should set the health to critical when one of the nodes is unclean" do
       assert {:ok,

--- a/test/trento/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/discovery/policies/cluster_policy_test.exs
@@ -2615,10 +2615,10 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                      %AscsErsClusterSapSystem{
                        nodes: [
                          %AscsErsClusterNode{
-                           attributes: %{}
+                           attributes: attributes1
                          },
                          %AscsErsClusterNode{
-                           attributes: %{}
+                           attributes: attributes2
                          }
                        ]
                      }
@@ -2631,6 +2631,9 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
              |> load_discovery_event_fixture()
              |> put_in(["payload", "Crmmon", "NodeAttributes", "Nodes"], nil)
              |> ClusterPolicy.handle(nil)
+
+    assert attributes1 == %{}
+    assert attributes2 == %{}
   end
 
   describe "ascs/ers clusters health" do


### PR DESCRIPTION
# Description

In some cluster scenarios, for example, when ASCS/ERS cluster nodes are stopped/started, some crm node attributes are sent as `null`.

```
"NodeAttributes": {
    "Nodes": null
},
````

In this case the payload decoding raises an error as it expects a list:
```
"reason": "{:validation, %{crmmon: %{node_attributes: %{nodes: [\"is invalid\"]}}}}",
```

Or code expects a list there in `Nodes` as usually we always receive at least one attribute, the normal things being:
```
"NodeAttributes": {
  "Nodes": [
    {
      "Name": "vmnwdev02",
        "Attributes": [
          {
            "Name": "runs_ers_NWD",
            "Value": "1"
          }
        ]
      }
    ]
  }
```

This change simply converts a possible `nil` value to a list, and does nothing if a list is already coming.

## How was this tested?

UT
