### PR TITLE
Add component versioning

### DIFF
--- a/assets/js/lib/test-utils/factories/index.js
+++ b/assets/js/lib/test-utils/factories/index.js
@@ -74,6 +74,7 @@ export const aboutFactory = Factory.define(() => ({
   sles_subscriptions: faker.number.int(),
   version: faker.system.networkInterface(),
   wanda_version: faker.system.semver(),
+  checks_version: faker.system.semver(),
   postgres_version: faker.system.semver(),
   rabbitmq_version: faker.system.semver(),
   prometheus_version: faker.system.semver(),

--- a/assets/js/lib/test-utils/factories/index.js
+++ b/assets/js/lib/test-utils/factories/index.js
@@ -73,6 +73,10 @@ export const healthSummaryFactory = Factory.define(() => ({
 export const aboutFactory = Factory.define(() => ({
   sles_subscriptions: faker.number.int(),
   version: faker.system.networkInterface(),
+  wanda_version: faker.system.semver(),
+  postgres_version: faker.system.semver(),
+  rabbitmq_version: faker.system.semver(),
+  prometheus_version: faker.system.semver(),
 }));
 
 export const objectTreeFactory = Factory.define(() => ({

--- a/assets/js/pages/AboutPage/AboutPage.jsx
+++ b/assets/js/pages/AboutPage/AboutPage.jsx
@@ -12,27 +12,61 @@ import AboutPageText from './AboutPageText';
 function AboutPage({ onFetch = getAboutData }) {
   const [subscriptions, setSubscriptions] = useState(0);
   const [version, setVersion] = useState('v0.0.0');
+  const [wandaVersion, setWandaVersion] = useState(null);
+  const [postgresVersion, setPostgresVersion] = useState(null);
+  const [rabbitmqVersion, setRabbitmqVersion] = useState(null);
+  const [prometheusVersion, setPrometheusVersion] = useState(null);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     setLoading(true);
     onFetch()
-      .then(({ data: { version: newVersion, sles_subscriptions } }) => {
-        setLoading(false);
-        setVersion(newVersion);
-        setSubscriptions(sles_subscriptions);
-      })
+      .then(
+        ({
+          data: {
+            version: newVersion,
+            sles_subscriptions,
+            wanda_version,
+            postgres_version,
+            rabbitmq_version,
+            prometheus_version,
+          },
+        }) => {
+          setLoading(false);
+          setVersion(newVersion);
+          setSubscriptions(sles_subscriptions);
+          setWandaVersion(wanda_version);
+          setPostgresVersion(postgres_version);
+          setRabbitmqVersion(rabbitmq_version);
+          setPrometheusVersion(prometheus_version);
+        }
+      )
       .catch((error) => {
         logError(error);
         setLoading(false);
       });
   }, []);
 
-  // TODO: check if the data is off now
   const listViewData = [
     {
       title: 'Server version',
       content: loading ? 'Loading...' : version,
+    },
+    {
+      title: 'Wanda version',
+      content: loading ? 'Loading...' : wandaVersion || 'N/A',
+    },
+    {
+      title: 'PostgreSQL version',
+      content: loading ? 'Loading...' : postgresVersion || 'N/A',
+    },
+    {
+      title: 'RabbitMQ version',
+      content: loading ? 'Loading...' : rabbitmqVersion || 'N/A',
+    },
+    {
+      title: 'Prometheus version',
+      content: loading ? 'Loading...' : prometheusVersion || 'N/A',
     },
     {
       title: 'GitHub repository',

--- a/assets/js/pages/AboutPage/AboutPage.jsx
+++ b/assets/js/pages/AboutPage/AboutPage.jsx
@@ -13,6 +13,7 @@ function AboutPage({ onFetch = getAboutData }) {
   const [subscriptions, setSubscriptions] = useState(0);
   const [version, setVersion] = useState('v0.0.0');
   const [wandaVersion, setWandaVersion] = useState(null);
+  const [checksVersion, setChecksVersion] = useState(null);
   const [postgresVersion, setPostgresVersion] = useState(null);
   const [rabbitmqVersion, setRabbitmqVersion] = useState(null);
   const [prometheusVersion, setPrometheusVersion] = useState(null);
@@ -27,6 +28,7 @@ function AboutPage({ onFetch = getAboutData }) {
             version: newVersion,
             sles_subscriptions,
             wanda_version,
+            checks_version,
             postgres_version,
             rabbitmq_version,
             prometheus_version,
@@ -36,6 +38,7 @@ function AboutPage({ onFetch = getAboutData }) {
           setVersion(newVersion);
           setSubscriptions(sles_subscriptions);
           setWandaVersion(wanda_version);
+          setChecksVersion(checks_version);
           setPostgresVersion(postgres_version);
           setRabbitmqVersion(rabbitmq_version);
           setPrometheusVersion(prometheus_version);
@@ -55,6 +58,10 @@ function AboutPage({ onFetch = getAboutData }) {
     {
       title: 'Wanda version',
       content: loading ? 'Loading...' : wandaVersion || 'N/A',
+    },
+    {
+      title: 'Checks version',
+      content: loading ? 'Loading...' : checksVersion || 'N/A',
     },
     {
       title: 'PostgreSQL version',

--- a/assets/js/pages/AboutPage/AboutPage.jsx
+++ b/assets/js/pages/AboutPage/AboutPage.jsx
@@ -48,7 +48,7 @@ function AboutPage({ onFetch = getAboutData }) {
         logError(error);
         setLoading(false);
       });
-  }, []);
+  }, [onFetch]);
 
   const listViewData = [
     {

--- a/assets/js/pages/AboutPage/AboutPage.test.jsx
+++ b/assets/js/pages/AboutPage/AboutPage.test.jsx
@@ -19,6 +19,7 @@ describe('AboutPage component', () => {
       screen.getByText(`${apiRequestData.sles_subscriptions} found`)
     ).toBeTruthy();
     expect(screen.getByText(apiRequestData.wanda_version)).toBeTruthy();
+    expect(screen.getByText(apiRequestData.checks_version)).toBeTruthy();
     expect(screen.getByText(apiRequestData.postgres_version)).toBeTruthy();
     expect(screen.getByText(apiRequestData.rabbitmq_version)).toBeTruthy();
     expect(screen.getByText(apiRequestData.prometheus_version)).toBeTruthy();
@@ -28,6 +29,7 @@ describe('AboutPage component', () => {
     const dataWithNullVersions = {
       ...apiRequestData,
       wanda_version: null,
+      checks_version: null,
       postgres_version: null,
       rabbitmq_version: null,
       prometheus_version: null,
@@ -42,7 +44,7 @@ describe('AboutPage component', () => {
     });
 
     const naElements = screen.getAllByText('N/A');
-    expect(naElements).toHaveLength(4);
+    expect(naElements).toHaveLength(5);
   });
 
   it('should render the about page with default values if api get request fails', async () => {

--- a/assets/js/pages/AboutPage/AboutPage.test.jsx
+++ b/assets/js/pages/AboutPage/AboutPage.test.jsx
@@ -18,6 +18,31 @@ describe('AboutPage component', () => {
     expect(
       screen.getByText(`${apiRequestData.sles_subscriptions} found`)
     ).toBeTruthy();
+    expect(screen.getByText(apiRequestData.wanda_version)).toBeTruthy();
+    expect(screen.getByText(apiRequestData.postgres_version)).toBeTruthy();
+    expect(screen.getByText(apiRequestData.rabbitmq_version)).toBeTruthy();
+    expect(screen.getByText(apiRequestData.prometheus_version)).toBeTruthy();
+  });
+
+  it('should render N/A when component versions are null', async () => {
+    const dataWithNullVersions = {
+      ...apiRequestData,
+      wanda_version: null,
+      postgres_version: null,
+      rabbitmq_version: null,
+      prometheus_version: null,
+    };
+
+    await act(async () => {
+      renderWithRouter(
+        <AboutPage
+          onFetch={() => Promise.resolve({ data: dataWithNullVersions })}
+        />
+      );
+    });
+
+    const naElements = screen.getAllByText('N/A');
+    expect(naElements).toHaveLength(4);
   });
 
   it('should render the about page with default values if api get request fails', async () => {

--- a/config/config.exs
+++ b/config/config.exs
@@ -210,6 +210,8 @@ config :trento, Trento.Infrastructure.Messaging.Adapter.AMQP,
     ]
   ]
 
+config :trento, :component_versions, adapter: Trento.Infrastructure.ComponentVersions
+
 config :trento, Trento.Infrastructure.Prometheus,
   adapter: Trento.Infrastructure.Prometheus.PrometheusApi
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -91,7 +91,7 @@ services:
 
   wanda:
     profiles: [wanda]
-    image: ghcr.io/trento-project/trento-wanda:demo
+    image: ghcr.io/trento-project/trento-wanda:rolling
     environment:
       DATABASE_URL: ecto://postgres:postgres@postgres/wanda_db
       SECRET_KEY_BASE: s2ZdE+3+ke1USHEJ5O45KT364KiXPYaB9cJPdH3p60t8yT0nkLexLBNw8TFSzC7k

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -91,7 +91,7 @@ services:
 
   wanda:
     profiles: [wanda]
-    image: ghcr.io/trento-project/trento-wanda:rolling
+    image: ghcr.io/trento-project/trento-wanda:demo
     environment:
       DATABASE_URL: ecto://postgres:postgres@postgres/wanda_db
       SECRET_KEY_BASE: s2ZdE+3+ke1USHEJ5O45KT364KiXPYaB9cJPdH3p60t8yT0nkLexLBNw8TFSzC7k

--- a/lib/trento/infrastructure/component_versions/component_versions.ex
+++ b/lib/trento/infrastructure/component_versions/component_versions.ex
@@ -11,13 +11,21 @@ defmodule Trento.Infrastructure.ComponentVersions do
 
   @timeout 5_000
 
+  @defaults %{
+    postgres_version: nil,
+    rabbitmq_version: nil,
+    prometheus_version: nil,
+    wanda_version: nil,
+    checks_version: nil
+  }
+
   @impl true
   def get_versions do
     fetchers = [
-      {:postgres_version, &fetch_postgres_version/0},
-      {:rabbitmq_version, &fetch_rabbitmq_version/0},
-      {:prometheus_version, &fetch_prometheus_version/0},
-      {:wanda_version, &fetch_wanda_version/0}
+      {:postgres, &fetch_postgres_version/0},
+      {:rabbitmq, &fetch_rabbitmq_version/0},
+      {:prometheus, &fetch_prometheus_version/0},
+      {:wanda, &fetch_wanda_info/0}
     ]
 
     results =
@@ -29,41 +37,33 @@ defmodule Trento.Infrastructure.ComponentVersions do
         timeout: @timeout,
         on_timeout: :kill_task
       )
-      |> Enum.reduce(%{}, fn
-        {:ok, {key, version}}, acc -> Map.put(acc, key, version)
+      |> Enum.reduce(@defaults, fn
+        {:ok, {_key, result}}, acc when is_map(result) -> Map.merge(acc, result)
         {:exit, _}, acc -> acc
       end)
 
-    Map.merge(
-      %{
-        postgres_version: nil,
-        rabbitmq_version: nil,
-        prometheus_version: nil,
-        wanda_version: nil
-      },
-      results
-    )
+    results
   end
 
   defp safe_fetch(key, fetcher) do
     case fetcher.() do
-      {:ok, version} -> version
-      {:error, _} -> nil
+      {:ok, result} -> result
+      {:error, _} -> %{}
     end
   rescue
     e ->
       Logger.error("Failed to fetch #{key}: #{inspect(e)}")
-      nil
+      %{}
   catch
     kind, reason ->
       Logger.error("Failed to fetch #{key}: #{inspect(kind)} #{inspect(reason)}")
-      nil
+      %{}
   end
 
   defp fetch_postgres_version do
     case SQL.query(Trento.Repo, "SHOW server_version", []) do
       {:ok, %{rows: [[version]]}} ->
-        {:ok, version}
+        {:ok, %{postgres_version: version}}
 
       {:error, reason} ->
         Logger.error("Failed to fetch PostgreSQL version: #{inspect(reason)}")
@@ -93,7 +93,7 @@ defmodule Trento.Infrastructure.ComponentVersions do
     case :amqp_connection.info(pid, [:server_properties]) do
       [{:server_properties, props}] ->
         case List.keyfind(props, "version", 0) do
-          {"version", :longstr, version} -> {:ok, to_string(version)}
+          {"version", :longstr, version} -> {:ok, %{rabbitmq_version: to_string(version)}}
           _ -> {:error, :version_not_found}
         end
 
@@ -112,7 +112,7 @@ defmodule Trento.Infrastructure.ComponentVersions do
     case HTTPoison.get(url, headers, recv_timeout: @timeout) do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         case Jason.decode(body) do
-          {:ok, %{"data" => %{"version" => version}}} -> {:ok, version}
+          {:ok, %{"data" => %{"version" => version}}} -> {:ok, %{prometheus_version: version}}
           _ -> {:error, :unexpected_response}
         end
 
@@ -126,7 +126,7 @@ defmodule Trento.Infrastructure.ComponentVersions do
     end
   end
 
-  defp fetch_wanda_version do
+  defp fetch_wanda_info do
     checks_base_url = Application.fetch_env!(:trento, :checks_service)[:base_url]
 
     case HTTPoison.get("#{checks_base_url}/api", [{"Accept", "application/json"}],
@@ -134,8 +134,15 @@ defmodule Trento.Infrastructure.ComponentVersions do
          ) do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         case Jason.decode(body) do
-          {:ok, %{"version" => version}} -> {:ok, version}
-          _ -> {:error, :unexpected_response}
+          {:ok, %{"version" => version} = data} ->
+            {:ok,
+             %{
+               wanda_version: version,
+               checks_version: Map.get(data, "checks_version")
+             }}
+
+          _ ->
+            {:error, :unexpected_response}
         end
 
       {:error, reason} ->

--- a/lib/trento/infrastructure/component_versions/component_versions.ex
+++ b/lib/trento/infrastructure/component_versions/component_versions.ex
@@ -1,0 +1,149 @@
+defmodule Trento.Infrastructure.ComponentVersions do
+  @moduledoc """
+  Fetches version information from all platform components.
+  """
+
+  @behaviour Trento.Infrastructure.ComponentVersions.Gen
+
+  alias Ecto.Adapters.SQL
+
+  require Logger
+
+  @timeout 5_000
+
+  @impl true
+  def get_versions do
+    fetchers = [
+      {:postgres_version, &fetch_postgres_version/0},
+      {:rabbitmq_version, &fetch_rabbitmq_version/0},
+      {:prometheus_version, &fetch_prometheus_version/0},
+      {:wanda_version, &fetch_wanda_version/0}
+    ]
+
+    results =
+      fetchers
+      |> Task.async_stream(
+        fn {key, fetcher} ->
+          {key, safe_fetch(key, fetcher)}
+        end,
+        timeout: @timeout,
+        on_timeout: :kill_task
+      )
+      |> Enum.reduce(%{}, fn
+        {:ok, {key, version}}, acc -> Map.put(acc, key, version)
+        {:exit, _}, acc -> acc
+      end)
+
+    Map.merge(
+      %{
+        postgres_version: nil,
+        rabbitmq_version: nil,
+        prometheus_version: nil,
+        wanda_version: nil
+      },
+      results
+    )
+  end
+
+  defp safe_fetch(key, fetcher) do
+    case fetcher.() do
+      {:ok, version} -> version
+      {:error, _} -> nil
+    end
+  rescue
+    e ->
+      Logger.error("Failed to fetch #{key}: #{inspect(e)}")
+      nil
+  catch
+    kind, reason ->
+      Logger.error("Failed to fetch #{key}: #{inspect(kind)} #{inspect(reason)}")
+      nil
+  end
+
+  defp fetch_postgres_version do
+    case SQL.query(Trento.Repo, "SHOW server_version", []) do
+      {:ok, %{rows: [[version]]}} ->
+        {:ok, version}
+
+      {:error, reason} ->
+        Logger.error("Failed to fetch PostgreSQL version: #{inspect(reason)}")
+        {:error, :unreachable}
+    end
+  end
+
+  defp fetch_rabbitmq_version do
+    amqp_config =
+      Application.fetch_env!(:trento, Trento.Infrastructure.Messaging.Adapter.AMQP)
+
+    amqp_url = amqp_config[:checks][:consumer][:connection]
+
+    case AMQP.Connection.open(amqp_url) do
+      {:ok, %AMQP.Connection{pid: pid} = conn} ->
+        version = extract_rabbitmq_version(pid)
+        AMQP.Connection.close(conn)
+        version
+
+      {:error, reason} ->
+        Logger.error("Failed to connect to RabbitMQ: #{inspect(reason)}")
+        {:error, :unreachable}
+    end
+  end
+
+  defp extract_rabbitmq_version(pid) do
+    case :amqp_connection.info(pid, [:server_properties]) do
+      [{:server_properties, props}] ->
+        case List.keyfind(props, "version", 0) do
+          {"version", :longstr, version} -> {:ok, to_string(version)}
+          _ -> {:error, :version_not_found}
+        end
+
+      _ ->
+        {:error, :version_not_found}
+    end
+  end
+
+  defp fetch_prometheus_version do
+    prometheus_url =
+      Application.fetch_env!(:trento, Trento.Infrastructure.Prometheus.PrometheusApi)[:url]
+
+    url = "#{prometheus_url}/api/v1/status/buildinfo"
+    headers = [{"Accept", "application/json"}]
+
+    case HTTPoison.get(url, headers, recv_timeout: @timeout) do
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        case Jason.decode(body) do
+          {:ok, %{"data" => %{"version" => version}}} -> {:ok, version}
+          _ -> {:error, :unexpected_response}
+        end
+
+      {:ok, %HTTPoison.Response{status_code: status_code}} ->
+        Logger.error("Unexpected Prometheus buildinfo response: #{status_code}")
+        {:error, :unexpected_response}
+
+      {:error, reason} ->
+        Logger.error("Failed to fetch Prometheus version: #{inspect(reason)}")
+        {:error, :unreachable}
+    end
+  end
+
+  defp fetch_wanda_version do
+    checks_base_url = Application.fetch_env!(:trento, :checks_service)[:base_url]
+
+    case HTTPoison.get("#{checks_base_url}/api", [{"Accept", "application/json"}],
+           recv_timeout: @timeout
+         ) do
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        case Jason.decode(body) do
+          {:ok, %{"version" => version}} -> {:ok, version}
+          _ -> {:error, :unexpected_response}
+        end
+
+      {:error, reason} ->
+        Logger.error("Failed to fetch Wanda version: #{inspect(reason)}")
+        {:error, :unreachable}
+
+      _ ->
+        {:error, :unexpected_response}
+    end
+  end
+end

--- a/lib/trento/infrastructure/component_versions/gen.ex
+++ b/lib/trento/infrastructure/component_versions/gen.ex
@@ -5,6 +5,7 @@ defmodule Trento.Infrastructure.ComponentVersions.Gen do
 
   @callback get_versions() :: %{
               wanda_version: String.t() | nil,
+              checks_version: String.t() | nil,
               postgres_version: String.t() | nil,
               rabbitmq_version: String.t() | nil,
               prometheus_version: String.t() | nil

--- a/lib/trento/infrastructure/component_versions/gen.ex
+++ b/lib/trento/infrastructure/component_versions/gen.ex
@@ -1,0 +1,12 @@
+defmodule Trento.Infrastructure.ComponentVersions.Gen do
+  @moduledoc """
+  Behaviour for fetching component versions.
+  """
+
+  @callback get_versions() :: %{
+              wanda_version: String.t() | nil,
+              postgres_version: String.t() | nil,
+              rabbitmq_version: String.t() | nil,
+              prometheus_version: String.t() | nil
+            }
+end

--- a/lib/trento_web/controllers/v1/about_controller.ex
+++ b/lib/trento_web/controllers/v1/about_controller.ex
@@ -21,11 +21,23 @@ defmodule TrentoWeb.V1.AboutController do
 
   @spec info(Plug.Conn.t(), map) :: Plug.Conn.t()
   def info(conn, _) do
+    versions = component_versions().get_versions()
+
     render(conn, :about,
-      about_info: %{
-        version: @version,
-        sles_subscriptions: Hosts.get_all_sles_subscriptions()
-      }
+      about_info:
+        Map.merge(
+          %{
+            version: @version,
+            sles_subscriptions: Hosts.get_all_sles_subscriptions()
+          },
+          versions
+        )
     )
   end
+
+  defp component_versions,
+    do:
+      Application.fetch_env!(:trento, :component_versions)[
+        :adapter
+      ]
 end

--- a/lib/trento_web/controllers/v1/about_json.ex
+++ b/lib/trento_web/controllers/v1/about_json.ex
@@ -11,6 +11,7 @@ defmodule TrentoWeb.V1.AboutJSON do
         sles_subscriptions: sles_subscriptions,
         flavor: "Community",
         wanda_version: Map.get(about_info, :wanda_version),
+        checks_version: Map.get(about_info, :checks_version),
         postgres_version: Map.get(about_info, :postgres_version),
         rabbitmq_version: Map.get(about_info, :rabbitmq_version),
         prometheus_version: Map.get(about_info, :prometheus_version)

--- a/lib/trento_web/controllers/v1/about_json.ex
+++ b/lib/trento_web/controllers/v1/about_json.ex
@@ -1,10 +1,18 @@
 defmodule TrentoWeb.V1.AboutJSON do
   def about(%{
-        about_info: %{version: version, sles_subscriptions: sles_subscriptions}
+        about_info:
+          %{
+            version: version,
+            sles_subscriptions: sles_subscriptions
+          } = about_info
       }),
       do: %{
         version: version,
         sles_subscriptions: sles_subscriptions,
-        flavor: "Community"
+        flavor: "Community",
+        wanda_version: Map.get(about_info, :wanda_version),
+        postgres_version: Map.get(about_info, :postgres_version),
+        rabbitmq_version: Map.get(about_info, :rabbitmq_version),
+        prometheus_version: Map.get(about_info, :prometheus_version)
       }
 end

--- a/lib/trento_web/openapi/v1/schema/platform.ex
+++ b/lib/trento_web/openapi/v1/schema/platform.ex
@@ -83,6 +83,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Platform do
           version: "2.4.0",
           sles_subscriptions: 5,
           wanda_version: "1.0.0",
+          checks_version: "1.0.0",
           postgres_version: "16.1",
           rabbitmq_version: "3.12.0",
           prometheus_version: "2.48.0"
@@ -107,6 +108,11 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Platform do
             type: :string,
             nullable: true,
             description: "Version of the Wanda checks engine."
+          },
+          checks_version: %Schema{
+            type: :string,
+            nullable: true,
+            description: "Version of the checks catalog."
           },
           postgres_version: %Schema{
             type: :string,

--- a/lib/trento_web/openapi/v1/schema/platform.ex
+++ b/lib/trento_web/openapi/v1/schema/platform.ex
@@ -81,7 +81,11 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Platform do
         example: %{
           flavor: "Community",
           version: "2.4.0",
-          sles_subscriptions: 5
+          sles_subscriptions: 5,
+          wanda_version: "1.0.0",
+          postgres_version: "16.1",
+          rabbitmq_version: "3.12.0",
+          prometheus_version: "2.48.0"
         },
         properties: %{
           flavor: %Schema{
@@ -98,6 +102,26 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Platform do
             type: :integer,
             description:
               "The number of SLES Subscription discovered on the target infrastructure."
+          },
+          wanda_version: %Schema{
+            type: :string,
+            nullable: true,
+            description: "Version of the Wanda checks engine."
+          },
+          postgres_version: %Schema{
+            type: :string,
+            nullable: true,
+            description: "Version of the PostgreSQL server."
+          },
+          rabbitmq_version: %Schema{
+            type: :string,
+            nullable: true,
+            description: "Version of the RabbitMQ server."
+          },
+          prometheus_version: %Schema{
+            type: :string,
+            nullable: true,
+            description: "Version of the Prometheus server."
           }
         }
       },

--- a/test/e2e/cypress/e2e/about.cy.js
+++ b/test/e2e/cypress/e2e/about.cy.js
@@ -22,6 +22,10 @@ describe('About page', () => {
     aboutPage.expectedWandaVersionIsDisplayed();
   });
 
+  it('should show the Checks version', () => {
+    aboutPage.expectedChecksVersionIsDisplayed();
+  });
+
   it('should show the PostgreSQL version', () => {
     aboutPage.expectedPostgresVersionIsDisplayed();
   });

--- a/test/e2e/cypress/e2e/about.cy.js
+++ b/test/e2e/cypress/e2e/about.cy.js
@@ -18,6 +18,22 @@ describe('About page', () => {
     aboutPage.expectedServerVersionIsDisplayed();
   });
 
+  it('should show the Wanda version', () => {
+    aboutPage.expectedWandaVersionIsDisplayed();
+  });
+
+  it('should show the PostgreSQL version', () => {
+    aboutPage.expectedPostgresVersionIsDisplayed();
+  });
+
+  it('should show the RabbitMQ version', () => {
+    aboutPage.expectedRabbitmqVersionIsDisplayed();
+  });
+
+  it('should show the Prometheus version', () => {
+    aboutPage.expectedPrometheusVersionIsDisplayed();
+  });
+
   it('should show the github project link', () => {
     aboutPage.expectedGithubUrlIsDisplayed();
   });

--- a/test/e2e/cypress/pageObject/about_po.js
+++ b/test/e2e/cypress/pageObject/about_po.js
@@ -37,36 +37,28 @@ export const expectedGithubUrlIsDisplayed = () =>
     .get(githubRepositoryLabel)
     .should('have.text', 'https://github.com/trento-project/web');
 
-export const componentVersionIsDisplayed = (selector) => {
-  return cy.get(selector).should('not.be.empty').and('be.visible');
-};
+export const componentVersionIsDisplayed = (selector) =>
+  cy.get(selector).should('not.be.empty').and('be.visible');
 
-export const expectedWandaVersionIsDisplayed = () => {
-  return componentVersionIsDisplayed(wandaVersionLabel);
-};
+export const expectedWandaVersionIsDisplayed = () =>
+  componentVersionIsDisplayed(wandaVersionLabel);
 
-export const expectedChecksVersionIsDisplayed = () => {
-  return componentVersionIsDisplayed(checksVersionLabel);
-};
+export const expectedChecksVersionIsDisplayed = () =>
+  componentVersionIsDisplayed(checksVersionLabel);
 
-export const expectedPostgresVersionIsDisplayed = () => {
-  return componentVersionIsDisplayed(postgresVersionLabel);
-};
+export const expectedPostgresVersionIsDisplayed = () =>
+  componentVersionIsDisplayed(postgresVersionLabel);
 
-export const expectedRabbitmqVersionIsDisplayed = () => {
-  return componentVersionIsDisplayed(rabbitmqVersionLabel);
-};
+export const expectedRabbitmqVersionIsDisplayed = () =>
+  componentVersionIsDisplayed(rabbitmqVersionLabel);
 
-export const expectedPrometheusVersionIsDisplayed = () => {
-  return componentVersionIsDisplayed(prometheusVersionLabel);
-};
+export const expectedPrometheusVersionIsDisplayed = () =>
+  componentVersionIsDisplayed(prometheusVersionLabel);
 
-export const expectedSlesForSapSubscriptionsAreDisplayed = () => {
-  const subscriptions = getValue('subscriptions');
-  return cy
+export const expectedSlesForSapSubscriptionsAreDisplayed = (subscriptions) =>
+  cy
     .get(amountOfSlesForSapSubscriptionsLabel)
     .should('have.text', `${subscriptions} found`);
-}
 
 export const apiDeregisterHost = () =>
   basePage.apiDeregisterHost(hostToDeregister);

--- a/test/e2e/cypress/pageObject/about_po.js
+++ b/test/e2e/cypress/pageObject/about_po.js
@@ -7,6 +7,8 @@ const url = '/about';
 const pageTitle = 'h2';
 const versionLabel = 'div.font-bold:contains("Server version") + div span';
 const wandaVersionLabel = 'div.font-bold:contains("Wanda version") + div span';
+const checksVersionLabel =
+  'div.font-bold:contains("Checks version") + div span';
 const postgresVersionLabel =
   'div.font-bold:contains("PostgreSQL version") + div span';
 const rabbitmqVersionLabel =
@@ -41,6 +43,10 @@ export const componentVersionIsDisplayed = (selector) => {
 
 export const expectedWandaVersionIsDisplayed = () => {
   return componentVersionIsDisplayed(wandaVersionLabel);
+};
+
+export const expectedChecksVersionIsDisplayed = () => {
+  return componentVersionIsDisplayed(checksVersionLabel);
 };
 
 export const expectedPostgresVersionIsDisplayed = () => {

--- a/test/e2e/cypress/pageObject/about_po.js
+++ b/test/e2e/cypress/pageObject/about_po.js
@@ -5,10 +5,18 @@ const hostToDeregister = '7269ee51-5007-5849-aaa7-7c4a98b0c9ce';
 
 const url = '/about';
 const pageTitle = 'h2';
-const versionLabel = 'div:contains("Server version") + div span';
-const githubRepositoryLabel = 'div:contains("GitHub repository") + div a';
+const versionLabel = 'div.font-bold:contains("Server version") + div span';
+const wandaVersionLabel = 'div.font-bold:contains("Wanda version") + div span';
+const postgresVersionLabel =
+  'div.font-bold:contains("PostgreSQL version") + div span';
+const rabbitmqVersionLabel =
+  'div.font-bold:contains("RabbitMQ version") + div span';
+const prometheusVersionLabel =
+  'div.font-bold:contains("Prometheus version") + div span';
+const githubRepositoryLabel =
+  'div.font-bold:contains("GitHub repository") + div a';
 const amountOfSlesForSapSubscriptionsLabel =
-  'div:contains("SLES for SAP subscriptions") + div span';
+  'div.font-bold:contains("SLES for SAP subscriptions") + div span';
 const versionFilePath = '../../VERSION';
 
 export const visit = () => basePage.visit(url);
@@ -27,10 +35,32 @@ export const expectedGithubUrlIsDisplayed = () =>
     .get(githubRepositoryLabel)
     .should('have.text', 'https://github.com/trento-project/web');
 
-export const expectedSlesForSapSubscriptionsAreDisplayed = (subscriptions) =>
-  cy
+export const componentVersionIsDisplayed = (selector) => {
+  return cy.get(selector).should('not.be.empty').and('be.visible');
+};
+
+export const expectedWandaVersionIsDisplayed = () => {
+  return componentVersionIsDisplayed(wandaVersionLabel);
+};
+
+export const expectedPostgresVersionIsDisplayed = () => {
+  return componentVersionIsDisplayed(postgresVersionLabel);
+};
+
+export const expectedRabbitmqVersionIsDisplayed = () => {
+  return componentVersionIsDisplayed(rabbitmqVersionLabel);
+};
+
+export const expectedPrometheusVersionIsDisplayed = () => {
+  return componentVersionIsDisplayed(prometheusVersionLabel);
+};
+
+export const expectedSlesForSapSubscriptionsAreDisplayed = () => {
+  const subscriptions = getValue('subscriptions');
+  return cy
     .get(amountOfSlesForSapSubscriptionsLabel)
     .should('have.text', `${subscriptions} found`);
+}
 
 export const apiDeregisterHost = () =>
   basePage.apiDeregisterHost(hostToDeregister);

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -46,6 +46,14 @@ Application.put_env(
   adapter: Trento.Infrastructure.Messaging.Adapter.Mock
 )
 
+Mox.defmock(Trento.Infrastructure.ComponentVersions.Mock,
+  for: Trento.Infrastructure.ComponentVersions.Gen
+)
+
+Application.put_env(:trento, :component_versions,
+  adapter: Trento.Infrastructure.ComponentVersions.Mock
+)
+
 Mox.defmock(GenRMQ.Processor.Mock, for: GenRMQ.Processor)
 
 Mox.defmock(Trento.Support.DateService.Mock, for: Trento.Support.DateService)

--- a/test/trento_web/views/v1/about_view_json_test.exs
+++ b/test/trento_web/views/v1/about_view_json_test.exs
@@ -15,6 +15,7 @@ defmodule TrentoWeb.V1.AboutJSONTest do
           version: version,
           sles_subscriptions: sles_subscriptions,
           wanda_version: "1.2.0",
+          checks_version: "1.0.0",
           postgres_version: "16.1",
           rabbitmq_version: "3.12.0",
           prometheus_version: "2.48.0"
@@ -26,6 +27,7 @@ defmodule TrentoWeb.V1.AboutJSONTest do
              sles_subscriptions: sles_subscriptions,
              flavor: "Community",
              wanda_version: "1.2.0",
+             checks_version: "1.0.0",
              postgres_version: "16.1",
              rabbitmq_version: "3.12.0",
              prometheus_version: "2.48.0"
@@ -49,6 +51,7 @@ defmodule TrentoWeb.V1.AboutJSONTest do
              sles_subscriptions: sles_subscriptions,
              flavor: "Community",
              wanda_version: nil,
+             checks_version: nil,
              postgres_version: nil,
              rabbitmq_version: nil,
              prometheus_version: nil

--- a/test/trento_web/views/v1/about_view_json_test.exs
+++ b/test/trento_web/views/v1/about_view_json_test.exs
@@ -13,6 +13,33 @@ defmodule TrentoWeb.V1.AboutJSONTest do
       AboutJSON.about(%{
         about_info: %{
           version: version,
+          sles_subscriptions: sles_subscriptions,
+          wanda_version: "1.2.0",
+          postgres_version: "16.1",
+          rabbitmq_version: "3.12.0",
+          prometheus_version: "2.48.0"
+        }
+      })
+
+    assert result == %{
+             version: version,
+             sles_subscriptions: sles_subscriptions,
+             flavor: "Community",
+             wanda_version: "1.2.0",
+             postgres_version: "16.1",
+             rabbitmq_version: "3.12.0",
+             prometheus_version: "2.48.0"
+           }
+  end
+
+  test "should render about/1 with nil versions when not available" do
+    version = "1.0.0"
+    sles_subscriptions = build_list(2, :sles_subscription)
+
+    result =
+      AboutJSON.about(%{
+        about_info: %{
+          version: version,
           sles_subscriptions: sles_subscriptions
         }
       })
@@ -20,7 +47,11 @@ defmodule TrentoWeb.V1.AboutJSONTest do
     assert result == %{
              version: version,
              sles_subscriptions: sles_subscriptions,
-             flavor: "Community"
+             flavor: "Community",
+             wanda_version: nil,
+             postgres_version: nil,
+             rabbitmq_version: nil,
+             prometheus_version: nil
            }
   end
 end


### PR DESCRIPTION
Displaying the version of the components in the About page.

<img width="1292" height="515" alt="image" src="https://github.com/user-attachments/assets/d9309bd7-5bbb-4c20-8c93-62d890f2e1bb" />

Missing Checks version so far (see https://github.com/trento-project/checks/pull/59)