### PR TITLE
Fix flaky test on user form

### DIFF
--- a/assets/js/pages/Users/UserForm.test.jsx
+++ b/assets/js/pages/Users/UserForm.test.jsx
@@ -181,7 +181,7 @@ describe('UserForm', () => {
   });
 
   it('should save the user', async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     const { fullname, email, username, timezone } = userFactory.build();
     const password = faker.internet.password();
     const mockOnSave = jest.fn();


### PR DESCRIPTION
Root cause:

`userEvent.setup()` implies `{ delay: 0 }`. That means that, when using `user.type` to simulate user typing, a `setTimeout(...., 0)` is created at every character to simulate human input. As per how the event loop works, React re-renders will interleave into the chain of events. On slow machines or on high parallelism, the loop can get slow and hence get the test to fail.

By setting `{ delay: null }`, we avoid the timeout mechanism altogether