### PR TITLE
[TRNT-3845] Add option alias openapi operation

### DIFF
--- a/lib/trento_web/openapi/api_spec.ex
+++ b/lib/trento_web/openapi/api_spec.ex
@@ -148,7 +148,7 @@ defmodule TrentoWeb.OpenApi.ApiSpec do
         excluded_versions = List.delete(available_versions, version)
         actual_versions = List.delete(available_versions, "unversioned")
 
-        # Get route aliasese from metadata openapi_operation_id entries
+        # Get route aliases from metadata openapi_operation_id entries
         openapi_operation_id_aliases =
           router.__routes__()
           |> Enum.filter(fn
@@ -181,9 +181,9 @@ defmodule TrentoWeb.OpenApi.ApiSpec do
       end
 
       # Transforms the PathItem operation ID in cases where multiple actions are associated
-      # to the same operation.
+      # to the same path.
       # It uses the route `metadata: %{openapi_operation_id: alias_id}` to get the new id.
-      # By default open_api_spex adds a `(n)` (`n` being the occurrance number) as a suffix
+      # By default open_api_spex adds a `(n)` (`n` being the occurrence number) as a suffix
       # to the operation ID in this case, which doesn't comply as a valid URL:
       # https://github.com/open-api-spex/open_api_spex/issues/123
       # https://quobix.com/vacuum/rules/operations/operation-operationid-valid-in-url/

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -118,15 +118,17 @@ defmodule TrentoWeb.Router do
            HostController,
            :request_checks_execution
 
+      delete "/hosts/:id", HostController, :delete
+
       post "/hosts/:id/tags", TagsController, :add_tag,
         assigns: %{resource_type: :host},
-        as: :hosts_tagging
-
-      delete "/hosts/:id", HostController, :delete
+        as: :hosts_tagging,
+        metadata: %{openapi_operation_id: :add_tag_host}
 
       delete "/hosts/:id/tags/:value", TagsController, :remove_tag,
         assigns: %{resource_type: :host},
-        as: :hosts_tagging
+        as: :hosts_tagging,
+        metadata: %{openapi_operation_id: :remove_tag_host}
 
       get "/hosts/:id/exporters_status", PrometheusController, :exporters_status
 
@@ -140,19 +142,23 @@ defmodule TrentoWeb.Router do
 
       post "/clusters/:id/tags", TagsController, :add_tag,
         assigns: %{resource_type: :cluster},
-        as: :clusters_tagging
+        as: :clusters_tagging,
+        metadata: %{openapi_operation_id: :add_tag_cluster}
 
       delete "/clusters/:id/tags/:value", TagsController, :remove_tag,
         assigns: %{resource_type: :cluster},
-        as: :clusters_tagging
+        as: :clusters_tagging,
+        metadata: %{openapi_operation_id: :remove_tag_cluster}
 
       post "/sap_systems/:id/tags", TagsController, :add_tag,
         assigns: %{resource_type: :sap_system},
-        as: :sap_systems_tagging
+        as: :sap_systems_tagging,
+        metadata: %{openapi_operation_id: :add_tag_sap_system}
 
       delete "/sap_systems/:id/tags/:value", TagsController, :remove_tag,
         assigns: %{resource_type: :sap_system},
-        as: :sap_systems_tagging
+        as: :sap_systems_tagging,
+        metadata: %{openapi_operation_id: :remove_tag_sap_system}
 
       delete "/sap_systems/:id/hosts/:host_id/instances/:instance_number",
              SapSystemController,
@@ -160,11 +166,13 @@ defmodule TrentoWeb.Router do
 
       post "/databases/:id/tags", TagsController, :add_tag,
         assigns: %{resource_type: :database},
-        as: :databases_tagging
+        as: :databases_tagging,
+        metadata: %{openapi_operation_id: :add_tag_database}
 
       delete "/databases/:id/tags/:value", TagsController, :remove_tag,
         assigns: %{resource_type: :database},
-        as: :databases_tagging
+        as: :databases_tagging,
+        metadata: %{openapi_operation_id: :remove_tag_database}
 
       delete "/databases/:id/hosts/:host_id/instances/:instance_number",
              DatabaseController,
@@ -185,7 +193,9 @@ defmodule TrentoWeb.Router do
              :request_instance_operation
       end
 
-      resources "/users", UsersController, except: [:new, :edit]
+      resources "/users", UsersController, except: [:new, :edit, :update]
+      put "/users/:id", UsersController, :update, metadata: %{openapi_operation_id: :put_user}
+      patch "/users/:id", UsersController, :update, metadata: %{openapi_operation_id: :patch_user}
 
       scope "/profile" do
         get "/", ProfileController, :show
@@ -213,8 +223,13 @@ defmodule TrentoWeb.Router do
         scope "/suse_manager" do
           get "/", SettingsController, :get_suse_manager_settings
           post "/", SettingsController, :save_suse_manager_settings
-          patch "/", SettingsController, :update_suse_manager_settings
-          put "/", SettingsController, :update_suse_manager_settings
+
+          patch "/", SettingsController, :update_suse_manager_settings,
+            metadata: %{openapi_operation_id: :patch_suse_manager_settings}
+
+          put "/", SettingsController, :update_suse_manager_settings,
+            metadata: %{openapi_operation_id: :put_suse_manager_settings}
+
           delete "/", SettingsController, :delete_suse_manager_settings
           post "/test", SettingsController, :test_suse_manager_settings
         end

--- a/test/trento_web/openapi/api_spec_test.exs
+++ b/test/trento_web/openapi/api_spec_test.exs
@@ -18,7 +18,17 @@ defmodule TrentoWeb.OpenApi.ApiSpecTest do
 
     scope "/api" do
       get "/not_versioned", TestController, :show
-      get "/v1/route", TestController, :show
+
+      get "/v1/route", TestController, :show,
+        metadata: %{
+          openapi_operation_id: :alias_id
+        }
+
+      get "/v1/route/:id/value", TestController, :show,
+        metadata: %{
+          openapi_operation_id: :alias_with_value
+        }
+
       get "/v2/route", TestController, :show
     end
 
@@ -38,7 +48,11 @@ defmodule TrentoWeb.OpenApi.ApiSpecTest do
   describe "ApiSpec" do
     test "should render only the v1 version routes" do
       assert %OpenApiSpex.OpenApi{
-               paths: %{"/api/not_versioned" => _, "/api/v1/route" => _}
+               paths: %{
+                 "/api/not_versioned" => _,
+                 "/api/v1/route" => _,
+                 "/api/v1/route/{id}/value" => _
+               }
              } = V1.spec(TestRouter)
     end
 
@@ -46,6 +60,24 @@ defmodule TrentoWeb.OpenApi.ApiSpecTest do
       assert %OpenApiSpex.OpenApi{
                paths: %{"/api/not_versioned" => _, "/api/v2/route" => _}
              } = V2.spec(TestRouter)
+    end
+
+    test "should alias open api operationId using metadata alias" do
+      assert %OpenApiSpex.OpenApi{
+               paths: %{
+                 "/api/v1/route" => %{
+                   get: %{operationId: "TrentoWeb.OpenApi.ApiSpecTest.TestController.alias_id"}
+                 },
+                 "/api/v1/route/{id}/value" => %{
+                   get: %{
+                     operationId: "TrentoWeb.OpenApi.ApiSpecTest.TestController.alias_with_value"
+                   }
+                 },
+                 "/api/not_versioned" => %{
+                   get: %{operationId: "TrentoWeb.OpenApi.ApiSpecTest.TestController.show"}
+                 }
+               }
+             } = V1.spec(TestRouter)
     end
   end
 end

--- a/test/trento_web/openapi/api_spec_test.exs
+++ b/test/trento_web/openapi/api_spec_test.exs
@@ -62,7 +62,7 @@ defmodule TrentoWeb.OpenApi.ApiSpecTest do
              } = V2.spec(TestRouter)
     end
 
-    test "should alias open api operationId using metadata alias" do
+    test "should alias operationId using metadata alias" do
       assert %OpenApiSpex.OpenApi{
                paths: %{
                  "/api/v1/route" => %{


### PR DESCRIPTION
# Description

The openapi opeartion ID must be unique for all the routes. Even though elixir `open_api_spex` creates unique IDs, the format used to distinguish between entries with multiple occurrences doesn't comply with all the openapi linters.

It add a `(n)` (`n` being the occurrence) as suffix to the operation ID. Like this: 
`TrentoWeb.V1.SettingsController.update_suse_manager_settings (2)`

This doesn't comply the [operation-operationid-valid-in-url](https://quobix.com/vacuum/rules/operations/operation-operationid-valid-in-url) linter entry.

This PR adds the option to alias the operation ID in the router code itself, for each entry. It uses the `metadata` option, and I have added a custom `openapi_operation_id` value that will replace the predefined value.

## How was this tested?

UT and open checks with `./hack/api_docs_check.sh`
