### PR TITLE
Fix storybook PLACES not found warning

### DIFF
--- a/assets/js/common/DisabledGuard/DisabledGuard.stories.jsx
+++ b/assets/js/common/DisabledGuard/DisabledGuard.stories.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
 import Button from '@common/Button';
-import Tooltip from '@common/Tooltip';
-import { PLACES } from '@common/Tooltip/Tooltip';
+import Tooltip, { PLACES } from '@common/Tooltip';
 
 import DisabledGuard from '.';
 

--- a/assets/js/common/Tooltip/Tooltip.stories.jsx
+++ b/assets/js/common/Tooltip/Tooltip.stories.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import Tooltip from '.';
-import { PLACES } from './Tooltip';
+import Tooltip, { PLACES } from '.';
 
 export default {
   title: 'Components/Tooltip',

--- a/assets/js/common/Tooltip/index.js
+++ b/assets/js/common/Tooltip/index.js
@@ -1,3 +1,5 @@
-import Tooltip from './Tooltip';
+import Tooltip, { PLACES } from './Tooltip';
+
+export { PLACES };
 
 export default Tooltip;


### PR DESCRIPTION
# Description

Fix issue in storybook imports:
```
 export 'PLACES' (imported as 'PLACES') was not found in '@common/Tooltip'
│  (possible exports: default)
```
This was happening in `OperationButton.stories.jsx` as it imports `PLACES` as `import { PLACES } from '@common/Tooltip';`

## How was this tested?

No need

## Did you update the documentation?

No need
