### PR TITLE
Fix failure rate calculation e2e flaky tests

### DIFF
--- a/.github/workflows/e2e-flaky-tests-detection.yaml
+++ b/.github/workflows/e2e-flaky-tests-detection.yaml
@@ -214,6 +214,7 @@ jobs:
         with:
           name: e2e-screenshots-${{ matrix.container }}
           path: test/e2e/cypress/screenshots/**/*.png
+          retention-days: 7
 
   flaky-tests-analysis:
     name: Flaky Tests Analysis
@@ -255,7 +256,7 @@ jobs:
           
           echo "### 📊 Suite Stability Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Failure rate:** ${FAILURE_PERCENTAGE}%**" >> $GITHUB_STEP_SUMMARY
+          echo "**Failure rate:** ${FAILURE_PERCENTAGE}%" >> $GITHUB_STEP_SUMMARY
           echo "*Calculated: (Failing threads / Total threads)*" >> $GITHUB_STEP_SUMMARY
           
           make venv-create

--- a/.github/workflows/e2e-flaky-tests-detection.yaml
+++ b/.github/workflows/e2e-flaky-tests-detection.yaml
@@ -242,6 +242,7 @@ jobs:
         env:
           TOTAL_CONTAINERS: ${{ github.event.inputs.num_containers || env.DEFAULT_NUM_CONTAINERS }}
         run: |
+          ls
           REPORTS_PATH="../../junit-reports"
           TOTAL_CONTAINERS=${{ env.TOTAL_CONTAINERS }}
           

--- a/.github/workflows/e2e-flaky-tests-detection.yaml
+++ b/.github/workflows/e2e-flaky-tests-detection.yaml
@@ -231,6 +231,12 @@ jobs:
           path: junit-reports
           pattern: e2e-junit-reports-*
           merge-multiple: true
+      - name: Download screenshot artifacts
+        uses: actions/download-artifact@v5
+        with:
+          path: screenshot-artifacts
+          pattern: e2e-screenshots-*
+          if-no-files-found: ignore
       - name: Analyze Flaky Tests and Generate Summary
         id: analyze
         env:
@@ -239,7 +245,9 @@ jobs:
           REPORTS_PATH="../../junit-reports"
           TOTAL_CONTAINERS=${{ env.TOTAL_CONTAINERS }}
           
-          FAILED_RUNS=$(grep -l -E "<failure|<error>" $REPORTS_PATH/*.xml 2>/dev/null | wc -l)
+          # Count the number of downloaded screenshot artifacts.
+          # Each downloaded artifact is placed in its own subdirectory, so we count the directories.
+          FAILED_RUNS=$(find screenshot-artifacts -mindepth 1 -maxdepth 1 -type d | wc -l)
 
           if [ "$TOTAL_CONTAINERS" -gt 0 ]; then
             FAILURE_PERCENTAGE=$(echo "scale=1; $FAILED_RUNS * 100 / $TOTAL_CONTAINERS" | bc)
@@ -250,6 +258,7 @@ jobs:
           echo "### 📊 Suite Stability Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Failure rate:** (Failing threads / Total threads) **${FAILURE_PERCENTAGE}%**" >> $GITHUB_STEP_SUMMARY
+          echo "*Calculated based on ${FAILED_RUNS} jobs that generated screenshot artifacts.*" >> $GITHUB_STEP_SUMMARY
           
           make venv-create
           source .venv/bin/activate
@@ -277,4 +286,5 @@ jobs:
       - name: Delete Artifacts
         uses: geekyeggo/delete-artifact@v5
         with:
-          name: e2e-junit-reports-*
+          name: |
+            e2e-junit-reports-*

--- a/.github/workflows/e2e-flaky-tests-detection.yaml
+++ b/.github/workflows/e2e-flaky-tests-detection.yaml
@@ -285,5 +285,4 @@ jobs:
       - name: Delete Artifacts
         uses: geekyeggo/delete-artifact@v5
         with:
-          name: |
-            e2e-junit-reports-*
+          name: e2e-junit-reports-*

--- a/.github/workflows/e2e-flaky-tests-detection.yaml
+++ b/.github/workflows/e2e-flaky-tests-detection.yaml
@@ -245,8 +245,6 @@ jobs:
           REPORTS_PATH="../../junit-reports"
           TOTAL_CONTAINERS=${{ env.TOTAL_CONTAINERS }}
           
-          # Count the number of downloaded screenshot artifacts.
-          # Each downloaded artifact is placed in its own subdirectory, so we count the directories.
           FAILED_RUNS=$(find ../../screenshot-artifacts -mindepth 1 -maxdepth 1 -type d | wc -l)
           echo $FAILED_RUNS
           if [ "$TOTAL_CONTAINERS" -gt 0 ]; then
@@ -257,8 +255,8 @@ jobs:
           
           echo "### 📊 Suite Stability Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Failure rate:** (Failing threads / Total threads) **${FAILURE_PERCENTAGE}%**" >> $GITHUB_STEP_SUMMARY
-          echo "*Calculated based on ${FAILED_RUNS} jobs that generated screenshot artifacts.*" >> $GITHUB_STEP_SUMMARY
+          echo "**Failure rate:** ${FAILURE_PERCENTAGE}%**" >> $GITHUB_STEP_SUMMARY
+          echo "*Calculated: (Failing threads / Total threads)*" >> $GITHUB_STEP_SUMMARY
           
           make venv-create
           source .venv/bin/activate

--- a/.github/workflows/e2e-flaky-tests-detection.yaml
+++ b/.github/workflows/e2e-flaky-tests-detection.yaml
@@ -242,13 +242,12 @@ jobs:
         env:
           TOTAL_CONTAINERS: ${{ github.event.inputs.num_containers || env.DEFAULT_NUM_CONTAINERS }}
         run: |
-          ls
           REPORTS_PATH="../../junit-reports"
           TOTAL_CONTAINERS=${{ env.TOTAL_CONTAINERS }}
           
           # Count the number of downloaded screenshot artifacts.
           # Each downloaded artifact is placed in its own subdirectory, so we count the directories.
-          FAILED_RUNS=$(find screenshot-artifacts -mindepth 1 -maxdepth 1 -type d | wc -l)
+          FAILED_RUNS=$(find ../../screenshot-artifacts -mindepth 1 -maxdepth 1 -type d | wc -l)
           echo $FAILED_RUNS
           if [ "$TOTAL_CONTAINERS" -gt 0 ]; then
             FAILURE_PERCENTAGE=$(echo "scale=1; $FAILED_RUNS * 100 / $TOTAL_CONTAINERS" | bc)

--- a/.github/workflows/e2e-flaky-tests-detection.yaml
+++ b/.github/workflows/e2e-flaky-tests-detection.yaml
@@ -248,7 +248,7 @@ jobs:
           # Count the number of downloaded screenshot artifacts.
           # Each downloaded artifact is placed in its own subdirectory, so we count the directories.
           FAILED_RUNS=$(find screenshot-artifacts -mindepth 1 -maxdepth 1 -type d | wc -l)
-
+          echo $FAILED_RUNS
           if [ "$TOTAL_CONTAINERS" -gt 0 ]; then
             FAILURE_PERCENTAGE=$(echo "scale=1; $FAILED_RUNS * 100 / $TOTAL_CONTAINERS" | bc)
           else

--- a/test/e2e/cypress/e2e/about.cy.js
+++ b/test/e2e/cypress/e2e/about.cy.js
@@ -12,6 +12,7 @@ describe('User account page', () => {
 
   it('should have the correct page title', () => {
     aboutPage.pageTitleIsDisplayed();
+    cy.wrap(Math.random()).should('be.lessThan', 0.5);
   });
 
   it('should show the correct server version', () => {

--- a/test/e2e/cypress/e2e/about.cy.js
+++ b/test/e2e/cypress/e2e/about.cy.js
@@ -12,7 +12,6 @@ describe('User account page', () => {
 
   it('should have the correct page title', () => {
     aboutPage.pageTitleIsDisplayed();
-    cy.wrap(Math.random()).should('be.lessThan', 0.5);
   });
 
   it('should show the correct server version', () => {


### PR DESCRIPTION
# Description

Now it uses the amount of screenshot zips (those generated for failures), generated per thread, to count how many threads failed. I also added a line to remove screenshots after a week.

Fixes # (issue)
https://jira.suse.com/browse/TRNT-3945

## Did you add the right label?

Remember to add the right labels to this PR.
- [x] **DONE**

## How was this tested?
Creating a flaky test and launching the job to debug the fix.

- [x] **DONE**
## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
- [Trento Web guides](https://github.com/trento-project/web/tree/main/guides)

Add a documentation PR or write that no changes are required for the documentation.
- [ ] **DONE**
