### PR TITLE
Refactor selector warnings

### DIFF
--- a/assets/js/lib/network/network.test.js
+++ b/assets/js/lib/network/network.test.js
@@ -20,11 +20,14 @@ describe('networkClient', () => {
     axiosMock.reset();
     mockAuthClient.reset();
     jest.spyOn(console, 'error').mockImplementation(() => null);
+    jest.spyOn(console, 'warn').mockImplementation(() => null);
   });
 
   afterEach(() => {
     /* eslint-disable-next-line */
     console.error.mockRestore();
+    /* eslint-disable-next-line */
+    console.warn.mockRestore();
     clearCredentialsFromStore();
   });
 

--- a/assets/js/pages/ChecksCatalog/ChecksCatalogPage.jsx
+++ b/assets/js/pages/ChecksCatalog/ChecksCatalogPage.jsx
@@ -28,7 +28,7 @@ function ChecksCatalogPage() {
     filteredCatalog,
     error: catalogError,
     loading,
-  } = useSelector(getCatalog());
+  } = useSelector(getCatalog);
 
   return (
     <ChecksCatalog

--- a/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
@@ -66,7 +66,7 @@ export function ClusterDetailsPage() {
   const architectureType = get(cluster, 'details.architecture_type');
   const hanaScenario = get(cluster, 'details.hana_scenario');
 
-  const catalog = useSelector(getCatalog());
+  const catalog = useSelector(getCatalog);
 
   const lastExecution = useSelector(getLastExecution(clusterID));
 

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -59,7 +59,7 @@ function HostDetailsPage() {
   const { abilities } = useSelector(getUserProfile);
 
   const lastExecution = useSelector(getLastExecution(hostID));
-  const catalog = useSelector(getCatalog());
+  const catalog = useSelector(getCatalog);
 
   const hostSelectedChecks = useSelector((state) =>
     getHostSelectedChecks(state, hostID)

--- a/assets/js/state/sagas/checksSelection.test.js
+++ b/assets/js/state/sagas/checksSelection.test.js
@@ -22,6 +22,15 @@ import { selectHostChecks, selectClusterChecks } from './checksSelection';
 const axiosMock = new MockAdapter(networkClient);
 
 describe('Checks Selection saga', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    /* eslint-disable-next-line */
+    console.error.mockRestore();
+  });
+
   describe('Host Checks Selection', () => {
     it('should successfully save check selection for a host', async () => {
       const { id: hostID, hostname: hostName } = hostFactory.build();

--- a/assets/js/state/selectors/catalog.js
+++ b/assets/js/state/selectors/catalog.js
@@ -1,12 +1,11 @@
 import { createSelector } from '@reduxjs/toolkit';
 
-export const getCatalog = () =>
-  createSelector(
-    [({ catalog }) => catalog],
-    ({ data, filteredCatalog, error, loading }) => ({
-      data,
-      filteredCatalog,
-      error,
-      loading,
-    })
-  );
+export const getCatalog = createSelector(
+  [({ catalog }) => catalog],
+  ({ data, filteredCatalog, error, loading }) => ({
+    data,
+    filteredCatalog,
+    error,
+    loading,
+  })
+);

--- a/assets/js/state/selectors/catalog.test.js
+++ b/assets/js/state/selectors/catalog.test.js
@@ -18,6 +18,6 @@ describe('Catalog selector', () => {
       error: null,
     };
 
-    expect(getCatalog()(state)).toEqual(expectedState);
+    expect(getCatalog(state)).toEqual(expectedState);
   });
 });

--- a/assets/js/state/selectors/lastExecutions.js
+++ b/assets/js/state/selectors/lastExecutions.js
@@ -70,7 +70,7 @@ export const getLastExecutionData = createSelector(
   [
     (state, groupID, targetType) => getTargetHosts(state, groupID, targetType),
     (state, groupID, targetType) => getTarget(state, groupID, targetType),
-    (state) => getCatalog()(state),
+    getCatalog,
     (state, groupID) => getLastExecution(groupID)(state),
   ],
   (targetHosts, target, catalog, lastExecution) => {

--- a/assets/js/state/selectors/sapSystem.js
+++ b/assets/js/state/selectors/sapSystem.js
@@ -51,13 +51,12 @@ export const getEnrichedSapSystemDetails = createSelector(
   [
     (state, sapSystemID) => getSapSystem(sapSystemID)(state),
     getEnrichedApplicationInstances,
-    (_state, sapSystemID) => sapSystemID,
   ],
-  (system, enrichedInstances, sapSystemID) => {
+  (system, enrichedInstances) => {
     if (!system) return null;
 
     const filteredInstances = filter(enrichedInstances, {
-      sap_system_id: sapSystemID,
+      sap_system_id: system.id,
     });
 
     return {
@@ -72,13 +71,12 @@ export const getEnrichedDatabaseDetails = createSelector(
   [
     (state, databaseID) => getDatabase(databaseID)(state),
     getEnrichedDatabaseInstances,
-    (_state, databaseID) => databaseID,
   ],
-  (database, enrichedInstances, databaseID) => {
+  (database, enrichedInstances) => {
     if (!database) return null;
 
     const filteredInstances = filter(enrichedInstances, {
-      database_id: databaseID,
+      database_id: database.id,
     });
 
     return {

--- a/assets/js/state/selectors/sapSystem.js
+++ b/assets/js/state/selectors/sapSystem.js
@@ -2,12 +2,12 @@ import { filter } from 'lodash';
 import { createSelector } from '@reduxjs/toolkit';
 
 import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model/sapSystems';
-import { getCluster } from '@state/selectors/cluster';
-import { getHost } from '@state/selectors/host';
 
-const enrichInstance = (instance) => (state) => {
-  const host = getHost(instance.host_id)(state);
-  const cluster = getCluster(host?.cluster_id)(state);
+const enrichInstance = (instance, hosts, clusters) => {
+  const host = hosts.find(({ id: hostID }) => hostID === instance.host_id);
+  const cluster = clusters.find(
+    ({ id: clusterID }) => clusterID === host.cluster_id
+  );
 
   return {
     ...instance,
@@ -18,20 +18,25 @@ const enrichInstance = (instance) => (state) => {
   };
 };
 
-const enrichInstances = (instances) => (state) =>
-  instances.map((instance) => enrichInstance(instance)(state));
+const enrichInstances = (instances, hosts, clusters) =>
+  instances.map((instance) => enrichInstance(instance, hosts, clusters));
 
 export const getEnrichedApplicationInstances = createSelector(
   [
-    (state) =>
-      enrichInstances(state.sapSystemsList.applicationInstances)(state),
+    (state) => state.sapSystemsList.applicationInstances,
+    (state) => state.hostsList.hosts,
+    (state) => state.clustersList.clusters,
   ],
-  (enrichedInstances) => enrichedInstances
+  (instances, hosts, clusters) => enrichInstances(instances, hosts, clusters)
 );
 
 export const getEnrichedDatabaseInstances = createSelector(
-  [(state) => enrichInstances(state.databasesList.databaseInstances)(state)],
-  (enrichedInstances) => enrichedInstances
+  [
+    (state) => state.databasesList.databaseInstances,
+    (state) => state.hostsList.hosts,
+    (state) => state.clustersList.clusters,
+  ],
+  (instances, hosts, clusters) => enrichInstances(instances, hosts, clusters)
 );
 
 export const getSapSystem = (sapSystemID) => (state) =>
@@ -45,20 +50,20 @@ export const getDatabase = (databaseID) => (state) =>
 export const getEnrichedSapSystemDetails = createSelector(
   [
     (state, sapSystemID) => getSapSystem(sapSystemID)(state),
-    (state, sapSystemID) =>
-      enrichInstances(
-        filter(state.sapSystemsList.applicationInstances, {
-          sap_system_id: sapSystemID,
-        })
-      )(state),
+    getEnrichedApplicationInstances,
+    (_state, sapSystemID) => sapSystemID,
   ],
-  (system, instances) => {
+  (system, enrichedInstances, sapSystemID) => {
     if (!system) return null;
+
+    const filteredInstances = filter(enrichedInstances, {
+      sap_system_id: sapSystemID,
+    });
 
     return {
       ...system,
-      instances,
-      hosts: instances?.flatMap((instance) => instance.host),
+      instances: filteredInstances,
+      hosts: filteredInstances?.flatMap((instance) => instance.host),
     };
   }
 );
@@ -66,20 +71,20 @@ export const getEnrichedSapSystemDetails = createSelector(
 export const getEnrichedDatabaseDetails = createSelector(
   [
     (state, databaseID) => getDatabase(databaseID)(state),
-    (state, databaseID) =>
-      enrichInstances(
-        filter(state.databasesList.databaseInstances, {
-          database_id: databaseID,
-        })
-      )(state),
+    getEnrichedDatabaseInstances,
+    (_state, databaseID) => databaseID,
   ],
-  (database, instances) => {
+  (database, enrichedInstances, databaseID) => {
     if (!database) return null;
+
+    const filteredInstances = filter(enrichedInstances, {
+      database_id: databaseID,
+    });
 
     return {
       ...database,
-      instances,
-      hosts: instances?.flatMap((instance) => instance.host),
+      instances: filteredInstances,
+      hosts: filteredInstances?.flatMap((instance) => instance.host),
     };
   }
 );

--- a/assets/js/state/selectors/sapSystem.js
+++ b/assets/js/state/selectors/sapSystem.js
@@ -6,7 +6,7 @@ import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model/sapSystems';
 const enrichInstance = (instance, hosts, clusters) => {
   const host = hosts.find(({ id: hostID }) => hostID === instance.host_id);
   const cluster = clusters.find(
-    ({ id: clusterID }) => clusterID === host.cluster_id
+    ({ id: clusterID }) => clusterID === host?.cluster_id
   );
 
   return {


### PR DESCRIPTION
# Description

Refactor some selectors usage to remove warning and apply good practices.
Basically, the input functions in `CreateSelector` shouldn't have complex transformations, which should happen in the return function.
Some of the warnings were:
```
console.warn
      An input selector returned a different result when passed same arguments.
      This means your output selector will likely run more frequently than intended.
      Avoid returning a new reference inside your input selector, e.g.
```

and

```
console.warn
      The result function returned its own inputs without modification. e.g
      `createSelector([state => state.todos], todos => todos)`
      This could lead to inefficient memoization and unnecessary re-renders.

```

Now, we have a clean tests execution in `lib` and `state`:
```
> npm test js/state/ js/lib/

> pretest
> ls ../priv/static/assets/app.css || npm run tailwind:build

../priv/static/assets/app.css

> test
> jest --maxWorkers=2 js/state/ js/lib/

 PASS  js/lib/model/activityLog.test.js
 PASS  js/state/sagas/user.test.js
 PASS  js/state/sagas/lastExecutions.test.js
 PASS  js/lib/model/hosts.test.js
 PASS  js/state/sagas/notifications.test.jsx
 PASS  js/state/sagas/catalog.test.js
 PASS  js/state/sagas/activityLogsSettings.test.js
 PASS  js/state/hosts.test.js
 PASS  js/state/sagas/hosts.test.js
 PASS  js/state/sagas/sapSystems.test.js
 PASS  js/state/selectors/sapSystem.test.js
 PASS  js/state/sagas/databases.test.js
 PASS  js/state/selectors/cluster.test.js
 PASS  js/state/selectors/lastExecutions.test.js
 PASS  js/state/sagas/operations.test.js
 PASS  js/lib/history/index.test.js
 PASS  js/state/sagas/checksSelection.test.js
 PASS  js/state/sagas/clusters.test.js
 PASS  js/lib/analytics/effects.test.js
 PASS  js/state/sagas/softwareUpdates.test.js
 PASS  js/state/selectors/checksResultsFilters.test.js
 PASS  js/lib/analytics/index.test.js
 PASS  js/state/sagas/activityLog.test.js
 PASS  js/lib/model/clusters.test.js
 PASS  js/state/sapSystems.test.js
 PASS  js/state/databases.test.js
 PASS  js/state/selectors/runningOperations.test.js
 PASS  js/state/sagas/settings.test.jsx
 PASS  js/state/selectors/host.test.js
 PASS  js/lib/model/users.test.js
 PASS  js/state/lastExecutions.test.js
 PASS  js/state/checksResultsFilters.test.js
 PASS  js/state/activityLog.test.js
 PASS  js/state/clusters.test.js
 PASS  js/lib/network/network.test.js
 PASS  js/state/user.test.js
 PASS  js/state/selectors/softwareUpdates.test.js
 PASS  js/state/softwareUpdates.test.js
 PASS  js/lib/filter/index.test.js
 PASS  js/state/checksSelection.test.js
 PASS  js/lib/checks/env.test.js
 PASS  js/state/runningOperations.test.js
 PASS  js/state/selectors/checksSelection.test.js
 PASS  js/lib/operations/operations.test.js
 PASS  js/lib/api/validationErrors.test.js
 PASS  js/state/sagas/channels.test.js
 PASS  js/lib/model/checks.test.js
 PASS  js/lib/ai/index.test.js
 PASS  js/lib/charts/index.test.js
 PASS  js/lib/saptune/saptune.test.js
 PASS  js/lib/lists/lists.test.js
 PASS  js/lib/config/config.test.js
 PASS  js/state/selectors/catalog.test.js
 PASS  js/state/selectors/activityLogsSettings.test.js
 PASS  js/lib/model/sapSystems.test.js
 PASS  js/lib/serialization/index.test.js
 PASS  js/lib/auth/config.test.js
 PASS  js/lib/agent/agent.test.js
 PASS  js/state/catalog.test.js
 PASS  js/state/activityLogsSettings.test.js
 PASS  js/state/selectors/activityLog.test.js
 PASS  js/lib/model/model.test.js

Test Suites: 62 passed, 62 total
Tests:       422 passed, 422 total
Snapshots:   0 total
Time:        10.411 s

```

## How was this tested?

UT

## Did you update the documentation?

No need
