### PR TITLE
Personal access tokens profile frontend

### DIFF
--- a/assets/js/common/PersonalAccessTokens/PersonalAccessTokens.jsx
+++ b/assets/js/common/PersonalAccessTokens/PersonalAccessTokens.jsx
@@ -1,0 +1,123 @@
+import React, { useState } from 'react';
+
+import { noop } from 'lodash';
+import { format, isAfter } from 'date-fns';
+import classNames from 'classnames';
+
+import Button from '@common/Button';
+
+import DeleteTokenModal from './DeleteTokenModal';
+import GenerateTokenModal from './GenerateTokenModal';
+import NewTokenModal from './NewTokenModal';
+
+function PersonalAccessTokens({
+  className,
+  personalAccessTokens,
+  generateTokenAvailable,
+  generatedAccessToken = null,
+  onDeleteToken = noop,
+  onGenerateToken = noop,
+  onCloseGeneratedTokenModal = noop,
+}) {
+  const [tokenToDelete, setTokenToDelete] = useState(null);
+  const [generateTokenModalOpen, setGenerateTokenModalOpen] = useState(false);
+
+  return (
+    <>
+      <DeleteTokenModal
+        name={tokenToDelete?.name}
+        isOpen={tokenToDelete !== null}
+        onDelete={() => {
+          onDeleteToken(tokenToDelete?.jti);
+          setTokenToDelete(null);
+        }}
+        onClose={() => setTokenToDelete(null)}
+      />
+      <GenerateTokenModal
+        isOpen={generateTokenModalOpen}
+        onGenerate={(name, expiresAt) => {
+          onGenerateToken(name, expiresAt);
+          setGenerateTokenModalOpen(false);
+        }}
+        onClose={() => setGenerateTokenModalOpen(false)}
+      />
+      <NewTokenModal
+        accessToken={generatedAccessToken}
+        isOpen={generatedAccessToken !== null}
+        onClose={() => onCloseGeneratedTokenModal(null)}
+      />
+      <div
+        className={classNames(
+          'container max-w-7xl mx-auto p-4 sm:p-6 lg:p-8 bg-white dark:bg-gray-800 rounded-lg',
+          className
+        )}
+      >
+        <div>
+          <h2 className="text-2xl font-bold inline-block">
+            Personal Access Tokens
+          </h2>
+          {generateTokenAvailable && (
+            <span className="float-right">
+              <Button
+                aria-label="generate-token"
+                className="mr-2"
+                type="primary-white"
+                onClick={() => setGenerateTokenModalOpen(true)}
+              >
+                Generate Token
+              </Button>
+            </span>
+          )}
+        </div>
+        <p className="mt-3 mb-3 text-gray-500">
+          Grant access to your Trento instance by using personal access tokens.
+        </p>
+        <div>
+          {personalAccessTokens && personalAccessTokens.length > 0 ? (
+            <div className="space-y-3">
+              {personalAccessTokens.map(
+                ({ jti, name, expires_at: expiresAt }) => (
+                  <div
+                    key={jti}
+                    className="flex border rounded-md border-gray-200 px-4 py-3"
+                  >
+                    <div>
+                      <p className="font-semibold">{name}</p>
+                      <p
+                        className={classNames(
+                          'text-sm',
+                          expiresAt && isAfter(new Date(), expiresAt)
+                            ? 'text-red-500'
+                            : 'text-gray-500'
+                        )}
+                      >
+                        Expires:{' '}
+                        {expiresAt ? format(expiresAt, 'd LLL yyyy') : 'Never'}
+                      </p>
+                    </div>
+                    <div className="flex justify-end ml-auto my-1">
+                      <Button
+                        aria-label="delete-token"
+                        type="danger"
+                        size="small"
+                        onClick={() => {
+                          setTokenToDelete({ jti, name });
+                        }}
+                      >
+                        Delete
+                      </Button>
+                    </div>
+                  </div>
+                )
+              )}
+            </div>
+          ) : (
+            <p className="text-gray-500 text-sm">No keys issued.</p>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default PersonalAccessTokens;

--- a/assets/js/common/PersonalAccessTokens/PersonalAccessTokens.stories.jsx
+++ b/assets/js/common/PersonalAccessTokens/PersonalAccessTokens.stories.jsx
@@ -1,0 +1,85 @@
+import { faker } from '@faker-js/faker';
+import { formatISO } from 'date-fns';
+
+import { personalAccessTokenFactory } from '@lib/test-utils/factories';
+
+import PersonalAccessTokens from './PersonalAccessTokens';
+
+export default {
+  title: 'Components/PersonalAccessTokens',
+  component: PersonalAccessTokens,
+  argTypes: {
+    className: {
+      description: 'CSS classes',
+      control: 'test',
+    },
+    personalAccessTokens: {
+      description: 'Current user personal access tokens',
+      control: { type: 'array' },
+    },
+    generateTokenAvailable: {
+      description: 'Generate Token button is available or not',
+      control: 'boolean',
+    },
+    generatedAccessToken: {
+      description:
+        'Generated personal access token. Used to display the GeneratedAccessTokenModal modal',
+      control: 'text',
+    },
+    onDeleteToken: {
+      description: 'Deletes personal access token',
+      control: 'boolean',
+    },
+    onGenerateToken: {
+      type: 'function',
+      description: 'Generates personal access token',
+    },
+    onCloseGeneratedTokenModal: {
+      type: 'function',
+      description: 'Closes new personal access token modal',
+    },
+  },
+  args: {
+    generatedAccessToken: null,
+  },
+};
+
+export const Default = {
+  args: {
+    personalAccessTokens: personalAccessTokenFactory.buildList(3),
+    generatedAccessToken: null,
+    generateTokenAvailable: true,
+  },
+};
+
+export const Empty = {
+  args: {
+    ...Default.args,
+    personalAccessTokens: [],
+  },
+};
+
+export const ExpiredToken = {
+  args: {
+    ...Default.args,
+    personalAccessTokens: personalAccessTokenFactory.buildList(1, {
+      expires_at: formatISO(faker.date.past()),
+    }),
+  },
+};
+
+export const TokenNeverExpires = {
+  args: {
+    ...Default.args,
+    personalAccessTokens: personalAccessTokenFactory.buildList(1, {
+      expires_at: null,
+    }),
+  },
+};
+
+export const TokenGenerationDisabled = {
+  args: {
+    ...Default.args,
+    generateTokenAvailable: false,
+  },
+};

--- a/assets/js/common/PersonalAccessTokens/PersonalAccessTokens.test.jsx
+++ b/assets/js/common/PersonalAccessTokens/PersonalAccessTokens.test.jsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { format, formatISO } from 'date-fns';
+import { faker } from '@faker-js/faker';
+import { personalAccessTokenFactory } from '@lib/test-utils/factories';
+
+import PersonalAccessTokens from './PersonalAccessTokens';
+
+describe('PersonalAccessTokens', () => {
+  it('should show personal access tokens', () => {
+    const tokens = personalAccessTokenFactory.buildList(3);
+    render(<PersonalAccessTokens personalAccessTokens={tokens} />);
+
+    expect(screen.getByText('Personal Access Tokens')).toBeInTheDocument();
+
+    tokens.forEach(({ name, expires_at: expiresAt }) => {
+      expect(screen.getByText(name)).toBeInTheDocument();
+      expect(
+        screen.getByText(`Expires: ${format(expiresAt, 'd LLL yyyy')}`)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('should show an empty list of tokens', () => {
+    render(<PersonalAccessTokens personalAccessTokens={[]} />);
+
+    expect(screen.getByText('No keys issued.')).toBeInTheDocument();
+  });
+
+  it('should show token without expiration', () => {
+    const token = personalAccessTokenFactory.build({
+      expires_at: null,
+    });
+    render(<PersonalAccessTokens personalAccessTokens={[token]} />);
+
+    expect(screen.getByText('Expires: Never')).toBeInTheDocument();
+  });
+
+  it('should show expired tokens with a red color', () => {
+    const token = personalAccessTokenFactory.build({
+      expires_at: formatISO(faker.date.past()),
+    });
+    render(<PersonalAccessTokens personalAccessTokens={[token]} />);
+
+    expect(
+      screen
+        .getByText(`Expires: ${format(token.expires_at, 'd LLL yyyy')}`)
+        .classList.toString()
+    ).toContain('text-red-500');
+  });
+
+  it('should show token generation button', () => {
+    render(<PersonalAccessTokens generateTokenAvailable />);
+
+    expect(
+      screen.getByRole('button', { name: 'generate-token' })
+    ).toBeInTheDocument();
+  });
+
+  it('should not show token generation button', () => {
+    render(<PersonalAccessTokens generateTokenAvailable={false} />);
+
+    expect(
+      screen.queryByRole('button', { name: 'generate-token' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('should open generate token modal when the button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<PersonalAccessTokens generateTokenAvailable />);
+
+    await user.click(screen.getByRole('button', { name: 'generate-token' }));
+
+    expect(
+      screen.getByText('Generate Personal Access Token')
+    ).toBeInTheDocument();
+  });
+
+  it('should delete token when confirmation modal delete button is clicked', async () => {
+    const user = userEvent.setup();
+    const token = personalAccessTokenFactory.build();
+    const mockOnDeleteToken = jest.fn();
+    render(
+      <PersonalAccessTokens
+        personalAccessTokens={[token]}
+        onDeleteToken={mockOnDeleteToken}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'delete-token' }));
+    await user.click(screen.getByRole('button', { name: 'Delete Token' }));
+
+    expect(mockOnDeleteToken).toHaveBeenCalledWith(token.jti);
+  });
+
+  it('should generate token when generation modal generate is clicked', async () => {
+    const user = userEvent.setup();
+    const tokenName = 'My token';
+    const mockOnGenerateToken = jest.fn();
+    render(
+      <PersonalAccessTokens
+        generateTokenAvailable
+        onGenerateToken={mockOnGenerateToken}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'generate-token' }));
+
+    await user.type(screen.getByRole('textbox'), tokenName);
+    await user.click(screen.getByRole('switch'));
+    await user.click(screen.getByRole('button', { name: 'Generate Token' }));
+    expect(mockOnGenerateToken).toHaveBeenCalledWith(tokenName, null);
+  });
+
+  it('should show new token modal if the generated token is given', async () => {
+    const user = userEvent.setup();
+    const token = faker.internet.jwt();
+    const mockOnCloseGenerated = jest.fn();
+    render(
+      <PersonalAccessTokens
+        generatedAccessToken={token}
+        onCloseGeneratedTokenModal={mockOnCloseGenerated}
+      />
+    );
+
+    expect(screen.getByText('Generated Token')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    expect(mockOnCloseGenerated).toHaveBeenCalled();
+  });
+});

--- a/assets/js/common/PersonalAccessTokens/index.js
+++ b/assets/js/common/PersonalAccessTokens/index.js
@@ -1,0 +1,3 @@
+import PersonalAccessTokens from './PersonalAccessTokens';
+
+export default PersonalAccessTokens;

--- a/assets/js/lib/api/users.js
+++ b/assets/js/lib/api/users.js
@@ -25,3 +25,8 @@ export const resetTotpEnrolling = () => del('/profile/totp_enrollment');
 
 export const confirmTotpEnrolling = (payload) =>
   post('/profile/totp_enrollment', payload);
+
+export const generatePersonalAccessToken = (name, expiresAt) =>
+  post('/profile/tokens', { name, expires_at: expiresAt });
+
+export const deletePersonalAccessToken = (jti) => del(`/profile/tokens/${jti}`);

--- a/assets/js/lib/test-utils/factories/users.js
+++ b/assets/js/lib/test-utils/factories/users.js
@@ -60,3 +60,10 @@ export const createUserRequestFactory = Factory.define(() => {
     password_confirmation: password,
   };
 });
+
+export const personalAccessTokenFactory = Factory.define(() => ({
+  jti: faker.string.uuid(),
+  name: faker.internet.displayName(),
+  expires_at: formatISO(faker.date.future()),
+  created_at: formatISO(faker.date.past()),
+}));


### PR DESCRIPTION
# Description

Create the new `PersonalAccessTokens` component and use it the `ProfilePage`.

You can play with the feature in the PR environment.

Here a demo:
![pats_demo](https://github.com/user-attachments/assets/63af105b-f0ab-4ede-86cc-7d057faf257b)

And a pic with multiple tokens from storybook:

<img width="1312" height="632" alt="image" src="https://github.com/user-attachments/assets/2ae89050-948f-4b1d-8a91-0ae35467e08d" />

## How was this tested?

UT. 
I have not included any test in the `ProfilePage` component.
I will add the tests for that as e2e tests, as it will cover more things there.
