### PR TITLE
Fix copy button usage warning in test

### DIFF
--- a/assets/js/common/ApiKeySettingsModal/ApiKeySettingsModal.test.jsx
+++ b/assets/js/common/ApiKeySettingsModal/ApiKeySettingsModal.test.jsx
@@ -217,6 +217,7 @@ describe('ApiKeySettingsModal', () => {
       const user = userEvent.setup();
       const apiKey = faker.string.alpha({ length: { min: 100, max: 100 } });
       const nowISO = new Date().toISOString();
+      jest.spyOn(window, 'prompt').mockReturnValue();
 
       render(
         <ApiKeySettingsModal
@@ -235,6 +236,7 @@ describe('ApiKeySettingsModal', () => {
         screen.getByRole('button', { name: 'copy to clipboard' })
       );
 
+      expect(window.prompt).toHaveBeenCalledWith(expect.anything(), apiKey);
       expect(screen.getByText(apiKey)).toBeVisible();
     });
   });


### PR DESCRIPTION
# Description

Fix error print `Error: Not implemented: window.prompt` from `ApiKeySettingsModal.test.jsx`

## How was this tested?

UT

## Did you update the documentation?

No need
