### PR TITLE
Update trento docs link in layout

### DIFF
--- a/assets/js/pages/Layout/Layout.jsx
+++ b/assets/js/pages/Layout/Layout.jsx
@@ -197,7 +197,7 @@ function Layout() {
               </div>
               <div className="absolute bottom-24 left-4">
                 <a
-                  href="https://www.trento-project.io/docs/"
+                  href="https://documentation.suse.com/sles-sap/trento/html/SLES-SAP-trento/index.html"
                   target="_blank"
                   className={classNames(
                     'flex gap-2 items-center text-green-800 font-bold bg-jungle-green-100 py-2 rounded-md hover:opacity-75',


### PR DESCRIPTION
# Description

Update the trento docs link in the layout (bottom left corner).

PD: Do we plan to link the new documentation @EMaksy is working on in the webpage as well at some point?
PD2: We have the upstream link still in the profile view, in the new analytics enablement button. I guess this will be changed at some point as well