### PR TITLE
Fixes nodejs references in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -371,8 +371,6 @@ jobs:
       matrix:
         containers: [1, 2, 3, 4, 5, 6, 7, 8]
         include:
-          - elixir: "1.15"
-            otp: "26"
           - elixir: "1.18"
             otp: "27"
     env:


### PR DESCRIPTION
# Description

Reads from env nodejs version. Uses nodejs version 22 for everything except FE tests (where we use both 20 and 22). Improves cache keys by unifying references in favour of the env var.