### PR TITLE
Use clustered SAP system/database instances to create SAP system link

### DIFF
--- a/assets/js/pages/ClusterDetails/ClustersList.jsx
+++ b/assets/js/pages/ClusterDetails/ClustersList.jsx
@@ -15,7 +15,7 @@ import {
 import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model/sapSystems';
 
 import { addTagToCluster, removeTagFromCluster } from '@state/clusters';
-import { getAllSAPInstances } from '@state/selectors/sapSystem';
+import { getClustersWithEnrichedSapInstances } from '@state/selectors/cluster';
 import { getInstanceID } from '@state/instances';
 
 import { getUserProfile } from '@state/selectors/user';
@@ -59,8 +59,7 @@ const removeTag = (tag, clusterId) => {
 };
 
 function ClustersList() {
-  const clusters = useSelector((state) => state.clustersList.clusters);
-  const allInstances = useSelector(getAllSAPInstances);
+  const clusters = useSelector(getClustersWithEnrichedSapInstances);
   const dispatch = useDispatch();
   const [searchParams, setSearchParams] = useSearchParams();
   const { abilities } = useSelector(getUserProfile);
@@ -97,9 +96,12 @@ function ClustersList() {
         filterFromParams: true,
         filter: (filter, key) => (element) =>
           element[key].some((sid) => filter.includes(sid)),
-        render: (_, { sid, type: clusterType }) => {
+        render: (
+          _,
+          { sid, type: clusterType, sap_instances: sapInstances }
+        ) => {
           const sidsArray = sid.map((singleSid) => {
-            const sapSystemData = getSapSystemBySID(allInstances, singleSid);
+            const sapSystemData = getSapSystemBySID(sapInstances, singleSid);
 
             return (
               <span key={singleSid}>
@@ -183,6 +185,7 @@ function ClustersList() {
     name: cluster.name,
     id: cluster.id,
     sid: getClusterSids(cluster),
+    sap_instances: cluster.sap_instances || [],
     type: cluster.type,
     hosts_number: cluster.hosts_number,
     resources_number: cluster.resources_number,

--- a/assets/js/pages/ClusterDetails/ClustersList.test.jsx
+++ b/assets/js/pages/ClusterDetails/ClustersList.test.jsx
@@ -9,6 +9,7 @@ import '@testing-library/jest-dom';
 import {
   clusterFactory,
   clusteredSapInstanceFactory,
+  hostFactory,
   sapSystemApplicationInstanceFactory,
 } from '@lib/test-utils/factories';
 import { filterTable, clearFilter } from '@lib/test-utils/table';
@@ -288,18 +289,24 @@ describe('ClustersList component', () => {
   describe('clustered SAP systems', () => {
     it('should identify SAP instance type correctly when SAP instance available', async () => {
       const sid = 'PRD';
+      const instanceNumber = '00';
+      const clusters = clusterFactory.buildList(1, {
+        sap_instances: [{ sid, instance_number: instanceNumber }],
+      });
+      const hosts = hostFactory.buildList(1, { cluster_id: clusters[0].id });
 
       const state = {
         ...cleanInitialState,
         clustersList: {
-          clusters: clusterFactory.buildList(1, {
-            sap_instances: [{ sid }],
-          }),
+          clusters,
+        },
+        hostsList: {
+          hosts,
         },
         sapSystemsList: {
           applicationInstances: sapSystemApplicationInstanceFactory.buildList(
             1,
-            { sid }
+            { sid, instance_number: instanceNumber, host_id: hosts[0].id }
           ),
         },
         databasesList: {

--- a/assets/js/state/selectors/cluster.js
+++ b/assets/js/state/selectors/cluster.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-import { get, find, uniq, has, includes } from 'lodash';
+import { get, find, uniq, has } from 'lodash';
 import { createSelector } from '@reduxjs/toolkit';
 
 import {
@@ -152,12 +152,11 @@ export const getClustersWithEnrichedSapInstances = createSelector(
         .map(getHostID);
 
       const enrichedSapInstances = cluster.sap_instances.map((sapInstance) => {
-        const instanceData = find(
-          allInstances,
+        const instanceData = allInstances.find(
           ({ sid, instance_number: instanceNumber, host_id: hostID }) =>
             sid === sapInstance.sid &&
             instanceNumber === sapInstance.instance_number &&
-            includes(clusterHostIDs, hostID)
+            clusterHostIDs.includes(hostID)
         );
         return { ...sapInstance, ...instanceData };
       });

--- a/assets/js/state/selectors/cluster.js
+++ b/assets/js/state/selectors/cluster.js
@@ -143,7 +143,7 @@ export const getClustersWithEnrichedSapInstances = createSelector(
   [
     (state) => state.clustersList.clusters,
     (state) => state.hostsList.hosts,
-    getAllSAPInstances,
+    (state) => getAllSAPInstances(state),
   ],
   (clusters, hosts, allInstances) =>
     clusters.map((cluster) => {

--- a/assets/js/state/selectors/cluster.js
+++ b/assets/js/state/selectors/cluster.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-import { get, find, uniq, has } from 'lodash';
+import { get, find, uniq, has, includes } from 'lodash';
 import { createSelector } from '@reduxjs/toolkit';
 
 import {
@@ -11,6 +11,7 @@ import {
 } from '@lib/model/clusters';
 
 import { getHostID } from './host';
+import { getAllSAPInstances } from './sapSystem';
 import { getInstanceID } from '../instances';
 
 export const getCluster =
@@ -128,4 +129,39 @@ export const getFilesystemType = createSelector(
 export const getClusterSelectedChecks = createSelector(
   [(state, clusterID) => getCluster(clusterID)(state)],
   (cluster) => get(cluster, 'selected_checks', [])
+);
+
+// getClustersWithEnrichedSapInstances enriches the sap_instances field
+// of the clusters. It looks for already registered SAP and database
+// instances, and if any of them matches with the SAP instance by SID,
+// instance number and the host where the instance is running is part
+// of the cluster, the data is included.
+// In HANA system replication setup, as the SID and instance number are
+// the same and both instances belong to the cluster, only the first found
+// instance data is attached.
+export const getClustersWithEnrichedSapInstances = createSelector(
+  [
+    (state) => state.clustersList.clusters,
+    (state) => state.hostsList.hosts,
+    getAllSAPInstances,
+  ],
+  (clusters, hosts, allInstances) =>
+    clusters.map((cluster) => {
+      const clusterHostIDs = hosts
+        .filter(({ cluster_id: clusterID }) => cluster.id === clusterID)
+        .map(getHostID);
+
+      const enrichedSapInstances = cluster.sap_instances.map((sapInstance) => {
+        const instanceData = find(
+          allInstances,
+          ({ sid, instance_number: instanceNumber, host_id: hostID }) =>
+            sid === sapInstance.sid &&
+            instanceNumber === sapInstance.instance_number &&
+            includes(clusterHostIDs, hostID)
+        );
+        return { ...sapInstance, ...instanceData };
+      });
+
+      return { ...cluster, sap_instances: enrichedSapInstances };
+    })
 );

--- a/assets/js/state/selectors/cluster.test.js
+++ b/assets/js/state/selectors/cluster.test.js
@@ -16,6 +16,7 @@ import {
   FS_TYPE_SIMPLE_MOUNT,
   FS_TYPE_MIXED,
 } from '@lib/model/clusters';
+import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model/sapSystems';
 
 import {
   getClusterHostIDs,
@@ -24,6 +25,7 @@ import {
   getClusterSapSystems,
   getClusterSelectedChecks,
   getClusterIDs,
+  getClustersWithEnrichedSapInstances,
   getFilesystemType,
   getEnsaVersion,
   MIXED_VERSIONS,
@@ -465,5 +467,54 @@ describe('Cluster selector', () => {
     };
 
     expect(getFilesystemType(state, clusterID)).toEqual(FS_TYPE_MIXED);
+  });
+
+  it('should return clusters with enriched SAP and database instances', () => {
+    const appInstance = sapSystemApplicationInstanceFactory.build();
+    const dbInstance = databaseInstanceFactory.build();
+    const instanceInOtherCluster = sapSystemApplicationInstanceFactory.build();
+
+    const cluster = clusterFactory.build({
+      sap_instances: [
+        { sid: appInstance.sid, instance_number: appInstance.instance_number },
+        { sid: dbInstance.sid, instance_number: dbInstance.instance_number },
+        {
+          sid: instanceInOtherCluster.sid,
+          instance_number: instanceInOtherCluster.instance_number,
+        },
+        { sid: 'Unknown', instance_number: '100' },
+      ],
+    });
+
+    const hosts = [
+      hostFactory.build({ id: appInstance.host_id, cluster_id: cluster.id }),
+      hostFactory.build({ id: dbInstance.host_id, cluster_id: cluster.id }),
+      hostFactory.build({ id: instanceInOtherCluster.host_id }),
+    ];
+
+    const state = {
+      clustersList: {
+        clusters: [cluster],
+      },
+      hostsList: {
+        hosts,
+      },
+      databasesList: {
+        databaseInstances: [dbInstance],
+      },
+      sapSystemsList: {
+        applicationInstances: [appInstance],
+      },
+    };
+
+    const enrichedClusters = getClustersWithEnrichedSapInstances(state);
+    const sapInstances = enrichedClusters[0].sap_instances;
+
+    expect(sapInstances[0].sap_system_id).toEqual(appInstance.sap_system_id);
+    expect(sapInstances[0].type).toEqual(APPLICATION_TYPE);
+    expect(sapInstances[1].database_id).toEqual(dbInstance.database_id);
+    expect(sapInstances[1].type).toEqual(DATABASE_TYPE);
+    expect(sapInstances[2].type).toEqual(undefined);
+    expect(sapInstances[3].type).toEqual(undefined);
   });
 });


### PR DESCRIPTION
# Description

Change how we associate the SAP system/database in the clusters list view when we create the SAP system link.
Right now, we match by SID using all the registered instances, but this can lead to bad links, as the SIDs can be duplicated (have 2 systems with the same SID). In that case, we would always link to the first finding.
Now, the clusters are enriched with SAP instances data, so we can only check instances that belong to that cluster to create the link. 

Here an example:
<img width="1328" height="555" alt="fixed_sap_link" src="https://github.com/user-attachments/assets/b7f1195e-df3e-49e1-97ba-5f9b6554041f" />


## How was this tested?

UT

## Did you update the documentation?

No need
