### PR TITLE
Add personal access tokens feature e2e tests

### DIFF
--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -349,4 +349,78 @@ describe('Users', () => {
       loginPage.loginShouldFail(usersPage.USER.username, usersPage.PASSWORD);
     });
   });
+
+  describe('Profile personal access tokens', () => {
+    beforeEach(() => {
+      basePage.logout();
+      usersPage.apiDeleteAllUsers();
+      usersPage.apiCreateUser();
+      basePage.visit();
+      loginPage.login(usersPage.USER.username, usersPage.PASSWORD);
+      basePage.clickUserDropdownProfileButton();
+      basePage.validateUrl('/profile');
+    });
+
+    it('should show an empty list of personal access tokens', () => {
+      usersPage.personalAccessTokensAreDisplayed([]);
+    });
+
+    it('should create a new personal access token and grant access to guarded resources', () => {
+      usersPage.clickGenerateTokenButton();
+      usersPage.typeTokenName();
+      usersPage.clickModalGenerateTokenButton();
+      usersPage.newAccessTokenIsDisplayed().then((token) => {
+        usersPage.apiPersonalAccessTokenAuthorized(token);
+      });
+      usersPage.modalCopyAccessTokenButtonIsDisplayed();
+      usersPage.clickGeneratedTokenCloseButton();
+      usersPage.personalAccessTokensAreDisplayed([
+        { name: usersPage.DEFAULT_TOKEN_NAME },
+      ]);
+    });
+
+    it('should delete a personal access token and revoke access to guarded resources', () => {
+      usersPage
+        .apiCreatePersonalAccessToken()
+        .then(({ name, access_token: token }) => {
+          usersPage.apiPersonalAccessTokenAuthorized(token);
+          cy.visit('/profile');
+          usersPage.personalAccessTokensAreDisplayed([{ name }]);
+          usersPage.clickDeleteTokenButton();
+          usersPage.clickModalDeleteTokenButton();
+          usersPage.personalAccessTokensAreDisplayed([]);
+          usersPage.apiPersonalAccessTokenUnauthorized(token);
+        });
+    });
+
+    it('should inherit user abilities when a personal access token is used', () => {
+      usersPage
+        .apiCreatePersonalAccessToken()
+        .then(({ access_token: token }) => {
+          usersPage.apiPersonalAccessTokenForbidden(token);
+          usersPage.apiApplyAllUsersPermission();
+          usersPage.apiPersonalAccessTokenAuthorized(token, '/api/v1/users');
+        });
+    });
+
+    it('should revoke access for a locked user', () => {
+      usersPage
+        .apiCreatePersonalAccessToken()
+        .then(({ access_token: token }) => {
+          usersPage.apiPersonalAccessTokenAuthorized(token);
+          usersPage.apiDisableUser();
+          usersPage.apiPersonalAccessTokenUnauthorized(token);
+        });
+    });
+
+    it('should revoke access for a deleted user', () => {
+      usersPage
+        .apiCreatePersonalAccessToken()
+        .then(({ access_token: token }) => {
+          usersPage.apiPersonalAccessTokenAuthorized(token);
+          usersPage.apiDeleteAllUsers();
+          usersPage.apiPersonalAccessTokenUnauthorized(token);
+        });
+    });
+  });
 });


### PR DESCRIPTION
# Description
Add Personal Access Token feature e2e tests.
I have covered the most important things:
- Check empty list of tokens
- Check existing tokens
- Create token in the UI and check it is authorized
- Delete token in the UI and check it is revoked
- Check token of a locked user is revoked
- Check token of a deleted user is revoked
Other more frontend related things like modals detailed usage and different expiration times are tested in frontend tests

Depends on: https://github.com/trento-project/web/pull/3793

## How was this tested?
e2e tests
