### PR TITLE
Operations preflight

### DIFF
--- a/assets/js/common/AbilitiesMultiSelect/AbilitiesMultiSelect.jsx
+++ b/assets/js/common/AbilitiesMultiSelect/AbilitiesMultiSelect.jsx
@@ -59,6 +59,7 @@ const groupedAbilities = [
       'maintenance_change:cluster',
       'cluster_host_start:cluster',
       'cluster_host_stop:cluster',
+      'reboot:host',
       'pacemaker_enable:cluster',
       'pacemaker_disable:cluster',
       'start:application_instance',

--- a/assets/js/common/AbilitiesMultiSelect/AbilitiesMultiSelect.test.jsx
+++ b/assets/js/common/AbilitiesMultiSelect/AbilitiesMultiSelect.test.jsx
@@ -120,6 +120,7 @@ describe('AbilitiesMultiSelect Component', () => {
           { id: 14, name: 'stop', resource: 'database' },
           { id: 15, name: 'cluster_host_start', resource: 'cluster' },
           { id: 16, name: 'cluster_host_stop', resource: 'cluster' },
+          { id: 17, name: 'reboot', resource: 'host' },
         ]}
         userAbilities={[
           { id: 1, name: 'all', resource: 'all' },
@@ -138,6 +139,7 @@ describe('AbilitiesMultiSelect Component', () => {
           { id: 14, name: 'stop', resource: 'database' },
           { id: 15, name: 'cluster_host_start', resource: 'cluster' },
           { id: 16, name: 'cluster_host_stop', resource: 'cluster' },
+          { id: 17, name: 'reboot', resource: 'host' },
         ]}
         setAbilities={noop}
         operationsEnabled
@@ -153,6 +155,8 @@ describe('AbilitiesMultiSelect Component', () => {
     expect(
       screen.queryByText('all:cluster_checks_selection')
     ).not.toBeInTheDocument();
+
+    expect(screen.queryByText('reboot:host')).not.toBeInTheDocument();
     expect(
       screen.queryByText('saptune_solution_apply:host')
     ).not.toBeInTheDocument();

--- a/assets/js/common/OperationModals/SimpleAcceptanceOperationModal.jsx
+++ b/assets/js/common/OperationModals/SimpleAcceptanceOperationModal.jsx
@@ -8,6 +8,7 @@ import {
   CLUSTER_MAINTENANCE_CHANGE,
   CLUSTER_HOST_START,
   CLUSTER_HOST_STOP,
+  HOST_REBOOT,
 } from '@lib/operations';
 
 import OperationModal from './OperationModal';
@@ -20,6 +21,7 @@ const TITLES = {
   [CLUSTER_MAINTENANCE_CHANGE]: 'Maintenance change',
   [CLUSTER_HOST_START]: 'Start cluster host',
   [CLUSTER_HOST_STOP]: 'Stop cluster host',
+  [HOST_REBOOT]: 'Reboot host',
 };
 
 const getOperationTitle = (operation) =>
@@ -53,6 +55,9 @@ const getClusterMaintenanceDescription = (
   );
 };
 
+const getHostRebootDescription = (operation, { hostName }) =>
+  `${getOperationTitle(operation)} ${hostName}`;
+
 const getClusterHostStartStopDescription = (operation, { hostName }) =>
   `${getOperationTitle(operation)} ${hostName}`;
 
@@ -64,6 +69,7 @@ const DESCRIPTION_RESOLVERS = {
   [CLUSTER_MAINTENANCE_CHANGE]: getClusterMaintenanceDescription,
   [CLUSTER_HOST_START]: getClusterHostStartStopDescription,
   [CLUSTER_HOST_STOP]: getClusterHostStartStopDescription,
+  [HOST_REBOOT]: getHostRebootDescription,
 };
 
 function SimpleAcceptanceOperationModal({

--- a/assets/js/common/OperationModals/SimpleAcceptanceOperationModal.stories.jsx
+++ b/assets/js/common/OperationModals/SimpleAcceptanceOperationModal.stories.jsx
@@ -120,3 +120,10 @@ export const ResourceMaintenanceChange = {
     },
   },
 };
+
+export const RebootHost = {
+  args: {
+    operation: 'host_reboot',
+    descriptionResolverArgs: { hostName },
+  },
+};

--- a/assets/js/common/OperationModals/SimpleAcceptanceOperationModal.test.jsx
+++ b/assets/js/common/OperationModals/SimpleAcceptanceOperationModal.test.jsx
@@ -15,6 +15,7 @@ import {
   CLUSTER_HOST_START,
   CLUSTER_HOST_STOP,
   CLUSTER_MAINTENANCE_CHANGE,
+  HOST_REBOOT,
 } from '@lib/operations';
 
 import SimpleAcceptanceOperationModal from './SimpleAcceptanceOperationModal';
@@ -85,6 +86,12 @@ describe('SimpleAcceptanceOperationModal', () => {
       descriptionResolverArgs: { hostName },
       title: 'Stop cluster host',
       expectedDescription: `Stop cluster host ${hostName}`,
+    },
+    {
+      operation: HOST_REBOOT,
+      descriptionResolverArgs: { hostName },
+      title: 'Reboot host',
+      expectedDescription: `Reboot host ${hostName}`,
     },
     {
       operation: 'unknown_operation',

--- a/assets/js/common/OperationsButton/OperationsButton.jsx
+++ b/assets/js/common/OperationsButton/OperationsButton.jsx
@@ -12,29 +12,37 @@ import { EOS_MORE_VERT, EOS_LOADING_ANIMATED } from 'eos-icons-react';
 
 import Button from '@common/Button';
 import DisabledGuard from '@common/DisabledGuard';
+import Tooltip from '@common/Tooltip';
+
 
 // The custom component is required to wrap in the DisabledGuard component
 // and pass the disabled value to the child
-function CustomMenuButton({ value, running, disabled, onClick }) {
+function CustomMenuButton({ value, running, disabled, onClick, tooltip }) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      role="menuitem"
-      className={classNames(
-        'w-full rounded-md text-left block px-4 py-2 text-sm',
-        {
-          'text-gray-700 hover:bg-gray-100': !disabled,
-        },
-        { 'text-gray-400': disabled }
-      )}
-      disabled={disabled}
+    <Tooltip
+      isEnabled={!!tooltip}
+      content={tooltip}
+      place="bottom"
     >
-      {running && (
-        <EOS_LOADING_ANIMATED className="inline-block fill-jungle-green-500 mr-1" />
-      )}
-      {value}
-    </button>
+      <button
+        type="button"
+        onClick={onClick}
+        role="menuitem"
+        className={classNames(
+          'w-full rounded-md text-left block px-4 py-2 text-sm',
+          {
+            'text-gray-700 hover:bg-gray-100': !disabled,
+          },
+          { 'text-gray-400': disabled }
+        )}
+        disabled={disabled}
+      >
+        {running && (
+          <EOS_LOADING_ANIMATED className="inline-block fill-jungle-green-500 mr-1" />
+        )}
+        {value}
+      </button>
+    </Tooltip>
   );
 }
 
@@ -74,7 +82,7 @@ function OperationsButton({
         className="rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 px-3 py-3 focus:outline-none"
       >
         {operations.map(
-          ({ value, running, disabled: itemDisabled, permitted, onClick }) => (
+          ({ value, running, disabled: itemDisabled, permitted, onClick, tooltip }) => (
             <Fragment key={value}>
               <MenuItem>
                 <DisabledGuard
@@ -87,6 +95,7 @@ function OperationsButton({
                     running={running}
                     disabled={itemDisabled || someRunning}
                     onClick={onClick}
+                    tooltip={tooltip}
                   />
                 </DisabledGuard>
               </MenuItem>

--- a/assets/js/lib/api/operations.js
+++ b/assets/js/lib/api/operations.js
@@ -1,4 +1,4 @@
-import { networkClient, post } from '@lib/network';
+import { networkClient, post, get } from '@lib/network';
 
 // eslint-disable-next-line no-undef
 const baseURL = config.checksServiceBaseUrl;
@@ -7,6 +7,9 @@ const defaultConfig = { baseURL };
 
 export const requestHostOperation = (hostID, operation, params) =>
   post(`/hosts/${hostID}/operations/${operation}`, params);
+
+export const requestHostOperationPreflight = (hostID, operation) =>
+  get(`/hosts/${hostID}/operations/${operation}`);
 
 export const requestClusterOperation = (clusterID, operation, params) =>
   post(`/clusters/${clusterID}/operations/${operation}`, params);

--- a/assets/js/lib/operations/index.js
+++ b/assets/js/lib/operations/index.js
@@ -22,6 +22,7 @@ export const PACEMAKER_ENABLE = 'pacemaker_enable';
 export const PACEMAKER_DISABLE = 'pacemaker_disable';
 export const DATABASE_START = 'database_start';
 export const DATABASE_STOP = 'database_stop';
+export const HOST_REBOOT = 'host_reboot';
 
 const OPERATION_LABELS = {
   [SAPTUNE_SOLUTION_APPLY]: 'Apply Saptune solution',
@@ -37,6 +38,7 @@ const OPERATION_LABELS = {
   [PACEMAKER_DISABLE]: 'Disable Pacemaker',
   [DATABASE_START]: 'Database start',
   [DATABASE_STOP]: 'Database stop',
+  [HOST_REBOOT]: 'Reboot host',
 };
 
 const OPERATION_INTERNAL_NAMES = {
@@ -53,6 +55,7 @@ const OPERATION_INTERNAL_NAMES = {
   'pacemakerdisable@v1': PACEMAKER_DISABLE,
   'databasestart@v1': DATABASE_START,
   'databasestop@v1': DATABASE_STOP,
+  'hostreboot@v1': HOST_REBOOT,
 };
 
 const OPERATION_RESOURCE_TYPES = {
@@ -69,6 +72,7 @@ const OPERATION_RESOURCE_TYPES = {
   [PACEMAKER_DISABLE]: CLUSTER_HOST_OPERATION,
   [DATABASE_START]: DATABASE_OPERATION,
   [DATABASE_STOP]: DATABASE_OPERATION,
+  [HOST_REBOOT]: HOST_OPERATION,
 };
 
 const OPERATION_FORBIDDEN_MESSAGES = {

--- a/assets/js/lib/operations/index.js
+++ b/assets/js/lib/operations/index.js
@@ -22,7 +22,7 @@ export const PACEMAKER_ENABLE = 'pacemaker_enable';
 export const PACEMAKER_DISABLE = 'pacemaker_disable';
 export const DATABASE_START = 'database_start';
 export const DATABASE_STOP = 'database_stop';
-export const HOST_REBOOT = 'host_reboot';
+export const HOST_REBOOT = 'reboot';
 
 const OPERATION_LABELS = {
   [SAPTUNE_SOLUTION_APPLY]: 'Apply Saptune solution',

--- a/assets/js/lib/operations/operations.test.js
+++ b/assets/js/lib/operations/operations.test.js
@@ -66,6 +66,10 @@ describe('operations', () => {
       operation: 'cluster_host_stop',
       label: 'Stop cluster host',
     },
+    {
+      operation: 'host_reboot',
+      label: 'Reboot host',
+    },
   ])(`should return the operation $operation label`, ({ operation, label }) => {
     expect(getOperationLabel(operation)).toBe(label);
   });
@@ -126,6 +130,10 @@ describe('operations', () => {
     {
       operation: 'crmclusterstop@v1',
       name: 'cluster_host_stop',
+    },
+    {
+      operation: 'hostreboot@v1',
+      name: 'host_reboot',
     },
   ])(
     `should return the operation $operation internal name`,
@@ -190,6 +198,10 @@ describe('operations', () => {
     {
       operation: 'cluster_host_stop',
       resourceType: 'cluster_host',
+    },
+    {
+      operation: 'host_reboot',
+      resourceType: 'host',
     },
   ])(
     `should return the operation $operation resource type`,

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
@@ -76,7 +76,7 @@ function HanaClusterDetails({
               {
                 title: 'SID',
                 content: enrichedSapSystems,
-                render: (content) => (
+                 render: (content) => (
                   <div>
                     {content.map(({ id, sid: sapSystemSid }) => (
                       <span key={sapSystemSid}>

--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -109,7 +109,7 @@ function HostDetails({
     saptuneSolutionOperationModalOpen,
     setSaptuneSolutionOperationModalOpen,
   ] = useState(false);
-  const [currentSaptuneOperation, setCurrentSaptuneOperation] = useState(null);
+  const [currentOperation, setCurrentOperation] = useState(null);
 
   const versionWarningMessage = agentVersionWarning(agentVersion);
 
@@ -146,9 +146,21 @@ function HostDetails({
 
   const timeNow = new Date();
 
-  const openSaptuneOperationModal = (saptuneOperation) => () => {
-    setCurrentSaptuneOperation(saptuneOperation);
-    setSaptuneSolutionOperationModalOpen(true);
+  const openOperationModal = (operation) => () => {
+    setCurrentOperation(operation);
+    switch (operation) {
+      case SAPTUNE_SOLUTION_APPLY:
+      case SAPTUNE_SOLUTION_CHANGE:
+        setSaptuneSolutionOperationModalOpen(true);
+        break;
+      case HOST_REBOOT:
+        setSimpleOperationModalOpen(true);
+        break;
+    }
+  };
+
+  const closeOperationModal = () => {
+    setSaptuneSolutionOperationModalOpen(false);
   };
 
   return (
@@ -175,16 +187,16 @@ function HostDetails({
             {getOperationForbiddenMessage(runningOperationName)}
           </OperationForbiddenModal>
           <SaptuneSolutionOperationModal
-            title={getOperationLabel(currentSaptuneOperation)}
+            title={getOperationLabel(currentOperation)}
             currentlyApplied={currentlyAppliedSolution}
             isHanaRunning={some(sapInstances, { type: DATABASE_TYPE })}
             isAppRunning={some(sapInstances, { type: APPLICATION_TYPE })}
             isOpen={!!saptuneSolutionOperationModalOpen}
             onRequest={(solution) => {
-              setSaptuneSolutionOperationModalOpen(false);
-              requestOperation(currentSaptuneOperation, { solution });
+              closeOperationModal();
+              requestOperation(currentOperation, { solution });
             }}
-            onCancel={() => setSaptuneSolutionOperationModalOpen(false)}
+            onCancel={closeOperationModal}
           />
         </>
       )}
@@ -207,18 +219,14 @@ function HostDetails({
                       running: runningOperationName === SAPTUNE_SOLUTION_APPLY,
                       disabled: !sapPresent || currentlyAppliedSolution,
                       permitted: ['saptune_solution_apply:host'],
-                      onClick: openSaptuneOperationModal(
-                        SAPTUNE_SOLUTION_APPLY
-                      ),
+                      onClick: openOperationModal(SAPTUNE_SOLUTION_APPLY),
                     },
                     {
                       value: 'Change Saptune Solution',
                       running: runningOperationName === SAPTUNE_SOLUTION_CHANGE,
                       disabled: !sapPresent || !currentlyAppliedSolution,
                       permitted: ['saptune_solution_change:host'],
-                      onClick: openSaptuneOperationModal(
-                        SAPTUNE_SOLUTION_CHANGE
-                      ),
+                      onClick: openOperationModal(SAPTUNE_SOLUTION_CHANGE),
                     },
                   ]}
                 />

--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -100,6 +100,7 @@ function HostDetails({
   userAbilities,
   operationsEnabled = false,
   runningOperation,
+  preflightOperations,
   cleanUpHost,
   requestHostChecksExecution,
   requestOperation,
@@ -170,9 +171,6 @@ function HostDetails({
     setSimpleOperationModalOpen(false);
   };
 
-  const isHanaRunning = some(sapInstances, { type: DATABASE_TYPE });
-  const isAppRunning = some(sapInstances, { type: APPLICATION_TYPE });
-
   return (
     <>
       <DeregistrationModal
@@ -237,12 +235,10 @@ function HostDetails({
                     {
                       value: 'Reboot Host',
                       running: runningOperationName === HOST_REBOOT,
-                      disabled:
-                        heartbeat !== 'passing' ||
-                        !isHanaRunning ||
-                        !isAppRunning,
+                      disabled: !preflightOperations[HOST_REBOOT]?.allowed,
                       permitted: ['reboot:host'],
                       onClick: openOperationModal(HOST_REBOOT),
+                      tooltip: preflightOperations[HOST_REBOOT]?.errors.join('; '),
                     },
                     {
                       value: 'Apply Saptune Solution',

--- a/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
@@ -354,6 +354,7 @@ export const WithRunningOperation = {
 export const WithDisabledOperation = {
   args: {
     ...Default.args,
+    hostname: 'my-host.example.com',
     saptuneStatus: {
       package_version: '3.0.0',
       enabled_solution: 'HANA',

--- a/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
@@ -18,6 +18,7 @@ import { DATABASE_TYPE } from '@lib/model/sapSystems';
 import {
   SAPTUNE_SOLUTION_APPLY,
   SAPTUNE_SOLUTION_CHANGE,
+  HOST_REBOOT,
 } from '@lib/operations';
 
 import HostDetails from './HostDetails';
@@ -397,6 +398,7 @@ describe('HostDetails component', () => {
       scenario            | runningOperation
       ${'Saptune apply'}  | ${{ operation: SAPTUNE_SOLUTION_APPLY, menuEntry: 'Apply Saptune Solution' }}
       ${'Saptune change'} | ${{ operation: SAPTUNE_SOLUTION_CHANGE, menuEntry: 'Change Saptune Solution' }}
+      ${'Host reboot'}    | ${{ operation: HOST_REBOOT, menuEntry: 'Reboot Host' }}
     `(
       'should show $scenario operation running',
       async ({ runningOperation: { operation, menuEntry } }) => {
@@ -433,6 +435,7 @@ describe('HostDetails component', () => {
       operation
       ${'Apply Saptune Solution'}
       ${'Change Saptune Solution'}
+      ${'Reboot Host'}
     `('should show $operation operation disabled', async ({ operation }) => {
       const user = userEvent.setup();
 
@@ -458,6 +461,7 @@ describe('HostDetails component', () => {
       scenario                     | operation                  | expectedMessage
       ${'Saptune apply solution'}  | ${SAPTUNE_SOLUTION_APPLY}  | ${'Unable to run Apply Saptune Solution operation'}
       ${'Saptune change solution'} | ${SAPTUNE_SOLUTION_CHANGE} | ${'Unable to run Change Saptune Solution operation'}
+      ${'host reboot'}             | ${HOST_REBOOT}             | ${'Unable to run Reboot Host operation'}
     `(
       'should show $scenario operation forbidden message',
       async ({ operation, expectedMessage }) => {

--- a/assets/js/state/index.js
+++ b/assets/js/state/index.js
@@ -15,6 +15,7 @@ import softwareUpdatesReducer from './softwareUpdates';
 import activityLogsSettingsReducer from './activityLogsSettings';
 import activityLogReducer from './activityLog';
 import runningOperationsReducer from './runningOperations';
+import preflightOperationsReducer from './preflightOperations';
 import rootSaga from './sagas';
 
 export const createStore = (router) => {
@@ -40,6 +41,7 @@ export const createStore = (router) => {
       activityLogsSettings: activityLogsSettingsReducer,
       activityLog: activityLogReducer,
       runningOperations: runningOperationsReducer,
+      preflightOperations: preflightOperationsReducer,
     },
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware().concat(sagaMiddleware),

--- a/assets/js/state/preflightOperations.js
+++ b/assets/js/state/preflightOperations.js
@@ -1,0 +1,52 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+export const OPERATION_PREFLIGHT_REQUESTED = 'OPERATION_PREFLIGHT_REQUESTED';
+
+const operationKey = (groupID, operation) => `${groupID}-${operation}`;
+
+const initialState = {};
+
+const initialOperationState = {
+  operation: null,
+  allowed: false,
+  errors: [],
+  metadata: {},
+};
+
+export const requestOperationPreflight = ({ groupID, operation }) => ({
+  type: OPERATION_PREFLIGHT_REQUESTED,
+  payload: { groupID, operation },
+});
+
+
+export const preflightOperationsSlice = createSlice({
+  name: 'preflightOperations',
+  initialState,
+  reducers: {
+    removePreflightOperation: (state, { payload }) => {
+      const { groupID, operation } = payload;
+      const key = operationKey(groupID, operation);
+      delete state[key];
+    },
+    setPreflightOperation: (state, { payload }) => {
+      const { groupID, operation, errors } = payload;
+      const allowed = errors && errors.length === 0;
+      const key = operationKey(groupID, operation);
+
+      state[key] = {
+        ...initialOperationState,
+        operation,
+        allowed,
+        errors,
+      };
+    },
+  },
+});
+
+
+export const {
+  removePreflightOperation,
+  setPreflightOperation,
+} = preflightOperationsSlice.actions;
+
+export default preflightOperationsSlice.reducer;

--- a/assets/js/state/selectors/preflightOperations.js
+++ b/assets/js/state/selectors/preflightOperations.js
@@ -1,0 +1,9 @@
+import { createSelector } from '@reduxjs/toolkit';
+import { get, } from 'lodash';
+
+export const getPreflightOperation = (groupID, operation) =>
+  createSelector(
+    ({ preflightOperations }) => preflightOperations,
+    (preflightOperations) =>
+      get(preflightOperations, `${groupID}-${operation}`, null)
+  );

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -171,6 +171,7 @@ defmodule TrentoWeb.Router do
              :delete_database_instance
 
       if Application.compile_env!(:trento, :operations_enabled) do
+        get "/hosts/:id/operations/:operation", HostController, :request_operation_preflight
         post "/hosts/:id/operations/:operation", HostController, :request_operation
         post "/clusters/:id/operations/:operation", ClusterController, :request_operation
         post "/sap_systems/:id/operations/:operation", SapSystemController, :request_operation

--- a/test/trento_web/controllers/v1/host_controller_test.exs
+++ b/test/trento_web/controllers/v1/host_controller_test.exs
@@ -466,20 +466,29 @@ defmodule TrentoWeb.V1.HostControllerTest do
           |> post("/api/v1/hosts/#{host_id}/operations/#{@operation}", %{})
           |> json_response(:unprocessable_entity)
 
-        assert %{
-                 "errors" => [
-                   %{
-                     "detail" => "Failed to cast value to one of: no schemas validate",
-                     "source" => %{"pointer" => "/"},
-                     "title" => "Invalid value"
-                   },
-                   %{
-                     "detail" => "Missing field: solution",
-                     "source" => %{"pointer" => "/solution"},
-                     "title" => "Invalid value"
-                   }
-                 ]
-               } == resp
+        resp_preflight =
+          conn
+          |> put_req_header("content-type", "application/json")
+          |> get("/api/v1/hosts/#{host_id}/operations/#{@operation}", %{})
+          |> json_response(:unprocessable_entity)
+
+        expected = %{
+          "errors" => [
+            %{
+              "detail" => "Failed to cast value to one of: no schemas validate",
+              "source" => %{"pointer" => "/"},
+              "title" => "Invalid value"
+            },
+            %{
+              "detail" => "Missing field: solution",
+              "source" => %{"pointer" => "/solution"},
+              "title" => "Invalid value"
+            }
+          ]
+        }
+
+        assert expected == resp
+        assert expected == resp_preflight
       end
 
       test "should respond with 500 on messaging error for operation '#{operation}'",


### PR DESCRIPTION
(The PR is still a PoC)

* Have a preflight endpoint for the operations so that their policy can be checked before executing the operation
* No policy is needed on the frontend as the very same is used in the backend (user permissions, too)
* In case the operation is disabled, a tooltip reports the reasons to the user