### PR TITLE
Refactor table filter tests

### DIFF
--- a/assets/js/common/Table/Table.test.jsx
+++ b/assets/js/common/Table/Table.test.jsx
@@ -126,6 +126,8 @@ describe('Table component', () => {
 
   describe('filtering', () => {
     it('should filter by the chosen filter option with default filter', async () => {
+      const user = userEvent.setup();
+
       const data = tableDataFactory.buildList(10);
       const { column1: value1 } = data[0];
 
@@ -133,7 +135,7 @@ describe('Table component', () => {
         <Table config={tableConfig} data={data} setSearchParams={() => {}} />
       );
 
-      filterTable('Column1', value1);
+      await filterTable(user, 'Column1', value1);
 
       await waitFor(() => {
         const table = screen.getByRole('table');
@@ -142,6 +144,8 @@ describe('Table component', () => {
     });
 
     it('should filter by the chosen filter option with custom filter', async () => {
+      const user = userEvent.setup();
+
       const data = [].concat(
         tableDataFactory.buildList(5),
         tableDataFactory.buildList(1, { column2: ['value1'] }),
@@ -153,8 +157,8 @@ describe('Table component', () => {
         <Table config={tableConfig} data={data} setSearchParams={() => {}} />
       );
 
-      filterTable('Column2', 'value1');
-      filterTable('Column2', 'value2');
+      await filterTable(user, 'Column2', 'value1');
+      await filterTable(user, 'Column2', 'value2');
 
       await waitFor(() => {
         const table = screen.getByRole('table');
@@ -177,7 +181,7 @@ describe('Table component', () => {
       const page2Button = within(pages).getByLabelText('next-page');
       await user.click(page2Button);
 
-      filterTable('Column3', 'value3');
+      await filterTable(user, 'Column3', 'value3');
 
       await waitFor(() => {
         const table = screen.getByRole('table');

--- a/assets/js/lib/test-utils/table.js
+++ b/assets/js/lib/test-utils/table.js
@@ -1,9 +1,9 @@
-import { screen, fireEvent } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 
-export const filterTable = (name, option) => {
+export const filterTable = async (user, name, option) => {
   const filterContainer = screen.getByTestId(`filter-${name}`);
 
-  fireEvent.click(filterContainer);
+  await user.click(filterContainer);
 
   const optionContainer = Array.from(
     screen
@@ -11,12 +11,12 @@ export const filterTable = (name, option) => {
       .querySelectorAll('li > div > span')
   ).find((f) => f.textContent === option);
 
-  fireEvent.click(optionContainer);
-  fireEvent.click(screen.getByTestId(`filter-${name}`));
+  await user.click(optionContainer);
+  await user.click(screen.getByTestId(`filter-${name}`));
 };
 
-export const clearFilter = (name) => {
+export const clearFilter = async (user, name) => {
   const filterContainer = screen.getByTestId(`filter-${name}-clear`);
 
-  fireEvent.click(filterContainer);
+  await user.click(filterContainer);
 };

--- a/assets/js/pages/ClusterDetails/ClustersList.test.jsx
+++ b/assets/js/pages/ClusterDetails/ClustersList.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import 'intersection-observer';
 import '@testing-library/jest-dom';
 import {
@@ -155,13 +156,16 @@ describe('ClustersList component', () => {
 
     it.each(scenarios)(
       'should filter the table content by $filter filter',
-      ({ filter, options, state, expectedRows }) => {
+      async ({ filter, options, state, expectedRows }) => {
+        const user = userEvent.setup();
+
         const [StatefulClustersList] = withState(<ClustersList />, state);
 
         renderWithRouter(StatefulClustersList);
 
-        options.forEach(async (option) => {
-          filterTable(filter, option);
+        for (const option of options) {
+          await filterTable(user, filter, option);
+
           const table = screen.getByRole('table');
           await waitFor(() =>
             expect(table.querySelectorAll('tbody > tr')).toHaveLength(
@@ -169,8 +173,8 @@ describe('ClustersList component', () => {
             )
           );
 
-          clearFilter(filter);
-        });
+          await clearFilter(user, filter);
+        }
       }
     );
 
@@ -195,7 +199,9 @@ describe('ClustersList component', () => {
       expect(screen.getByText('HA2')).toBeVisible();
     });
 
-    it('should put the filters values in the query string when filters are selected', () => {
+    it('should put the filters values in the query string when filters are selected', async () => {
+      const user = userEvent.setup();
+
       const tag = 'Tag1';
       const sap_instance = clusteredSapInstanceFactory.build();
       const clusters = clusterFactory.buildList(1, {
@@ -219,24 +225,30 @@ describe('ClustersList component', () => {
       const [StatefulClustersList] = withState(<ClustersList />, state);
       renderWithRouter(StatefulClustersList);
 
-      [
+      const filters = [
         ['Health', health],
         ['Name', name],
         ['SID', sid],
         ['Type', type],
         ['Tags', tag],
-      ].forEach(([filter, option]) => {
-        filterTable(filter, option);
-      });
+      ];
 
-      expect(window.location.search).toEqual(
-        `?health=${health}&name=${name}&sid=${sid}&type=${type}&tags=${tag}`
+      for (const [filter, option] of filters) {
+        await filterTable(user, filter, option);
+      }
+
+      await waitFor(() =>
+        expect(window.location.search).toEqual(
+          `?health=${health}&name=${name}&sid=${sid}&type=${type}&tags=${tag}`
+        )
       );
     });
   });
 
   describe('cluster type', () => {
     it('should add not supported tooltip to HANA+ASCS/ERS cluster types', async () => {
+      const user = userEvent.setup();
+
       const state = {
         ...cleanInitialState,
         clustersList: {
@@ -252,9 +264,8 @@ describe('ClustersList component', () => {
 
       const typeLabel = screen.getByText('HANA+ASCS/ERS');
       expect(typeLabel).toBeInTheDocument();
-      // Cannot user userEvent, as other tests in suite are using fireEvent in the
-      // filterTable function, and it messes up everything
-      fireEvent.mouseOver(typeLabel);
+
+      await user.hover(typeLabel);
       expect(
         screen.getByText(
           'Cluster managing HANA and ASCS/ERS together is not supported by Trento'

--- a/assets/js/pages/DatabasesOverview/DatabasesOverview.test.jsx
+++ b/assets/js/pages/DatabasesOverview/DatabasesOverview.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
+
 import 'intersection-observer';
 import '@testing-library/jest-dom';
 import { faker } from '@faker-js/faker';
@@ -155,7 +156,9 @@ describe('DatabasesOverview component', () => {
 
     it.each(scenarios)(
       'should filter the table content by $filter filter',
-      ({ filter, options, databases, expectedRows }) => {
+      async ({ filter, options, databases, expectedRows }) => {
+        const user = userEvent.setup();
+
         renderWithRouter(
           <DatabasesOverview
             databases={databases}
@@ -164,21 +167,24 @@ describe('DatabasesOverview component', () => {
           />
         );
 
-        options.forEach(async (option) => {
-          filterTable(filter, option);
-          screen.getByRole('table');
-          const table = await waitFor(() =>
+        for (const option of options) {
+          await filterTable(user, filter, option);
+
+          const table = screen.getByRole('table');
+          await waitFor(() =>
             expect(
-              table.querySelectorAll('tbody > tr.cursor-pointer')
+              table.querySelectorAll('tbody > tr:not([hidden])')
             ).toHaveLength(expectedRows)
           );
 
-          clearFilter(filter);
-        });
+          await clearFilter(user, filter);
+        }
       }
     );
 
-    it('should put the filters values in the query string when filters are selected', () => {
+    it('should put the filters values in the query string when filters are selected', async () => {
+      const user = userEvent.setup();
+
       const databases = databaseFactory.buildList(1, {
         tags: [{ value: 'Tag1' }],
       });
@@ -193,16 +199,20 @@ describe('DatabasesOverview component', () => {
         />
       );
 
-      [
+      const filters = [
         ['Health', health],
         ['SID', sid],
         ['Tags', tags[0].value],
-      ].forEach(([filter, option]) => {
-        filterTable(filter, option);
-      });
+      ];
 
-      expect(window.location.search).toEqual(
-        `?health=${health}&sid=${sid}&tags=${tags[0].value}`
+      for (const [filter, option] of filters) {
+        await filterTable(user, filter, option);
+      }
+
+      await waitFor(() =>
+        expect(window.location.search).toEqual(
+          `?health=${health}&sid=${sid}&tags=${tags[0].value}`
+        )
       );
     });
   });

--- a/assets/js/pages/HostsList/HostsList.test.jsx
+++ b/assets/js/pages/HostsList/HostsList.test.jsx
@@ -349,6 +349,8 @@ describe('HostsLists component', () => {
               { sid: 'PRD', host_id: 'host1' },
               { sid: 'QAS', host_id: 'host3' },
             ],
+          },
+          databasesList: {
             databaseInstances: [
               { sid: 'PRD', host_id: 'host2' },
               { sid: 'QAS', host_id: 'host4' },
@@ -376,26 +378,31 @@ describe('HostsLists component', () => {
 
     it.each(scenarios)(
       'should filter the table content by $filter filter',
-      ({ filter, options, state, expectedRows }) => {
+      async ({ filter, options, state, expectedRows }) => {
+        const user = userEvent.setup();
+
         const [StatefulHostsList] = withState(<HostsList />, state);
 
         renderWithRouter(StatefulHostsList);
 
-        options.forEach(async (option) => {
-          filterTable(filter, option);
-          screen.getByRole('table');
-          const table = await waitFor(() =>
+        for (const option of options) {
+          await filterTable(user, filter, option);
+
+          const table = screen.getByRole('table');
+          await waitFor(() =>
             expect(table.querySelectorAll('tbody > tr')).toHaveLength(
               expectedRows
             )
           );
 
-          clearFilter(filter);
-        });
+          await clearFilter(user, filter);
+        }
       }
     );
 
-    it('should put the filters values in the query string when filters are selected', () => {
+    it('should put the filters values in the query string when filters are selected', async () => {
+      const user = userEvent.setup();
+
       const hosts = hostFactory.buildList(1, {
         id: 'host1',
         tags: [{ value: 'Tag1' }],
@@ -417,17 +424,21 @@ describe('HostsLists component', () => {
       const [StatefulHostsList] = withState(<HostsList />, state);
       renderWithRouter(StatefulHostsList);
 
-      [
+      const filters = [
         ['Health', health],
         ['Hostname', hostname],
         ['SID', sid],
         ['Tags', tags[0].value],
-      ].forEach(([filter, option]) => {
-        filterTable(filter, option);
-      });
+      ];
 
-      expect(window.location.search).toEqual(
-        `?health=${health}&hostname=${hostname}&sid=${sid}&tags=${tags[0].value}`
+      for (const [filter, option] of filters) {
+        await filterTable(user, filter, option);
+      }
+
+      await waitFor(() =>
+        expect(window.location.search).toEqual(
+          `?health=${health}&hostname=${hostname}&sid=${sid}&tags=${tags[0].value}`
+        )
       );
     });
   });

--- a/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.test.jsx
+++ b/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.test.jsx
@@ -440,7 +440,9 @@ describe('SapSystemsOverviews component', () => {
 
     it.each(scenarios)(
       'should filter the table content by $filter filter',
-      ({ filter, options, sapSystems, expectedRows }) => {
+      async ({ filter, options, sapSystems, expectedRows }) => {
+        const user = userEvent.setup();
+
         renderWithRouter(
           <SapSystemsOverview
             userAbilities={userAbilities}
@@ -450,21 +452,24 @@ describe('SapSystemsOverviews component', () => {
           />
         );
 
-        options.forEach(async (option) => {
-          filterTable(filter, option);
-          screen.getByRole('table');
-          const table = await waitFor(() =>
+        for (const option of options) {
+          await filterTable(user, filter, option);
+
+          const table = screen.getByRole('table');
+          await waitFor(() =>
             expect(
-              table.querySelectorAll('tbody > tr.cursor-pointer')
+              table.querySelectorAll('tbody > tr:not([hidden])')
             ).toHaveLength(expectedRows)
           );
 
-          clearFilter(filter);
-        });
+          await clearFilter(user, filter);
+        }
       }
     );
 
-    it('should put the filters values in the query string when filters are selected', () => {
+    it('should put the filters values in the query string when filters are selected', async () => {
+      const user = userEvent.setup();
+
       const sapSystems = sapSystemFactory.buildList(1, {
         tags: [{ value: 'Tag1' }],
       });
@@ -480,16 +485,20 @@ describe('SapSystemsOverviews component', () => {
         />
       );
 
-      [
+      const filters = [
         ['Health', health],
         ['SID', sid],
         ['Tags', tags[0].value],
-      ].forEach(([filter, option]) => {
-        filterTable(filter, option);
-      });
+      ];
 
-      expect(window.location.search).toEqual(
-        `?health=${health}&sid=${sid}&tags=${tags[0].value}`
+      for (const [filter, option] of filters) {
+        await filterTable(user, filter, option);
+      }
+
+      await waitFor(() =>
+        expect(window.location.search).toEqual(
+          `?health=${health}&sid=${sid}&tags=${tags[0].value}`
+        )
       );
     });
   });


### PR DESCRIPTION
# Description

Refactor frontend tests using `table` `filterTable` and `clearTable` helpers using appropriate `user-event`.
We were using `fireEvent` which prevents adding new test cases properly.
`fireEvent` is deprecated, but we still have usages of it.
This at least removes some of them.

## How was this tested?

UT

## Did you update the documentation?

No need