### PR TITLE
Remove unnecessary LLMRegistry.get_model_provider/1 function

### DIFF
--- a/lib/trento/ai/llm_registry.ex
+++ b/lib/trento/ai/llm_registry.ex
@@ -30,20 +30,6 @@ defmodule Trento.AI.LLMRegistry do
   def get_provider_models(_), do: []
 
   @doc """
-  Returns the provider for a given model or nil if the model is not supported.
-  """
-  @spec get_model_provider(bitstring()) :: atom() | nil
-  def get_model_provider(model) do
-    Enum.find_value(get_ai_providers_config(), fn {provider, config} ->
-      if model in Keyword.get(config, :models, []) do
-        provider
-      else
-        nil
-      end
-    end)
-  end
-
-  @doc """
   Checks if a given model is supported by a specific provider.
   """
   @spec model_supported_by_provider?(bitstring(), atom()) :: boolean()

--- a/test/trento/ai/configurations_test.exs
+++ b/test/trento/ai/configurations_test.exs
@@ -4,7 +4,7 @@ defmodule Trento.Ai.ConfigurationsTest do
 
   alias Trento.Users.User
 
-  alias Trento.AI.{Configurations, LLMRegistry, UserConfiguration}
+  alias Trento.AI.{Configurations, UserConfiguration}
 
   import Trento.Factory
 
@@ -260,12 +260,10 @@ defmodule Trento.Ai.ConfigurationsTest do
       model = build(:random_ai_model, provider: provider)
       api_key = Faker.String.base64()
 
-      expected_provider = LLMRegistry.get_model_provider(model)
-
       assert {:ok,
               %UserConfiguration{
                 model: ^model,
-                provider: ^expected_provider,
+                provider: ^provider,
                 api_key: ^api_key,
                 user_id: ^user_id
               } = created_config} =

--- a/test/trento/ai/llm_registry_test.exs
+++ b/test/trento/ai/llm_registry_test.exs
@@ -84,21 +84,6 @@ defmodule Trento.AI.LLMRegistryTest do
     end
   end
 
-  describe "get_model_provider/1" do
-    test "returns the provider for a given model" do
-      expect_config_loader_to_be_called_times(2)
-
-      assert LLMRegistry.get_model_provider("model6") == :provider3
-      assert LLMRegistry.get_model_provider("model1") == :provider1
-    end
-
-    test "returns nil for an unknown model" do
-      expect_config_loader_to_be_called_times(1)
-
-      assert LLMRegistry.get_model_provider("unknown-model") == nil
-    end
-  end
-
   describe "model_supported?/1" do
     test "returns true for a supported model" do
       expect_config_loader_to_be_called_times(2)


### PR DESCRIPTION
# Description

A test was failing in main https://github.com/trento-project/web/actions/runs/24236988457/job/70762242041#step:7:637

That's because in test environment we have the scenario where the same model is available for many providers.

Using the, now, deleted function was causing flakiness since retrieving the provider for a specified model could have returned different values.