### PR TITLE
Fix npm11/node24 resolution problem with optional peerDep

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -12048,15 +12048,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -23438,6 +23429,15 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/assets/package.json
+++ b/assets/package.json
@@ -95,7 +95,10 @@
     "eos-icons-react": {
       "react": "$react"
     },
-    "@assistant-ui/core": "0.1.13"
+    "@assistant-ui/core": "0.1.13",
+    "tailwindcss": {
+      "yaml": "^1.10.0"
+    }
   },
   "scripts": {
     "tailwind:build": "tailwindcss --postcss --minify --input=css/app.css --output=../priv/static/assets/app.css",


### PR DESCRIPTION
Fix a NPM resolution problem when  using npm11/node24.
`tailwindcss` depends on `postcss-load-config` which defines `yaml` as _optional_ peerDependency. However, this conflicts with `react-select` dependency which uses older version of `yaml`. Since npm11/node24, the resolution of deps changed and optional peerDeps are considered when doing resolution although they might not actually be used.

Since we're not using `yaml` module as top-level/peer-dep ourselves, we override the version to the older one that is used in react-select.