### PR TITLE
FIx flaky check result test

### DIFF
--- a/assets/js/lib/test-utils/factories/checks.js
+++ b/assets/js/lib/test-utils/factories/checks.js
@@ -5,29 +5,23 @@ import { faker } from '@faker-js/faker';
 import { Factory } from 'fishery';
 import { EXPECT, EXPECT_ENUM, EXPECT_SAME } from '@lib/model';
 
-export const catalogExpectExpectationFactory = Factory.define(
-  ({ sequence }) => ({
-    name: `${faker.lorem.word()}_${sequence}`,
-    type: EXPECT,
-    expression: faker.lorem.sentence(),
-  })
-);
+export const catalogExpectExpectationFactory = Factory.define(() => ({
+  name: faker.string.uuid(),
+  type: EXPECT,
+  expression: faker.lorem.sentence(),
+}));
 
-export const catalogExpectSameExpectationFactory = Factory.define(
-  ({ sequence }) => ({
-    name: `${faker.lorem.word()}_${sequence}`,
-    type: EXPECT_SAME,
-    expression: faker.lorem.sentence(),
-  })
-);
+export const catalogExpectSameExpectationFactory = Factory.define(() => ({
+  name: faker.string.uuid(),
+  type: EXPECT_SAME,
+  expression: faker.lorem.sentence(),
+}));
 
-export const catalogExpectEnumExpectationFactory = Factory.define(
-  ({ sequence }) => ({
-    name: `${faker.lorem.word()}_${sequence}`,
-    type: EXPECT_ENUM,
-    expression: faker.lorem.sentence(),
-  })
-);
+export const catalogExpectEnumExpectationFactory = Factory.define(() => ({
+  name: faker.string.uuid(),
+  type: EXPECT_ENUM,
+  expression: faker.lorem.sentence(),
+}));
 
 export const catalogConditionFactory = Factory.define(() => ({
   value: faker.lorem.word(),

--- a/assets/js/pages/ExecutionResults/CheckResultDetail/CheckResultDetail.test.jsx
+++ b/assets/js/pages/ExecutionResults/CheckResultDetail/CheckResultDetail.test.jsx
@@ -26,7 +26,6 @@ import {
 } from '@lib/test-utils/factories';
 
 import '@testing-library/jest-dom';
-import { faker } from '@faker-js/faker';
 import CheckResultDetail from './CheckResultDetail';
 
 describe('CheckResultDetail Component', () => {
@@ -99,17 +98,9 @@ describe('CheckResultDetail Component', () => {
     const [{ id: target1 }, { id: target2 }] = clusterHosts;
     const targetType = 'cluster';
 
-    const expectationName = faker.lorem.word();
-    const anotherExpectationName = faker.color.human();
-
-    const expectations = [
-      catalogExpectSameExpectationFactory.build({
-        name: expectationName,
-      }),
-      catalogExpectSameExpectationFactory.build({
-        name: anotherExpectationName,
-      }),
-    ];
+    const expectations = catalogExpectSameExpectationFactory.buildList(2);
+    const [{ name: expectationName }, { name: anotherExpectationName }] =
+      expectations;
 
     const agent1CheckResult = agentCheckResultFactory.build({
       agent_id: target1,

--- a/assets/js/pages/ExecutionResults/CheckResultOutline.test.jsx
+++ b/assets/js/pages/ExecutionResults/CheckResultOutline.test.jsx
@@ -62,30 +62,18 @@ describe('CheckResultOutline Component', () => {
     const checkID = faker.string.uuid();
     const clusterName = faker.lorem.word();
 
-    // expectation names are not required to be uuids. using uuids for their uniqueness.
-    const expectationName1 = faker.string.uuid();
-    const expectationName2 = faker.string.uuid();
-    const expectationName3 = faker.string.uuid();
-    const expectSameExpectationName1 = faker.string.uuid();
-    const expectSameExpectationName2 = faker.string.uuid();
-
     const expectations = [
-      catalogExpectExpectationFactory.build({
-        name: expectationName1,
-      }),
-      catalogExpectExpectationFactory.build({
-        name: expectationName2,
-      }),
-      catalogExpectExpectationFactory.build({
-        name: expectationName3,
-      }),
-      catalogExpectSameExpectationFactory.build({
-        name: expectSameExpectationName1,
-      }),
-      catalogExpectSameExpectationFactory.build({
-        name: expectSameExpectationName2,
-      }),
+      ...catalogExpectExpectationFactory.buildList(3),
+      ...catalogExpectSameExpectationFactory.buildList(2),
     ];
+
+    const [
+      { name: expectationName1 },
+      { name: expectationName2 },
+      { name: expectationName3 },
+      { name: expectSameExpectationName1 },
+      { name: expectSameExpectationName2 },
+    ] = expectations;
 
     let checkResult = emptyCheckResultFactory.build({
       checkID,
@@ -223,17 +211,7 @@ describe('CheckResultOutline Component', () => {
     const checkID = faker.string.uuid();
     const clusterName = faker.animal.bear();
 
-    const expectationName1 = faker.company.name();
-    const expectationName2 = faker.color.human();
-
-    const expectations = [
-      catalogExpectExpectationFactory.build({
-        name: expectationName1,
-      }),
-      catalogExpectExpectationFactory.build({
-        name: expectationName2,
-      }),
-    ];
+    const expectations = catalogExpectExpectationFactory.buildList(2);
 
     const agentsCheckResults = agentsCheckResultsWithHostname(
       agentCheckErrorFactory.buildList(2)

--- a/assets/js/pages/ExecutionResults/ExecutionResults.test.jsx
+++ b/assets/js/pages/ExecutionResults/ExecutionResults.test.jsx
@@ -32,11 +32,19 @@ const prepareStateData = (checkExecutionStatus) => {
   const [{ id: agent1 }, { id: agent2 }] = clusterHosts;
   const targets = [agent1, agent2];
 
-  const expectationName1 = faker.company.name();
-  const expectationName2 = faker.company.name();
-  const expectationName3 = faker.company.name();
-  const expectationName4 = faker.company.name();
-  const expectationName5 = faker.company.name();
+  const check1Expectations = [
+    ...catalogExpectExpectationFactory.buildList(2),
+    catalogExpectSameExpectationFactory.build(),
+  ];
+  const check2Expectations = catalogExpectExpectationFactory.buildList(2);
+
+  const [
+    { name: expectationName1 },
+    { name: expectationName2 },
+    { name: expectationName3 },
+  ] = check1Expectations;
+  const [{ name: expectationName4 }, { name: expectationName5 }] =
+    check2Expectations;
 
   let checkResult1 = emptyCheckResultFactory.build({
     checkID: checkID1,
@@ -82,29 +90,12 @@ const prepareStateData = (checkExecutionStatus) => {
       catalogCheckFactory.build({
         id: checkID1,
         description: aCheckDescription,
-        expectations: [
-          catalogExpectExpectationFactory.build({
-            name: expectationName1,
-          }),
-          catalogExpectExpectationFactory.build({
-            name: expectationName2,
-          }),
-          catalogExpectSameExpectationFactory.build({
-            name: expectationName3,
-          }),
-        ],
+        expectations: check1Expectations,
       }),
       catalogCheckFactory.build({
         id: checkID2,
         description: anotherCheckDescription,
-        expectations: [
-          catalogExpectExpectationFactory.build({
-            name: expectationName4,
-          }),
-          catalogExpectExpectationFactory.build({
-            name: expectationName5,
-          }),
-        ],
+        expectations: check2Expectations,
       }),
     ],
     error: null,

--- a/assets/js/pages/ExecutionResults/checksUtils.test.js
+++ b/assets/js/pages/ExecutionResults/checksUtils.test.js
@@ -269,18 +269,12 @@ describe('checksUtils', () => {
   });
 
   it('should get expect_same statement results for a set of catalog expectations', () => {
-    const expectationName = faker.lorem.word();
-    const anotherExpectationName = faker.color.human();
-
     const expectations = [
       ...catalogExpectExpectationFactory.buildList(2),
-      catalogExpectSameExpectationFactory.build({
-        name: expectationName,
-      }),
-      catalogExpectSameExpectationFactory.build({
-        name: anotherExpectationName,
-      }),
+      ...catalogExpectSameExpectationFactory.buildList(2),
     ];
+    const [, , { name: expectationName }, { name: anotherExpectationName }] =
+      expectations;
 
     const expectSameResult = expectationResultFactory.build({
       type: EXPECT_SAME,
@@ -311,18 +305,12 @@ describe('checksUtils', () => {
       { id: agent2, hostname: hostname2 },
     ] = clusterHosts;
 
-    const expectationName = faker.lorem.word();
-    const anotherExpectationName = faker.color.human();
-
     const expectations = [
       ...catalogExpectExpectationFactory.buildList(2),
-      catalogExpectSameExpectationFactory.build({
-        name: expectationName,
-      }),
-      catalogExpectSameExpectationFactory.build({
-        name: anotherExpectationName,
-      }),
+      ...catalogExpectSameExpectationFactory.buildList(2),
     ];
+    const [, , { name: expectationName }, { name: anotherExpectationName }] =
+      expectations;
 
     const factValueFromAgent1ForExpectation1 = faker.lorem.word();
     const factValueFromAgent1ForExpectation2 = faker.lorem.sentence();
@@ -396,18 +384,12 @@ describe('checksUtils', () => {
       { id: agent3, hostname: hostname3 },
     ] = clusterHosts;
 
-    const expectationName = faker.lorem.word();
-    const anotherExpectationName = faker.color.human();
-
     const expectations = [
       ...catalogExpectExpectationFactory.buildList(2),
-      catalogExpectSameExpectationFactory.build({
-        name: expectationName,
-      }),
-      catalogExpectSameExpectationFactory.build({
-        name: anotherExpectationName,
-      }),
+      ...catalogExpectSameExpectationFactory.buildList(2),
     ];
+    const [, , { name: expectationName }, { name: anotherExpectationName }] =
+      expectations;
 
     const errorFromAgent1 = faker.lorem.sentence();
     const errorFromAgent2 = faker.lorem.paragraph();


### PR DESCRIPTION
Enforce different values using uuid, as faker.lorem.word() can generate duplicates (it selects random values from a finite set)

Target test: `checksUtils::should get host expectation statements results`