### PR TITLE
Load OS CA certificates when calling wanda

### DIFF
--- a/lib/trento/infrastructure/component_versions/component_versions.ex
+++ b/lib/trento/infrastructure/component_versions/component_versions.ex
@@ -134,7 +134,8 @@ defmodule Trento.Infrastructure.ComponentVersions do
 
     case HTTPoison.get(url, [{"Accept", "application/json"}],
            recv_timeout: @timeout,
-           follow_redirect: true
+           follow_redirect: true,
+           ssl: [verify: :verify_peer, cacerts: resolve_ca_certs()]
          ) do
       {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
         case Jason.decode(body) do
@@ -172,5 +173,13 @@ defmodule Trento.Infrastructure.ComponentVersions do
       _ ->
         base_url <> path
     end
+  end
+
+  defp resolve_ca_certs do
+    :public_key.cacerts_get()
+  rescue
+    e ->
+      Logger.error("Failed to load system CA certificates: #{inspect(e)}")
+      []
   end
 end


### PR DESCRIPTION
# Description

When we get wanda and checks version, we might be calling it via the reverse proxy, and when there is ssl termination enabled with a self-signed certificate the request would fail because we are not providing any ca certificate to the http client.

If the OS has the relevant ca cert, httpoison does not load it automatically.

This fix makes sure it's loaded and provided to the request.