### PR TITLE
Refactors dispatch functions and their usage

### DIFF
--- a/lib/trento/databases.ex
+++ b/lib/trento/databases.ex
@@ -15,6 +15,7 @@ defmodule Trento.Databases do
   alias Trento.Infrastructure.Operations
 
   alias Trento.Support.DateService
+  alias Trento.Support.CommandedUtils
 
   alias Trento.Databases.Commands.DeregisterDatabaseInstance
 
@@ -78,7 +79,7 @@ defmodule Trento.Databases do
         {:error, :instance_present}
 
       _ ->
-        correlated_dispatch(
+        CommandedUtils.correlated_dispatch(
           DeregisterDatabaseInstance.new!(%{
             database_id: database_id,
             host_id: host_id,
@@ -139,12 +140,4 @@ defmodule Trento.Databases do
   end
 
   defp maybe_filter_by_site(databases, _), do: databases
-
-  defp commanded,
-    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
-
-  defp correlated_dispatch(command) do
-    correlation_id = Process.get(:correlation_id)
-    commanded().dispatch(command, correlation_id: correlation_id, causation_id: correlation_id)
-  end
 end

--- a/lib/trento/databases.ex
+++ b/lib/trento/databases.ex
@@ -14,8 +14,8 @@ defmodule Trento.Databases do
 
   alias Trento.Infrastructure.Operations
 
-  alias Trento.Support.DateService
   alias Trento.Support.CommandedUtils
+  alias Trento.Support.DateService
 
   alias Trento.Databases.Commands.DeregisterDatabaseInstance
 

--- a/lib/trento/heartbeats.ex
+++ b/lib/trento/heartbeats.ex
@@ -3,14 +3,13 @@ defmodule Trento.Heartbeats do
   Heartbeat related functions
   """
 
-  alias Trento.ActivityLog
-
   alias Trento.Hosts.Commands.UpdateHeartbeat
 
   alias Trento.Heartbeats.Heartbeat
   alias Trento.Hosts.Projections.HostReadModel
 
   alias Trento.Support.DateService
+  alias Trento.Support.CommandedUtils
 
   alias Trento.Repo
 
@@ -84,34 +83,12 @@ defmodule Trento.Heartbeats do
   defp dispatch_command(agent_id, heartbeat) do
     case %{host_id: agent_id, heartbeat: heartbeat}
          |> UpdateHeartbeat.new!()
-         |> maybe_correlated_dispatch() do
+         |> CommandedUtils.maybe_correlated_dispatch(:api_key) do
       :ok ->
         {:ok, :done}
 
       {:error, _} = error ->
         error
-    end
-  end
-
-  defp commanded,
-    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
-
-  defp maybe_correlated_dispatch(command) do
-    key = ActivityLog.correlation_key(:api_key)
-
-    case ActivityLog.get_correlation_id(key) do
-      nil ->
-        # in case the correlation_id entry has expired
-        # or is absent we do the default dispatch
-        commanded().dispatch(command)
-
-      correlation_id ->
-        # in case correlation_id exists, we
-        # pass it on to the dispatch function
-        commanded().dispatch(command,
-          correlation_id: correlation_id,
-          causation_id: correlation_id
-        )
     end
   end
 end

--- a/lib/trento/heartbeats.ex
+++ b/lib/trento/heartbeats.ex
@@ -8,8 +8,8 @@ defmodule Trento.Heartbeats do
   alias Trento.Heartbeats.Heartbeat
   alias Trento.Hosts.Projections.HostReadModel
 
-  alias Trento.Support.DateService
   alias Trento.Support.CommandedUtils
+  alias Trento.Support.DateService
 
   alias Trento.Repo
 

--- a/lib/trento/heartbeats.ex
+++ b/lib/trento/heartbeats.ex
@@ -83,7 +83,7 @@ defmodule Trento.Heartbeats do
   defp dispatch_command(agent_id, heartbeat) do
     case %{host_id: agent_id, heartbeat: heartbeat}
          |> UpdateHeartbeat.new!()
-         |> CommandedUtils.maybe_correlated_dispatch(:api_key) do
+         |> CommandedUtils.correlated_dispatch(:api_key) do
       :ok ->
         {:ok, :done}
 

--- a/lib/trento/hosts.ex
+++ b/lib/trento/hosts.ex
@@ -101,7 +101,7 @@ defmodule Trento.Hosts do
     Logger.debug("Selecting checks, host: #{host_id}")
 
     with {:ok, command} <- SelectHostChecks.new(%{host_id: host_id, checks: checks}) do
-      CommandedUtils.commanded().dispatch(command)
+      CommandedUtils.dispatch(command)
     end
   end
 

--- a/lib/trento/hosts.ex
+++ b/lib/trento/hosts.ex
@@ -15,6 +15,7 @@ defmodule Trento.Hosts do
   }
 
   alias Trento.Support.DateService
+  alias Trento.Support.CommandedUtils
 
   alias Trento.Hosts.Commands.{
     RequestHostDeregistration,
@@ -100,7 +101,7 @@ defmodule Trento.Hosts do
     Logger.debug("Selecting checks, host: #{host_id}")
 
     with {:ok, command} <- SelectHostChecks.new(%{host_id: host_id, checks: checks}) do
-      commanded().dispatch(command)
+      CommandedUtils.commanded().dispatch(command)
     end
   end
 
@@ -127,7 +128,7 @@ defmodule Trento.Hosts do
   @spec deregister_host(Ecto.UUID.t(), DateService) ::
           :ok | {:error, :host_alive} | {:error, :host_not_registered}
   def deregister_host(host_id, date_service \\ DateService) do
-    correlated_dispatch(
+    CommandedUtils.correlated_dispatch(
       RequestHostDeregistration.new!(%{host_id: host_id, requested_at: date_service.utc_now()})
     )
   end
@@ -182,13 +183,5 @@ defmodule Trento.Hosts do
       selected_checks,
       :host
     )
-  end
-
-  defp commanded,
-    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
-
-  defp correlated_dispatch(command) do
-    correlation_id = Process.get(:correlation_id)
-    commanded().dispatch(command, correlation_id: correlation_id, causation_id: correlation_id)
   end
 end

--- a/lib/trento/hosts.ex
+++ b/lib/trento/hosts.ex
@@ -14,8 +14,8 @@ defmodule Trento.Hosts do
     SlesSubscriptionReadModel
   }
 
-  alias Trento.Support.DateService
   alias Trento.Support.CommandedUtils
+  alias Trento.Support.DateService
 
   alias Trento.Hosts.Commands.{
     RequestHostDeregistration,

--- a/lib/trento/sap_systems.ex
+++ b/lib/trento/sap_systems.ex
@@ -16,6 +16,7 @@ defmodule Trento.SapSystems do
   alias Trento.Infrastructure.Operations
 
   alias Trento.Support.DateService
+  alias Trento.Support.CommandedUtils
 
   alias Trento.SapSystems.Commands.DeregisterApplicationInstance
 
@@ -81,7 +82,7 @@ defmodule Trento.SapSystems do
         {:error, :instance_present}
 
       _ ->
-        correlated_dispatch(
+        CommandedUtils.correlated_dispatch(
           DeregisterApplicationInstance.new!(%{
             sap_system_id: sap_system_id,
             host_id: host_id,
@@ -155,12 +156,4 @@ defmodule Trento.SapSystems do
   end
 
   def request_operation(_, _, _), do: {:error, :operation_not_found}
-
-  defp commanded,
-    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
-
-  defp correlated_dispatch(command) do
-    correlation_id = Process.get(:correlation_id)
-    commanded().dispatch(command, correlation_id: correlation_id, causation_id: correlation_id)
-  end
 end

--- a/lib/trento/sap_systems.ex
+++ b/lib/trento/sap_systems.ex
@@ -15,8 +15,8 @@ defmodule Trento.SapSystems do
 
   alias Trento.Infrastructure.Operations
 
-  alias Trento.Support.DateService
   alias Trento.Support.CommandedUtils
+  alias Trento.Support.DateService
 
   alias Trento.SapSystems.Commands.DeregisterApplicationInstance
 

--- a/lib/trento/software_updates/discovery.ex
+++ b/lib/trento/software_updates/discovery.ex
@@ -9,7 +9,6 @@ defmodule Trento.SoftwareUpdates.Discovery do
 
   alias Ecto.Multi
 
-  alias Trento.ActivityLog
   alias Trento.Hosts
 
   alias Trento.Hosts.Commands.{
@@ -19,6 +18,7 @@ defmodule Trento.SoftwareUpdates.Discovery do
 
   alias Trento.Hosts.Projections.HostReadModel
   alias Trento.SoftwareUpdates.Discovery.DiscoveryResult
+  alias Trento.Support.CommandedUtils
 
   require Trento.SoftwareUpdates.Enums.SoftwareUpdatesHealth, as: SoftwareUpdatesHealth
   require Trento.SoftwareUpdates.Enums.AdvisoryType, as: AdvisoryType
@@ -96,7 +96,7 @@ defmodule Trento.SoftwareUpdates.Discovery do
     |> Enum.each(fn command_payload ->
       command_payload
       |> ClearSoftwareUpdatesDiscovery.new!()
-      |> maybe_correlated_dispatch()
+      |> CommandedUtils.maybe_correlated_dispatch(:suse_manager_settings)
     end)
 
     clear()
@@ -224,7 +224,7 @@ defmodule Trento.SoftwareUpdates.Discovery do
            health: discovered_health
          }
          |> CompleteSoftwareUpdatesDiscovery.new!()
-         |> maybe_correlated_dispatch() do
+         |> CommandedUtils.maybe_correlated_dispatch(:suse_manager_settings) do
       :ok ->
         {:ok, :dispatched}
 
@@ -303,25 +303,4 @@ defmodule Trento.SoftwareUpdates.Discovery do
   defp failure_reason_to_atom(_), do: :unknown_discovery_error
 
   defp adapter, do: Application.fetch_env!(:trento, __MODULE__)[:adapter]
-
-  defp commanded, do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
-
-  defp maybe_correlated_dispatch(command) do
-    key = ActivityLog.correlation_key(:suse_manager_settings)
-
-    case ActivityLog.get_correlation_id(key) do
-      nil ->
-        # in case the correlation_id entry has expired
-        # or is absent we do the default dispatch
-        commanded().dispatch(command)
-
-      correlation_id ->
-        # in case correlation_id exists, we
-        # pass it on to the dispatch function
-        commanded().dispatch(command,
-          correlation_id: correlation_id,
-          causation_id: correlation_id
-        )
-    end
-  end
 end

--- a/lib/trento/software_updates/discovery.ex
+++ b/lib/trento/software_updates/discovery.ex
@@ -96,7 +96,7 @@ defmodule Trento.SoftwareUpdates.Discovery do
     |> Enum.each(fn command_payload ->
       command_payload
       |> ClearSoftwareUpdatesDiscovery.new!()
-      |> CommandedUtils.maybe_correlated_dispatch(:suse_manager_settings)
+      |> CommandedUtils.correlated_dispatch(:suse_manager_settings)
     end)
 
     clear()
@@ -224,7 +224,7 @@ defmodule Trento.SoftwareUpdates.Discovery do
            health: discovered_health
          }
          |> CompleteSoftwareUpdatesDiscovery.new!()
-         |> CommandedUtils.maybe_correlated_dispatch(:suse_manager_settings) do
+         |> CommandedUtils.correlated_dispatch(:suse_manager_settings) do
       :ok ->
         {:ok, :dispatched}
 

--- a/lib/trento/support/commanded_utils.ex
+++ b/lib/trento/support/commanded_utils.ex
@@ -2,7 +2,7 @@ defmodule Trento.Support.CommandedUtils do
   @moduledoc false
   alias Trento.ActivityLog
 
-  def commanded, do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
+  def dispatch(command), do: commanded().dispatch(command)
 
   def maybe_correlated_dispatch(command, ctx \\ :uncorrelated_dispatch) do
     case ctx == :uncorrelated_dispatch do
@@ -33,4 +33,6 @@ defmodule Trento.Support.CommandedUtils do
     correlation_id = Process.get(:correlation_id)
     commanded().dispatch(command, correlation_id: correlation_id, causation_id: correlation_id)
   end
+
+  defp commanded, do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
 end

--- a/lib/trento/support/commanded_utils.ex
+++ b/lib/trento/support/commanded_utils.ex
@@ -4,28 +4,22 @@ defmodule Trento.Support.CommandedUtils do
 
   def dispatch(command), do: commanded().dispatch(command)
 
-  def maybe_correlated_dispatch(command, ctx \\ :uncorrelated_dispatch) do
-    case ctx == :uncorrelated_dispatch do
-      false ->
-        key = ActivityLog.correlation_key(ctx)
+  def correlated_dispatch(command, ctx) do
+    key = ActivityLog.correlation_key(ctx)
 
-        case ActivityLog.get_correlation_id(key) do
-          nil ->
-            # in case the correlation_id entry has expired
-            # or is absent we do the default dispatch
-            commanded().dispatch(command)
-
-          correlation_id ->
-            # in case correlation_id exists, we
-            # pass it on to the dispatch function
-            commanded().dispatch(command,
-              correlation_id: correlation_id,
-              causation_id: correlation_id
-            )
-        end
-
-      true ->
+    case ActivityLog.get_correlation_id(key) do
+      nil ->
+        # in case the correlation_id entry has expired
+        # or is absent we do the default dispatch
         commanded().dispatch(command)
+
+      correlation_id ->
+        # in case correlation_id exists, we
+        # pass it on to the dispatch function
+        commanded().dispatch(command,
+          correlation_id: correlation_id,
+          causation_id: correlation_id
+        )
     end
   end
 

--- a/lib/trento/support/commanded_utils.ex
+++ b/lib/trento/support/commanded_utils.ex
@@ -1,0 +1,36 @@
+defmodule Trento.Support.CommandedUtils do
+  @moduledoc false
+  alias Trento.ActivityLog
+
+  def commanded, do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
+
+  def maybe_correlated_dispatch(command, ctx \\ :uncorrelated_dispatch) do
+    case ctx == :uncorrelated_dispatch do
+      false ->
+        key = ActivityLog.correlation_key(ctx)
+
+        case ActivityLog.get_correlation_id(key) do
+          nil ->
+            # in case the correlation_id entry has expired
+            # or is absent we do the default dispatch
+            commanded().dispatch(command)
+
+          correlation_id ->
+            # in case correlation_id exists, we
+            # pass it on to the dispatch function
+            commanded().dispatch(command,
+              correlation_id: correlation_id,
+              causation_id: correlation_id
+            )
+        end
+
+      true ->
+        commanded().dispatch(command)
+    end
+  end
+
+  def correlated_dispatch(command) do
+    correlation_id = Process.get(:correlation_id)
+    commanded().dispatch(command, correlation_id: correlation_id, causation_id: correlation_id)
+  end
+end

--- a/test/trento/support/commanded_utils_test.exs
+++ b/test/trento/support/commanded_utils_test.exs
@@ -8,8 +8,7 @@ defmodule Trento.Support.CommandedUtilsTest do
 
   describe "maybe_correlated_dispatch/2" do
     test "should perform uncorrelated dispatch when called with arity 1" do
-      uuid = Faker.UUID.v4()
-      some_command = %{uuid: uuid}
+      some_command = %{uuid: Faker.UUID.v4()}
 
       expect(
         Trento.Commanded.Mock,
@@ -25,8 +24,7 @@ defmodule Trento.Support.CommandedUtilsTest do
     for ctx <- [:api_key, :suse_manager_settings] do
       @ctx ctx
       test "should perform uncorrelated dispatch when called with #{@ctx} ctx parameter but not setup anything on the correlation cache" do
-        uuid = Faker.UUID.v4()
-        some_command = %{uuid: uuid}
+        some_command = %{uuid: Faker.UUID.v4()}
 
         expect(
           Trento.Commanded.Mock,
@@ -40,8 +38,7 @@ defmodule Trento.Support.CommandedUtilsTest do
       end
 
       test "should perform correlated dispatch when called with #{@ctx} ctx parameter with kv setup on correlation cache" do
-        uuid = Faker.UUID.v4()
-        some_command = %{uuid: uuid}
+        some_command = %{uuid: Faker.UUID.v4()}
 
         key0 = UUID.uuid4()
         correlation_id = UUID.uuid4()
@@ -66,8 +63,7 @@ defmodule Trento.Support.CommandedUtilsTest do
 
   describe "correlated_dispatch/1" do
     test "should perform correlated dispatch when correlation_id is setup in process dictionary" do
-      uuid = Faker.UUID.v4()
-      some_command = %{uuid: uuid}
+      some_command = %{uuid: Faker.UUID.v4()}
 
       correlation_id = UUID.uuid4()
       _ = Process.put(:correlation_id, correlation_id)

--- a/test/trento/support/commanded_utils_test.exs
+++ b/test/trento/support/commanded_utils_test.exs
@@ -6,21 +6,7 @@ defmodule Trento.Support.CommandedUtilsTest do
 
   setup :verify_on_exit!
 
-  describe "maybe_correlated_dispatch/2" do
-    test "should perform uncorrelated dispatch when called with arity 1" do
-      some_command = %{uuid: Faker.UUID.v4()}
-
-      expect(
-        Trento.Commanded.Mock,
-        :dispatch,
-        fn ^some_command ->
-          :ok
-        end
-      )
-
-      assert :ok == CommandedUtils.maybe_correlated_dispatch(some_command)
-    end
-
+  describe "correlated_dispatch/2" do
     for ctx <- [:api_key, :suse_manager_settings] do
       @ctx ctx
       test "should perform uncorrelated dispatch when called with #{@ctx} ctx parameter but not setup anything on the correlation cache" do
@@ -34,7 +20,7 @@ defmodule Trento.Support.CommandedUtilsTest do
           end
         )
 
-        assert :ok == CommandedUtils.maybe_correlated_dispatch(some_command, @ctx)
+        assert :ok == CommandedUtils.correlated_dispatch(some_command, @ctx)
       end
 
       test "should perform correlated dispatch when called with #{@ctx} ctx parameter with kv setup on correlation cache" do
@@ -56,7 +42,7 @@ defmodule Trento.Support.CommandedUtilsTest do
           end
         )
 
-        assert :ok == CommandedUtils.maybe_correlated_dispatch(some_command, @ctx)
+        assert :ok == CommandedUtils.correlated_dispatch(some_command, @ctx)
       end
     end
   end

--- a/test/trento/support/commanded_utils_test.exs
+++ b/test/trento/support/commanded_utils_test.exs
@@ -1,0 +1,86 @@
+defmodule Trento.Support.CommandedUtilsTest do
+  use ExUnit.Case
+  import Mox
+  alias Trento.ActivityLog.Correlations
+  alias Trento.Support.CommandedUtils
+
+  setup :verify_on_exit!
+
+  describe "maybe_correlated_dispatch/2" do
+    test "should perform uncorrelated dispatch when called with arity 1" do
+      uuid = Faker.UUID.v4()
+      some_command = %{uuid: uuid}
+
+      expect(
+        Trento.Commanded.Mock,
+        :dispatch,
+        fn ^some_command ->
+          :ok
+        end
+      )
+
+      assert :ok == CommandedUtils.maybe_correlated_dispatch(some_command)
+    end
+
+    for ctx <- [:api_key, :suse_manager_settings] do
+      @ctx ctx
+      test "should perform uncorrelated dispatch when called with #{@ctx} ctx parameter but not setup anything on the correlation cache" do
+        uuid = Faker.UUID.v4()
+        some_command = %{uuid: uuid}
+
+        expect(
+          Trento.Commanded.Mock,
+          :dispatch,
+          fn ^some_command ->
+            :ok
+          end
+        )
+
+        assert :ok == CommandedUtils.maybe_correlated_dispatch(some_command, @ctx)
+      end
+
+      test "should perform correlated dispatch when called with #{@ctx} ctx parameter with kv setup on correlation cache" do
+        uuid = Faker.UUID.v4()
+        some_command = %{uuid: uuid}
+
+        key0 = UUID.uuid4()
+        correlation_id = UUID.uuid4()
+        _ = Process.put(:correlation_key, key0)
+
+        key = Correlations.correlation_key(@ctx)
+        assert key0 == key
+        :ok = Correlations.put_correlation_id(key, correlation_id)
+
+        expect(
+          Trento.Commanded.Mock,
+          :dispatch,
+          fn ^some_command, [correlation_id: ^correlation_id, causation_id: ^correlation_id] ->
+            :ok
+          end
+        )
+
+        assert :ok == CommandedUtils.maybe_correlated_dispatch(some_command, @ctx)
+      end
+    end
+  end
+
+  describe "correlated_dispatch/1" do
+    test "should perform correlated dispatch when correlation_id is setup in process dictionary" do
+      uuid = Faker.UUID.v4()
+      some_command = %{uuid: uuid}
+
+      correlation_id = UUID.uuid4()
+      _ = Process.put(:correlation_id, correlation_id)
+
+      expect(
+        Trento.Commanded.Mock,
+        :dispatch,
+        fn ^some_command, [correlation_id: ^correlation_id, causation_id: ^correlation_id] ->
+          :ok
+        end
+      )
+
+      assert :ok == CommandedUtils.correlated_dispatch(some_command)
+    end
+  end
+end


### PR DESCRIPTION
# Description

Previously, many top level context modules had their own definitions of commanded command dispatch functions. This PR refactors this usage by centralizing the definitions in a single module and adds tests for the case of correlated/uncorrelated command dispatches. In addition to less repetition, we also get some tested scenarios of when to expect a correlated vs uncorrelated dispatch of commands from certain contexts.

## How was this tested?

UT
