### PR TITLE
Validate operation request site parameter in database operation policy

### DIFF
--- a/lib/trento/operations/database_policy.ex
+++ b/lib/trento/operations/database_policy.ex
@@ -25,9 +25,10 @@ defmodule Trento.Operations.DatabasePolicy do
         params
       )
       when operation in DatabaseOperations.values() do
+    site_instances = filter_by_site(instances, params)
+
     sites_without_passing_heartbeat =
-      instances
-      |> filter_by_site(params)
+      site_instances
       |> Enum.group_by(& &1.system_replication_site)
       |> Enum.reject(fn {_site, grouped_instances} ->
         Enum.any?(grouped_instances, fn %DatabaseInstanceReadModel{
@@ -38,21 +39,9 @@ defmodule Trento.Operations.DatabasePolicy do
       end)
       |> Enum.map(fn {site, _} -> site end)
 
-    if Enum.empty?(sites_without_passing_heartbeat) do
+    with :ok <- validate_site_exists(site_instances, params),
+         :ok <- validate_heartbeats(sites_without_passing_heartbeat) do
       do_authorize_operation(operation, database, params)
-    else
-      {:error,
-       Enum.map(sites_without_passing_heartbeat, fn
-         nil ->
-           OperationsHelper.build_error(
-             "Trento agent is not currently running in any of the hosts in the database"
-           )
-
-         site ->
-           OperationsHelper.build_error(
-             "Trento agent is not currently running in any of the hosts in the database site #{site}"
-           )
-       end)}
     end
   end
 
@@ -65,6 +54,32 @@ defmodule Trento.Operations.DatabasePolicy do
     do: Enum.filter(instances, fn %{system_replication_site: site} -> site == params_site end)
 
   defp filter_by_site(instances, _), do: instances
+
+  defp validate_site_exists([], %{site: site}),
+    do:
+      {:error,
+       [
+         OperationsHelper.build_error("Requested site #{site} is not found in the database")
+       ]}
+
+  defp validate_site_exists(_instances, _params), do: :ok
+
+  defp validate_heartbeats([]), do: :ok
+
+  defp validate_heartbeats(sites_without_passing_heartbeat) do
+    {:error,
+     Enum.map(sites_without_passing_heartbeat, fn
+       nil ->
+         OperationsHelper.build_error(
+           "Trento agent is not currently running in any of the hosts in the database"
+         )
+
+       site ->
+         OperationsHelper.build_error(
+           "Trento agent is not currently running in any of the hosts in the database site #{site}"
+         )
+     end)}
+  end
 
   defp do_authorize_operation(
          :database_start,

--- a/lib/trento/operations/database_policy.ex
+++ b/lib/trento/operations/database_policy.ex
@@ -25,21 +25,9 @@ defmodule Trento.Operations.DatabasePolicy do
         params
       )
       when operation in DatabaseOperations.values() do
-    site_instances = filter_by_site(instances, params)
-
-    sites_without_passing_heartbeat =
-      site_instances
-      |> Enum.group_by(& &1.system_replication_site)
-      |> Enum.reject(fn {_site, grouped_instances} ->
-        Enum.any?(grouped_instances, fn %DatabaseInstanceReadModel{
-                                          host: %HostReadModel{heartbeat: heartbeat}
-                                        } ->
-          heartbeat == :passing
-        end)
-      end)
-      |> Enum.map(fn {site, _} -> site end)
-
-    with :ok <- validate_site_exists(site_instances, params),
+    with site_instances <- filter_by_site(instances, params),
+         :ok <- validate_site_exists(site_instances, params),
+         sites_without_passing_heartbeat <- get_sites_without_heartbeats(site_instances),
          :ok <- validate_heartbeats(sites_without_passing_heartbeat) do
       do_authorize_operation(operation, database, params)
     end
@@ -63,6 +51,19 @@ defmodule Trento.Operations.DatabasePolicy do
        ]}
 
   defp validate_site_exists(_instances, _params), do: :ok
+
+  defp get_sites_without_heartbeats(site_instances) do
+    site_instances
+    |> Enum.group_by(& &1.system_replication_site)
+    |> Enum.reject(fn {_site, grouped_instances} ->
+      Enum.any?(grouped_instances, fn %DatabaseInstanceReadModel{
+                                        host: %HostReadModel{heartbeat: heartbeat}
+                                      } ->
+        heartbeat == :passing
+      end)
+    end)
+    |> Enum.map(fn {site, _} -> site end)
+  end
 
   defp validate_heartbeats([]), do: :ok
 

--- a/test/trento/operations/database_policy_test.exs
+++ b/test/trento/operations/database_policy_test.exs
@@ -127,6 +127,26 @@ defmodule Trento.Operations.DatabasePolicyTest do
     end
   end
 
+  test "should forbid operation if the requested site is not found" do
+    site = "unknown"
+
+    database =
+      build(:database,
+        database_instances: build_list(2, :database_instance)
+      )
+
+    for operation <- DatabaseOperations.values() do
+      assert {:error,
+              [
+                %{
+                  message: "Requested site #{site} is not found in the database",
+                  metadata: []
+                }
+              ]} ==
+               DatabasePolicy.authorize_operation(operation, database, %{site: site})
+    end
+  end
+
   describe "database_start" do
     test "should forbid operation if the database cluster is not in maintenance" do
       %{


### PR DESCRIPTION
# Description

Follow up for: https://github.com/trento-project/web/pull/4172

Validate if the `site` coming in the operation request exists.
Otherwise, fail with a forbidden message.
This scenario won't happen when the operation is requested from the frontend.

## How was this tested?

UT
