### PR TITLE
Restore cluster health after checks customization suite

### DIFF
--- a/test/e2e/cypress/e2e/checks_customization.cy.js
+++ b/test/e2e/cypress/e2e/checks_customization.cy.js
@@ -133,7 +133,7 @@ context('Checks customization', () => {
       checksSelectionPage.clickOnWarningCheckbox();
       checksSelectionPage.inputCheckValue('expected_max_messages', '100');
       checksSelectionPage.clickModalSaveButton();
-      checksSelectionPage.clickCorosyncSelectionToggle();
+      checksSelectionPage.selectCheck('00081D');
       checksSelectionPage.clickSaveChecksSelectionButton();
       checksSelectionPage.clickStartExecutionButton();
       checksSelectionPage.waitForCustomizedCheckElements();

--- a/test/e2e/cypress/e2e/checks_customization.cy.js
+++ b/test/e2e/cypress/e2e/checks_customization.cy.js
@@ -16,7 +16,10 @@ context('Checks customization', () => {
   });
 
   after(() => {
+    // Reset checks and run new execution to restore health
     checksSelectionPage.apiResetAllChecks();
+    checksSelectionPage.apiRequestExecution();
+    checksSelectionPage.waitUntilExecutionFinished();
   });
 
   describe('Checks customization should be possible for a cluster target', () => {

--- a/test/e2e/cypress/pageObject/checks_customization_po.js
+++ b/test/e2e/cypress/pageObject/checks_customization_po.js
@@ -10,6 +10,7 @@ import {
 } from '@lib/test-utils/factories';
 
 import { availableHanaCluster } from '../fixtures/hana-cluster-details/available_hana_cluster.js';
+import { apiRequestChecksExecution } from './clusters_overview_po.js';
 
 const url = '/clusters';
 
@@ -261,6 +262,11 @@ export const validateCustomValue = () =>
 export const vailidateGatheredFactsValue = () =>
   cy.get(gatheredFactsValue).should('have.text', firstCheckValue);
 
+export const waitUntilExecutionFinished = () => {
+  cy.intercept('/api/**/executions/last').as('executionFinished');
+  return basePage.waitForRequest('executionFinished');
+};
+
 // Api
 export const visit = (clusterId = '') =>
   basePage.visit(`${url}/${clusterId}/settings`);
@@ -284,3 +290,6 @@ export const apiResetAllChecks = () => _resetChecks(checkList);
 
 export const apiResetCheckSelection = () =>
   basePage.apiSelectChecks(availableHanaCluster.id, []);
+
+export const apiRequestExecution = () =>
+  apiRequestChecksExecution(availableHanaCluster.id);

--- a/test/e2e/cypress/pageObject/checks_customization_po.js
+++ b/test/e2e/cypress/pageObject/checks_customization_po.js
@@ -91,8 +91,6 @@ const saveChecksSelectionButton = 'button:contains("Save Checks Selection")';
 const startExecutionButton = 'button:contains("Start Execution")';
 const checkCustomizationToastSuccess = `p:contains(${checkCustomizationToastSuccessLabel})`;
 const checkCustomizationToastReset = `p:contains(${checkCustomizationToastResetLabel})`;
-const corosyncheckSelectionToggle =
-  'div[aria-label="accordion-header"]:contains("Corosync") button';
 
 const modifiedCheckID =
   'tbody tr td span[class="inline-flex leading-5 cursor-pointer"]';
@@ -136,8 +134,10 @@ export const clickStartExecutionButton = () =>
 export const inputCheckValue = (valueName, newValue) =>
   _setInputValue(valueName, newValue);
 
-export const clickCorosyncSelectionToggle = () =>
-  cy.get(corosyncheckSelectionToggle).click();
+export const selectCheck = (checkID) => {
+  const checkSelection = `a[class*="block"]:contains("${checkID}") button[role="switch"]`;
+  return cy.get(checkSelection).click();
+};
 
 export const expandModifiedCheckResult = () =>
   cy.get(checkResultCollapsibleCell).click();

--- a/test/e2e/cypress/pageObject/clusters_overview_po.js
+++ b/test/e2e/cypress/pageObject/clusters_overview_po.js
@@ -206,7 +206,7 @@ export const apiSetTagsHanaCluster1 = () => {
     .each((tag) => _apiSetTag('hana_cluster_1', tag));
 };
 
-const apiRequestChecksExecution = (clusterId) =>
+export const apiRequestChecksExecution = (clusterId) =>
   basePage.apiLogin().then(({ accessToken }) => {
     const url = `/api/v1/clusters/${clusterId}/checks/request_execution`;
     return cy.request({


### PR DESCRIPTION
# Description

Restore `hana_cluster_3` health to initial state after executing `checks_customization` e2e suite.

Basically, we need to rerun a new checks execution after check customized values are restored.

## How was this tested?

e2e

## Did you update the documentation?

No need
