### PR TITLE
Add timings file for cypress split plugin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -655,6 +655,7 @@ jobs:
         env:
           SPLIT: ${{ strategy.job-total }}
           SPLIT_INDEX: ${{ strategy.job-index }}
+          SPLIT_FILE: cypress-split-timings.json
           cypress_video: false
           cypress_photofinish_binary: $(whereis photofinish | cut -d" " -f2)
         with:

--- a/test/e2e/cypress-split-timings.json
+++ b/test/e2e/cypress-split-timings.json
@@ -2,39 +2,39 @@
   "durations": [
     {
       "spec": "cypress/e2e/about.cy.js",
-      "duration": 37323
+      "duration": 37000
     },
     {
       "spec": "cypress/e2e/activity_log.cy.js",
-      "duration": 51084
+      "duration": 51000
     },
     {
       "spec": "cypress/e2e/alerting.cy.js",
-      "duration": 188
+      "duration": 0
     },
     {
       "spec": "cypress/e2e/checks_catalog.cy.js",
-      "duration": 19597
+      "duration": 20000
     },
     {
       "spec": "cypress/e2e/checks_customization.cy.js",
-      "duration": 53299
+      "duration": 53000
     },
     {
       "spec": "cypress/e2e/clusters_overview.cy.js",
-      "duration": 34919
+      "duration": 35000
     },
     {
       "spec": "cypress/e2e/databases_overview.cy.js",
-      "duration": 63361
+      "duration": 63000
     },
     {
       "spec": "cypress/e2e/hana_cluster_details.cy.js",
-      "duration": 136861
+      "duration": 137000
     },
     {
       "spec": "cypress/e2e/hana_database_details.cy.js",
-      "duration": 41612
+      "duration": 42000
     },
     {
       "spec": "cypress/e2e/hana_scale_up_checks.cy.js",
@@ -42,35 +42,35 @@
     },
     {
       "spec": "cypress/e2e/home.cy.js",
-      "duration": 39469
+      "duration": 39000
     },
     {
       "spec": "cypress/e2e/host_details.cy.js",
-      "duration": 82662
+      "duration": 83000
     },
     {
       "spec": "cypress/e2e/hosts_overview.cy.js",
-      "duration": 218727
+      "duration": 219000
     },
     {
       "spec": "cypress/e2e/sap_system_details.cy.js",
-      "duration": 36610
+      "duration": 37000
     },
     {
       "spec": "cypress/e2e/sap_systems_overview.cy.js",
-      "duration": 136724
+      "duration": 137000
     },
     {
       "spec": "cypress/e2e/saptune_details.cy.js",
-      "duration": 39094
+      "duration": 39000
     },
     {
       "spec": "cypress/e2e/settings.cy.js",
-      "duration": 151545
+      "duration": 152000
     },
     {
       "spec": "cypress/e2e/settings_integration.cy.js",
-      "duration": 440
+      "duration": 0
     },
     {
       "spec": "cypress/e2e/sso_integration.cy.js",
@@ -78,11 +78,11 @@
     },
     {
       "spec": "cypress/e2e/suse_manager_overviews.cy.js",
-      "duration": 39770
+      "duration": 40000
     },
     {
       "spec": "cypress/e2e/users.cy.js",
-      "duration": 177501
+      "duration": 178000
     }
   ]
 }

--- a/test/e2e/cypress-split-timings.json
+++ b/test/e2e/cypress-split-timings.json
@@ -1,0 +1,88 @@
+{
+  "durations": [
+    {
+      "spec": "cypress/e2e/about.cy.js",
+      "duration": 37323
+    },
+    {
+      "spec": "cypress/e2e/activity_log.cy.js",
+      "duration": 51084
+    },
+    {
+      "spec": "cypress/e2e/alerting.cy.js",
+      "duration": 188
+    },
+    {
+      "spec": "cypress/e2e/checks_catalog.cy.js",
+      "duration": 19597
+    },
+    {
+      "spec": "cypress/e2e/checks_customization.cy.js",
+      "duration": 53299
+    },
+    {
+      "spec": "cypress/e2e/clusters_overview.cy.js",
+      "duration": 34919
+    },
+    {
+      "spec": "cypress/e2e/databases_overview.cy.js",
+      "duration": 63361
+    },
+    {
+      "spec": "cypress/e2e/hana_cluster_details.cy.js",
+      "duration": 136861
+    },
+    {
+      "spec": "cypress/e2e/hana_database_details.cy.js",
+      "duration": 41612
+    },
+    {
+      "spec": "cypress/e2e/hana_scale_up_checks.cy.js",
+      "duration": 0
+    },
+    {
+      "spec": "cypress/e2e/home.cy.js",
+      "duration": 39469
+    },
+    {
+      "spec": "cypress/e2e/host_details.cy.js",
+      "duration": 82662
+    },
+    {
+      "spec": "cypress/e2e/hosts_overview.cy.js",
+      "duration": 218727
+    },
+    {
+      "spec": "cypress/e2e/sap_system_details.cy.js",
+      "duration": 36610
+    },
+    {
+      "spec": "cypress/e2e/sap_systems_overview.cy.js",
+      "duration": 136724
+    },
+    {
+      "spec": "cypress/e2e/saptune_details.cy.js",
+      "duration": 39094
+    },
+    {
+      "spec": "cypress/e2e/settings.cy.js",
+      "duration": 151545
+    },
+    {
+      "spec": "cypress/e2e/settings_integration.cy.js",
+      "duration": 440
+    },
+    {
+      "spec": "cypress/e2e/sso_integration.cy.js",
+      "duration": 0
+    },
+    {
+      "spec": "cypress/e2e/suse_manager_overviews.cy.js",
+      "duration": 39770
+    },
+    {
+      "spec": "cypress/e2e/users.cy.js",
+      "duration": 177501
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Setup cypress split plugin to balance tests that every machine would run based on the usual time they take, of course this comes with the burden of having to maintain `cypress-split-timings.json` file from time to time to make sure the tests are being balanced in the correct way, otherwise the tests are being balanced alphabetically. 

**Comparison**: this only includes test execution time; it does not include environment setup or other CI overhead. The slowest chunk is now almost 3 minutes faster

| Chunk | Previous grouping | Duration | New grouping | Estimated duration |
| --- | --- | ---: | --- | ---: |
| 1 | `about.cy.js`<br>`activity_log.cy.js`<br>`alerting.cy.js` | 1m 29s | `hosts_overview.cy.js` | 3m 39s |
| 2 | `checks_catalog.cy.js`<br>`checks_customization.cy.js`<br>`clusters_overview.cy.js` | 1m 48s | `users.cy.js` | 2m 58s |
| 3 | `databases_overview.cy.js`<br>`hana_cluster_details.cy.js`<br>`hana_database_details.cy.js` | 4m 2s | `settings.cy.js` | 2m 32s |
| 4 | `hana_scale_up_checks.cy.js`<br>`home.cy.js`<br>`host_details.cy.js` | 2m 2s | `hana_cluster_details.cy.js`<br>`sap_system_details.cy.js` | 2m 54s |
| 5 | `hosts_overview.cy.js`<br>`sap_system_details.cy.js`<br>`sap_systems_overview.cy.js` | 6m 32s | `sap_systems_overview.cy.js`<br>`clusters_overview.cy.js` | 2m 52s |
| 6 | `saptune_details.cy.js`<br>`settings.cy.js` | 3m 11s | `host_details.cy.js`<br>`suse_manager_overviews.cy.js`<br>`about.cy.js` | 2m 40s |
| 7 | `settings_integration.cy.js`<br>`sso_integration.cy.js` | 0s | `databases_overview.cy.js`<br>`hana_database_details.cy.js`<br>`saptune_details.cy.js`<br>`alerting.cy.js`<br>`hana_scale_up_checks.cy.js`<br>`settings_integration.cy.js`<br>`sso_integration.cy.js` | 2m 24s |
| 8 | `suse_manager_overviews.cy.js`<br>`users.cy.js` | 3m 37s | `checks_customization.cy.js`<br>`activity_log.cy.js`<br>`home.cy.js`<br>`checks_catalog.cy.js` | 2m 43s |


As a follow-up task, we could add a job to regenerate cypress-split-timings.json from the Cypress JUnit reports. It would read the latest E2E durations and update the timings file so we don’t have to maintain it manually.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
