### PR TITLE
Add deprecated flag to operation and schemas

### DIFF
--- a/lib/trento_web/controllers/v1/cluster_controller.ex
+++ b/lib/trento_web/controllers/v1/cluster_controller.ex
@@ -44,6 +44,7 @@ defmodule TrentoWeb.V1.ClusterController do
 
   operation :list,
     summary: "List Pacemaker Clusters.",
+    deprecated: true,
     tags: ["Target Infrastructure"],
     description:
       "Retrieves a comprehensive list of all Pacemaker Clusters discovered on the target infrastructure, supporting monitoring and management tasks for administrators.",

--- a/lib/trento_web/openapi/v1/schema/cluster.ex
+++ b/lib/trento_web/openapi/v1/schema/cluster.ex
@@ -13,6 +13,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Cluster do
     OpenApiSpex.schema(
       %{
         title: "ClusterResource",
+        deprecated: true,
         description:
           "Represents a resource within a cluster, including its type, role, and operational status for management and monitoring.",
         type: :object,
@@ -42,6 +43,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Cluster do
     OpenApiSpex.schema(
       %{
         title: "HanaClusterNode",
+        deprecated: true,
         description:
           "Represents a node in a HANA cluster, including its attributes, status, and associated resources for high availability.",
         additionalProperties: false,
@@ -117,6 +119,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Cluster do
     OpenApiSpex.schema(
       %{
         title: "HanaClusterDetails",
+        deprecated: true,
         description:
           "Provides detailed information about a HANA Pacemaker Cluster, including replication, health, and resource status.",
         type: :object,
@@ -199,6 +202,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Cluster do
     OpenApiSpex.schema(
       %{
         title: "PacemakerClusterDetails",
+        deprecated: true,
         description:
           "Provides details about the detected PacemakerCluster, including configuration, health, and operational status.",
         type: :object,
@@ -238,6 +242,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Cluster do
     OpenApiSpex.schema(
       %{
         title: "PacemakerCluster",
+        deprecated: true,
         description:
           "Represents a Pacemaker Cluster discovered on the target infrastructure, including its configuration, health, and associated resources.",
         type: :object,
@@ -340,6 +345,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Cluster do
     OpenApiSpex.schema(
       %{
         title: "PacemakerClustersCollection",
+        deprecated: true,
         description:
           "A list containing all Pacemaker Clusters discovered on the target infrastructure, supporting monitoring and management.",
         type: :array,

--- a/lib/trento_web/openapi/v2/schema/cluster.ex
+++ b/lib/trento_web/openapi/v2/schema/cluster.ex
@@ -246,6 +246,7 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
           resources: %Schema{
             description:
               "A list of cluster resources associated with this HANA cluster, supporting infrastructure management.",
+            type: :array,
             items: ClusterResource
           }
         },
@@ -470,6 +471,7 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
           resources: %Schema{
             description:
               "A list of cluster resources associated with this ASCS/ERS cluster, supporting infrastructure management.",
+            type: :array,
             items: ClusterResource
           }
         },


### PR DESCRIPTION
# Description

Deprecate routes that have newer version of operations and the schemas associated to this version:
- `GET /api/v1/clusters`

PD: I have added the `object: :array` to a couple of schemas that were missing this property