### PR TITLE
Fix test modal component not wrapped in `act` warning

### DIFF
--- a/assets/js/common/AIConfiguration/AIConfigurationModal.test.jsx
+++ b/assets/js/common/AIConfiguration/AIConfigurationModal.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { aiConfigurationFactory } from '@lib/test-utils/factories';
@@ -13,8 +13,10 @@ describe('AIConfigurationModal', () => {
     openai: ['gpt-4o', 'gpt-4-turbo'],
   };
 
-  it('should render empty form', () => {
-    render(<AIConfigurationModal open aiProviders={aiProviders} />);
+  it('should render empty form', async () => {
+    await act(() => {
+      render(<AIConfigurationModal open aiProviders={aiProviders} />);
+    });
 
     expect(screen.getByText('AI Configuration')).toBeVisible();
     expect(screen.getByText('Select Provider')).toBeVisible();
@@ -31,18 +33,20 @@ describe('AIConfigurationModal', () => {
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeEnabled();
   });
 
-  it('should render with saved configuration', () => {
+  it('should render with saved configuration', async () => {
     const aiConfiguration = aiConfigurationFactory.build({
       provider: 'googleai',
       model: 'gemini-2.5-pro',
     });
 
-    render(
-      <AIConfigurationModal
-        open
-        aiProviders={aiProviders}
-        aiConfiguration={aiConfiguration}
-      />
+    await act(() =>
+      render(
+        <AIConfigurationModal
+          open
+          aiProviders={aiProviders}
+          aiConfiguration={aiConfiguration}
+        />
+      )
     );
 
     expect(screen.getByText('Google Gemini')).toBeVisible();
@@ -56,7 +60,9 @@ describe('AIConfigurationModal', () => {
 
   it('should enable Save button when a Provider is selected', async () => {
     const user = userEvent.setup();
-    render(<AIConfigurationModal open aiProviders={aiProviders} />);
+    await act(() =>
+      render(<AIConfigurationModal open aiProviders={aiProviders} />)
+    );
 
     // Select Provider
     await user.click(screen.getByText('Select an AI Provider'));
@@ -82,8 +88,10 @@ describe('AIConfigurationModal', () => {
     const user = userEvent.setup();
     const onSave = jest.fn();
 
-    render(
-      <AIConfigurationModal open aiProviders={aiProviders} onSave={onSave} />
+    await act(() =>
+      render(
+        <AIConfigurationModal open aiProviders={aiProviders} onSave={onSave} />
+      )
     );
 
     // Select Provider
@@ -112,13 +120,15 @@ describe('AIConfigurationModal', () => {
       model: 'gemini-2.5-pro',
     });
 
-    render(
-      <AIConfigurationModal
-        open
-        aiProviders={aiProviders}
-        aiConfiguration={aiConfiguration}
-        onUpdate={onUpdate}
-      />
+    await act(() =>
+      render(
+        <AIConfigurationModal
+          open
+          aiProviders={aiProviders}
+          aiConfiguration={aiConfiguration}
+          onUpdate={onUpdate}
+        />
+      )
     );
 
     // Type new API Key
@@ -138,8 +148,10 @@ describe('AIConfigurationModal', () => {
     const user = userEvent.setup();
     const onSave = jest.fn();
 
-    render(
-      <AIConfigurationModal open aiProviders={aiProviders} onSave={onSave} />
+    await act(() =>
+      render(
+        <AIConfigurationModal open aiProviders={aiProviders} onSave={onSave} />
+      )
     );
 
     // Select Provider
@@ -158,12 +170,14 @@ describe('AIConfigurationModal', () => {
     const user = userEvent.setup();
     const onCancel = jest.fn();
 
-    render(
-      <AIConfigurationModal
-        open
-        aiProviders={aiProviders}
-        onCancel={onCancel}
-      />
+    await act(() =>
+      render(
+        <AIConfigurationModal
+          open
+          aiProviders={aiProviders}
+          onCancel={onCancel}
+        />
+      )
     );
 
     await user.click(screen.getByRole('button', { name: 'Cancel' }));
@@ -180,8 +194,10 @@ describe('AIConfigurationModal', () => {
       },
     ];
 
-    render(
-      <AIConfigurationModal open aiProviders={aiProviders} errors={errors} />
+    await act(() =>
+      render(
+        <AIConfigurationModal open aiProviders={aiProviders} errors={errors} />
+      )
     );
 
     expect(

--- a/assets/js/common/ActivityLogDetailsModal/ActivityLogDetailModal.test.jsx
+++ b/assets/js/common/ActivityLogDetailsModal/ActivityLogDetailModal.test.jsx
@@ -33,7 +33,9 @@ describe('ActivityLogDetailModal component', () => {
       userRelatedActivity = false,
     }) => {
       const { id } = entry;
-      render(<ActivityLogDetailModal open entry={toRenderedEntry(entry)} />);
+      await act(() =>
+        render(<ActivityLogDetailModal open entry={toRenderedEntry(entry)} />)
+      );
 
       expect(screen.getByText('ID')).toBeVisible();
       expect(screen.getByText(id)).toBeVisible();
@@ -62,7 +64,9 @@ describe('ActivityLogDetailModal component', () => {
   it('should render detail for unknown activity type', async () => {
     const unknownActivityType = faker.lorem.word();
     const entry = activityLogEntryFactory.build({ type: unknownActivityType });
-    render(<ActivityLogDetailModal open entry={toRenderedEntry(entry)} />);
+    await act(() =>
+      render(<ActivityLogDetailModal open entry={toRenderedEntry(entry)} />)
+    );
 
     const activityReferences = screen.getAllByText(unknownActivityType);
     expect(activityReferences).toHaveLength(2);
@@ -80,11 +84,11 @@ describe('ActivityLogDetailModal component', () => {
       metadata,
       type: unknownActivityType,
     });
-    await act(async () => {
+    await act(() =>
       renderWithRouter(
         <ActivityLogDetailModal open entry={toRenderedEntry(entry)} />
-      );
-    });
+      )
+    );
 
     expect(screen.getByText('Related Events')).toBeVisible();
     expect(screen.getByText('Show Events')).toBeVisible();
@@ -97,11 +101,11 @@ describe('ActivityLogDetailModal component', () => {
       metadata,
       type: unknownActivityType,
     });
-    await act(async () => {
+    await act(() =>
       renderWithRouter(
         <ActivityLogDetailModal open entry={toRenderedEntry(entry)} />
-      );
-    });
+      )
+    );
 
     expect(screen.queryByText('Related Events')).not.toBeInTheDocument();
     expect(screen.queryByText('Show Events')).not.toBeInTheDocument();
@@ -109,12 +113,14 @@ describe('ActivityLogDetailModal component', () => {
 
   it('should call onClose when the close button is clicked', async () => {
     const onClose = jest.fn();
-    render(
-      <ActivityLogDetailModal
-        open
-        entry={activityLogEntryFactory.build()}
-        onClose={onClose}
-      />
+    await act(() =>
+      render(
+        <ActivityLogDetailModal
+          open
+          entry={activityLogEntryFactory.build()}
+          onClose={onClose}
+        />
+      )
     );
 
     await userEvent.click(screen.getByText('Close'));

--- a/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.test.jsx
+++ b/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.test.jsx
@@ -11,6 +11,15 @@ import ActivityLogsSettingsModal from '.';
 const positiveInt = () => faker.number.int({ min: 1 });
 
 describe('ActivityLogsSettingsModal component', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    /* eslint-disable-next-line */
+    console.error.mockRestore();
+  });
+
   it('renders correctly', async () => {
     const initialRetentionTime = { value: faker.number.int(), unit: 'day' };
     await act(async () =>
@@ -49,6 +58,13 @@ describe('ActivityLogsSettingsModal component', () => {
     );
 
     expect(errorSpy).toHaveBeenCalled();
+    /* eslint-disable-next-line */
+    expect(console.error).toHaveBeenCalledWith(
+      expect.any(String),
+      TypeError("Cannot read properties of undefined (reading 'value')"),
+      expect.any(String),
+      expect.any(String)
+    );
   });
 
   it('should try to save all the changed fields', async () => {

--- a/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.test.jsx
+++ b/assets/js/common/ActivityLogsSettingsModal/ActivityLogsSettingsModal.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { faker } from '@faker-js/faker';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
@@ -13,13 +13,15 @@ const positiveInt = () => faker.number.int({ min: 1 });
 describe('ActivityLogsSettingsModal component', () => {
   it('renders correctly', async () => {
     const initialRetentionTime = { value: faker.number.int(), unit: 'day' };
-    render(
-      <ActivityLogsSettingsModal
-        open
-        onSave={() => {}}
-        onChange={() => {}}
-        initialRetentionTime={initialRetentionTime}
-      />
+    await act(async () =>
+      render(
+        <ActivityLogsSettingsModal
+          open
+          onSave={() => {}}
+          onChange={() => {}}
+          initialRetentionTime={initialRetentionTime}
+        />
+      )
     );
 
     await waitFor(() => {
@@ -34,10 +36,16 @@ describe('ActivityLogsSettingsModal component', () => {
   it('should throw when required props are not provided', async () => {
     const errorSpy = jest.fn();
 
-    render(
-      <ErrorBoundary onError={errorSpy}>
-        <ActivityLogsSettingsModal open onSave={() => {}} onChange={() => {}} />
-      </ErrorBoundary>
+    await act(async () =>
+      render(
+        <ErrorBoundary onError={errorSpy}>
+          <ActivityLogsSettingsModal
+            open
+            onSave={() => {}}
+            onChange={() => {}}
+          />
+        </ErrorBoundary>
+      )
     );
 
     expect(errorSpy).toHaveBeenCalled();
@@ -55,13 +63,15 @@ describe('ActivityLogsSettingsModal component', () => {
     };
     const onSave = jest.fn();
 
-    render(
-      <ActivityLogsSettingsModal
-        open
-        initialRetentionTime={initialRetentionTime}
-        onSave={onSave}
-        onCancel={() => {}}
-      />
+    await act(() =>
+      render(
+        <ActivityLogsSettingsModal
+          open
+          initialRetentionTime={initialRetentionTime}
+          onSave={onSave}
+          onCancel={() => {}}
+        />
+      )
     );
 
     // first clean up the text input then type the new value
@@ -88,13 +98,15 @@ describe('ActivityLogsSettingsModal component', () => {
     const initialRetentionTime = { value: positiveInt(), unit: 'month' };
     const onSave = jest.fn();
 
-    render(
-      <ActivityLogsSettingsModal
-        open
-        initialRetentionTime={initialRetentionTime}
-        onSave={onSave}
-        onCancel={() => {}}
-      />
+    await act(() =>
+      render(
+        <ActivityLogsSettingsModal
+          open
+          initialRetentionTime={initialRetentionTime}
+          onSave={onSave}
+          onCancel={() => {}}
+        />
+      )
     );
 
     await user.click(screen.getByText('Save Settings'));
@@ -131,14 +143,16 @@ describe('ActivityLogsSettingsModal component', () => {
     async ({ errors, expectedErrorMessage }) => {
       const initialRetentionTime = { value: positiveInt(), unit: 'month' };
 
-      render(
-        <ActivityLogsSettingsModal
-          errors={errors}
-          initialRetentionTime={initialRetentionTime}
-          open
-          onSave={() => {}}
-          onCancel={() => {}}
-        />
+      await act(() =>
+        render(
+          <ActivityLogsSettingsModal
+            errors={errors}
+            initialRetentionTime={initialRetentionTime}
+            open
+            onSave={() => {}}
+            onCancel={() => {}}
+          />
+        )
       );
 
       await waitFor(() => {

--- a/assets/js/common/AlertingSettingsModal/AlertingSettingsModal.test.jsx
+++ b/assets/js/common/AlertingSettingsModal/AlertingSettingsModal.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { faker } from '@faker-js/faker';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { capitalize } from 'lodash';
@@ -14,7 +14,7 @@ import AlertingSettingsModal from './AlertingSettingsModal';
 
 describe('AlertingSettingsModal', () => {
   it('renders correctly when opened with no arguments passed', async () => {
-    render(<AlertingSettingsModal open />);
+    await act(() => render(<AlertingSettingsModal open />));
 
     const alertingEnabled = screen.getByRole('switch', {
       name: 'Send Email Alerts',
@@ -62,7 +62,9 @@ describe('AlertingSettingsModal', () => {
     const { smtpServer, smtpPort, smtpUsername, senderEmail, recipientEmail } =
       alertingSettings;
 
-    render(<AlertingSettingsModal previousSettings={alertingSettings} open />);
+    await act(() =>
+      render(<AlertingSettingsModal previousSettings={alertingSettings} open />)
+    );
 
     expect(
       screen.getByRole('switch', { name: 'Send Email Alerts' })
@@ -98,7 +100,7 @@ describe('AlertingSettingsModal', () => {
     const user = userEvent.setup();
     const onSave = jest.fn();
 
-    render(<AlertingSettingsModal open onSave={onSave} />);
+    await act(() => render(<AlertingSettingsModal open onSave={onSave} />));
 
     await user.click(screen.getByRole('switch', 'Email Alerts'));
     await user.type(
@@ -143,12 +145,14 @@ describe('AlertingSettingsModal', () => {
     const user = userEvent.setup();
     const onSave = jest.fn();
 
-    render(
-      <AlertingSettingsModal
-        previousSettings={alertingSettings}
-        open
-        onSave={onSave}
-      />
+    await act(() =>
+      render(
+        <AlertingSettingsModal
+          previousSettings={alertingSettings}
+          open
+          onSave={onSave}
+        />
+      )
     );
     await user.click(screen.getByRole('button', { name: 'Save Settings' }));
 
@@ -179,19 +183,21 @@ describe('AlertingSettingsModal', () => {
 
     const user = userEvent.setup();
 
-    render(
-      <AlertingSettingsModal
-        open
-        previousSettings={alertingSettingsFactory.build()}
-        errors={[
-          constructErrorMessage('smtp_server', smtpServerError),
-          constructErrorMessage('smtp_port', smtpPortError),
-          constructErrorMessage('smtp_username', smtpUsernameError),
-          constructErrorMessage('smtp_password', smtpPasswordError),
-          constructErrorMessage('sender_email', senderEmailError),
-          constructErrorMessage('recipient_email', recipientEmailError),
-        ]}
-      />
+    await act(() =>
+      render(
+        <AlertingSettingsModal
+          open
+          previousSettings={alertingSettingsFactory.build()}
+          errors={[
+            constructErrorMessage('smtp_server', smtpServerError),
+            constructErrorMessage('smtp_port', smtpPortError),
+            constructErrorMessage('smtp_username', smtpUsernameError),
+            constructErrorMessage('smtp_password', smtpPasswordError),
+            constructErrorMessage('sender_email', senderEmailError),
+            constructErrorMessage('recipient_email', recipientEmailError),
+          ]}
+        />
+      )
     );
     await user.click(screen.getByRole('button', { name: 'Remove' }));
 

--- a/assets/js/common/ApiKeySettingsModal/ApiKeySettingsModal.test.jsx
+++ b/assets/js/common/ApiKeySettingsModal/ApiKeySettingsModal.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { faker } from '@faker-js/faker';
 import {
@@ -21,7 +21,7 @@ describe('ApiKeySettingsModal', () => {
   describe('Generation form', () => {
     it('render the generation form', async () => {
       const user = userEvent.setup();
-      render(<ApiKeySettingsModal open />);
+      await act(() => render(<ApiKeySettingsModal open />));
 
       expect(screen.getByText('Never Expires')).toBeVisible();
       expect(screen.getByText('Key Expiration')).toBeVisible();
@@ -52,7 +52,7 @@ describe('ApiKeySettingsModal', () => {
     it('should show a validation error when quantity is 0 and the form is enabled', async () => {
       const user = userEvent.setup();
 
-      render(<ApiKeySettingsModal open />);
+      await act(() => render(<ApiKeySettingsModal open />));
 
       await user.type(screen.getByRole('spinbutton'), '0');
 
@@ -66,7 +66,7 @@ describe('ApiKeySettingsModal', () => {
     it('should not show a validation error when quantity is > 0 and the form is enabled', async () => {
       const user = userEvent.setup();
 
-      render(<ApiKeySettingsModal open />);
+      await act(() => render(<ApiKeySettingsModal open />));
 
       await user.type(screen.getByRole('spinbutton'), '20');
 
@@ -81,7 +81,9 @@ describe('ApiKeySettingsModal', () => {
       const user = userEvent.setup();
       const onGenerate = jest.fn();
 
-      render(<ApiKeySettingsModal open onGenerate={onGenerate} />);
+      await act(() =>
+        render(<ApiKeySettingsModal open onGenerate={onGenerate} />)
+      );
 
       await user.type(screen.getByRole('spinbutton'), '20');
 
@@ -113,7 +115,9 @@ describe('ApiKeySettingsModal', () => {
       const user = userEvent.setup();
       const onGenerate = jest.fn();
 
-      render(<ApiKeySettingsModal open onGenerate={onGenerate} />);
+      await act(() =>
+        render(<ApiKeySettingsModal open onGenerate={onGenerate} />)
+      );
 
       await user.type(screen.getByRole('spinbutton'), '2');
 
@@ -148,7 +152,9 @@ describe('ApiKeySettingsModal', () => {
       const user = userEvent.setup();
       const onGenerate = jest.fn();
 
-      render(<ApiKeySettingsModal open onGenerate={onGenerate} />);
+      await act(() =>
+        render(<ApiKeySettingsModal open onGenerate={onGenerate} />)
+      );
 
       await user.type(screen.getByRole('spinbutton'), '20');
 
@@ -180,14 +186,14 @@ describe('ApiKeySettingsModal', () => {
     });
 
     it('should have generate button disabled when the modal has loading prop set to true', async () => {
-      render(<ApiKeySettingsModal open loading />);
+      await act(() => render(<ApiKeySettingsModal open loading />));
       expect(screen.getByRole('button', { name: 'Generate' })).toBeDisabled();
     });
 
     it('should have the form inputs disabled when the generation if form is disabled by the user', async () => {
       const user = userEvent.setup();
 
-      render(<ApiKeySettingsModal open />);
+      await act(() => render(<ApiKeySettingsModal open />));
 
       await user.click(screen.getByRole('switch'));
 
@@ -202,7 +208,9 @@ describe('ApiKeySettingsModal', () => {
       const user = userEvent.setup();
       const onGenerate = jest.fn();
 
-      render(<ApiKeySettingsModal open onGenerate={onGenerate} />);
+      await act(() =>
+        render(<ApiKeySettingsModal open onGenerate={onGenerate} />)
+      );
 
       await user.click(screen.getByRole('switch'));
 
@@ -219,12 +227,14 @@ describe('ApiKeySettingsModal', () => {
       const nowISO = new Date().toISOString();
       jest.spyOn(window, 'prompt').mockReturnValue();
 
-      render(
-        <ApiKeySettingsModal
-          open
-          generatedApiKey={apiKey}
-          generatedApiKeyExpiration={nowISO}
-        />
+      await act(() =>
+        render(
+          <ApiKeySettingsModal
+            open
+            generatedApiKey={apiKey}
+            generatedApiKeyExpiration={nowISO}
+          />
+        )
       );
 
       await user.click(screen.getByRole('switch'));
@@ -247,12 +257,14 @@ describe('ApiKeySettingsModal', () => {
       const apiKey = faker.string.alpha({ length: { min: 100, max: 100 } });
       const nowISO = new Date().toISOString();
 
-      render(
-        <ApiKeySettingsModal
-          open
-          generatedApiKey={apiKey}
-          generatedApiKeyExpiration={nowISO}
-        />
+      await act(() =>
+        render(
+          <ApiKeySettingsModal
+            open
+            generatedApiKey={apiKey}
+            generatedApiKeyExpiration={nowISO}
+          />
+        )
       );
 
       await user.click(screen.getByRole('switch'));
@@ -271,12 +283,14 @@ describe('ApiKeySettingsModal', () => {
       const apiKey = faker.string.alpha({ length: { min: 100, max: 100 } });
       const nowISO = new Date().toISOString();
 
-      render(
-        <ApiKeySettingsModal
-          open
-          generatedApiKey={apiKey}
-          generatedApiKeyExpiration={nowISO}
-        />
+      await act(() =>
+        render(
+          <ApiKeySettingsModal
+            open
+            generatedApiKey={apiKey}
+            generatedApiKeyExpiration={nowISO}
+          />
+        )
       );
 
       await user.click(screen.getByRole('switch'));
@@ -292,13 +306,15 @@ describe('ApiKeySettingsModal', () => {
       const nowISO = new Date().toISOString();
       const onGenerate = jest.fn();
 
-      render(
-        <ApiKeySettingsModal
-          open
-          generatedApiKey={apiKey}
-          generatedApiKeyExpiration={nowISO}
-          onGenerate={onGenerate}
-        />
+      await act(() =>
+        render(
+          <ApiKeySettingsModal
+            open
+            generatedApiKey={apiKey}
+            generatedApiKeyExpiration={nowISO}
+            onGenerate={onGenerate}
+          />
+        )
       );
 
       await user.click(screen.getByRole('switch'));

--- a/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.test.jsx
+++ b/assets/js/common/CheckCustomizationModal/CheckCustomizationModal.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import {
@@ -62,7 +62,9 @@ describe('CheckCustomizationModal', () => {
       'Trento and SUSE are not responsible for cluster operation failure due to deviation from Best Practices.';
     const user = userEvent.setup();
 
-    render(<CheckCustomizationModal {...checkCustomizationModalProps} />);
+    await act(() =>
+      render(<CheckCustomizationModal {...checkCustomizationModalProps} />)
+    );
 
     expect(screen.getByText(expectedModalTitle)).toBeInTheDocument();
     expect(
@@ -91,7 +93,9 @@ describe('CheckCustomizationModal', () => {
     const expectedCheckValues = [999, 'veryImportantValue', false];
     const { onSave } = checkCustomizationModalProps;
 
-    render(<CheckCustomizationModal {...checkCustomizationModalProps} />);
+    await act(() =>
+      render(<CheckCustomizationModal {...checkCustomizationModalProps} />)
+    );
 
     const warningBannerCheckbox = screen.getByRole('checkbox');
     expect(warningBannerCheckbox).not.toBeChecked();
@@ -146,7 +150,9 @@ describe('CheckCustomizationModal', () => {
       values: checkValueList,
     };
 
-    render(<CheckCustomizationModal {...checkWithMultipleValues} />);
+    await act(() =>
+      render(<CheckCustomizationModal {...checkWithMultipleValues} />)
+    );
     const warningBannerCheckbox = screen.getByRole('checkbox');
     await user.click(warningBannerCheckbox);
     expect(warningBannerCheckbox).toBeChecked();
@@ -167,7 +173,9 @@ describe('CheckCustomizationModal', () => {
   });
 
   it('should disable reset customization button if check is not customized', async () => {
-    render(<CheckCustomizationModal open customized={false} />);
+    await act(() =>
+      render(<CheckCustomizationModal open customized={false} />)
+    );
 
     expect(screen.getByText('Reset Check')).toBeDisabled();
   });
@@ -176,8 +184,10 @@ describe('CheckCustomizationModal', () => {
     const user = userEvent.setup();
     const { onReset } = checkCustomizationModalProps;
 
-    render(
-      <CheckCustomizationModal {...checkCustomizationModalProps} customized />
+    await act(() =>
+      render(
+        <CheckCustomizationModal {...checkCustomizationModalProps} customized />
+      )
     );
 
     await user.click(screen.getByText('Reset Check'));
@@ -193,11 +203,13 @@ describe('CheckCustomizationModal', () => {
   `(
     'should show error message when customization status is failed',
     async ({ customizationStatus, expectedMessage }) => {
-      render(
-        <CheckCustomizationModal
-          {...checkCustomizationModalProps}
-          customizationStatus={customizationStatus}
-        />
+      await act(() =>
+        render(
+          <CheckCustomizationModal
+            {...checkCustomizationModalProps}
+            customizationStatus={customizationStatus}
+          />
+        )
       );
 
       expectedMessage
@@ -207,11 +219,13 @@ describe('CheckCustomizationModal', () => {
   );
 
   it('should not allow saving customization while another one is ongoing', async () => {
-    render(
-      <CheckCustomizationModal
-        {...checkCustomizationModalProps}
-        customizationStatus={ONGOING}
-      />
+    await act(() =>
+      render(
+        <CheckCustomizationModal
+          {...checkCustomizationModalProps}
+          customizationStatus={ONGOING}
+        />
+      )
     );
 
     expect(screen.getByText('Save')).toBeDisabled();

--- a/assets/js/common/OperationModals/OperationForbiddenModal.test.jsx
+++ b/assets/js/common/OperationModals/OperationForbiddenModal.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { act, render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { noop } from 'lodash';
@@ -9,12 +9,14 @@ import OperationForbiddenModal from './OperationForbiddenModal';
 
 describe('OperationForbiddenModal', () => {
   it('should show forbidden operation modal', async () => {
-    render(
-      <OperationForbiddenModal
-        operation="My operation"
-        errors={[{ detail: 'error1' }, { detail: 'error2' }]}
-        isOpen
-      />
+    await act(() =>
+      render(
+        <OperationForbiddenModal
+          operation="My operation"
+          errors={[{ detail: 'error1' }, { detail: 'error2' }]}
+          isOpen
+        />
+      )
     );
 
     expect(screen.getByText('Operation Forbidden')).toBeInTheDocument();
@@ -39,22 +41,24 @@ describe('OperationForbiddenModal', () => {
     const { id: hostID2, hostname: hostname2 } = hostFactory.build();
     const { id: hostID3, hostname: hostname3 } = hostFactory.build();
 
-    renderWithRouter(
-      <OperationForbiddenModal
-        operation="My operation"
-        errors={[
-          {
-            detail: 'error message {0}, {1} and {2} links',
-            metadata: [
-              { id: hostID1, label: hostname1, type: 'host' },
-              { id: hostID2, label: hostname2, type: 'host' },
-              { id: hostID3, label: hostname3, type: 'host' },
-            ],
-          },
-        ]}
-        isOpen
-        onCancel={noop}
-      />
+    await act(() =>
+      renderWithRouter(
+        <OperationForbiddenModal
+          operation="My operation"
+          errors={[
+            {
+              detail: 'error message {0}, {1} and {2} links',
+              metadata: [
+                { id: hostID1, label: hostname1, type: 'host' },
+                { id: hostID2, label: hostname2, type: 'host' },
+                { id: hostID3, label: hostname3, type: 'host' },
+              ],
+            },
+          ]}
+          isOpen
+          onCancel={noop}
+        />
+      )
     );
 
     const list = screen.getByRole('list');
@@ -94,17 +98,19 @@ describe('OperationForbiddenModal', () => {
     const id = 'some-id';
     const label = 'label';
 
-    renderWithRouter(
-      <OperationForbiddenModal
-        operation="My operation"
-        errors={[
-          {
-            detail: 'error message {0}',
-            metadata: [{ id, label, type: resource }],
-          },
-        ]}
-        isOpen
-      />
+    await act(() =>
+      renderWithRouter(
+        <OperationForbiddenModal
+          operation="My operation"
+          errors={[
+            {
+              detail: 'error message {0}',
+              metadata: [{ id, label, type: resource }],
+            },
+          ]}
+          isOpen
+        />
+      )
     );
 
     const list = screen.getByRole('list');
@@ -118,15 +124,17 @@ describe('OperationForbiddenModal', () => {
   it('should run onCancel when the close button is clicked', async () => {
     const user = userEvent.setup();
     const mockOnCancel = jest.fn();
-    render(
-      <OperationForbiddenModal
-        operation="My operation"
-        errors={[]}
-        isOpen
-        onCancel={mockOnCancel}
-      >
-        Some children
-      </OperationForbiddenModal>
+    await act(() =>
+      render(
+        <OperationForbiddenModal
+          operation="My operation"
+          errors={[]}
+          isOpen
+          onCancel={mockOnCancel}
+        >
+          Some children
+        </OperationForbiddenModal>
+      )
     );
 
     await user.click(screen.getByRole('button', { name: 'Close' }));

--- a/assets/js/common/OperationModals/OperationModal.test.jsx
+++ b/assets/js/common/OperationModals/OperationModal.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { faker } from '@faker-js/faker';
@@ -13,13 +13,15 @@ describe('OperationModal', () => {
     const operationTitle = faker.lorem.sentence();
     const operationDescription = faker.lorem.paragraph();
     const operationText = faker.lorem.word();
-    render(
-      <OperationModal
-        title={operationTitle}
-        description={operationDescription}
-        operationText={operationText}
-        isOpen
-      />
+    await act(() =>
+      render(
+        <OperationModal
+          title={operationTitle}
+          description={operationDescription}
+          operationText={operationText}
+          isOpen
+        />
+      )
     );
 
     const pattern = `By proceeding I confirm to be aware of the impact that executing operation "${operationText}" will have in my environment`;
@@ -44,16 +46,18 @@ describe('OperationModal', () => {
     const specificOperationModalContent = faker.person.fullName();
     const mockOnRequest = jest.fn();
 
-    render(
-      <OperationModal
-        title={operationTitle}
-        description={operationDescription}
-        operationText={operationText}
-        isOpen
-        onRequest={mockOnRequest}
-      >
-        {specificOperationModalContent}
-      </OperationModal>
+    await act(() =>
+      render(
+        <OperationModal
+          title={operationTitle}
+          description={operationDescription}
+          operationText={operationText}
+          isOpen
+          onRequest={mockOnRequest}
+        >
+          {specificOperationModalContent}
+        </OperationModal>
+      )
     );
 
     await user.click(screen.getByText('Proceed'));
@@ -80,7 +84,7 @@ describe('OperationModal', () => {
   it(`should not waive disclaimer by just clicking the "Don't show this again" checkbox`, async () => {
     const user = userEvent.setup();
 
-    const { rerender } = render(<OperationModal isOpen />);
+    const { rerender } = await act(() => render(<OperationModal isOpen />));
 
     await user.click(screen.getByRole('checkbox'));
     expect(screen.getByRole('checkbox')).toBeChecked();
@@ -98,15 +102,17 @@ describe('OperationModal', () => {
     const operationText = faker.lorem.word();
     const specificOperationModalContent = faker.person.fullName();
 
-    const { rerender } = render(
-      <OperationModal
-        title={operationTitle}
-        description={operationDescription}
-        operationText={operationText}
-        isOpen
-      >
-        {specificOperationModalContent}
-      </OperationModal>
+    const { rerender } = await act(() =>
+      render(
+        <OperationModal
+          title={operationTitle}
+          description={operationDescription}
+          operationText={operationText}
+          isOpen
+        >
+          {specificOperationModalContent}
+        </OperationModal>
+      )
     );
 
     await user.click(screen.getByRole('checkbox'));
@@ -133,7 +139,7 @@ describe('OperationModal', () => {
   it('should be possible to disable requesting operation after disclaimer step', async () => {
     const user = userEvent.setup();
 
-    render(<OperationModal isOpen requestDisabled />);
+    await act(() => render(<OperationModal isOpen requestDisabled />));
 
     await user.click(screen.getByText('Proceed'));
 

--- a/assets/js/common/OperationModals/SapStartStopOperationModal.test.jsx
+++ b/assets/js/common/OperationModals/SapStartStopOperationModal.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { faker } from '@faker-js/faker';
@@ -53,13 +53,15 @@ describe('SapStartStopOperationModal', () => {
   ])(
     `should show correct title and description for $operation`,
     async ({ operation, title, site, expectedDescription }) => {
-      render(
-        <SapStartStopOperationModal
-          operation={operation}
-          sid={sid}
-          site={site}
-          isOpen
-        />
+      await act(() =>
+        render(
+          <SapStartStopOperationModal
+            operation={operation}
+            sid={sid}
+            site={site}
+            isOpen
+          />
+        )
       );
 
       expect(screen.getByText(title)).toBeInTheDocument();
@@ -94,14 +96,16 @@ describe('SapStartStopOperationModal', () => {
       const user = userEvent.setup();
       const onRequest = jest.fn();
 
-      render(
-        <SapStartStopOperationModal
-          operation={SAP_SYSTEM_START}
-          sid={sid}
-          type={APPLICATION_TYPE}
-          isOpen
-          onRequest={onRequest}
-        />
+      await act(() =>
+        render(
+          <SapStartStopOperationModal
+            operation={SAP_SYSTEM_START}
+            sid={sid}
+            type={APPLICATION_TYPE}
+            isOpen
+            onRequest={onRequest}
+          />
+        )
       );
 
       expect(screen.getByText('Request')).toBeEnabled();
@@ -120,15 +124,17 @@ describe('SapStartStopOperationModal', () => {
     const user = userEvent.setup();
     const onRequest = jest.fn();
 
-    render(
-      <SapStartStopOperationModal
-        operation={DATABASE_START}
-        sid={sid}
-        type={DATABASE_TYPE}
-        site={systemReplicationSite}
-        isOpen
-        onRequest={onRequest}
-      />
+    await act(() =>
+      render(
+        <SapStartStopOperationModal
+          operation={DATABASE_START}
+          sid={sid}
+          type={DATABASE_TYPE}
+          site={systemReplicationSite}
+          isOpen
+          onRequest={onRequest}
+        />
+      )
     );
 
     expect(screen.getByText('Request')).toBeEnabled();
@@ -144,13 +150,15 @@ describe('SapStartStopOperationModal', () => {
     const user = userEvent.setup();
     const onCancel = jest.fn();
 
-    render(
-      <SapStartStopOperationModal
-        operation={SAP_SYSTEM_START}
-        sid={sid}
-        isOpen
-        onCancel={onCancel}
-      />
+    await act(() =>
+      render(
+        <SapStartStopOperationModal
+          operation={SAP_SYSTEM_START}
+          sid={sid}
+          isOpen
+          onCancel={onCancel}
+        />
+      )
     );
 
     await user.click(screen.getByText('Cancel'));

--- a/assets/js/common/OperationModals/SaptuneSolutionOperationModal.test.jsx
+++ b/assets/js/common/OperationModals/SaptuneSolutionOperationModal.test.jsx
@@ -19,7 +19,9 @@ describe('SaptuneSolutionOperationModal', () => {
   `(
     'should show correct title and description',
     async ({ operation, title }) => {
-      render(<SaptuneSolutionOperationModal operation={operation} isOpen />);
+      await act(() =>
+        render(<SaptuneSolutionOperationModal operation={operation} isOpen />)
+      );
 
       expect(screen.getByText(title)).toBeInTheDocument();
       expect(
@@ -31,12 +33,14 @@ describe('SaptuneSolutionOperationModal', () => {
   it('should forbid applying a solution until one is actually selected', async () => {
     const user = userEvent.setup();
 
-    render(
-      <SaptuneSolutionOperationModal
-        operation={SAPTUNE_SOLUTION_APPLY}
-        isOpen
-        isAppRunning
-      />
+    await act(() =>
+      render(
+        <SaptuneSolutionOperationModal
+          operation={SAPTUNE_SOLUTION_APPLY}
+          isOpen
+          isAppRunning
+        />
+      )
     );
 
     expect(screen.getByText('Request')).toBeDisabled();
@@ -50,14 +54,17 @@ describe('SaptuneSolutionOperationModal', () => {
   it('should reset internal state when closing the modal', async () => {
     const user = userEvent.setup();
 
-    const { rerender } = await act(async () =>
-      render(
-        <SaptuneSolutionOperationModal
-          operation={SAPTUNE_SOLUTION_APPLY}
-          isOpen
-          isAppRunning
-        />
-      )
+    const { rerender } = await act(
+      async () =>
+        await act(() =>
+          render(
+            <SaptuneSolutionOperationModal
+              operation={SAPTUNE_SOLUTION_APPLY}
+              isOpen
+              isAppRunning
+            />
+          )
+        )
     );
 
     await user.click(screen.getByText('Select a saptune solution'));
@@ -65,7 +72,7 @@ describe('SaptuneSolutionOperationModal', () => {
 
     await user.click(screen.getByText('Cancel'));
 
-    await act(async () =>
+    await act(() =>
       rerender(
         <SaptuneSolutionOperationModal
           operation={SAPTUNE_SOLUTION_APPLY}
@@ -85,7 +92,7 @@ describe('SaptuneSolutionOperationModal', () => {
     const user = userEvent.setup();
     const onCancel = jest.fn();
 
-    await act(async () =>
+    await act(() =>
       render(
         <SaptuneSolutionOperationModal
           operation={SAPTUNE_SOLUTION_APPLY}
@@ -105,13 +112,15 @@ describe('SaptuneSolutionOperationModal', () => {
     const user = userEvent.setup();
     const mockOnRequest = jest.fn();
 
-    render(
-      <SaptuneSolutionOperationModal
-        operation={SAPTUNE_SOLUTION_APPLY}
-        isOpen
-        isHanaRunning
-        onRequest={mockOnRequest}
-      />
+    await act(() =>
+      render(
+        <SaptuneSolutionOperationModal
+          operation={SAPTUNE_SOLUTION_APPLY}
+          isOpen
+          isHanaRunning
+          onRequest={mockOnRequest}
+        />
+      )
     );
 
     expect(screen.getByText('Request')).toBeDisabled();
@@ -130,12 +139,14 @@ describe('SaptuneSolutionOperationModal', () => {
   it('should render Application solutions', async () => {
     const user = userEvent.setup();
 
-    render(
-      <SaptuneSolutionOperationModal
-        operation={SAPTUNE_SOLUTION_APPLY}
-        isOpen
-        isAppRunning
-      />
+    await act(() =>
+      render(
+        <SaptuneSolutionOperationModal
+          operation={SAPTUNE_SOLUTION_APPLY}
+          isOpen
+          isAppRunning
+        />
+      )
     );
 
     await user.click(screen.getByText('Select a saptune solution'));
@@ -147,13 +158,15 @@ describe('SaptuneSolutionOperationModal', () => {
   it('should render HANA and Application solutions', async () => {
     const user = userEvent.setup();
 
-    render(
-      <SaptuneSolutionOperationModal
-        operation={SAPTUNE_SOLUTION_APPLY}
-        isOpen
-        isHanaRunning
-        isAppRunning
-      />
+    await act(() =>
+      render(
+        <SaptuneSolutionOperationModal
+          operation={SAPTUNE_SOLUTION_APPLY}
+          isOpen
+          isHanaRunning
+          isAppRunning
+        />
+      )
     );
 
     await waitFor(async () => {
@@ -167,13 +180,15 @@ describe('SaptuneSolutionOperationModal', () => {
   it('should render proper options when a solution is currently applied', async () => {
     const user = userEvent.setup();
 
-    render(
-      <SaptuneSolutionOperationModal
-        operation={SAPTUNE_SOLUTION_CHANGE}
-        isOpen
-        isHanaRunning
-        currentlyApplied="HANA"
-      />
+    await act(() =>
+      render(
+        <SaptuneSolutionOperationModal
+          operation={SAPTUNE_SOLUTION_CHANGE}
+          isOpen
+          isHanaRunning
+          currentlyApplied="HANA"
+        />
+      )
     );
 
     expect(screen.getByText('HANA')).toBeInTheDocument();
@@ -188,13 +203,15 @@ describe('SaptuneSolutionOperationModal', () => {
   it('currently applied solution should be disabled', async () => {
     const user = userEvent.setup();
 
-    render(
-      <SaptuneSolutionOperationModal
-        operation={SAPTUNE_SOLUTION_CHANGE}
-        isOpen
-        isHanaRunning
-        currentlyApplied="HANA"
-      />
+    await act(() =>
+      render(
+        <SaptuneSolutionOperationModal
+          operation={SAPTUNE_SOLUTION_CHANGE}
+          isOpen
+          isHanaRunning
+          currentlyApplied="HANA"
+        />
+      )
     );
 
     await user.click(screen.getByRole('combobox', { name: 'solutions' }));

--- a/assets/js/common/OperationModals/SimpleAcceptanceOperationModal.test.jsx
+++ b/assets/js/common/OperationModals/SimpleAcceptanceOperationModal.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { waiveOperationDisclaimer } from '@lib/operations';
@@ -125,12 +125,14 @@ describe('SimpleAcceptanceOperationModal', () => {
       descriptionResolverArgs,
       expectedDescription,
     }) => {
-      render(
-        <SimpleAcceptanceOperationModal
-          operation={operation}
-          descriptionResolverArgs={descriptionResolverArgs}
-          isOpen
-        />
+      await act(() =>
+        render(
+          <SimpleAcceptanceOperationModal
+            operation={operation}
+            descriptionResolverArgs={descriptionResolverArgs}
+            isOpen
+          />
+        )
       );
 
       expect(screen.getByText(title)).toBeInTheDocument();
@@ -142,12 +144,14 @@ describe('SimpleAcceptanceOperationModal', () => {
     const user = userEvent.setup();
     const onRequest = jest.fn();
 
-    render(
-      <SimpleAcceptanceOperationModal
-        operation={SAP_INSTANCE_START}
-        isOpen
-        onRequest={onRequest}
-      />
+    await act(() =>
+      render(
+        <SimpleAcceptanceOperationModal
+          operation={SAP_INSTANCE_START}
+          isOpen
+          onRequest={onRequest}
+        />
+      )
     );
 
     expect(screen.getByText('Request')).toBeEnabled();
@@ -160,12 +164,14 @@ describe('SimpleAcceptanceOperationModal', () => {
     const user = userEvent.setup();
     const onCancel = jest.fn();
 
-    render(
-      <SimpleAcceptanceOperationModal
-        operation={SAP_INSTANCE_START}
-        isOpen
-        onCancel={onCancel}
-      />
+    await act(() =>
+      render(
+        <SimpleAcceptanceOperationModal
+          operation={SAP_INSTANCE_START}
+          isOpen
+          onCancel={onCancel}
+        />
+      )
     );
 
     await user.click(screen.getByText('Cancel'));

--- a/assets/js/common/PersonalAccessTokens/DeleteTokenModal.test.jsx
+++ b/assets/js/common/PersonalAccessTokens/DeleteTokenModal.test.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import DeleteTokenModal from './DeleteTokenModal';
 
 describe('DeleteTokenModal', () => {
   it('should show personal access token modal', async () => {
-    render(<DeleteTokenModal name="My token" isOpen />);
+    await act(() => render(<DeleteTokenModal name="My token" isOpen />));
 
     expect(screen.getByText('My token')).toBeInTheDocument();
   });
@@ -14,7 +14,9 @@ describe('DeleteTokenModal', () => {
   it('should run onDelete when the delete button is clicked', async () => {
     const user = userEvent.setup();
     const mockOnDelete = jest.fn();
-    render(<DeleteTokenModal isOpen onDelete={mockOnDelete} />);
+    await act(() =>
+      render(<DeleteTokenModal isOpen onDelete={mockOnDelete} />)
+    );
 
     await user.click(screen.getByRole('button', { name: 'Delete Token' }));
     expect(mockOnDelete).toHaveBeenCalled();
@@ -23,7 +25,7 @@ describe('DeleteTokenModal', () => {
   it('should run onClose when the close button is clicked', async () => {
     const user = userEvent.setup();
     const mockOnClose = jest.fn();
-    render(<DeleteTokenModal isOpen onClose={mockOnClose} />);
+    await act(() => render(<DeleteTokenModal isOpen onClose={mockOnClose} />));
 
     await user.click(screen.getByRole('button', { name: 'Close' }));
     expect(mockOnClose).toHaveBeenCalled();

--- a/assets/js/common/PersonalAccessTokens/GenerateTokenModal.test.jsx
+++ b/assets/js/common/PersonalAccessTokens/GenerateTokenModal.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import {
@@ -18,7 +18,9 @@ describe('GenerateTokenModal', () => {
     const user = userEvent.setup();
     const mockOnGenerate = jest.fn();
     const tokenName = 'My token';
-    render(<GenerateTokenModal isOpen onGenerate={mockOnGenerate} />);
+    await act(() =>
+      render(<GenerateTokenModal isOpen onGenerate={mockOnGenerate} />)
+    );
 
     expect(
       screen.getByRole('button', { name: 'Generate Token' })
@@ -41,7 +43,9 @@ describe('GenerateTokenModal', () => {
       const user = userEvent.setup();
       const mockOnGenerate = jest.fn();
       const tokenName = 'My token';
-      render(<GenerateTokenModal isOpen onGenerate={mockOnGenerate} />);
+      await act(() =>
+        render(<GenerateTokenModal isOpen onGenerate={mockOnGenerate} />)
+      );
 
       expect(
         screen.getByRole('button', { name: 'Generate Token' })
@@ -76,7 +80,9 @@ describe('GenerateTokenModal', () => {
   it('should run onClose when the close button is clicked', async () => {
     const user = userEvent.setup();
     const mockOnClose = jest.fn();
-    render(<GenerateTokenModal isOpen onClose={mockOnClose} />);
+    await act(() =>
+      render(<GenerateTokenModal isOpen onClose={mockOnClose} />)
+    );
 
     await user.click(screen.getByRole('button', { name: 'Close' }));
     expect(mockOnClose).toHaveBeenCalled();

--- a/assets/js/common/PersonalAccessTokens/NewTokenModal.test.jsx
+++ b/assets/js/common/PersonalAccessTokens/NewTokenModal.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { faker } from '@faker-js/faker';
@@ -12,7 +12,7 @@ describe('NewTokenModal', () => {
 
   it('should show new personal access token modal', async () => {
     const token = faker.internet.jwt();
-    render(<NewTokenModal accessToken={token} isOpen />);
+    await act(() => render(<NewTokenModal accessToken={token} isOpen />));
 
     expect(screen.getByText(token)).toBeInTheDocument();
   });
@@ -22,7 +22,7 @@ describe('NewTokenModal', () => {
     const token = faker.internet.jwt();
     jest.spyOn(window, 'prompt').mockReturnValue();
 
-    render(<NewTokenModal accessToken={token} isOpen />);
+    await act(() => render(<NewTokenModal accessToken={token} isOpen />));
 
     await user.click(screen.getByRole('button', { name: 'copy to clipboard' }));
 
@@ -32,7 +32,7 @@ describe('NewTokenModal', () => {
   it('should run onClose when the close button is clicked', async () => {
     const user = userEvent.setup();
     const mockOnClose = jest.fn();
-    render(<NewTokenModal isOpen onClose={mockOnClose} />);
+    await act(() => render(<NewTokenModal isOpen onClose={mockOnClose} />));
 
     await user.click(screen.getByRole('button', { name: 'Close' }));
     expect(mockOnClose).toHaveBeenCalled();

--- a/assets/js/common/ResetCheckCustomizationModal/ResetCheckCustomizationModal.test.jsx
+++ b/assets/js/common/ResetCheckCustomizationModal/ResetCheckCustomizationModal.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
@@ -11,7 +11,9 @@ describe('ResetCheckCustomizationModal component', () => {
   it('should render the reset check customization confirmation modal correctly', async () => {
     const checkId = faker.string.uuid();
 
-    render(<ResetCheckCustomizationModal checkId={checkId} open />);
+    await act(() =>
+      render(<ResetCheckCustomizationModal checkId={checkId} open />)
+    );
 
     expect(screen.getByText(`Reset check: ${checkId}`)).toBeVisible();
     expect(
@@ -30,12 +32,14 @@ describe('ResetCheckCustomizationModal component', () => {
   `('$scenario', async ({ button, callbackName }) => {
     const callback = jest.fn();
 
-    render(
-      <ResetCheckCustomizationModal
-        checkId={faker.string.uuid()}
-        open
-        {...{ [callbackName]: callback }}
-      />
+    await act(() =>
+      render(
+        <ResetCheckCustomizationModal
+          checkId={faker.string.uuid()}
+          open
+          {...{ [callbackName]: callback }}
+        />
+      )
     );
 
     await userEvent.click(screen.getByText(button));

--- a/assets/js/common/SuseManagerClearSettingsDialog/SuseManagerClearSettingsModal.test.jsx
+++ b/assets/js/common/SuseManagerClearSettingsDialog/SuseManagerClearSettingsModal.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
@@ -10,12 +10,14 @@ describe('SuseManagerClearSettingsModal', () => {
     const user = userEvent.setup();
     const onClearSettings = jest.fn();
 
-    render(
-      <SuseManagerClearSettingsModal
-        open
-        onClearSettings={onClearSettings}
-        onCancel={() => {}}
-      />
+    await act(() =>
+      render(
+        <SuseManagerClearSettingsModal
+          open
+          onClearSettings={onClearSettings}
+          onCancel={() => {}}
+        />
+      )
     );
 
     expect(
@@ -30,12 +32,14 @@ describe('SuseManagerClearSettingsModal', () => {
     const user = userEvent.setup();
     const onCancel = jest.fn();
 
-    render(
-      <SuseManagerClearSettingsModal
-        open
-        onClearSettings={() => {}}
-        onCancel={onCancel}
-      />
+    await act(() =>
+      render(
+        <SuseManagerClearSettingsModal
+          open
+          onClearSettings={() => {}}
+          onCancel={onCancel}
+        />
+      )
     );
 
     expect(

--- a/assets/js/common/SuseManagerSettingsDialog/SuseManagerSettingsModal.test.jsx
+++ b/assets/js/common/SuseManagerSettingsDialog/SuseManagerSettingsModal.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { faker } from '@faker-js/faker';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
@@ -10,8 +10,10 @@ import SuseManagerSettingsModal from '.';
 
 describe('SuseManagerSettingsModal component', () => {
   it('renders correctly', async () => {
-    render(
-      <SuseManagerSettingsModal open onSave={() => {}} onChange={() => {}} />
+    await act(() =>
+      render(
+        <SuseManagerSettingsModal open onSave={() => {}} onChange={() => {}} />
+      )
     );
 
     expect(screen.getByText('SUSE Manager URL')).toBeVisible();
@@ -29,15 +31,17 @@ describe('SuseManagerSettingsModal component', () => {
     const initialUsername = faker.word.noun();
     const certUploadDate = faker.date.recent();
 
-    render(
-      <SuseManagerSettingsModal
-        open
-        initialUrl={initialUrl}
-        initialUsername={initialUsername}
-        certUploadDate={certUploadDate}
-        onSave={() => {}}
-        onCancel={() => {}}
-      />
+    await act(() =>
+      render(
+        <SuseManagerSettingsModal
+          open
+          initialUrl={initialUrl}
+          initialUsername={initialUsername}
+          certUploadDate={certUploadDate}
+          onSave={() => {}}
+          onCancel={() => {}}
+        />
+      )
     );
 
     expect(screen.getByText('Certificate Uploaded')).toBeVisible();
@@ -55,8 +59,10 @@ describe('SuseManagerSettingsModal component', () => {
     const certificate = faker.lorem.text();
     const onSave = jest.fn();
 
-    render(
-      <SuseManagerSettingsModal open onSave={onSave} onCancel={() => {}} />
+    await act(() =>
+      render(
+        <SuseManagerSettingsModal open onSave={onSave} onCancel={() => {}} />
+      )
     );
 
     const urlInput = screen.getByPlaceholderText('Enter a URL');
@@ -91,15 +97,17 @@ describe('SuseManagerSettingsModal component', () => {
     const username = faker.word.noun();
     const onSave = jest.fn();
 
-    render(
-      <SuseManagerSettingsModal
-        initialUsername={faker.word.noun()}
-        initialUrl={faker.internet.url()}
-        certUploadDate={faker.date.recent()}
-        open
-        onSave={onSave}
-        onCancel={() => {}}
-      />
+    await act(() =>
+      render(
+        <SuseManagerSettingsModal
+          initialUsername={faker.word.noun()}
+          initialUrl={faker.internet.url()}
+          certUploadDate={faker.date.recent()}
+          open
+          onSave={onSave}
+          onCancel={() => {}}
+        />
+      )
     );
 
     const urlInput = screen.getByPlaceholderText('Enter a URL');
@@ -137,15 +145,17 @@ describe('SuseManagerSettingsModal component', () => {
       },
     ];
 
-    render(
-      <SuseManagerSettingsModal
-        initialUsername={faker.word.noun()}
-        initialUrl={faker.internet.url()}
-        errors={errors}
-        open
-        onSave={() => {}}
-        onCancel={() => {}}
-      />
+    await act(() =>
+      render(
+        <SuseManagerSettingsModal
+          initialUsername={faker.word.noun()}
+          initialUrl={faker.internet.url()}
+          errors={errors}
+          open
+          onSave={() => {}}
+          onCancel={() => {}}
+        />
+      )
     );
 
     expect(screen.getAllByText(detail)).toHaveLength(2);

--- a/assets/js/pages/Profile/ProfileForm.test.jsx
+++ b/assets/js/pages/Profile/ProfileForm.test.jsx
@@ -103,14 +103,16 @@ describe('ProfileForm', () => {
     const user = userEvent.setup();
     const onModalToggle = jest.fn();
 
-    render(<ProfileForm togglePasswordModal={onModalToggle} />);
+    await act(() =>
+      render(<ProfileForm togglePasswordModal={onModalToggle} />)
+    );
     await user.click(screen.getByRole('button', { name: 'Change Password' }));
 
     expect(onModalToggle).toHaveBeenCalled();
   });
 
-  it('should open the modal when the modal open props is set to true', () => {
-    render(<ProfileForm passwordModalOpen />);
+  it('should open the modal when the modal open props is set to true', async () => {
+    await act(() => render(<ProfileForm passwordModalOpen />));
 
     expect(screen.getByText('Current Password')).toBeVisible();
   });


### PR DESCRIPTION
# Description

Fix `act not wrapped` error in frontend modal tests. When a modal is rendered, it needs to wait until it is completely mounted.
That's why we need to wrap it in an `act`.
Don't get scared by the added lines, everything is just putting `act` in every modal render.

This is the error:
```
An update to TransitionRootFn inside a test was not wrapped in act(...).
      When testing, code that causes React state updates should be wrapped into act(...):
      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */
```

Besides this, I have fixed other error output in `ActivityLogsSettingsModal` test

## How was this tested?

UT

## Did you update the documentation?

No need
