### PR TITLE
Fix flaky test - Link to known clusters in SAP Systems Overview

### DIFF
--- a/test/e2e/cypress/e2e/sap_systems_overview.cy.js
+++ b/test/e2e/cypress/e2e/sap_systems_overview.cy.js
@@ -1,7 +1,7 @@
 import * as sapSystemsOverviewPage from '../pageObject/sap_systems_overview_po';
 
 context('SAP Systems Overview', () => {
-  before(() => sapSystemsOverviewPage.preloadTestData());
+  // before(() => sapSystemsOverviewPage.preloadTestData());
 
   beforeEach(() => sapSystemsOverviewPage.visit());
 

--- a/test/e2e/cypress/e2e/sap_systems_overview.cy.js
+++ b/test/e2e/cypress/e2e/sap_systems_overview.cy.js
@@ -1,7 +1,7 @@
 import * as sapSystemsOverviewPage from '../pageObject/sap_systems_overview_po';
 
 context('SAP Systems Overview', () => {
-  // before(() => sapSystemsOverviewPage.preloadTestData());
+  before(() => sapSystemsOverviewPage.preloadTestData());
 
   beforeEach(() => sapSystemsOverviewPage.visit());
 

--- a/test/e2e/cypress/e2e/sap_systems_overview.cy.js
+++ b/test/e2e/cypress/e2e/sap_systems_overview.cy.js
@@ -45,7 +45,6 @@ context('SAP Systems Overview', () => {
 
       // eslint-disable-next-line mocha/no-exclusive-tests
       it.only('should have a link to known type clusters', () => {
-        // eslint-disable-next-line cypress/no-unnecessary-waiting
         sapSystemsOverviewPage.eachHanaInstanceHasItsClusterWorkingLink();
       });
 

--- a/test/e2e/cypress/e2e/sap_systems_overview.cy.js
+++ b/test/e2e/cypress/e2e/sap_systems_overview.cy.js
@@ -43,7 +43,8 @@ context('SAP Systems Overview', () => {
         sapSystemsOverviewPage.instanceDataIsTheExpected();
       });
 
-      it('should have a link to known type clusters', () => {
+      // eslint-disable-next-line mocha/no-exclusive-tests
+      it.only('should have a link to known type clusters', () => {
         sapSystemsOverviewPage.eachHanaInstanceHasItsClusterWorkingLink();
       });
 

--- a/test/e2e/cypress/e2e/sap_systems_overview.cy.js
+++ b/test/e2e/cypress/e2e/sap_systems_overview.cy.js
@@ -46,7 +46,6 @@ context('SAP Systems Overview', () => {
       // eslint-disable-next-line mocha/no-exclusive-tests
       it.only('should have a link to known type clusters', () => {
         // eslint-disable-next-line cypress/no-unnecessary-waiting
-        cy.wait(30000);
         sapSystemsOverviewPage.eachHanaInstanceHasItsClusterWorkingLink();
       });
 

--- a/test/e2e/cypress/e2e/sap_systems_overview.cy.js
+++ b/test/e2e/cypress/e2e/sap_systems_overview.cy.js
@@ -45,6 +45,8 @@ context('SAP Systems Overview', () => {
 
       // eslint-disable-next-line mocha/no-exclusive-tests
       it.only('should have a link to known type clusters', () => {
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(30000);
         sapSystemsOverviewPage.eachHanaInstanceHasItsClusterWorkingLink();
       });
 

--- a/test/e2e/cypress/e2e/sap_systems_overview.cy.js
+++ b/test/e2e/cypress/e2e/sap_systems_overview.cy.js
@@ -43,8 +43,7 @@ context('SAP Systems Overview', () => {
         sapSystemsOverviewPage.instanceDataIsTheExpected();
       });
 
-      // eslint-disable-next-line mocha/no-exclusive-tests
-      it.only('should have a link to known type clusters', () => {
+      it('should have a link to known type clusters', () => {
         sapSystemsOverviewPage.eachHanaInstanceHasItsClusterWorkingLink();
       });
 

--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -230,7 +230,8 @@ export const apiDeleteAllUsers = () => {
   });
 };
 
-export const waitForRequest = (requestAlias) => cy.wait(`@${requestAlias}`);
+export const waitForRequest = (requestAlias, timeout = 5000) =>
+  cy.wait(`@${requestAlias}`, { timeout: timeout });
 
 export const preloadTestData = ({
   isDataLoadedFunc = isTestDataLoaded,

--- a/test/e2e/cypress/pageObject/sap_systems_overview_po.js
+++ b/test/e2e/cypress/pageObject/sap_systems_overview_po.js
@@ -75,7 +75,7 @@ const nwdSystemRowCollapsibleCell = `tr:contains('${sapSystemNwd.sid}') > td:eq(
 export const visit = () => {
   cy.intercept('/api/v1/databases').as('databasesRequest');
   basePage.visit(url);
-  cy.wait('@databasesRequest');
+  basePage.waitForRequest('@databasesRequest', { timeout: 10000 });
 };
 
 export const tagSapSystems = () => {

--- a/test/e2e/cypress/pageObject/sap_systems_overview_po.js
+++ b/test/e2e/cypress/pageObject/sap_systems_overview_po.js
@@ -253,8 +253,7 @@ export const eachHanaInstanceHasItsClusterWorkingLink = () => {
   );
   hanaInstances.forEach((hanaInstance, index) => {
     clickAllRows();
-    cy.get('div[class*="table"] div[class*="table-row "]').should('be.visible');
-    cy.pause();
+    // cy.get('div[class*="table"] div[class*="table-row "]').should('be.visible');
     cy.get(`${hanaClusterLinks}:eq(${index})`).click();
     validateUrl(`/clusters/${hanaInstance.clusterID}`);
     cy.go('back');

--- a/test/e2e/cypress/pageObject/sap_systems_overview_po.js
+++ b/test/e2e/cypress/pageObject/sap_systems_overview_po.js
@@ -251,9 +251,9 @@ export const eachHanaInstanceHasItsClusterWorkingLink = () => {
   const hanaInstances = instancesData.filter(
     (instance) => instance.clusterID !== ''
   );
-  hanaInstances.forEach((hanaInstance, index) => {
+  cy.wrap(hanaInstances).each((hanaInstance, index) => {
     clickAllRows();
-    cy.get(`${hanaClusterLinks}:eq(${index})`).click({ force: true });
+    cy.get(`${hanaClusterLinks}:eq(${index})`).click();
     validateUrl(`/clusters/${hanaInstance.clusterID}`);
     cy.go('back');
   });

--- a/test/e2e/cypress/pageObject/sap_systems_overview_po.js
+++ b/test/e2e/cypress/pageObject/sap_systems_overview_po.js
@@ -75,7 +75,8 @@ const nwdSystemRowCollapsibleCell = `tr:contains('${sapSystemNwd.sid}') > td:eq(
 export const visit = () => {
   cy.intercept('/api/v1/databases').as('databasesRequest');
   basePage.visit(url);
-  basePage.waitForRequest('databasesRequest', 10000);
+  cy.wait('@databasesRequest', { timeout: 10000 });
+  // basePage.waitForRequest('databasesRequest', 10000);
 };
 
 export const tagSapSystems = () => {

--- a/test/e2e/cypress/pageObject/sap_systems_overview_po.js
+++ b/test/e2e/cypress/pageObject/sap_systems_overview_po.js
@@ -253,6 +253,8 @@ export const eachHanaInstanceHasItsClusterWorkingLink = () => {
   );
   hanaInstances.forEach((hanaInstance, index) => {
     clickAllRows();
+    cy.get('div[class*="table"] div[class*="table-row "]').should('be.visible');
+    cy.pause();
     cy.get(`${hanaClusterLinks}:eq(${index})`).click();
     validateUrl(`/clusters/${hanaInstance.clusterID}`);
     cy.go('back');

--- a/test/e2e/cypress/pageObject/sap_systems_overview_po.js
+++ b/test/e2e/cypress/pageObject/sap_systems_overview_po.js
@@ -253,8 +253,7 @@ export const eachHanaInstanceHasItsClusterWorkingLink = () => {
   );
   hanaInstances.forEach((hanaInstance, index) => {
     clickAllRows();
-    // cy.get('div[class*="table"] div[class*="table-row "]').should('be.visible');
-    cy.get(`${hanaClusterLinks}:eq(${index})`).click();
+    cy.get(`${hanaClusterLinks}:eq(${index})`).click({ force: true });
     validateUrl(`/clusters/${hanaInstance.clusterID}`);
     cy.go('back');
   });

--- a/test/e2e/cypress/pageObject/sap_systems_overview_po.js
+++ b/test/e2e/cypress/pageObject/sap_systems_overview_po.js
@@ -75,7 +75,7 @@ const nwdSystemRowCollapsibleCell = `tr:contains('${sapSystemNwd.sid}') > td:eq(
 export const visit = () => {
   cy.intercept('/api/v1/databases').as('databasesRequest');
   basePage.visit(url);
-  basePage.waitForRequest('@databasesRequest', { timeout: 10000 });
+  basePage.waitForRequest('databasesRequest', 10000);
 };
 
 export const tagSapSystems = () => {

--- a/test/e2e/cypress/pageObject/sap_systems_overview_po.js
+++ b/test/e2e/cypress/pageObject/sap_systems_overview_po.js
@@ -253,6 +253,9 @@ export const eachHanaInstanceHasItsClusterWorkingLink = () => {
   );
   cy.wrap(hanaInstances).each((hanaInstance, index) => {
     clickAllRows();
+    cy.get(`${hanaClusterLinks}:eq(${index})`).should('be.visible', {
+      timeout: 10000,
+    });
     cy.get(`${hanaClusterLinks}:eq(${index})`).click();
     validateUrl(`/clusters/${hanaInstance.clusterID}`);
     cy.go('back');

--- a/test/e2e/cypress/pageObject/sap_systems_overview_po.js
+++ b/test/e2e/cypress/pageObject/sap_systems_overview_po.js
@@ -103,6 +103,9 @@ const clickAllRows = () => {
   const expandTableElement = 'td svg[class*="cursor"]';
   cy.get(expandTableElement).each((cell, index) => {
     cy.get(`${expandTableElement}:eq(${index})`).click();
+    // cy.get('tr[class*="bg-gray-100"]')
+    //   .eq(index)
+    //   .should('have.css', 'display', 'table-row', { timeout: 10000 });
   });
 };
 
@@ -248,17 +251,13 @@ export const instanceDataIsTheExpected = () => {
 };
 
 export const eachHanaInstanceHasItsClusterWorkingLink = () => {
+  cy.get('h1:contains("SAP Systems")').should('be.visible');
+
   const hanaInstances = instancesData.filter(
     (instance) => instance.clusterID !== ''
   );
   cy.wrap(hanaInstances).each((hanaInstance, index) => {
     clickAllRows();
-    cy.get('tr[class*="bg-gray-100"]').should(
-      'have.css',
-      'display',
-      'table-row',
-      { timeout: 10000 }
-    );
     cy.get(`${hanaClusterLinks}:eq(${index})`).click();
     validateUrl(`/clusters/${hanaInstance.clusterID}`);
     cy.go('back');

--- a/test/e2e/cypress/pageObject/sap_systems_overview_po.js
+++ b/test/e2e/cypress/pageObject/sap_systems_overview_po.js
@@ -70,6 +70,7 @@ const hanaClusterLinks = 'div[class*="cell"] a span:contains("hana")';
 const instanceHostLinks = 'div[class*="cell"] a[href*="/host"]';
 const systemToRemoveCollapsibleCell = `${sapSystemsTableRows}:eq(0) td:first-child`;
 const nwdSystemRowCollapsibleCell = `tr:contains('${sapSystemNwd.sid}') > td:eq(0)`;
+const pageTitle = 'h1:contains("SAP Systems")';
 
 // UI Interactions
 export const visit = () => {
@@ -103,11 +104,15 @@ const clickAllRows = () => {
   const expandTableElement = 'td svg[class*="cursor"]';
   cy.get(expandTableElement).each((cell, index) => {
     cy.get(`${expandTableElement}:eq(${index})`).click();
-    cy.get('tr[class*="bg-gray-100"]')
-      .eq(index)
-      .should('have.css', 'display', 'table-row', { timeout: 10000 });
+    tableRowIsVisible(index);
   });
 };
+
+const tableRowIsVisible = (index) =>
+  cy
+    .get('tr[class*="bg-gray-100"]')
+    .eq(index)
+    .should('have.css', 'display', 'table-row', { timeout: 10000 });
 
 // UI Validations
 export const nwdInstance01CleanUpButtonIsVisible = () =>
@@ -250,6 +255,9 @@ export const instanceDataIsTheExpected = () => {
   });
 };
 
+const pageTitleIsCorrectlyDisplayed = () =>
+  cy.get(pageTitle).should('be.visible');
+
 export const eachHanaInstanceHasItsClusterWorkingLink = () => {
   const hanaInstances = instancesData.filter(
     (instance) => instance.clusterID !== ''
@@ -259,7 +267,7 @@ export const eachHanaInstanceHasItsClusterWorkingLink = () => {
     cy.get(`${hanaClusterLinks}:eq(${index})`).click();
     validateUrl(`/clusters/${hanaInstance.clusterID}`);
     cy.go('back');
-    cy.get('h1:contains("SAP Systems")').should('be.visible');
+    pageTitleIsCorrectlyDisplayed();
   });
 };
 

--- a/test/e2e/cypress/pageObject/sap_systems_overview_po.js
+++ b/test/e2e/cypress/pageObject/sap_systems_overview_po.js
@@ -75,8 +75,7 @@ const nwdSystemRowCollapsibleCell = `tr:contains('${sapSystemNwd.sid}') > td:eq(
 export const visit = () => {
   cy.intercept('/api/v1/databases').as('databasesRequest');
   basePage.visit(url);
-  cy.wait('@databasesRequest', { timeout: 10000 });
-  // basePage.waitForRequest('databasesRequest', 10000);
+  basePage.waitForRequest('databasesRequest', 10000);
 };
 
 export const tagSapSystems = () => {
@@ -254,9 +253,12 @@ export const eachHanaInstanceHasItsClusterWorkingLink = () => {
   );
   cy.wrap(hanaInstances).each((hanaInstance, index) => {
     clickAllRows();
-    cy.get(`${hanaClusterLinks}:eq(${index})`).should('be.visible', {
-      timeout: 10000,
-    });
+    cy.get('tr[class*="bg-gray-100"]').should(
+      'have.css',
+      'display',
+      'table-row',
+      { timeout: 10000 }
+    );
     cy.get(`${hanaClusterLinks}:eq(${index})`).click();
     validateUrl(`/clusters/${hanaInstance.clusterID}`);
     cy.go('back');

--- a/test/e2e/cypress/pageObject/sap_systems_overview_po.js
+++ b/test/e2e/cypress/pageObject/sap_systems_overview_po.js
@@ -103,9 +103,9 @@ const clickAllRows = () => {
   const expandTableElement = 'td svg[class*="cursor"]';
   cy.get(expandTableElement).each((cell, index) => {
     cy.get(`${expandTableElement}:eq(${index})`).click();
-    // cy.get('tr[class*="bg-gray-100"]')
-    //   .eq(index)
-    //   .should('have.css', 'display', 'table-row', { timeout: 10000 });
+    cy.get('tr[class*="bg-gray-100"]')
+      .eq(index)
+      .should('have.css', 'display', 'table-row', { timeout: 10000 });
   });
 };
 

--- a/test/e2e/cypress/pageObject/sap_systems_overview_po.js
+++ b/test/e2e/cypress/pageObject/sap_systems_overview_po.js
@@ -251,8 +251,6 @@ export const instanceDataIsTheExpected = () => {
 };
 
 export const eachHanaInstanceHasItsClusterWorkingLink = () => {
-  cy.get('h1:contains("SAP Systems")').should('be.visible');
-
   const hanaInstances = instancesData.filter(
     (instance) => instance.clusterID !== ''
   );
@@ -261,6 +259,7 @@ export const eachHanaInstanceHasItsClusterWorkingLink = () => {
     cy.get(`${hanaClusterLinks}:eq(${index})`).click();
     validateUrl(`/clusters/${hanaInstance.clusterID}`);
     cy.go('back');
+    cy.get('h1:contains("SAP Systems")').should('be.visible');
   });
 };
 


### PR DESCRIPTION
# Description

This was a very tricky one related to the nested tables in SAP Systems Overview, the issue was that sometimes the test tried to click on a link but it complained that the parent tr was still having css attribute display as none, instead of being table-row, so I fixed that by waiting for the parent tr to have the expected css attribute value. Also, after doing `cy.back` after clicking a link, actions were happening right away in that page instead of waiting for the SAP systems page again to be displayed, that's why I added another assertion to make sure that Sap Systems page is displayed prior to perform any other action.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [x] **DONE**

## How was this tested? 
Launching flaky tests job many times.

- [x] **DONE**
## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
- [Trento Web guides](https://github.com/trento-project/web/tree/main/guides)

Add a documentation PR or write that no changes are required for the documentation.
- [ ] **DONE**
