### PR TITLE
Add basic AI provider/models configuration

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -277,6 +277,40 @@ config :trento, Trento.Repo, types: Trento.Postgrex.Types
 
 config :trento, correlations: Trento.ActivityLog.Correlations.UnscopedCorrelations
 
+config :trento, :ai,
+  enabled: true,
+  providers: [
+    googleai: [
+      models: [
+        "gemini-2.5-pro",
+        "gemini-2.5-flash",
+        "gemini-2.5-flash-lite",
+        "gemini-3.1-flash-preview",
+        "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-pro-preview"
+      ]
+    ],
+    openai: [
+      models: [
+        "gpt-4o",
+        "gpt-4o-mini",
+        "o3-mini",
+        "o3",
+        "gpt-4.1",
+        "gpt-4",
+        "gpt-5-mini",
+        "gpt-5.4"
+      ]
+    ],
+    anthropic: [
+      models: [
+        "claude-opus-4-6",
+        "claude-sonnet-4-6",
+        "claude-haiku-4-5"
+      ]
+    ]
+  ]
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -292,8 +292,6 @@ config :trento, :ai,
     ],
     openai: [
       models: [
-        "gpt-4o",
-        "gpt-4o-mini",
         "o3-mini",
         "o3",
         "gpt-4.1",

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -12,5 +12,7 @@ config :trento, Trento.SoftwareUpdates.Discovery,
 config :trento,
   operations_enabled: true
 
+config :trento, :ai, enabled: false
+
 # Do not print debug messages in production
 # config :logger, level: :info


### PR DESCRIPTION
# Description

This PR introduces basic config for the AI integration within Trento.

It will be used during users' AI onboarding, to provide the list of available models for the chosen provider.

`enabled` feature flag added.

We are targeting Gemini, OpenAI and Anthropic models, to begin with 

With regards to which models, I relied on 
- https://rancher.github.io/rancher-ai-product-docs/rancher-ai/latest/en/explanations/models.html
- https://ai.google.dev/gemini-api/docs/models
- https://developers.openai.com/api/docs/models/all
- https://platform.claude.com/docs/en/about-claude/models/overview

There are APIs for the specific provider that enumerate their models, but that kind of integration is out of scope for the moment.

## Did you update the documentation?

Documentation will follow, eventually.