### PR TITLE
Improve SAP link tooltip

### DIFF
--- a/assets/js/common/SapSystemLink/SapSystemLink.jsx
+++ b/assets/js/common/SapSystemLink/SapSystemLink.jsx
@@ -4,16 +4,29 @@ import { EOS_WARNING_OUTLINED } from 'eos-icons-react';
 import Tooltip from '@common/Tooltip';
 import { Link } from 'react-router';
 
+import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model/sapSystems';
+
+const TOOLTIPS = {
+  [APPLICATION_TYPE]: 'SAP system currently not registered',
+  [DATABASE_TYPE]: 'HANA database currently not registered',
+};
+
+const buildHref = (id, type) =>
+  `/${type === APPLICATION_TYPE ? 'sap_systems' : 'databases'}/${id}`;
+
+const renderTooltip = (type) =>
+  TOOLTIPS[type] ?? 'System currently not registered';
+
 function SapSystemLink({ systemType, sapSystemId, children }) {
   return sapSystemId && systemType ? (
     <Link
       className="text-jungle-green-500 hover:opacity-75"
-      to={`/${systemType}/${sapSystemId}`}
+      to={buildHref(sapSystemId, systemType)}
     >
       {children}
     </Link>
   ) : (
-    <Tooltip content="System currently not registered." place="bottom">
+    <Tooltip content={renderTooltip(systemType)} place="bottom">
       <span className="group flex items-center relative">
         <EOS_WARNING_OUTLINED
           size="base"

--- a/assets/js/common/SapSystemLink/SapSystemLink.test.jsx
+++ b/assets/js/common/SapSystemLink/SapSystemLink.test.jsx
@@ -55,6 +55,10 @@ describe('SapSystemLink', () => {
       systemType: undefined,
       expectedTooltip: 'System currently not registered',
     },
+    {
+      systemType: null,
+      expectedTooltip: 'System currently not registered',
+    },
   ])(
     `renders $systemType tooltip when sapSystemId or systemType are not provided`,
     async ({ systemType, expectedTooltip }) => {

--- a/assets/js/common/SapSystemLink/SapSystemLink.test.jsx
+++ b/assets/js/common/SapSystemLink/SapSystemLink.test.jsx
@@ -17,7 +17,7 @@ describe('SapSystemLink', () => {
       </SapSystemLink>
     );
 
-    const sapSystemLinkElement = screen.getByRole('link', { sid });
+    const sapSystemLinkElement = screen.getByRole('link', { name: sid });
 
     expect(sapSystemLinkElement).toBeInTheDocument();
     expect(sapSystemLinkElement).toHaveAttribute('href', `/databases/${id}`);
@@ -32,7 +32,7 @@ describe('SapSystemLink', () => {
       </SapSystemLink>
     );
 
-    const sapSystemLinkElement = screen.getByRole('link', { sid });
+    const sapSystemLinkElement = screen.getByRole('link', { name: sid });
 
     expect(sapSystemLinkElement).toBeInTheDocument();
     expect(sapSystemLinkElement).toHaveAttribute('href', `/sap_systems/${id}`);

--- a/assets/js/common/SapSystemLink/SapSystemLink.test.jsx
+++ b/assets/js/common/SapSystemLink/SapSystemLink.test.jsx
@@ -4,14 +4,15 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { renderWithRouter } from '@lib/test-utils';
 import { sapSystemFactory } from '@lib/test-utils/factories';
+import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model/sapSystems';
 import SapSystemLink from './SapSystemLink';
 
 describe('SapSystemLink', () => {
-  it('renders Link when sapSystemId and systemType are provided', () => {
+  it('renders database link when sapSystemId and systemType are provided', () => {
     const { id, sid } = sapSystemFactory.build();
 
     renderWithRouter(
-      <SapSystemLink systemType="databases" sapSystemId={id}>
+      <SapSystemLink systemType={DATABASE_TYPE} sapSystemId={id}>
         {sid}
       </SapSystemLink>
     );
@@ -22,18 +23,51 @@ describe('SapSystemLink', () => {
     expect(sapSystemLinkElement).toHaveAttribute('href', `/databases/${id}`);
   });
 
-  it('renders tooltip when sapSystemId or systemType are not provided', async () => {
-    const user = userEvent.setup();
-    const { sid } = sapSystemFactory.build();
+  it('renders SAP system link when sapSystemId and systemType are provided', () => {
+    const { id, sid } = sapSystemFactory.build();
 
-    render(<SapSystemLink>{sid}</SapSystemLink>);
+    renderWithRouter(
+      <SapSystemLink systemType={APPLICATION_TYPE} sapSystemId={id}>
+        {sid}
+      </SapSystemLink>
+    );
 
-    const sidElement = screen.getByText(sid);
+    const sapSystemLinkElement = screen.getByRole('link', { sid });
 
-    await act(async () => user.hover(sidElement));
-
-    expect(
-      screen.getByText('System currently not registered.')
-    ).toBeInTheDocument();
+    expect(sapSystemLinkElement).toBeInTheDocument();
+    expect(sapSystemLinkElement).toHaveAttribute('href', `/sap_systems/${id}`);
   });
+
+  it.each([
+    {
+      systemType: APPLICATION_TYPE,
+      expectedTooltip: 'SAP system currently not registered',
+    },
+    {
+      systemType: DATABASE_TYPE,
+      expectedTooltip: 'HANA database currently not registered',
+    },
+    {
+      systemType: 'unknown',
+      expectedTooltip: 'System currently not registered',
+    },
+    {
+      systemType: undefined,
+      expectedTooltip: 'System currently not registered',
+    },
+  ])(
+    `renders $systemType tooltip when sapSystemId or systemType are not provided`,
+    async ({ systemType, expectedTooltip }) => {
+      const user = userEvent.setup();
+      const { sid } = sapSystemFactory.build();
+
+      render(<SapSystemLink systemType={systemType}>{sid}</SapSystemLink>);
+
+      const sidElement = screen.getByText(sid);
+
+      await act(async () => user.hover(sidElement));
+
+      expect(screen.getByText(expectedTooltip)).toBeInTheDocument();
+    }
+  );
 });

--- a/assets/js/pages/ClusterDetails/AscsErsClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/AscsErsClusterDetails.jsx
@@ -3,7 +3,7 @@ import { capitalize, get, noop } from 'lodash';
 
 import { OPERATION_NOT_ALLOWED_HOST } from '@lib/operations';
 import { isHeartbeatPassing } from '@lib/model/hosts';
-import { getEnsaVersionLabel } from '@lib/model/sapSystems';
+import { getEnsaVersionLabel, APPLICATION_TYPE } from '@lib/model/sapSystems';
 
 import DottedPagination from '@common/DottedPagination';
 import ListView from '@common/ListView';
@@ -160,7 +160,7 @@ function AscsErsClusterDetails({
                 render: (content) => (
                   <SapSystemLink
                     sapSystemId={content?.id}
-                    systemType="sap_systems"
+                    systemType={APPLICATION_TYPE}
                   >
                     {content?.sid}
                   </SapSystemLink>

--- a/assets/js/pages/ClusterDetails/ClustersList.jsx
+++ b/assets/js/pages/ClusterDetails/ClustersList.jsx
@@ -4,10 +4,12 @@ import { useSearchParams } from 'react-router';
 
 import { post, del } from '@lib/network';
 import {
+  ASCS_ERS,
   HANA_ASCS_ERS,
   getClusterTypeLabel,
   getClusterSids,
 } from '@lib/model/clusters';
+import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model/sapSystems';
 
 import { addTagToCluster, removeTagFromCluster } from '@state/clusters';
 import { getAllSAPInstances } from '@state/selectors/sapSystem';
@@ -29,6 +31,22 @@ import ClusterLink from './ClusterLink';
 
 const getSapSystemBySID = (instances, sid) =>
   instances.find((instance) => instance.sid === sid);
+
+// getSapSystemType gets the current SAP system type.
+// if the SAP system is not found, it evaluates the
+// cluster type.
+const getSapSystemType = (systemType, clusterType) => {
+  if (systemType) return systemType;
+
+  switch (clusterType) {
+    case ASCS_ERS:
+      return APPLICATION_TYPE;
+    case HANA_ASCS_ERS:
+      return null;
+    default:
+      return DATABASE_TYPE;
+  }
+};
 
 const addTag = (tag, clusterId) => {
   post(`/clusters/${clusterId}/tags`, {
@@ -79,14 +97,14 @@ function ClustersList() {
         filterFromParams: true,
         filter: (filter, key) => (element) =>
           element[key].some((sid) => filter.includes(sid)),
-        render: (_, { sid }) => {
+        render: (_, { sid, type: clusterType }) => {
           const sidsArray = sid.map((singleSid) => {
             const sapSystemData = getSapSystemBySID(allInstances, singleSid);
 
             return (
               <span key={singleSid}>
                 <SapSystemLink
-                  systemType={sapSystemData?.type}
+                  systemType={getSapSystemType(sapSystemData?.type, clusterType)}
                   sapSystemId={getInstanceID(sapSystemData)}
                 >
                   {singleSid}

--- a/assets/js/pages/ClusterDetails/ClustersList.jsx
+++ b/assets/js/pages/ClusterDetails/ClustersList.jsx
@@ -32,12 +32,9 @@ import ClusterLink from './ClusterLink';
 const getSapSystemBySID = (instances, sid) =>
   instances.find((instance) => instance.sid === sid);
 
-// getSapSystemType gets the current SAP system type.
-// if the SAP system is not found, it evaluates the
-// cluster type.
-const getSapSystemType = (systemType, clusterType) => {
-  if (systemType) return systemType;
-
+// getSapSystemType gets the current SAP system type
+// evaluating the cluster type.
+const getSapSystemType = (clusterType) => {
   switch (clusterType) {
     case ASCS_ERS:
       return APPLICATION_TYPE;
@@ -104,10 +101,9 @@ function ClustersList() {
             return (
               <span key={singleSid}>
                 <SapSystemLink
-                  systemType={getSapSystemType(
-                    sapSystemData?.type,
-                    clusterType
-                  )}
+                  systemType={
+                    sapSystemData?.type ?? getSapSystemType(clusterType)
+                  }
                   sapSystemId={getInstanceID(sapSystemData)}
                 >
                   {singleSid}

--- a/assets/js/pages/ClusterDetails/ClustersList.jsx
+++ b/assets/js/pages/ClusterDetails/ClustersList.jsx
@@ -104,7 +104,10 @@ function ClustersList() {
             return (
               <span key={singleSid}>
                 <SapSystemLink
-                  systemType={getSapSystemType(sapSystemData?.type, clusterType)}
+                  systemType={getSapSystemType(
+                    sapSystemData?.type,
+                    clusterType
+                  )}
                   sapSystemId={getInstanceID(sapSystemData)}
                 >
                   {singleSid}

--- a/assets/js/pages/ClusterDetails/ClustersList.test.jsx
+++ b/assets/js/pages/ClusterDetails/ClustersList.test.jsx
@@ -6,9 +6,17 @@ import '@testing-library/jest-dom';
 import {
   clusterFactory,
   clusteredSapInstanceFactory,
+  sapSystemApplicationInstanceFactory,
 } from '@lib/test-utils/factories';
 import { filterTable, clearFilter } from '@lib/test-utils/table';
 import { renderWithRouter, withState } from '@lib/test-utils';
+
+import {
+  ASCS_ERS,
+  HANA_ASCS_ERS,
+  HANA_SCALE_UP,
+  HANA_SCALE_OUT,
+} from '@lib/model/clusters';
 
 import ClustersList from './ClustersList';
 
@@ -272,5 +280,74 @@ describe('ClustersList component', () => {
         )
       ).toBeInTheDocument();
     });
+  });
+
+  describe('clustered SAP systems', () => {
+    it('should identify SAP instance type correctly when SAP instance available', async () => {
+      const sid = 'PRD';
+
+      const state = {
+        ...cleanInitialState,
+        clustersList: {
+          clusters: clusterFactory.buildList(1, {
+            sap_instances: [{ sid }],
+          }),
+        },
+        sapSystemsList: {
+          applicationInstances: sapSystemApplicationInstanceFactory.buildList(
+            1,
+            { sid }
+          ),
+        },
+        databasesList: {
+          databaseInstances: [],
+        },
+      };
+
+      const [StatefulClustersList] = withState(<ClustersList />, state);
+
+      renderWithRouter(StatefulClustersList);
+
+      expect(screen.getByRole('link', { name: sid })).toBeInTheDocument();
+    });
+
+    it.each([
+      { type: ASCS_ERS, tooltip: 'SAP system currently not registered' },
+      { type: HANA_ASCS_ERS, tooltip: 'System currently not registered' },
+      {
+        type: HANA_SCALE_UP,
+        tooltip: 'HANA database currently not registered',
+      },
+      {
+        type: HANA_SCALE_OUT,
+        tooltip: 'HANA database currently not registered',
+      },
+    ])(
+      'should identify $type instance type correctly when SAP instance is not available',
+      async ({ type, tooltip }) => {
+        const user = userEvent.setup();
+        const sid = 'PRD';
+
+        const state = {
+          ...cleanInitialState,
+          clustersList: {
+            clusters: clusterFactory.buildList(1, {
+              type,
+              sap_instances: [{ sid }],
+            }),
+          },
+        };
+
+        const [StatefulClustersList] = withState(<ClustersList />, state);
+
+        renderWithRouter(StatefulClustersList);
+
+        const sidLabel = screen.getByText(sid);
+        expect(sidLabel).toBeInTheDocument();
+
+        await user.hover(sidLabel);
+        await expect(screen.getByText(tooltip)).toBeInTheDocument();
+      }
+    );
   });
 });

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { get, capitalize, sortBy, noop } from 'lodash';
 
+import { DATABASE_TYPE } from '@lib/model/sapSystems';
+
 import ListView from '@common/ListView';
 import ProviderLabel from '@common/ProviderLabel';
 import ClusterTypeLabel from '@common/ClusterTypeLabel';
@@ -80,7 +82,10 @@ function HanaClusterDetails({
                   <div>
                     {content.map(({ id, sid: sapSystemSid }) => (
                       <span key={sapSystemSid}>
-                        <SapSystemLink sapSystemId={id} systemType="databases">
+                        <SapSystemLink
+                          sapSystemId={id}
+                          systemType={DATABASE_TYPE}
+                        >
                           {sapSystemSid}
                         </SapSystemLink>{' '}
                       </span>

--- a/assets/js/state/selectors/sapSystem.js
+++ b/assets/js/state/selectors/sapSystem.js
@@ -84,25 +84,6 @@ export const getEnrichedDatabaseDetails = createSelector(
   }
 );
 
-export const getInstancesOnHost = createSelector(
-  [
-    (state) => state.sapSystemsList.applicationInstances,
-    (state) => state.databasesList.databaseInstances,
-    (_, hostID) => hostID,
-  ],
-  (applicationInstances, databaseInstances, hostID) => {
-    const foundDatabaseInstances = filter(databaseInstances, {
-      host_id: hostID,
-    }).map((instance) => ({ ...instance, type: DATABASE_TYPE }));
-
-    const foundApplicationInstances = filter(applicationInstances, {
-      host_id: hostID,
-    }).map((instance) => ({ ...instance, type: APPLICATION_TYPE }));
-
-    return [...foundApplicationInstances, ...foundDatabaseInstances];
-  }
-);
-
 export const getAllSAPInstances = createSelector(
   [
     (state) => state.sapSystemsList.applicationInstances,
@@ -110,11 +91,19 @@ export const getAllSAPInstances = createSelector(
   ],
   (applicationInstances, databaseInstances) =>
     applicationInstances
-      .map((instance) => ({ ...instance, type: 'sap_systems' }))
+      .map((instance) => ({ ...instance, type: APPLICATION_TYPE }))
       .concat(
         databaseInstances.map((instance) => ({
           ...instance,
-          type: 'databases',
+          type: DATABASE_TYPE,
         }))
       )
+);
+
+export const getInstancesOnHost = createSelector(
+  [getAllSAPInstances, (_, hostID) => hostID],
+  (instances, hostID) =>
+    filter(instances, {
+      host_id: hostID,
+    })
 );

--- a/assets/js/state/selectors/sapSystem.test.js
+++ b/assets/js/state/selectors/sapSystem.test.js
@@ -1,3 +1,5 @@
+import { faker } from '@faker-js/faker';
+
 import { clusterFactory } from '@lib/test-utils/factories/clusters';
 import {
   databaseFactory,
@@ -9,12 +11,15 @@ import {
   sapSystemApplicationInstanceFactory,
 } from '@lib/test-utils/factories/sapSystems';
 
+import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model/sapSystems';
+
 import {
   getEnrichedApplicationInstances,
   getEnrichedDatabaseInstances,
   getEnrichedSapSystemDetails,
   getEnrichedDatabaseDetails,
   getAllSAPInstances,
+  getInstancesOnHost,
 } from './sapSystem';
 
 describe('sapSystem selector', () => {
@@ -242,12 +247,37 @@ describe('sapSystem selector', () => {
     };
 
     const expectedOutput = [
-      { id: 1, name: 'APP1', type: 'sap_systems' },
-      { id: 2, name: 'APP2', type: 'sap_systems' },
-      { id: 3, name: 'DB1', type: 'databases' },
-      { id: 4, name: 'DB2', type: 'databases' },
+      { id: 1, name: 'APP1', type: APPLICATION_TYPE },
+      { id: 2, name: 'APP2', type: APPLICATION_TYPE },
+      { id: 3, name: 'DB1', type: DATABASE_TYPE },
+      { id: 4, name: 'DB2', type: DATABASE_TYPE },
     ];
 
     expect(getAllSAPInstances(state)).toEqual(expectedOutput);
+  });
+
+  it('should get all instances in host', () => {
+    const hostID = faker.string.uuid();
+    const state = {
+      sapSystemsList: {
+        applicationInstances: [
+          { id: 1, name: 'APP1', host_id: hostID },
+          { id: 2, name: 'APP2', host_id: faker.string.uuid() },
+        ],
+      },
+      databasesList: {
+        databaseInstances: [
+          { id: 3, name: 'DB1', host_id: hostID },
+          { id: 4, name: 'DB2', host_id: faker.string.uuid() },
+        ],
+      },
+    };
+
+    const expectedOutput = [
+      { id: 1, name: 'APP1', type: APPLICATION_TYPE, host_id: hostID },
+      { id: 3, name: 'DB1', type: DATABASE_TYPE, host_id: hostID },
+    ];
+
+    expect(getInstancesOnHost(state, hostID)).toEqual(expectedOutput);
   });
 });


### PR DESCRIPTION
# Description

Improve the tooltip we use in several places (specially cluster related views) when the SAP system is references, but not registered in Trento (for example, the Cluster of a ASCS/ERS system is found, but the system itself is not in Trento).

In this case, we can improve the tooltip from `System not currently registered` to `SAP system not currently registered` or `HANA database not currently registered`.

It is just a small cosmethic improvement.
I have taken advantage to improve some tech-debts we had and use properly `APPLICATION_TYPE` and `DATABASE_TYPE` to identify the instances.

**Disclamier:** If this happens with HANA+ASCS/ERS cluster, we cannot get the correct type, so we fall back to the previous message. We could try to improve this scenario, it is not impossible, but I think it is such a extreme case that the effort is not worthy.

<img width="1328" height="555" alt="not_registered_tooltip" src="https://github.com/user-attachments/assets/49b64280-688b-4b33-bf03-36a4e3150b22" />

Depends on: https://github.com/trento-project/web/pull/4220

## How was this tested?

UT

## Did you update the documentation?

No need
