### PR TITLE
Add Filesystem type filter to File System Capacity chart

### DIFF
--- a/assets/js/common/FilesystemCharts/MountpointsChart.jsx
+++ b/assets/js/common/FilesystemCharts/MountpointsChart.jsx
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
+import React, { useState } from 'react';
 import classNames from 'classnames';
 
-import { keys, values, map } from 'lodash';
+import { keys, values, map, uniq, flow, orderBy, pickBy, xor } from 'lodash';
 
 import {
   Chart as ChartJS,
@@ -18,6 +18,8 @@ import {
 import { Bar } from 'react-chartjs-2';
 import { formatBytes } from '@lib/charts';
 
+import Pill from '@common/Pill';
+
 ChartJS.register(
   CategoryScale,
   LinearScale,
@@ -27,10 +29,36 @@ ChartJS.register(
   Legend
 );
 
+const initialActiveFsTypes = ['gpfs', 'nfs', 'xfs', 'nfs4'];
+
+// getFsTypes gets all uniq and sorted filesystem types from
+// the given mountpoints
+const getFsTypes = flow([values, (arr) => map(arr, 'fsType'), uniq, orderBy]);
+
 function MountpointsChart({ mountpoints, className }) {
-  const mountpointsLabels = keys(mountpoints);
-  const used = map(values(mountpoints), ({ usedBytes }) => usedBytes);
-  const available = map(values(mountpoints), ({ availBytes }) => availBytes);
+  // Get all FS types and store in state as initial selected types
+  const allFsTypes = getFsTypes(mountpoints);
+  const initialFsTypes = allFsTypes.filter((fsType) =>
+    initialActiveFsTypes.includes(fsType)
+  );
+
+  const [selectedTypes, setSelectedTypes] = useState(initialFsTypes);
+
+  // Filter the mountpoints based on selection
+  const filteredMountpoints = pickBy(mountpoints, (mountpoint) =>
+    selectedTypes.includes(mountpoint.fsType)
+  );
+
+  const mountpointsLabels = keys(filteredMountpoints);
+  const used = map(values(filteredMountpoints), ({ usedBytes }) => usedBytes);
+  const available = map(
+    values(filteredMountpoints),
+    ({ availBytes }) => availBytes
+  );
+
+  const toggleType = (type) => {
+    setSelectedTypes((prev) => xor(prev, [type]));
+  };
 
   const mountpointsData = {
     labels: mountpointsLabels,
@@ -71,8 +99,10 @@ function MountpointsChart({ mountpoints, className }) {
         callbacks: {
           beforeBody(tooltipItem) {
             const mountpoint = tooltipItem[0].label;
-            const device = mountpoints[mountpoint].device;
-            return `Device: ${device}`;
+            const currentMountpoint = filteredMountpoints[mountpoint];
+            const device = currentMountpoint.device;
+            const fsType = currentMountpoint.fsType;
+            return `Device: ${device}\nFS type: ${fsType}`;
           },
           label(tooltipItem) {
             const label = tooltipItem.dataset.label;
@@ -96,6 +126,22 @@ function MountpointsChart({ mountpoints, className }) {
       )}
     >
       <h2 className="font-bold text-center text-xl">File System Capacity</h2>
+      <div className="flex flex-wrap justify-center gap-2 mt-4">
+        {allFsTypes.map((type) => (
+          <Pill
+            key={type}
+            onClick={() => toggleType(type)}
+            className={classNames(
+              'cursor-pointer bg-green-100 text-green-800',
+              {
+                'opacity-50': !selectedTypes.includes(type),
+              }
+            )}
+          >
+            {type}
+          </Pill>
+        ))}
+      </div>
       <div className="pt-6 relative text-center h-[92%] w-full flex justify-center h-[350px]">
         <Bar options={mountpointsChartOptions} data={mountpointsData} />
       </div>

--- a/assets/js/common/FilesystemCharts/MountpointsChart.stories.jsx
+++ b/assets/js/common/FilesystemCharts/MountpointsChart.stories.jsx
@@ -23,21 +23,25 @@ export const Default = {
         usedBytes: 8589934592, // 8 GB
         availBytes: 12884901888, // 12 GB
         device: '/dev/sda1',
+        fsType: 'btrfs',
       },
       '/home': {
         usedBytes: 53687091200, // 50 GB
         availBytes: 53687091200, // 50 GB
         device: '/dev/sda2',
+        fsType: 'xfs',
       },
       '/boot/efi': {
         usedBytes: 52428800, // 50 MB
         availBytes: 471859200, // 450 MB
         device: '/dev/nvme0n1p1',
+        fsType: 'vfat',
       },
       '/var/log': {
         usedBytes: 2147483648, // 2GB
         availBytes: 8589934592, // 8GB
         device: '/dev/mapper/system-var_log',
+        fsType: 'xfs',
       },
     },
   },
@@ -51,6 +55,7 @@ export const FullDisk = {
         usedBytes: 1099511627776, // 1 TB
         availBytes: 1073741824, // 1 GB
         device: '/dev/sdb1',
+        fsType: 'xfs',
       },
     },
   },

--- a/assets/js/common/FilesystemCharts/MountpointsChart.test.jsx
+++ b/assets/js/common/FilesystemCharts/MountpointsChart.test.jsx
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+
+import MountpointsChart from './MountpointsChart';
+
+const testMountpoints = {
+  '/': {
+    device: '/dev/sda1',
+    fsType: 'btrfs',
+  },
+  '/home': {
+    device: '/dev/sda2',
+    fsType: 'xfs',
+  },
+  '/boot/efi': {
+    device: '/dev/nvme0n1p1',
+    fsType: 'vfat',
+  },
+  '/var/log': {
+    device: '/dev/mapper/system-var_log',
+    fsType: 'xfs',
+  },
+};
+
+describe('MountpointsChart', () => {
+  it('should display all FS types as filters', () => {
+    render(<MountpointsChart mountpoints={testMountpoints} />);
+
+    expect(screen.getByText('btrfs')).toBeInTheDocument();
+    const xfsLabels = screen.getAllByText('xfs');
+    expect(xfsLabels).toHaveLength(1);
+    expect(screen.getByText('vfat')).toBeInTheDocument();
+  });
+
+  it('should filter FS types cliking the filter', async () => {
+    const user = userEvent.setup();
+
+    render(<MountpointsChart mountpoints={testMountpoints} />);
+
+    const xfsLabel = screen.getByText('xfs');
+    expect(xfsLabel).not.toHaveClass('opacity-50');
+    await user.click(xfsLabel);
+    expect(xfsLabel).toHaveClass('opacity-50');
+  });
+});

--- a/assets/js/common/FilesystemCharts/dataMapper.js
+++ b/assets/js/common/FilesystemCharts/dataMapper.js
@@ -39,6 +39,7 @@ export const calculateFilesystemUsage = ({
           mountpoint,
           {
             device: get(sizeData, 'metric.device'),
+            fsType: get(sizeData, 'metric.fstype'),
             totalBytes,
             availBytes,
             usedBytes: totalBytes - availBytes,

--- a/assets/js/common/FilesystemCharts/dataMapper.test.js
+++ b/assets/js/common/FilesystemCharts/dataMapper.test.js
@@ -9,8 +9,16 @@ import {
 
 describe('dataMapper', () => {
   it('should correctly calculate filesystem and swap usage', () => {
-    const commonRootMetric = { mountpoint: '/', device: '/dev/sda1' };
-    const commonDataMetric = { mountpoint: '/data', device: '/dev/sdb1' };
+    const commonRootMetric = {
+      mountpoint: '/',
+      device: '/dev/sda1',
+      fstype: 'xfs',
+    };
+    const commonDataMetric = {
+      mountpoint: '/data',
+      device: '/dev/sdb1',
+      fstype: 'xfs',
+    };
 
     const filesystems_size = [
       filesystemFactory.build({
@@ -48,12 +56,14 @@ describe('dataMapper', () => {
       mountpoints: {
         '/': {
           device: '/dev/sda1',
+          fsType: 'xfs',
           totalBytes: 1000,
           availBytes: 500,
           usedBytes: 500,
         },
         '/data': {
           device: '/dev/sdb1',
+          fsType: 'xfs',
           totalBytes: 2000,
           availBytes: 1000,
           usedBytes: 1000,
@@ -68,7 +78,7 @@ describe('dataMapper', () => {
   });
 
   it('should return null for swap when swap data is not available', () => {
-    const metric = { mountpoint: '/', device: '/dev/sda1' };
+    const metric = { mountpoint: '/', device: '/dev/sda1', fstype: 'xfs' };
     const filesystems_size = [
       filesystemFactory.build({
         metric,
@@ -91,6 +101,7 @@ describe('dataMapper', () => {
     expect(result.mountpoints).toEqual({
       '/': {
         device: '/dev/sda1',
+        fsType: 'xfs',
         totalBytes: 1000,
         availBytes: 500,
         usedBytes: 500,


### PR DESCRIPTION
# Description

Add Filesystem filters to host details view `File System Capacity` chart.
The next types are enabled on initial page view: `['gpfs', 'nfs', 'xfs', 'nfs4']`
We can change them, remove initial filtering, etc.

<img width="836" height="555" alt="filter_by_fstype" src="https://github.com/user-attachments/assets/fb73f07d-1afb-4c3e-a50f-fa697a99f082" />

Only 

## How was this tested?

I did test manually and with storybook.
Testing with jest is not possible as react-chart is creating a canvas without real dom elements.
I could test the pills, but they don't check anything more than they exist.

## Did you update the documentation?

No need