### PR TITLE
[TRNT-3845] Run linters on the API spec and fix the errors (controllers: type to schema)

### DIFF
--- a/lib/trento_web/controllers/v1/chart_controller.ex
+++ b/lib/trento_web/controllers/v1/chart_controller.ex
@@ -21,7 +21,7 @@ defmodule TrentoWeb.V1.ChartController do
         required: true,
         description:
           "Unique identifier of the host for which CPU usage data is requested. This value must be a valid UUID string.",
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           description:
@@ -34,7 +34,7 @@ defmodule TrentoWeb.V1.ChartController do
         required: true,
         description:
           "Specifies the start of the time interval for the CPU usage chart, formatted as an ISO8601 timestamp (e.g., 2024-01-15T10:00:00Z).",
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :"date-time",
           description:
@@ -47,7 +47,7 @@ defmodule TrentoWeb.V1.ChartController do
         required: true,
         description:
           "Specifies the end of the time interval for the CPU usage chart, formatted as an ISO8601 timestamp (e.g., 2024-01-15T12:00:00Z).",
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :"date-time",
           description:
@@ -78,7 +78,7 @@ defmodule TrentoWeb.V1.ChartController do
         required: true,
         description:
           "Unique identifier of the host for which memory usage data is requested. This value must be a valid UUID string.",
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           description:
@@ -91,7 +91,7 @@ defmodule TrentoWeb.V1.ChartController do
         required: true,
         description:
           "Specifies the start of the time interval for the memory usage chart, formatted as an ISO8601 timestamp (e.g., 2024-01-15T10:00:00Z).",
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :"date-time",
           description:
@@ -104,7 +104,7 @@ defmodule TrentoWeb.V1.ChartController do
         required: true,
         description:
           "Specifies the end of the time interval for the memory usage chart, formatted as an ISO8601 timestamp (e.g., 2024-01-15T12:00:00Z).",
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :"date-time",
           description:

--- a/lib/trento_web/controllers/v1/cluster_controller.ex
+++ b/lib/trento_web/controllers/v1/cluster_controller.ex
@@ -69,7 +69,7 @@ defmodule TrentoWeb.V1.ClusterController do
         description:
           "Unique identifier of the cluster for which the Checks execution is being requested. This value must be a valid UUID string.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "c1a2b3c4-d5e6-7890-abcd-ef1234567890"
@@ -103,7 +103,7 @@ defmodule TrentoWeb.V1.ClusterController do
         description:
           "Unique identifier of the cluster for which Checks selection is being performed. This value must be a valid UUID string.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "c1a2b3c4-d5e6-7890-abcd-ef1234567890"
@@ -139,7 +139,7 @@ defmodule TrentoWeb.V1.ClusterController do
         description:
           "Unique identifier of the cluster on which the operation will be performed. This value must be a valid UUID string.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "c1a2b3c4-d5e6-7890-abcd-ef1234567890"
@@ -150,7 +150,7 @@ defmodule TrentoWeb.V1.ClusterController do
         description:
           "Specifies the type of operation to be performed on the cluster, such as maintenance or configuration change.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           example: "cluster_maintenance_change"
         }
@@ -188,7 +188,7 @@ defmodule TrentoWeb.V1.ClusterController do
         required: true,
         description:
           "Unique identifier of the cluster containing the host. This value must be a valid UUID string.",
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "c1a2b3c4-d5e6-7890-abcd-ef1234567890"
@@ -199,7 +199,7 @@ defmodule TrentoWeb.V1.ClusterController do
         required: true,
         description:
           "Unique identifier of the host within the cluster on which the operation will be performed. This value must be a valid UUID string.",
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "d59523fc-0497-4b1e-9fdd-14aa7cda77f1"
@@ -210,7 +210,7 @@ defmodule TrentoWeb.V1.ClusterController do
         required: true,
         description:
           "Specifies the type of operation to be performed on the cluster's host, such as enabling or disabling pacemaker services.",
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           example: "pacemaker_enable"
         }

--- a/lib/trento_web/controllers/v1/database_controller.ex
+++ b/lib/trento_web/controllers/v1/database_controller.ex
@@ -69,7 +69,7 @@ defmodule TrentoWeb.V1.DatabaseController do
         description:
           "Unique identifier of the database instance to be deleted. This value must be a valid UUID string.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "d1a2b3c4-d5e6-7890-abcd-ef1234567890"
@@ -80,7 +80,7 @@ defmodule TrentoWeb.V1.DatabaseController do
         description:
           "Unique identifier of the host associated with the database instance. This value must be a valid UUID string.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "d59523fc-0497-4b1e-9fdd-14aa7cda77f1"
@@ -91,7 +91,7 @@ defmodule TrentoWeb.V1.DatabaseController do
         description:
           "The instance number of the database to be deleted, used to uniquely identify the specific database instance within the host.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           example: "10"
         }
@@ -125,7 +125,7 @@ defmodule TrentoWeb.V1.DatabaseController do
         description:
           "Unique identifier of the database for which the operation is requested. This value must be a valid UUID string.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "d1a2b3c4-d5e6-7890-abcd-ef1234567890"
@@ -136,7 +136,7 @@ defmodule TrentoWeb.V1.DatabaseController do
         description:
           "The type of operation to perform on the database. Supported operations include 'database_start' and 'database_stop' for controlling database lifecycle.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           example: "database_start"
         }

--- a/lib/trento_web/controllers/v1/host_controller.ex
+++ b/lib/trento_web/controllers/v1/host_controller.ex
@@ -74,7 +74,7 @@ defmodule TrentoWeb.V1.HostController do
         description:
           "Unique identifier of the host to be deregistered. This value must be a valid UUID string.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "d59523fc-0497-4b1e-9fdd-14aa7cda77f1"
@@ -106,7 +106,7 @@ defmodule TrentoWeb.V1.HostController do
         description:
           "Unique identifier of the host agent sending the heartbeat signal. This value must be a valid UUID string.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "d59523fc-0497-4b1e-9fdd-14aa7cda77f1"
@@ -138,7 +138,7 @@ defmodule TrentoWeb.V1.HostController do
         description:
           "Unique identifier of the host for which Checks selection is being performed. This value must be a valid UUID string.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "d59523fc-0497-4b1e-9fdd-14aa7cda77f1"
@@ -207,7 +207,7 @@ defmodule TrentoWeb.V1.HostController do
         description:
           "Unique identifier of the host on which the operation will be performed. This value must be a valid UUID string.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "d59523fc-0497-4b1e-9fdd-14aa7cda77f1"
@@ -218,7 +218,7 @@ defmodule TrentoWeb.V1.HostController do
         description:
           "Specifies the type of operation to be performed on the host, such as restart or configuration change.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           example: "restart"
         }

--- a/lib/trento_web/controllers/v1/sap_system_controller.ex
+++ b/lib/trento_web/controllers/v1/sap_system_controller.ex
@@ -78,7 +78,7 @@ defmodule TrentoWeb.V1.SapSystemController do
         description:
           "Unique identifier of the SAP system associated with the application instance to be deleted. This value must be a valid UUID string.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "d59523fc-0497-4b1e-9fdd-14aa7cda77f1"
@@ -89,7 +89,7 @@ defmodule TrentoWeb.V1.SapSystemController do
         description:
           "Unique identifier of the host associated with the application instance. This value must be a valid UUID string.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "d59523fc-0497-4b1e-9fdd-14aa7cda77f1"
@@ -100,7 +100,7 @@ defmodule TrentoWeb.V1.SapSystemController do
         description:
           "The instance number of the SAP application to be deleted, used to uniquely identify the specific application instance within the host.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           example: "10"
         }
@@ -135,7 +135,7 @@ defmodule TrentoWeb.V1.SapSystemController do
         description:
           "Unique identifier of the SAP system associated with the application instance. This value must be a valid UUID string.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "d59523fc-0497-4b1e-9fdd-14aa7cda77f1"
@@ -146,7 +146,7 @@ defmodule TrentoWeb.V1.SapSystemController do
         description:
           "Unique identifier of the host associated with the application instance. This value must be a valid UUID string.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "d59523fc-0497-4b1e-9fdd-14aa7cda77f1"
@@ -157,7 +157,7 @@ defmodule TrentoWeb.V1.SapSystemController do
         description:
           "The instance number of the SAP application instance, used to uniquely identify the specific instance within the host.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           example: "10"
         }
@@ -167,7 +167,7 @@ defmodule TrentoWeb.V1.SapSystemController do
         description:
           "Specifies the type of operation to be performed on the SAP application instance, such as restart or configuration change.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           example: "restart"
         }
@@ -214,7 +214,7 @@ defmodule TrentoWeb.V1.SapSystemController do
         description:
           "Unique identifier of the SAP system on which the operation will be performed. This value must be a valid UUID string.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "d59523fc-0497-4b1e-9fdd-14aa7cda77f1"
@@ -225,7 +225,7 @@ defmodule TrentoWeb.V1.SapSystemController do
         description:
           "Specifies the type of operation to be performed on the SAP system, such as restart or configuration change.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           example: "restart"
         }

--- a/lib/trento_web/controllers/v1/suse_manager_controller.ex
+++ b/lib/trento_web/controllers/v1/suse_manager_controller.ex
@@ -30,7 +30,7 @@ defmodule TrentoWeb.V1.SUSEManagerController do
         description:
           "Unique identifier of the host for which software updates are being requested. This value must be a valid UUID string.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "d59523fc-0497-4b1e-9fdd-14aa7cda77f1"
@@ -68,7 +68,7 @@ defmodule TrentoWeb.V1.SUSEManagerController do
         description:
           "Unique identifier of the host for which patch information is being requested. This value must be a valid UUID string.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "d59523fc-0497-4b1e-9fdd-14aa7cda77f1"
@@ -99,7 +99,7 @@ defmodule TrentoWeb.V1.SUSEManagerController do
         description:
           "The name of the advisory for which details are being requested, such as SUSE-2025-1234.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           example: "SUSE-2025-1234"
         }

--- a/lib/trento_web/controllers/v1/tags_controller.ex
+++ b/lib/trento_web/controllers/v1/tags_controller.ex
@@ -30,7 +30,7 @@ defmodule TrentoWeb.V1.TagsController do
         description:
           "Unique identifier of the resource to which the tag will be added. This value must be a valid UUID string.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "d59523fc-0497-4b1e-9fdd-14aa7cda77f1"
@@ -81,7 +81,7 @@ defmodule TrentoWeb.V1.TagsController do
         description:
           "Unique identifier of the resource from which the tag will be removed. This value must be a valid UUID string.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           format: :uuid,
           example: "d59523fc-0497-4b1e-9fdd-14aa7cda77f1"
@@ -91,7 +91,7 @@ defmodule TrentoWeb.V1.TagsController do
         in: :path,
         description: "The value of the tag to be removed from the resource.",
         required: true,
-        type: %OpenApiSpex.Schema{
+        schema: %OpenApiSpex.Schema{
           type: :string,
           example: "production"
         }

--- a/lib/trento_web/controllers/v1/users_controller.ex
+++ b/lib/trento_web/controllers/v1/users_controller.ex
@@ -80,7 +80,7 @@ defmodule TrentoWeb.V1.UsersController do
         description:
           "Unique identifier of the user whose details are being requested. This value must be an integer.",
         required: true,
-        type: %OpenApiSpex.Schema{type: :integer, example: 1}
+        schema: %OpenApiSpex.Schema{type: :integer, example: 1}
       ]
     ],
     responses: [
@@ -92,7 +92,7 @@ defmodule TrentoWeb.V1.UsersController do
              required: true,
              description:
                "The entity version of the user, used for conditional HTTP requests and concurrency control.",
-             type: %OpenApiSpex.Schema{type: :string},
+             schema: %OpenApiSpex.Schema{type: :string},
              allowEmptyValues: false
            }
          }},
@@ -118,13 +118,13 @@ defmodule TrentoWeb.V1.UsersController do
         description:
           "Unique identifier of the user to be updated. This value must be an integer.",
         required: true,
-        type: %OpenApiSpex.Schema{type: :integer, example: 1}
+        schema: %OpenApiSpex.Schema{type: :integer, example: 1}
       ],
       "if-match": [
         # The field is required, we put to false to avoid openapispex validate that value with 422 status code.
         required: false,
         in: :header,
-        type: %OpenApiSpex.Schema{type: :integer},
+        schema: %OpenApiSpex.Schema{type: :integer, example: 2},
         description:
           "The entity version of the user, provided in the If-Match header, to ensure safe and conditional updates."
       ]
@@ -141,7 +141,7 @@ defmodule TrentoWeb.V1.UsersController do
              required: true,
              description:
                "The entity version of the user, used for conditional HTTP requests and concurrency control.",
-             type: %OpenApiSpex.Schema{type: :string},
+             schema: %OpenApiSpex.Schema{type: :string},
              allowEmptyValues: false
            }
          }},
@@ -175,7 +175,7 @@ defmodule TrentoWeb.V1.UsersController do
         description:
           "Unique identifier of the user to be deleted. This value must be an integer.",
         required: true,
-        type: %OpenApiSpex.Schema{type: :integer, example: 1}
+        schema: %OpenApiSpex.Schema{type: :integer, example: 1}
       ]
     ],
     responses: [


### PR DESCRIPTION
# Description

This PR continues the work in #3743 and starts passing some linters (`redocly`, `vacuum` and `spectral`) over the API spec file. For now, the main goal is just to reduce the number of errors being found. Reaching zero errors/warnings is not yet intended.

Particularly, this PR performs some breaking changes that needs a closer review.

Related # TRNT-3845

## How was this tested?

`openapi-diff`