### PR TITLE
Prune events cron job

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -157,9 +157,17 @@ config :trento, Trento.Scheduler,
       task: {Trento.ActivityLog, :clear_expired_logs, []},
       run_strategy: {Quantum.RunStrategy.Random, :cluster},
       overlap: false
+    ],
+    prune_discovery_events: [
+      schedule: "0 0 * * *",
+      task: {Trento.Discovery, :prune_discovery_events, [10]},
+      run_strategy: {Quantum.RunStrategy.Random, :cluster},
+      overlap: false
     ]
   ],
   debug_logging: false
+
+config :trento, prune_events_cronjob_schedule: "0 0 * * *"
 
 config :trento, Trento.Infrastructure.Messaging,
   adapter: Trento.Infrastructure.Messaging.Adapter.AMQP

--- a/config/config.exs
+++ b/config/config.exs
@@ -167,8 +167,6 @@ config :trento, Trento.Scheduler,
   ],
   debug_logging: false
 
-config :trento, prune_events_cronjob_schedule: "0 0 * * *"
-
 config :trento, Trento.Infrastructure.Messaging,
   adapter: Trento.Infrastructure.Messaging.Adapter.AMQP
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -207,6 +207,12 @@ if config_env() in [:prod, :demo] do
       ],
       hosts_checks_execution: [
         schedule: "*/#{System.get_env("CHECKS_INTERVAL", "5")} * * * *"
+      ],
+      prune_discovery_events: [
+        schedule: System.get_env("PRUNE_EVENTS_INTERVAL", "0 0 * * *"),
+        task:
+          {Trento.Discovery, :prune_discovery_events,
+           ["PRUNE_EVENTS_OLDER_THAN" |> System.get_env("10") |> String.to_integer()]}
       ]
     ]
 

--- a/lib/mix/tasks/prune_events.ex
+++ b/lib/mix/tasks/prune_events.ex
@@ -24,10 +24,8 @@ defmodule Mix.Tasks.PruneEvents do
       {:ok, _} ->
         days = Keyword.get(opts, :days, @default_older_than)
         IO.puts(IO.ANSI.green() <> "Pruning events...")
-        events_number = Discovery.prune_events(days)
-        IO.puts(IO.ANSI.green() <> "Deleted #{events_number} events.")
-        discarded_events_number = Discovery.prune_discarded_discovery_events(days)
-        IO.puts(IO.ANSI.green() <> "Deleted #{discarded_events_number} discarded events.")
+        Discovery.prune_discovery_events(days)
+        IO.puts(IO.ANSI.green() <> "Done.")
 
       {:error, error} ->
         print_error("Could not start repo: #{error}")

--- a/lib/trento/discovery.ex
+++ b/lib/trento/discovery.ex
@@ -89,6 +89,16 @@ defmodule Trento.Discovery do
   end
 
   @doc """
+  Prune all discovery events (regular and discarded) older than the given number of days.
+  """
+  @spec prune_discovery_events(number) :: :ok
+  def prune_discovery_events(days) do
+    prune_events(days)
+    prune_discarded_discovery_events(days)
+    :ok
+  end
+
+  @doc """
   Prune the discovery events log by removing the events older than the given number of days.
   """
   @spec prune_events(number) :: non_neg_integer()

--- a/lib/trento/discovery.ex
+++ b/lib/trento/discovery.ex
@@ -98,11 +98,8 @@ defmodule Trento.Discovery do
     :ok
   end
 
-  @doc """
-  Prune the discovery events log by removing the events older than the given number of days.
-  """
   @spec prune_events(number) :: non_neg_integer()
-  def prune_events(days) do
+  defp prune_events(days) do
     end_datetime = Timex.shift(DateTime.utc_now(), days: -days)
 
     {events_number, nil} =
@@ -113,11 +110,8 @@ defmodule Trento.Discovery do
     events_number
   end
 
-  @doc """
-  Prune the discarded discovery events log by removing the events older than the given number of days.
-  """
   @spec prune_discarded_discovery_events(number) :: non_neg_integer()
-  def prune_discarded_discovery_events(days) do
+  defp prune_discarded_discovery_events(days) do
     end_datetime = Timex.shift(DateTime.utc_now(), days: -days)
 
     {discarded_events_number, nil} =

--- a/test/trento/discovery_test.exs
+++ b/test/trento/discovery_test.exs
@@ -92,7 +92,7 @@ defmodule Trento.DiscoveryTest do
     ] = discarded_events
   end
 
-  test "should delete events older than the specified days" do
+  test "should delete events and discarded events older than the specified days" do
     insert_list(
       10,
       :discovery_event,
@@ -101,18 +101,14 @@ defmodule Trento.DiscoveryTest do
       inserted_at: Timex.shift(DateTime.utc_now(), days: -11)
     )
 
-    assert 10 == Discovery.prune_events(10)
-    assert 0 == DiscoveryEvent |> Trento.Repo.all() |> length()
-  end
-
-  test "should delete discarded events older than the specified days" do
     insert_list(
       10,
       :discarded_discovery_event,
       inserted_at: Timex.shift(DateTime.utc_now(), days: -11)
     )
 
-    assert 10 == Discovery.prune_discarded_discovery_events(10)
+    assert :ok == Discovery.prune_discovery_events(10)
+    assert 0 == DiscoveryEvent |> Trento.Repo.all() |> length()
     assert 0 == DiscardedDiscoveryEvent |> Trento.Repo.all() |> length()
   end
 


### PR DESCRIPTION
Periodically prune discovery events using a cron job. The default values are borrowed from the batch job implemented in the helm chart https://github.com/trento-project/helm-charts/blob/main/charts/trento-server/charts/trento-web/templates/prune-events-cronjob.yaml

The job can be configured using env variables:
* `PRUNE_EVENTS_INTERVAL` the crontab for the job
* `PRUNE_EVENTS_OLDER_THAN` the retention threshold of the events, in days 