### PR TITLE
Fix misused waitFor

### DIFF
--- a/assets/js/common/ApiKeySettingsModal/ApiKeySettingsModal.test.jsx
+++ b/assets/js/common/ApiKeySettingsModal/ApiKeySettingsModal.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { faker } from '@faker-js/faker';
 import {
@@ -85,9 +85,10 @@ describe('ApiKeySettingsModal', () => {
 
       await user.type(screen.getByRole('spinbutton'), '20');
 
-      await user.click(
-        await waitFor(() => screen.getByRole('button', { name: 'Generate' }))
-      );
+      const generateBtn = await screen.findByRole('button', {
+        name: 'Generate',
+      });
+      await user.click(generateBtn);
 
       await user.click(screen.getByRole('button', { name: 'Generate' }));
 

--- a/assets/js/pages/ChecksSelection/ChecksSelection.test.jsx
+++ b/assets/js/pages/ChecksSelection/ChecksSelection.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { screen, waitFor } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 
@@ -29,7 +29,7 @@ describe('ChecksSelection component', () => {
       />
     );
 
-    const groupItem = await waitFor(() => screen.getByText(group));
+    const groupItem = await screen.findByText(group);
 
     await user.click(groupItem);
 
@@ -59,7 +59,7 @@ describe('ChecksSelection component', () => {
       />
     );
 
-    const groupItem = await waitFor(() => screen.getByText(group));
+    const groupItem = await screen.findByText(group);
 
     await user.click(groupItem);
 
@@ -91,7 +91,7 @@ describe('ChecksSelection component', () => {
       />
     );
 
-    const groupItem = await waitFor(() => screen.getByText(group));
+    const groupItem = await screen.findByText(group);
 
     await user.click(groupItem);
 
@@ -124,7 +124,7 @@ describe('ChecksSelection component', () => {
       />
     );
 
-    const groupItem = await waitFor(() => screen.getByText(group));
+    const groupItem = await screen.findByText(group);
 
     await user.click(groupItem);
 

--- a/assets/js/pages/Login/Login.test.jsx
+++ b/assets/js/pages/Login/Login.test.jsx
@@ -45,7 +45,7 @@ describe('Login component', () => {
 
     renderWithRouter(StatefulLogin);
 
-    await waitFor(() => screen.getByText('Invalid credentials'));
+    await screen.findByText('Invalid credentials');
 
     const username = screen.getByTestId(`login-username`);
     expect(username).toHaveClass('border-red-500');


### PR DESCRIPTION
`waitFor` shouldn't be used when the element is meant to already be i the page. By removing, we optimise both failure time and error messages.