### PR TITLE
Group operation abilities by resource

### DIFF
--- a/assets/js/common/AbilitiesMultiSelect/AbilitiesMultiSelect.jsx
+++ b/assets/js/common/AbilitiesMultiSelect/AbilitiesMultiSelect.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { assign, find } from 'lodash';
+import { assign, find, orderBy, startsWith } from 'lodash';
 import { getFromConfig } from '@lib/config';
 
 import Select from '@common/Select';
@@ -51,24 +51,39 @@ const groupedAbilities = [
     ],
   },
   {
-    ability: 'operation:all',
-    tooltip: 'Permits running operations in all resources',
+    ability: 'operation:host',
+    tooltip: 'Permits running operations in hosts',
     groupAbilities: [
       'saptune_solution_apply:host',
       'saptune_solution_change:host',
+      'reboot:host',
+    ],
+  },
+  {
+    ability: 'operation:cluster',
+    tooltip: 'Permits running operations in clusters',
+    groupAbilities: [
       'maintenance_change:cluster',
       'cluster_host_start:cluster',
       'cluster_host_stop:cluster',
-      'reboot:host',
       'pacemaker_enable:cluster',
       'pacemaker_disable:cluster',
+      'resource_refresh:cluster',
+    ],
+  },
+  {
+    ability: 'operation:database',
+    tooltip: 'Permits running operations in databases',
+    groupAbilities: ['start:database', 'stop:database'],
+  },
+  {
+    ability: 'operation:sap_system',
+    tooltip: 'Permits running operations in SAP systems',
+    groupAbilities: [
       'start:application_instance',
       'stop:application_instance',
       'start:sap_system',
       'stop:sap_system',
-      'start:database',
-      'stop:database',
-      'resource_refresh:cluster',
     ],
   },
 ];
@@ -85,7 +100,10 @@ const mapAbilities = (abilities, operationsEnabled) =>
     }
 
     // remove operations abilities by now
-    if (!operationsEnabled && groupedAbility.ability === 'operation:all') {
+    if (
+      !operationsEnabled &&
+      startsWith(groupedAbility.ability, 'operation:')
+    ) {
       return acc;
     }
 
@@ -117,7 +135,7 @@ function AbilitiesMultiSelect({
       aria-label="permissions"
       placeholder={placeholder}
       initialValues={mapAbilities(userAbilities, operationsEnabled)}
-      options={mapAbilities(abilities, operationsEnabled)}
+      options={orderBy(mapAbilities(abilities, operationsEnabled), ['label'])}
       onChange={setAbilities}
       getOptionValue={(option) => option.value.toString()}
       {...props}

--- a/assets/js/common/AbilitiesMultiSelect/AbilitiesMultiSelect.test.jsx
+++ b/assets/js/common/AbilitiesMultiSelect/AbilitiesMultiSelect.test.jsx
@@ -15,7 +15,10 @@ describe('AbilitiesMultiSelect Component', () => {
       'all:checks_selection',
       'all:checks_execution',
       'cleanup:all',
-      'operation:all',
+      'operation:cluster',
+      'operation:database',
+      'operation:host',
+      'operation:sap_system',
     ];
     const abilities = [
       { id: 1, name: 'all', resource: 'host_checks_selection' },
@@ -74,7 +77,13 @@ describe('AbilitiesMultiSelect Component', () => {
     await user.click(screen.getByLabelText('permissions'));
     await user.click(screen.getByText('all:settings'));
     await user.click(screen.getByLabelText('permissions'));
-    await user.click(screen.getByText('operation:all'));
+    await user.click(screen.getByText('operation:cluster'));
+    await user.click(screen.getByLabelText('permissions'));
+    await user.click(screen.getByText('operation:database'));
+    await user.click(screen.getByLabelText('permissions'));
+    await user.click(screen.getByText('operation:host'));
+    await user.click(screen.getByLabelText('permissions'));
+    await user.click(screen.getByText('operation:sap_system'));
     await user.click(screen.getByLabelText('permissions'));
 
     expect(screen.getByText('No options')).toBeVisible();
@@ -151,7 +160,10 @@ describe('AbilitiesMultiSelect Component', () => {
 
     screen.getByText('all:checks_selection');
     screen.getByText('all:all');
-    screen.getByText('operation:all');
+    screen.getByText('operation:cluster');
+    screen.getByText('operation:database');
+    screen.getByText('operation:host');
+    screen.getByText('operation:sap_system');
     expect(
       screen.queryByText('all:host_checks_selection')
     ).not.toBeInTheDocument();

--- a/assets/js/common/OperationsButton/OperationsButton.jsx
+++ b/assets/js/common/OperationsButton/OperationsButton.jsx
@@ -1,6 +1,6 @@
 import React, { useRef, Fragment } from 'react';
 import classNames from 'classnames';
-import { some } from 'lodash';
+import { concat, some } from 'lodash';
 import {
   Menu,
   MenuButton,
@@ -90,7 +90,7 @@ function OperationsButton({
               <MenuItem>
                 <DisabledGuard
                   userAbilities={userAbilities}
-                  permitted={permitted}
+                  permitted={concat(permitted, 'operation:all')}
                   tooltipWrap
                 >
                   <CustomMenuButton

--- a/assets/js/common/OperationsButton/OperationsButton.test.jsx
+++ b/assets/js/common/OperationsButton/OperationsButton.test.jsx
@@ -110,6 +110,22 @@ describe('OperationsButton', () => {
     ).toBeInTheDocument();
   });
 
+  it('should authorize operation if the user has operation:all ability', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <OperationsButton
+        operations={testOperations}
+        userAbilities={[{ name: 'operation', resource: 'all' }]}
+      />
+    );
+
+    await user.click(screen.getByText('Operations'));
+
+    expect(screen.getByText('Operation 1')).toBeEnabled();
+    expect(screen.getByText('Operation 2')).toBeEnabled();
+  });
+
   it('should show a transparent operations button', () => {
     const buttonText = 'test';
     render(

--- a/lib/trento/clusters/policy.ex
+++ b/lib/trento/clusters/policy.ex
@@ -20,9 +20,7 @@ defmodule Trento.Clusters.Policy do
   def authorize(operation, %User{} = user, ClusterReadModel)
       when operation in ClusterOperations.values() or
              operation in ClusterHostOperations.values(),
-      do:
-        has_global_ability?(user) or
-          user_has_ability?(user, %{name: to_ability_name(operation), resource: "cluster"})
+      do: has_operation_ability?(user, to_ability_name(operation), "cluster")
 
   def authorize(_, _, _), do: true
 

--- a/lib/trento/databases/policy.ex
+++ b/lib/trento/databases/policy.ex
@@ -14,19 +14,13 @@ defmodule Trento.Databases.Policy do
     do: has_global_ability?(user) or has_cleanup_ability?(user)
 
   def authorize(:database_start, %User{} = user, DatabaseReadModel),
-    do: has_global_ability?(user) or has_database_start_ability?(user)
+    do: has_operation_ability?(user, "start", "database")
 
   def authorize(:database_stop, %User{} = user, DatabaseReadModel),
-    do: has_global_ability?(user) or has_database_stop_ability?(user)
+    do: has_operation_ability?(user, "stop", "database")
 
   def authorize(_, _, _), do: true
 
   defp has_cleanup_ability?(user),
     do: user_has_ability?(user, %{name: "cleanup", resource: "database_instance"})
-
-  defp has_database_start_ability?(user),
-    do: user_has_ability?(user, %{name: "start", resource: "database"})
-
-  defp has_database_stop_ability?(user),
-    do: user_has_ability?(user, %{name: "stop", resource: "database"})
 end

--- a/lib/trento/hosts/policy.ex
+++ b/lib/trento/hosts/policy.ex
@@ -30,9 +30,7 @@ defmodule Trento.Hosts.Policy do
 
   def authorize(operation, %User{} = user, HostReadModel)
       when operation in HostOperations.values(),
-      do:
-        has_global_ability?(user) or
-          user_has_ability?(user, %{name: Atom.to_string(operation), resource: "host"})
+      do: has_operation_ability?(user, Atom.to_string(operation), "host")
 
   def authorize(_, _, _), do: true
 end

--- a/lib/trento/sap_systems/policy.ex
+++ b/lib/trento/sap_systems/policy.ex
@@ -19,31 +19,19 @@ defmodule Trento.SapSystems.Policy do
     do: has_global_ability?(user) or has_cleanup_ability?(user)
 
   def authorize(:sap_instance_start, %User{} = user, ApplicationInstanceReadModel),
-    do: has_global_ability?(user) or has_app_instance_start_ability?(user)
+    do: has_operation_ability?(user, "start", "application_instance")
 
   def authorize(:sap_instance_stop, %User{} = user, ApplicationInstanceReadModel),
-    do: has_global_ability?(user) or has_app_instance_stop_ability?(user)
+    do: has_operation_ability?(user, "stop", "application_instance")
 
   def authorize(:sap_system_start, %User{} = user, SapSystemReadModel),
-    do: has_global_ability?(user) or has_sap_system_start_ability?(user)
+    do: has_operation_ability?(user, "start", "sap_system")
 
   def authorize(:sap_system_stop, %User{} = user, SapSystemReadModel),
-    do: has_global_ability?(user) or has_sap_system_stop_ability?(user)
+    do: has_operation_ability?(user, "stop", "sap_system")
 
   def authorize(_, _, _), do: true
 
   defp has_cleanup_ability?(user),
     do: user_has_ability?(user, %{name: "cleanup", resource: "application_instance"})
-
-  defp has_app_instance_start_ability?(user),
-    do: user_has_ability?(user, %{name: "start", resource: "application_instance"})
-
-  defp has_app_instance_stop_ability?(user),
-    do: user_has_ability?(user, %{name: "stop", resource: "application_instance"})
-
-  defp has_sap_system_start_ability?(user),
-    do: user_has_ability?(user, %{name: "start", resource: "sap_system"})
-
-  defp has_sap_system_stop_ability?(user),
-    do: user_has_ability?(user, %{name: "stop", resource: "sap_system"})
 end

--- a/lib/trento/support/abilities_helper.ex
+++ b/lib/trento/support/abilities_helper.ex
@@ -10,6 +10,17 @@ defmodule Trento.Support.AbilitiesHelper do
   def has_global_ability?(%User{} = user),
     do: user_has_ability?(user, %{name: "all", resource: "all"})
 
+  def has_operation_all_ability?(%User{} = user),
+    do: user_has_ability?(user, %{name: "operation", resource: "all"})
+
+  def has_operation_ability?(user, name, resource) do
+    Enum.any?([
+      has_global_ability?(user),
+      has_operation_all_ability?(user),
+      user_has_ability?(user, %{name: name, resource: resource})
+    ])
+  end
+
   def user_has_any_ability?(%User{} = user, abilities),
     do: Enum.any?(abilities, &user_has_ability?(user, &1))
 end

--- a/priv/repo/migrations/20260421073949_add_operation_all_abilities.exs
+++ b/priv/repo/migrations/20260421073949_add_operation_all_abilities.exs
@@ -1,0 +1,11 @@
+defmodule Trento.Repo.Migrations.AddOperationAllAbilities do
+  use Ecto.Migration
+
+  def up do
+    execute "INSERT INTO abilities(name, resource, label, inserted_at, updated_at) VALUES ('operation', 'all', 'Permits running operations in all resources', NOW(), NOW())"
+  end
+
+  def down do
+    execute "DELETE FROM abilities WHERE name = 'operation' AND resource = 'all'"
+  end
+end

--- a/test/trento/clusters/policy_test.exs
+++ b/test/trento/clusters/policy_test.exs
@@ -60,6 +60,12 @@ defmodule Trento.Clusters.PolicyTest do
         assert Policy.authorize(@operation, user, ClusterReadModel)
       end
 
+      test "should allow #{@operation} operation if the user has operation:all ability" do
+        user = %User{abilities: [%Ability{name: "operation", resource: "all"}]}
+
+        assert Policy.authorize(@operation, user, ClusterReadModel)
+      end
+
       test "should disallow #{@operation} operation if the user does not have #{@ability}:cluster ability" do
         user = %User{abilities: [%Ability{name: "all", resource: "other_resource"}]}
 
@@ -80,6 +86,12 @@ defmodule Trento.Clusters.PolicyTest do
 
       test "should allow #{operation} operation if the user has all:all ability" do
         user = %User{abilities: [%Ability{name: "all", resource: "all"}]}
+
+        assert Policy.authorize(@operation, user, ClusterReadModel)
+      end
+
+      test "should allow #{operation} operation if the user has operation:all ability" do
+        user = %User{abilities: [%Ability{name: "operation", resource: "all"}]}
 
         assert Policy.authorize(@operation, user, ClusterReadModel)
       end

--- a/test/trento/databases/policy_test.exs
+++ b/test/trento/databases/policy_test.exs
@@ -60,6 +60,12 @@ defmodule Trento.Databases.PolicyTest do
         assert Policy.authorize(@operation, user, DatabaseReadModel)
       end
 
+      test "should allow #{operation} operation if the user has operation:all ability" do
+        user = %User{abilities: [%Ability{name: "operation", resource: "all"}]}
+
+        assert Policy.authorize(@operation, user, DatabaseReadModel)
+      end
+
       test "should disallow #{operation} operation if the user does not have #{ability}:database ability" do
         user = %User{abilities: [%Ability{name: "all", resource: "other_resource"}]}
 

--- a/test/trento/hosts/policy_test.exs
+++ b/test/trento/hosts/policy_test.exs
@@ -70,6 +70,12 @@ defmodule Trento.Hosts.PolicyTest do
         assert Policy.authorize(@operation, user, HostReadModel)
       end
 
+      test "should allow #{operation} operation if the user has operation:all ability" do
+        user = %User{abilities: [%Ability{name: "operation", resource: "all"}]}
+
+        assert Policy.authorize(@operation, user, HostReadModel)
+      end
+
       test "should disallow #{operation} operation if the user does not have #{operation}:host ability" do
         user = %User{abilities: []}
 

--- a/test/trento/sap_systems/policy_test.exs
+++ b/test/trento/sap_systems/policy_test.exs
@@ -57,6 +57,12 @@ defmodule Trento.SapSystems.PolicyTest do
         assert Policy.authorize(@operation, user, ApplicationInstanceReadModel)
       end
 
+      test "should allow #{operation} operation if the user has operation:all ability" do
+        user = %User{abilities: [%Ability{name: "operation", resource: "all"}]}
+
+        assert Policy.authorize(@operation, user, ApplicationInstanceReadModel)
+      end
+
       test "should disallow #{operation} operation if the user does not have #{ability}:application_instance ability" do
         user = %User{abilities: [%Ability{name: "all", resource: "other_resource"}]}
 
@@ -89,6 +95,12 @@ defmodule Trento.SapSystems.PolicyTest do
 
       test "should allow #{operation} operation if the user has all:all ability" do
         user = %User{abilities: [%Ability{name: "all", resource: "all"}]}
+
+        assert Policy.authorize(@operation, user, SapSystemReadModel)
+      end
+
+      test "should allow #{operation} operation if the user has operation:all ability" do
+        user = %User{abilities: [%Ability{name: "operation", resource: "all"}]}
 
         assert Policy.authorize(@operation, user, SapSystemReadModel)
       end

--- a/test/trento/support/abilities_helper_test.exs
+++ b/test/trento/support/abilities_helper_test.exs
@@ -66,4 +66,40 @@ defmodule Trento.Support.AbilitiesHelperTest do
              %{name: "baz", resource: "qux"}
            ])
   end
+
+  test "has_operation_ability?/3 returns true if user has global ability" do
+    first_ability = build(:ability, name: "manage", resource: "things")
+    second_ability = build(:ability, name: "all", resource: "all")
+
+    user = build(:user, abilities: [first_ability, second_ability])
+
+    assert AbilitiesHelper.has_operation_ability?(user, "start", "database")
+  end
+
+  test "has_operation_ability?/3 returns true if user has operations ability" do
+    first_ability = build(:ability, name: "manage", resource: "things")
+    second_ability = build(:ability, name: "operation", resource: "all")
+
+    user = build(:user, abilities: [first_ability, second_ability])
+
+    assert AbilitiesHelper.has_operation_ability?(user, "start", "database")
+  end
+
+  test "has_operation_ability?/3 returns true if user has specific operation ability" do
+    first_ability = build(:ability, name: "manage", resource: "things")
+    second_ability = build(:ability, name: "start", resource: "database")
+
+    user = build(:user, abilities: [first_ability, second_ability])
+
+    assert AbilitiesHelper.has_operation_ability?(user, "start", "database")
+  end
+
+  test "has_operation_ability?/3 returns false if user does not have any of the required abilities" do
+    first_ability = build(:ability, name: "manage", resource: "things")
+    second_ability = build(:ability, name: "read", resource: "things")
+
+    user = build(:user, abilities: [first_ability, second_ability])
+
+    refute AbilitiesHelper.has_operation_ability?(user, "start", "database")
+  end
 end


### PR DESCRIPTION
# Description

Change how operation permissions are grouped in the frontend. `operation:all` is not generic, and doesn't allow tailored permissions.
Having permissions per resource (`cluster`, `database`, `host` and `sap_system`) is enough, as these are the main "admin" groups we have seen in the field.

The grouping is done simply in the frontend.
Besides, I have included the `operation:all` ability which authorizes any operation to the user. 
Without this, we cannot keep the `operation:all` in the frontend (which still comes handy) because it would meant grouping abilities in multiple groups.

<img width="1189" height="488" alt="operation_grouping" src="https://github.com/user-attachments/assets/73951930-86db-47d3-9df1-014c0efe751b" />

## How was this tested?

UT

## Did you update the documentation?

@abravosuse do you have some reference about this? we should update in that case
