### PR TITLE
Expose AI configuration in profile

### DIFF
--- a/lib/trento/users.ex
+++ b/lib/trento/users.ex
@@ -13,6 +13,10 @@ defmodule Trento.Users do
   alias Trento.Abilities.UsersAbilities
   alias Trento.UserIdentities.UserIdentity
 
+  alias Trento.PersonalAccessTokens.PersonalAccessToken
+
+  alias Trento.AI.UserConfiguration, as: AIUserConfiguration
+
   alias Trento.Users.User
 
   @spec by_id(id :: non_neg_integer()) :: {:ok, User.t()} | {:error, :not_found}
@@ -53,6 +57,7 @@ defmodule Trento.Users do
          |> preload(:abilities)
          |> preload(:user_identities)
          |> preload(:personal_access_tokens)
+         |> preload(:ai_configuration)
          |> Repo.one() do
       nil -> {:error, :not_found}
       user -> {:ok, user}
@@ -169,6 +174,8 @@ defmodule Trento.Users do
         )
         |> delete_abilities_multi()
         |> delete_user_identities_multi()
+        |> delete_personal_access_tokens_multi()
+        |> delete_ai_user_configuration_multi()
         |> Repo.transaction()
 
       case result do
@@ -321,6 +328,26 @@ defmodule Trento.Users do
       :delete_user_identities,
       fn %{user: %User{id: user_id}} ->
         from(u in UserIdentity, where: u.user_id == ^user_id)
+      end
+    )
+  end
+
+  defp delete_personal_access_tokens_multi(multi) do
+    Ecto.Multi.delete_all(
+      multi,
+      :delete_personal_access_tokens,
+      fn %{user: %User{id: user_id}} ->
+        from(u in PersonalAccessToken, where: u.user_id == ^user_id)
+      end
+    )
+  end
+
+  defp delete_ai_user_configuration_multi(multi) do
+    Ecto.Multi.delete_all(
+      multi,
+      :delete_ai_user_configuration,
+      fn %{user: %User{id: user_id}} ->
+        from(u in AIUserConfiguration, where: u.user_id == ^user_id)
       end
     )
   end

--- a/lib/trento_web/controllers/v1/profile_json.ex
+++ b/lib/trento_web/controllers/v1/profile_json.ex
@@ -14,6 +14,7 @@ defmodule TrentoWeb.V1.ProfileJSON do
           user_identities: user_identities,
           analytics_enabled_at: analytics_enabled_at,
           analytics_eula_accepted_at: analytics_eula_accepted_at,
+          ai_configuration: ai_configuration,
           inserted_at: created_at,
           updated_at: updated_at
         }
@@ -31,6 +32,7 @@ defmodule TrentoWeb.V1.ProfileJSON do
         created_at: created_at,
         analytics_enabled: analytics_enabled_at != nil,
         analytics_eula_accepted: analytics_eula_accepted_at != nil,
+        ai_configuration: ai_configuration(ai_configuration),
         idp_user: length(user_identities) > 0,
         updated_at: updated_at
       }
@@ -47,4 +49,15 @@ defmodule TrentoWeb.V1.ProfileJSON do
         }
       }),
       do: %{secret: Base.encode32(secret, padding: false), secret_qr_encoded: secret_qr_encoded}
+
+  defp ai_configuration(%{
+         provider: provider,
+         model: model
+       }),
+       do: %{
+         provider: provider,
+         model: model
+       }
+
+  defp ai_configuration(_), do: nil
 end

--- a/lib/trento_web/openapi/v1/schema/user.ex
+++ b/lib/trento_web/openapi/v1/schema/user.ex
@@ -7,6 +7,40 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
   alias TrentoWeb.OpenApi.V1.Schema.Ability.AbilityCollection
   alias TrentoWeb.OpenApi.V1.Schema.PersonalAccessToken.PersonalAccessTokenCollection
 
+  defmodule AIConfiguration do
+    @moduledoc false
+
+    OpenApiSpex.schema(
+      %{
+        title: "AIConfigurationV1",
+        description: "AI configuration for a user.",
+        type: :object,
+        nullable: true,
+        additionalProperties: false,
+        properties: %{
+          provider: %Schema{
+            type: :string,
+            description: "Chosen AI provider.",
+            example: "googleai",
+            nullable: false
+          },
+          model: %Schema{
+            type: :string,
+            description: "Chosen AI model.",
+            example: "gemini-2.0-flash",
+            nullable: false
+          }
+        },
+        example: %{
+          provider: "googleai",
+          model: "gemini-2.0-flash"
+        },
+        required: [:provider, :model]
+      },
+      struct?: false
+    )
+  end
+
   defmodule UserTOTPEnrollmentPayload do
     @moduledoc false
 
@@ -157,6 +191,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             nullable: false,
             example: true
           },
+          ai_configuration: AIConfiguration,
           created_at: %OpenApiSpex.Schema{
             type: :string,
             format: :"date-time",

--- a/test/trento/users_test.exs
+++ b/test/trento/users_test.exs
@@ -12,6 +12,8 @@ defmodule Trento.UsersTest do
 
   alias Trento.PersonalAccessTokens.PersonalAccessToken
 
+  alias Trento.AI.UserConfiguration, as: AIUserConfiguration
+
   import Trento.Factory
 
   describe "user profile" do
@@ -218,7 +220,8 @@ defmodule Trento.UsersTest do
                  id: ^user_id,
                  user_identities: [%{id: ^identity_id}],
                  abilities: [%{id: ^ability_id}],
-                 personal_access_tokens: [^expected_pat]
+                 personal_access_tokens: [^expected_pat],
+                 ai_configuration: %Ecto.Association.NotLoaded{}
                }
              ] = users
 
@@ -292,6 +295,33 @@ defmodule Trento.UsersTest do
                 id: ^user_id2,
                 personal_access_tokens: []
               }} = Users.get_user(user_id2)
+    end
+
+    test "get_user returns a user with its AI configuration" do
+      %{id: user_id_with_ai_configuration} = insert(:user)
+      %{id: user_id_without_ai_configuration} = insert(:user)
+
+      %AIUserConfiguration{
+        model: model,
+        provider: provider,
+        api_key: api_key
+      } = insert(:ai_user_configuration, user_id: user_id_with_ai_configuration)
+
+      assert {:ok,
+              %User{
+                id: ^user_id_with_ai_configuration,
+                ai_configuration: %AIUserConfiguration{
+                  model: ^model,
+                  provider: ^provider,
+                  api_key: ^api_key
+                }
+              }} = Users.get_user(user_id_with_ai_configuration)
+
+      assert {:ok,
+              %User{
+                id: ^user_id_without_ai_configuration,
+                ai_configuration: nil
+              }} = Users.get_user(user_id_without_ai_configuration)
     end
 
     test "create_user with valid data creates a user" do
@@ -654,6 +684,45 @@ defmodule Trento.UsersTest do
 
       refute deleted_at == nil
       assert [] == Trento.Repo.all(from u in UserIdentity, where: u.user_id == ^user_id)
+    end
+
+    test "delete_user/1 deletes user Personal Access Tokens" do
+      %{id: user_id} = user = insert(:user)
+      insert_list(3, :personal_access_token, user_id: user_id)
+
+      assert {:ok, %User{}} = Users.delete_user(user)
+
+      %User{deleted_at: deleted_at} =
+        Trento.Repo.get_by!(User, id: user_id)
+
+      refute deleted_at == nil
+
+      assert [] ==
+               Trento.Repo.all(
+                 from pat in PersonalAccessToken,
+                   where: pat.user_id == ^user_id
+               )
+    end
+
+    test "delete_user/1 deletes user AI configuration" do
+      load_users_ai_configuration = fn user_id ->
+        Trento.Repo.get_by(AIUserConfiguration, user_id: user_id)
+      end
+
+      %{id: user_id} = user = insert(:user)
+
+      insert(:ai_user_configuration, user_id: user_id)
+
+      assert %AIUserConfiguration{} = load_users_ai_configuration.(user_id)
+
+      assert {:ok, %User{}} = Users.delete_user(user)
+
+      %User{deleted_at: deleted_at} =
+        Trento.Repo.get_by!(User, id: user_id)
+
+      refute deleted_at == nil
+
+      assert nil == load_users_ai_configuration.(user_id)
     end
 
     test "reset_totp/1 reset user topt values" do

--- a/test/trento_web/controllers/v1/profile_controller_test.exs
+++ b/test/trento_web/controllers/v1/profile_controller_test.exs
@@ -58,7 +58,11 @@ defmodule TrentoWeb.V1.ProfileControllerTest do
       |> json_response(200)
       |> assert_schema("UserProfileV1", api_spec)
 
-    assert %{id: ^user_id} = resp
+    assert %{
+             id: ^user_id,
+             personal_access_tokens: _,
+             ai_configuration: _
+           } = resp
   end
 
   test "should update the profile with allowed fields", %{

--- a/test/trento_web/views/v1/profile_view_json_test.exs
+++ b/test/trento_web/views/v1/profile_view_json_test.exs
@@ -71,5 +71,42 @@ defmodule TrentoWeb.V1.ProfileJSONTest do
         assert length(rendered_user.personal_access_tokens) == expected_pat_count
       end
     end
+
+    test "should render a user profile with AI configuration" do
+      %{
+        provider: provider,
+        model: model
+      } = ai_user_configuration = build(:ai_user_configuration)
+
+      scenarios = [
+        %{
+          user: build(:user, abilities: [], user_identities: [], ai_configuration: nil),
+          expected_ai_configuration: nil
+        },
+        %{
+          # not providing ai_configuration results in an Ecto.Association.NotLoaded
+          user: build(:user, abilities: [], user_identities: []),
+          expected_ai_configuration: nil
+        },
+        %{
+          user:
+            build(:user,
+              abilities: [],
+              user_identities: [],
+              ai_configuration: ai_user_configuration
+            ),
+          expected_ai_configuration: %{
+            provider: provider,
+            model: model
+          }
+        }
+      ]
+
+      for %{user: user, expected_ai_configuration: expected_ai_configuration} <- scenarios do
+        rendered_user = ProfileJSON.profile(%{user: user})
+
+        assert rendered_user.ai_configuration == expected_ai_configuration
+      end
+    end
   end
 end


### PR DESCRIPTION
# Description

This PR exposes a user's AI configuration as part of the `/profile` endpoint.

We need to decide wether a user manager can operate on specific users' AI configuration, similarly to what happens with PATs. 

Additionally:
- when a user is deleted, its AI config is deleted
- took the chance to add the missing "when a user is deleted, its PATs are deleted" (it does not change the overall behavior, it just helps in keeping things clean)

Depends on https://github.com/trento-project/web/pull/4140

## How was this tested?

Automated and IRL tests.