### PR TITLE
Add resources links in operation forbidden modal

### DIFF
--- a/assets/js/common/OperationModals/OperationForbiddenModal.jsx
+++ b/assets/js/common/OperationModals/OperationForbiddenModal.jsx
@@ -24,7 +24,7 @@ const formatError = (error, metadata, onCancel) => {
     // corresponding metadata by index and create the link
     if (part.match(replacePattern)) {
       const index = parseInt(part.substring(1));
-      const { id, label, type } = get(metadata, index);
+      const { id, label, type } = get(metadata, index) ?? {};
 
       return id ? (
         <Link

--- a/assets/js/common/OperationModals/OperationForbiddenModal.jsx
+++ b/assets/js/common/OperationModals/OperationForbiddenModal.jsx
@@ -1,9 +1,47 @@
 import React from 'react';
-import { noop } from 'lodash';
+import { Link } from 'react-router';
+
+import { get, map, noop, split } from 'lodash';
 
 import Modal from '@common/Modal';
 import Button from '@common/Button';
 import Banner from '@common/Banners';
+
+const replacePattern = /({\d+})/;
+const urlTypes = {
+  cluster: 'clusters',
+  database: 'databases',
+  host: 'hosts',
+  sap_system: 'sap_systems',
+};
+
+const formatError = (error, metadata, onCancel) => {
+  // find {i} entries in the text splitting the whole content
+  const parts = split(error, replacePattern);
+
+  return map(parts, (part) => {
+    // if a part matches with the replacement pattern, find the
+    // corresponding metadata by index and create the link
+    if (part.match(replacePattern)) {
+      const index = parseInt(part.substring(1));
+      const { id, label, type } = get(metadata, index);
+
+      return id ? (
+        <Link
+          className="text-jungle-green-500 hover:opacity-75"
+          onClick={onCancel}
+          key={id}
+          to={`/${urlTypes[type]}/${id}`}
+        >
+          {label}
+        </Link>
+      ) : (
+        part
+      );
+    }
+    return part;
+  });
+};
 
 function OperationForbiddenModal({
   operation,
@@ -23,9 +61,9 @@ function OperationForbiddenModal({
       </Banner>
       <p className="text-sm mb-1">Some of the next conditions are not met:</p>
       <ul className="list-disc list-inside space-y-1 mb-1">
-        {errors.map((error) => (
-          <li key={error} className="text-sm">
-            {error}
+        {errors.map(({ detail, metadata }) => (
+          <li key={detail} className="text-sm">
+            {formatError(detail, metadata, onCancel)}
           </li>
         ))}
       </ul>

--- a/assets/js/common/OperationModals/OperationForbiddenModal.test.jsx
+++ b/assets/js/common/OperationModals/OperationForbiddenModal.test.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
+import { noop } from 'lodash';
+import { renderWithRouter } from '@lib/test-utils';
+import { hostFactory } from '@lib/test-utils/factories';
 import OperationForbiddenModal from './OperationForbiddenModal';
 
 describe('OperationForbiddenModal', () => {
@@ -9,7 +12,7 @@ describe('OperationForbiddenModal', () => {
     render(
       <OperationForbiddenModal
         operation="My operation"
-        errors={['error1', 'error2']}
+        errors={[{ detail: 'error1' }, { detail: 'error2' }]}
         isOpen
       />
     );
@@ -26,6 +29,87 @@ describe('OperationForbiddenModal', () => {
     const items = getAllByRole('listitem');
     expect(items[0].textContent).toBe('error1');
     expect(items[1].textContent).toBe('error2');
+  });
+
+  it('should interpolate multiple placeholders', async () => {
+    const { id: hostID1, hostname: hostname1 } = hostFactory.build();
+    const { id: hostID2, hostname: hostname2 } = hostFactory.build();
+    const { id: hostID3, hostname: hostname3 } = hostFactory.build();
+
+    renderWithRouter(
+      <OperationForbiddenModal
+        operation="My operation"
+        errors={[
+          {
+            detail: 'error message {0}, {1} and {2} links',
+            metadata: [
+              { id: hostID1, label: hostname1, type: 'host' },
+              { id: hostID2, label: hostname2, type: 'host' },
+              { id: hostID3, label: hostname3, type: 'host' },
+            ],
+          },
+        ]}
+        isOpen
+        onCancel={noop}
+      />
+    );
+
+    const list = screen.getByRole('list');
+    const { getAllByRole } = within(list);
+    const items = getAllByRole('listitem');
+    expect(items[0].textContent).toBe(
+      `error message ${hostname1}, ${hostname2} and ${hostname3} links`
+    );
+
+    const hostElement1 = screen.getByRole('link', { name: hostname1 });
+    const hostElement2 = screen.getByRole('link', { name: hostname2 });
+    const hostElement3 = screen.getByRole('link', { name: hostname3 });
+
+    expect(hostElement1).toHaveAttribute('href', `/hosts/${hostID1}`);
+    expect(hostElement2).toHaveAttribute('href', `/hosts/${hostID2}`);
+    expect(hostElement3).toHaveAttribute('href', `/hosts/${hostID3}`);
+  });
+
+  it.each([
+    {
+      resource: 'host',
+      href: '/hosts/',
+    },
+    {
+      resource: 'cluster',
+      href: '/clusters/',
+    },
+    {
+      resource: 'database',
+      href: '/databases/',
+    },
+    {
+      resource: 'sap_system',
+      href: '/sap_systems/',
+    },
+  ])('should add $resource link to the message', async ({ resource, href }) => {
+    const id = 'some-id';
+    const label = 'label';
+
+    renderWithRouter(
+      <OperationForbiddenModal
+        operation="My operation"
+        errors={[
+          {
+            detail: 'error message {0}',
+            metadata: [{ id, label, type: resource }],
+          },
+        ]}
+        isOpen
+      />
+    );
+
+    const list = screen.getByRole('list');
+    const { getAllByRole } = within(list);
+    const items = getAllByRole('listitem');
+    expect(items[0].textContent).toBe(`error message ${label}`);
+    const hostElement1 = screen.getByRole('link', { name: label });
+    expect(hostElement1).toHaveAttribute('href', `${href}${id}`);
   });
 
   it('should run onCancel when the close button is clicked', async () => {

--- a/assets/js/pages/ClusterDetails/ClusterDetails.test.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetails.test.jsx
@@ -408,7 +408,7 @@ describe('ClusterDetails ClusterDetails component', () => {
             runningOperation={{
               operation,
               forbidden: true,
-              errors: ['error1', 'error2'],
+              errors: [{ detail: 'error1' }, { detail: 'error2' }],
             }}
             selectedChecks={[]}
             userAbilities={userAbilities}

--- a/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
@@ -500,7 +500,7 @@ describe('HostDetails component', () => {
             runningOperation={{
               operation,
               forbidden: true,
-              errors: ['error1', 'error2'],
+              errors: [{ detail: 'error1' }, { detail: 'error2' }],
             }}
             cleanForbiddenOperation={mockCleanForbiddenOperation}
           />

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
@@ -913,7 +913,7 @@ describe('GenericSystemDetails', () => {
         groupID: hostID,
         operation: forbiddenOperation,
         forbidden: true,
-        errors: ['error1', 'error2'],
+        errors: [{ detail: 'error1' }, { detail: 'error2' }],
       },
     ];
 

--- a/assets/js/state/sagas/operations.js
+++ b/assets/js/state/sagas/operations.js
@@ -1,5 +1,5 @@
 import { all, call, put, select, takeEvery } from 'redux-saga/effects';
-import { map, noop } from 'lodash';
+import { noop } from 'lodash';
 
 import {
   HOST_OPERATION,
@@ -116,8 +116,9 @@ export function* requestOperation({ payload }) {
     );
   } catch ({ response: { status, data } }) {
     if (status === 403) {
-      const errors = map(data.errors, 'detail');
-      yield put(setForbiddenOperation({ groupID, operation, errors }));
+      yield put(
+        setForbiddenOperation({ groupID, operation, errors: data.errors })
+      );
       return;
     }
 

--- a/assets/js/state/sagas/operations.test.js
+++ b/assets/js/state/sagas/operations.test.js
@@ -328,10 +328,14 @@ describe('operations saga', () => {
       const groupID = faker.string.uuid();
       const operation = KNOWN_OPERATION;
       const hostname = faker.internet.displayName();
+      const errors = [
+        { detail: 'error1', metadata: [{ key: 'value' }] },
+        { detail: 'error2' },
+      ];
 
       axiosMock
         .onPost(hostOperationRequestURL(groupID, operation))
-        .reply(403, { errors: [{ detail: 'error1' }, { detail: 'error2' }] });
+        .reply(403, { errors });
 
       const dispatched = await recordSaga(
         requestOperation,
@@ -350,7 +354,7 @@ describe('operations saga', () => {
         setForbiddenOperation({
           groupID,
           operation,
-          errors: ['error1', 'error2'],
+          errors,
         }),
       ]);
     });

--- a/lib/trento/operations/application_instance_policy.ex
+++ b/lib/trento/operations/application_instance_policy.ex
@@ -100,7 +100,6 @@ defmodule Trento.Operations.ApplicationInstancePolicy do
 
   # Enq rep and App servers, start only if Message server is started
   defp other_instances_started(%ApplicationInstanceReadModel{
-         sap_system_id: sap_system_id,
          host_id: host_id,
          sid: sid,
          instance_number: instance_number,
@@ -123,8 +122,8 @@ defmodule Trento.Operations.ApplicationInstancePolicy do
         {:error,
          [
            OperationsHelper.build_error(
-             "Message server #{msg_instance_number} of SAP system {0} is not started",
-             [%{id: sap_system_id, label: sid, type: :sap_system}]
+             "Message server #{msg_instance_number} of SAP system #{sid} is not started",
+             []
            )
          ]}
 
@@ -132,8 +131,8 @@ defmodule Trento.Operations.ApplicationInstancePolicy do
         {:error,
          [
            OperationsHelper.build_error(
-             "Message server not found in SAP system {0}",
-             [%{id: sap_system_id, label: sid, type: :sap_system}]
+             "Message server not found in SAP system #{sid}",
+             []
            )
          ]}
     end
@@ -172,7 +171,6 @@ defmodule Trento.Operations.ApplicationInstancePolicy do
 
   # Message server, stop only if the other instances are stopped
   defp other_instances_stopped(%ApplicationInstanceReadModel{
-         sap_system_id: sap_system_id,
          features: "MESSAGESERVER" <> _,
          host_id: host_id,
          sid: sid,
@@ -194,8 +192,8 @@ defmodule Trento.Operations.ApplicationInstancePolicy do
         {:error,
          Enum.map(running_instances, fn %{instance_number: inst_number} ->
            OperationsHelper.build_error(
-             "Instance #{inst_number} of SAP system {0} is not stopped",
-             [%{id: sap_system_id, label: sid, type: :sap_system}]
+             "Instance #{inst_number} of SAP system #{sid} is not stopped",
+             []
            )
          end)}
     end

--- a/lib/trento/operations/application_instance_policy.ex
+++ b/lib/trento/operations/application_instance_policy.ex
@@ -55,7 +55,7 @@ defmodule Trento.Operations.ApplicationInstancePolicy do
       do:
         {:error,
          [
-           "Trento agent is not currently running in the host"
+           OperationsHelper.build_error("Trento agent is not currently running in the host")
          ]}
 
   # instance start operation authorized when:
@@ -88,7 +88,8 @@ defmodule Trento.Operations.ApplicationInstancePolicy do
     ])
   end
 
-  def authorize_operation(_, _, _), do: {:error, ["Unknown operation"]}
+  def authorize_operation(_, _, _),
+    do: {:error, [OperationsHelper.build_error("Unknown operation")]}
 
   # Message Server, start without depending on other instances
   defp other_instances_started(%ApplicationInstanceReadModel{
@@ -99,6 +100,7 @@ defmodule Trento.Operations.ApplicationInstancePolicy do
 
   # Enq rep and App servers, start only if Message server is started
   defp other_instances_started(%ApplicationInstanceReadModel{
+         sap_system_id: sap_system_id,
          host_id: host_id,
          sid: sid,
          instance_number: instance_number,
@@ -118,10 +120,22 @@ defmodule Trento.Operations.ApplicationInstancePolicy do
         :ok
 
       %{instance_number: msg_instance_number} ->
-        {:error, ["Message server #{msg_instance_number} of SAP system #{sid} is not started"]}
+        {:error,
+         [
+           OperationsHelper.build_error(
+             "Message server #{msg_instance_number} of SAP system {0} is not started",
+             [%{id: sap_system_id, label: sid, type: :sap_system}]
+           )
+         ]}
 
       nil ->
-        {:error, ["Message server not found in SAP system #{sid}"]}
+        {:error,
+         [
+           OperationsHelper.build_error(
+             "Message server not found in SAP system {0}",
+             [%{id: sap_system_id, label: sid, type: :sap_system}]
+           )
+         ]}
     end
   end
 
@@ -142,14 +156,23 @@ defmodule Trento.Operations.ApplicationInstancePolicy do
   defp database_started(%ApplicationInstanceReadModel{
          sap_system: %{
            database: %{
+             id: database_id,
              sid: sid
            }
          }
        }),
-       do: {:error, ["Database #{sid} is not started"]}
+       do:
+         {:error,
+          [
+            OperationsHelper.build_error(
+              "Database {0} is not started",
+              [%{id: database_id, label: sid, type: :database}]
+            )
+          ]}
 
   # Message server, stop only if the other instances are stopped
   defp other_instances_stopped(%ApplicationInstanceReadModel{
+         sap_system_id: sap_system_id,
          features: "MESSAGESERVER" <> _,
          host_id: host_id,
          sid: sid,
@@ -170,7 +193,10 @@ defmodule Trento.Operations.ApplicationInstancePolicy do
       running_instances ->
         {:error,
          Enum.map(running_instances, fn %{instance_number: inst_number} ->
-           "Instance #{inst_number} of SAP system #{sid} is not stopped"
+           OperationsHelper.build_error(
+             "Instance #{inst_number} of SAP system {0} is not stopped",
+             [%{id: sap_system_id, label: sid, type: :sap_system}]
+           )
          end)}
     end
   end

--- a/lib/trento/operations/cluster_policy.ex
+++ b/lib/trento/operations/cluster_policy.ex
@@ -163,8 +163,8 @@ defmodule Trento.Operations.ClusterPolicy do
         {:error,
          [
            OperationsHelper.build_error(
-             "Cluster on host {0} cannot be set online because no primary database instance is running in the cluster",
-             [%{id: host.id, label: host.hostname, type: :host}]
+             "Cluster on host #{host.hostname} cannot be set online because no primary database instance is running in the cluster",
+             []
            )
          ]}
 
@@ -175,8 +175,8 @@ defmodule Trento.Operations.ClusterPolicy do
         {:error,
          [
            OperationsHelper.build_error(
-             "Cluster on host {0} cannot be set online because no primary database instance is running in the cluster",
-             [%{id: host.id, label: host.hostname, type: :host}]
+             "Cluster on host #{host.hostname} cannot be set online because no primary database instance is running in the cluster",
+             []
            )
          ]}
     end
@@ -214,8 +214,8 @@ defmodule Trento.Operations.ClusterPolicy do
       {:error,
        [
          OperationsHelper.build_error(
-           "Cluster on host {0} cannot be set offline because some secondary nodes are still online",
-           [%{id: host.id, label: host.hostname, type: :host}]
+           "Cluster on host #{host.hostname} cannot be set offline because some secondary nodes are still online",
+           []
          )
        ]}
     else
@@ -253,8 +253,8 @@ defmodule Trento.Operations.ClusterPolicy do
         {:error,
          [
            OperationsHelper.build_error(
-             "Pacemaker service on host {0} is already #{already_applied_state}",
-             [%{id: host_id, label: hostname, type: :host}]
+             "Pacemaker service on host #{hostname} is already #{already_applied_state}",
+             []
            )
          ]}
 
@@ -262,8 +262,8 @@ defmodule Trento.Operations.ClusterPolicy do
         {:error,
          [
            OperationsHelper.build_error(
-             "Pacemaker service unit state is unrecognized on host {0}",
-             [%{id: host_id, label: hostname, type: :host}]
+             "Pacemaker service unit state is unrecognized on host #{hostname}",
+             []
            )
          ]}
     end

--- a/lib/trento/operations/cluster_policy.ex
+++ b/lib/trento/operations/cluster_policy.ex
@@ -10,6 +10,8 @@ defmodule Trento.Operations.ClusterPolicy do
   require Trento.Operations.Enums.ClusterOperations, as: ClusterOperations
   require Trento.Operations.Enums.ClusterHostOperations, as: ClusterHostOperations
 
+  alias Trento.Support.OperationsHelper
+
   alias Trento.Clusters
 
   alias Trento.Clusters.Projections.ClusterReadModel
@@ -21,19 +23,25 @@ defmodule Trento.Operations.ClusterPolicy do
   # - cluster resource is not managed
   def authorize_operation(
         :maintenance,
-        %ClusterReadModel{name: name} = cluster,
+        %ClusterReadModel{id: id, name: name} = cluster,
         %{cluster_resource_id: nil}
       ) do
     if Clusters.maintenance?(cluster) do
       :ok
     else
-      {:error, ["Cluster #{name} operating this host is not in maintenance mode"]}
+      {:error,
+       [
+         OperationsHelper.build_error(
+           "Cluster {0} operating this host is not in maintenance mode",
+           [%{id: id, label: name, type: :cluster}]
+         )
+       ]}
     end
   end
 
   def authorize_operation(
         :maintenance,
-        %ClusterReadModel{name: name} = cluster,
+        %ClusterReadModel{id: id, name: name} = cluster,
         %{cluster_resource_id: cluster_resource_id}
       ) do
     if Enum.any?([
@@ -44,7 +52,10 @@ defmodule Trento.Operations.ClusterPolicy do
     else
       {:error,
        [
-         "Cluster #{name} or resource #{cluster_resource_id} operating this host are not in maintenance mode"
+         OperationsHelper.build_error(
+           "Cluster {0} or resource #{cluster_resource_id} operating this host are not in maintenance mode",
+           [%{id: id, label: name, type: :cluster}]
+         )
        ]}
     end
   end
@@ -65,7 +76,12 @@ defmodule Trento.Operations.ClusterPolicy do
     if some_heartbeat_passing? do
       do_authorize_operation(operation, cluster, params)
     else
-      {:error, ["Trento agent is not currently running in any of the hosts in the cluster"]}
+      {:error,
+       [
+         OperationsHelper.build_error(
+           "Trento agent is not currently running in any of the hosts in the cluster"
+         )
+       ]}
     end
   end
 
@@ -86,15 +102,17 @@ defmodule Trento.Operations.ClusterPolicy do
     if heartbeat == :passing do
       do_authorize_operation(operation, cluster, params)
     else
-      {:error, ["Trento agent is not currently running in the host"]}
+      {:error,
+       [OperationsHelper.build_error("Trento agent is not currently running in the host")]}
     end
   end
 
-  def authorize_operation(_, _, _), do: {:error, ["Unknown operation"]}
+  def authorize_operation(_, _, _),
+    do: {:error, [OperationsHelper.build_error("Unknown operation")]}
 
   defp do_authorize_operation(
          operation,
-         %ClusterReadModel{name: name, hosts: hosts},
+         %ClusterReadModel{id: id, name: name, hosts: hosts},
          _
        )
        when operation in ClusterOperations.values() do
@@ -103,7 +121,12 @@ defmodule Trento.Operations.ClusterPolicy do
        end) do
       :ok
     else
-      {:error, ["Cluster #{name} does not have any online node"]}
+      {:error,
+       [
+         OperationsHelper.build_error("Cluster {0} does not have any online node", [
+           %{id: id, label: name, type: :cluster}
+         ])
+       ]}
     end
   end
 
@@ -139,7 +162,10 @@ defmodule Trento.Operations.ClusterPolicy do
       count_primary_running == 0 ->
         {:error,
          [
-           "Cluster on host #{host.hostname} cannot be set online because no primary database instance is running in the cluster"
+           OperationsHelper.build_error(
+             "Cluster on host {0} cannot be set online because no primary database instance is running in the cluster",
+             [%{id: host.id, label: host.hostname, type: :host}]
+           )
          ]}
 
       host_running_primary? or all_primary_running? ->
@@ -148,7 +174,10 @@ defmodule Trento.Operations.ClusterPolicy do
       true ->
         {:error,
          [
-           "Cluster on host #{host.hostname} cannot be set online because no primary database instance is running in the cluster"
+           OperationsHelper.build_error(
+             "Cluster on host {0} cannot be set online because no primary database instance is running in the cluster",
+             [%{id: host.id, label: host.hostname, type: :host}]
+           )
          ]}
     end
   end
@@ -184,7 +213,10 @@ defmodule Trento.Operations.ClusterPolicy do
 
       {:error,
        [
-         "Cluster on host #{host.hostname} cannot be set offline because some secondary nodes are still online"
+         OperationsHelper.build_error(
+           "Cluster on host {0} cannot be set offline because some secondary nodes are still online",
+           [%{id: host.id, label: host.hostname, type: :host}]
+         )
        ]}
     else
       :ok
@@ -220,13 +252,19 @@ defmodule Trento.Operations.ClusterPolicy do
       ^already_applied_state ->
         {:error,
          [
-           "Pacemaker service on host #{hostname} is already #{already_applied_state}"
+           OperationsHelper.build_error(
+             "Pacemaker service on host {0} is already #{already_applied_state}",
+             [%{id: host_id, label: hostname, type: :host}]
+           )
          ]}
 
       _ ->
         {:error,
          [
-           "Pacemaker service unit state is unrecognized on host #{hostname}"
+           OperationsHelper.build_error(
+             "Pacemaker service unit state is unrecognized on host {0}",
+             [%{id: host_id, label: hostname, type: :host}]
+           )
          ]}
     end
   end

--- a/lib/trento/operations/database_instance_policy.ex
+++ b/lib/trento/operations/database_instance_policy.ex
@@ -5,6 +5,8 @@ defmodule Trento.Operations.DatabaseInstancePolicy do
 
   @behaviour Trento.Operations.PolicyBehaviour
 
+  alias Trento.Support.OperationsHelper
+
   alias Trento.Clusters.Projections.ClusterReadModel
   alias Trento.Databases.Projections.DatabaseInstanceReadModel
   alias Trento.Hosts.Projections.HostReadModel
@@ -42,7 +44,8 @@ defmodule Trento.Operations.DatabaseInstancePolicy do
     end
   end
 
-  def authorize_operation(_, _, _), do: {:error, ["Unknown operation"]}
+  def authorize_operation(_, _, _),
+    do: {:error, [OperationsHelper.build_error("Unknown operation")]}
 
   defp get_cluster_resource_id(%ClusterReadModel{
          details: %{resources: resources}

--- a/lib/trento/operations/database_policy.ex
+++ b/lib/trento/operations/database_policy.ex
@@ -132,7 +132,6 @@ defmodule Trento.Operations.DatabasePolicy do
   # secondary sites, check primary is started
   defp primary_site_started(
          %DatabaseReadModel{
-           id: db_id,
            sid: sid,
            database_instances: database_instances
          },
@@ -148,8 +147,8 @@ defmodule Trento.Operations.DatabasePolicy do
       {:error,
        [
          OperationsHelper.build_error(
-           "Primary site #{primary_site} of database {0} is not started",
-           [%{id: db_id, label: sid, type: :database}]
+           "Primary site #{primary_site} of database #{sid} is not started",
+           []
          )
        ]}
     end
@@ -160,7 +159,6 @@ defmodule Trento.Operations.DatabasePolicy do
   # primary site, check secondary sites are stopped
   defp secondary_sites_stopped(
          %DatabaseReadModel{
-           id: db_id,
            sid: sid,
            database_instances: database_instances
          },
@@ -176,8 +174,8 @@ defmodule Trento.Operations.DatabasePolicy do
       {:error,
        [
          OperationsHelper.build_error(
-           "Secondary sites of database {0} are not stopped",
-           [%{id: db_id, label: sid, type: :database}]
+           "Secondary sites of database #{sid} are not stopped",
+           []
          )
        ]}
     end

--- a/lib/trento/operations/database_policy.ex
+++ b/lib/trento/operations/database_policy.ex
@@ -44,15 +44,20 @@ defmodule Trento.Operations.DatabasePolicy do
       {:error,
        Enum.map(sites_without_passing_heartbeat, fn
          nil ->
-           "Trento agent is not currently running in any of the hosts in the database"
+           OperationsHelper.build_error(
+             "Trento agent is not currently running in any of the hosts in the database"
+           )
 
          site ->
-           "Trento agent is not currently running in any of the hosts in the database site #{site}"
+           OperationsHelper.build_error(
+             "Trento agent is not currently running in any of the hosts in the database site #{site}"
+           )
        end)}
     end
   end
 
-  def authorize_operation(_, _, _), do: {:error, ["Unknown operation"]}
+  def authorize_operation(_, _, _),
+    do: {:error, [OperationsHelper.build_error("Unknown operation")]}
 
   defp filter_by_site(instances, %{site: nil}), do: instances
 
@@ -127,6 +132,7 @@ defmodule Trento.Operations.DatabasePolicy do
   # secondary sites, check primary is started
   defp primary_site_started(
          %DatabaseReadModel{
+           id: db_id,
            sid: sid,
            database_instances: database_instances
          },
@@ -139,7 +145,13 @@ defmodule Trento.Operations.DatabasePolicy do
     |> if do
       :ok
     else
-      {:error, ["Primary site #{primary_site} of database #{sid} is not started"]}
+      {:error,
+       [
+         OperationsHelper.build_error(
+           "Primary site #{primary_site} of database {0} is not started",
+           [%{id: db_id, label: sid, type: :database}]
+         )
+       ]}
     end
   end
 
@@ -148,6 +160,7 @@ defmodule Trento.Operations.DatabasePolicy do
   # primary site, check secondary sites are stopped
   defp secondary_sites_stopped(
          %DatabaseReadModel{
+           id: db_id,
            sid: sid,
            database_instances: database_instances
          },
@@ -160,7 +173,13 @@ defmodule Trento.Operations.DatabasePolicy do
     |> if do
       :ok
     else
-      {:error, ["Secondary sites of database #{sid} are not stopped"]}
+      {:error,
+       [
+         OperationsHelper.build_error(
+           "Secondary sites of database {0} are not stopped",
+           [%{id: db_id, label: sid, type: :database}]
+         )
+       ]}
     end
   end
 
@@ -186,8 +205,15 @@ defmodule Trento.Operations.DatabasePolicy do
 
       running_instances ->
         {:error,
-         Enum.map(running_instances, fn %{sid: sid, instance_number: inst_number} ->
-           "Instance #{inst_number} of SAP system #{sid} is not stopped"
+         Enum.map(running_instances, fn %{
+                                          sap_system_id: app_id,
+                                          sid: sid,
+                                          instance_number: inst_number
+                                        } ->
+           OperationsHelper.build_error(
+             "Instance #{inst_number} of SAP system {0} is not stopped",
+             [%{id: app_id, label: sid, type: :sap_system}]
+           )
          end)}
     end
   end

--- a/lib/trento/operations/host_policy.ex
+++ b/lib/trento/operations/host_policy.ex
@@ -22,7 +22,7 @@ defmodule Trento.Operations.HostPolicy do
       do:
         {:error,
          [
-           "Trento agent is not currently running in the host"
+           OperationsHelper.build_error("Trento agent is not currently running in the host")
          ]}
 
   # saptune_solution_apply and saptune_solution_change operation authorized when:
@@ -82,7 +82,9 @@ defmodule Trento.Operations.HostPolicy do
       do:
         {:error,
          [
-           "The host belongs to unsupported cluster type #{cluster_type}"
+           OperationsHelper.build_error(
+             "The host belongs to unsupported cluster type #{cluster_type}"
+           )
          ]}
 
   def authorize_operation(
@@ -103,7 +105,8 @@ defmodule Trento.Operations.HostPolicy do
           cluster_host_status == ClusterHostStatus.offline()
         )
 
-  def authorize_operation(_, _, _), do: {:error, ["Unknown operation"]}
+  def authorize_operation(_, _, _),
+    do: {:error, [OperationsHelper.build_error("Unknown operation")]}
 
   defp authorize_saptune_solution_operation(
          :saptune_solution_apply,
@@ -154,7 +157,7 @@ defmodule Trento.Operations.HostPolicy do
   end
 
   defp or_error(true, _), do: :ok
-  defp or_error(false, error), do: {:error, [error]}
+  defp or_error(false, error), do: {:error, [OperationsHelper.build_error(error)]}
 
   defp systemd_unit_enabled?(systemd_units, unit_name) do
     Enum.any?(systemd_units, fn
@@ -169,24 +172,41 @@ defmodule Trento.Operations.HostPolicy do
     do: Enum.map(instances, &ensure_instance_stopped/1)
 
   defp ensure_instance_stopped(%ApplicationInstanceReadModel{
+         sap_system_id: sap_system_id,
          sid: sid,
          instance_number: instance_number,
          health: health
        })
        when health != Health.unknown(),
-       do: {:error, ["Instance #{instance_number} of SAP system #{sid} is not stopped"]}
+       do:
+         {:error,
+          [
+            OperationsHelper.build_error(
+              "Instance #{instance_number} of SAP system {0} is not stopped",
+              [%{id: sap_system_id, label: sid, type: :sap_system}]
+            )
+          ]}
 
   defp ensure_instance_stopped(%DatabaseInstanceReadModel{
+         database_id: database_id,
          sid: sid,
          instance_number: instance_number,
          health: health
        })
        when health != Health.unknown(),
-       do: {:error, ["Instance #{instance_number} of HANA database #{sid} is not stopped"]}
+       do:
+         {:error,
+          [
+            OperationsHelper.build_error(
+              "Instance #{instance_number} of HANA database {0} is not stopped",
+              [%{id: database_id, label: sid, type: :database}]
+            )
+          ]}
 
   defp ensure_instance_stopped(%instance_module{})
        when instance_module in [ApplicationInstanceReadModel, DatabaseInstanceReadModel],
        do: :ok
 
-  defp ensure_instance_stopped(_), do: {:error, ["Unknown instance type"]}
+  defp ensure_instance_stopped(_),
+    do: {:error, [OperationsHelper.build_error("Unknown instance type")]}
 end

--- a/lib/trento/operations/policy_behaviour.ex
+++ b/lib/trento/operations/policy_behaviour.ex
@@ -17,6 +17,8 @@ defmodule Trento.Operations.PolicyBehaviour do
     SapSystemReadModel
   }
 
+  alias Trento.Support.OperationsHelper
+
   @callback authorize_operation(
               operation :: atom,
               read_model ::
@@ -27,5 +29,5 @@ defmodule Trento.Operations.PolicyBehaviour do
                 | HostReadModel.t()
                 | SapSystemReadModel.t(),
               params :: map
-            ) :: :ok | {:error, [String.t()]}
+            ) :: :ok | {:error, [OperationsHelper.forbidden_error()]}
 end

--- a/lib/trento/operations/sap_system_policy.ex
+++ b/lib/trento/operations/sap_system_policy.ex
@@ -141,7 +141,6 @@ defmodule Trento.Operations.SapSystemPolicy do
 
   defp other_instances_started(
          %SapSystemReadModel{
-           id: id,
            application_instances: application_instances
          },
          _
@@ -158,8 +157,8 @@ defmodule Trento.Operations.SapSystemPolicy do
         {:error,
          Enum.map(running_instances, fn %{sid: sid, instance_number: inst_number} ->
            OperationsHelper.build_error(
-             "Instance #{inst_number} of SAP system {0} is not started",
-             [%{id: id, label: sid, type: :sap_system}]
+             "Instance #{inst_number} of SAP system #{sid} is not started",
+             []
            )
          end)}
     end
@@ -167,7 +166,6 @@ defmodule Trento.Operations.SapSystemPolicy do
 
   defp other_instances_stopped(
          %SapSystemReadModel{
-           id: id,
            application_instances: application_instances
          },
          %{instance_type: "scs"}
@@ -184,8 +182,8 @@ defmodule Trento.Operations.SapSystemPolicy do
         {:error,
          Enum.map(running_instances, fn %{sid: sid, instance_number: inst_number} ->
            OperationsHelper.build_error(
-             "Instance #{inst_number} of SAP system {0} is not stopped",
-             [%{id: id, label: sid, type: :sap_system}]
+             "Instance #{inst_number} of SAP system #{sid} is not stopped",
+             []
            )
          end)}
     end

--- a/lib/trento/operations/sap_system_policy.ex
+++ b/lib/trento/operations/sap_system_policy.ex
@@ -34,11 +34,17 @@ defmodule Trento.Operations.SapSystemPolicy do
     if some_heartbeat_passing? do
       do_authorize_operation(operation, sap_systen, params)
     else
-      {:error, ["Trento agent is not currently running in any of the hosts in the SAP system"]}
+      {:error,
+       [
+         OperationsHelper.build_error(
+           "Trento agent is not currently running in any of the hosts in the SAP system"
+         )
+       ]}
     end
   end
 
-  def authorize_operation(_, _, _), do: {:error, ["Unknown operation"]}
+  def authorize_operation(_, _, _),
+    do: {:error, [OperationsHelper.build_error("Unknown operation")]}
 
   defp do_authorize_operation(
          :sap_system_start,
@@ -101,11 +107,31 @@ defmodule Trento.Operations.SapSystemPolicy do
       [] ->
         :ok
 
-      [%{sid: sid, system_replication: "Primary", system_replication_site: site} | _] ->
-        {:error, ["Database #{sid} primary site #{site} is not started"]}
+      [
+        %{
+          database_id: database_id,
+          sid: sid,
+          system_replication: "Primary",
+          system_replication_site: site
+        }
+        | _
+      ] ->
+        {:error,
+         [
+           OperationsHelper.build_error(
+             "Database {0} primary site #{site} is not started",
+             [%{id: database_id, label: sid, type: :database}]
+           )
+         ]}
 
-      [%{sid: sid} | _] ->
-        {:error, ["Database #{sid} is not started"]}
+      [%{database_id: database_id, sid: sid} | _] ->
+        {:error,
+         [
+           OperationsHelper.build_error(
+             "Database {0} is not started",
+             [%{id: database_id, label: sid, type: :database}]
+           )
+         ]}
     end
   end
 
@@ -115,6 +141,7 @@ defmodule Trento.Operations.SapSystemPolicy do
 
   defp other_instances_started(
          %SapSystemReadModel{
+           id: id,
            application_instances: application_instances
          },
          _
@@ -130,13 +157,17 @@ defmodule Trento.Operations.SapSystemPolicy do
       running_instances ->
         {:error,
          Enum.map(running_instances, fn %{sid: sid, instance_number: inst_number} ->
-           "Instance #{inst_number} of SAP system #{sid} is not started"
+           OperationsHelper.build_error(
+             "Instance #{inst_number} of SAP system {0} is not started",
+             [%{id: id, label: sid, type: :sap_system}]
+           )
          end)}
     end
   end
 
   defp other_instances_stopped(
          %SapSystemReadModel{
+           id: id,
            application_instances: application_instances
          },
          %{instance_type: "scs"}
@@ -152,7 +183,10 @@ defmodule Trento.Operations.SapSystemPolicy do
       running_instances ->
         {:error,
          Enum.map(running_instances, fn %{sid: sid, instance_number: inst_number} ->
-           "Instance #{inst_number} of SAP system #{sid} is not stopped"
+           OperationsHelper.build_error(
+             "Instance #{inst_number} of SAP system {0} is not stopped",
+             [%{id: id, label: sid, type: :sap_system}]
+           )
          end)}
     end
   end

--- a/lib/trento/support/operations_helper.ex
+++ b/lib/trento/support/operations_helper.ex
@@ -3,11 +3,22 @@ defmodule Trento.Support.OperationsHelper do
   Helper functions for operations
   """
 
+  @type metadata :: %{
+          id: Ecto.UUID.t(),
+          label: String.t(),
+          type: :host | :cluster | :sap_system | :database
+        }
+
+  @type forbidden_error :: %{
+          message: String.t(),
+          metadata: [metadata()]
+        }
+
   @spec reduce_operation_authorizations(
           authorizations :: [Enumerable.t()],
-          acc :: :ok | {:error, [String.t()]}
+          acc :: :ok | {:error, [forbidden_error()]}
         ) ::
-          :ok | {:error, [String.t()]}
+          :ok | {:error, [forbidden_error]}
   def reduce_operation_authorizations(authorizations, acc \\ :ok) do
     Enum.reduce(authorizations, acc, fn
       :ok, :ok ->
@@ -26,13 +37,16 @@ defmodule Trento.Support.OperationsHelper do
 
   @spec reduce_operation_authorizations(
           authorizations :: [Enumerable.t()],
-          acc :: :ok | {:error, [String.t()]},
+          acc :: :ok | {:error, [forbidden_error()]},
           func :: function()
         ) ::
-          :ok | {:error, [String.t()]}
+          :ok | {:error, [forbidden_error]}
   def reduce_operation_authorizations(authorizations, acc, fun) do
     authorizations
     |> Enum.map(fn x -> fun.(x) end)
     |> reduce_operation_authorizations(acc)
   end
+
+  @spec build_error(message :: String.t(), metadata :: [metadata()]) :: forbidden_error
+  def build_error(message, metadata \\ []), do: %{message: message, metadata: metadata}
 end

--- a/lib/trento_web/controllers/error_json.ex
+++ b/lib/trento_web/controllers/error_json.ex
@@ -35,24 +35,19 @@ defmodule TrentoWeb.ErrorJSON do
   def render("403.json", %{errors: errors}) do
     %{
       errors:
-        Enum.map(errors, fn error ->
-          %{
-            title: "Forbidden",
-            detail: error
-          }
-        end)
-    }
-  end
+        Enum.map(errors, fn
+          %{message: message, metadata: metadata} ->
+            %{
+              title: "Forbidden",
+              detail: message,
+              metadata: metadata
+            }
 
-  def render("403.json", %{operation_errors: errors}) do
-    %{
-      errors:
-        Enum.map(errors, fn %{message: message, metadata: metadata} ->
-          %{
-            title: "Forbidden",
-            detail: message,
-            metadata: metadata
-          }
+          error ->
+            %{
+              title: "Forbidden",
+              detail: error
+            }
         end)
     }
   end

--- a/lib/trento_web/controllers/error_json.ex
+++ b/lib/trento_web/controllers/error_json.ex
@@ -44,6 +44,19 @@ defmodule TrentoWeb.ErrorJSON do
     }
   end
 
+  def render("403.json", %{operation_errors: errors}) do
+    %{
+      errors:
+        Enum.map(errors, fn %{message: message, metadata: metadata} ->
+          %{
+            title: "Forbidden",
+            detail: message,
+            metadata: metadata
+          }
+        end)
+    }
+  end
+
   def render("403.json", _) do
     %{
       errors: [

--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -242,6 +242,13 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"403", errors: errors)
   end
 
+  def call(conn, {:error, :operation_forbidden, errors}) do
+    conn
+    |> put_status(:forbidden)
+    |> put_view(json: ErrorJSON)
+    |> render(:"403", operation_errors: errors)
+  end
+
   def call(conn, {:error, :stale_entry}) do
     conn
     |> put_status(:precondition_failed)

--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -242,13 +242,6 @@ defmodule TrentoWeb.FallbackController do
     |> render(:"403", errors: errors)
   end
 
-  def call(conn, {:error, :operation_forbidden, errors}) do
-    conn
-    |> put_status(:forbidden)
-    |> put_view(json: ErrorJSON)
-    |> render(:"403", operation_errors: errors)
-  end
-
   def call(conn, {:error, :stale_entry}) do
     conn
     |> put_status(:precondition_failed)

--- a/lib/trento_web/openapi/v1/schema/forbidden.ex
+++ b/lib/trento_web/openapi/v1/schema/forbidden.ex
@@ -33,6 +33,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Forbidden do
           ],
           items: %Schema{
             type: :object,
+            additionalProperties: false,
             properties: %{
               detail: %Schema{
                 type: :string,
@@ -45,6 +46,21 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Forbidden do
                 description:
                   "A short summary indicating the forbidden status, used for quick identification and error handling.",
                 example: "Forbidden"
+              },
+              metadata: %Schema{
+                type: :array,
+                description:
+                  "List of additional metadata information to complement error details",
+                items: %Schema{
+                  type: :object,
+                  description: "Additional metadata information to complement error details",
+                  additionalProperties: true,
+                  example: %{
+                    id: "9876b7a8-2e1f-4b9a-8e7d-3a4b5c6d7e8f",
+                    label: "hana01",
+                    type: "host"
+                  }
+                }
               }
             }
           }

--- a/lib/trento_web/plugs/operations_policy_plug.ex
+++ b/lib/trento_web/plugs/operations_policy_plug.ex
@@ -117,7 +117,7 @@ defmodule TrentoWeb.Plugs.OperationsPolicyPlug do
   defp handle_permission(policy, operation, resource, params) do
     case policy.authorize_operation(operation, resource, params) do
       :ok -> :ok
-      {:error, errors} -> {:error, :operation_forbidden, errors}
+      {:error, errors} -> {:error, :forbidden, errors}
     end
   end
 end

--- a/lib/trento_web/plugs/operations_policy_plug.ex
+++ b/lib/trento_web/plugs/operations_policy_plug.ex
@@ -117,7 +117,7 @@ defmodule TrentoWeb.Plugs.OperationsPolicyPlug do
   defp handle_permission(policy, operation, resource, params) do
     case policy.authorize_operation(operation, resource, params) do
       :ok -> :ok
-      {:error, errors} -> {:error, :forbidden, errors}
+      {:error, errors} -> {:error, :operation_forbidden, errors}
     end
   end
 end

--- a/test/trento/operations/application_instance_policy_test.exs
+++ b/test/trento/operations/application_instance_policy_test.exs
@@ -49,7 +49,6 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
     end
 
     test "should authorize other instances start depending on Message server running status" do
-      sap_system_id = Faker.UUID.v4()
       instance_number = "00"
       sid = "PRD"
 
@@ -61,8 +60,8 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
             {:error,
              [
                %{
-                 message: "Message server #{instance_number} of SAP system {0} is not started",
-                 metadata: [%{id: sap_system_id, label: sid, type: :sap_system}]
+                 message: "Message server #{instance_number} of SAP system #{sid} is not started",
+                 metadata: []
                }
              ]}
         }
@@ -78,7 +77,6 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
 
         instance =
           build(:application_instance,
-            sap_system_id: sap_system_id,
             sid: sid,
             host: build(:host, heartbeat: :passing, cluster: @empty_ascs_ers_cluster)
           )
@@ -99,7 +97,7 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
     end
 
     test "should forbid other instances start if Message server is not found" do
-      %{sap_system_id: sap_system_id, sid: sid} =
+      %{sid: sid} =
         instance =
         build(:application_instance,
           host: build(:host, heartbeat: :passing, cluster: @empty_ascs_ers_cluster)
@@ -114,8 +112,8 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
       assert {:error,
               [
                 %{
-                  message: "Message server not found in SAP system {0}",
-                  metadata: [%{id: sap_system_id, label: sid, type: :sap_system}]
+                  message: "Message server not found in SAP system #{sid}",
+                  metadata: []
                 }
               ]} ==
                ApplicationInstancePolicy.authorize_operation(
@@ -225,7 +223,7 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
     end
 
     test "should forbid Message server stop if the other instances are running" do
-      %{sap_system_id: sap_system_id, sid: sid} =
+      %{sid: sid} =
         instance =
         build(:application_instance,
           features: "MESSAGESERVER|ENQUE",
@@ -243,12 +241,12 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
       assert {:error,
               [
                 %{
-                  message: "Instance #{inst_number_1} of SAP system {0} is not stopped",
-                  metadata: [%{id: sap_system_id, label: sid, type: :sap_system}]
+                  message: "Instance #{inst_number_1} of SAP system #{sid} is not stopped",
+                  metadata: []
                 },
                 %{
-                  message: "Instance #{inst_number_2} of SAP system {0} is not stopped",
-                  metadata: [%{id: sap_system_id, label: sid, type: :sap_system}]
+                  message: "Instance #{inst_number_2} of SAP system #{sid} is not stopped",
+                  metadata: []
                 }
               ]} ==
                ApplicationInstancePolicy.authorize_operation(

--- a/test/trento/operations/application_instance_policy_test.exs
+++ b/test/trento/operations/application_instance_policy_test.exs
@@ -19,7 +19,7 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
   test "should forbid unknown operation" do
     instance = build(:application_instance)
 
-    assert {:error, ["Unknown operation"]} ==
+    assert {:error, [%{message: "Unknown operation", metadata: []}]} ==
              ApplicationInstancePolicy.authorize_operation(:unknown, instance, %{})
   end
 
@@ -30,7 +30,8 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
       )
 
     for operation <- SapInstanceOperations.values() do
-      assert {:error, ["Trento agent is not currently running in the host"]} ==
+      assert {:error,
+              [%{message: "Trento agent is not currently running in the host", metadata: []}]} ==
                ApplicationInstancePolicy.authorize_operation(operation, instance, %{})
     end
   end
@@ -48,6 +49,7 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
     end
 
     test "should authorize other instances start depending on Message server running status" do
+      sap_system_id = Faker.UUID.v4()
       instance_number = "00"
       sid = "PRD"
 
@@ -56,7 +58,13 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
         %{
           health: :unknown,
           result:
-            {:error, ["Message server #{instance_number} of SAP system #{sid} is not started"]}
+            {:error,
+             [
+               %{
+                 message: "Message server #{instance_number} of SAP system {0} is not started",
+                 metadata: [%{id: sap_system_id, label: sid, type: :sap_system}]
+               }
+             ]}
         }
       ]
 
@@ -70,6 +78,7 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
 
         instance =
           build(:application_instance,
+            sap_system_id: sap_system_id,
             sid: sid,
             host: build(:host, heartbeat: :passing, cluster: @empty_ascs_ers_cluster)
           )
@@ -90,7 +99,7 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
     end
 
     test "should forbid other instances start if Message server is not found" do
-      %{sid: sid} =
+      %{sap_system_id: sap_system_id, sid: sid} =
         instance =
         build(:application_instance,
           host: build(:host, heartbeat: :passing, cluster: @empty_ascs_ers_cluster)
@@ -102,7 +111,13 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
           database: build(:database, health: :passing)
         )
 
-      assert {:error, ["Message server not found in SAP system #{sid}"]} ==
+      assert {:error,
+              [
+                %{
+                  message: "Message server not found in SAP system {0}",
+                  metadata: [%{id: sap_system_id, label: sid, type: :sap_system}]
+                }
+              ]} ==
                ApplicationInstancePolicy.authorize_operation(
                  :sap_instance_start,
                  %{instance | sap_system: sap_system},
@@ -140,13 +155,21 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
     end
 
     test "should authorize other instances start depending on database running state" do
+      database_id = Faker.UUID.v4()
       sid = "PRD"
 
       scenarios = [
         %{database_health: :passing, result: :ok},
         %{
           database_health: :unknown,
-          result: {:error, ["Database #{sid} is not started"]}
+          result:
+            {:error,
+             [
+               %{
+                 message: "Database {0} is not started",
+                 metadata: [%{id: database_id, label: sid, type: :database}]
+               }
+             ]}
         }
       ]
 
@@ -165,7 +188,7 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
         sap_system =
           build(:sap_system,
             application_instances: [message_server_instance, instance],
-            database: build(:database, sid: sid, health: database_health)
+            database: build(:database, id: database_id, sid: sid, health: database_health)
           )
 
         assert result ==
@@ -202,7 +225,7 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
     end
 
     test "should forbid Message server stop if the other instances are running" do
-      %{sid: sid} =
+      %{sap_system_id: sap_system_id, sid: sid} =
         instance =
         build(:application_instance,
           features: "MESSAGESERVER|ENQUE",
@@ -219,8 +242,14 @@ defmodule Trento.Operations.ApplicationInstancePolicyTest do
 
       assert {:error,
               [
-                "Instance #{inst_number_1} of SAP system #{sid} is not stopped",
-                "Instance #{inst_number_2} of SAP system #{sid} is not stopped"
+                %{
+                  message: "Instance #{inst_number_1} of SAP system {0} is not stopped",
+                  metadata: [%{id: sap_system_id, label: sid, type: :sap_system}]
+                },
+                %{
+                  message: "Instance #{inst_number_2} of SAP system {0} is not stopped",
+                  metadata: [%{id: sap_system_id, label: sid, type: :sap_system}]
+                }
               ]} ==
                ApplicationInstancePolicy.authorize_operation(
                  :sap_instance_stop,

--- a/test/trento/operations/cluster_policy_test.exs
+++ b/test/trento/operations/cluster_policy_test.exs
@@ -219,40 +219,47 @@ defmodule Trento.Operations.ClusterPolicyTest do
           host_units: [
             [name: "pacemaker.service", unit_file_state: "enabled"]
           ],
-          expected_error: "Pacemaker service on host {0} is already enabled"
+          expected_error: fn %{hostname: hostname} ->
+            "Pacemaker service on host #{hostname} is already enabled"
+          end
         },
         %{
           operation: :pacemaker_disable,
           host_units: [
             [name: "pacemaker.service", unit_file_state: "disabled"]
           ],
-          expected_error: "Pacemaker service on host {0} is already disabled"
+          expected_error: fn %{hostname: hostname} ->
+            "Pacemaker service on host #{hostname} is already disabled"
+          end
         },
         %{
           operation: :pacemaker_enable,
           host_units: [
             [name: "pacemaker.service", unit_file_state: "unrecognized_state"]
           ],
-          expected_error: "Pacemaker service unit state is unrecognized on host {0}"
+          expected_error: fn %{hostname: hostname} ->
+            "Pacemaker service unit state is unrecognized on host #{hostname}"
+          end
         },
         %{
           operation: :pacemaker_disable,
           host_units: [
             [name: "pacemaker.service", unit_file_state: "unrecognized_state"]
           ],
-          expected_error: "Pacemaker service unit state is unrecognized on host {0}"
+          expected_error: fn %{hostname: hostname} ->
+            "Pacemaker service unit state is unrecognized on host #{hostname}"
+          end
         }
       ]
 
       for %{
             operation: operation,
             host_units: host_units,
-            expected_error: expected_error
+            expected_error: expected_error_fn
           } <- unauthorized_scenarios do
         host_id = Faker.UUID.v4()
 
-        %{hostname: hostname} =
-          host =
+        host =
           build(:host,
             id: host_id,
             heartbeat: :passing,
@@ -261,13 +268,9 @@ defmodule Trento.Operations.ClusterPolicyTest do
 
         cluster = build(:cluster, hosts: [host])
 
-        assert {:error,
-                [
-                  %{
-                    message: expected_error,
-                    metadata: [%{id: host_id, label: hostname, type: :host}]
-                  }
-                ]} ==
+        expected_error = expected_error_fn.(host)
+
+        assert {:error, [%{message: expected_error, metadata: []}]} ==
                  ClusterPolicy.authorize_operation(operation, cluster, %{host_id: host_id})
       end
     end

--- a/test/trento/operations/cluster_policy_test.exs
+++ b/test/trento/operations/cluster_policy_test.exs
@@ -13,7 +13,7 @@ defmodule Trento.Operations.ClusterPolicyTest do
   test "should forbid unknown operation" do
     cluster = build(:cluster)
 
-    assert {:error, ["Unknown operation"]} ==
+    assert {:error, [%{message: "Unknown operation", metadata: []}]} ==
              ClusterPolicy.authorize_operation(:unknown, cluster, %{})
   end
 
@@ -23,7 +23,8 @@ defmodule Trento.Operations.ClusterPolicyTest do
       build(:cluster, hosts: build_list(2, :host, heartbeat: :critical))
 
     for operation <- ClusterHostOperations.values() do
-      assert {:error, ["Trento agent is not currently running in the host"]} ==
+      assert {:error,
+              [%{message: "Trento agent is not currently running in the host", metadata: []}]} ==
                ClusterPolicy.authorize_operation(operation, cluster, %{host_id: host_id})
     end
   end
@@ -34,7 +35,13 @@ defmodule Trento.Operations.ClusterPolicyTest do
 
     for operation <- ClusterOperations.values() do
       assert {:error,
-              ["Trento agent is not currently running in any of the hosts in the cluster"]} ==
+              [
+                %{
+                  message:
+                    "Trento agent is not currently running in any of the hosts in the cluster",
+                  metadata: []
+                }
+              ]} ==
                ClusterPolicy.authorize_operation(operation, cluster, %{})
     end
   end
@@ -50,13 +57,20 @@ defmodule Trento.Operations.ClusterPolicyTest do
 
     for operation <- ClusterOperations.values() do
       refute {:error,
-              ["Trento agent is not currently running in any of the hosts in the cluster"]} ==
+              [
+                %{
+                  message:
+                    "Trento agent is not currently running in any of the hosts in the cluster",
+                  metadata: []
+                }
+              ]} ==
                ClusterPolicy.authorize_operation(operation, cluster, %{})
     end
   end
 
   describe "maintenance" do
     test "should authorize operation depending on the cluster maintenance mode" do
+      cluster_id = Faker.UUID.v4()
       cluster_name = Faker.StarWars.character()
 
       scenarios = [
@@ -64,7 +78,13 @@ defmodule Trento.Operations.ClusterPolicyTest do
         %{
           maintenance_mode: false,
           result:
-            {:error, ["Cluster #{cluster_name} operating this host is not in maintenance mode"]}
+            {:error,
+             [
+               %{
+                 message: "Cluster {0} operating this host is not in maintenance mode",
+                 metadata: [%{id: cluster_id, label: cluster_name, type: :cluster}]
+               }
+             ]}
         }
       ]
 
@@ -72,7 +92,7 @@ defmodule Trento.Operations.ClusterPolicyTest do
         cluster_details =
           build(:hana_cluster_details, maintenance_mode: maintenance_mode, nodes: [])
 
-        cluster = build(:cluster, name: cluster_name, details: cluster_details)
+        cluster = build(:cluster, id: cluster_id, name: cluster_name, details: cluster_details)
 
         assert result ==
                  ClusterPolicy.authorize_operation(:maintenance, cluster, %{
@@ -82,6 +102,7 @@ defmodule Trento.Operations.ClusterPolicyTest do
     end
 
     test "should authorize operation depending on the given cluster resource managed state" do
+      cluster_id = Faker.UUID.v4()
       cluster_name = Faker.StarWars.character()
       cluster_resource_id = UUID.uuid4()
 
@@ -91,7 +112,11 @@ defmodule Trento.Operations.ClusterPolicyTest do
           result:
             {:error,
              [
-               "Cluster #{cluster_name} or resource #{cluster_resource_id} operating this host are not in maintenance mode"
+               %{
+                 message:
+                   "Cluster {0} or resource #{cluster_resource_id} operating this host are not in maintenance mode",
+                 metadata: [%{id: cluster_id, label: cluster_name, type: :cluster}]
+               }
              ]}
         },
         %{managed: false, result: :ok}
@@ -103,7 +128,7 @@ defmodule Trento.Operations.ClusterPolicyTest do
         cluster_details =
           build(:hana_cluster_details, maintenance_mode: false, resources: [cluster_resource])
 
-        cluster = build(:cluster, name: cluster_name, details: cluster_details)
+        cluster = build(:cluster, id: cluster_id, name: cluster_name, details: cluster_details)
 
         assert result ==
                  ClusterPolicy.authorize_operation(:maintenance, cluster, %{
@@ -130,7 +155,7 @@ defmodule Trento.Operations.ClusterPolicyTest do
       end
 
       test "should forbid #{@operation} operation if all hosts are offline" do
-        %{name: cluster_name} =
+        %{id: cluster_id, name: cluster_name} =
           cluster =
           build(:cluster,
             hosts:
@@ -140,7 +165,13 @@ defmodule Trento.Operations.ClusterPolicyTest do
               )
           )
 
-        assert {:error, ["Cluster #{cluster_name} does not have any online node"]} ==
+        assert {:error,
+                [
+                  %{
+                    message: "Cluster {0} does not have any online node",
+                    metadata: [%{id: cluster_id, label: cluster_name, type: :cluster}]
+                  }
+                ]} ==
                  ClusterPolicy.authorize_operation(@operation, cluster, %{})
       end
     end
@@ -188,47 +219,40 @@ defmodule Trento.Operations.ClusterPolicyTest do
           host_units: [
             [name: "pacemaker.service", unit_file_state: "enabled"]
           ],
-          expected_error: fn %{hostname: hostname} ->
-            "Pacemaker service on host #{hostname} is already enabled"
-          end
+          expected_error: "Pacemaker service on host {0} is already enabled"
         },
         %{
           operation: :pacemaker_disable,
           host_units: [
             [name: "pacemaker.service", unit_file_state: "disabled"]
           ],
-          expected_error: fn %{hostname: hostname} ->
-            "Pacemaker service on host #{hostname} is already disabled"
-          end
+          expected_error: "Pacemaker service on host {0} is already disabled"
         },
         %{
           operation: :pacemaker_enable,
           host_units: [
             [name: "pacemaker.service", unit_file_state: "unrecognized_state"]
           ],
-          expected_error: fn %{hostname: hostname} ->
-            "Pacemaker service unit state is unrecognized on host #{hostname}"
-          end
+          expected_error: "Pacemaker service unit state is unrecognized on host {0}"
         },
         %{
           operation: :pacemaker_disable,
           host_units: [
             [name: "pacemaker.service", unit_file_state: "unrecognized_state"]
           ],
-          expected_error: fn %{hostname: hostname} ->
-            "Pacemaker service unit state is unrecognized on host #{hostname}"
-          end
+          expected_error: "Pacemaker service unit state is unrecognized on host {0}"
         }
       ]
 
       for %{
             operation: operation,
             host_units: host_units,
-            expected_error: expected_error_fn
+            expected_error: expected_error
           } <- unauthorized_scenarios do
         host_id = Faker.UUID.v4()
 
-        host =
+        %{hostname: hostname} =
+          host =
           build(:host,
             id: host_id,
             heartbeat: :passing,
@@ -237,9 +261,13 @@ defmodule Trento.Operations.ClusterPolicyTest do
 
         cluster = build(:cluster, hosts: [host])
 
-        expected_error = expected_error_fn.(host)
-
-        assert {:error, [^expected_error]} =
+        assert {:error,
+                [
+                  %{
+                    message: expected_error,
+                    metadata: [%{id: host_id, label: hostname, type: :host}]
+                  }
+                ]} ==
                  ClusterPolicy.authorize_operation(operation, cluster, %{host_id: host_id})
       end
     end

--- a/test/trento/operations/database_instance_policy_test.exs
+++ b/test/trento/operations/database_instance_policy_test.exs
@@ -9,7 +9,7 @@ defmodule Trento.Operations.DatabaseInstancePolicyTest do
   test "should forbid unknown operation" do
     instance = build(:database_instance)
 
-    assert {:error, ["Unknown operation"]} ==
+    assert {:error, [%{message: "Unknown operation", metadata: []}]} ==
              DatabaseInstancePolicy.authorize_operation(:unknown, instance, %{})
   end
 end

--- a/test/trento/operations/database_policy_test.exs
+++ b/test/trento/operations/database_policy_test.exs
@@ -12,7 +12,7 @@ defmodule Trento.Operations.DatabasePolicyTest do
   test "should forbid unknown operation" do
     database = build(:database)
 
-    assert {:error, ["Unknown operation"]} ==
+    assert {:error, [%{message: "Unknown operation", metadata: []}]} ==
              DatabasePolicy.authorize_operation(:unknown, database, %{})
   end
 
@@ -46,8 +46,16 @@ defmodule Trento.Operations.DatabasePolicyTest do
     for operation <- DatabaseOperations.values() do
       assert {:error,
               [
-                "Trento agent is not currently running in any of the hosts in the database",
-                "Trento agent is not currently running in any of the hosts in the database site Site1"
+                %{
+                  message:
+                    "Trento agent is not currently running in any of the hosts in the database",
+                  metadata: []
+                },
+                %{
+                  message:
+                    "Trento agent is not currently running in any of the hosts in the database site Site1",
+                  metadata: []
+                }
               ]} ==
                DatabasePolicy.authorize_operation(operation, database, %{})
     end
@@ -80,7 +88,11 @@ defmodule Trento.Operations.DatabasePolicyTest do
     for operation <- DatabaseOperations.values() do
       assert {:error,
               [
-                "Trento agent is not currently running in any of the hosts in the database site #{site}"
+                %{
+                  message:
+                    "Trento agent is not currently running in any of the hosts in the database site #{site}",
+                  metadata: []
+                }
               ]} ==
                DatabasePolicy.authorize_operation(operation, database, %{site: site})
     end
@@ -104,14 +116,24 @@ defmodule Trento.Operations.DatabasePolicyTest do
 
     for operation <- DatabaseOperations.values() do
       refute {:error,
-              ["Trento agent is not currently running in any of the hosts in the database"]} ==
+              [
+                %{
+                  message:
+                    "Trento agent is not currently running in any of the hosts in the database",
+                  metadata: []
+                }
+              ]} ==
                DatabasePolicy.authorize_operation(operation, database, %{})
     end
   end
 
   describe "database_start" do
     test "should forbid operation if the database cluster is not in maintenance" do
-      %{name: cluster_name, sap_instances: [%{sid: sid, instance_number: instance_number}]} =
+      %{
+        id: cluster_id,
+        name: cluster_name,
+        sap_instances: [%{sid: sid, instance_number: instance_number}]
+      } =
         cluster = build_cluster_with_maintenance(false)
 
       database =
@@ -124,12 +146,18 @@ defmodule Trento.Operations.DatabasePolicyTest do
             )
         )
 
-      assert {:error, ["Cluster #{cluster_name} operating this host is not in maintenance mode"]} ==
+      assert {:error,
+              [
+                %{
+                  message: "Cluster {0} operating this host is not in maintenance mode",
+                  metadata: [%{id: cluster_id, label: cluster_name, type: :cluster}]
+                }
+              ]} ==
                DatabasePolicy.authorize_operation(:database_start, database, %{})
     end
 
     test "should forbid operation in secondary site if primary site is not started" do
-      %{sid: sid} =
+      %{id: database_id, sid: sid} =
         database =
         build(:database,
           database_instances: [
@@ -147,7 +175,13 @@ defmodule Trento.Operations.DatabasePolicyTest do
           ]
         )
 
-      assert {:error, ["Primary site Site1 of database #{sid} is not started"]} ==
+      assert {:error,
+              [
+                %{
+                  message: "Primary site Site1 of database {0} is not started",
+                  metadata: [%{id: database_id, label: sid, type: :database}]
+                }
+              ]} ==
                DatabasePolicy.authorize_operation(:database_start, database, %{site: "Site2"})
     end
 
@@ -243,7 +277,11 @@ defmodule Trento.Operations.DatabasePolicyTest do
 
   describe "database_stop" do
     test "should forbid operation if the database cluster is not in maintenance" do
-      %{name: cluster_name, sap_instances: [%{sid: sid, instance_number: instance_number}]} =
+      %{
+        id: cluster_id,
+        name: cluster_name,
+        sap_instances: [%{sid: sid, instance_number: instance_number}]
+      } =
         cluster = build_cluster_with_maintenance(false)
 
       database =
@@ -257,12 +295,18 @@ defmodule Trento.Operations.DatabasePolicyTest do
             )
         )
 
-      assert {:error, ["Cluster #{cluster_name} operating this host is not in maintenance mode"]} ==
+      assert {:error,
+              [
+                %{
+                  message: "Cluster {0} operating this host is not in maintenance mode",
+                  metadata: [%{id: cluster_id, label: cluster_name, type: :cluster}]
+                }
+              ]} ==
                DatabasePolicy.authorize_operation(:database_stop, database, %{})
     end
 
     test "should forbid operation if the request is for the primary site and secondary sites are not stopped" do
-      %{sid: sid} =
+      %{id: database_id, sid: sid} =
         database =
         build(:database,
           sap_systems: [],
@@ -281,7 +325,13 @@ defmodule Trento.Operations.DatabasePolicyTest do
           ]
         )
 
-      assert {:error, ["Secondary sites of database #{sid} are not stopped"]} ==
+      assert {:error,
+              [
+                %{
+                  message: "Secondary sites of database {0} are not stopped",
+                  metadata: [%{id: database_id, label: sid, type: :database}]
+                }
+              ]} ==
                DatabasePolicy.authorize_operation(:database_stop, database, %{site: "Site1"})
     end
 
@@ -292,8 +342,8 @@ defmodule Trento.Operations.DatabasePolicyTest do
             %{
               application_instances:
                 [
-                  %{sid: sid1, instance_number: inst_number1},
-                  %{sid: sid2, instance_number: inst_number2}
+                  %{sap_system_id: sap_system_id1, sid: sid1, instance_number: inst_number1},
+                  %{sap_system_id: sap_system_id2, sid: sid2, instance_number: inst_number2}
                 ] =
                   build_list(2, :application_instance,
                     health: Health.passing(),
@@ -317,8 +367,14 @@ defmodule Trento.Operations.DatabasePolicyTest do
 
       assert {:error,
               [
-                "Instance #{inst_number1} of SAP system #{sid1} is not stopped",
-                "Instance #{inst_number2} of SAP system #{sid2} is not stopped"
+                %{
+                  message: "Instance #{inst_number1} of SAP system {0} is not stopped",
+                  metadata: [%{id: sap_system_id1, label: sid1, type: :sap_system}]
+                },
+                %{
+                  message: "Instance #{inst_number2} of SAP system {0} is not stopped",
+                  metadata: [%{id: sap_system_id2, label: sid2, type: :sap_system}]
+                }
               ]} ==
                DatabasePolicy.authorize_operation(:database_stop, database, %{site: "Site1"})
     end
@@ -330,8 +386,8 @@ defmodule Trento.Operations.DatabasePolicyTest do
             %{
               application_instances:
                 [
-                  %{sid: sid1, instance_number: inst_number1},
-                  %{sid: sid2, instance_number: inst_number2}
+                  %{sap_system_id: sap_system_id1, sid: sid1, instance_number: inst_number1},
+                  %{sap_system_id: sap_system_id2, sid: sid2, instance_number: inst_number2}
                 ] =
                   build_list(2, :application_instance,
                     health: Health.passing(),
@@ -350,8 +406,14 @@ defmodule Trento.Operations.DatabasePolicyTest do
 
       assert {:error,
               [
-                "Instance #{inst_number1} of SAP system #{sid1} is not stopped",
-                "Instance #{inst_number2} of SAP system #{sid2} is not stopped"
+                %{
+                  message: "Instance #{inst_number1} of SAP system {0} is not stopped",
+                  metadata: [%{id: sap_system_id1, label: sid1, type: :sap_system}]
+                },
+                %{
+                  message: "Instance #{inst_number2} of SAP system {0} is not stopped",
+                  metadata: [%{id: sap_system_id2, label: sid2, type: :sap_system}]
+                }
               ]} ==
                DatabasePolicy.authorize_operation(:database_stop, database, %{})
     end

--- a/test/trento/operations/database_policy_test.exs
+++ b/test/trento/operations/database_policy_test.exs
@@ -157,7 +157,7 @@ defmodule Trento.Operations.DatabasePolicyTest do
     end
 
     test "should forbid operation in secondary site if primary site is not started" do
-      %{id: database_id, sid: sid} =
+      %{sid: sid} =
         database =
         build(:database,
           database_instances: [
@@ -178,8 +178,8 @@ defmodule Trento.Operations.DatabasePolicyTest do
       assert {:error,
               [
                 %{
-                  message: "Primary site Site1 of database {0} is not started",
-                  metadata: [%{id: database_id, label: sid, type: :database}]
+                  message: "Primary site Site1 of database #{sid} is not started",
+                  metadata: []
                 }
               ]} ==
                DatabasePolicy.authorize_operation(:database_start, database, %{site: "Site2"})
@@ -306,7 +306,7 @@ defmodule Trento.Operations.DatabasePolicyTest do
     end
 
     test "should forbid operation if the request is for the primary site and secondary sites are not stopped" do
-      %{id: database_id, sid: sid} =
+      %{sid: sid} =
         database =
         build(:database,
           sap_systems: [],
@@ -328,8 +328,8 @@ defmodule Trento.Operations.DatabasePolicyTest do
       assert {:error,
               [
                 %{
-                  message: "Secondary sites of database {0} are not stopped",
-                  metadata: [%{id: database_id, label: sid, type: :database}]
+                  message: "Secondary sites of database #{sid} are not stopped",
+                  metadata: []
                 }
               ]} ==
                DatabasePolicy.authorize_operation(:database_stop, database, %{site: "Site1"})

--- a/test/trento/operations/host_policy_test.exs
+++ b/test/trento/operations/host_policy_test.exs
@@ -13,14 +13,16 @@ defmodule Trento.Operations.HostPolicyTest do
   test "should forbid unknown operation" do
     host = build(:host, heartbeat: :passing)
 
-    assert {:error, ["Unknown operation"]} == HostPolicy.authorize_operation(:unknown, host, %{})
+    assert {:error, [%{message: "Unknown operation", metadata: []}]} ==
+             HostPolicy.authorize_operation(:unknown, host, %{})
   end
 
   test "should forbid operation if the host heartbeat is not passing" do
     host = build(:host, heartbeat: :critical)
 
     for operation <- HostOperations.values() do
-      assert {:error, ["Trento agent is not currently running in the host"]} ==
+      assert {:error,
+              [%{message: "Trento agent is not currently running in the host", metadata: []}]} ==
                HostPolicy.authorize_operation(operation, host, %{})
     end
   end
@@ -51,7 +53,7 @@ defmodule Trento.Operations.HostPolicyTest do
       test "should forbid operation '#{operation}' if an application instance is not stopped. Scenario: #{name}" do
         application_instances = [
           build(:application_instance, health: Health.unknown()),
-          %{sid: sid, instance_number: instance_number} =
+          %{sap_system_id: sap_system_id, sid: sid, instance_number: instance_number} =
             build(:application_instance, health: Health.passing())
         ]
 
@@ -68,7 +70,10 @@ defmodule Trento.Operations.HostPolicyTest do
 
         assert {:error,
                 [
-                  "Instance #{instance_number} of SAP system #{sid} is not stopped"
+                  %{
+                    message: "Instance #{instance_number} of SAP system {0} is not stopped",
+                    metadata: [%{id: sap_system_id, label: sid, type: :sap_system}]
+                  }
                 ]} == HostPolicy.authorize_operation(@saptune_operation, host, %{})
       end
 
@@ -77,7 +82,7 @@ defmodule Trento.Operations.HostPolicyTest do
 
         database_instances = [
           build(:database_instance, health: Health.unknown()),
-          %{sid: sid, instance_number: instance_number} =
+          %{database_id: database_id, sid: sid, instance_number: instance_number} =
             build(:database_instance, health: Health.passing())
         ]
 
@@ -92,20 +97,23 @@ defmodule Trento.Operations.HostPolicyTest do
 
         assert {:error,
                 [
-                  "Instance #{instance_number} of HANA database #{sid} is not stopped"
+                  %{
+                    message: "Instance #{instance_number} of HANA database {0} is not stopped",
+                    metadata: [%{id: database_id, label: sid, type: :database}]
+                  }
                 ]} == HostPolicy.authorize_operation(@saptune_operation, host, %{})
       end
 
       test "should forbid operation '#{operation}' if an application and database instances are not stopped. Scenario: #{name}" do
         application_instances = [
           build(:application_instance, health: Health.unknown()),
-          %{sid: app_sid, instance_number: app_instance_number} =
+          %{sap_system_id: sap_system_id, sid: app_sid, instance_number: app_instance_number} =
             build(:application_instance, health: Health.passing())
         ]
 
         database_instances = [
           build(:database_instance, health: Health.unknown()),
-          %{sid: db_sid, instance_number: db_instance_number} =
+          %{database_id: database_id, sid: db_sid, instance_number: db_instance_number} =
             build(:database_instance, health: Health.passing())
         ]
 
@@ -120,8 +128,14 @@ defmodule Trento.Operations.HostPolicyTest do
 
         assert {:error,
                 [
-                  "Instance #{app_instance_number} of SAP system #{app_sid} is not stopped",
-                  "Instance #{db_instance_number} of HANA database #{db_sid} is not stopped"
+                  %{
+                    message: "Instance #{app_instance_number} of SAP system {0} is not stopped",
+                    metadata: [%{id: sap_system_id, label: app_sid, type: :sap_system}]
+                  },
+                  %{
+                    message: "Instance #{db_instance_number} of HANA database {0} is not stopped",
+                    metadata: [%{id: database_id, label: db_sid, type: :database}]
+                  }
                 ]} == HostPolicy.authorize_operation(@saptune_operation, host, %{})
       end
 
@@ -199,7 +213,11 @@ defmodule Trento.Operations.HostPolicyTest do
 
       assert {:error,
               [
-                "Cannot apply the requested solution because there is an already applied one on this host"
+                %{
+                  message:
+                    "Cannot apply the requested solution because there is an already applied one on this host",
+                  metadata: []
+                }
               ]} == HostPolicy.authorize_operation(:saptune_solution_apply, host, %{})
     end
 
@@ -219,7 +237,11 @@ defmodule Trento.Operations.HostPolicyTest do
 
         assert {:error,
                 [
-                  "Cannot change the requested solution because there is no currently applied one on this host"
+                  %{
+                    message:
+                      "Cannot change the requested solution because there is no currently applied one on this host",
+                    metadata: []
+                  }
                 ]} == HostPolicy.authorize_operation(:saptune_solution_change, host, %{})
       end
     end
@@ -282,7 +304,7 @@ defmodule Trento.Operations.HostPolicyTest do
           database_instances: []
         )
 
-      {:error, ["Cluster is running in the host"]} =
+      {:error, [%{message: "Cluster is running in the host", metadata: []}]} =
         HostPolicy.authorize_operation(:reboot, host, %{})
     end
 
@@ -308,13 +330,13 @@ defmodule Trento.Operations.HostPolicyTest do
     test "should forbid host reboot if not all application instances are stopped" do
       application_instances = [
         build(:application_instance, health: Health.unknown()),
-        %{sid: sid1, instance_number: instance_number1} =
+        %{sap_system_id: sap_system_id, sid: sid1, instance_number: instance_number1} =
           build(:application_instance, health: Health.passing())
       ]
 
       database_instances = [
         build(:database_instance, health: Health.unknown()),
-        %{sid: sid2, instance_number: instance_number2} =
+        %{database_id: database_id, sid: sid2, instance_number: instance_number2} =
           build(:database_instance, health: Health.passing())
       ]
 
@@ -329,8 +351,14 @@ defmodule Trento.Operations.HostPolicyTest do
 
       assert {:error,
               [
-                "Instance #{instance_number1} of SAP system #{sid1} is not stopped",
-                "Instance #{instance_number2} of HANA database #{sid2} is not stopped"
+                %{
+                  message: "Instance #{instance_number1} of SAP system {0} is not stopped",
+                  metadata: [%{id: sap_system_id, label: sid1, type: :sap_system}]
+                },
+                %{
+                  message: "Instance #{instance_number2} of HANA database {0} is not stopped",
+                  metadata: [%{id: database_id, label: sid2, type: :database}]
+                }
               ]} == HostPolicy.authorize_operation(:reboot, host, %{})
     end
 

--- a/test/trento/operations/sap_system_policy_test.exs
+++ b/test/trento/operations/sap_system_policy_test.exs
@@ -157,8 +157,7 @@ defmodule Trento.Operations.SapSystemPolicyTest do
     end
 
     test "should forbid operation if the message server is not started for other type start request" do
-      %{id: sap_system_id} =
-        sap_system =
+      sap_system =
         build(:sap_system,
           database_instances: [],
           application_instances: [
@@ -174,8 +173,8 @@ defmodule Trento.Operations.SapSystemPolicyTest do
       assert {:error,
               [
                 %{
-                  message: "Instance #{inst_number} of SAP system {0} is not started",
-                  metadata: [%{id: sap_system_id, label: sid, type: :sap_system}]
+                  message: "Instance #{inst_number} of SAP system #{sid} is not started",
+                  metadata: []
                 }
               ]} ==
                SapSystemPolicy.authorize_operation(:sap_system_start, sap_system, %{
@@ -325,8 +324,7 @@ defmodule Trento.Operations.SapSystemPolicyTest do
     end
 
     test "should forbid operation if other instances are not stopped and the request is for the message server" do
-      %{id: sap_system_id} =
-        sap_system =
+      sap_system =
         build(:sap_system,
           application_instances: [
             %{sid: sid, instance_number: inst_number} =
@@ -346,8 +344,8 @@ defmodule Trento.Operations.SapSystemPolicyTest do
       assert {:error,
               [
                 %{
-                  message: "Instance #{inst_number} of SAP system {0} is not stopped",
-                  metadata: [%{id: sap_system_id, label: sid, type: :sap_system}]
+                  message: "Instance #{inst_number} of SAP system #{sid} is not stopped",
+                  metadata: []
                 }
               ]} ==
                SapSystemPolicy.authorize_operation(:sap_system_stop, sap_system, %{

--- a/test/trento/operations/sap_system_policy_test.exs
+++ b/test/trento/operations/sap_system_policy_test.exs
@@ -12,7 +12,7 @@ defmodule Trento.Operations.SapSystemPolicyTest do
   test "should forbid unknown operation" do
     sap_system = build(:sap_system)
 
-    assert {:error, ["Unknown operation"]} ==
+    assert {:error, [%{message: "Unknown operation", metadata: []}]} ==
              SapSystemPolicy.authorize_operation(:unknown, sap_system, %{})
   end
 
@@ -27,7 +27,13 @@ defmodule Trento.Operations.SapSystemPolicyTest do
 
     for operation <- SapSystemOperations.values() do
       assert {:error,
-              ["Trento agent is not currently running in any of the hosts in the SAP system"]} ==
+              [
+                %{
+                  message:
+                    "Trento agent is not currently running in any of the hosts in the SAP system",
+                  metadata: []
+                }
+              ]} ==
                SapSystemPolicy.authorize_operation(operation, sap_system, %{})
     end
   end
@@ -44,7 +50,13 @@ defmodule Trento.Operations.SapSystemPolicyTest do
 
     for operation <- SapSystemOperations.values() do
       refute {:error,
-              ["Trento agent is not currently running in any of the hosts in the SAP system"]} ==
+              [
+                %{
+                  message:
+                    "Trento agent is not currently running in any of the hosts in the SAP system",
+                  metadata: []
+                }
+              ]} ==
                SapSystemPolicy.authorize_operation(operation, sap_system, %{})
     end
   end
@@ -52,6 +64,7 @@ defmodule Trento.Operations.SapSystemPolicyTest do
   describe "sap_system_start" do
     test "should forbid operation if the application cluster is not in maintenance" do
       %{
+        id: cluster_id,
         name: cluster_name,
         sap_instances: [%{sid: sid, instance_number: instance_number}],
         details: %{resources: [%{id: resource_id}]}
@@ -71,7 +84,11 @@ defmodule Trento.Operations.SapSystemPolicyTest do
 
       assert {:error,
               [
-                "Cluster #{cluster_name} or resource #{resource_id} operating this host are not in maintenance mode"
+                %{
+                  message:
+                    "Cluster {0} or resource #{resource_id} operating this host are not in maintenance mode",
+                  metadata: [%{id: cluster_id, label: cluster_name, type: :cluster}]
+                }
               ]} ==
                SapSystemPolicy.authorize_operation(:sap_system_start, sap_system, %{
                  instance_type: "all"
@@ -82,7 +99,7 @@ defmodule Trento.Operations.SapSystemPolicyTest do
       sap_system =
         build(:sap_system,
           database_instances: [
-            %{sid: sid} =
+            %{database_id: database_id, sid: sid} =
               build(:database_instance,
                 health: Health.unknown(),
                 system_replication: nil
@@ -94,7 +111,13 @@ defmodule Trento.Operations.SapSystemPolicyTest do
             )
         )
 
-      assert {:error, ["Database #{sid} is not started"]} ==
+      assert {:error,
+              [
+                %{
+                  message: "Database {0} is not started",
+                  metadata: [%{id: database_id, label: sid, type: :database}]
+                }
+              ]} ==
                SapSystemPolicy.authorize_operation(:sap_system_start, sap_system, %{
                  instance_type: "abap"
                })
@@ -104,7 +127,7 @@ defmodule Trento.Operations.SapSystemPolicyTest do
       sap_system =
         build(:sap_system,
           database_instances: [
-            %{sid: sid} =
+            %{database_id: database_id, sid: sid} =
               build(:database_instance,
                 health: Health.unknown(),
                 system_replication: "Primary",
@@ -121,14 +144,21 @@ defmodule Trento.Operations.SapSystemPolicyTest do
             )
         )
 
-      assert {:error, ["Database #{sid} primary site Site1 is not started"]} ==
+      assert {:error,
+              [
+                %{
+                  message: "Database {0} primary site Site1 is not started",
+                  metadata: [%{id: database_id, label: sid, type: :database}]
+                }
+              ]} ==
                SapSystemPolicy.authorize_operation(:sap_system_start, sap_system, %{
                  instance_type: "abap"
                })
     end
 
     test "should forbid operation if the message server is not started for other type start request" do
-      sap_system =
+      %{id: sap_system_id} =
+        sap_system =
         build(:sap_system,
           database_instances: [],
           application_instances: [
@@ -141,7 +171,13 @@ defmodule Trento.Operations.SapSystemPolicyTest do
           ]
         )
 
-      assert {:error, ["Instance #{inst_number} of SAP system #{sid} is not started"]} ==
+      assert {:error,
+              [
+                %{
+                  message: "Instance #{inst_number} of SAP system {0} is not started",
+                  metadata: [%{id: sap_system_id, label: sid, type: :sap_system}]
+                }
+              ]} ==
                SapSystemPolicy.authorize_operation(:sap_system_start, sap_system, %{
                  instance_type: "abap"
                })
@@ -258,6 +294,7 @@ defmodule Trento.Operations.SapSystemPolicyTest do
   describe "sap_system_stop" do
     test "should forbid operation if the application cluster is not in maintenance" do
       %{
+        id: cluster_id,
         name: cluster_name,
         sap_instances: [%{sid: sid, instance_number: instance_number}],
         details: %{resources: [%{id: resource_id}]}
@@ -276,7 +313,11 @@ defmodule Trento.Operations.SapSystemPolicyTest do
 
       assert {:error,
               [
-                "Cluster #{cluster_name} or resource #{resource_id} operating this host are not in maintenance mode"
+                %{
+                  message:
+                    "Cluster {0} or resource #{resource_id} operating this host are not in maintenance mode",
+                  metadata: [%{id: cluster_id, label: cluster_name, type: :cluster}]
+                }
               ]} ==
                SapSystemPolicy.authorize_operation(:sap_system_stop, sap_system, %{
                  instance_type: "all"
@@ -284,7 +325,8 @@ defmodule Trento.Operations.SapSystemPolicyTest do
     end
 
     test "should forbid operation if other instances are not stopped and the request is for the message server" do
-      sap_system =
+      %{id: sap_system_id} =
+        sap_system =
         build(:sap_system,
           application_instances: [
             %{sid: sid, instance_number: inst_number} =
@@ -301,7 +343,13 @@ defmodule Trento.Operations.SapSystemPolicyTest do
           ]
         )
 
-      assert {:error, ["Instance #{inst_number} of SAP system #{sid} is not stopped"]} ==
+      assert {:error,
+              [
+                %{
+                  message: "Instance #{inst_number} of SAP system {0} is not stopped",
+                  metadata: [%{id: sap_system_id, label: sid, type: :sap_system}]
+                }
+              ]} ==
                SapSystemPolicy.authorize_operation(:sap_system_stop, sap_system, %{
                  instance_type: "scs"
                })

--- a/test/trento_web/plugs/operations_policy_plug_test.exs
+++ b/test/trento_web/plugs/operations_policy_plug_test.exs
@@ -10,7 +10,14 @@ defmodule TrentoWeb.Plugs.OperationsPolicyPlugTest do
     @behaviour Trento.Operations.PolicyBehaviour
 
     def authorize_operation(:authorized, _, _), do: :ok
-    def authorize_operation(:forbidden, _, _), do: {:error, ["error1", "error2"]}
+
+    def authorize_operation(:forbidden, _, _),
+      do:
+        {:error,
+         [
+           %{message: "error1", metadata: [%{"key" => "value"}]},
+           %{message: "error2", metadata: []}
+         ]}
   end
 
   setup %{conn: conn} do
@@ -69,11 +76,13 @@ defmodule TrentoWeb.Plugs.OperationsPolicyPlugTest do
              "errors" => [
                %{
                  "detail" => "error1",
-                 "title" => "Forbidden"
+                 "title" => "Forbidden",
+                 "metadata" => [%{"key" => "value"}]
                },
                %{
                  "detail" => "error2",
-                 "title" => "Forbidden"
+                 "title" => "Forbidden",
+                 "metadata" => []
                }
              ]
            } == resp


### PR DESCRIPTION
# Description

Improvement for current operation forbidden modal messages to include some links to referenced resources.
This way it is easier to navigate to the failed resources from the modal itself.

**I'm adding only the host usage by now, as example. Extending to others is pretty simple**.

In order to achieve this, additional metadata information is sent in the `forbidden` message and interpolated in the frontend using `{0}/{1}` kind of templating syntax. 
So for each `{i}`, we need to send it corresponding metadata.
The metadata is composed by `id`, `label` and `type`. These 3 elements are needed to created the link.

I didn't want to send html tags from the backend in the error message as it is not a good practice and you need to render dangerous html in the frontend.

I guess there are other options, so I'm open for feedback.

An example:
![link_in_message](https://github.com/user-attachments/assets/c842804e-c1fd-4de4-8d2d-11b2ae98c4d3)

## How was this tested?

UT and manual testing

## Did you update the documentation?

No need to update
