### PR TITLE
Fix timezone flaky test

### DIFF
--- a/assets/js/lib/test-utils/factories/users.js
+++ b/assets/js/lib/test-utils/factories/users.js
@@ -2,6 +2,13 @@ import { faker } from '@faker-js/faker';
 import { Factory } from 'fishery';
 import { formatISO } from 'date-fns';
 
+import { timezones } from '@lib/timezones';
+
+// use the actual timezones from prduction code instead of faker.location.timeZone()
+// to avoid flaky test failures when the random pick lands on a filtered zone.
+export const fakeAppTimezone = () =>
+  faker.helpers.arrayElement(timezones).value;
+
 export const abilityFactory = Factory.define(() => ({
   id: faker.number.int(),
   name: faker.word.noun(),
@@ -20,7 +27,7 @@ export const userFactory = Factory.define(() => ({
   totp_enabled_at: formatISO(faker.date.past()),
   analytics_enabled: faker.datatype.boolean(),
   analytics_eula_enabled: faker.datatype.boolean(),
-  timezone: faker.location.timeZone(),
+  timezone: fakeAppTimezone(),
   last_login_at: formatISO(faker.date.past()),
   created_at: formatISO(faker.date.past()),
   updated_at: formatISO(faker.date.past()),
@@ -36,7 +43,7 @@ export const profileFactory = Factory.define(() => ({
   totp_enabled: faker.datatype.boolean(),
   analytics_enabled: faker.datatype.boolean(),
   analytics_eula_accepted: faker.datatype.boolean(),
-  timezone: faker.location.timeZone(),
+  timezone: fakeAppTimezone(),
   created_at: formatISO(faker.date.past()),
   updated_at: formatISO(faker.date.past()),
 }));

--- a/assets/js/pages/Users/Users.test.jsx
+++ b/assets/js/pages/Users/Users.test.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import '@testing-library/jest-dom';
 import { screen, render, waitFor } from '@testing-library/react';
-import { adminUser, userFactory } from '@lib/test-utils/factories/users';
+import {
+  adminUser,
+  fakeAppTimezone,
+  userFactory,
+} from '@lib/test-utils/factories/users';
 import { renderWithRouter } from '@lib/test-utils';
 import { userEvent } from '@testing-library/user-event';
 import Users from './Users';
-import { faker } from '@faker-js/faker';
 import { DEFAULT_TIMEZONE } from '@lib/timezones';
 
 describe('Users', () => {
@@ -31,7 +34,7 @@ describe('Users', () => {
 
   it('should render an empty table with an enabled create user button', () => {
     render(<Users loading={false} />, {
-      initialState: { user: { timezone: faker.location.timeZone() } },
+      initialState: { user: { timezone: fakeAppTimezone() } },
     });
     const button = screen.getByRole('button', { name: /Create User/i });
     expect(button).not.toBeDisabled();

--- a/assets/js/pages/Users/UsersPage.test.jsx
+++ b/assets/js/pages/Users/UsersPage.test.jsx
@@ -7,14 +7,16 @@ import { toast } from 'react-hot-toast';
 import { networkClient } from '@lib/network';
 import { screen, act, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
-import { adminUser, userFactory } from '@lib/test-utils/factories/users';
+import {
+  adminUser,
+  fakeAppTimezone,
+  userFactory,
+} from '@lib/test-utils/factories/users';
 import {
   defaultInitialState,
   renderWithRouter,
   withState,
 } from '@lib/test-utils';
-import { faker } from '@faker-js/faker';
-
 import UsersPage from './UsersPage';
 
 const axiosMock = new MockAdapter(networkClient);
@@ -140,7 +142,7 @@ describe('UsersPage', () => {
 
     await act(async () => {
       renderUsersPage({
-        user: { timezone: faker.location.timeZone() },
+        user: { timezone: fakeAppTimezone() },
       });
     });
 


### PR DESCRIPTION
# Description

Fix a flaky test related to `faker.location.timeZone()` not being among the actual timezones that the app uses.

Fixes

This run for instance
https://github.com/trento-project/web/actions/runs/25361655478/job/74362818110#step:5:425