### PR TITLE
Analytics - Mask events data

### DIFF
--- a/assets/js/common/ProfileMenu/ProfileMenu.jsx
+++ b/assets/js/common/ProfileMenu/ProfileMenu.jsx
@@ -17,7 +17,7 @@ function ProfileMenu({ username, email, logout }) {
             color="currentColor"
             className="text-gray-600 group-hover:text-gray-400"
           />
-          <span className="text-gray-600 ml-2 group-hover:text-gray-400">
+          <span className="ph-mask text-gray-600 ml-2 group-hover:text-gray-400">
             {username}
           </span>
           <svg

--- a/assets/js/lib/analytics/index.js
+++ b/assets/js/lib/analytics/index.js
@@ -13,6 +13,28 @@ const DEFAULT_OPTS = {
   opt_out_capturing_by_default: true,
   capture_pageview: false,
   disable_persistence: true,
+  // mask $autocapture event `text` field for elements with
+  // `ph-mask` class
+  before_send: (event) => {
+    if (!event) {
+      return null;
+    }
+
+    if (event.event !== '$autocapture') return event;
+
+    const elements = event.properties.$elements_chain;
+    const shouldMask = elements.includes('ph-mask');
+    if (shouldMask) {
+      const textToMask = event.properties.$el_text;
+      event.properties.$elements_chain = elements.replace(
+        `"${textToMask}"`,
+        '"*****"'
+      );
+      event.properties.$el_text = '*****';
+    }
+
+    return event;
+  },
 };
 
 const analyticsEnabledConfig = getFromConfig('analyticsEnabled');

--- a/assets/js/lib/analytics/index.test.js
+++ b/assets/js/lib/analytics/index.test.js
@@ -67,6 +67,7 @@ describe('analytics', () => {
         capture_pageview: false,
         disable_persistence: true,
         loaded: expect.any(Function),
+        before_send: expect.any(Function),
         opt_out_capturing_by_default: true,
       });
     });
@@ -109,4 +110,76 @@ describe('analytics', () => {
       );
     });
   });
+
+  it.each([
+    {
+      beforeEvent: {
+        event: '$autocapture',
+        properties: {
+          $el_text: 'toBeMasked',
+          $elements_chain: '<span class="ph-mask">"toBeMasked"</span>',
+        },
+      },
+      updatedEvent: {
+        event: '$autocapture',
+        properties: {
+          $el_text: '*****',
+          $elements_chain: '<span class="ph-mask">"*****"</span>',
+        },
+      },
+    },
+    {
+      beforeEvent: {
+        event: '$autocapture',
+        properties: {
+          $el_text: 'goodToGo',
+          $elements_chain: '<span>"goodToGo"</span>',
+        },
+      },
+      updatedEvent: {
+        event: '$autocapture',
+        properties: {
+          $el_text: 'goodToGo',
+          $elements_chain: '<span>"goodToGo"</span>',
+        },
+      },
+    },
+    {
+      beforeEvent: null,
+      updatedEvent: null,
+    },
+    {
+      beforeEvent: {
+        event: '$snapshot',
+        properties: {
+          $el_text: 'toBeMasked',
+          $elements_chain: '<span class="ph-mask">"toBeMasked"</span>',
+        },
+      },
+      updatedEvent: {
+        event: '$snapshot',
+        properties: {
+          $el_text: 'toBeMasked',
+          $elements_chain: '<span class="ph-mask">"toBeMasked"</span>',
+        },
+      },
+    },
+  ])(
+    'should mask event text before sending it',
+    ({ beforeEvent, updatedEvent }) => {
+      const mockInit = jest.fn();
+
+      jest.mock('posthog-js', () => ({
+        init: mockInit,
+      }));
+
+      return import('.').then(({ init }) => {
+        init();
+        const initArgs = mockInit.mock.calls[0];
+        const config = initArgs[1];
+        const beforeSend = config.before_send;
+        expect(beforeSend(beforeEvent)).toStrictEqual(updatedEvent);
+      });
+    }
+  );
 });

--- a/assets/js/pages/Users/Users.jsx
+++ b/assets/js/pages/Users/Users.jsx
@@ -35,6 +35,7 @@ function Users({
       {
         title: 'Username',
         key: 'username',
+        className: 'ph-mask',
         render: (content, item) => (
           <Link
             className="text-jungle-green-500 hover:opacity-75"


### PR DESCRIPTION
# Description

Mask analytics events data.
- When a element is clicked, mask the event `$el_text` and chain so it doesn't show the value in the event. Using the `ph-mask` class implies that the field is not showed in the session recording as well. (`ph-mask` is the default class, we could change it: https://posthog.com/docs/libraries/js/usage)

<img width="1762" height="810" alt="mask_text" src="https://github.com/user-attachments/assets/3ee5da82-4a59-47f0-8af3-41492ee87769" />

## How was this tested?

UT and manual testing

## Did you update the documentation?

No need
