### PR TITLE
Addded a short version tag for OBS container image packaging

### DIFF
--- a/packaging/suse/container/Dockerfile
+++ b/packaging/suse/container/Dockerfile
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #!BuildTag: trento/trento-web:%%VERSION%%
+#!BuildTag: trento/trento-web:%%VERSION_SHORT%%
 #!BuildTag: trento/trento-web:%%VERSION%%-build%RELEASE%
 #!BuildName: trento-web
 #!BuildVersion: %%VERSION%%


### PR DESCRIPTION
# Description

Minor change that adds a short tag for the built containers in OBS --> depending on which OBS project is building the image, it should be replaced with a shorter tag than the full version string.

For example, for a version "1.2.3" on the stable branch that might be "1.2". However, this change has detrimental effect on rolling releases in OBS, since our Helm charts pin the version of their containers to a specific version. So, for the rolling helm charts built to be able to pickup the latest images (which have names like `1.2.3-git.*`) we have to add additional tag that hides the git commit information. This is a common practice with container images, and it's safe since these tags are only available in the context of our rolling OBS project (`:factory`).

