### PR TITLE
Add Nav Menu Scrollbar

### DIFF
--- a/assets/js/pages/Layout/Layout.jsx
+++ b/assets/js/pages/Layout/Layout.jsx
@@ -154,7 +154,7 @@ function Layout() {
             <div className="flex items-center justify-center pt-6">
               <img
                 className={classNames('h-auto transition-scale duration-100', {
-                  'w-12': isCollapsed,
+                  'w-12 ml-1': isCollapsed,
                   'w-24': !isCollapsed,
                 })}
                 alt="trento project logo"


### PR DESCRIPTION
# Description

This PR adds a scrollbar to the main navigation sidebar when the screen height is too small (It is not visible by default for normal/large screen heights). The scrollbar has been styled to align with the rest of the UI.  There has also been a minor improvement to the location of the Docs button so that it can scroll with the nav menu. Minor improvements were also made to the collapsed state of the menu.

![Trento-Nav-Scroll](https://github.com/user-attachments/assets/f84c66c1-2572-441f-813f-a47609c871b5)

**Menu Expanded (Small Screen)**
<img width="1188" height="707" alt="Screenshot 2025-09-25 at 12 09 20" src="https://github.com/user-attachments/assets/6f5c5ce9-ba75-48f8-bfe7-e3abec7e2745" />

**Menu Collapsed (Small Screen)**
<img width="1189" height="707" alt="Screenshot 2025-09-25 at 12 09 33" src="https://github.com/user-attachments/assets/78da2b77-fcd5-42b6-9719-90b334bc5fcc" />

Docs Button Placement (Large Screen)
<img width="1396" height="930" alt="Screenshot 2025-09-25 at 12 16 02" src="https://github.com/user-attachments/assets/c1f9026c-f7db-491a-a0f0-487df45bb685" />

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [x] **DONE** Visually
