### PR TITLE
Analytics Modal Docs Link

### DIFF
--- a/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.jsx
+++ b/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.jsx
@@ -20,7 +20,7 @@ function AnalyticsEulaModal({ isOpen = false, onEnable, onCancel }) {
       Allow the collection of{' '}
       <a
         className="text-jungle-green-500 hover:opacity-75"
-        href="https://trento-project.io/docs/user-guide/trento-analytics"
+        href="https://documentation.suse.com/sles-sap/trento/single-html/SLES-SAP-trento/SLES-SAP-trento.html#sec-trento-analytics"
         target="_blank"
         rel="noreferrer"
       >

--- a/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.jsx
+++ b/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.jsx
@@ -20,7 +20,7 @@ function AnalyticsEulaModal({ isOpen = false, onEnable, onCancel }) {
       Allow the collection of{' '}
       <a
         className="text-jungle-green-500 hover:opacity-75"
-        href="https://trento-project.io/docs"
+        href="https://trento-project.io/docs/user-guide/trento-analytics"
         target="_blank"
         rel="noreferrer"
       >

--- a/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.test.jsx
+++ b/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.test.jsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import AnalyticsEulaModal from './AnalyticsEulaModal';
@@ -72,22 +72,14 @@ describe('Analytics Eula Modal component', () => {
   });
 
   it('should open a new window with the docs url when the link is clicked', async () => {
-    const user = userEvent.setup();
-    const mockOpen = jest.spyOn(window, 'open').mockImplementation(() => {});
-
-    render(<AnalyticsEulaModal isOpen />);
+    await act(() => render(<AnalyticsEulaModal isOpen />));
 
     const linkElement = screen.getByRole('link', { name: 'anonymous metrics' });
-    linkElement.onclick = mockOpen;
 
     expect(linkElement).toHaveProperty('target', '_blank');
     expect(linkElement).toHaveProperty(
       'href',
       'https://trento-project.io/docs/user-guide/trento-analytics'
     );
-
-    await user.click(linkElement);
-
-    expect(mockOpen).toHaveBeenCalled();
   });
 });

--- a/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.test.jsx
+++ b/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.test.jsx
@@ -79,7 +79,7 @@ describe('Analytics Eula Modal component', () => {
     expect(linkElement).toHaveProperty('target', '_blank');
     expect(linkElement).toHaveProperty(
       'href',
-      'https://trento-project.io/docs/user-guide/trento-analytics'
+      'https://documentation.suse.com/sles-sap/trento/single-html/SLES-SAP-trento/SLES-SAP-trento.html#sec-trento-analytics'
     );
   });
 });

--- a/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.test.jsx
+++ b/assets/js/pages/AnalyticsEula/AnalyticsEulaModal.test.jsx
@@ -70,4 +70,24 @@ describe('Analytics Eula Modal component', () => {
 
     expect(mockOnCancel).toHaveBeenCalledWith(true);
   });
+
+  it('should open a new window with the docs url when the link is clicked', async () => {
+    const user = userEvent.setup();
+    const mockOpen = jest.spyOn(window, 'open').mockImplementation(() => {});
+
+    render(<AnalyticsEulaModal isOpen />);
+
+    const linkElement = screen.getByRole('link', { name: 'anonymous metrics' });
+    linkElement.onclick = mockOpen;
+
+    expect(linkElement).toHaveProperty('target', '_blank');
+    expect(linkElement).toHaveProperty(
+      'href',
+      'https://trento-project.io/docs/user-guide/trento-analytics'
+    );
+
+    await user.click(linkElement);
+
+    expect(mockOpen).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
# Description

This PR adds the link to the documentation page which relates to the "anonymous metrics" link which is displayed in the Analytics modal.

**Analytics Modal**
<img width="1509" height="791" alt="Screenshot 2026-05-04 at 11 08 46" src="https://github.com/user-attachments/assets/e55ff615-63da-4bb3-9cb2-ccda45c1695e" />

**Documentation Page**
<img width="1509" height="791" alt="Screenshot 2026-05-04 at 15 40 08" src="https://github.com/user-attachments/assets/f26a900c-d3a6-44de-82ed-c974147ba73b" />

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [x] **DONE** Visually
- [x] **DONE** Added a test to check for the analytics link

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [x] **DONE** User Documentation was updated in [PR 185](https://github.com/trento-project/docs/pull/185)
