### PR TITLE
Retrieve user Personal Access Tokens

### DIFF
--- a/lib/trento/users.ex
+++ b/lib/trento/users.ex
@@ -42,6 +42,7 @@ defmodule Trento.Users do
     |> where([u], is_nil(u.deleted_at))
     |> preload(:abilities)
     |> preload(:user_identities)
+    |> preload(:personal_access_tokens)
     |> order_by(asc: :id)
     |> Repo.all()
   end
@@ -51,6 +52,7 @@ defmodule Trento.Users do
          |> where([u], is_nil(u.deleted_at) and u.id == ^id)
          |> preload(:abilities)
          |> preload(:user_identities)
+         |> preload(:personal_access_tokens)
          |> Repo.one() do
       nil -> {:error, :not_found}
       user -> {:ok, user}

--- a/lib/trento_web/controllers/v1/personal_access_tokens_json.ex
+++ b/lib/trento_web/controllers/v1/personal_access_tokens_json.ex
@@ -3,6 +3,20 @@ defmodule TrentoWeb.V1.PersonalAccessTokensJSON do
 
   alias Trento.PersonalAccessTokens.PersonalAccessToken
 
+  def personal_access_tokens(%Ecto.Association.NotLoaded{}), do: []
+
+  def personal_access_tokens(personal_access_tokens) do
+    Enum.map(
+      personal_access_tokens,
+      &%{
+        jti: &1.jti,
+        name: &1.name,
+        created_at: &1.created_at,
+        expires_at: &1.expires_at
+      }
+    )
+  end
+
   def new_personal_access_token(%{
         personal_access_token: %PersonalAccessToken{
           jti: jti,

--- a/lib/trento_web/controllers/v1/profile_json.ex
+++ b/lib/trento_web/controllers/v1/profile_json.ex
@@ -1,5 +1,5 @@
 defmodule TrentoWeb.V1.ProfileJSON do
-  alias TrentoWeb.V1.AbilityJSON
+  alias TrentoWeb.V1.{AbilityJSON, PersonalAccessTokensJSON}
 
   def profile(%{
         user: %{
@@ -8,6 +8,7 @@ defmodule TrentoWeb.V1.ProfileJSON do
           username: username,
           email: email,
           abilities: abilities,
+          personal_access_tokens: personal_access_tokens,
           password_change_requested_at: password_change_requested_at,
           totp_enabled_at: totp_enabled_at,
           user_identities: user_identities,
@@ -23,6 +24,8 @@ defmodule TrentoWeb.V1.ProfileJSON do
         username: username,
         email: email,
         abilities: Enum.map(abilities, &AbilityJSON.ability/1),
+        personal_access_tokens:
+          PersonalAccessTokensJSON.personal_access_tokens(personal_access_tokens),
         password_change_requested: password_change_requested_at != nil,
         totp_enabled: totp_enabled_at != nil,
         created_at: created_at,

--- a/lib/trento_web/controllers/v1/users_json.ex
+++ b/lib/trento_web/controllers/v1/users_json.ex
@@ -1,5 +1,5 @@
 defmodule TrentoWeb.V1.UsersJSON do
-  alias TrentoWeb.V1.AbilityJSON
+  alias TrentoWeb.V1.{AbilityJSON, PersonalAccessTokensJSON}
 
   def index(%{users: users}), do: Enum.map(users, &user(%{user: &1}))
 
@@ -12,6 +12,7 @@ defmodule TrentoWeb.V1.UsersJSON do
           username: username,
           email: email,
           abilities: abilities,
+          personal_access_tokens: personal_access_tokens,
           locked_at: locked_at,
           password_change_requested_at: password_change_requested_at,
           user_identities: user_identities,
@@ -27,6 +28,8 @@ defmodule TrentoWeb.V1.UsersJSON do
         username: username,
         email: email,
         abilities: Enum.map(abilities, &AbilityJSON.ability/1),
+        personal_access_tokens:
+          PersonalAccessTokensJSON.personal_access_tokens(personal_access_tokens),
         enabled: locked_at == nil,
         idp_user: length(user_identities) > 0,
         password_change_requested_at: password_change_requested_at,

--- a/lib/trento_web/openapi/v1/schema/personal_access_token.ex
+++ b/lib/trento_web/openapi/v1/schema/personal_access_token.ex
@@ -4,6 +4,64 @@ defmodule TrentoWeb.OpenApi.V1.Schema.PersonalAccessToken do
   require OpenApiSpex
   alias OpenApiSpex.Schema
 
+  defmodule PersonalAccessTokenEntry do
+    @moduledoc false
+
+    OpenApiSpex.schema(
+      %{
+        title: "PersonalAccessTokenEntry",
+        description: "A User's Personal Access Token",
+        type: :object,
+        additionalProperties: false,
+        properties: %{
+          jti: %Schema{
+            type: :string,
+            format: :uuid,
+            description: "Personal Access Token ID",
+            nullable: false,
+            example: "550e8400-e29b-41d4-a716-446655440000"
+          },
+          name: %Schema{
+            type: :string,
+            description: "Personal Access Token name",
+            nullable: false,
+            example: "My Token"
+          },
+          expires_at: %Schema{
+            type: :string,
+            format: :"date-time",
+            description: "Personal Access Token expiration date",
+            nullable: true,
+            example: "2024-12-31T23:59:59Z"
+          },
+          created_at: %Schema{
+            type: :string,
+            format: :"date-time",
+            description: "Date of API Key creation",
+            nullable: false,
+            example: "2023-01-01T00:00:00Z"
+          }
+        },
+        required: [:jti, :name, :expires_at, :created_at]
+      },
+      struct?: false
+    )
+  end
+
+  defmodule PersonalAccessTokenCollection do
+    @moduledoc false
+
+    OpenApiSpex.schema(
+      %{
+        title: "PersonalAccessTokenCollection",
+        description: "List of a user's Personal Access Tokens",
+        type: :array,
+        items: PersonalAccessTokenEntry
+      },
+      struct?: false
+    )
+  end
+
   defmodule CreatePersonalAccessToken do
     @moduledoc false
 

--- a/lib/trento_web/openapi/v1/schema/user.ex
+++ b/lib/trento_web/openapi/v1/schema/user.ex
@@ -5,6 +5,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
   alias OpenApiSpex.Schema
 
   alias TrentoWeb.OpenApi.V1.Schema.Ability.AbilityCollection
+  alias TrentoWeb.OpenApi.V1.Schema.PersonalAccessToken.PersonalAccessTokenCollection
 
   defmodule UserTOTPEnrollmentPayload do
     @moduledoc false
@@ -131,6 +132,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             example: false
           },
           abilities: AbilityCollection,
+          personal_access_tokens: PersonalAccessTokenCollection,
           password_change_requested: %Schema{
             type: :boolean,
             description: "Password change is requested.",
@@ -170,7 +172,15 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             example: "2024-01-15T12:00:00Z"
           }
         },
-        required: [:username, :id, :fullname, :email, :created_at, :totp_enabled],
+        required: [
+          :username,
+          :id,
+          :fullname,
+          :email,
+          :created_at,
+          :totp_enabled,
+          :personal_access_tokens
+        ],
         example: %{
           id: 1,
           fullname: "John Doe",
@@ -178,6 +188,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
           email: "john.doe@example.com",
           idp_user: false,
           abilities: [],
+          personal_access_tokens: [],
           password_change_requested: false,
           analytics_enabled: false,
           totp_enabled: true,
@@ -445,6 +456,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             nullable: false
           },
           abilities: AbilityCollection,
+          personal_access_tokens: PersonalAccessTokenCollection,
           password_change_requested_at: %OpenApiSpex.Schema{
             type: :string,
             format: :"date-time",
@@ -478,7 +490,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             example: "2024-01-15T09:00:00Z"
           }
         },
-        required: [:username, :id, :fullname, :email, :created_at],
+        required: [:username, :id, :fullname, :email, :created_at, :personal_access_tokens],
         example: %{
           id: 1,
           fullname: "User Item",
@@ -487,6 +499,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
           enabled: true,
           idp_user: false,
           abilities: [],
+          personal_access_tokens: [],
           created_at: "2024-01-15T09:00:00Z",
           updated_at: "2024-01-15T10:30:00Z",
           analytics_enabled: false,
@@ -517,7 +530,8 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             password_change_requested_at: "2024-01-14T08:00:00Z",
             created_at: "2024-01-15T09:00:00Z",
             updated_at: "2024-01-15T10:30:00Z",
-            abilities: []
+            abilities: [],
+            personal_access_tokens: []
           }
         ]
       },

--- a/test/trento_web/views/v1/personal_access_tokens_view_json_test.exs
+++ b/test/trento_web/views/v1/personal_access_tokens_view_json_test.exs
@@ -2,9 +2,81 @@ defmodule TrentoWeb.V1.PersonalAccessTokensViewJSONTest do
   use ExUnit.Case
 
   alias Trento.PersonalAccessTokens.PersonalAccessToken
+
   alias TrentoWeb.V1.PersonalAccessTokensJSON
 
   import Trento.Factory
+
+  describe "rendering a list of PATs" do
+    test "should render an empty list of personal access tokens" do
+      %{personal_access_tokens: not_loaded_personal_access_tokens} = build(:user)
+
+      assert [] ==
+               PersonalAccessTokensJSON.personal_access_tokens(not_loaded_personal_access_tokens)
+
+      assert [] == PersonalAccessTokensJSON.personal_access_tokens([])
+    end
+
+    test "should render a list of personal access tokens" do
+      jti1 = Faker.UUID.v4()
+      name1 = Faker.Lorem.word()
+      created_at1 = Faker.DateTime.backward(1)
+      expires_at1 = nil
+
+      jti2 = Faker.UUID.v4()
+      name2 = Faker.StarWars.character()
+      created_at2 = Faker.DateTime.backward(2)
+      expires_at2 = Faker.DateTime.forward(3)
+
+      jti3 = Faker.UUID.v4()
+      name3 = Faker.StarWars.character()
+      created_at3 = Faker.DateTime.backward(3)
+      expires_at3 = Faker.DateTime.forward(4)
+
+      personal_access_tokens = [
+        build(:personal_access_token,
+          jti: jti1,
+          name: name1,
+          created_at: created_at1,
+          expires_at: expires_at1
+        ),
+        build(:personal_access_token,
+          jti: jti2,
+          name: name2,
+          created_at: created_at2,
+          expires_at: expires_at2
+        ),
+        build(:personal_access_token,
+          jti: jti3,
+          name: name3,
+          created_at: created_at3,
+          expires_at: expires_at3
+        )
+      ]
+
+      assert [
+               %{
+                 jti: jti1,
+                 name: name1,
+                 created_at: created_at1,
+                 expires_at: expires_at1
+               },
+               %{
+                 jti: jti2,
+                 name: name2,
+                 created_at: created_at2,
+                 expires_at: expires_at2
+               },
+               %{
+                 jti: jti3,
+                 name: name3,
+                 created_at: created_at3,
+                 expires_at: expires_at3
+               }
+             ] ==
+               PersonalAccessTokensJSON.personal_access_tokens(personal_access_tokens)
+    end
+  end
 
   describe "rendering a newly created token" do
     scenarios = [

--- a/test/trento_web/views/v1/profile_view_json_test.exs
+++ b/test/trento_web/views/v1/profile_view_json_test.exs
@@ -43,5 +43,33 @@ defmodule TrentoWeb.V1.ProfileJSONTest do
                analytics_eula_accepted: true
              } = ProfileJSON.profile(%{user: user})
     end
+
+    test "should render a user profile with PAT list" do
+      scenarios = [
+        %{
+          user: build(:user, abilities: [], user_identities: []),
+          expected_pat_count: 0
+        },
+        %{
+          user: build(:user, abilities: [], user_identities: [], personal_access_tokens: []),
+          expected_pat_count: 0
+        },
+        %{
+          user:
+            build(:user,
+              abilities: [],
+              user_identities: [],
+              personal_access_tokens: build_list(2, :personal_access_token)
+            ),
+          expected_pat_count: 2
+        }
+      ]
+
+      for %{user: user, expected_pat_count: expected_pat_count} <- scenarios do
+        rendered_user = ProfileJSON.profile(%{user: user})
+
+        assert length(rendered_user.personal_access_tokens) == expected_pat_count
+      end
+    end
   end
 end

--- a/test/trento_web/views/v1/users_view_json_test.exs
+++ b/test/trento_web/views/v1/users_view_json_test.exs
@@ -59,5 +59,33 @@ defmodule TrentoWeb.V1.UsersJSONTest do
                analytics_enabled: true
              } = UsersJSON.user(%{user: user})
     end
+
+    test "should render a user profile with PAT list" do
+      scenarios = [
+        %{
+          user: build(:user, abilities: [], user_identities: []),
+          expected_pat_count: 0
+        },
+        %{
+          user: build(:user, abilities: [], user_identities: [], personal_access_tokens: []),
+          expected_pat_count: 0
+        },
+        %{
+          user:
+            build(:user,
+              abilities: [],
+              user_identities: [],
+              personal_access_tokens: build_list(2, :personal_access_token)
+            ),
+          expected_pat_count: 2
+        }
+      ]
+
+      for %{user: user, expected_pat_count: expected_pat_count} <- scenarios do
+        rendered_user = UsersJSON.user(%{user: user})
+
+        assert length(rendered_user.personal_access_tokens) == expected_pat_count
+      end
+    end
   end
 end


### PR DESCRIPTION
# Description

This PR - based off https://github.com/trento-project/web/pull/3739 - adds the ability to load a user's api keys.
Note that it does not expose the actual token, which, as mentioned in https://github.com/trento-project/web/pull/3739, is only visible at creation time.

It will be the data feeding the following UI

<img width="709" height="315" alt="image" src="https://github.com/user-attachments/assets/a3180f5d-0244-4d27-9bb7-c485a61427ac" />

## How was this tested?

Automated and manual testing

Depends on https://github.com/trento-project/web/pull/3739