### PR TITLE
Fix flaky notification box test

### DIFF
--- a/assets/js/common/NotificationBox/NotificationBox.test.jsx
+++ b/assets/js/common/NotificationBox/NotificationBox.test.jsx
@@ -59,9 +59,9 @@ describe('NotificationBox Component', () => {
   it('should display the title', () => {
     const icon = faker.color.human();
     const text = faker.lorem.paragraph();
-    const buttonText = faker.lorem.word();
+    const buttonText = `button-${faker.string.uuid()}`;
     const buttonOnClick = () => {};
-    const title = faker.lorem.word();
+    const title = `title-${faker.string.uuid()}`;
 
     render(
       <NotificationBox


### PR DESCRIPTION
Enforce different values using uuid, as `faker.lorem.word()` can generate duplicates (it selects random values from a finite set)

Target test: `NotificationBox Component::should display the title`