### PR TITLE
Fix Flaky test - Activity log should reset pagination when filters changed

### DIFF
--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -4,7 +4,7 @@ import * as basePage from '../pageObject/base_po';
 const defaultSeverity = 'severity=info&severity=warning&severity=critical';
 
 context('Activity Log page', () => {
-  // before(() => activityLogPage.preloadTestData());
+  before(() => activityLogPage.preloadTestData());
   beforeEach(() => activityLogPage.interceptActivityLogEndpoint());
 
   describe('Navigation', () => {

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -150,8 +150,9 @@ context('Activity Log page', () => {
         activityLogPage.validateUrl(expectedUrl);
       });
       activityLogPage.clickFilterTypeButton();
+      cy.get('button[data-testid="filter-Type"] + div').should('be.visible');
       // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(500);
+      // cy.wait(500);
       activityLogPage.selectFilterTypeOption('Login Attempt');
       cy.get('div h1').click();
       activityLogPage.clickApplyFiltersButton();

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -153,8 +153,8 @@ context('Activity Log page', () => {
       cy.get('button[data-testid="filter-Type"] + div').should('be.visible');
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       // cy.wait(500);
+      cy.get('button[data-testid="filter-Type"] + div input').type('Login');
       activityLogPage.selectFilterTypeOption('Login Attempt');
-      cy.get('div h1').click();
       activityLogPage.clickApplyFiltersButton();
       cy.get('button[data-testid="filter-Type"]').should(
         'have.text',

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -150,10 +150,8 @@ context('Activity Log page', () => {
         activityLogPage.validateUrl(expectedUrl);
       });
       activityLogPage.clickFilterTypeButton();
-      cy.get('button[data-testid="filter-Type"] + div li').should(
-        'have.length',
-        91
-      );
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(500);
       activityLogPage.selectFilterTypeOption('Login Attempt');
       cy.get('div h1').click();
       activityLogPage.clickApplyFiltersButton();

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -4,7 +4,7 @@ import * as basePage from '../pageObject/base_po';
 const defaultSeverity = 'severity=info&severity=warning&severity=critical';
 
 context('Activity Log page', () => {
-  before(() => activityLogPage.preloadTestData());
+  // before(() => activityLogPage.preloadTestData());
   beforeEach(() => activityLogPage.interceptActivityLogEndpoint());
 
   describe('Navigation', () => {
@@ -140,7 +140,8 @@ context('Activity Log page', () => {
       });
     });
 
-    it('should reset pagination when filters are changed', () => {
+    // eslint-disable-next-line mocha/no-exclusive-tests
+    it.only('should reset pagination when filters are changed', () => {
       activityLogPage.visit(`?${defaultSeverity}`);
       activityLogPage.waitForActivityLogRequest().then(({ response }) => {
         activityLogPage.paginationPropertiesAreTheExpected(response);
@@ -150,7 +151,12 @@ context('Activity Log page', () => {
       });
       activityLogPage.clickFilterTypeButton();
       activityLogPage.selectFilterTypeOption('Login Attempt');
+      cy.get('div h1').click();
       activityLogPage.clickApplyFiltersButton();
+      cy.get('button[data-testid="filter-Type"]').should(
+        'have.text',
+        'Login Attempt'
+      );
       const expectedUrl = `/activity_log?${defaultSeverity}&type=login_attempt&first=20`;
       activityLogPage.validateUrl(expectedUrl);
     });

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -140,8 +140,7 @@ context('Activity Log page', () => {
       });
     });
 
-    // eslint-disable-next-line mocha/no-exclusive-tests
-    it.only('should reset pagination when filters are changed', () => {
+    it('should reset pagination when filters are changed', () => {
       activityLogPage.visit(`?${defaultSeverity}`);
       activityLogPage.waitForActivityLogRequest().then(({ response }) => {
         activityLogPage.paginationPropertiesAreTheExpected(response);
@@ -150,10 +149,8 @@ context('Activity Log page', () => {
         activityLogPage.validateUrl(expectedUrl);
       });
       activityLogPage.clickFilterTypeButton();
-      cy.get('button[data-testid="filter-Type"] + div').should('be.visible');
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      // cy.wait(500);
-      cy.get('button[data-testid="filter-Type"] + div input').type('Login');
+      activityLogPage.filterTypeOptionsAreDisplayed();
+      activityLogPage.searchForDesiredFilterType('Login');
       activityLogPage.selectFilterTypeOption('Login Attempt');
       activityLogPage.clickApplyFiltersButton();
       cy.get('button[data-testid="filter-Type"]').should(

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -150,6 +150,10 @@ context('Activity Log page', () => {
         activityLogPage.validateUrl(expectedUrl);
       });
       activityLogPage.clickFilterTypeButton();
+      cy.get('button[data-testid="filter-Type"] + div li').should(
+        'have.length',
+        91
+      );
       activityLogPage.selectFilterTypeOption('Login Attempt');
       cy.get('div h1').click();
       activityLogPage.clickApplyFiltersButton();

--- a/test/e2e/cypress/pageObject/activity_log_po.js
+++ b/test/e2e/cypress/pageObject/activity_log_po.js
@@ -15,7 +15,7 @@ const filterOlderThanInputField = `${filterOlderThanButton} + div input`;
 const filterNewerThanButton = 'button:contains("Filter newer than...")';
 const filterNewerThanInputField = `${filterNewerThanButton} + div input`;
 
-const filterTypeButton = 'button:contains("Filter Type")';
+const filterTypeButton = 'button[data-testid="filter-Type"]';
 
 const applyFiltersButton = 'button:contains("Apply Filter")';
 const resetFiltersButton = 'button:contains("Reset Filters")';
@@ -112,6 +112,12 @@ export const selectRefreshRate = (refreshRate) => {
 };
 
 // UI Validations
+
+export const searchForDesiredFilterType = (text) =>
+  cy.get(`${filterTypeButton} + div input`).type(text);
+
+export const filterTypeOptionsAreDisplayed = () =>
+  cy.get(`${filterTypeButton} + div`).should('be.visible');
 
 export const autoRefreshIntervalButtonHasTheExpectedValue = (refreshRate) =>
   cy.get(autoRefreshIntervalButton).should('have.text', refreshRate);


### PR DESCRIPTION
# Description

Fix flaky test in activity log that was failing when reseting filters after moving to another page.

Fixes # (issue)
https://jira.suse.com/browse/TRNT-3953

## Did you add the right label?

Remember to add the right labels to this PR.
- [x] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [x] **DONE**
## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [Manual installation guide](https://github.com/trento-project/docs/blob/main/guides/manual-installation.md)
- [Trento Ansible guide](https://github.com/trento-project/ansible/blob/main/README.md)
- [Trento Web guides](https://github.com/trento-project/web/tree/main/guides)

Add a documentation PR or write that no changes are required for the documentation.
- [ ] **DONE**
