### PR TITLE
Update gen_rmq dependency to new GitHub repo

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -80,7 +80,7 @@ defmodule Trento.MixProject do
       {:gen_smtp, "~> 1.2.0"},
       # see: https://github.com/pma/amqp/issues/231#issuecomment-2445049446
       {:ranch, "~> 1.8.0", override: true},
-      {:gen_rmq, github: "cdimonaco/gen_rmq", ref: "v5.0.1"},
+      {:gen_rmq, github: "trento-project/trnt_gen_rmq", ref: "v5.0.1"},
       {:httpoison, "== 2.2.3"},
       {:jason, "~> 1.2"},
       {:junit_formatter, "~> 3.4", only: [:test]},


### PR DESCRIPTION
We were using a gen_rmq from a personal repo from a team member that is no longer part of the team. To control the repo and its updates, we have forked the code to trnt_gen_rmq. This PR modifies the dependency to point to the new place. This will also allow us to publish it on hex.pm if we want to with the new name.

# Description

Change on the dependency from an external repo to an internal one.

Fixes # (issue)

Nothing

## Did you add the right label?

Remember to add the right labels to this PR.
- [ x ] **DONE**

## How was this tested?
There is no change. The code is the same, just stored in a different place.


Describe the tests that have been added/changed for this new behavior.
- [  x ] **DONE**

## Did you update the documentation?

There is no need to do so.

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [x] **DONE**
