### PR TITLE
Fix CheckResultDetailPage.test warnings

### DIFF
--- a/assets/js/lib/test-utils/factories/executions.js
+++ b/assets/js/lib/test-utils/factories/executions.js
@@ -156,30 +156,6 @@ const checkResultForTarget = (agentId) =>
     agent_id: agentId,
   });
 
-export const checksExecutionCompletedForTargetsFactory = Factory.define(
-  ({ params }) => {
-    const targets = params.targets || [
-      faker.string.uuid(),
-      faker.string.uuid(),
-    ];
-
-    const checkResults = params.check_id
-      ? params.check_id.map((checkID) =>
-          checkResultFactory.build({
-            agents_check_results: targets.map(checkResultForTarget),
-            check_id: checkID,
-          })
-        )
-      : checkResultFactory.buildList(2, {
-          agents_check_results: targets.map(checkResultForTarget),
-        });
-
-    return checksExecutionCompletedFactory.build({
-      check_results: checkResults,
-    });
-  }
-);
-
 export const withEmptyExpectations = (checkResult) => {
   const agents = checkResult.agents_check_results.map((agent) => ({
     ...agent,
@@ -254,6 +230,40 @@ export const addCriticalExpectExpectation = (checkResult, expectationName) => {
 };
 export const addPassingExpectSameExpectation = (checkResult, expectationName) =>
   addExpectationWithResult(checkResult, 'expect_same', expectationName, true);
+
+export const checksExecutionCompletedForTargetsFactory = Factory.define(
+  ({ params }) => {
+    const targets = params.targets || [
+      faker.string.uuid(),
+      faker.string.uuid(),
+    ];
+
+    const expectations = params.expectations || [];
+
+    const checkResults = params.check_id
+      ? params.check_id.map((checkID) =>
+          checkResultFactory.build({
+            agents_check_results: targets.map(checkResultForTarget),
+            check_id: checkID,
+          })
+        )
+      : checkResultFactory.buildList(2, {
+          agents_check_results: targets.map(checkResultForTarget),
+        });
+
+    const checkResultsWithExpectations = checkResults.map((checkResult) =>
+      expectations.reduce(
+        (acc, expectation) =>
+          addExpectation(acc, expectation.name, expectation, resultEnum()),
+        checkResult
+      )
+    );
+
+    return checksExecutionCompletedFactory.build({
+      check_results: checkResultsWithExpectations,
+    });
+  }
+);
 
 export const agentsCheckResultsWithHostname = (
   agentsCheckResults,

--- a/assets/js/lib/test-utils/index.jsx
+++ b/assets/js/lib/test-utils/index.jsx
@@ -81,7 +81,10 @@ export const renderWithRouter = (ui, { route = '/' } = {}) => {
   };
 };
 
-export function renderWithRouterMatch(ui, { path = '/', route = '/' } = {}) {
+export function renderWithRouterMatch(
+  ui,
+  { path = '/', route = '/', children } = {}
+) {
   window.history.pushState({}, 'Test page', route);
 
   return {
@@ -89,6 +92,7 @@ export function renderWithRouterMatch(ui, { path = '/', route = '/' } = {}) {
       <BrowserRouter>
         <Routes>
           <Route path={path} element={ui} />
+          {children}
         </Routes>
       </BrowserRouter>
     ),

--- a/assets/js/pages/ExecutionResults/CheckResultDetail/CheckResultDetailPage.test.jsx
+++ b/assets/js/pages/ExecutionResults/CheckResultDetail/CheckResultDetailPage.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen, fireEvent } from '@testing-library/react';
 import { faker } from '@faker-js/faker';
+import { Route } from 'react-router';
 
 import '@testing-library/jest-dom';
 
@@ -28,9 +29,11 @@ describe('CheckResultDetailPage Component', () => {
     ] = hostsList;
 
     const checksCatalog = catalogCheckFactory.buildList(2);
+    const firstCheckExpectations = checksCatalog[0].expectations;
     const completedExecution = checksExecutionCompletedForTargetsFactory.build({
       targets: [agent1, agent2],
       check_id: [checksCatalog[0].id, checksCatalog[1].id],
+      expectations: firstCheckExpectations,
     });
 
     const initialState = {
@@ -92,6 +95,7 @@ describe('CheckResultDetailPage Component', () => {
     renderWithRouterMatch(StatefulCheckResultDetailPage, {
       path: 'clusters/:targetID/executions/last/:checkID/:resultTargetType/:resultTargetName',
       route: `/clusters/${falseClusterID}/executions/last/${validCheckID}/${validTargetType}/${validTargetName}`,
+      children: <Route path={'/clusters'} element={<></>} />,
     });
 
     expect(screen.getByText('Go back to clusters overview')).toBeTruthy();
@@ -112,6 +116,12 @@ describe('CheckResultDetailPage Component', () => {
     renderWithRouterMatch(StatefulCheckResultDetailPage, {
       path: 'clusters/:targetID/executions/last/:checkID/:resultTargetType/:resultTargetName',
       route: `/clusters/${validClusterID}/executions/last/${falseCheckID}/${validTargetType}/${validTargetName}`,
+      children: (
+        <Route
+          path={`/clusters/${validClusterID}/executions/last`}
+          element={<></>}
+        />
+      ),
     });
 
     expect(screen.getByText('Go back to last execution')).toBeTruthy();
@@ -133,6 +143,12 @@ describe('CheckResultDetailPage Component', () => {
     renderWithRouterMatch(StatefulCheckResultDetailPage, {
       path: 'clusters/:targetID/executions/last/:checkID/:resultTargetType/:resultTargetName',
       route: `/clusters/${validClusterID}/executions/last/${validCheckID}/${invalidTargetType}/${validTargetName}`,
+      children: (
+        <Route
+          path={`/clusters/${validClusterID}/executions/last`}
+          element={<></>}
+        />
+      ),
     });
     expect(screen.getByText('Go back to last execution')).toBeTruthy();
     fireEvent.click(screen.getByText('Go back to last execution'));
@@ -153,6 +169,12 @@ describe('CheckResultDetailPage Component', () => {
     renderWithRouterMatch(StatefulCheckResultDetailPage, {
       path: 'clusters/:targetID/executions/last/:checkID/:resultTargetType/:resultTargetName',
       route: `/clusters/${validClusterID}/executions/last/${validCheckID}/${validTargetType}/${invalidTargetName}`,
+      children: (
+        <Route
+          path={`/clusters/${validClusterID}/executions/last`}
+          element={<></>}
+        />
+      ),
     });
     expect(screen.getByText('Go back to last execution')).toBeTruthy();
     fireEvent.click(screen.getByText('Go back to last execution'));

--- a/assets/js/pages/ExecutionResults/CheckResultDetail/CheckResultDetailPage.test.jsx
+++ b/assets/js/pages/ExecutionResults/CheckResultDetail/CheckResultDetailPage.test.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { screen, fireEvent } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { faker } from '@faker-js/faker';
 import { Route } from 'react-router';
+import userEvent from '@testing-library/user-event';
 
 import '@testing-library/jest-dom';
 
@@ -83,7 +84,8 @@ describe('CheckResultDetailPage Component', () => {
     return { validClusterID, validCheckID, validTargetType, validTargetName };
   };
 
-  it('should not render CheckResultDetailPage when clusterID in the url is false', () => {
+  it('should not render CheckResultDetailPage when clusterID in the url is false', async () => {
+    const user = userEvent.setup();
     const reduxStore = initialStore();
     const { validCheckID, validTargetName, validTargetType } =
       getValidStoreData(reduxStore);
@@ -99,11 +101,12 @@ describe('CheckResultDetailPage Component', () => {
     });
 
     expect(screen.getByText('Go back to clusters overview')).toBeTruthy();
-    fireEvent.click(screen.getByText('Go back to clusters overview'));
+    await user.click(screen.getByText('Go back to clusters overview'));
     expect(window.location.pathname).toEqual('/clusters');
   });
 
-  it('should not render CheckResultDetailPage when checkID in the url is false', () => {
+  it('should not render CheckResultDetailPage when checkID in the url is false', async () => {
+    const user = userEvent.setup();
     const reduxStore = initialStore();
     const { validClusterID, validTargetType, validTargetName } =
       getValidStoreData(reduxStore);
@@ -125,13 +128,14 @@ describe('CheckResultDetailPage Component', () => {
     });
 
     expect(screen.getByText('Go back to last execution')).toBeTruthy();
-    fireEvent.click(screen.getByText('Go back to last execution'));
+    await user.click(screen.getByText('Go back to last execution'));
     expect(window.location.pathname).toEqual(
       `/clusters/${validClusterID}/executions/last`
     );
   });
 
-  it('should not render CheckResultDetailPage when targetType in the url is false', () => {
+  it('should not render CheckResultDetailPage when targetType in the url is false', async () => {
+    const user = userEvent.setup();
     const reduxStore = initialStore();
     const { validClusterID, validCheckID, validTargetName } =
       getValidStoreData(reduxStore);
@@ -151,13 +155,14 @@ describe('CheckResultDetailPage Component', () => {
       ),
     });
     expect(screen.getByText('Go back to last execution')).toBeTruthy();
-    fireEvent.click(screen.getByText('Go back to last execution'));
+    await user.click(screen.getByText('Go back to last execution'));
     expect(window.location.pathname).toEqual(
       `/clusters/${validClusterID}/executions/last`
     );
   });
 
-  it('should not render CheckResultDetailPage when targetName in the url is false', () => {
+  it('should not render CheckResultDetailPage when targetName in the url is false', async () => {
+    const user = userEvent.setup();
     const reduxStore = initialStore();
     const { validClusterID, validCheckID, validTargetType } =
       getValidStoreData(reduxStore);
@@ -177,7 +182,7 @@ describe('CheckResultDetailPage Component', () => {
       ),
     });
     expect(screen.getByText('Go back to last execution')).toBeTruthy();
-    fireEvent.click(screen.getByText('Go back to last execution'));
+    await user.click(screen.getByText('Go back to last execution'));
     expect(window.location.pathname).toEqual(
       `/clusters/${validClusterID}/executions/last`
     );


### PR DESCRIPTION
# Description

Fix frontend UT warnings for CheckResultDetailPage.test file.
I took advantage and removed the used `fireEvent` as well.

1. Add needed route to avoid the warning
```
  console.warn
    No routes matched location "/clusters/751fc14c-dc52-4e44-932f-99aa71b02ee6/executions/last" 

      156 |     });
      157 |     expect(screen.getByText('Go back to last execution')).toBeTruthy();
    > 158 |     fireEvent.click(screen.getByText('Go back to last execution'));
          |               ^
      159 |     expect(window.location.pathname).toEqual(
      160 |       `/clusters/${validClusterID}/executions/last`
      161 |     );
```

2. Update factory data to create the same expectation and expecation results. Otherwise, one of the keys of a list gets `undefined` value.
```
  console.error
    Each child in a list should have a unique "key" prop.
    
    Check the render method of `ListView`. See https://react.dev/link/warning-keys for more information.

      86 |
      87 |   return {
    > 88 |     ...render(
         |              ^
      89 |       <BrowserRouter>
      90 |         <Routes>
      91 |           <Route path={path} element={ui} />
```

With this the tests executions goes clean:
```
> npm test js/pages/ExecutionResults/CheckResultDetail/CheckResultDetailPage.test.jsx

> pretest
> ls ../priv/static/assets/app.css || npm run tailwind:build

../priv/static/assets/app.css

> test
> jest --maxWorkers=2 js/pages/ExecutionResults/CheckResultDetail/CheckResultDetailPage.test.jsx

 PASS  js/pages/ExecutionResults/CheckResultDetail/CheckResultDetailPage.test.jsx
  CheckResultDetailPage Component
    ✓ should not render CheckResultDetailPage when clusterID in the url is false (125 ms)
    ✓ should not render CheckResultDetailPage when checkID in the url is false (43 ms)
    ✓ should not render CheckResultDetailPage when targetType in the url is false (40 ms)
    ✓ should not render CheckResultDetailPage when targetName in the url is false (31 ms)
    ✓ should render CheckResultDetailPage when the parts of url [ClusterID, CheckID, TargetType, TargetName] are valid (79 ms)

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   0 total
Time:        3.816 s, estimated 6 s

```

## How was this tested?

UT

## Did you update the documentation?

No need