### PR TITLE
[TRNT-3845] Run linters on the API spec and fix the errors (controllers: content-type)

### DIFF
--- a/lib/trento_web/controllers/v1/cluster_controller.ex
+++ b/lib/trento_web/controllers/v1/cluster_controller.ex
@@ -78,7 +78,13 @@ defmodule TrentoWeb.V1.ClusterController do
     ],
     responses: [
       accepted:
-        "Checks execution request for the specified cluster has been accepted and scheduled for processing.",
+        {"Checks execution request for the specified cluster has been accepted and scheduled for processing.",
+         "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{},
+           example: %{}
+         }},
       not_found: NotFound.response(),
       bad_request: BadRequest.response(),
       unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
@@ -112,7 +118,14 @@ defmodule TrentoWeb.V1.ClusterController do
     ],
     request_body: {"Checks Selection.", "application/json", Checks.ChecksSelectionRequest},
     responses: [
-      accepted: "The Selection has been successfully collected",
+      accepted:
+        {"Selected checks for the cluster have been successfully collected and are ready for execution.",
+         "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{},
+           example: %{}
+         }},
       not_found: NotFound.response(),
       bad_request: BadRequest.response(),
       unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()

--- a/lib/trento_web/controllers/v1/discovery_controller.ex
+++ b/lib/trento_web/controllers/v1/discovery_controller.ex
@@ -19,7 +19,13 @@ defmodule TrentoWeb.V1.DiscoveryController do
        "application/json", Schema.DiscoveryEvent},
     responses: [
       accepted:
-        "Discovery event accepted for processing and infrastructure data analysis, supporting automated system inventory updates.",
+        {"Discovery event accepted for processing and infrastructure data analysis, supporting automated system inventory updates.",
+         "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{},
+           example: %{}
+         }},
       unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
     ]
 

--- a/lib/trento_web/controllers/v1/host_controller.ex
+++ b/lib/trento_web/controllers/v1/host_controller.ex
@@ -115,7 +115,13 @@ defmodule TrentoWeb.V1.HostController do
     ],
     responses: [
       no_content:
-        "Heartbeat signal successfully updated for the host agent, supporting health monitoring and availability tracking.",
+        {"Heartbeat signal successfully updated for the host agent, supporting health monitoring and availability tracking.",
+         "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{},
+           example: %{}
+         }},
       not_found: NotFound.response(),
       bad_request: BadRequest.response(),
       unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
@@ -148,7 +154,13 @@ defmodule TrentoWeb.V1.HostController do
     request_body: {"Checks Selection.", "application/json", Schema.Checks.ChecksSelectionRequest},
     responses: [
       accepted:
-        "Selected checks for the host have been successfully collected and are ready for execution.",
+        {"Selected checks for the host have been successfully collected and are ready for execution.",
+         "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{},
+           example: %{}
+         }},
       not_found: NotFound.response(),
       unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
     ]

--- a/lib/trento_web/controllers/v1/tags_controller.ex
+++ b/lib/trento_web/controllers/v1/tags_controller.ex
@@ -48,7 +48,13 @@ defmodule TrentoWeb.V1.TagsController do
        }},
     responses: [
       created:
-        "Tag has been successfully added to the specified resource, supporting resource categorization and management.",
+        {"Tag has been successfully added to the specified resource, supporting resource categorization and management.",
+         "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{},
+           example: %{}
+         }},
       bad_request: Schema.BadRequest.response(),
       unprocessable_entity: OpenApiSpex.JsonErrorResponse.response()
     ]
@@ -98,7 +104,13 @@ defmodule TrentoWeb.V1.TagsController do
       ]
     ],
     responses: [
-      no_content: "The tag has been removed from the resource.",
+      no_content:
+        {"The tag has been removed from the resource.", "application/json",
+         %OpenApiSpex.Schema{
+           type: :object,
+           properties: %{},
+           example: %{}
+         }},
       bad_request: Schema.BadRequest.response(),
       unprocessable_entity: OpenApiSpex.JsonErrorResponse.response(),
       not_found: OpenApiSpex.JsonErrorResponse.response()


### PR DESCRIPTION
# Description

This PR continues the work in #3743 and starts passing some linters (`redocly`, `vacuum` and `spectral`) over the API spec file. For now, the main goal is just to reduce the number of errors being found. Reaching zero errors/warnings is not yet intended.

Particularly, this PR performs some breaking changes that needs a closer review.

Related # TRNT-3845

## How was this tested?

`openapi-diff`