### PR TITLE
Reword forbidden operation modal texts

### DIFF
--- a/assets/js/common/OperationModals/OperationForbiddenModal.jsx
+++ b/assets/js/common/OperationModals/OperationForbiddenModal.jsx
@@ -57,9 +57,11 @@ function OperationForbiddenModal({
       onClose={onCancel}
     >
       <Banner type="error">
-        Unable to run {operation} operation. Some of the conditions are not met.
+        Unable to run {operation} operation. Some pre-requisites are not met.
       </Banner>
-      <p className="text-sm mb-1">Some of the next conditions are not met:</p>
+      <p className="text-sm mb-1">
+        Some of the following pre-requisites are not met:
+      </p>
       <ul className="list-disc list-inside space-y-1 mb-1">
         {errors.map(({ detail, metadata }) => (
           <li key={detail} className="text-sm">

--- a/assets/js/common/OperationModals/OperationForbiddenModal.test.jsx
+++ b/assets/js/common/OperationModals/OperationForbiddenModal.test.jsx
@@ -20,8 +20,11 @@ describe('OperationForbiddenModal', () => {
     expect(screen.getByText('Operation Forbidden')).toBeInTheDocument();
     expect(
       screen.getByText(
-        'Unable to run My operation operation. Some of the conditions are not met.'
+        'Unable to run My operation operation. Some pre-requisites are not met.'
       )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Some of the following pre-requisites are not met:')
     ).toBeInTheDocument();
 
     const list = screen.getByRole('list');


### PR DESCRIPTION
# Description

Reword operation forbidden modal text.

"Unable to run <operation_name> operation. Some of the conditions are not met" > "Unable to run <operation_name> operation. Some pre-requisites are not met".

"Some of the next conditions are not met" > "Some of the following pre-requisites are not met"

<img width="815" height="334" alt="image" src="https://github.com/user-attachments/assets/fb33d7ba-b8fc-42cd-855c-757848f7ec40" />

## How was this tested?

UT

## Did you update the documentation?

No need
