### PR TITLE
Fix flaky test for Hana cluster details forbidden actions

### DIFF
--- a/test/e2e/cypress/e2e/hana_cluster_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_cluster_details.cy.js
@@ -418,7 +418,12 @@ context('HANA cluster details', () => {
         hanaClusterDetailsPage.startExecutionButtonIsDisabled();
         hanaClusterDetailsPage.clickStartExecutionButton();
         hanaClusterDetailsPage.notAuthorizedTooltipIsDisplayed();
+        cy.intercept(
+          'GET',
+          'http://localhost:4001/api/v1/groups/*/checks?*'
+        ).as('getChecks');
         hanaClusterDetailsPage.clickCheckSelectionButton();
+        cy.wait('@getChecks');
         hanaClusterDetailsPage.startExecutionButtonIsDisabled();
         hanaClusterDetailsPage.clickStartExecutionButton();
         hanaClusterDetailsPage.notAuthorizedTooltipIsDisplayed();

--- a/test/e2e/cypress/e2e/hana_cluster_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_cluster_details.cy.js
@@ -410,7 +410,8 @@ context('HANA cluster details', () => {
     });
 
     describe('Check Execution', () => {
-      it('should forbid check execution when the correct user abilities are missing in details and settings', () => {
+      // eslint-disable-next-line mocha/no-exclusive-tests
+      it.only('should forbid check execution when the correct user abilities are missing in details and settings', () => {
         hanaClusterDetailsPage.apiCreateUserWithoutAbilities();
         hanaClusterDetailsPage.loginWithoutAbilities();
         hanaClusterDetailsPage.visitAvailableHanaCluster();

--- a/test/e2e/cypress/e2e/hana_cluster_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_cluster_details.cy.js
@@ -410,20 +410,16 @@ context('HANA cluster details', () => {
     });
 
     describe('Check Execution', () => {
-      // eslint-disable-next-line mocha/no-exclusive-tests
-      it.only('should forbid check execution when the correct user abilities are missing in details and settings', () => {
+      it('should forbid check execution when the correct user abilities are missing in details and settings', () => {
         hanaClusterDetailsPage.apiCreateUserWithoutAbilities();
         hanaClusterDetailsPage.loginWithoutAbilities();
         hanaClusterDetailsPage.visitAvailableHanaCluster();
         hanaClusterDetailsPage.startExecutionButtonIsDisabled();
         hanaClusterDetailsPage.clickStartExecutionButton();
         hanaClusterDetailsPage.notAuthorizedTooltipIsDisplayed();
-        cy.intercept(
-          'GET',
-          'http://localhost:4001/api/v1/groups/*/checks?*'
-        ).as('getChecks');
+        hanaClusterDetailsPage.interceptGetChecks();
         hanaClusterDetailsPage.clickCheckSelectionButton();
-        cy.wait('@getChecks');
+        hanaClusterDetailsPage.waitForGetChecksEndpoint();
         hanaClusterDetailsPage.startExecutionButtonIsDisabled();
         hanaClusterDetailsPage.clickStartExecutionButton();
         hanaClusterDetailsPage.notAuthorizedTooltipIsDisplayed();

--- a/test/e2e/cypress/pageObject/hana_cluster_details_po.js
+++ b/test/e2e/cypress/pageObject/hana_cluster_details_po.js
@@ -35,6 +35,7 @@ const catalog = catalogCheckFactory.buildList(5);
 const url = '/clusters';
 const catalogEndpointAlias = 'catalog';
 const lastExecutionEndpointAlias = 'lastExecution';
+const getChecksEndpointAlias = 'getChecks';
 
 // Selectors
 
@@ -471,6 +472,12 @@ export const notAuthorizedTooltipIsNotDisplayed = () => {
 };
 
 // API
+export const interceptGetChecks = () =>
+  cy.intercept('GET', '/api/v1/groups/*/checks?*').as(getChecksEndpointAlias);
+
+export const waitForGetChecksEndpoint = () =>
+  basePage.waitForRequest(getChecksEndpointAlias);
+
 export const interceptLastExecutionRequestMocked = () => {
   const lastExecutionURL = '/api/v2/checks/groups/**/executions/last';
   cy.intercept(lastExecutionURL, {


### PR DESCRIPTION
# Description

added a wait for the request before asserting that the tooltip is displayed.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

To test this fix I ran the flaky test execution 2 times with 150 threads for only this test, meaning 300 hundred times the test passed with the current fix, while before there were some failures, as can be seen also in the regular flaky tests executions.

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**
## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
- [Trento Web guides](https://github.com/trento-project/web/tree/main/guides)

Add a documentation PR or write that no changes are required for the documentation.
- [ ] **DONE**
