### PR TITLE
Fix flaky test on clusters overview suite

### DIFF
--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -7,7 +7,7 @@ context('Clusters Overview', () => {
   before(() => clustersOverviewPage.preloadTestData());
 
   beforeEach(() => {
-    clustersOverviewPage.interceptClustersEndpoint();
+    clustersOverviewPage.interceptInitialDataFetch();
     clustersOverviewPage.visit();
     clustersOverviewPage.validateUrl();
   });

--- a/test/e2e/cypress/pageObject/clusters_overview_po.js
+++ b/test/e2e/cypress/pageObject/clusters_overview_po.js
@@ -19,6 +19,7 @@ const clusterNames = '.tn-clustername';
 const paginationNavigationButtons = 'div[class*="bg-gray-50"] ul button';
 const tableRows = 'tbody tr';
 const rowCells = 'td';
+
 //Test data
 export const healthyClusterName = healthyClusterScenario.clusterName;
 export const unhealthyClusterName = unhealthyClusterScenario.clusterName;

--- a/test/e2e/cypress/pageObject/clusters_overview_po.js
+++ b/test/e2e/cypress/pageObject/clusters_overview_po.js
@@ -19,7 +19,6 @@ const clusterNames = '.tn-clustername';
 const paginationNavigationButtons = 'div[class*="bg-gray-50"] ul button';
 const tableRows = 'tbody tr';
 const rowCells = 'td';
-
 //Test data
 export const healthyClusterName = healthyClusterScenario.clusterName;
 export const unhealthyClusterName = unhealthyClusterScenario.clusterName;
@@ -76,9 +75,10 @@ export const hanaCluster1TagsAreDisplayed = () =>
 
 export const clusterNameLinkIsDisplayedAsId = (clusterName) => {
   const clusterID = _clusterIdByName(clusterName);
+  const clusterNameLinkCellSelector = `${tableRows} > ${rowCells}:nth-child(2):contains("${clusterID}")`;
   basePage.waitForInitialDataFetch();
   cy.get(tableRows).should('have.length', availableClusters.length);
-  return cy.get(tableRows).eq(8).find(rowCells).eq(1).should('have.text', clusterID);
+  return cy.get(clusterNameLinkCellSelector).should('have.text', clusterID);
 };
 
 export const allRegisteredClustersAreDisplayed = () =>

--- a/test/e2e/cypress/pageObject/clusters_overview_po.js
+++ b/test/e2e/cypress/pageObject/clusters_overview_po.js
@@ -76,9 +76,9 @@ export const hanaCluster1TagsAreDisplayed = () =>
 
 export const clusterNameLinkIsDisplayedAsId = (clusterName) => {
   const clusterID = _clusterIdByName(clusterName);
-  return waitForClustersEndpoint().then(() =>
-    cy.get(tableRows).eq(8).find(rowCells).eq(1).should('have.text', clusterID)
-  );
+  basePage.waitForInitialDataFetch();
+  cy.get(tableRows).should('have.length', availableClusters.length);
+  return cy.get(tableRows).eq(8).find(rowCells).eq(1).should('have.text', clusterID);
 };
 
 export const allRegisteredClustersAreDisplayed = () =>

--- a/test/e2e/cypress/pageObject/clusters_overview_po.js
+++ b/test/e2e/cypress/pageObject/clusters_overview_po.js
@@ -87,15 +87,23 @@ export const allRegisteredClustersAreDisplayed = () =>
 export const paginationButtonsAreDisabled = () =>
   cy.get(paginationNavigationButtons).should('be.disabled');
 
-export const clustersDataIsDisplayedAsExpected = () =>
-  waitForClustersEndpoint().then(() =>
-    cy.get(tableRows).each(($row, index) => {
-      const cluster = availableClusters[index];
-      cy.wrap($row).find('td').eq(1).should('have.text', cluster.name);
-      cy.wrap($row).find('td').eq(2).should('have.text', cluster.sid);
-      return cy.wrap($row).find('td').eq(5).should('have.text', cluster.type);
-    })
-  );
+export const clustersDataIsDisplayedAsExpected = () => {
+  basePage.waitForInitialDataFetch();
+  cy.get(tableRows).should('have.length', availableClusters.length);
+  return cy.wrap(availableClusters).each((cluster, index) => {
+    cy.get(`${tableRows}:eq(${index}) > ${rowCells}:eq(1)`).should(
+      'have.text',
+      cluster.name
+    );
+    cy.get(`${tableRows}:eq(${index}) > ${rowCells}:eq(2)`).should(
+      'have.text',
+      cluster.sid
+    );
+    return cy
+      .get(`${tableRows}:eq(${index}) > ${rowCells}:eq(5)`)
+      .should('have.text', cluster.type);
+  });
+};
 
 export const healthyClusterNameDisplaysHealthyState = () =>
   clusterHealthIconHasExpectedClass(

--- a/test/e2e/cypress/pageObject/clusters_overview_po.js
+++ b/test/e2e/cypress/pageObject/clusters_overview_po.js
@@ -92,17 +92,13 @@ export const clustersDataIsDisplayedAsExpected = () => {
   basePage.waitForInitialDataFetch();
   cy.get(tableRows).should('have.length', availableClusters.length);
   return cy.wrap(availableClusters).each((cluster, index) => {
-    cy.get(`${tableRows}:eq(${index}) > ${rowCells}:eq(1)`).should(
-      'have.text',
-      cluster.name
-    );
-    cy.get(`${tableRows}:eq(${index}) > ${rowCells}:eq(2)`).should(
-      'have.text',
-      cluster.sid
-    );
-    return cy
-      .get(`${tableRows}:eq(${index}) > ${rowCells}:eq(5)`)
-      .should('have.text', cluster.type);
+    const clusterNameSelector = `${tableRows}:eq(${index}) > ${rowCells}:eq(1)`;
+    const clusterSidSelector = `${tableRows}:eq(${index}) > ${rowCells}:eq(2)`;
+    const clusterTypeSelector = `${tableRows}:eq(${index}) > ${rowCells}:eq(5)`;
+
+    cy.get(clusterNameSelector).should('have.text', cluster.name);
+    cy.get(clusterSidSelector).should('have.text', cluster.sid);
+    return cy.get(clusterTypeSelector).should('have.text', cluster.type);
   });
 };
 


### PR DESCRIPTION
# Description

 Fix flaky Cypress tests in Clusters Overview by waiting for the full initial page data fetch.
  
 - Use `interceptInitialDataFetch()` in the test setup
 - Wait for the full initial data load in page object assertions instead of only the clusters request
 - Assert the expected row count before validating row contents

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
