### PR TITLE
[TRNT-4358] Add license headers linter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -235,6 +235,18 @@ jobs:
       - name: codespell
         run: codespell -S priv*,*package*json,deps*,*node_modules*,*svg,*.git,*.app -L enque,daa,afterall,statics
 
+  license-headers:
+    name: Ensure license headers are present and correct
+    needs: [detect-changes]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - name: Check license Headers
+        uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
+
   generate-docs:
     name: Generate project documentation
     needs: [detect-changes]

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+header:
+  comment: on-failure
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: SUSE LLC
+    software-name: trento-web
+    content: |
+      SPDX-FileCopyrightText: SUSE LLC
+      SPDX-License-Identifier: Apache-2.0
+  paths-ignore:
+    - "**/*.adoc"
+    - "**/*.eslintrc"
+    - "**/*.example"
+    - "**/*.json"
+    - "**/*.md"
+    - "**/*.pem"
+    - "**/*.service"
+    - "**/*.svg"
+    - "**/*.txt"
+    - ".github/CODEOWNERS"
+    - ".github/dependabot.yml"
+    - ".tool-versions"
+    - "LICENSE"
+    - "VERSION"
+    - "assets/vendor/**"
+
+  language:
+    JavaScript:
+      extensions:
+        - ".js"
+        - ".jsx"
+        - ".mjs"
+        - ".cjs"
+      comment_style_id: DoubleSlash


### PR DESCRIPTION
# Description

This PR simply adds a new linter in CI for checking the license headers. 

It is expected to fail until https://github.com/trento-project/web/pull/4237 is merged.

Related # TRNT-4358

## How was this tested?

N/A