### PR TITLE
Fix refresh token flow execution in frontend

### DIFF
--- a/assets/js/lib/network/index.js
+++ b/assets/js/lib/network/index.js
@@ -54,7 +54,9 @@ const refreshAuthLogic = async (failedRequest) => {
 
 // Even though it looks counter intuitive, we need to add `deduplicateRefresh: false`
 // to enable the retry of all the requests that got 401 at the same time.
-// Otherwise, only the first request with 401 response is retried.
+// The functionality of this flag is not properly implemented and it doesn't do what
+// it should. However, setting it to false fixes our problem.
+// Without this change, only the first request with 401 response is retried.
 // What the library docs explain about this field doesn't apply if the requests
 // receive 401 almost at the same time, as the retry is not handled in that case.
 // In any case, the refresh flow is done once

--- a/assets/js/lib/network/index.js
+++ b/assets/js/lib/network/index.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import axios from 'axios';
-import createAuthRefreshInterceptor from 'axios-auth-refresh';
+import createAuthRefresh from 'axios-auth-refresh';
 import { logError, logWarn } from '@lib/log';
 import {
   getAccessTokenFromStore,
@@ -52,7 +52,15 @@ const refreshAuthLogic = async (failedRequest) => {
   }
 };
 
-createAuthRefreshInterceptor(networkClient, refreshAuthLogic);
+// Even though it looks counter intuitive, we need to add `deduplicateRefresh: false`
+// to enable the retry of all the requests that got 401 at the same time.
+// Otherwise, only the first request with 401 response is retried.
+// What the library docs explain about this field doesn't apply if the requests
+// receive 401 almost at the same time, as the retry is not handled in that case.
+// In any case, the refresh flow is done once
+createAuthRefresh(networkClient, refreshAuthLogic, {
+  deduplicateRefresh: false,
+});
 
 networkClient.interceptors.response.use(null, (error) => {
   if (error === unrecoverableAuthError) {

--- a/test/e2e/cypress/e2e/settings.cy.js
+++ b/test/e2e/cypress/e2e/settings.cy.js
@@ -5,8 +5,9 @@ import * as settingsPage from '../pageObject/settings_po';
 
 context('Settings page', () => {
   beforeEach(() => {
+    settingsPage.interceptInitialDataFetch();
     settingsPage.visit();
-    settingsPage.waitForRequest('settingsEndpoint');
+    settingsPage.waitForSettingsPageRequests();
   });
 
   after(() => settingsPage.updateApiKeyExpiration(null));
@@ -108,7 +109,7 @@ context('Settings page', () => {
       it('should clear existing settings', () => {
         settingsPage.saveDefaultSUMAsettings();
         settingsPage.refresh();
-        settingsPage.waitForRequest('settingsEndpoint');
+        settingsPage.waitForRequest('sumaSettingsEndpoint');
 
         settingsPage.sumaUrlHasExpectedValue();
         settingsPage.sumaCaCertUploadDateHasExpectedValue();
@@ -116,7 +117,7 @@ context('Settings page', () => {
         settingsPage.sumaPasswordHasExpectedValue('•••••');
 
         settingsPage.clearSumaSettings();
-        settingsPage.waitForRequest('settingsEndpoint');
+        settingsPage.waitForRequest('sumaSettingsEndpoint');
 
         settingsPage.sumaUrlHasExpectedValue('https://');
         settingsPage.sumaCaCertUploadDateHasExpectedValue('-');
@@ -127,7 +128,7 @@ context('Settings page', () => {
       it('should succeed even though settings do not exist', () => {
         settingsPage.clearSUMASettings();
         settingsPage.refresh();
-        settingsPage.waitForRequest('settingsEndpoint');
+        settingsPage.waitForRequest('sumaSettingsEndpoint');
 
         settingsPage.sumaUrlHasExpectedValue('https://');
         settingsPage.sumaCaCertUploadDateHasExpectedValue('-');
@@ -135,7 +136,7 @@ context('Settings page', () => {
         settingsPage.sumaPasswordHasExpectedValue('.....');
 
         settingsPage.clearSumaSettings();
-        settingsPage.waitForRequest('settingsEndpoint');
+        settingsPage.waitForRequest('sumaSettingsEndpoint');
 
         settingsPage.sumaUrlHasExpectedValue('https://');
         settingsPage.sumaCaCertUploadDateHasExpectedValue('-');
@@ -148,7 +149,7 @@ context('Settings page', () => {
       it('should be disabled when there are no settings', () => {
         settingsPage.clearSUMASettings();
         settingsPage.refresh();
-        settingsPage.waitForRequest('settingsEndpoint');
+        settingsPage.waitForRequest('sumaSettingsEndpoint');
         settingsPage.sumaConnectionButtonIsDisabled();
       });
 
@@ -195,7 +196,6 @@ context('Settings page', () => {
     describe('Changing Settings', () => {
       it('should change retention time', () => {
         settingsPage.clickEditActivityLogSettingsButton();
-        settingsPage.waitForRequest('activityLogSettingsEndpoint');
         settingsPage.typeRetentionTime(6);
         settingsPage.clickActivityLogSettingsSaveButton();
         settingsPage.retentionTimeIsTheExpected('6 months');
@@ -221,6 +221,24 @@ context('Settings page', () => {
           settingsPage.retentionTimeIsTheExpected(currentRetentionTime);
         });
       });
+    });
+  });
+
+  describe('Page reload after refresh token flow', () => {
+    it('should reload all settings data after refresh token flow', () => {
+      settingsPage.waitForInitialDataFetch();
+
+      settingsPage.goNavigationMenuItem('Dashboard');
+      settingsPage.clearAccessTokenFromStorage();
+      settingsPage.interceptRefreshTokenRequest();
+      settingsPage.goNavigationMenuItem('Settings');
+
+      settingsPage.checkSettingsEndpointsRequestsAreForbidden(true);
+      settingsPage.waitForRefreshRequest();
+      // repeat check to see the requests are retried but not forbidden again
+      settingsPage.checkSettingsEndpointsRequestsAreForbidden(false);
+      // check only one refresh token request is done
+      settingsPage.checkRefreshRequestCount(1);
     });
   });
 

--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -127,6 +127,9 @@ export const getSelectControlValue = (ariaLabel) =>
 
 export const clickOutside = () => cy.get('body').click();
 
+export const goNavigationMenuItem = (item) =>
+  cy.get(`a:contains("${item}")`).click();
+
 // UI Validations
 
 export const shouldRedirectToIdpUrl = () =>
@@ -491,3 +494,29 @@ export const getAlertingSettings = () =>
       failOnStatusCode: false,
     })
   );
+
+export const interceptInitialDataFetch = () => {
+  cy.intercept('/api/v1/hosts').as('hostsInitialFetch');
+  cy.intercept('/api/v1/sap_systems').as('sapSystemsInitialFetch');
+  cy.intercept('/api/v1/databases').as('databasesInitialFetch');
+  return cy.intercept('/api/v2/clusters').as('clustersInitialFetch');
+};
+
+export const waitForInitialDataFetch = () => {
+  waitForRequest('hostsInitialFetch');
+  waitForRequest('sapSystemsInitialFetch');
+  waitForRequest('databasesInitialFetch');
+  return waitForRequest('clustersInitialFetch');
+};
+
+export const interceptRefreshTokenRequest = () =>
+  cy.intercept('/api/session/refresh').as('refreshEndpoint');
+
+export const waitForRefreshRequest = () => waitForRequest('refreshEndpoint');
+
+export const checkRefreshRequestCount = (count) =>
+  cy.get('@refreshEndpoint.all').should('have.length', count);
+
+// Other support helpers
+export const clearAccessTokenFromStorage = () =>
+  cy.clearLocalStorage('access_token');

--- a/test/e2e/cypress/pageObject/settings_po.js
+++ b/test/e2e/cypress/pageObject/settings_po.js
@@ -192,11 +192,7 @@ export const visit = () => {
     '/api/v1/settings/activity_log',
     cy.spy().as('changeSettingsEndpoint')
   );
-  cy.intercept('/api/v1/settings/activity_log').as(
-    'activityLogSettingsEndpoint'
-  );
-  cy.intercept('/api/v1/settings/suse_manager').as('settingsEndpoint');
-  cy.intercept('/api/v1/settings/alerting').as('alertingSettingsEndpoint');
+  interceptSettingsPageEndpoints();
   return basePage.visit(url);
 };
 
@@ -341,6 +337,46 @@ export const enterAlertingUpdateSettingsWithoutPassword = () =>
 
 export const enterAlertingUpdateSettingsWithPassword = () =>
   enterAlertingSettings(alertingUpdateSettings, true);
+
+export const interceptSettingsPageEndpoints = () => {
+  cy.intercept('/api/v1/settings/api_key').as('apiKeySettingsEndpoint');
+  cy.intercept('/api/v1/settings/activity_log').as(
+    'activityLogSettingsEndpoint'
+  );
+  cy.intercept('/api/v1/settings/suse_manager').as('sumaSettingsEndpoint');
+  return cy
+    .intercept('/api/v1/settings/alerting')
+    .as('alertingSettingsEndpoint');
+};
+
+export const waitForSettingsPageRequests = () => {
+  basePage.waitForRequest('apiKeySettingsEndpoint');
+  // need to wait twice for api key as it is loaded in the initial fetch as well
+  basePage.waitForRequest('apiKeySettingsEndpoint');
+  basePage.waitForRequest('activityLogSettingsEndpoint');
+  basePage.waitForRequest('sumaSettingsEndpoint');
+  return basePage.waitForRequest('alertingSettingsEndpoint');
+};
+
+export const checkSettingsEndpointsRequestsAreForbidden = (forbidden) => {
+  const matcher = forbidden ? 'eq' : 'not.eq';
+  basePage
+    .waitForRequest('apiKeySettingsEndpoint')
+    .its('response.statusCode')
+    .should(matcher, 401);
+  basePage
+    .waitForRequest('activityLogSettingsEndpoint')
+    .its('response.statusCode')
+    .should(matcher, 401);
+  basePage
+    .waitForRequest('sumaSettingsEndpoint')
+    .its('response.statusCode')
+    .should(matcher, 401);
+  return basePage
+    .waitForRequest('alertingSettingsEndpoint')
+    .its('response.statusCode')
+    .should(matcher, 401);
+};
 
 // UI Validations
 
@@ -490,7 +526,7 @@ export const expectedSavingValidationsAreDisplayed = () => {
       );
 
       clickSumaSettingsModalSaveButton();
-      basePage.waitForRequest('settingsEndpoint');
+      basePage.waitForRequest('sumaSettingsEndpoint');
 
       cy.wrap(expectedErrors).each(({ selector, error }) => {
         const errorMessageSelector = `${selector.split('+')[0]} + div p`;
@@ -537,7 +573,7 @@ export const eachSaveSettingsScenarioWorkAsExpected = () => {
     );
 
     clickSumaSettingsModalSaveButton();
-    basePage.waitForRequest('settingsEndpoint');
+    basePage.waitForRequest('sumaSettingsEndpoint');
 
     sumaUrlHasExpectedValue(sumaUrl);
     const expectedCaCertDate = expectCertUploadDate
@@ -656,7 +692,7 @@ export const changingSettingsValidationsWorkAsExpected = () => {
         };
         basePage.saveSUMASettings(initialSettings);
         basePage.refresh();
-        basePage.waitForRequest('settingsEndpoint');
+        basePage.waitForRequest('sumaSettingsEndpoint');
         clickSumaEditSettingsButton();
 
         if (withInitialCert) _clickRemoveSumaCaCertButton();
@@ -667,7 +703,7 @@ export const changingSettingsValidationsWorkAsExpected = () => {
         );
 
         clickSumaSettingsModalSaveButton();
-        basePage.waitForRequest('settingsEndpoint');
+        basePage.waitForRequest('sumaSettingsEndpoint');
 
         cy.wrap(expectedErrors).each(({ selector, error }) => {
           const errorMessageSelector = `${selector.split('+')[0]} + div p`;
@@ -760,7 +796,7 @@ export const sumaSettingsAreCorrectlyChanged = () => {
     };
     basePage.saveSUMASettings(initialSettings);
     basePage.refresh();
-    basePage.waitForRequest('settingsEndpoint');
+    basePage.waitForRequest('sumaSettingsEndpoint');
 
     clickSumaEditSettingsButton();
 
@@ -772,7 +808,7 @@ export const sumaSettingsAreCorrectlyChanged = () => {
     );
 
     clickSumaSettingsModalSaveButton();
-    basePage.waitForRequest('settingsEndpoint');
+    basePage.waitForRequest('sumaSettingsEndpoint');
 
     const expectedUrl = expectNewUrl ? newUrl : baseInitialSettings.url;
     sumaUrlHasExpectedValue(expectedUrl);


### PR DESCRIPTION
# Description

Then a multiple requests are forbidden at the same time, only the first one is retried.

<img width="1225" height="509" alt="image" src="https://github.com/user-attachments/assets/bda47fc9-66ed-419d-b9ec-51b041571e33" />

Set `deduplicateRefresh: false` in the `axios-auth-refresh` pacakge usage to retry the forbidden requests.
In reality, this field should be let to `true`, as the library states that this is the way to retry to failed requests, but checking the code and usage, it is just the opposite, strange...
Related all closed issue: https://github.com/Flyrell/axios-auth-refresh/issues/123

## How was this tested?

e2e test and manual testing

## Did you update the documentation?

No need
