### PR TITLE
Fix cluster registered broadcast

### DIFF
--- a/lib/trento_web/controllers/v2/cluster_json.ex
+++ b/lib/trento_web/controllers/v2/cluster_json.ex
@@ -77,6 +77,8 @@ defmodule TrentoWeb.V2.ClusterJSON do
   end
 
   defp remove_sid_from_resources(resources) do
-    Enum.map(resources, &Map.drop(&1, [:sid]))
+    # Cannot use Map.from_struct to remove __struct__
+    # as the object can be loaded from the db already as map
+    Enum.map(resources, &Map.drop(&1, [:__struct__, :sid]))
   end
 end

--- a/test/trento/clusters/projections/cluster_projector_test.exs
+++ b/test/trento/clusters/projections/cluster_projector_test.exs
@@ -112,9 +112,12 @@ defmodule Trento.Clusters.Projections.ClusterProjectorTest do
         selected_checks: [],
         state: :S_IDLE,
         type: :hana_scale_up
-      },
+      } = message,
       1000
     )
+
+    # Check message can be properly encoded to json
+    assert {:ok, _} = Jason.encode(message)
   end
 
   test "should update the cluster details when ClusterDetailsUpdated is received" do

--- a/test/trento_web/views/v2/cluster_view_json_test.exs
+++ b/test/trento_web/views/v2/cluster_view_json_test.exs
@@ -63,6 +63,7 @@ defmodule TrentoWeb.V2.ClusterJSONTest do
 
     Enum.each(resources, fn resource ->
       refute Map.has_key?(resource, :sid)
+      refute Map.has_key?(resource, :__struct__)
     end)
   end
 end


### PR DESCRIPTION
# Description

Fix a long on-going error during `cluster_registered` broadcast after projection.

You might have seen the next error when new cluster registered events are emitted in Trento and web app is opened (so websocket channel open):

```
  ** (stop) %FunctionClauseError{module: Jason.Encoder.Trento.Clusters.ValueObjects.ClusterResource, function: :"-inlined-encode/2-", arity: 2, kind: nil, args: nil, clauses: nil}
# The error has a lot of more lines
```

I guess we have overlooked it, as new clusters registration while you are watching the app are not so common, and refreshing the web simply shows the clusters. At the end, the projector stream is restarted and the data is properly stored in the database. Only the broadcast fails.

The thing is that in this case, when the data was being converted, one function was transforming a struct to a map, but in the process as `Map.from_struct` was not used (because we cannot, as the data might come as struct or map), the `__struct__` field is not removed, so the json encoding of the message fails.

The encode was traying and failing to convert this:

```
%{
    id: "stonith-sbd",
    node: "vmnwprd01",
    parent: nil,
    status: "Active",
    type: "stonith:external/sbd",
    __struct__: Trento.Clusters.ValueObjects.ClusterResource,
    role: "Started",
    managed: true,
    fail_count: 0
  },
```

## How was this tested?
Unit test added. I wonder if having some macro to test the encoding for all the broadcasts could be useful.
Adding e2e tests is really difficult, as we rarely start from empty states, so having a repeatable test is not that simple.

## Did you update the documentation?

No need
