### PR TITLE
Apply eslint rules to prefer arrow functions in test folder

### DIFF
--- a/test/e2e/cypress/pageObject/about_po.js
+++ b/test/e2e/cypress/pageObject/about_po.js
@@ -32,6 +32,5 @@ export const expectedSlesForSapSubscriptionsAreDisplayed = (subscriptions) =>
     .get(amountOfSlesForSapSubscriptionsLabel)
     .should('have.text', `${subscriptions} found`);
 
-export const apiDeregisterHost = () => {
+export const apiDeregisterHost = () =>
   basePage.apiDeregisterHost(hostToDeregister);
-};

--- a/test/e2e/cypress/pageObject/about_po.js
+++ b/test/e2e/cypress/pageObject/about_po.js
@@ -13,28 +13,24 @@ const versionFilePath = '../../VERSION';
 
 export const visit = () => basePage.visit(url);
 
-export const pageTitleIsDisplayed = () => {
-  return cy.get(pageTitle).should('have.text', 'About Trento Console');
-};
+export const pageTitleIsDisplayed = () =>
+  cy.get(pageTitle).should('have.text', 'About Trento Console');
 
-export const expectedServerVersionIsDisplayed = () => {
-  return cy.readFile(versionFilePath, 'utf8').then((version) => {
+export const expectedServerVersionIsDisplayed = () =>
+  cy.readFile(versionFilePath, 'utf8').then((version) => {
     version = version.trim();
     return cy.get(versionLabel).should('have.text', version);
   });
-};
 
-export const expectedGithubUrlIsDisplayed = () => {
-  return cy
+export const expectedGithubUrlIsDisplayed = () =>
+  cy
     .get(githubRepositoryLabel)
     .should('have.text', 'https://github.com/trento-project/web');
-};
 
-export const expectedSlesForSapSubscriptionsAreDisplayed = (subscriptions) => {
-  return cy
+export const expectedSlesForSapSubscriptionsAreDisplayed = (subscriptions) =>
+  cy
     .get(amountOfSlesForSapSubscriptionsLabel)
     .should('have.text', `${subscriptions} found`);
-};
 
 export const apiDeregisterHost = () => {
   basePage.apiDeregisterHost(hostToDeregister);

--- a/test/e2e/cypress/pageObject/activity_log_po.js
+++ b/test/e2e/cypress/pageObject/activity_log_po.js
@@ -40,13 +40,12 @@ export const visit = (queryString = '') =>
 
 // Network Interception
 
-export const interceptActivityLogEndpoint = () => {
-  return cy
+export const interceptActivityLogEndpoint = () =>
+  cy
     .intercept({
       url: activityLogEndpoint,
     })
     .as(activityLogEndpointAlias);
-};
 
 export const spyActivityLogRequest = () => {
   cy.clock();
@@ -131,13 +130,12 @@ export const autoRefreshButtonIsEnabled = () =>
 export const autoRefreshIntervalButtonIsDisabled = () =>
   cy.get(refreshRateLabel).should('be.disabled');
 
-export const filteredActionsAreTheExpectedOnes = (filteredActions) => {
-  return cy
+export const filteredActionsAreTheExpectedOnes = (filteredActions) =>
+  cy
     .get(filteringElements)
     .eq(1)
     .find('span span')
     .should('have.text', filteredActions);
-};
 
 export const filterNewerThanHasTheExpectedValue = (filterValue) => {
   let expectedValue;
@@ -176,12 +174,11 @@ export const filterTypeHasNothingSelected = () =>
 export const refreshRateFilterHasTheExpectedValue = (refreshRate) =>
   cy.get(refreshRateFilter).should('have.text', refreshRate);
 
-export const metadataSearchHasTheExpectedPlaceholder = () => {
-  return cy
+export const metadataSearchHasTheExpectedPlaceholder = () =>
+  cy
     .get(metadataSearchInput)
     .should('have.attr', 'placeholder', 'Filter by metadata')
     .should('be.visible');
-};
 
 export const metadataSearchHasTheExpectedValue = (searchValue) =>
   cy.get(metadataSearchInput).should('have.value', searchValue);
@@ -195,12 +192,8 @@ export const activityLogEndpointIsCalledOnlyOnce = () => {
   return cy.get(`@${activityLogEndpointAlias}.all`).should('have.length', 1);
 };
 
-export const activityLogRequestHasExpectedStatusCode = (statusCode) => {
-  return basePage.validateResponseStatusCode(
-    activityLogEndpointAlias,
-    statusCode
-  );
-};
+export const activityLogRequestHasExpectedStatusCode = (statusCode) =>
+  basePage.validateResponseStatusCode(activityLogEndpointAlias, statusCode);
 
 export const paginationPropertiesAreTheExpected = (response) => {
   expect(response.body).to.have.property('pagination');
@@ -210,12 +203,11 @@ export const paginationPropertiesAreTheExpected = (response) => {
   expect(response.body.pagination).to.have.property('first', 20);
 };
 
-export const validateResponsePagination = (amountOfItems) => {
-  return basePage
+export const validateResponsePagination = (amountOfItems) =>
+  basePage
     .waitForRequest(activityLogEndpointAlias)
     .its('response.body.pagination.first')
     .should('eq', amountOfItems);
-};
 
 export const responseMatchesFirstPageContent = (expectedResponse) => {
   waitForActivityLogRequest().then(({ response }) => {
@@ -226,11 +218,10 @@ export const responseMatchesFirstPageContent = (expectedResponse) => {
   });
 };
 
-export const apiCallDoesNotContainRefreshRate = (refreshRate) => {
-  return waitForActivityLogRequest().then(({ response }) => {
+export const apiCallDoesNotContainRefreshRate = (refreshRate) =>
+  waitForActivityLogRequest().then(({ response }) => {
     expect(response.url).to.not.contain(refreshRate);
   });
-};
 
 export const expectedRefreshRatesAreAvailable = () => {
   clickAutoRefreshRateButton();

--- a/test/e2e/cypress/pageObject/activity_log_po.js
+++ b/test/e2e/cypress/pageObject/activity_log_po.js
@@ -64,7 +64,7 @@ export const clickFilterTypeButton = () =>
 
 export const clickAutoRefreshRateButton = () => {
   basePage.clickOutside();
-  cy.get(refreshRateFilter).click();
+  return cy.get(refreshRateFilter).click();
 };
 
 export const clickFilterNewerThanButton = () =>

--- a/test/e2e/cypress/pageObject/alerting_po.js
+++ b/test/e2e/cypress/pageObject/alerting_po.js
@@ -14,8 +14,8 @@ const alertingDevEnvSettings = {
   recipientEmail: 'admin@trento-project.io',
 };
 
-export const apiSetDevEnvAlertingSettings = (method = 'POST') => {
-  basePage.apiLogin().then(({ accessToken }) => {
+export const apiSetDevEnvAlertingSettings = (method = 'POST') =>
+  basePage.apiLogin().then(({ accessToken }) =>
     cy.request({
       url: '/api/v1/settings/alerting',
       method: method,
@@ -31,24 +31,22 @@ export const apiSetDevEnvAlertingSettings = (method = 'POST') => {
         sender_email: alertingDevEnvSettings.senderEmail,
         recipient_email: alertingDevEnvSettings.recipientEmail,
       },
-    });
-  });
-};
+    })
+  );
 
-export const emailIsReceived = (type) => {
-  cy.task('searchEmailInMailpit', `Trento Alert: ${type}`).then((result) => {
-    cy.wrap(result.length).should('equal', 1);
-  });
-};
+export const emailIsReceived = (type) =>
+  cy
+    .task('searchEmailInMailpit', `Trento Alert: ${type}`)
+    .then((result) => cy.wrap(result.length).should('equal', 1));
 
 export const triggerHostAlertingEmail = () => {
   cy.task('startAgentHeartbeat', ['9cd46919-5f19-59aa-993e-cf3736c71053']);
-  basePage.stopAgentsHeartbeat();
+  return basePage.stopAgentsHeartbeat();
 };
 
 export const triggerClusterAlertingEmail = () => {
   basePage.loadScenario('cluster-unnamed');
-  basePage.loadScenario('cluster-1-SOK');
+  return basePage.loadScenario('cluster-1-SOK');
 };
 
 export const triggerSapSystemAlertingEmail = () =>

--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -203,7 +203,7 @@ export const logout = () => {
     win.localStorage.removeItem('access_token');
     win.localStorage.removeItem('refresh_token');
   });
-  Cypress.session.clearAllSavedSessions();
+  return Cypress.session.clearAllSavedSessions();
 };
 
 export const apiDeleteUser = (id, accessToken) =>
@@ -214,17 +214,19 @@ export const apiDeleteUser = (id, accessToken) =>
   });
 
 export const apiDeleteAllUsers = () =>
-  apiLogin().then(({ accessToken }) => {
-    cy.request({
-      url: '/api/v1/users',
-      method: 'GET',
-      auth: { bearer: accessToken },
-    }).then(({ body: users }) => {
-      users.forEach(({ id }) => {
-        if (id !== 1) apiDeleteUser(id, accessToken);
-      });
-    });
-  });
+  apiLogin().then(({ accessToken }) =>
+    cy
+      .request({
+        url: '/api/v1/users',
+        method: 'GET',
+        auth: { bearer: accessToken },
+      })
+      .then(({ body: users }) => {
+        users.forEach(({ id }) => {
+          if (id !== 1) apiDeleteUser(id, accessToken);
+        });
+      })
+  );
 
 export const waitForRequest = (requestAlias, timeout = 5000) =>
   cy.wait(`@${requestAlias}`, { timeout: timeout });
@@ -253,11 +255,11 @@ export const loadScenario = (scenario) => {
   ];
   if (photofinishBinary) {
     cy.log(`Loading scenario "${scenario}"...`);
-    cy.exec(
+    return cy.exec(
       `cd ${projectRoot} && ${photofinishBinary} run --url "http://${webAPIHost}:${webAPIPort}/api/v1/collect" ${scenario}`
     );
   } else {
-    cy.log(`Photofinish is not used.`);
+    return cy.log(`Photofinish is not used.`);
   }
 };
 
@@ -291,7 +293,7 @@ export const apiCreateUserWithAbilities = (abilities) =>
           ),
         }));
 
-        cy.request({
+        return cy.request({
           url: '/api/v1/users',
           method: 'POST',
           auth: { bearer: accessToken },
@@ -335,7 +337,7 @@ export const isHostRegistered = (hostId) =>
   apiLogin()
     .then(({ accessToken }) => {
       const url = '/api/v1/hosts/';
-      cy.request({
+      return cy.request({
         method: 'GET',
         url: url,
         auth: {
@@ -385,7 +387,7 @@ export const apiSelectChecks = (clusterId, checks) => {
 
   return apiLogin().then(({ accessToken }) => {
     const url = `/api/v1/clusters/${clusterId}/checks`;
-    cy.request({
+    return cy.request({
       method: 'POST',
       url: url,
       body: checksBody,
@@ -398,7 +400,7 @@ export const apiSelectChecks = (clusterId, checks) => {
 };
 
 export const saveSUMASettings = ({ url, username, password, ca_cert }) =>
-  clearSUMASettings().then(() => {
+  clearSUMASettings().then(() =>
     apiLogin().then(({ accessToken }) =>
       cy.request({
         url: '/api/v1/settings/suse_manager',
@@ -413,8 +415,8 @@ export const saveSUMASettings = ({ url, username, password, ca_cert }) =>
           ...(ca_cert && { ca_cert }),
         },
       })
-    );
-  });
+    )
+  );
 
 export const clearSUMASettings = () =>
   apiLogin().then(({ accessToken }) =>

--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -53,14 +53,13 @@ export const validateUrl = (url = '/') =>
 
 export const refresh = () => cy.reload();
 
-export const addTagByColumnValue = (columnValue, tagValue) => {
-  return cy
+export const addTagByColumnValue = (columnValue, tagValue) =>
+  cy
     .get(`td:contains(${columnValue})`)
     .parents('tr')
     .within(() => {
       cy.get(addTagButtons).type(`${tagValue}{enter}`);
     });
-};
 
 export const clickActivityLogNavigationItem = () =>
   cy.get(navigation.activityLog).click();
@@ -104,15 +103,15 @@ export const typeNextGeneratedTotpCode = (
 ) => {
   const timeToWait = _getTotpWaitTime(forceNext);
 
-  return cy.wait(timeToWait).then(() => {
-    return cy.wrap(TOTP.generate(totpSecret)).then(({ otp }) => {
-      return cy
+  return cy.wait(timeToWait).then(() =>
+    cy.wrap(TOTP.generate(totpSecret)).then(({ otp }) =>
+      cy
         .get(inputField)
         .clear()
         .type(otp)
-        .then(() => otp);
-    });
-  });
+        .then(() => otp)
+    )
+  );
 };
 
 export const selectOptions = '[role="listbox"] [role="option"]';
@@ -144,11 +143,10 @@ export const pageTitleIsCorrectlyDisplayed = (title) =>
 export const accessForbiddenMessageIsDisplayed = () =>
   cy.get(accessForbiddenMessage).should('be.visible');
 
-export const validateItemNotPresentInNavigationMenu = (itemName) => {
-  return cy.get(navigation.navigationItems).each(($element) => {
+export const validateItemNotPresentInNavigationMenu = (itemName) =>
+  cy.get(navigation.navigationItems).each(($element) => {
     cy.wrap($element).should('not.include.text', itemName);
   });
-};
 
 export const validateItemPresentInNavigationMenu = (navigationMenuItem) =>
   cy.get(`a:contains("${navigationMenuItem}")`).should('be.visible');
@@ -167,21 +165,17 @@ export const removeTagButtonIsEnabled = () =>
 
 // API Interactions & Validations
 
-export const validateResponseStatusCode = (
-  endpointAlias,
-  expectedStatusCode
-) => {
-  return cy
+export const validateResponseStatusCode = (endpointAlias, expectedStatusCode) =>
+  cy
     .wait(`@${endpointAlias}`)
     .its('response.statusCode')
     .should('eq', expectedStatusCode);
-};
 
 export const apiLogin = (
   username = DEFAULT_USERNAME,
   password = DEFAULT_PASSWORD
-) => {
-  return cy
+) =>
+  cy
     .request({
       method: 'POST',
       url: '/api/session',
@@ -192,19 +186,17 @@ export const apiLogin = (
         response.body;
       return { accessToken, refreshToken };
     });
-};
 
 export const apiLoginAndCreateSession = (
   username = DEFAULT_USERNAME,
   password = DEFAULT_PASSWORD
-) => {
-  return cy.session([username, password], () => {
+) =>
+  cy.session([username, password], () => {
     apiLogin(username, password).then(({ accessToken, refreshToken }) => {
       window.localStorage.setItem('access_token', accessToken);
       window.localStorage.setItem('refresh_token', refreshToken);
     });
   });
-};
 
 export const logout = () => {
   cy.window().then((win) => {
@@ -214,16 +206,15 @@ export const logout = () => {
   Cypress.session.clearAllSavedSessions();
 };
 
-export const apiDeleteUser = (id, accessToken) => {
-  return cy.request({
+export const apiDeleteUser = (id, accessToken) =>
+  cy.request({
     url: `/api/v1/users/${id}`,
     method: 'DELETE',
     auth: { bearer: accessToken },
   });
-};
 
-export const apiDeleteAllUsers = () => {
-  return apiLogin().then(({ accessToken }) => {
+export const apiDeleteAllUsers = () =>
+  apiLogin().then(({ accessToken }) => {
     cy.request({
       url: '/api/v1/users',
       method: 'GET',
@@ -234,7 +225,6 @@ export const apiDeleteAllUsers = () => {
       });
     });
   });
-};
 
 export const waitForRequest = (requestAlias, timeout = 5000) =>
   cy.wait(`@${requestAlias}`, { timeout: timeout });
@@ -284,8 +274,8 @@ const isTestDataLoaded = () =>
       .then(({ body }) => body.length !== 0)
   );
 
-export const apiCreateUserWithAbilities = (abilities) => {
-  return apiLogin().then(({ accessToken }) =>
+export const apiCreateUserWithAbilities = (abilities) =>
+  apiLogin().then(({ accessToken }) =>
     cy
       .request({
         url: '/api/v1/abilities',
@@ -309,24 +299,22 @@ export const apiCreateUserWithAbilities = (abilities) => {
         });
       })
   );
-};
 
 export const apiAcceptAnalyticsEula = (
   username = user.username,
   pass = password
-) => {
-  return apiLogin(username, pass).then(({ accessToken }) => {
-    return cy.request({
+) =>
+  apiLogin(username, pass).then(({ accessToken }) =>
+    cy.request({
       url: '/api/v1/profile',
       method: 'PATCH',
       auth: { bearer: accessToken },
       body: { analytics_eula_accepted: true },
-    });
-  });
-};
+    })
+  );
 
-export const apiDeregisterHost = (hostId) => {
-  return isHostRegistered(hostId).then((isRegistered) => {
+export const apiDeregisterHost = (hostId) =>
+  isHostRegistered(hostId).then((isRegistered) => {
     if (isRegistered) {
       return apiLogin().then(({ accessToken }) => {
         const url = `/api/v1/hosts/${hostId}`;
@@ -340,12 +328,11 @@ export const apiDeregisterHost = (hostId) => {
       });
     } else return;
   });
-};
 
 export const stopAgentsHeartbeat = () => cy.task('stopAgentsHeartbeat');
 
-export const isHostRegistered = (hostId) => {
-  return apiLogin()
+export const isHostRegistered = (hostId) =>
+  apiLogin()
     .then(({ accessToken }) => {
       const url = '/api/v1/hosts/';
       cy.request({
@@ -357,7 +344,6 @@ export const isHostRegistered = (hostId) => {
       });
     })
     .then(({ body }) => body.some((host) => host.id === hostId));
-};
 
 export const loginWithoutAbilities = () =>
   apiLoginAndCreateSession(user.username, password);
@@ -378,8 +364,8 @@ export const getResourceTags = (resourceResponse) => {
   return resourceTags;
 };
 
-export const apiSetTag = (resource, resourceId, tag) => {
-  return apiLogin().then(({ accessToken }) =>
+export const apiSetTag = (resource, resourceId, tag) =>
+  apiLogin().then(({ accessToken }) =>
     cy.request({
       url: `/api/v1/${resource}/${resourceId}/tags`,
       method: 'POST',
@@ -387,7 +373,6 @@ export const apiSetTag = (resource, resourceId, tag) => {
       body: { value: tag },
     })
   );
-};
 
 export const apiSelectChecks = (clusterId, checks) => {
   const checksBody = JSON.stringify({
@@ -442,8 +427,8 @@ export const clearSUMASettings = () =>
     })
   );
 
-export const getAlertingSettings = () => {
-  return apiLogin().then(({ accessToken }) =>
+export const getAlertingSettings = () =>
+  apiLogin().then(({ accessToken }) =>
     cy.request({
       url: '/api/v1/settings/alerting',
       method: 'GET',
@@ -453,4 +438,3 @@ export const getAlertingSettings = () => {
       failOnStatusCode: false,
     })
   );
-};

--- a/test/e2e/cypress/pageObject/checks_catalog_po.js
+++ b/test/e2e/cypress/pageObject/checks_catalog_po.js
@@ -172,11 +172,11 @@ export const expectedTargetTypeClusterIconsAreDisplayed = () =>
     .parents(checkGroups)
     .within(() => cy.get(targetIcon).should('have.length', group1Checks));
 
-export const expectedTargetTypeHostIconsAreDisplayed = () => {
-  cy.get(`h3:contains("${hostChecksGroup}")`)
+export const expectedTargetTypeHostIconsAreDisplayed = () =>
+  cy
+    .get(`h3:contains("${hostChecksGroup}")`)
     .parents(checkGroups)
     .within(() => cy.get(targetIcon).should('have.length', group2Checks));
-};
 
 export const checkPanelIsNotVisible = () =>
   cy.get(checkPanels).should('not.exist');

--- a/test/e2e/cypress/pageObject/checks_catalog_po.js
+++ b/test/e2e/cypress/pageObject/checks_catalog_po.js
@@ -110,20 +110,19 @@ export const eachGroupShouldBeExpanded = () => {
     return cy
       .get(checkGroups)
       .eq(index)
-      .then((checkGroup) => {
-        return cy
+      .then((checkGroup) =>
+        cy
           .wrap(checkGroup)
           .find(checkRows)
-          .should('have.length', checksInGroup[groupText]);
-      });
+          .should('have.length', checksInGroup[groupText])
+      );
   });
 };
 
-export const expandAllGroups = () => {
-  return cy.get(groupNames).each((group, index) => {
+export const expandAllGroups = () =>
+  cy.get(groupNames).each((group, index) => {
     if (index !== 0) cy.wrap(group).click();
   });
-};
 
 export const clickFirstCheckRow = () => cy.get(checkRows).first().click();
 
@@ -147,23 +146,16 @@ export const selectFromArchitectureDropdown = (choice) => {
   return waitForChecksCatalogRequest().then((response) => response.request.url);
 };
 
-export const waitForChecksCatalogRequest = () => {
-  return basePage.waitForRequest(checksCatalogEndpointAlias);
-};
-export const networkErrorLabelIsDisplayed = () => {
-  return cy.get(networkErrorLabel).should('be.visible');
-};
+export const waitForChecksCatalogRequest = () =>
+  basePage.waitForRequest(checksCatalogEndpointAlias);
+export const networkErrorLabelIsDisplayed = () =>
+  cy.get(networkErrorLabel).should('be.visible');
 
-export const tryAgainButtonIsDisplayed = () => {
-  return cy.get(tryAgainButton).should('be.visible');
-};
+export const tryAgainButtonIsDisplayed = () =>
+  cy.get(tryAgainButton).should('be.visible');
 
-export const checkPanelHasTheExpectedText = () => {
-  return cy
-    .get(checkPanels)
-    .first()
-    .should('have.text', catalog[0].remediation);
-};
+export const checkPanelHasTheExpectedText = () =>
+  cy.get(checkPanels).first().should('have.text', catalog[0].remediation);
 
 export const eachGroupHasExpectedCheckIds = () => {
   expandAllGroups();
@@ -174,12 +166,11 @@ export const eachGroupHasExpectedCheckIds = () => {
   });
 };
 
-export const expectedTargetTypeClusterIconsAreDisplayed = () => {
-  return cy
+export const expectedTargetTypeClusterIconsAreDisplayed = () =>
+  cy
     .get(`h3:contains("${clusterChecksGroup}")`)
     .parents(checkGroups)
     .within(() => cy.get(targetIcon).should('have.length', group1Checks));
-};
 
 export const expectedTargetTypeHostIconsAreDisplayed = () => {
   cy.get(`h3:contains("${hostChecksGroup}")`)

--- a/test/e2e/cypress/pageObject/checks_customization_po.js
+++ b/test/e2e/cypress/pageObject/checks_customization_po.js
@@ -107,7 +107,7 @@ const gatheredFactsValue = `div[class*="w-full my-4 mr-4"]:contains("Gathered Fa
 export const clickCorosyncCategory = () => cy.get(corosyncCategory).click();
 export const openCheckCustomizationModal = (checkID) => {
   const checksCustomizationSettingsIcon = `a[class*="block"] button[aria-label*="customize-check-${checkID}"]`;
-  cy.get(checksCustomizationSettingsIcon).click();
+  return cy.get(checksCustomizationSettingsIcon).click();
 };
 export const clickOnWarningCheckbox = () => cy.get(modalCheckbox).click();
 export const clickResetCheckModalButton = () =>
@@ -132,28 +132,25 @@ export const inputCheckValue = (valueName, newValue) => {
   _setInputValue(valueName, newValue);
 };
 
-export const clickCorosyncSelectionToggle = () => {
+export const clickCorosyncSelectionToggle = () =>
   cy.get(corosyncheckSelectionToggle).click();
-};
 
-export const expandModifiedCheckResult = () => {
+export const expandModifiedCheckResult = () =>
   cy.get(checkResultCollapsibleCell).click();
-};
 
-export const clickModifiedCheckExpectations = () => {
+export const clickModifiedCheckExpectations = () =>
   cy.get(hostExpectationsNotMet).first().click();
-};
 
 // UI validations
 export const resetIconShouldNotExistInOverview = () =>
   cy.get(resetCustomizedCheckIcon).should('not.exist');
 export const checkShouldHaveModifiedPill = (checkID) => {
   const checkIDPill = `div[class*="px-4 py-4"] p:contains(${checkID}) + span`;
-  cy.get(checkIDPill).should('contain', modifiedPillLabel);
+  return cy.get(checkIDPill).should('contain', modifiedPillLabel);
 };
 export const checkShouldNotHaveModifiedPill = (checkID) => {
   const checkIDPill = `div[class*="px-4 py-4"] p:contains(${checkID}) + span`;
-  cy.get(checkIDPill).should('not.exist');
+  return cy.get(checkIDPill).should('not.exist');
 };
 
 const _validateCheckId = (value) =>
@@ -202,11 +199,11 @@ export const validateProviderLabel = () =>
   cy.get(modalProvider).should('have.text', modalProviderLabel);
 export const validateProviderValue = () =>
   cy.get(modalProviderValueSpan).should('have.text', modalProviderValue);
-export const providerIconShouldBeDisplayed = () => {
-  cy.get(modalProviderSvg)
+export const providerIconShouldBeDisplayed = () =>
+  cy
+    .get(modalProviderSvg)
     .should('be.visible')
     .and('have.attr', 'alt', 'azure');
-};
 export const validateResetModalTitle = () =>
   cy.get(resetModalTitle).should('contain', resetModalTitleLabel);
 export const validateResetModalWarningText = () =>
@@ -238,32 +235,30 @@ export const waitForCustomizedCheckElements = () => {
     timeout: 20000,
   });
   cy.contains(modifiedPillLabel).should('be.visible');
-  cy.contains('tr.tn-check-result-row', firstCheck.description)
+  return cy
+    .contains('tr.tn-check-result-row', firstCheck.description)
     .find(modifiedResultCriticalIcon)
     .should('be.visible');
 };
-export const validateCheckStatus = () => {
-  cy.get(evaluationResultsStatus)
+export const validateCheckStatus = () =>
+  cy
+    .get(evaluationResultsStatus)
     .should('be.visible')
     .and('have.text', checkStatus);
-};
-export const validateEvaluationResultsDescription = () => {
-  cy.get(evaluationResultsLabel)
+export const validateEvaluationResultsDescription = () =>
+  cy
+    .get(evaluationResultsLabel)
     .should('be.visible')
     .and('have.text', evaluationResults);
-};
 
-export const validateEvaluationResultsModifiedPill = () => {
+export const validateEvaluationResultsModifiedPill = () =>
   cy.contains(modifiedPillLabel).should('be.visible');
-};
 
-export const validateCustomValue = () => {
+export const validateCustomValue = () =>
   cy.get(customizedValue).should('have.text', customValue);
-};
 
-export const vailidateGatheredFactsValue = () => {
+export const vailidateGatheredFactsValue = () =>
   cy.get(gatheredFactsValue).should('have.text', firstCheckValue);
-};
 
 // Api
 export const visit = (clusterId = '') =>

--- a/test/e2e/cypress/pageObject/clusters_overview_po.js
+++ b/test/e2e/cypress/pageObject/clusters_overview_po.js
@@ -61,15 +61,14 @@ export const setClusterTags = () => {
 
 // Validations
 
-export const hanaCluster1TagsAreDisplayed = () => {
-  return cy
+export const hanaCluster1TagsAreDisplayed = () =>
+  cy
     .get(`tr:contains("${hanaCluster1.name}")`)
     .within(() =>
       cy
         .get(`span span:contains("${clusterTags[hanaCluster1.name]}")`)
         .should('be.visible')
     );
-};
 
 export const clusterNameLinkIsDisplayedAsId = (clusterName) => {
   const clusterID = _clusterIdByName(clusterName);
@@ -84,16 +83,15 @@ export const allRegisteredClustersAreDisplayed = () =>
 export const paginationButtonsAreDisabled = () =>
   cy.get(paginationNavigationButtons).should('be.disabled');
 
-export const clustersDataIsDisplayedAsExpected = () => {
-  return waitForClustersEndpoint().then(() => {
-    return cy.get(tableRows).each(($row, index) => {
+export const clustersDataIsDisplayedAsExpected = () =>
+  waitForClustersEndpoint().then(() =>
+    cy.get(tableRows).each(($row, index) => {
       const cluster = availableClusters[index];
       cy.wrap($row).find('td').eq(1).should('have.text', cluster.name);
       cy.wrap($row).find('td').eq(2).should('have.text', cluster.sid);
       return cy.wrap($row).find('td').eq(5).should('have.text', cluster.type);
-    });
-  });
-};
+    })
+  );
 
 export const healthyClusterNameDisplaysHealthyState = () =>
   clusterHealthIconHasExpectedClass(
@@ -107,20 +105,18 @@ export const unhealthyClusterNameDisplaysUnhealthyState = () =>
     'fill-red-500'
   );
 
-export const clusterHealthIconHasExpectedClass = (clusterName, className) => {
-  return cy
+export const clusterHealthIconHasExpectedClass = (clusterName, className) =>
+  cy
     .get(`td:contains("${clusterName}")`)
     .parents('tr')
     .within(() =>
       cy.get('td').eq(0).find('svg').should('have.class', className)
     );
-};
 
-export const eachClusterTagsIsCorrectlyDisplayed = () => {
-  return taggingRules.forEach(([tag]) =>
+export const eachClusterTagsIsCorrectlyDisplayed = () =>
+  taggingRules.forEach(([tag]) =>
     cy.get(`span span:contains(${tag})`).should('be.visible')
   );
-};
 
 export const clusterIsNotDisplayedWhenNodesAreDeregistered = () =>
   cy.get(`span span:contains("${hanaCluster1.name}")`).should('not.exist');
@@ -134,18 +130,17 @@ const _clusterIdByName = (clusterName) =>
   availableClusters.find(({ name }) => name === clusterName).id;
 
 // API Interactions
-const _apiRemoveTagByClusterId = (clusterId, tagId) => {
-  return basePage.apiLogin().then(({ accessToken }) =>
+const _apiRemoveTagByClusterId = (clusterId, tagId) =>
+  basePage.apiLogin().then(({ accessToken }) =>
     cy.request({
       url: `/api/v1/clusters/${clusterId}/tags/${tagId}`,
       method: 'DELETE',
       auth: { bearer: accessToken },
     })
   );
-};
 
-const _apiGetClusters = () => {
-  return basePage.apiLogin().then(({ accessToken }) => {
+const _apiGetClusters = () =>
+  basePage.apiLogin().then(({ accessToken }) => {
     const url = '/api/v2/clusters';
     return cy
       .request({
@@ -157,7 +152,6 @@ const _apiGetClusters = () => {
       })
       .then((response) => response);
   });
-};
 
 export const apiRemoveAllClusterTags = () => {
   _apiGetClusters().then((response) => {
@@ -198,8 +192,8 @@ export const apiSetTagsHanaCluster1 = () => {
   return tagsForCluster1.forEach((tag) => _apiSetTag('hana_cluster_1', tag));
 };
 
-const apiRequestChecksExecution = (clusterId) => {
-  return basePage.apiLogin().then(({ accessToken }) => {
+const apiRequestChecksExecution = (clusterId) =>
+  basePage.apiLogin().then(({ accessToken }) => {
     const url = `/api/v1/clusters/${clusterId}/checks/request_execution`;
     cy.request({
       method: 'POST',
@@ -209,7 +203,6 @@ const apiRequestChecksExecution = (clusterId) => {
       },
     });
   });
-};
 
 export const apiSelectChecksForHealthyCluster = () =>
   basePage.apiSelectChecks(

--- a/test/e2e/cypress/pageObject/clusters_overview_po.js
+++ b/test/e2e/cypress/pageObject/clusters_overview_po.js
@@ -53,11 +53,10 @@ export const waitForClustersEndpoint = () =>
 
 // UI Interactions
 
-export const setClusterTags = () => {
+export const setClusterTags = () =>
   taggingRules.forEach(([clusterName, tag]) => {
     basePage.addTagByColumnValue(clusterName, tag);
   });
-};
 
 // Validations
 
@@ -121,9 +120,8 @@ export const eachClusterTagsIsCorrectlyDisplayed = () =>
 export const clusterIsNotDisplayedWhenNodesAreDeregistered = () =>
   cy.get(`span span:contains("${hanaCluster1.name}")`).should('not.exist');
 
-export const clusterNameIsDisplayed = () => {
+export const clusterNameIsDisplayed = () =>
   cy.get(`span span:contains("${hanaCluster1.name}")`).should('be.visible');
-};
 
 // Helpers
 const _clusterIdByName = (clusterName) =>
@@ -195,7 +193,7 @@ export const apiSetTagsHanaCluster1 = () => {
 const apiRequestChecksExecution = (clusterId) =>
   basePage.apiLogin().then(({ accessToken }) => {
     const url = `/api/v1/clusters/${clusterId}/checks/request_execution`;
-    cy.request({
+    return cy.request({
       method: 'POST',
       url: url,
       auth: {

--- a/test/e2e/cypress/pageObject/databases_overview_po.js
+++ b/test/e2e/cypress/pageObject/databases_overview_po.js
@@ -160,17 +160,15 @@ export const deregisterNwqSystemAscsInstance = () =>
 export const restoreHdqDatabasePrimaryInstance = () =>
   basePage.loadScenario(`host-${hdqDatabase.instances[0].name}-restore`);
 
-export const markHddDatabaseAsAbsent = () => {
+export const markHddDatabaseAsAbsent = () =>
   basePage.loadScenario(
     `sap-systems-overview-${hddDatabase.sid}-${hddDatabase.instance.instanceNumber}-absent`
   );
-};
 
-export const markHddDatabaseAsPresent = () => {
+export const markHddDatabaseAsPresent = () =>
   basePage.loadScenario(
     `sap-systems-overview-${hddDatabase.sid}-${hddDatabase.instance.instanceNumber}-present`
   );
-};
 
 export const apiCreateUserWithDatabaseTagsAbilities = () =>
   basePage.apiCreateUserWithAbilities([

--- a/test/e2e/cypress/pageObject/databases_overview_po.js
+++ b/test/e2e/cypress/pageObject/databases_overview_po.js
@@ -78,14 +78,13 @@ export const bothDatabaseInstancesAreDisplayed = () => {
   return cy.get(databaseInstance2).should('be.visible');
 };
 
-export const activePillIsDisplayedInTheRightHost = () => {
-  return cy.wrap(hdqDatabase.instances).each((instance) => {
+export const activePillIsDisplayedInTheRightHost = () =>
+  cy.wrap(hdqDatabase.instances).each((instance) => {
     cy.get(`div.table-row:contains("${instance.name}")`).within(() => {
       const isHostActive = instance.state === 'ACTIVE';
       cy.get(activePill).should(isHostActive ? 'be.visible' : 'not.exist');
     });
   });
-};
 
 export const deletedSapSystemToasterIsDisplayed = () =>
   cy.get(deletedSapSystemToaster).should('be.visible');
@@ -183,8 +182,8 @@ export const apiCreateUserWithCleanupAbilities = () =>
     { name: 'cleanup', resource: 'database_instance' },
   ]);
 
-const apiGetDatabases = () => {
-  return basePage.apiLogin().then(({ accessToken }) => {
+const apiGetDatabases = () =>
+  basePage.apiLogin().then(({ accessToken }) => {
     const url = '/api/v1/databases';
     return cy.request({
       method: 'GET',
@@ -194,7 +193,6 @@ const apiGetDatabases = () => {
       },
     });
   });
-};
 
 export const apiRemoveAllDatabaseTags = () => {
   apiGetDatabases().then((response) => {
@@ -206,12 +204,11 @@ export const apiRemoveAllDatabaseTags = () => {
   return basePage.refresh();
 };
 
-const apiRemoveTagByDatabaseId = (databaseId, tagId) => {
-  return basePage.apiLogin().then(({ accessToken }) =>
+const apiRemoveTagByDatabaseId = (databaseId, tagId) =>
+  basePage.apiLogin().then(({ accessToken }) =>
     cy.request({
       url: `/api/v1/databases/${databaseId}/tags/${tagId}`,
       method: 'DELETE',
       auth: { bearer: accessToken },
     })
   );
-};

--- a/test/e2e/cypress/pageObject/hana_cluster_details_po.js
+++ b/test/e2e/cypress/pageObject/hana_cluster_details_po.js
@@ -103,7 +103,7 @@ export const visit = (clusterId = '') => basePage.visit(`${url}/${clusterId}`);
 
 export const waitForInitialEndpoints = () => {
   basePage.waitForRequest(lastExecutionEndpointAlias);
-  basePage.waitForRequest(catalogEndpointAlias);
+  return basePage.waitForRequest(catalogEndpointAlias);
 };
 
 export const visitAvailableHanaCluster = (wait = true) =>
@@ -170,7 +170,7 @@ export const expectedWarningMessageIsDisplayed = (expectedWarningMessage) =>
     .get(checkSettingsWarningMessage)
     .should('have.text', expectedWarningMessage);
 
-export const expectedResultRowsAreDisplayed = () => {
+export const expectedResultRowsAreDisplayed = () =>
   basePage.waitForRequest(lastExecutionEndpointAlias).then(
     ({
       response: {
@@ -178,22 +178,20 @@ export const expectedResultRowsAreDisplayed = () => {
       },
     }) => {
       const amountOfChecks = check_results.length;
-      cy.get(checkResultRows).should('have.length', amountOfChecks);
+      return cy.get(checkResultRows).should('have.length', amountOfChecks);
     }
   );
-};
 
 export const expectedCheckIsDisplayed = (checkNameValue) =>
   cy.get(checkName(checkNameValue)).should('be.visible');
 
-export const validateExpectedCheckResults = (expectedCheckResults) => {
+export const validateExpectedCheckResults = (expectedCheckResults) =>
   expectedCheckResults.forEach((result) => {
     cy.get(`td:contains("${result[0]}") + td + td svg`).should(
       `have.class`,
       `${result[1]}`
     );
   });
-};
 
 const validateUrl = (path = '') => basePage.validateUrl(`${url}${path}`);
 
@@ -208,12 +206,14 @@ export const expectedClusterNameIsDisplayedInHeader = () =>
 
 export const expectedProviderIsDisplayed = (clusterType) => {
   const provider = getPropertyFromClusterType(clusterType, 'provider');
-  cy.get(providerLabel).should('have.text', provider);
+  return cy.get(providerLabel).should('have.text', provider);
 };
 
 export const hasExpectedSidAndHrefAttribute = (clusterType) => {
   const systemId = getPropertyFromClusterType(clusterType, 'systemID');
-  cy.get(clusterSid).should('have.attr', 'href', `/databases/${systemId}`);
+  return cy
+    .get(clusterSid)
+    .should('have.attr', 'href', `/databases/${systemId}`);
 };
 
 export const hasExpectedSidsAndHrefAttributes = () =>
@@ -230,7 +230,7 @@ export const hasExpectedClusterType = (clusterType) => {
     clusterType,
     'clusterType'
   );
-  cy.get(clusterTypeLabel).should('contain', clusterTypeProperty);
+  return cy.get(clusterTypeLabel).should('contain', clusterTypeProperty);
 };
 
 export const architectureTooltipIsDisplayed = (clusterType) => {
@@ -239,7 +239,7 @@ export const architectureTooltipIsDisplayed = (clusterType) => {
     'architectureType'
   );
   const architectureTypeLabel = `span:contains("${architectureType}")`;
-  cy.get(architectureTypeLabel).should('be.visible');
+  return cy.get(architectureTypeLabel).should('be.visible');
 };
 
 export const expectedReplicationModeIsDisplayed = (clusterType) => {
@@ -247,12 +247,12 @@ export const expectedReplicationModeIsDisplayed = (clusterType) => {
     clusterType,
     'hanaSystemReplicationMode'
   );
-  cy.get(logReplicationModeLabel).should('have.text', replicationMode);
+  return cy.get(logReplicationModeLabel).should('have.text', replicationMode);
 };
 
 export const expectedFencingTypeIsDisplayed = (clusterType) => {
   const fencingType = getPropertyFromClusterType(clusterType, 'fencingType');
-  cy.get(fencingTypeLabel).should('have.text', fencingType);
+  return cy.get(fencingTypeLabel).should('have.text', fencingType);
 };
 
 export const expectedHanaSecondarySyncStateIsDisplayed = (clusterType) => {
@@ -260,7 +260,9 @@ export const expectedHanaSecondarySyncStateIsDisplayed = (clusterType) => {
     clusterType,
     'hanaSecondarySyncState'
   );
-  cy.get(hanaSecondarySyncStateLabel).should('contain', hanaSecondarySyncState);
+  return cy
+    .get(hanaSecondarySyncStateLabel)
+    .should('contain', hanaSecondarySyncState);
 };
 
 export const expectedMaintenanceModeIsDisplayed = (clusterType) => {
@@ -268,10 +270,9 @@ export const expectedMaintenanceModeIsDisplayed = (clusterType) => {
     clusterType,
     'maintenanceMode'
   );
-  cy.get(maintenanceModeLabel).should(
-    'have.text',
-    capitalize(maintenanceMode.toString())
-  );
+  return cy
+    .get(maintenanceModeLabel)
+    .should('have.text', capitalize(maintenanceMode.toString()));
 };
 
 export const expectedHanaLogOperationModeIsDisplayed = (clusterType) => {
@@ -279,10 +280,9 @@ export const expectedHanaLogOperationModeIsDisplayed = (clusterType) => {
     clusterType,
     'hanaSystemReplicationOperationMode'
   );
-  cy.get(hanaLogOperationModeLabel).should(
-    'have.text',
-    hanaSystemReplicationOperationMode
-  );
+  return cy
+    .get(hanaLogOperationModeLabel)
+    .should('have.text', hanaSystemReplicationOperationMode);
 };
 
 export const expectedCibLastWrittenValueIsDisplayed = (clusterType) => {
@@ -290,7 +290,7 @@ export const expectedCibLastWrittenValueIsDisplayed = (clusterType) => {
     clusterType,
     'cibLastWritten'
   );
-  cy.get(cibLastWrittenLabel).should('have.text', cibLastWritten);
+  return cy.get(cibLastWrittenLabel).should('have.text', cibLastWritten);
 };
 
 export const expectedPassingChecksCountIsDisplayed = () =>
@@ -304,7 +304,7 @@ export const expectedCriticalChecksCountIsDisplayed = () =>
 
 export const allExpectedVirtualIPsAreDisplayed = () => {
   const virtualIps = getHostsProperty('virtualIps');
-  cy.wrap(virtualIps).each(({ siteName, virtualIp }) => {
+  return cy.wrap(virtualIps).each(({ siteName, virtualIp }) => {
     cy.get(`.tn-site-details-${siteName} tbody td`)
       .eq(4)
       .should('contain', virtualIp);
@@ -313,25 +313,29 @@ export const allExpectedVirtualIPsAreDisplayed = () => {
 
 export const allExpectedIndexServerRolesAreDisplayed = () => {
   const indexServerRoles = getHostsProperty('indexserver_actual_role');
-  cy.wrap(indexServerRoles).each(({ siteName, indexserver_actual_role }) => {
-    cy.get(`.tn-site-details-${siteName} tbody td`)
-      .eq(2)
-      .should('have.text', capitalize(indexserver_actual_role));
-  });
+  return cy
+    .wrap(indexServerRoles)
+    .each(({ siteName, indexserver_actual_role }) => {
+      cy.get(`.tn-site-details-${siteName} tbody td`)
+        .eq(2)
+        .should('have.text', capitalize(indexserver_actual_role));
+    });
 };
 
 export const allExpectedNameServerRolesAreDisplayed = () => {
   const nameServerRoles = getHostsProperty('nameserver_actual_role');
-  cy.wrap(nameServerRoles).each(({ siteName, nameserver_actual_role }) => {
-    cy.get(`.tn-site-details-${siteName} tbody td`)
-      .eq(1)
-      .should('have.text', capitalize(nameserver_actual_role));
-  });
+  return cy
+    .wrap(nameServerRoles)
+    .each(({ siteName, nameserver_actual_role }) => {
+      cy.get(`.tn-site-details-${siteName} tbody td`)
+        .eq(1)
+        .should('have.text', capitalize(nameserver_actual_role));
+    });
 };
 
 export const allExpectedStatusesAreDisplayed = () => {
   const hostsStatuses = getHostsProperty('status');
-  cy.wrap(hostsStatuses).each(({ siteName, status }) => {
+  return cy.wrap(hostsStatuses).each(({ siteName, status }) => {
     cy.get(`.tn-site-details-${siteName} tbody td svg`).should(
       'have.class',
       status
@@ -341,36 +345,33 @@ export const allExpectedStatusesAreDisplayed = () => {
 
 export const allExpectedIPsAreDisplayed = () => {
   const ips = getHostsProperty('ips');
-  cy.wrap(ips).each(({ siteName, ip }) => {
+  return cy.wrap(ips).each(({ siteName, ip }) => {
     cy.get(`.tn-site-details-${siteName} tbody td`).eq(3).should('contain', ip);
   });
 };
 
-export const expectedSiteStatesAreDisplayed = () => {
+export const expectedSiteStatesAreDisplayed = () =>
   cy.wrap(availableHanaCluster.sites).each((site) => {
     cy.get(`.tn-site-details-${site.name} h3 + span`).should(
       'have.text',
       site.state
     );
   });
-};
 
-export const expectedSiteNamesAreDisplayed = () => {
+export const expectedSiteNamesAreDisplayed = () =>
   cy.wrap(availableHanaCluster.sites).each((site) => {
     cy.get(`.tn-site-details-${site.name} h3`).should('have.text', site.name);
   });
-};
 
-export const expectedSrHealthStatesAreDisplayed = () => {
+export const expectedSrHealthStatesAreDisplayed = () =>
   cy.wrap(availableHanaCluster.sites).each((site) => {
     cy.get(`.tn-site-details-${site.name} svg`).should(
       'have.class',
       site.srHealthState
     );
   });
-};
 
-export const expectedResourcesDisplayed = () => {
+export const expectedResourcesDisplayed = () =>
   cy.wrap(availableHanaCluster.resources).each((resource, index) => {
     cy.get(`${resourcesTable} tr:nth-child(${index + 1}) td`)
       .eq(1)
@@ -394,26 +395,25 @@ export const expectedResourcesDisplayed = () => {
       .eq(7)
       .should('contain', resource.type);
   });
-};
 
 export const expectedClusterStateIsDisplayed = (state) => {
   const { displayedText, icon } = clusterStates[state];
   cy.get(clusterStateLabel).contains(displayedText);
-  cy.get(clusterStateBadge)
+  return cy
+    .get(clusterStateBadge)
     .invoke('attr', 'class')
     .then((classAttr) => {
       expect(classAttr).to.contain(icon);
     });
 };
 
-export const sbdClusterHasExpectedNameAndStatus = () => {
+export const sbdClusterHasExpectedNameAndStatus = () =>
   availableHanaCluster.sbd.forEach((item) => {
     cy.get('.tn-sbd-details')
       .contains(item.deviceName)
       .children()
       .contains(item.status);
   });
-};
 
 export const passingChecksUrlIsTheExpected = () =>
   validateUrl(`/${availableHanaCluster.id}/executions/last?health=passing`);
@@ -430,14 +430,13 @@ export const availableHanaClusterCostOpHeaderIsDisplayed = () =>
 export const availableHanaAngiHeaderIsDisplayed = () =>
   basePage.pageTitleIsCorrectlyDisplayed(availableAngiCluster.name);
 
-export const bothHanaCostOptSidsAreDisplayed = () => {
+export const bothHanaCostOptSidsAreDisplayed = () =>
   cy.wrap(availableHanaClusterCostOpt.sids).each((sid) => {
     cy.get(`td:contains("${availableHanaClusterCostOpt.name}") + td`).should(
       'contain',
       sid
     );
   });
-};
 
 export const saveChecksSelectionButtonIsDisabled = () =>
   cy.get(saveChecksSelectionButton).should('be.disabled');
@@ -445,14 +444,13 @@ export const saveChecksSelectionButtonIsDisabled = () =>
 export const saveChecksSelectionButtonIsDisplayed = () =>
   cy.get(saveChecksSelectionButton).should('be.visible');
 
-export const hanaAngiClusterSitesAreDisplayed = () => {
+export const hanaAngiClusterSitesAreDisplayed = () =>
   cy.wrap(availableAngiCluster.sites).each((site) => {
     cy.get(`.tn-site-details-${site.name} h3 + span`).should(
       'have.text',
       site.state
     );
   });
-};
 
 export const hanaAngiSitesHaveExpectedStateAfterFailover = () => {
   const site1 = availableAngiCluster.sites[0];
@@ -461,34 +459,33 @@ export const hanaAngiSitesHaveExpectedStateAfterFailover = () => {
     'have.text',
     'Failed'
   );
-  cy.get(`.tn-site-details-${site2.name} h3 + span`).should(
-    'have.text',
-    site1.state
-  );
+  return cy
+    .get(`.tn-site-details-${site2.name} h3 + span`)
+    .should('have.text', site1.state);
 };
 
-export const linkToDeregisteredHostIsNotAvailable = () => {
-  cy.get(
-    `div[class*="tn-site-details-${hostToDeregister.sid}"] tbody td span:contains("${hostToDeregister.name}")`
-  ).should('not.have.attr', 'href');
-};
+export const linkToDeregisteredHostIsNotAvailable = () =>
+  cy
+    .get(
+      `div[class*="tn-site-details-${hostToDeregister.sid}"] tbody td span:contains("${hostToDeregister.name}")`
+    )
+    .should('not.have.attr', 'href');
 
-export const linkToDeregisteredHostIsAvailable = () => {
-  cy.get(
-    `div[class*="tn-site-details-${hostToDeregister.sid}"] tbody td a:contains("${hostToDeregister.name}")`
-  ).should('have.attr', 'href');
-};
+export const linkToDeregisteredHostIsAvailable = () =>
+  cy
+    .get(
+      `div[class*="tn-site-details-${hostToDeregister.sid}"] tbody td a:contains("${hostToDeregister.name}")`
+    )
+    .should('have.attr', 'href');
 
 export const startExecutionButtonIsDisabled = () =>
   cy.get(startExecutionButton).should('be.disabled');
 
-export const notAuthorizedTooltipIsDisplayed = () => {
+export const notAuthorizedTooltipIsDisplayed = () =>
   cy.get(actionNotAuthorizedTooltip).should('be.visible');
-};
 
-export const notAuthorizedTooltipIsNotDisplayed = () => {
+export const notAuthorizedTooltipIsNotDisplayed = () =>
   cy.get(actionNotAuthorizedTooltip).should('not.exist');
-};
 
 // API
 export const interceptGetChecks = () =>
@@ -499,21 +496,23 @@ export const waitForGetChecksEndpoint = () =>
 
 export const interceptLastExecutionRequestMocked = () => {
   const lastExecutionURL = '/api/v2/checks/groups/**/executions/last';
-  cy.intercept(lastExecutionURL, {
-    body: lastExecution,
-  }).as(lastExecutionEndpointAlias);
+  return cy
+    .intercept(lastExecutionURL, {
+      body: lastExecution,
+    })
+    .as(lastExecutionEndpointAlias);
 };
 
 export const interceptLastExecutionRequest = () => {
   const lastExecutionURL = '/api/v2/checks/groups/**/executions/last';
-  cy.intercept(lastExecutionURL).as(lastExecutionEndpointAlias);
+  return cy.intercept(lastExecutionURL).as(lastExecutionEndpointAlias);
 };
 
 export const interceptCatalogRequest = () => {
   const catalogURL = '/api/v3/checks/catalog*';
-  cy.intercept(catalogURL, { body: { items: catalog } }).as(
-    catalogEndpointAlias
-  );
+  return cy
+    .intercept(catalogURL, { body: { items: catalog } })
+    .as(catalogEndpointAlias);
 };
 
 export const apiDeregisterWdfHost = () =>
@@ -522,23 +521,21 @@ export const apiDeregisterWdfHost = () =>
 export const apiRestoreWdfHost = () =>
   basePage.loadScenario(`host-${hostToDeregister.name}-restore`);
 
-export const apiCreateUserWithChecksExecutionAbility = () => {
+export const apiCreateUserWithChecksExecutionAbility = () =>
   basePage.apiCreateUserWithAbilities([
     {
       name: 'all',
       resource: 'cluster_checks_execution',
     },
   ]);
-};
 
-export const apiCreateUserWithChecksSelectionAbility = () => {
+export const apiCreateUserWithChecksSelectionAbility = () =>
   basePage.apiCreateUserWithAbilities([
     {
       name: 'all',
       resource: 'cluster_checks_selection',
     },
   ]);
-};
 
 export const deregisterHanaClusterCostOptHosts = () =>
   availableHanaClusterCostOpt.hosts.forEach(({ id }) =>

--- a/test/e2e/cypress/pageObject/hana_database_details_po.js
+++ b/test/e2e/cypress/pageObject/hana_database_details_po.js
@@ -268,7 +268,7 @@ export const eachAttachedHostHasExpectedWorkingLink = () =>
 export const newInstanceIsDisplayed = () => {
   const newInstanceSelector = `div[class="mt-16"]:contains("Layout") td:contains("${selectedDatabase.Hosts[0].Hostname}")`;
   cy.get(newInstanceSelector).eq(1).should('be.visible');
-  cy.get(`${newInstanceSelector} + td`).eq(1).should('have.text', 11);
+  return cy.get(`${newInstanceSelector} + td`).eq(1).should('have.text', 11);
 };
 
 export const tableHasExpectedAmountOfRows = (expectedAmountOfRows) =>

--- a/test/e2e/cypress/pageObject/hana_database_details_po.js
+++ b/test/e2e/cypress/pageObject/hana_database_details_po.js
@@ -100,9 +100,7 @@ const hostStatusHasExpectedClass = (hostName) => {
   validateHostClass(hostName, status);
 };
 
-const getSiteContainer = (site) => {
-  return cy.get(siteHeader(site));
-};
+const getSiteContainer = (site) => cy.get(siteHeader(site));
 
 const siteHasExpectedName = (site) => {
   getSiteContainer(site).should('include.text', site);

--- a/test/e2e/cypress/pageObject/host_details_po.js
+++ b/test/e2e/cypress/pageObject/host_details_po.js
@@ -397,16 +397,11 @@ const _processAttributeName = (attributeHeaderName) => {
   else return splittedAttribute;
 };
 
-const _getTableHeaders = (tableName) => {
-  return cy
-    .get(`div[class*="mt-"]:contains("${tableName}") th`)
-    .then((headers) => {
-      const headerTexts = [...headers].map((header) =>
-        header.textContent.trim()
-      );
-      return cy.wrap(headerTexts);
-    });
-};
+const _getTableHeaders = (tableName) =>
+  cy.get(`div[class*="mt-"]:contains("${tableName}") th`).then((headers) => {
+    const headerTexts = [...headers].map((header) => header.textContent.trim());
+    return cy.wrap(headerTexts);
+  });
 
 export const agentStatusIsCorrectlyDisplayed = () => {
   cy.get(agentRunningLabel).should('be.visible');

--- a/test/e2e/cypress/pageObject/host_details_po.js
+++ b/test/e2e/cypress/pageObject/host_details_po.js
@@ -359,12 +359,11 @@ export const expectedImageIsDisplayed = (cloudProvider) => {
   );
 };
 
-export const expectedNetworkIsDisplayed = (cloudProvider) => {
+export const expectedNetworkIsDisplayed = (cloudProvider) =>
   _checkText(
     providerDetails.network,
     selectedHost[`${cloudProvider}CloudDetails`].network
   );
-};
 
 export const validateSaptuneStatus = (installationStatus) => {
   let installationData;
@@ -383,7 +382,7 @@ export const validateSaptuneStatus = (installationStatus) => {
   cy.get(saptuneSummaryLabel).should('be.visible');
   cy.get(saptuneInstallationStatus).should('have.text', packageVersion);
   cy.get(saptuneConfiguredVersion).should('have.text', configuredVersion);
-  cy.get(saptuneTuningLabel).should('have.text', tuningStatus);
+  return cy.get(saptuneTuningLabel).should('have.text', tuningStatus);
 };
 
 export const notRecognizedProviderIsDisplayed = () =>
@@ -405,7 +404,8 @@ const _getTableHeaders = (tableName) =>
 
 export const agentStatusIsCorrectlyDisplayed = () => {
   cy.get(agentRunningLabel).should('be.visible');
-  cy.get(agentRunningBadge)
+  return cy
+    .get(agentRunningBadge)
     .invoke('attr', 'class')
     .then((classAttr) => {
       expect(classAttr).to.contain('jungle-green');
@@ -414,7 +414,8 @@ export const agentStatusIsCorrectlyDisplayed = () => {
 
 export const nodeExporterStatusIsCorrectlyDisplayed = () => {
   cy.get(nodeExporterLabel).should('be.visible');
-  cy.get(nodeExporterBadge)
+  return cy
+    .get(nodeExporterBadge)
     .invoke('attr', 'class')
     .then((classAttr) => {
       expect(classAttr).to.contain('jungle-green');
@@ -445,13 +446,11 @@ export const cleanUpUnhealthyHostButtonNotVisible = () =>
 export const cleanUpModalTitleIsDisplayed = () =>
   cy.get(cleanUpModalTitle).should('be.visible');
 
-export const cleanuUpModalIsNotDisplayed = () => {
+export const cleanuUpModalIsNotDisplayed = () =>
   cy.get(cleanUpModal).should('not.exist');
-};
 
-export const cleanedUpHostIsNotDisplayed = () => {
+export const cleanedUpHostIsNotDisplayed = () =>
   cy.get(cleanedUpHost).should('not.exist');
-};
 
 export const startExecutionButtonIsDisabled = () =>
   cy.get(startExecutionButton).should('be.disabled');
@@ -460,12 +459,12 @@ export const notAuthorizedMessageIsNotDisplayed = () => {
   cy.get(startExecutionButton).trigger('mouseover', {
     force: true,
   });
-  cy.get(notAuthorizedMessage).should('not.exist');
+  return cy.get(notAuthorizedMessage).should('not.exist');
 };
 
 export const notAuthorizedMessageIsDisplayed = () => {
   cy.get(startExecutionButton).click({ force: true });
-  cy.get(notAuthorizedMessage).should('be.visible');
+  return cy.get(notAuthorizedMessage).should('be.visible');
 };
 
 export const saveChecksSelectionButtonIsDisabled = () =>
@@ -536,7 +535,7 @@ const _validateCell = (tableName, header, rowIndex, expectedValue) => {
 // API
 export const loadSaptuneScenario = (state) => {
   const { hostName } = selectedHost;
-  basePage.loadScenario(`host-${hostName}-saptune-${state}`);
+  return basePage.loadScenario(`host-${hostName}-saptune-${state}`);
 };
 
 export const loadAwsHostDetails = () =>

--- a/test/e2e/cypress/pageObject/hosts_overview_po.js
+++ b/test/e2e/cypress/pageObject/hosts_overview_po.js
@@ -279,12 +279,11 @@ export const hostsTableContentsAreTheExpected = () => {
   });
 };
 
-const _getTableHeaders = () => {
-  return cy.get('thead th').then((headers) => {
+const _getTableHeaders = () =>
+  cy.get('thead th').then((headers) => {
     const headerTexts = [...headers].map((header) => header.textContent.trim());
     return cy.wrap(headerTexts);
   });
-};
 
 const _processAttributeName = (attributeHeaderName) => {
   const splittedAttribute = attributeHeaderName.toLowerCase().split(' ');
@@ -366,15 +365,14 @@ export const apiDeregisterHost = () => {
   basePage.apiDeregisterHost(id);
 };
 
-const apiRemoveTagByHostId = (hostId, tagId) => {
-  return basePage.apiLogin().then(({ accessToken }) =>
+const apiRemoveTagByHostId = (hostId, tagId) =>
+  basePage.apiLogin().then(({ accessToken }) =>
     cy.request({
       url: `/api/v1/hosts/${hostId}/tags/${tagId}`,
       method: 'DELETE',
       auth: { bearer: accessToken },
     })
   );
-};
 
 export const apiDeleteAllHostsTags = () => {
   apiGetHosts().then((response) => {
@@ -386,8 +384,8 @@ export const apiDeleteAllHostsTags = () => {
   return basePage.refresh();
 };
 
-const apiGetHosts = () => {
-  return basePage.apiLogin().then(({ accessToken }) => {
+const apiGetHosts = () =>
+  basePage.apiLogin().then(({ accessToken }) => {
     const url = '/api/v1/hosts';
     return cy
       .request({
@@ -399,7 +397,6 @@ const apiGetHosts = () => {
       })
       .then((response) => response);
   });
-};
 
 const getHostTags = (jsonData) => {
   const clusterTags = {};

--- a/test/e2e/cypress/pageObject/hosts_overview_po.js
+++ b/test/e2e/cypress/pageObject/hosts_overview_po.js
@@ -67,7 +67,7 @@ export const visit = (params) => {
   cy.intercept('/api/v2/clusters').as('clustersEndpoint');
   const visitUrl = [url, params].filter(Boolean).join('?');
   basePage.visit(visitUrl);
-  cy.wait('@clustersEndpoint');
+  return cy.wait('@clustersEndpoint');
 };
 
 export const validateUrl = () => basePage.validateUrl(url);
@@ -75,7 +75,7 @@ export const validateUrl = () => basePage.validateUrl(url);
 export const selectHostnameFilter = (hostname) => {
   cy.get(hostnameFilterButton).click();
   cy.get(hostnameFilterOptions).find(`li`).contains(hostname).click();
-  cy.get(hostnameFilterButton).click();
+  return cy.get(hostnameFilterButton).click();
 };
 
 export const hostsListedAre = (amount) =>
@@ -95,7 +95,7 @@ export const selectItemsPerPage = (amountOfItems) => {
 
 export const addTagToHost = () => {
   const host = _getHostToDeregisterData(hostToDeregister);
-  basePage.addTagByColumnValue(host.name, host.tag);
+  return basePage.addTagByColumnValue(host.name, host.tag);
 };
 
 export const clickCleanupOnHostToDeregister = () =>
@@ -106,9 +106,8 @@ export const clickCleanupConfirmationButton = () =>
 
 // UI Validations
 
-export const hostsIsHighglightedInSidebar = () => {
+export const hostsIsHighglightedInSidebar = () =>
   cy.get(basePage.navigation.hosts).should('have.attr', 'aria-current', 'page');
-};
 
 export const expectedPaginationIsDisplayed = (expectedPaginationDetails) =>
   cy
@@ -118,15 +117,14 @@ export const expectedPaginationIsDisplayed = (expectedPaginationDetails) =>
 export const nextPageButtonIsDisabled = () =>
   cy.get(nextPageSelector).should('be.disabled');
 
-export const everyLinkGoesToExpectedHostDetailsPage = () => {
+export const everyLinkGoesToExpectedHostDetailsPage = () =>
   availableHosts.slice(0, 10).forEach((host) => {
     cy.get(`a[href*="${host.id}"]`).click();
     basePage.validateUrl(`${url}/${host.id}`);
     cy.go('back');
   });
-};
 
-export const everyClusterLinkGoesToExpectedClusterDetailsPage = () => {
+export const everyClusterLinkGoesToExpectedClusterDetailsPage = () =>
   availableHosts.slice(0, 10).forEach((host, index) => {
     cy.get(clusterTableHeader)
       .invoke('index')
@@ -138,9 +136,8 @@ export const everyClusterLinkGoesToExpectedClusterDetailsPage = () => {
         }
       });
   });
-};
 
-export const everySapSystemLinkGoesToExpectedSapSystemDetailsPage = () => {
+export const everySapSystemLinkGoesToExpectedSapSystemDetailsPage = () =>
   availableHosts.slice(0, 10).forEach((host, index) => {
     cy.get(sidTableHeader)
       .invoke('index')
@@ -153,7 +150,6 @@ export const everySapSystemLinkGoesToExpectedSapSystemDetailsPage = () => {
         }
       });
   });
-};
 
 export const expectedWarningHostsAreDisplayed = (amount) =>
   cy.get(hostsWithWarning).should('have.text', amount);
@@ -168,9 +164,11 @@ export const expectedAmountOfWarningsIsDisplayed = (amount) =>
   cy.get(warningHostBadge).should('have.length', amount);
 
 export const expectedAmountOfCriticalsIsDisplayed = (amount) => {
-  if (amount === 0) cy.get(criticalHostBadge).should('not.exist');
+  if (amount === 0) return cy.get(criticalHostBadge).should('not.exist');
   else {
-    cy.get(criticalHostBadge, { timeout: 20000 }).should('have.length', amount);
+    return cy
+      .get(criticalHostBadge, { timeout: 20000 })
+      .should('have.length', amount);
   }
 };
 
@@ -197,9 +195,8 @@ export const hostWithSaptuneNotTunedHasExpectedStatus = () =>
 export const hostWithSaptuneCompliantHasExpectedStatus = () =>
   _hostHasExpectedStatus(hostWithSap, 'fill-jungle-green-500');
 
-export const cleanupButtonIsNotDisplayedForHostSendingHeartbeat = () => {
+export const cleanupButtonIsNotDisplayedForHostSendingHeartbeat = () =>
   cy.get(hostToDeregisterCleanupButton, { timeout: 20000 }).should('not.exist');
-};
 
 export const cleanupButtonIsDisplayedForHostSendingHeartbeat = () =>
   cy.get(hostToDeregisterCleanupButton).should('be.visible');
@@ -219,19 +216,19 @@ export const deregisterModalTitleIsDisplayed = () =>
 
 export const deregisteredHostIsNotVisible = () => {
   const host = _getHostToDeregisterData();
-  cy.get(`#host-${host.id}`).should('not.exist');
+  return cy.get(`#host-${host.id}`).should('not.exist');
 };
 
 export const restoredHostIsDisplayed = () => {
   const host = _getHostToDeregisterData();
-  cy.get(`#host-${host.id}`, { timeout: 20000 }).should('be.visible');
+  return cy.get(`#host-${host.id}`, { timeout: 20000 }).should('be.visible');
 };
 
 export const tagOfRestoredHostIsDisplayed = () => {
   const host = _getHostToDeregisterData();
-  cy.get(`tr:contains("${host.name}") td:contains("${host.tag}")`).should(
-    'be.visible'
-  );
+  return cy
+    .get(`tr:contains("${host.name}") td:contains("${host.tag}")`)
+    .should('be.visible');
 };
 
 export const sapSystemHasExpectedAmountOfHosts = (expectedHosts) =>
@@ -299,20 +296,25 @@ const _validateCell = (header, rowIndex, expectedValue) => {
   const tableHeaderSelector = `thead th:contains("${header}")`;
   const tableRowSelector = `tbody tr`;
 
-  cy.get(tableHeaderSelector)
+  return cy
+    .get(tableHeaderSelector)
     .invoke('index')
     .then((i) => {
       const isPropertyArray = Array.isArray(expectedValue);
       if (isPropertyArray) {
-        cy.wrap(expectedValue).each((value) => {
-          cy.get(tableRowSelector)
-            .eq(rowIndex)
-            .find('td')
-            .eq(i)
-            .should('contain', value);
-        });
+        return cy
+          .wrap(expectedValue)
+          .each((value) =>
+            cy
+              .get(tableRowSelector)
+              .eq(rowIndex)
+              .find('td')
+              .eq(i)
+              .should('contain', value)
+          );
       } else {
-        cy.get(tableRowSelector)
+        return cy
+          .get(tableRowSelector)
           .eq(rowIndex)
           .find('td')
           .eq(i)
@@ -336,7 +338,7 @@ const _getHostToDeregisterData = () => {
 // API
 export const startAgentHeartbeat = () => {
   const hostToDeregister = _getHostToDeregisterData();
-  cy.task('startAgentHeartbeat', [hostToDeregister.id]);
+  return cy.task('startAgentHeartbeat', [hostToDeregister.id]);
 };
 
 export const startAgentsHeartbeat = () =>
@@ -362,7 +364,7 @@ export const apiRestoreCleanedUpHost = () =>
 
 export const apiDeregisterHost = () => {
   const { id } = _getHostToDeregisterData();
-  basePage.apiDeregisterHost(id);
+  return basePage.apiDeregisterHost(id);
 };
 
 const apiRemoveTagByHostId = (hostId, tagId) =>
@@ -417,7 +419,7 @@ export const apiDeregisterSapSystemHost = () =>
 
 export const loadSapSystemsOverviewMovedScenario = () => {
   restoreSapSystem();
-  basePage.loadScenario('sap-systems-overview-moved');
+  return basePage.loadScenario('sap-systems-overview-moved');
 };
 
 export const apiDeregisterMovedHost = () =>
@@ -431,9 +433,8 @@ export const apiSetTag = () => {
   return basePage.apiSetTag('hosts', host.id, host.tag);
 };
 
-export const apiCreateUserWithHostTagsAbility = () => {
+export const apiCreateUserWithHostTagsAbility = () =>
   basePage.apiCreateUserWithAbilities([{ name: 'all', resource: 'host_tags' }]);
-};
 
 export const apiCreateUserWithHostCleanupAbility = () =>
   basePage.apiCreateUserWithAbilities([{ name: 'cleanup', resource: 'host' }]);

--- a/test/e2e/cypress/pageObject/login_po.js
+++ b/test/e2e/cypress/pageObject/login_po.js
@@ -68,8 +68,8 @@ const _assertSessionStatusCode = (
   username,
   password,
   expectedStatusCode = 401
-) => {
-  return cy
+) =>
+  cy
     .request({
       method: 'POST',
       url: '/api/session',
@@ -85,7 +85,6 @@ const _assertSessionStatusCode = (
         'Session endpoint has the expected status code'
       ).to.eq(expectedStatusCode);
     });
-};
 export const loginFailsIfOtpNotProvided = (username, password) =>
   _assertSessionStatusCode(username, password, 422);
 

--- a/test/e2e/cypress/pageObject/login_po.js
+++ b/test/e2e/cypress/pageObject/login_po.js
@@ -30,7 +30,7 @@ export const clickLoginWithSsoButton = () => cy.get(loginWithSsoButton).click();
 
 export const cleanBrowserData = () => {
   cy.clearAllLocalStorage();
-  cy.clearAllCookies();
+  return cy.clearAllCookies();
 };
 
 export const ssoLoginPlainUser = () =>

--- a/test/e2e/cypress/pageObject/sap_system_details_po.js
+++ b/test/e2e/cypress/pageObject/sap_system_details_po.js
@@ -32,7 +32,7 @@ const sapSystemsRows = 'div[class="mt-16"]:contains("Layout") table tbody tr';
 export const visit = () => {
   cy.intercept('/api/v1/hosts').as('hostsEndpoint');
   basePage.visit(`/sap_systems/${selectedSystem.Id}`);
-  cy.wait('@hostsEndpoint');
+  return cy.wait('@hostsEndpoint');
 };
 export const visitNonExistentSapSystem = () =>
   basePage.visit('/sap_systems/other', { failOnStatusCode: false });
@@ -51,7 +51,7 @@ export const sapSystemHasExpectedType = () =>
 export const notFoundLabelIsDisplayed = () =>
   cy.get(notFoundLabel).should('be.visible');
 
-export const layoutTableShowsExpectedData = () => {
+export const layoutTableShowsExpectedData = () =>
   selectedSystem.Hosts.forEach((instance, index) => {
     const keys = Object.keys(instance);
 
@@ -69,7 +69,6 @@ export const layoutTableShowsExpectedData = () => {
         );
     }
   });
-};
 
 const _getFormattedExpectedValue = (key, value) => {
   if (key === 'Features') return value.replaceAll('|', '');
@@ -77,7 +76,7 @@ const _getFormattedExpectedValue = (key, value) => {
   else return value;
 };
 
-export const shouldDisplayExpectedHealthStatusChanges = () => {
+export const shouldDisplayExpectedHealthStatusChanges = () =>
   Object.entries(healthMap).forEach(([state, health]) => {
     basePage.loadScenario(`sap-system-detail-${state.toUpperCase()}`);
     cy.get(thirdRowStatusCellSelector).should(
@@ -86,18 +85,16 @@ export const shouldDisplayExpectedHealthStatusChanges = () => {
     );
     cy.get(`${thirdRowStatusCellSelector} svg`).should('have.class', health);
   });
-};
 
-export const eachHostHasTheExpectedLink = () => {
+export const eachHostHasTheExpectedLink = () =>
   attachedHosts.forEach((host, index) => {
     const tableCellSelector = `div[class="mt-8"]:contains("Hosts") table tbody tr:eq(${index}) td:eq(0) a`;
     cy.get(tableCellSelector).click();
     basePage.validateUrl(`/hosts/${host.AgentId}`);
     cy.go('back');
   });
-};
 
-export const eachHostHasTheExpectedData = () => {
+export const eachHostHasTheExpectedData = () =>
   attachedHosts.forEach((host, index) => {
     delete host.AgentId;
     const keys = Object.keys(host);
@@ -108,15 +105,14 @@ export const eachHostHasTheExpectedData = () => {
       cy.get(tableCellSelector).should('have.text', expectedValue);
     });
   });
-};
 
 export const hostToDeregisterIsDisplayed = () => {
   cy.get(hostToDeregisterName).should('be.visible');
-  cy.get(hostToDeregisterFeatures).should('be.visible');
+  return cy.get(hostToDeregisterFeatures).should('be.visible');
 };
 export const hostToDeregisterIsNotDisplayed = () => {
   cy.get(hostToDeregisterName).should('not.exist');
-  cy.get(hostToDeregisterFeatures).should('not.exist');
+  return cy.get(hostToDeregisterFeatures).should('not.exist');
 };
 
 export const cleanUpButtonIsEnabled = () =>
@@ -128,7 +124,7 @@ export const cleanUpButtonIsDisabled = () =>
 export const newSapSystemIsDisplayed = () => {
   cy.get(sapSystemsRows).should('have.length', 5);
   cy.get('div:contains("sapnwdaas1")').should('be.visible');
-  cy.get('div:contains("99")').should('be.visible');
+  return cy.get('div:contains("99")').should('be.visible');
 };
 
 // API
@@ -145,11 +141,10 @@ export const restoreDeregisteredHost = () =>
 export const loadAbsentHostScenario = () =>
   basePage.loadScenario('sap-systems-overview-NWD-00-absent');
 
-export const apiCreateUserWithApplicationCleanupAbility = () => {
+export const apiCreateUserWithApplicationCleanupAbility = () =>
   basePage.apiCreateUserWithAbilities([
     { name: 'cleanup', resource: 'application_instance' },
   ]);
-};
 
 export const loadNewSapSystem = () =>
   basePage.loadScenario('sap-system-detail-NEW');

--- a/test/e2e/cypress/pageObject/sap_systems_overview_po.js
+++ b/test/e2e/cypress/pageObject/sap_systems_overview_po.js
@@ -385,18 +385,17 @@ export const apiRemoveAllSapSystemsTags = () => {
   return basePage.refresh();
 };
 
-const apiRemoveTagBySapSystemId = (systemId, tagId) => {
-  return basePage.apiLogin().then(({ accessToken }) =>
+const apiRemoveTagBySapSystemId = (systemId, tagId) =>
+  basePage.apiLogin().then(({ accessToken }) =>
     cy.request({
       url: `/api/v1/sap_systems/${systemId}/tags/${tagId}`,
       method: 'DELETE',
       auth: { bearer: accessToken },
     })
   );
-};
 
-const apiGetSapSystems = () => {
-  return basePage.apiLogin().then(({ accessToken }) => {
+const apiGetSapSystems = () =>
+  basePage.apiLogin().then(({ accessToken }) => {
     const url = '/api/v1/sap_systems';
     return cy
       .request({
@@ -408,7 +407,6 @@ const apiGetSapSystems = () => {
       })
       .then((response) => response);
   });
-};
 
 const getSapSystemTags = (jsonData) => {
   const clusterTags = {};

--- a/test/e2e/cypress/pageObject/sap_systems_overview_po.js
+++ b/test/e2e/cypress/pageObject/sap_systems_overview_po.js
@@ -76,14 +76,13 @@ const pageTitle = 'h1:contains("SAP Systems")';
 export const visit = () => {
   cy.intercept('/api/v1/databases').as('databasesRequest');
   basePage.visit(url);
-  basePage.waitForRequest('databasesRequest', 10000);
+  return basePage.waitForRequest('databasesRequest', 10000);
 };
 
-export const tagSapSystems = () => {
+export const tagSapSystems = () =>
   availableSAPSystems.forEach(({ sid, tag }) => {
     basePage.addTagByColumnValue(sid, tag);
   });
-};
 
 export const expandSystemToRemove = () =>
   cy.get(systemToRemoveCollapsibleCell).click();
@@ -134,27 +133,24 @@ export const systemApplicationLayerRowsAreTheExpected = (amount) =>
 export const movedSystemIsNotDisplayed = () =>
   cy.get(`td:contains('${sapSystemNwd.hostname}')`).should('not.exist');
 
-export const expectedSidsAreDisplayed = () => {
-  availableSAPSystems.forEach(({ sid: sid }) => {
-    cy.get(`td:contains('${sid}')`).should('be.visible');
-  });
-};
+export const expectedSidsAreDisplayed = () =>
+  availableSAPSystems.forEach(({ sid: sid }) =>
+    cy.get(`td:contains('${sid}')`).should('be.visible')
+  );
 
-export const eachSystemHasItsExpectedWorkingLink = () => {
+export const eachSystemHasItsExpectedWorkingLink = () =>
   availableSAPSystems.forEach(({ sid: sid, id: id }) => {
     cy.get(`td:contains("${sid}")`).click();
     basePage.validateUrl(`${url}/${id}`);
-    cy.go('back');
+    return cy.go('back');
   });
-};
 
-export const eachSystemHasExpectedHealth = () => {
+export const eachSystemHasExpectedHealth = () =>
   availableSAPSystems.forEach(({ health: health }, index) => {
     const healthClass = healthMap[health];
     const healthCellSelector = `tbody tr:nth-child(odd):eq(${index}) td:eq(1) svg`;
-    cy.get(healthCellSelector).should('have.class', healthClass);
+    return cy.get(healthCellSelector).should('have.class', healthClass);
   });
-};
 
 export const eachAttachedDatabaseDetailsAreTheExpected = () => {
   const tableCell = (rowIndex, columnIndex) =>
@@ -202,7 +198,7 @@ export const nwpSystemIsNotDisplayed = () =>
     .get(`td:contains('${sapSystemNwp.sid}')`, { timeout: 15000 })
     .should('not.exist');
 
-export const eachSystemHasItsDatabaseWorkingLink = () => {
+export const eachSystemHasItsDatabaseWorkingLink = () =>
   availableSAPSystems.forEach(
     ({ attachedDatabase: attachedDatabase }, index) => {
       const databaseSidLink = `tbody > tr:nth-child(odd):eq(${index}) td:contains("${attachedDatabase.sid}") a`;
@@ -211,7 +207,6 @@ export const eachSystemHasItsDatabaseWorkingLink = () => {
       cy.go('back');
     }
   );
-};
 
 const validateInstanceRowData = (instance, rowIndex) => {
   const currentRow = `${instancesRowsSelector}:eq(${rowIndex})`;
@@ -267,7 +262,7 @@ export const eachHanaInstanceHasItsClusterWorkingLink = () => {
   const hanaInstances = instancesData.filter(
     (instance) => instance.clusterID !== ''
   );
-  cy.wrap(hanaInstances).each((hanaInstance, index) => {
+  return cy.wrap(hanaInstances).each((hanaInstance, index) => {
     clickAllRows();
     cy.get(`${hanaClusterLinks}:eq(${index})`).click();
     validateUrl(`/clusters/${hanaInstance.clusterID}`);
@@ -276,21 +271,20 @@ export const eachHanaInstanceHasItsClusterWorkingLink = () => {
   });
 };
 
-export const eachInstanceHasItsHostWorkingLink = () => {
+export const eachInstanceHasItsHostWorkingLink = () =>
   instancesData.forEach((instance, rowIndex) => {
     clickAllRows();
     cy.get(`${instanceHostLinks}:eq(${rowIndex})`).click();
     validateUrl(`/hosts/${instance.hostID}`);
     cy.go('back');
   });
-};
 
 export const javaSystemIsDiscoveredCorrectly = () => {
   const javaSystemRowSelector = `tbody tr:contains('${availableJavaSystem.sid}')`;
   cy.get(javaSystemRowSelector).should('be.visible');
   const javaSystemTypeSelector = `${javaSystemRowSelector} td:eq(5)`;
   cy.get(javaSystemTypeSelector).should('have.text', availableJavaSystem.type);
-  tableDisplaysExpectedAmountOfSystems(4);
+  return tableDisplaysExpectedAmountOfSystems(4);
 };
 
 export const tableDisplaysExpectedAmountOfSystems = (systemsAmount) =>
@@ -301,7 +295,7 @@ export const eachInstanceHasItsHealthStatusCorrectlyUpdated = () => {
   const collapsibleCell = `${sapSystemsFirstRow} > td:eq(0)`;
   cy.get(collapsibleCell).click();
 
-  Object.entries(healthMap).forEach(([state, health], index) => {
+  return Object.entries(healthMap).forEach(([state, health], index) => {
     basePage.loadScenario(`sap-systems-overview-${state}`);
 
     const sapSystemInstanceHealthBadge = `${sapSystemsFirstRow} td:eq(1) svg`;
@@ -328,12 +322,12 @@ export const sapSystemHealthChangesToRedAsExpected = () => {
 
   const appLayerInstanceHealthBadge =
     'tr td div[class*="flex bg-white"] div[class*="row"] div[class*="cell"] svg:eq(4)';
-  cy.get(appLayerInstanceHealthBadge).should('have.class', healthClass);
+  return cy.get(appLayerInstanceHealthBadge).should('have.class', healthClass);
 };
 
 export const sapDiagnosticsAgentDiscoveryVisualizationIsSkipped = () => {
   basePage.loadScenario('sap-systems-overview-DAA');
-  cy.get('table[class*="table-fixed"]').should('not.contain', 'DAA');
+  return cy.get('table[class*="table-fixed"]').should('not.contain', 'DAA');
 };
 
 export const systemNwdIsVisible = () =>
@@ -421,7 +415,7 @@ const getSapSystemTags = (jsonData) => {
 
 export const loadJavaScenario = () => {
   basePage.loadScenario('multi-tenant');
-  basePage.loadScenario('java-system');
+  return basePage.loadScenario('java-system');
 };
 
 export const apiDeregisterJavaSystems = () =>
@@ -451,9 +445,9 @@ const apiDeregisterInstance = (sapSystemdId, hostId, instanceNumber) => {
     'Content-Type': 'application/json;charset=UTF-8',
   };
 
-  basePage.apiLogin().then(({ accessToken }) => {
+  return basePage.apiLogin().then(({ accessToken }) => {
     const url = `http://${webAPIHost}:${webAPIPort}/api/v1/sap_systems/${sapSystemdId}/hosts/${hostId}/instances/${instanceNumber}`;
-    cy.request({
+    return cy.request({
       method: 'DELETE',
       url: url,
       headers: headers,
@@ -472,7 +466,7 @@ export const apiDeregisterNwqHost = () =>
 
 export const apiDeregisterNwdInstances = () => {
   basePage.apiDeregisterHost(sapSystemNwd.applicationInstances[0].id);
-  basePage.apiDeregisterHost(sapSystemNwd.applicationInstances[1].id);
+  return basePage.apiDeregisterHost(sapSystemNwd.applicationInstances[1].id);
 };
 
 export const restoreNwdHost = () =>
@@ -510,12 +504,12 @@ export const apiCreateUserWithSapSystemTagsAbility = () =>
 
 export const loadAppCleanUpPermissionsScenario = () => {
   basePage.loadScenario('sap-systems-overview-NWD-00-absent');
-  basePage.loadScenario('sap-systems-overview-HDD-10-present');
+  return basePage.loadScenario('sap-systems-overview-HDD-10-present');
 };
 
 export const loadDatabaseCleanUpPermissionsScenario = () => {
   basePage.loadScenario('sap-systems-overview-NWD-00-present');
-  basePage.loadScenario('sap-systems-overview-HDD-10-absent');
+  return basePage.loadScenario('sap-systems-overview-HDD-10-absent');
 };
 
 export const apiCreateUserWithAppInstanceCleanUpAbility = () =>

--- a/test/e2e/cypress/pageObject/settings_po.js
+++ b/test/e2e/cypress/pageObject/settings_po.js
@@ -194,7 +194,7 @@ export const visit = () => {
   );
   cy.intercept('/api/v1/settings/suse_manager').as('settingsEndpoint');
   cy.intercept('/api/v1/settings/alerting').as('alertingSettingsEndpoint');
-  basePage.visit(url);
+  return basePage.visit(url);
 };
 
 export const getCurrentRetentionTime = () =>
@@ -206,16 +206,15 @@ export const clickActivityLogSettingsCancelButton = () =>
 export const typeRetentionTime = (amount) =>
   cy.get(retentionTimeInput).clear().type(amount);
 
-export const clickActivityLogSettingsSaveButton = () => {
+export const clickActivityLogSettingsSaveButton = () =>
   cy.get(activityLogSettingsSaveButton).click();
-};
 
 export const clickEditActivityLogSettingsButton = () =>
   cy.get(editActivityLogsSettingsButton).click();
 
 export const clearSumaSettings = () => {
   cy.get(clearSumaSettingsButton).click();
-  cy.get(confirmClearSumaSettings).click();
+  return cy.get(confirmClearSumaSettings).click();
 };
 
 export const clickSumaSettingsModalSaveButton = () =>
@@ -238,8 +237,9 @@ const getAlertingRemovePasswordButton = () =>
 export const removeAlertringPasswordProtection = () =>
   getAlertingRemovePasswordButton().click();
 
-export const setAlertingEnabledEditSwitch = (value) => {
-  cy.get(alertingEnabledEditSwitch)
+export const setAlertingEnabledEditSwitch = (value) =>
+  cy
+    .get(alertingEnabledEditSwitch)
     .invoke('attr', 'aria-checked')
     .then((checked) => {
       const currentlyChecked = checked == 'true';
@@ -247,18 +247,17 @@ export const setAlertingEnabledEditSwitch = (value) => {
         return;
       }
 
-      cy.get(alertingEnabledEditSwitch).click();
+      return cy.get(alertingEnabledEditSwitch).click();
     });
-};
 
 export const generateApiKeyButtonIsEnabled = () =>
   cy.get(generateApiKeyButton).should('be.visible').and('be.enabled');
 
-export const generateApiKeyButtonIsDisabled = () => {
-  cy.get(generateApiKeyButton)
+export const generateApiKeyButtonIsDisabled = () =>
+  cy
+    .get(generateApiKeyButton)
     .should('have.class', 'opacity-50')
     .and('be.disabled');
-};
 
 export const setApiKeyExpiration = (amount) =>
   cy.get(apiKeyExpirationInput).type(amount);
@@ -321,7 +320,7 @@ export const enterAlertingSettings = (
   if (recipientEmail) typeAlertingRecipient(recipientEmail);
 
   submitAlertingSettings();
-  basePage.waitForRequest('alertingSettingsEndpoint');
+  return basePage.waitForRequest('alertingSettingsEndpoint');
 };
 
 export const enterAlertingInitialSettings = () =>
@@ -375,11 +374,10 @@ export const activityLogSettingsModalIsNotDisplayed = () =>
 export const retentionTimeIsTheExpected = (expectedValue) =>
   cy.get(retentionTime).should('have.text', expectedValue);
 
-export const showExpectedToasterAfterTestingSUMA = (expectedToasterMessage) => {
-  cy.get(`p:contains("Connection ${expectedToasterMessage}!")`).should(
-    'be.visible'
-  );
-};
+export const showExpectedToasterAfterTestingSUMA = (expectedToasterMessage) =>
+  cy
+    .get(`p:contains("Connection ${expectedToasterMessage}!")`)
+    .should('be.visible');
 
 export const sumaConnectionButtonIsDisabled = () =>
   cy.get(testSumaConnectionButton).should('be.disabled');
@@ -483,7 +481,7 @@ export const expectedSavingValidationsAreDisplayed = () => {
     },
   ];
 
-  savingValidationScenarios.forEach(({ values, expectedErrors }) => {
+  return savingValidationScenarios.forEach(({ values, expectedErrors }) => {
     clickSumaEditSettingsButton();
     values.forEach(({ selector, value }) =>
       cy.get(selector).type(value, { delay: 0 })
@@ -530,7 +528,7 @@ export const eachSaveSettingsScenarioWorkAsExpected = () => {
     },
   ];
 
-  savingScenarios.forEach(({ values, expectCertUploadDate }) => {
+  return savingScenarios.forEach(({ values, expectCertUploadDate }) => {
     clickSumaEditSettingsButton();
     values.forEach(({ selector, value }) =>
       cy.get(selector).type(value, { delay: 0 })
@@ -564,7 +562,7 @@ export const editFormIsDisplayedAsExpected = () => {
     },
   ];
 
-  initialEditFormScenarios.forEach(({ settings }) => {
+  return initialEditFormScenarios.forEach(({ settings }) => {
     basePage.saveSUMASettings(settings);
     basePage.refresh();
     clickSumaEditSettingsButton();
@@ -641,7 +639,7 @@ export const changingSettingsValidationsWorkAsExpected = () => {
     },
   ];
 
-  changingValidationScenarios.forEach(
+  return changingValidationScenarios.forEach(
     ({
       withInitialCert = false,
       changeInitialPassword = false,
@@ -741,7 +739,7 @@ export const sumaSettingsAreCorrectlyChanged = () => {
     },
   ];
 
-  changingSettingsScenarios.forEach((scenario) => {
+  return changingSettingsScenarios.forEach((scenario) => {
     const {
       withInitialCert = false,
       changeInitialPassword = false,
@@ -829,7 +827,7 @@ export const sumaCaCertUploadDateHasExpectedValue = (
 ) => {
   const specificSelector = expectedValue === '-' ? '' : ' div div div';
   const selector = `${sumaCertUploadDateLabel}${specificSelector}`;
-  cy.get(selector).first().should('have.text', expectedValue);
+  return cy.get(selector).first().should('have.text', expectedValue);
 };
 
 export const expiredApiKeyToasterIsDisplayed = () =>
@@ -856,11 +854,10 @@ export const apiKeyCodeIsNotEmpty = () =>
 export const copyToClipboardButtonIsDisplayed = () =>
   cy.get(copyToClipboardButton).should('be.visible');
 
-export const showExpectedErrors = (errConfig) => {
+export const showExpectedErrors = (errConfig) =>
   errConfig.forEach(({ selector, error }) => {
     cy.get(selector).should('have.text', error);
   });
-};
 
 const alertingConfigDisplaysSettings = ({
   enabled,
@@ -918,7 +915,7 @@ export const alertingEditFormDisplaysEmptyFields = () => {
   cy.get(alertingPasswordDisplayField).should('not.exist');
   alertingRemovePasswordButtonNotExist();
   cy.get(alertingSenderEditField).should('have.value', '');
-  cy.get(alertingRecipientEditField).should('have.value', '');
+  return cy.get(alertingRecipientEditField).should('have.value', '');
 };
 
 const alertingEditFormDisplaysSettings = ({
@@ -954,7 +951,7 @@ export const saveDefaultSUMAsettings = () => {
     ...baseInitialSettings,
     ca_cert: validCertificate,
   };
-  basePage.saveSUMASettings(defaultSumaSettings);
+  return basePage.saveSUMASettings(defaultSumaSettings);
 };
 
 export const setExpiredApiKey = () =>
@@ -963,8 +960,8 @@ export const setExpiredApiKey = () =>
 export const setCloseToExpireApiKey = () =>
   updateApiKeyExpiration(addDays(new Date(), 10));
 
-export const updateApiKeyExpiration = (apiKeyExpiration) => {
-  basePage.apiLogin().then(({ accessToken }) => {
+export const updateApiKeyExpiration = (apiKeyExpiration) =>
+  basePage.apiLogin().then(({ accessToken }) =>
     cy.request({
       url: '/api/v1/settings/api_key',
       method: 'PATCH',
@@ -974,16 +971,14 @@ export const updateApiKeyExpiration = (apiKeyExpiration) => {
       body: {
         expire_at: apiKeyExpiration,
       },
-    });
-  });
-};
+    })
+  );
 
-export const resetAlertingSettingsDB = () => {
+export const resetAlertingSettingsDB = () =>
   cy.exec(`cd ${Cypress.env('project_root')} && mix clear_alerting_settings`);
-};
 
-export const saveInitialAlertingSettings = () => {
-  basePage.apiLogin().then(({ accessToken }) => {
+export const saveInitialAlertingSettings = () =>
+  basePage.apiLogin().then(({ accessToken }) =>
     cy.request({
       url: '/api/v1/settings/alerting',
       method: 'POST',
@@ -999,9 +994,8 @@ export const saveInitialAlertingSettings = () => {
         sender_email: alertingInitialSettings.senderEmail,
         recipient_email: alertingInitialSettings.recipientEmail,
       },
-    });
-  });
-};
+    })
+  );
 
 export const apiCreateUserWithSettingsAbilities = () =>
   basePage.apiCreateUserWithAbilities([

--- a/test/e2e/cypress/pageObject/users_po.js
+++ b/test/e2e/cypress/pageObject/users_po.js
@@ -322,12 +322,11 @@ export const authenticatorAppSwitchIsEnabled = () =>
 export const totpEnabledToasterIsDisplayed = () =>
   cy.get(totpEnabledToaster).should('be.visible');
 
-export const enableTotpOptionIsDisabled = () => {
-  return cy
+export const enableTotpOptionIsDisabled = () =>
+  cy
     .get(enableUserTotpOption)
     .invoke('attr', 'aria-disabled')
     .should('eq', 'true');
-};
 
 export const newIssuedTotpSecretIsDifferent = (originalTotpSecret) => {
   getTotpSecret().then((newTotpSecret) => {
@@ -474,20 +473,17 @@ export const waitForTotpEnrollmentEndpoint = () =>
 export const apiGetProfileInfo = (
   username = USER.username,
   password = PASSWORD
-) => {
-  return basePage.apiLogin(username, password).then(({ accessToken }) => {
-    return cy
+) =>
+  basePage.apiLogin(username, password).then(({ accessToken }) =>
+    cy
       .request({
         url: '/api/v1/profile',
         method: 'GET',
         auth: { bearer: accessToken },
         body: {},
       })
-      .then(({ body: profile }) => {
-        return profile;
-      });
-  });
-};
+      .then(({ body: profile }) => profile)
+  );
 
 export const apiDisableUser = () =>
   apiGetProfileInfo().then(({ id }) => {
@@ -501,8 +497,8 @@ export const apiApplyAllUsersPermission = () =>
     });
   });
 
-export const apiCreateUser = () => {
-  return basePage.apiLogin().then(({ accessToken }) => {
+export const apiCreateUser = () =>
+  basePage.apiLogin().then(({ accessToken }) => {
     const body = {
       fullname: USER.fullname,
       email: USER.email,
@@ -519,10 +515,9 @@ export const apiCreateUser = () => {
       body,
     });
   });
-};
 
-export const apiPatchUser = (id, payload) => {
-  return basePage.apiLogin().then(({ accessToken }) =>
+export const apiPatchUser = (id, payload) =>
+  basePage.apiLogin().then(({ accessToken }) =>
     cy
       .request({
         url: `${usersEndpoint}/${id}`,
@@ -539,14 +534,13 @@ export const apiPatchUser = (id, payload) => {
         });
       })
   );
-};
 
 export const apiCreatePersonalAccessToken = (
   name = DEFAULT_TOKEN_NAME,
   expiresAt = DEFAULT_TOKEN_EXPIRES_AT
-) => {
-  return basePage.apiLogin(USER.username, PASSWORD).then(({ accessToken }) => {
-    return cy
+) =>
+  basePage.apiLogin(USER.username, PASSWORD).then(({ accessToken }) =>
+    cy
       .request({
         url: '/api/v1/profile/tokens',
         method: 'POST',
@@ -556,21 +550,17 @@ export const apiCreatePersonalAccessToken = (
           expires_at: expiresAt,
         },
       })
-      .then(({ body: token }) => {
-        return token;
-      });
-  });
-};
+      .then(({ body: token }) => token)
+  );
 
-export const apiDeletePersonalAccessToken = (id) => {
-  return basePage.apiLogin(USER.username, PASSWORD).then(({ accessToken }) =>
+export const apiDeletePersonalAccessToken = (id) =>
+  basePage.apiLogin(USER.username, PASSWORD).then(({ accessToken }) =>
     cy.request({
       url: `/api/v1/profile/tokens/${id}`,
       method: 'DELETE',
       auth: { bearer: accessToken },
     })
   );
-};
 
 export const apiPersonalAccessTokenAuthorized = (
   accessToken,
@@ -587,9 +577,9 @@ export const apiPersonalAccessTokenForbidden = (accessToken) => {
   _assertAuthenticationStatusCode(accessToken, 403, usersEndpoint);
 };
 
-export const apiCreateAIConfiguration = (provider, model, apiKey) => {
-  return basePage.apiLogin(USER.username, PASSWORD).then(({ accessToken }) => {
-    return cy
+export const apiCreateAIConfiguration = (provider, model, apiKey) =>
+  basePage.apiLogin(USER.username, PASSWORD).then(({ accessToken }) =>
+    cy
       .request({
         url: '/api/v1/profile/ai_configuration',
         method: 'POST',
@@ -600,11 +590,8 @@ export const apiCreateAIConfiguration = (provider, model, apiKey) => {
           api_key: apiKey,
         },
       })
-      .then(({ body: aiConfiguration }) => {
-        return aiConfiguration;
-      });
-  });
-};
+      .then(({ body: aiConfiguration }) => aiConfiguration)
+  );
 
 export const aiConfigurationSectionIsDisplayed = () => {
   cy.get(aiConfigurationSection).should('be.visible');
@@ -685,8 +672,8 @@ const _assertAuthenticationStatusCode = (
   accessToken,
   expectedStatusCode,
   url = '/api/v1/hosts'
-) => {
-  return cy
+) =>
+  cy
     .request({
       method: 'GET',
       url: url,
@@ -698,4 +685,3 @@ const _assertAuthenticationStatusCode = (
         expectedStatusCode
       );
     });
-};

--- a/test/e2e/cypress/pageObject/users_po.js
+++ b/test/e2e/cypress/pageObject/users_po.js
@@ -328,11 +328,10 @@ export const enableTotpOptionIsDisabled = () =>
     .invoke('attr', 'aria-disabled')
     .should('eq', 'true');
 
-export const newIssuedTotpSecretIsDifferent = (originalTotpSecret) => {
-  getTotpSecret().then((newTotpSecret) => {
-    cy.wrap(newTotpSecret).should('not.equal', originalTotpSecret);
-  });
-};
+export const newIssuedTotpSecretIsDifferent = (originalTotpSecret) =>
+  getTotpSecret().then((newTotpSecret) =>
+    cy.wrap(newTotpSecret).should('not.equal', originalTotpSecret)
+  );
 
 export const plainUserFullNameIsDisplayed = () =>
   _expectedFullNameIsDisplayed(basePage.plainUser.fullname);
@@ -377,9 +376,9 @@ export const adminUserPermissionsAreDisplayed = () =>
 
 export const personalAccessTokensAreDisplayed = (tokens) => {
   if (tokens.length === 0) {
-    cy.get(emptyListAccessTokens).should('be.visible');
+    return cy.get(emptyListAccessTokens).should('be.visible');
   } else {
-    tokens.forEach(({ name }) => {
+    return cy.wrap(tokens).each(({ name }) => {
       cy.get(accessTokenName).should('have.text', name);
     });
   }
@@ -396,20 +395,18 @@ export const newAccessTokenIsDisplayed = () => {
 export const modalCopyAccessTokenButtonIsDisplayed = () =>
   cy.get(modalCopyAccessTokenButton).should('be.visible');
 
-export const lastLoginShouldBeEmpty = () => {
+export const lastLoginShouldBeEmpty = () =>
   cy.get(newUserLastLogin).should('contain', '-');
-};
 
-export const lastLoginShouldNotBeEmpty = () => {
+export const lastLoginShouldNotBeEmpty = () =>
   cy.get(newUserLastLogin).should('not.contain', '-');
-};
 
-export const lastLoginUserViewShouldBeEmpty = () => {
+export const lastLoginUserViewShouldBeEmpty = () =>
   cy.get(userViewLastLoginField).should('contain', '-');
-};
 
-export const lastLoginUserViewShouldHaveUpdatedDate = () => {
-  cy.get(userViewLastLoginField)
+export const lastLoginUserViewShouldHaveUpdatedDate = () =>
+  cy
+    .get(userViewLastLoginField)
     .invoke('text')
     .then((dateText) => {
       const date = Number(new Date(dateText));
@@ -418,7 +415,6 @@ export const lastLoginUserViewShouldHaveUpdatedDate = () => {
       // 5 seconds delta
       expect(date).to.be.closeTo(today, 5000);
     });
-};
 
 export const ifAnalyticsModalIsDisplayed = (callback, neverShowAgain) =>
   cy.get('body').then(($body) => {
@@ -432,13 +428,13 @@ export const analyticsModalIsNotDisplayed = () => {
   // the intercept is needed to wait until the page is loaded
   cy.intercept('GET', '/api/v1/profile').as(profileEndpointAlias);
   basePage.waitForRequest(profileEndpointAlias);
-  cy.get(analyticsModal).should('not.exist');
+  return cy.get(analyticsModal).should('not.exist');
 };
 
 export const clickEnableAnalytics = () => {
   cy.intercept('PATCH', '/api/v1/profile').as(profileEndpointAlias);
   cy.get(enableAnalyticsButton).click();
-  basePage.waitForRequest(profileEndpointAlias);
+  return basePage.waitForRequest(profileEndpointAlias);
 };
 
 export const clickContinueWithoutAnalytics = (neverShowAgain = true) => {
@@ -446,10 +442,15 @@ export const clickContinueWithoutAnalytics = (neverShowAgain = true) => {
     cy.get(neverShowAgainCheckbox).click();
     cy.intercept('PATCH', '/api/v1/profile').as(profileEndpointAlias);
   }
-  cy.get(continueWithoutAnalyticsButton).click();
-  if (neverShowAgain) {
-    basePage.waitForRequest(profileEndpointAlias);
-  }
+
+  return cy
+    .get(continueWithoutAnalyticsButton)
+    .click()
+    .then(() => {
+      if (neverShowAgain) {
+        return basePage.waitForRequest(profileEndpointAlias);
+      }
+    });
 };
 
 export const clickAnalyticsOptInSwitch = () =>
@@ -524,15 +525,15 @@ export const apiPatchUser = (id, payload) =>
         method: 'GET',
         auth: { bearer: accessToken },
       })
-      .then(({ headers: { etag } }) => {
+      .then(({ headers: { etag } }) =>
         cy.request({
           url: `${usersEndpoint}/${id}`,
           method: 'PATCH',
           auth: { bearer: accessToken },
           body: payload,
           headers: { 'if-match': etag },
-        });
-      })
+        })
+      )
   );
 
 export const apiCreatePersonalAccessToken = (
@@ -596,20 +597,17 @@ export const apiCreateAIConfiguration = (provider, model, apiKey) =>
 export const aiConfigurationSectionIsDisplayed = () => {
   cy.get(aiConfigurationSection).should('be.visible');
   cy.get(aiConfigurationSectionDescription).should('be.visible');
-  cy.get(aiConfigurationEditButton).should('be.visible');
+  return cy.get(aiConfigurationEditButton).should('be.visible');
 };
 
-export const aiConfigurationModelProviderShouldBe = (expectedContent) => {
+export const aiConfigurationModelProviderShouldBe = (expectedContent) =>
   cy.get(aiConfigurationModelProvider).should('contain', expectedContent);
-};
 
-export const aiConfigurationModelShouldBe = (expectedContent) => {
+export const aiConfigurationModelShouldBe = (expectedContent) =>
   cy.get(aiConfigurationModel).should('contain', expectedContent);
-};
 
-export const aiConfigurationApiKeyShouldBe = (expectedContent) => {
+export const aiConfigurationApiKeyShouldBe = (expectedContent) =>
   cy.get(aiConfigurationApiKey).should('contain', expectedContent);
-};
 
 export const requiredAPIKeyErrorIsDisplayed = (
   errorMessage = 'Required field'
@@ -664,9 +662,7 @@ const _getUserIdFromPath = () =>
 export const apiLoginAndCreateSession = (
   username = USER.username,
   password = PASSWORD
-) => {
-  basePage.apiLoginAndCreateSession(username, password);
-};
+) => basePage.apiLoginAndCreateSession(username, password);
 
 const _assertAuthenticationStatusCode = (
   accessToken,

--- a/test/e2e/eslint.config.js
+++ b/test/e2e/eslint.config.js
@@ -25,6 +25,8 @@ module.exports = [
     rules: {
       'no-console': 'error',
       'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      'arrow-body-style': ['error', 'as-needed'],
+      'prefer-arrow-callback': 'error',
       'mocha/no-mocha-arrows': 0,
       'mocha/no-setup-in-describe': 0,
       'mocha/no-exclusive-tests': 'error',


### PR DESCRIPTION
# Description

Set this new rules:
```
'arrow-body-style': ['error', 'as-needed'],
'prefer-arrow-callback': 'error',
```
to make sure cypress wrapper functions always have a return statement while also reducing boilerplate.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [x] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
