### PR TITLE
Add health icon in details views

### DIFF
--- a/assets/js/common/PageHeader/DetailsViewHeader.jsx
+++ b/assets/js/common/PageHeader/DetailsViewHeader.jsx
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import HealthIcon from '@common/HealthIcon';
+import PageHeader from './PageHeader';
+
+function DetailsViewHeader({ className, health, children }) {
+  return (
+    <PageHeader className={className}>
+      <div className="flex items-center justify-center space-x-2">
+        <HealthIcon health={health} size="xl" />
+        <span>{children}</span>
+      </div>
+    </PageHeader>
+  );
+}
+
+export default DetailsViewHeader;

--- a/assets/js/common/PageHeader/DetailsViewHeader.stories.jsx
+++ b/assets/js/common/PageHeader/DetailsViewHeader.stories.jsx
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import DetailsViewHeader from './DetailsViewHeader';
+
+export default {
+  title: 'Components/DetailsViewHeader',
+  component: DetailsViewHeader,
+  argTypes: {
+    className: {
+      description: 'Additional CSS classes applied to the component',
+      control: { type: 'text' },
+    },
+    health: {
+      description: 'Health icon type',
+      control: { type: 'radio' },
+      options: ['passing', 'warning', 'critical', 'unknown'],
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'passing' },
+      },
+    },
+    children: {
+      description: 'Content or text displayed inside the component',
+      control: { type: 'text' },
+    },
+  },
+};
+
+export const Default = {
+  args: {
+    className: '',
+    health: 'passing',
+    children: 'Default children',
+  },
+};

--- a/assets/js/common/PageHeader/DetailsViewHeader.test.jsx
+++ b/assets/js/common/PageHeader/DetailsViewHeader.test.jsx
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { DetailsViewHeader } from '.';
+import '@testing-library/jest-dom';
+
+describe('DetailsViewHeader', () => {
+  it('should render a header with the correct text and health', () => {
+    render(<DetailsViewHeader health="passing">Hello World</DetailsViewHeader>);
+    expect(screen.getByText('Hello World')).toBeVisible();
+    expect(screen.getByTestId('eos-svg-component')).toHaveClass(
+      'fill-jungle-green-500'
+    );
+  });
+});

--- a/assets/js/common/PageHeader/index.js
+++ b/assets/js/common/PageHeader/index.js
@@ -2,5 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import PageHeader from './PageHeader';
+import DetailsViewHeader from './DetailsViewHeader';
+
+export { DetailsViewHeader };
 
 export default PageHeader;

--- a/assets/js/pages/ClusterDetails/ClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetails.jsx
@@ -32,7 +32,7 @@ import BackButton from '@common/BackButton';
 import Button from '@common/Button';
 import DisabledGuard from '@common/DisabledGuard';
 import OperationsButton from '@common/OperationsButton';
-import PageHeader from '@common/PageHeader';
+import { DetailsViewHeader } from '@common/PageHeader';
 import Tooltip from '@common/Tooltip';
 import {
   OperationForbiddenModal,
@@ -56,6 +56,7 @@ function ClusterDetails({
   details,
   hasSelectedChecks,
   hosts,
+  health,
   state,
   lastExecution = {},
   operationsEnabled = false,
@@ -187,10 +188,10 @@ function ClusterDetails({
       <BackButton url="/clusters">Back to Clusters</BackButton>
       <div className="flex flex-wrap">
         <div className="flex w-1/2 h-auto overflow-hidden overflow-ellipsis break-words">
-          <PageHeader className="whitespace-normal">
+          <DetailsViewHeader className="whitespace-normal" health={health}>
             Pacemaker Cluster Details:{' '}
             <span className="font-bold">{clusterName}</span>
-          </PageHeader>
+          </DetailsViewHeader>
         </div>
         <div className="flex w-1/2 justify-end">
           <div className="flex w-fit whitespace-nowrap">

--- a/assets/js/pages/ClusterDetails/ClusterDetails.test.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetails.test.jsx
@@ -27,8 +27,8 @@ import ClusterDetails from './ClusterDetails';
 const userAbilities = [{ name: 'all', resource: 'all' }];
 
 describe('ClusterDetails ClusterDetails component', () => {
-  it('should display cluster name', () => {
-    const { id, name, details } = clusterFactory.build();
+  it('should display cluster name and health', () => {
+    const { id, name, health, details } = clusterFactory.build();
 
     renderWithRouter(
       <ClusterDetails
@@ -37,6 +37,7 @@ describe('ClusterDetails ClusterDetails component', () => {
         details={details}
         hasSelectedChecks={false}
         hosts={[]}
+        health={health}
         selectedChecks={[]}
         userAbilities={userAbilities}
         onStartExecution={noop}
@@ -44,11 +45,13 @@ describe('ClusterDetails ClusterDetails component', () => {
       />
     );
 
-    expect(
-      screen.getByRole('heading', {
-        name: `Pacemaker Cluster Details: ${name}`,
-      })
-    ).toBeInTheDocument();
+    const header = screen.getByRole('heading', {
+      name: `Pacemaker Cluster Details: ${name}`,
+    });
+
+    expect(header).toBeInTheDocument();
+    const { getByTestId } = within(header);
+    expect(getByTestId('eos-svg-component')).toBeInTheDocument();
   });
 
   it.each([

--- a/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
@@ -124,6 +124,7 @@ export function ClusterDetailsPage() {
       details={cluster.details}
       hasSelectedChecks={hasSelectedChecks}
       hosts={clusterHosts}
+      health={cluster.health}
       state={cluster.state}
       lastExecution={lastExecution}
       operationsEnabled={operationsEnabled}

--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -26,7 +26,7 @@ import { formatDateTime } from '@lib/timezones';
 import BackButton from '@common/BackButton';
 import Button from '@common/Button';
 import CleanUpButton from '@common/CleanUpButton';
-import PageHeader from '@common/PageHeader';
+import { DetailsViewHeader } from '@common/PageHeader';
 import Table from '@common/Table';
 import Tooltip from '@common/Tooltip';
 import Banner from '@common/Banners';
@@ -76,6 +76,7 @@ function HostDetails({
   deregistering,
   exportersStatus = {},
   heartbeat,
+  health,
   hostID,
   hostname,
   ipAddresses = [],
@@ -230,9 +231,9 @@ function HostDetails({
         <BackButton url="/hosts">Back to Hosts</BackButton>
         <div className="flex flex-wrap">
           <div className="flex w-1/2 h-auto overflow-hidden overflow-ellipsis break-words">
-            <PageHeader>
+            <DetailsViewHeader health={health}>
               Host Details: <span className="font-bold">{hostname}</span>
-            </PageHeader>
+            </DetailsViewHeader>
           </div>
           <div className="flex w-1/2 justify-end">
             <div className="flex w-fit whitespace-nowrap">
@@ -366,8 +367,10 @@ function HostDetails({
               timezone={timezone}
               loading={catalogLoading || lastExecutionLoading}
               error={catalogError || lastExecutionError}
-              onCheckClick={(health) =>
-                navigate(`/hosts/${hostID}/executions/last?health=${health}`)
+              onCheckClick={(checksHealth) =>
+                navigate(
+                  `/hosts/${hostID}/executions/last?health=${checksHealth}`
+                )
               }
             />
           </div>

--- a/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
@@ -87,6 +87,15 @@ export default {
         defaultValue: { summary: 'passing' },
       },
     },
+    health: {
+      control: { type: 'radio' },
+      options: ['passing', 'warning', 'critical', 'unknown'],
+      description: 'Host health',
+      table: {
+        type: { summary: 'string' },
+        defaultValue: { summary: 'passing' },
+      },
+    },
     hostID: {
       control: 'text',
       description: 'The host identifier',
@@ -205,6 +214,7 @@ export const Default = {
     deregistering: false,
     exportersStatus: {},
     heartbeat: host.heartbeat,
+    health: host.health,
     hostID: host.id,
     hostname: host.hostname,
     ipAddresses: host.ip_addresses,

--- a/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
@@ -38,6 +38,29 @@ describe('HostDetails component', () => {
     axiosMock.onGet(/\/api\/v1\/charts.*/gm).reply(200, {});
   });
 
+  describe('Header', () => {
+    it('should display host name and health', () => {
+      const { hostname, health } = hostFactory.build();
+
+      renderWithRouter(
+        <HostDetails
+          hostname={hostname}
+          health={health}
+          agentVersion="1.0.0"
+          userAbilities={userAbilities}
+        />
+      );
+
+      const header = screen.getByRole('heading', {
+        name: `Host Details: ${hostname}`,
+      });
+
+      expect(header).toBeInTheDocument();
+      const { getByTestId } = within(header);
+      expect(getByTestId('eos-svg-component')).toBeInTheDocument();
+    });
+  });
+
   describe('Checks execution', () => {
     it('should show the Checks related action buttons', () => {
       renderWithRouter(

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.jsx
@@ -134,6 +134,7 @@ function HostDetailsPage() {
       deregistering={host.deregistering}
       exportersStatus={exportersStatus}
       heartbeat={host.heartbeat}
+      health={host.health}
       hostID={host.id}
       hostname={host.hostname}
       ipAddresses={host.ip_addresses}

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
@@ -47,7 +47,7 @@ import { isSomeHostHeartbeatPassing } from '@lib/model/hosts';
 
 import ListView from '@common/ListView';
 import Table from '@common/Table';
-import PageHeader from '@common/PageHeader';
+import { DetailsViewHeader } from '@common/PageHeader';
 import {
   OperationForbiddenModal,
   SimpleAcceptanceOperationModal,
@@ -285,7 +285,9 @@ export function GenericSystemDetails({
       />
       <div className="flex flex-wrap">
         <div className="flex w-1/2 h-auto overflow-hidden overflow-ellipsis break-words">
-          <PageHeader className="font-bold">{title}</PageHeader>
+          <DetailsViewHeader className="font-bold" health={system.health}>
+            {title}
+          </DetailsViewHeader>
         </div>
         {operationsEnabled && (
           <div className="flex w-1/2 justify-end">

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
@@ -125,7 +125,14 @@ describe('GenericSystemDetails', () => {
       />
     );
 
-    expect(screen.getByText(title)).toBeTruthy();
+    const header = screen.getByRole('heading', {
+      name: title,
+    });
+
+    expect(header).toBeInTheDocument();
+    const { getByTestId } = within(header);
+    expect(getByTestId('eos-svg-component')).toBeInTheDocument();
+
     expect(screen.getByText('Application server')).toBeTruthy();
     expect(screen.getByText(sid)).toBeTruthy();
     expect(screen.getByText('ENSA1')).toBeTruthy();
@@ -316,7 +323,7 @@ describe('GenericSystemDetails', () => {
     );
 
     expect(screen.queryByRole('button', { name: 'Clean up' })).toBeVisible();
-    const [_sapSystemIcon, health, _cleanUpIcon] =
+    const [_mainHealth, _sapSystemIcon, health, _cleanUpIcon] =
       screen.getAllByTestId('eos-svg-component');
     expect(health).toHaveClass('fill-black');
   });

--- a/test/e2e/cypress/e2e/hana_cluster_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_cluster_details.cy.js
@@ -18,6 +18,10 @@ context('HANA cluster details', () => {
       hanaClusterDetailsPage.expectedClusterNameIsDisplayedInHeader();
     });
 
+    it('should have expected cluster health in header', () => {
+      hanaClusterDetailsPage.expectedClusterHealthIsDisplayedInHeader();
+    });
+
     it('should have expected provider', () => {
       hanaClusterDetailsPage.expectedProviderIsDisplayed('hana');
     });

--- a/test/e2e/cypress/e2e/hana_database_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_database_details.cy.js
@@ -18,6 +18,7 @@ context('HANA database details', () => {
 
     it('should display the expected SID in database details page', () => {
       hanaDbDetailsPage.pageTitleIsCorrectlyDisplayed('HANA Database Details');
+      hanaDbDetailsPage.pageTitleHealthIsCorrectlyDisplayed();
       hanaDbDetailsPage.databaseHasExpectedName();
       hanaDbDetailsPage.databaseHasExpectedType();
     });

--- a/test/e2e/cypress/e2e/host_details.cy.js
+++ b/test/e2e/cypress/e2e/host_details.cy.js
@@ -32,6 +32,10 @@ context('Host Details', () => {
       hostDetailsPage.hostNavigationItemIsHighlighted();
     });
 
+    it('should show the correct host health', () => {
+      hostDetailsPage.healthHasExpectedValue();
+    });
+
     it('should show the correct cluster', () => {
       hostDetailsPage.clusterNameHasExpectedValue();
     });

--- a/test/e2e/cypress/e2e/sap_system_details.cy.js
+++ b/test/e2e/cypress/e2e/sap_system_details.cy.js
@@ -15,6 +15,7 @@ context('SAP system details', () => {
 
     it('should display the selected system details page', () => {
       sapSystemDetailsPage.pageTitleIsCorrectlyDisplayed('SAP System Details');
+      sapSystemDetailsPage.pageTitleHealthIsCorrectlyDisplayed();
       sapSystemDetailsPage.sapSystemHasExpectedName();
       sapSystemDetailsPage.sapSystemHasExpectedType();
     });

--- a/test/e2e/cypress/fixtures/hana-cluster-details/available_hana_cluster.js
+++ b/test/e2e/cypress/fixtures/hana-cluster-details/available_hana_cluster.js
@@ -4,6 +4,7 @@
 export const availableHanaCluster = {
   id: '469e7be5-4e20-5007-b044-c6f540a87493',
   name: 'hana_cluster_3',
+  health: 'fill-jungle-green-500',
   sid: 'HDP',
   systemID: '6c9208eb-a5bb-57ef-be5c-6422dedab602',
   clusterType: 'HANA Scale Up',

--- a/test/e2e/cypress/fixtures/hana-database-details/selected_database.js
+++ b/test/e2e/cypress/fixtures/hana-database-details/selected_database.js
@@ -3,6 +3,7 @@
 
 export const selectedDatabase = {
   Id: 'f534a4ad-cef7-5234-b196-e67082ffb50c',
+  Health: 'fill-jungle-green-500',
   Sid: 'HDD',
   Type: 'HANA Database',
   SystemReplication: 'True',

--- a/test/e2e/cypress/fixtures/host-details/selected_host.js
+++ b/test/e2e/cypress/fixtures/host-details/selected_host.js
@@ -5,6 +5,7 @@ export const selectedHost = {
   agentId: '9cd46919-5f19-59aa-993e-cf3736c71053',
   agentVersion: '2.1.0',
   hostName: 'vmhdbprd01',
+  health: 'fill-jungle-green-500',
   clusterName: 'hana_cluster_3',
   clusterId: '469e7be5-4e20-5007-b044-c6f540a87493',
   ipAddresses: '10.80.1.11/24, 10.80.1.13/24',

--- a/test/e2e/cypress/fixtures/sap-system-details/selected_system.js
+++ b/test/e2e/cypress/fixtures/sap-system-details/selected_system.js
@@ -10,6 +10,7 @@ export const healthMap = {
 
 export const selectedSystem = {
   Id: '67b247e4-ab5b-5094-993a-a4fd70d0e8d1',
+  Health: 'fill-jungle-green-500',
   Sid: 'NWD',
   Type: 'Application server',
   Hosts: [

--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -28,6 +28,7 @@ const user = createUserRequestFactory.build({
 
 // Selectors
 const pageTitle = 'h1';
+const pageTitleHealth = 'h1 div svg';
 const userDropdownMenuButton = 'header button[id*="menu"]';
 const userDropdownProfileButton = 'a:contains("Profile")';
 const accessForbiddenMessage =
@@ -141,6 +142,9 @@ export const userDropdownMenuButtonHasTheExpectedText = (username) =>
 
 export const pageTitleIsCorrectlyDisplayed = (title) =>
   cy.get(pageTitle).should('contain', title);
+
+export const pageTitleHealthIsCorrectlyDisplayed = (health) =>
+  cy.get(pageTitleHealth).should('have.class', health);
 
 export const accessForbiddenMessageIsDisplayed = () =>
   cy.get(accessForbiddenMessage).should('be.visible');

--- a/test/e2e/cypress/pageObject/hana_cluster_details_po.js
+++ b/test/e2e/cypress/pageObject/hana_cluster_details_po.js
@@ -208,10 +208,10 @@ export const validateAvailableHanaClusterCostOptUrl = () =>
   validateUrl(`/${availableHanaClusterCostOpt.id}`);
 
 export const expectedClusterNameIsDisplayedInHeader = () =>
-  basePage.pageTitleHealthIsCorrectlyDisplayed(availableHanaCluster.health);
+  basePage.pageTitleIsCorrectlyDisplayed(availableHanaCluster.name);
 
 export const expectedClusterHealthIsDisplayedInHeader = () =>
-  basePage.pageTitleIsCorrectlyDisplayed(availableHanaCluster.name);
+  basePage.pageTitleHealthIsCorrectlyDisplayed(availableHanaCluster.health);
 
 export const expectedProviderIsDisplayed = (clusterType) => {
   const provider = getPropertyFromClusterType(clusterType, 'provider');

--- a/test/e2e/cypress/pageObject/hana_cluster_details_po.js
+++ b/test/e2e/cypress/pageObject/hana_cluster_details_po.js
@@ -208,6 +208,9 @@ export const validateAvailableHanaClusterCostOptUrl = () =>
   validateUrl(`/${availableHanaClusterCostOpt.id}`);
 
 export const expectedClusterNameIsDisplayedInHeader = () =>
+  basePage.pageTitleHealthIsCorrectlyDisplayed(availableHanaCluster.health);
+
+export const expectedClusterHealthIsDisplayedInHeader = () =>
   basePage.pageTitleIsCorrectlyDisplayed(availableHanaCluster.name);
 
 export const expectedProviderIsDisplayed = (clusterType) => {

--- a/test/e2e/cypress/pageObject/hana_database_details_po.js
+++ b/test/e2e/cypress/pageObject/hana_database_details_po.js
@@ -47,6 +47,9 @@ export const validatePageUrl = () =>
 export const validateNonExistentDatabaseUrl = () =>
   basePage.validateUrl(`${url}/other`);
 
+export const pageTitleHealthIsCorrectlyDisplayed = () =>
+  basePage.pageTitleHealthIsCorrectlyDisplayed(selectedDatabase.Health);
+
 export const databaseHasExpectedName = () =>
   cy.get(databaseNameLabel).should('have.text', selectedDatabase.Sid);
 

--- a/test/e2e/cypress/pageObject/host_details_po.js
+++ b/test/e2e/cypress/pageObject/host_details_po.js
@@ -207,6 +207,9 @@ export const expectedRelevantPatchesAreDisplayed = (expectedValue) =>
 export const validateSelectedHostUrl = () =>
   basePage.validateUrl(`${url}/${selectedHost.agentId}`);
 
+export const healthHasExpectedValue = () =>
+  basePage.pageTitleHealthIsCorrectlyDisplayed(selectedHost.health);
+
 export const clusterNameHasExpectedValue = () =>
   cy.get(clusterNameLabel).should('have.text', selectedHost.clusterName);
 

--- a/test/e2e/cypress/pageObject/sap_system_details_po.js
+++ b/test/e2e/cypress/pageObject/sap_system_details_po.js
@@ -45,6 +45,9 @@ export const visitNonExistentSapSystem = () =>
 export const validatePageUrl = (systemId = selectedSystem.Id) =>
   basePage.validateUrl(`/sap_systems/${systemId}`);
 
+export const pageTitleHealthIsCorrectlyDisplayed = () =>
+  basePage.pageTitleHealthIsCorrectlyDisplayed(selectedSystem.Health);
+
 export const sapSystemHasExpectedName = () =>
   cy.get(sapSystemName).should('have.text', selectedSystem.Sid);
 


### PR DESCRIPTION
# Description

Add health icon to the all details view pages (host, cluster, sap system and database details views), before the page header.
This value was not available, only the previous overview list views.

<img width="1307" height="594" alt="image" src="https://github.com/user-attachments/assets/6f80f43a-0492-41a0-ba48-4fe90ff0ed62" />

PD: In the future, we might use this as placeholder for a tooltip detailing the different concept and their health affecting the health of the resource itself

## How was this tested?

UT and e2e

## Did you update the documentation?

No need
