### PR TITLE
Separate elixir test and coveralls upload

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -415,10 +415,17 @@ jobs:
           down-flags: "--volumes"
       - name: Run test
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_PARALLEL: true
-          COVERALLS_FLAG_NAME: Elixir-${{ matrix.elixir }}
-        run: mix coveralls.github --warnings-as-errors --trace
+          MIX_ENV: test
+        run: mix coveralls.json --warnings-as-errors --trace
+      - name: Upload coverage to Coveralls
+        continue-on-error: true
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2
+        with:
+          file: cover/excoveralls.json
+          format: coveralls
+          parallel: true
+          flag-name: Elixir-${{ matrix.elixir }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   coveralls-finish:
     needs: [test-elixir]
@@ -426,7 +433,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2
         with:
           parallel-finished: true
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In the CI, it happens sometimes that the coveralls updload fails and that make tests CI to fail even if tests are green

```
Finished in 76.8 seconds (48.7s async, 28.0s sync)
1891 tests, 0 failures
** (ExCoveralls.ReportUploadError) Failed to upload the report to 'https://coveralls.io/' (reason: status_code = 422, body = {"message":"Can't add a job to a build that is already closed. Build 1b50fd0f78e73ecc31249addef6e1c6bda64ff2c-PR-4188 is closed. See docs.coveralls.io/parallel-builds","error":true}).
```

This PR separates the two phases to make the CI more resilient