### PR TITLE
Group dependabot PRs by scope

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: "mix"
     directory: "/"
     schedule:
@@ -12,3 +16,16 @@ updates:
     directory: "/assets"
     schedule:
       interval: "daily"
+    groups:
+      npm-production:
+        dependency-type: "production"
+      npm-development:
+        dependency-type: "development"
+  - package-ecosystem: "npm"
+    directory: "/test/e2e"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm-e2e:
+        patterns:
+          - "*"


### PR DESCRIPTION
By grouping the dependabot update PRs, we aim to reduce the scatter of the update process

TO BE VALIDATED AND TESTED PROPERLY