### PR TITLE
CI Improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,12 @@ concurrency:
 
 env:
   MIX_ENV: test
+  elixir_dev: "1.18.4-otp-27"
+  erlang_dev: "27.1.3"
+  nodejs_dev: "22.15.1"
+  elixir_bc: "1.15.7-otp-26"
+  erlang_bc: "26.2.1"
+  nodejs_bc: "20.14.0"
 
 jobs:
   elixir-deps:
@@ -31,17 +37,17 @@ jobs:
       matrix:
         include:
           - mix_env: dev
-            elixir: "1.15"
-            otp: "26"
+            elixir: ${{ env.elixir_bc }}
+            otp: ${{ env.erlang_bc }}
           - mix_env: dev
-            elixir: "1.18"
-            otp: "27"
+            elixir: ${{ env.elixir_dev }}
+            otp: ${{ env.erlang_dev }}
           - mix_env: test
-            elixir: "1.15"
-            otp: "26"
+            elixir: ${{ env.elixir_bc }}
+            otp: ${{ env.erlang_bc }}
           - mix_env: test
-            elixir: "1.18"
-            otp: "27"
+            elixir: ${{ env.elixir_dev }}
+            otp: ${{ env.erlang_dev }}
     env:
       MIX_ENV: ${{ matrix.mix_env }}
     steps:
@@ -80,24 +86,25 @@ jobs:
     strategy:
       matrix:
         include:
-          - nodejs: "20"
-          - nodejs: "22"
+          - nodejs: ${{ env.nodejs_bc }}
+          - nodejs: ${{ env.nodejs_dev }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+      - name: Setup Node
+        id: setup-node
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ matrix.nodejs }}
       - name: Retrieve NPM Cached Dependencies
         uses: actions/cache@v4
         id: npm-cache
         with:
           path: |
             assets/node_modules
-          key: nodejs-${{ matrix.nodejs }}-${{ hashFiles('assets/package-lock.json') }}
-      - name: Setup Node
-        uses: actions/setup-node@v5
-        with:
-          node-version: ${{ matrix.nodejs }}
+          key: nodejs-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('assets/package-lock.json') }}
       - name: Install NPM dependencies
         if: steps.npm-cache.outputs.cache-hit != 'true'
         run: cd assets && npm install
@@ -164,12 +171,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: "1.15"
-            otp: "26"
-            nodejs: "20"
-          - elixir: "1.18"
-            otp: "27"
-            nodejs: "22"
+          - elixir: ${{ env.elixir_bc }}
+            otp: ${{ env.erlang_bc }}
+            nodejs: ${{ env.nodejs_bc }}
+          - elixir: ${{ env.elixir_dev }}
+            otp: ${{ env.erlang_dev }}
+            nodejs: ${{ env.nodejs_dev }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -182,6 +189,7 @@ jobs:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
       - name: Setup Node
+        id: setup-node
         uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.nodejs }}
@@ -200,7 +208,7 @@ jobs:
         with:
           path: |
             assets/node_modules
-          key: nodejs-${{ matrix.nodejs }}-${{ hashFiles('assets/package-lock.json') }}
+          key: nodejs-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('assets/package-lock.json') }}
       - name: Check for unused dependencies
         run: mix deps.unlock --check-unused
       - name: Check Code Format
@@ -221,14 +229,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - nodejs: "20"
-          - nodejs: "22"
+          - nodejs: ${{ env.nodejs_bc }}
+          - nodejs: ${{ env.nodejs_dev }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Setup Node
+        id: setup-node
         uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.nodejs }}
@@ -238,7 +247,7 @@ jobs:
         with:
           path: |
             assets/node_modules
-          key: nodejs-${{ matrix.nodejs }}-${{ hashFiles('assets/package-lock.json') }}
+          key: nodejs-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('assets/package-lock.json') }}
       - name: Run JS tests
         run: cd assets && npm test
 
@@ -249,10 +258,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: "1.15"
-            otp: "26"
-          - elixir: "1.18"
-            otp: "27"
+          - elixir: ${{ env.elixir_bc }}
+            otp: ${{ env.erlang_bc }}
+          - elixir: ${{ env.elixir_dev }}
+            otp: ${{ env.erlang_dev }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -289,8 +298,6 @@ jobs:
     name: Chromatic deployment
     needs: [elixir-deps, npm-deps]
     runs-on: ubuntu-24.04
-    env:
-      NODEJS_VERSION: "22"
     if: github.event_name != 'repository_dispatch' && github.secret_source != 'None' && vars.CHROMATIC_ENABLED == 'true'
     steps:
       - name: Checkout
@@ -304,9 +311,10 @@ jobs:
           otp-version: "27"
           elixir-version: "1.18"
       - name: Setup Node
+        id: setup-node
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ env.NODEJS_VERSION }}
+          node-version: ${{ env.nodejs_dev }}
       - name: Retrieve Elixir Cached Dependencies
         uses: actions/cache@v4
         id: mix-cache
@@ -322,7 +330,7 @@ jobs:
         with:
           path: |
             assets/node_modules
-          key: nodejs-${{ env.NODEJS_VERSION }}-${{ hashFiles('assets/package-lock.json') }}
+          key: nodejs-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('assets/package-lock.json') }}
       - name: Build CSS
         run: npx tailwindcss --input=css/app.css --output=../priv/static/assets/app.css --postcss
         working-directory: assets
@@ -340,24 +348,23 @@ jobs:
   npm-e2e-deps:
     name: Npm E2E dependencies
     runs-on: ubuntu-24.04
-    env:
-      NODEJS_VERSION: "22"
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+      - name: Setup Node
+        id: setup-node
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.nodejs_dev }}
       - name: Retrieve E2E NPM Cached Dependencies
         uses: actions/cache@v4
         id: npm-e2e-cache
         with:
           path: |
             test/e2e/node_modules
-          key: nodejs-${{ env.NODEJS_VERSION }}-${{ hashFiles('test/e2e/package-lock.json') }}
-      - name: Setup Node
-        uses: actions/setup-node@v5
-        with:
-          node-version: ${{ env.NODEJS_VERSION }}
+          key: nodejs-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('test/e2e/package-lock.json') }}
       - name: Install E2E NPM dependencies
         if: steps.npm-e2e-cache.outputs.cache-hit != 'true'
         run: cd test/e2e && npm install
@@ -371,11 +378,10 @@ jobs:
       matrix:
         containers: [1, 2, 3, 4, 5, 6, 7, 8]
         include:
-          - elixir: "1.18"
-            otp: "27"
+          - elixir: ${{ env.elixir_dev }}
+            otp: ${{ env.erlang_dev }}
     env:
       MIX_ENV: dev
-      NODEJS_VERSION: "22"
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -388,9 +394,10 @@ jobs:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
       - name: Setup Node
+        id: setup-node
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ env.NODEJS_VERSION }}
+          node-version: ${{ env.nodejs_dev }}
       - name: Retrieve Elixir Cached Dependencies
         uses: actions/cache@v4
         id: mix-cache
@@ -406,14 +413,14 @@ jobs:
         with:
           path: |
             assets/node_modules
-          key: nodejs-${{ env.NODEJS_VERSION }}-${{ hashFiles('assets/package-lock.json') }}
+          key: nodejs-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('assets/package-lock.json') }}
       - name: Retrieve E2E NPM Cached Dependencies
         uses: actions/cache@v4
         id: npm-e2e-cache
         with:
           path: |
             test/e2e/node_modules
-          key: nodejs-${{ env.NODEJS_VERSION }}-${{ hashFiles('test/e2e/package-lock.json') }}
+          key: nodejs-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('test/e2e/package-lock.json') }}
       - name: Check Eslint and JS Code Format
         run: cd test/e2e && npm run lint && npm run format:check
       - name: "Docker compose dependencies"
@@ -469,7 +476,6 @@ jobs:
               cypress/e2e/host_details.cy.js
     env:
       MIX_ENV: dev
-      NODEJS_VERSION: "22"
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -482,9 +488,10 @@ jobs:
           version-file: .tool-versions
           version-type: strict
       - name: Setup Node
+        id: setup-node
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ env.NODEJS_VERSION }}
+          node-version: ${{ env.nodejs_dev }}
       - name: Retrieve Elixir Cached Dependencies
         uses: actions/cache@v4
         id: mix-cache
@@ -500,14 +507,14 @@ jobs:
         with:
           path: |
             assets/node_modules
-          key: nodejs-${{ env.NODEJS_VERSION }}-${{ hashFiles('assets/package-lock.json') }}
+          key: nodejs-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('assets/package-lock.json') }}
       - name: Retrieve E2E NPM Cached Dependencies
         uses: actions/cache@v4
         id: npm-e2e-cache
         with:
           path: |
             test/e2e/node_modules
-          key: nodejs-${{ env.NODEJS_VERSION }}-${{ hashFiles('test/e2e/package-lock.json') }}
+          key: nodejs-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('test/e2e/package-lock.json') }}
       - name: "Docker compose dependencies"
         uses: isbang/compose-action@v2.3.0
         with:
@@ -575,7 +582,7 @@ jobs:
               MIX_ENV: dev
               CYPRESS_SSO_INTEGRATION_TESTS: true
               CYPRESS_SSO_TYPE: oidc
-              NODEJS_VERSION: "22"
+              NODEJS_VERSION: ${{ env.nodejs_dev }}
           - test: oauth2
             cypress_spec: |
               cypress/e2e/sso_integration.cy.js
@@ -587,7 +594,7 @@ jobs:
               MIX_ENV: dev
               CYPRESS_SSO_INTEGRATION_TESTS: true
               CYPRESS_SSO_TYPE: oauth2
-              NODEJS_VERSION: "22"
+              NODEJS_VERSION: ${{ env.nodejs_dev }}
           - test: saml
             cypress_spec: |
               cypress/e2e/sso_integration.cy.js
@@ -599,7 +606,7 @@ jobs:
               MIX_ENV: dev
               CYPRESS_SSO_INTEGRATION_TESTS: true
               CYPRESS_SSO_TYPE: saml
-              NODEJS_VERSION: "22"
+              NODEJS_VERSION: ${{ env.nodejs_dev }}
           - test: alerting_db
             cypress_spec: |
               cypress/e2e/settings_integration.cy.js
@@ -617,14 +624,14 @@ jobs:
               MIX_ENV: dev
               CYPRESS_ALERTING_DB_TESTS: true
               CYPRESS_ALERTING_TESTS: true
-              NODEJS_VERSION: "22"
+              NODEJS_VERSION: ${{ env.nodejs_dev }}
           - test: alerting_from_env
             cypress_spec: |
               cypress/e2e/alerting.cy.js
             env:
               MIX_ENV: dev
               CYPRESS_ALERTING_TESTS: true
-              NODEJS_VERSION: "22"
+              NODEJS_VERSION: ${{ env.nodejs_dev }}
     env: ${{ matrix.env }}
     steps:
       - name: Checkout
@@ -638,6 +645,7 @@ jobs:
           version-file: .tool-versions
           version-type: strict
       - name: Setup Node
+        id: setup-node
         uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODEJS_VERSION }}
@@ -656,14 +664,14 @@ jobs:
         with:
           path: |
             assets/node_modules
-          key: nodejs-${{ env.NODEJS_VERSION }}-${{ hashFiles('assets/package-lock.json') }}
+          key: nodejs-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('assets/package-lock.json') }}
       - name: Retrieve E2E NPM Cached Dependencies
         uses: actions/cache@v4
         id: npm-e2e-cache
         with:
           path: |
             test/e2e/node_modules
-          key: nodejs-${{ env.NODEJS_VERSION }}-${{ hashFiles('test/e2e/package-lock.json') }}
+          key: nodejs-${{steps.setup-node.outputs.node-version }}-${{ hashFiles('test/e2e/package-lock.json') }}
       - name: Install photofinish
         uses: jaxxstorm/action-install-gh-release@v2.1.0
         with:
@@ -672,7 +680,7 @@ jobs:
           cache: enable
           chmod: +x
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}        
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Docker compose dependencies"
         uses: isbang/compose-action@v2.3.0
         with:
@@ -708,10 +716,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: "1.15"
-            otp: "26"
-          - elixir: "1.18"
-            otp: "27"
+          - elixir: ${{ env.elixir_bc }}
+            otp: ${{ env.erlang_bc }}
+          - elixir: ${{ env.elixir_dev }}
+            otp: ${{ env.erlang_dev }}
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout target branch
@@ -751,12 +759,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: "1.15"
-            otp: "26"
-          - elixir: "1.18"
-            otp: "27"
-    env:
-      NODEJS_VERSION: "22"
+          - elixir: ${{ env.elixir_bc }}
+            otp: ${{ env.erlang_bc }}
+          - elixir: ${{ env.elixir_dev }}
+            otp: ${{ env.erlang_dev }}
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1
@@ -782,9 +788,10 @@ jobs:
             priv/plts
           key: erlang-${{ steps.setup-elixir.outputs.otp-version }}-elixir-${{ steps.setup-elixir.outputs.elixir-version }}-${{ hashFiles('mix.lock') }}-${{ env.MIX_ENV }}
       - name: Setup Node.js
+        id: setup-node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODEJS_VERSION }}
+          node-version: ${{ env.nodejs_dev }}
       - name: Install API linting tools
         run: |
           npm install -g @redocly/cli@latest
@@ -802,23 +809,23 @@ jobs:
       matrix:
         include:
           - version: Unversioned
-            elixir: "1.15"
-            otp: "26"
+            elixir: ${{ env.elixir_bc }}
+            otp: ${{ env.erlang_bc }}
           - version: Unversioned
-            elixir: "1.18"
-            otp: "27"
+            elixir: ${{ env.elixir_dev }}
+            otp: ${{ env.erlang_dev }}
           - version: V1
-            elixir: "1.15"
-            otp: "26"
+            elixir: ${{ env.elixir_bc }}
+            otp: ${{ env.erlang_bc }}
           - version: V1
-            elixir: "1.18"
-            otp: "27"
+            elixir: ${{ env.elixir_dev }}
+            otp: ${{ env.erlang_dev }}
           - version: V2
-            elixir: "1.15"
-            otp: "26"
+            elixir: ${{ env.elixir_bc }}
+            otp: ${{ env.erlang_bc }}
           - version: V2
-            elixir: "1.18"
-            otp: "27"
+            elixir: ${{ env.elixir_dev }}
+            otp: ${{ env.erlang_dev }}
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -318,7 +318,7 @@ jobs:
 
   chromatic:
     name: Chromatic deployment
-    needs: [elixir-deps, npm-deps]
+    needs: [setup-matrix-env, elixir-deps, npm-deps]
     runs-on: ubuntu-24.04
     if: github.event_name != 'repository_dispatch' && github.secret_source != 'None' && vars.CHROMATIC_ENABLED == 'true'
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,7 @@ jobs:
 
   elixir-deps:
     name: Elixir ${{ matrix.mix_env }} dependencies
+    needs: [setup-matrix-env]
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -733,6 +733,7 @@ jobs:
 
   target-branch-deps:
     name: Rebuild target branch dependencies
+    needs: [setup-matrix-env]
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -246,7 +246,7 @@ jobs:
 
   test-javascript:
     name: Javascript tests
-    needs: npm-deps
+    needs: [setup-matrix-env, npm-deps]
     runs-on: ubuntu-24.04
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,9 +30,9 @@ jobs:
   setup-matrix-env:
     runs-on: ubuntu-24.04
     outputs:
-      ELIXIR_DEV: ${{ env.ELIXIR_DEV }}
-      ERLANG_DEV: ${{ env.ERLANG_DEV }}
-      NODEJS_DEV: ${{ env.NODEJS_DEV }}
+      ELIXIR_DEV: ${{ env.ELIXIR_VERSION }}
+      ERLANG_DEV: ${{ env.ERLANG_VERSION }}
+      NODEJS_DEV: ${{ env.NODEJS_VERSION }}
       ELIXIR_BC: ${{ env.ELIXIR_BC }}
       ERLANG_BC: ${{ env.ERLANG_BC }}
       NODEJS_BC: ${{ env.NODEJS_BC }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,14 +22,34 @@ concurrency:
 
 env:
   MIX_ENV: test
-  elixir_dev: "1.18.4-otp-27"
-  erlang_dev: "27.1.3"
-  nodejs_dev: "22.15.1"
-  elixir_bc: "1.15.7-otp-26"
-  erlang_bc: "26.2.1"
-  nodejs_bc: "20.14.0"
+  ELIXIR_DEV: "1.18.4-otp-27"
+  ERLANG_DEV: "27.1.3"
+  NODEJS_DEV: "22.15.1"
+  ELIXIR_BC: "1.15.7-otp-26"
+  ERLANG_BC: "26.2.1"
+  NODEJS_BC: "20.14.0"
 
 jobs:
+  setup-matrix-env:
+    runs-on: ubuntu-24.04
+    outputs:
+      ELIXIR_DEV: ${{ env.ELIXIR_DEV }}
+      ERLANG_DEV: ${{ env.ERLANG_DEV }}
+      NODEJS_DEV: ${{ env.NODEJS_DEV }}
+      ELIXIR_BC: ${{ env.ELIXIR_BC }}
+      ERLANG_BC: ${{ env.ERLANG_BC }}
+      NODEJS_BC: ${{ env.NODEJS_BC }}
+    steps:
+      - name: Compute matrix
+        run: |
+          echo "ELIXIR_DEV=${{ env.ELIXIR_DEV }}" >> $GITHUB_OUTPUT
+          echo "ERLANG_DEV=${{ env.ERLANG_DEV }}" >> $GITHUB_OUTPUT
+          echo "NODEJS_DEV=${{ env.NODEJS_DEV }}" >> $GITHUB_OUTPUT
+          echo "ELIXIR_BC=${{ env.ELIXIR_BC }}" >> $GITHUB_OUTPUT
+          echo "ERLANG_BC=${{ env.ERLANG_BC }}" >> $GITHUB_OUTPUT
+          echo "NODEJS_BC=${{ env.NODEJS_BC }}" >> $GITHUB_OUTPUT
+
+
   elixir-deps:
     name: Elixir ${{ matrix.mix_env }} dependencies
     runs-on: ubuntu-24.04
@@ -37,17 +57,17 @@ jobs:
       matrix:
         include:
           - mix_env: dev
-            elixir: ${{ env.elixir_bc }}
-            otp: ${{ env.erlang_bc }}
+            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
           - mix_env: dev
-            elixir: ${{ env.elixir_dev }}
-            otp: ${{ env.erlang_dev }}
+            otp: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
           - mix_env: test
-            elixir: ${{ env.elixir_bc }}
-            otp: ${{ env.erlang_bc }}
+            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
           - mix_env: test
-            elixir: ${{ env.elixir_dev }}
-            otp: ${{ env.erlang_dev }}
+            otp: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     env:
       MIX_ENV: ${{ matrix.mix_env }}
     steps:
@@ -86,8 +106,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - nodejs: ${{ env.nodejs_bc }}
-          - nodejs: ${{ env.nodejs_dev }}
+          - nodejs: ${{ needs.setup-matrix-env.outputs.NODEJS_BC }}
+          - nodejs: ${{ needs.setup-matrix-env.outputs.NODEJS_DEV }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -171,12 +191,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: ${{ env.elixir_bc }}
-            otp: ${{ env.erlang_bc }}
-            nodejs: ${{ env.nodejs_bc }}
-          - elixir: ${{ env.elixir_dev }}
-            otp: ${{ env.erlang_dev }}
-            nodejs: ${{ env.nodejs_dev }}
+          - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
+            nodejs: ${{ needs.setup-matrix-env.outputs.NODEJS_BC }}
+          - otp: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
+            nodejs: ${{ needs.setup-matrix-env.outputs.NODEJS_DEV }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -229,8 +249,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - nodejs: ${{ env.nodejs_bc }}
-          - nodejs: ${{ env.nodejs_dev }}
+          - nodejs: ${{ needs.setup-matrix-env.outputs.NODEJS_BC }}
+          - nodejs: ${{ needs.setup-matrix-env.outputs.NODEJS_DEV }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -258,10 +278,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: ${{ env.elixir_bc }}
-            otp: ${{ env.erlang_bc }}
-          - elixir: ${{ env.elixir_dev }}
-            otp: ${{ env.erlang_dev }}
+          - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
+          - otp: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -378,8 +398,8 @@ jobs:
       matrix:
         containers: [1, 2, 3, 4, 5, 6, 7, 8]
         include:
-          - elixir: ${{ env.elixir_dev }}
-            otp: ${{ env.erlang_dev }}
+          - otp: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     env:
       MIX_ENV: dev
     steps:
@@ -716,10 +736,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: ${{ env.elixir_bc }}
-            otp: ${{ env.erlang_bc }}
-          - elixir: ${{ env.elixir_dev }}
-            otp: ${{ env.erlang_dev }}
+          - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
+          - otp: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout target branch
@@ -759,10 +779,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: ${{ env.elixir_bc }}
-            otp: ${{ env.erlang_bc }}
-          - elixir: ${{ env.elixir_dev }}
-            otp: ${{ env.erlang_dev }}
+          - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
+          - otp: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1
@@ -809,23 +829,23 @@ jobs:
       matrix:
         include:
           - version: Unversioned
-            elixir: ${{ env.elixir_bc }}
-            otp: ${{ env.erlang_bc }}
+            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
           - version: Unversioned
-            elixir: ${{ env.elixir_dev }}
-            otp: ${{ env.erlang_dev }}
+            otp: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
           - version: V1
-            elixir: ${{ env.elixir_bc }}
-            otp: ${{ env.erlang_bc }}
+            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
           - version: V1
-            elixir: ${{ env.elixir_dev }}
-            otp: ${{ env.erlang_dev }}
+            otp: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
           - version: V2
-            elixir: ${{ env.elixir_bc }}
-            otp: ${{ env.erlang_bc }}
+            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
           - version: V2
-            elixir: ${{ env.elixir_dev }}
-            otp: ${{ env.erlang_dev }}
+            otp: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+            otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,13 +60,13 @@ jobs:
             elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
           - mix_env: dev
-            elixir: ${{ needs.setup-matrix-env.ELIXIR_DEV }}
+            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
           - mix_env: test
             elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
           - mix_env: test
-            elixir: ${{ needs.setup-matrix-env.ELIXIR_DEV }}
+            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     env:
       MIX_ENV: ${{ matrix.mix_env }}
@@ -157,8 +157,8 @@ jobs:
         id: setup-elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
-          elixir-version: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+          version-file: .tool-versions
+          version-type: strict
       - name: Retrieve Elixir Cached Dependencies
         uses: actions/cache@v4
         id: mix-cache
@@ -194,7 +194,7 @@ jobs:
           - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
             nodejs: ${{ needs.setup-matrix-env.outputs.NODEJS_BC }}
-          - elixir: ${{ needs.setup-matrix-env.ELIXIR_DEV }}
+          - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
             nodejs: ${{ needs.setup-matrix-env.outputs.NODEJS_DEV }}
     steps:
@@ -280,7 +280,7 @@ jobs:
         include:
           - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
-          - elixir: ${{ needs.setup-matrix-env.ELIXIR_DEV }}
+          - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     steps:
       - name: Checkout
@@ -398,7 +398,7 @@ jobs:
       matrix:
         containers: [1, 2, 3, 4, 5, 6, 7, 8]
         include:
-          - elixir: ${{ needs.setup-matrix-env.ELIXIR_DEV }}
+          - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     env:
       MIX_ENV: dev
@@ -505,8 +505,8 @@ jobs:
         id: setup-elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
-          elixir-version: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+          version-file: .tool-versions
+          version-type: strict
       - name: Setup Node
         id: setup-node
         uses: actions/setup-node@v5
@@ -662,8 +662,8 @@ jobs:
         id: setup-elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
-          elixir-version: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+          version-file: .tool-versions
+          version-type: strict
       - name: Setup Node
         id: setup-node
         uses: actions/setup-node@v5
@@ -738,7 +738,7 @@ jobs:
         include:
           - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
-          - elixir: ${{ needs.setup-matrix-env.ELIXIR_DEV }}
+          - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     if: github.event_name == 'pull_request'
     steps:
@@ -781,7 +781,7 @@ jobs:
         include:
           - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
-          - elixir: ${{ needs.setup-matrix-env.ELIXIR_DEV }}
+          - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     steps:
       - name: Cancel Previous Runs
@@ -832,19 +832,19 @@ jobs:
             elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
           - version: Unversioned
-            elixir: ${{ needs.setup-matrix-env.ELIXIR_DEV }}
+            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
           - version: V1
             elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
           - version: V1
-            elixir: ${{ needs.setup-matrix-env.ELIXIR_DEV }}
+            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
           - version: V2
             elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
           - version: V2
-            elixir: ${{ needs.setup-matrix-env.ELIXIR_DEV }}
+            elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     steps:
       - name: Checkout current branch

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,13 +60,13 @@ jobs:
             elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
           - mix_env: dev
-            otp: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+            elixir: ${{ needs.setup-matrix-env.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
           - mix_env: test
             elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
           - mix_env: test
-            otp: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+            elixir: ${{ needs.setup-matrix-env.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     env:
       MIX_ENV: ${{ matrix.mix_env }}
@@ -157,8 +157,8 @@ jobs:
         id: setup-elixir
         uses: erlef/setup-beam@v1
         with:
-          version-file: .tool-versions
-          version-type: strict
+          otp-version: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
+          elixir-version: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
       - name: Retrieve Elixir Cached Dependencies
         uses: actions/cache@v4
         id: mix-cache
@@ -194,7 +194,7 @@ jobs:
           - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
             nodejs: ${{ needs.setup-matrix-env.outputs.NODEJS_BC }}
-          - otp: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+          - elixir: ${{ needs.setup-matrix-env.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
             nodejs: ${{ needs.setup-matrix-env.outputs.NODEJS_DEV }}
     steps:
@@ -280,7 +280,7 @@ jobs:
         include:
           - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
-          - otp: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+          - elixir: ${{ needs.setup-matrix-env.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     steps:
       - name: Checkout
@@ -334,7 +334,7 @@ jobs:
         id: setup-node
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ env.nodejs_dev }}
+          node-version: ${{ needs.setup-matrix-env.outputs.NODEJS_DEV }}
       - name: Retrieve Elixir Cached Dependencies
         uses: actions/cache@v4
         id: mix-cache
@@ -377,7 +377,7 @@ jobs:
         id: setup-node
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ env.nodejs_dev }}
+          node-version: ${{ needs.setup-matrix-env.outputs.NODEJS_DEV }}
       - name: Retrieve E2E NPM Cached Dependencies
         uses: actions/cache@v4
         id: npm-e2e-cache
@@ -398,7 +398,7 @@ jobs:
       matrix:
         containers: [1, 2, 3, 4, 5, 6, 7, 8]
         include:
-          - otp: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+          - elixir: ${{ needs.setup-matrix-env.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     env:
       MIX_ENV: dev
@@ -417,7 +417,7 @@ jobs:
         id: setup-node
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ env.nodejs_dev }}
+          node-version: ${{ needs.setup-matrix-env.outputs.NODEJS_DEV }}
       - name: Retrieve Elixir Cached Dependencies
         uses: actions/cache@v4
         id: mix-cache
@@ -505,13 +505,13 @@ jobs:
         id: setup-elixir
         uses: erlef/setup-beam@v1
         with:
-          version-file: .tool-versions
-          version-type: strict
+          otp-version: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
+          elixir-version: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
       - name: Setup Node
         id: setup-node
         uses: actions/setup-node@v5
         with:
-          node-version: ${{ env.nodejs_dev }}
+          node-version: ${{ needs.setup-matrix-env.outputs.NODEJS_DEV }}
       - name: Retrieve Elixir Cached Dependencies
         uses: actions/cache@v4
         id: mix-cache
@@ -602,7 +602,7 @@ jobs:
               MIX_ENV: dev
               CYPRESS_SSO_INTEGRATION_TESTS: true
               CYPRESS_SSO_TYPE: oidc
-              NODEJS_VERSION: ${{ env.nodejs_dev }}
+              NODEJS_VERSION: ${{ needs.setup-matrix-env.outputs.NODEJS_DEV }}
           - test: oauth2
             cypress_spec: |
               cypress/e2e/sso_integration.cy.js
@@ -614,7 +614,7 @@ jobs:
               MIX_ENV: dev
               CYPRESS_SSO_INTEGRATION_TESTS: true
               CYPRESS_SSO_TYPE: oauth2
-              NODEJS_VERSION: ${{ env.nodejs_dev }}
+              NODEJS_VERSION: ${{ needs.setup-matrix-env.outputs.NODEJS_DEV }}
           - test: saml
             cypress_spec: |
               cypress/e2e/sso_integration.cy.js
@@ -626,7 +626,7 @@ jobs:
               MIX_ENV: dev
               CYPRESS_SSO_INTEGRATION_TESTS: true
               CYPRESS_SSO_TYPE: saml
-              NODEJS_VERSION: ${{ env.nodejs_dev }}
+              NODEJS_VERSION: ${{ needs.setup-matrix-env.outputs.NODEJS_DEV }}
           - test: alerting_db
             cypress_spec: |
               cypress/e2e/settings_integration.cy.js
@@ -644,14 +644,14 @@ jobs:
               MIX_ENV: dev
               CYPRESS_ALERTING_DB_TESTS: true
               CYPRESS_ALERTING_TESTS: true
-              NODEJS_VERSION: ${{ env.nodejs_dev }}
+              NODEJS_VERSION: ${{ needs.setup-matrix-env.outputs.NODEJS_DEV }}
           - test: alerting_from_env
             cypress_spec: |
               cypress/e2e/alerting.cy.js
             env:
               MIX_ENV: dev
               CYPRESS_ALERTING_TESTS: true
-              NODEJS_VERSION: ${{ env.nodejs_dev }}
+              NODEJS_VERSION: ${{ needs.setup-matrix-env.outputs.NODEJS_DEV }}
     env: ${{ matrix.env }}
     steps:
       - name: Checkout
@@ -662,8 +662,8 @@ jobs:
         id: setup-elixir
         uses: erlef/setup-beam@v1
         with:
-          version-file: .tool-versions
-          version-type: strict
+          otp-version: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
+          elixir-version: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
       - name: Setup Node
         id: setup-node
         uses: actions/setup-node@v5
@@ -738,7 +738,7 @@ jobs:
         include:
           - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
-          - otp: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+          - elixir: ${{ needs.setup-matrix-env.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     if: github.event_name == 'pull_request'
     steps:
@@ -781,7 +781,7 @@ jobs:
         include:
           - elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
-          - otp: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+          - elixir: ${{ needs.setup-matrix-env.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     steps:
       - name: Cancel Previous Runs
@@ -811,7 +811,7 @@ jobs:
         id: setup-node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.nodejs_dev }}
+          node-version: ${{ needs.setup-matrix-env.outputs.NODEJS_DEV }}
       - name: Install API linting tools
         run: |
           npm install -g @redocly/cli@latest
@@ -832,19 +832,19 @@ jobs:
             elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
           - version: Unversioned
-            otp: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+            elixir: ${{ needs.setup-matrix-env.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
           - version: V1
             elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
           - version: V1
-            otp: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+            elixir: ${{ needs.setup-matrix-env.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
           - version: V2
             elixir: ${{ needs.setup-matrix-env.outputs.ELIXIR_BC }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_BC }}
           - version: V2
-            otp: ${{ needs.setup-matrix-env.outputs.ELIXIR_DEV }}
+            elixir: ${{ needs.setup-matrix-env.ELIXIR_DEV }}
             otp: ${{ needs.setup-matrix-env.outputs.ERLANG_DEV }}
     steps:
       - name: Checkout current branch

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,6 +103,7 @@ jobs:
 
   npm-deps:
     name: Npm dependencies
+    needs: [setup-matrix-env]
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -368,6 +369,7 @@ jobs:
 
   npm-e2e-deps:
     name: Npm E2E dependencies
+    needs: [setup-matrix-env]
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,6 @@ concurrency:
 
 env:
   MIX_ENV: test
-  ELIXIR_DEV: "1.18.4-otp-27"
-  ERLANG_DEV: "27.1.3"
-  NODEJS_DEV: "22.15.1"
   ELIXIR_BC: "1.15.7-otp-26"
   ERLANG_BC: "26.2.1"
   NODEJS_BC: "20.14.0"
@@ -40,11 +37,15 @@ jobs:
       ERLANG_BC: ${{ env.ERLANG_BC }}
       NODEJS_BC: ${{ env.NODEJS_BC }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: gather versions
+        uses: endorama/asdf-parse-tool-versions@v1
       - name: Compute matrix
         run: |
-          echo "ELIXIR_DEV=${{ env.ELIXIR_DEV }}" >> $GITHUB_OUTPUT
-          echo "ERLANG_DEV=${{ env.ERLANG_DEV }}" >> $GITHUB_OUTPUT
-          echo "NODEJS_DEV=${{ env.NODEJS_DEV }}" >> $GITHUB_OUTPUT
+          echo "ELIXIR_DEV=${{ env.ELIXIR_VERSION }}" >> $GITHUB_OUTPUT
+          echo "ERLANG_DEV=${{ env.ERLANG_VERSION }}" >> $GITHUB_OUTPUT
+          echo "NODEJS_DEV=${{ env.NODEJS_VERSION }}" >> $GITHUB_OUTPUT
           echo "ELIXIR_BC=${{ env.ELIXIR_BC }}" >> $GITHUB_OUTPUT
           echo "ERLANG_BC=${{ env.ERLANG_BC }}" >> $GITHUB_OUTPUT
           echo "NODEJS_BC=${{ env.NODEJS_BC }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -187,7 +187,7 @@ jobs:
 
   static-code-analysis:
     name: Static Code Analysis
-    needs: [elixir-deps, npm-deps]
+    needs: [setup-matrix-env, elixir-deps, npm-deps]
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -274,7 +274,7 @@ jobs:
 
   test-elixir:
     name: Elixir tests
-    needs: [elixir-deps]
+    needs: [setup-matrix-env, elixir-deps]
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -392,7 +392,7 @@ jobs:
 
   test-e2e:
     name: E2E Tests
-    needs: [elixir-deps, npm-deps, npm-e2e-deps]
+    needs: [setup-matrix-env, elixir-deps, npm-deps, npm-e2e-deps]
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -483,7 +483,7 @@ jobs:
 
   test-regression:
     name: Regression tests
-    needs: [elixir-deps, npm-deps, npm-e2e-deps]
+    needs: [setup-matrix-env, elixir-deps, npm-deps, npm-e2e-deps]
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -587,7 +587,7 @@ jobs:
 
   test-integration:
     name: Integration tests
-    needs: [elixir-deps, npm-deps, npm-e2e-deps]
+    needs: [setup-matrix-env, elixir-deps, npm-deps, npm-e2e-deps]
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -775,7 +775,7 @@ jobs:
 
   api-docs-check:
     name: API docs check
-    needs: elixir-deps
+    needs: [setup-matrix-env, elixir-deps]
     if: github.event_name == 'pull_request' && !failure() && !cancelled()
     runs-on: ubuntu-24.04
     strategy:
@@ -824,7 +824,7 @@ jobs:
 
   api-bc-check:
     name: API bc check
-    needs: [elixir-deps, target-branch-deps]
+    needs: [setup-matrix-env, elixir-deps, target-branch-deps]
     if: github.event_name == 'pull_request' && !failure() && !cancelled()
     runs-on: ubuntu-24.04
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,6 @@ jobs:
           echo "ERLANG_BC=${{ env.ERLANG_BC }}" >> $GITHUB_OUTPUT
           echo "NODEJS_BC=${{ env.NODEJS_BC }}" >> $GITHUB_OUTPUT
 
-
   elixir-deps:
     name: Elixir ${{ matrix.mix_env }} dependencies
     needs: [setup-matrix-env]


### PR DESCRIPTION
# Summary 

- Implements a single source of truth for application stack components. Previously every matrix had its own declaration of versions hard-coded.

- Declared top-level `*_dev` and `*_bc` env vars for application stack components and propagates them/references them everywhere. These env vars are copied/taken from the the current and previous tool-versions file used by asdf.

- `*_dev` refers to the versions developed against and also those available in SLE16 and are read from the `.tool-versions` file. `*_bc` are declared in the the CI file under the `env` section and are put there for backwards compatibility (hence the bc) reasons in SLE15. 

- The output of the `setup-matrix-env` job is propagated wherever needed. Note that env is not accessible in the matrix section of any job and this was the main reason for using a job output as a variable here and not env variables.


