### PR TITLE
Ai assistant UI core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ config/dev.local.exs
 storybook-static
 
 .DS_Store
+
+/.claude/

--- a/assets/.storybook/main.js
+++ b/assets/.storybook/main.js
@@ -18,6 +18,10 @@ module.exports = {
       '@pages': path.resolve(__dirname, '../js/pages'),
       '@state': path.resolve(__dirname, '../js/state'),
       '@static': path.resolve(__dirname, '../static'),
+      // phoenix is loaded transitively via SocketProvider/AssistantChatProvider
+      // when AIAssistant components are rendered in stories — alias to the
+      // same mock Jest uses so Storybook can build.
+      phoenix: path.resolve(__dirname, '../mocks/phoenix.js'),
     };
 
     config.resolve.roots = [path.resolve(__dirname, '../../priv/static')];

--- a/assets/jest.config.js
+++ b/assets/jest.config.js
@@ -117,6 +117,7 @@ module.exports = {
     'react-markdown': '<rootDir>/mocks/reactMarkdown.js',
     'remark-gfm': '<rootDir>/mocks/remarkPlugin.js',
     '\\.(jpg|ico|jpeg|png|gif|svg)$': '<rootDir>/mocks/fileMock.js',
+    '\\.css$': '<rootDir>/mocks/fileMock.js',
   },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
@@ -227,7 +228,9 @@ module.exports = {
 
   // Allow transforming ESM-only deps (e.g. @faker-js/faker) inside node_modules.
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-  transformIgnorePatterns: ['/node_modules/(?!(?:@faker-js/faker)/)'],
+  transformIgnorePatterns: [
+    '/node_modules/(?!(?:@faker-js/faker|@assistant-ui|@ag-ui|assistant-stream|assistant-cloud|nanoid|zustand|use-sync-external-store)/)',
+  ],
 
   // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
   // unmockedModulePathPatterns: undefined,

--- a/assets/js/common/AIAssistant/AIAssistant.jsx
+++ b/assets/js/common/AIAssistant/AIAssistant.jsx
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useState } from 'react';
+
+import { useAuiState } from '@assistant-ui/react';
+
+import { CONNECTION_STATUS } from '@lib/ai';
+
+import AssistantChatProvider from './AssistantChatProvider';
+import AssistantThread from './AssistantThread';
+import ModalFrame from './ModalFrame';
+
+export function AssistantUI({
+  open,
+  connectionStatus,
+  onOpenChange,
+  onNewThread,
+  handleClose,
+}) {
+  const isEmpty = useAuiState((s) => s.thread.isEmpty);
+  const isRunning = useAuiState((s) => s.thread.isRunning);
+
+  return (
+    <ModalFrame open={open} onOpenChange={onOpenChange}>
+      <AssistantThread
+        connectionStatus={connectionStatus}
+        onClose={handleClose}
+        onNewThread={onNewThread}
+        isEmpty={isEmpty}
+        isRunning={isRunning}
+      />
+    </ModalFrame>
+  );
+}
+
+function AIAssistant({
+  userID,
+  open = false,
+  initialConnectionStatus = CONNECTION_STATUS.DISCONNECTED,
+}) {
+  const [isOpen, setIsOpen] = useState(open);
+  const handleClose = () => setIsOpen(false);
+  const [threadID, setThreadID] = useState(() => crypto.randomUUID());
+  const [connectionStatus, setConnectionStatus] = useState(
+    initialConnectionStatus
+  );
+
+  const onNewThread = () => setThreadID(crypto.randomUUID());
+
+  return (
+    <AssistantChatProvider
+      userID={userID}
+      threadID={threadID}
+      onConnectionChange={setConnectionStatus}
+    >
+      <AssistantUI
+        open={isOpen}
+        connectionStatus={connectionStatus}
+        onOpenChange={setIsOpen}
+        onNewThread={onNewThread}
+        handleClose={handleClose}
+      />
+    </AssistantChatProvider>
+  );
+}
+
+export default AIAssistant;

--- a/assets/js/common/AIAssistant/AIAssistant.stories.jsx
+++ b/assets/js/common/AIAssistant/AIAssistant.stories.jsx
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useEffect, useState } from 'react';
+
+import { SocketContext } from '@common/SocketProvider';
+import { makeMockSocket } from '@lib/test-utils/phoenixDoubles';
+import { buildAssistantTurn } from '@lib/test-utils/aguiEvents';
+
+import AIAssistant from './AIAssistant';
+
+const USER_ID = 1;
+const TOPIC = `ai_assistant:${USER_ID}`;
+
+function StoryProviders({ socket, children }) {
+  return (
+    <SocketContext.Provider value={socket}>{children}</SocketContext.Provider>
+  );
+}
+
+function useFreshSocket() {
+  const [socket] = useState(makeMockSocket());
+  return socket;
+}
+
+// Drives the channel into the connection state requested by the story.
+//
+//  - 'fireOk'             — fire join 'ok' once the channel exists, then idle.
+//  - 'dropAfterConnect'   — connect, then drop the transport after a short delay.
+//  - 'none'               — leave the channel pending (status stays 'connecting').
+function useChannelScript(socket, script) {
+  useEffect(() => {
+    const channel = socket.channels.get(TOPIC);
+    if (!channel) return undefined;
+
+    if (script === 'fireOk' || script === 'dropAfterConnect') {
+      channel.joinPush.fire('ok');
+    }
+    if (script === 'dropAfterConnect') {
+      const t = setTimeout(
+        () => channel.errorHandlers.forEach((cb) => cb()),
+        50
+      );
+      return () => clearTimeout(t);
+    }
+    return undefined;
+  }, [socket, script]);
+}
+
+// Types the user's prompt into the composer, hits send, then plays an
+// assistant turn back through the channel. Assumes useChannelScript has
+// already brought the channel up. `turn.stepDelayMs > 0` reveals deltas
+// progressively for the streaming demo; 0 fires synchronously for a frozen
+// conversation.
+function useSimulatedTurn(socket, turn) {
+  useEffect(() => {
+    if (!turn) return undefined;
+
+    let cancelled = false;
+    const timers = [];
+
+    const channel = socket.channels.get(TOPIC);
+    if (!channel) return undefined;
+
+    const setNativeValue = (el, value) => {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype,
+        'value'
+      ).set;
+      setter.call(el, value);
+      el.dispatchEvent(new window.Event('input', { bubbles: true }));
+    };
+
+    const run = async () => {
+      // Wait one paint so composer + send have mounted.
+      await new Promise((resolve) => window.requestAnimationFrame(resolve));
+      if (cancelled) return;
+
+      const composer = document.querySelector('[aria-label="Message input"]');
+      const send = document.querySelector('[aria-label="Send message"]');
+      if (!composer || !send) return;
+
+      setNativeValue(composer, turn.userText);
+      send.click();
+
+      // Wait for WebSocketAIAgent to push send_message back to the channel.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      if (cancelled) return;
+
+      const sent = channel.pushed
+        .filter((p) => p.event === 'send_message')
+        .at(-1);
+      if (!sent) return;
+
+      const { thread_id: threadId, run_id: runId } = sent.payload;
+      const events = buildAssistantTurn({
+        threadId,
+        runId,
+        messageId: 'asst-1',
+        deltas: turn.assistantDeltas,
+      });
+
+      const fire = (e) => channel.emit('ag_ui_event', e);
+
+      if (turn.stepDelayMs > 0) {
+        events.forEach((event, i) => {
+          timers.push(
+            setTimeout(() => {
+              if (!cancelled) fire(event);
+            }, i * turn.stepDelayMs)
+          );
+        });
+      } else {
+        events.forEach(fire);
+      }
+    };
+
+    run();
+
+    return () => {
+      cancelled = true;
+      timers.forEach(clearTimeout);
+    };
+    // The turn config is captured at mount; restarting on field changes is
+    // never what we want here.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [socket]);
+}
+
+export default {
+  title: 'Components/AIAssistant/AIAssistant',
+  component: AIAssistant,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      story: { inline: false, iframeHeight: 720 },
+    },
+    aiAssistant: {
+      script: 'fireOk',
+      turn: null,
+    },
+  },
+  args: { userID: USER_ID },
+  decorators: [
+    (Story, context) => {
+      const socket = useFreshSocket();
+      const { script, turn } = context.parameters.aiAssistant ?? {};
+      useChannelScript(socket, script);
+      useSimulatedTurn(socket, turn);
+      return (
+        <StoryProviders socket={socket}>
+          <Story />
+        </StoryProviders>
+      );
+    },
+  ],
+};
+
+export const Closed = {
+  name: 'Closed (FAB only)',
+  args: { open: false },
+};
+
+export const OpenEmpty = {
+  name: 'Open — empty thread',
+  args: { open: true },
+};
+
+export const OpenConversation = {
+  name: 'Open — with conversation',
+  args: { open: true },
+  parameters: {
+    aiAssistant: {
+      turn: {
+        userText: 'What is the API key for adding agents?',
+        assistantDeltas: [
+          'You can find the API key on the **Settings → Agents** page. ',
+          'Copy it and paste it into the agent installer.',
+        ],
+        stepDelayMs: 0,
+      },
+    },
+  },
+};
+
+export const OpenDisconnected = {
+  name: 'Open — disconnected',
+  args: { open: true },
+  parameters: {
+    aiAssistant: { script: 'dropAfterConnect' },
+  },
+};
+
+export const OpenStreaming = {
+  name: 'Open — streaming response (interactive)',
+  args: { open: true },
+  parameters: {
+    aiAssistant: {
+      turn: {
+        userText: 'Walk me through the trento deployment.',
+        assistantDeltas: [
+          'The deployment ',
+          'consists of two ',
+          'main parts: ',
+          '**web** ',
+          '(this UI + control plane) ',
+          'and **wanda** ',
+          '(the checks engine).\n\n',
+          'Both run as Elixir releases, ',
+          'usually behind a reverse proxy.',
+        ],
+        stepDelayMs: 250,
+      },
+    },
+  },
+};

--- a/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
+++ b/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { config as rxjsConfig } from 'rxjs';
+import { makeMockSocket } from '@lib/test-utils/phoenixDoubles';
+import { buildAssistantTurn } from '@lib/test-utils/aguiEvents';
+
+import { useSocket } from '@common/SocketProvider';
+import AIAssistant from './AIAssistant';
+
+// RxJS reports unhandled subscriber errors via setTimeout(() => throw err) by
+// default — terminal AG-UI events (ie RUN_ERROR) hit
+// this path and would crash the test runner. Capture them instead so tests
+// can assert on observable outcomes.
+let unhandledRxErrors = [];
+beforeEach(() => {
+  unhandledRxErrors = [];
+  rxjsConfig.onUnhandledError = (err) => unhandledRxErrors.push(err);
+});
+afterEach(() => {
+  rxjsConfig.onUnhandledError = null;
+});
+
+jest.mock('@common/SocketProvider', () => ({
+  useSocket: jest.fn(),
+}));
+
+// Markdown rendering is its own concern — replace with a plain span so the
+// scenarios can assert text directly without dragging react-markdown into
+// the test path.
+jest.mock('@assistant-ui/react-markdown', () => ({
+  MarkdownTextPrimitive: ({ text }) => <span data-aui-md>{text}</span>,
+}));
+
+async function renderAssistant({ userId = 'user-1' } = {}) {
+  const socket = makeMockSocket();
+  useSocket.mockReturnValue(socket);
+
+  const utils = render(<AIAssistant userID={userId} open />);
+
+  const channel = await waitFor(() => {
+    const c = socket.channels.get(`ai_assistant:${userId}`);
+    if (!c) throw new Error('channel not opened yet');
+    return c;
+  });
+
+  // Complete the channel join handshake — agent transitions to 'connected'.
+  await act(async () => {
+    channel.joinPush.fire('ok');
+  });
+
+  await screen.findByLabelText('Message input');
+  const user = userEvent.setup();
+
+  // Synchronously fire an AG-UI event on the channel. Terminal events
+  // (ie RUN_ERROR) call subscriber.error which RxJS
+  // reports as an unhandled error after a microtask tick — act() surfaces
+  // that as a throw, so we swallow it; tests assert on observable outcomes.
+  const emitAgUi = async (event) => {
+    try {
+      await act(async () => {
+        try {
+          channel.emit('ag_ui_event', event);
+        } catch {
+          // assistant-ui's subscription error handlers re-throw synchronously
+          // for terminal events (RUN_ERROR); swallow here so the test can
+          // assert on observable outcomes rather than the throw.
+        }
+      });
+    } catch {
+      // ditto, in case act() surfaces it on the outer await
+    }
+  };
+
+  // Drives a user turn through the real composer and waits for the agent to
+  // push a NEW send_message back to the channel. Re-queries DOM each time
+  // because assistant-ui swaps composer/send subtrees as thread state changes.
+  const sendUserMessage = async (text) => {
+    const sentBefore = channel.pushed.filter(
+      (p) => p.event === 'send_message'
+    ).length;
+    const composer = await screen.findByLabelText('Message input');
+    const send = await screen.findByLabelText('Send message');
+    await user.click(composer);
+    await user.keyboard(text);
+    await user.click(send);
+    await waitFor(() => {
+      const sent = channel.pushed.filter((p) => p.event === 'send_message');
+      if (sent.length <= sentBefore) {
+        throw new Error('send_message not pushed yet');
+      }
+    });
+    const sent = channel.pushed.filter((p) => p.event === 'send_message');
+    return sent[sent.length - 1].payload;
+  };
+
+  // Streams a complete assistant turn (RUN_STARTED → text → RUN_FINISHED)
+  // through the channel one event at a time so each is wrapped in act().
+  const streamAssistantTurn = async (params) => {
+    for (const event of buildAssistantTurn(params)) {
+      await emitAgUi(event);
+    }
+    return params.messageId;
+  };
+
+  return {
+    ...utils,
+    channel,
+    socket,
+    emitAgUi,
+    sendUserMessage,
+    streamAssistantTurn,
+  };
+}
+
+const assistantBubble = () => {
+  const nodes = document.querySelectorAll('[data-role="assistant"]');
+  return nodes[nodes.length - 1] || null;
+};
+
+describe('AG-UI event flow', () => {
+  it('streams an assistant response delta-by-delta into a message bubble', async () => {
+    const { emitAgUi, sendUserMessage } = await renderAssistant();
+    const { thread_id: threadId, run_id: runId } =
+      await sendUserMessage('hello');
+
+    const messageId = 'asst-1';
+    await emitAgUi({ type: 'RUN_STARTED', threadId, runId });
+    await emitAgUi({
+      type: 'TEXT_MESSAGE_START',
+      messageId,
+      role: 'assistant',
+    });
+    await emitAgUi({ type: 'TEXT_MESSAGE_CONTENT', messageId, delta: 'Hi ' });
+
+    await waitFor(() => {
+      expect(assistantBubble()).toHaveTextContent(/Hi/);
+    });
+
+    await emitAgUi({
+      type: 'TEXT_MESSAGE_CONTENT',
+      messageId,
+      delta: 'there',
+    });
+    await emitAgUi({ type: 'TEXT_MESSAGE_END', messageId });
+    await emitAgUi({ type: 'RUN_FINISHED', threadId, runId });
+
+    await waitFor(() => {
+      expect(assistantBubble()).toHaveTextContent('Hi there');
+    });
+  });
+
+  it('disables the composer input when the channel drops', async () => {
+    const { channel } = await renderAssistant();
+
+    expect(screen.getByLabelText('Message input')).not.toBeDisabled();
+
+    await act(async () => {
+      channel.errorHandlers.forEach((cb) => cb());
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Message input')).toBeDisabled();
+    });
+  });
+
+  it('handles a follow-up turn after the previous one finishes', async () => {
+    const { sendUserMessage, streamAssistantTurn } = await renderAssistant();
+
+    {
+      const { thread_id: threadId, run_id: runId } =
+        await sendUserMessage('first');
+      await streamAssistantTurn({
+        threadId,
+        runId,
+        messageId: 'a',
+        deltas: ['one'],
+      });
+    }
+    {
+      const { thread_id: threadId, run_id: runId } =
+        await sendUserMessage('second');
+      await streamAssistantTurn({
+        threadId,
+        runId,
+        messageId: 'b',
+        deltas: ['two'],
+      });
+    }
+
+    await waitFor(() => {
+      expect(screen.getByText('first')).toBeInTheDocument();
+      expect(screen.getByText('one')).toBeInTheDocument();
+      expect(screen.getByText('second')).toBeInTheDocument();
+      expect(screen.getByText('two')).toBeInTheDocument();
+    });
+  });
+});

--- a/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.jsx
+++ b/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.jsx
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { useAuiState } from '@assistant-ui/react';
+import { filter, isUndefined, last } from 'lodash';
+
+import Spinner from '@common/Spinner';
+
+export function deriveProgressLabel(content) {
+  const lastToolCall = last(filter(content, { type: 'tool-call' }));
+  if (lastToolCall && isUndefined(lastToolCall.result))
+    return `Calling ${lastToolCall.toolName || 'tool'}...`;
+  return 'Thinking...';
+}
+
+export function AgentProgressIndicatorView({ children }) {
+  return (
+    <div className="flex items-center gap-2 text-muted-foreground mt-2">
+      <Spinner />
+      <span className="text-sm">{children}</span>
+    </div>
+  );
+}
+
+// Reads `s.message` from the per-message scope set up by assistant-ui's
+// MessageByIndexProvider (one per <MessagePrimitive.Root>). Subscribing
+// directly here keeps the indicator reactive to streaming tool-call
+// updates
+function AgentProgressIndicator({ isRunning }) {
+  const message = useAuiState((s) => s.message);
+
+  if (!isRunning) return null;
+  if (
+    message.content.some(
+      (part) => part.type === 'text' && part.text?.trim().length > 0
+    )
+  ) {
+    return null;
+  }
+
+  return (
+    <AgentProgressIndicatorView>
+      {deriveProgressLabel(message.content)}
+    </AgentProgressIndicatorView>
+  );
+}
+
+export default AgentProgressIndicator;

--- a/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.stories.jsx
+++ b/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.stories.jsx
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { AgentProgressIndicatorView } from './AgentProgressIndicator';
+
+export default {
+  title: 'Components/AIAssistant/AgentProgressIndicator',
+  component: AgentProgressIndicatorView,
+  argTypes: {
+    children: {
+      description: 'Label rendered next to the spinner',
+      control: { type: 'text' },
+    },
+  },
+  render: (args) => (
+    <AgentProgressIndicatorView>{args.children}</AgentProgressIndicatorView>
+  ),
+};
+
+export const Thinking = {
+  args: { children: 'Thinking...' },
+};
+
+export const CallingTool = {
+  args: { children: 'Calling get_hosts...' },
+};

--- a/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.test.jsx
+++ b/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.test.jsx
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { useAuiState } from '@assistant-ui/react';
+import AgentProgressIndicator, {
+  AgentProgressIndicatorView,
+  deriveProgressLabel,
+} from './AgentProgressIndicator';
+
+jest.mock('@assistant-ui/react', () => ({
+  useAuiState: jest.fn(),
+}));
+
+const mockMessage = (message) => useAuiState.mockReturnValue(message);
+
+describe('AgentProgressIndicatorView', () => {
+  it.each(['Thinking...', 'Calling get_hosts...'])(
+    'renders the "%s" label',
+    (label) => {
+      render(<AgentProgressIndicatorView>{label}</AgentProgressIndicatorView>);
+      expect(screen.getByText(label)).toBeVisible();
+    }
+  );
+
+  it('renders a spinner alongside the label', () => {
+    const { container } = render(
+      <AgentProgressIndicatorView>Thinking...</AgentProgressIndicatorView>
+    );
+    expect(
+      container.querySelector('svg, [role="status"], .animate-spin')
+    ).not.toBeNull();
+  });
+});
+
+describe('deriveProgressLabel', () => {
+  it.each([
+    {
+      label: 'no parts',
+      content: [],
+      expected: 'Thinking...',
+    },
+    {
+      label: 'only non-tool parts',
+      content: [{ type: 'text', text: '' }],
+      expected: 'Thinking...',
+    },
+    {
+      label: 'tool call in flight',
+      content: [
+        { type: 'tool-call', toolName: 'get_hosts' },
+        { type: 'tool-call', toolName: 'get_clusters' },
+      ],
+      expected: 'Calling get_clusters...',
+    },
+    {
+      label: 'in-flight tool call without a name',
+      content: [{ type: 'tool-call' }],
+      expected: 'Calling tool...',
+    },
+    {
+      label: 'tool call has a result (waiting for assistant text)',
+      content: [{ type: 'tool-call', toolName: 'get_hosts', result: [] }],
+      expected: 'Thinking...',
+    },
+    {
+      label: 'an earlier tool completed but a new one is in flight',
+      content: [
+        { type: 'tool-call', toolName: 'get_hosts', result: [] },
+        { type: 'tool-call', toolName: 'get_clusters' },
+      ],
+      expected: 'Calling get_clusters...',
+    },
+  ])('returns "$expected" when $label', ({ content, expected }) => {
+    expect(deriveProgressLabel(content)).toBe(expected);
+  });
+});
+
+describe('AgentProgressIndicator', () => {
+  it('renders nothing when the thread is not running', () => {
+    mockMessage({ content: [] });
+    const { container } = render(<AgentProgressIndicator isRunning={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the assistant has already produced text', () => {
+    mockMessage({
+      content: [{ type: 'text', text: 'partial answer' }],
+    });
+    const { container } = render(<AgentProgressIndicator isRunning />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders "Thinking..." while the thread is running and no content has streamed', () => {
+    mockMessage({ content: [] });
+    render(<AgentProgressIndicator isRunning />);
+    expect(screen.getByText('Thinking...')).toBeVisible();
+  });
+
+  it('renders the tool name while a tool call is in flight', () => {
+    mockMessage({
+      content: [{ type: 'tool-call', toolName: 'get_hosts' }],
+    });
+    render(<AgentProgressIndicator isRunning />);
+    expect(screen.getByText('Calling get_hosts...')).toBeVisible();
+  });
+});

--- a/assets/js/common/AIAssistant/AgentProgressIndicator/index.js
+++ b/assets/js/common/AIAssistant/AgentProgressIndicator/index.js
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import AgentProgressIndicator from './AgentProgressIndicator';
+
+export default AgentProgressIndicator;

--- a/assets/js/common/AIAssistant/AssistantChatProvider.jsx
+++ b/assets/js/common/AIAssistant/AssistantChatProvider.jsx
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useEffect, useMemo, useRef } from 'react';
+import { noop } from 'lodash';
+
+import { AssistantRuntimeProvider, useAui } from '@assistant-ui/react';
+import { useAgUiRuntime } from '@assistant-ui/react-ag-ui';
+
+import { useSocket } from '@common/SocketProvider';
+import { WebSocketAIAgent } from '@lib/ai';
+
+function AssistantChatProvider({
+  userID,
+  threadID,
+  onConnectionChange = noop,
+  children,
+}) {
+  const socket = useSocket();
+
+  const agent = useMemo(() => {
+    if (!socket || !userID) return null;
+    // AG-UI's AgentConfig field is `threadId` (camel) — translate.
+    return new WebSocketAIAgent({
+      socket,
+      userID,
+      threadId: threadID,
+      onConnectionChange,
+    });
+  }, [socket, userID, threadID, onConnectionChange]);
+
+  useEffect(() => {
+    if (!agent) return undefined;
+    // Catch rejections (channel-join error / timeout / missing socket)
+    // so they don't bubble up as unhandled promise rejections —
+    // onConnectionChange handles flipping the UI to DISCONNECTED
+    agent.initialize().catch(noop);
+    return () => agent.disconnect();
+  }, [agent]);
+
+  const runtime = useAgUiRuntime({ agent });
+  const aui = useAui();
+
+  // useAgUiRuntime keeps its core (and the message store) in a useRef across
+  // agent swaps, so bumping threadID rebuilds the agent + websocket but
+  // leaves the prior thread's messages onscreen. Wipe them explicitly when
+  // the thread id actually changes; the first mount is a no-op.
+  const previousThreadIDRef = useRef(threadID);
+  useEffect(() => {
+    if (previousThreadIDRef.current === threadID) return;
+    previousThreadIDRef.current = threadID;
+    runtime.thread.reset();
+  }, [threadID, runtime]);
+
+  return (
+    <AssistantRuntimeProvider aui={aui} runtime={runtime}>
+      {children}
+    </AssistantRuntimeProvider>
+  );
+}
+
+export default AssistantChatProvider;

--- a/assets/js/common/AIAssistant/AssistantChatProvider.test.jsx
+++ b/assets/js/common/AIAssistant/AssistantChatProvider.test.jsx
@@ -1,0 +1,187 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { useAgUiRuntime } from '@assistant-ui/react-ag-ui';
+import * as agentModule from '@lib/ai';
+import { useSocket } from '@common/SocketProvider';
+import AssistantChatProvider from './AssistantChatProvider';
+
+jest.mock('@common/SocketProvider', () => ({
+  useSocket: jest.fn(),
+}));
+
+jest.mock('@assistant-ui/react-ag-ui', () => ({
+  useAgUiRuntime: jest.fn(),
+}));
+
+jest.mock('@assistant-ui/react', () => ({
+  AssistantRuntimeProvider: ({ children }) => <>{children}</>,
+  useAui: () => ({}),
+}));
+
+jest.mock('@lib/ai', () => {
+  const instances = [];
+  class WebSocketAIAgent {
+    constructor(opts) {
+      this.opts = opts;
+      this.initialize = jest.fn(() => Promise.resolve());
+      this.disconnect = jest.fn();
+      instances.push(this);
+    }
+  }
+  return {
+    WebSocketAIAgent,
+    __getInstances: () => instances,
+    __resetInstances: () => {
+      instances.length = 0;
+    },
+  };
+});
+
+const lastRuntimeOptions = () =>
+  useAgUiRuntime.mock.calls[useAgUiRuntime.mock.calls.length - 1][0];
+
+let fakeSocket;
+let runtimeStub;
+
+beforeEach(() => {
+  agentModule.__resetInstances();
+  jest.clearAllMocks();
+
+  runtimeStub = { thread: { reset: jest.fn() } };
+  useAgUiRuntime.mockImplementation(() => runtimeStub);
+
+  fakeSocket = {
+    channel: jest.fn(),
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+  };
+  useSocket.mockReturnValue(fakeSocket);
+});
+
+const renderProvider = (
+  props = {},
+  children = <div data-testid="child">hi</div>
+) =>
+  render(
+    <AssistantChatProvider userID={42} threadID="thread-1" {...props}>
+      {children}
+    </AssistantChatProvider>
+  );
+
+describe('AssistantChatProvider', () => {
+  it('renders children inside the runtime provider', () => {
+    renderProvider();
+    expect(screen.getByTestId('child')).toBeVisible();
+  });
+
+  it('does not create the agent when no socket is available', () => {
+    useSocket.mockReturnValue(null);
+    renderProvider();
+    expect(lastRuntimeOptions().agent).toBeNull();
+    expect(agentModule.__getInstances()).toHaveLength(0);
+  });
+
+  it('does not create the agent when no userID is provided', () => {
+    renderProvider({ userID: undefined });
+    expect(lastRuntimeOptions().agent).toBeNull();
+    expect(agentModule.__getInstances()).toHaveLength(0);
+  });
+
+  it('creates the agent and forwards it to useAgUiRuntime when userID and socket are present', async () => {
+    renderProvider({ userID: 7, threadID: 'thread-x' });
+
+    await waitFor(() => {
+      expect(agentModule.__getInstances()).toHaveLength(1);
+    });
+    const [agent] = agentModule.__getInstances();
+    expect(agent.opts.userID).toBe(7);
+    // Provider translates threadID prop to AG-UI's `threadId` constructor option.
+    expect(agent.opts.threadId).toBe('thread-x');
+    expect(agent.opts.socket).toBe(fakeSocket);
+    expect(lastRuntimeOptions().agent).toBe(agent);
+  });
+
+  it('does not pass a threadList adapter to the runtime', () => {
+    renderProvider();
+    expect(lastRuntimeOptions().adapters).toBeUndefined();
+  });
+
+  it('initializes the agent after construction', async () => {
+    renderProvider();
+    await waitFor(() => {
+      expect(agentModule.__getInstances()[0].initialize).toHaveBeenCalled();
+    });
+  });
+
+  it('disconnects the agent when the provider unmounts', async () => {
+    const { unmount } = renderProvider();
+    await waitFor(() => expect(agentModule.__getInstances()).toHaveLength(1));
+    const [agent] = agentModule.__getInstances();
+
+    unmount();
+    expect(agent.disconnect).toHaveBeenCalled();
+  });
+
+  it('forwards onConnectionChange to the agent so the parent can observe transitions', async () => {
+    const onConnectionChange = jest.fn();
+    renderProvider({ onConnectionChange });
+    await waitFor(() => expect(agentModule.__getInstances()).toHaveLength(1));
+    const [agent] = agentModule.__getInstances();
+
+    expect(agent.opts.onConnectionChange).toBe(onConnectionChange);
+
+    act(() => agent.opts.onConnectionChange('connected'));
+    expect(onConnectionChange).toHaveBeenCalledWith('connected');
+  });
+
+  it('rebuilds the agent and disconnects the old one when threadID changes', async () => {
+    const { rerender } = render(
+      <AssistantChatProvider userID={42} threadID="thread-1">
+        <div />
+      </AssistantChatProvider>
+    );
+    await waitFor(() => expect(agentModule.__getInstances()).toHaveLength(1));
+    const [first] = agentModule.__getInstances();
+    expect(first.opts.threadId).toBe('thread-1');
+
+    rerender(
+      <AssistantChatProvider userID={42} threadID="thread-2">
+        <div />
+      </AssistantChatProvider>
+    );
+
+    await waitFor(() => expect(agentModule.__getInstances()).toHaveLength(2));
+    const [, second] = agentModule.__getInstances();
+    expect(second.opts.threadId).toBe('thread-2');
+    expect(first.disconnect).toHaveBeenCalled();
+  });
+
+  it('does not reset the runtime on the first mount', () => {
+    renderProvider();
+    expect(runtimeStub.thread.reset).not.toHaveBeenCalled();
+  });
+
+  it('resets the runtime when threadID changes so prior messages are wiped', async () => {
+    const { rerender } = render(
+      <AssistantChatProvider userID={42} threadID="thread-1">
+        <div />
+      </AssistantChatProvider>
+    );
+    expect(runtimeStub.thread.reset).not.toHaveBeenCalled();
+
+    rerender(
+      <AssistantChatProvider userID={42} threadID="thread-2">
+        <div />
+      </AssistantChatProvider>
+    );
+
+    await waitFor(() => {
+      expect(runtimeStub.thread.reset).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/assets/js/common/AIAssistant/AssistantThread.jsx
+++ b/assets/js/common/AIAssistant/AssistantThread.jsx
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { noop } from 'lodash';
+import { ThreadPrimitive } from '@assistant-ui/react';
+
+import ChatHeader from './ChatHeader';
+import PromptComposer from './PromptComposer';
+import { AssistantMessage, UserMessage } from './MessageBubble';
+import ThreadWelcome from './ThreadWelcome';
+
+const SUGGESTION_CLASS_NAME =
+  'text-left bg-[#f8f9fa] border border-gray-200 rounded-lg p-3.5 text-gray-500 hover:bg-gray-100 transition-colors text-[15px]';
+
+function AssistantThread({
+  connectionStatus,
+  isEmpty = false,
+  isRunning = false,
+  onNewThread = noop,
+  onClose = noop,
+}) {
+  return (
+    <ThreadPrimitive.Root
+      className="relative flex h-full flex-col bg-white text-sm"
+      style={{
+        '--thread-max-width': '44rem',
+        '--accent-color': '#2fb371',
+        '--accent-foreground': '#ffffff',
+      }}
+    >
+      <ChatHeader
+        connectionStatus={connectionStatus}
+        onNewChat={onNewThread}
+        onClose={onClose}
+      />
+      <ThreadPrimitive.Viewport
+        turnAnchor="top"
+        className="relative flex flex-1 flex-col overflow-x-hidden overflow-y-auto scroll-smooth px-6 pt-4"
+      >
+        {isEmpty && <WelcomePanel />}
+
+        <ThreadPrimitive.Messages>
+          {({ message }) => {
+            switch (message.role) {
+              case 'user':
+                return <UserMessage />;
+              case 'assistant':
+                return <AssistantMessage isRunning={isRunning} />;
+              default:
+                return null;
+            }
+          }}
+        </ThreadPrimitive.Messages>
+        <ThreadPrimitive.ViewportFooter className="sticky bottom-0 mx-auto mt-auto flex w-full max-w-[var(--thread-max-width)] flex-col bg-white pt-4 pb-4">
+          <PromptComposer
+            connectionStatus={connectionStatus}
+            isRunning={isRunning}
+          />
+        </ThreadPrimitive.ViewportFooter>
+      </ThreadPrimitive.Viewport>
+    </ThreadPrimitive.Root>
+  );
+}
+
+function WelcomePanel() {
+  return (
+    <ThreadWelcome>
+      <ThreadPrimitive.Suggestion
+        prompt="What is the API key for adding agents?"
+        className={SUGGESTION_CLASS_NAME}
+      >
+        <span className="font-bold text-gray-600">What is the API key</span> for
+        adding agents?
+      </ThreadPrimitive.Suggestion>
+      <ThreadPrimitive.Suggestion
+        prompt="What is the check results that was run recently?"
+        className={SUGGESTION_CLASS_NAME}
+      >
+        <span className="font-bold text-gray-600">
+          What is the check results
+        </span>{' '}
+        that was run recently?
+      </ThreadPrimitive.Suggestion>
+    </ThreadWelcome>
+  );
+}
+
+export default AssistantThread;

--- a/assets/js/common/AIAssistant/ChatHeader/ChatHeader.jsx
+++ b/assets/js/common/AIAssistant/ChatHeader/ChatHeader.jsx
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { EOS_CLOSE } from 'eos-icons-react';
+
+import Button from '@common/Button';
+import { CONNECTION_STATUS } from '@lib/ai';
+
+const STATUS_VIEW = {
+  [CONNECTION_STATUS.CONNECTED]: { text: 'Online', dot: 'bg-white' },
+  [CONNECTION_STATUS.CONNECTING]: {
+    text: 'Connecting...',
+    dot: 'bg-yellow-300 animate-pulse',
+  },
+  [CONNECTION_STATUS.DISCONNECTED]: { text: 'Offline', dot: 'bg-red-400' },
+};
+
+const stopPointerDown = (e) => e.stopPropagation();
+
+function ChatHeader({ connectionStatus, onNewChat, onClose }) {
+  const { text, dot } =
+    STATUS_VIEW[connectionStatus] ??
+    STATUS_VIEW[CONNECTION_STATUS.DISCONNECTED];
+
+  return (
+    <div className="drag-handle flex items-center justify-between bg-[#2fb371] px-5 py-4 text-white cursor-move">
+      <div className="flex items-center gap-3">
+        <div
+          className={`w-2.5 h-2.5 rounded-full mt-1 shadow-sm ml-1 ${dot}`}
+        />
+        <div className="flex flex-col leading-tight">
+          <span className="font-bold text-lg">Liz</span>
+          <span className="text-sm font-medium opacity-95">{text}</span>
+        </div>
+      </div>
+      <div className="flex items-center gap-3">
+        <Button
+          type="link"
+          size="none"
+          onPointerDown={stopPointerDown}
+          onClick={onNewChat}
+          className="text-sm !text-white hover:!text-white hover:underline"
+        >
+          New chat
+        </Button>
+        <Button
+          type="icon"
+          size="none"
+          onPointerDown={stopPointerDown}
+          onClick={onClose}
+          aria-label="Close"
+        >
+          <EOS_CLOSE className="h-6 w-6 fill-current" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default ChatHeader;

--- a/assets/js/common/AIAssistant/ChatHeader/ChatHeader.stories.jsx
+++ b/assets/js/common/AIAssistant/ChatHeader/ChatHeader.stories.jsx
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import { action } from 'storybook/actions';
+import ChatHeader from './ChatHeader';
+
+export default {
+  title: 'Components/AIAssistant/ChatHeader',
+  component: ChatHeader,
+  argTypes: {
+    connectionStatus: {
+      description: 'Current connection status of the AI assistant',
+      options: ['connected', 'connecting', 'disconnected'],
+      control: { type: 'radio' },
+    },
+    onNewChat: {
+      description: 'Fired when the "New chat" button is clicked',
+      type: 'function',
+    },
+    onClose: {
+      description: 'Fired when the close button is clicked',
+      type: 'function',
+    },
+  },
+  args: {
+    onNewChat: action('onNewChat'),
+    onClose: action('onClose'),
+  },
+};
+
+export const Connected = {
+  args: { connectionStatus: 'connected' },
+};
+
+export const Connecting = {
+  args: { connectionStatus: 'connecting' },
+};
+
+export const Disconnected = {
+  args: { connectionStatus: 'disconnected' },
+};

--- a/assets/js/common/AIAssistant/ChatHeader/ChatHeader.test.jsx
+++ b/assets/js/common/AIAssistant/ChatHeader/ChatHeader.test.jsx
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import ChatHeader from './ChatHeader';
+
+const defaults = {
+  connectionStatus: 'connected',
+  onNewChat: () => {},
+  onClose: () => {},
+};
+
+describe('ChatHeader', () => {
+  it.each([
+    { status: 'connected', text: 'Online' },
+    { status: 'connecting', text: 'Connecting...' },
+    { status: 'disconnected', text: 'Offline' },
+  ])('renders the $text label for $status', ({ status, text }) => {
+    render(<ChatHeader {...defaults} connectionStatus={status} />);
+    expect(screen.getByText(text)).toBeVisible();
+    expect(screen.getByText('Liz')).toBeVisible();
+  });
+
+  it('falls back to the disconnected label for an unknown status', () => {
+    render(<ChatHeader {...defaults} connectionStatus="unknown" />);
+    expect(screen.getByText('Offline')).toBeVisible();
+  });
+
+  it('invokes onNewChat when the "New chat" button is clicked', async () => {
+    const user = userEvent.setup();
+    const onNewChat = jest.fn();
+    render(<ChatHeader {...defaults} onNewChat={onNewChat} />);
+
+    await user.click(screen.getByRole('button', { name: 'New chat' }));
+
+    expect(onNewChat).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onClose when the close button is clicked', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    render(<ChatHeader {...defaults} onClose={onClose} />);
+
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops pointer-down propagation on the buttons so the drag handle does not trigger', () => {
+    const user = userEvent.setup();
+    const parentPointerDown = jest.fn();
+    render(
+      <div onPointerDown={parentPointerDown}>
+        <ChatHeader {...defaults} />
+      </div>
+    );
+
+    user.click(screen.getByRole('button', { name: 'New chat' }));
+    user.click(screen.getByRole('button', { name: 'Close' }));
+
+    expect(parentPointerDown).not.toHaveBeenCalled();
+  });
+
+  it('marks the bar as a drag handle so the surrounding modal can be dragged', () => {
+    const { container } = render(<ChatHeader {...defaults} />);
+    expect(container.firstChild).toHaveClass('drag-handle');
+  });
+});

--- a/assets/js/common/AIAssistant/ChatHeader/index.js
+++ b/assets/js/common/AIAssistant/ChatHeader/index.js
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import ChatHeader from './ChatHeader';
+
+export default ChatHeader;

--- a/assets/js/common/AIAssistant/MessageBubble/MessageBubble.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/MessageBubble.jsx
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { ErrorPrimitive, MessagePrimitive } from '@assistant-ui/react';
+import { MarkdownTextPrimitive } from '@assistant-ui/react-markdown';
+import '@assistant-ui/react-markdown/styles/dot.css';
+import remarkGfm from 'remark-gfm';
+
+import AgentProgressIndicator from '../AgentProgressIndicator';
+
+const ROOT_CLASS_NAME =
+  'mx-auto w-full max-w-[var(--thread-max-width)] py-2 fade-in slide-in-from-bottom-1 animate-in duration-150';
+
+function MessageBubbleView({ variant, children }) {
+  if (variant === 'user') {
+    return (
+      <div className="rounded-lg bg-[#e8f5ef] px-5 py-4">
+        <div className="mb-1.5 font-semibold text-[#208b57] text-base">You</div>
+        <div className="break-words text-gray-800 text-base">{children}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white px-5 py-4">
+      <div className="break-words text-gray-800 text-base leading-relaxed">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function MarkdownText(props) {
+  return (
+    <MarkdownTextPrimitive
+      remarkPlugins={[remarkGfm]}
+      className="aui-md"
+      {...props}
+    />
+  );
+}
+
+function MessageError() {
+  return (
+    <MessagePrimitive.Error>
+      <ErrorPrimitive.Root className="mt-2 rounded-md border border-destructive bg-destructive/10 p-3 text-destructive text-sm dark:bg-destructive/5 dark:text-red-200">
+        <ErrorPrimitive.Message className="line-clamp-2" />
+      </ErrorPrimitive.Root>
+    </MessagePrimitive.Error>
+  );
+}
+
+export function UserMessage() {
+  return (
+    <MessagePrimitive.Root className={ROOT_CLASS_NAME} data-role="user">
+      <MessageBubbleView variant="user">
+        <MessagePrimitive.Parts />
+      </MessageBubbleView>
+    </MessagePrimitive.Root>
+  );
+}
+
+export function AssistantMessage({ isRunning }) {
+  return (
+    <MessagePrimitive.Root className={ROOT_CLASS_NAME} data-role="assistant">
+      <MessageBubbleView variant="assistant">
+        <MessagePrimitive.Parts components={{ Text: MarkdownText }} />
+        <MessageError />
+        <AgentProgressIndicator isRunning={isRunning} />
+      </MessageBubbleView>
+    </MessagePrimitive.Root>
+  );
+}

--- a/assets/js/common/AIAssistant/MessageBubble/MessageBubble.stories.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/MessageBubble.stories.jsx
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import {
+  AssistantRuntimeProvider,
+  ThreadPrimitive,
+  useAui,
+  useExternalStoreRuntime,
+} from '@assistant-ui/react';
+
+import { AssistantMessage, UserMessage } from './MessageBubble';
+import { identity } from 'lodash';
+
+// UserMessage / AssistantMessage rely on MessagePrimitive scoping established
+// by <ThreadPrimitive.Messages>. Mount a minimal external-store runtime
+// seeded with the messages we want to render — no backend, no agent, just
+// static state. onNew is required by the adapter contract but never fires
+// here since the stories don't render a composer.
+function StubRuntime({ messages, children }) {
+  const runtime = useExternalStoreRuntime({
+    messages,
+    isRunning: false,
+    isLoading: false,
+    convertMessage: identity,
+    onNew: () => Promise.resolve(),
+  });
+  const aui = useAui();
+  return (
+    <AssistantRuntimeProvider aui={aui} runtime={runtime}>
+      <ThreadPrimitive.Root>{children}</ThreadPrimitive.Root>
+    </AssistantRuntimeProvider>
+  );
+}
+
+function SeededThread({ messages }) {
+  return (
+    <StubRuntime messages={messages}>
+      <ThreadPrimitive.Messages
+        components={{ UserMessage, AssistantMessage }}
+      />
+    </StubRuntime>
+  );
+}
+
+const RICH_ASSISTANT_MARKDOWN = [
+  'Here are the steps:',
+  '',
+  '1. Open the agents page.',
+  '2. Click the copy button next to the key.',
+  '3. Run `trento-agent install`.',
+].join('\n');
+
+export default {
+  title: 'Components/AIAssistant/MessageBubble',
+  parameters: { layout: 'padded' },
+};
+
+export const User = {
+  render: () => (
+    <SeededThread
+      messages={[
+        { role: 'user', content: 'What is the API key for adding agents?' },
+      ]}
+    />
+  ),
+};
+
+export const Assistant = {
+  render: () => (
+    <SeededThread
+      messages={[
+        {
+          role: 'assistant',
+          content: 'Use the API key shown in the Settings → Agents page.',
+        },
+      ]}
+    />
+  ),
+};
+
+export const AssistantWithRichContent = {
+  render: () => (
+    <SeededThread
+      messages={[{ role: 'assistant', content: RICH_ASSISTANT_MARKDOWN }]}
+    />
+  ),
+};
+
+export const Conversation = {
+  render: () => (
+    <SeededThread
+      messages={[
+        { role: 'user', content: 'What is the API key for adding agents?' },
+        {
+          role: 'assistant',
+          content: 'Use the API key shown in the Settings → Agents page.',
+        },
+      ]}
+    />
+  ),
+};

--- a/assets/js/common/AIAssistant/MessageBubble/MessageBubble.test.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/MessageBubble.test.jsx
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { UserMessage, AssistantMessage } from './MessageBubble';
+
+jest.mock('@assistant-ui/react', () => ({
+  ErrorPrimitive: {
+    Root: ({ children }) => <div>{children}</div>,
+    Message: () => <span>Error message</span>,
+  },
+  MessagePrimitive: {
+    Root: ({ children, ...props }) => <div {...props}>{children}</div>,
+    Parts: () => <span data-testid="parts">parts</span>,
+    Error: ({ children }) => <div data-testid="error-slot">{children}</div>,
+  },
+  // AssistantMessage renders <AgentProgressIndicator> which subscribes via
+  // useAuiState((s) => s.message). Default: empty content + no run in flight.
+  useAuiState: () => ({ content: [] }),
+}));
+
+jest.mock('@assistant-ui/react-markdown', () => ({
+  MarkdownTextPrimitive: () => null,
+}));
+
+describe('UserMessage', () => {
+  it('renders the user message bubble with the "You" label and parts slot', () => {
+    const { container } = render(<UserMessage />);
+
+    expect(container.querySelector('[data-role="user"]')).toBeInTheDocument();
+    expect(screen.getByText('You')).toBeVisible();
+    expect(screen.getByTestId('parts')).toBeVisible();
+  });
+
+  it('does not render the assistant-only error slot', () => {
+    render(<UserMessage />);
+    expect(screen.queryByTestId('error-slot')).not.toBeInTheDocument();
+  });
+});
+
+describe('AssistantMessage', () => {
+  it('renders the assistant message bubble with the parts and error slots', () => {
+    const { container } = render(<AssistantMessage />);
+
+    expect(
+      container.querySelector('[data-role="assistant"]')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('parts')).toBeVisible();
+    expect(screen.getByTestId('error-slot')).toBeInTheDocument();
+  });
+
+  it('omits the user-only "You" label', () => {
+    render(<AssistantMessage />);
+    expect(screen.queryByText('You')).toBeNull();
+  });
+
+  it('shows the agent progress indicator while a run is in flight', () => {
+    render(<AssistantMessage isRunning />);
+    expect(screen.getByText('Thinking...')).toBeVisible();
+  });
+});

--- a/assets/js/common/AIAssistant/MessageBubble/index.js
+++ b/assets/js/common/AIAssistant/MessageBubble/index.js
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+export { UserMessage, AssistantMessage } from './MessageBubble';

--- a/assets/js/common/AIAssistant/ModalFrame/ModalFrame.jsx
+++ b/assets/js/common/AIAssistant/ModalFrame/ModalFrame.jsx
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { Rnd } from 'react-rnd';
+import { EOS_CHAT_BUBBLE_OUTLINED } from 'eos-icons-react';
+import { AssistantModalPrimitive } from '@assistant-ui/react';
+
+import Button from '@common/Button';
+
+const defaultTrigger = (
+  <Button
+    type="fab"
+    size="none"
+    className="size-full"
+    data-testid="ai-assistant-trigger"
+    aria-label="Open AI Assistant"
+  >
+    <EOS_CHAT_BUBBLE_OUTLINED className="fill-white" />
+  </Button>
+);
+
+function ModalFrame({
+  open,
+  onOpenChange,
+  trigger = defaultTrigger,
+  initialSize = { width: 384, height: 650 },
+  initialPosition = { x: -400, y: -650 },
+  minWidth = 300,
+  minHeight = 400,
+  children,
+}) {
+  return (
+    <AssistantModalPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <AssistantModalPrimitive.Anchor className="fixed right-6 bottom-20 size-12 z-40">
+        <AssistantModalPrimitive.Trigger asChild>
+          {trigger}
+        </AssistantModalPrimitive.Trigger>
+      </AssistantModalPrimitive.Anchor>
+
+      <AssistantModalPrimitive.Content
+        sideOffset={16}
+        className="z-[101] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+      >
+        <Rnd
+          bounds="window"
+          default={{ ...initialSize, ...initialPosition }}
+          minWidth={minWidth}
+          minHeight={minHeight}
+          maxWidth={window.innerWidth - 100}
+          maxHeight={window.innerHeight - 200}
+          dragHandleClassName="drag-handle"
+          className="rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 shadow-2xl flex flex-col overflow-hidden"
+        >
+          {children}
+        </Rnd>
+      </AssistantModalPrimitive.Content>
+    </AssistantModalPrimitive.Root>
+  );
+}
+
+export default ModalFrame;

--- a/assets/js/common/AIAssistant/ModalFrame/ModalFrame.stories.jsx
+++ b/assets/js/common/AIAssistant/ModalFrame/ModalFrame.stories.jsx
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useState } from 'react';
+import ModalFrame from './ModalFrame';
+
+export default {
+  title: 'Components/AIAssistant/ModalFrame',
+  component: ModalFrame,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      story: {
+        inline: false,
+        iframeHeight: 700,
+      },
+    },
+  },
+};
+
+function PlaceholderContent() {
+  return (
+    <div className="flex h-full flex-col bg-white">
+      <div className="drag-handle bg-[#2fb371] px-5 py-4 text-white cursor-move font-bold">
+        Liz · placeholder header (drag me)
+      </div>
+      <div className="flex-1 px-6 py-4 text-gray-500">
+        ModalFrame content slot — chat thread renders here in the real app.
+      </div>
+    </div>
+  );
+}
+
+export const Open = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <ModalFrame open={open} onOpenChange={setOpen}>
+        <PlaceholderContent />
+      </ModalFrame>
+    );
+  },
+};
+
+export const Closed = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <ModalFrame open={open} onOpenChange={setOpen}>
+        <PlaceholderContent />
+      </ModalFrame>
+    );
+  },
+};

--- a/assets/js/common/AIAssistant/ModalFrame/index.js
+++ b/assets/js/common/AIAssistant/ModalFrame/index.js
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import ModalFrame from './ModalFrame';
+
+export default ModalFrame;

--- a/assets/js/common/AIAssistant/PromptComposer/PromptComposer.jsx
+++ b/assets/js/common/AIAssistant/PromptComposer/PromptComposer.jsx
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { ComposerPrimitive } from '@assistant-ui/react';
+
+import Button from '@common/Button';
+import { CONNECTION_STATUS } from '@lib/ai';
+
+const COMPOSER_INPUT_CLASS_NAME =
+  'w-full border border-gray-300 rounded-lg p-4 text-gray-700 resize-none h-[130px] focus:outline-none focus:border-[#2fb371] focus:ring-1 focus:ring-[#2fb371] placeholder-gray-400 text-lg font-medium bg-white shadow-sm disabled:bg-gray-50 disabled:cursor-not-allowed';
+
+const PLACEHOLDERS = {
+  [CONNECTION_STATUS.CONNECTED]: 'How can I help you?',
+  [CONNECTION_STATUS.CONNECTING]: 'Connecting...',
+  [CONNECTION_STATUS.DISCONNECTED]: 'Offline - waiting to reconnect...',
+};
+
+const footnote = (
+  <>
+    AI assistants can make mistakes.
+    <br />
+    <a
+      href="https://documentation.suse.com/sles-sap/trento/html/SLES-SAP-trento/index.html"
+      className="underline hover:text-gray-500"
+    >
+      Learn more
+    </a>
+  </>
+);
+
+function SendButton({ disabled, isRunning }) {
+  if (isRunning) return null;
+  return (
+    <ComposerPrimitive.Send asChild>
+      <Button
+        asSubmit
+        type="default-fit"
+        disabled={disabled}
+        aria-label="Send message"
+        title={disabled ? 'Waiting for connection...' : 'Send message'}
+      >
+        Send
+      </Button>
+    </ComposerPrimitive.Send>
+  );
+}
+
+function PromptComposer({ connectionStatus, isRunning = false }) {
+  const isConnected = connectionStatus === CONNECTION_STATUS.CONNECTED;
+  const placeholder =
+    PLACEHOLDERS[connectionStatus] ??
+    PLACEHOLDERS[CONNECTION_STATUS.DISCONNECTED];
+
+  return (
+    <ComposerPrimitive.Root className="relative flex w-full flex-col">
+      <div className="relative flex w-full flex-col outline-none">
+        <ComposerPrimitive.AttachmentDropzone className="relative flex w-full flex-col outline-none">
+          <ComposerPrimitive.Input
+            className={COMPOSER_INPUT_CLASS_NAME}
+            placeholder={placeholder}
+            disabled={!isConnected}
+            aria-label="Message input"
+          />
+        </ComposerPrimitive.AttachmentDropzone>
+      </div>
+      <div className="flex justify-between items-center w-full mt-4">
+        <div className="text-sm text-gray-400 leading-tight">{footnote}</div>
+        <SendButton disabled={!isConnected} isRunning={isRunning} />
+      </div>
+    </ComposerPrimitive.Root>
+  );
+}
+
+export default PromptComposer;

--- a/assets/js/common/AIAssistant/PromptComposer/PromptComposer.stories.jsx
+++ b/assets/js/common/AIAssistant/PromptComposer/PromptComposer.stories.jsx
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useState } from 'react';
+
+import { SocketContext } from '@common/SocketProvider';
+import { makeMockSocket } from '@lib/test-utils/phoenixDoubles';
+
+import AssistantChatProvider from '../AssistantChatProvider';
+import PromptComposer from './PromptComposer';
+
+// PromptComposer relies on @assistant-ui/react's ComposerPrimitive.*, which
+// in turn need an AssistantRuntimeProvider in scope. Mount the real
+// AssistantChatProvider over a no-op mock socket so the primitives mount
+// cleanly without talking to a backend. The connection-state visuals are
+// driven by the `connectionStatus` prop, not the runtime, so the join
+// handshake never has to fire.
+function StoryProviders({ children }) {
+  const [socket] = useState(makeMockSocket());
+  return (
+    <SocketContext.Provider value={socket}>
+      <AssistantChatProvider userID="storybook" threadID="storybook">
+        {children}
+      </AssistantChatProvider>
+    </SocketContext.Provider>
+  );
+}
+
+export default {
+  title: 'Components/AIAssistant/PromptComposer',
+  component: PromptComposer,
+  parameters: { layout: 'padded' },
+  argTypes: {
+    connectionStatus: {
+      description:
+        'Connection state used to drive the placeholder + disabled state',
+      options: ['connected', 'connecting', 'disconnected'],
+      control: { type: 'radio' },
+    },
+    isRunning: {
+      description: 'Whether a run is in flight (hides the send button)',
+      control: { type: 'boolean' },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <StoryProviders>
+        <Story />
+      </StoryProviders>
+    ),
+  ],
+};
+
+export const Idle = {
+  args: { connectionStatus: 'connected', isRunning: false },
+};
+
+export const Disabled = {
+  args: { connectionStatus: 'disconnected', isRunning: false },
+};
+
+export const Sending = {
+  args: { connectionStatus: 'connected', isRunning: true },
+};

--- a/assets/js/common/AIAssistant/PromptComposer/PromptComposer.test.jsx
+++ b/assets/js/common/AIAssistant/PromptComposer/PromptComposer.test.jsx
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import PromptComposer from './PromptComposer';
+
+jest.mock('@assistant-ui/react', () => ({
+  ComposerPrimitive: {
+    Root: ({ children, ...props }) => <form {...props}>{children}</form>,
+    AttachmentDropzone: ({ children, ...props }) => (
+      <div {...props}>{children}</div>
+    ),
+    Input: ({ disabled, placeholder, ...props }) => (
+      <textarea disabled={disabled} placeholder={placeholder} {...props} />
+    ),
+    Send: ({ children }) => children,
+  },
+}));
+
+describe('PromptComposer', () => {
+  it.each([
+    { status: 'connected', placeholder: 'How can I help you?' },
+    { status: 'connecting', placeholder: 'Connecting...' },
+    {
+      status: 'disconnected',
+      placeholder: 'Offline - waiting to reconnect...',
+    },
+  ])(
+    'uses the $placeholder placeholder when status is $status',
+    ({ status, placeholder }) => {
+      render(<PromptComposer connectionStatus={status} />);
+      expect(screen.getByPlaceholderText(placeholder)).toBeVisible();
+    }
+  );
+
+  it('disables the input and the send button when not connected', () => {
+    render(<PromptComposer connectionStatus="disconnected" />);
+    expect(screen.getByLabelText('Message input')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled();
+  });
+
+  it('enables the input and the send button when connected', () => {
+    render(<PromptComposer connectionStatus="connected" />);
+    expect(screen.getByLabelText('Message input')).not.toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: 'Send message' })
+    ).not.toBeDisabled();
+  });
+
+  it('hides the send button while the thread is running', () => {
+    render(<PromptComposer connectionStatus="connected" isRunning />);
+    expect(screen.queryByRole('button', { name: 'Send message' })).toBeNull();
+  });
+
+  it('renders the footnote with the documentation link', () => {
+    render(<PromptComposer connectionStatus="connected" />);
+    expect(screen.getByText(/AI assistants can make mistakes/)).toBeVisible();
+    expect(screen.getByRole('link', { name: 'Learn more' })).toHaveAttribute(
+      'href',
+      expect.stringContaining('documentation.suse.com')
+    );
+  });
+});

--- a/assets/js/common/AIAssistant/PromptComposer/index.js
+++ b/assets/js/common/AIAssistant/PromptComposer/index.js
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import PromptComposer from './PromptComposer';
+
+export default PromptComposer;

--- a/assets/js/common/AIAssistant/ThreadWelcome/ThreadWelcome.jsx
+++ b/assets/js/common/AIAssistant/ThreadWelcome/ThreadWelcome.jsx
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+
+const defaultGreeting = (
+  <>
+    <div className="font-bold text-gray-600">Hi, I&apos;m Liz.</div>
+    <div>How can I help you today?</div>
+  </>
+);
+
+function ThreadWelcome({ greeting = defaultGreeting, children }) {
+  return (
+    <div className="mx-auto flex w-full max-w-[var(--thread-max-width)] flex-col gap-6 pt-32 pb-2">
+      <div className="text-[22px] leading-snug text-gray-500">{greeting}</div>
+      {children && <div className="flex flex-col gap-3">{children}</div>}
+    </div>
+  );
+}
+
+export default ThreadWelcome;

--- a/assets/js/common/AIAssistant/ThreadWelcome/ThreadWelcome.stories.jsx
+++ b/assets/js/common/AIAssistant/ThreadWelcome/ThreadWelcome.stories.jsx
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import ThreadWelcome from './ThreadWelcome';
+
+const suggestionClassName =
+  'text-left bg-[#f8f9fa] border border-gray-200 rounded-lg p-3.5 text-gray-500 hover:bg-gray-100 transition-colors text-[15px]';
+
+export default {
+  title: 'Components/AIAssistant/ThreadWelcome',
+  component: ThreadWelcome,
+  argTypes: {
+    greeting: {
+      description: 'Greeting node rendered above the suggestions',
+      control: false,
+    },
+    children: {
+      description: 'Clickable suggestion elements rendered under the greeting',
+      control: false,
+    },
+  },
+};
+
+export const Default = {
+  render: () => (
+    <ThreadWelcome>
+      <button type="button" className={suggestionClassName}>
+        <span className="font-bold text-gray-600">What is the API key</span> for
+        adding agents?
+      </button>
+      <button type="button" className={suggestionClassName}>
+        <span className="font-bold text-gray-600">
+          What is the check results
+        </span>{' '}
+        that was run recently?
+      </button>
+    </ThreadWelcome>
+  ),
+};
+
+export const NoSuggestions = {
+  render: () => <ThreadWelcome />,
+};
+
+export const CustomGreeting = {
+  render: () => (
+    <ThreadWelcome
+      greeting={
+        <>
+          <div className="font-bold text-gray-600">Welcome back.</div>
+          <div>Pick up where you left off.</div>
+        </>
+      }
+    />
+  ),
+};

--- a/assets/js/common/AIAssistant/ThreadWelcome/ThreadWelcome.test.jsx
+++ b/assets/js/common/AIAssistant/ThreadWelcome/ThreadWelcome.test.jsx
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import ThreadWelcome from './ThreadWelcome';
+
+describe('ThreadWelcome', () => {
+  it('renders the default Liz greeting when no greeting is provided', () => {
+    render(<ThreadWelcome />);
+    expect(screen.getByText("Hi, I'm Liz.")).toBeVisible();
+    expect(screen.getByText('How can I help you today?')).toBeVisible();
+  });
+
+  it('renders a custom greeting when provided', () => {
+    render(<ThreadWelcome greeting={<div>Welcome back.</div>} />);
+    expect(screen.getByText('Welcome back.')).toBeVisible();
+    expect(screen.queryByText("Hi, I'm Liz.")).toBeNull();
+  });
+
+  it('renders suggestion children inside the suggestions container', () => {
+    render(
+      <ThreadWelcome>
+        <button type="button">First</button>
+        <button type="button">Second</button>
+      </ThreadWelcome>
+    );
+    expect(screen.getByRole('button', { name: 'First' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Second' })).toBeVisible();
+  });
+
+  it('omits the suggestions container when no children are provided', () => {
+    const { container } = render(<ThreadWelcome />);
+    expect(container.querySelectorAll('button')).toHaveLength(0);
+  });
+});

--- a/assets/js/common/AIAssistant/ThreadWelcome/index.js
+++ b/assets/js/common/AIAssistant/ThreadWelcome/index.js
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import ThreadWelcome from './ThreadWelcome';
+
+export default ThreadWelcome;

--- a/assets/js/common/AIAssistant/index.js
+++ b/assets/js/common/AIAssistant/index.js
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import AIAssistant from './AIAssistant';
+import AssistantChatProvider from './AssistantChatProvider';
+import AssistantThread from './AssistantThread';
+
+export { AssistantChatProvider, AssistantThread };
+
+export default AIAssistant;

--- a/assets/js/common/Button/Button.jsx
+++ b/assets/js/common/Button/Button.jsx
@@ -10,6 +10,8 @@ const getSizeClasses = (size) => {
       return 'py-1 px-2 text-sm';
     case 'fit':
       return 'text-sm';
+    case 'none':
+      return '';
     default:
       return 'py-2 px-4 text-base';
   }
@@ -33,6 +35,10 @@ const getButtonClasses = (type) => {
       return 'bg-red-500 hover:opacity-75 focus:outline-none text-white border border-red-500 transition ease-in duration-200 text-center font-semibold rounded shadow';
     case 'link':
       return 'cursor-pointer text-jungle-green-500 hover:text-jungle-green-300';
+    case 'icon':
+      return 'bg-transparent hover:opacity-80 focus:outline-none transition-opacity flex items-center justify-center cursor-pointer';
+    case 'fab':
+      return 'bg-jungle-green-500 hover:opacity-90 focus:outline-none text-white shadow-lg flex items-center justify-center transition-all duration-200 hover:scale-110 active:scale-90 rounded-full';
     default:
       return 'bg-jungle-green-500 hover:opacity-75 focus:outline-none text-white w-full transition ease-in duration-200 text-center font-semibold rounded shadow disabled:bg-gray-400 disabled:text-gray-200';
   }

--- a/assets/js/common/Button/Button.stories.jsx
+++ b/assets/js/common/Button/Button.stories.jsx
@@ -68,3 +68,26 @@ export function SmallSecondary() {
 export function Disabled() {
   return <Button disabled>Hello world!</Button>;
 }
+
+export function Icon() {
+  return (
+    <Button type="icon" size="none" aria-label="Close">
+      <span className="text-2xl leading-none">×</span>
+    </Button>
+  );
+}
+
+export function FloatingActionButton() {
+  return (
+    <div className="size-12">
+      <Button
+        type="fab"
+        size="none"
+        className="size-full"
+        aria-label="Open assistant"
+      >
+        <span className="text-xl leading-none">+</span>
+      </Button>
+    </div>
+  );
+}

--- a/assets/js/common/Button/Button.test.jsx
+++ b/assets/js/common/Button/Button.test.jsx
@@ -17,9 +17,11 @@ const types = [
   'danger-bold',
   'link',
   'primary-white-fit',
+  'icon',
+  'fab',
 ];
 
-const sizes = ['small', 'fit'];
+const sizes = ['small', 'fit', 'none'];
 
 describe('Button', () => {
   it('should display a default button with its text', () => {

--- a/assets/js/common/SocketProvider/SocketProvider.jsx
+++ b/assets/js/common/SocketProvider/SocketProvider.jsx
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import { initSocketConnection } from '@lib/network/socket';
+import { getUserProfile } from '@state/selectors/user';
+
+// Exported so test/story scaffolding can short-circuit SocketProvider and
+// inject a fake socket directly via SocketContext.Provider.
+export const SocketContext = createContext(null);
+
+export function SocketProvider({ children }) {
+  const user = useSelector(getUserProfile);
+  const userId = user?.id;
+  const [socket, setSocket] = useState(null);
+
+  useEffect(() => {
+    if (!userId) {
+      setSocket(null);
+      return;
+    }
+    setSocket(initSocketConnection());
+  }, [userId]);
+
+  return (
+    <SocketContext.Provider value={socket}>{children}</SocketContext.Provider>
+  );
+}
+
+export function useSocket() {
+  return useContext(SocketContext);
+}

--- a/assets/js/common/SocketProvider/SocketProvider.test.jsx
+++ b/assets/js/common/SocketProvider/SocketProvider.test.jsx
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+
+import { initSocketConnection } from '@lib/network/socket';
+import { SocketProvider, useSocket } from './SocketProvider';
+
+jest.mock('@lib/network/socket', () => ({
+  initSocketConnection: jest.fn(),
+}));
+
+const mockStore = configureStore([]);
+
+function SocketProbe() {
+  const socket = useSocket();
+  return <div data-testid="socket">{socket ? 'present' : 'absent'}</div>;
+}
+
+const renderWithStore = (store) =>
+  render(
+    <Provider store={store}>
+      <SocketProvider>
+        <SocketProbe />
+      </SocketProvider>
+    </Provider>
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('SocketProvider', () => {
+  it('exposes null when no user is logged in', () => {
+    renderWithStore(mockStore({ user: {} }));
+    expect(screen.getByTestId('socket')).toHaveTextContent('absent');
+    expect(initSocketConnection).not.toHaveBeenCalled();
+  });
+
+  it('initialises and exposes the socket once a user id is present', () => {
+    const fakeSocket = { connect: jest.fn() };
+    initSocketConnection.mockReturnValue(fakeSocket);
+
+    renderWithStore(mockStore({ user: { id: 7 } }));
+
+    expect(initSocketConnection).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('socket')).toHaveTextContent('present');
+  });
+});

--- a/assets/js/common/SocketProvider/index.js
+++ b/assets/js/common/SocketProvider/index.js
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+export { SocketContext, SocketProvider, useSocket } from './SocketProvider';

--- a/assets/js/lib/ai/WebSocketAIAgent.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.js
@@ -30,14 +30,14 @@ class AbortError extends Error {
 }
 
 // Bridges assistant-ui's AG-UI runtime with Phoenix channels: translates
-// AG-UI protocol events to/from channel events for the ai_assistant:{userId}
+// AG-UI protocol events to/from channel events for the ai_assistant:{userID}
 // topic.
 export class WebSocketAIAgent extends AbstractAgent {
-  constructor({ socket, userId, onConnectionChange, ...options }) {
+  constructor({ socket, userID, onConnectionChange, ...options }) {
     super(options);
 
     this.socket = socket;
-    this.userId = userId;
+    this.userID = userID;
     this.channel = null;
     this.onConnectionChange = onConnectionChange;
     this._connectionStatus = CONNECTION_STATUS.DISCONNECTED;
@@ -52,13 +52,13 @@ export class WebSocketAIAgent extends AbstractAgent {
       this._setConnectionStatus(CONNECTION_STATUS.DISCONNECTED);
       throw new Error('No socket available');
     }
-    if (!this.userId) {
+    if (!this.userID) {
       this._setConnectionStatus(CONNECTION_STATUS.DISCONNECTED);
-      throw new Error('No userId available');
+      throw new Error('No userID available');
     }
 
     this._setConnectionStatus(CONNECTION_STATUS.CONNECTING);
-    this.channel = this.socket.channel(`ai_assistant:${this.userId}`, {});
+    this.channel = this.socket.channel(`ai_assistant:${this.userID}`, {});
     this._setupChannelHandlers();
 
     return new Promise((resolve, reject) => {

--- a/assets/js/lib/ai/WebSocketAIAgent.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.js
@@ -1,0 +1,195 @@
+import { AbstractAgent } from '@ag-ui/client';
+import { Observable } from 'rxjs';
+import { isArray, isString } from 'lodash';
+
+import { EventType } from '@ag-ui/core';
+
+import { CONNECTION_STATUS } from './connectionStatus';
+
+// Pure helper: collapse a message's content (string or array of parts) to
+// the plain text the server expects in `send_message`.
+export function extractMessageText({ content } = {}) {
+  if (isString(content)) return content;
+  if (isArray(content)) {
+    return content
+      .filter(({ type }) => type === 'text')
+      .map(({ text }) => text)
+      .join('\n');
+  }
+  return '';
+}
+
+class AbortError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'AbortError';
+  }
+}
+
+// Bridges assistant-ui's AG-UI runtime with Phoenix channels: translates
+// AG-UI protocol events to/from channel events for the ai_assistant:{userId}
+// topic.
+export class WebSocketAIAgent extends AbstractAgent {
+  constructor({ socket, userId, onConnectionChange, ...options }) {
+    super(options);
+
+    this.socket = socket;
+    this.userId = userId;
+    this.channel = null;
+    this.onConnectionChange = onConnectionChange;
+    this._connectionStatus = CONNECTION_STATUS.DISCONNECTED;
+    this._activeSubscriber = null;
+    this._activeRunId = null;
+  }
+
+  async initialize() {
+    if (this.channel) return undefined;
+
+    if (!this.socket) {
+      this._setConnectionStatus(CONNECTION_STATUS.DISCONNECTED);
+      throw new Error('No socket available');
+    }
+    if (!this.userId) {
+      this._setConnectionStatus(CONNECTION_STATUS.DISCONNECTED);
+      throw new Error('No userId available');
+    }
+
+    this._setConnectionStatus(CONNECTION_STATUS.CONNECTING);
+    this.channel = this.socket.channel(`ai_assistant:${this.userId}`, {});
+    this._setupChannelHandlers();
+
+    return new Promise((resolve, reject) => {
+      const fail = (message) => {
+        this.channel = null;
+        this._setConnectionStatus(CONNECTION_STATUS.DISCONNECTED);
+        reject(new Error(message));
+      };
+
+      this.channel
+        .join()
+        .receive('ok', () => {
+          this._setConnectionStatus(CONNECTION_STATUS.CONNECTED);
+          resolve();
+        })
+        .receive('error', (resp) => {
+          fail(`Failed to join channel: ${JSON.stringify(resp)}`);
+        })
+        .receive('timeout', () => {
+          fail('Channel join timeout');
+        });
+    });
+  }
+
+  _setupChannelHandlers() {
+    // Keep `this.channel` non-null on transport drops: Phoenix's Socket
+    // auto-rejoins the channel when the WS comes back, and the joinPush's
+    // existing receive('ok') handler will flip status back to CONNECTED.
+    // Channel.push also buffers while the socket is down and flushes on
+    // rejoin, so preserving the reference makes a "drop → recover → prompt"
+    // sequence Just Work.
+    const dropConnection = () => {
+      this._setConnectionStatus(CONNECTION_STATUS.DISCONNECTED);
+      this._failActiveRun(new Error('AI assistant connection lost'));
+    };
+
+    this.channel.on('ag_ui_event', (event) => this._handleAgUiEvent(event));
+    this.channel.onError(dropConnection);
+    this.channel.onClose(dropConnection);
+  }
+
+  _handleAgUiEvent(event) {
+    const subscriber = this._activeSubscriber;
+    if (!subscriber) return;
+
+    subscriber.next(event);
+
+    if (event.type === EventType.RUN_FINISHED) {
+      subscriber.complete();
+      this._clearActiveRun();
+    } else if (event.type === EventType.RUN_ERROR) {
+      subscriber.error(new Error(event.message || 'Agent execution failed'));
+      this._clearActiveRun();
+    }
+  }
+
+  // Implements AbstractAgent.run — invoked by assistant-ui when the user
+  // submits a message. Returns an Observable of AG-UI events.
+  run({ messages, threadId }) {
+    return new Observable((subscriber) => {
+      const runId = crypto.randomUUID();
+
+      const setupRun = async () => {
+        try {
+          if (
+            !this.channel ||
+            this._connectionStatus !== CONNECTION_STATUS.CONNECTED
+          ) {
+            await this.initialize();
+          }
+
+          const lastMessage = messages[messages.length - 1];
+          if (!lastMessage || lastMessage.role !== 'user') {
+            subscriber.error(
+              new Error('Cannot start a run without a new user message')
+            );
+            return;
+          }
+
+          this._activeRunId = runId;
+          this._activeSubscriber = subscriber;
+
+          this.channel
+            .push('send_message', {
+              message: extractMessageText(lastMessage),
+              thread_id: threadId,
+              run_id: runId,
+            })
+            .receive('error', (error) => {
+              if (this._activeRunId === runId) this._clearActiveRun();
+              subscriber.error(error);
+            });
+        } catch (error) {
+          subscriber.error(error);
+        }
+      };
+
+      setupRun();
+
+      // Guard against clearing a newer run when an older subscription
+      // is torn down out of order.
+      return () => {
+        if (this._activeRunId === runId) this._clearActiveRun();
+      };
+    });
+  }
+
+  _failActiveRun(error) {
+    const subscriber = this._activeSubscriber;
+    if (!subscriber) return;
+    subscriber.error(error);
+    this._clearActiveRun();
+  }
+
+  _clearActiveRun() {
+    this._activeSubscriber = null;
+    this._activeRunId = null;
+  }
+
+  _setConnectionStatus(status) {
+    if (this._connectionStatus === status) return;
+    this._connectionStatus = status;
+    this.onConnectionChange?.(status);
+  }
+
+  disconnect() {
+    if (!this.channel) return;
+    this.channel.leave();
+    this.channel = null;
+    // Tag the teardown error as an AbortError so AbstractAgent's `onError`
+    // treats it as an expected unmount/cancel.
+    //
+    // (See AbstractAgent.onError's allowlist in @ag-ui/client.)
+    this._failActiveRun(new AbortError('AI assistant disconnected'));
+    this._setConnectionStatus(CONNECTION_STATUS.DISCONNECTED);
+  }
+}

--- a/assets/js/lib/ai/WebSocketAIAgent.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.js
@@ -1,6 +1,6 @@
 import { AbstractAgent } from '@ag-ui/client';
 import { Observable } from 'rxjs';
-import { isArray, isString } from 'lodash';
+import { isArray, isString, last } from 'lodash';
 
 import { EventType } from '@ag-ui/core';
 
@@ -127,7 +127,7 @@ export class WebSocketAIAgent extends AbstractAgent {
             await this.initialize();
           }
 
-          const lastMessage = messages[messages.length - 1];
+          const lastMessage = last(messages);
           if (!lastMessage || lastMessage.role !== 'user') {
             subscriber.error(
               new Error('Cannot start a run without a new user message')

--- a/assets/js/lib/ai/WebSocketAIAgent.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { AbstractAgent } from '@ag-ui/client';
 import { Observable } from 'rxjs';
 import { isArray, isString, last } from 'lodash';

--- a/assets/js/lib/ai/WebSocketAIAgent.test.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.test.js
@@ -34,12 +34,12 @@ function makeAgent(overrides = {}) {
   const onConnectionChange = jest.fn();
   const agent = new WebSocketAIAgent({
     socket,
-    userId: 'u',
+    userID: 'u',
     onConnectionChange,
     ...overrides,
   });
   const getChannel = () =>
-    agent.socket?.channels.get(`ai_assistant:${agent.userId}`);
+    agent.socket?.channels.get(`ai_assistant:${agent.userID}`);
   return { agent, socket: agent.socket, onConnectionChange, getChannel };
 }
 
@@ -63,9 +63,9 @@ function runAgent(agent, input = { threadId: 't', messages: [userMessage()] }) {
 
 describe('WebSocketAIAgent', () => {
   describe('initialize', () => {
-    it('joins ai_assistant:{userId} and reports connecting → connected', async () => {
+    it('joins ai_assistant:{userID} and reports connecting → connected', async () => {
       const { agent, socket, onConnectionChange, getChannel } = makeAgent({
-        userId: 'u42',
+        userID: 'u42',
       });
 
       const initPromise = agent.initialize();
@@ -111,9 +111,9 @@ describe('WebSocketAIAgent', () => {
         error: /No socket available/,
       },
       {
-        missing: 'userId',
-        overrides: { userId: undefined },
-        error: /No userId available/,
+        missing: 'userID',
+        overrides: { userID: undefined },
+        error: /No userID available/,
       },
     ])(
       'throws when no $missing is provided and never reports a status change',
@@ -252,7 +252,7 @@ describe('WebSocketAIAgent', () => {
 
     it('initializes the channel lazily when run() is called before initialize()', async () => {
       const { agent, getChannel, onConnectionChange } = makeAgent({
-        userId: 'u2',
+        userID: 'u2',
       });
 
       runAgent(agent);

--- a/assets/js/lib/ai/WebSocketAIAgent.test.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.test.js
@@ -1,0 +1,375 @@
+import { makeMockSocket } from '@lib/test-utils/phoenixDoubles';
+import { extractMessageText, WebSocketAIAgent } from './WebSocketAIAgent';
+
+// Wrap socket.channel + each channel.leave with jest.fn so the existing
+// `toHaveBeenCalled` / `mockClear` assertions still apply. The shared
+// makeMockSocket stays jest-free so stories can use it too.
+function makeJestSocket() {
+  const socket = makeMockSocket();
+  const original = socket.channel;
+  socket.channel = jest.fn((topic) => {
+    const channel = original(topic);
+    if (!jest.isMockFunction(channel.leave)) {
+      channel.leave = jest.fn(channel.leave);
+    }
+    return channel;
+  });
+  return socket;
+}
+
+const flushMicrotasks = async () => {
+  for (let i = 0; i < 5; i += 1) await Promise.resolve();
+};
+
+const userMessage = (content = 'hi') => ({ role: 'user', content });
+
+// Standard test setup: a fresh agent + socket + channel + onConnectionChange spy.
+// `overrides` is spread after the defaults so callers can pass `userId: undefined`
+// or `socket: undefined` to exercise the missing-prerequisite branches.
+function makeAgent(overrides = {}) {
+  const socket = makeJestSocket();
+  const onConnectionChange = jest.fn();
+  const agent = new WebSocketAIAgent({
+    socket,
+    userId: 'u',
+    onConnectionChange,
+    ...overrides,
+  });
+  const getChannel = () =>
+    agent.socket?.channels.get(`ai_assistant:${agent.userId}`);
+  return { agent, socket: agent.socket, onConnectionChange, getChannel };
+}
+
+// Setup that resolves agent.initialize() by firing 'ok' on the join push.
+async function connectedAgent(opts) {
+  const ctx = makeAgent(opts);
+  const initPromise = ctx.agent.initialize();
+  ctx.getChannel().joinPush.fire('ok');
+  await initPromise;
+  return { ...ctx, channel: ctx.getChannel() };
+}
+
+// Subscribe to agent.run and capture next/error/complete in spies.
+function runAgent(agent, input = { threadId: 't', messages: [userMessage()] }) {
+  const next = jest.fn();
+  const error = jest.fn();
+  const complete = jest.fn();
+  const subscription = agent.run(input).subscribe({ next, error, complete });
+  return { subscription, next, error, complete };
+}
+
+describe('WebSocketAIAgent', () => {
+  describe('initialize', () => {
+    it('joins ai_assistant:{userId} and reports connecting → connected', async () => {
+      const { agent, socket, onConnectionChange, getChannel } = makeAgent({
+        userId: 'u42',
+      });
+
+      const initPromise = agent.initialize();
+
+      expect(socket.channel).toHaveBeenCalledWith('ai_assistant:u42', {});
+      expect(onConnectionChange).toHaveBeenNthCalledWith(1, 'connecting');
+
+      getChannel().joinPush.fire('ok');
+      await initPromise;
+
+      expect(onConnectionChange).toHaveBeenNthCalledWith(2, 'connected');
+    });
+
+    it.each([
+      {
+        scenario: 'join error',
+        receive: 'error',
+        payload: { reason: 'boom' },
+        rejectsWith: /Failed to join channel/,
+      },
+      {
+        scenario: 'join timeout',
+        receive: 'timeout',
+        payload: undefined,
+        rejectsWith: /Channel join timeout/,
+      },
+    ])(
+      'rejects on $scenario and reports disconnected',
+      async ({ receive, payload, rejectsWith }) => {
+        const { agent, onConnectionChange, getChannel } = makeAgent();
+        const initPromise = agent.initialize();
+        getChannel().joinPush.fire(receive, payload);
+
+        await expect(initPromise).rejects.toThrow(rejectsWith);
+        expect(onConnectionChange).toHaveBeenLastCalledWith('disconnected');
+      }
+    );
+
+    it.each([
+      {
+        missing: 'socket',
+        overrides: { socket: undefined },
+        error: /No socket available/,
+      },
+      {
+        missing: 'userId',
+        overrides: { userId: undefined },
+        error: /No userId available/,
+      },
+    ])(
+      'throws when no $missing is provided and never reports a status change',
+      async ({ overrides, error }) => {
+        const { agent, onConnectionChange } = makeAgent(overrides);
+        await expect(agent.initialize()).rejects.toThrow(error);
+        expect(onConnectionChange).not.toHaveBeenCalled();
+      }
+    );
+
+    it('is idempotent when channel is already initialized', async () => {
+      const { agent, socket } = await connectedAgent();
+
+      socket.channel.mockClear();
+      await agent.initialize();
+
+      expect(socket.channel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('connection status changes', () => {
+    it.each([
+      { trigger: 'channel error', method: 'triggerError' },
+      { trigger: 'channel close', method: 'triggerClose' },
+    ])('reports disconnected on $trigger', async ({ method }) => {
+      const { channel, onConnectionChange } = await connectedAgent();
+      onConnectionChange.mockClear();
+
+      channel[method]();
+
+      expect(onConnectionChange).toHaveBeenCalledWith('disconnected');
+    });
+
+    it('only invokes onConnectionChange when the status actually changes', () => {
+      const { agent, onConnectionChange } = makeAgent();
+
+      agent._setConnectionStatus('disconnected'); // already disconnected
+      agent._setConnectionStatus('connecting');
+      agent._setConnectionStatus('connecting'); // no change
+
+      expect(onConnectionChange.mock.calls).toEqual([['connecting']]);
+    });
+  });
+
+  describe('run', () => {
+    it('pushes send_message with text, thread_id, and a generated run_id', async () => {
+      const { agent, channel } = await connectedAgent();
+
+      runAgent(agent, {
+        threadId: 'thread-1',
+        messages: [userMessage('hello there')],
+      });
+
+      expect(channel.pushed).toHaveLength(1);
+      expect(channel.pushed[0]).toMatchObject({
+        event: 'send_message',
+        payload: {
+          message: 'hello there',
+          thread_id: 'thread-1',
+          run_id: agent._activeRunId,
+        },
+      });
+      expect(typeof agent._activeRunId).toBe('string');
+    });
+
+    it('forwards ag_ui_event payloads to the active subscriber', async () => {
+      const { agent, channel } = await connectedAgent();
+      const { next } = runAgent(agent);
+
+      const event = { type: 'TEXT_MESSAGE_CONTENT', delta: 'hello' };
+      channel.emit('ag_ui_event', event);
+
+      expect(next).toHaveBeenCalledWith(event);
+    });
+
+    it('completes the observable on RUN_FINISHED and clears active run state', async () => {
+      const { agent, channel } = await connectedAgent();
+      const { complete } = runAgent(agent);
+
+      channel.emit('ag_ui_event', { type: 'RUN_FINISHED' });
+
+      expect(complete).toHaveBeenCalledTimes(1);
+      expect(agent._activeSubscriber).toBeNull();
+      expect(agent._activeRunId).toBeNull();
+    });
+
+    it.each([
+      {
+        scenario: 'with explicit message',
+        event: { type: 'RUN_ERROR', message: 'oops' },
+        message: 'oops',
+      },
+      {
+        scenario: 'with default message when none is given',
+        event: { type: 'RUN_ERROR' },
+        message: 'Agent execution failed',
+      },
+    ])(
+      'errors the observable on RUN_ERROR $scenario',
+      async ({ event, message }) => {
+        const { agent, channel } = await connectedAgent();
+        const { error } = runAgent(agent);
+
+        channel.emit('ag_ui_event', event);
+
+        expect(error).toHaveBeenCalledWith(
+          expect.objectContaining({ message })
+        );
+        expect(agent._activeSubscriber).toBeNull();
+      }
+    );
+
+    it('errors when there is no new user message to start the run with', async () => {
+      const { agent } = await connectedAgent();
+      const { error } = runAgent(agent, {
+        threadId: 't',
+        messages: [{ role: 'assistant', content: 'oh' }],
+      });
+
+      expect(error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Cannot start a run without a new user message',
+        })
+      );
+    });
+
+    it('errors when channel.push receives an error', async () => {
+      const { agent, channel } = await connectedAgent();
+      const { error } = runAgent(agent);
+
+      channel.pushed[0].push.fire('error', { reason: 'rejected' });
+
+      expect(error).toHaveBeenCalledWith({ reason: 'rejected' });
+      expect(agent._activeSubscriber).toBeNull();
+    });
+
+    it('initializes the channel lazily when run() is called before initialize()', async () => {
+      const { agent, getChannel, onConnectionChange } = makeAgent({
+        userId: 'u2',
+      });
+
+      runAgent(agent);
+
+      expect(getChannel()).toBeDefined();
+      expect(onConnectionChange).toHaveBeenCalledWith('connecting');
+
+      getChannel().joinPush.fire('ok');
+      await flushMicrotasks();
+
+      expect(getChannel().pushed).toHaveLength(1);
+      expect(getChannel().pushed[0].event).toBe('send_message');
+    });
+
+    it('clears active run state when the subscription is unsubscribed', async () => {
+      const { agent } = await connectedAgent();
+      const { subscription } = runAgent(agent);
+
+      expect(agent._activeSubscriber).not.toBeNull();
+
+      subscription.unsubscribe();
+
+      expect(agent._activeSubscriber).toBeNull();
+      expect(agent._activeRunId).toBeNull();
+    });
+  });
+
+  describe('connection drops during an active run', () => {
+    it.each([
+      { trigger: 'channel error', method: 'triggerError' },
+      { trigger: 'channel close', method: 'triggerClose' },
+    ])('errors the active subscriber on $trigger', async ({ method }) => {
+      const { agent, channel } = await connectedAgent();
+      const { error } = runAgent(agent);
+
+      channel[method]();
+
+      expect(error).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'AI assistant connection lost' })
+      );
+      expect(agent._activeSubscriber).toBeNull();
+      expect(agent._activeRunId).toBeNull();
+    });
+
+    it('keeps the channel reference after a drop so a later push does not throw', async () => {
+      const { agent, channel } = await connectedAgent();
+      channel.triggerClose();
+      expect(agent.channel).toBe(channel);
+
+      // Simulate Phoenix's auto-rejoin: same channel, same joinPush, fires 'ok' again.
+      channel.joinPush.fire('ok');
+      expect(agent._connectionStatus).toBe('connected');
+
+      runAgent(agent);
+      expect(channel.pushed).toContainEqual(
+        expect.objectContaining({ event: 'send_message' })
+      );
+    });
+  });
+
+  describe('extractMessageText', () => {
+    it('returns string content as-is', () => {
+      expect(extractMessageText({ content: 'hello' })).toBe('hello');
+    });
+
+    it('joins text parts with newlines and skips non-text parts', () => {
+      expect(
+        extractMessageText({
+          content: [
+            { type: 'text', text: 'one' },
+            { type: 'image', url: 'x' },
+            { type: 'text', text: 'two' },
+          ],
+        })
+      ).toBe('one\ntwo');
+    });
+
+    it.each([
+      ['missing message', undefined],
+      ['missing content', {}],
+      ['null content', { content: null }],
+      ['number content', { content: 42 }],
+    ])('returns an empty string for %s', (_label, message) => {
+      expect(extractMessageText(message)).toBe('');
+    });
+  });
+
+  describe('disconnect', () => {
+    it('leaves the channel and reports disconnected', async () => {
+      const { agent, channel, onConnectionChange } = await connectedAgent();
+      onConnectionChange.mockClear();
+
+      agent.disconnect();
+
+      expect(channel.leave).toHaveBeenCalled();
+      expect(agent.channel).toBeNull();
+      expect(onConnectionChange).toHaveBeenCalledWith('disconnected');
+    });
+
+    it('errors the active subscriber when disconnected mid-run', async () => {
+      const { agent } = await connectedAgent();
+      const { error } = runAgent(agent);
+
+      agent.disconnect();
+
+      expect(error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'AbortError',
+          message: 'AI assistant disconnected',
+        })
+      );
+      expect(agent._activeSubscriber).toBeNull();
+      expect(agent._activeRunId).toBeNull();
+    });
+
+    it('is a no-op when never connected', () => {
+      const { agent, onConnectionChange } = makeAgent();
+
+      expect(() => agent.disconnect()).not.toThrow();
+      expect(onConnectionChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/assets/js/lib/ai/WebSocketAIAgent.test.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.test.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { makeMockSocket } from '@lib/test-utils/phoenixDoubles';
 import { extractMessageText, WebSocketAIAgent } from './WebSocketAIAgent';
 

--- a/assets/js/lib/ai/WebSocketAIAgent.test.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.test.js
@@ -310,33 +310,6 @@ describe('WebSocketAIAgent', () => {
     });
   });
 
-  describe('extractMessageText', () => {
-    it('returns string content as-is', () => {
-      expect(extractMessageText({ content: 'hello' })).toBe('hello');
-    });
-
-    it('joins text parts with newlines and skips non-text parts', () => {
-      expect(
-        extractMessageText({
-          content: [
-            { type: 'text', text: 'one' },
-            { type: 'image', url: 'x' },
-            { type: 'text', text: 'two' },
-          ],
-        })
-      ).toBe('one\ntwo');
-    });
-
-    it.each([
-      ['missing message', undefined],
-      ['missing content', {}],
-      ['null content', { content: null }],
-      ['number content', { content: 42 }],
-    ])('returns an empty string for %s', (_label, message) => {
-      expect(extractMessageText(message)).toBe('');
-    });
-  });
-
   describe('disconnect', () => {
     it('leaves the channel and reports disconnected', async () => {
       const { agent, channel, onConnectionChange } = await connectedAgent();
@@ -370,6 +343,33 @@ describe('WebSocketAIAgent', () => {
 
       expect(() => agent.disconnect()).not.toThrow();
       expect(onConnectionChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('extractMessageText', () => {
+    it('returns string content as-is', () => {
+      expect(extractMessageText({ content: 'hello' })).toBe('hello');
+    });
+
+    it('joins text parts with newlines and skips non-text parts', () => {
+      expect(
+        extractMessageText({
+          content: [
+            { type: 'text', text: 'one' },
+            { type: 'image', url: 'x' },
+            { type: 'text', text: 'two' },
+          ],
+        })
+      ).toBe('one\ntwo');
+    });
+
+    it.each([
+      ['missing message', undefined],
+      ['missing content', {}],
+      ['null content', { content: null }],
+      ['number content', { content: 42 }],
+    ])('returns an empty string for %s', (_label, message) => {
+      expect(extractMessageText(message)).toBe('');
     });
   });
 });

--- a/assets/js/lib/ai/connectionStatus.js
+++ b/assets/js/lib/ai/connectionStatus.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 // Connection lifecycle states reported by the WebSocketAIAgent and consumed
 // by the AssistantChatProvider context. Single source of truth so UI code
 // (status indicators, composer placeholders, header dot) doesn't drift from

--- a/assets/js/lib/ai/connectionStatus.js
+++ b/assets/js/lib/ai/connectionStatus.js
@@ -1,0 +1,9 @@
+// Connection lifecycle states reported by the WebSocketAIAgent and consumed
+// by the AssistantChatProvider context. Single source of truth so UI code
+// (status indicators, composer placeholders, header dot) doesn't drift from
+// what the agent actually emits.
+export const CONNECTION_STATUS = Object.freeze({
+  CONNECTED: 'connected',
+  CONNECTING: 'connecting',
+  DISCONNECTED: 'disconnected',
+});

--- a/assets/js/lib/ai/index.js
+++ b/assets/js/lib/ai/index.js
@@ -1,29 +1,6 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-import { get } from 'lodash';
-
-import GeminiIcon from '@static/gemini-logo.svg';
-import OpenAIIcon from '@static/openai-logo.svg';
-import AnthropicIcon from '@static/anthropic-logo.svg';
-
-const providerRenderingConfig = {
-  googleai: {
-    icon: GeminiIcon,
-    label: 'Google Gemini',
-  },
-  openai: {
-    icon: OpenAIIcon,
-    label: 'OpenAI GPT',
-  },
-  anthropic: {
-    icon: AnthropicIcon,
-    label: 'Anthropic Claude',
-  },
-};
-
-export const getProviderLabel = (provider) =>
-  get(providerRenderingConfig, [provider, 'label'], provider);
-
-export const getProviderIcon = (provider) =>
-  get(providerRenderingConfig, [provider, 'icon']);
+export { getProviderLabel, getProviderIcon } from './providers';
+export { WebSocketAIAgent, extractMessageText } from './WebSocketAIAgent';
+export { CONNECTION_STATUS } from './connectionStatus';

--- a/assets/js/lib/ai/providers.js
+++ b/assets/js/lib/ai/providers.js
@@ -1,0 +1,26 @@
+import { get } from 'lodash';
+
+import GeminiIcon from '@static/gemini-logo.svg';
+import OpenAIIcon from '@static/openai-logo.svg';
+import AnthropicIcon from '@static/anthropic-logo.svg';
+
+const providerRenderingConfig = {
+  googleai: {
+    icon: GeminiIcon,
+    label: 'Google Gemini',
+  },
+  openai: {
+    icon: OpenAIIcon,
+    label: 'OpenAI GPT',
+  },
+  anthropic: {
+    icon: AnthropicIcon,
+    label: 'Anthropic Claude',
+  },
+};
+
+export const getProviderLabel = (provider) =>
+  get(providerRenderingConfig, [provider, 'label'], provider);
+
+export const getProviderIcon = (provider) =>
+  get(providerRenderingConfig, [provider, 'icon']);

--- a/assets/js/lib/ai/providers.js
+++ b/assets/js/lib/ai/providers.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 import { get } from 'lodash';
 
 import GeminiIcon from '@static/gemini-logo.svg';

--- a/assets/js/lib/ai/providers.test.js
+++ b/assets/js/lib/ai/providers.test.js
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-import { getProviderLabel, getProviderIcon } from '.';
+import { getProviderLabel, getProviderIcon } from './providers';
 
-describe('aizz', () => {
+describe('providers', () => {
   describe('getProviderLabel', () => {
     it('should return the provider label', () => {
       expect(getProviderLabel('googleai')).toBe('Google Gemini');

--- a/assets/js/lib/network/socket.js
+++ b/assets/js/lib/network/socket.js
@@ -39,7 +39,15 @@ const getWebsocketParams = () => ({
   access_token: getAccessTokenFromStore(),
 });
 
+// Singleton socket instance
+let socketInstance = null;
+
 export const initSocketConnection = () => {
+  // Return existing socket if already initialized
+  if (socketInstance) {
+    return socketInstance;
+  }
+
   const socket = new Socket('/socket', {
     params: () => getWebsocketParams(),
   });
@@ -51,5 +59,11 @@ export const initSocketConnection = () => {
   });
   socket.connect();
 
+  // Store singleton instance
+  socketInstance = socket;
+
   return socket;
 };
+
+// Get existing socket instance (returns null if not initialized)
+export const getSocketInstance = () => socketInstance;

--- a/assets/js/lib/test-utils/aguiEvents.js
+++ b/assets/js/lib/test-utils/aguiEvents.js
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// AG-UI event factories for tests/stories.
+//
+// Each helper builds a single event payload of the matching AG-UI type
+// (sourced from `@ag-ui/core`'s `EventType` enum so the spec stays
+// single-source). `buildAssistantTurn` composes a complete RUN_STARTED →
+// text streaming → RUN_FINISHED sequence; consumers decide how to emit it
+// (sync, with delays, inside an act() wrapper, etc.).
+
+import { EventType } from '@ag-ui/core';
+
+export const aguiEvents = {
+  runStarted: ({ threadId, runId }) => ({
+    type: EventType.RUN_STARTED,
+    threadId,
+    runId,
+  }),
+  runFinished: ({ threadId, runId }) => ({
+    type: EventType.RUN_FINISHED,
+    threadId,
+    runId,
+  }),
+  runError: ({ message }) => ({ type: EventType.RUN_ERROR, message }),
+  textStart: ({ messageId, role = 'assistant' }) => ({
+    type: EventType.TEXT_MESSAGE_START,
+    messageId,
+    role,
+  }),
+  textContent: ({ messageId, delta }) => ({
+    type: EventType.TEXT_MESSAGE_CONTENT,
+    messageId,
+    delta,
+  }),
+  textEnd: ({ messageId }) => ({
+    type: EventType.TEXT_MESSAGE_END,
+    messageId,
+  }),
+};
+
+export function buildAssistantTurn({ threadId, runId, messageId, deltas }) {
+  return [
+    aguiEvents.runStarted({ threadId, runId }),
+    aguiEvents.textStart({ messageId }),
+    ...deltas.map((delta) => aguiEvents.textContent({ messageId, delta })),
+    aguiEvents.textEnd({ messageId }),
+    aguiEvents.runFinished({ threadId, runId }),
+  ];
+}

--- a/assets/js/lib/test-utils/phoenixDoubles.js
+++ b/assets/js/lib/test-utils/phoenixDoubles.js
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
 // Test/story doubles for Phoenix Channel APIs.
 //
 // Plain JS only — no jest.fn — so this module can be imported from Storybook

--- a/assets/js/lib/test-utils/phoenixDoubles.js
+++ b/assets/js/lib/test-utils/phoenixDoubles.js
@@ -1,0 +1,77 @@
+// Test/story doubles for Phoenix Channel APIs.
+//
+// Plain JS only — no jest.fn — so this module can be imported from Storybook
+// stories as well as Jest tests. If a test needs jest.fn semantics on a
+// specific method (e.g. channel.leave), use jest.spyOn(target, 'method')
+// after construction.
+
+export function makePush() {
+  const handlers = {};
+  const push = {
+    receive: (event, cb) => {
+      handlers[event] = cb;
+      return push;
+    },
+    fire: (event, payload) => handlers[event]?.(payload),
+  };
+  return push;
+}
+
+export class MockChannel {
+  constructor() {
+    this.listeners = new Map();
+    this.errorHandlers = [];
+    this.closeHandlers = [];
+    this.pushed = [];
+    this.joinPush = makePush();
+  }
+
+  on(event, cb) {
+    if (!this.listeners.has(event)) this.listeners.set(event, []);
+    this.listeners.get(event).push(cb);
+  }
+
+  emit(event, payload) {
+    (this.listeners.get(event) || []).forEach((cb) => cb(payload));
+  }
+
+  push(event, payload) {
+    const push = makePush();
+    this.pushed.push({ event, payload, push });
+    return push;
+  }
+
+  join() {
+    return this.joinPush;
+  }
+
+  onError(cb) {
+    this.errorHandlers.push(cb);
+  }
+
+  onClose(cb) {
+    this.closeHandlers.push(cb);
+  }
+
+  // Test convenience: trip the registered onError/onClose listeners.
+  triggerError() {
+    this.errorHandlers.forEach((cb) => cb());
+  }
+
+  triggerClose() {
+    this.closeHandlers.forEach((cb) => cb());
+  }
+
+  leave() {}
+}
+
+export function makeMockSocket() {
+  const channels = new Map();
+  return {
+    channels,
+    channel: (topic) => {
+      if (!channels.has(topic)) channels.set(topic, new MockChannel());
+      return channels.get(topic);
+    },
+  };
+}

--- a/assets/js/pages/Layout/Layout.jsx
+++ b/assets/js/pages/Layout/Layout.jsx
@@ -5,6 +5,7 @@ import React, { useState, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { NavLink, Outlet } from 'react-router';
 
+import { getFromConfig } from '@lib/config';
 import { clearCredentialsFromStore } from '@lib/auth';
 import { getUserProfile } from '@state/selectors/user';
 import { optinCapturing, reset } from '@lib/analytics';
@@ -31,6 +32,8 @@ import classNames from 'classnames';
 import ProfileMenu from '@common/ProfileMenu';
 import ForbiddenGuard from '@common/ForbiddenGuard';
 import AnalyticsEula from '@pages/AnalyticsEula';
+import { SocketProvider } from '@common/SocketProvider';
+import AIAssistant from '@common/AIAssistant';
 
 const navigation = [
   { name: 'Dashboard', href: '/', icon: EOS_HOME_OUTLINED },
@@ -99,7 +102,7 @@ function Layout() {
       : localStorage.setItem('sidebar-collapsed', true);
   }, [isCollapsed]);
 
-  const { username, email } = useSelector(getUserProfile);
+  const { id, username, email } = useSelector(getUserProfile);
 
   const sidebarIconColor = 'currentColor';
   const sidebarIconClassName = 'text-gray-400 hover:text-gray-300';
@@ -245,6 +248,11 @@ function Layout() {
           </span>
         </footer>
       </div>
+      {getFromConfig('aiEnabled') && (
+        <SocketProvider>
+          <AIAssistant userID={id} />
+        </SocketProvider>
+      )}
     </main>
   );
 }

--- a/assets/mocks/reactMarkdown.js
+++ b/assets/mocks/reactMarkdown.js
@@ -1,8 +1,10 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
+import React from 'react';
+
 function MarkdownMock({ children }) {
-  return [children];
+  return <>{children}</>;
 }
 
 export default MarkdownMock;

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -5,6 +5,11 @@
   "packages": {
     "": {
       "dependencies": {
+        "@ag-ui/client": "^0.0.52",
+        "@ag-ui/core": "^0.0.52",
+        "@assistant-ui/react": "^0.12.24",
+        "@assistant-ui/react-ag-ui": "^0.0.25",
+        "@assistant-ui/react-markdown": "^0.12.8",
         "@date-fns/tz": "^1.4.1",
         "@date-fns/utc": "^2.1.1",
         "@headlessui/react": "^2.2.7",
@@ -39,6 +44,7 @@
         "react-select": "^5.10.2",
         "redux-saga": "^1.4.2",
         "remark-gfm": "^4.0.1",
+        "rxjs": "^7.8.1",
         "semver": "^7.7.4",
         "tzdata": "^1.0.48",
         "uuid": "^11.1.0"
@@ -97,6 +103,77 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@ag-ui/client": {
+      "version": "0.0.52",
+      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.52.tgz",
+      "integrity": "sha512-U407VvDDwR5qs8TiyN1qY38x87qMWc2n0epw8iA5aa1qwzCKBBDgg3Fkm4JogQf0X4jwNsz8HUbIZrBB56mrpg==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.52",
+        "@ag-ui/encoder": "0.0.52",
+        "@ag-ui/proto": "0.0.52",
+        "@types/uuid": "^10.0.0",
+        "compare-versions": "^6.1.1",
+        "fast-json-patch": "^3.1.1",
+        "rxjs": "7.8.1",
+        "untruncate-json": "^0.0.1",
+        "uuid": "^11.1.0",
+        "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@ag-ui/client/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@ag-ui/client/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@ag-ui/core": {
+      "version": "0.0.52",
+      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.52.tgz",
+      "integrity": "sha512-Xo0bUaNV56EqylzcrAuhUkQX7et7+SZIrqZZtEByGwEq/I1EHny6ZMkWHLkKR7UNi0FJZwJyhKYmKJS3B2SEgA==",
+      "dependencies": {
+        "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@ag-ui/core/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@ag-ui/encoder": {
+      "version": "0.0.52",
+      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.52.tgz",
+      "integrity": "sha512-6GVDTb1dv2rjap7VVnmXYypDutZi6nrsTcdfxoP6ryDG5ynlXtmmS+FSDAt62JbIMD5CtEE963xNCb6d1iXw9g==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.52",
+        "@ag-ui/proto": "0.0.52"
+      }
+    },
+    "node_modules/@ag-ui/proto": {
+      "version": "0.0.52",
+      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.52.tgz",
+      "integrity": "sha512-+iCGzNUNL50YIoThVmsolWPjG4MJidl+R9k8QAGVwErEfHRtQ64KFyrdpeOXNVuWtM3SViJqPSgFyv7eGVS63A==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.52",
+        "@bufbuild/protobuf": "^2.2.5",
+        "@protobuf-ts/protoc": "^2.11.1"
+      }
+    },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
@@ -130,6 +207,253 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@assistant-ui/core": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/core/-/core-0.1.16.tgz",
+      "integrity": "sha512-G8Fl0u5EkwItWxOna9CscJdAuGHOQjYz1p95fVFfiOAb88eGElTecnntzmIUp3YWi7qbhM1e8c2exJDHLt8BIA==",
+      "license": "MIT",
+      "dependencies": {
+        "assistant-stream": "^0.3.12",
+        "nanoid": "^5.1.9"
+      },
+      "peerDependencies": {
+        "@assistant-ui/store": "^0.2.9",
+        "@assistant-ui/tap": "^0.5.10",
+        "@types/react": "*",
+        "assistant-cloud": "^0.1.27",
+        "react": "^18 || ^19",
+        "zustand": "^5.0.11"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "assistant-cloud": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "zustand": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@assistant-ui/core/node_modules/nanoid": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
+      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@assistant-ui/react": {
+      "version": "0.12.27",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/react/-/react-0.12.27.tgz",
+      "integrity": "sha512-h/cS8v0loHF6jVoINUJZJI7vJFRiE3uPYzvHLTjsaaiaWfMGq76mVj3PbIE21r/WFUOWM4TnoYNL7S8LaNA2rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@assistant-ui/core": "^0.1.16",
+        "@assistant-ui/store": "^0.2.9",
+        "@assistant-ui/tap": "^0.5.10",
+        "@radix-ui/primitive": "^1.1.3",
+        "@radix-ui/react-compose-refs": "^1.1.2",
+        "@radix-ui/react-context": "^1.1.3",
+        "@radix-ui/react-primitive": "^2.1.4",
+        "@radix-ui/react-use-callback-ref": "^1.1.1",
+        "@radix-ui/react-use-escape-keydown": "^1.1.1",
+        "assistant-cloud": "^0.1.27",
+        "assistant-stream": "^0.3.12",
+        "nanoid": "^5.1.9",
+        "radix-ui": "^1.4.3",
+        "react-textarea-autosize": "^8.5.9",
+        "zod": "^4.3.6",
+        "zustand": "^5.0.12"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@assistant-ui/react-ag-ui": {
+      "version": "0.0.25",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/react-ag-ui/-/react-ag-ui-0.0.25.tgz",
+      "integrity": "sha512-tgun6NFO/np3ZKczz81Le7a2MAQVKFfD6DkfGDN/wjnsNEihKYxngjbPFcfG9Kazz2+q32FIWBdZ0iPsD787yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@ag-ui/client": "^0.0.50",
+        "@assistant-ui/core": "^0.1.13",
+        "assistant-stream": "^0.3.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@assistant-ui/react-ag-ui/node_modules/@ag-ui/client": {
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@ag-ui/client/-/client-0.0.50.tgz",
+      "integrity": "sha512-Dug3lyB0RbPaQsxKkb+cyl1ODn36uZvaugwiHtOjQHTEWBLtqUz9WQCQc9dKBrDaHWh6EsxnzfvAAh2CrJLZHQ==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.50",
+        "@ag-ui/encoder": "0.0.50",
+        "@ag-ui/proto": "0.0.50",
+        "@types/uuid": "^10.0.0",
+        "compare-versions": "^6.1.1",
+        "fast-json-patch": "^3.1.1",
+        "rxjs": "7.8.1",
+        "untruncate-json": "^0.0.1",
+        "uuid": "^11.1.0",
+        "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@assistant-ui/react-ag-ui/node_modules/@ag-ui/core": {
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@ag-ui/core/-/core-0.0.50.tgz",
+      "integrity": "sha512-bvY9nyIJ7NQVLUk6LpnwqhkR1Ctv+yPE1hWPmfVJSgM3PHDJ9PDryR1/KRnbf/Mc5Smh7lJXepFt4OSWMgUdDA==",
+      "dependencies": {
+        "zod": "^3.22.4"
+      }
+    },
+    "node_modules/@assistant-ui/react-ag-ui/node_modules/@ag-ui/encoder": {
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@ag-ui/encoder/-/encoder-0.0.50.tgz",
+      "integrity": "sha512-NysK/N4gpZDOk1VILLp4jcbLp6qvpnwGWz8cgNuVtr3TaGyhWdfDLSaok/u8S4yfIaiF5UHdBWu7j3PNYVq3ig==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.50",
+        "@ag-ui/proto": "0.0.50"
+      }
+    },
+    "node_modules/@assistant-ui/react-ag-ui/node_modules/@ag-ui/proto": {
+      "version": "0.0.50",
+      "resolved": "https://registry.npmjs.org/@ag-ui/proto/-/proto-0.0.50.tgz",
+      "integrity": "sha512-XIHuClEvLDAKRE9wFuhpTBbP6rgAh5gWDIKfv87bqCXwbri3+zyTm9Eg1YCEZmzfRCk4/qR9Cs9NqVPs2lL8SQ==",
+      "dependencies": {
+        "@ag-ui/core": "0.0.50",
+        "@bufbuild/protobuf": "^2.2.5",
+        "@protobuf-ts/protoc": "^2.11.1"
+      }
+    },
+    "node_modules/@assistant-ui/react-ag-ui/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@assistant-ui/react-ag-ui/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@assistant-ui/react-markdown": {
+      "version": "0.12.11",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/react-markdown/-/react-markdown-0.12.11.tgz",
+      "integrity": "sha512-gYu4XVI2lX3lp9UG7V5VWP1+eO7SZomiBKsAZOKUOeuwn/hoL+J0vFY52FUgJixdF2R8NPPto2lb98DmJE70lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "^2.1.4",
+        "@radix-ui/react-use-callback-ref": "^1.1.1",
+        "classnames": "^2.5.1",
+        "react-markdown": "^10.1.0"
+      },
+      "peerDependencies": {
+        "@assistant-ui/react": "^0.12.26",
+        "@types/react": "*",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@assistant-ui/react/node_modules/nanoid": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
+      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/@assistant-ui/store": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/store/-/store-0.2.9.tgz",
+      "integrity": "sha512-EDd6yCfirb2OsAKoTo7HeMtqPG+1cqVlNXOzUsho35ZF3O1XQ2CyEY4iUbdhj3HfmWeZo7rmfhvbaYQVEqAfeA==",
+      "license": "MIT",
+      "dependencies": {
+        "use-effect-event": "^2.0.3"
+      },
+      "peerDependencies": {
+        "@assistant-ui/tap": "^0.5.10",
+        "@types/react": "*",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@assistant-ui/tap": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/tap/-/tap-0.5.10.tgz",
+      "integrity": "sha512-sBHTf+q1geRyu5l4gJJp2hk6ZxwhHZHj39ixjC9ARADuIYedYv1B8bCNS82eTC/COpD1xe86mzvT/+HwIsO9WA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -2013,6 +2337,12 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
+      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
@@ -4023,6 +4353,15 @@
       "integrity": "sha512-bgw5FBgxiS+aBql0UxZApNgdIdhxjRuKAs/qWUHoRSNnE8tOLVewB/Hb5mzBQCbyQVSVDAkmHEZAa7ePgtqfhw==",
       "license": "MIT"
     },
+    "node_modules/@protobuf-ts/protoc": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/protoc/-/protoc-2.11.1.tgz",
+      "integrity": "sha512-mUZJaV0daGO6HUX90o/atzQ6A7bbN2RSuHtdwo8SSF2Qoe3zHwa4IHyCN1evftTeHfLmdz+45qo47sL+5P8nyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "protoc": "protoc.js"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -4086,6 +4425,3553 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-accessible-icon": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.7.tgz",
+      "integrity": "sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
+      "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collapsible": "1.1.12",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-arrow/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-arrow/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-aspect-ratio": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.7.tgz",
+      "integrity": "sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-aspect-ratio/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-aspect-ratio/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
+      "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
+      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz",
+      "integrity": "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu": {
+      "version": "2.2.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
+      "integrity": "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-form": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.8.tgz",
+      "integrity": "sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-label": "2.1.7",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-form/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-form/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-form/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz",
+      "integrity": "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-hover-card/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menubar": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.16.tgz",
+      "integrity": "sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menubar/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menubar/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menubar/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz",
+      "integrity": "sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-navigation-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-one-time-password-field": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.8.tgz",
+      "integrity": "sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-one-time-password-field/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-one-time-password-field/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-one-time-password-field/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-password-toggle-field": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.3.tgz",
+      "integrity": "sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-is-hydrated": "0.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-password-toggle-field/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-password-toggle-field/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-password-toggle-field/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
+      "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
+      "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
+      "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
+      "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-toggle": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toolbar": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.11.tgz",
+      "integrity": "sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-separator": "1.1.7",
+        "@radix-ui/react-toggle-group": "1.1.11"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toolbar/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toolbar/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toolbar/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
+      "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.5.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
     },
     "node_modules/@rc-component/mini-decimal": {
       "version": "1.1.0",
@@ -4352,9 +8238,9 @@
       }
     },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
@@ -5175,6 +9061,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -6084,6 +9976,18 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -6262,6 +10166,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/assistant-cloud": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/assistant-cloud/-/assistant-cloud-0.1.27.tgz",
+      "integrity": "sha512-BGfVnx7YFN5xtB/kbrgGxRI0TfSWq4yxB3MwYn6RDPlv4JvdtPupvDC1Y6An0EhAe42Z0AYtSmDSsR6p6eeBng==",
+      "license": "MIT",
+      "dependencies": {
+        "assistant-stream": "^0.3.12"
+      }
+    },
+    "node_modules/assistant-stream": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/assistant-stream/-/assistant-stream-0.3.12.tgz",
+      "integrity": "sha512-ZdfdyeZjeffkUfZLGTre9rW+9nBSPi6U5tYvchYjAxVuyiYVf5H9vw7SxegTq5bAMT9IitpDOaYMZGWFoMtaow==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "nanoid": "^5.1.9",
+        "secure-json-parse": "^4.1.0"
+      }
+    },
+    "node_modules/assistant-stream/node_modules/nanoid": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
+      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
       }
     },
     "node_modules/ast-types": {
@@ -7337,6 +11279,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -7809,6 +11757,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/devlop": {
       "version": "1.1.0",
@@ -9028,6 +12982,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-json-patch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -9505,6 +13465,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-package-type": {
@@ -14432,6 +18401,139 @@
       ],
       "license": "MIT"
     },
+    "node_modules/radix-ui": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.4.3.tgz",
+      "integrity": "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-accessible-icon": "1.1.7",
+        "@radix-ui/react-accordion": "1.2.12",
+        "@radix-ui/react-alert-dialog": "1.1.15",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-aspect-ratio": "1.1.7",
+        "@radix-ui/react-avatar": "1.1.10",
+        "@radix-ui/react-checkbox": "1.3.3",
+        "@radix-ui/react-collapsible": "1.1.12",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-context-menu": "2.2.16",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-dropdown-menu": "2.1.16",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-form": "0.1.8",
+        "@radix-ui/react-hover-card": "1.1.15",
+        "@radix-ui/react-label": "2.1.7",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-menubar": "1.1.16",
+        "@radix-ui/react-navigation-menu": "1.2.14",
+        "@radix-ui/react-one-time-password-field": "0.1.8",
+        "@radix-ui/react-password-toggle-field": "0.1.3",
+        "@radix-ui/react-popover": "1.1.15",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-progress": "1.1.7",
+        "@radix-ui/react-radio-group": "1.3.8",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-scroll-area": "1.2.10",
+        "@radix-ui/react-select": "2.2.6",
+        "@radix-ui/react-separator": "1.1.7",
+        "@radix-ui/react-slider": "1.3.6",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-switch": "1.2.6",
+        "@radix-ui/react-tabs": "1.1.13",
+        "@radix-ui/react-toast": "1.2.15",
+        "@radix-ui/react-toggle": "1.1.10",
+        "@radix-ui/react-toggle-group": "1.1.11",
+        "@radix-ui/react-toolbar": "1.1.11",
+        "@radix-ui/react-tooltip": "1.2.8",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-escape-keydown": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -14712,6 +18814,53 @@
         }
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-router": {
       "version": "7.13.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
@@ -14753,6 +18902,45 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-textarea-autosize": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
+      "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-transition-group": {
@@ -15249,6 +19437,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -15348,6 +19545,22 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -17532,6 +21745,12 @@
         "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
       }
     },
+    "node_modules/untruncate-json": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/untruncate-json/-/untruncate-json-0.0.1.tgz",
+      "integrity": "sha512-4W9enDK4X1y1s2S/Rz7ysw6kDuMS3VmRjMFg7GZrNO+98OSe+x5Lh7PKYoVjy3lW/1wmhs6HW0lusnQRHgMarA==",
+      "license": "MIT"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -17573,6 +21792,50 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-composed-ref": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
+      "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-effect-event": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/use-effect-event/-/use-effect-event-2.0.3.tgz",
+      "integrity": "sha512-fz1en+z3fYXCXx3nMB8hXDMuygBltifNKZq29zDx+xNJ+1vEs6oJlYd9sK31vxJ0YI534VUsHEBY0k2BATsmBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.3 || ^19.0.0-0"
+      }
+    },
     "node_modules/use-isomorphic-layout-effect": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
@@ -17580,6 +21843,45 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-latest": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
+      "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -18403,7 +22705,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -18420,6 +22721,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -40,6 +40,7 @@
         "react-hot-toast": "^2.6.0",
         "react-markdown": "^10.1.0",
         "react-redux": "^9.2.0",
+        "react-rnd": "^10.5.3",
         "react-router": "^7.13.2",
         "react-select": "^5.10.2",
         "redux-saga": "^1.4.2",
@@ -208,56 +209,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/@assistant-ui/core": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/core/-/core-0.1.16.tgz",
-      "integrity": "sha512-G8Fl0u5EkwItWxOna9CscJdAuGHOQjYz1p95fVFfiOAb88eGElTecnntzmIUp3YWi7qbhM1e8c2exJDHLt8BIA==",
-      "license": "MIT",
-      "dependencies": {
-        "assistant-stream": "^0.3.12",
-        "nanoid": "^5.1.9"
-      },
-      "peerDependencies": {
-        "@assistant-ui/store": "^0.2.9",
-        "@assistant-ui/tap": "^0.5.10",
-        "@types/react": "*",
-        "assistant-cloud": "^0.1.27",
-        "react": "^18 || ^19",
-        "zustand": "^5.0.11"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "assistant-cloud": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "zustand": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@assistant-ui/core/node_modules/nanoid": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
-      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      }
-    },
     "node_modules/@assistant-ui/react": {
       "version": "0.12.27",
       "resolved": "https://registry.npmjs.org/@assistant-ui/react/-/react-0.12.27.tgz",
@@ -360,6 +311,56 @@
         "@protobuf-ts/protoc": "^2.11.1"
       }
     },
+    "node_modules/@assistant-ui/react-ag-ui/node_modules/@assistant-ui/core": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/core/-/core-0.1.13.tgz",
+      "integrity": "sha512-UV8j/l3SbyRz51yHEh8wt6k6eV0cJ5wEaXYwi36hMq/+GwIZydzDmX0XHwFaHTB2Ev0nlrTW5RlF6/g2tVPgoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "assistant-stream": "^0.3.10",
+        "nanoid": "^5.1.7"
+      },
+      "peerDependencies": {
+        "@assistant-ui/store": "^0.2.6",
+        "@assistant-ui/tap": "^0.5.7",
+        "@types/react": "*",
+        "assistant-cloud": "^0.1.25",
+        "react": "^18 || ^19",
+        "zustand": "^5.0.11"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "assistant-cloud": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "zustand": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@assistant-ui/react-ag-ui/node_modules/nanoid": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
+      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
     "node_modules/@assistant-ui/react-ag-ui/node_modules/rxjs": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -396,6 +397,38 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@assistant-ui/react/node_modules/@assistant-ui/core": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/core/-/core-0.1.13.tgz",
+      "integrity": "sha512-UV8j/l3SbyRz51yHEh8wt6k6eV0cJ5wEaXYwi36hMq/+GwIZydzDmX0XHwFaHTB2Ev0nlrTW5RlF6/g2tVPgoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "assistant-stream": "^0.3.10",
+        "nanoid": "^5.1.7"
+      },
+      "peerDependencies": {
+        "@assistant-ui/store": "^0.2.6",
+        "@assistant-ui/tap": "^0.5.7",
+        "@types/react": "*",
+        "assistant-cloud": "^0.1.25",
+        "react": "^18 || ^19",
+        "zustand": "^5.0.11"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "assistant-cloud": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "zustand": {
           "optional": true
         }
       }
@@ -18643,6 +18676,16 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
+    "node_modules/re-resizable": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.11.2.tgz",
+      "integrity": "sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -18729,6 +18772,20 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-draggable": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.5.0.tgz",
+      "integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
       }
     },
     "node_modules/react-error-boundary": {
@@ -18860,6 +18917,27 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-rnd": {
+      "version": "10.5.3",
+      "resolved": "https://registry.npmjs.org/react-rnd/-/react-rnd-10.5.3.tgz",
+      "integrity": "sha512-s/sIT3pGZnQ+57egijkTp9mizjIWrJz68Pq6yd+F/wniFY3IriML18dUXnQe/HP9uMiJ+9MAp44hljG99fZu6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "re-resizable": "^6.11.2",
+        "react-draggable": "^4.5.0",
+        "tslib": "2.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0",
+        "react-dom": ">=16.3.0"
+      }
+    },
+    "node_modules/react-rnd/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "license": "0BSD"
     },
     "node_modules/react-router": {
       "version": "7.13.2",

--- a/assets/package.json
+++ b/assets/package.json
@@ -46,6 +46,11 @@
     "tailwindcss": "^3.4.19"
   },
   "dependencies": {
+    "@ag-ui/client": "^0.0.52",
+    "@ag-ui/core": "^0.0.52",
+    "@assistant-ui/react": "^0.12.24",
+    "@assistant-ui/react-ag-ui": "^0.0.25",
+    "@assistant-ui/react-markdown": "^0.12.8",
     "@date-fns/tz": "^1.4.1",
     "@date-fns/utc": "^2.1.1",
     "@headlessui/react": "^2.2.7",
@@ -80,6 +85,7 @@
     "react-select": "^5.10.2",
     "redux-saga": "^1.4.2",
     "remark-gfm": "^4.0.1",
+    "rxjs": "^7.8.1",
     "semver": "^7.7.4",
     "tzdata": "^1.0.48",
     "uuid": "^11.1.0"

--- a/assets/package.json
+++ b/assets/package.json
@@ -81,6 +81,7 @@
     "react-hot-toast": "^2.6.0",
     "react-markdown": "^10.1.0",
     "react-redux": "^9.2.0",
+    "react-rnd": "^10.5.3",
     "react-router": "^7.13.2",
     "react-select": "^5.10.2",
     "redux-saga": "^1.4.2",
@@ -93,7 +94,8 @@
   "overrides": {
     "eos-icons-react": {
       "react": "$react"
-    }
+    },
+    "@assistant-ui/core": "0.1.13"
   },
   "scripts": {
     "tailwind:build": "tailwindcss --postcss --minify --input=css/app.css --output=../priv/static/assets/app.css",

--- a/assets/setupTests.js
+++ b/assets/setupTests.js
@@ -12,10 +12,30 @@ global.ResizeObserver = jest.fn().mockImplementation(() => ({
   disconnect: jest.fn(),
 }));
 
+// jsdom does not implement scrollTo on Elements
+globalThis.Element.prototype.scrollTo = function scrollTo() {};
+
 const { TextEncoder, TextDecoder } = require('util');
 
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
+
+// Web Streams API polyfill for jsdom (used by assistant-ui via assistant-stream)
+const {
+  TransformStream,
+  ReadableStream,
+  WritableStream,
+} = require('stream/web');
+
+global.TransformStream = TransformStream;
+global.ReadableStream = ReadableStream;
+global.WritableStream = WritableStream;
+
+// Fetch API stubs — assistant-stream evaluates `class X extends Response`
+// at module load time; we never exercise the network code path in tests,
+// so empty-class stubs are enough to satisfy the inheritance.
+class FetchStub {}
+global.Response = FetchStub;
 
 // Mock Chart.js
 jest.mock('chart.js/auto', () => ({


### PR DESCRIPTION
# Description

This is part of a group of 3 stacked PRs, might be useful reviewing in the following order:
- https://github.com/trento-project/web/pull/4246
- https://github.com/trento-project/web/pull/4251
- https://github.com/trento-project/web/pull/4245 (current PR)

Disclaimer: ~90% of the changes is package lock

This PR adds the core `WebSocketAIAgent` allowing UI to communicate with backend websocket via AG-UI events.

Add AI assistant transport core + tooling

Foundation for the AI assistant feature: 
- a Phoenix-channel-backed AbstractAgent (`WebSocketAIAgent`)
- the connection-status context module that downstream components consume

## How was this tested?

Automated tests and manual.

## Did you update the documentation?

TBD