### PR TITLE
Exclude common workflows from cooldown and group them into single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      common-workflows:
+        patterns:
+          - "trento-project/.github*"
     cooldown:
       default-days: 14
+      exclude:
+        - "trento-project/.github*"
   - package-ecosystem: "mix"
     directory: "/"
     schedule:


### PR DESCRIPTION
# Description

As with the rest of our repos:
Exclude common workflows from cooldown and group them into single PR
