### PR TITLE
Group dependabot eslint updates & Add e2e deps to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,8 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 14
+    groups:
+      eslint:
+        patterns:
+          - "eslint*"
+          - "@eslint*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,18 @@ updates:
         patterns:
           - "eslint*"
           - "@eslint*"
+  - package-ecosystem: "npm"
+    directory: "/test/e2e"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 14
+    groups:
+      cypress:
+        patterns:
+          - "cypress*"
+          - "@cypress*"
+      eslint:
+        patterns:
+          - "eslint*"
+          - "@eslint*"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -411,7 +411,20 @@ jobs:
       - name: Run test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_PARALLEL: true
+          COVERALLS_FLAG_NAME: Elixir-${{ matrix.elixir }}
         run: mix coveralls.github --warnings-as-errors --trace
+
+  coveralls-finish:
+    needs: [test-elixir]
+    if: needs.detect-changes.outputs.elixir-changed == 'true' || always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   test-release:
     name: Test release build

--- a/test/e2e/cypress/support/e2e.js
+++ b/test/e2e/cypress/support/e2e.js
@@ -13,8 +13,6 @@
 // https://on.cypress.io/configuration
 // ***********************************************************
 
-// import 'cypress-localstorage-commands';
-
 // Import commands.js using ES2015 syntax:
 import { apiLoginAndCreateSession } from '../pageObject/base_po';
 

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -9,7 +9,6 @@
   },
   "devDependencies": {
     "cypress": "^13.2.0",
-    "cypress-localstorage-commands": "^2.2.2",
     "cypress-split": "^1.24.7",
     "eslint": "^8.15.0",
     "eslint-plugin-cypress": "^2.12.1",


### PR DESCRIPTION
# Description

- Groups dependabot eslint updates for /assets
- Adds dependabot config for /test/e2e
- Adds proper parallel config for coveralls report of elixir tests, based on [this](https://docs.coveralls.io/parallel-builds) 
- Remove unused dep `cypress-localstorage-commands` from /test/e2e

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
