### PR TITLE
Create/update AI Configuration

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -160,3 +160,17 @@ config :junit_formatter,
 config :trento,
        :flaky_tests_detection,
        enabled?: System.get_env("WRITE_JUNIT") == "1"
+
+config :trento, :ai,
+  providers: [
+    provider1: [
+      models: [
+        "model1"
+      ]
+    ],
+    provider2: [
+      models: [
+        "model1"
+      ]
+    ]
+  ]

--- a/lib/trento/ai/llm_registry.ex
+++ b/lib/trento/ai/llm_registry.ex
@@ -44,10 +44,26 @@ defmodule Trento.AI.LLMRegistry do
   end
 
   @doc """
+  Checks if a given model is supported by a specific provider.
+  """
+  @spec model_supported_by_provider?(bitstring(), atom()) :: boolean()
+  def model_supported_by_provider?(model, provider) do
+    model in get_provider_models(provider)
+  end
+
+  @doc """
   Checks if a given model is supported by any provider.
   """
   @spec model_supported?(bitstring()) :: boolean()
   def model_supported?(model), do: model in get_provider_models(:all)
+
+  @doc """
+  Checks if a given provider is supported.
+  """
+  @spec provider_supported?(atom()) :: boolean()
+  def provider_supported?(provider) when is_atom(provider), do: provider in providers()
+
+  def provider_supported?(_), do: false
 
   defp get_ai_providers_config, do: Keyword.get(ApplicationConfigLoader.load(), :providers, [])
 end

--- a/lib/trento/ai/user_configuration.ex
+++ b/lib/trento/ai/user_configuration.ex
@@ -14,6 +14,7 @@ defmodule Trento.AI.UserConfiguration do
   schema "ai_configurations" do
     field :model, :string
     field :provider, Ecto.Enum, values: LLMRegistry.providers()
+    # field :provider, :string
     field :api_key, EncryptedBinary, redact: true
 
     belongs_to :user, Trento.Users.User, primary_key: true
@@ -22,12 +23,11 @@ defmodule Trento.AI.UserConfiguration do
   end
 
   def changeset(ai_configuration, attrs) do
-    updated_attrs = maybe_update_provider(attrs)
-
     ai_configuration
-    |> cast(updated_attrs, [:user_id, :model, :provider, :api_key])
-    |> validate_required([:user_id, :model, :api_key])
-    |> validate_change(:model, &validate_model/2)
+    |> cast(attrs, [:user_id, :model, :provider, :api_key])
+    |> validate_required([:user_id, :model, :provider, :api_key])
+    |> validate_change(:provider, &validate_provider/2)
+    |> validate_model()
     |> unique_constraint(:user_id,
       name: :ai_configurations_pkey,
       message: "User already has a configuration"
@@ -35,16 +35,41 @@ defmodule Trento.AI.UserConfiguration do
     |> foreign_key_constraint(:user_id, message: "User does not exist")
   end
 
-  defp maybe_update_provider(%{model: model} = attrs),
-    do: Map.put(attrs, :provider, LLMRegistry.get_model_provider(model))
-
-  defp maybe_update_provider(attrs), do: attrs
-
-  defp validate_model(_model_field_atom, model) do
-    if LLMRegistry.model_supported?(model) do
+  defp validate_provider(_provider_field_atom, provider) do
+    if LLMRegistry.provider_supported?(provider) do
       []
     else
-      [model: {"is not supported", validation: :ai_model_validity}]
+      [provider: {"is not supported", validation: :ai_provider_validity}]
     end
+  end
+
+  defp validate_model(%{errors: [provider: _]} = changeset), do: changeset
+
+  defp validate_model(changeset) do
+    provider = get_field(changeset, :provider)
+    model = get_field(changeset, :model)
+
+    changeset
+    |> force_change(:model, model)
+    |> force_change(:provider, provider)
+    |> validate_change(:model, fn _model_atom, _model ->
+      model_supported? = LLMRegistry.model_supported?(model)
+      model_supported_by_provider? = LLMRegistry.model_supported_by_provider?(model, provider)
+
+      case {model_supported?, model_supported_by_provider?} do
+        {true, true} ->
+          []
+
+        {true, false} ->
+          [
+            model:
+              {"is not supported by the specified provider",
+               validation: :ai_model_provider_mismatch}
+          ]
+
+        {false, _} ->
+          [model: {"is not supported", validation: :ai_model_validity}]
+      end
+    end)
   end
 end

--- a/lib/trento_web/controllers/v1/ai_configuration_controller.ex
+++ b/lib/trento_web/controllers/v1/ai_configuration_controller.ex
@@ -1,0 +1,75 @@
+defmodule TrentoWeb.V1.AIConfigurationController do
+  use TrentoWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias Trento.Users.User
+
+  alias Trento.AI
+
+  alias Trento.AI.UserConfiguration
+
+  alias TrentoWeb.OpenApi.V1.Schema
+
+  import Plug.Conn
+
+  plug TrentoWeb.Plugs.LoadUserPlug
+
+  plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
+  action_fallback TrentoWeb.FallbackController
+
+  operation :create_ai_configuration,
+    summary: "Creates User's AI Configuration",
+    description: "Creates a new AI configuration for the currently authenticated user.",
+    tags: ["Profile"],
+    request_body:
+      {"CreateUserAIConfiguration", "application/json", Schema.AI.CreateUserConfigurationRequest},
+    responses: [
+      created:
+        {"User AI Configuration created successfully.", "application/json",
+         Schema.AI.UserConfiguration},
+      unprocessable_entity: Schema.UnprocessableEntity.response(),
+      unauthorized: Schema.Unauthorized.response(),
+      forbidden: Schema.Forbidden.response()
+    ]
+
+  def create_ai_configuration(conn, _) do
+    %User{} = current_user = Pow.Plug.current_user(conn)
+
+    creation_params = OpenApiSpex.body_params(conn)
+
+    with {:ok, %UserConfiguration{} = user_ai_config} <-
+           AI.create_user_configuration(current_user, creation_params) do
+      conn
+      |> put_status(:created)
+      |> render(:ai_configuration, %{ai_configuration: user_ai_config})
+    end
+  end
+
+  operation :update_ai_configuration,
+    summary: "Updates User's AI Configuration",
+    description: "Updates the AI configuration for the currently authenticated user.",
+    tags: ["Profile"],
+    request_body:
+      {"UpdateUserAIConfiguration", "application/json", Schema.AI.UpdateUserConfigurationRequest},
+    responses: [
+      ok:
+        {"User AI Configuration updated successfully.", "application/json",
+         Schema.AI.UserConfiguration},
+      unprocessable_entity: Schema.UnprocessableEntity.response(),
+      unauthorized: Schema.Unauthorized.response(),
+      forbidden: Schema.Forbidden.response()
+    ]
+
+  def update_ai_configuration(conn, _) do
+    %User{} = current_user = Pow.Plug.current_user(conn)
+
+    update_params = OpenApiSpex.body_params(conn)
+
+    with {:ok, %UserConfiguration{} = user_ai_config} <-
+           AI.update_user_configuration(current_user, update_params) do
+      conn
+      |> put_status(:ok)
+      |> render(:ai_configuration, %{ai_configuration: user_ai_config})
+    end
+  end
+end

--- a/lib/trento_web/controllers/v1/ai_configuration_json.ex
+++ b/lib/trento_web/controllers/v1/ai_configuration_json.ex
@@ -1,0 +1,15 @@
+defmodule TrentoWeb.V1.AIConfigurationJSON do
+  def ai_configuration(%{ai_configuration: ai_configuration}),
+    do: ai_configuration_entry(ai_configuration)
+
+  def ai_configuration_entry(%{
+        provider: provider,
+        model: model
+      }),
+      do: %{
+        provider: provider,
+        model: model
+      }
+
+  def ai_configuration_entry(_), do: nil
+end

--- a/lib/trento_web/controllers/v1/profile_json.ex
+++ b/lib/trento_web/controllers/v1/profile_json.ex
@@ -1,5 +1,9 @@
 defmodule TrentoWeb.V1.ProfileJSON do
-  alias TrentoWeb.V1.{AbilityJSON, PersonalAccessTokensJSON}
+  alias TrentoWeb.V1.{
+    AbilityJSON,
+    AIConfigurationJSON,
+    PersonalAccessTokensJSON
+  }
 
   def profile(%{
         user: %{
@@ -32,7 +36,7 @@ defmodule TrentoWeb.V1.ProfileJSON do
         created_at: created_at,
         analytics_enabled: analytics_enabled_at != nil,
         analytics_eula_accepted: analytics_eula_accepted_at != nil,
-        ai_configuration: ai_configuration(ai_configuration),
+        ai_configuration: AIConfigurationJSON.ai_configuration_entry(ai_configuration),
         idp_user: length(user_identities) > 0,
         updated_at: updated_at
       }
@@ -49,15 +53,4 @@ defmodule TrentoWeb.V1.ProfileJSON do
         }
       }),
       do: %{secret: Base.encode32(secret, padding: false), secret_qr_encoded: secret_qr_encoded}
-
-  defp ai_configuration(%{
-         provider: provider,
-         model: model
-       }),
-       do: %{
-         provider: provider,
-         model: model
-       }
-
-  defp ai_configuration(_), do: nil
 end

--- a/lib/trento_web/openapi/v1/schema/ai.ex
+++ b/lib/trento_web/openapi/v1/schema/ai.ex
@@ -1,0 +1,119 @@
+defmodule TrentoWeb.OpenApi.V1.Schema.AI do
+  @moduledoc false
+
+  require OpenApiSpex
+  alias OpenApiSpex.Schema
+
+  defmodule UserConfiguration do
+    @moduledoc false
+
+    OpenApiSpex.schema(
+      %{
+        title: "AIUserConfigurationV1",
+        description: "AI configuration for a user.",
+        type: :object,
+        nullable: true,
+        additionalProperties: false,
+        properties: %{
+          provider: %Schema{
+            type: :string,
+            description: "Chosen AI provider.",
+            example: "googleai",
+            nullable: false
+          },
+          model: %Schema{
+            type: :string,
+            description: "Chosen AI model.",
+            example: "gemini-2.0-flash",
+            nullable: false
+          }
+        },
+        example: %{
+          provider: "googleai",
+          model: "gemini-2.0-flash"
+        },
+        required: [:provider, :model]
+      },
+      struct?: false
+    )
+  end
+
+  defmodule CreateUserConfigurationRequest do
+    @moduledoc false
+
+    OpenApiSpex.schema(
+      %{
+        title: "CreateUserConfigurationRequestV1",
+        description: "AI configuration request for a user.",
+        type: :object,
+        additionalProperties: false,
+        properties: %{
+          provider: %Schema{
+            type: :string,
+            description: "AI provider.",
+            nullable: false,
+            example: "googleai"
+          },
+          model: %Schema{
+            type: :string,
+            description: "AI model.",
+            nullable: false,
+            example: "gemini-2.0-flash"
+          },
+          api_key: %Schema{
+            type: :string,
+            description: "AI API key.",
+            nullable: false,
+            example: "AIza..."
+          }
+        },
+        example: %{
+          provider: "googleai",
+          model: "gemini-2.0-flash",
+          api_key: "AIza..."
+        },
+        required: [:provider, :model, :api_key]
+      },
+      struct?: false
+    )
+  end
+
+  defmodule UpdateUserConfigurationRequest do
+    @moduledoc false
+
+    OpenApiSpex.schema(
+      %{
+        title: "UpdateUserConfigurationRequestV1",
+        description: "AI configuration request for a user.",
+        type: :object,
+        additionalProperties: false,
+        minProperties: 1,
+        properties: %{
+          provider: %Schema{
+            type: :string,
+            description: "AI provider.",
+            nullable: false,
+            example: "googleai"
+          },
+          model: %Schema{
+            type: :string,
+            description: "AI model.",
+            nullable: false,
+            example: "gemini-2.0-flash"
+          },
+          api_key: %Schema{
+            type: :string,
+            description: "AI API key.",
+            nullable: false,
+            example: "AIza..."
+          }
+        },
+        example: %{
+          api_key: "AIza...",
+          model: "gemini-2.0-flash"
+        }
+      },
+      struct?: false
+    )
+  end
+end

--- a/lib/trento_web/openapi/v1/schema/user.ex
+++ b/lib/trento_web/openapi/v1/schema/user.ex
@@ -5,41 +5,8 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
   alias OpenApiSpex.Schema
 
   alias TrentoWeb.OpenApi.V1.Schema.Ability.AbilityCollection
+  alias TrentoWeb.OpenApi.V1.Schema.AI.UserConfiguration, as: AIConfiguration
   alias TrentoWeb.OpenApi.V1.Schema.PersonalAccessToken.PersonalAccessTokenCollection
-
-  defmodule AIConfiguration do
-    @moduledoc false
-
-    OpenApiSpex.schema(
-      %{
-        title: "AIConfigurationV1",
-        description: "AI configuration for a user.",
-        type: :object,
-        nullable: true,
-        additionalProperties: false,
-        properties: %{
-          provider: %Schema{
-            type: :string,
-            description: "Chosen AI provider.",
-            example: "googleai",
-            nullable: false
-          },
-          model: %Schema{
-            type: :string,
-            description: "Chosen AI model.",
-            example: "gemini-2.0-flash",
-            nullable: false
-          }
-        },
-        example: %{
-          provider: "googleai",
-          model: "gemini-2.0-flash"
-        },
-        required: [:provider, :model]
-      },
-      struct?: false
-    )
-  end
 
   defmodule UserTOTPEnrollmentPayload do
     @moduledoc false

--- a/lib/trento_web/router.ex
+++ b/lib/trento_web/router.ex
@@ -239,6 +239,13 @@ defmodule TrentoWeb.Router do
           post "/", PersonalAccessTokensController, :create_personal_access_token
           delete "/:token_id", PersonalAccessTokensController, :revoke_personal_access_token
         end
+
+        if Application.compile_env!(:trento, :ai)[:enabled] do
+          scope "/ai_configuration" do
+            post "/", AIConfigurationController, :create_ai_configuration
+            patch "/", AIConfigurationController, :update_ai_configuration
+          end
+        end
       end
 
       get "/abilities", AbilityController, :index

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -184,6 +184,8 @@ defmodule Trento.Factory do
 
   alias Trento.AI.{LLMRegistry, UserConfiguration}
 
+  alias Trento.AI.AICase
+
   use ExMachina.Ecto, repo: Trento.Repo
 
   def host_registered_event_factory do
@@ -1461,24 +1463,43 @@ defmodule Trento.Factory do
     }
   end
 
-  def random_ai_model do
-    Trento.AI.AICase.stub_config_loader()
+  def random_ai_provider_factory(_) do
+    AICase.stub_config_loader()
 
-    :all
+    Enum.random(LLMRegistry.providers())
+  end
+
+  def random_ai_model_factory(attrs) do
+    AICase.stub_config_loader()
+
+    attrs
+    |> Map.get(:provider, :all)
     |> LLMRegistry.get_provider_models()
     |> Enum.random()
   end
 
   def ai_user_configuration_factory(attrs) do
     user_id = Map.get(attrs, :user_id, 1)
-    model = Map.get(attrs, :model, random_ai_model())
+    provider = Map.get(attrs, :provider, build(:random_ai_provider))
+    model = Map.get(attrs, :model, build(:random_ai_model, provider: provider))
 
-    %UserConfiguration{}
-    |> UserConfiguration.changeset(%{
+    %UserConfiguration{
       user_id: user_id,
+      provider: provider,
       model: model,
       api_key: Faker.String.base64(32)
-    })
-    |> Ecto.Changeset.apply_changes()
+    }
+  end
+
+  def ai_configuration_creation_params_factory(attrs) do
+    provider = Map.get(attrs, :provider, build(:random_ai_provider))
+    model = Map.get(attrs, :model, build(:random_ai_model, provider: provider))
+    api_key = Map.get(attrs, :api_key, Faker.String.base64(32))
+
+    %{
+      provider: provider,
+      model: model,
+      api_key: api_key
+    }
   end
 end

--- a/test/trento/ai/configurations_test.exs
+++ b/test/trento/ai/configurations_test.exs
@@ -6,9 +6,11 @@ defmodule Trento.Ai.ConfigurationsTest do
 
   alias Trento.AI.{Configurations, LLMRegistry, UserConfiguration}
 
-  alias Trento.Factory
-
   import Trento.Factory
+
+  import Mox
+
+  setup :verify_on_exit!
 
   describe "creating a user AI configuration" do
     test "should not allow creating AI configuration for a deleted or disabled user" do
@@ -19,10 +21,7 @@ defmodule Trento.Ai.ConfigurationsTest do
         assert {:error, :forbidden} ==
                  Configurations.create_user_configuration(
                    user,
-                   %{
-                     model: Factory.random_ai_model(),
-                     api_key: Faker.String.base64()
-                   }
+                   build(:ai_configuration_creation_params)
                  )
       end
     end
@@ -34,10 +33,7 @@ defmodule Trento.Ai.ConfigurationsTest do
               %Ecto.Changeset{errors: [user_id: {"can't be blank", [validation: :required]}]}} =
                Configurations.create_user_configuration(
                  user,
-                 %{
-                   model: Factory.random_ai_model(),
-                   api_key: Faker.String.base64()
-                 }
+                 build(:ai_configuration_creation_params)
                )
     end
 
@@ -47,10 +43,7 @@ defmodule Trento.Ai.ConfigurationsTest do
       assert {:error, %Ecto.Changeset{errors: [user_id: {"User does not exist", _}]}} =
                Configurations.create_user_configuration(
                  user,
-                 %{
-                   model: Factory.random_ai_model(),
-                   api_key: Faker.String.base64()
-                 }
+                 build(:ai_configuration_creation_params)
                )
     end
 
@@ -60,12 +53,39 @@ defmodule Trento.Ai.ConfigurationsTest do
         attrs: %{},
         expected_errors: [
           model: {"can't be blank", [validation: :required]},
+          provider: {"can't be blank", [validation: :required]},
           api_key: {"can't be blank", [validation: :required]}
+        ]
+      },
+      %{
+        name: "missing provider",
+        attrs: %{
+          model: build(:random_ai_model),
+          api_key: Faker.String.base64()
+        },
+        expected_errors: [
+          provider: {"can't be blank", [validation: :required]}
+        ]
+      },
+      %{
+        name: "empty provider",
+        attrs_sceanarios:
+          Enum.map(
+            [nil, "", "  "],
+            &%{
+              provider: &1,
+              model: build(:random_ai_model),
+              api_key: Faker.String.base64()
+            }
+          ),
+        expected_errors: [
+          provider: {"can't be blank", [validation: :required]}
         ]
       },
       %{
         name: "missing model",
         attrs: %{
+          provider: build(:random_ai_provider),
           api_key: Faker.String.base64()
         },
         expected_errors: [
@@ -78,6 +98,7 @@ defmodule Trento.Ai.ConfigurationsTest do
           Enum.map(
             [nil, "", "  "],
             &%{
+              provider: build(:random_ai_provider),
               model: &1,
               api_key: Faker.String.base64()
             }
@@ -93,6 +114,7 @@ defmodule Trento.Ai.ConfigurationsTest do
             [123, true, %{}, []],
             &%{
               model: &1,
+              provider: build(:random_ai_provider),
               api_key: Faker.String.base64()
             }
           ),
@@ -104,6 +126,7 @@ defmodule Trento.Ai.ConfigurationsTest do
         name: "unsupported model",
         attrs: %{
           model: Faker.Lorem.word(),
+          provider: build(:random_ai_provider),
           api_key: Faker.String.base64()
         },
         expected_errors: [
@@ -111,9 +134,23 @@ defmodule Trento.Ai.ConfigurationsTest do
         ]
       },
       %{
+        name: "model unsupported by the specified provider",
+        attrs: %{
+          provider: :googleai,
+          model: "gpt-5.4",
+          api_key: Faker.String.base64()
+        },
+        expected_errors: [
+          model:
+            {"is not supported by the specified provider",
+             [validation: :ai_model_provider_mismatch]}
+        ]
+      },
+      %{
         name: "missing api key",
         attrs: %{
-          model: Factory.random_ai_model()
+          provider: :googleai,
+          model: build(:random_ai_model, provider: :googleai)
         },
         expected_errors: [
           api_key: {"can't be blank", [validation: :required]}
@@ -125,7 +162,8 @@ defmodule Trento.Ai.ConfigurationsTest do
           Enum.map(
             [nil, "", "  "],
             &%{
-              model: Factory.random_ai_model(),
+              provider: :openai,
+              model: build(:random_ai_model, provider: :openai),
               api_key: &1
             }
           ),
@@ -139,7 +177,8 @@ defmodule Trento.Ai.ConfigurationsTest do
           Enum.map(
             [123, true, %{}, []],
             &%{
-              model: Factory.random_ai_model(),
+              provider: :anthropic,
+              model: build(:random_ai_model, provider: :anthropic),
               api_key: &1
             }
           ),
@@ -169,6 +208,34 @@ defmodule Trento.Ai.ConfigurationsTest do
       end
     end
 
+    test "should fail creating AI configuration when the provider is not among the supported ones" do
+      %User{id: user_id} = user = insert(:user)
+
+      unsuppoerted_providers = [:unsupported_provider, Faker.Lorem.word(), 123, true, %{}, []]
+
+      for unsuppoerted_provider <- unsuppoerted_providers do
+        assert {:error,
+                %Ecto.Changeset{
+                  errors: [
+                    provider:
+                      {"is invalid",
+                       [
+                         type: _,
+                         validation: :inclusion,
+                         enum: ["anthropic", "googleai", "openai" | _]
+                       ]}
+                  ]
+                }} =
+                 Configurations.create_user_configuration(user, %{
+                   provider: unsuppoerted_provider,
+                   model: build(:random_ai_model),
+                   api_key: Faker.String.base64()
+                 })
+
+        assert nil == load_ai_config(user_id)
+      end
+    end
+
     test "should not allow creating AI configuration for a user that already has one" do
       %User{id: user_id} = user = insert(:user)
 
@@ -182,17 +249,15 @@ defmodule Trento.Ai.ConfigurationsTest do
               }} =
                Configurations.create_user_configuration(
                  user,
-                 %{
-                   model: random_ai_model(),
-                   api_key: Faker.String.base64()
-                 }
+                 build(:ai_configuration_creation_params)
                )
     end
 
     test "should allow creating AI configuration with valid data" do
       %User{id: user_id} = user = insert(:user)
 
-      model = Factory.random_ai_model()
+      provider = build(:random_ai_provider)
+      model = build(:random_ai_model, provider: provider)
       api_key = Faker.String.base64()
 
       expected_provider = LLMRegistry.get_model_provider(model)
@@ -204,9 +269,56 @@ defmodule Trento.Ai.ConfigurationsTest do
                 api_key: ^api_key,
                 user_id: ^user_id
               } = created_config} =
-               Configurations.create_user_configuration(user, %{model: model, api_key: api_key})
+               Configurations.create_user_configuration(
+                 user,
+                 build(:ai_configuration_creation_params,
+                   provider: provider,
+                   model: model,
+                   api_key: api_key
+                 )
+               )
 
       assert ^created_config = load_ai_config(user_id)
+    end
+
+    test "should support creating AI configuration with a model that is supported by multiple providers" do
+      %User{id: user_id1} = user1 = insert(:user)
+
+      assert {:ok,
+              %UserConfiguration{
+                model: "model1",
+                provider: :provider1,
+                api_key: _api_key,
+                user_id: ^user_id1
+              } = created_config1} =
+               Configurations.create_user_configuration(
+                 user1,
+                 build(:ai_configuration_creation_params,
+                   provider: :provider1,
+                   model: "model1"
+                 )
+               )
+
+      assert ^created_config1 = load_ai_config(user_id1)
+
+      %User{id: user_id2} = user2 = insert(:user)
+
+      assert {:ok,
+              %UserConfiguration{
+                model: "model1",
+                provider: :provider2,
+                api_key: _api_key,
+                user_id: ^user_id2
+              } = created_config2} =
+               Configurations.create_user_configuration(
+                 user2,
+                 build(:ai_configuration_creation_params,
+                   provider: :provider2,
+                   model: "model1"
+                 )
+               )
+
+      assert ^created_config2 = load_ai_config(user_id2)
     end
   end
 
@@ -225,7 +337,7 @@ defmodule Trento.Ai.ConfigurationsTest do
         assert {:error, :forbidden} ==
                  Configurations.update_user_configuration(
                    user,
-                   %{model: Factory.random_ai_model(), api_key: Faker.String.base64()}
+                   build(:ai_configuration_creation_params)
                  )
 
         assert %UserConfiguration{} = load_ai_config(user_id)
@@ -238,7 +350,7 @@ defmodule Trento.Ai.ConfigurationsTest do
       assert {:error, :forbidden} =
                Configurations.update_user_configuration(
                  user,
-                 %{model: Factory.random_ai_model(), api_key: Faker.String.base64()}
+                 build(:ai_configuration_creation_params)
                )
     end
 
@@ -248,7 +360,7 @@ defmodule Trento.Ai.ConfigurationsTest do
       assert {:error, :not_found} =
                Configurations.update_user_configuration(
                  user,
-                 %{model: Factory.random_ai_model(), api_key: Faker.String.base64()}
+                 build(:ai_configuration_creation_params)
                )
     end
 
@@ -258,7 +370,7 @@ defmodule Trento.Ai.ConfigurationsTest do
       assert {:error, :not_found} =
                Configurations.update_user_configuration(
                  user,
-                 %{model: Factory.random_ai_model(), api_key: Faker.String.base64()}
+                 build(:ai_configuration_creation_params)
                )
     end
 
@@ -284,6 +396,33 @@ defmodule Trento.Ai.ConfigurationsTest do
         },
         expected_errors: [
           model: {"is not supported", [validation: :ai_model_validity]}
+        ]
+      },
+      %{
+        name: "model unsupported by the specified provider",
+        attrs: %{
+          provider: :googleai,
+          model: "gpt-5.4"
+        },
+        expected_errors: [
+          model:
+            {"is not supported by the specified provider",
+             [validation: :ai_model_provider_mismatch]}
+        ]
+      },
+      %{
+        name: "empty provider",
+        attrs_sceanarios:
+          Enum.map(
+            [nil, "", "  "],
+            &%{
+              provider: &1,
+              model: build(:random_ai_model),
+              api_key: Faker.String.base64()
+            }
+          ),
+        expected_errors: [
+          provider: {"can't be blank", [validation: :required]}
         ]
       },
       %{
@@ -325,13 +464,20 @@ defmodule Trento.Ai.ConfigurationsTest do
           api_key: initial_api_key
         } = insert(:ai_user_configuration, user_id: user_id)
 
-        %{expected_errors: expected_errors} = @failing_update_validation_scenario
+        expected_errors = Map.get(@failing_update_validation_scenario, :expected_errors, [])
+
+        expected_errors_scenarios =
+          Map.get(@failing_update_validation_scenario, :expected_errors_scenarios, [
+            expected_errors
+          ])
 
         attrs = Map.get(@failing_update_validation_scenario, :attrs, %{})
         attrs_scenarios = Map.get(@failing_update_validation_scenario, :attrs_sceanarios, [attrs])
 
-        for resolved_scenario <- attrs_scenarios do
-          assert {:error, %Ecto.Changeset{errors: ^expected_errors}} =
+        for {resolved_scenario, index} <- Enum.with_index(attrs_scenarios) do
+          resolved_expected_errors = Enum.at(expected_errors_scenarios, index, expected_errors)
+
+          assert {:error, %Ecto.Changeset{errors: ^resolved_expected_errors}} =
                    Configurations.update_user_configuration(user, resolved_scenario)
 
           assert %UserConfiguration{
@@ -344,23 +490,56 @@ defmodule Trento.Ai.ConfigurationsTest do
       end
     end
 
+    test "should fail updating only the provider" do
+      %User{id: user_id} = user = insert(:user)
+
+      %UserConfiguration{
+        model: initial_model,
+        provider: initial_provider,
+        api_key: initial_api_key
+      } =
+        insert(:ai_user_configuration,
+          user_id: user_id,
+          provider: :googleai,
+          model: build(:random_ai_model, provider: :googleai)
+        )
+
+      new_provider = :openai
+
+      assert {:error,
+              %Ecto.Changeset{
+                errors: [
+                  model:
+                    {"is not supported by the specified provider",
+                     [validation: :ai_model_provider_mismatch]}
+                ]
+              }} =
+               Configurations.update_user_configuration(user, %{
+                 provider: new_provider
+               })
+
+      assert %UserConfiguration{
+               model: ^initial_model,
+               provider: ^initial_provider,
+               api_key: ^initial_api_key
+             } = load_ai_config(user_id)
+    end
+
     test "should allow updating only the model" do
       %User{id: user_id} = user = insert(:user)
 
       %UserConfiguration{
         model: _initial_model,
-        provider: _initial_provider,
+        provider: initial_provider,
         api_key: initial_api_key
       } = insert(:ai_user_configuration, user_id: user_id)
 
-      new_model = Factory.random_ai_model()
-
-      expected_provider = LLMRegistry.get_model_provider(new_model)
+      new_model = build(:random_ai_model, provider: initial_provider)
 
       assert {:ok,
               %UserConfiguration{
                 model: ^new_model,
-                provider: ^expected_provider,
+                provider: ^initial_provider,
                 api_key: ^initial_api_key,
                 user_id: ^user_id
               } = updated_config} =
@@ -371,27 +550,55 @@ defmodule Trento.Ai.ConfigurationsTest do
       assert ^updated_config = load_ai_config(user_id)
     end
 
+    test "should allow updating only the api key" do
+      %User{id: user_id} = user = insert(:user)
+
+      %UserConfiguration{
+        model: initial_model,
+        provider: initial_provider,
+        api_key: _initial_api_key
+      } = insert(:ai_user_configuration, user_id: user_id)
+
+      new_api_key = Faker.String.base64()
+
+      assert {:ok,
+              %UserConfiguration{
+                model: ^initial_model,
+                provider: ^initial_provider,
+                api_key: ^new_api_key,
+                user_id: ^user_id
+              } = updated_config} =
+               Configurations.update_user_configuration(user, %{
+                 api_key: new_api_key
+               })
+
+      assert ^updated_config = load_ai_config(user_id)
+    end
+
     test "should allow updating AI configuration with valid data" do
       %User{id: user_id} = user = insert(:user)
 
       insert(:ai_user_configuration, user_id: user_id)
 
-      new_model = Factory.random_ai_model()
+      new_provider = build(:random_ai_provider)
+      new_model = build(:random_ai_model, provider: new_provider)
       new_api_key = Faker.String.base64()
-
-      expected_provider = LLMRegistry.get_model_provider(new_model)
 
       assert {:ok,
               %UserConfiguration{
                 model: ^new_model,
-                provider: ^expected_provider,
+                provider: ^new_provider,
                 api_key: ^new_api_key,
                 user_id: ^user_id
               } = updated_config} =
-               Configurations.update_user_configuration(user, %{
-                 model: new_model,
-                 api_key: new_api_key
-               })
+               Configurations.update_user_configuration(
+                 user,
+                 build(:ai_configuration_creation_params,
+                   provider: new_provider,
+                   model: new_model,
+                   api_key: new_api_key
+                 )
+               )
 
       assert ^updated_config = load_ai_config(user_id)
     end

--- a/test/trento/ai/llm_registry_test.exs
+++ b/test/trento/ai/llm_registry_test.exs
@@ -113,4 +113,38 @@ defmodule Trento.AI.LLMRegistryTest do
       assert LLMRegistry.model_supported?("unknown-model") == false
     end
   end
+
+  describe "provider_supported?/1" do
+    test "returns true for a supported provider" do
+      expect_config_loader_to_be_called_times(2)
+
+      assert LLMRegistry.provider_supported?(:provider1) == true
+      assert LLMRegistry.provider_supported?(:provider2) == true
+    end
+
+    test "returns false for an unsupported provider" do
+      expect_config_loader_to_be_called_times(1)
+
+      assert LLMRegistry.provider_supported?(:unknown) == false
+      assert LLMRegistry.provider_supported?("foo") == false
+    end
+  end
+
+  describe "model_supported_by_provider?/2" do
+    test "returns true if the model is supported by the provider" do
+      expect_config_loader_to_be_called_times(2)
+
+      assert LLMRegistry.model_supported_by_provider?("model1", :provider1) == true
+      assert LLMRegistry.model_supported_by_provider?("model4", :provider2) == true
+    end
+
+    test "returns false if the model is not supported by the provider" do
+      expect_config_loader_to_be_called_times(3)
+
+      assert LLMRegistry.model_supported_by_provider?("model1", :provider2) == false
+      assert LLMRegistry.model_supported_by_provider?("model3", :provider1) == false
+      assert LLMRegistry.model_supported_by_provider?("foo", :provider1) == false
+      assert LLMRegistry.model_supported_by_provider?("bar", "baz") == false
+    end
+  end
 end

--- a/test/trento_web/controllers/v1/ai_configuration_controller_test.exs
+++ b/test/trento_web/controllers/v1/ai_configuration_controller_test.exs
@@ -1,0 +1,773 @@
+defmodule TrentoWeb.V1.AIConfigurationControllerTest do
+  use TrentoWeb.ConnCase, async: true
+  use Trento.AI.AICase
+
+  alias Trento.AI.UserConfiguration
+
+  import Trento.Factory
+  import OpenApiSpex.TestAssertions
+  import Trento.Support.Helpers.AbilitiesTestHelper
+
+  setup :setup_api_spec_v1
+  setup :setup_user
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "content-type", "application/json")}
+  end
+
+  describe "creating AI configuration" do
+    failing_validation_scenarios = [
+      %{
+        name: "empty payload",
+        request_body_scenarios: [
+          %{},
+          nil,
+          ""
+        ],
+        expected_errors: [
+          %{
+            "detail" => "Missing field: provider",
+            "source" => %{"pointer" => "/provider"},
+            "title" => "Invalid value"
+          },
+          %{
+            "detail" => "Missing field: model",
+            "source" => %{"pointer" => "/model"},
+            "title" => "Invalid value"
+          },
+          %{
+            "detail" => "Missing field: api_key",
+            "source" => %{"pointer" => "/api_key"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "missing provider",
+        request_body: %{
+          model: build(:random_ai_model),
+          api_key: Faker.String.base64(32)
+        },
+        expected_errors: [
+          %{
+            "detail" => "Missing field: provider",
+            "source" => %{"pointer" => "/provider"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "nil provider",
+        request_body: %{
+          model: build(:random_ai_model),
+          provider: nil,
+          api_key: Faker.String.base64(32)
+        },
+        expected_errors: [
+          %{
+            "detail" => "null value where string expected",
+            "source" => %{"pointer" => "/provider"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "empty provider",
+        request_body_scenarios:
+          Enum.map(
+            ["", "  "],
+            &%{
+              model: build(:random_ai_model),
+              provider: &1,
+              api_key: Faker.String.base64(32)
+            }
+          ),
+        expected_errors: [
+          %{
+            "detail" => "can't be blank",
+            "source" => %{"pointer" => "/provider"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "unsupported provider",
+        request_body: %{
+          model: build(:random_ai_model),
+          provider: Faker.Lorem.word(),
+          api_key: Faker.String.base64(32)
+        },
+        expected_errors: [
+          %{
+            "detail" => "is invalid",
+            "source" => %{"pointer" => "/provider"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "non string provider",
+        request_body_scenarios:
+          Enum.map(
+            [123, true, %{}, []],
+            &%{
+              model: build(:random_ai_model),
+              provider: &1,
+              api_key: Faker.String.base64()
+            }
+          ),
+        expected_errors_scenarios:
+          Enum.map(
+            ["integer", "boolean", "object", "array"],
+            &[
+              %{
+                "detail" => "Invalid string. Got: #{&1}",
+                "source" => %{"pointer" => "/provider"},
+                "title" => "Invalid value"
+              }
+            ]
+          )
+      },
+      %{
+        name: "missing model",
+        request_body: %{
+          provider: build(:random_ai_provider),
+          api_key: Faker.String.base64(32)
+        },
+        expected_errors: [
+          %{
+            "detail" => "Missing field: model",
+            "source" => %{"pointer" => "/model"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "nil model",
+        request_body: %{
+          model: nil,
+          provider: build(:random_ai_provider),
+          api_key: Faker.String.base64()
+        },
+        expected_errors: [
+          %{
+            "detail" => "null value where string expected",
+            "source" => %{"pointer" => "/model"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "empty model",
+        request_body_scenarios:
+          Enum.map(
+            ["", "  "],
+            &%{
+              model: &1,
+              provider: build(:random_ai_provider),
+              api_key: Faker.String.base64()
+            }
+          ),
+        expected_errors: [
+          %{
+            "detail" => "can't be blank",
+            "source" => %{"pointer" => "/model"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "non string model",
+        request_body_scenarios:
+          Enum.map(
+            [123, true, %{}, []],
+            &%{
+              model: &1,
+              provider: build(:random_ai_provider),
+              api_key: Faker.String.base64()
+            }
+          ),
+        expected_errors_scenarios:
+          Enum.map(
+            ["integer", "boolean", "object", "array"],
+            &[
+              %{
+                "detail" => "Invalid string. Got: #{&1}",
+                "source" => %{"pointer" => "/model"},
+                "title" => "Invalid value"
+              }
+            ]
+          )
+      },
+      %{
+        name: "unsupported model",
+        request_body: %{
+          model: "unsupported-model",
+          provider: build(:random_ai_provider),
+          api_key: Faker.String.base64()
+        },
+        expected_errors: [
+          %{
+            "detail" => "is not supported",
+            "source" => %{"pointer" => "/model"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "model unsupported by the specified provider",
+        request_body: %{
+          model: build(:random_ai_model, provider: :googleai),
+          provider: :openai,
+          api_key: Faker.String.base64()
+        },
+        expected_errors: [
+          %{
+            "detail" => "is not supported by the specified provider",
+            "source" => %{"pointer" => "/model"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "missing api_key",
+        request_body: %{
+          model: build(:random_ai_model),
+          provider: build(:random_ai_provider)
+        },
+        expected_errors: [
+          %{
+            "detail" => "Missing field: api_key",
+            "source" => %{"pointer" => "/api_key"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "nil api_key",
+        request_body: %{
+          model: build(:random_ai_model),
+          provider: build(:random_ai_provider),
+          api_key: nil
+        },
+        expected_errors: [
+          %{
+            "detail" => "null value where string expected",
+            "source" => %{"pointer" => "/api_key"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "empty api_key",
+        request_body_scenarios:
+          Enum.map(
+            [nil, "", "  "],
+            fn empty_api_key ->
+              provider = build(:random_ai_provider)
+              model = build(:random_ai_model, provider: provider)
+
+              %{
+                model: model,
+                provider: provider,
+                api_key: empty_api_key
+              }
+            end
+          ),
+        expected_errors_scenarios:
+          Enum.map([nil, "", "  "], fn empty_api_key ->
+            expected_detail =
+              case empty_api_key do
+                nil -> "null value where string expected"
+                _ -> "can't be blank"
+              end
+
+            [
+              %{
+                "detail" => expected_detail,
+                "source" => %{"pointer" => "/api_key"},
+                "title" => "Invalid value"
+              }
+            ]
+          end)
+      },
+      %{
+        name: "non string api_key",
+        request_body_scenarios:
+          Enum.map(
+            [123, true, %{}, []],
+            fn non_string_api_key ->
+              provider = build(:random_ai_provider)
+              model = build(:random_ai_model, provider: provider)
+
+              %{
+                model: model,
+                provider: provider,
+                api_key: non_string_api_key
+              }
+            end
+          ),
+        expected_errors_scenarios:
+          Enum.map(
+            ["integer", "boolean", "object", "array"],
+            &[
+              %{
+                "detail" => "Invalid string. Got: #{&1}",
+                "source" => %{"pointer" => "/api_key"},
+                "title" => "Invalid value"
+              }
+            ]
+          )
+      }
+    ]
+
+    for %{name: name} = failing_validation_scenario <- failing_validation_scenarios do
+      @failing_validation_scenario failing_validation_scenario
+
+      test "should fail to create a new AI configuration with invalid data - #{name}", %{
+        conn: conn,
+        api_spec: api_spec
+      } do
+        expected_errors = Map.get(@failing_validation_scenario, :expected_errors, [])
+
+        expected_errors_scenarios =
+          Map.get(@failing_validation_scenario, :expected_errors_scenarios, [expected_errors])
+
+        request_body = Map.get(@failing_validation_scenario, :request_body, %{})
+
+        request_body_scenarios =
+          Map.get(@failing_validation_scenario, :request_body_scenarios, [request_body])
+
+        for {resolved_scenario, index} <- Enum.with_index(request_body_scenarios) do
+          resolved_expected_errors = Enum.at(expected_errors_scenarios, index, expected_errors)
+
+          response =
+            conn
+            |> post("/api/v1/profile/ai_configuration", resolved_scenario)
+            |> json_response(:unprocessable_entity)
+
+          assert_schema(response, "UnprocessableEntityV1", api_spec)
+
+          assert %{
+                   "errors" => resolved_expected_errors
+                 } == response
+        end
+      end
+    end
+
+    test "should fail to create a new AI configuration for a user that already has one", %{
+      conn: conn,
+      api_spec: api_spec,
+      admin_user: %{id: user_id}
+    } do
+      insert(:ai_user_configuration, user_id: user_id)
+
+      payload = build(:ai_configuration_creation_params)
+
+      response =
+        conn
+        |> post("/api/v1/profile/ai_configuration", payload)
+        |> json_response(:unprocessable_entity)
+
+      assert_schema(response, "UnprocessableEntityV1", api_spec)
+
+      assert %{
+               "errors" => [
+                 %{
+                   "detail" => "User already has a configuration",
+                   "source" => %{"pointer" => "/user_id"},
+                   "title" => "Invalid value"
+                 }
+               ]
+             } == response
+    end
+
+    test "should create an AI configuration for the user", %{
+      conn: conn,
+      api_spec: api_spec
+    } do
+      %{provider: provider, model: model, api_key: _} =
+        creation_params = build(:ai_configuration_creation_params)
+
+      expected_provider = Atom.to_string(provider)
+
+      response =
+        conn
+        |> post("/api/v1/profile/ai_configuration", creation_params)
+        |> json_response(:created)
+
+      assert_schema(response, "AIUserConfigurationV1", api_spec)
+
+      assert %{
+               "provider" => expected_provider,
+               "model" => model
+             } == response
+    end
+  end
+
+  describe "updating AI configuration" do
+    test "should not allow updating AI configuration for a user that does not have one", %{
+      conn: conn,
+      api_spec: api_spec
+    } do
+      conn
+      |> patch("/api/v1/profile/ai_configuration", %{
+        model: build(:random_ai_model),
+        api_key: Faker.String.base64()
+      })
+      |> json_response(:not_found)
+      |> assert_schema("NotFoundV1", api_spec)
+    end
+
+    failing_update_validation_scenarios = [
+      %{
+        name: "empty payload",
+        request_body_scenarios: [
+          %{},
+          nil,
+          ""
+        ],
+        expected_errors: [
+          %{
+            "detail" => "Object property count 0 is less than minProperties: 1",
+            "source" => %{"pointer" => "/"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "nil provider",
+        request_body: %{
+          provider: nil
+        },
+        expected_errors: [
+          %{
+            "detail" => "null value where string expected",
+            "source" => %{"pointer" => "/provider"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "empty provider",
+        request_body_scenarios:
+          Enum.map(
+            ["", "  "],
+            &%{
+              provider: &1
+            }
+          ),
+        expected_errors: [
+          %{
+            "detail" => "can't be blank",
+            "source" => %{"pointer" => "/provider"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "unsupported provider",
+        request_body: %{
+          provider: Faker.Lorem.word()
+        },
+        expected_errors: [
+          %{
+            "detail" => "is invalid",
+            "source" => %{"pointer" => "/provider"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "non string provider",
+        request_body_scenarios:
+          Enum.map(
+            [123, true, %{}, []],
+            &%{
+              provider: &1
+            }
+          ),
+        expected_errors_scenarios:
+          Enum.map(
+            ["integer", "boolean", "object", "array"],
+            &[
+              %{
+                "detail" => "Invalid string. Got: #{&1}",
+                "source" => %{"pointer" => "/provider"},
+                "title" => "Invalid value"
+              }
+            ]
+          )
+      },
+      %{
+        name: "nil model",
+        request_body: %{
+          model: nil,
+          api_key: Faker.String.base64()
+        },
+        expected_errors: [
+          %{
+            "detail" => "null value where string expected",
+            "source" => %{"pointer" => "/model"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "empty model",
+        request_body_scenarios:
+          Enum.map(
+            ["", "  "],
+            &%{
+              model: &1,
+              api_key: Faker.String.base64()
+            }
+          ),
+        expected_errors: [
+          %{
+            "detail" => "can't be blank",
+            "source" => %{"pointer" => "/model"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "non string model",
+        request_body_scenarios:
+          Enum.map(
+            [123, true, %{}, []],
+            &%{
+              model: &1,
+              api_key: Faker.String.base64()
+            }
+          ),
+        expected_errors_scenarios:
+          Enum.map(
+            ["integer", "boolean", "object", "array"],
+            &[
+              %{
+                "detail" => "Invalid string. Got: #{&1}",
+                "source" => %{"pointer" => "/model"},
+                "title" => "Invalid value"
+              }
+            ]
+          )
+      },
+      %{
+        name: "unsupported model",
+        request_body: %{
+          model: Faker.Lorem.word(),
+          api_key: Faker.String.base64()
+        },
+        expected_errors: [
+          %{
+            "detail" => "is not supported",
+            "source" => %{"pointer" => "/model"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "model unsupported by the specified provider",
+        request_body: %{
+          provider: :googleai,
+          model: "gpt-5.4",
+          api_key: Faker.String.base64()
+        },
+        expected_errors: [
+          %{
+            "detail" => "is not supported by the specified provider",
+            "source" => %{"pointer" => "/model"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "nil api_key",
+        request_body: %{
+          model: build(:random_ai_model),
+          api_key: nil
+        },
+        expected_errors: [
+          %{
+            "detail" => "null value where string expected",
+            "source" => %{"pointer" => "/api_key"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "empty api_key",
+        request_body_scenarios:
+          Enum.map(
+            ["", "  "],
+            fn empty_api_key ->
+              provider = build(:random_ai_provider)
+              model = build(:random_ai_model, provider: provider)
+
+              %{
+                provider: provider,
+                model: model,
+                api_key: empty_api_key
+              }
+            end
+          ),
+        expected_errors: [
+          %{
+            "detail" => "can't be blank",
+            "source" => %{"pointer" => "/api_key"},
+            "title" => "Invalid value"
+          }
+        ]
+      },
+      %{
+        name: "non string api_key",
+        request_body_scenarios:
+          Enum.map(
+            [123, true, %{}, []],
+            &%{
+              model: build(:random_ai_model),
+              api_key: &1
+            }
+          ),
+        expected_errors_scenarios:
+          Enum.map(
+            ["integer", "boolean", "object", "array"],
+            &[
+              %{
+                "detail" => "Invalid string. Got: #{&1}",
+                "source" => %{"pointer" => "/api_key"},
+                "title" => "Invalid value"
+              }
+            ]
+          )
+      }
+    ]
+
+    for %{name: name} = failing_update_validation_scenario <- failing_update_validation_scenarios do
+      @failing_update_validation_scenario failing_update_validation_scenario
+
+      test "should fail to update an AI configuration with invalid data - #{name}", %{
+        conn: conn,
+        api_spec: api_spec,
+        admin_user: %{id: user_id}
+      } do
+        %UserConfiguration{} = insert(:ai_user_configuration, user_id: user_id)
+
+        expected_errors = Map.get(@failing_update_validation_scenario, :expected_errors, [])
+
+        expected_errors_scenarios =
+          Map.get(@failing_update_validation_scenario, :expected_errors_scenarios, [
+            expected_errors
+          ])
+
+        request_body = Map.get(@failing_update_validation_scenario, :request_body, %{})
+
+        request_body_scenarios =
+          Map.get(@failing_update_validation_scenario, :request_body_scenarios, [request_body])
+
+        for {resolved_scenario, index} <- Enum.with_index(request_body_scenarios) do
+          resolved_expected_errors = Enum.at(expected_errors_scenarios, index, expected_errors)
+
+          response =
+            conn
+            |> patch("/api/v1/profile/ai_configuration", resolved_scenario)
+            |> json_response(:unprocessable_entity)
+
+          assert_schema(response, "UnprocessableEntityV1", api_spec)
+
+          assert %{
+                   "errors" => resolved_expected_errors
+                 } == response
+        end
+      end
+    end
+
+    test "should allow partial updates to the AI configuration - model only", %{
+      conn: conn,
+      api_spec: api_spec,
+      admin_user: %{id: user_id}
+    } do
+      %UserConfiguration{
+        provider: initial_provider,
+        model: _initial_model
+      } = insert(:ai_user_configuration, user_id: user_id)
+
+      new_model = build(:random_ai_model, provider: initial_provider)
+
+      expected_provider = Atom.to_string(initial_provider)
+
+      response =
+        conn
+        |> patch("/api/v1/profile/ai_configuration", %{
+          model: new_model
+        })
+        |> json_response(:ok)
+
+      assert_schema(response, "AIUserConfigurationV1", api_spec)
+
+      assert %{
+               "provider" => expected_provider,
+               "model" => new_model
+             } == response
+    end
+
+    test "should allow partial updates to the AI configuration - api key only", %{
+      conn: conn,
+      api_spec: api_spec,
+      admin_user: %{id: user_id}
+    } do
+      %UserConfiguration{
+        model: initial_model,
+        provider: initial_provider
+      } = insert(:ai_user_configuration, user_id: user_id)
+
+      response =
+        conn
+        |> patch("/api/v1/profile/ai_configuration", %{
+          api_key: Faker.String.base64(32)
+        })
+        |> json_response(:ok)
+
+      assert_schema(response, "AIUserConfigurationV1", api_spec)
+
+      assert %{
+               "provider" => Atom.to_string(initial_provider),
+               "model" => initial_model
+             } == response
+    end
+
+    test "should allow complete updates to the AI configuration", %{
+      conn: conn,
+      api_spec: api_spec,
+      admin_user: %{id: user_id}
+    } do
+      %UserConfiguration{
+        model: _initial_model,
+        provider: _initial_provider
+      } = insert(:ai_user_configuration, user_id: user_id)
+
+      new_provider = build(:random_ai_provider)
+      new_model = build(:random_ai_model, provider: new_provider)
+      new_api_key = Faker.String.base64(32)
+
+      expected_provider = Atom.to_string(new_provider)
+
+      response =
+        conn
+        |> patch("/api/v1/profile/ai_configuration", %{
+          provider: new_provider,
+          model: new_model,
+          api_key: new_api_key
+        })
+        |> json_response(:ok)
+
+      assert_schema(response, "AIUserConfigurationV1", api_spec)
+
+      assert %{
+               "provider" => expected_provider,
+               "model" => new_model
+             } == response
+    end
+  end
+end

--- a/test/trento_web/views/v1/ai_configuration_view_json_test.exs
+++ b/test/trento_web/views/v1/ai_configuration_view_json_test.exs
@@ -1,0 +1,42 @@
+defmodule TrentoWeb.V1.AIConfigurationJSONTest do
+  use ExUnit.Case
+
+  import Trento.Factory
+
+  alias TrentoWeb.V1.AIConfigurationJSON
+
+  describe "rendering AI Configuration" do
+    test "AI configuration" do
+      %{
+        provider: provider,
+        model: model
+      } = ai_user_configuration = build(:ai_user_configuration)
+
+      scenarios = [
+        %{
+          ai_configuration: ai_user_configuration,
+          expected_ai_configuration: %{
+            provider: provider,
+            model: model
+          }
+        },
+        %{
+          ai_configuration: nil,
+          expected_ai_configuration: nil
+        },
+        %{
+          ai_configuration: "foo",
+          expected_ai_configuration: nil
+        }
+      ]
+
+      for %{
+            ai_configuration: ai_configuration,
+            expected_ai_configuration: expected_ai_configuration
+          } <- scenarios do
+        assert AIConfigurationJSON.ai_configuration(%{ai_configuration: ai_configuration}) ==
+                 expected_ai_configuration
+      end
+    end
+  end
+end

--- a/test/trento_web/views/v1/profile_view_json_test.exs
+++ b/test/trento_web/views/v1/profile_view_json_test.exs
@@ -73,39 +73,21 @@ defmodule TrentoWeb.V1.ProfileJSONTest do
     end
 
     test "should render a user profile with AI configuration" do
-      %{
-        provider: provider,
-        model: model
-      } = ai_user_configuration = build(:ai_user_configuration)
-
       scenarios = [
-        %{
-          user: build(:user, abilities: [], user_identities: [], ai_configuration: nil),
-          expected_ai_configuration: nil
-        },
-        %{
-          # not providing ai_configuration results in an Ecto.Association.NotLoaded
-          user: build(:user, abilities: [], user_identities: []),
-          expected_ai_configuration: nil
-        },
-        %{
-          user:
-            build(:user,
-              abilities: [],
-              user_identities: [],
-              ai_configuration: ai_user_configuration
-            ),
-          expected_ai_configuration: %{
-            provider: provider,
-            model: model
-          }
-        }
+        # not providing ai_configuration results in an Ecto.Association.NotLoaded
+        build(:user, abilities: [], user_identities: []),
+        build(:user, abilities: [], user_identities: [], ai_configuration: nil),
+        build(:user,
+          abilities: [],
+          user_identities: [],
+          ai_configuration: build(:ai_user_configuration)
+        )
       ]
 
-      for %{user: user, expected_ai_configuration: expected_ai_configuration} <- scenarios do
-        rendered_user = ProfileJSON.profile(%{user: user})
-
-        assert rendered_user.ai_configuration == expected_ai_configuration
+      for user <- scenarios do
+        assert %{user: user}
+               |> ProfileJSON.profile()
+               |> Map.has_key?(:ai_configuration)
       end
     end
   end


### PR DESCRIPTION
# Description

This PR adds the endpoints to create and update own AI configuration.

More than half of the changes are tests.

Comes after https://github.com/trento-project/web/pull/4140 and https://github.com/trento-project/web/pull/4143

Depends on https://github.com/trento-project/web/pull/4143

## How was this tested?

Automated and IRL tests.