### PR TITLE
Makes npm version constraints flexible

### DIFF
--- a/packaging/suse/rpm/trento-web.spec
+++ b/packaging/suse/rpm/trento-web.spec
@@ -28,7 +28,7 @@ Source2:        package-lock.json
 Source3:        node_modules.spec.inc
 %include        %{_sourcedir}/node_modules.spec.inc
 Group:          System/Monitoring
-BuildRequires:  elixir >= 1.15, elixir-hex, npm22, erlang-rebar3, git-core, local-npm-registry, make, gcc
+BuildRequires:  elixir >= 1.15, elixir-hex, npm >= 20, npm < 23, erlang-rebar3, git-core, local-npm-registry, make, gcc
 
 %description
 Trento is an open cloud-native web application for SAP Applications administrators.


### PR DESCRIPTION
Previously, npm/nodejs was pinned to v22. With this change, we allow a range of versions from 20 to 22 (both ends inclusive).
