### PR TITLE
Fully apply page object pattern to url filter tests in hosts overview

### DIFF
--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -207,7 +207,7 @@ context('Hosts Overview', () => {
     const anotherHostname = availableHosts[1].name;
     const anyPageUrl = '/any-page';
 
-    beforeEach(() => hostsOverviewPage.restoreSapSystem());
+    before(() => hostsOverviewPage.restoreSapSystem());
 
     it('should update the URL with filter params when a filter is selected', () => {
       hostsOverviewPage.visit();
@@ -216,7 +216,8 @@ context('Hosts Overview', () => {
       hostsOverviewPage.hostsListedAre(1);
     });
 
-    it('should preserve filters when coming back', () => {
+    // eslint-disable-next-line mocha/no-exclusive-tests
+    it.only('should preserve filters when coming back', () => {
       hostsOverviewPage.visit();
       hostsOverviewPage.selectHostnameFilter(hostname);
       hostsOverviewPage.validateUrl(`hostname=${hostname}`);

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -224,6 +224,7 @@ context('Hosts Overview', () => {
       basePage.visit(anyPageUrl);
       basePage.validateUrl(anyPageUrl);
       hostsOverviewPage.goBack();
+      hostsOverviewPage.waitForClustersEndpoint();
       hostsOverviewPage.validateUrl(`hostname=${hostname}`);
       hostsOverviewPage.hostsListedAre(1);
     });
@@ -238,9 +239,11 @@ context('Hosts Overview', () => {
       hostsOverviewPage.hostsListedAre(1);
 
       hostsOverviewPage.goBack();
+      hostsOverviewPage.waitForClustersEndpoint();
       basePage.validateUrl(anyPageUrl);
 
       hostsOverviewPage.goForward();
+      hostsOverviewPage.waitForClustersEndpoint();
       hostsOverviewPage.validateUrl(`hostname=${hostname}`);
       hostsOverviewPage.hostsListedAre(1);
     });
@@ -305,9 +308,8 @@ context('Hosts Overview', () => {
       hostsOverviewPage.expectedPaginationIsDisplayed('Showing 11–20 of 27');
       basePage.visit(anyPageUrl);
       basePage.validateUrl(anyPageUrl);
-      hostsOverviewPage.interceptGetHosts();
       hostsOverviewPage.goBack();
-      hostsOverviewPage.waitForGetHosts();
+      hostsOverviewPage.waitForClustersEndpoint();
       hostsOverviewPage.validateUrl(expectedParams);
       hostsOverviewPage.expectedPaginationIsDisplayed('Showing 11–20 of 27');
     });
@@ -323,6 +325,7 @@ context('Hosts Overview', () => {
       basePage.validateUrl(anyPageUrl);
 
       hostsOverviewPage.goBack();
+      hostsOverviewPage.waitForClustersEndpoint();
 
       hostsOverviewPage.validateUrl(expectedParams);
       hostsOverviewPage.hostsListedAre(20);

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as hostsOverviewPage from '../pageObject/hosts_overview_po';
+import * as basePage from '../pageObject/base_po';
+
 import { availableHosts } from '../fixtures/hosts-overview/available_hosts';
 
 context('Hosts Overview', () => {
@@ -210,57 +212,48 @@ context('Hosts Overview', () => {
     it('should update the URL with filter params when a filter is selected', () => {
       hostsOverviewPage.visit();
       hostsOverviewPage.selectHostnameFilter(hostname);
-      cy.url().should('contain', `hostname=${hostname}`);
+      hostsOverviewPage.validateUrl(`hostname=${hostname}`);
       hostsOverviewPage.hostsListedAre(1);
     });
 
     it('should preserve filters when coming back', () => {
       hostsOverviewPage.visit();
       hostsOverviewPage.selectHostnameFilter(hostname);
-      cy.url().should('contain', `hostname=${hostname}`);
+      hostsOverviewPage.validateUrl(`hostname=${hostname}`);
       hostsOverviewPage.hostsListedAre(1);
-
-      cy.visit(anyPageUrl);
-      cy.url().should('contain', anyPageUrl);
-
-      cy.go('back');
-
-      cy.url().should('contain', '/hosts');
-      cy.url().should('contain', `hostname=${hostname}`);
+      basePage.visit(anyPageUrl);
+      basePage.validateUrl(anyPageUrl);
+      hostsOverviewPage.goBack();
+      hostsOverviewPage.validateUrl(`hostname=${hostname}`);
       hostsOverviewPage.hostsListedAre(1);
     });
 
     it('should preserve filters when going forward', () => {
-      cy.visit(anyPageUrl);
-      cy.url().should('contain', anyPageUrl);
+      basePage.visit(anyPageUrl);
+      basePage.validateUrl(anyPageUrl);
 
       hostsOverviewPage.visit();
       hostsOverviewPage.selectHostnameFilter(hostname);
-      cy.url().should('contain', `hostname=${hostname}`);
+      hostsOverviewPage.validateUrl(`hostname=${hostname}`);
       hostsOverviewPage.hostsListedAre(1);
 
-      cy.go('back');
-      cy.url().should('contain', anyPageUrl);
+      hostsOverviewPage.goBack();
+      basePage.validateUrl(anyPageUrl);
 
-      cy.go('forward');
-      cy.url().should('contain', '/hosts');
-      cy.url().should('contain', `hostname=${hostname}`);
+      hostsOverviewPage.goForward();
+      hostsOverviewPage.validateUrl(`hostname=${hostname}`);
       hostsOverviewPage.hostsListedAre(1);
     });
 
     it('should allow navigating back to previous page', () => {
-      cy.visit(anyPageUrl);
-      cy.url().should('contain', anyPageUrl);
-
+      basePage.visit(anyPageUrl);
+      basePage.validateUrl(anyPageUrl);
       hostsOverviewPage.visit();
       hostsOverviewPage.hostsListedAre(10);
-
       hostsOverviewPage.selectHostnameFilter(hostname);
       hostsOverviewPage.hostsListedAre(1);
-
-      cy.go('back');
-
-      cy.url().should('contain', anyPageUrl);
+      hostsOverviewPage.goBack();
+      basePage.validateUrl(anyPageUrl);
     });
 
     it('should render filtered results when visiting a URL with filter params', () => {
@@ -269,19 +262,76 @@ context('Hosts Overview', () => {
     });
 
     it('should not produce duplicate history entries when filters are applied', () => {
-      cy.visit(anyPageUrl);
-      cy.url().should('contain', anyPageUrl);
+      basePage.visit(anyPageUrl);
+      basePage.validateUrl(anyPageUrl);
 
       hostsOverviewPage.visit();
-
       hostsOverviewPage.selectHostnameFilter(hostname);
-      cy.url().should('contain', `hostname=${hostname}`);
+      hostsOverviewPage.validateUrl(`hostname=${hostname}`);
 
       hostsOverviewPage.selectHostnameFilter(anotherHostname);
-      cy.url().should('contain', `hostname=${anotherHostname}`);
+      const expectedParams = `hostname=${hostname}&hostname=${anotherHostname}`;
+      hostsOverviewPage.validateUrl(expectedParams);
 
-      cy.go('back');
-      cy.url().should('contain', anyPageUrl);
+      hostsOverviewPage.goBack();
+      basePage.validateUrl(anyPageUrl);
+    });
+  });
+
+  describe('Pagination and browser navigation', () => {
+    const anyPageUrl = '/any-page';
+
+    it('should update the URL with page param when navigating pages', () => {
+      hostsOverviewPage.visit();
+      hostsOverviewPage.clickNextPageButton();
+      const expectedParams = 'page=2&per_page=10';
+      hostsOverviewPage.validateUrl(expectedParams);
+      hostsOverviewPage.expectedPaginationIsDisplayed('Showing 11–20 of 27');
+    });
+
+    it('should update the URL with per_page param when changing items per page', () => {
+      hostsOverviewPage.visit();
+      hostsOverviewPage.selectItemsPerPage(20);
+      const expectedParams = 'page=1&per_page=20';
+      hostsOverviewPage.validateUrl(expectedParams);
+      hostsOverviewPage.hostsListedAre(20);
+    });
+
+    it('should preserve pagination when coming back from another page', () => {
+      hostsOverviewPage.visit();
+      hostsOverviewPage.clickNextPageButton();
+      const expectedParams = 'page=2&per_page=10';
+      hostsOverviewPage.validateUrl(expectedParams);
+      hostsOverviewPage.expectedPaginationIsDisplayed('Showing 11–20 of 27');
+      basePage.visit(anyPageUrl);
+      basePage.validateUrl(anyPageUrl);
+      hostsOverviewPage.interceptGetHosts();
+      hostsOverviewPage.goBack();
+      hostsOverviewPage.waitForGetHosts();
+      hostsOverviewPage.validateUrl(expectedParams);
+      hostsOverviewPage.expectedPaginationIsDisplayed('Showing 11–20 of 27');
+    });
+
+    it('should preserve per_page when coming back from another page', () => {
+      hostsOverviewPage.visit();
+      hostsOverviewPage.selectItemsPerPage(20);
+      const expectedParams = 'page=1&per_page=20';
+      hostsOverviewPage.validateUrl(expectedParams);
+      hostsOverviewPage.hostsListedAre(20);
+
+      basePage.visit(anyPageUrl);
+      basePage.validateUrl(anyPageUrl);
+
+      hostsOverviewPage.goBack();
+
+      hostsOverviewPage.validateUrl(expectedParams);
+      hostsOverviewPage.hostsListedAre(20);
+    });
+
+    it('should render the correct page when visiting a URL with pagination params', () => {
+      hostsOverviewPage.visit('page=2&per_page=20');
+      hostsOverviewPage.hostsListedAre(7);
+      hostsOverviewPage.expectedPaginationIsDisplayed('Showing 21–27 of 27');
     });
   });
 

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -9,13 +9,14 @@ import { availableHosts } from '../fixtures/hosts-overview/available_hosts';
 context('Hosts Overview', () => {
   before(() => hostsOverviewPage.preloadTestData());
 
-  beforeEach(() => hostsOverviewPage.visit());
-
   it('should have expected url', () => {
+    hostsOverviewPage.visit();
     hostsOverviewPage.validateUrl();
   });
 
   describe('Registered Hosts are shown in the list', () => {
+    beforeEach(() => hostsOverviewPage.visit());
+
     it('should highlight the hosts sidebar entry', () => {
       hostsOverviewPage.hostsIsHighglightedInSidebar();
     });
@@ -52,7 +53,10 @@ context('Hosts Overview', () => {
 
   describe('Health Detection', () => {
     describe('Health Container shows the health overview of the deployed landscape', () => {
-      beforeEach(() => hostsOverviewPage.startAgentsHeartbeat());
+      beforeEach(() => {
+        hostsOverviewPage.startAgentsHeartbeat();
+        hostsOverviewPage.visit();
+      });
 
       it('should show health status of the entire cluster of 27 hosts with partial pagination', () => {
         hostsOverviewPage.expectedPassingHostsAreDisplayed(11);
@@ -69,7 +73,10 @@ context('Hosts Overview', () => {
     });
 
     describe('Health is changed based on saptune status', () => {
-      beforeEach(() => hostsOverviewPage.startAgentsHeartbeat());
+      beforeEach(() => {
+        hostsOverviewPage.startAgentsHeartbeat();
+        hostsOverviewPage.visit();
+      });
 
       it('should not change the health if saptune is not installed and a SAP workload is not running', () => {
         hostsOverviewPage.loadHostWithoutSaptune();
@@ -110,7 +117,10 @@ context('Hosts Overview', () => {
     });
 
     describe('Health is changed to critical when the heartbeat is not sent', () => {
-      beforeEach(() => hostsOverviewPage.startAgentsHeartbeat());
+      beforeEach(() => {
+        hostsOverviewPage.startAgentsHeartbeat();
+        hostsOverviewPage.visit();
+      });
 
       it('should show health status of the entire cluster of 27 hosts with critical health', () => {
         hostsOverviewPage.expectedCriticalHostsAreDisplayed(4);
@@ -130,6 +140,8 @@ context('Hosts Overview', () => {
 
   describe('Deregistration', () => {
     describe('Clean-up buttons should be visible only when needed', () => {
+      beforeEach(() => hostsOverviewPage.visit());
+
       it('should not display a clean-up button when heartbeat is sent', () => {
         hostsOverviewPage.cleanupButtonIsDisplayedForHostSendingHeartbeat();
         hostsOverviewPage.startAgentHeartbeat();
@@ -147,6 +159,7 @@ context('Hosts Overview', () => {
 
     describe('Clean-up button should deregister a host', () => {
       beforeEach(() => {
+        hostsOverviewPage.visit();
         hostsOverviewPage.apiRestoreCleanedUpHost();
         hostsOverviewPage.apiDeleteAllHostsTags();
         hostsOverviewPage.addTagToHost();
@@ -171,6 +184,7 @@ context('Hosts Overview', () => {
         afterEach(() => hostsOverviewPage.restoreSapSystem());
 
         it('should remove the SAP system sid from hosts belonging the deregistered SAP system', () => {
+          hostsOverviewPage.visit();
           hostsOverviewPage.clickNextPageButton();
           hostsOverviewPage.sapSystemHasExpectedAmountOfHosts(4);
           hostsOverviewPage.apiDeregisterSapSystemHost();
@@ -180,6 +194,7 @@ context('Hosts Overview', () => {
 
       describe('Movement of application instances on hosts', () => {
         beforeEach(() => {
+          hostsOverviewPage.visit();
           hostsOverviewPage.loadSapSystemsOverviewMovedScenario();
           hostsOverviewPage.clickNextPageButton();
           hostsOverviewPage.sapSystemHasExpectedAmountOfHosts(3);
@@ -202,7 +217,8 @@ context('Hosts Overview', () => {
     });
   });
 
-  describe('Filter and browser navigation', () => {
+  // eslint-disable-next-line mocha/no-exclusive-tests
+  describe.only('Filter and browser navigation', () => {
     const hostname = availableHosts[0].name;
     const anotherHostname = availableHosts[1].name;
     const anyPageUrl = '/any-page';
@@ -216,8 +232,7 @@ context('Hosts Overview', () => {
       hostsOverviewPage.hostsListedAre(1);
     });
 
-    // eslint-disable-next-line mocha/no-exclusive-tests
-    it.only('should preserve filters when coming back', () => {
+    it('should preserve filters when coming back', () => {
       hostsOverviewPage.visit();
       hostsOverviewPage.selectHostnameFilter(hostname);
       hostsOverviewPage.validateUrl(`hostname=${hostname}`);
@@ -233,16 +248,12 @@ context('Hosts Overview', () => {
     it('should preserve filters when going forward', () => {
       basePage.visit(anyPageUrl);
       basePage.validateUrl(anyPageUrl);
-
       hostsOverviewPage.visit();
       hostsOverviewPage.selectHostnameFilter(hostname);
       hostsOverviewPage.validateUrl(`hostname=${hostname}`);
       hostsOverviewPage.hostsListedAre(1);
-
       hostsOverviewPage.goBack();
-      hostsOverviewPage.waitForClustersEndpoint();
       basePage.validateUrl(anyPageUrl);
-
       hostsOverviewPage.goForward();
       hostsOverviewPage.waitForClustersEndpoint();
       hostsOverviewPage.validateUrl(`hostname=${hostname}`);
@@ -282,7 +293,8 @@ context('Hosts Overview', () => {
     });
   });
 
-  describe('Pagination and browser navigation', () => {
+  // eslint-disable-next-line mocha/no-exclusive-tests
+  describe.only('Pagination and browser navigation', () => {
     const anyPageUrl = '/any-page';
 
     it('should update the URL with page param when navigating pages', () => {

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -217,8 +217,7 @@ context('Hosts Overview', () => {
     });
   });
 
-  // eslint-disable-next-line mocha/no-exclusive-tests
-  describe.only('Filter and browser navigation', () => {
+  describe('Filter and browser navigation', () => {
     const hostname = availableHosts[0].name;
     const anotherHostname = availableHosts[1].name;
     const anyPageUrl = '/any-page';
@@ -293,8 +292,7 @@ context('Hosts Overview', () => {
     });
   });
 
-  // eslint-disable-next-line mocha/no-exclusive-tests
-  describe.only('Pagination and browser navigation', () => {
+  describe('Pagination and browser navigation', () => {
     const anyPageUrl = '/any-page';
 
     it('should update the URL with page param when navigating pages', () => {

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -239,7 +239,6 @@ context('Hosts Overview', () => {
       basePage.visit(anyPageUrl);
       basePage.validateUrl(anyPageUrl);
       hostsOverviewPage.goBack();
-      hostsOverviewPage.waitForClustersEndpoint();
       hostsOverviewPage.validateUrl(`hostname=${hostname}`);
       hostsOverviewPage.hostsListedAre(1);
     });
@@ -254,7 +253,6 @@ context('Hosts Overview', () => {
       hostsOverviewPage.goBack();
       basePage.validateUrl(anyPageUrl);
       hostsOverviewPage.goForward();
-      hostsOverviewPage.waitForClustersEndpoint();
       hostsOverviewPage.validateUrl(`hostname=${hostname}`);
       hostsOverviewPage.hostsListedAre(1);
     });
@@ -320,7 +318,6 @@ context('Hosts Overview', () => {
       basePage.visit(anyPageUrl);
       basePage.validateUrl(anyPageUrl);
       hostsOverviewPage.goBack();
-      hostsOverviewPage.waitForClustersEndpoint();
       hostsOverviewPage.validateUrl(expectedParams);
       hostsOverviewPage.expectedPaginationIsDisplayed('Showing 11–20 of 27');
     });
@@ -336,7 +333,6 @@ context('Hosts Overview', () => {
       basePage.validateUrl(anyPageUrl);
 
       hostsOverviewPage.goBack();
-      hostsOverviewPage.waitForClustersEndpoint();
 
       hostsOverviewPage.validateUrl(expectedParams);
       hostsOverviewPage.hostsListedAre(20);

--- a/test/e2e/cypress/e2e/hosts_overview.cy.js
+++ b/test/e2e/cypress/e2e/hosts_overview.cy.js
@@ -184,7 +184,6 @@ context('Hosts Overview', () => {
         afterEach(() => hostsOverviewPage.restoreSapSystem());
 
         it('should remove the SAP system sid from hosts belonging the deregistered SAP system', () => {
-          hostsOverviewPage.visit();
           hostsOverviewPage.clickNextPageButton();
           hostsOverviewPage.sapSystemHasExpectedAmountOfHosts(4);
           hostsOverviewPage.apiDeregisterSapSystemHost();
@@ -194,7 +193,6 @@ context('Hosts Overview', () => {
 
       describe('Movement of application instances on hosts', () => {
         beforeEach(() => {
-          hostsOverviewPage.visit();
           hostsOverviewPage.loadSapSystemsOverviewMovedScenario();
           hostsOverviewPage.clickNextPageButton();
           hostsOverviewPage.sapSystemHasExpectedAmountOfHosts(3);

--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -49,6 +49,10 @@ const usernameMenu = `span[class="flex items-center"]:contains("${plainUser.user
 // UI Interactions
 export const visit = (url = '/') => cy.visit(url);
 
+export const goBack = () => cy.go('back');
+
+export const goForward = () => cy.go('forward');
+
 export const clickUsernameMenu = () => cy.get(usernameMenu).click();
 
 export const validateUrl = (url = '/') =>

--- a/test/e2e/cypress/pageObject/hosts_overview_po.js
+++ b/test/e2e/cypress/pageObject/hosts_overview_po.js
@@ -65,8 +65,11 @@ export const visit = (params) => {
   cy.intercept('/api/v2/clusters').as('clustersEndpoint');
   const visitUrl = [url, params].filter(Boolean).join('?');
   basePage.visit(visitUrl);
-  return cy.wait('@clustersEndpoint');
+  return waitForClustersEndpoint();
 };
+
+export const waitForClustersEndpoint = () =>
+  basePage.waitForRequest('clustersEndpoint');
 
 export const validateUrl = (params) =>
   basePage.validateUrl(`${url}${params ? '?' + params : ''}`);
@@ -327,11 +330,6 @@ const _getHostToDeregisterData = () => {
 };
 
 // API
-export const interceptGetHosts = () =>
-  cy.intercept('/api/v1/hosts').as('hosts');
-
-export const waitForGetHosts = () => basePage.waitForRequest('hosts');
-
 export const startAgentHeartbeat = () => {
   const hostToDeregister = _getHostToDeregisterData();
   return basePage.startAgentsHeartbeat([hostToDeregister.id]);

--- a/test/e2e/cypress/pageObject/hosts_overview_po.js
+++ b/test/e2e/cypress/pageObject/hosts_overview_po.js
@@ -65,11 +65,8 @@ export const visit = (params) => {
   cy.intercept('/api/v2/clusters').as('clustersEndpoint');
   const visitUrl = [url, params].filter(Boolean).join('?');
   basePage.visit(visitUrl);
-  return waitForClustersEndpoint();
+  return basePage.waitForRequest('clustersEndpoint');
 };
-
-export const waitForClustersEndpoint = () =>
-  basePage.waitForRequest('clustersEndpoint');
 
 export const validateUrl = (params) =>
   basePage.validateUrl(`${url}${params ? '?' + params : ''}`);

--- a/test/e2e/cypress/pageObject/hosts_overview_po.js
+++ b/test/e2e/cypress/pageObject/hosts_overview_po.js
@@ -68,7 +68,8 @@ export const visit = (params) => {
   return cy.wait('@clustersEndpoint');
 };
 
-export const validateUrl = () => basePage.validateUrl(url);
+export const validateUrl = (params) =>
+  basePage.validateUrl(`${url}${params ? '?' + params : ''}`);
 
 export const selectHostnameFilter = (hostname) => {
   cy.get(hostnameFilterButton).click();
@@ -326,6 +327,11 @@ const _getHostToDeregisterData = () => {
 };
 
 // API
+export const interceptGetHosts = () =>
+  cy.intercept('/api/v1/hosts').as('hosts');
+
+export const waitForGetHosts = () => basePage.waitForRequest('hosts');
+
 export const startAgentHeartbeat = () => {
   const hostToDeregister = _getHostToDeregisterData();
   return basePage.startAgentsHeartbeat([hostToDeregister.id]);

--- a/test/e2e/cypress/pageObject/hosts_overview_po.js
+++ b/test/e2e/cypress/pageObject/hosts_overview_po.js
@@ -146,13 +146,13 @@ export const everySapSystemLinkGoesToExpectedSapSystemDetailsPage = () =>
   );
 
 export const expectedWarningHostsAreDisplayed = (amount) =>
-  cy.get(hostsWithWarning).should('have.text', amount);
+  cy.get(hostsWithWarning, { timeout: 20000 }).should('have.text', amount);
 
 export const expectedCriticalHostsAreDisplayed = (amount) =>
   cy.get(hostsWithCritical, { timeout: 20000 }).should('have.text', amount);
 
 export const expectedPassingHostsAreDisplayed = (amount) =>
-  cy.get(hostsWithPassing).should('have.text', amount);
+  cy.get(hostsWithPassing, { timeout: 20000 }).should('have.text', amount);
 
 export const expectedAmountOfWarningsIsDisplayed = (amount) =>
   cy.get(warningHostBadge).should('have.length', amount);
@@ -203,7 +203,7 @@ export const expectedAmountOfCleanupButtonsIsDisplayed = (amount) =>
     .should('have.length', amount);
 
 export const heartbeatFailingToasterIsDisplayed = () =>
-  cy.get(heartbeatFailingToaster, { timeout: 20000 }).should('be.visible');
+  cy.get(heartbeatFailingToaster, { timeout: 25000 }).should('be.visible');
 
 export const deregisterModalTitleIsDisplayed = () =>
   cy.get(deregisterHostModalTitle).should('be.visible');


### PR DESCRIPTION
# Description

- Properly relocate `visit()` statements to those tests that really require them as previously there were tests doing `visit()` more than once without need.
- Use more strict validations of urls/params making `validateUrl` to accept query params.
- Wrap some `cy` functions
- Bonus: Adjust some timeouts to more genereous ones.


Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
