### PR TITLE
Stabilize HANA database details deregistration

### DIFF
--- a/test/e2e/cypress/e2e/hana_database_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_database_details.cy.js
@@ -35,6 +35,7 @@ context('HANA database details', () => {
 
   describe('The database layout shows all the running instances', () => {
     beforeEach(() => {
+      hanaDbDetailsPage.restoreDatabaseInstanceHealth();
       hanaDbDetailsPage.visitDatabase();
     });
 
@@ -83,6 +84,7 @@ context('HANA database details', () => {
 
   describe('The database layout shows system replication data properly', () => {
     beforeEach(() => {
+      hanaDbDetailsPage.restoreDatabaseInstanceHealth();
       hanaDbDetailsPage.visitDatabase();
     });
 
@@ -116,8 +118,16 @@ context('HANA database details', () => {
   });
 
   describe('Deregistration', () => {
-    it('should not include deregistered host in the list of hosts', () => {
+    beforeEach(() => {
+      hanaDbDetailsPage.restoreFirstAttachedHost();
+      hanaDbDetailsPage.visitDatabase();
+      hanaDbDetailsPage.deregisteredHostIsDisplayed();
       hanaDbDetailsPage.deregisterFirstAttachedHost();
+    });
+
+    afterEach(() => hanaDbDetailsPage.restoreFirstAttachedHost());
+
+    it('should not include deregistered host in the list of hosts', () => {
       hanaDbDetailsPage.deregisteredHostIsNotDisplayed();
     });
 

--- a/test/e2e/cypress/pageObject/hana_database_details_po.js
+++ b/test/e2e/cypress/pageObject/hana_database_details_po.js
@@ -296,7 +296,7 @@ export const deregisteredHostIsNotDisplayed = () =>
   cy.get(newRegisteredHost).should('not.exist');
 
 export const deregisteredHostIsDisplayed = () =>
-  cy.get(newRegisteredHost).should('be.visible');
+  cy.get(newRegisteredHost, { timeout: 20000 }).should('be.visible');
 
 // API
 


### PR DESCRIPTION
# Description

Stabilizes the HANA database details E2E tests by ensuring test preconditions are restored before each scenario.
 - Restores database instance health before layout and system replication checks.
 - Resets the first attached host before and after deregistration tests.
 - Waits longer for the re-registered host to become visible before deregistering it.
 
 50 runs with no errors of `hana_database_details.cy.js` suite
 https://github.com/trento-project/web/actions/runs/25917798536
 
Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
