### PR TITLE
Improve database start/stop operation policies to handle multi-tier setup

### DIFF
--- a/lib/trento/operations/database_policy.ex
+++ b/lib/trento/operations/database_policy.ex
@@ -228,6 +228,13 @@ defmodule Trento.Operations.DatabasePolicy do
        ),
        do: application_instances_stopped(database, nil, nil)
 
+  # full database stop request, check if app instances are stopped
+  defp application_instances_stopped(database, params, _) when not is_map_key(params, :site),
+    do: application_instances_stopped(database, nil, nil)
+
+  defp application_instances_stopped(database, %{site: nil}, _),
+    do: application_instances_stopped(database, nil, nil)
+
   # secondary site
   defp application_instances_stopped(_, _, _), do: :ok
 end

--- a/lib/trento/operations/database_policy.ex
+++ b/lib/trento/operations/database_policy.ex
@@ -74,7 +74,7 @@ defmodule Trento.Operations.DatabasePolicy do
     primary_site = get_primary_site(database)
 
     OperationsHelper.reduce_operation_authorizations([
-      database_instances_cluster_maintenance(database),
+      database_instances_cluster_maintenance(database, params),
       primary_site_started(database, params, primary_site)
     ])
   end
@@ -87,7 +87,7 @@ defmodule Trento.Operations.DatabasePolicy do
     primary_site = get_primary_site(database)
 
     OperationsHelper.reduce_operation_authorizations([
-      database_instances_cluster_maintenance(database),
+      database_instances_cluster_maintenance(database, params),
       secondary_sites_stopped(database, params, primary_site),
       application_instances_stopped(database, params, primary_site)
     ])
@@ -106,11 +106,15 @@ defmodule Trento.Operations.DatabasePolicy do
     end)
   end
 
-  defp database_instances_cluster_maintenance(%DatabaseReadModel{
-         database_instances: database_instances
-       }) do
-    OperationsHelper.reduce_operation_authorizations(
-      database_instances,
+  defp database_instances_cluster_maintenance(
+         %DatabaseReadModel{
+           database_instances: database_instances
+         },
+         params
+       ) do
+    database_instances
+    |> filter_by_site(params)
+    |> OperationsHelper.reduce_operation_authorizations(
       :ok,
       fn database_instance ->
         DatabaseInstanceReadModel.authorize_operation(

--- a/lib/trento/operations/database_policy.ex
+++ b/lib/trento/operations/database_policy.ex
@@ -185,7 +185,7 @@ defmodule Trento.Operations.DatabasePolicy do
          _
        ) do
     database_instances
-    |> Enum.filter(fn %{system_replication_source_site: soure_site} -> site == soure_site end)
+    |> Enum.filter(fn %{system_replication_source_site: source_site} -> site == source_site end)
     |> Enum.all?(fn %{health: health} -> health == :unknown end)
     |> if do
       :ok

--- a/lib/trento/operations/database_policy.ex
+++ b/lib/trento/operations/database_policy.ex
@@ -133,17 +133,32 @@ defmodule Trento.Operations.DatabasePolicy do
   defp primary_site_started(_, %{site: nil}, _), do: :ok
   # primary site
   defp primary_site_started(_, %{site: site}, site), do: :ok
-  # secondary sites, check primary is started
+  # secondary sites, check primary of this site is started.
+  # for that, check site instances with the previous tier number are started.
+  # for example: to start tier 3 check if tier 2 instances are started.
+  # this policy is sub-optimal as it doesn't handle well a potential multi-target + multi-tier setup.
+  # in that scenario, the policy would check all instances in 2nd tier, without filtering only
+  # replicated sites by the 3rd tier site.
   defp primary_site_started(
          %DatabaseReadModel{
            sid: sid,
            database_instances: database_instances
          },
-         _,
-         primary_site
+         %{site: site},
+         _
        ) do
+    requested_site_tier =
+      Enum.find_value(database_instances, 0, fn %{
+                                                  system_replication_tier: tier,
+                                                  system_replication_site: inst_site
+                                                } ->
+        if site == inst_site do
+          tier
+        end
+      end)
+
     database_instances
-    |> Enum.filter(fn %{system_replication_site: site} -> site == primary_site end)
+    |> Enum.filter(fn %{system_replication_tier: tier} -> tier == requested_site_tier - 1 end)
     |> Enum.all?(fn %{health: health} -> health == :passing end)
     |> if do
       :ok
@@ -151,7 +166,7 @@ defmodule Trento.Operations.DatabasePolicy do
       {:error,
        [
          OperationsHelper.build_error(
-           "Primary site #{primary_site} of database #{sid} is not started",
+           "Primary site of #{site} in database #{sid} is not started",
            []
          )
        ]}
@@ -166,11 +181,11 @@ defmodule Trento.Operations.DatabasePolicy do
            sid: sid,
            database_instances: database_instances
          },
-         %{site: primary_site},
-         primary_site
+         %{site: site},
+         _
        ) do
     database_instances
-    |> Enum.reject(fn %{system_replication_site: site} -> site == primary_site end)
+    |> Enum.filter(fn %{system_replication_source_site: soure_site} -> site == soure_site end)
     |> Enum.all?(fn %{health: health} -> health == :unknown end)
     |> if do
       :ok
@@ -178,7 +193,7 @@ defmodule Trento.Operations.DatabasePolicy do
       {:error,
        [
          OperationsHelper.build_error(
-           "Secondary sites of database #{sid} are not stopped",
+           "Secondary sites for site #{site} in database #{sid} are not stopped",
            []
          )
        ]}

--- a/test/trento/operations/database_policy_test.exs
+++ b/test/trento/operations/database_policy_test.exs
@@ -407,6 +407,50 @@ defmodule Trento.Operations.DatabasePolicyTest do
                DatabasePolicy.authorize_operation(:database_stop, database, %{site: "Site1"})
     end
 
+    test "should forbid operation if the request is for full database and attached application instances are not stopped" do
+      database =
+        build(:database,
+          sap_systems: [
+            %{
+              application_instances:
+                [
+                  %{sid: sid1, instance_number: inst_number1},
+                  %{sid: sid2, instance_number: inst_number2}
+                ] =
+                  build_list(2, :application_instance,
+                    health: Health.passing(),
+                    features: "ABAP|GATEWAY|ICMAN|IGS"
+                  )
+            }
+          ],
+          database_instances: [
+            build(:database_instance,
+              system_replication: "Primary",
+              system_replication_site: "Site1",
+              host: build(:host, heartbeat: :passing, cluster: nil)
+            ),
+            build(:database_instance,
+              health: Health.unknown(),
+              system_replication: "Secondary",
+              host: build(:host, heartbeat: :passing, cluster: nil)
+            )
+          ]
+        )
+
+      expected_error =
+        {:error,
+         [
+           "Instance #{inst_number1} of SAP system #{sid1} is not stopped",
+           "Instance #{inst_number2} of SAP system #{sid2} is not stopped"
+         ]}
+
+      assert expected_error ==
+               DatabasePolicy.authorize_operation(:database_stop, database, %{site: nil})
+
+      assert expected_error ==
+               DatabasePolicy.authorize_operation(:database_stop, database, %{})
+    end
+
     test "should forbid operation if the request is for a database without system replication and attached application instances are not stopped" do
       database =
         build(:database,
@@ -495,9 +539,18 @@ defmodule Trento.Operations.DatabasePolicyTest do
                DatabasePolicy.authorize_operation(:database_stop, database, %{site: site})
     end
 
-    test "should authorize operation in full database if instances are running" do
+    test "should authorize operation in full database if instances are running and attached application instances are stopped" do
       database =
         build(:database,
+          sap_systems: [
+            %{
+              application_instances:
+                build_list(2, :application_instance,
+                  health: Health.unknown(),
+                  features: "ABAP|GATEWAY|ICMAN|IGS"
+                )
+            }
+          ],
           database_instances: [
             build(:database_instance,
               health: Health.passing(),

--- a/test/trento/operations/database_policy_test.exs
+++ b/test/trento/operations/database_policy_test.exs
@@ -469,8 +469,8 @@ defmodule Trento.Operations.DatabasePolicyTest do
             %{
               application_instances:
                 [
-                  %{sid: sid1, instance_number: inst_number1},
-                  %{sid: sid2, instance_number: inst_number2}
+                  %{sap_system_id: sap_system_id1, sid: sid1, instance_number: inst_number1},
+                  %{sap_system_id: sap_system_id2, sid: sid2, instance_number: inst_number2}
                 ] =
                   build_list(2, :application_instance,
                     health: Health.passing(),
@@ -495,8 +495,14 @@ defmodule Trento.Operations.DatabasePolicyTest do
       expected_error =
         {:error,
          [
-           "Instance #{inst_number1} of SAP system #{sid1} is not stopped",
-           "Instance #{inst_number2} of SAP system #{sid2} is not stopped"
+           %{
+             message: "Instance #{inst_number1} of SAP system {0} is not stopped",
+             metadata: [%{id: sap_system_id1, label: sid1, type: :sap_system}]
+           },
+           %{
+             message: "Instance #{inst_number2} of SAP system {0} is not stopped",
+             metadata: [%{id: sap_system_id2, label: sid2, type: :sap_system}]
+           }
          ]}
 
       assert expected_error ==

--- a/test/trento/operations/database_policy_test.exs
+++ b/test/trento/operations/database_policy_test.exs
@@ -157,6 +157,9 @@ defmodule Trento.Operations.DatabasePolicyTest do
     end
 
     test "should forbid operation in secondary site if primary site is not started" do
+      site1 = "Site1"
+      site2 = "Site2"
+
       %{sid: sid} =
         database =
         build(:database,
@@ -164,12 +167,20 @@ defmodule Trento.Operations.DatabasePolicyTest do
             build(:database_instance,
               health: Health.unknown(),
               system_replication: "Primary",
-              system_replication_site: "Site1",
+              system_replication_tier: 1,
               host: build(:host, heartbeat: :critical, cluster: nil)
             ),
             build(:database_instance,
+              health: Health.unknown(),
               system_replication: "Secondary",
-              system_replication_site: "Site2",
+              system_replication_site: site1,
+              system_replication_tier: 2,
+              host: build(:host, heartbeat: :passing, cluster: nil)
+            ),
+            build(:database_instance,
+              system_replication: "Secondary",
+              system_replication_site: site2,
+              system_replication_tier: 3,
               host: build(:host, heartbeat: :passing, cluster: nil)
             )
           ]
@@ -178,11 +189,20 @@ defmodule Trento.Operations.DatabasePolicyTest do
       assert {:error,
               [
                 %{
-                  message: "Primary site Site1 of database #{sid} is not started",
+                  message: "Primary site of #{site1} in database #{sid} is not started",
                   metadata: []
                 }
               ]} ==
-               DatabasePolicy.authorize_operation(:database_start, database, %{site: "Site2"})
+               DatabasePolicy.authorize_operation(:database_start, database, %{site: site1})
+
+      assert {:error,
+              [
+                %{
+                  message: "Primary site of #{site2} in database #{sid} is not started",
+                  metadata: []
+                }
+              ]} ==
+               DatabasePolicy.authorize_operation(:database_start, database, %{site: site2})
     end
 
     test "should authorize operation if cluster is in maintenance and system replication is not enabled" do
@@ -334,6 +354,11 @@ defmodule Trento.Operations.DatabasePolicyTest do
     end
 
     test "should forbid operation if the request is for the primary site and secondary sites are not stopped" do
+      site1 = "Site1"
+      site2 = "Site2"
+      site3 = "Site3"
+      site4 = "Site3"
+
       %{sid: sid} =
         database =
         build(:database,
@@ -341,13 +366,28 @@ defmodule Trento.Operations.DatabasePolicyTest do
           database_instances: [
             build(:database_instance,
               system_replication: "Primary",
-              system_replication_site: "Site1",
+              system_replication_site: site1,
               host: build(:host, heartbeat: :passing, cluster: nil)
             ),
             build(:database_instance,
               health: Health.passing(),
               system_replication: "Secondary",
-              system_replication_site: "Site2",
+              system_replication_site: site2,
+              system_replication_source_site: site1,
+              host: build(:host, heartbeat: :passing, cluster: nil)
+            ),
+            build(:database_instance,
+              health: Health.unknown(),
+              system_replication: "Secondary 2",
+              system_replication_site: site3,
+              system_replication_source_site: site1,
+              host: build(:host, heartbeat: :passing, cluster: nil)
+            ),
+            build(:database_instance,
+              health: Health.passing(),
+              system_replication: "Secondary",
+              system_replication_site: site4,
+              system_replication_source_site: site2,
               host: build(:host, heartbeat: :passing, cluster: nil)
             )
           ]
@@ -356,11 +396,26 @@ defmodule Trento.Operations.DatabasePolicyTest do
       assert {:error,
               [
                 %{
-                  message: "Secondary sites of database #{sid} are not stopped",
+                  message: "Secondary sites for site #{site1} in database #{sid} are not stopped",
                   metadata: []
                 }
               ]} ==
-               DatabasePolicy.authorize_operation(:database_stop, database, %{site: "Site1"})
+               DatabasePolicy.authorize_operation(:database_stop, database, %{site: site1})
+
+      assert {:error,
+              [
+                %{
+                  message: "Secondary sites for site #{site2} in database #{sid} are not stopped",
+                  metadata: []
+                }
+              ]} ==
+               DatabasePolicy.authorize_operation(:database_stop, database, %{site: site2})
+
+      assert :ok ==
+               DatabasePolicy.authorize_operation(:database_stop, database, %{site: site3})
+
+      assert :ok ==
+               DatabasePolicy.authorize_operation(:database_stop, database, %{site: site4})
     end
 
     test "should forbid operation if the request is for the primary site and attached application instances are not stopped" do

--- a/test/trento/operations/database_policy_test.exs
+++ b/test/trento/operations/database_policy_test.exs
@@ -205,6 +205,34 @@ defmodule Trento.Operations.DatabasePolicyTest do
                DatabasePolicy.authorize_operation(:database_start, database, %{})
     end
 
+    test "should authorize operation if cluster is not configured in the requested site" do
+      site = "Site1"
+
+      %{sap_instances: [%{sid: sid, instance_number: instance_number}]} =
+        cluster = build_cluster_with_maintenance(false)
+
+      database =
+        build(:database,
+          database_instances: [
+            build(:database_instance,
+              health: Health.passing(),
+              system_replication: "Primary",
+              sid: sid,
+              instance_number: instance_number,
+              host: build(:host, heartbeat: :passing, cluster: cluster)
+            ),
+            build(:database_instance,
+              system_replication: nil,
+              system_replication_site: site,
+              host: build(:host, heartbeat: :passing, cluster: nil)
+            )
+          ]
+        )
+
+      assert :ok ==
+               DatabasePolicy.authorize_operation(:database_start, database, %{site: site})
+    end
+
     test "should authorize operation in full database if instances are stopped" do
       database =
         build(:database,
@@ -437,6 +465,34 @@ defmodule Trento.Operations.DatabasePolicyTest do
 
       assert :ok ==
                DatabasePolicy.authorize_operation(:database_stop, database, %{})
+    end
+
+    test "should authorize operation if cluster is not configured in the requested site" do
+      site = "Site1"
+
+      %{sap_instances: [%{sid: sid, instance_number: instance_number}]} =
+        cluster = build_cluster_with_maintenance(false)
+
+      database =
+        build(:database,
+          database_instances: [
+            build(:database_instance,
+              health: Health.unknown(),
+              system_replication: "Primary",
+              sid: sid,
+              instance_number: instance_number,
+              host: build(:host, heartbeat: :passing, cluster: cluster)
+            ),
+            build(:database_instance,
+              system_replication: nil,
+              system_replication_site: site,
+              host: build(:host, heartbeat: :passing, cluster: nil)
+            )
+          ]
+        )
+
+      assert :ok ==
+               DatabasePolicy.authorize_operation(:database_stop, database, %{site: site})
     end
 
     test "should authorize operation in full database if instances are running" do

--- a/test/trento/operations/database_policy_test.exs
+++ b/test/trento/operations/database_policy_test.exs
@@ -357,7 +357,7 @@ defmodule Trento.Operations.DatabasePolicyTest do
       site1 = "Site1"
       site2 = "Site2"
       site3 = "Site3"
-      site4 = "Site3"
+      site4 = "Site4"
 
       %{sid: sid} =
         database =


### PR DESCRIPTION
# Description

Now that multi-tier setups are implemented, the `database start/stop` operation must be improved.
- In a multi-tier setup, the 3rd site (the disaster recovery one) is not handled by Pacemaker cluster.
In this case, if we want to start/stop this site, we don't need to check if pacemaker is there or if it is in maintenance mode. This PR filters out database instances that are not part of the requested site in the cluster maintenance check. 
- In a full database stop operation, check if application instances are stopped. It was not checked due this scenario was not even considered in the code
- Replace the usage of Primary/Secondary relation to start/stop. In a multi-tier setup we can have different secondary setups in tier 2 and tier 3. And their relationship is different. 

## How was this tested?

UT and manual testing

## Did you update the documentation?

No need
