### PR TITLE
Export version in rpm packages to use same value during compilation

### DIFF
--- a/packaging/suse/rpm/trento-web.spec
+++ b/packaging/suse/rpm/trento-web.spec
@@ -55,6 +55,7 @@ export MIX_HOME=/usr/bin
 export MIX_REBAR3=/usr/bin/rebar3
 export MIX_PATH=/usr/lib/elixir/lib/hex/ebin
 export GTM_ID=%%GTM_ID%%
+export VERSION=%{version}
 mix phx.digest
 mix release
 


### PR DESCRIPTION
# Description

Use `rpm` package version to build the package.
Otherwise the `VERSION` file content is used, and this doesn't include "rolling" versions.

## How was this tested?

Visually on OBS

## Did you update the documentation?

No need
