### PR TITLE
Fix 'change refresh rate' flaky test in activity log test suite

### DIFF
--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -282,21 +282,24 @@ context('Activity Log page', () => {
 
     it('should change refresh rate', () => {
       activityLogPage.visit();
-      activityLogPage.expectedRefreshRatesAreAvailable();
-      const changingRefreshRateScenarios =
-        activityLogPage.buildChangingRefreshRateScenarios();
-      changingRefreshRateScenarios.forEach(
-        ({ currentRefreshRate, newRefreshRate, expectedRefreshRate }) => {
-          activityLogPage.autoRefreshIntervalButtonHasTheExpectedValue(
-            currentRefreshRate
-          );
-          activityLogPage.selectRefreshRate(newRefreshRate);
-          const expectedUrl = `/activity_log${
-            expectedRefreshRate ? `?refreshRate=${expectedRefreshRate}` : ''
-          }`;
-          activityLogPage.validateUrl(expectedUrl);
-        }
-      );
+      activityLogPage.waitForActivityLogRequest().then(() => {
+        activityLogPage.expectedRefreshRatesAreAvailable();
+        const changingRefreshRateScenarios =
+          activityLogPage.buildChangingRefreshRateScenarios();
+
+        cy.wrap(changingRefreshRateScenarios).each(
+          ({ currentRefreshRate, newRefreshRate, expectedRefreshRate }) => {
+            activityLogPage.autoRefreshIntervalButtonHasTheExpectedValue(
+              currentRefreshRate
+            );
+            activityLogPage.selectRefreshRate(newRefreshRate);
+            const expectedUrl = `/activity_log${
+              expectedRefreshRate ? `?refreshRate=${expectedRefreshRate}` : ''
+            }`;
+            activityLogPage.validateUrl(expectedUrl);
+          }
+        );
+      });
     });
 
     it('should start autorefresh ticker', () => {


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue, if it exists. 
Also, include relevant motivation and context for this PR. List any dependencies that are required for this change.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**
## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
- [Trento Web guides](https://github.com/trento-project/web/tree/main/guides)

Add a documentation PR or write that no changes are required for the documentation.
- [ ] **DONE**
