### PR TITLE
Fix wanda versioning

### DIFF
--- a/lib/trento/infrastructure/component_versions/component_versions.ex
+++ b/lib/trento/infrastructure/component_versions/component_versions.ex
@@ -23,12 +23,12 @@ defmodule Trento.Infrastructure.ComponentVersions do
   }
 
   @impl true
-  def get_versions do
+  def get_versions(origin \\ nil) do
     fetchers = [
       {:postgres, &fetch_postgres_version/0},
       {:rabbitmq, &fetch_rabbitmq_version/0},
       {:prometheus, &fetch_prometheus_version/0},
-      {:wanda, &fetch_wanda_info/0}
+      {:wanda, fn -> fetch_wanda_info(origin) end}
     ]
 
     results =
@@ -129,12 +129,10 @@ defmodule Trento.Infrastructure.ComponentVersions do
     end
   end
 
-  defp fetch_wanda_info do
-    checks_base_url = Application.fetch_env!(:trento, :checks_service)[:base_url]
+  defp fetch_wanda_info(origin) do
+    url = resolve_checks_url("/api", origin)
 
-    case HTTPoison.get("#{checks_base_url}/api", [{"Accept", "application/json"}],
-           recv_timeout: @timeout
-         ) do
+    case HTTPoison.get(url, [{"Accept", "application/json"}], recv_timeout: @timeout) do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         case Jason.decode(body) do
           {:ok, %{"version" => version} = data} ->
@@ -154,6 +152,22 @@ defmodule Trento.Infrastructure.ComponentVersions do
 
       _ ->
         {:error, :unexpected_response}
+    end
+  end
+
+  @doc false
+  def resolve_checks_url(path, origin) do
+    base_url = Application.fetch_env!(:trento, :checks_service)[:base_url] || ""
+
+    case URI.parse(base_url) do
+      %URI{scheme: scheme} when scheme in ["http", "https"] ->
+        base_url <> path
+
+      _ when is_binary(origin) and origin != "" ->
+        origin <> base_url <> path
+
+      _ ->
+        base_url <> path
     end
   end
 end

--- a/lib/trento/infrastructure/component_versions/component_versions.ex
+++ b/lib/trento/infrastructure/component_versions/component_versions.ex
@@ -112,7 +112,7 @@ defmodule Trento.Infrastructure.ComponentVersions do
     url = "#{prometheus_url}/api/v1/status/buildinfo"
     headers = [{"Accept", "application/json"}]
 
-    case HTTPoison.get(url, headers, recv_timeout: @timeout) do
+    case HTTPoison.get(url, headers, recv_timeout: @timeout, follow_redirect: true) do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         case Jason.decode(body) do
           {:ok, %{"data" => %{"version" => version}}} -> {:ok, %{prometheus_version: version}}
@@ -132,7 +132,10 @@ defmodule Trento.Infrastructure.ComponentVersions do
   defp fetch_wanda_info(origin) do
     url = resolve_checks_url("/api", origin)
 
-    case HTTPoison.get(url, [{"Accept", "application/json"}], recv_timeout: @timeout) do
+    case HTTPoison.get(url, [{"Accept", "application/json"}],
+           recv_timeout: @timeout,
+           follow_redirect: true
+         ) do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         case Jason.decode(body) do
           {:ok, %{"version" => version} = data} ->

--- a/lib/trento/infrastructure/component_versions/gen.ex
+++ b/lib/trento/infrastructure/component_versions/gen.ex
@@ -6,7 +6,7 @@ defmodule Trento.Infrastructure.ComponentVersions.Gen do
   Behaviour for fetching component versions.
   """
 
-  @callback get_versions() :: %{
+  @callback get_versions(origin :: String.t() | nil) :: %{
               wanda_version: String.t() | nil,
               checks_version: String.t() | nil,
               postgres_version: String.t() | nil,

--- a/lib/trento_web/controllers/v1/about_controller.ex
+++ b/lib/trento_web/controllers/v1/about_controller.ex
@@ -24,7 +24,7 @@ defmodule TrentoWeb.V1.AboutController do
 
   @spec info(Plug.Conn.t(), map) :: Plug.Conn.t()
   def info(conn, _) do
-    versions = component_versions().get_versions()
+    versions = component_versions().get_versions(request_origin(conn))
 
     render(conn, :about,
       about_info:
@@ -43,4 +43,15 @@ defmodule TrentoWeb.V1.AboutController do
       Application.fetch_env!(:trento, :component_versions)[
         :adapter
       ]
+
+  defp request_origin(%Plug.Conn{scheme: scheme, host: host, port: port}) do
+    port_part =
+      case {scheme, port} do
+        {:http, 80} -> ""
+        {:https, 443} -> ""
+        {_, port} -> ":#{port}"
+      end
+
+    "#{scheme}://#{host}#{port_part}"
+  end
 end

--- a/test/trento/infrastructure/component_versions/component_versions_test.exs
+++ b/test/trento/infrastructure/component_versions/component_versions_test.exs
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Infrastructure.ComponentVersionsTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: false
+
+  alias Trento.Infrastructure.ComponentVersions
+
+  describe "resolve_checks_url/2" do
+    setup do
+      original = Application.get_env(:trento, :checks_service)
+
+      on_exit(fn ->
+        if is_nil(original) do
+          Application.delete_env(:trento, :checks_service)
+        else
+          Application.put_env(:trento, :checks_service, original)
+        end
+      end)
+
+      :ok
+    end
+
+    test "leaves the base url untouched when it is absolute, ignoring the origin" do
+      Application.put_env(:trento, :checks_service, base_url: "https://wanda.example.com")
+
+      assert ComponentVersions.resolve_checks_url("/api", "https://trento.example.com") ==
+               "https://wanda.example.com/api"
+    end
+
+    test "prepends the origin when the base url is relative" do
+      Application.put_env(:trento, :checks_service, base_url: "/checks")
+
+      assert ComponentVersions.resolve_checks_url("/api", "https://trento.example.com") ==
+               "https://trento.example.com/checks/api"
+    end
+  end
+end


### PR DESCRIPTION
The versioning introduced in https://github.com/trento-project/web/pull/4155 didn't consider the case that the `check_url` config value can be set to a relative path (which is the case of a k8s installation).

This PR fix the thing so that the origin hostname is prepended if needed.