### PR TITLE
Fix flaky tests hana db details & host details

### DIFF
--- a/test/e2e/cypress/e2e/hana_cluster_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_cluster_details.cy.js
@@ -311,7 +311,9 @@ context('HANA cluster details', () => {
     beforeEach(() => hanaClusterDetailsPage.visitAvailableHanaCluster());
 
     it('should include the checks catalog in the checks results once enabled', () => {
+      hanaClusterDetailsPage.interceptGetChecks();
       hanaClusterDetailsPage.clickCheckSelectionButton();
+      hanaClusterDetailsPage.waitForGetChecksEndpoint();
       hanaClusterDetailsPage.expectedCheckIsDisplayed(CHECK_COROSYNC);
       hanaClusterDetailsPage.expectedCheckIsDisplayed(CHECK_MISCELLANEOUS);
       hanaClusterDetailsPage.expectedCheckIsDisplayed(
@@ -362,7 +364,9 @@ context('HANA cluster details', () => {
     });
 
     it('should show the default check catalog with corosync token timeout default value', () => {
+      hanaClusterDetailsPage.interceptGetChecks();
       hanaClusterDetailsPage.clickCheckSelectionButton();
+      hanaClusterDetailsPage.waitForGetChecksEndpoint();
       hanaClusterDetailsPage.clickCorosyncCheckCategory();
       hanaClusterDetailsPage.clickCorosyncTokenTimeoutCheckSettings();
       hanaClusterDetailsPage.checkInputValueIsTheExpected(5000);
@@ -388,7 +392,9 @@ context('HANA cluster details', () => {
     });
 
     it('should show the default check catalog with corosync token timeout default value', () => {
+      hanaClusterDetailsPage.interceptGetChecks();
       hanaClusterDetailsPage.clickCheckSelectionButton();
+      hanaClusterDetailsPage.waitForGetChecksEndpoint();
       hanaClusterDetailsPage.clickCorosyncCheckCategory();
       hanaClusterDetailsPage.clickCorosyncTokenTimeoutCheckSettings();
       hanaClusterDetailsPage.checkInputValueIsTheExpected(5000);

--- a/test/e2e/cypress/pageObject/host_details_po.js
+++ b/test/e2e/cypress/pageObject/host_details_po.js
@@ -450,7 +450,7 @@ export const cleanedUpHostIsNotDisplayed = () =>
   cy.get(cleanedUpHost).should('not.exist');
 
 export const startExecutionButtonIsDisabled = () =>
-  cy.get(startExecutionButton).should('be.disabled');
+  cy.get(startExecutionButton, { timeout: 30000 }).should('be.disabled');
 
 export const notAuthorizedMessageIsNotDisplayed = () => {
   cy.get(startExecutionButton).trigger('mouseover', {


### PR DESCRIPTION
# Description

Minor changes to make host_details and hana_cluster_details flaky tests a bit more robust, avoiding race conditions and setting a more generous timeout.

Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [x] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [x] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
