### PR TITLE
Remove abilities from token claims

### DIFF
--- a/lib/trento_web/plugs/app_jwt_auth_plug.ex
+++ b/lib/trento_web/plugs/app_jwt_auth_plug.ex
@@ -24,18 +24,13 @@ defmodule TrentoWeb.Plugs.AppJWTAuthPlug do
   """
   def fetch(conn, _config) do
     with {:ok, jwt_token} <- read_token(conn),
-         {:ok, %{"sub" => sub, "abilities" => abilities}} <- validate_access_token(jwt_token) do
+         {:ok, %{"sub" => sub}} <- validate_access_token(jwt_token) do
       conn =
         conn
         |> Conn.put_private(:api_access_token, jwt_token)
         |> Conn.put_private(:user_id, sub)
 
-      {conn,
-       %{
-         "access_token" => jwt_token,
-         "user_id" => sub,
-         "abilities" => abilities
-       }}
+      {conn, %{"access_token" => jwt_token, "user_id" => sub}}
     else
       _ -> {conn, nil}
     end
@@ -47,12 +42,10 @@ defmodule TrentoWeb.Plugs.AppJWTAuthPlug do
     The generated credentials will be stored in private section of the Plug.Conn struct
   """
   def create(conn, user, _config) do
-    {:ok, user} = Users.get_user(user.id)
+    claims = %{"sub" => user.id}
 
-    {default_claims, access_token_claims} = token_claims(user)
-
-    access_token = AccessToken.generate_access_token!(access_token_claims)
-    refresh_token = RefreshToken.generate_refresh_token!(default_claims)
+    access_token = AccessToken.generate_access_token!(claims)
+    refresh_token = RefreshToken.generate_refresh_token!(claims)
 
     conn =
       conn
@@ -110,9 +103,7 @@ defmodule TrentoWeb.Plugs.AppJWTAuthPlug do
 
   defp attach_refresh_token_to_conn(conn, user) do
     if user_allowed_to_renew?(user) do
-      {_, access_token_claims} = token_claims(user)
-
-      new_access_token = AccessToken.generate_access_token!(access_token_claims)
+      new_access_token = AccessToken.generate_access_token!(%{"sub" => user.id})
 
       conn =
         conn
@@ -130,19 +121,4 @@ defmodule TrentoWeb.Plugs.AppJWTAuthPlug do
        do: false
 
   defp user_allowed_to_renew?(%User{}), do: true
-
-  defp token_claims(%{id: id, abilities: abilities}) do
-    default_claims = %{
-      "sub" => id
-    }
-
-    access_token_claims =
-      Map.put(
-        default_claims,
-        "abilities",
-        Enum.map(abilities, &%{name: &1.name, resource: &1.resource})
-      )
-
-    {default_claims, access_token_claims}
-  end
 end

--- a/test/trento/activity_logging/activity_logger_test.exs
+++ b/test/trento/activity_logging/activity_logger_test.exs
@@ -41,7 +41,7 @@ defmodule Trento.ActivityLog.ActivityLoggerTest do
   end
 
   defp with_token(conn, user_id) do
-    jwt = AccessToken.generate_access_token!(%{"sub" => user_id, "abilities" => []})
+    jwt = AccessToken.generate_access_token!(%{"sub" => user_id})
 
     Plug.Conn.put_req_header(conn, "authorization", "Bearer " <> jwt)
   end

--- a/test/trento_web/plugs/app_jwt_auth_plug_test.exs
+++ b/test/trento_web/plugs/app_jwt_auth_plug_test.exs
@@ -13,7 +13,6 @@ defmodule TrentoWeb.Plugs.AppJWTAuthPlugTest do
   alias TrentoWeb.Plugs.AppJWTAuthPlug
 
   import Mox
-  import Trento.Factory
 
   @pow_config [otp_app: :trento]
 
@@ -132,48 +131,30 @@ defmodule TrentoWeb.Plugs.AppJWTAuthPlugTest do
 
   describe "create/3" do
     test "should add to the conn the access/refresh token pair and the expiration", %{conn: conn} do
-      %{id: user_id, abilities: [%{name: name, resource: resource} | _]} =
-        user = insert(:user_with_abilities)
+      user = %{id: 1}
 
-      assert {
-               res_conn,
-               %{
-                 id: ^user_id,
-                 abilities: [%{name: ^name, resource: ^resource}]
-               }
-             } = AppJWTAuthPlug.create(conn, user, @pow_config)
+      assert {res_conn, ^user} = AppJWTAuthPlug.create(conn, user, @pow_config)
 
       assert %{
                private: %{
-                 api_access_token: jwt,
+                 api_access_token: _jwt,
                  access_token_expiration: 180,
                  api_refresh_token: _refresh
                }
              } = res_conn
-
-      assert {:ok,
-              %{
-                "sub" => ^user_id,
-                "abilities" => [%{"name" => ^name, "resource" => ^resource}]
-              }} = AccessToken.verify_and_validate(jwt)
     end
   end
 
   describe "fetch/2" do
     test "should fetch a user when the jwt is valid", %{conn: conn} do
-      jwt =
-        AccessToken.generate_access_token!(%{
-          "sub" => 1,
-          "abilities" => [%{name: "foo", resource: "bar"}]
-        })
+      jwt = AccessToken.generate_access_token!(%{"sub" => 1})
 
       conn = Plug.Conn.put_req_header(conn, "authorization", "Bearer " <> jwt)
 
       assert {res_conn,
               %{
                 "access_token" => ^jwt,
-                "user_id" => 1,
-                "abilities" => [%{"name" => "foo", "resource" => "bar"}]
+                "user_id" => 1
               }} = AppJWTAuthPlug.fetch(conn, @pow_config)
 
       assert %{


### PR DESCRIPTION
# Description

Basically reverting the changes introduced in this PR https://github.com/trento-project/web/pull/3240

Since we are going to have an `introspection` endpoint from web, we do not need anymore to carry user abilities as token claims.

## How was this tested?

Automated tests

Keeping temporarily on hold because this would be breaking for wanda until we change it to call the introspection endpoint.