### PR TITLE
Migrate Cypress.env to Cypress.expose for public config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -665,6 +665,9 @@ jobs:
           chmod: 0755
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get photofinish path
+        id: photofinish-path
+        run: echo "path=$(which photofinish)" >> $GITHUB_OUTPUT
       - name: Cypress run
         uses: cypress-io/github-action@dace029018fcdf86e0df89a31bc3cfa5b32570d8 # v7.3.0
         env:
@@ -676,7 +679,7 @@ jobs:
           working-directory: test/e2e
           wait-on-timeout: 30
           config: baseUrl=http://localhost:4000
-          expose: photofinish_binary=$(whereis photofinish | cut -d" " -f2)
+          expose: photofinish_binary=${{ steps.photofinish-path.outputs.path }}
       - name: Upload cypress test screenshots
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
@@ -772,6 +775,9 @@ jobs:
           chmod: 0755
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get photofinish path
+        id: photofinish-path
+        run: echo "path=$(which photofinish)" >> $GITHUB_OUTPUT
       - name: Cypress run
         uses: cypress-io/github-action@dace029018fcdf86e0df89a31bc3cfa5b32570d8 # v7.3.0
         env:
@@ -781,7 +787,7 @@ jobs:
           spec: ${{ matrix.cypress_spec }}
           wait-on-timeout: 30
           config: baseUrl=http://localhost:4000
-          expose: photofinish_binary=$(whereis photofinish | cut -d" " -f2)
+          expose: photofinish_binary=${{ steps.photofinish-path.outputs.path }}
       - name: Upload cypress test screenshots
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
@@ -903,6 +909,9 @@ jobs:
           chmod: 0755
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get photofinish path
+        id: photofinish-path
+        run: echo "path=$(which photofinish)" >> $GITHUB_OUTPUT
       - name: "Docker compose dependencies"
         uses: isbang/compose-action@d2bee4f07e8ca410d6b196d00f90c12e7d48c33a # v2.6.0
         with:
@@ -924,7 +933,7 @@ jobs:
           spec: ${{ matrix.cypress_spec }}
           wait-on-timeout: 30
           config: baseUrl=http://localhost:4000
-          expose: photofinish_binary=$(whereis photofinish | cut -d" " -f2),${{ matrix.cypress_expose }}
+          expose: photofinish_binary=${{ steps.photofinish-path.outputs.path }},${{ matrix.cypress_expose }}
       - name: Upload cypress test screenshots
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -667,7 +667,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Get photofinish path
         id: photofinish-path
-        run: echo "path=$(which photofinish)" >> $GITHUB_OUTPUT
+        run: |
+          set -euo pipefail
+          photofinish_path="$(command -v photofinish)"
+          echo "path=$photofinish_path" >> "$GITHUB_OUTPUT"
       - name: Cypress run
         uses: cypress-io/github-action@dace029018fcdf86e0df89a31bc3cfa5b32570d8 # v7.3.0
         env:
@@ -777,7 +780,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Get photofinish path
         id: photofinish-path
-        run: echo "path=$(which photofinish)" >> $GITHUB_OUTPUT
+        run: |
+          set -euo pipefail
+          photofinish_path="$(command -v photofinish)"
+          echo "path=$photofinish_path" >> "$GITHUB_OUTPUT"
       - name: Cypress run
         uses: cypress-io/github-action@dace029018fcdf86e0df89a31bc3cfa5b32570d8 # v7.3.0
         env:
@@ -911,7 +917,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Get photofinish path
         id: photofinish-path
-        run: echo "path=$(which photofinish)" >> $GITHUB_OUTPUT
+        run: |
+          set -euo pipefail
+          photofinish_path="$(command -v photofinish)"
+          echo "path=$photofinish_path" >> "$GITHUB_OUTPUT"
       - name: "Docker compose dependencies"
         uses: isbang/compose-action@d2bee4f07e8ca410d6b196d00f90c12e7d48c33a # v2.6.0
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -672,11 +672,11 @@ jobs:
           SPLIT_INDEX: ${{ strategy.job-index }}
           SPLIT_FILE: cypress-split-timings.json
           cypress_video: false
-          cypress_photofinish_binary: $(whereis photofinish | cut -d" " -f2)
         with:
           working-directory: test/e2e
           wait-on-timeout: 30
           config: baseUrl=http://localhost:4000
+          expose: photofinish_binary=$(whereis photofinish | cut -d" " -f2)
       - name: Upload cypress test screenshots
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
@@ -776,12 +776,12 @@ jobs:
         uses: cypress-io/github-action@c495c3ddffba403ba11be95fffb67e25203b3799 # v7.1.10
         env:
           cypress_video: false
-          cypress_photofinish_binary: $(whereis photofinish | cut -d" " -f2)
         with:
           working-directory: test/e2e
           spec: ${{ matrix.cypress_spec }}
           wait-on-timeout: 30
           config: baseUrl=http://localhost:4000
+          expose: photofinish_binary=$(whereis photofinish | cut -d" " -f2)
       - name: Upload cypress test screenshots
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
@@ -800,43 +800,41 @@ jobs:
           - test: oidc
             cypress_spec: |
               cypress/e2e/sso_integration.cy.js
+            cypress_expose: SSO_INTEGRATION_TESTS=true,SSO_TYPE=oidc
             config_file_content: |
               import Config
 
               config :trento, :oidc, enabled: true
             env:
               MIX_ENV: dev
-              CYPRESS_SSO_INTEGRATION_TESTS: true
-              CYPRESS_SSO_TYPE: oidc
               NODEJS_VERSION: ${{ needs.setup-matrix-env.outputs.NODEJS_DEV }}
           - test: oauth2
             cypress_spec: |
               cypress/e2e/sso_integration.cy.js
+            cypress_expose: SSO_INTEGRATION_TESTS=true,SSO_TYPE=oauth2
             config_file_content: |
               import Config
 
               config :trento, :oauth2, enabled: true
             env:
               MIX_ENV: dev
-              CYPRESS_SSO_INTEGRATION_TESTS: true
-              CYPRESS_SSO_TYPE: oauth2
               NODEJS_VERSION: ${{ needs.setup-matrix-env.outputs.NODEJS_DEV }}
           - test: saml
             cypress_spec: |
               cypress/e2e/sso_integration.cy.js
+            cypress_expose: SSO_INTEGRATION_TESTS=true,SSO_TYPE=saml
             config_file_content: |
               import Config
 
               config :trento, :saml, enabled: true
             env:
               MIX_ENV: dev
-              CYPRESS_SSO_INTEGRATION_TESTS: true
-              CYPRESS_SSO_TYPE: saml
               NODEJS_VERSION: ${{ needs.setup-matrix-env.outputs.NODEJS_DEV }}
           - test: alerting_db
             cypress_spec: |
               cypress/e2e/settings_integration.cy.js
               cypress/e2e/alerting.cy.js
+            cypress_expose: ALERTING_DB_TESTS=true,ALERTING_TESTS=true
             config_file_content: |
               import Config
 
@@ -848,15 +846,13 @@ jobs:
                 smtp_password: nil
             env:
               MIX_ENV: dev
-              CYPRESS_ALERTING_DB_TESTS: true
-              CYPRESS_ALERTING_TESTS: true
               NODEJS_VERSION: ${{ needs.setup-matrix-env.outputs.NODEJS_DEV }}
           - test: alerting_from_env
             cypress_spec: |
               cypress/e2e/alerting.cy.js
+            cypress_expose: ALERTING_TESTS=true
             env:
               MIX_ENV: dev
-              CYPRESS_ALERTING_TESTS: true
               NODEJS_VERSION: ${{ needs.setup-matrix-env.outputs.NODEJS_DEV }}
     env: ${{ matrix.env }}
     steps:
@@ -923,12 +919,12 @@ jobs:
         uses: cypress-io/github-action@c495c3ddffba403ba11be95fffb67e25203b3799 # v7.1.10
         env:
           cypress_video: false
-          cypress_photofinish_binary: $(whereis photofinish | cut -d" " -f2)
         with:
           working-directory: test/e2e
           spec: ${{ matrix.cypress_spec }}
           wait-on-timeout: 30
           config: baseUrl=http://localhost:4000
+          expose: photofinish_binary=$(whereis photofinish | cut -d" " -f2),${{ matrix.cypress_expose }}
       - name: Upload cypress test screenshots
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -666,7 +666,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Cypress run
-        uses: cypress-io/github-action@c495c3ddffba403ba11be95fffb67e25203b3799 # v7.1.10
+        uses: cypress-io/github-action@dace029018fcdf86e0df89a31bc3cfa5b32570d8 # v7.3.0
         env:
           SPLIT: ${{ strategy.job-total }}
           SPLIT_INDEX: ${{ strategy.job-index }}
@@ -773,7 +773,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Cypress run
-        uses: cypress-io/github-action@c495c3ddffba403ba11be95fffb67e25203b3799 # v7.1.10
+        uses: cypress-io/github-action@dace029018fcdf86e0df89a31bc3cfa5b32570d8 # v7.3.0
         env:
           cypress_video: false
         with:
@@ -916,7 +916,7 @@ jobs:
       - name: Run trento detached
         run: mix phx.server &
       - name: Cypress run
-        uses: cypress-io/github-action@c495c3ddffba403ba11be95fffb67e25203b3799 # v7.1.10
+        uses: cypress-io/github-action@dace029018fcdf86e0df89a31bc3cfa5b32570d8 # v7.3.0
         env:
           cypress_video: false
         with:

--- a/.github/workflows/e2e-flaky-tests-detection.yaml
+++ b/.github/workflows/e2e-flaky-tests-detection.yaml
@@ -200,7 +200,7 @@ jobs:
       - name: Set ENV_TS to get current Timestamp for JUnit reports
         run: echo "ENV_TS=$(date +%F_%T | sed 's/:/-/g')" >> $GITHUB_ENV
       - name: Cypress run
-        uses: cypress-io/github-action@c495c3ddffba403ba11be95fffb67e25203b3799 # v7.1.10
+        uses: cypress-io/github-action@dace029018fcdf86e0df89a31bc3cfa5b32570d8 # v7.3.0
         env:
           cypress_video: false
           cypress_db_host: postgres

--- a/.github/workflows/e2e-flaky-tests-detection.yaml
+++ b/.github/workflows/e2e-flaky-tests-detection.yaml
@@ -195,11 +195,12 @@ jobs:
           cache: enable
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Give executable permissions to photofinish
-        run: chmod +x $(whereis photofinish | cut -d" " -f2)
       - name: Get photofinish path
         id: photofinish-path
-        run: echo "path=$(which photofinish)" >> $GITHUB_OUTPUT
+        run: |
+          set -euo pipefail
+          photofinish_path="$(command -v photofinish)"
+          echo "path=$photofinish_path" >> "$GITHUB_OUTPUT"
       - name: Set ENV_TS to get current Timestamp for JUnit reports
         run: echo "ENV_TS=$(date +%F_%T | sed 's/:/-/g')" >> $GITHUB_ENV
       - name: Cypress run

--- a/.github/workflows/e2e-flaky-tests-detection.yaml
+++ b/.github/workflows/e2e-flaky-tests-detection.yaml
@@ -197,6 +197,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Give executable permissions to photofinish
         run: chmod +x $(whereis photofinish | cut -d" " -f2)
+      - name: Get photofinish path
+        id: photofinish-path
+        run: echo "path=$(which photofinish)" >> $GITHUB_OUTPUT
       - name: Set ENV_TS to get current Timestamp for JUnit reports
         run: echo "ENV_TS=$(date +%F_%T | sed 's/:/-/g')" >> $GITHUB_ENV
       - name: Cypress run
@@ -209,7 +212,7 @@ jobs:
           command: npx cypress run --reporter junit --reporter-options mochaFile=/tmp/trento-e2e-junit-[hash]-${{ env.ENV_TS }}.xml --spec ${{ github.event.inputs.spec_pattern || '**/*.cy.js' }}
           working-directory: test/e2e
           wait-on-timeout: 30
-          expose: photofinish_binary=$(whereis photofinish | cut -d" " -f2)
+          expose: photofinish_binary=${{ steps.photofinish-path.outputs.path }}
       - name: Upload cypress test junit reports
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/e2e-flaky-tests-detection.yaml
+++ b/.github/workflows/e2e-flaky-tests-detection.yaml
@@ -205,11 +205,11 @@ jobs:
           cypress_video: false
           cypress_db_host: postgres
           cypress_db_port: 5432
-          cypress_photofinish_binary: $(whereis photofinish | cut -d" " -f2)
         with:
           command: npx cypress run --reporter junit --reporter-options mochaFile=/tmp/trento-e2e-junit-[hash]-${{ env.ENV_TS }}.xml --spec ${{ github.event.inputs.spec_pattern || '**/*.cy.js' }}
           working-directory: test/e2e
           wait-on-timeout: 30
+          expose: photofinish_binary=$(whereis photofinish | cut -d" " -f2)
       - name: Upload cypress test junit reports
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/test/e2e/cypress.config.js
+++ b/test/e2e/cypress.config.js
@@ -6,38 +6,6 @@ const { defineConfig } = require('cypress');
 const DEMO = 'demo';
 const DEV = 'dev';
 
-// Whitelist of environment variables allowed to override 'expose' configuration
-const PUBLIC_CONFIG_KEYS = [
-  'ALERTING_DB_TESTS',
-  'ALERTING_TESTS',
-  'REAL_CLUSTER_TESTS',
-  'SSO_INTEGRATION_TESTS',
-  'SSO_TYPE',
-  'idp_url',
-  'photofinish_binary',
-  'project_root',
-  'wandaUrl',
-  'wanda_mode',
-  'web_mode',
-];
-
-// Filters Cypress.env to only include allowed keys from the whitelist
-const getPublicEnvOverrides = (env = {}) => {
-  const overrides = {};
-
-  PUBLIC_CONFIG_KEYS.forEach((key) => {
-    if (env[key] !== undefined) overrides[key] = env[key];
-  });
-
-  return overrides;
-};
-
-// Merges default 'expose' config with environment overrides (overrides take precedence)
-const exposePublicConfig = (config) => ({
-  ...config.expose,
-  ...getPublicEnvOverrides(config.env),
-});
-
 const calculateWandaUrl = (config) => {
   const { wandaUrl, wanda_mode: wandaMode } = config.expose;
 
@@ -70,7 +38,6 @@ module.exports = defineConfig({
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.
     async setupNodeEvents(on, config) {
-      config.expose = exposePublicConfig(config);
       config.expose.wandaUrl = calculateWandaUrl(config);
       return require('./cypress/plugins/index.js')(on, config);
     },

--- a/test/e2e/cypress.config.js
+++ b/test/e2e/cypress.config.js
@@ -6,6 +6,7 @@ const { defineConfig } = require('cypress');
 const DEMO = 'demo';
 const DEV = 'dev';
 
+// Whitelist of environment variables allowed to override 'expose' configuration
 const PUBLIC_CONFIG_KEYS = [
   'ALERTING_DB_TESTS',
   'ALERTING_TESTS',
@@ -20,6 +21,7 @@ const PUBLIC_CONFIG_KEYS = [
   'web_mode',
 ];
 
+// Filters Cypress.env to only include allowed keys from the whitelist
 const getPublicEnvOverrides = (env = {}) => {
   const overrides = {};
 
@@ -30,6 +32,7 @@ const getPublicEnvOverrides = (env = {}) => {
   return overrides;
 };
 
+// Merges default 'expose' config with environment overrides (overrides take precedence)
 const exposePublicConfig = (config) => ({
   ...config.expose,
   ...getPublicEnvOverrides(config.env),
@@ -49,6 +52,7 @@ module.exports = defineConfig({
   viewportWidth: 1366,
   viewportHeight: 768,
   defaultCommandTimeout: 10000,
+  // Default public configuration (can be overridden by environment variables)
   expose: {
     project_root: '../..',
     photofinish_binary: 'photofinish',
@@ -56,6 +60,7 @@ module.exports = defineConfig({
     wanda_mode: DEMO, //demo: local dev instance with, docker compose with wanda profile / prod: instance installed via rpm
     web_mode: DEV, //dev: local dev instance / prod: instance installed via rpm
   },
+  // Internal Cypress environment variables (not exposed by default)
   env: {
     heartbeat_interval: 5000,
     login_user: 'admin',

--- a/test/e2e/cypress.config.js
+++ b/test/e2e/cypress.config.js
@@ -6,32 +6,67 @@ const { defineConfig } = require('cypress');
 const DEMO = 'demo';
 const DEV = 'dev';
 
+const PUBLIC_CONFIG_KEYS = [
+  'ALERTING_DB_TESTS',
+  'ALERTING_TESTS',
+  'REAL_CLUSTER_TESTS',
+  'SSO_INTEGRATION_TESTS',
+  'SSO_TYPE',
+  'idp_url',
+  'photofinish_binary',
+  'project_root',
+  'wandaUrl',
+  'wanda_mode',
+  'web_mode',
+];
+
+const getPublicEnvOverrides = (env = {}) => {
+  const overrides = {};
+
+  PUBLIC_CONFIG_KEYS.forEach((key) => {
+    if (env[key] !== undefined) overrides[key] = env[key];
+  });
+
+  return overrides;
+};
+
+const exposePublicConfig = (config) => ({
+  ...config.expose,
+  ...getPublicEnvOverrides(config.env),
+});
+
 const calculateWandaUrl = (config) => {
-  if (config.env.wandaUrl) return config.env.wandaUrl;
-  return config.env.wanda_mode === DEMO
+  const { wandaUrl, wanda_mode: wandaMode } = config.expose;
+
+  if (wandaUrl) return wandaUrl;
+  return wandaMode === DEMO
     ? 'http://localhost:4001'
     : `${config.baseUrl}/wanda`;
 };
 
 module.exports = defineConfig({
+  allowCypressEnv: false,
   viewportWidth: 1366,
   viewportHeight: 768,
   defaultCommandTimeout: 10000,
-  env: {
-    heartbeat_interval: 5000,
+  expose: {
     project_root: '../..',
     photofinish_binary: 'photofinish',
-    login_user: 'admin',
-    login_password: 'adminpassword',
     idp_url: 'http://localhost:8081',
     wanda_mode: DEMO, //demo: local dev instance with, docker compose with wanda profile / prod: instance installed via rpm
     web_mode: DEV, //dev: local dev instance / prod: instance installed via rpm
+  },
+  env: {
+    heartbeat_interval: 5000,
+    login_user: 'admin',
+    login_password: 'adminpassword',
   },
   e2e: {
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.
     async setupNodeEvents(on, config) {
-      config.env.wandaUrl = calculateWandaUrl(config);
+      config.expose = exposePublicConfig(config);
+      config.expose.wandaUrl = calculateWandaUrl(config);
       return require('./cypress/plugins/index.js')(on, config);
     },
     testIsolation: false,

--- a/test/e2e/cypress/e2e/alerting.cy.js
+++ b/test/e2e/cypress/e2e/alerting.cy.js
@@ -5,7 +5,7 @@ import * as alertingPage from '../pageObject/alerting_po';
 
 context('Email Alerting feature', () => {
   before(function () {
-    if (!Cypress.env('ALERTING_TESTS')) {
+    if (!Cypress.expose('ALERTING_TESTS')) {
       this.skip();
     }
     alertingPage.deleteAllEmailsFromMailpit();

--- a/test/e2e/cypress/e2e/checks_customization.cy.js
+++ b/test/e2e/cypress/e2e/checks_customization.cy.js
@@ -122,7 +122,7 @@ context('Checks customization', () => {
 
   describe('Execution with customized check values', () => {
     before(function () {
-      if (Cypress.env('wanda_mode') !== 'demo') this.skip();
+      if (Cypress.expose('wanda_mode') !== 'demo') this.skip();
     });
 
     it('should run a checks execution with customized check values', () => {

--- a/test/e2e/cypress/e2e/hana_cluster_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_cluster_details.cy.js
@@ -305,7 +305,7 @@ context('HANA cluster details', () => {
     const CHECK_SBD = 'SBD';
 
     before(function () {
-      if (Cypress.env('wanda_mode') !== 'demo') this.skip();
+      if (Cypress.expose('wanda_mode') !== 'demo') this.skip();
     });
 
     beforeEach(() => hanaClusterDetailsPage.visitAvailableHanaCluster());

--- a/test/e2e/cypress/e2e/hana_scale_up_checks.cy.js
+++ b/test/e2e/cypress/e2e/hana_scale_up_checks.cy.js
@@ -3,7 +3,7 @@
 
 import * as hanaClusterDetailsPage from '../pageObject/hana_cluster_details_po';
 
-if (Cypress.env('REAL_CLUSTER_TESTS')) {
+if (Cypress.expose('REAL_CLUSTER_TESTS')) {
   context('HANA scale-up checks', () => {
     const clusterID = 'd2522281-2c76-52dc-8500-10bdf2cc6664';
 

--- a/test/e2e/cypress/e2e/settings_integration.cy.js
+++ b/test/e2e/cypress/e2e/settings_integration.cy.js
@@ -5,7 +5,7 @@ import * as settingsPage from '../pageObject/settings_po';
 
 describe('Alerting settings from DB', () => {
   before(function () {
-    if (!Cypress.env('ALERTING_DB_TESTS')) {
+    if (!Cypress.expose('ALERTING_DB_TESTS')) {
       this.skip();
     }
   });

--- a/test/e2e/cypress/e2e/sso_integration.cy.js
+++ b/test/e2e/cypress/e2e/sso_integration.cy.js
@@ -6,7 +6,7 @@ import * as loginPage from '../pageObject/login_po';
 import * as dashboardPage from '../pageObject/dashboard_po';
 
 describe('SSO integration', () => {
-  if (!Cypress.env('SSO_INTEGRATION_TESTS')) {
+  if (!Cypress.expose('SSO_INTEGRATION_TESTS')) {
     return;
   }
 

--- a/test/e2e/cypress/pageObject/alerting_po.js
+++ b/test/e2e/cypress/pageObject/alerting_po.js
@@ -59,5 +59,5 @@ export const triggerDatabaseAlertingEmail = () =>
   basePage.loadScenario('hana-database-detail-RED');
 
 export const deleteAllEmailsFromMailpit = () => {
-  if (Cypress.env('ALERTING_TESTS')) cy.task('deleteAllEmailsFromMailpit');
+  if (Cypress.expose('ALERTING_TESTS')) cy.task('deleteAllEmailsFromMailpit');
 };

--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -169,17 +169,15 @@ export const removeTagButtonIsEnabled = () =>
 
 const getLoginCredentials = (username, password) => {
   if (username !== undefined && password !== undefined) {
-    return cy.wrap({ username, password }, { log: false });
+    return cy.wrap({ username, password });
   }
 
   return cy
-    .env(['login_user', 'login_password'], { log: false })
-    .then(
-      ({ login_user: defaultUsername, login_password: defaultPassword }) => ({
-        username: username ?? defaultUsername,
-        password: password ?? defaultPassword,
-      })
-    );
+    .env(['login_user', 'login_password'])
+    .then(({ login_user, login_password }) => ({
+      username: login_user,
+      password: login_password,
+    }));
 };
 
 const requestLogin = (credentials) =>

--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -167,6 +167,12 @@ export const removeTagButtonIsEnabled = () =>
 
 // API Interactions & Validations
 
+export const validateResponseStatusCode = (endpointAlias, expectedStatusCode) =>
+  cy
+    .wait(`@${endpointAlias}`)
+    .its('response.statusCode')
+    .should('eq', expectedStatusCode);
+
 const getLoginCredentials = (username, password) => {
   if (username !== undefined && password !== undefined) {
     return cy.wrap({ username, password });
@@ -192,12 +198,6 @@ const requestLogin = (credentials) =>
         response.body;
       return { accessToken, refreshToken };
     });
-
-export const validateResponseStatusCode = (endpointAlias, expectedStatusCode) =>
-  cy
-    .wait(`@${endpointAlias}`)
-    .its('response.statusCode')
-    .should('eq', expectedStatusCode);
 
 export const apiLogin = (username, password) =>
   getLoginCredentials(username, password).then(requestLogin);

--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -4,10 +4,6 @@
 import { TOTP } from 'totp-generator';
 import { createUserRequestFactory } from '@lib/test-utils/factories';
 
-// Test data
-const DEFAULT_USERNAME = Cypress.env('login_user');
-const DEFAULT_PASSWORD = Cypress.env('login_password');
-
 export const plainUser = {
   username: 'trentoidp',
   password: 'password',
@@ -171,21 +167,27 @@ export const removeTagButtonIsEnabled = () =>
 
 // API Interactions & Validations
 
-export const validateResponseStatusCode = (endpointAlias, expectedStatusCode) =>
-  cy
-    .wait(`@${endpointAlias}`)
-    .its('response.statusCode')
-    .should('eq', expectedStatusCode);
+const getLoginCredentials = (username, password) => {
+  if (username !== undefined && password !== undefined) {
+    return cy.wrap({ username, password }, { log: false });
+  }
 
-export const apiLogin = (
-  username = DEFAULT_USERNAME,
-  password = DEFAULT_PASSWORD
-) =>
+  return cy
+    .env(['login_user', 'login_password'], { log: false })
+    .then(
+      ({ login_user: defaultUsername, login_password: defaultPassword }) => ({
+        username: username ?? defaultUsername,
+        password: password ?? defaultPassword,
+      })
+    );
+};
+
+const requestLogin = (credentials) =>
   cy
     .request({
       method: 'POST',
       url: '/api/session',
-      body: { username, password },
+      body: credentials,
     })
     .then((response) => {
       const { access_token: accessToken, refresh_token: refreshToken } =
@@ -193,16 +195,24 @@ export const apiLogin = (
       return { accessToken, refreshToken };
     });
 
-export const apiLoginAndCreateSession = (
-  username = DEFAULT_USERNAME,
-  password = DEFAULT_PASSWORD
-) =>
-  cy.session([username, password], () => {
-    apiLogin(username, password).then(({ accessToken, refreshToken }) => {
-      window.localStorage.setItem('access_token', accessToken);
-      window.localStorage.setItem('refresh_token', refreshToken);
-    });
-  });
+export const validateResponseStatusCode = (endpointAlias, expectedStatusCode) =>
+  cy
+    .wait(`@${endpointAlias}`)
+    .its('response.statusCode')
+    .should('eq', expectedStatusCode);
+
+export const apiLogin = (username, password) =>
+  getLoginCredentials(username, password).then(requestLogin);
+
+export const apiLoginAndCreateSession = (username, password) =>
+  getLoginCredentials(username, password).then((credentials) =>
+    cy.session([credentials.username, credentials.password], () => {
+      requestLogin(credentials).then(({ accessToken, refreshToken }) => {
+        window.localStorage.setItem('access_token', accessToken);
+        window.localStorage.setItem('refresh_token', refreshToken);
+      });
+    })
+  );
 
 export const logout = () => {
   cy.window().then((win) => {
@@ -251,10 +261,10 @@ export const preloadTestData = ({ isDataLoadedFunc = isTestDataLoaded } = {}) =>
 
 export const loadScenario = (scenario) => {
   const [projectRoot, photofinishBinary] = [
-    Cypress.env('project_root'),
-    Cypress.env('photofinish_binary'),
+    Cypress.expose('project_root'),
+    Cypress.expose('photofinish_binary'),
   ];
-  const isTrentoProdInstance = Cypress.env('web_mode') === 'prod';
+  const isTrentoProdInstance = Cypress.expose('web_mode') === 'prod';
   const photofinishExecTimeout = isTrentoProdInstance ? 180000 : 60000;
 
   const baseUrl = Cypress.config().baseUrl;
@@ -276,7 +286,7 @@ export const loadScenario = (scenario) => {
     });
   };
 
-  if (Cypress.env('web_mode') === 'dev') return runPhotofinish();
+  if (Cypress.expose('web_mode') === 'dev') return runPhotofinish();
   else return getApiKey().then((apiKey) => runPhotofinish(apiKey));
 };
 
@@ -307,7 +317,7 @@ const isTestDataLoaded = () =>
   );
 
 export const startAgentsHeartbeat = (agents) => {
-  if (Cypress.env('web_mode') === 'dev') {
+  if (Cypress.expose('web_mode') === 'dev') {
     return cy.task('startAgentHeartbeat', { agents });
   }
 

--- a/test/e2e/cypress/pageObject/checks_customization_po.js
+++ b/test/e2e/cypress/pageObject/checks_customization_po.js
@@ -270,7 +270,7 @@ const _resetCheck = (groupId, checkId) =>
   basePage.apiLogin().then(({ accessToken }) =>
     cy.request({
       method: 'DELETE',
-      url: `${Cypress.env(
+      url: `${Cypress.expose(
         'wandaUrl'
       )}/api/v1/groups/${groupId}/checks/${checkId}/customization`,
       auth: { bearer: accessToken },

--- a/test/e2e/cypress/pageObject/hana_cluster_details_po.js
+++ b/test/e2e/cypress/pageObject/hana_cluster_details_po.js
@@ -43,7 +43,7 @@ const clusterStates = {
 //Attributes
 
 const url = '/clusters';
-const wandaUrl = Cypress.env('wandaUrl');
+const wandaUrl = Cypress.expose('wandaUrl');
 const catalogEndpointAlias = 'catalog';
 const lastExecutionEndpointAlias = 'lastExecution';
 const getChecksEndpointAlias = 'getChecks';

--- a/test/e2e/cypress/pageObject/host_details_po.js
+++ b/test/e2e/cypress/pageObject/host_details_po.js
@@ -533,7 +533,7 @@ const _validateCell = (tableName, header, rowIndex, expectedValue) => {
 
 // API
 export const interceptSoftwareUpdatesRequestsMockedForProdInstance = () => {
-  const isTrentoProdInstance = Cypress.env('web_mode') === 'prod';
+  const isTrentoProdInstance = Cypress.expose('web_mode') === 'prod';
 
   if (isTrentoProdInstance) {
     return cy
@@ -546,7 +546,7 @@ export const interceptSoftwareUpdatesRequestsMockedForProdInstance = () => {
 };
 
 export const interceptSumaRequestsMockedForProdInstance = () => {
-  const isTrentoProdInstance = Cypress.env('web_mode') === 'prod';
+  const isTrentoProdInstance = Cypress.expose('web_mode') === 'prod';
 
   if (isTrentoProdInstance) {
     cy.intercept('GET', '/api/v1/hosts/*/software_updates', {
@@ -571,7 +571,7 @@ export const interceptSumaRequestsMockedForProdInstance = () => {
 };
 
 export const interceptNodeExporterStatusMockedForProdInstance = () => {
-  const isTrentoProdInstance = Cypress.env('web_mode') === 'prod';
+  const isTrentoProdInstance = Cypress.expose('web_mode') === 'prod';
 
   if (isTrentoProdInstance) {
     return cy.intercept('/api/v1/hosts/*/exporters_status', {

--- a/test/e2e/cypress/pageObject/login_po.js
+++ b/test/e2e/cypress/pageObject/login_po.js
@@ -5,7 +5,7 @@ export * from './base_po.js';
 import * as basePage from './base_po.js';
 
 // Test data
-const ssoType = Cypress.env('SSO_TYPE') || 'oidc';
+const ssoType = Cypress.expose('SSO_TYPE') || 'oidc';
 
 // Selectors
 const usernameInputField = 'input[autocomplete="username"]';
@@ -47,7 +47,7 @@ const _loginWithSSO = (username, password) => {
   return cy.session(args, () => {
     cy.visit('/');
     cy.get('button').contains('Login with Single Sign-on').click();
-    cy.origin(Cypress.env('idp_url'), { args }, ([username, password]) => {
+    cy.origin(Cypress.expose('idp_url'), { args }, ([username, password]) => {
       cy.get('[id="username"]').type(username);
       cy.get('[id="password"]').type(password);
       return cy.get('input').contains('Sign In').click();

--- a/test/e2e/cypress/pageObject/settings_po.js
+++ b/test/e2e/cypress/pageObject/settings_po.js
@@ -1017,7 +1017,9 @@ export const updateApiKeyExpiration = (apiKeyExpiration) =>
   );
 
 export const resetAlertingSettingsDB = () =>
-  cy.exec(`cd ${Cypress.env('project_root')} && mix clear_alerting_settings`);
+  cy.exec(
+    `cd ${Cypress.expose('project_root')} && mix clear_alerting_settings`
+  );
 
 export const saveInitialAlertingSettings = () =>
   basePage.apiLogin().then(({ accessToken }) =>

--- a/test/e2e/cypress/support/e2e.js
+++ b/test/e2e/cypress/support/e2e.js
@@ -29,7 +29,7 @@ import {
 // eslint-disable-next-line mocha/no-top-level-hooks
 before(() => {
   Cypress.session.clearAllSavedSessions();
-  if (!Cypress.env('SSO_INTEGRATION_TESTS')) {
+  if (!Cypress.expose('SSO_INTEGRATION_TESTS')) {
     apiLoginAndCreateSession();
   }
 


### PR DESCRIPTION
# Description

Address the Cypress deprecation warning introduced in Cypress 15 regarding `allowCypressEnv`

 - Set `allowCypressEnv: false` in `cypress.config.js`
 - Moved all public config values (feature flags, URLs, binary paths) to the expose block in `cypress.config.js`
 - Replaced all `Cypress.env()` calls with `Cypress.expose()` across specs and page objects
 - Sensitive credentials (login_user, login_password) remain in env and are read with the async `cy.env()`
 - Updated workflows to pass feature flags via the expose input of cypress github action, replacing CYPRESS_* environment variables
 - Bumped cypress github action from v7.1.10 to v7.3.0, which adds support for the expose input

Deprecation warning:
```
Warning: The allowCypressEnv configuration option is enabled. This allows any browser code to read values from Cypress.env(). This is insecure and will be removed in a future major version.

1. Replace Cypress.env() calls with cy.env() (for sensitive values) or Cypress.expose() (for public configuration)
2. Set allowCypressEnv: false in your Cypress configuration to disable Cypress.env()

Learn more: https://on.cypress.io/cypress-env-migration
```
Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
