### PR TITLE
Update NodeJS dependency to v24

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 elixir 1.18.4-otp-27
 erlang 27.1.3
-nodejs 22.15.1
+nodejs 24.13.1

--- a/packaging/suse/rpm/trento-web.spec
+++ b/packaging/suse/rpm/trento-web.spec
@@ -29,7 +29,7 @@ Source2:        package-lock.json
 Source3:        node_modules.spec.inc
 %include        %{_sourcedir}/node_modules.spec.inc
 Group:          System/Monitoring
-BuildRequires:  elixir >= 1.15, elixir-hex, npm >= 20, npm < 23, erlang-rebar3, git-core, local-npm-registry, make, gcc
+BuildRequires:  elixir >= 1.15, elixir-hex, npm >= 20, erlang-rebar3, git-core, local-npm-registry, make, gcc
 
 %description
 Trento is an open cloud-native web application for SAP Applications administrators.


### PR DESCRIPTION
# Description

Removes the upper limit of node <24 in the RPM spec file -- this would enable builds on sle 16.1.
Bumping the nodejs version in .tools-version to v24. 

