### PR TITLE
Updated License in spec file

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -27,6 +27,7 @@ header:
     - "VERSION"
     - "assets/vendor/**"
     - "mix.lock"
+    - "packaging/suse/rpm/trento-web.spec"
 
   language:
     JavaScript:

--- a/packaging/suse/rpm/trento-web.spec
+++ b/packaging/suse/rpm/trento-web.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package trento-web
 #
-# Copyright (c) 2026 SUSE LLC and contributors
+# Copyright SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed

--- a/packaging/suse/rpm/trento-web.spec
+++ b/packaging/suse/rpm/trento-web.spec
@@ -1,8 +1,7 @@
 #
 # spec file for package trento-web
 #
-# SPDX-FileCopyrightText: SUSE LLC
-# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 SUSE LLC and contributors
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -14,6 +13,7 @@
 # published by the Open Source Initiative.
 
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
 
 
 Name:           trento-web
@@ -29,7 +29,14 @@ Source2:        package-lock.json
 Source3:        node_modules.spec.inc
 %include        %{_sourcedir}/node_modules.spec.inc
 Group:          System/Monitoring
-BuildRequires:  elixir >= 1.15, elixir-hex, npm >= 20, erlang-rebar3, git-core, local-npm-registry, make, gcc
+BuildRequires:  elixir >= 1.15
+BuildRequires:  elixir-hex
+BuildRequires:  erlang-rebar3
+BuildRequires:  gcc
+BuildRequires:  git-core
+BuildRequires:  local-npm-registry
+BuildRequires:  make
+BuildRequires:  npm >= 20
 
 %description
 Trento is an open cloud-native web application for SAP Applications administrators.


### PR DESCRIPTION
Updated License in spec file because OBS linter don't support SPDX format.