### PR TITLE
Fix flaky suma settings test

### DIFF
--- a/assets/js/common/SuseManagerSettingsDialog/SuseManagerSettingsModal.test.jsx
+++ b/assets/js/common/SuseManagerSettingsDialog/SuseManagerSettingsModal.test.jsx
@@ -55,7 +55,7 @@ describe('SuseManagerSettingsModal component', () => {
   });
 
   it('should try to save all the fields', async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     const url = faker.internet.url();
     const username = faker.word.noun();
     const password = faker.word.noun();


### PR DESCRIPTION
Same as https://github.com/trento-project/web/pull/4294

> Root cause:

`userEvent.setup()` implies `{ delay: 0 }`. That means that, when using `user.type` to simulate user typing, a `setTimeout(...., 0)` is created at every character to simulate human input. As per how the event loop works, React re-renders will interleave into the chain of events. On slow machines or on high parallelism, the loop can get slow and hence get the test to fail.

By setting `{ delay: null }`, we avoid the timeout mechanism altogether

Target test: `SuseManagerSettingsModal component::should try to save all the fields`