### PR TITLE
[TRNT-3845] Run linters on the API spec and fix the errors (controllers: missing params)

### DIFF
--- a/lib/trento_web/controllers/session_controller.ex
+++ b/lib/trento_web/controllers/session_controller.ex
@@ -236,6 +236,14 @@ defmodule TrentoWeb.SessionController do
     description:
       "Authenticates the user against an external authentication provider using SAML, enabling single sign-on and federated identity management for secure platform access.",
     security: [],
+    parameters: [
+      provider: [
+        in: :path,
+        description:
+          "The name of the SAML identity provider to use for authentication. This value should match a configured provider.",
+        schema: %OpenApiSpex.Schema{type: :string, example: "saml"}
+      ]
+    ],
     responses: [
       unauthorized: Schema.Unauthorized.response(),
       unprocessable_entity: Schema.UnprocessableEntity.response(),

--- a/lib/trento_web/controllers/v1/prometheus_controller.ex
+++ b/lib/trento_web/controllers/v1/prometheus_controller.ex
@@ -32,6 +32,19 @@ defmodule TrentoWeb.V1.PrometheusController do
     tags: ["Target Infrastructure"],
     description:
       "Returns the status of Prometheus exporters for a specific host, identified by its unique ID, supporting health monitoring and diagnostics for infrastructure components.",
+    parameters: [
+      id: [
+        in: :path,
+        description:
+          "Unique identifier of the host for which Prometheus exporter status is requested. This value must be a valid UUID string.",
+        required: true,
+        schema: %OpenApiSpex.Schema{
+          type: :string,
+          format: :uuid,
+          example: "d59523fc-0497-4b1e-9fdd-14aa7cda77f1"
+        }
+      ]
+    ],
     responses: [
       ok:
         {"Status information for Prometheus exporters on the specified host, supporting health monitoring and diagnostics.",


### PR DESCRIPTION
# Description

This PR continues the work in #3743 and starts passing some linters (`redocly`, `vacuum` and `spectral`) over the API spec file. For now, the main goal is just to reduce the number of errors being found. Reaching zero errors/warnings is not yet intended.

Particularly, this PR performs some breaking changes that needs a closer review.

Related # TRNT-3845

## How was this tested?

`openapi-diff`