### PR TITLE
Fix polyfilled warning in frontend UT

### DIFF
--- a/assets/jest.config.js
+++ b/assets/jest.config.js
@@ -171,10 +171,10 @@ module.exports = {
   // runner: "jest-runner",
 
   // The paths to modules that run some code to configure or set up the testing environment before each test
-  setupFiles: ['./setupTests.js'],
+  // setupFiles: [],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  // setupFilesAfterEnv: [],
+  setupFilesAfterEnv: ['./setupTests.js'],
 
   // The number of seconds after which a test is considered as slow and reported as such in the results.
   // slowTestThreshold: 5,

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -79,6 +79,7 @@
         "jest": "^30.3.0",
         "jest-environment-jsdom": "^30.3.0",
         "jest-junit": "^16.0.0",
+        "jsdom-testing-mocks": "^1.16.0",
         "postcss": "^8.5.12",
         "postcss-import": "^16.1.1",
         "prettier": "^3.8.1",
@@ -6676,6 +6677,13 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/bezier-easing": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bezier-easing/-/bezier-easing-2.1.0.tgz",
+      "integrity": "sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -7453,6 +7461,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/css-mediaquery": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+      "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==",
+      "dev": true,
+      "license": "BSD"
     },
     "node_modules/css-select": {
       "version": "4.3.0",
@@ -11975,6 +11990,20 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom-testing-mocks": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/jsdom-testing-mocks/-/jsdom-testing-mocks-1.16.0.tgz",
+      "integrity": "sha512-wLrulXiLpjmcUYOYGEvz4XARkrmdVpyxzdBl9IAMbQ+ib2/UhUTRCn49McdNfXLff2ysGBUms49ZKX0LR1Q0gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bezier-easing": "^2.1.0",
+        "css-mediaquery": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/jsesc": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -38,6 +38,7 @@
     "jest-environment-jsdom": "^30.3.0",
     "jest-junit": "^16.0.0",
     "postcss": "^8.5.12",
+    "jsdom-testing-mocks": "^1.16.0",
     "postcss-import": "^16.1.1",
     "prettier": "^3.8.1",
     "redux-mock-store": "^1.5.5",

--- a/assets/setupTests.js
+++ b/assets/setupTests.js
@@ -1,3 +1,8 @@
+import { mockAnimationsApi } from 'jsdom-testing-mocks';
+
+// Silence the Headless UI warning globally
+mockAnimationsApi();
+
 global.ResizeObserver = jest.fn().mockImplementation(() => ({
   observe: jest.fn(),
   unobserve: jest.fn(),


### PR DESCRIPTION
# Description

Fix jest tests warning for animations.

```
console.warn
      Headless UI has polyfilled `Element.prototype.getAnimations` for your tests.
      Please install a proper polyfill e.g. `jsdom-testing-mocks`, to silence these warnings.
      
      Example usage:
      ```js
      import { mockAnimationsApi } from 'jsdom-testing-mocks'
      mockAnimationsApi()
      ```
```
I just followed the warning recommendation. It works fine.


## How was this tested?

UT

## Did you update the documentation?
No need
