### PR TITLE
Fix flaky test activity log start refresh ticker

### DIFF
--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -301,7 +301,7 @@ context('Activity Log page', () => {
 
     it('should start autorefresh ticker', () => {
       activityLogPage.visit();
-      activityLogPage.waitForRequest('activityLogRequest').then(() => {
+      activityLogPage.waitForActivityLogRequest().then(() => {
         activityLogPage.spyActivityLogRequest();
         activityLogPage.expectedAggregateAmountOfRequests(0);
         activityLogPage.selectRefreshRate('5s');

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -301,7 +301,7 @@ context('Activity Log page', () => {
 
     it('should start autorefresh ticker', () => {
       activityLogPage.visit();
-      basePage.waitForRequest('activityLogRequest').then(() => {
+      activityLogPage.waitForRequest('activityLogRequest').then(() => {
         activityLogPage.spyActivityLogRequest();
         activityLogPage.expectedAggregateAmountOfRequests(0);
         activityLogPage.selectRefreshRate('5s');

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -300,15 +300,17 @@ context('Activity Log page', () => {
     });
 
     it('should start autorefresh ticker', () => {
-      activityLogPage.spyActivityLogRequest();
       activityLogPage.visit();
-      activityLogPage.expectedAggregateAmountOfRequests(1);
-      activityLogPage.selectRefreshRate('5s');
-      activityLogPage.expectedAggregateAmountOfRequests(2);
-      activityLogPage.advanceTimeBy(5);
-      activityLogPage.expectedAggregateAmountOfRequests(3);
-      activityLogPage.advanceTimeBy(10);
-      activityLogPage.expectedAggregateAmountOfRequests(5);
+      basePage.waitForRequest('activityLogRequest').then(() => {
+        activityLogPage.spyActivityLogRequest();
+        activityLogPage.expectedAggregateAmountOfRequests(0);
+        activityLogPage.selectRefreshRate('5s');
+        activityLogPage.expectedAggregateAmountOfRequests(1);
+        activityLogPage.advanceTimeBy(5);
+        activityLogPage.expectedAggregateAmountOfRequests(2);
+        activityLogPage.advanceTimeBy(10);
+        activityLogPage.expectedAggregateAmountOfRequests(4);
+      });
     });
 
     it(`should update querystring when filters are selected`, () => {

--- a/test/e2e/cypress/pageObject/activity_log_po.js
+++ b/test/e2e/cypress/pageObject/activity_log_po.js
@@ -50,7 +50,7 @@ export const interceptActivityLogEndpoint = () => {
 export const spyActivityLogRequest = () => {
   cy.clock();
   return cy.intercept(
-    '/api/v1/activity_log*',
+    '/api/v1/activity_log?first=20',
     cy.spy().as(activityLogEndpointAlias)
   );
 };

--- a/test/e2e/cypress/pageObject/activity_log_po.js
+++ b/test/e2e/cypress/pageObject/activity_log_po.js
@@ -2,6 +2,7 @@ export * from './base_po';
 import * as basePage from './base_po';
 
 const activityLogEndpointAlias = 'activityLogRequest';
+const activityLogEndpoint = '/api/v1/activity_log*';
 
 //Selectors
 const filteringElements = 'div[class="relative"]';
@@ -42,7 +43,7 @@ export const visit = (queryString = '') =>
 export const interceptActivityLogEndpoint = () => {
   return cy
     .intercept({
-      url: '/api/v1/activity_log*',
+      url: activityLogEndpoint,
     })
     .as(activityLogEndpointAlias);
 };
@@ -50,7 +51,7 @@ export const interceptActivityLogEndpoint = () => {
 export const spyActivityLogRequest = () => {
   cy.clock();
   return cy.intercept(
-    '/api/v1/activity_log?first=20',
+    activityLogEndpoint,
     cy.spy().as(activityLogEndpointAlias)
   );
 };


### PR DESCRIPTION
# Description

- The test logic for autorefresh ticker was restructured.
- Instead of starting with a spy and then visiting the page, the test now:
  - Waits for the initial request to complete.
  - Sets up the spy after the initial load.
- The number of expected aggregate requests was adjusted for the new flow.
- Overall, the test now better synchronizes with the application’s behavior, reducing flakiness.
- Introduced a constant `activityLogEndpoint` to represent the activity log API endpoint.
- All references to the endpoint in the page object methods now use this constant, replacing hardcoded URLs.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [x] **DONE**

## How was this tested?
Test suite has been executed 400 times without a single failure after this change.

- [x] **DONE**
## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
- [Trento Web guides](https://github.com/trento-project/web/tree/main/guides)

Add a documentation PR or write that no changes are required for the documentation.
- [ ] **DONE**
