### PR TITLE
Remove not needed act usage from tests to silence warning

### DIFF
--- a/assets/js/common/ComposedFilter/ComposedFilter.test.jsx
+++ b/assets/js/common/ComposedFilter/ComposedFilter.test.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import ComposedFilter from '.';
@@ -123,7 +123,7 @@ describe('ComposedFilter component', () => {
     expect(screen.getByText('Diavola')).toBeInTheDocument();
     expect(screen.getByDisplayValue('Banana')).toBeInTheDocument();
 
-    await act(() => userEvent.click(screen.getByText('Click me')));
+    await userEvent.click(screen.getByText('Click me'));
 
     expect(screen.getByText('Filter Pasta...')).toBeInTheDocument();
     expect(screen.getByText('Filter Pizza...')).toBeInTheDocument();
@@ -158,22 +158,20 @@ describe('ComposedFilter component', () => {
     );
 
     // select Carbonara and Gricia from pasta filter
-    await act(() => userEvent.click(screen.getByText('Filter Pasta...')));
-    await act(() => userEvent.click(screen.getByText('Carbonara')));
-    await act(() => userEvent.click(screen.getByText('Gricia')));
-    await act(() => userEvent.click(screen.getByText('Carbonara, Gricia')));
+    await userEvent.click(screen.getByText('Filter Pasta...'));
+    await userEvent.click(screen.getByText('Carbonara'));
+    await userEvent.click(screen.getByText('Gricia'));
+    await userEvent.click(screen.getByText('Carbonara, Gricia'));
 
     // select Diavola from pizza filter
-    await act(() => userEvent.click(screen.getByText('Filter Pizza...')));
-    await act(() => userEvent.click(screen.getByText('Diavola')));
-    await act(() => userEvent.click(screen.getAllByText('Diavola')[0]));
+    await userEvent.click(screen.getByText('Filter Pizza...'));
+    await userEvent.click(screen.getByText('Diavola'));
+    await userEvent.click(screen.getAllByText('Diavola')[0]);
 
     // type a query in the search box
-    await act(() =>
-      userEvent.type(
-        screen.getByPlaceholderText('Filter by frutta'),
-        'Dragonfruit'
-      )
+    await userEvent.type(
+      screen.getByPlaceholderText('Filter by frutta'),
+      'Dragonfruit'
     );
 
     expect(mockOnChange).toHaveBeenCalledTimes(14);
@@ -223,29 +221,27 @@ describe('ComposedFilter component', () => {
     render(<ComposedFilter filters={filters} onChange={mockOnChange} />);
 
     // select Carbonara and Gricia from pasta filter
-    await act(() => userEvent.click(screen.getByText('Filter Pasta...')));
-    await act(() => userEvent.click(screen.getByText('Carbonara')));
-    await act(() => userEvent.click(screen.getByText('Gricia')));
-    await act(() => userEvent.click(screen.getByText('Carbonara, Gricia')));
+    await userEvent.click(screen.getByText('Filter Pasta...'));
+    await userEvent.click(screen.getByText('Carbonara'));
+    await userEvent.click(screen.getByText('Gricia'));
+    await userEvent.click(screen.getByText('Carbonara, Gricia'));
 
     // select Diavola from pizza filter
-    await act(() => userEvent.click(screen.getByText('Filter Pizza...')));
-    await act(() => userEvent.click(screen.getByText('Diavola')));
-    await act(() => userEvent.click(screen.getAllByText('Diavola')[0]));
+    await userEvent.click(screen.getByText('Filter Pizza...'));
+    await userEvent.click(screen.getByText('Diavola'));
+    await userEvent.click(screen.getAllByText('Diavola')[0]);
 
     // type a query in the search box
-    await act(() =>
-      userEvent.type(
-        screen.getByPlaceholderText('Filter by frutta'),
-        'Dragonfruit'
-      )
+    await userEvent.type(
+      screen.getByPlaceholderText('Filter by frutta'),
+      'Dragonfruit'
     );
 
     // not applied yet
     expect(mockOnChange).not.toHaveBeenCalled();
 
     // apply
-    await act(() => userEvent.click(screen.getByText('Apply Filter')));
+    await userEvent.click(screen.getByText('Apply Filter'));
 
     // after apply
     expect(mockOnChange).toHaveBeenCalledTimes(1);
@@ -282,25 +278,23 @@ describe('ComposedFilter component', () => {
     render(<ComposedFilter filters={filters} onChange={mockOnChange} />);
 
     // select Carbonara and Gricia from pasta filter
-    await act(() => userEvent.click(screen.getByText('Filter Pasta...')));
-    await act(() => userEvent.click(screen.getByText('Carbonara')));
-    await act(() => userEvent.click(screen.getByText('Gricia')));
-    await act(() => userEvent.click(screen.getByText('Carbonara, Gricia')));
+    await userEvent.click(screen.getByText('Filter Pasta...'));
+    await userEvent.click(screen.getByText('Carbonara'));
+    await userEvent.click(screen.getByText('Gricia'));
+    await userEvent.click(screen.getByText('Carbonara, Gricia'));
 
     // select Diavola from pizza filter
-    await act(() => userEvent.click(screen.getByText('Filter Pizza...')));
-    await act(() => userEvent.click(screen.getByText('Diavola')));
-    await act(() => userEvent.click(screen.getAllByText('Diavola')[0]));
+    await userEvent.click(screen.getByText('Filter Pizza...'));
+    await userEvent.click(screen.getByText('Diavola'));
+    await userEvent.click(screen.getAllByText('Diavola')[0]);
 
     // type a query in the search box
-    await act(() =>
-      userEvent.type(
-        screen.getByPlaceholderText('Filter by frutta'),
-        'Dragonfruit'
-      )
+    await userEvent.type(
+      screen.getByPlaceholderText('Filter by frutta'),
+      'Dragonfruit'
     );
 
-    await act(() => userEvent.click(screen.getByText('Reset Filters')));
+    await userEvent.click(screen.getByText('Reset Filters'));
 
     expect(mockOnChange).toHaveBeenCalledTimes(1);
     expect(mockOnChange).toHaveBeenCalledWith({});

--- a/assets/js/common/DateFilter/DateFilter.test.jsx
+++ b/assets/js/common/DateFilter/DateFilter.test.jsx
@@ -1,4 +1,4 @@
-import React, { act } from 'react';
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
@@ -20,7 +20,7 @@ describe('DateFilter component', () => {
     // Assert that the title is rendered
     expect(screen.getByText(placeholder)).toBeInTheDocument();
 
-    await act(() => user.click(screen.getByText(placeholder)));
+    await user.click(screen.getByText(placeholder));
 
     // Assert that the options are rendered
     ['1h ago', '24h ago', '7d ago', '30d ago'].forEach((label) => {
@@ -34,9 +34,9 @@ describe('DateFilter component', () => {
 
     render(<DateFilter title="by date" prefilled onChange={mockOnChange} />);
 
-    await act(() => user.click(screen.getByText('Filter by date...')));
+    await user.click(screen.getByText('Filter by date...'));
 
-    await act(() => user.click(screen.getByText('24h ago')));
+    await user.click(screen.getByText('24h ago'));
 
     expect(mockOnChange).toHaveBeenCalledWith(['24h ago', expect.any(Date)]);
   });
@@ -81,7 +81,7 @@ describe('DateFilter component', () => {
       />
     );
 
-    await act(() => user.click(screen.getByText('Filter by date...')));
+    await user.click(screen.getByText('Filter by date...'));
 
     expect(screen.getByText('Custom')).toBeInTheDocument();
   });
@@ -105,7 +105,7 @@ describe('DateFilter component', () => {
       />
     );
 
-    await act(() => user.click(screen.getByText('Filter by date...')));
+    await user.click(screen.getByText('Filter by date...'));
 
     expect(screen.queryByText(labelToFind)).not.toBeInTheDocument();
   });
@@ -124,8 +124,8 @@ describe('DateFilter component', () => {
       />
     );
 
-    await act(() => user.click(screen.getByText('Filter by date...')));
-    await act(() => user.click(screen.getByText('my overridden item')));
+    await user.click(screen.getByText('Filter by date...'));
+    await user.click(screen.getByText('my overridden item'));
 
     expect(mockOnChange).toHaveBeenCalledWith(['30d ago', anyDate]);
   });
@@ -136,9 +136,9 @@ describe('DateFilter component', () => {
     const { container } = render(
       <DateFilter title="by date" prefilled onChange={mockOnChange} />
     );
-    await act(() => user.click(screen.getByText('Filter by date...')));
+    await user.click(screen.getByText('Filter by date...'));
     const input = container.querySelector('input[type="datetime-local"]');
-    await act(() => user.type(input, '2024-08-14T10:21'));
+    await user.type(input, '2024-08-14T10:21');
 
     expect(mockOnChange).toHaveBeenCalledWith([
       'custom',

--- a/assets/js/common/Filter/Filter.test.jsx
+++ b/assets/js/common/Filter/Filter.test.jsx
@@ -1,4 +1,4 @@
-import React, { act } from 'react';
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
@@ -22,11 +22,9 @@ describe('Filter component', () => {
       expect(screen.queryByText(option)).not.toBeInTheDocument();
     });
 
-    await act(() =>
-      // select a button which text starts with 'Filter '
-      // click on the button to open the options
-      user.click(screen.getByText(/Filter *.../))
-    );
+    // select a button which text starts with 'Filter '
+    // click on the button to open the options
+    await user.click(screen.getByText(/Filter *.../));
 
     // assert that the options are rendered
     options.forEach((option) => {
@@ -46,9 +44,9 @@ describe('Filter component', () => {
 
     render(<Filter options={options} title="names" onChange={mockOnChange} />);
 
-    await act(() => user.click(screen.getByText(/Filter *.../)));
+    await user.click(screen.getByText(/Filter *.../));
 
-    await act(() => user.click(screen.getByText('Michael Scott')));
+    await user.click(screen.getByText('Michael Scott'));
 
     expect(mockOnChange).toHaveBeenCalledWith(['Michael Scott']);
   });
@@ -74,9 +72,9 @@ describe('Filter component', () => {
       />
     );
 
-    await act(() => user.click(screen.getByText(selectedItem)));
+    await user.click(screen.getByText(selectedItem));
 
-    await act(() => user.click(screen.getByText('Jane Smith')));
+    await user.click(screen.getByText('Jane Smith'));
 
     expect(mockOnChange).toHaveBeenCalledTimes(1);
 
@@ -104,9 +102,9 @@ describe('Filter component', () => {
       />
     );
 
-    await act(() => user.click(screen.getByText(selectedItem)));
+    await user.click(screen.getByText(selectedItem));
 
-    await act(() => user.click(screen.getByText('Jane Smith')));
+    await user.click(screen.getByText('Jane Smith'));
 
     expect(mockOnChange).toHaveBeenCalledTimes(1);
 
@@ -136,9 +134,9 @@ describe('Filter component', () => {
     );
 
     const filterText = [selectedItem1, selectedItem2].join(', ');
-    await act(() => user.click(screen.getByText(filterText)));
+    await user.click(screen.getByText(filterText));
 
-    await act(() => user.click(screen.getByText('Jane Smith')));
+    await user.click(screen.getByText('Jane Smith'));
 
     expect(mockOnChange).toHaveBeenCalledTimes(1);
 
@@ -171,9 +169,9 @@ describe('Filter component', () => {
       />
     );
 
-    await act(() => user.click(screen.getByText(selectedItem)));
+    await user.click(screen.getByText(selectedItem));
 
-    await act(() => user.click(screen.getAllByText(selectedItem)[1]));
+    await user.click(screen.getAllByText(selectedItem)[1]);
 
     expect(mockOnChange).toHaveBeenCalledWith([]);
   });
@@ -203,17 +201,13 @@ describe('Filter component', () => {
       />
     );
 
-    await act(() => user.click(screen.getByText(selectedItemLabel)));
+    await user.click(screen.getByText(selectedItemLabel));
 
-    await act(() => {
-      options.forEach(([, label]) => {
-        expect(screen.getAllByText(label)[0]).toBeInTheDocument();
-      });
-    });
+    for (const [, label] of options) {
+      await expect(screen.getAllByText(label)[0]).toBeInTheDocument();
+    }
 
-    await act(() =>
-      user.click(screen.getAllByText(anotherSelectedItemLabel)[0])
-    );
+    await user.click(screen.getAllByText(anotherSelectedItemLabel)[0]);
 
     expect(mockOnChange).toHaveBeenCalledWith([
       selectedItem,
@@ -240,20 +234,18 @@ describe('Filter component', () => {
       />
     );
 
-    await act(() => user.click(screen.getByText('Michael Scott')));
+    await user.click(screen.getByText('Michael Scott'));
 
-    await act(() => {
-      expect(screen.getByText('John Doe')).toBeInTheDocument();
-      expect(screen.getByText('Jane Smith')).toBeInTheDocument();
-    });
+    await expect(screen.getByText('John Doe')).toBeInTheDocument();
+    await expect(screen.getByText('Jane Smith')).toBeInTheDocument();
 
     /* Remember that the component is stateless,
       it does not change its internal state on selection. */
 
-    await act(() => user.click(screen.getByText('John Doe')));
+    await user.click(screen.getByText('John Doe'));
     expect(mockOnChange).toHaveBeenCalledWith(['Michael Scott', 'john-doe']);
 
-    await act(() => user.click(screen.getByText('Jane Smith')));
+    await user.click(screen.getByText('Jane Smith'));
     expect(mockOnChange).toHaveBeenCalledWith(['Michael Scott', 'Jane Smith']);
   });
 
@@ -276,13 +268,11 @@ describe('Filter component', () => {
       />
     );
 
-    await act(() => user.click(screen.getByText('Michael Scott')));
+    await user.click(screen.getByText('Michael Scott'));
 
-    await act(() => {
-      options.forEach((label) => {
-        expect(screen.getAllByText(label)[0]).toBeInTheDocument();
-      });
-    });
+    for (const label of options) {
+      expect(screen.getAllByText(label)[0]).toBeInTheDocument();
+    }
   });
 
   it('should ignore undefined options', async () => {
@@ -310,12 +300,10 @@ describe('Filter component', () => {
       />
     );
 
-    await act(() => user.click(screen.getByText('PRD')));
+    await user.click(screen.getByText('PRD'));
 
-    await act(() => {
-      options.filter(Boolean).forEach((label) => {
-        expect(screen.getAllByText(label)[0]).toBeInTheDocument();
-      });
-    });
+    for (const label of options.filter(Boolean)) {
+      await expect(screen.getAllByText(label)[0]).toBeInTheDocument();
+    }
   });
 });

--- a/assets/js/common/Tags/Tags.test.jsx
+++ b/assets/js/common/Tags/Tags.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
@@ -38,17 +38,17 @@ describe('Tags', () => {
 
     expect(screen.queryByText(msg)).toBeNull();
 
-    await act(async () => user.click(screen.queryByText('Add Tag')));
+    await user.click(screen.queryByText('Add Tag'));
 
-    await act(async () => userEvent.keyboard('A'));
+    await userEvent.keyboard('A');
 
     await waitFor(() => expect(screen.queryByText(msg)).toBeNull());
 
-    await act(async () => userEvent.keyboard('>'));
+    await userEvent.keyboard('>');
 
     await waitFor(() => expect(screen.queryByText(msg)).toBeVisible());
 
-    await act(async () => userEvent.keyboard('Z'));
+    await userEvent.keyboard('Z');
 
     // FIXME: The visibility is due to a css class.
     // Being the css is not loaded, it cannot be detected by js-dom
@@ -72,17 +72,17 @@ describe('Tags', () => {
 
     expect(screen.queryByText(msg)).toBeNull();
 
-    await act(async () => user.click(screen.queryByText('Add Tag')));
+    await user.click(screen.queryByText('Add Tag'));
 
-    await act(async () => userEvent.keyboard('>'));
+    await userEvent.keyboard('>');
 
     await waitFor(() => expect(screen.queryByText(msg)).toBeVisible());
 
-    await act(async () => user.click(screen.queryByText('sibling')));
+    await user.click(screen.queryByText('sibling'));
 
     await waitFor(() => expect(screen.queryByText(msg)).toBeNull());
 
-    await act(async () => user.click(screen.queryByText('Add Tag')));
+    await user.click(screen.queryByText('Add Tag'));
 
     await waitFor(() => expect(screen.queryByText(msg)).toBeNull());
   });

--- a/assets/js/pages/Profile/ProfileForm.test.jsx
+++ b/assets/js/pages/Profile/ProfileForm.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { faker } from '@faker-js/faker';

--- a/assets/js/pages/Profile/ProfileForm.test.jsx
+++ b/assets/js/pages/Profile/ProfileForm.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, screen, act } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { faker } from '@faker-js/faker';
@@ -248,9 +248,7 @@ describe('ProfileForm', () => {
 
     expect(screen.getByRole('switch')).toBeVisible();
 
-    await act(async () => {
-      await user.click(screen.getByRole('switch'));
-    });
+    await user.click(screen.getByRole('switch'));
 
     expect(onEnableTotp).toHaveBeenCalled();
   });
@@ -274,13 +272,8 @@ describe('ProfileForm', () => {
 
     expect(screen.getByRole('switch')).toBeVisible();
 
-    await act(async () => {
-      await user.click(screen.getByRole('switch'));
-    });
-
-    await act(async () => {
-      await user.click(screen.getByText('Disable'));
-    });
+    await user.click(screen.getByRole('switch'));
+    await user.click(screen.getByText('Disable'));
 
     expect(onResetTotp).toHaveBeenCalled();
   });
@@ -328,9 +321,7 @@ describe('ProfileForm', () => {
 
     expect(screen.getByText(totpSecret)).toBeVisible();
 
-    await act(async () => {
-      await user.click(screen.getByText('Cancel'));
-    });
+    await user.click(screen.getByText('Cancel'));
 
     expect(toggleTotpBox).toHaveBeenCalledWith(false);
   });
@@ -356,10 +347,8 @@ describe('ProfileForm', () => {
       />
     );
 
-    await act(async () => {
-      await user.type(screen.getByLabelText('totp_code'), '1234');
-      await user.click(screen.getByRole('button', { name: 'Verify' }));
-    });
+    await user.type(screen.getByLabelText('totp_code'), '1234');
+    await user.click(screen.getByRole('button', { name: 'Verify' }));
 
     expect(onVerifyTotp).toHaveBeenNthCalledWith(1, '1234');
   });


### PR DESCRIPTION
# Description

Remove not needed `act` usage from frontend UT tests.
`userEvent` functions are already correctly wrapped by `act`.

This was causing the next error log:
```
console.error
    The current testing environment is not configured to support act(...)
```

## How was this tested?
UT

## Did you update the documentation?
NO need
