### PR TITLE
[TRNT-3845] Publish merged API docs in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,8 +141,17 @@ jobs:
           key: erlang-${{ steps.setup-elixir.outputs.otp-version }}-elixir-${{ steps.setup-elixir.outputs.elixir-version }}-${{ hashFiles('mix.lock') }}-${{ env.MIX_ENV }}
       - name: Build docs
         uses: lee-dohm/generate-elixir-docs@v1
-      - name: Generate openapi.json
-        run: mix openapi.spec.json --start-app=false --spec TrentoWeb.OpenApi.V1.ApiSpec
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODEJS_VERSION }}
+      - name: Install API linting tools
+        run: |
+          npm install -g @redocly/cli@latest
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Run API docs merge script
+        run: ./hack/api_docs_check.sh --join-only
       - name: Generate Swagger UI
         uses: Legion2/swagger-ui-action@v1
         with:

--- a/hack/api_docs_check.sh
+++ b/hack/api_docs_check.sh
@@ -16,6 +16,7 @@
 #
 # Options:
 #   -s, --skip    Skip API docs generation and merging (lint only)
+#   -j, --join-only  Only generate and merge specs (skip all linting)
 #   -h, --help    Show this help message
 #
 # Requirements:


### PR DESCRIPTION
# Description

This PR updates the script we have to run the linters and adds a "join-only" option. This approach is now used by CI, so, instead of `mix openapi.spec.json --start-app=false --spec TrentoWeb.OpenApi.V1.ApiSpec` (which only generates the V1 docs), it now delegates the generation to the script. This script yields an `openapi.json` file, combining all the specs in a single file.

Related # TRNT-3845

See https://github.com/trento-project/wanda/pull/649

## How was this tested?

N/A