### PR TITLE
Revoke Personal Access Tokens

### DIFF
--- a/lib/trento_web/controllers/v1/personal_access_tokens_controller.ex
+++ b/lib/trento_web/controllers/v1/personal_access_tokens_controller.ex
@@ -16,6 +16,8 @@ defmodule TrentoWeb.V1.PersonalAccessTokensController do
 
   operation :create_personal_access_token,
     summary: "Creates a new Personal Access Token",
+    description:
+      "Creates a new Personal Access Token for the currently authenticated user, allowing programmatic access to the APIs.",
     tags: ["Profile"],
     request_body:
       {"CreatePersonalAccessToken", "application/json",
@@ -56,12 +58,15 @@ defmodule TrentoWeb.V1.PersonalAccessTokensController do
 
   operation :revoke_personal_access_token,
     summary: "Revokes an existing Personal Access Token",
+    description:
+      "Revokes a Personal Access Token identified by its unique identifier (JTI), ensuring that it can no longer be used for authentication.",
     tags: ["Profile"],
     parameters: [
       jti: [
         in: :path,
         required: true,
-        type: %OpenApiSpex.Schema{
+        description: "The unique identifier (JTI) of the Personal Access Token to be revoked.",
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "550e8400-e29b-41d4-a716-446655440000"
@@ -70,6 +75,7 @@ defmodule TrentoWeb.V1.PersonalAccessTokensController do
     ],
     responses: [
       no_content: "Personal Access Token revoked successfully",
+      not_found: Schema.NotFound.response(),
       unauthorized: Schema.Unauthorized.response(),
       forbidden: Schema.Forbidden.response()
     ]

--- a/lib/trento_web/controllers/v1/personal_access_tokens_controller.ex
+++ b/lib/trento_web/controllers/v1/personal_access_tokens_controller.ex
@@ -53,4 +53,33 @@ defmodule TrentoWeb.V1.PersonalAccessTokensController do
       })
     end
   end
+
+  operation :revoke_personal_access_token,
+    summary: "Revokes an existing Personal Access Token",
+    tags: ["Profile"],
+    parameters: [
+      jti: [
+        in: :path,
+        required: true,
+        type: %OpenApiSpex.Schema{
+          type: :string,
+          format: :uuid,
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        }
+      ]
+    ],
+    responses: [
+      no_content: "Personal Access Token revoked successfully",
+      unauthorized: Schema.Unauthorized.response(),
+      forbidden: Schema.Forbidden.response()
+    ]
+
+  def revoke_personal_access_token(conn, %{jti: jti}) do
+    with {:ok, _} <-
+           conn
+           |> Pow.Plug.current_user()
+           |> PersonalAccessTokens.revoke_personal_access_token(jti) do
+      send_resp(conn, :no_content, "")
+    end
+  end
 end

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -196,6 +196,7 @@ defmodule TrentoWeb.Router do
 
         scope "/tokens" do
           post "/", PersonalAccessTokensController, :create_personal_access_token
+          delete "/:jti", PersonalAccessTokensController, :revoke_personal_access_token
         end
       end
 

--- a/test/trento_web/controllers/v1/personal_acces_tokens_controller_test.exs
+++ b/test/trento_web/controllers/v1/personal_acces_tokens_controller_test.exs
@@ -199,4 +199,30 @@ defmodule TrentoWeb.V1.PersonalAccessTokensControllerTest do
       end
     end
   end
+
+  describe "revoking personal access tokens" do
+    test "should return an error when revoking a non existent personal access token", %{
+      conn: conn,
+      api_spec: api_spec
+    } do
+      conn
+      |> delete("/api/v1/profile/tokens/#{Faker.UUID.v4()}")
+      |> json_response(:not_found)
+      |> assert_response_schema("NotFound", api_spec)
+    end
+
+    test "should successfully revoke a personal access token", %{
+      conn: conn,
+      admin_user: %{id: user_id}
+    } do
+      %PersonalAccessToken{jti: jti} = insert(:personal_access_token, user_id: user_id)
+
+      resp =
+        conn
+        |> delete("/api/v1/profile/tokens/#{jti}")
+        |> response(:no_content)
+
+      assert resp == ""
+    end
+  end
 end


### PR DESCRIPTION
# Description

This PR adds the capability to revoke a user's api key.

Notes:
- in this specific change it means removing references to a key
- this specific endpoint is for a user revoking own PATs

Follow ups:
- changes to the auth mechanism so that a revoked key actually does not allow making requests to trento anymore
- user admin specific revoking endpoint (`DELETE /users/:id/tokens/:jti`)

## How was this tested?

Automated tests.