### PR TITLE
Normalize query string to list

### DIFF
--- a/lib/trento_web/controllers/v1/activity_log_controller.ex
+++ b/lib/trento_web/controllers/v1/activity_log_controller.ex
@@ -10,6 +10,11 @@ defmodule TrentoWeb.V1.ActivityLogController do
   alias Trento.Users.User
   alias TrentoWeb.OpenApi.V1.Schema
 
+  plug TrentoWeb.Plugs.NormalizeListsPlug,
+    list_fields: %{
+      get_activity_log: ["severity", "actor", "type"]
+    }
+
   plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
   action_fallback TrentoWeb.FallbackController
   plug TrentoWeb.Plugs.LoadUserPlug

--- a/lib/trento_web/controllers/v1/activity_log_controller.ex
+++ b/lib/trento_web/controllers/v1/activity_log_controller.ex
@@ -76,6 +76,7 @@ defmodule TrentoWeb.V1.ActivityLogController do
           items: %OpenApiSpex.Schema{type: :string},
           example: ["john.doe@example.com", "admin@example.com"]
         },
+        explode: true,
         required: false,
         example: ["john.doe@example.com", "admin@example.com"]
       ],
@@ -99,6 +100,7 @@ defmodule TrentoWeb.V1.ActivityLogController do
           items: %OpenApiSpex.Schema{type: :string},
           example: ["host_registered", "user_login"]
         },
+        explode: true,
         required: false,
         example: ["host_registered", "user_login"]
       ],
@@ -111,6 +113,7 @@ defmodule TrentoWeb.V1.ActivityLogController do
           items: %OpenApiSpex.Schema{type: :string},
           default: ["debug", "info", "warning", "critical"]
         },
+        explode: true,
         required: false
       ]
     ],

--- a/lib/trento_web/plugs/normalize_lists_plug.ex
+++ b/lib/trento_web/plugs/normalize_lists_plug.ex
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule TrentoWeb.Plugs.NormalizeListsPlug do
+  @moduledoc """
+  This plug normalizes query string elements into lists when they are not formmated
+  in brackets format.
+  This is needed to be compatible with openAPI 3.0, as brackets format is not supported.
+  The plug must be used before `plug OpenApiSpex.Plug.CastAndValidate` to make effect.
+
+  Options:
+  - list_fields: Query fields to convert into a list for each action
+
+  Usage example:
+  plug TrentoWeb.Plugs.NormalizeListsPlug,
+    list_fields: %{
+      get_activity_log: ["severity", "actor", "type"]
+    }
+  """
+  @behaviour Plug
+
+  @impl true
+  def init(opts), do: Map.new(opts)
+
+  @impl true
+  @spec call(Plug.Conn.t(), any) :: Plug.Conn.t()
+  def call(%{query_string: ""} = conn, _opts), do: conn
+
+  def call(%{params: params, query_string: query_string} = conn, opts) do
+    action = Phoenix.Controller.action_name(conn)
+    list_fields = get_in(opts, [:list_fields, action]) || []
+
+    # get query field/values from raw query string and make a list if
+    # the field is in the whitelist
+    normalized_params =
+      query_string
+      |> String.split("&", trim: true)
+      |> Enum.reduce(%{}, fn pair, acc ->
+        {query_field, query_value} =
+          case String.split(pair, "=", parts: 2) do
+            [key, value] -> {URI.decode_www_form(key), URI.decode_www_form(value)}
+            [key] -> {URI.decode_www_form(key), ""}
+          end
+
+        is_bracket_array = String.contains?(query_field, "[]")
+        query_field = String.replace(query_field, "[]", "")
+        is_force_list = query_field in list_fields || is_bracket_array
+
+        Map.update(acc, query_field, wrap_if(query_value, is_force_list), fn existing ->
+          List.wrap(existing) ++ [query_value]
+        end)
+      end)
+
+    %{conn | params: Map.merge(params, normalized_params), query_params: normalized_params}
+  end
+
+  defp wrap_if(v, true), do: [v]
+  defp wrap_if(v, false), do: v
+end

--- a/test/trento_web/controllers/v1/activity_log_controller_test.exs
+++ b/test/trento_web/controllers/v1/activity_log_controller_test.exs
@@ -8,6 +8,8 @@ defmodule TrentoWeb.V1.ActivityLogControllerTest do
   import OpenApiSpex.TestAssertions
   import Trento.Support.Helpers.AbilitiesTestHelper
 
+  alias Trento.ActivityLog.SeverityLevel
+
   setup :setup_api_spec_v1
   setup :setup_user
 
@@ -326,6 +328,30 @@ defmodule TrentoWeb.V1.ActivityLogControllerTest do
         resp["data"] |> Enum.map(fn entry -> entry["severity"] end) |> Enum.uniq() |> Enum.sort()
 
       assert severity_levels == Enum.sort(["critical"])
+      assert_schema(resp, "ActivityLogV1", api_spec)
+    end
+
+    test "should use query string fields without brackets as list", %{
+      conn: conn,
+      api_spec: api_spec
+    } do
+      %{actor: actor1, type: type1, severity: severity1} = insert(:activity_log_entry)
+      %{actor: actor2, type: type2, severity: severity2} = insert(:activity_log_entry)
+
+      query =
+        "actor=#{actor1}&" <>
+          "type=#{type1}&" <>
+          "severity=#{SeverityLevel.map_severity_integer_to_text(severity1)}&" <>
+          "actor=#{actor2}&" <>
+          "type=#{type2}&" <>
+          "severity=#{SeverityLevel.map_severity_integer_to_text(severity2)}"
+
+      resp =
+        conn
+        |> get("/api/v1/activity_log?#{query}")
+        |> json_response(200)
+
+      assert length(resp["data"]) == 2
       assert_schema(resp, "ActivityLogV1", api_spec)
     end
   end

--- a/test/trento_web/plugs/normalize_lists_plug_test.exs
+++ b/test/trento_web/plugs/normalize_lists_plug_test.exs
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule TrentoWeb.Plugs.NormalizeListsPlugTest do
+  use TrentoWeb.ConnCase, async: true
+
+  alias TrentoWeb.Plugs.NormalizeListsPlug
+
+  test "should convert whitelisted fields to list", %{conn: conn} do
+    opts = %{
+      list_fields: %{
+        my_action: ["to_list", "to_list_single"]
+      }
+    }
+
+    conn =
+      conn
+      |> put_private(:phoenix_action, :my_action)
+      |> Map.put(
+        :query_string,
+        "to_list=1&to_list=2&other=3&to_list_single=4&bracket_list[]=5&repeated=6&repeated=7"
+      )
+      |> NormalizeListsPlug.call(opts)
+
+    assert %{
+             query_params: %{
+               "to_list" => ["1", "2"],
+               "other" => "3",
+               "to_list_single" => ["4"],
+               "bracket_list" => ["5"],
+               "repeated" => ["6", "7"]
+             }
+           } = conn
+  end
+
+  test "should not convert if the action does not match", %{conn: conn} do
+    opts = %{
+      list_fields: %{
+        my_action: ["to_list"]
+      }
+    }
+
+    conn =
+      conn
+      |> put_private(:phoenix_action, :other_action)
+      |> Map.put(:query_string, "to_list=1")
+      |> NormalizeListsPlug.call(opts)
+
+    assert %{
+             query_params: %{"to_list" => "1"}
+           } = conn
+  end
+end


### PR DESCRIPTION
# Description

Support openAPI styles query string arrays usage, like `?severity=info&severity=debug`.
Without this, phoenix doesn't convert these elements into lists even though they are defined in the openAPI schema, as only bracket notation (`severity[]=info`) is supported.

## How was this tested?

UT and manual testing with swagger

## Did you update the documentation?

No need
