### PR TITLE
Database start/stop policy

### DIFF
--- a/lib/trento/operations/database_instance_policy.ex
+++ b/lib/trento/operations/database_instance_policy.ex
@@ -29,13 +29,13 @@ defmodule Trento.Operations.DatabaseInstancePolicy do
         },
         _params
       ) do
-    is_clustered =
+    is_clustered? =
       Enum.any?(sap_instances, fn
         %{sid: ^sid, instance_number: ^instance_number} -> true
         _ -> false
       end)
 
-    if is_clustered do
+    if is_clustered? do
       resource_id = get_cluster_resource_id(cluster)
 
       ClusterReadModel.authorize_operation(:maintenance, cluster, %{

--- a/lib/trento/operations/database_instance_policy.ex
+++ b/lib/trento/operations/database_instance_policy.ex
@@ -13,40 +13,22 @@ defmodule Trento.Operations.DatabaseInstancePolicy do
   alias Trento.Databases.Projections.DatabaseInstanceReadModel
   alias Trento.Hosts.Projections.HostReadModel
 
-  # maintenance operation authorized when:
-  # - instance is not running
-  # - cluster is in maintenance
   def authorize_operation(
-        :maintenance,
-        %DatabaseInstanceReadModel{} = application_instance,
+        :cluster_maintenance,
+        %DatabaseInstanceReadModel{host: %HostReadModel{cluster: nil}},
+        _params
+      ),
+      do: :ok
+
+  def authorize_operation(
+        :cluster_maintenance,
+        %DatabaseInstanceReadModel{
+          sid: sid,
+          instance_number: instance_number,
+          host: %{cluster: %{sap_instances: sap_instances} = cluster}
+        },
         _params
       ) do
-    OperationsHelper.reduce_operation_authorizations([
-      instance_running(application_instance),
-      cluster_maintenance(application_instance)
-    ])
-  end
-
-  def authorize_operation(_, _, _), do: {:error, ["Unknown operation"]}
-
-  defp instance_running(%DatabaseInstanceReadModel{
-         sid: sid,
-         instance_number: instance_number,
-         health: health
-       })
-       when health != Health.unknown(),
-       do: {:error, ["Instance #{instance_number} of HANA database #{sid} is not stopped"]}
-
-  defp instance_running(_), do: :ok
-
-  defp cluster_maintenance(%DatabaseInstanceReadModel{host: %HostReadModel{cluster: nil}}),
-    do: :ok
-
-  defp cluster_maintenance(%DatabaseInstanceReadModel{
-         sid: sid,
-         instance_number: instance_number,
-         host: %{cluster: %{sap_instances: sap_instances} = cluster}
-       }) do
     is_clustered =
       Enum.any?(sap_instances, fn
         %{sid: ^sid, instance_number: ^instance_number} -> true
@@ -63,6 +45,32 @@ defmodule Trento.Operations.DatabaseInstancePolicy do
       :ok
     end
   end
+
+  # maintenance operation authorized when:
+  # - instance is not running
+  # - cluster is in maintenance
+  def authorize_operation(
+        :maintenance,
+        %DatabaseInstanceReadModel{} = database_instance,
+        _params
+      ) do
+    OperationsHelper.reduce_operation_authorizations([
+      instance_running(database_instance),
+      authorize_operation(:cluster_maintenance, database_instance, %{})
+    ])
+  end
+
+  def authorize_operation(_, _, _), do: {:error, ["Unknown operation"]}
+
+  defp instance_running(%DatabaseInstanceReadModel{
+         sid: sid,
+         instance_number: instance_number,
+         health: health
+       })
+       when health != Health.unknown(),
+       do: {:error, ["Instance #{instance_number} of HANA database #{sid} is not stopped"]}
+
+  defp instance_running(_), do: :ok
 
   defp get_cluster_resource_id(%ClusterReadModel{
          details: %{resources: resources}

--- a/lib/trento/operations/database_policy.ex
+++ b/lib/trento/operations/database_policy.ex
@@ -5,16 +5,135 @@ defmodule Trento.Operations.DatabasePolicy do
 
   @behaviour Trento.Operations.PolicyBehaviour
 
-  require Trento.Operations.Enums.DatabaseOperations, as: DatabaseOperations
+  alias Trento.Support.OperationsHelper
+
+  alias Trento.Databases.Projections.{
+    DatabaseInstanceReadModel,
+    DatabaseReadModel
+  }
 
   def authorize_operation(
-        operation,
-        _,
-        _
-      )
-      when operation in DatabaseOperations.values() do
-    :ok
+        :database_start,
+        %DatabaseReadModel{} = database,
+        params
+      ) do
+    primary_site = get_primary_site(database)
+
+    OperationsHelper.reduce_operation_authorizations([
+      database_instances_cluster_maintenance(database),
+      primary_site_started(database, params, primary_site)
+    ])
+  end
+
+  def authorize_operation(
+        :database_stop,
+        %DatabaseReadModel{} = database,
+        params
+      ) do
+    primary_site = get_primary_site(database)
+
+    OperationsHelper.reduce_operation_authorizations([
+      database_instances_cluster_maintenance(database),
+      secondary_sites_stopped(database, params, primary_site),
+      application_instances_stopped(database)
+    ])
   end
 
   def authorize_operation(_, _, _), do: {:error, ["Unknown operation"]}
+
+  defp get_primary_site(%DatabaseReadModel{
+         database_instances: database_instances
+       }) do
+    Enum.find_value(database_instances, nil, fn %{
+                                                  system_replication: sr,
+                                                  system_replication_site: site
+                                                } ->
+      if sr == "Primary" do
+        site
+      end
+    end)
+  end
+
+  defp database_instances_cluster_maintenance(%DatabaseReadModel{
+         database_instances: database_instances
+       }) do
+    OperationsHelper.reduce_operation_authorizations(
+      database_instances,
+      :ok,
+      fn database_instance ->
+        DatabaseInstanceReadModel.authorize_operation(
+          :cluster_maintenance,
+          database_instance,
+          %{}
+        )
+      end
+    )
+  end
+
+  # system replication not configured
+  defp primary_site_started(_, _, nil), do: :ok
+  # primary site
+  defp primary_site_started(_, %{site: site}, site), do: :ok
+  # secondary sites, check primary is started
+  defp primary_site_started(
+         %DatabaseReadModel{
+           sid: sid,
+           database_instances: database_instances
+         },
+         _,
+         primary_site
+       ) do
+    database_instances
+    |> Enum.filter(fn %{system_replication_site: site} -> site == primary_site end)
+    |> Enum.all?(fn %{health: health} -> health == :passing end)
+    |> if do
+      :ok
+    else
+      {:error, ["Primary site #{primary_site} of database #{sid} is not started"]}
+    end
+  end
+
+  # system replication not configured
+  defp secondary_sites_stopped(_, _, nil), do: :ok
+  # primary site, check secondary sites are stopped
+  defp secondary_sites_stopped(
+         %DatabaseReadModel{
+           sid: sid,
+           database_instances: database_instances
+         },
+         %{site: primary_site},
+         primary_site
+       ) do
+    database_instances
+    |> Enum.reject(fn %{system_replication_site: site} -> site == primary_site end)
+    |> Enum.all?(fn %{health: health} -> health == :unknown end)
+    |> if do
+      :ok
+    else
+      {:error, ["Secondary sites of database #{sid} are not stopped"]}
+    end
+  end
+
+  # secondary sites
+  defp secondary_sites_stopped(_, _, _), do: :ok
+
+  defp application_instances_stopped(%DatabaseReadModel{sap_systems: []}), do: :ok
+
+  defp application_instances_stopped(%DatabaseReadModel{sap_systems: sap_systems}) do
+    sap_systems
+    |> Enum.flat_map(fn %{application_instances: app_instances} -> app_instances end)
+    |> Enum.filter(fn %{health: health, features: features} ->
+      health != :unknown and (features =~ "ABAP" or features =~ "J2EE")
+    end)
+    |> case do
+      [] ->
+        :ok
+
+      running_instances ->
+        {:error,
+         Enum.map(running_instances, fn %{sid: sid, instance_number: inst_number} ->
+           "Instance #{inst_number} of SAP system #{sid} is not stopped"
+         end)}
+    end
+  end
 end

--- a/lib/trento_web/controllers/v1/database_controller.ex
+++ b/lib/trento_web/controllers/v1/database_controller.ex
@@ -34,7 +34,8 @@ defmodule TrentoWeb.V1.DatabaseController do
          policy: Trento.Operations.DatabasePolicy,
          resource: &__MODULE__.get_operation_database/1,
          operation: &__MODULE__.get_operation/1,
-         assigns_to: :database
+         assigns_to: :database,
+         params: &__MODULE__.get_operation_params/1
        ]
        when action == :request_operation
 
@@ -156,7 +157,7 @@ defmodule TrentoWeb.V1.DatabaseController do
 
     database_id
     |> Databases.get_database_by_id()
-    |> Repo.preload([:database_instances])
+    |> Repo.preload(database_instances: [host: [:cluster]], sap_systems: [:application_instances])
     |> case do
       nil ->
         nil
@@ -174,6 +175,12 @@ defmodule TrentoWeb.V1.DatabaseController do
   end
 
   def get_operation_database(_), do: nil
+
+  def get_operation_params(%{
+        body_params: body_params
+      }) do
+    body_params
+  end
 
   def get_operation(%{params: %{operation: "database_start"}}),
     do: :database_start

--- a/test/trento/operations/database_policy_test.exs
+++ b/test/trento/operations/database_policy_test.exs
@@ -1,0 +1,275 @@
+defmodule Trento.Operations.DatabasePolicyTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  require Trento.Enums.Health, as: Health
+
+  alias Trento.Operations.DatabasePolicy
+
+  import Trento.Factory
+
+  test "should forbid unknown operation" do
+    database = build(:database)
+
+    assert {:error, ["Unknown operation"]} ==
+             DatabasePolicy.authorize_operation(:unknown, database, %{})
+  end
+
+  describe "database_start" do
+    test "should forbid operation if the database cluster is not in maintenance" do
+      %{name: cluster_name, sap_instances: [%{sid: sid, instance_number: instance_number}]} =
+        cluster = build_cluster_with_maintenance(false)
+
+      database =
+        build(:database,
+          database_instances:
+            build_list(2, :database_instance,
+              sid: sid,
+              instance_number: instance_number,
+              host: build(:host, cluster: cluster)
+            )
+        )
+
+      assert {:error, ["Cluster #{cluster_name} operating this host is not in maintenance mode"]} ==
+               DatabasePolicy.authorize_operation(:database_start, database, %{})
+    end
+
+    test "should forbid operation in secondary site if primary site is not started" do
+      %{sid: sid} =
+        database =
+        build(:database,
+          database_instances: [
+            build(:database_instance,
+              health: Health.unknown(),
+              system_replication: "Primary",
+              system_replication_site: "Site1",
+              host: build(:host, cluster: nil)
+            ),
+            build(:database_instance,
+              system_replication: "Secondary",
+              system_replication_site: "Site2",
+              host: build(:host, cluster: nil)
+            )
+          ]
+        )
+
+      assert {:error, ["Primary site Site1 of database #{sid} is not started"]} ==
+               DatabasePolicy.authorize_operation(:database_start, database, %{site: "Site2"})
+    end
+
+    test "should authorize operation if cluster is in maintenance and system replication is not enabled" do
+      %{sap_instances: [%{sid: sid, instance_number: instance_number}]} =
+        cluster = build_cluster_with_maintenance(true)
+
+      database =
+        build(:database,
+          database_instances: [
+            build(:database_instance,
+              system_replication: nil,
+              sid: sid,
+              instance_number: instance_number,
+              host: build(:host, cluster: cluster)
+            )
+          ]
+        )
+
+      assert :ok ==
+               DatabasePolicy.authorize_operation(:database_start, database, %{})
+    end
+
+    test "should authorize operation if the request is for the primary site" do
+      database =
+        build(:database,
+          database_instances: [
+            build(:database_instance,
+              system_replication: "Primary",
+              system_replication_site: "Site1",
+              host: build(:host, cluster: nil)
+            ),
+            build(:database_instance,
+              system_replication: "Secondary",
+              system_replication_site: "Site2",
+              host: build(:host, cluster: nil)
+            )
+          ]
+        )
+
+      assert :ok ==
+               DatabasePolicy.authorize_operation(:database_start, database, %{site: "Site1"})
+    end
+
+    test "should authorize operation if the request is for the secondary site and primary is started" do
+      database =
+        build(:database,
+          database_instances: [
+            build(:database_instance,
+              health: Health.passing(),
+              system_replication: "Primary",
+              system_replication_site: "Site1",
+              host: build(:host, cluster: nil)
+            ),
+            build(:database_instance,
+              system_replication: "Secondary",
+              system_replication_site: "Site2",
+              host: build(:host, cluster: nil)
+            )
+          ]
+        )
+
+      assert :ok ==
+               DatabasePolicy.authorize_operation(:database_start, database, %{site: "Site2"})
+    end
+  end
+
+  describe "database_stop" do
+    test "should forbid operation if the database cluster is not in maintenance" do
+      %{name: cluster_name, sap_instances: [%{sid: sid, instance_number: instance_number}]} =
+        cluster = build_cluster_with_maintenance(false)
+
+      database =
+        build(:database,
+          sap_systems: [],
+          database_instances:
+            build_list(2, :database_instance,
+              sid: sid,
+              instance_number: instance_number,
+              host: build(:host, cluster: cluster)
+            )
+        )
+
+      assert {:error, ["Cluster #{cluster_name} operating this host is not in maintenance mode"]} ==
+               DatabasePolicy.authorize_operation(:database_stop, database, %{})
+    end
+
+    test "should forbid operation if the request is for the primary site and secondary sites are not stopped" do
+      %{sid: sid} =
+        database =
+        build(:database,
+          sap_systems: [],
+          database_instances: [
+            build(:database_instance,
+              system_replication: "Primary",
+              system_replication_site: "Site1",
+              host: build(:host, cluster: nil)
+            ),
+            build(:database_instance,
+              health: Health.passing(),
+              system_replication: "Secondary",
+              system_replication_site: "Site2",
+              host: build(:host, cluster: nil)
+            )
+          ]
+        )
+
+      assert {:error, ["Secondary sites of database #{sid} are not stopped"]} ==
+               DatabasePolicy.authorize_operation(:database_stop, database, %{site: "Site1"})
+    end
+
+    test "should forbid operation if attached application instances are not stopped" do
+      database =
+        build(:database,
+          sap_systems: [
+            %{
+              application_instances:
+                [
+                  %{sid: sid1, instance_number: inst_number1},
+                  %{sid: sid2, instance_number: inst_number2}
+                ] =
+                  build_list(2, :application_instance,
+                    health: Health.passing(),
+                    features: "ABAP|GATEWAY|ICMAN|IGS"
+                  )
+            }
+          ],
+          database_instances: build_list(2, :database_instance, host: build(:host, cluster: nil))
+        )
+
+      assert {:error,
+              [
+                "Instance #{inst_number1} of SAP system #{sid1} is not stopped",
+                "Instance #{inst_number2} of SAP system #{sid2} is not stopped"
+              ]} ==
+               DatabasePolicy.authorize_operation(:database_stop, database, %{})
+    end
+
+    test "should authorize operation if cluster is in maintenance and system replication is not enabled" do
+      %{sap_instances: [%{sid: sid, instance_number: instance_number}]} =
+        cluster = build_cluster_with_maintenance(true)
+
+      database =
+        build(:database,
+          sap_systems: [],
+          database_instances: [
+            build(:database_instance,
+              system_replication: nil,
+              sid: sid,
+              instance_number: instance_number,
+              host: build(:host, cluster: cluster)
+            )
+          ]
+        )
+
+      assert :ok ==
+               DatabasePolicy.authorize_operation(:database_stop, database, %{})
+    end
+
+    test "should authorize operation if the request is for the secondary site" do
+      database =
+        build(:database,
+          sap_systems: [],
+          database_instances: [
+            build(:database_instance,
+              health: Health.unknown(),
+              system_replication: "Primary",
+              system_replication_site: "Site1",
+              host: build(:host, cluster: nil)
+            ),
+            build(:database_instance,
+              system_replication: "Secondary",
+              system_replication_site: "Site2",
+              host: build(:host, cluster: nil)
+            )
+          ]
+        )
+
+      assert :ok ==
+               DatabasePolicy.authorize_operation(:database_stop, database, %{site: "Site2"})
+    end
+
+    test "should authorize operation if attached application instances are stopped" do
+      database =
+        build(:database,
+          sap_systems: [
+            %{
+              application_instances:
+                build_list(2, :application_instance,
+                  health: Health.unknown(),
+                  features: "ABAP|GATEWAY|ICMAN|IGS"
+                )
+            },
+            %{
+              application_instances:
+                build_list(2, :application_instance,
+                  health: Health.unknown(),
+                  features: "J2EE|GATEWAY|ICMAN|IGS"
+                )
+            }
+          ],
+          database_instances: build_list(2, :database_instance, host: build(:host, cluster: nil))
+        )
+
+      assert :ok ==
+               DatabasePolicy.authorize_operation(:database_stop, database, %{})
+    end
+  end
+
+  defp build_cluster_with_maintenance(maintenance_mode) do
+    clustered_sap_instances =
+      build_list(1, :clustered_sap_instance)
+
+    cluster_details =
+      build(:hana_cluster_details, maintenance_mode: maintenance_mode, nodes: [])
+
+    build(:cluster, sap_instances: clustered_sap_instances, details: cluster_details)
+  end
+end

--- a/test/trento_web/controllers/v1/database_controller_test.exs
+++ b/test/trento_web/controllers/v1/database_controller_test.exs
@@ -284,13 +284,17 @@ defmodule TrentoWeb.V1.DatabaseControllerTest do
 
         site = "Trento"
         %{id: database_id} = insert(:database)
-        %{id: host_id} = insert(:host, heartbeat: :passing)
+        %{id: cluster_id} = insert(:cluster)
+        %{id: host_id} = insert(:host, heartbeat: :passing, cluster_id: cluster_id)
 
         insert(:database_instance,
           database_id: database_id,
           host_id: host_id,
           system_replication_site: site
         )
+
+        %{id: sap_system_id} = insert(:sap_system, database_id: database_id)
+        insert(:application_instance, sap_system_id: sap_system_id, host_id: host_id)
 
         expect(
           Trento.Infrastructure.Messaging.Adapter.Mock,
@@ -331,7 +335,26 @@ defmodule TrentoWeb.V1.DatabaseControllerTest do
         assert %{
                  assigns: %{
                    database: %{
-                     id: ^database_id
+                     id: ^database_id,
+                     database_instances: [
+                       %{
+                         database_id: ^database_id,
+                         host: %{
+                           id: ^host_id,
+                           cluster: %{id: ^cluster_id}
+                         }
+                       }
+                     ],
+                     sap_systems: [
+                       %{
+                         id: ^sap_system_id,
+                         application_instances: [
+                           %{
+                             sap_system_id: ^sap_system_id
+                           }
+                         ]
+                       }
+                     ]
                    },
                    operation: operation
                  }


### PR DESCRIPTION
# Description

Add operation policies for `database_start` and `database_stop` operations.

These are the rules:
`database_start`:
- If the database instances are clustered with pacemaker, check cluster is in maintenance (or `ocf::suse:SAPHana/ocf::suse:SAPHanaController` are in maintenance
- If there is not system replication enabled, it is authorized
- If the request is for the primary site, it is authorized
- If the request is for a secondary site, check the primary site is running

`database_stop`:
- If the database instances are clustered with pacemaker, check cluster is in maintenance (same as above)
- If there is not system replication enabled, it is authorized
- If the request is for a secondary site, it is authorized
- If the request is for the primary site, check secondary sites are stopped
- If the database is not used by a SAP system, it is authorized
- If the database is used by a SAP system, check app instances (abap/j2ee) are stopped

@abravosuse to simply confirm what I wrote above is correct and I didn't miss anything

## How was this tested?

UT
