### PR TITLE
Refactor keep filters tests & fix hosts overview flaky tests

### DIFF
--- a/assets/js/lib/auth/index.js
+++ b/assets/js/lib/auth/index.js
@@ -65,6 +65,8 @@ export const getRefreshTokenFromStore = () =>
   window.localStorage.getItem(STORAGE_REFRESH_TOKEN_IDENTIFIER);
 
 export const clearCredentialsFromStore = () => {
+  // eslint-disable-next-line no-console
+  console.log('clear_credentials_reached');
   window.localStorage.removeItem(STORAGE_ACCESS_TOKEN_IDENTIFIER);
   window.localStorage.removeItem(STORAGE_REFRESH_TOKEN_IDENTIFIER);
 };

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -221,6 +221,7 @@ context('Hosts Overview', () => {
       basePage.visit(anyPageUrl);
       basePage.validateUrl(anyPageUrl);
       hostsOverviewPage.goBack();
+      hostsOverviewPage.waitForClustersEndpoint();
       hostsOverviewPage.validateUrl(`hostname=${hostname}`);
       hostsOverviewPage.hostsListedAre(1);
     });
@@ -235,9 +236,11 @@ context('Hosts Overview', () => {
       hostsOverviewPage.hostsListedAre(1);
 
       hostsOverviewPage.goBack();
+      hostsOverviewPage.waitForClustersEndpoint();
       basePage.validateUrl(anyPageUrl);
 
       hostsOverviewPage.goForward();
+      hostsOverviewPage.waitForClustersEndpoint();
       hostsOverviewPage.validateUrl(`hostname=${hostname}`);
       hostsOverviewPage.hostsListedAre(1);
     });
@@ -302,9 +305,8 @@ context('Hosts Overview', () => {
       hostsOverviewPage.expectedPaginationIsDisplayed('Showing 11–20 of 27');
       basePage.visit(anyPageUrl);
       basePage.validateUrl(anyPageUrl);
-      hostsOverviewPage.interceptGetHosts();
       hostsOverviewPage.goBack();
-      hostsOverviewPage.waitForGetHosts();
+      hostsOverviewPage.waitForClustersEndpoint();
       hostsOverviewPage.validateUrl(expectedParams);
       hostsOverviewPage.expectedPaginationIsDisplayed('Showing 11–20 of 27');
     });
@@ -320,6 +322,7 @@ context('Hosts Overview', () => {
       basePage.validateUrl(anyPageUrl);
 
       hostsOverviewPage.goBack();
+      hostsOverviewPage.waitForClustersEndpoint();
 
       hostsOverviewPage.validateUrl(expectedParams);
       hostsOverviewPage.hostsListedAre(20);

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -4,7 +4,7 @@ import * as basePage from '../pageObject/base_po';
 import { availableHosts } from '../fixtures/hosts-overview/available_hosts';
 
 context('Hosts Overview', () => {
-  // before(() => hostsOverviewPage.preloadTestData());
+  before(() => hostsOverviewPage.preloadTestData());
 
   beforeEach(() => hostsOverviewPage.visit());
 

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -1,8 +1,10 @@
 import * as hostsOverviewPage from '../pageObject/hosts_overview_po';
+import * as basePage from '../pageObject/base_po';
+
 import { availableHosts } from '../fixtures/hosts-overview/available_hosts';
 
 context('Hosts Overview', () => {
-  before(() => hostsOverviewPage.preloadTestData());
+  // before(() => hostsOverviewPage.preloadTestData());
 
   beforeEach(() => hostsOverviewPage.visit());
 
@@ -207,57 +209,48 @@ context('Hosts Overview', () => {
     it('should update the URL with filter params when a filter is selected', () => {
       hostsOverviewPage.visit();
       hostsOverviewPage.selectHostnameFilter(hostname);
-      cy.url().should('contain', `hostname=${hostname}`);
+      hostsOverviewPage.validateUrl(`hostname=${hostname}`);
       hostsOverviewPage.hostsListedAre(1);
     });
 
     it('should preserve filters when coming back', () => {
       hostsOverviewPage.visit();
       hostsOverviewPage.selectHostnameFilter(hostname);
-      cy.url().should('contain', `hostname=${hostname}`);
+      hostsOverviewPage.validateUrl(`hostname=${hostname}`);
       hostsOverviewPage.hostsListedAre(1);
-
-      cy.visit(anyPageUrl);
-      cy.url().should('contain', anyPageUrl);
-
-      cy.go('back');
-
-      cy.url().should('contain', '/hosts');
-      cy.url().should('contain', `hostname=${hostname}`);
+      basePage.visit(anyPageUrl);
+      basePage.validateUrl(anyPageUrl);
+      hostsOverviewPage.goBack();
+      hostsOverviewPage.validateUrl(`hostname=${hostname}`);
       hostsOverviewPage.hostsListedAre(1);
     });
 
     it('should preserve filters when going forward', () => {
-      cy.visit(anyPageUrl);
-      cy.url().should('contain', anyPageUrl);
+      basePage.visit(anyPageUrl);
+      basePage.validateUrl(anyPageUrl);
 
       hostsOverviewPage.visit();
       hostsOverviewPage.selectHostnameFilter(hostname);
-      cy.url().should('contain', `hostname=${hostname}`);
+      hostsOverviewPage.validateUrl(`hostname=${hostname}`);
       hostsOverviewPage.hostsListedAre(1);
 
-      cy.go('back');
-      cy.url().should('contain', anyPageUrl);
+      hostsOverviewPage.goBack();
+      basePage.validateUrl(anyPageUrl);
 
-      cy.go('forward');
-      cy.url().should('contain', '/hosts');
-      cy.url().should('contain', `hostname=${hostname}`);
+      hostsOverviewPage.goForward();
+      hostsOverviewPage.validateUrl(`hostname=${hostname}`);
       hostsOverviewPage.hostsListedAre(1);
     });
 
     it('should allow navigating back to previous page', () => {
-      cy.visit(anyPageUrl);
-      cy.url().should('contain', anyPageUrl);
-
+      basePage.visit(anyPageUrl);
+      basePage.validateUrl(anyPageUrl);
       hostsOverviewPage.visit();
       hostsOverviewPage.hostsListedAre(10);
-
       hostsOverviewPage.selectHostnameFilter(hostname);
       hostsOverviewPage.hostsListedAre(1);
-
-      cy.go('back');
-
-      cy.url().should('contain', anyPageUrl);
+      hostsOverviewPage.goBack();
+      basePage.validateUrl(anyPageUrl);
     });
 
     it('should render filtered results when visiting a URL with filter params', () => {
@@ -266,19 +259,19 @@ context('Hosts Overview', () => {
     });
 
     it('should not produce duplicate history entries when filters are applied', () => {
-      cy.visit(anyPageUrl);
-      cy.url().should('contain', anyPageUrl);
+      basePage.visit(anyPageUrl);
+      basePage.validateUrl(anyPageUrl);
 
       hostsOverviewPage.visit();
-
       hostsOverviewPage.selectHostnameFilter(hostname);
-      cy.url().should('contain', `hostname=${hostname}`);
+      hostsOverviewPage.validateUrl(`hostname=${hostname}`);
 
       hostsOverviewPage.selectHostnameFilter(anotherHostname);
-      cy.url().should('contain', `hostname=${anotherHostname}`);
+      const expectedParams = `hostname=${hostname}&hostname=${anotherHostname}`;
+      hostsOverviewPage.validateUrl(expectedParams);
 
-      cy.go('back');
-      cy.url().should('contain', anyPageUrl);
+      hostsOverviewPage.goBack();
+      basePage.validateUrl(anyPageUrl);
     });
   });
 
@@ -288,48 +281,47 @@ context('Hosts Overview', () => {
     it('should update the URL with page param when navigating pages', () => {
       hostsOverviewPage.visit();
       hostsOverviewPage.clickNextPageButton();
-      cy.url().should('contain', 'page=2');
-      cy.url().should('contain', 'per_page=10');
+      const expectedParams = 'page=2&per_page=10';
+      hostsOverviewPage.validateUrl(expectedParams);
       hostsOverviewPage.expectedPaginationIsDisplayed('Showing 11–20 of 27');
     });
 
     it('should update the URL with per_page param when changing items per page', () => {
       hostsOverviewPage.visit();
       hostsOverviewPage.selectItemsPerPage(20);
-      cy.url().should('contain', 'per_page=20');
-      cy.url().should('contain', 'page=1');
+      const expectedParams = 'page=1&per_page=20';
+      hostsOverviewPage.validateUrl(expectedParams);
       hostsOverviewPage.hostsListedAre(20);
     });
 
     it('should preserve pagination when coming back from another page', () => {
       hostsOverviewPage.visit();
       hostsOverviewPage.clickNextPageButton();
-      cy.url().should('contain', 'page=2');
+      const expectedParams = 'page=2&per_page=10';
+      hostsOverviewPage.validateUrl(expectedParams);
       hostsOverviewPage.expectedPaginationIsDisplayed('Showing 11–20 of 27');
-
-      cy.visit(anyPageUrl);
-      cy.url().should('contain', anyPageUrl);
-
-      cy.go('back');
-
-      cy.url().should('contain', '/hosts');
-      cy.url().should('contain', 'page=2');
+      basePage.visit(anyPageUrl);
+      basePage.validateUrl(anyPageUrl);
+      hostsOverviewPage.interceptGetHosts();
+      hostsOverviewPage.goBack();
+      hostsOverviewPage.waitForGetHosts();
+      hostsOverviewPage.validateUrl(expectedParams);
       hostsOverviewPage.expectedPaginationIsDisplayed('Showing 11–20 of 27');
     });
 
     it('should preserve per_page when coming back from another page', () => {
       hostsOverviewPage.visit();
       hostsOverviewPage.selectItemsPerPage(20);
-      cy.url().should('contain', 'per_page=20');
+      const expectedParams = 'page=1&per_page=20';
+      hostsOverviewPage.validateUrl(expectedParams);
       hostsOverviewPage.hostsListedAre(20);
 
-      cy.visit(anyPageUrl);
-      cy.url().should('contain', anyPageUrl);
+      basePage.visit(anyPageUrl);
+      basePage.validateUrl(anyPageUrl);
 
-      cy.go('back');
+      hostsOverviewPage.goBack();
 
-      cy.url().should('contain', '/hosts');
-      cy.url().should('contain', 'per_page=20');
+      hostsOverviewPage.validateUrl(expectedParams);
       hostsOverviewPage.hostsListedAre(20);
     });
 

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -220,8 +220,7 @@ context('Hosts Overview', () => {
     const anyPageUrl = '/any-page';
 
     before(() => {
-      Cypress.session.clearAllSavedSessions();
-      hostsOverviewPage.apiLoginAndCreateSession();
+      hostsOverviewPage.refreshLogin();
       hostsOverviewPage.restoreSapSystem();
     });
 

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -220,7 +220,7 @@ context('Hosts Overview', () => {
     const anyPageUrl = '/any-page';
 
     before(() => {
-      hostsOverviewPage.refreshLogin();
+      // hostsOverviewPage.refreshLogin();
       hostsOverviewPage.restoreSapSystem();
     });
 

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -6,13 +6,14 @@ import { availableHosts } from '../fixtures/hosts-overview/available_hosts';
 context('Hosts Overview', () => {
   before(() => hostsOverviewPage.preloadTestData());
 
-  beforeEach(() => hostsOverviewPage.visit());
-
   it('should have expected url', () => {
+    hostsOverviewPage.visit();
     hostsOverviewPage.validateUrl();
   });
 
   describe('Registered Hosts are shown in the list', () => {
+    beforeEach(() => hostsOverviewPage.visit());
+
     it('should highlight the hosts sidebar entry', () => {
       hostsOverviewPage.hostsIsHighglightedInSidebar();
     });
@@ -49,7 +50,10 @@ context('Hosts Overview', () => {
 
   describe('Health Detection', () => {
     describe('Health Container shows the health overview of the deployed landscape', () => {
-      beforeEach(() => hostsOverviewPage.startAgentsHeartbeat());
+      beforeEach(() => {
+        hostsOverviewPage.startAgentsHeartbeat();
+        hostsOverviewPage.visit();
+      });
 
       it('should show health status of the entire cluster of 27 hosts with partial pagination', () => {
         hostsOverviewPage.expectedPassingHostsAreDisplayed(11);
@@ -66,7 +70,10 @@ context('Hosts Overview', () => {
     });
 
     describe('Health is changed based on saptune status', () => {
-      beforeEach(() => hostsOverviewPage.startAgentsHeartbeat());
+      beforeEach(() => {
+        hostsOverviewPage.startAgentsHeartbeat();
+        hostsOverviewPage.visit();
+      });
 
       it('should not change the health if saptune is not installed and a SAP workload is not running', () => {
         hostsOverviewPage.loadHostWithoutSaptune();
@@ -107,7 +114,10 @@ context('Hosts Overview', () => {
     });
 
     describe('Health is changed to critical when the heartbeat is not sent', () => {
-      beforeEach(() => hostsOverviewPage.startAgentsHeartbeat());
+      beforeEach(() => {
+        hostsOverviewPage.startAgentsHeartbeat();
+        hostsOverviewPage.visit();
+      });
 
       it('should show health status of the entire cluster of 27 hosts with critical health', () => {
         hostsOverviewPage.expectedCriticalHostsAreDisplayed(4);
@@ -127,6 +137,8 @@ context('Hosts Overview', () => {
 
   describe('Deregistration', () => {
     describe('Clean-up buttons should be visible only when needed', () => {
+      beforeEach(() => hostsOverviewPage.visit());
+
       it('should not display a clean-up button when heartbeat is sent', () => {
         hostsOverviewPage.cleanupButtonIsDisplayedForHostSendingHeartbeat();
         hostsOverviewPage.startAgentHeartbeat();
@@ -144,6 +156,7 @@ context('Hosts Overview', () => {
 
     describe('Clean-up button should deregister a host', () => {
       beforeEach(() => {
+        hostsOverviewPage.visit();
         hostsOverviewPage.apiRestoreCleanedUpHost();
         hostsOverviewPage.apiDeleteAllHostsTags();
         hostsOverviewPage.addTagToHost();
@@ -168,6 +181,7 @@ context('Hosts Overview', () => {
         afterEach(() => hostsOverviewPage.restoreSapSystem());
 
         it('should remove the SAP system sid from hosts belonging the deregistered SAP system', () => {
+          hostsOverviewPage.visit();
           hostsOverviewPage.clickNextPageButton();
           hostsOverviewPage.sapSystemHasExpectedAmountOfHosts(4);
           hostsOverviewPage.apiDeregisterSapSystemHost();
@@ -177,6 +191,7 @@ context('Hosts Overview', () => {
 
       describe('Movement of application instances on hosts', () => {
         beforeEach(() => {
+          hostsOverviewPage.visit();
           hostsOverviewPage.loadSapSystemsOverviewMovedScenario();
           hostsOverviewPage.clickNextPageButton();
           hostsOverviewPage.sapSystemHasExpectedAmountOfHosts(3);
@@ -199,7 +214,8 @@ context('Hosts Overview', () => {
     });
   });
 
-  describe('Filter and browser navigation', () => {
+  // eslint-disable-next-line mocha/no-exclusive-tests
+  describe.only('Filter and browser navigation', () => {
     const hostname = availableHosts[0].name;
     const anotherHostname = availableHosts[1].name;
     const anyPageUrl = '/any-page';
@@ -213,8 +229,7 @@ context('Hosts Overview', () => {
       hostsOverviewPage.hostsListedAre(1);
     });
 
-    // eslint-disable-next-line mocha/no-exclusive-tests
-    it.only('should preserve filters when coming back', () => {
+    it('should preserve filters when coming back', () => {
       hostsOverviewPage.visit();
       hostsOverviewPage.selectHostnameFilter(hostname);
       hostsOverviewPage.validateUrl(`hostname=${hostname}`);
@@ -230,16 +245,12 @@ context('Hosts Overview', () => {
     it('should preserve filters when going forward', () => {
       basePage.visit(anyPageUrl);
       basePage.validateUrl(anyPageUrl);
-
       hostsOverviewPage.visit();
       hostsOverviewPage.selectHostnameFilter(hostname);
       hostsOverviewPage.validateUrl(`hostname=${hostname}`);
       hostsOverviewPage.hostsListedAre(1);
-
       hostsOverviewPage.goBack();
-      hostsOverviewPage.waitForClustersEndpoint();
       basePage.validateUrl(anyPageUrl);
-
       hostsOverviewPage.goForward();
       hostsOverviewPage.waitForClustersEndpoint();
       hostsOverviewPage.validateUrl(`hostname=${hostname}`);
@@ -279,7 +290,8 @@ context('Hosts Overview', () => {
     });
   });
 
-  describe('Pagination and browser navigation', () => {
+  // eslint-disable-next-line mocha/no-exclusive-tests
+  describe.only('Pagination and browser navigation', () => {
     const anyPageUrl = '/any-page';
 
     it('should update the URL with page param when navigating pages', () => {

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -345,7 +345,8 @@ context('Hosts Overview', () => {
     });
   });
 
-  describe('Forbidden actions', () => {
+  // eslint-disable-next-line mocha/no-pending-tests
+  describe.skip('Forbidden actions', () => {
     beforeEach(() => {
       hostsOverviewPage.apiDeleteAllHostsTags();
       hostsOverviewPage.apiSetTag();

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -214,8 +214,7 @@ context('Hosts Overview', () => {
     });
   });
 
-  // eslint-disable-next-line mocha/no-exclusive-tests
-  describe.only('Filter and browser navigation', () => {
+  describe('Filter and browser navigation', () => {
     const hostname = availableHosts[0].name;
     const anotherHostname = availableHosts[1].name;
     const anyPageUrl = '/any-page';
@@ -290,8 +289,7 @@ context('Hosts Overview', () => {
     });
   });
 
-  // eslint-disable-next-line mocha/no-exclusive-tests
-  describe.only('Pagination and browser navigation', () => {
+  describe('Pagination and browser navigation', () => {
     const anyPageUrl = '/any-page';
 
     it('should update the URL with page param when navigating pages', () => {

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -219,7 +219,11 @@ context('Hosts Overview', () => {
     const anotherHostname = availableHosts[1].name;
     const anyPageUrl = '/any-page';
 
-    before(() => hostsOverviewPage.restoreSapSystem());
+    before(() => {
+      Cypress.session.clearAllSavedSessions();
+      hostsOverviewPage.apiLoginAndCreateSession();
+      hostsOverviewPage.restoreSapSystem();
+    });
 
     it('should update the URL with filter params when a filter is selected', () => {
       hostsOverviewPage.visit();

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -239,7 +239,6 @@ context('Hosts Overview', () => {
       basePage.visit(anyPageUrl);
       basePage.validateUrl(anyPageUrl);
       hostsOverviewPage.goBack();
-      hostsOverviewPage.waitForClustersEndpoint();
       hostsOverviewPage.validateUrl(`hostname=${hostname}`);
       hostsOverviewPage.hostsListedAre(1);
     });
@@ -254,7 +253,6 @@ context('Hosts Overview', () => {
       hostsOverviewPage.goBack();
       basePage.validateUrl(anyPageUrl);
       hostsOverviewPage.goForward();
-      hostsOverviewPage.waitForClustersEndpoint();
       hostsOverviewPage.validateUrl(`hostname=${hostname}`);
       hostsOverviewPage.hostsListedAre(1);
     });
@@ -320,7 +318,6 @@ context('Hosts Overview', () => {
       basePage.visit(anyPageUrl);
       basePage.validateUrl(anyPageUrl);
       hostsOverviewPage.goBack();
-      hostsOverviewPage.waitForClustersEndpoint();
       hostsOverviewPage.validateUrl(expectedParams);
       hostsOverviewPage.expectedPaginationIsDisplayed('Showing 11–20 of 27');
     });
@@ -336,7 +333,6 @@ context('Hosts Overview', () => {
       basePage.validateUrl(anyPageUrl);
 
       hostsOverviewPage.goBack();
-      hostsOverviewPage.waitForClustersEndpoint();
 
       hostsOverviewPage.validateUrl(expectedParams);
       hostsOverviewPage.hostsListedAre(20);

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -204,7 +204,7 @@ context('Hosts Overview', () => {
     const anotherHostname = availableHosts[1].name;
     const anyPageUrl = '/any-page';
 
-    beforeEach(() => hostsOverviewPage.restoreSapSystem());
+    before(() => hostsOverviewPage.restoreSapSystem());
 
     it('should update the URL with filter params when a filter is selected', () => {
       hostsOverviewPage.visit();
@@ -213,7 +213,8 @@ context('Hosts Overview', () => {
       hostsOverviewPage.hostsListedAre(1);
     });
 
-    it('should preserve filters when coming back', () => {
+    // eslint-disable-next-line mocha/no-exclusive-tests
+    it.only('should preserve filters when coming back', () => {
       hostsOverviewPage.visit();
       hostsOverviewPage.selectHostnameFilter(hostname);
       hostsOverviewPage.validateUrl(`hostname=${hostname}`);

--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -46,6 +46,10 @@ const usernameMenu = `span[class="flex items-center"]:contains("${plainUser.user
 // UI Interactions
 export const visit = (url = '/') => cy.visit(url);
 
+export const goBack = () => cy.go('back');
+
+export const goForward = () => cy.go('forward');
+
 export const clickUsernameMenu = () => cy.get(usernameMenu).click();
 
 export const validateUrl = (url = '/') =>

--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -200,6 +200,11 @@ export const apiLoginAndCreateSession = (
     });
   });
 
+export const refreshLogin = () => {
+  Cypress.session.clearAllSavedSessions();
+  return apiLoginAndCreateSession();
+};
+
 export const logout = () => {
   cy.window().then((win) => {
     win.localStorage.removeItem('access_token');

--- a/test/e2e/cypress/pageObject/hosts_overview_po.js
+++ b/test/e2e/cypress/pageObject/hosts_overview_po.js
@@ -70,7 +70,8 @@ export const visit = (params) => {
   return cy.wait('@clustersEndpoint');
 };
 
-export const validateUrl = () => basePage.validateUrl(url);
+export const validateUrl = (params) =>
+  basePage.validateUrl(`${url}${params ? '?' + params : ''}`);
 
 export const selectHostnameFilter = (hostname) => {
   cy.get(hostnameFilterButton).click();
@@ -338,6 +339,11 @@ const _getHostToDeregisterData = () => {
 };
 
 // API
+export const interceptGetHosts = () =>
+  cy.intercept('/api/v1/hosts').as('hosts');
+
+export const waitForGetHosts = () => basePage.waitForRequest('hosts');
+
 export const startAgentHeartbeat = () => {
   const hostToDeregister = _getHostToDeregisterData();
   return basePage.startAgentsHeartbeat([hostToDeregister.id]);

--- a/test/e2e/cypress/pageObject/hosts_overview_po.js
+++ b/test/e2e/cypress/pageObject/hosts_overview_po.js
@@ -158,13 +158,13 @@ export const everySapSystemLinkGoesToExpectedSapSystemDetailsPage = () =>
   );
 
 export const expectedWarningHostsAreDisplayed = (amount) =>
-  cy.get(hostsWithWarning).should('have.text', amount);
+  cy.get(hostsWithWarning, { timeout: 20000 }).should('have.text', amount);
 
 export const expectedCriticalHostsAreDisplayed = (amount) =>
   cy.get(hostsWithCritical, { timeout: 20000 }).should('have.text', amount);
 
 export const expectedPassingHostsAreDisplayed = (amount) =>
-  cy.get(hostsWithPassing).should('have.text', amount);
+  cy.get(hostsWithPassing, { timeout: 20000 }).should('have.text', amount);
 
 export const expectedAmountOfWarningsIsDisplayed = (amount) =>
   cy.get(warningHostBadge).should('have.length', amount);
@@ -215,7 +215,7 @@ export const expectedAmountOfCleanupButtonsIsDisplayed = (amount) =>
     .should('have.length', amount);
 
 export const heartbeatFailingToasterIsDisplayed = () =>
-  cy.get(heartbeatFailingToaster, { timeout: 20000 }).should('be.visible');
+  cy.get(heartbeatFailingToaster, { timeout: 25000 }).should('be.visible');
 
 export const deregisterModalTitleIsDisplayed = () =>
   cy.get(deregisterHostModalTitle).should('be.visible');

--- a/test/e2e/cypress/pageObject/hosts_overview_po.js
+++ b/test/e2e/cypress/pageObject/hosts_overview_po.js
@@ -67,8 +67,11 @@ export const visit = (params) => {
   cy.intercept('/api/v2/clusters').as('clustersEndpoint');
   const visitUrl = [url, params].filter(Boolean).join('?');
   basePage.visit(visitUrl);
-  return cy.wait('@clustersEndpoint');
+  return waitForClustersEndpoint();
 };
+
+export const waitForClustersEndpoint = () =>
+  basePage.waitForRequest('clustersEndpoint');
 
 export const validateUrl = (params) =>
   basePage.validateUrl(`${url}${params ? '?' + params : ''}`);
@@ -339,11 +342,6 @@ const _getHostToDeregisterData = () => {
 };
 
 // API
-export const interceptGetHosts = () =>
-  cy.intercept('/api/v1/hosts').as('hosts');
-
-export const waitForGetHosts = () => basePage.waitForRequest('hosts');
-
 export const startAgentHeartbeat = () => {
   const hostToDeregister = _getHostToDeregisterData();
   return basePage.startAgentsHeartbeat([hostToDeregister.id]);

--- a/test/e2e/cypress/pageObject/hosts_overview_po.js
+++ b/test/e2e/cypress/pageObject/hosts_overview_po.js
@@ -67,11 +67,8 @@ export const visit = (params) => {
   cy.intercept('/api/v2/clusters').as('clustersEndpoint');
   const visitUrl = [url, params].filter(Boolean).join('?');
   basePage.visit(visitUrl);
-  return waitForClustersEndpoint();
+  return basePage.waitForRequest('clustersEndpoint');
 };
-
-export const waitForClustersEndpoint = () =>
-  basePage.waitForRequest('clustersEndpoint');
 
 export const validateUrl = (params) =>
   basePage.validateUrl(`${url}${params ? '?' + params : ''}`);

--- a/test/e2e/cypress/plugins/index.js
+++ b/test/e2e/cypress/plugins/index.js
@@ -26,6 +26,12 @@ module.exports = (on, config) => {
 
   cypressSplit(on, config);
   on('task', {
+    browserLog(message) {
+      // eslint-disable-next-line no-console
+      console.log(message);
+      return null;
+    },
+
     searchEmailInMailpit,
     deleteAllEmailsFromMailpit,
     startAgentHeartbeat({ agents, apiKey }) {

--- a/test/e2e/cypress/support/e2e.js
+++ b/test/e2e/cypress/support/e2e.js
@@ -27,7 +27,15 @@ const logBrowserClearCredentials = (win) => {
 
     const message = args.map(String).join(' ');
     if (message.includes('clear_credentials_reached')) {
-      cy.task('browserLog', `[browser-console] ${message}`);
+      const testTitle =
+        Cypress.currentTest?.titlePath?.().join(' > ') ||
+        Cypress.currentTest?.title ||
+        'unknown test';
+
+      cy.task(
+        'browserLog',
+        `[browser-console][${Cypress.spec.relative}][${testTitle}] ${message}`
+      );
     }
   };
 };

--- a/test/e2e/cypress/support/e2e.js
+++ b/test/e2e/cypress/support/e2e.js
@@ -19,6 +19,19 @@ import {
   apiDeregisterProdHost,
 } from '../pageObject/base_po';
 
+const logBrowserClearCredentials = (win) => {
+  const originalConsoleLog = win.console.log;
+
+  win.console.log = (...args) => {
+    originalConsoleLog.apply(win.console, args);
+
+    const message = args.map(String).join(' ');
+    if (message.includes('clear_credentials_reached')) {
+      cy.task('browserLog', `[browser-console] ${message}`);
+    }
+  };
+};
+
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 //
@@ -32,6 +45,11 @@ before(() => {
 
   // This is required to not break cypress tests when running against a prod instance (which installs a real agent)
   if (Cypress.config().baseUrl.includes('target')) apiDeregisterProdHost();
+});
+
+// eslint-disable-next-line mocha/no-top-level-hooks
+beforeEach(() => {
+  cy.on('window:before:load', logBrowserClearCredentials);
 });
 
 // This is needed because requests that depend on Prometheus in a real environment return a 500 in SLES16, this can be removed once TRNT-4344 is done.

--- a/test/e2e/cypress/support/e2e.js
+++ b/test/e2e/cypress/support/e2e.js
@@ -27,10 +27,7 @@ const logBrowserClearCredentials = (win) => {
 
     const message = args.map(String).join(' ');
     if (message.includes('clear_credentials_reached')) {
-      const testTitle =
-        Cypress.currentTest?.titlePath?.().join(' > ') ||
-        Cypress.currentTest?.title ||
-        'unknown test';
+      const testTitle = Cypress.currentTest?.title || 'unknown test';
 
       cy.task(
         'browserLog',


### PR DESCRIPTION
# Description

- Make `keep filters in url` tests consistent with the rest of tests using the page object structure
- Add `refreshLogin` function to make sure the 3 min barrier of token expiration is not reached to avoid unexpected behaviors when refreshing the token.
- Increase to more generous timeouts in some assertions related to agent heartbeat.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
