### PR TITLE
[TRNT-4339] Add timezone awareness

### DIFF
--- a/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
+++ b/assets/js/common/ActivityLogOverview/ActivityLogOverview.jsx
@@ -1,6 +1,4 @@
 import React, { useState } from 'react';
-import { format } from 'date-fns';
-import { utc } from '@date-fns/utc';
 
 import {
   EOS_KEYBOARD_ARROW_RIGHT_FILLED,
@@ -20,6 +18,7 @@ import {
   LEVEL_CRITICAL,
   logLevelToLabel,
 } from '@lib/model/activityLog';
+import { formatDateTime } from '@lib/timezones';
 
 import ActivityLogDetailModal from '@common/ActivityLogDetailsModal';
 
@@ -34,17 +33,17 @@ export const logLevelToIcon = {
   ),
 };
 
-export const toRenderedEntry = (entry) => ({
+export const toRenderedEntry = (entry, timezone) => ({
   id: entry.id,
   type: entry.type,
-  time: format(new Date(entry.occurred_on), 'yyyy-MM-dd HH:mm:ss', { in: utc }),
+  time: formatDateTime(entry.occurred_on, timezone),
   message: toMessage(entry),
   user: entry.actor,
   severity: entry.severity ? logLevelToLabel[entry.severity] : LEVEL_INFO,
   metadata: entry.metadata,
 });
 
-function ActivityLogOverview({ activityLog, loading = false }) {
+function ActivityLogOverview({ activityLog, timezone, loading = false }) {
   const [selectedEntry, setEntry] = useState({});
   const [activityLogDetailModalOpen, setActivityLogDetailModalOpen] =
     useState(false);
@@ -110,7 +109,7 @@ function ActivityLogOverview({ activityLog, loading = false }) {
       />
       <Table
         config={activityLogTableConfig}
-        data={activityLog.map(toRenderedEntry)}
+        data={activityLog.map((entry) => toRenderedEntry(entry, timezone))}
         emptyStateText={loading ? 'Loading...' : 'No data available'}
         roundedTop={false}
       />

--- a/assets/js/common/ActivityLogOverview/ActivityLogOverview.test.jsx
+++ b/assets/js/common/ActivityLogOverview/ActivityLogOverview.test.jsx
@@ -210,4 +210,29 @@ describe('Activity Log Overview', () => {
     expect(screen.getByText('ID')).toBeVisible();
     expect(screen.getByText(id)).toBeVisible();
   });
+
+  it('should render entry time in the provided timezone', () => {
+    const entry = activityLogEntryFactory.build({
+      occurred_on: '2024-01-10T23:30:00Z',
+    });
+
+    render(
+      <ActivityLogOverview
+        activityLog={[entry]}
+        timezone="Pacific/Kiritimati"
+      />
+    );
+
+    expect(screen.getByText('11 Jan 2024, 13:30:00')).toBeVisible();
+  });
+
+  it('should render entry time in an extreme negative-offset timezone', () => {
+    const entry = activityLogEntryFactory.build({
+      occurred_on: '2024-01-10T08:30:00Z',
+    });
+
+    render(<ActivityLogOverview activityLog={[entry]} timezone="Etc/GMT+12" />);
+
+    expect(screen.getByText('09 Jan 2024, 20:30:00')).toBeVisible();
+  });
 });

--- a/assets/js/common/ApiKeySettingsModal/ApiKeySettingsModal.jsx
+++ b/assets/js/common/ApiKeySettingsModal/ApiKeySettingsModal.jsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { format, parseISO } from 'date-fns';
+
 import { noop } from 'lodash';
 import { EOS_INFO_OUTLINED } from 'eos-icons-react';
 import { availableSelectTimeOptions, normalizeDate } from '@lib/date';
+import { formatDateOnly } from '@lib/timezones';
 import Button from '@common/Button';
 import Modal from '@common/Modal';
 import { InputNumber } from '@common/Input';
@@ -18,6 +19,7 @@ function ApiKeySettingsModal({
   loading = false,
   onGenerate = noop,
   onClose = noop,
+  timezone,
   generatedApiKey,
   generatedApiKeyExpiration,
 }) {
@@ -162,10 +164,7 @@ function ApiKeySettingsModal({
 
                   <div className="mt-2 text-gray-600 text-sm">
                     {generatedApiKeyExpiration
-                      ? `Key will expire ${format(
-                          parseISO(generatedApiKeyExpiration),
-                          'd LLL yyyy'
-                        )}`
+                      ? `Key will expire ${formatDateOnly(generatedApiKeyExpiration, timezone)}`
                       : 'Key will never expire'}
                   </div>
                 </div>

--- a/assets/js/common/ComposedFilter/ComposedFilter.test.jsx
+++ b/assets/js/common/ComposedFilter/ComposedFilter.test.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
+import { parseDateTimeLocalToUtc } from '@lib/timezones';
 import ComposedFilter from '.';
 
 jest.setTimeout(100000);
@@ -123,7 +124,7 @@ describe('ComposedFilter component', () => {
     expect(screen.getByText('Diavola')).toBeInTheDocument();
     expect(screen.getByDisplayValue('Banana')).toBeInTheDocument();
 
-    await act(() => userEvent.click(screen.getByText('Click me')));
+    await userEvent.click(screen.getByText('Click me'));
 
     expect(screen.getByText('Filter Pasta...')).toBeInTheDocument();
     expect(screen.getByText('Filter Pizza...')).toBeInTheDocument();
@@ -158,15 +159,15 @@ describe('ComposedFilter component', () => {
     );
 
     // select Carbonara and Gricia from pasta filter
-    await act(() => userEvent.click(screen.getByText('Filter Pasta...')));
-    await act(() => userEvent.click(screen.getByText('Carbonara')));
-    await act(() => userEvent.click(screen.getByText('Gricia')));
-    await act(() => userEvent.click(screen.getByText('Carbonara, Gricia')));
+    await userEvent.click(screen.getByText('Filter Pasta...'));
+    await userEvent.click(screen.getByText('Carbonara'));
+    await userEvent.click(screen.getByText('Gricia'));
+    await userEvent.click(screen.getByText('Carbonara, Gricia'));
 
     // select Diavola from pizza filter
-    await act(() => userEvent.click(screen.getByText('Filter Pizza...')));
-    await act(() => userEvent.click(screen.getByText('Diavola')));
-    await act(() => userEvent.click(screen.getAllByText('Diavola')[0]));
+    await userEvent.click(screen.getByText('Filter Pizza...'));
+    await userEvent.click(screen.getByText('Diavola'));
+    await userEvent.click(screen.getAllByText('Diavola')[0]);
 
     // type a query in the search box
     await act(() =>
@@ -223,15 +224,15 @@ describe('ComposedFilter component', () => {
     render(<ComposedFilter filters={filters} onChange={mockOnChange} />);
 
     // select Carbonara and Gricia from pasta filter
-    await act(() => userEvent.click(screen.getByText('Filter Pasta...')));
-    await act(() => userEvent.click(screen.getByText('Carbonara')));
-    await act(() => userEvent.click(screen.getByText('Gricia')));
-    await act(() => userEvent.click(screen.getByText('Carbonara, Gricia')));
+    await userEvent.click(screen.getByText('Filter Pasta...'));
+    await userEvent.click(screen.getByText('Carbonara'));
+    await userEvent.click(screen.getByText('Gricia'));
+    await userEvent.click(screen.getByText('Carbonara, Gricia'));
 
     // select Diavola from pizza filter
-    await act(() => userEvent.click(screen.getByText('Filter Pizza...')));
-    await act(() => userEvent.click(screen.getByText('Diavola')));
-    await act(() => userEvent.click(screen.getAllByText('Diavola')[0]));
+    await userEvent.click(screen.getByText('Filter Pizza...'));
+    await userEvent.click(screen.getByText('Diavola'));
+    await userEvent.click(screen.getAllByText('Diavola')[0]);
 
     // type a query in the search box
     await act(() =>
@@ -245,7 +246,7 @@ describe('ComposedFilter component', () => {
     expect(mockOnChange).not.toHaveBeenCalled();
 
     // apply
-    await act(() => userEvent.click(screen.getByText('Apply Filter')));
+    await userEvent.click(screen.getByText('Apply Filter'));
 
     // after apply
     expect(mockOnChange).toHaveBeenCalledTimes(1);
@@ -282,15 +283,15 @@ describe('ComposedFilter component', () => {
     render(<ComposedFilter filters={filters} onChange={mockOnChange} />);
 
     // select Carbonara and Gricia from pasta filter
-    await act(() => userEvent.click(screen.getByText('Filter Pasta...')));
-    await act(() => userEvent.click(screen.getByText('Carbonara')));
-    await act(() => userEvent.click(screen.getByText('Gricia')));
-    await act(() => userEvent.click(screen.getByText('Carbonara, Gricia')));
+    await userEvent.click(screen.getByText('Filter Pasta...'));
+    await userEvent.click(screen.getByText('Carbonara'));
+    await userEvent.click(screen.getByText('Gricia'));
+    await userEvent.click(screen.getByText('Carbonara, Gricia'));
 
     // select Diavola from pizza filter
-    await act(() => userEvent.click(screen.getByText('Filter Pizza...')));
-    await act(() => userEvent.click(screen.getByText('Diavola')));
-    await act(() => userEvent.click(screen.getAllByText('Diavola')[0]));
+    await userEvent.click(screen.getByText('Filter Pizza...'));
+    await userEvent.click(screen.getByText('Diavola'));
+    await userEvent.click(screen.getAllByText('Diavola')[0]);
 
     // type a query in the search box
     await act(() =>
@@ -300,7 +301,7 @@ describe('ComposedFilter component', () => {
       )
     );
 
-    await act(() => userEvent.click(screen.getByText('Reset Filters')));
+    await userEvent.click(screen.getByText('Reset Filters'));
 
     expect(mockOnChange).toHaveBeenCalledTimes(1);
     expect(mockOnChange).toHaveBeenCalledWith({});
@@ -309,5 +310,36 @@ describe('ComposedFilter component', () => {
     expect(screen.getByText('Filter Pasta...')).toBeInTheDocument();
     expect(screen.getByText('Filter Pizza...')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Filter by frutta')).toBeInTheDocument();
+  });
+
+  it('should pass timezone to date filters', async () => {
+    const user = userEvent.setup();
+    const mockOnChange = jest.fn();
+    const timezone = 'Pacific/Kiritimati';
+    const datetime = '2024-01-10T09:30';
+    const filters = [
+      {
+        key: 'to_date',
+        type: 'date',
+        title: 'newer than',
+        prefilled: true,
+        timezone,
+      },
+    ];
+
+    render(
+      <ComposedFilter filters={filters} onChange={mockOnChange} autoApply />
+    );
+
+    await user.click(screen.getByText('Filter newer than...'));
+
+    const input = document.querySelector('input[type="datetime-local"]');
+    await user.type(input, datetime);
+
+    const expectedDate = parseDateTimeLocalToUtc(datetime, timezone);
+
+    expect(mockOnChange).toHaveBeenLastCalledWith({
+      to_date: ['custom', expectedDate],
+    });
   });
 });

--- a/assets/js/common/DateFilter/DateFilter.jsx
+++ b/assets/js/common/DateFilter/DateFilter.jsx
@@ -1,26 +1,21 @@
 import React, { Fragment, useState, useRef } from 'react';
 import classNames from 'classnames';
 import { Transition } from '@headlessui/react';
-import { utc } from '@date-fns/utc';
-import { format, parseISO } from 'date-fns';
+import { TZDate, tz } from '@date-fns/tz';
 
 import useOnClickOutside from '@hooks/useOnClickOutside';
 import { EOS_CLOSE, EOS_CHECK } from 'eos-icons-react';
+import { format, subDays, subHours } from 'date-fns';
+import { DATETIME_LOCAL_FORMAT, formatDateTime } from '@lib/timezones';
 
 import Input from '@common/Input';
 
-const oneHour = 60 * 60 * 1000;
 const preconfiguredOptions = {
-  '1h ago': () => new Date(Date.now() - oneHour),
-  '24h ago': () => new Date(Date.now() - 24 * oneHour),
-  '7d ago': () => new Date(Date.now() - 7 * 24 * oneHour),
-  '30d ago': () => new Date(Date.now() - 30 * 24 * oneHour),
+  '1h ago': () => subHours(new Date(), 1),
+  '24h ago': () => subHours(new Date(), 24),
+  '7d ago': () => subDays(new Date(), 7),
+  '30d ago': () => subDays(new Date(), 30),
 };
-
-const toHumanDate = (date) =>
-  date &&
-  date instanceof Date &&
-  format(date, 'MM/dd/yyyy hh:mm:ss a', { in: utc });
 
 const renderOptionItem = (option, placeholder) => {
   if (!option || !Array.isArray(option)) {
@@ -55,11 +50,11 @@ const parseInputOptions = (options) =>
     )
     .sort((a, b) => b[1]().getTime() - a[1]().getTime());
 
-const getSelectedOption = (options, value) => {
+const getSelectedOption = (options, value, timezone) => {
   const selectedId = Array.isArray(value) ? value[0] : value;
   if (selectedId === 'custom') {
     const date = new Date(value[1]);
-    return ['custom', date, () => toHumanDate(date)];
+    return ['custom', date, () => formatDateTime(date, timezone)];
   }
   if (typeof selectedId === 'string') {
     return options.find((option) => option[0] === selectedId);
@@ -75,18 +70,63 @@ function Tick() {
   );
 }
 
-function DateTimeInput({ value, onChange }) {
-  const dateToValue = (date) =>
-    format(date, "yyyy-MM-dd'T'HH:mm:ss.SSS", { in: utc });
+function DateTimeInput({ value, onChange, timezone }) {
+  // Transforms a datetime-local input value (which is in the user's browser timezone) to a UTC Date object in the user's profile timezone.
+  const dateTimeLocalToUtcDate = (dateTimeLocalValue) => {
+    // Example: user selected in the dropdown "2009-10-09T18:00"
+    // their profile's timezone is GMT+5,
+    // but their browser is set to GMT+2
+    if (!dateTimeLocalValue) {
+      return null;
+    }
+
+    // Parse the text input as a date in the user's local timezone
+    // Example: "2009-10-09T18:00, GMT+2" in GMT+2 is parsed as "2009-10-09T18:00, GMT+2"
+    const parsedDate = new Date(dateTimeLocalValue);
+
+    if (Number.isNaN(parsedDate.getTime())) {
+      return null;
+    }
+
+    // Transform the parsed date from the user's profile timezone to UTC, accounting for DST if applicable.
+    // Example: "2009-10-09T18:00, GMT+2" in GMT+2 is transformed to UTC to "2009-10-09T15:00, GMT+2"
+    // That is the actual UTC date corresponding to GMT+5, as "18:00"- 5 hours = "13:00" UTC, which is the same instant as "18:00" GMT+5.
+    // This date will be converted by ActivityLogPage/searchParams.js using "toISOString" to the string "2009-10-09T13:00:00.000Z", which is the format expected by the backend.
+    const utcDate = TZDate.tz(
+      timezone,
+      parsedDate.getFullYear(),
+      parsedDate.getMonth(),
+      parsedDate.getDate(),
+      parsedDate.getHours(),
+      parsedDate.getMinutes(),
+      parsedDate.getSeconds(),
+      parsedDate.getMilliseconds()
+    );
+
+    return utcDate;
+  };
+
+  // Transforms a date into a string formatted for the datetime-local input, using the user's profile timezone.
+  const dateToValue = (date) => {
+    // Example: "2009-10-09T15:00, GMT+2"
+    if (!(date instanceof Date)) {
+      return '';
+    }
+
+    // Example: the UTC date "2009-10-09T15:00, GMT+2" is transformed to the string "2026-04-16T18:21"
+    // This format is internal to the "datetime-local"
+    return format(date, DATETIME_LOCAL_FORMAT, { in: tz(timezone) });
+  };
 
   return (
     <Input
       value={value && dateToValue(value)}
       onChange={(e) => {
-        // `parseISO handles "normalization" (missing seconds or
-        // milliseconds in the string) and returns UTCDate, we then
-        // convert it to normal Date.
-        onChange(new Date(parseISO(`${e.target.value}`, { in: utc })));
+        const utcDate = dateTimeLocalToUtcDate(e.target.value);
+
+        if (utcDate) {
+          onChange(utcDate);
+        }
       }}
       type="datetime-local"
     />
@@ -126,6 +166,7 @@ function DateFilter({
   prefilled = true,
   onChange,
   className,
+  timezone,
 }) {
   const ref = useRef();
   const [open, setOpen] = useState(false);
@@ -134,7 +175,7 @@ function DateFilter({
     prefilled ? [...Object.entries(preconfiguredOptions), ...options] : options
   );
 
-  const selectedOption = getSelectedOption(parsedOptions, value);
+  const selectedOption = getSelectedOption(parsedOptions, value, timezone);
 
   useOnClickOutside(ref, () => setOpen(false));
 
@@ -248,6 +289,7 @@ function DateFilter({
                           selectedOption[0] === 'custom' &&
                           selectedOption[1]
                         }
+                        timezone={timezone}
                         onChange={(date) => onChange(['custom', date])}
                       />
                       {selectedOption && selectedOption[0] === 'custom' && (

--- a/assets/js/common/DateFilter/DateFilter.test.jsx
+++ b/assets/js/common/DateFilter/DateFilter.test.jsx
@@ -1,13 +1,9 @@
-import React, { act } from 'react';
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import { format } from 'date-fns';
+import { DEFAULT_TIMEZONE, parseDateTimeLocalToUtc } from '@lib/timezones';
 import DateFilter from '.';
-
-function as_localtime_str(utc_timestamp) {
-  return format(new Date(utc_timestamp), "yyyy-MM-dd'T'HH:mm:ss");
-}
 
 describe('DateFilter component', () => {
   it('should render with pre-configured options', async () => {
@@ -20,7 +16,7 @@ describe('DateFilter component', () => {
     // Assert that the title is rendered
     expect(screen.getByText(placeholder)).toBeInTheDocument();
 
-    await act(() => user.click(screen.getByText(placeholder)));
+    await user.click(screen.getByText(placeholder));
 
     // Assert that the options are rendered
     ['1h ago', '24h ago', '7d ago', '30d ago'].forEach((label) => {
@@ -34,9 +30,9 @@ describe('DateFilter component', () => {
 
     render(<DateFilter title="by date" prefilled onChange={mockOnChange} />);
 
-    await act(() => user.click(screen.getByText('Filter by date...')));
+    await user.click(screen.getByText('Filter by date...'));
 
-    await act(() => user.click(screen.getByText('24h ago')));
+    await user.click(screen.getByText('24h ago'));
 
     expect(mockOnChange).toHaveBeenCalledWith(['24h ago', expect.any(Date)]);
   });
@@ -81,7 +77,7 @@ describe('DateFilter component', () => {
       />
     );
 
-    await act(() => user.click(screen.getByText('Filter by date...')));
+    await user.click(screen.getByText('Filter by date...'));
 
     expect(screen.getByText('Custom')).toBeInTheDocument();
   });
@@ -105,7 +101,7 @@ describe('DateFilter component', () => {
       />
     );
 
-    await act(() => user.click(screen.getByText('Filter by date...')));
+    await user.click(screen.getByText('Filter by date...'));
 
     expect(screen.queryByText(labelToFind)).not.toBeInTheDocument();
   });
@@ -124,8 +120,8 @@ describe('DateFilter component', () => {
       />
     );
 
-    await act(() => user.click(screen.getByText('Filter by date...')));
-    await act(() => user.click(screen.getByText('my overridden item')));
+    await user.click(screen.getByText('Filter by date...'));
+    await user.click(screen.getByText('my overridden item'));
 
     expect(mockOnChange).toHaveBeenCalledWith(['30d ago', anyDate]);
   });
@@ -133,24 +129,53 @@ describe('DateFilter component', () => {
   it('should select a custom date when typed into the input field', async () => {
     const user = userEvent.setup();
     const mockOnChange = jest.fn();
+    const timezone = DEFAULT_TIMEZONE;
+    const datetime = '2024-08-14T10:21';
     const { container } = render(
-      <DateFilter title="by date" prefilled onChange={mockOnChange} />
+      <DateFilter
+        title="by date"
+        prefilled
+        onChange={mockOnChange}
+        timezone={timezone}
+      />
     );
-    await act(() => user.click(screen.getByText('Filter by date...')));
+    await user.click(screen.getByText('Filter by date...'));
     const input = container.querySelector('input[type="datetime-local"]');
-    await act(() => user.type(input, '2024-08-14T10:21'));
+    await user.type(input, datetime);
 
-    expect(mockOnChange).toHaveBeenCalledWith([
-      'custom',
-      new Date(Date.UTC(2024, 8 - 1, 14, 10, 21)),
-    ]);
+    const expectedDate = parseDateTimeLocalToUtc(datetime, timezone);
+
+    expect(mockOnChange).toHaveBeenCalledWith(['custom', expectedDate]);
+  });
+
+  it('should select a custom date with custom timezone when typed into the input field', async () => {
+    const user = userEvent.setup();
+    const timezone = 'Pacific/Kiritimati';
+    const datetime = '2024-03-31T03:30';
+    const mockOnChange = jest.fn();
+    const { container } = render(
+      <DateFilter
+        title="by date"
+        prefilled
+        onChange={mockOnChange}
+        timezone={timezone}
+      />
+    );
+
+    await user.click(screen.getByText('Filter by date...'));
+    const input = container.querySelector('input[type="datetime-local"]');
+    await user.type(input, datetime);
+
+    const expectedDate = parseDateTimeLocalToUtc(datetime, timezone);
+
+    expect(mockOnChange).toHaveBeenCalledWith(['custom', expectedDate]);
   });
 
   it.each`
-    value                                                     | expected
-    ${new Date(Date.UTC(2024, 8 - 1, 14, 15, 21))}            | ${'08/14/2024 03:21:00 PM'}
-    ${as_localtime_str(Date.UTC(2021, 1 - 1, 24, 5, 50, 23))} | ${'01/24/2021 05:50:23 AM'}
-    ${'2021-01-24T05:50:23.000Z'}                             | ${'01/24/2021 05:50:23 AM'}
+    value                                          | expected
+    ${new Date(Date.UTC(2024, 8 - 1, 14, 15, 21))} | ${'14 Aug 2024, 15:21:00'}
+    ${Date.UTC(2021, 1 - 1, 24, 5, 50, 23)}        | ${'24 Jan 2021, 05:50:23'}
+    ${'2021-01-24T05:50:23.000Z'}                  | ${'24 Jan 2021, 05:50:23'}
   `('should render the custom date ($value)', async ({ value, expected }) => {
     const mockOnChange = jest.fn();
 
@@ -160,6 +185,7 @@ describe('DateFilter component', () => {
         value={['custom', value]}
         prefilled
         onChange={mockOnChange}
+        timezone={DEFAULT_TIMEZONE}
       />
     );
 

--- a/assets/js/common/PatchList/PatchList.jsx
+++ b/assets/js/common/PatchList/PatchList.jsx
@@ -4,9 +4,9 @@ import {
   EOS_CRITICAL_BUG_OUTLINED,
   EOS_ADD_BOX_OUTLINED,
 } from 'eos-icons-react';
-import { format as formatDate } from 'date-fns';
 import classNames from 'classnames';
 import { noop } from 'lodash';
+import { formatDateOnly } from '@lib/timezones';
 
 import Button from '@common/Button';
 import Table, {
@@ -62,7 +62,7 @@ const iconFromAdvisoryType = (
   }
 };
 
-export default function PatchList({ patches, onNavigate = noop }) {
+export default function PatchList({ patches, timezone, onNavigate = noop }) {
   const [sortingColumn, setSortingColumn] = useState(null);
   const [sortDirection, setSortDirection] = useState('asc');
 
@@ -142,7 +142,7 @@ export default function PatchList({ patches, onNavigate = noop }) {
         sortable: true,
         sortDirection: sortingColumn === 'update_date' ? sortDirection : null,
         handleClick: handleUpdateDateColClick,
-        render: (content, _) => formatDate(content, 'd MMM y'),
+        render: (content, _) => formatDateOnly(content, timezone),
       },
     ],
   };

--- a/assets/js/common/PatchList/PatchList.test.jsx
+++ b/assets/js/common/PatchList/PatchList.test.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-
-import { format as formatDate } from 'date-fns';
+import { DEFAULT_TIMEZONE, formatDateOnly } from '@lib/timezones';
 
 import { relevantPatchFactory } from '@lib/test-utils/factories/relevantPatches';
 import PatchList from '.';
@@ -21,7 +20,7 @@ describe('PatchList', () => {
       }),
     ];
 
-    render(<PatchList patches={patches} />);
+    render(<PatchList patches={patches} timezone={DEFAULT_TIMEZONE} />);
 
     patches.forEach((patch) => {
       expect(
@@ -31,7 +30,7 @@ describe('PatchList', () => {
       expect(screen.getByText(patch.advisory_name)).toBeVisible();
       expect(screen.getByText(patch.advisory_synopsis)).toBeVisible();
       expect(
-        screen.getByText(formatDate(patches[0].update_date, 'd MMM y'))
+        screen.getByText(formatDateOnly(patch.update_date, DEFAULT_TIMEZONE))
       ).toBeVisible();
     });
   });
@@ -49,5 +48,16 @@ describe('PatchList', () => {
       screen.getByText(patchUnknownAdvisoryType[0].advisory_synopsis)
         .parentElement.parentElement.firstChild.firstChild
     ).toBeNull();
+  });
+
+  it('renders update date using provided non-default timezone', () => {
+    const timezone = 'Pacific/Kiritimati';
+    const patch = relevantPatchFactory.build({
+      update_date: '2024-01-10T23:30:00.000Z',
+    });
+
+    render(<PatchList patches={[patch]} timezone={timezone} />);
+
+    expect(screen.getByText('11 Jan 2024')).toBeVisible();
   });
 });

--- a/assets/js/common/PersonalAccessTokens/GenerateTokenModal.jsx
+++ b/assets/js/common/PersonalAccessTokens/GenerateTokenModal.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 
 import { noop } from 'lodash';
 import { EOS_INFO_OUTLINED } from 'eos-icons-react';
-import { format } from 'date-fns';
+import { formatDateOnly } from '@lib/timezones';
 
 import { availableSelectTimeOptions, normalizeDate } from '@lib/date';
 import Button from '@common/Button';
@@ -19,6 +19,7 @@ function GenerateTokenModal({
   isOpen = false,
   onGenerate = noop,
   onClose = noop,
+  timezone,
 }) {
   const timeOptions = availableSelectTimeOptions.map((o) => o.type);
   const [tokenName, setTokenName] = useState('');
@@ -114,7 +115,7 @@ function GenerateTokenModal({
 
           <div className="mt-2 text-gray-600 text-sm">
             {expirationDate
-              ? `Key will expire ${isValidDate(expirationDate) ? format(expirationDate, 'd LLL yyyy') : ''}`
+              ? `Key will expire ${isValidDate(expirationDate) ? formatDateOnly(expirationDate, timezone) : ''}`
               : 'Key will never expire'}
           </div>
         </div>

--- a/assets/js/common/PersonalAccessTokens/PersonalAccessTokens.jsx
+++ b/assets/js/common/PersonalAccessTokens/PersonalAccessTokens.jsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 
 import { noop } from 'lodash';
-import { format, isAfter } from 'date-fns';
+import { isAfter } from 'date-fns';
 import classNames from 'classnames';
+import { formatDateOnly } from '@lib/timezones';
 
 import Button from '@common/Button';
 
@@ -18,6 +19,7 @@ function PersonalAccessTokens({
   onDeleteToken = noop,
   onGenerateToken = noop,
   onCloseGeneratedTokenModal = noop,
+  timezone,
 }) {
   const [tokenToDelete, setTokenToDelete] = useState(null);
   const [generateTokenModalOpen, setGenerateTokenModalOpen] = useState(false);
@@ -35,6 +37,7 @@ function PersonalAccessTokens({
       />
       <GenerateTokenModal
         isOpen={generateTokenModalOpen}
+        timezone={timezone}
         onGenerate={(name, expiresAt) => {
           onGenerateToken(name, expiresAt);
           setGenerateTokenModalOpen(false);
@@ -92,7 +95,9 @@ function PersonalAccessTokens({
                         )}
                       >
                         Expires:{' '}
-                        {expiresAt ? format(expiresAt, 'd LLL yyyy') : 'Never'}
+                        {expiresAt
+                          ? formatDateOnly(expiresAt, timezone)
+                          : 'Never'}
                       </p>
                     </div>
                     <div className="flex justify-end ml-auto my-1">

--- a/assets/js/common/PersonalAccessTokens/PersonalAccessTokens.test.jsx
+++ b/assets/js/common/PersonalAccessTokens/PersonalAccessTokens.test.jsx
@@ -2,29 +2,41 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
-import { format, formatISO } from 'date-fns';
+import { formatISO } from 'date-fns';
 import { faker } from '@faker-js/faker';
 import { personalAccessTokenFactory } from '@lib/test-utils/factories';
-
+import { DEFAULT_TIMEZONE, formatDateOnly } from '@lib/timezones';
 import PersonalAccessTokens from './PersonalAccessTokens';
 
 describe('PersonalAccessTokens', () => {
   it('should show personal access tokens', () => {
     const tokens = personalAccessTokenFactory.buildList(3);
-    render(<PersonalAccessTokens personalAccessTokens={tokens} />);
+    render(
+      <PersonalAccessTokens
+        personalAccessTokens={tokens}
+        timezone={DEFAULT_TIMEZONE}
+      />
+    );
 
     expect(screen.getByText('Personal Access Tokens')).toBeInTheDocument();
 
     tokens.forEach(({ name, expires_at: expiresAt }) => {
       expect(screen.getByText(name)).toBeInTheDocument();
       expect(
-        screen.getByText(`Expires: ${format(expiresAt, 'd LLL yyyy')}`)
+        screen.getByText(
+          `Expires: ${formatDateOnly(expiresAt, DEFAULT_TIMEZONE)}`
+        )
       ).toBeInTheDocument();
     });
   });
 
   it('should show an empty list of tokens', () => {
-    render(<PersonalAccessTokens personalAccessTokens={[]} />);
+    render(
+      <PersonalAccessTokens
+        personalAccessTokens={[]}
+        timezone={DEFAULT_TIMEZONE}
+      />
+    );
 
     expect(screen.getByText('No keys issued.')).toBeInTheDocument();
   });
@@ -33,20 +45,49 @@ describe('PersonalAccessTokens', () => {
     const token = personalAccessTokenFactory.build({
       expires_at: null,
     });
-    render(<PersonalAccessTokens personalAccessTokens={[token]} />);
+    render(
+      <PersonalAccessTokens
+        personalAccessTokens={[token]}
+        timezone={DEFAULT_TIMEZONE}
+      />
+    );
 
     expect(screen.getByText('Expires: Never')).toBeInTheDocument();
+  });
+
+  it('should display token expiration date with timezone day rollover', () => {
+    const expiresAt = '2024-01-10T23:30:00.000Z';
+    const timezone = 'Pacific/Kiritimati';
+    const token = personalAccessTokenFactory.build({
+      expires_at: expiresAt,
+    });
+
+    render(
+      <PersonalAccessTokens
+        personalAccessTokens={[token]}
+        timezone={timezone}
+      />
+    );
+
+    expect(screen.getByText('Expires: 11 Jan 2024')).toBeInTheDocument();
   });
 
   it('should show expired tokens with a red color', () => {
     const token = personalAccessTokenFactory.build({
       expires_at: formatISO(faker.date.past()),
     });
-    render(<PersonalAccessTokens personalAccessTokens={[token]} />);
+    render(
+      <PersonalAccessTokens
+        personalAccessTokens={[token]}
+        timezone={DEFAULT_TIMEZONE}
+      />
+    );
 
     expect(
       screen
-        .getByText(`Expires: ${format(token.expires_at, 'd LLL yyyy')}`)
+        .getByText(
+          `Expires: ${formatDateOnly(token.expires_at, DEFAULT_TIMEZONE)}`
+        )
         .classList.toString()
     ).toContain('text-red-500');
   });
@@ -109,9 +150,11 @@ describe('PersonalAccessTokens', () => {
     await user.click(screen.getByRole('button', { name: 'generate-token' }));
 
     await user.type(screen.getByRole('textbox'), tokenName);
-    await user.click(screen.getByRole('switch'));
     await user.click(screen.getByRole('button', { name: 'Generate Token' }));
-    expect(mockOnGenerateToken).toHaveBeenCalledWith(tokenName, null);
+    expect(mockOnGenerateToken).toHaveBeenCalledWith(
+      tokenName,
+      expect.any(Date)
+    );
   });
 
   it('should show new token modal if the generated token is given', async () => {

--- a/assets/js/common/SuseManagerConfig/CertificateUploadDate.jsx
+++ b/assets/js/common/SuseManagerConfig/CertificateUploadDate.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { format } from 'date-fns';
 import { EOS_LOCK_OUTLINED } from 'eos-icons-react';
+import { formatDateOnly } from '@lib/timezones';
 
-function CertificateUploadDate({ date }) {
+function CertificateUploadDate({ date, timezone }) {
   if (!date) {
     return '-';
   }
@@ -13,7 +13,9 @@ function CertificateUploadDate({ date }) {
 
       <div>
         <div>Certificate Uploaded</div>
-        <div className="text-xs">{format(date, "'Uploaded:' dd MMM y")}</div>
+        <div className="text-xs">
+          Uploaded: {formatDateOnly(date, timezone)}
+        </div>
       </div>
     </div>
   );

--- a/assets/js/common/SuseManagerConfig/SuseManagerConfig.jsx
+++ b/assets/js/common/SuseManagerConfig/SuseManagerConfig.jsx
@@ -18,6 +18,7 @@ function SuseManagerConfig({
   url = 'https://',
   username,
   certUploadDate,
+  timezone,
   onEditClick = noop,
   clearSettingsDialogOpen = false,
   testConnectionEnabled = false,
@@ -96,7 +97,7 @@ function SuseManagerConfig({
             aria-label="suma-cacert-upload-date"
             className="col-span-2 text-gray-500 mb-3"
           >
-            <CertificateUploadDate date={certUploadDate} />
+            <CertificateUploadDate date={certUploadDate} timezone={timezone} />
           </div>
 
           <div className="font-bold">Username</div>

--- a/assets/js/common/SuseManagerConfig/SuseManagerConfig.test.jsx
+++ b/assets/js/common/SuseManagerConfig/SuseManagerConfig.test.jsx
@@ -46,6 +46,23 @@ describe('SuseManagerConfig', () => {
     expect(onEditClick).toHaveBeenCalled();
   });
 
+  it('renders certificate upload date in the provided timezone', () => {
+    const certUploadDate = '2024-01-10T23:30:00.000Z';
+    const timezone = 'Pacific/Kiritimati';
+
+    render(
+      <SuseManagerConfig
+        url={faker.internet.url()}
+        username={faker.animal.cat()}
+        certUploadDate={certUploadDate}
+        timezone={timezone}
+        userAbilities={adminUser}
+      />
+    );
+
+    expect(screen.getByText('Uploaded: 11 Jan 2024')).toBeInTheDocument();
+  });
+
   it('allows testing connection', async () => {
     const user = userEvent.setup();
 

--- a/assets/js/common/SuseManagerSettingsDialog/SuseManagerSettingsModal.jsx
+++ b/assets/js/common/SuseManagerSettingsDialog/SuseManagerSettingsModal.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { capitalize, noop } from 'lodash';
-import { format } from 'date-fns';
 import { EOS_LOCK_OUTLINED } from 'eos-icons-react';
+import { formatDateOnly } from '@lib/timezones';
 
 import {
   SUMA_PRODUCT_LABEL,
@@ -42,6 +42,7 @@ function SuseManagerSettingsModal({
   initialUsername,
   initialUrl,
   certUploadDate,
+  timezone,
   errors = defaultErrors,
   onSave = noop,
   onCancel = noop,
@@ -117,7 +118,7 @@ function SuseManagerSettingsModal({
             <div>
               <div>Certificate Uploaded</div>
               <div className="text-xs">
-                {format(certUploadDate, "'Uploaded:' dd MMM y")}
+                Uploaded: {formatDateOnly(certUploadDate, timezone)}
               </div>
             </div>
             <div className="flex flex-row grow justify-end">

--- a/assets/js/common/TimeSeriesLineChart/TimeSeriesLineChart.jsx
+++ b/assets/js/common/TimeSeriesLineChart/TimeSeriesLineChart.jsx
@@ -13,6 +13,7 @@ import ZoomPlugin from 'chartjs-plugin-zoom';
 import classNames from 'classnames';
 import 'chartjs-adapter-date-fns';
 import { Line } from 'react-chartjs-2';
+import { formatDateTime, formatTimeOnly } from '@lib/timezones';
 
 const AVAILABLE_COLORS = [
   {
@@ -61,6 +62,7 @@ function TimeSeriesLineChart({
   onIntervalChange,
   start,
   title,
+  timezone,
   yAxisMaxValue,
   yAxisLabelFormatter = (value) => value,
   yAxisScaleType = 'linear',
@@ -137,6 +139,9 @@ function TimeSeriesLineChart({
         autoSkip: true,
         autoSkipPadding: 50,
         maxRotation: 0,
+        callback: (value) => {
+          formatTimeOnly(new Date(value), timezone);
+        },
       },
       time: {
         displayFormats: {
@@ -166,6 +171,13 @@ function TimeSeriesLineChart({
         bodyAlign: 'center',
         footerAlign: 'center',
         displayColors: 'false',
+        callbacks: {
+          title: (context) => {
+            return context.length
+              ? formatDateTime(new Date(context[0].parsed.x), timezone)
+              : '';
+          },
+        },
       },
       legend: {
         position: 'bottom',

--- a/assets/js/lib/test-utils/factories/clusters.js
+++ b/assets/js/lib/test-utils/factories/clusters.js
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { Factory } from 'fishery';
-import { format } from 'date-fns';
 import { flatMap } from 'lodash';
+import { formatDateTime } from '@lib/timezones';
 
 import {
   healthEnum,
@@ -170,7 +170,7 @@ export const clusterFactory = Factory.define(({ sequence, params }) => {
     health: healthEnum(),
     selected_checks: [],
     provider: cloudProviderEnum(),
-    cib_last_written: format(faker.date.recent(), 'EEE MMM d h:mm:ss yyyy'),
+    cib_last_written: formatDateTime(faker.date.recent()),
     state: stateEnum(),
     details,
   };

--- a/assets/js/lib/test-utils/factories/hosts.js
+++ b/assets/js/lib/test-utils/factories/hosts.js
@@ -1,11 +1,10 @@
 import { faker } from '@faker-js/faker';
 import { Factory } from 'fishery';
-import { format, formatISO } from 'date-fns';
+import { formatISO } from 'date-fns';
 import { times } from 'lodash';
 
 import { healthEnum } from '.';
-
-const slesSubscriptionDateFormat = "yyyy-MMM-dd h:mm:ss 'UTC'";
+import { formatDateTime } from '@lib/timezones';
 
 const slesSubscriptionIdentifierEnum = () =>
   faker.helpers.arrayElement([
@@ -27,11 +26,11 @@ const saptuneTuningStateEnum = () =>
 
 export const slesSubscriptionFactory = Factory.define(() => ({
   arch: 'x86_64',
-  expires_at: format(faker.date.future(), slesSubscriptionDateFormat),
+  expires_at: formatDateTime(faker.date.future()),
   host_id: faker.string.uuid(),
   identifier: slesSubscriptionIdentifierEnum(),
   inserted_at: formatISO(faker.date.recent()),
-  starts_at: format(faker.date.past(), slesSubscriptionDateFormat),
+  starts_at: formatDateTime(faker.date.past()),
   status: 'Registered',
   subscription_status: 'ACTIVE',
   type: 'internal',

--- a/assets/js/lib/test-utils/factories/users.js
+++ b/assets/js/lib/test-utils/factories/users.js
@@ -20,6 +20,7 @@ export const userFactory = Factory.define(() => ({
   totp_enabled_at: formatISO(faker.date.past()),
   analytics_enabled: faker.datatype.boolean(),
   analytics_eula_enabled: faker.datatype.boolean(),
+  timezone: faker.location.timeZone(),
   last_login_at: formatISO(faker.date.past()),
   created_at: formatISO(faker.date.past()),
   updated_at: formatISO(faker.date.past()),
@@ -35,6 +36,7 @@ export const profileFactory = Factory.define(() => ({
   totp_enabled: faker.datatype.boolean(),
   analytics_enabled: faker.datatype.boolean(),
   analytics_eula_accepted: faker.datatype.boolean(),
+  timezone: faker.location.timeZone(),
   created_at: formatISO(faker.date.past()),
   updated_at: formatISO(faker.date.past()),
 }));

--- a/assets/js/lib/timezones/index.js
+++ b/assets/js/lib/timezones/index.js
@@ -1,0 +1,61 @@
+import tzdata from 'tzdata';
+import { tzName, tzOffset } from '@date-fns/tz';
+
+const DEFAULT_TIMEZONE = 'Etc/UTC';
+
+/**
+ * Generate timezone options from the IANA tzdata database.
+ * Each option includes the timezone name and current UTC offset with DST accounted for.
+ * Automatically filters out alias zones by checking if they're references to other zones.
+ */
+
+function generateTimezoneOptions() {
+  const zoneNames = Object.entries(tzdata?.zones)
+    .filter(([zone, data]) => {
+      if (typeof data === 'string') {
+        return false;
+      }
+
+      if (zone.startsWith('Etc/')) {
+        return zone === DEFAULT_TIMEZONE;
+      }
+
+      return !zone.startsWith('Factory');
+    })
+    .map(([zone]) => zone);
+
+  const now = new Date();
+  const timezoneOptions = zoneNames
+    .map((zone) => {
+      try {
+        // Current UTC offset in minutes for the timezone, accounting for DST if applicable.
+        const offsetMinutes = tzOffset(zone, now);
+
+        // Format the offset as a short label (e.g., "UTC+02:00").
+        const offsetLabel = tzName(zone, now, 'shortOffset');
+
+        // Generic timezone name to avoid DST-specific wording in the UI.
+        const tzNameLong = tzName(zone, now, 'longGeneric');
+
+        return {
+          value: zone, // "Europe/Berlin"
+          label: `${zone} - ${tzNameLong} (${offsetLabel})`, // "Europe/Berlin - Central European Time (UTC+02:00)"
+          searchLabel: zone,
+          offsetMinutes,
+        };
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean)
+    .sort(
+      (a, b) =>
+        a.offsetMinutes - b.offsetMinutes || a.value.localeCompare(b.value)
+    )
+    .map(({ offsetMinutes, ...option }) => option);
+
+  return timezoneOptions;
+}
+const timezones = generateTimezoneOptions();
+
+export { DEFAULT_TIMEZONE, generateTimezoneOptions, timezones };

--- a/assets/js/lib/timezones/index.js
+++ b/assets/js/lib/timezones/index.js
@@ -1,14 +1,18 @@
+import { tz, TZDate, tzName, tzOffset } from '@date-fns/tz';
+import { format } from 'date-fns';
 import tzdata from 'tzdata';
-import { tzName, tzOffset } from '@date-fns/tz';
 
 const DEFAULT_TIMEZONE = 'Etc/UTC';
+const DATETIME_DAY_MONTH_24H_FORMAT = 'dd MMM yyyy, HH:mm:ss'; // For formatting date and time values in the UI (e.g., "01 Jun 2024, 14:30:00")
+const DATE_DAY_MONTH_YEAR_FORMAT = 'dd MMM yyyy'; // For formatting date-only values in the UI (e.g., "01 Jun 2024")
+const TIME_24H_HH_MM_FORMAT = 'HH:mm:ss'; // For formatting time-only values in the UI (e.g., "14:30:00")
+const DATETIME_LOCAL_FORMAT = "yyyy-MM-dd'T'HH:mm"; // For parsing datetime-local input values (e.g., "2024-06-01T14:30")
 
 /**
  * Generate timezone options from the IANA tzdata database.
  * Each option includes the timezone name and current UTC offset with DST accounted for.
  * Automatically filters out alias zones by checking if they're references to other zones.
  */
-
 function generateTimezoneOptions() {
   const zoneNames = Object.entries(tzdata?.zones)
     .filter(([zone, data]) => {
@@ -56,6 +60,49 @@ function generateTimezoneOptions() {
 
   return timezoneOptions;
 }
+
+// Parse datetime-local string (YYYY-MM-DDTHH:mm) as a date in timezone
+function parseDateTimeLocalToUtc(dateTimeLocalValue, timezone) {
+  const [datePart, timePart] = dateTimeLocalValue.split('T');
+  const [year, month, day] = datePart.split('-').map(Number);
+  const [hour, minute] = timePart.split(':').map(Number);
+
+  const zonedDate = new TZDate(year, month - 1, day, hour, minute, 0, timezone);
+  return new Date(zonedDate.getTime());
+}
+
 const timezones = generateTimezoneOptions();
 
-export { DEFAULT_TIMEZONE, generateTimezoneOptions, timezones };
+// Internal helper to format a date with a given format and timezone
+function formatWithTimezone(date, formatStr, timezone) {
+  return format(date, formatStr, { in: tz(timezone) });
+}
+
+// formatDateTime formats returns, in the specified timezone, a date formatted as "dd MMM yyyy, HH:mm:ss"
+function formatDateTime(date, timezone = DEFAULT_TIMEZONE) {
+  return formatWithTimezone(date, DATETIME_DAY_MONTH_24H_FORMAT, timezone);
+}
+
+// formatDateOnly returns, in the specified timezone, a date formatted as "dd MMM yyyy"
+function formatDateOnly(date, timezone = DEFAULT_TIMEZONE) {
+  return formatWithTimezone(date, DATE_DAY_MONTH_YEAR_FORMAT, timezone);
+}
+
+// formatTimeOnly returns, in the specified timezone, a date formatted as "HH:mm:ss"
+function formatTimeOnly(date, timezone = DEFAULT_TIMEZONE) {
+  return formatWithTimezone(date, TIME_24H_HH_MM_FORMAT, timezone);
+}
+
+export {
+  DATETIME_DAY_MONTH_24H_FORMAT,
+  DATETIME_LOCAL_FORMAT,
+  DATE_DAY_MONTH_YEAR_FORMAT,
+  DEFAULT_TIMEZONE,
+  TIME_24H_HH_MM_FORMAT,
+  formatDateOnly,
+  formatDateTime,
+  formatTimeOnly,
+  generateTimezoneOptions,
+  parseDateTimeLocalToUtc,
+  timezones,
+};

--- a/assets/js/lib/timezones/index.js
+++ b/assets/js/lib/timezones/index.js
@@ -93,14 +93,39 @@ function formatTimeOnly(date, timezone = DEFAULT_TIMEZONE) {
   return formatWithTimezone(date, TIME_24H_HH_MM_FORMAT, timezone);
 }
 
+// Compute browser/profile offsets
+function computeTimezoneOffsets(selectedTimezone, now = new Date()) {
+  const browserUtcOffset = -now.getTimezoneOffset();
+  const profileUtcOffset =
+    selectedTimezone && selectedTimezone.value
+      ? tzOffset(selectedTimezone.value, now)
+      : null;
+
+  return { browserUtcOffset, profileUtcOffset };
+}
+
+// Directly formats offsets, e.g. -120 -> "-02:00",
+// instead of relying on tzName or format,
+// which can return different formats based on the locale and DST status.
+function formatOffset(offsetMinutes) {
+  const sign = offsetMinutes < 0 ? '-' : '+';
+  const abs = Math.abs(offsetMinutes);
+  const hours = String(Math.trunc(abs / 60)).padStart(2, '0');
+  const minutes = String(abs % 60).padStart(2, '0');
+
+  return `${sign}${hours}:${minutes}`;
+}
+
 export {
   DATETIME_DAY_MONTH_24H_FORMAT,
   DATETIME_LOCAL_FORMAT,
   DATE_DAY_MONTH_YEAR_FORMAT,
   DEFAULT_TIMEZONE,
   TIME_24H_HH_MM_FORMAT,
+  computeTimezoneOffsets,
   formatDateOnly,
   formatDateTime,
+  formatOffset,
   formatTimeOnly,
   generateTimezoneOptions,
   parseDateTimeLocalToUtc,

--- a/assets/js/lib/timezones/index.test.js
+++ b/assets/js/lib/timezones/index.test.js
@@ -1,0 +1,135 @@
+describe('generateTimezoneOptions', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('keeps canonical zones, excludes aliases, and preserves Etc/UTC only among Etc zones', () => {
+    jest.doMock('tzdata', () => ({
+      zones: {
+        'Etc/UTC': [0],
+        'Etc/GMT+1': [0],
+        'Europe/Berlin': [0],
+        'America/New_York': [0],
+        Factory: [0],
+        'America/Argentina/Cordoba': 'America/Cordoba',
+      },
+    }));
+
+    jest.doMock('@date-fns/tz', () => ({
+      tzOffset: (zone) =>
+        ({
+          'Etc/UTC': 0,
+          'Europe/Berlin': 120,
+          'America/New_York': -240,
+        })[zone],
+      tzName: (zone, _date, type) => {
+        const names = {
+          'Etc/UTC': {
+            shortOffset: 'UTC+00:00',
+            longGeneric: 'Coordinated Universal Time',
+          },
+          'Europe/Berlin': {
+            shortOffset: 'UTC+02:00',
+            longGeneric: 'Central European Time',
+          },
+          'America/New_York': {
+            shortOffset: 'UTC-04:00',
+            longGeneric: 'Eastern Time',
+          },
+        };
+        return names[zone][type];
+      },
+    }));
+
+    let generateTimezoneOptions;
+    jest.isolateModules(() => {
+      ({ generateTimezoneOptions } = require('./index'));
+    });
+
+    expect(generateTimezoneOptions()).toEqual([
+      {
+        value: 'America/New_York',
+        label: 'America/New_York - Eastern Time (UTC-04:00)',
+        searchLabel: 'America/New_York',
+      },
+      {
+        value: 'Etc/UTC',
+        label: 'Etc/UTC - Coordinated Universal Time (UTC+00:00)',
+        searchLabel: 'Etc/UTC',
+      },
+      {
+        value: 'Europe/Berlin',
+        label: 'Europe/Berlin - Central European Time (UTC+02:00)',
+        searchLabel: 'Europe/Berlin',
+      },
+    ]);
+  });
+
+  it('sorts by UTC offset and then alphabetically by zone', () => {
+    jest.doMock('tzdata', () => ({
+      zones: {
+        'Zone/B': [0],
+        'Zone/A': [0],
+        'Zone/C': [0],
+      },
+    }));
+
+    jest.doMock('@date-fns/tz', () => ({
+      tzOffset: (zone) =>
+        ({
+          'Zone/C': -60,
+          'Zone/A': 0,
+          'Zone/B': 0,
+        })[zone],
+      tzName: (_zone, _date, type) =>
+        type === 'shortOffset' ? 'UTC+00:00' : 'Mock Timezone',
+    }));
+
+    let generateTimezoneOptions;
+    jest.isolateModules(() => {
+      ({ generateTimezoneOptions } = require('./index'));
+    });
+
+    expect(generateTimezoneOptions().map(({ value }) => value)).toEqual([
+      'Zone/C',
+      'Zone/A',
+      'Zone/B',
+    ]);
+  });
+
+  it('skips zones that throw while computing labels', () => {
+    jest.doMock('tzdata', () => ({
+      zones: {
+        'Etc/UTC': [0],
+        'Broken/Zone': [0],
+      },
+    }));
+
+    jest.doMock('@date-fns/tz', () => ({
+      tzOffset: () => 0,
+      tzName: (zone, _date, type) => {
+        if (zone === 'Broken/Zone') {
+          throw new RangeError('Invalid time zone');
+        }
+
+        return type === 'shortOffset'
+          ? 'UTC+00:00'
+          : 'Coordinated Universal Time';
+      },
+    }));
+
+    let generateTimezoneOptions;
+    jest.isolateModules(() => {
+      ({ generateTimezoneOptions } = require('./index'));
+    });
+
+    expect(generateTimezoneOptions()).toEqual([
+      {
+        value: 'Etc/UTC',
+        label: 'Etc/UTC - Coordinated Universal Time (UTC+00:00)',
+        searchLabel: 'Etc/UTC',
+      },
+    ]);
+  });
+});

--- a/assets/js/lib/timezones/index.test.js
+++ b/assets/js/lib/timezones/index.test.js
@@ -1,6 +1,12 @@
 import { DEFAULT_TIMEZONE, parseDateTimeLocalToUtc } from './index';
 
-import { formatDateTime, formatDateOnly, formatTimeOnly } from './index';
+import {
+  formatDateTime,
+  formatDateOnly,
+  formatTimeOnly,
+  formatOffset,
+  computeTimezoneOffsets,
+} from './index';
 
 describe('timezone format constants', () => {
   const sampleDate = new Date('2024-08-04T10:21:00.123Z');
@@ -17,6 +23,48 @@ describe('timezone format constants', () => {
 
   it('formatTimeOnly returns correct string', () => {
     expect(formatTimeOnly(sampleDate, DEFAULT_TIMEZONE)).toBe('10:21:00');
+  });
+});
+
+describe('computeTimezoneOffsets', () => {
+  it('returns browser offset and null profile when no timezone selected', () => {
+    const now = new Date('2009-10-09T21:00:00.000Z');
+    now.getTimezoneOffset = () => -120;
+
+    const res = computeTimezoneOffsets(null, now);
+
+    expect(res).toEqual({
+      browserUtcOffset: 120,
+      profileUtcOffset: null,
+    });
+  });
+
+  it('returns both browser and profile offsets when timezone selected', () => {
+    const now = new Date('2009-10-09T21:00:00.000Z');
+    now.getTimezoneOffset = () => -120;
+
+    const res = computeTimezoneOffsets({ value: 'Europe/Berlin' }, now);
+
+    expect(res).toEqual({
+      browserUtcOffset: 120,
+      profileUtcOffset: 120,
+    });
+  });
+});
+
+describe('formatOffset', () => {
+  it('formats positive offsets correctly', () => {
+    expect(formatOffset(120)).toBe('+02:00');
+    expect(formatOffset(30)).toBe('+00:30');
+  });
+
+  it('formats negative offsets correctly', () => {
+    expect(formatOffset(-90)).toBe('-01:30');
+    expect(formatOffset(-0)).toBe('+00:00');
+  });
+
+  it('formats zero offset as +00:00', () => {
+    expect(formatOffset(0)).toBe('+00:00');
   });
 });
 

--- a/assets/js/lib/timezones/index.test.js
+++ b/assets/js/lib/timezones/index.test.js
@@ -1,3 +1,44 @@
+import { DEFAULT_TIMEZONE, parseDateTimeLocalToUtc } from './index';
+
+import { formatDateTime, formatDateOnly, formatTimeOnly } from './index';
+
+describe('timezone format constants', () => {
+  const sampleDate = new Date('2024-08-04T10:21:00.123Z');
+
+  it('formatDateTime returns correct string', () => {
+    expect(formatDateTime(sampleDate, DEFAULT_TIMEZONE)).toBe(
+      '04 Aug 2024, 10:21:00'
+    );
+  });
+
+  it('formatDateOnly returns correct string', () => {
+    expect(formatDateOnly(sampleDate, DEFAULT_TIMEZONE)).toBe('04 Aug 2024');
+  });
+
+  it('formatTimeOnly returns correct string', () => {
+    expect(formatTimeOnly(sampleDate, DEFAULT_TIMEZONE)).toBe('10:21:00');
+  });
+});
+
+describe('parseDateTimeLocalToUtc', () => {
+  it('parses datetime-local as UTC when timezone is Etc/UTC', () => {
+    const d = parseDateTimeLocalToUtc('2024-08-14T21:00', 'Etc/UTC');
+    expect(d.toISOString()).toBe('2024-08-14T21:00:00.000Z');
+  });
+
+  it('parses datetime-local in Europe/Berlin (UTC+02:00) to correct UTC', () => {
+    const d = parseDateTimeLocalToUtc('2024-08-14T21:00', 'Europe/Berlin');
+    // 21:00 in Berlin (UTC+2) is 19:00 UTC
+    expect(d.toISOString()).toBe('2024-08-14T19:00:00.000Z');
+  });
+
+  it('parses datetime-local in Pacific/Kiritimati (UTC+14) to correct UTC', () => {
+    const d = parseDateTimeLocalToUtc('2024-03-31T03:30', 'Pacific/Kiritimati');
+    // 03:30 in UTC+14 is previous day 13:30 UTC
+    expect(d.toISOString()).toBe('2024-03-30T13:30:00.000Z');
+  });
+});
+
 describe('generateTimezoneOptions', () => {
   afterEach(() => {
     jest.resetModules();

--- a/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
+++ b/assets/js/pages/ActivityLogPage/ActivityLogPage.jsx
@@ -86,6 +86,7 @@ function MainView({
   itemsPerPage,
   onPageChange,
   onChangeItemsPerPage,
+  timezone,
 }) {
   if (status === 'initial') {
     return <> </>;
@@ -118,7 +119,7 @@ function MainView({
   const { data, pagination } = response;
   return (
     <>
-      <ActivityLogOverview activityLog={data} />
+      <ActivityLogOverview activityLog={data} timezone={timezone} />
       <Pagination
         className="rounded-b-lg"
         hasPrev={pagination?.has_previous_page}
@@ -189,7 +190,7 @@ function ActivityLogPage() {
   );
   const [isFirstPage, setIsFirstPage] = useState(true);
   const [autorefreshInterval, setAutorefreshInterval] = useState(null);
-  const { abilities } = useSelector(getUserProfile);
+  const { abilities, timezone } = useSelector(getUserProfile);
 
   const searchInfo = (
     <div className="text-center">
@@ -250,6 +251,7 @@ function ActivityLogPage() {
       title: 'newer than',
       type: 'date',
       prefilled: true,
+      timezone,
       className: 'col-span-1',
     },
     {
@@ -257,6 +259,7 @@ function ActivityLogPage() {
       title: 'older than',
       type: 'date',
       prefilled: true,
+      timezone,
       className: 'col-span-1',
     },
   ];
@@ -353,6 +356,7 @@ function ActivityLogPage() {
         <MainView
           request={activityLogRequest}
           itemsPerPage={itemsPerPage}
+          timezone={timezone}
           onPageChange={pipe(
             setPaginationToSearchParams(searchParams),
             setSearchParams

--- a/assets/js/pages/ActivityLogPage/ActivityLogPage.test.jsx
+++ b/assets/js/pages/ActivityLogPage/ActivityLogPage.test.jsx
@@ -2,6 +2,7 @@ import React, { act } from 'react';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
+import { parseDateTimeLocalToUtc } from '@lib/timezones';
 
 import MockAdapter from 'axios-mock-adapter';
 
@@ -152,5 +153,46 @@ describe('ActivityLogPage', () => {
           : expect(autorefreshButton).toBeDisabled();
       }
     );
+  });
+
+  it('should send to_date as timezone-aware ISO when custom date is selected', async () => {
+    const user = userEvent.setup();
+    const timezone = 'Pacific/Kiritimati';
+    const datetime = '2024-08-14T21:00';
+    const onGetSpy = jest.spyOn(networkClient, 'get');
+
+    axiosMock.onGet('/api/v1/activity_log').reply(200, { data: [] });
+
+    const [StatefulActivityLogPage] = withState(<ActivityLogPage />, {
+      ...defaultInitialState,
+      user: {
+        ...defaultInitialState.user,
+        timezone,
+      },
+    });
+
+    await act(() => renderWithRouter(StatefulActivityLogPage));
+
+    await user.click(screen.getByText('Filter newer than...'));
+
+    const input = document.querySelector('input[type="datetime-local"]');
+    await user.type(input, datetime);
+    await user.click(screen.getByText('Apply Filter'));
+
+    const expectedToDate = parseDateTimeLocalToUtc(
+      datetime,
+      timezone
+    ).toISOString();
+
+    expect(onGetSpy).toHaveBeenLastCalledWith(
+      '/activity_log',
+      expect.objectContaining({
+        params: expect.objectContaining({
+          to_date: expectedToDate,
+        }),
+      })
+    );
+
+    onGetSpy.mockRestore();
   });
 });

--- a/assets/js/pages/AdvisoryDetails/AdvisoryDetails.jsx
+++ b/assets/js/pages/AdvisoryDetails/AdvisoryDetails.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { format } from 'date-fns';
+import { formatDateOnly } from '@lib/timezones';
 
 import PageHeader from '@common/PageHeader';
 import ListView from '@common/ListView';
@@ -16,6 +16,7 @@ function AdvisoryDetails({
   advisoryName,
   errata,
   affectsPackageMaintenanceStack,
+  timezone,
 }) {
   const {
     issue_date: issueDate,
@@ -52,7 +53,7 @@ function AdvisoryDetails({
             data={[
               {
                 title: 'Issued',
-                content: format(issueDate, 'd MMM y'),
+                content: formatDateOnly(issueDate, timezone),
               },
               {
                 title: 'Status',
@@ -60,7 +61,7 @@ function AdvisoryDetails({
               },
               {
                 title: 'Updated',
-                content: format(updateDate, 'd MMM y'),
+                content: formatDateOnly(updateDate, timezone),
               },
               {
                 title: 'Reboot Required',

--- a/assets/js/pages/AdvisoryDetails/AdvisoryDetails.test.jsx
+++ b/assets/js/pages/AdvisoryDetails/AdvisoryDetails.test.jsx
@@ -39,6 +39,31 @@ describe('AdvisoryDetails', () => {
     expect(screen.getByText(errata.errata_details.description)).toBeVisible();
   });
 
+  it('renders issued and updated dates using the provided timezone', () => {
+    const timezone = 'Pacific/Kiritimati';
+    const errata = advisoryErrataFactory.build({
+      errata_details: {
+        issue_date: '2024-01-10T23:30:00.000Z',
+        update_date: '2024-01-11T23:30:00.000Z',
+      },
+    });
+
+    render(
+      <AdvisoryDetails
+        advisoryName={faker.lorem.word()}
+        errata={errata}
+        timezone={timezone}
+      />
+    );
+
+    expect(screen.getByText('Issued').nextSibling).toHaveTextContent(
+      '11 Jan 2024'
+    );
+    expect(screen.getByText('Updated').nextSibling).toHaveTextContent(
+      '12 Jan 2024'
+    );
+  });
+
   it('displays affected packages', () => {
     const errata = advisoryErrataFactory.build();
     const advisoryName = faker.lorem.word();

--- a/assets/js/pages/AdvisoryDetails/AdvisoryDetailsPage.jsx
+++ b/assets/js/pages/AdvisoryDetails/AdvisoryDetailsPage.jsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router';
+import { useSelector } from 'react-redux';
 
 import { getAdvisoryErrata } from '@lib/api/softwareUpdates';
 import * as history from '@lib/history';
 import BackButton from '@common/BackButton';
 import GenericError from '@common/GenericError';
+import { getUserProfile } from '@state/selectors/user';
 import AdvisoryDetails from './AdvisoryDetails';
 
 function AdvisoryDetailsPage() {
@@ -13,6 +15,7 @@ function AdvisoryDetailsPage() {
   const [error, setError] = useState(undefined);
   const [isLoading, setIsLoading] = useState(true);
   const { hostID, advisoryID } = useParams();
+  const { timezone } = useSelector(getUserProfile);
 
   useEffect(() => {
     getAdvisoryErrata(advisoryID)
@@ -39,7 +42,11 @@ function AdvisoryDetailsPage() {
         Back
       </BackButton>
       {!isLoading && !error && (
-        <AdvisoryDetails advisoryName={advisoryID} errata={advisoryErrata} />
+        <AdvisoryDetails
+          advisoryName={advisoryID}
+          errata={advisoryErrata}
+          timezone={timezone}
+        />
       )}
       {!isLoading && error && <GenericError message={error} />}
     </>

--- a/assets/js/pages/CheckResultsOverview/CheckResultsOverview.jsx
+++ b/assets/js/pages/CheckResultsOverview/CheckResultsOverview.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { format } from 'date-fns';
 
 import Spinner from '@common/Spinner';
+import { formatDateTime } from '@lib/timezones';
 import {
   REQUESTED_EXECUTION_STATE,
   RUNNING_EXECUTION_STATE,
@@ -15,6 +15,7 @@ const pendingStates = [RUNNING_EXECUTION_STATE, REQUESTED_EXECUTION_STATE];
 function CheckResultsOverview({
   data,
   catalogDataEmpty = false,
+  timezone,
   loading = false,
   error = null,
   onCheckClick,
@@ -65,7 +66,7 @@ function CheckResultsOverview({
     <div className="flex flex-col items-center">
       <h1 className="text-center text-2xl font-bold">Check Results</h1>
       <h6 className="opacity-60 text-xs">
-        {format(new Date(data.completed_at), 'iii MMM dd, HH:mm:ss y')}
+        {formatDateTime(data.completed_at, timezone)}
       </h6>
 
       <div className="flex flex-col self-start w-full px-4 mt-2">

--- a/assets/js/pages/CheckResultsOverview/CheckResultsOverview.test.jsx
+++ b/assets/js/pages/CheckResultsOverview/CheckResultsOverview.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { DEFAULT_TIMEZONE } from '@lib/timezones';
 
 import { faker } from '@faker-js/faker';
 
@@ -65,16 +66,22 @@ describe('CheckResultsOverview component', () => {
     const passing_count = faker.number.int();
     const warning_count = faker.number.int();
     const critical_count = faker.number.int();
+    const completedAt = '2024-01-10T23:30:00Z';
 
     const data = {
-      completed_at: faker.date.past().toISOString(),
+      completed_at: completedAt,
       passing_count,
       warning_count,
       critical_count,
       status: 'completed',
     };
-
-    render(<CheckResultsOverview data={data} catalogDataEmpty={false} />);
+    render(
+      <CheckResultsOverview
+        data={data}
+        catalogDataEmpty={false}
+        timezone={DEFAULT_TIMEZONE}
+      />
+    );
 
     expect(screen.getByText('Passing')).toBeVisible();
     expect(screen.getByText(passing_count)).toBeVisible();
@@ -82,5 +89,28 @@ describe('CheckResultsOverview component', () => {
     expect(screen.getByText(warning_count)).toBeVisible();
     expect(screen.getByText('Critical')).toBeVisible();
     expect(screen.getByText(critical_count)).toBeVisible();
+    expect(screen.getByText('10 Jan 2024, 23:30:00')).toBeVisible();
+  });
+
+  it('should display completion time using provided timezone', () => {
+    const completedAt = '2024-01-10T23:30:00Z';
+    const data = {
+      completed_at: completedAt,
+      passing_count: faker.number.int(),
+      warning_count: faker.number.int(),
+      critical_count: faker.number.int(),
+      status: 'completed',
+    };
+
+    render(
+      <CheckResultsOverview
+        data={data}
+        catalogDataEmpty={false}
+        timezone="Pacific/Kiritimati"
+      />
+    );
+
+    // UTC+14 shifts this timestamp to the next day: 10 Jan -> 11 Jan.
+    expect(screen.getByText('11 Jan 2024, 13:30:00')).toBeVisible();
   });
 });

--- a/assets/js/pages/ClusterDetails/AscsErsClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/AscsErsClusterDetails.jsx
@@ -4,6 +4,7 @@ import { capitalize, get, noop } from 'lodash';
 import { OPERATION_NOT_ALLOWED_HOST } from '@lib/operations';
 import { isHeartbeatPassing } from '@lib/model/hosts';
 import { getEnsaVersionLabel, APPLICATION_TYPE } from '@lib/model/sapSystems';
+import { formatDateTime } from '@lib/timezones';
 
 import DottedPagination from '@common/DottedPagination';
 import ListView from '@common/ListView';
@@ -88,6 +89,7 @@ function AscsErsClusterDetails({
   catalog,
   lastExecution,
   userAbilities = [],
+  timezone,
   navigate = () => {},
   getClusterHostOperations = noop,
 }) {
@@ -143,7 +145,9 @@ function AscsErsClusterDetails({
 
               {
                 title: 'CIB last written',
-                content: cibLastWritten || '-',
+                content: cibLastWritten
+                  ? formatDateTime(cibLastWritten, timezone)
+                  : '-',
               },
             ]}
           />
@@ -194,6 +198,7 @@ function AscsErsClusterDetails({
           <CheckResultsOverview
             data={executionData}
             catalogDataEmpty={catalogData?.length === 0}
+            timezone={timezone}
             loading={catalogLoading || executionLoading}
             error={catalogError || executionError}
             onCheckClick={(health) =>

--- a/assets/js/pages/ClusterDetails/AscsErsClusterDetails.test.jsx
+++ b/assets/js/pages/ClusterDetails/AscsErsClusterDetails.test.jsx
@@ -12,6 +12,7 @@ import {
   ascsErsClusterDetailsFactory,
   clusterFactory,
 } from '@lib/test-utils/factories';
+import { DEFAULT_TIMEZONE } from '@lib/timezones';
 
 import { providerData } from '@common/ProviderLabel/ProviderLabel';
 
@@ -25,6 +26,7 @@ describe('ClusterDetails AscsErsClusterDetails component', () => {
       details,
     } = clusterFactory.build({
       type: 'ascs_ers',
+      cib_last_written: '2025-04-09T02:32:05Z',
     });
 
     const {
@@ -43,6 +45,7 @@ describe('ClusterDetails AscsErsClusterDetails component', () => {
         hosts={buildHostsFromAscsErsClusterDetails(details)}
         sapSystems={sapSystems}
         details={details}
+        timezone={DEFAULT_TIMEZONE}
       />
     );
 
@@ -53,7 +56,7 @@ describe('ClusterDetails AscsErsClusterDetails component', () => {
       'ASCS/ERS'
     );
     expect(screen.getByText('CIB last written').nextSibling).toHaveTextContent(
-      cibLastWritten
+      '09 Apr 2025, 02:32:05'
     );
     expect(
       screen.getByText('Cluster maintenance').nextSibling
@@ -259,5 +262,31 @@ describe('ClusterDetails AscsErsClusterDetails component', () => {
         expect(element).toBeInTheDocument();
       });
     });
+  });
+
+  it('should format CIB last written using provided timezone', () => {
+    const {
+      cib_last_written: cibLastWritten,
+      provider,
+      details,
+    } = clusterFactory.build({
+      type: 'ascs_ers',
+      cib_last_written: '2024-01-10T23:30:00Z',
+    });
+
+    renderWithRouter(
+      <AscsErsClusterDetails
+        cibLastWritten={cibLastWritten}
+        provider={provider}
+        hosts={buildHostsFromAscsErsClusterDetails(details)}
+        sapSystems={buildSapSystemsFromAscsErsClusterDetails(details)}
+        details={details}
+        timezone="Pacific/Kiritimati"
+      />
+    );
+
+    expect(screen.getByText('CIB last written').nextSibling).toHaveTextContent(
+      '11 Jan 2024, 13:30:00'
+    );
   });
 });

--- a/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
@@ -75,7 +75,7 @@ export function ClusterDetailsPage() {
     getFilesystemType(state, clusterID)
   );
 
-  const { abilities } = useSelector(getUserProfile);
+  const { abilities, timezone } = useSelector(getUserProfile);
 
   useEffect(() => {
     const env = buildEnv({
@@ -165,6 +165,7 @@ export function ClusterDetailsPage() {
         lastExecution={lastExecution}
         sapSystems={clusterSapSystems}
         userAbilities={abilities}
+        timezone={timezone}
         navigate={navigate}
         // the following props are specific to hana details
         clusterSids={getClusterSids(cluster)}

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.jsx
@@ -7,6 +7,7 @@ import ListView from '@common/ListView';
 import ProviderLabel from '@common/ProviderLabel';
 import ClusterTypeLabel from '@common/ClusterTypeLabel';
 import SapSystemLink from '@common/SapSystemLink';
+import { formatDateTime } from '@lib/timezones';
 
 import CheckResultsOverview from '@pages/CheckResultsOverview';
 
@@ -40,6 +41,7 @@ function HanaClusterDetails({
   catalog,
   lastExecution,
   userAbilities,
+  timezone,
   navigate = noop,
   getClusterHostOperations = noop,
 }) {
@@ -114,7 +116,9 @@ function HanaClusterDetails({
               },
               {
                 title: 'CIB last written',
-                content: cibLastWritten || '-',
+                content: cibLastWritten
+                  ? formatDateTime(cibLastWritten, timezone)
+                  : '-',
               },
               {
                 title: 'HANA log replication mode',
@@ -135,6 +139,7 @@ function HanaClusterDetails({
           <CheckResultsOverview
             data={executionData}
             catalogDataEmpty={catalogData?.length === 0}
+            timezone={timezone}
             loading={catalogLoading || executionLoading}
             error={catalogError || executionError}
             onCheckClick={(health) =>

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.test.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.test.jsx
@@ -414,4 +414,35 @@ describe('HanaClusterDetails component', () => {
     // as we consider the one from the cluster more reliable (it's coming from the DC node)
     expect(container.querySelectorAll('.tn-online')).toHaveLength(hosts.length);
   });
+
+  it('should format CIB last written using provided timezone', () => {
+    const {
+      clusterID,
+      type: clusterType,
+      sap_instances: [{ sid }],
+      provider,
+      details,
+    } = clusterFactory.build({ cib_last_written: '2024-01-10T23:30:00Z' });
+
+    const hosts = hostFactory.buildList(2, { cluster_id: clusterID });
+
+    renderWithRouter(
+      <HanaClusterDetails
+        clusterID={clusterID}
+        hosts={hosts}
+        clusterType={clusterType}
+        cibLastWritten="2024-01-10T23:30:00Z"
+        clusterSids={[sid]}
+        provider={provider}
+        sapSystems={[]}
+        details={details}
+        timezone="Pacific/Kiritimati"
+        lastExecution={null}
+      />
+    );
+
+    expect(screen.getByText('CIB last written').nextSibling).toHaveTextContent(
+      '11 Jan 2024, 13:30:00'
+    );
+  });
 });

--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -18,6 +18,7 @@ import {
 import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model/sapSystems';
 import { isHeartbeatPassing } from '@lib/model/hosts';
 import { formatBytes } from '@lib/charts';
+import { formatDateTime } from '@lib/timezones';
 
 import BackButton from '@common/BackButton';
 import Button from '@common/Button';
@@ -100,6 +101,7 @@ function HostDetails({
   requestOperation,
   cleanForbiddenOperation,
   navigate,
+  timezone,
 }) {
   const [cleanUpModalOpen, setCleanUpModalOpen] = useState(false);
   const [
@@ -118,6 +120,17 @@ function HostDetails({
   const saptuneConfiguredVersion = get(saptuneStatus, 'configured_version');
   const saptuneTuning = get(saptuneStatus, 'tuning_state');
   const currentlyAppliedSolution = get(saptuneStatus, 'applied_solution.id');
+
+  // Format SLES subscriptions dates to be displayed in user's timezone
+  const formatSlesSubscriptionsTimes = (subs, tz) =>
+    (subs || []).map((subscription) => {
+      const format = (date) => (date ? formatDateTime(date, tz) || date : date);
+      return {
+        ...subscription,
+        starts_at: format(subscription?.starts_at),
+        expires_at: format(subscription?.expires_at),
+      };
+    });
 
   const renderedExporters = Object.entries(exportersStatus).map(
     ([exporterName, exporterStatus]) => (
@@ -332,6 +345,7 @@ function HostDetails({
             cluster={cluster}
             ipAddresses={buildCidrNotation(ipAddresses, netmasks)}
             lastBootTimestamp={lastBootTimestamp}
+            timezone={timezone}
           />
           <div className="flex flex-col mt-4 bg-white shadow rounded-lg pt-8 px-8 xl:w-2/5 mr-4">
             <SaptuneSummary
@@ -346,6 +360,7 @@ function HostDetails({
             <CheckResultsOverview
               data={lastExecutionData}
               catalogDataEmpty={catalogData?.length === 0}
+              timezone={timezone}
               loading={catalogLoading || lastExecutionLoading}
               error={catalogError || lastExecutionError}
               onCheckClick={(health) =>
@@ -376,6 +391,7 @@ function HostDetails({
               yAxisFormatter={(value) => `${value}%`}
               startInterval={subHours(timeNow, 3)}
               className="w-1/2"
+              timezone={timezone}
             />
             <HostTimeSeriesLineChart
               hostId={hostID}
@@ -384,6 +400,7 @@ function HostDetails({
               startInterval={subHours(timeNow, 3)}
               yAxisFormatter={(value) => formatBytes(value, 3)}
               className="w-1/2"
+              timezone={timezone}
             />
           </div>
           <DiskSpaceChart hostId={hostID} />
@@ -416,7 +433,7 @@ function HostDetails({
           <Table
             className="pt-2"
             config={subscriptionsTableConfiguration}
-            data={slesSubscriptions}
+            data={formatSlesSubscriptionsTimes(slesSubscriptions, timezone)}
           />
         </div>
       </div>

--- a/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
@@ -141,6 +141,23 @@ describe('HostDetails component', () => {
 
         expect(screen.getByText('10.0.0.5, 10.0.0.6')).toBeInTheDocument();
       });
+
+      it('should render last boot using provided timezone', () => {
+        renderWithRouter(
+          <HostDetails
+            agentVersion="2.0.0"
+            ipAddresses={['10.0.0.5']}
+            netmasks={[24]}
+            lastBootTimestamp="2024-01-10T23:30:00Z"
+            timezone="Pacific/Kiritimati"
+            userAbilities={userAbilities}
+          />
+        );
+
+        expect(screen.getByText('Last Boot').nextSibling.textContent).toBe(
+          '11 Jan 2024, 13:30:00'
+        );
+      });
     });
   });
 
@@ -364,10 +381,10 @@ describe('HostDetails component', () => {
 
       const lastExecution = {
         data: {
-          completed_at: faker.date.past().toISOString(),
+          completed_at: '2024-01-10T23:30:00Z',
           passing_count: passingCount,
-          warning_ccount: warningCount,
-          critical_ccount: criticalCount,
+          warning_count: warningCount,
+          critical_count: criticalCount,
         },
       };
 
@@ -375,11 +392,13 @@ describe('HostDetails component', () => {
         <HostDetails
           agentVersion="2.0.0"
           lastExecution={lastExecution}
+          timezone="Pacific/Kiritimati"
           userAbilities={userAbilities}
         />
       );
 
       expect(screen.getByText(passingCount)).toBeInTheDocument();
+      expect(screen.getByText('11 Jan 2024, 13:30:00')).toBeInTheDocument();
     });
 
     it('should display nothing if lastExecution is an empty object', () => {
@@ -668,6 +687,27 @@ describe('HostDetails component', () => {
           exact: false,
         })
       ).toBeVisible();
+    });
+
+    it('should format SLES subscription dates using provided timezone prop', () => {
+      renderWithRouter(
+        <HostDetails
+          agentVersion="1.0.0"
+          userAbilities={userAbilities}
+          timezone="Pacific/Kiritimati"
+          slesSubscriptions={[
+            {
+              starts_at: '2024-01-10T23:30:00Z',
+              expires_at: '2024-01-11T23:30:00Z',
+              status: 'active',
+              subscription_id: 'sub-1',
+            },
+          ]}
+        />
+      );
+
+      expect(screen.getByText('11 Jan 2024, 13:30:00')).toBeVisible();
+      expect(screen.getByText('11 Jan 2024, 13:30:00')).toBeVisible();
     });
   });
 });

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -56,7 +56,7 @@ function HostDetailsPage() {
   const sapInstances = useSelector((state) =>
     getInstancesOnHost(state, hostID)
   );
-  const { abilities } = useSelector(getUserProfile);
+  const { abilities, timezone } = useSelector(getUserProfile);
 
   const lastExecution = useSelector(getLastExecution(hostID));
   const catalog = useSelector(getCatalog());
@@ -152,6 +152,7 @@ function HostDetailsPage() {
       softwareUpdatesErrorMessage={softwareUpdatesErrorMessage}
       softwareUpdatesTooltip={softwareUpdatesTooltip}
       userAbilities={abilities}
+      timezone={timezone}
       operationsEnabled={operationsEnabled}
       runningOperation={runningOperation}
       cleanUpHost={() => {

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.test.jsx
@@ -181,4 +181,40 @@ describe('HostDetailsPage', () => {
       screen.queryByText('Please review SUSE Manager settings')
     ).toBeVisible();
   });
+
+  it('passes user timezone to host details rendering', async () => {
+    const host = hostFactory.build({
+      last_boot_timestamp: '2024-01-10T23:30:00Z',
+    });
+    const { id: hostID } = host;
+
+    const state = {
+      ...defaultInitialState,
+      user: {
+        ...defaultInitialState.user,
+        timezone: 'Pacific/Kiritimati',
+      },
+      hostsList: {
+        hosts: [host],
+      },
+      lastExecutions: { data: null, loading: false, errors: null },
+      softwareUpdates: {
+        settingsConfigured: false,
+        softwareUpdates: {},
+      },
+    };
+
+    const [StatefulHostDetails] = withState(<HostDetailsPage />, state);
+
+    await act(async () =>
+      renderWithRouterMatch(StatefulHostDetails, {
+        path: 'hosts/:hostID',
+        route: `/hosts/${hostID}`,
+      })
+    );
+
+    expect(screen.getByText('Last Boot').nextSibling.textContent).toBe(
+      '11 Jan 2024, 13:30:00'
+    );
+  });
 });

--- a/assets/js/pages/HostDetailsPage/HostSummary.jsx
+++ b/assets/js/pages/HostDetailsPage/HostSummary.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { chunk } from 'lodash';
-import { format } from 'date-fns';
-import { utc } from '@date-fns/utc';
 
 import HealthIcon from '@common/HealthIcon';
+import { formatDateTime } from '@lib/timezones';
 import ListView from '@common/ListView';
 import Tooltip from '@common/Tooltip';
 
@@ -39,11 +38,10 @@ function HostSummary({
   cluster,
   ipAddresses,
   lastBootTimestamp,
+  timezone,
 }) {
   const formattedLastBoot = lastBootTimestamp
-    ? `${format(new Date(lastBootTimestamp), 'dd MMM yyyy, HH:mm:ss', {
-        in: utc,
-      })} GMT`
+    ? formatDateTime(lastBootTimestamp, timezone)
     : 'N/A';
 
   return (

--- a/assets/js/pages/HostDetailsPage/HostSummary.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostSummary.test.jsx
@@ -4,10 +4,9 @@ import { renderWithRouter } from '@lib/test-utils';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { faker } from '@faker-js/faker';
-import { format } from 'date-fns';
-import { utc } from '@date-fns/utc';
 import { clusterFactory } from '@lib/test-utils/factories';
 import HostSummary from './HostSummary';
+import { DEFAULT_TIMEZONE } from '@lib/timezones';
 
 describe('HostSummary', () => {
   it('should render the content correctly', () => {
@@ -81,11 +80,7 @@ describe('HostSummary', () => {
     const ipAddresses = [faker.internet.ipv4()];
     const arch = faker.helpers.arrayElement(['x86_64', 'ppc64le', 's390x']);
     const lastBootTimestamp = '2024-01-10T07:30:00Z';
-    const expectedLastBoot = `${format(
-      new Date(lastBootTimestamp),
-      'dd MMM yyyy, HH:mm:ss',
-      { in: utc }
-    )} GMT`;
+    const expectedLastBoot = '10 Jan 2024, 07:30:00';
 
     renderWithRouter(
       <HostSummary
@@ -94,11 +89,33 @@ describe('HostSummary', () => {
         cluster={cluster}
         ipAddresses={ipAddresses}
         lastBootTimestamp={lastBootTimestamp}
+        timezone={DEFAULT_TIMEZONE}
       />
     );
 
     expect(screen.getByText('Last Boot').nextSibling.textContent).toBe(
       expectedLastBoot
+    );
+  });
+
+  it('should display last boot timestamp using the provided timezone', () => {
+    const cluster = clusterFactory.build();
+    const lastBootTimestamp = '2024-01-10T23:30:00Z';
+
+    renderWithRouter(
+      <HostSummary
+        arch={faker.helpers.arrayElement(['x86_64', 'ppc64le', 's390x'])}
+        agentVersion={faker.system.semver()}
+        cluster={cluster}
+        ipAddresses={[faker.internet.ipv4()]}
+        lastBootTimestamp={lastBootTimestamp}
+        timezone="Pacific/Kiritimati"
+      />
+    );
+
+    // UTC+14 shifts this timestamp to the next day: 10 Jan -> 11 Jan.
+    expect(screen.getByText('Last Boot').nextSibling.textContent).toBe(
+      '11 Jan 2024, 13:30:00'
     );
   });
 

--- a/assets/js/pages/HostDetailsPage/HostTimeSeriesLineChart.jsx
+++ b/assets/js/pages/HostDetailsPage/HostTimeSeriesLineChart.jsx
@@ -14,6 +14,7 @@ function HostTimeSeriesLineChart({
   endInterval = new Date(),
   updateFrequency = 30000,
   className,
+  timezone,
 }) {
   const [chartStartInterval, setChartStartInterval] = useState(startInterval);
   const [chartEndInterval, setChartEndInterval] = useState(endInterval);
@@ -88,6 +89,7 @@ function HostTimeSeriesLineChart({
       start={chartStartInterval}
       end={chartEndInterval}
       chartRef={chartRef}
+      timezone={timezone}
       yAxisScaleType={yAxisScaleType}
       yAxisMaxValue={yAxisMaxValue}
       yAxisLabelFormatter={yAxisFormatter}

--- a/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.jsx
+++ b/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.jsx
@@ -18,7 +18,7 @@ const filterPatchesByAdvisoryType = (patches, advisoryType) =>
     advisoryType === 'all' ? true : advisory_type === advisoryType
   );
 
-function HostRelevantPatches({ hostName, onNavigate, patches }) {
+function HostRelevantPatches({ hostName, onNavigate, patches, timezone }) {
   const advisoryTypes = ['all'].concat(advisoryTypesFromPatches(patches));
 
   const [displayedAdvisories, setDisplayedAdvisories] = useState('all');
@@ -106,7 +106,11 @@ function HostRelevantPatches({ hostName, onNavigate, patches }) {
           </a>
         </div>
       </div>
-      <PatchList onNavigate={onNavigate} patches={displayedPatches} />
+      <PatchList
+        onNavigate={onNavigate}
+        patches={displayedPatches}
+        timezone={timezone}
+      />
     </>
   );
 }

--- a/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.stories.jsx
+++ b/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.stories.jsx
@@ -15,7 +15,28 @@ function ContainerWrapper({ children }) {
 export default {
   title: 'Layouts/HostRelevantPatchesPage',
   components: HostRelevantPatchesPage,
-  argTypes: {},
+  argTypes: {
+    hostName: {
+      type: 'string',
+      description: 'The hostname to display in the header and CSV filename.',
+      control: { type: 'text' },
+    },
+    onNavigate: {
+      type: { name: 'function' },
+      description: 'Callback for navigation actions in PatchList.',
+      action: 'onNavigate',
+    },
+    patches: {
+      type: { name: 'array' },
+      description: 'Array of patch objects to display.',
+    },
+    timezone: {
+      type: 'string',
+      description: 'Timezone string for date formatting.',
+      control: { type: 'text' },
+      defaultValue: 'Etc/UTC',
+    },
+  },
   render: (args) => (
     <ContainerWrapper>
       <HostRelevantPatchesPage {...args} />
@@ -28,5 +49,6 @@ export const HasPatches = {
     hostName: hostFactory.build().hostname,
     patches: relevantPatchFactory.buildList(15),
     onNavigate: action('onNavigate'),
+    timezone: 'Etc/UTC',
   },
 };

--- a/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.test.jsx
+++ b/assets/js/pages/HostRelevantPatches/HostRelevantPatchesPage.test.jsx
@@ -5,8 +5,9 @@ import '@testing-library/jest-dom';
 import { faker } from '@faker-js/faker';
 import { noop } from 'lodash';
 
-import { renderWithRouter as render } from '@lib/test-utils';
+import { renderWithRouter } from '@lib/test-utils';
 import { hostFactory, relevantPatchFactory } from '@lib/test-utils/factories';
+import { DEFAULT_TIMEZONE } from '@lib/timezones';
 
 import HostRelevantPatchesPage from './HostRelevantPatchesPage';
 
@@ -24,7 +25,13 @@ describe('HostRelevantPatchesPage', () => {
     it('displays the hostname', () => {
       const host = hostFactory.build();
 
-      render(<HostRelevantPatchesPage hostName={host.hostname} patches={[]} />);
+      renderWithRouter(
+        <HostRelevantPatchesPage
+          hostName={host.hostname}
+          patches={[]}
+          timezone={DEFAULT_TIMEZONE}
+        />
+      );
       expect(
         screen.getByRole('heading', {
           name: `Relevant Patches: ${host.hostname}`,
@@ -39,8 +46,12 @@ describe('HostRelevantPatchesPage', () => {
       );
       const user = userEvent.setup();
 
-      render(
-        <HostRelevantPatchesPage hostName={host.hostname} patches={patches} />
+      renderWithRouter(
+        <HostRelevantPatchesPage
+          hostName={host.hostname}
+          patches={patches}
+          timezone={DEFAULT_TIMEZONE}
+        />
       );
 
       const advisorySelect = screen.getByRole('combobox', {
@@ -61,13 +72,17 @@ describe('HostRelevantPatchesPage', () => {
     });
 
     it('shows an input for searching the patches', () => {
-      render(<HostRelevantPatchesPage patches={[]} />);
+      renderWithRouter(
+        <HostRelevantPatchesPage patches={[]} timezone={DEFAULT_TIMEZONE} />
+      );
 
       expect(screen.getByRole('textbox')).toBeVisible();
     });
 
     it('shows a button for downloading the data as CSV', () => {
-      render(<HostRelevantPatchesPage patches={[]} />);
+      renderWithRouter(
+        <HostRelevantPatchesPage patches={[]} timezone={DEFAULT_TIMEZONE} />
+      );
 
       expect(
         screen.getByRole('button', { name: 'Download CSV' })
@@ -75,11 +90,32 @@ describe('HostRelevantPatchesPage', () => {
     });
 
     it('shows the relevant patches component', () => {
-      render(<HostRelevantPatchesPage patches={[]} />);
+      renderWithRouter(
+        <HostRelevantPatchesPage patches={[]} timezone={DEFAULT_TIMEZONE} />
+      );
 
       expect(
         screen.getByRole('row', { name: 'Type Advisory Synopsis Updated' })
       ).toBeVisible();
+    });
+
+    it('renders patch update date according to the provided timezone', () => {
+      const timezone = 'Pacific/Kiritimati';
+      const patch = relevantPatchFactory.build({
+        update_date: '2024-01-10T23:30:00.000Z',
+        advisory_synopsis: 'timezone test',
+      });
+
+      renderWithRouter(
+        <HostRelevantPatchesPage
+          hostName="host"
+          patches={[patch]}
+          timezone={timezone}
+        />
+      );
+
+      expect(screen.getByText('11 Jan 2024')).toBeVisible();
+      expect(screen.getByText('timezone test')).toBeVisible();
     });
   });
 
@@ -87,7 +123,12 @@ describe('HostRelevantPatchesPage', () => {
     it('shows all patches by default', () => {
       const patches = relevantPatchFactory.buildList(8);
 
-      render(<HostRelevantPatchesPage patches={patches} />);
+      renderWithRouter(
+        <HostRelevantPatchesPage
+          patches={patches}
+          timezone={DEFAULT_TIMEZONE}
+        />
+      );
 
       patches.forEach((patch) => {
         expect(screen.getByText(patch.advisory_synopsis)).toBeVisible();
@@ -106,7 +147,12 @@ describe('HostRelevantPatchesPage', () => {
         (patch) => patch.advisory_type === filteredType
       );
 
-      render(<HostRelevantPatchesPage patches={patches} />);
+      renderWithRouter(
+        <HostRelevantPatchesPage
+          patches={patches}
+          timezone={DEFAULT_TIMEZONE}
+        />
+      );
 
       const advisorySelect = screen.getByRole('combobox', {
         name: 'advisories',
@@ -126,8 +172,11 @@ describe('HostRelevantPatchesPage', () => {
       const patches = relevantPatchFactory.buildList(8);
       const searchTerm = patches[0].advisory_synopsis;
 
-      const { container } = render(
-        <HostRelevantPatchesPage patches={patches} />
+      const { container } = renderWithRouter(
+        <HostRelevantPatchesPage
+          patches={patches}
+          timezone={DEFAULT_TIMEZONE}
+        />
       );
 
       const searchInput = screen.getByRole('textbox');
@@ -156,7 +205,13 @@ describe('HostRelevantPatchesPage', () => {
 
       const patches = [];
 
-      render(<HostRelevantPatchesPage hostName={hostName} patches={patches} />);
+      renderWithRouter(
+        <HostRelevantPatchesPage
+          hostName={hostName}
+          patches={patches}
+          timezone={DEFAULT_TIMEZONE}
+        />
+      );
 
       const csvButton = screen.getByText('Download CSV');
 
@@ -180,7 +235,13 @@ describe('HostRelevantPatchesPage', () => {
         }),
       ];
 
-      render(<HostRelevantPatchesPage hostName={hostName} patches={patches} />);
+      renderWithRouter(
+        <HostRelevantPatchesPage
+          hostName={hostName}
+          patches={patches}
+          timezone={DEFAULT_TIMEZONE}
+        />
+      );
 
       const csvButton = screen.getByText('Download CSV');
       user.click(csvButton);

--- a/assets/js/pages/HostRelevantPatches/Page.jsx
+++ b/assets/js/pages/HostRelevantPatches/Page.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router';
 import { useSelector, useDispatch } from 'react-redux';
+import { getUserProfile } from '@state/selectors/user';
 
 import BackButton from '@common/BackButton';
 
@@ -24,6 +25,8 @@ export default function Page() {
     getSoftwareUpdatesPatches(state, hostID)
   );
 
+  const { timezone } = useSelector(getUserProfile);
+
   if (!host || !patches) {
     return <div>Retrieving data</div>;
   }
@@ -39,6 +42,7 @@ export default function Page() {
         onNavigate={(advisoryID) =>
           navigate(`/hosts/${hostID}/patches/${advisoryID}`)
         }
+        timezone={timezone}
       />
     </>
   );

--- a/assets/js/pages/Layout/Layout.jsx
+++ b/assets/js/pages/Layout/Layout.jsx
@@ -234,7 +234,7 @@ function Layout() {
         </div>
         <footer className="p-4 z-30 relative bottom-0 w-full bg-white shadow md:flex md:items-center md:justify-between md:p-6 dark:bg-gray-800">
           <span className="text-sm text-gray-500 sm:text-center dark:text-gray-400">
-            © 2020-2025 SUSE LLC
+            © 2020-2026 SUSE LLC
           </span>
           <span className="flex items-center mt-3 text-sm text-gray-500 dark:text-gray-400 sm:mt-0">
             This tool is free software released under the Apache License,

--- a/assets/js/pages/Profile/ProfileForm.jsx
+++ b/assets/js/pages/Profile/ProfileForm.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { computeTimezoneOffsets, formatOffset } from '@lib/timezones';
 import { Link } from 'react-router';
 import { noop } from 'lodash';
 import { getError } from '@lib/api/validationErrors';
@@ -116,6 +117,17 @@ function ProfileForm({
 
   const selectedTimezone =
     timezones.find((opt) => opt.value === timezoneState) || null;
+
+  // Compute UTC offsets (in minutes) from helper and evaluate warning locally
+  const { browserUtcOffset, profileUtcOffset } =
+    computeTimezoneOffsets(selectedTimezone);
+
+  // Show warning if browser and profile offsets differ
+  const showTimezoneWarning = Boolean(
+    selectedTimezone &&
+    profileUtcOffset !== null &&
+    browserUtcOffset !== profileUtcOffset
+  );
 
   return (
     <div>
@@ -241,6 +253,19 @@ function ProfileForm({
               noOptionsMessage={() => 'No timezones found'}
             />
             {timezoneErrorState && errorMessage(timezoneErrorState)}
+            {showTimezoneWarning && (
+              <div
+                className="mt-2 text-yellow-700 bg-yellow-100 border border-yellow-300 rounded px-3 py-2 text-sm"
+                data-testid="timezone-warning"
+              >
+                <strong>Warning:</strong> Your browser UTC offset is{' '}
+                <b>{formatOffset(browserUtcOffset)}</b>, but your profile
+                timezone offset is <b>{formatOffset(profileUtcOffset)}</b>.{' '}
+                <br />
+                The Trento UI will always use your profile timezone to display
+                timestamps, not your browser&apos;s.
+              </div>
+            )}
           </div>
           {analyticsEnabledConfig && (
             <>

--- a/assets/js/pages/Profile/ProfileForm.jsx
+++ b/assets/js/pages/Profile/ProfileForm.jsx
@@ -8,8 +8,10 @@ import Label from '@common/Label';
 import Modal from '@common/Modal';
 import Switch from '@common/Switch';
 import AbilitiesMultiSelect from '@common/AbilitiesMultiSelect';
+import Select from '@common/Select';
 import ProfilePasswordChangeForm from '@pages/Profile/ProfilePasswordChangeForm';
 import TotpEnrollementBox from '@pages/Profile/TotpEnrollmentBox';
+import { DEFAULT_TIMEZONE } from '@lib/timezones';
 
 import { REQUIRED_FIELD_TEXT, errorMessage } from '@lib/forms';
 
@@ -38,6 +40,8 @@ function ProfileForm({
   analyticsEnabledConfig = false,
   analyticsEnabled = false,
   analyticsEulaAccepted = false,
+  timezone = DEFAULT_TIMEZONE,
+  timezones = [],
   errors,
   loading,
   disableForm,
@@ -57,6 +61,8 @@ function ProfileForm({
   const [emailAddressErrorState, setEmailAddressError] = useState(null);
   const [totpDisableModalOpen, setTotpDisableModalOpen] = useState(false);
   const [analyticsEnabledState, setAnalyticsState] = useState(analyticsEnabled);
+  const [timezoneState, setTimezone] = useState(timezone);
+  const [timezoneErrorState, setTimezoneError] = useState(null);
 
   const saveButtonVisible = !singleSignOnEnabled || analyticsEnabledConfig;
 
@@ -88,6 +94,7 @@ function ProfileForm({
       analytics_enabled: analyticsEnabledState,
       ...(analyticsEnabledState &&
         !analyticsEulaAccepted && { analytics_eula_accepted: true }),
+      timezone: timezoneState,
     };
 
     onSave(user);
@@ -104,7 +111,11 @@ function ProfileForm({
   useEffect(() => {
     setFullNameError(getError('fullname', errors));
     setEmailAddressError(getError('email', errors));
+    setTimezoneError(getError('timezone', errors));
   }, [errors]);
+
+  const selectedTimezone =
+    timezones.find((opt) => opt.value === timezoneState) || null;
 
   return (
     <div>
@@ -205,6 +216,31 @@ function ProfileForm({
               placeholder=""
               isDisabled
             />
+          </div>
+          <Label
+            htmlFor="timezone"
+            className="col-start-1 col-span-2 pt-2"
+            info={'Aligns timestamps according to timezone selection'}
+          >
+            Timezone
+          </Label>
+          <div className="col-start-3 col-span-4">
+            <Select
+              inputId="timezone"
+              name="timezone"
+              value={selectedTimezone}
+              options={timezones}
+              onChange={(value) => {
+                setTimezone(value || '');
+                setTimezoneError(null);
+              }}
+              isMulti={false}
+              isSearchable
+              disabled={loading || disableForm}
+              placeholder="Select timezone..."
+              noOptionsMessage={() => 'No timezones found'}
+            />
+            {timezoneErrorState && errorMessage(timezoneErrorState)}
           </div>
           {analyticsEnabledConfig && (
             <>

--- a/assets/js/pages/Profile/ProfileForm.stories.jsx
+++ b/assets/js/pages/Profile/ProfileForm.stories.jsx
@@ -12,6 +12,7 @@ const {
   updated_at: updatedAt,
   abilities,
   analytics_enabled: analyticsEnabled,
+  timezone,
 } = userFactory.build();
 
 function ContainerWrapper({ children }) {
@@ -44,13 +45,22 @@ export default {
     },
     abilities: {
       description: 'User abilities array',
+      control: {
+        type: 'text'
+      },
     },
     errors: {
       description: 'OpenAPI errors coming from backend validation',
+      control: {
+        type: 'text'
+      },
     },
     onSave: {
       action: 'Save user',
       description: 'Save user action',
+      control: {
+        type: 'text'
+      },
     },
     totpEnabled: {
       description: 'User TOTP enabled',
@@ -76,6 +86,30 @@ export default {
         type: 'text',
       },
     },
+    analyticsEulaAccepted: {
+      description: 'Whether the user accepted the analytics EULA',
+      control: {
+        type: 'text'
+      },
+    },
+    timezone: {
+      description: 'User timezone',
+      control: {
+        type: 'text',
+      },
+    },
+    timezones: {
+      description: 'Available timezone options for the timezone select (array of { value, label })',
+      control: {
+        type: 'text'
+      },
+    },
+    disableForm: {
+      description: 'When true, disables all inputs and actions in the form',
+      control: {
+        type: 'text'
+      },
+    },
     singleSignOnEnabled: {
       description: 'Single sign on login is enabled',
       control: { type: 'boolean' },
@@ -88,6 +122,48 @@ export default {
     analyticsEnabled: {
       description: 'Toggles tracking user analytics',
       control: { type: 'boolean' },
+    },
+    toggleTotpBox: {
+      description: 'Callback to open or close the TOTP enrollment box',
+      control: {
+        type: 'text'
+      },
+    },
+    loading: {
+      description: 'Indicates whether the form is in a loading state',
+      control: {
+        type: 'boolean'
+      },
+    },
+    togglePasswordModal: {
+      description: 'Callback to open or close the password change modal',
+      control: {
+        type: 'text'
+      },
+    },
+    onResetTotp: {
+      description: "Callback invoked to reset the user's TOTP (disable TOTP)",
+      control: {
+        type: 'text'
+      },
+    },
+    onVerifyTotp: {
+      description: 'Callback invoked to verify a TOTP token during enrollment',
+      control: {
+        type: 'text'
+      },
+    },
+    onEnableTotp: {
+      description: 'Callback invoked to start the TOTP enrollment flow',
+      control: {
+        type: 'text'
+      },
+    },
+    passwordModalOpen: {
+      description: 'Whether the change-password modal is currently open',
+      control: {
+        type: 'text'
+      },
     },
   },
   render: (args) => (
@@ -108,6 +184,8 @@ export const Default = {
       'otpauth://totp/Example:alice@google.com?secret=JBSWY3DPEHPK3PXP&issuer=Example',
     analyticsEnabledConfig: true,
     analyticsEnabled,
+    timezone,
+    timezones: ["GMT+00:00", "GMT+01:00", "GMT+02:00"],
   },
 };
 
@@ -121,6 +199,7 @@ export const Loading = {
     updatedAt,
     analyticsEnabledConfig: true,
     loading: true,
+    timezone,
   },
 };
 

--- a/assets/js/pages/Profile/ProfileForm.stories.jsx
+++ b/assets/js/pages/Profile/ProfileForm.stories.jsx
@@ -46,20 +46,20 @@ export default {
     abilities: {
       description: 'User abilities array',
       control: {
-        type: 'text'
+        type: 'text',
       },
     },
     errors: {
       description: 'OpenAPI errors coming from backend validation',
       control: {
-        type: 'text'
+        type: 'text',
       },
     },
     onSave: {
       action: 'Save user',
       description: 'Save user action',
       control: {
-        type: 'text'
+        type: 'text',
       },
     },
     totpEnabled: {
@@ -89,7 +89,7 @@ export default {
     analyticsEulaAccepted: {
       description: 'Whether the user accepted the analytics EULA',
       control: {
-        type: 'text'
+        type: 'text',
       },
     },
     timezone: {
@@ -99,15 +99,16 @@ export default {
       },
     },
     timezones: {
-      description: 'Available timezone options for the timezone select (array of { value, label })',
+      description:
+        'Available timezone options for the timezone select (array of { value, label })',
       control: {
-        type: 'text'
+        type: 'text',
       },
     },
     disableForm: {
       description: 'When true, disables all inputs and actions in the form',
       control: {
-        type: 'text'
+        type: 'text',
       },
     },
     singleSignOnEnabled: {
@@ -126,43 +127,43 @@ export default {
     toggleTotpBox: {
       description: 'Callback to open or close the TOTP enrollment box',
       control: {
-        type: 'text'
+        type: 'text',
       },
     },
     loading: {
       description: 'Indicates whether the form is in a loading state',
       control: {
-        type: 'boolean'
+        type: 'boolean',
       },
     },
     togglePasswordModal: {
       description: 'Callback to open or close the password change modal',
       control: {
-        type: 'text'
+        type: 'text',
       },
     },
     onResetTotp: {
       description: "Callback invoked to reset the user's TOTP (disable TOTP)",
       control: {
-        type: 'text'
+        type: 'text',
       },
     },
     onVerifyTotp: {
       description: 'Callback invoked to verify a TOTP token during enrollment',
       control: {
-        type: 'text'
+        type: 'text',
       },
     },
     onEnableTotp: {
       description: 'Callback invoked to start the TOTP enrollment flow',
       control: {
-        type: 'text'
+        type: 'text',
       },
     },
     passwordModalOpen: {
       description: 'Whether the change-password modal is currently open',
       control: {
-        type: 'text'
+        type: 'text',
       },
     },
   },
@@ -185,7 +186,7 @@ export const Default = {
     analyticsEnabledConfig: true,
     analyticsEnabled,
     timezone,
-    timezones: ["GMT+00:00", "GMT+01:00", "GMT+02:00"],
+    timezones: ['GMT+00:00', 'GMT+01:00', 'GMT+02:00'],
   },
 };
 

--- a/assets/js/pages/Profile/ProfileForm.test.jsx
+++ b/assets/js/pages/Profile/ProfileForm.test.jsx
@@ -15,6 +15,9 @@ const getTimezoneLabel = (timezone) =>
 const userTimezone = 'Europe/Berlin';
 
 describe('ProfileForm', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
   it('should render a pre-filled form', () => {
     const { username, fullname, email, abilities } = profileFactory.build();
 
@@ -98,6 +101,7 @@ describe('ProfileForm', () => {
         analyticsEnabled={analytics_enabled}
         analyticsEulaAccepted={analytics_eula_accepted}
         timezone={timezone}
+        timezones={timezones}
         onSave={mockOnSave}
       />
     );
@@ -474,6 +478,49 @@ describe('ProfileForm', () => {
     expect(mockOnSave).toHaveBeenCalledWith(
       expect.objectContaining({ timezone })
     );
+  });
+
+  it('should display a timezone warning when browser and profile offsets differ', async () => {
+    const { username, fullname, email, abilities } = profileFactory.build();
+    jest.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-120);
+    const timezone = 'Pacific/Port_Moresby';
+    const expectedWarning =
+      "Warning: Your browser UTC offset is +02:00, but your profile timezone offset is +10:00. The Trento UI will always use your profile timezone to display timestamps, not your browser's.";
+
+    render(
+      <ProfileForm
+        fullName={fullname}
+        emailAddress={email}
+        username={username}
+        abilities={abilities}
+        timezone={timezone}
+        timezones={timezones}
+      />
+    );
+
+    const warning = await screen.findByTestId('timezone-warning');
+    expect(warning).toBeVisible();
+    expect(warning).toHaveTextContent(expectedWarning);
+  });
+
+  it('should not display a timezone warning when browser and profile offsets match', () => {
+    const { username, fullname, email, abilities } = profileFactory.build();
+    jest.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(0);
+
+    render(
+      <ProfileForm
+        fullName={fullname}
+        emailAddress={email}
+        username={username}
+        abilities={abilities}
+        timezone={DEFAULT_TIMEZONE}
+        timezones={timezones}
+      />
+    );
+
+    expect(
+      screen.queryByText(/The Trento UI will always use your profile timezone/i)
+    ).not.toBeInTheDocument();
   });
 
   it('should set timezone error when timezone error is provided', async () => {

--- a/assets/js/pages/Profile/ProfileForm.test.jsx
+++ b/assets/js/pages/Profile/ProfileForm.test.jsx
@@ -467,7 +467,9 @@ describe('ProfileForm', () => {
       />
     );
 
-    const timezoneSelectorInput = screen.getByLabelText('Timezone');
+    const timezoneSelectorInput = screen.getByRole('combobox', {
+      name: 'Timezone',
+    });
     const timezoneLabel = getTimezoneLabel(timezone);
 
     await user.click(timezoneSelectorInput);
@@ -647,7 +649,9 @@ describe('ProfileForm', () => {
         />
       );
 
-      const timezoneSelectorInput = screen.getByLabelText('Timezone');
+      const timezoneSelectorInput = screen.getByRole('combobox', {
+        name: 'Timezone',
+      });
       const timezoneLabel = getTimezoneLabel(timezone);
 
       await user.click(timezoneSelectorInput);

--- a/assets/js/pages/Profile/ProfileForm.test.jsx
+++ b/assets/js/pages/Profile/ProfileForm.test.jsx
@@ -7,6 +7,12 @@ import { faker } from '@faker-js/faker';
 import { profileFactory } from '@lib/test-utils/factories/users';
 
 import ProfileForm from '@pages/Profile/ProfileForm';
+import { DEFAULT_TIMEZONE, timezones } from '@lib/timezones';
+
+const getTimezoneLabel = (timezone) =>
+  timezones.find((option) => option.value === timezone)?.label;
+
+const userTimezone = 'Europe/Berlin';
 
 describe('ProfileForm', () => {
   it('should render a pre-filled form', () => {
@@ -57,12 +63,18 @@ describe('ProfileForm', () => {
         source: { pointer: '/email' },
         title: 'Invalid value',
       },
+      {
+        detail: 'Error validating timezone',
+        source: { pointer: '/timezone' },
+        title: 'Invalid value',
+      },
     ];
 
     render(<ProfileForm errors={errors} />);
 
     expect(screen.getByText('Error validating fullname')).toBeVisible();
     expect(screen.getByText('Error validating email')).toBeVisible();
+    expect(screen.getByText('Error validating timezone')).toBeVisible();
   });
 
   it('should send the form values when correctly filled', async () => {
@@ -73,6 +85,7 @@ describe('ProfileForm', () => {
       abilities,
       analytics_enabled,
       analytics_eula_accepted,
+      timezone,
     } = profileFactory.build({ analytics_eula_accepted: true });
     const mockOnSave = jest.fn();
 
@@ -84,6 +97,7 @@ describe('ProfileForm', () => {
         abilities={abilities}
         analyticsEnabled={analytics_enabled}
         analyticsEulaAccepted={analytics_eula_accepted}
+        timezone={timezone}
         onSave={mockOnSave}
       />
     );
@@ -96,6 +110,7 @@ describe('ProfileForm', () => {
       fullname,
       email,
       analytics_enabled,
+      timezone,
     });
   });
 
@@ -192,6 +207,7 @@ describe('ProfileForm', () => {
           analyticsEnabled={analytics_enabled}
           analyticsEulaAccepted={analytics_eula_accepted}
           onSave={mockOnSave}
+          timezones={timezones}
         />
       );
 
@@ -204,6 +220,7 @@ describe('ProfileForm', () => {
         email,
         analytics_enabled: analyticsEnabled,
         ...(updateValue && { analytics_eula_accepted: true }),
+        timezone: DEFAULT_TIMEZONE,
       });
     }
   );
@@ -390,6 +407,91 @@ describe('ProfileForm', () => {
     expect(screen.getByText('Error validating totp code')).toBeVisible();
   });
 
+  it('should set timezone selector value when timezone is not provided', () => {
+    const { username, fullname, email, abilities } = profileFactory.build();
+
+    render(
+      <ProfileForm
+        fullName={fullname}
+        emailAddress={email}
+        username={username}
+        abilities={abilities}
+        timezones={timezones}
+      />
+    );
+
+    expect(screen.getByText('Timezone')).toBeVisible();
+    expect(screen.getByLabelText('Timezone')).toBeVisible();
+    expect(screen.getByText(getTimezoneLabel(DEFAULT_TIMEZONE))).toBeVisible();
+  });
+
+  it('should set timezone selector value when timezone is provided', () => {
+    const { username, fullname, email, abilities } = profileFactory.build();
+    const timezone = userTimezone;
+
+    render(
+      <ProfileForm
+        fullName={fullname}
+        emailAddress={email}
+        username={username}
+        abilities={abilities}
+        timezone={timezone}
+        timezones={timezones}
+      />
+    );
+
+    expect(screen.getByText('Timezone')).toBeVisible();
+    expect(screen.getByLabelText('Timezone')).toBeVisible();
+    expect(screen.getByText(getTimezoneLabel(timezone))).toBeVisible();
+  });
+
+  it('should set timezone in save payload when timezone selector changes', async () => {
+    const { username, fullname, email, abilities } = profileFactory.build();
+    const timezone = userTimezone;
+    const mockOnSave = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <ProfileForm
+        fullName={fullname}
+        emailAddress={email}
+        username={username}
+        abilities={abilities}
+        timezone={DEFAULT_TIMEZONE}
+        timezones={timezones}
+        onSave={mockOnSave}
+      />
+    );
+
+    const timezoneSelectorInput = screen.getByLabelText('Timezone');
+    const timezoneLabel = getTimezoneLabel(timezone);
+
+    await user.click(timezoneSelectorInput);
+    await user.type(timezoneSelectorInput, timezone);
+    await user.click(await screen.findByText(timezoneLabel));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(mockOnSave).toHaveBeenCalledWith(
+      expect.objectContaining({ timezone })
+    );
+  });
+
+  it('should set timezone error when timezone error is provided', async () => {
+    const errors = [
+      {
+        detail: 'is not a valid IANA timezone',
+        source: { pointer: '/timezone' },
+        title: 'Invalid value',
+      },
+    ];
+
+    render(<ProfileForm errors={errors} timezones={timezones} />);
+
+    expect(
+      await screen.findByText(/is not a valid IANA timezone/i)
+    ).toBeVisible();
+  });
+
   describe('Single sign on', () => {
     it('should disable fullname, email and username fields', () => {
       const { username, fullname, email, abilities } = profileFactory.build();
@@ -428,6 +530,26 @@ describe('ProfileForm', () => {
       expect(screen.getByText('Permissions')).toBeVisible();
     });
 
+    it('should keep timezone selector enabled', () => {
+      const { username, fullname, email, abilities } = profileFactory.build();
+
+      render(
+        <ProfileForm
+          fullName={fullname}
+          emailAddress={email}
+          username={username}
+          abilities={abilities}
+          timezones={timezones}
+          singleSignOnEnabled
+        />
+      );
+
+      expect(screen.getByLabelText('Timezone')).toBeEnabled();
+      expect(
+        screen.getByText(getTimezoneLabel(DEFAULT_TIMEZONE))
+      ).toBeVisible();
+    });
+
     it('should show save button if analytics configuration is enabled', async () => {
       const { username, fullname, email, abilities } = profileFactory.build();
 
@@ -440,6 +562,7 @@ describe('ProfileForm', () => {
           username={username}
           abilities={abilities}
           onSave={mockOnSave}
+          timezones={timezones}
           singleSignOnEnabled
           analyticsEnabledConfig
         />
@@ -453,6 +576,41 @@ describe('ProfileForm', () => {
 
       expect(mockOnSave).toHaveBeenNthCalledWith(1, {
         analytics_enabled: false,
+        timezone: DEFAULT_TIMEZONE,
+      });
+    });
+
+    it('should set timezone in save payload when timezone selector changes', async () => {
+      const { username, fullname, email, abilities } = profileFactory.build();
+      const timezone = userTimezone;
+      const mockOnSave = jest.fn();
+      const user = userEvent.setup();
+
+      render(
+        <ProfileForm
+          fullName={fullname}
+          emailAddress={email}
+          username={username}
+          abilities={abilities}
+          timezone={DEFAULT_TIMEZONE}
+          timezones={timezones}
+          onSave={mockOnSave}
+          singleSignOnEnabled
+          analyticsEnabledConfig
+        />
+      );
+
+      const timezoneSelectorInput = screen.getByLabelText('Timezone');
+      const timezoneLabel = getTimezoneLabel(timezone);
+
+      await user.click(timezoneSelectorInput);
+      await user.type(timezoneSelectorInput, timezone);
+      await user.click(await screen.findByText(timezoneLabel));
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      expect(mockOnSave).toHaveBeenCalledWith({
+        analytics_enabled: false,
+        timezone,
       });
     });
   });

--- a/assets/js/pages/Profile/ProfilePage.jsx
+++ b/assets/js/pages/Profile/ProfilePage.jsx
@@ -27,6 +27,7 @@ import {
 import { dismissNotification } from '@state/notifications';
 import { getAnalyticsEnabledConfig } from '@lib/analytics';
 import { getFromConfig } from '@lib/config';
+import { timezones } from '@lib/timezones';
 
 const analyticsEnabledConfig = getAnalyticsEnabledConfig();
 
@@ -210,6 +211,7 @@ function ProfilePage() {
     analytics_enabled: analyticsEnabled,
     analytics_eula_accepted: analyticsEulaAccepted,
     totp_enabled: totpEnabled,
+    timezone,
   } = userState;
   const isDefaultAdmin = isAdmin(userState);
 
@@ -227,6 +229,8 @@ function ProfilePage() {
         analyticsEnabled={analyticsEnabled}
         analyticsEulaAccepted={analyticsEulaAccepted}
         totpEnabled={totpEnabled}
+        timezone={timezone}
+        timezones={timezones}
         totpSecret={totpEnrollmentSecret}
         totpQrData={totpEnrollmentQrData}
         errors={errorsState}
@@ -250,6 +254,7 @@ function ProfilePage() {
         onCloseGeneratedTokenModal={setGeneratedAccessToken}
         onDeleteToken={deleteToken}
         onGenerateToken={generateToken}
+        timezone={timezone}
       />
       {getFromConfig('aiEnabled') && (
         <AIConfiguration

--- a/assets/js/pages/SettingsPage/SettingsPage.jsx
+++ b/assets/js/pages/SettingsPage/SettingsPage.jsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Transition } from '@headlessui/react';
-import { format, isBefore, parseISO } from 'date-fns';
+import { isBefore, parseISO } from 'date-fns';
 import { EOS_INFO_OUTLINED } from 'eos-icons-react';
 
 import { SUMA_PRODUCT_LABEL_SHORT } from '@lib/model/suse_manager';
+import { formatDateOnly } from '@lib/timezones';
 
 import DisabledGuard from '@common/DisabledGuard';
 import PageHeader from '@common/PageHeader';
@@ -44,7 +45,7 @@ import {
 
 const apiKeySettingsPermittedFor = ['all:api_key_settings'];
 
-function ApiKeyExpireInfo({ apiKeyExpiration }) {
+function ApiKeyExpireInfo({ apiKeyExpiration, timezone }) {
   const expirationLabel = () => {
     if (!apiKeyExpiration) {
       return 'Key will never expire';
@@ -52,7 +53,7 @@ function ApiKeyExpireInfo({ apiKeyExpiration }) {
 
     const expireDate = parseISO(apiKeyExpiration);
     if (apiKeyExpiration && isBefore(new Date(), expireDate)) {
-      return `Key will expire ${format(expireDate, 'd LLL yyyy')}`;
+      return `Key will expire ${formatDateOnly(expireDate, timezone)}`;
     }
 
     return 'Key expired';
@@ -102,7 +103,7 @@ function SettingsPage() {
   const hasSoftwareUpdatesSettings =
     Object.keys(suseManagerSettings).length > 0;
 
-  const { abilities } = useSelector(getUserProfile);
+  const { abilities, timezone } = useSelector(getUserProfile);
 
   const {
     settings: activityLogsSettings = {},
@@ -169,7 +170,10 @@ function SettingsPage() {
                     )}
 
                     {apiKey && (
-                      <ApiKeyExpireInfo apiKeyExpiration={apiKeyExpiration} />
+                      <ApiKeyExpireInfo
+                        apiKeyExpiration={apiKeyExpiration}
+                        timezone={timezone}
+                      />
                     )}
                   </div>
                 </Transition>
@@ -254,6 +258,7 @@ function SettingsPage() {
           loading={apiKeyLoading}
           generatedApiKey={apiKey}
           generatedApiKeyExpiration={apiKeyExpiration}
+          timezone={timezone}
           onClose={() => setApiKeySettingsModalOpen(false)}
           onGenerate={({ apiKeyExpiration: generatedApiKeyExpiration }) =>
             saveApiKeySettings(generatedApiKeyExpiration)
@@ -273,6 +278,7 @@ function SettingsPage() {
           >
             <SuseManagerConfig
               userAbilities={abilities}
+              timezone={timezone}
               url={suseManagerSettings.url}
               username={suseManagerSettings.username}
               certUploadDate={suseManagerSettings.ca_uploaded_at}
@@ -303,6 +309,7 @@ function SettingsPage() {
             initialUsername={suseManagerSettings.username}
             initialUrl={suseManagerSettings.url}
             certUploadDate={suseManagerSettings.ca_uploaded_at}
+            timezone={timezone}
             onSave={(payload) => {
               if (
                 suseManagerSettings.username ||

--- a/assets/js/pages/SettingsPage/SettingsPage.test.jsx
+++ b/assets/js/pages/SettingsPage/SettingsPage.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { format } from 'date-fns';
 import { act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
@@ -12,6 +11,7 @@ import {
 } from '@lib/test-utils';
 import { softwareUpdatesSettingsFactory } from '@lib/test-utils/factories/softwareUpdatesSettings';
 import { networkClient } from '@lib/network';
+import { formatDateOnly } from '@lib/timezones';
 import MockAdapter from 'axios-mock-adapter';
 
 import SettingsPage from './SettingsPage';
@@ -66,6 +66,30 @@ describe('Settings Page', () => {
       expect(
         screen.getByRole('button', { name: 'copy to clipboard' })
       ).toBeVisible();
+    });
+
+    it('should render api key expiration date according to user timezone', async () => {
+      const futureDate = '2026-05-14T10:30:00.000Z';
+
+      const [StatefulSettings] = withState(<SettingsPage />, {
+        ...defaultInitialState,
+        user: {
+          abilities: defaultInitialStateBase.user.abilities,
+          timezone: 'Pacific/Kiritimati',
+        },
+      });
+
+      axiosMock.onGet('/api/v1/settings/api_key').reply(200, {
+        expire_at: futureDate,
+        generated_api_key: 'api_key_with_expiration',
+      });
+
+      await act(async () => {
+        renderWithRouter(StatefulSettings);
+      });
+
+      const expectedDate = formatDateOnly(futureDate, 'Pacific/Kiritimati');
+      expect(screen.getByText(`Key will expire ${expectedDate}`)).toBeVisible();
     });
   });
 
@@ -136,9 +160,9 @@ describe('Settings Page', () => {
 
       expect(screen.getByText('CA Certificate')).toBeVisible();
       expect(screen.getByText('Certificate Uploaded')).toBeVisible();
-      expect(
-        screen.getByText(format(ca_uploaded_at, "'Uploaded:' dd MMM y"))
-      ).toBeVisible();
+
+      const expectedDate = formatDateOnly(ca_uploaded_at);
+      expect(screen.getByText(`Uploaded: ${expectedDate}`)).toBeVisible();
 
       const sumaUsername = screen.getByLabelText('suma-username');
       expect(sumaUsername).toBeVisible();

--- a/assets/js/pages/Users/CreateUserPage.jsx
+++ b/assets/js/pages/Users/CreateUserPage.jsx
@@ -9,6 +9,7 @@ import NotFound from '@pages/NotFound';
 import { isSingleSignOnEnabled } from '@lib/auth/config';
 import { listAbilities } from '@lib/api/abilities';
 import { createUser } from '@lib/api/users';
+import { timezones } from '@lib/timezones';
 
 import UserForm from './UserForm';
 
@@ -75,6 +76,7 @@ function CreateUserPage() {
         saving={savingState}
         errors={errorsState}
         onSave={onCreateUser}
+        timezones={timezones}
         onCancel={onCancel}
       />
     </div>

--- a/assets/js/pages/Users/CreateUserPage.test.jsx
+++ b/assets/js/pages/Users/CreateUserPage.test.jsx
@@ -12,6 +12,7 @@ import { faker } from '@faker-js/faker';
 import * as router from 'react-router';
 
 import { networkClient } from '@lib/network';
+import { timezones } from '@lib/timezones';
 import * as authConfig from '@lib/auth/config';
 import { abilityFactory, userFactory } from '@lib/test-utils/factories/users';
 
@@ -71,6 +72,7 @@ describe('CreateUserPage', () => {
     const { fullname, email, username } = userFactory.build();
     const password = faker.internet.password();
     const abilities = abilityFactory.buildList(2);
+    const { value: timezoneValue, label: timezoneLabel } = timezones[0];
 
     axiosMock
       .onPost(USERS_URL)
@@ -85,6 +87,11 @@ describe('CreateUserPage', () => {
     await user.type(screen.getByPlaceholderText('Enter username'), username);
     await user.type(screen.getByPlaceholderText('Enter password'), password);
     await user.type(screen.getByPlaceholderText('Re-enter password'), password);
+
+    const timezoneSelector = screen.getByRole('combobox', { name: 'Timezone' });
+    await user.click(timezoneSelector);
+    await user.type(timezoneSelector, timezoneValue);
+    await user.click(await screen.findByText(timezoneLabel));
 
     await user.click(screen.getByLabelText('permissions'));
 

--- a/assets/js/pages/Users/EditUserPage.jsx
+++ b/assets/js/pages/Users/EditUserPage.jsx
@@ -9,6 +9,7 @@ import PersonalAccessTokens from '@common/PersonalAccessTokens';
 
 import { isAdmin } from '@lib/model/users';
 import { isSingleSignOnEnabled } from '@lib/auth/config';
+import { timezones } from '@lib/timezones';
 
 import { editUser, getUser, deleteUserAccessToken } from '@lib/api/users';
 import { getAnalyticsEnabledConfig } from '@lib/analytics';
@@ -112,6 +113,7 @@ function EditUserPage() {
     totp_enabled_at: totpEnabledAt,
     last_login_at: lastLoginAt,
     analytics_enabled: analyticsEnabled,
+    timezone,
   } = userState;
 
   return (
@@ -141,6 +143,8 @@ function EditUserPage() {
         lastLoginAt={lastLoginAt}
         analyticsEnabledConfig={analyticsEnabledConfig}
         analyticsEnabled={analyticsEnabled}
+        timezone={timezone}
+        timezones={timezones}
         saveEnabled={!isAdmin(userState)}
         saving={savingState}
         errors={errorsState}
@@ -154,6 +158,7 @@ function EditUserPage() {
         personalAccessTokens={personalAccessTokens}
         generateTokenAvailable={false}
         onDeleteToken={onDeleteToken}
+        timezone={timezone}
       />
     </div>
   );

--- a/assets/js/pages/Users/UserForm.jsx
+++ b/assets/js/pages/Users/UserForm.jsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { noop } from 'lodash';
-import { format, parseISO } from 'date-fns';
-
 import Button from '@common/Button';
+import { formatDateTime, DEFAULT_TIMEZONE } from '@lib/timezones';
 import Input, { Password } from '@common/Input';
 import Label from '@common/Label';
 import AbilitiesMultiSelect from '@common/AbilitiesMultiSelect';
@@ -16,7 +15,6 @@ import {
   errorMessage,
 } from '@lib/forms';
 import { getError } from '@lib/api/validationErrors';
-import { DEFAULT_TIMEZONE } from '@lib/timezones';
 import { generateValidPassword } from './generatePassword';
 
 const USER_ENABLED = 'Enabled';
@@ -346,15 +344,15 @@ function UserForm({
                 <>
                   <Label className="col-start-1 col-span-2">Created</Label>
                   <span className="col-start-3 col-span-4">
-                    {format(parseISO(createdAt), 'PPpp')}
+                    {formatDateTime(createdAt, timezone)}
                   </span>
                   <Label className="col-start-1 col-span-2">Updated</Label>
                   <span className="col-start-3 col-span-4">
-                    {format(parseISO(updatedAt), 'PPpp')}
+                    {formatDateTime(updatedAt, timezone)}
                   </span>
                   <Label className="col-start-1 col-span-2">Last Login</Label>
                   <span className="col-start-3 col-span-4">
-                    {lastLoginAt ? format(parseISO(lastLoginAt), 'PPpp') : '-'}
+                    {lastLoginAt ? formatDateTime(lastLoginAt, timezone) : '-'}
                   </span>
                 </>
               )}

--- a/assets/js/pages/Users/UserForm.jsx
+++ b/assets/js/pages/Users/UserForm.jsx
@@ -114,13 +114,13 @@ function UserForm({
     }),
     abilities: abilities.filter(({ id }) => selectedAbilities.includes(id)),
     ...(totpEnabledAt && !totpState && { totp_disabled: true }),
-    ...(editing && { timezone: timezoneState }),
+    timezone: timezoneState,
   });
 
   const buildSSOUserPayload = () => ({
     enabled: statusState === USER_ENABLED,
     abilities: abilities.filter(({ id }) => selectedAbilities.includes(id)),
-    ...(editing && { timezone: timezoneState }),
+    timezone: timezoneState,
   });
 
   const onSaveClicked = () => {
@@ -274,33 +274,33 @@ function UserForm({
               onChange={setStatus}
             />
           </div>
+          <Label
+            htmlFor="timezone"
+            className="col-start-1 col-span-2 sm:pt-2"
+            info={'Aligns timestamps according to timezone selection'}
+          >
+            Timezone
+          </Label>
+          <div className="col-start-3 col-span-4">
+            <Select
+              inputId="timezone"
+              name="timezone"
+              value={selectedTimezone}
+              options={timezones}
+              onChange={(value) => {
+                setTimezone(value || '');
+                setTimezoneError(null);
+              }}
+              isMulti={false}
+              isSearchable
+              disabled={!saveEnabled || saving}
+              placeholder="Select timezone..."
+              noOptionsMessage={() => 'No timezones found'}
+            />
+            {timezoneErrorState && errorMessage(timezoneErrorState)}
+          </div>
           {editing && (
             <>
-              <Label
-                htmlFor="timezone"
-                className="col-start-1 col-span-2 sm:pt-2"
-                info={'Aligns timestamps according to timezone selection'}
-              >
-                Timezone
-              </Label>
-              <div className="col-start-3 col-span-4">
-                <Select
-                  inputId="timezone"
-                  name="timezone"
-                  value={selectedTimezone}
-                  options={timezones}
-                  onChange={(value) => {
-                    setTimezone(value || '');
-                    setTimezoneError(null);
-                  }}
-                  isMulti={false}
-                  isSearchable
-                  disabled={!saveEnabled || saving}
-                  placeholder="Select timezone..."
-                  noOptionsMessage={() => 'No timezones found'}
-                />
-                {timezoneErrorState && errorMessage(timezoneErrorState)}
-              </div>
               {!singleSignOnEnabled && (
                 <>
                   <Label

--- a/assets/js/pages/Users/UserForm.jsx
+++ b/assets/js/pages/Users/UserForm.jsx
@@ -16,7 +16,7 @@ import {
   errorMessage,
 } from '@lib/forms';
 import { getError } from '@lib/api/validationErrors';
-
+import { DEFAULT_TIMEZONE } from '@lib/timezones';
 import { generateValidPassword } from './generatePassword';
 
 const USER_ENABLED = 'Enabled';
@@ -37,6 +37,8 @@ function UserForm({
   lastLoginAt = '',
   analyticsEnabledConfig = false,
   analyticsEnabled,
+  timezone = DEFAULT_TIMEZONE,
+  timezones = [],
   errors = defaultErrors,
   saving = false,
   saveEnabled = true,
@@ -58,6 +60,8 @@ function UserForm({
   const [confirmPasswordErrorState, setConfirmPasswordError] = useState(null);
   const [statusState, setStatus] = useState(status);
   const [totpState, setTotpState] = useState(Boolean(totpEnabledAt));
+  const [timezoneState, setTimezone] = useState(timezone);
+  const [timezoneErrorState, setTimezoneError] = useState(null);
   const [selectedAbilities, setAbilities] = useState(
     userAbilities.map(({ id }) => id)
   );
@@ -68,6 +72,7 @@ function UserForm({
     setUsernameError(getError('username', errors));
     setPasswordError(getError('password', errors));
     setConfirmPasswordError(getError('password_confirmation', errors));
+    setTimezoneError(getError('timezone', errors));
   }, [errors]);
 
   const validateRequired = () => {
@@ -111,11 +116,13 @@ function UserForm({
     }),
     abilities: abilities.filter(({ id }) => selectedAbilities.includes(id)),
     ...(totpEnabledAt && !totpState && { totp_disabled: true }),
+    ...(editing && { timezone: timezoneState }),
   });
 
   const buildSSOUserPayload = () => ({
     enabled: statusState === USER_ENABLED,
     abilities: abilities.filter(({ id }) => selectedAbilities.includes(id)),
+    ...(editing && { timezone: timezoneState }),
   });
 
   const onSaveClicked = () => {
@@ -135,6 +142,9 @@ function UserForm({
     setPassword(newPassword);
     setConfirmPassword(newPassword);
   };
+
+  const selectedTimezone =
+    timezones.find((opt) => opt.value === timezoneState) || null;
 
   return (
     <div>
@@ -268,6 +278,31 @@ function UserForm({
           </div>
           {editing && (
             <>
+              <Label
+                htmlFor="timezone"
+                className="col-start-1 col-span-2 sm:pt-2"
+                info={'Aligns timestamps according to timezone selection'}
+              >
+                Timezone
+              </Label>
+              <div className="col-start-3 col-span-4">
+                <Select
+                  inputId="timezone"
+                  name="timezone"
+                  value={selectedTimezone}
+                  options={timezones}
+                  onChange={(value) => {
+                    setTimezone(value || '');
+                    setTimezoneError(null);
+                  }}
+                  isMulti={false}
+                  isSearchable
+                  disabled={!saveEnabled || saving}
+                  placeholder="Select timezone..."
+                  noOptionsMessage={() => 'No timezones found'}
+                />
+                {timezoneErrorState && errorMessage(timezoneErrorState)}
+              </div>
               {!singleSignOnEnabled && (
                 <>
                   <Label

--- a/assets/js/pages/Users/UserForm.stories.jsx
+++ b/assets/js/pages/Users/UserForm.stories.jsx
@@ -99,15 +99,16 @@ export default {
       },
     },
     analyticsEnabledConfig: {
-      description: 'Toggles visibility of Analytics switch. Analytics config is enabled',
+      description:
+        'Toggles visibility of Analytics switch. Analytics config is enabled',
       control: {
-        type: 'boolean'
+        type: 'boolean',
       },
     },
     analyticsEnabled: {
       description: 'Toggles tracking user analytics',
       control: {
-        type: 'boolean'
+        type: 'boolean',
       },
     },
     timezone: {
@@ -190,7 +191,7 @@ export const Editing = {
     timezone,
     editing: true,
     saveText: 'Save',
-    timezones: ["GMT+00:00", "GMT+01:00", "GMT+02:00"],
+    timezones: ['GMT+00:00', 'GMT+01:00', 'GMT+02:00'],
   },
 };
 

--- a/assets/js/pages/Users/UserForm.stories.jsx
+++ b/assets/js/pages/Users/UserForm.stories.jsx
@@ -17,6 +17,7 @@ const {
   updated_at: updatedAt,
   totp_enabled_at: totpEnabledAt,
   last_login_at: lastLoginAt,
+  timezone,
 } = userFactory.build();
 
 const {
@@ -79,7 +80,7 @@ export default {
         type: 'text',
       },
     },
-    udpatedAt: {
+    updatedAt: {
       description: 'User last update timestamp',
       control: {
         type: 'text',
@@ -97,10 +98,34 @@ export default {
         type: 'text',
       },
     },
+    analyticsEnabledConfig: {
+      description: 'Toggles visibility of Analytics switch. Analytics config is enabled',
+      control: {
+        type: 'boolean'
+      },
+    },
+    analyticsEnabled: {
+      description: 'Toggles tracking user analytics',
+      control: {
+        type: 'boolean'
+      },
+    },
+    timezone: {
+      description: 'User timezone',
+      control: {
+        type: 'text',
+      },
+    },
     editing: {
       description: 'User is being edited',
       control: {
         type: 'boolean',
+      },
+    },
+    timezones: {
+      description: 'Available timezones',
+      control: {
+        type: 'object',
       },
     },
     saving: {
@@ -162,8 +187,10 @@ export const Editing = {
     updatedAt,
     totpEnabledAt,
     lastLoginAt,
+    timezone,
     editing: true,
     saveText: 'Save',
+    timezones: ["GMT+00:00", "GMT+01:00", "GMT+02:00"],
   },
 };
 

--- a/assets/js/pages/Users/UserForm.test.jsx
+++ b/assets/js/pages/Users/UserForm.test.jsx
@@ -7,8 +7,12 @@ import userEvent from '@testing-library/user-event';
 import { faker } from '@faker-js/faker';
 
 import { abilityFactory, userFactory } from '@lib/test-utils/factories/users';
+import { DEFAULT_TIMEZONE, timezones } from '@lib/timezones';
 
 import UserForm from './UserForm';
+
+const getTimezoneLabel = (timezone) =>
+  timezones.find((option) => option.value === timezone)?.label;
 
 describe('UserForm', () => {
   it('should display an empty user form', () => {
@@ -27,6 +31,7 @@ describe('UserForm', () => {
     expect(screen.getByText('Generate Password')).toBeVisible();
     expect(screen.getByText('Permissions')).toBeVisible();
     expect(screen.getByText('Status')).toBeVisible();
+    expect(screen.queryByText('Timezone')).not.toBeInTheDocument();
     expect(screen.queryByText('TOTP')).not.toBeInTheDocument();
     expect(screen.queryByText('Analytics Opt-in')).not.toBeInTheDocument();
     expect(screen.queryByText('Created')).not.toBeInTheDocument();
@@ -47,6 +52,7 @@ describe('UserForm', () => {
       totp_enabled_at: totpEnabledAt,
       analytics_enabled: analyticsEnabled,
       last_login_at: lastLoginAt,
+      timezone,
     } = userFactory.build();
 
     render(
@@ -60,6 +66,8 @@ describe('UserForm', () => {
         analyticsEnabledConfig
         analytics_enabled={analyticsEnabled}
         lastLoginAt={lastLoginAt}
+        timezone={timezone}
+        timezones={timezones}
         editing
       />
     );
@@ -72,6 +80,7 @@ describe('UserForm', () => {
     expect(screen.getByText('Created')).toBeVisible();
     expect(screen.getByText('Updated')).toBeVisible();
     expect(screen.getByText('Last Login')).toBeVisible();
+    expect(screen.getByText('Timezone')).toBeVisible();
     expect(screen.getByText('TOTP')).toBeVisible();
     expect(screen.getByText('Analytics Opt-in')).toBeVisible();
     expect(screen.getByText('Enabled')).toBeVisible();
@@ -208,6 +217,7 @@ describe('UserForm', () => {
       username,
       created_at: createdAt,
       updated_at: updatedAt,
+      timezone,
     } = userFactory.build();
 
     render(
@@ -219,6 +229,8 @@ describe('UserForm', () => {
         updatedAt={updatedAt}
         editing
         onSave={mockOnSave}
+        timezone={timezone}
+        timezones={timezones}
       />
     );
 
@@ -232,6 +244,7 @@ describe('UserForm', () => {
       email,
       enabled: result,
       abilities: [],
+      timezone,
     });
   });
 
@@ -259,6 +272,7 @@ describe('UserForm', () => {
         totpEnabledAt={totpEnabledAt}
         editing
         onSave={mockOnSave}
+        timezones={timezones}
       />
     );
     await user.click(screen.getAllByText('Enabled')[1]);
@@ -272,6 +286,7 @@ describe('UserForm', () => {
       enabled: true,
       abilities: [],
       totp_disabled: true,
+      timezone: DEFAULT_TIMEZONE,
     });
   });
 
@@ -334,6 +349,7 @@ describe('UserForm', () => {
         userAbilities={userAbilities}
         createdAt={createdAt}
         updatedAt={updatedAt}
+        timezones={timezones}
         editing
       />
     );
@@ -359,6 +375,7 @@ describe('UserForm', () => {
       email,
       enabled: true,
       abilities: abilities.slice(0, 2),
+      timezone: DEFAULT_TIMEZONE,
     });
   });
 
@@ -376,6 +393,186 @@ describe('UserForm', () => {
     );
 
     expect(screen.getByText('Last Login').nextSibling).toHaveTextContent('-');
+  });
+
+  it('should set timezone selector value when timezone is not provided', () => {
+    const {
+      fullname,
+      email,
+      username,
+      created_at: createdAt,
+      updated_at: updatedAt,
+    } = userFactory.build();
+
+    render(
+      <UserForm
+        fullName={fullname}
+        emailAddress={email}
+        username={username}
+        createdAt={createdAt}
+        updatedAt={updatedAt}
+        editing
+        timezones={timezones}
+      />
+    );
+
+    expect(screen.getByText('Timezone')).toBeVisible();
+    expect(screen.getByLabelText('Timezone')).toBeVisible();
+    expect(document.querySelector('input[name="timezone"]')).toHaveValue(
+      DEFAULT_TIMEZONE
+    );
+  });
+
+  it('should include provided timezone in save payload', async () => {
+    const user = userEvent.setup();
+    const mockOnSave = jest.fn();
+    const {
+      fullname,
+      email,
+      username,
+      created_at: createdAt,
+      updated_at: updatedAt,
+      timezone,
+    } = userFactory.build();
+
+    render(
+      <UserForm
+        fullName={fullname}
+        emailAddress={email}
+        username={username}
+        createdAt={createdAt}
+        updatedAt={updatedAt}
+        timezone={timezone}
+        timezones={timezones}
+        editing
+        onSave={mockOnSave}
+      />
+    );
+
+    expect(screen.getByText('Timezone')).toBeVisible();
+    expect(screen.getByLabelText('Timezone')).toBeVisible();
+
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(mockOnSave).toHaveBeenNthCalledWith(1, {
+      fullname,
+      email,
+      enabled: true,
+      abilities: [],
+      timezone,
+    });
+  });
+
+  it('should set timezone in save payload when timezone selector changes', async () => {
+    const user = userEvent.setup();
+    const mockOnSave = jest.fn();
+    const timezone = 'Europe/Berlin';
+
+    const {
+      fullname,
+      email,
+      username,
+      created_at: createdAt,
+      updated_at: updatedAt,
+    } = userFactory.build();
+
+    render(
+      <UserForm
+        fullName={fullname}
+        emailAddress={email}
+        username={username}
+        createdAt={createdAt}
+        updatedAt={updatedAt}
+        timezone={DEFAULT_TIMEZONE}
+        timezones={timezones}
+        editing
+        onSave={mockOnSave}
+      />
+    );
+
+    const timezoneSelectorInput = screen.getByLabelText('Timezone');
+
+    await user.click(timezoneSelectorInput);
+    await user.type(timezoneSelectorInput, timezone);
+    await user.click(await screen.findByText(getTimezoneLabel(timezone)));
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(mockOnSave).toHaveBeenNthCalledWith(1, {
+      fullname,
+      email,
+      enabled: true,
+      abilities: [],
+      timezone,
+    });
+  });
+
+  it('should include default timezone in save payload when timezone is omitted', async () => {
+    const user = userEvent.setup();
+    const mockOnSave = jest.fn();
+    const {
+      fullname,
+      email,
+      username,
+      created_at: createdAt,
+      updated_at: updatedAt,
+    } = userFactory.build();
+
+    render(
+      <UserForm
+        fullName={fullname}
+        emailAddress={email}
+        username={username}
+        createdAt={createdAt}
+        updatedAt={updatedAt}
+        editing
+        onSave={mockOnSave}
+        timezones={timezones}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(mockOnSave).toHaveBeenNthCalledWith(1, {
+      fullname,
+      email,
+      enabled: true,
+      abilities: [],
+      timezone: DEFAULT_TIMEZONE,
+    });
+  });
+
+  it('should set timezone error when timezone error is provided', async () => {
+    const {
+      created_at: createdAt,
+      updated_at: updatedAt,
+      fullname,
+      email,
+      username,
+    } = userFactory.build();
+    const errors = [
+      {
+        detail: 'is not a valid IANA timezone',
+        source: { pointer: '/timezone' },
+        title: 'Invalid value',
+      },
+    ];
+
+    render(
+      <UserForm
+        fullName={fullname}
+        emailAddress={email}
+        username={username}
+        createdAt={createdAt}
+        updatedAt={updatedAt}
+        errors={errors}
+        editing
+        timezones={timezones}
+      />
+    );
+
+    expect(
+      await screen.findByText(/is not a valid IANA timezone/i)
+    ).toBeVisible();
   });
 
   describe('Single sign on', () => {
@@ -396,12 +593,13 @@ describe('UserForm', () => {
       expect(screen.queryByText('TOTP')).not.toBeInTheDocument();
       expect(screen.getByText('Permissions')).toBeVisible();
       expect(screen.getByText('Enabled')).toBeVisible();
+      expect(screen.getByText('Timezone')).toBeVisible();
     });
 
     it('should save permissions and status', async () => {
       const user = userEvent.setup();
 
-      const { fullname, email, username } = userFactory.build();
+      const { fullname, email, username, timezone } = userFactory.build();
 
       const abilities = abilityFactory.buildList(3);
       const userAbilities = [abilities[0]];
@@ -418,6 +616,8 @@ describe('UserForm', () => {
           editing
           abilities={abilities}
           userAbilities={userAbilities}
+          timezone={timezone}
+          timezones={timezones}
           singleSignOnEnabled
         />
       );
@@ -443,6 +643,7 @@ describe('UserForm', () => {
       expect(mockOnSave).toHaveBeenNthCalledWith(1, {
         enabled: true,
         abilities: abilities.slice(0, 2),
+        timezone,
       });
     });
   });

--- a/assets/js/pages/Users/UserForm.test.jsx
+++ b/assets/js/pages/Users/UserForm.test.jsx
@@ -31,7 +31,7 @@ describe('UserForm', () => {
     expect(screen.getByText('Generate Password')).toBeVisible();
     expect(screen.getByText('Permissions')).toBeVisible();
     expect(screen.getByText('Status')).toBeVisible();
-    expect(screen.queryByText('Timezone')).not.toBeInTheDocument();
+    expect(screen.getByText('Timezone')).toBeVisible();
     expect(screen.queryByText('TOTP')).not.toBeInTheDocument();
     expect(screen.queryByText('Analytics Opt-in')).not.toBeInTheDocument();
     expect(screen.queryByText('Created')).not.toBeInTheDocument();
@@ -179,17 +179,30 @@ describe('UserForm', () => {
 
   it('should save the user', async () => {
     const user = userEvent.setup();
-    const { fullname, email, username } = userFactory.build();
+    const { fullname, email, username, timezone } = userFactory.build();
     const password = faker.internet.password();
     const mockOnSave = jest.fn();
 
-    render(<UserForm saveText="Save" onSave={mockOnSave} />);
+    render(
+      <UserForm
+        saveText="Save"
+        onSave={mockOnSave}
+        timezone={DEFAULT_TIMEZONE}
+        timezones={timezones}
+      />
+    );
 
     await user.type(screen.getByPlaceholderText('Enter full name'), fullname);
     await user.type(screen.getByPlaceholderText('Enter email address'), email);
     await user.type(screen.getByPlaceholderText('Enter username'), username);
     await user.type(screen.getByPlaceholderText('Enter password'), password);
     await user.type(screen.getByPlaceholderText('Re-enter password'), password);
+    const timezoneSelectorInput = screen.getByRole('combobox', {
+      name: 'Timezone',
+    });
+    await user.click(timezoneSelectorInput);
+    await user.type(timezoneSelectorInput, timezone);
+    await user.click(await screen.findByText(getTimezoneLabel(timezone)));
 
     await user.click(screen.getByRole('button', { name: 'Save' }));
 
@@ -201,6 +214,7 @@ describe('UserForm', () => {
       password_confirmation: password,
       enabled: true,
       abilities: [],
+      timezone,
     });
   });
 
@@ -490,7 +504,9 @@ describe('UserForm', () => {
       />
     );
 
-    const timezoneSelectorInput = screen.getByLabelText('Timezone');
+    const timezoneSelectorInput = screen.getByRole('combobox', {
+      name: 'Timezone',
+    });
 
     await user.click(timezoneSelectorInput);
     await user.type(timezoneSelectorInput, timezone);

--- a/assets/js/pages/Users/Users.jsx
+++ b/assets/js/pages/Users/Users.jsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router';
 import { noop } from 'lodash';
-import { format, parseISO } from 'date-fns';
 
 import { isAdmin } from '@lib/model/users';
+import { formatDateOnly } from '@lib/timezones';
 
 import Banner from '@common/Banners';
 import Button from '@common/Button';
@@ -20,6 +20,7 @@ function Users({
   users = defaultUsers,
   loading = false,
   singleSignOnEnabled = false,
+  timezone,
 }) {
   const [modalOpen, setModalOpen] = useState(false);
   const [user, setUser] = useState(null);
@@ -59,7 +60,7 @@ function Users({
         title: 'Created',
         key: 'created_at',
         render: (content, item) => (
-          <span>{format(parseISO(item.created_at), 'MMMM dd, yyyy')}</span>
+          <span>{formatDateOnly(item.created_at, timezone)}</span>
         ),
       },
       ...(!singleSignOnEnabled
@@ -68,9 +69,7 @@ function Users({
               title: 'Last Login',
               key: 'last_login_at',
               render: (content) => (
-                <span>
-                  {content ? format(parseISO(content), 'MMMM dd, yyyy') : '-'}
-                </span>
+                <span>{content ? formatDateOnly(content, timezone) : '-'}</span>
               ),
             },
           ]

--- a/assets/js/pages/Users/Users.test.jsx
+++ b/assets/js/pages/Users/Users.test.jsx
@@ -5,6 +5,8 @@ import { adminUser, userFactory } from '@lib/test-utils/factories/users';
 import { renderWithRouter } from '@lib/test-utils';
 import { userEvent } from '@testing-library/user-event';
 import Users from './Users';
+import { faker } from '@faker-js/faker';
+import { DEFAULT_TIMEZONE } from '@lib/timezones';
 
 describe('Users', () => {
   it('should render a loading table with a disabled create user button', () => {
@@ -28,8 +30,9 @@ describe('Users', () => {
   });
 
   it('should render an empty table with an enabled create user button', () => {
-    render(<Users loading={false} />);
-
+    render(<Users loading={false} />, {
+      initialState: { user: { timezone: faker.location.timeZone() } },
+    });
     const button = screen.getByRole('button', { name: /Create User/i });
     expect(button).not.toBeDisabled();
     expect(screen.getByText('No data available')).toBeVisible();
@@ -40,12 +43,12 @@ describe('Users', () => {
       '2024-03-22T16:20:57.801758Z',
       '2024-04-22T16:20:57.801758Z',
     ];
-    const expectedCreationTime = ['March 22, 2024', 'April 22, 2024'];
+    const expectedCreationTime = ['22 Mar 2024', '22 Apr 2024'];
     const lastLoginTime = [
       '2025-11-26T16:20:57.801758Z',
       '2025-12-26T16:20:57.801758Z',
     ];
-    const expectedLastLoginTime = ['November 26, 2025', 'December 26, 2025'];
+    const expectedLastLoginTime = ['26 Nov 2025', '26 Dec 2025'];
     const admin = adminUser.build({
       enabled: true,
       created_at: creationTime[0],
@@ -58,7 +61,9 @@ describe('Users', () => {
     });
     const users = [admin, user];
 
-    renderWithRouter(<Users users={users} loading={false} />);
+    renderWithRouter(
+      <Users users={users} loading={false} timezone={DEFAULT_TIMEZONE} />
+    );
 
     expect(screen.getByText(admin.username)).toBeVisible();
     expect(screen.getByText(admin.fullname)).toBeVisible();
@@ -90,6 +95,27 @@ describe('Users', () => {
     expect(table.querySelector('td:nth-child(6)')).toHaveTextContent('-');
   });
 
+  it('should render created and last login dates according to user timezone', () => {
+    const createdAt = '2024-01-10T23:30:00.000Z';
+    const lastLoginAt = '2024-01-11T23:30:00.000Z';
+    const timezone = 'Pacific/Kiritimati';
+    const users = [
+      userFactory.build({
+        created_at: createdAt,
+        last_login_at: lastLoginAt,
+        enabled: true,
+      }),
+    ];
+
+    renderWithRouter(
+      <Users users={users} loading={false} timezone={timezone} />
+    );
+
+    expect(screen.getByText('11 Jan 2024')).toBeVisible();
+    expect(screen.getByText('12 Jan 2024')).toBeVisible();
+    expect(screen.queryByText('10 Jan 2024')).not.toBeInTheDocument();
+  });
+
   it('should open modal when delete button is pressed and close when cancel button is pressed', async () => {
     const user = userFactory.build();
     const users = [adminUser.build(), user];
@@ -117,12 +143,12 @@ describe('Users', () => {
 
   describe('Single sign on', () => {
     it('should disable user creation', () => {
-      renderWithRouter(<Users users={[]} singleSignOnEnabled />);
+      render(<Users users={[]} singleSignOnEnabled />);
       expect(screen.queryByText('Create User')).not.toBeInTheDocument();
     });
 
     it('should not display last login time information', () => {
-      renderWithRouter(<Users users={[]} singleSignOnEnabled />);
+      render(<Users users={[]} singleSignOnEnabled />);
       expect(screen.queryByText('Last Login')).not.toBeInTheDocument();
     });
   });

--- a/assets/js/pages/Users/UsersPage.jsx
+++ b/assets/js/pages/Users/UsersPage.jsx
@@ -4,6 +4,8 @@ import { toast } from 'react-hot-toast';
 
 import { listUsers, deleteUser } from '@lib/api/users';
 import { isSingleSignOnEnabled } from '@lib/auth/config';
+import { useSelector } from 'react-redux';
+import { getUserProfile } from '@state/selectors/user';
 
 import Users from './Users';
 
@@ -15,6 +17,8 @@ function UsersPage() {
   const [loading, setLoading] = useState(true);
   const [users, setUsers] = useState([]);
   const [error, setError] = useState(null);
+
+  const { timezone } = useSelector(getUserProfile);
 
   const navigate = useNavigate();
 
@@ -64,6 +68,7 @@ function UsersPage() {
       users={users}
       loading={loading}
       singleSignOnEnabled={isSingleSignOnEnabled()}
+      timezone={timezone}
     />
   );
 }

--- a/assets/js/pages/Users/UsersPage.test.jsx
+++ b/assets/js/pages/Users/UsersPage.test.jsx
@@ -8,11 +8,29 @@ import { networkClient } from '@lib/network';
 import { screen, act, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { adminUser, userFactory } from '@lib/test-utils/factories/users';
-import { renderWithRouter } from '@lib/test-utils';
+import {
+  defaultInitialState,
+  renderWithRouter,
+  withState,
+} from '@lib/test-utils';
+import { faker } from '@faker-js/faker';
 
 import UsersPage from './UsersPage';
 
 const axiosMock = new MockAdapter(networkClient);
+
+const renderUsersPage = (initialState = {}) => {
+  const [StatefulUsersPage] = withState(<UsersPage />, {
+    ...defaultInitialState,
+    ...initialState,
+    user: {
+      ...defaultInitialState.user,
+      ...initialState.user,
+    },
+  });
+
+  return renderWithRouter(StatefulUsersPage);
+};
 
 jest.mock('react-hot-toast', () => ({
   toast: {
@@ -34,7 +52,7 @@ describe('UsersPage', () => {
   it('should render table without data', async () => {
     axiosMock.onGet('/api/v1/users').reply(200, []);
     await act(async () => {
-      renderWithRouter(<UsersPage />);
+      renderUsersPage();
     });
     expect(await screen.getByText('No data available')).toBeVisible();
   });
@@ -46,18 +64,38 @@ describe('UsersPage', () => {
     axiosMock.onGet('/api/v1/users').reply(200, [admin, user]);
 
     await act(async () => {
-      renderWithRouter(<UsersPage />);
+      renderUsersPage();
     });
 
     expect(await screen.getByText(admin.username)).toBeInTheDocument();
     expect(await screen.getByText(user.username)).toBeInTheDocument();
   });
 
+  it('should render created and last login dates using timezone from user state', async () => {
+    const admin = adminUser.build({
+      created_at: '2024-01-10T23:30:00.000Z',
+      last_login_at: '2024-01-11T23:30:00.000Z',
+    });
+
+    axiosMock.onGet('/api/v1/users').reply(200, [admin]);
+
+    await act(async () => {
+      renderUsersPage({
+        user: {
+          timezone: 'Pacific/Kiritimati',
+        },
+      });
+    });
+
+    expect(await screen.findByText('11 Jan 2024')).toBeVisible();
+    expect(await screen.findByText('12 Jan 2024')).toBeVisible();
+  });
+
   it('should render toast with failing message when fetching users failed', async () => {
     const fetchErrorMessage = 'An error occurred: Fetching users failed';
     axiosMock.onGet('/api/v1/users').reply(404);
     await act(async () => {
-      renderWithRouter(<UsersPage />);
+      renderUsersPage();
     });
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(fetchErrorMessage);
@@ -77,7 +115,7 @@ describe('UsersPage', () => {
       .reply(204);
 
     await act(async () => {
-      renderWithRouter(<UsersPage />);
+      renderUsersPage();
     });
 
     const deleteButtons = screen.getAllByText('Delete');
@@ -101,7 +139,9 @@ describe('UsersPage', () => {
     axiosMock.onDelete(`/api/v1/users/${user.id}`).reply(404);
 
     await act(async () => {
-      renderWithRouter(<UsersPage />);
+      renderUsersPage({
+        user: { timezone: faker.location.timeZone() },
+      });
     });
 
     const deleteButtons = screen.getAllByText('Delete');

--- a/assets/js/state/user.js
+++ b/assets/js/state/user.js
@@ -15,6 +15,7 @@ export const initialState = {
   authInProgress: false,
   analytics_enabled: undefined,
   analytics_eula_accepted: undefined,
+  timezone: undefined,
 };
 
 export const userSlice = createSlice({
@@ -48,6 +49,7 @@ export const userSlice = createSlice({
           password_change_requested,
           analytics_enabled,
           analytics_eula_accepted,
+          timezone,
         },
       }
     ) {
@@ -61,6 +63,7 @@ export const userSlice = createSlice({
       state.password_change_requested = password_change_requested;
       state.analytics_enabled = analytics_enabled;
       state.analytics_eula_accepted = analytics_eula_accepted;
+      state.timezone = timezone;
     },
   },
 });

--- a/assets/js/state/user.test.js
+++ b/assets/js/state/user.test.js
@@ -53,6 +53,7 @@ describe('user reducer', () => {
       updated_at,
       analytics_enabled,
       analytics_eula_accepted,
+      timezone,
     } = userFactory.build();
 
     const action = setUser({
@@ -65,6 +66,7 @@ describe('user reducer', () => {
       updated_at,
       analytics_enabled,
       analytics_eula_accepted,
+      timezone,
     });
 
     expect(userReducer(initialState, action)).toEqual({
@@ -78,6 +80,7 @@ describe('user reducer', () => {
       updated_at,
       analytics_enabled,
       analytics_eula_accepted,
+      timezone,
     });
   });
 });

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@date-fns/tz": "^1.4.1",
         "@date-fns/utc": "^2.1.1",
         "@headlessui/react": "^2.2.7",
         "@heroicons/react": "^2.2.0",
@@ -39,6 +40,7 @@
         "redux-saga": "^1.4.2",
         "remark-gfm": "^4.0.1",
         "semver": "^7.7.4",
+        "tzdata": "^1.0.48",
         "uuid": "^11.1.0"
       },
       "devDependencies": {
@@ -2125,6 +2127,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
     },
     "node_modules/@date-fns/utc": {
       "version": "2.1.1",
@@ -17258,6 +17266,12 @@
       "dependencies": {
         "typescript-compare": "^0.0.2"
       }
+    },
+    "node_modules/tzdata": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/tzdata/-/tzdata-1.0.48.tgz",
+      "integrity": "sha512-dTveS1xSqCPA+PssFrhBQpWHF0ut8GR2jx3YRcjHV9KQmHCvdzJoo+VUfsXo88X7wLIAprnWDFtoGAQLJDmTZw==",
+      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -99,7 +99,7 @@
     "format:check": "prettier -c .",
     "format": "prettier --write .",
     "pretest": "ls ../priv/static/assets/app.css || npm run tailwind:build",
-    "test": "jest --maxWorkers=2",
+    "test": "TZ=UTC jest --maxWorkers=2",
     "chromatic": "npx chromatic --exit-zero-on-changes"
   }
 }

--- a/assets/package.json
+++ b/assets/package.json
@@ -45,6 +45,7 @@
     "tailwindcss": "^3.4.19"
   },
   "dependencies": {
+    "@date-fns/tz": "^1.4.1",
     "@date-fns/utc": "^2.1.1",
     "@headlessui/react": "^2.2.7",
     "@heroicons/react": "^2.2.0",
@@ -79,6 +80,7 @@
     "redux-saga": "^1.4.2",
     "remark-gfm": "^4.0.1",
     "semver": "^7.7.4",
+    "tzdata": "^1.0.48",
     "uuid": "^11.1.0"
   },
   "overrides": {

--- a/lib/trento/users/user.ex
+++ b/lib/trento/users/user.ex
@@ -45,6 +45,7 @@ defmodule Trento.Users.User do
     field :analytics_enabled_at, :utc_datetime_usec
     field :analytics_eula_accepted_at, :utc_datetime_usec
     field :last_login_at, :utc_datetime_usec
+    field :timezone, :string, default: "Etc/UTC"
     field :lock_version, :integer, default: 1
 
     many_to_many :abilities, Ability, join_through: UsersAbilities, unique: true
@@ -82,8 +83,15 @@ defmodule Trento.Users.User do
     |> maybe_apply_password_changesets(attrs)
     |> pow_extension_changeset(attrs)
     |> custom_fields_changeset(attrs)
-    |> cast(attrs, [:locked_at, :lock_version, :password_change_requested_at, :totp_enabled_at])
+    |> cast(attrs, [
+      :locked_at,
+      :lock_version,
+      :password_change_requested_at,
+      :totp_enabled_at,
+      :timezone
+    ])
     |> validate_inclusion(:totp_enabled_at, [nil])
+    |> validate_timezone()
     |> optimistic_lock(:lock_version)
   end
 
@@ -97,12 +105,16 @@ defmodule Trento.Users.User do
     |> cast(attrs, [
       :password_change_requested_at,
       :analytics_enabled_at,
-      :analytics_eula_accepted_at
+      :analytics_eula_accepted_at,
+      :timezone
     ])
+    |> validate_timezone()
   end
 
   def profile_update_sso_enabled_changeset(user, attrs) do
-    cast(user, attrs, [:analytics_enabled_at, :analytics_eula_accepted_at])
+    user
+    |> cast(attrs, [:analytics_enabled_at, :analytics_eula_accepted_at, :timezone])
+    |> validate_timezone()
   end
 
   def totp_update_changeset(user, attrs) do
@@ -149,6 +161,18 @@ defmodule Trento.Users.User do
   end
 
   defp maybe_apply_password_changesets(user, _), do: user
+
+  # Custom validation to check if the timezone is a valid IANA timezone,
+  # as the default Ecto validation only checks if the field is a string.
+  defp validate_timezone(changeset) do
+    Ecto.Changeset.validate_change(changeset, :timezone, fn :timezone, timezone ->
+      if Timex.Timezone.exists?(timezone) do
+        []
+      else
+        [timezone: "is not a valid IANA timezone"]
+      end
+    end)
+  end
 
   defp validate_current_password(changeset, %{password: _password} = attrs),
     do: pow_current_password_changeset(changeset, attrs)

--- a/lib/trento/users/user.ex
+++ b/lib/trento/users/user.ex
@@ -63,7 +63,8 @@ defmodule Trento.Users.User do
     |> pow_extension_changeset(attrs)
     |> validate_password()
     |> custom_fields_changeset(attrs)
-    |> cast(attrs, [:locked_at, :password_change_requested_at])
+    |> cast(attrs, [:locked_at, :password_change_requested_at, :timezone])
+    |> validate_timezone()
   end
 
   def user_identity_changeset(user_or_changeset, user_identity, attrs, user_id_attrs) do

--- a/lib/trento_web/controllers/v1/profile_json.ex
+++ b/lib/trento_web/controllers/v1/profile_json.ex
@@ -19,6 +19,7 @@ defmodule TrentoWeb.V1.ProfileJSON do
           analytics_enabled_at: analytics_enabled_at,
           analytics_eula_accepted_at: analytics_eula_accepted_at,
           ai_configuration: ai_configuration,
+          timezone: timezone,
           inserted_at: created_at,
           updated_at: updated_at
         }
@@ -38,6 +39,7 @@ defmodule TrentoWeb.V1.ProfileJSON do
         analytics_eula_accepted: analytics_eula_accepted_at != nil,
         ai_configuration: AIConfigurationJSON.ai_configuration_entry(ai_configuration),
         idp_user: length(user_identities) > 0,
+        timezone: timezone,
         updated_at: updated_at
       }
 

--- a/lib/trento_web/controllers/v1/users_controller.ex
+++ b/lib/trento_web/controllers/v1/users_controller.ex
@@ -272,7 +272,9 @@ defmodule TrentoWeb.V1.UsersController do
     put_resp_header(conn, "etag", Integer.to_string(lock_version))
   end
 
-  # when sso is enabled, we only allow abilities and enabled as parameters
-  defp clean_params_for_sso_integration(attrs, true), do: Map.take(attrs, [:abilities, :enabled])
+  # when sso is enabled, we only allow abilities, enabled and timezone as parameters
+  defp clean_params_for_sso_integration(attrs, true),
+    do: Map.take(attrs, [:abilities, :enabled, :timezone])
+
   defp clean_params_for_sso_integration(attrs, _), do: attrs
 end

--- a/lib/trento_web/controllers/v1/users_json.ex
+++ b/lib/trento_web/controllers/v1/users_json.ex
@@ -18,6 +18,7 @@ defmodule TrentoWeb.V1.UsersJSON do
           user_identities: user_identities,
           totp_enabled_at: totp_enabled_at,
           analytics_enabled_at: analytics_enabled_at,
+          timezone: timezone,
           last_login_at: last_login_at,
           inserted_at: created_at,
           updated_at: updated_at
@@ -36,6 +37,7 @@ defmodule TrentoWeb.V1.UsersJSON do
         password_change_requested_at: password_change_requested_at,
         totp_enabled_at: totp_enabled_at,
         analytics_enabled: analytics_enabled_at != nil,
+        timezone: timezone,
         last_login_at: last_login_at,
         created_at: created_at,
         updated_at: updated_at

--- a/lib/trento_web/openapi/v1/schema/user.ex
+++ b/lib/trento_web/openapi/v1/schema/user.ex
@@ -338,6 +338,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
           enabled: true,
           password: "secure_password",
           password_confirmation: "secure_password",
+          timezone: "Europe/Berlin",
           abilities: []
         },
         properties: %{
@@ -383,6 +384,12 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
               "Confirmation of the new user's password, which must match the password field for security.",
             nullable: false,
             example: "secure_password"
+          },
+          timezone: %Schema{
+            type: :string,
+            description: "IANA timezone name for the user.",
+            nullable: false,
+            example: "Europe/Berlin"
           },
           abilities: AbilityCollection
         },
@@ -565,7 +572,15 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             example: "Europe/Berlin"
           }
         },
-        required: [:username, :id, :fullname, :email, :created_at, :personal_access_tokens],
+        required: [
+          :username,
+          :id,
+          :fullname,
+          :email,
+          :created_at,
+          :personal_access_tokens,
+          :timezone
+        ],
         example: %{
           id: 1,
           fullname: "User Item",

--- a/lib/trento_web/openapi/v1/schema/user.ex
+++ b/lib/trento_web/openapi/v1/schema/user.ex
@@ -172,6 +172,12 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             description: "Date of user last update.",
             nullable: true,
             example: "2024-01-15T12:00:00Z"
+          },
+          timezone: %Schema{
+            type: :string,
+            description: "IANA timezone name for the user, used to align timestamps in the UI.",
+            nullable: false,
+            example: "Europe/Berlin"
           }
         },
         required: [
@@ -195,7 +201,8 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
           analytics_enabled: false,
           totp_enabled: true,
           created_at: "2024-01-15T09:00:00Z",
-          updated_at: "2024-01-15T12:00:00Z"
+          updated_at: "2024-01-15T12:00:00Z",
+          timezone: "Europe/Berlin"
         }
       },
       struct?: false
@@ -254,6 +261,12 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             description: "Whether user analytics EULA is accepted.",
             nullable: false,
             example: false
+          },
+          timezone: %Schema{
+            type: :string,
+            description: "IANA timezone name for the user.",
+            nullable: false,
+            example: "Europe/Berlin"
           }
         },
         example: %{
@@ -262,7 +275,8 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
           password: "new_secure_password123",
           current_password: "current_password123",
           password_confirmation: "new_secure_password123",
-          analytics_enabled: true
+          analytics_enabled: true,
+          timezone: "Europe/Berlin"
         }
       },
       struct?: false
@@ -290,10 +304,17 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             description: "Whether user analytics EULA is accepted.",
             nullable: false,
             example: false
+          },
+          timezone: %Schema{
+            type: :string,
+            description: "IANA timezone name for the user.",
+            nullable: false,
+            example: "Europe/Berlin"
           }
         },
         example: %{
-          analytics_enabled: true
+          analytics_enabled: true,
+          timezone: "Europe/Berlin"
         }
       },
       struct?: false
@@ -425,6 +446,12 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
               "Indicates that the TOTP feature is disabled for the user. The only accepted value here is 'true', supporting multi-factor authentication management.",
             nullable: false,
             example: true
+          },
+          timezone: %Schema{
+            type: :string,
+            description: "IANA timezone name for the user.",
+            nullable: false,
+            example: "Europe/Berlin"
           }
         },
         example: %{
@@ -433,7 +460,8 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
           enabled: true,
           password: "new_secure_password123",
           password_confirmation: "new_secure_password123",
-          abilities: []
+          abilities: [],
+          timezone: "Europe/Berlin"
         }
       },
       struct?: false
@@ -529,6 +557,12 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
               "Date of user last login. It is null if the user hasn't logged in yet or an external IDP is configured.",
             nullable: true,
             example: "2024-01-15T09:00:00Z"
+          },
+          timezone: %Schema{
+            type: :string,
+            description: "IANA timezone name for the user.",
+            nullable: false,
+            example: "Europe/Berlin"
           }
         },
         required: [:username, :id, :fullname, :email, :created_at, :personal_access_tokens],
@@ -545,7 +579,8 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
           updated_at: "2024-01-15T10:30:00Z",
           analytics_enabled: false,
           totp_enabled_at: "2024-01-15T09:00:00Z",
-          last_login_at: "2024-01-15T09:00:00Z"
+          last_login_at: "2024-01-15T09:00:00Z",
+          timezone: "Europe/Berlin"
         }
       },
       struct?: false
@@ -574,7 +609,10 @@ defmodule TrentoWeb.OpenApi.V1.Schema.User do
             updated_at: "2024-01-15T10:30:00Z",
             last_login_at: "2024-01-15T09:00:00Z",
             abilities: [],
-            personal_access_tokens: []
+            personal_access_tokens: [],
+            idp_user: false,
+            analytics_enabled: false,
+            timezone: "Europe/Berlin"
           }
         ]
       },

--- a/priv/repo/migrations/20260409000000_add_timezone_to_users.exs
+++ b/priv/repo/migrations/20260409000000_add_timezone_to_users.exs
@@ -1,0 +1,9 @@
+defmodule Trento.Repo.Migrations.AddTimezoneToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :timezone, :string, default: "Etc/UTC"
+    end
+  end
+end

--- a/test/e2e/cypress/e2e/sso_integration.cy.js
+++ b/test/e2e/cypress/e2e/sso_integration.cy.js
@@ -64,6 +64,18 @@ describe('SSO integration', () => {
       usersPage.clickAnalyticsOptInSwitch();
       usersPage.clickSaveUserButton();
     });
+
+    it('should be able to change timezone when SSO is enabled', () => {
+      const timezone = 'Europe/Berlin';
+
+      usersPage.visit('/profile');
+      usersPage.selectTimezone(timezone);
+      usersPage.clickSaveUserButton();
+      usersPage.profileChangesSavedToasterIsDisplayed();
+
+      usersPage.visit('/profile');
+      usersPage.timezoneValueIsDisplayed(timezone);
+    });
   });
 
   describe('Admin user', () => {
@@ -80,18 +92,24 @@ describe('SSO integration', () => {
       usersPage.createUserButtonIsNotDisplayed();
     });
 
-    it('should have the ability to update user permissions and status', () => {
+    it('should have the ability to update user permissions, status and timezone', () => {
+      const timezone = 'Europe/Madrid';
+
       usersPage.visit();
       usersPage.clickPlainUserInList();
       usersPage.clickPermissionsDropdown();
       usersPage.selectPermission('all:users');
       usersPage.selectDisabledStatus();
+      usersPage.selectTimezone(timezone);
       usersPage.clickSaveUserButton();
+      usersPage.userEditedSuccessfullyToasterIsDisplayed();
 
       usersPage.clickPlainUserInList();
+      usersPage.timezoneValueIsDisplayed(timezone);
       usersPage.clickRemovePermissionButton();
       usersPage.selectEnabledStatus();
       usersPage.clickSaveUserButton();
+      usersPage.userEditedSuccessfullyToasterIsDisplayed();
     });
 
     it('should have a read only profile view and all:all permissions', () => {

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -54,6 +54,26 @@ describe('Users', () => {
       usersPage.newUserIsDisplayed();
     });
 
+    it('should create user with timezone properly', () => {
+      const timezone = 'Pacific/Auckland';
+      usersPage.typeUserFullName();
+      usersPage.typeUserEmail();
+      usersPage.typeUserName();
+      usersPage.typeUserPassword();
+      usersPage.typeUserPasswordConfirmation();
+      usersPage.selectTimezone(timezone);
+      usersPage.clickSubmitUserCreationButton();
+      usersPage.userCreatedSuccessfullyToasterIsDisplayed();
+
+      usersPage.pageTitleIsCorrectlyDisplayed('Users');
+      usersPage.newUserIsDisplayed();
+
+      // Verify timezone was saved by editing the user
+      usersPage.clickNewUser();
+      usersPage.pageTitleIsCorrectlyDisplayed('Edit User');
+      usersPage.timezoneValueIsDisplayed(timezone);
+    });
+
     it('should not allow creating the user with the same data', () => {
       usersPage.apiCreateUser();
       usersPage.typeUserFullName();

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -110,6 +110,21 @@ describe('Users', () => {
       usersPage.pageTitleIsCorrectlyDisplayed('Users');
       usersPage.userWithModifiedNameIsDisplayed(fullname);
     });
+
+    it('should edit timezone properly', () => {
+      usersPage.apiCreateUser();
+      usersPage.refresh();
+      usersPage.clickNewUser();
+      const timezone = 'Europe/Madrid';
+
+      usersPage.selectTimezone(timezone);
+      usersPage.clickEditUserSaveButton();
+      usersPage.userEditedSuccessfullyToasterIsDisplayed();
+      usersPage.pageTitleIsCorrectlyDisplayed('Users');
+
+      usersPage.clickNewUser();
+      usersPage.timezoneValueIsDisplayed(timezone);
+    });
   });
 
   describe('Admin user profile', () => {
@@ -169,6 +184,16 @@ describe('Users', () => {
       usersPage.typeUserFullName('new_name');
       usersPage.clickEditUserSaveButton();
       usersPage.profileChangesSavedToasterIsDisplayed();
+    });
+
+    it('should edit timezone properly from the profile view', () => {
+      const timezone = 'Europe/Berlin';
+
+      basePage.clickUserDropdownProfileButton();
+      usersPage.selectTimezone(timezone);
+      usersPage.clickEditUserSaveButton();
+      usersPage.profileChangesSavedToasterIsDisplayed();
+      usersPage.timezoneValueIsDisplayed(timezone);
     });
 
     it('should fail editing user password if current password is wrong', () => {

--- a/test/e2e/cypress/fixtures/hana-cluster-details/available_hana_cluster.js
+++ b/test/e2e/cypress/fixtures/hana-cluster-details/available_hana_cluster.js
@@ -11,7 +11,7 @@ export const availableHanaCluster = {
   maintenanceMode: false,
   hanaSecondarySyncState: 'SOK',
   sapHanaSRHealthState: 4,
-  cibLastWritten: 'Tue Jan 25 15:36:59 2022',
+  cibLastWritten: '25 Jan 2022, 15:36:59',
   hanaSystemReplicationOperationMode: 'logreplay',
   sites: [
     {
@@ -266,7 +266,7 @@ export const availableHanaClusterCostOpt = {
   maintenanceMode: false,
   hanaSecondarySyncState: 'SOK',
   sapHanaSRHealthState: 4,
-  cibLastWritten: 'Mon Aug 26 14:52:19 2024',
+  cibLastWritten: '26 Aug 2024, 14:52:19',
   hanaSystemReplicationOperationMode: 'logreplay',
   hosts: [
     {
@@ -292,7 +292,7 @@ export const availableAngiCluster = {
   fencingType: 'external/sbd',
   maintenanceMode: false,
   hanaSecondarySyncState: 'SOK',
-  cibLastWritten: 'Mon Jun 10 13:03:57 2024',
+  cibLastWritten: '10 Jun 2024, 13:03:57',
   hanaSystemReplicationOperationMode: 'logreplay',
   hosts: [
     {

--- a/test/e2e/cypress/fixtures/host-details/selected_host.js
+++ b/test/e2e/cypress/fixtures/host-details/selected_host.js
@@ -60,8 +60,8 @@ export const selectedHost = {
       type: 'internal',
       status: 'Registered',
       subscriptionStatus: 'ACTIVE',
-      startsAt: '2021-10-18 06:23:46 UTC',
-      expiresAt: '2026-10-18 06:23:46 UTC',
+      startsAt: '18 Oct 2021, 06:23:46',
+      expiresAt: '18 Oct 2026, 06:23:46',
     },
     {
       id: 'sle-module-server-applications',

--- a/test/e2e/cypress/pageObject/activity_log_po.js
+++ b/test/e2e/cypress/pageObject/activity_log_po.js
@@ -238,15 +238,13 @@ export const expectedAggregateAmountOfRequests = (amount) =>
 export const formatEncodedDate = (encodedDate) => {
   const decodedDate = decodeURIComponent(encodedDate);
   const date = new Date(decodedDate);
-  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
   const day = String(date.getUTCDate()).padStart(2, '0');
+  const month = date.toLocaleString('en', { month: 'short', timeZone: 'UTC' }); // Assuming UTC
   const year = date.getUTCFullYear();
-  let hours = date.getUTCHours();
+  const hours = String(date.getUTCHours()).padStart(2, '0');
   const minutes = String(date.getUTCMinutes()).padStart(2, '0');
   const seconds = String(date.getUTCSeconds()).padStart(2, '0');
-  const ampm = hours >= 12 ? 'PM' : 'AM';
-  hours = hours % 12 || 12;
-  return `${month}/${day}/${year} ${hours}:${minutes}:${seconds} ${ampm}`;
+  return `${day} ${month} ${year}, ${hours}:${minutes}:${seconds}`;
 };
 
 const _isUriComponentDate = (encodedDate) => {

--- a/test/e2e/cypress/pageObject/users_po.js
+++ b/test/e2e/cypress/pageObject/users_po.js
@@ -76,6 +76,8 @@ const continueWithoutAnalyticsButton =
   'button:contains("Continue without Analytics")';
 const neverShowAgainCheckbox = 'div input[type="checkbox"]';
 const analyticsOptInSwitch = 'label:contains("Analytics Opt-in") + div button';
+const timezoneInputField = 'input#timezone';
+const timezoneStoredValue = 'input[name="timezone"]';
 
 // AI Configuration Selectors
 
@@ -249,8 +251,10 @@ export const userDeletedSuccesfullyToasterIsDisplayed = () =>
 export const invalidCurrentPasswordErrorIsDisplayed = () =>
   cy.get(invalidPasswordErrorLabel).should('be.visible');
 
-export const validateRequiredFieldsErrors = () =>
+export const validateRequiredFieldsErrors = () => {
+  cy.get(requiredFieldsErrors).should('exist');
   cy.get(requiredFieldsErrors).should('have.length', 5);
+};
 
 export const invalidEmailErrorIsDisplayed = () =>
   cy
@@ -455,6 +459,21 @@ export const clickContinueWithoutAnalytics = (neverShowAgain = true) => {
 
 export const clickAnalyticsOptInSwitch = () =>
   cy.get(analyticsOptInSwitch).click();
+
+export const selectTimezone = (timezone) =>
+  cy
+    .get(timezoneInputField)
+    .should('be.visible')
+    .click()
+    .type(`{selectall}{backspace}${timezone}`)
+    .get('[role="listbox"]', { timeout: 10000 })
+    .contains('[role="option"]', timezone)
+    .click()
+    .get(timezoneStoredValue)
+    .should('have.value', timezone);
+
+export const timezoneValueIsDisplayed = (timezone) =>
+  cy.get(timezoneStoredValue).should('have.value', timezone);
 
 // API
 export const interceptDeleteUser = () =>

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1324,7 +1324,8 @@ defmodule Trento.Factory do
       totp_last_used_at: nil,
       analytics_enabled_at: nil,
       analytics_eula_accepted_at: nil,
-      last_login_at: nil
+      last_login_at: nil,
+      timezone: "Etc/UTC"
     }
   end
 

--- a/test/trento/users/user_test.exs
+++ b/test/trento/users/user_test.exs
@@ -76,5 +76,41 @@ defmodule Trento.Users.UsersTest do
       assert changeset.changes[:analytics_enabled_at]
       assert changeset.changes[:analytics_eula_accepted_at]
     end
+
+    test "profile_update_changeset/2 validates timezone field is cast properly" do
+      changeset =
+        User.profile_update_changeset(%User{}, %{
+          "timezone" => "Europe/Berlin"
+        })
+
+      assert changeset.changes[:timezone] == "Europe/Berlin"
+    end
+
+    test "profile_update_changeset/2 rejects invalid IANA timezone" do
+      changeset =
+        User.profile_update_changeset(%User{}, %{
+          "timezone" => "US/Pacific-New"
+        })
+
+      assert changeset.errors[:timezone]
+    end
+
+    test "profile_update_sso_enabled_changeset/2 validates timezone field is cast properly" do
+      changeset =
+        User.profile_update_sso_enabled_changeset(%User{}, %{
+          "timezone" => "Europe/Berlin"
+        })
+
+      assert changeset.changes[:timezone] == "Europe/Berlin"
+    end
+
+    test "profile_update_sso_enabled_changeset/2 rejects invalid IANA timezone" do
+      changeset =
+        User.profile_update_sso_enabled_changeset(%User{}, %{
+          "timezone" => "US/Pacific-New"
+        })
+
+      assert changeset.errors[:timezone]
+    end
   end
 end

--- a/test/trento/users_test.exs
+++ b/test/trento/users_test.exs
@@ -194,6 +194,36 @@ defmodule Trento.UsersTest do
       assert analytics_enabled_at == nil
       assert analytics_eula_accepted_at == nil
     end
+
+    test "update_user_profile updates timezone" do
+      user = insert(:user)
+
+      assert {:ok, %User{timezone: "Europe/Berlin"}} =
+               Users.update_user_profile(user, %{timezone: "Europe/Berlin"})
+    end
+
+    test "update_user_profile returns error for invalid timezone" do
+      user = insert(:user)
+
+      assert {:error, changeset} = Users.update_user_profile(user, %{timezone: "US/Pacific-New"})
+      assert changeset.errors[:timezone]
+    end
+
+    test "update_user_profile_sso_enabled updates timezone" do
+      user = insert(:user)
+
+      assert {:ok, %User{timezone: "Europe/Berlin"}} =
+               Users.update_user_profile_sso_enabled(user, %{timezone: "Europe/Berlin"})
+    end
+
+    test "update_user_profile_sso_enabled returns error for invalid timezone" do
+      user = insert(:user)
+
+      assert {:error, changeset} =
+               Users.update_user_profile_sso_enabled(user, %{timezone: "US/Pacific-New"})
+
+      assert changeset.errors[:timezone]
+    end
   end
 
   describe "users" do

--- a/test/trento_web/controllers/v1/profile_controller_test.exs
+++ b/test/trento_web/controllers/v1/profile_controller_test.exs
@@ -76,7 +76,8 @@ defmodule TrentoWeb.V1.ProfileControllerTest do
         email: Faker.Internet.email(),
         password: "testpassword89",
         current_password: current_password,
-        password_confirmation: "testpassword89"
+        password_confirmation: "testpassword89",
+        timezone: "Europe/Moscow"
       }
 
     resp =
@@ -86,7 +87,7 @@ defmodule TrentoWeb.V1.ProfileControllerTest do
       |> json_response(:ok)
       |> assert_schema("UserProfileV1", api_spec)
 
-    assert %{id: ^user_id, fullname: ^fullname, email: ^email} = resp
+    assert %{id: ^user_id, fullname: ^fullname, email: ^email, timezone: "Europe/Moscow"} = resp
   end
 
   test "should update the profile with allowed fields when SSO is enabled", %{
@@ -96,7 +97,8 @@ defmodule TrentoWeb.V1.ProfileControllerTest do
   } do
     valid_params = %{
       analytics_enabled: true,
-      analytics_eula_accepted: true
+      analytics_eula_accepted: true,
+      timezone: "Asia/Tokyo"
     }
 
     Application.put_env(:trento, :oidc, enabled: true)
@@ -110,7 +112,12 @@ defmodule TrentoWeb.V1.ProfileControllerTest do
 
     Application.put_env(:trento, :oidc, enabled: false)
 
-    assert %{id: ^user_id, analytics_enabled: true, analytics_eula_accepted: true} = resp
+    assert %{
+             id: ^user_id,
+             analytics_enabled: true,
+             analytics_eula_accepted: true,
+             timezone: "Asia/Tokyo"
+           } = resp
   end
 
   test "should get an error updating profile when SSO is enabled and invalid fields are sent", %{
@@ -120,7 +127,8 @@ defmodule TrentoWeb.V1.ProfileControllerTest do
     invalid_params = %{
       fullname: Faker.Person.name(),
       analytics_enabled: true,
-      analytics_eula_accepted: true
+      analytics_eula_accepted: true,
+      timezone: "US/Pacific-New"
     }
 
     Application.put_env(:trento, :oidc, enabled: true)
@@ -175,11 +183,21 @@ defmodule TrentoWeb.V1.ProfileControllerTest do
         Pow.Plug.fetch_config(conn)
       )
 
-    conn
-    |> put_req_header("content-type", "application/json")
-    |> get("/api/v1/profile/totp_enrollment")
-    |> json_response(:unprocessable_entity)
-    |> assert_schema("UnprocessableEntityV1", api_spec)
+    resp =
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> get("/api/v1/profile/totp_enrollment")
+      |> json_response(:unprocessable_entity)
+      |> assert_schema("UnprocessableEntityV1", api_spec)
+
+    assert %{
+             errors: [
+               %{
+                 title: "Unprocessable Entity",
+                 detail: "TOTP already enabled, could not process the enrollment procedure"
+               }
+             ]
+           } == resp
   end
 
   test "should return forbidden if the totp enrollment is requested for default admin", %{
@@ -269,11 +287,21 @@ defmodule TrentoWeb.V1.ProfileControllerTest do
         Pow.Plug.fetch_config(conn)
       )
 
-    conn
-    |> put_req_header("content-type", "application/json")
-    |> post("/api/v1/profile/totp_enrollment", %{totp_code: "12345"})
-    |> json_response(:unprocessable_entity)
-    |> assert_schema("UnprocessableEntityV1", api_spec)
+    resp =
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> post("/api/v1/profile/totp_enrollment", %{totp_code: "12345"})
+      |> json_response(:unprocessable_entity)
+      |> assert_schema("UnprocessableEntityV1", api_spec)
+
+    assert %{
+             errors: [
+               %{
+                 title: "Unprocessable Entity",
+                 detail: "TOTP already enabled, could not process the enrollment procedure"
+               }
+             ]
+           } == resp
   end
 
   test "should not confirm a totp enrollment if totp is not valid", %{
@@ -292,11 +320,21 @@ defmodule TrentoWeb.V1.ProfileControllerTest do
         Pow.Plug.fetch_config(conn)
       )
 
-    conn
-    |> put_req_header("content-type", "application/json")
-    |> post("/api/v1/profile/totp_enrollment", %{totp_code: "12345"})
-    |> json_response(:unprocessable_entity)
-    |> assert_schema("UnprocessableEntityV1", api_spec)
+    resp =
+      conn
+      |> put_req_header("content-type", "application/json")
+      |> post("/api/v1/profile/totp_enrollment", %{totp_code: "12345"})
+      |> json_response(:unprocessable_entity)
+      |> assert_schema("UnprocessableEntityV1", api_spec)
+
+    assert %{
+             errors: [
+               %{
+                 title: "Unprocessable Entity",
+                 detail: "TOTP code not valid for the enrollment procedure."
+               }
+             ]
+           } == resp
   end
 
   test "should confirm a totp enrollment if totp is valid for the enrollment", %{

--- a/test/trento_web/controllers/v1/users_controller_test.exs
+++ b/test/trento_web/controllers/v1/users_controller_test.exs
@@ -157,11 +157,22 @@ defmodule TrentoWeb.V1.UsersControllerTest do
         password_confirmation: "testpassword89"
       }
 
-      conn
-      |> put_req_header("content-type", "application/json")
-      |> post("/api/v1/users", invalid_request_params)
-      |> json_response(:unprocessable_entity)
-      |> assert_schema("UnprocessableEntityV1", api_spec)
+      resp =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/v1/users", invalid_request_params)
+        |> json_response(:unprocessable_entity)
+        |> assert_schema("UnprocessableEntityV1", api_spec)
+
+      assert %{
+               errors: [
+                 %{
+                   title: "Invalid value",
+                   source: %{pointer: "/enabled"},
+                   detail: "Missing field: enabled"
+                 }
+               ]
+             } == resp
     end
 
     test "should not create the user when request parameters are valid but error are returned during creation",
@@ -177,11 +188,22 @@ defmodule TrentoWeb.V1.UsersControllerTest do
         password_confirmation: "notequal"
       }
 
-      conn
-      |> put_req_header("content-type", "application/json")
-      |> post("/api/v1/users", valid_params)
-      |> json_response(:unprocessable_entity)
-      |> assert_schema("UnprocessableEntityV1", api_spec)
+      resp =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/v1/users", valid_params)
+        |> json_response(:unprocessable_entity)
+        |> assert_schema("UnprocessableEntityV1", api_spec)
+
+      assert %{
+               errors: [
+                 %{
+                   title: "Invalid value",
+                   source: %{pointer: "/password_confirmation"},
+                   detail: "does not match confirmation"
+                 }
+               ]
+             } == resp
     end
   end
 
@@ -230,12 +252,23 @@ defmodule TrentoWeb.V1.UsersControllerTest do
         email: already_taken_email
       }
 
-      conn
-      |> put_req_header("content-type", "application/json")
-      |> put_req_header("if-match", "#{lock_version}")
-      |> patch("/api/v1/users/#{id}", valid_params)
-      |> json_response(:unprocessable_entity)
-      |> assert_schema("UnprocessableEntityV1", api_spec)
+      resp =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("if-match", "#{lock_version}")
+        |> patch("/api/v1/users/#{id}", valid_params)
+        |> json_response(:unprocessable_entity)
+        |> assert_schema("UnprocessableEntityV1", api_spec)
+
+      assert %{
+               errors: [
+                 %{
+                   title: "Invalid value",
+                   source: %{pointer: "/email"},
+                   detail: "has already been taken"
+                 }
+               ]
+             } == resp
     end
 
     test "should not update the user if parameters are not valid", %{
@@ -245,14 +278,26 @@ defmodule TrentoWeb.V1.UsersControllerTest do
       %{id: id} = insert(:user)
 
       invalid_params = %{
-        enabled: "invalid"
+        enabled: "invalid",
+        timezone: "US/Pacific-New"
       }
 
-      conn
-      |> put_req_header("content-type", "application/json")
-      |> patch("/api/v1/users/#{id}", invalid_params)
-      |> json_response(:unprocessable_entity)
-      |> assert_schema("UnprocessableEntityV1", api_spec)
+      resp =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> patch("/api/v1/users/#{id}", invalid_params)
+        |> json_response(:unprocessable_entity)
+        |> assert_schema("UnprocessableEntityV1", api_spec)
+
+      assert %{
+               errors: [
+                 %{
+                   title: "Invalid value",
+                   source: %{pointer: "/enabled"},
+                   detail: "Invalid boolean. Got: string"
+                 }
+               ]
+             } == resp
     end
 
     test "should not update the user when the request conditional prerequisite is missing", %{
@@ -282,7 +327,8 @@ defmodule TrentoWeb.V1.UsersControllerTest do
         email: Faker.Internet.email(),
         enabled: false,
         password: "testpassword89",
-        password_confirmation: "testpassword89"
+        password_confirmation: "testpassword89",
+        timezone: "Australia/Melbourne"
       }
 
       conn
@@ -306,7 +352,8 @@ defmodule TrentoWeb.V1.UsersControllerTest do
         email: Faker.Internet.email(),
         enabled: false,
         password: "testpassword89",
-        password_confirmation: "testpassword89"
+        password_confirmation: "testpassword89",
+        timezone: "America/Guatemala"
       }
 
       conn =
@@ -323,6 +370,7 @@ defmodule TrentoWeb.V1.UsersControllerTest do
       refute resp.fullname == fullname
       refute resp.enabled == true
       refute resp.email == email
+      assert resp.timezone == valid_params.timezone
 
       assert_broadcast "user_locked", %{}, 1000
 
@@ -340,7 +388,8 @@ defmodule TrentoWeb.V1.UsersControllerTest do
         enabled: false,
         password: "testpassword89",
         password_confirmation: "testpassword89",
-        abilities: [%{id: id, name: name, resource: resource, label: label}]
+        abilities: [%{id: id, name: name, resource: resource, label: label}],
+        timezone: "Pacific/Auckland"
       }
 
       conn
@@ -358,6 +407,7 @@ defmodule TrentoWeb.V1.UsersControllerTest do
       Application.put_env(:trento, :oidc, enabled: true)
 
       %{id: id, name: name, resource: resource, label: label} = insert(:ability)
+
       %{id: user_id, lock_version: lock_version} = insert(:user, locked_at: DateTime.utc_now())
 
       valid_params = %{
@@ -366,7 +416,8 @@ defmodule TrentoWeb.V1.UsersControllerTest do
         enabled: true,
         password: "testpassword89",
         password_confirmation: "testpassword89",
-        abilities: [%{id: id, name: name, resource: resource, label: label}]
+        abilities: [%{id: id, name: name, resource: resource, label: label}],
+        timezone: "America/Recife"
       }
 
       %{abilities: abilities} =
@@ -381,6 +432,7 @@ defmodule TrentoWeb.V1.UsersControllerTest do
       refute resp.fullname == valid_params.fullname
       refute resp.email == valid_params.email
       assert resp.enabled
+      assert resp.timezone == valid_params.timezone
       assert resp.password_change_requested_at == nil
       assert abilities == [%{id: id, name: name, resource: resource, label: label}]
 
@@ -400,7 +452,8 @@ defmodule TrentoWeb.V1.UsersControllerTest do
         fullname: Faker.Person.name(),
         email: Faker.Internet.email(),
         password: "testpassword89",
-        password_confirmation: "testpassword89"
+        password_confirmation: "testpassword89",
+        timezone: "Europe/Berlin"
       }
 
       resp =
@@ -414,13 +467,13 @@ defmodule TrentoWeb.V1.UsersControllerTest do
       refute resp.fullname == valid_params.fullname
       refute resp.email == valid_params.email
       assert resp.password_change_requested_at == nil
+      assert resp.timezone == valid_params.timezone
 
       Application.put_env(:trento, :oidc, enabled: false)
     end
 
     test "should disable the TOTP feature for a user", %{conn: conn, api_spec: api_spec} do
-      %{id: user_id, lock_version: lock_version} =
-        insert(:user, totp_enabled_at: DateTime.utc_now())
+      %{id: user_id, lock_version: lock_version} = insert(:user, totp_enabled_at: DateTime.utc_now())
 
       valid_params = %{
         totp_disabled: true

--- a/test/trento_web/controllers/v1/users_controller_test.exs
+++ b/test/trento_web/controllers/v1/users_controller_test.exs
@@ -7,6 +7,8 @@ defmodule TrentoWeb.V1.UsersControllerTest do
   import Trento.Factory
   import Trento.Support.Helpers.AbilitiesTestHelper
 
+  alias Faker.{Address, Internet, Person, Pokemon}
+
   @endpoint TrentoWeb.Endpoint
 
   setup :setup_api_spec_v1
@@ -104,12 +106,13 @@ defmodule TrentoWeb.V1.UsersControllerTest do
   describe "create user" do
     test "should create the user when parameters are valid", %{conn: conn, api_spec: api_spec} do
       valid_params = %{
-        fullname: Faker.Person.name(),
-        email: Faker.Internet.email(),
-        username: Faker.Pokemon.name(),
+        fullname: Person.name(),
+        email: Internet.email(),
+        username: Pokemon.name(),
         enabled: true,
         password: "testpassword89",
-        password_confirmation: "testpassword89"
+        password_confirmation: "testpassword89",
+        timezone: Address.En.time_zone()
       }
 
       conn =
@@ -117,9 +120,12 @@ defmodule TrentoWeb.V1.UsersControllerTest do
         |> put_req_header("content-type", "application/json")
         |> post("/api/v1/users", valid_params)
 
-      conn
-      |> json_response(:created)
-      |> assert_schema("UserItemV1", api_spec)
+      resp =
+        conn
+        |> json_response(:created)
+        |> assert_schema("UserItemV1", api_spec)
+
+      assert resp.timezone == valid_params.timezone
 
       [etag] = get_resp_header(conn, "etag")
       assert etag == "1"
@@ -129,12 +135,13 @@ defmodule TrentoWeb.V1.UsersControllerTest do
       %{id: id, name: name, resource: resource, label: label} = insert(:ability)
 
       valid_params = %{
-        fullname: Faker.Person.name(),
-        email: Faker.Internet.email(),
-        username: Faker.Pokemon.name(),
+        fullname: Person.name(),
+        email: Internet.email(),
+        username: Pokemon.name(),
         enabled: true,
         password: "testpassword89",
         password_confirmation: "testpassword89",
+        timezone: Address.En.time_zone(),
         abilities: [%{id: id, name: name, resource: resource, label: label}]
       }
 
@@ -150,9 +157,9 @@ defmodule TrentoWeb.V1.UsersControllerTest do
       api_spec: api_spec
     } do
       invalid_request_params = %{
-        fullname: Faker.Person.name(),
-        email: Faker.Internet.email(),
-        username: Faker.Pokemon.name(),
+        fullname: Person.name(),
+        email: Internet.email(),
+        username: Pokemon.name(),
         password: "testpassword89",
         password_confirmation: "testpassword89"
       }
@@ -180,9 +187,9 @@ defmodule TrentoWeb.V1.UsersControllerTest do
       %{email: already_taken_email} = insert(:user)
 
       valid_params = %{
-        fullname: Faker.Person.name(),
+        fullname: Person.name(),
         email: already_taken_email,
-        username: Faker.Pokemon.name(),
+        username: Pokemon.name(),
         enabled: true,
         password: "testpassword89",
         password_confirmation: "notequal"
@@ -323,8 +330,8 @@ defmodule TrentoWeb.V1.UsersControllerTest do
         |> subscribe_and_join(TrentoWeb.UserChannel, "users:#{id}")
 
       valid_params = %{
-        fullname: Faker.Person.name(),
-        email: Faker.Internet.email(),
+        fullname: Person.name(),
+        email: Internet.email(),
         enabled: false,
         password: "testpassword89",
         password_confirmation: "testpassword89",
@@ -348,8 +355,8 @@ defmodule TrentoWeb.V1.UsersControllerTest do
         |> subscribe_and_join(TrentoWeb.UserChannel, "users:#{id}")
 
       valid_params = %{
-        fullname: Faker.Person.name(),
-        email: Faker.Internet.email(),
+        fullname: Person.name(),
+        email: Internet.email(),
         enabled: false,
         password: "testpassword89",
         password_confirmation: "testpassword89",
@@ -383,8 +390,8 @@ defmodule TrentoWeb.V1.UsersControllerTest do
       %{id: user_id, lock_version: lock_version} = insert(:user)
 
       valid_params = %{
-        fullname: Faker.Person.name(),
-        email: Faker.Internet.email(),
+        fullname: Person.name(),
+        email: Internet.email(),
         enabled: false,
         password: "testpassword89",
         password_confirmation: "testpassword89",
@@ -411,8 +418,8 @@ defmodule TrentoWeb.V1.UsersControllerTest do
       %{id: user_id, lock_version: lock_version} = insert(:user, locked_at: DateTime.utc_now())
 
       valid_params = %{
-        fullname: Faker.Person.name(),
-        email: Faker.Internet.email(),
+        fullname: Person.name(),
+        email: Internet.email(),
         enabled: true,
         password: "testpassword89",
         password_confirmation: "testpassword89",
@@ -449,8 +456,8 @@ defmodule TrentoWeb.V1.UsersControllerTest do
       %{id: user_id, lock_version: lock_version} = insert(:user)
 
       valid_params = %{
-        fullname: Faker.Person.name(),
-        email: Faker.Internet.email(),
+        fullname: Person.name(),
+        email: Internet.email(),
         password: "testpassword89",
         password_confirmation: "testpassword89",
         timezone: "Europe/Berlin"
@@ -473,7 +480,8 @@ defmodule TrentoWeb.V1.UsersControllerTest do
     end
 
     test "should disable the TOTP feature for a user", %{conn: conn, api_spec: api_spec} do
-      %{id: user_id, lock_version: lock_version} = insert(:user, totp_enabled_at: DateTime.utc_now())
+      %{id: user_id, lock_version: lock_version} =
+        insert(:user, totp_enabled_at: DateTime.utc_now())
 
       valid_params = %{
         totp_disabled: true


### PR DESCRIPTION
## Description

This series of PRs aims to make the UI totally timezone-aware, depending on each user's preference. Not a browser preference, but a Trento user setting.

Since the changes are numerous, they have been split into several PRs targeting this feature branch. No additional commits (except for merge commits from `main`) have been added here.

- [X] https://github.com/trento-project/web/pull/4165
- [X] https://github.com/trento-project/web/pull/4169 
- [X] https://github.com/trento-project/web/pull/4174 
  - [X] https://github.com/trento-project/web/pull/4187 
  - [X] https://github.com/trento-project/web/pull/4196 
- [x] https://github.com/trento-project/web/pull/4197 
- [x] https://github.com/trento-project/web/pull/4200 

Related to https://github.com/trento-project/docs/pull/189


Related # TRNT-4339

---- 

Current status:

https://github.com/user-attachments/assets/468d3ac3-af8d-44c6-a974-75768f17885c

https://github.com/user-attachments/assets/69eaa674-6345-43c8-af03-7dee622d830c


https://github.com/user-attachments/assets/c58df174-90b3-46f8-b393-b7b4ce2fb78e


https://github.com/user-attachments/assets/5e28ab3d-59a8-4723-bb35-a5345b2cd87f


https://github.com/user-attachments/assets/059196ed-dfe4-48fc-ae00-402d2510fa64


https://github.com/user-attachments/assets/528d4f31-6819-4cce-b5ba-debd485cc703


https://github.com/user-attachments/assets/9997fc2e-f581-4046-9f46-5574b9ae1e5b


## How was this tested?

IRL, unit and e2e tests

## Did you update the documentation?

N/A
