### PR TITLE
Add navigation links for clusters, SAP systems and databases in tables

### DIFF
--- a/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
@@ -13,8 +13,9 @@ import {
   hostFactory,
   saptuneStatusFactory,
   databaseInstanceFactory,
+  sapSystemApplicationInstanceFactory,
 } from '@lib/test-utils/factories';
-import { DATABASE_TYPE } from '@lib/model/sapSystems';
+import { APPLICATION_TYPE, DATABASE_TYPE } from '@lib/model/sapSystems';
 import {
   SAPTUNE_SOLUTION_APPLY,
   SAPTUNE_SOLUTION_CHANGE,
@@ -157,6 +158,68 @@ describe('HostDetails component', () => {
         expect(screen.getByText('Last Boot').nextSibling.textContent).toBe(
           '11 Jan 2024, 13:30:00'
         );
+      });
+    });
+  });
+
+  describe('SLES subscriptions', () => {
+    it('should format SLES subscription dates using provided timezone prop', () => {
+      renderWithRouter(
+        <HostDetails
+          agentVersion="1.0.0"
+          userAbilities={userAbilities}
+          timezone="Pacific/Kiritimati"
+          slesSubscriptions={[
+            {
+              starts_at: '2024-01-10T23:30:00Z',
+              expires_at: '2024-01-11T23:30:00Z',
+              status: 'active',
+              subscription_id: 'sub-1',
+            },
+          ]}
+        />
+      );
+
+      expect(screen.getByText('11 Jan 2024, 13:30:00')).toBeVisible();
+      expect(screen.getByText('11 Jan 2024, 13:30:00')).toBeVisible();
+    });
+  });
+
+  describe('SAP instances', () => {
+    it('should show SAP instances in host', () => {
+      const sapInstances = databaseInstanceFactory
+        .buildList(2)
+        .map((inst) => ({ ...inst, type: DATABASE_TYPE }))
+        .concat(
+          sapSystemApplicationInstanceFactory
+            .buildList(2)
+            .map((inst) => ({ ...inst, type: APPLICATION_TYPE }))
+        );
+      renderWithRouter(
+        <HostDetails
+          agentVersion="1.0.0"
+          userAbilities={userAbilities}
+          sapInstances={sapInstances}
+        />
+      );
+
+      const heading = screen.getByRole('heading', { name: 'SAP instances' });
+      const section = heading.closest('div').nextSibling;
+      const table = within(section).getByRole('table');
+      const rows = table.querySelectorAll('tbody > tr');
+
+      sapInstances.forEach((instance, index) => {
+        const row = rows[index];
+        const healthIcon = within(row).getByTestId('eos-svg-component');
+        expect(healthIcon).toBeInTheDocument();
+        const sidLink = within(row).getByRole('link', { name: instance.sid });
+        const href = instance.database_id
+          ? `/databases/${instance.database_id}`
+          : `/sap_systems/${instance.sap_system_id}`;
+        expect(sidLink).toHaveAttribute('href', href);
+        expect(
+          within(row).getByText(instance.instance_number)
+        ).toBeInTheDocument();
       });
     });
   });
@@ -687,27 +750,6 @@ describe('HostDetails component', () => {
           exact: false,
         })
       ).toBeVisible();
-    });
-
-    it('should format SLES subscription dates using provided timezone prop', () => {
-      renderWithRouter(
-        <HostDetails
-          agentVersion="1.0.0"
-          userAbilities={userAbilities}
-          timezone="Pacific/Kiritimati"
-          slesSubscriptions={[
-            {
-              starts_at: '2024-01-10T23:30:00Z',
-              expires_at: '2024-01-11T23:30:00Z',
-              status: 'active',
-              subscription_id: 'sub-1',
-            },
-          ]}
-        />
-      );
-
-      expect(screen.getByText('11 Jan 2024, 13:30:00')).toBeVisible();
-      expect(screen.getByText('11 Jan 2024, 13:30:00')).toBeVisible();
     });
   });
 });

--- a/assets/js/pages/HostDetailsPage/tableConfigs.jsx
+++ b/assets/js/pages/HostDetailsPage/tableConfigs.jsx
@@ -1,4 +1,8 @@
 import React from 'react';
+import { capitalize } from 'lodash';
+
+import SapSystemLink from '@common/SapSystemLink';
+import HealthIcon from '@common/HealthIcon';
 import { Features } from '@pages/SapSystemDetails';
 
 import { getInstanceID } from '@state/instances';
@@ -46,12 +50,27 @@ export const sapInstancesTableConfiguration = {
   usePadding: false,
   columns: [
     {
-      title: 'ID',
-      key: '',
-      render: (_content, item) => getInstanceID(item),
+      title: 'Health',
+      key: 'health',
+      render: (content) => (
+        <div className="ml-3">
+          <HealthIcon health={content} />
+        </div>
+      ),
     },
-    { title: 'SID', key: 'sid' },
-    { title: 'Type', key: 'type' },
+    {
+      title: 'SID',
+      key: 'sid',
+      render: (_content, item) => (
+        <SapSystemLink
+          systemType={item?.type}
+          sapSystemId={getInstanceID(item)}
+        >
+          {item?.sid}
+        </SapSystemLink>
+      ),
+    },
+    { title: 'Type', key: 'type', render: capitalize },
     {
       title: 'Features',
       key: 'features',

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
@@ -19,6 +19,7 @@ import { renderWithRouter } from '@lib/test-utils';
 import userEvent from '@testing-library/user-event';
 
 import {
+  clusterFactory,
   hostFactory,
   sapSystemApplicationInstanceFactory,
   sapSystemFactory,
@@ -260,6 +261,37 @@ describe('GenericSystemDetails', () => {
     expect(getByTextSite2('Operation Mode').nextSibling).toHaveTextContent(
       instance2.system_replication_operation_mode
     );
+  });
+
+  it('should render hosts table', () => {
+    const cluster = clusterFactory.build({ type: 'hana_scale_up' });
+    const host = hostFactory.build({ cluster });
+    const sapSystem = sapSystemFactory.build({
+      instances: sapSystemApplicationInstanceFactory.buildList(5),
+      hosts: [host],
+    });
+
+    renderWithRouter(
+      <GenericSystemDetails
+        title={faker.string.uuid()}
+        system={sapSystem}
+        userAbilities={[{ name: 'all', resource: 'all' }]}
+        cleanUpPermittedFor={[]}
+        type={APPLICATION_TYPE}
+      />
+    );
+
+    const heading = screen.getByRole('heading', { name: 'Hosts' });
+    const section = heading.closest('div').nextSibling;
+    const table = within(section).getByRole('table');
+    const row = table.querySelector('tbody > tr');
+    const hostLink = within(row).getByRole('link', { name: host.hostname });
+    expect(hostLink).toHaveAttribute('href', `/hosts/${host.id}`);
+    const clusterLink = within(row).getByRole('link', {
+      name: cluster.name,
+    });
+    expect(clusterLink).toHaveAttribute('href', `/clusters/${cluster.id}`);
+    expect(within(row).getByText(host.agent_version)).toBeInTheDocument();
   });
 
   it('should render a cleanup button and correct health icon when absent instances exist', () => {

--- a/assets/js/pages/SapSystemDetails/tableConfigs.jsx
+++ b/assets/js/pages/SapSystemDetails/tableConfigs.jsx
@@ -10,8 +10,9 @@ import ProviderLabel from '@common/ProviderLabel';
 import CleanUpButton from '@common/CleanUpButton';
 import Tooltip from '@common/Tooltip';
 import HealthIcon from '@common/HealthIcon';
-
 import OperationsButton from '@common/OperationsButton';
+
+import ClusterLink from '@pages/ClusterDetails/ClusterLink';
 
 import Features from './Features';
 import InstanceStatus from './InstanceStatus';
@@ -149,7 +150,7 @@ export const systemHostsTableConfiguration = {
     {
       title: 'Cluster',
       key: 'cluster',
-      render: (cluster) => cluster?.name,
+      render: (cluster) => <ClusterLink cluster={cluster} />,
     },
     {
       title: 'Agent version',

--- a/test/e2e/cypress/e2e/host_details.cy.js
+++ b/test/e2e/cypress/e2e/host_details.cy.js
@@ -136,6 +136,10 @@ context('Host Details', () => {
     it('should show SAP instance data', () => {
       hostDetailsPage.sapSystemsTableDisplaysExpectedData();
     });
+
+    it('should have a correct link to the SAP system', () => {
+      hostDetailsPage.sapSystemHasTheExpectedLink();
+    });
   });
 
   describe('SLES subscriptions details for this host should be displayed', () => {

--- a/test/e2e/cypress/e2e/sap_system_details.cy.js
+++ b/test/e2e/cypress/e2e/sap_system_details.cy.js
@@ -52,6 +52,10 @@ context('SAP system details', () => {
       sapSystemDetailsPage.eachHostHasTheExpectedLink();
     });
 
+    it('should have a correct link to the cluster', () => {
+      sapSystemDetailsPage.eachHostHasTheExpectedClusterLink();
+    });
+
     it('should show every host with its data', () => {
       sapSystemDetailsPage.eachHostHasTheExpectedData();
     });

--- a/test/e2e/cypress/fixtures/host-details/selected_host.js
+++ b/test/e2e/cypress/fixtures/host-details/selected_host.js
@@ -46,9 +46,9 @@ export const selectedHost = {
     provider: 'VMware',
   },
   sapInstance: {
-    id: '6c9208eb-a5bb-57ef-be5c-6422dedab602',
+    health: '',
     sid: 'HDP',
-    type: 'database',
+    type: 'Database',
     features: ['HDB', 'HDB_WORKER'],
     instanceNumber: '10',
   },
@@ -74,4 +74,8 @@ export const selectedHost = {
       expiresAt: '',
     },
   ],
+};
+
+export const attachedSapInstance = {
+  id: '6c9208eb-a5bb-57ef-be5c-6422dedab602',
 };

--- a/test/e2e/cypress/fixtures/sap-system-details/selected_system.js
+++ b/test/e2e/cypress/fixtures/sap-system-details/selected_system.js
@@ -56,6 +56,7 @@ export const attachedHosts = [
     Addresses: ['10.100.1.21', '10.100.1.25'],
     Provider: 'Azure',
     Cluster: 'netweaver_cluster',
+    ClusterId: '5284f376-c1f4-5178-8966-d490df3dab4f',
     Version: '2.1.0',
   },
   {
@@ -64,6 +65,7 @@ export const attachedHosts = [
     Addresses: ['10.100.1.23', '10.100.1.27'],
     Provider: 'Azure',
     Cluster: '',
+    ClusterId: '',
     Version: '2.1.0',
   },
   {
@@ -72,6 +74,7 @@ export const attachedHosts = [
     Addresses: ['10.100.1.24', '10.100.1.28'],
     Provider: 'Azure',
     Cluster: '',
+    ClusterId: '',
     Version: '2.1.0',
   },
   {
@@ -80,6 +83,7 @@ export const attachedHosts = [
     Addresses: ['10.100.1.22', '10.100.1.26'],
     Provider: 'Azure',
     Cluster: 'netweaver_cluster',
+    ClusterId: '5284f376-c1f4-5178-8966-d490df3dab4f',
     Version: '2.1.0',
   },
 ];

--- a/test/e2e/cypress/pageObject/host_details_po.js
+++ b/test/e2e/cypress/pageObject/host_details_po.js
@@ -5,7 +5,10 @@ import { capitalize } from 'lodash';
 
 // Test Data
 import * as sumaMocks from '../fixtures/suma-software-updates/software_updates.js';
-import { selectedHost } from '../fixtures/host-details/selected_host.js';
+import {
+  selectedHost,
+  attachedSapInstance,
+} from '../fixtures/host-details/selected_host.js';
 import {
   saptuneDetailsData,
   saptuneDetailsDataUnsupportedVersion,
@@ -411,6 +414,13 @@ export const slesSubscriptionsTableDisplaysExpectedData = () =>
 
 export const sapSystemsTableDisplaysExpectedData = () =>
   _genericTableValidation('SAP instances', selectedHost);
+
+export const sapSystemHasTheExpectedLink = () => {
+  const tableCellSelector = `div:contains("SAP instances") table tbody tr:eq(0) td:eq(1) a`;
+  cy.get(tableCellSelector).click();
+  basePage.validateUrl(`/databases/${attachedSapInstance.id}`);
+  return cy.go('back');
+};
 
 export const heartbeatFailingToasterIsDisplayed = () =>
   cy.get(heartbeatFailingToaster, { timeout: 20000 }).should('be.visible');

--- a/test/e2e/cypress/pageObject/sap_system_details_po.js
+++ b/test/e2e/cypress/pageObject/sap_system_details_po.js
@@ -94,9 +94,20 @@ export const eachHostHasTheExpectedLink = () =>
     return cy.go('back');
   });
 
+export const eachHostHasTheExpectedClusterLink = () =>
+  cy.wrap(attachedHosts).each((host, index) => {
+    if (!host.ClusterId) return;
+    const tableCellSelector = `div[class="mt-8"]:contains("Hosts") table tbody tr:eq(${index}) td:eq(3) a`;
+    cy.get(tableCellSelector).click();
+    basePage.validateUrl(`/clusters/${host.ClusterId}`);
+    return cy.go('back');
+  });
+
 export const eachHostHasTheExpectedData = () =>
   cy.wrap(attachedHosts).each((host, index) => {
-    const keys = Object.keys(host).filter((key) => key !== 'AgentId');
+    const keys = Object.keys(host).filter(
+      (key) => !['AgentId', 'ClusterId'].includes(key)
+    );
     return cy.wrap(keys).each((key, rowIndex) => {
       const tableCellSelector = `div[class="mt-8"]:contains("Hosts") table tbody tr:eq(${index}) td:eq(${rowIndex})`;
       const expectedValue =


### PR DESCRIPTION
# Description

Add navigation links for clusters, SAP systems and databases in tables.
I have removed the ID column in the SAP instances table and replace it with health.
Once the link is there the ID is not informative.

SAP system details:
<img width="1311" height="485" alt="image" src="https://github.com/user-attachments/assets/c9236174-6ebd-4f77-81b0-dfd06da34eae" />

Database details:
<img width="1312" height="315" alt="image" src="https://github.com/user-attachments/assets/bcf2de40-5a43-41b2-8a71-db25b885f91d" />

Host details view:
<img width="1292" height="215" alt="image" src="https://github.com/user-attachments/assets/2d43d58d-fa10-4985-a61e-aedc33c7adc3" />
<img width="1273" height="203" alt="image" src="https://github.com/user-attachments/assets/208b9532-cc92-4d9e-abd3-2926a32ffb98" />



## How was this tested?

UT

## Did you update the documentation?

No need
