### PR TITLE
Show and revoke personal access token in user edition view

### DIFF
--- a/assets/js/lib/api/users.js
+++ b/assets/js/lib/api/users.js
@@ -15,6 +15,9 @@ export const editUser = (userID, payload, version) =>
 
 export const deleteUser = (userID) => del(`/users/${userID}`);
 
+export const deleteUserAccessToken = (userID, jti) =>
+  del(`/users/${userID}/tokens/${jti}`);
+
 export const getUserProfile = () => get('/profile');
 
 export const editUserProfile = (payload) => patch('/profile', payload);

--- a/assets/js/pages/Users/EditUserPage.jsx
+++ b/assets/js/pages/Users/EditUserPage.jsx
@@ -5,11 +5,12 @@ import { toast } from 'react-hot-toast';
 import BackButton from '@common/BackButton';
 import Banner from '@common/Banners/Banner';
 import PageHeader from '@common/PageHeader';
+import PersonalAccessTokens from '@common/PersonalAccessTokens';
 
 import { isAdmin } from '@lib/model/users';
 import { isSingleSignOnEnabled } from '@lib/auth/config';
 
-import { editUser, getUser } from '@lib/api/users';
+import { editUser, getUser, deleteUserAccessToken } from '@lib/api/users';
 import { getAnalyticsEnabledConfig } from '@lib/analytics';
 
 import { fetchAbilities } from './CreateUserPage';
@@ -75,6 +76,18 @@ function EditUserPage() {
       });
   };
 
+  const onDeleteToken = (jti) => {
+    deleteUserAccessToken(userID, jti)
+      .then(() => {
+        const updatedTokens = userState.personal_access_tokens.filter(
+          (token) => token.jti !== jti
+        );
+        setUser({ ...userState, personal_access_tokens: updatedTokens });
+        toast.success('Personal access token deleted!');
+      })
+      .catch(() => toast.error('Error deleting personal access token.'));
+  };
+
   const onCancel = () => {
     navigate('/users');
   };
@@ -93,6 +106,7 @@ function EditUserPage() {
     username,
     enabled,
     abilities: userAbilities,
+    personal_access_tokens: personalAccessTokens,
     created_at: createdAt,
     updated_at: updatedAt,
     totp_enabled_at: totpEnabledAt,
@@ -132,6 +146,12 @@ function EditUserPage() {
         onCancel={onCancel}
         editing
         singleSignOnEnabled={isSingleSignOnEnabled()}
+      />
+      <PersonalAccessTokens
+        className="mt-4"
+        personalAccessTokens={personalAccessTokens}
+        generateTokenAvailable={false}
+        onDeleteToken={onDeleteToken}
       />
     </div>
   );

--- a/lib/trento/users/policy.ex
+++ b/lib/trento/users/policy.ex
@@ -12,8 +12,9 @@ defmodule Trento.Users.Policy do
   def authorize(action, %User{} = user, User) when action in [:index, :show],
     do: has_read_ability?(user)
 
-  def authorize(action, %User{} = user, User) when action in [:update, :delete, :create],
-    do: has_write_ability?(user)
+  def authorize(action, %User{} = user, User)
+      when action in [:update, :delete, :create, :revoke_personal_access_token],
+      do: has_write_ability?(user)
 
   def authorize(_, _, _), do: false
 

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -188,6 +188,7 @@ defmodule TrentoWeb.Router do
       resources "/users", UsersController, except: [:new, :edit, :update]
       patch "/users/:id", UsersController, :patch
       put "/users/:id", UsersController, :put
+      delete "/users/:id/tokens/:jti", UsersController, :revoke_personal_access_token
 
       scope "/profile" do
         get "/", ProfileController, :show

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -423,4 +423,39 @@ describe('Users', () => {
         });
     });
   });
+
+  describe('Edit user personal access tokens', () => {
+    beforeEach(() => {
+      usersPage.apiDeleteAllUsers();
+      usersPage.apiCreateUser();
+      basePage.apiLoginAndCreateSession();
+    });
+
+    it('should show an empty list of personal access tokens', () => {
+      usersPage.visit();
+      usersPage.clickNewUser();
+      usersPage.personalAccessTokensAreDisplayed([]);
+    });
+
+    it('should display personal access tokens created by selected user', () => {
+      usersPage.apiCreatePersonalAccessToken().then(({ name }) => {
+        usersPage.visit();
+        usersPage.clickNewUser();
+        usersPage.personalAccessTokensAreDisplayed([{ name }]);
+      });
+    });
+
+    it('should delete the user personal access token and revoke access to guarded resources', () => {
+      usersPage
+        .apiCreatePersonalAccessToken()
+        .then(({ access_token: token }) => {
+          usersPage.visit();
+          usersPage.clickNewUser();
+          usersPage.clickDeleteTokenButton();
+          usersPage.clickModalDeleteTokenButton();
+          usersPage.personalAccessTokensAreDisplayed([]);
+          usersPage.apiPersonalAccessTokenUnauthorized(token);
+        });
+    });
+  });
 });

--- a/test/trento/users/policy_test.exs
+++ b/test/trento/users/policy_test.exs
@@ -24,7 +24,7 @@ defmodule Trento.Users.PolicyTest do
   test "should allow write operations if the user has all:all ability" do
     user = %User{abilities: [%Ability{name: "all", resource: "all"}]}
 
-    Enum.each([:update, :create, :delete], fn action ->
+    Enum.each([:update, :create, :delete, :revoke_personal_access_token], fn action ->
       assert true == Policy.authorize(action, user, User)
     end)
   end
@@ -32,7 +32,7 @@ defmodule Trento.Users.PolicyTest do
   test "should allow write operations if the user has all:users ability" do
     user = %User{abilities: [%Ability{name: "all", resource: "all"}]}
 
-    Enum.each([:update, :create, :delete], fn action ->
+    Enum.each([:update, :create, :delete, :revoke_personal_access_token], fn action ->
       assert true == Policy.authorize(action, user, User)
     end)
   end
@@ -40,8 +40,11 @@ defmodule Trento.Users.PolicyTest do
   test "should disallow other abilities" do
     user = %User{abilities: [%Ability{name: "other", resource: "other"}]}
 
-    Enum.each([:update, :create, :index, :show, :delete], fn action ->
-      assert false == Policy.authorize(action, user, User)
-    end)
+    Enum.each(
+      [:update, :create, :index, :show, :delete, :revoke_personal_access_token],
+      fn action ->
+        assert false == Policy.authorize(action, user, User)
+      end
+    )
   end
 end


### PR DESCRIPTION
# Description

Add personal access token visualization and deletion options in the user edition view for user admins.
This actions are only available for users with `users:all` and `all:all`.

The deletion flow is the same as for tokens removed in the profile view.

![delete_token_admin](https://github.com/user-attachments/assets/6ffa4c9a-dac9-4798-ac4b-e6839d556822)

## How was this tested?

UT and e2e test.
I'm not adding UT in the frontend edit view. This is tested in the e2e tests
@vicenteqa Adding to the review, if you wanna give a look to the e2e tests. It is really simple, but at least you are aware of them. As the feature is almost identical to the one in the profile, most the functions can be reused safely.
