### PR TITLE
Split cluster discovered health events

### DIFF
--- a/assets/js/lib/model/activityLog.js
+++ b/assets/js/lib/model/activityLog.js
@@ -75,7 +75,11 @@ export const CLUSTER_CHECKS_HEALTH_CHANGED = 'cluster_checks_health_changed';
 export const CLUSTER_DEREGISTERED = 'cluster_deregistered';
 export const CLUSTER_DETAILS_UPDATED = 'cluster_details_updated';
 export const CLUSTER_DISCOVERED_HEALTH_CHANGED =
-  'cluster_discovered_health_changed';
+  'cluster_discovered_health_changed'; // deprecated
+export const CLUSTER_REPLICATION_HEALTH_CHANGED =
+  'cluster_replication_health_changed';
+export const CLUSTER_DISTRIBUTED_HEALTH_CHANGED =
+  'cluster_distributed_health_changed';
 export const CLUSTER_HEALTH_CHANGED = 'cluster_health_changed';
 export const CLUSTER_REGISTERED = 'cluster_registered';
 export const CLUSTER_RESTORED = 'cluster_restored';
@@ -462,6 +466,16 @@ export const ACTIVITY_TYPES_CONFIG = {
   [CLUSTER_DISCOVERED_HEALTH_CHANGED]: {
     label: 'Cluster Discovered Health Changed',
     message: (_entry) => `Cluster's discovered health changed`,
+    resource: clusterResourceType,
+  },
+  [CLUSTER_REPLICATION_HEALTH_CHANGED]: {
+    label: 'Cluster Replication Health Changed',
+    message: (_entry) => `Cluster's replication health changed`,
+    resource: clusterResourceType,
+  },
+  [CLUSTER_DISTRIBUTED_HEALTH_CHANGED]: {
+    label: 'Cluster Distributed Health Changed',
+    message: (_entry) => `Cluster's ASCS/ERS nodes distribution health changed`,
     resource: clusterResourceType,
   },
   [CLUSTER_HEALTH_CHANGED]: {

--- a/lib/trento/activity_logging/severity_level.ex
+++ b/lib/trento/activity_logging/severity_level.ex
@@ -79,10 +79,26 @@ defmodule Trento.ActivityLog.SeverityLevel do
     },
     "cluster_deregistered" => :warning,
     "cluster_details_updated" => :debug,
-    "cluster_discovered_health_changed" => %{
+    "cluster_replication_health_changed" => %{
       type: :kv,
       key_suffix: "health",
-      values: %{"critical" => :critical, "unknown" => :warning, "*" => :info},
+      values: %{
+        "critical" => :critical,
+        "warning" => :warning,
+        "unknown" => :warning,
+        "*" => :info
+      },
+      condition: :map_value_to_severity
+    },
+    "cluster_distributed_health_changed" => %{
+      type: :kv,
+      key_suffix: "health",
+      values: %{
+        "critical" => :critical,
+        "warning" => :warning,
+        "unknown" => :warning,
+        "*" => :info
+      },
       condition: :map_value_to_severity
     },
     "cluster_health_changed" => %{

--- a/lib/trento/clusters/cluster.ex
+++ b/lib/trento/clusters/cluster.ex
@@ -78,8 +78,9 @@ defmodule Trento.Clusters.Cluster do
 
   alias Trento.Clusters.ValueObjects.{
     AscsErsClusterDetails,
+    AscsErsClusterHealthDetails,
     HanaClusterDetails,
-    HealthDetails,
+    HanaClusterHealthDetails,
     SapInstance
   }
 
@@ -136,7 +137,6 @@ defmodule Trento.Clusters.Cluster do
     field :hosts_number, :integer
     field :provider, Ecto.Enum, values: Provider.values()
     field :health, Ecto.Enum, values: Health.values(), default: Health.unknown()
-    embeds_one :health_details, HealthDetails, defaults_to_struct: true, on_replace: :update
     field :state, Ecto.Enum, values: ClusterState.values()
     field :hosts, {:array, :string}, default: []
     field :offline_hosts, {:array, :string}, default: []
@@ -153,6 +153,17 @@ defmodule Trento.Clusters.Cluster do
         ascs_ers: [module: AscsErsClusterDetails, identify_by_fields: [:sap_systems]]
       ],
       on_replace: :update
+    )
+
+    polymorphic_embeds_one(:health_details,
+      types: [
+        hana_scale_up: HanaClusterHealthDetails,
+        hana_scale_out: HanaClusterHealthDetails,
+        ascs_ers: AscsErsClusterHealthDetails
+      ],
+      on_replace: :update,
+      use_parent_field_for_type: :type,
+      on_type_not_found: :nilify
     )
 
     embeds_many :sap_instances, SapInstance
@@ -179,7 +190,7 @@ defmodule Trento.Clusters.Cluster do
         }
       ) do
     health_details = parse_discovered_health(details)
-    health = compute_discovered_health(type, health_details)
+    health = compute_discovered_health(health_details)
 
     [
       %ClusterRegistered{
@@ -222,7 +233,7 @@ defmodule Trento.Clusters.Cluster do
         hosts_number: nil,
         details: nil,
         health: Health.unknown(),
-        health_details: %HealthDetails{},
+        health_details: nil,
         state: ClusterState.unknown()
       },
       %HostAddedToCluster{
@@ -251,7 +262,7 @@ defmodule Trento.Clusters.Cluster do
         hosts_number: nil,
         details: nil,
         health: Health.unknown(),
-        health_details: %HealthDetails{},
+        health_details: nil,
         state: ClusterState.unknown()
       },
       %HostAddedToCluster{
@@ -366,14 +377,22 @@ defmodule Trento.Clusters.Cluster do
       maybe_emit_cluster_details_updated_event(cluster, command)
     end)
     |> Multi.execute(fn cluster ->
-      maybe_emit_cluster_replication_health_changed_event(cluster, command, %HealthDetails{
-        replication_health: Health.unknown()
-      })
+      maybe_emit_cluster_replication_health_changed_event(
+        cluster,
+        command,
+        %HanaClusterHealthDetails{
+          replication_health: Health.unknown()
+        }
+      )
     end)
     |> Multi.execute(fn cluster ->
-      maybe_emit_cluster_distributed_health_changed_event(cluster, command, %HealthDetails{
-        distributed_health: Health.unknown()
-      })
+      maybe_emit_cluster_distributed_health_changed_event(
+        cluster,
+        command,
+        %AscsErsClusterHealthDetails{
+          distributed_health: Health.unknown()
+        }
+      )
     end)
     |> Multi.execute(&maybe_emit_cluster_health_changed_event/1)
   end
@@ -477,10 +496,12 @@ defmodule Trento.Clusters.Cluster do
           replication_health: replication_health
         }
       ) do
+    current_health_details = health_details || %HanaClusterHealthDetails{}
+
     %Cluster{
       cluster
-      | health_details: %HealthDetails{
-          health_details
+      | health_details: %HanaClusterHealthDetails{
+          current_health_details
           | replication_health: replication_health
         }
     }
@@ -492,10 +513,12 @@ defmodule Trento.Clusters.Cluster do
           distributed_health: distributed_health
         }
       ) do
+    current_health_details = health_details || %AscsErsClusterHealthDetails{}
+
     %Cluster{
       cluster
-      | health_details: %HealthDetails{
-          health_details
+      | health_details: %AscsErsClusterHealthDetails{
+          current_health_details
           | distributed_health: distributed_health
         }
     }
@@ -510,10 +533,12 @@ defmodule Trento.Clusters.Cluster do
         }
       )
       when cluster_type in [ClusterType.hana_scale_up(), ClusterType.hana_scale_out()] do
+    current_health_details = health_details || %HanaClusterHealthDetails{}
+
     %Cluster{
       cluster
-      | health_details: %HealthDetails{
-          health_details
+      | health_details: %HanaClusterHealthDetails{
+          current_health_details
           | replication_health: discovered_health
         }
     }
@@ -525,10 +550,12 @@ defmodule Trento.Clusters.Cluster do
           discovered_health: discovered_health
         }
       ) do
+    current_health_details = health_details || %AscsErsClusterHealthDetails{}
+
     %Cluster{
       cluster
-      | health_details: %HealthDetails{
-          health_details
+      | health_details: %AscsErsClusterHealthDetails{
+          current_health_details
           | distributed_health: discovered_health
         }
     }
@@ -539,14 +566,29 @@ defmodule Trento.Clusters.Cluster do
   end
 
   def apply(
-        %Cluster{health_details: health_details} = cluster,
+        %Cluster{health_details: %HanaClusterHealthDetails{} = health_details} = cluster,
         %ClusterChecksHealthChanged{
           checks_health: checks_health
         }
       ) do
     %Cluster{
       cluster
-      | health_details: %HealthDetails{
+      | health_details: %HanaClusterHealthDetails{
+          health_details
+          | checks_health: checks_health
+        }
+    }
+  end
+
+  def apply(
+        %Cluster{health_details: %AscsErsClusterHealthDetails{} = health_details} = cluster,
+        %ClusterChecksHealthChanged{
+          checks_health: checks_health
+        }
+      ) do
+    %Cluster{
+      cluster
+      | health_details: %AscsErsClusterHealthDetails{
           health_details
           | checks_health: checks_health
         }
@@ -832,24 +874,29 @@ defmodule Trento.Clusters.Cluster do
        do: nil
 
   defp maybe_emit_cluster_replication_health_changed_event(
-         %Cluster{health_details: %HealthDetails{replication_health: replication_health}},
+         %Cluster{
+           health_details: %HanaClusterHealthDetails{replication_health: replication_health}
+         },
          __command,
-         %HealthDetails{replication_health: replication_health}
+         %HanaClusterHealthDetails{replication_health: replication_health}
        ),
        do: nil
 
   defp maybe_emit_cluster_replication_health_changed_event(
          %Cluster{state: state},
          %RegisterOfflineClusterHost{},
-         %HealthDetails{}
+         %HanaClusterHealthDetails{}
        )
        when state != ClusterState.stopped(),
        do: nil
 
   defp maybe_emit_cluster_replication_health_changed_event(
-         %Cluster{cluster_id: cluster_id},
+         %Cluster{
+           cluster_id: cluster_id,
+           health_details: %HanaClusterHealthDetails{}
+         },
          _command,
-         %HealthDetails{replication_health: replication_health}
+         %HanaClusterHealthDetails{replication_health: replication_health}
        ) do
     %ClusterReplicationHealthChanged{
       cluster_id: cluster_id,
@@ -857,25 +904,32 @@ defmodule Trento.Clusters.Cluster do
     }
   end
 
+  defp maybe_emit_cluster_replication_health_changed_event(_, _, _), do: nil
+
   defp maybe_emit_cluster_distributed_health_changed_event(
-         %Cluster{health_details: %HealthDetails{distributed_health: distributed_health}},
+         %Cluster{
+           health_details: %AscsErsClusterHealthDetails{distributed_health: distributed_health}
+         },
          _command,
-         %HealthDetails{distributed_health: distributed_health}
+         %AscsErsClusterHealthDetails{distributed_health: distributed_health}
        ),
        do: nil
 
   defp maybe_emit_cluster_distributed_health_changed_event(
          %Cluster{state: state},
          %RegisterOfflineClusterHost{},
-         %HealthDetails{}
+         %AscsErsClusterHealthDetails{}
        )
        when state != ClusterState.stopped(),
        do: nil
 
   defp maybe_emit_cluster_distributed_health_changed_event(
-         %Cluster{cluster_id: cluster_id},
+         %Cluster{
+           cluster_id: cluster_id,
+           health_details: %AscsErsClusterHealthDetails{}
+         },
          _command,
-         %HealthDetails{distributed_health: distributed_health}
+         %AscsErsClusterHealthDetails{distributed_health: distributed_health}
        ) do
     %ClusterDistributedHealthChanged{
       cluster_id: cluster_id,
@@ -883,8 +937,10 @@ defmodule Trento.Clusters.Cluster do
     }
   end
 
+  defp maybe_emit_cluster_distributed_health_changed_event(_, _, _), do: nil
+
   defp maybe_emit_cluster_checks_health_changed_event(
-         %Cluster{health_details: %HealthDetails{checks_health: checks_health}},
+         %Cluster{health_details: %{checks_health: checks_health}},
          %CompleteChecksExecution{health: checks_health}
        ),
        do: nil
@@ -898,6 +954,8 @@ defmodule Trento.Clusters.Cluster do
       checks_health: checks_health
     }
   end
+
+  defp maybe_emit_cluster_checks_health_changed_event(_, _), do: nil
 
   defp maybe_emit_cluster_deregistered_event(
          %Cluster{cluster_id: cluster_id, hosts: []},
@@ -916,18 +974,15 @@ defmodule Trento.Clusters.Cluster do
 
   defp maybe_emit_cluster_health_changed_event(%Cluster{
          cluster_id: cluster_id,
-         health_details: %HealthDetails{
-           replication_health: replication_health,
-           distributed_health: distributed_health,
-           checks_health: checks_health
-         },
-         health: health,
-         type: cluster_type
+         health_details:
+           %{
+             checks_health: checks_health
+           } = health_details,
+         health: health
        }) do
     new_health =
-      []
-      |> maybe_add_replication_health(replication_health, cluster_type)
-      |> maybe_add_distributed_health(distributed_health, cluster_type)
+      health_details
+      |> add_primary_health()
       |> maybe_add_checks_health(checks_health)
       |> Enum.filter(& &1)
       |> HealthService.compute_aggregated_health()
@@ -937,33 +992,34 @@ defmodule Trento.Clusters.Cluster do
     end
   end
 
-  defp maybe_add_replication_health(healths, replication_health, cluster_type)
-       when cluster_type in [ClusterType.hana_scale_up(), ClusterType.hana_scale_out()],
-       do: [replication_health | healths]
+  defp maybe_emit_cluster_health_changed_event(_), do: nil
 
-  defp maybe_add_replication_health(healths, _, _), do: healths
+  defp add_primary_health(%HanaClusterHealthDetails{
+         replication_health: replication_health
+       }),
+       do: [replication_health]
 
-  defp maybe_add_distributed_health(healths, distributed_health, ClusterType.ascs_ers()),
-    do: [distributed_health | healths]
-
-  defp maybe_add_distributed_health(healths, _, _), do: healths
+  defp add_primary_health(%AscsErsClusterHealthDetails{
+         distributed_health: distributed_health
+       }),
+       do: [distributed_health]
 
   defp maybe_add_checks_health(healths, Health.unknown()), do: healths
   defp maybe_add_checks_health(healths, checks_health), do: [checks_health | healths]
 
   defp parse_discovered_health(%HanaClusterDetails{} = details) do
-    %HealthDetails{
+    %HanaClusterHealthDetails{
       replication_health: parse_replication_health(details)
     }
   end
 
   defp parse_discovered_health(%AscsErsClusterDetails{} = details) do
-    %HealthDetails{
+    %AscsErsClusterHealthDetails{
       distributed_health: parse_distributed_health(details)
     }
   end
 
-  defp parse_discovered_health(_), do: %HealthDetails{}
+  defp parse_discovered_health(_), do: nil
 
   # Passing state if SR Health state is 4 and Sync state is SOK, everything else is critical
   # If data is not present for some reason the state goes to unknown
@@ -986,16 +1042,15 @@ defmodule Trento.Clusters.Cluster do
 
   defp parse_distributed_health(_), do: Health.unknown()
 
-  defp compute_discovered_health(cluster_type, %HealthDetails{
+  defp compute_discovered_health(%HanaClusterHealthDetails{
          replication_health: replication_health
-       })
-       when cluster_type in [ClusterType.hana_scale_up(), ClusterType.hana_scale_out()],
+       }),
        do: replication_health
 
-  defp compute_discovered_health(ClusterType.ascs_ers(), %HealthDetails{
+  defp compute_discovered_health(%AscsErsClusterHealthDetails{
          distributed_health: distributed_health
        }),
        do: distributed_health
 
-  defp compute_discovered_health(_, _), do: Health.unknown()
+  defp compute_discovered_health(_), do: Health.unknown()
 end

--- a/lib/trento/clusters/cluster.ex
+++ b/lib/trento/clusters/cluster.ex
@@ -189,7 +189,7 @@ defmodule Trento.Clusters.Cluster do
           designated_controller: true
         }
       ) do
-    health_details = parse_discovered_health(details)
+    health_details = derive_discovered_health(details)
     health = compute_discovered_health(health_details)
 
     [
@@ -728,40 +728,43 @@ defmodule Trento.Clusters.Cluster do
 
   def apply(%Cluster{} = cluster, %ClusterTombstoned{}), do: cluster
 
-  defp parse_discovered_health(%HanaClusterDetails{} = details) do
+  defp derive_discovered_health(%HanaClusterDetails{} = details) do
     %HanaClusterHealthDetails{
-      replication_health: parse_replication_health(details)
+      replication_health: derive_replication_health(details)
     }
   end
 
-  defp parse_discovered_health(%AscsErsClusterDetails{} = details) do
+  defp derive_discovered_health(%AscsErsClusterDetails{} = details) do
     %AscsErsClusterHealthDetails{
-      distributed_health: parse_distributed_health(details)
+      distributed_health: derive_distributed_health(details)
     }
   end
 
-  defp parse_discovered_health(_), do: nil
+  defp derive_discovered_health(_), do: nil
 
   # Passing state if SR Health state is 4 and Sync state is SOK, everything else is critical
   # If data is not present for some reason the state goes to unknown
-  defp parse_replication_health(%HanaClusterDetails{
+  defp derive_replication_health(%HanaClusterDetails{
          sr_health_state: "4",
          secondary_sync_state: "SOK"
        }),
        do: Health.passing()
 
-  defp parse_replication_health(%HanaClusterDetails{sr_health_state: _, secondary_sync_state: _}),
-    do: Health.critical()
+  defp derive_replication_health(%HanaClusterDetails{
+         sr_health_state: _,
+         secondary_sync_state: _
+       }),
+       do: Health.critical()
 
-  defp parse_replication_health(_), do: Health.unknown()
+  defp derive_replication_health(_), do: Health.unknown()
 
-  defp parse_distributed_health(%AscsErsClusterDetails{sap_systems: sap_systems}) do
+  defp derive_distributed_health(%AscsErsClusterDetails{sap_systems: sap_systems}) do
     Enum.find_value(sap_systems, Health.passing(), fn %{distributed: distributed} ->
       if not distributed, do: Health.critical()
     end)
   end
 
-  defp parse_distributed_health(_), do: Health.unknown()
+  defp derive_distributed_health(_), do: Health.unknown()
 
   defp compute_discovered_health(%HanaClusterHealthDetails{
          replication_health: replication_health
@@ -811,7 +814,7 @@ defmodule Trento.Clusters.Cluster do
          multi,
          %RegisterOnlineClusterHost{host_id: host_id, details: details} = command
        ) do
-    health_details = parse_discovered_health(details)
+    health_details = derive_discovered_health(details)
 
     multi
     |> Multi.execute(fn cluster ->

--- a/lib/trento/clusters/cluster.ex
+++ b/lib/trento/clusters/cluster.ex
@@ -496,7 +496,8 @@ defmodule Trento.Clusters.Cluster do
           replication_health: replication_health
         }
       ) do
-    current_health_details = health_details || %HanaClusterHealthDetails{}
+    %HanaClusterHealthDetails{} =
+      current_health_details = health_details || %HanaClusterHealthDetails{}
 
     %Cluster{
       cluster
@@ -513,7 +514,8 @@ defmodule Trento.Clusters.Cluster do
           distributed_health: distributed_health
         }
       ) do
-    current_health_details = health_details || %AscsErsClusterHealthDetails{}
+    %AscsErsClusterHealthDetails{} =
+      current_health_details = health_details || %AscsErsClusterHealthDetails{}
 
     %Cluster{
       cluster
@@ -533,7 +535,8 @@ defmodule Trento.Clusters.Cluster do
         }
       )
       when cluster_type in [ClusterType.hana_scale_up(), ClusterType.hana_scale_out()] do
-    current_health_details = health_details || %HanaClusterHealthDetails{}
+    %HanaClusterHealthDetails{} =
+      current_health_details = health_details || %HanaClusterHealthDetails{}
 
     %Cluster{
       cluster
@@ -550,7 +553,8 @@ defmodule Trento.Clusters.Cluster do
           discovered_health: discovered_health
         }
       ) do
-    current_health_details = health_details || %AscsErsClusterHealthDetails{}
+    %AscsErsClusterHealthDetails{} =
+      current_health_details = health_details || %AscsErsClusterHealthDetails{}
 
     %Cluster{
       cluster

--- a/lib/trento/clusters/cluster.ex
+++ b/lib/trento/clusters/cluster.ex
@@ -136,7 +136,7 @@ defmodule Trento.Clusters.Cluster do
     field :hosts_number, :integer
     field :provider, Ecto.Enum, values: Provider.values()
     field :health, Ecto.Enum, values: Health.values(), default: Health.unknown()
-    embeds_one :health_details, HealthDetails, defaults_to_struct: true
+    embeds_one :health_details, HealthDetails, defaults_to_struct: true, on_replace: :update
     field :state, Ecto.Enum, values: ClusterState.values()
     field :hosts, {:array, :string}, default: []
     field :offline_hosts, {:array, :string}, default: []
@@ -364,6 +364,16 @@ defmodule Trento.Clusters.Cluster do
     end)
     |> Multi.execute(fn cluster ->
       maybe_emit_cluster_details_updated_event(cluster, command)
+    end)
+    |> Multi.execute(fn cluster ->
+      maybe_emit_cluster_replication_health_changed_event(cluster, %HealthDetails{
+        replication_health: Health.unknown()
+      })
+    end)
+    |> Multi.execute(fn cluster ->
+      maybe_emit_cluster_distributed_health_changed_event(cluster, %HealthDetails{
+        distributed_health: Health.unknown()
+      })
     end)
     |> Multi.execute(&maybe_emit_cluster_health_changed_event/1)
   end
@@ -799,10 +809,6 @@ defmodule Trento.Clusters.Cluster do
         hosts_number: hosts_number,
         state: ClusterState.stopped(),
         details: details
-      },
-      %ClusterDiscoveredHealthChanged{
-        cluster_id: cluster_id,
-        discovered_health: :unknown
       }
     ]
   end
@@ -934,12 +940,6 @@ defmodule Trento.Clusters.Cluster do
          secondary_sync_state: "SOK"
        }),
        do: Health.passing()
-
-  defp parse_replication_health(%HanaClusterDetails{
-         sr_health_state: "",
-         secondary_sync_state: ""
-       }),
-       do: Health.unknown()
 
   defp parse_replication_health(%HanaClusterDetails{sr_health_state: _, secondary_sync_state: _}),
     do: Health.critical()

--- a/lib/trento/clusters/cluster.ex
+++ b/lib/trento/clusters/cluster.ex
@@ -724,6 +724,53 @@ defmodule Trento.Clusters.Cluster do
 
   def apply(%Cluster{} = cluster, %ClusterTombstoned{}), do: cluster
 
+  defp parse_discovered_health(%HanaClusterDetails{} = details) do
+    %HanaClusterHealthDetails{
+      replication_health: parse_replication_health(details)
+    }
+  end
+
+  defp parse_discovered_health(%AscsErsClusterDetails{} = details) do
+    %AscsErsClusterHealthDetails{
+      distributed_health: parse_distributed_health(details)
+    }
+  end
+
+  defp parse_discovered_health(_), do: nil
+
+  # Passing state if SR Health state is 4 and Sync state is SOK, everything else is critical
+  # If data is not present for some reason the state goes to unknown
+  defp parse_replication_health(%HanaClusterDetails{
+         sr_health_state: "4",
+         secondary_sync_state: "SOK"
+       }),
+       do: Health.passing()
+
+  defp parse_replication_health(%HanaClusterDetails{sr_health_state: _, secondary_sync_state: _}),
+    do: Health.critical()
+
+  defp parse_replication_health(_), do: Health.unknown()
+
+  defp parse_distributed_health(%AscsErsClusterDetails{sap_systems: sap_systems}) do
+    Enum.find_value(sap_systems, Health.passing(), fn %{distributed: distributed} ->
+      if not distributed, do: Health.critical()
+    end)
+  end
+
+  defp parse_distributed_health(_), do: Health.unknown()
+
+  defp compute_discovered_health(%HanaClusterHealthDetails{
+         replication_health: replication_health
+       }),
+       do: replication_health
+
+  defp compute_discovered_health(%AscsErsClusterHealthDetails{
+         distributed_health: distributed_health
+       }),
+       do: distributed_health
+
+  defp compute_discovered_health(_), do: Health.unknown()
+
   defp maybe_emit_host_added_to_cluster_event(
          %Cluster{cluster_id: cluster_id, hosts: hosts, offline_hosts: offline_hosts},
          host_id,
@@ -1006,51 +1053,4 @@ defmodule Trento.Clusters.Cluster do
 
   defp maybe_add_checks_health(healths, Health.unknown()), do: healths
   defp maybe_add_checks_health(healths, checks_health), do: [checks_health | healths]
-
-  defp parse_discovered_health(%HanaClusterDetails{} = details) do
-    %HanaClusterHealthDetails{
-      replication_health: parse_replication_health(details)
-    }
-  end
-
-  defp parse_discovered_health(%AscsErsClusterDetails{} = details) do
-    %AscsErsClusterHealthDetails{
-      distributed_health: parse_distributed_health(details)
-    }
-  end
-
-  defp parse_discovered_health(_), do: nil
-
-  # Passing state if SR Health state is 4 and Sync state is SOK, everything else is critical
-  # If data is not present for some reason the state goes to unknown
-  defp parse_replication_health(%HanaClusterDetails{
-         sr_health_state: "4",
-         secondary_sync_state: "SOK"
-       }),
-       do: Health.passing()
-
-  defp parse_replication_health(%HanaClusterDetails{sr_health_state: _, secondary_sync_state: _}),
-    do: Health.critical()
-
-  defp parse_replication_health(_), do: Health.unknown()
-
-  defp parse_distributed_health(%AscsErsClusterDetails{sap_systems: sap_systems}) do
-    Enum.find_value(sap_systems, Health.passing(), fn %{distributed: distributed} ->
-      if not distributed, do: Health.critical()
-    end)
-  end
-
-  defp parse_distributed_health(_), do: Health.unknown()
-
-  defp compute_discovered_health(%HanaClusterHealthDetails{
-         replication_health: replication_health
-       }),
-       do: replication_health
-
-  defp compute_discovered_health(%AscsErsClusterHealthDetails{
-         distributed_health: distributed_health
-       }),
-       do: distributed_health
-
-  defp compute_discovered_health(_), do: Health.unknown()
 end

--- a/lib/trento/clusters/cluster.ex
+++ b/lib/trento/clusters/cluster.ex
@@ -35,16 +35,23 @@ defmodule Trento.Clusters.Cluster do
   what is the roout cause of the issue and if there is some possible remediation.
   It is composed by sub-health elements:
 
-  - Discovered health
+  - Replication health (only applicable for HANA clusters)
+  - Distributed health (only applicable for ASCS/ERS clusters)
   - Checks health
 
-  The main cluster health is computed using the values from these two. This means that the cluster health is the
+  The main cluster health is computed using the values from all of them. This means that the cluster health is the
   worst of the two.
 
-  ### Discovered health
+  ### Replication health
 
-  The discovered health comes from the cluster discovery messages and it depends on the cluster type.
-  Each cluster type has a different way of evaluating the health.
+  The discovered replication health. It is based in the cluster replication values coming from cluster attributes.
+  The health is passing if the SR health is 4 and the secondary sync state "SOK". It is critical otherwise or
+  unknown (when the data is not available) otherwise.
+
+  # Distributed health
+
+  The discovered distributed health checks if ASCS and ERS workloads are distributed among 2 nodes and not running
+  in a single one.
 
   ### Checks health
 

--- a/lib/trento/clusters/cluster.ex
+++ b/lib/trento/clusters/cluster.ex
@@ -79,6 +79,7 @@ defmodule Trento.Clusters.Cluster do
   alias Trento.Clusters.ValueObjects.{
     AscsErsClusterDetails,
     HanaClusterDetails,
+    HealthDetails,
     SapInstance
   }
 
@@ -134,10 +135,8 @@ defmodule Trento.Clusters.Cluster do
     field :resources_number, :integer
     field :hosts_number, :integer
     field :provider, Ecto.Enum, values: Provider.values()
-    field :replication_health, Ecto.Enum, values: Health.values(), default: Health.unknown()
-    field :distributed_health, Ecto.Enum, values: Health.values(), default: Health.unknown()
-    field :checks_health, Ecto.Enum, values: Health.values(), default: Health.unknown()
     field :health, Ecto.Enum, values: Health.values(), default: Health.unknown()
+    embeds_one :health_details, HealthDetails
     field :state, Ecto.Enum, values: ClusterState.values()
     field :hosts, {:array, :string}, default: []
     field :offline_hosts, {:array, :string}, default: []
@@ -179,16 +178,8 @@ defmodule Trento.Clusters.Cluster do
           designated_controller: true
         }
       ) do
-    replication_health = parse_replication_health(details)
-    distributed_health = parse_distributed_health(details)
-
-    health =
-      case type do
-        ClusterType.hana_scale_up() -> replication_health
-        ClusterType.hana_scale_out() -> replication_health
-        ClusterType.ascs_ers() -> distributed_health
-        _ -> Health.unknown()
-      end
+    health_details = parse_discovered_health(details)
+    health = compute_discovered_health(type, health_details)
 
     [
       %ClusterRegistered{
@@ -200,9 +191,8 @@ defmodule Trento.Clusters.Cluster do
         resources_number: resources_number,
         hosts_number: hosts_number,
         details: details,
-        replication_health: replication_health,
-        distributed_health: distributed_health,
         health: health,
+        health_details: health_details,
         state: state
       },
       %HostAddedToCluster{
@@ -231,9 +221,8 @@ defmodule Trento.Clusters.Cluster do
         resources_number: nil,
         hosts_number: nil,
         details: nil,
-        replication_health: Health.unknown(),
-        distributed_health: Health.unknown(),
         health: Health.unknown(),
+        health_details: %HealthDetails{},
         state: ClusterState.unknown()
       },
       %HostAddedToCluster{
@@ -261,9 +250,8 @@ defmodule Trento.Clusters.Cluster do
         resources_number: nil,
         hosts_number: nil,
         details: nil,
-        replication_health: Health.unknown(),
-        distributed_health: Health.unknown(),
         health: Health.unknown(),
+        health_details: %HealthDetails{},
         state: ClusterState.unknown()
       },
       %HostAddedToCluster{
@@ -453,8 +441,7 @@ defmodule Trento.Clusters.Cluster do
           hosts_number: hosts_number,
           details: details,
           health: health,
-          replication_health: replication_health,
-          distributed_health: distributed_health,
+          health_details: health_details,
           state: state
         }
       ) do
@@ -468,28 +455,39 @@ defmodule Trento.Clusters.Cluster do
         resources_number: resources_number,
         hosts_number: hosts_number,
         details: details,
-        replication_health: replication_health,
-        distributed_health: distributed_health,
         health: health,
+        health_details: health_details,
         state: state
     }
   end
 
-  def apply(%Cluster{} = cluster, %ClusterReplicationHealthChanged{
-        replication_health: replication_health
-      }) do
+  def apply(
+        %Cluster{health_details: health_details} = cluster,
+        %ClusterReplicationHealthChanged{
+          replication_health: replication_health
+        }
+      ) do
     %Cluster{
       cluster
-      | replication_health: replication_health
+      | health_details: %HealthDetails{
+          health_details
+          | replication_health: replication_health
+        }
     }
   end
 
-  def apply(%Cluster{} = cluster, %ClusterDistributedHealthChanged{
-        distributed_health: distributed_health
-      }) do
+  def apply(
+        %Cluster{health_details: health_details} = cluster,
+        %ClusterDistributedHealthChanged{
+          distributed_health: distributed_health
+        }
+      ) do
     %Cluster{
       cluster
-      | distributed_health: distributed_health
+      | health_details: %HealthDetails{
+          health_details
+          | distributed_health: distributed_health
+        }
     }
   end
 
@@ -501,7 +499,7 @@ defmodule Trento.Clusters.Cluster do
       when cluster_type in [ClusterType.hana_scale_up(), ClusterType.hana_scale_out()] do
     %Cluster{
       cluster
-      | replication_health: discovered_health
+      | health_details: %HealthDetails{replication_health: discovered_health}
     }
   end
 
@@ -510,7 +508,7 @@ defmodule Trento.Clusters.Cluster do
       }) do
     %Cluster{
       cluster
-      | distributed_health: discovered_health
+      | health_details: %HealthDetails{distributed_health: discovered_health}
     }
   end
 
@@ -518,12 +516,18 @@ defmodule Trento.Clusters.Cluster do
     cluster
   end
 
-  def apply(%Cluster{} = cluster, %ClusterChecksHealthChanged{
-        checks_health: checks_health
-      }) do
+  def apply(
+        %Cluster{health_details: health_details} = cluster,
+        %ClusterChecksHealthChanged{
+          checks_health: checks_health
+        }
+      ) do
     %Cluster{
       cluster
-      | checks_health: checks_health
+      | health_details: %HealthDetails{
+          health_details
+          | checks_health: checks_health
+        }
     }
   end
 
@@ -690,18 +694,20 @@ defmodule Trento.Clusters.Cluster do
 
   defp maybe_update_cluster(
          multi,
-         %RegisterOnlineClusterHost{host_id: host_id} = command
+         %RegisterOnlineClusterHost{host_id: host_id, details: details} = command
        ) do
+    health_details = parse_discovered_health(details)
+
     multi
     |> Multi.execute(fn cluster ->
       maybe_emit_host_added_to_cluster_event(cluster, host_id, ClusterHostStatus.online())
     end)
     |> Multi.execute(fn cluster -> maybe_emit_cluster_details_updated_event(cluster, command) end)
     |> Multi.execute(fn cluster ->
-      maybe_emit_cluster_replication_health_changed_event(cluster, command)
+      maybe_emit_cluster_replication_health_changed_event(cluster, health_details)
     end)
     |> Multi.execute(fn cluster ->
-      maybe_emit_cluster_distributed_health_changed_event(cluster, command)
+      maybe_emit_cluster_distributed_health_changed_event(cluster, health_details)
     end)
     |> Multi.execute(fn cluster -> maybe_emit_cluster_health_changed_event(cluster) end)
   end
@@ -808,40 +814,39 @@ defmodule Trento.Clusters.Cluster do
        do: nil
 
   defp maybe_emit_cluster_replication_health_changed_event(
-         %Cluster{cluster_id: cluster_id, replication_health: replication_health},
-         %RegisterOnlineClusterHost{type: cluster_type, details: details}
-       )
-       when cluster_type in [ClusterType.hana_scale_up(), ClusterType.hana_scale_out()] do
-    new_replication_health = parse_replication_health(details)
+         %Cluster{health_details: %HealthDetails{replication_health: replication_health}},
+         %HealthDetails{replication_health: replication_health}
+       ),
+       do: nil
 
-    if replication_health != new_replication_health do
-      %ClusterReplicationHealthChanged{
-        cluster_id: cluster_id,
-        replication_health: new_replication_health
-      }
-    end
+  defp maybe_emit_cluster_replication_health_changed_event(
+         %Cluster{cluster_id: cluster_id},
+         %HealthDetails{replication_health: replication_health}
+       ) do
+    %ClusterReplicationHealthChanged{
+      cluster_id: cluster_id,
+      replication_health: replication_health
+    }
   end
-
-  defp maybe_emit_cluster_replication_health_changed_event(_, _), do: nil
 
   defp maybe_emit_cluster_distributed_health_changed_event(
-         %Cluster{cluster_id: cluster_id, distributed_health: distributed_health},
-         %RegisterOnlineClusterHost{type: ClusterType.ascs_ers(), details: details}
-       ) do
-    new_distributed_health = parse_distributed_health(details)
+         %Cluster{health_details: %HealthDetails{distributed_health: distributed_health}},
+         %HealthDetails{distributed_health: distributed_health}
+       ),
+       do: nil
 
-    if distributed_health != new_distributed_health do
-      %ClusterDistributedHealthChanged{
-        cluster_id: cluster_id,
-        distributed_health: new_distributed_health
-      }
-    end
+  defp maybe_emit_cluster_distributed_health_changed_event(
+         %Cluster{cluster_id: cluster_id},
+         %HealthDetails{distributed_health: distributed_health}
+       ) do
+    %ClusterDistributedHealthChanged{
+      cluster_id: cluster_id,
+      distributed_health: distributed_health
+    }
   end
 
-  defp maybe_emit_cluster_distributed_health_changed_event(_, _), do: nil
-
   defp maybe_emit_cluster_checks_health_changed_event(
-         %Cluster{checks_health: checks_health},
+         %Cluster{health_details: %HealthDetails{checks_health: checks_health}},
          %CompleteChecksExecution{health: checks_health}
        ),
        do: nil
@@ -873,9 +878,11 @@ defmodule Trento.Clusters.Cluster do
 
   defp maybe_emit_cluster_health_changed_event(%Cluster{
          cluster_id: cluster_id,
-         replication_health: replication_health,
-         distributed_health: distributed_health,
-         checks_health: checks_health,
+         health_details: %HealthDetails{
+           replication_health: replication_health,
+           distributed_health: distributed_health,
+           checks_health: checks_health
+         },
          health: health,
          type: cluster_type
        }) do
@@ -906,6 +913,20 @@ defmodule Trento.Clusters.Cluster do
   defp maybe_add_checks_health(healths, Health.unknown()), do: healths
   defp maybe_add_checks_health(healths, checks_health), do: [checks_health | healths]
 
+  defp parse_discovered_health(%HanaClusterDetails{} = details) do
+    %HealthDetails{
+      replication_health: parse_replication_health(details)
+    }
+  end
+
+  defp parse_discovered_health(%AscsErsClusterDetails{} = details) do
+    %HealthDetails{
+      distributed_health: parse_distributed_health(details)
+    }
+  end
+
+  defp parse_discovered_health(_), do: %HealthDetails{}
+
   # Passing state if SR Health state is 4 and Sync state is SOK, everything else is critical
   # If data is not present for some reason the state goes to unknown
   defp parse_replication_health(%HanaClusterDetails{
@@ -932,4 +953,17 @@ defmodule Trento.Clusters.Cluster do
   end
 
   defp parse_distributed_health(_), do: Health.unknown()
+
+  defp compute_discovered_health(cluster_type, %HealthDetails{
+         replication_health: replication_health
+       })
+       when cluster_type in [ClusterType.hana_scale_up(), ClusterType.hana_scale_out()],
+       do: replication_health
+
+  defp compute_discovered_health(ClusterType.ascs_ers(), %HealthDetails{
+         distributed_health: distributed_health
+       }),
+       do: distributed_health
+
+  defp compute_discovered_health(_, _), do: Health.unknown()
 end

--- a/lib/trento/clusters/cluster.ex
+++ b/lib/trento/clusters/cluster.ex
@@ -366,12 +366,12 @@ defmodule Trento.Clusters.Cluster do
       maybe_emit_cluster_details_updated_event(cluster, command)
     end)
     |> Multi.execute(fn cluster ->
-      maybe_emit_cluster_replication_health_changed_event(cluster, %HealthDetails{
+      maybe_emit_cluster_replication_health_changed_event(cluster, command, %HealthDetails{
         replication_health: Health.unknown()
       })
     end)
     |> Multi.execute(fn cluster ->
-      maybe_emit_cluster_distributed_health_changed_event(cluster, %HealthDetails{
+      maybe_emit_cluster_distributed_health_changed_event(cluster, command, %HealthDetails{
         distributed_health: Health.unknown()
       })
     end)
@@ -714,12 +714,12 @@ defmodule Trento.Clusters.Cluster do
     end)
     |> Multi.execute(fn cluster -> maybe_emit_cluster_details_updated_event(cluster, command) end)
     |> Multi.execute(fn cluster ->
-      maybe_emit_cluster_replication_health_changed_event(cluster, health_details)
+      maybe_emit_cluster_replication_health_changed_event(cluster, command, health_details)
     end)
     |> Multi.execute(fn cluster ->
-      maybe_emit_cluster_distributed_health_changed_event(cluster, health_details)
+      maybe_emit_cluster_distributed_health_changed_event(cluster, command, health_details)
     end)
-    |> Multi.execute(fn cluster -> maybe_emit_cluster_health_changed_event(cluster) end)
+    |> Multi.execute(&maybe_emit_cluster_health_changed_event/1)
   end
 
   defp maybe_emit_cluster_details_updated_event(
@@ -821,12 +821,22 @@ defmodule Trento.Clusters.Cluster do
 
   defp maybe_emit_cluster_replication_health_changed_event(
          %Cluster{health_details: %HealthDetails{replication_health: replication_health}},
+         __command,
          %HealthDetails{replication_health: replication_health}
        ),
        do: nil
 
   defp maybe_emit_cluster_replication_health_changed_event(
+         %Cluster{state: state},
+         %RegisterOfflineClusterHost{},
+         %HealthDetails{}
+       )
+       when state != ClusterState.stopped(),
+       do: nil
+
+  defp maybe_emit_cluster_replication_health_changed_event(
          %Cluster{cluster_id: cluster_id},
+         _command,
          %HealthDetails{replication_health: replication_health}
        ) do
     %ClusterReplicationHealthChanged{
@@ -837,12 +847,22 @@ defmodule Trento.Clusters.Cluster do
 
   defp maybe_emit_cluster_distributed_health_changed_event(
          %Cluster{health_details: %HealthDetails{distributed_health: distributed_health}},
+         _command,
          %HealthDetails{distributed_health: distributed_health}
        ),
        do: nil
 
   defp maybe_emit_cluster_distributed_health_changed_event(
+         %Cluster{state: state},
+         %RegisterOfflineClusterHost{},
+         %HealthDetails{}
+       )
+       when state != ClusterState.stopped(),
+       do: nil
+
+  defp maybe_emit_cluster_distributed_health_changed_event(
          %Cluster{cluster_id: cluster_id},
+         _command,
          %HealthDetails{distributed_health: distributed_health}
        ) do
     %ClusterDistributedHealthChanged{

--- a/lib/trento/clusters/cluster.ex
+++ b/lib/trento/clusters/cluster.ex
@@ -97,9 +97,11 @@ defmodule Trento.Clusters.Cluster do
     ClusterDeregistered,
     ClusterDetailsUpdated,
     ClusterDiscoveredHealthChanged,
+    ClusterDistributedHealthChanged,
     ClusterHealthChanged,
     ClusterHostStatusChanged,
     ClusterRegistered,
+    ClusterReplicationHealthChanged,
     ClusterRestored,
     ClusterRolledUp,
     ClusterRollUpRequested,
@@ -125,7 +127,8 @@ defmodule Trento.Clusters.Cluster do
     field :resources_number, :integer
     field :hosts_number, :integer
     field :provider, Ecto.Enum, values: Provider.values()
-    field :discovered_health, Ecto.Enum, values: Health.values()
+    field :replication_health, Ecto.Enum, values: Health.values(), default: Health.unknown()
+    field :distributed_health, Ecto.Enum, values: Health.values(), default: Health.unknown()
     field :checks_health, Ecto.Enum, values: Health.values(), default: Health.unknown()
     field :health, Ecto.Enum, values: Health.values(), default: Health.unknown()
     field :state, Ecto.Enum, values: ClusterState.values()
@@ -165,11 +168,21 @@ defmodule Trento.Clusters.Cluster do
           resources_number: resources_number,
           hosts_number: hosts_number,
           details: details,
-          discovered_health: health,
           state: state,
           designated_controller: true
         }
       ) do
+    replication_health = parse_replication_health(details)
+    distributed_health = parse_distributed_health(details)
+
+    health =
+      case type do
+        ClusterType.hana_scale_up() -> replication_health
+        ClusterType.hana_scale_out() -> replication_health
+        ClusterType.ascs_ers() -> distributed_health
+        _ -> Health.unknown()
+      end
+
     [
       %ClusterRegistered{
         cluster_id: cluster_id,
@@ -180,6 +193,8 @@ defmodule Trento.Clusters.Cluster do
         resources_number: resources_number,
         hosts_number: hosts_number,
         details: details,
+        replication_health: replication_health,
+        distributed_health: distributed_health,
         health: health,
         state: state
       },
@@ -209,7 +224,9 @@ defmodule Trento.Clusters.Cluster do
         resources_number: nil,
         hosts_number: nil,
         details: nil,
-        health: :unknown,
+        replication_health: Health.unknown(),
+        distributed_health: Health.unknown(),
+        health: Health.unknown(),
         state: ClusterState.unknown()
       },
       %HostAddedToCluster{
@@ -237,7 +254,9 @@ defmodule Trento.Clusters.Cluster do
         resources_number: nil,
         hosts_number: nil,
         details: nil,
-        health: :unknown,
+        replication_health: Health.unknown(),
+        distributed_health: Health.unknown(),
+        health: Health.unknown(),
         state: ClusterState.unknown()
       },
       %HostAddedToCluster{
@@ -427,6 +446,8 @@ defmodule Trento.Clusters.Cluster do
           hosts_number: hosts_number,
           details: details,
           health: health,
+          replication_health: replication_health,
+          distributed_health: distributed_health,
           state: state
         }
       ) do
@@ -440,19 +461,54 @@ defmodule Trento.Clusters.Cluster do
         resources_number: resources_number,
         hosts_number: hosts_number,
         details: details,
-        discovered_health: health,
+        replication_health: replication_health,
+        distributed_health: distributed_health,
         health: health,
         state: state
     }
   end
 
-  def apply(%Cluster{} = cluster, %ClusterDiscoveredHealthChanged{
+  def apply(%Cluster{} = cluster, %ClusterReplicationHealthChanged{
+        replication_health: replication_health
+      }) do
+    %Cluster{
+      cluster
+      | replication_health: replication_health
+    }
+  end
+
+  def apply(%Cluster{} = cluster, %ClusterDistributedHealthChanged{
+        distributed_health: distributed_health
+      }) do
+    %Cluster{
+      cluster
+      | distributed_health: distributed_health
+    }
+  end
+
+  # Handle old ClusterDiscoveredHealthChanged event.
+  # Cannot be superseded by other events as it has different meanings for each cluster type.
+  def apply(%Cluster{type: cluster_type} = cluster, %ClusterDiscoveredHealthChanged{
+        discovered_health: discovered_health
+      })
+      when cluster_type in [ClusterType.hana_scale_up(), ClusterType.hana_scale_out()] do
+    %Cluster{
+      cluster
+      | replication_health: discovered_health
+    }
+  end
+
+  def apply(%Cluster{type: ClusterType.ascs_ers()} = cluster, %ClusterDiscoveredHealthChanged{
         discovered_health: discovered_health
       }) do
     %Cluster{
       cluster
-      | discovered_health: discovered_health
+      | distributed_health: discovered_health
     }
+  end
+
+  def apply(%Cluster{} = cluster, %ClusterDiscoveredHealthChanged{}) do
+    cluster
   end
 
   def apply(%Cluster{} = cluster, %ClusterChecksHealthChanged{
@@ -635,7 +691,10 @@ defmodule Trento.Clusters.Cluster do
     end)
     |> Multi.execute(fn cluster -> maybe_emit_cluster_details_updated_event(cluster, command) end)
     |> Multi.execute(fn cluster ->
-      maybe_emit_cluster_discovered_health_changed_event(cluster, command)
+      maybe_emit_cluster_replication_health_changed_event(cluster, command)
+    end)
+    |> Multi.execute(fn cluster ->
+      maybe_emit_cluster_distributed_health_changed_event(cluster, command)
     end)
     |> Multi.execute(fn cluster -> maybe_emit_cluster_health_changed_event(cluster) end)
   end
@@ -741,21 +800,38 @@ defmodule Trento.Clusters.Cluster do
        ),
        do: nil
 
-  defp maybe_emit_cluster_discovered_health_changed_event(
-         %Cluster{discovered_health: discovered_health},
-         %RegisterOnlineClusterHost{discovered_health: discovered_health}
-       ),
-       do: nil
+  defp maybe_emit_cluster_replication_health_changed_event(
+         %Cluster{cluster_id: cluster_id, replication_health: replication_health},
+         %RegisterOnlineClusterHost{type: cluster_type, details: details}
+       )
+       when cluster_type in [ClusterType.hana_scale_up(), ClusterType.hana_scale_out()] do
+    new_replication_health = parse_replication_health(details)
 
-  defp maybe_emit_cluster_discovered_health_changed_event(
-         %Cluster{cluster_id: cluster_id},
-         %RegisterOnlineClusterHost{discovered_health: discovered_health}
-       ) do
-    %ClusterDiscoveredHealthChanged{
-      cluster_id: cluster_id,
-      discovered_health: discovered_health
-    }
+    if replication_health != new_replication_health do
+      %ClusterReplicationHealthChanged{
+        cluster_id: cluster_id,
+        replication_health: new_replication_health
+      }
+    end
   end
+
+  defp maybe_emit_cluster_replication_health_changed_event(_, _), do: nil
+
+  defp maybe_emit_cluster_distributed_health_changed_event(
+         %Cluster{cluster_id: cluster_id, distributed_health: distributed_health},
+         %RegisterOnlineClusterHost{type: ClusterType.ascs_ers(), details: details}
+       ) do
+    new_distributed_health = parse_distributed_health(details)
+
+    if distributed_health != new_distributed_health do
+      %ClusterDistributedHealthChanged{
+        cluster_id: cluster_id,
+        distributed_health: new_distributed_health
+      }
+    end
+  end
+
+  defp maybe_emit_cluster_distributed_health_changed_event(_, _), do: nil
 
   defp maybe_emit_cluster_checks_health_changed_event(
          %Cluster{checks_health: checks_health},
@@ -788,17 +864,18 @@ defmodule Trento.Clusters.Cluster do
 
   defp maybe_emit_cluster_deregistered_event(_, _), do: nil
 
-  defp maybe_add_checks_health(healths, Health.unknown()), do: healths
-  defp maybe_add_checks_health(healths, checks_health), do: [checks_health | healths]
-
   defp maybe_emit_cluster_health_changed_event(%Cluster{
          cluster_id: cluster_id,
-         discovered_health: discovered_health,
+         replication_health: replication_health,
+         distributed_health: distributed_health,
          checks_health: checks_health,
-         health: health
+         health: health,
+         type: cluster_type
        }) do
     new_health =
-      [discovered_health]
+      []
+      |> maybe_add_replication_health(replication_health, cluster_type)
+      |> maybe_add_distributed_health(distributed_health, cluster_type)
       |> maybe_add_checks_health(checks_health)
       |> Enum.filter(& &1)
       |> HealthService.compute_aggregated_health()
@@ -807,4 +884,45 @@ defmodule Trento.Clusters.Cluster do
       %ClusterHealthChanged{cluster_id: cluster_id, health: new_health}
     end
   end
+
+  defp maybe_add_replication_health(healths, replication_health, cluster_type)
+       when cluster_type in [ClusterType.hana_scale_up(), ClusterType.hana_scale_out()],
+       do: [replication_health | healths]
+
+  defp maybe_add_replication_health(healths, _, _), do: healths
+
+  defp maybe_add_distributed_health(healths, distributed_health, ClusterType.ascs_ers()),
+    do: [distributed_health | healths]
+
+  defp maybe_add_distributed_health(healths, _, _), do: healths
+
+  defp maybe_add_checks_health(healths, Health.unknown()), do: healths
+  defp maybe_add_checks_health(healths, checks_health), do: [checks_health | healths]
+
+  # Passing state if SR Health state is 4 and Sync state is SOK, everything else is critical
+  # If data is not present for some reason the state goes to unknown
+  defp parse_replication_health(%HanaClusterDetails{
+         sr_health_state: "4",
+         secondary_sync_state: "SOK"
+       }),
+       do: Health.passing()
+
+  defp parse_replication_health(%HanaClusterDetails{
+         sr_health_state: "",
+         secondary_sync_state: ""
+       }),
+       do: Health.unknown()
+
+  defp parse_replication_health(%HanaClusterDetails{sr_health_state: _, secondary_sync_state: _}),
+    do: Health.critical()
+
+  defp parse_replication_health(_), do: Health.unknown()
+
+  defp parse_distributed_health(%AscsErsClusterDetails{sap_systems: sap_systems}) do
+    Enum.find_value(sap_systems, Health.passing(), fn %{distributed: distributed} ->
+      if not distributed, do: Health.critical()
+    end)
+  end
+
+  defp parse_distributed_health(_), do: Health.unknown()
 end

--- a/lib/trento/clusters/cluster.ex
+++ b/lib/trento/clusters/cluster.ex
@@ -944,11 +944,12 @@ defmodule Trento.Clusters.Cluster do
   defp maybe_emit_cluster_replication_health_changed_event(
          %Cluster{
            cluster_id: cluster_id,
-           health_details: %HanaClusterHealthDetails{}
+           type: cluster_type
          },
          _command,
          %HanaClusterHealthDetails{replication_health: replication_health}
-       ) do
+       )
+       when cluster_type in [ClusterType.hana_scale_up(), ClusterType.hana_scale_out()] do
     %ClusterReplicationHealthChanged{
       cluster_id: cluster_id,
       replication_health: replication_health
@@ -977,7 +978,7 @@ defmodule Trento.Clusters.Cluster do
   defp maybe_emit_cluster_distributed_health_changed_event(
          %Cluster{
            cluster_id: cluster_id,
-           health_details: %AscsErsClusterHealthDetails{}
+           type: ClusterType.ascs_ers()
          },
          _command,
          %AscsErsClusterHealthDetails{distributed_health: distributed_health}
@@ -1005,8 +1006,6 @@ defmodule Trento.Clusters.Cluster do
       checks_health: checks_health
     }
   end
-
-  defp maybe_emit_cluster_checks_health_changed_event(_, _), do: nil
 
   defp maybe_emit_cluster_deregistered_event(
          %Cluster{cluster_id: cluster_id, hosts: []},

--- a/lib/trento/clusters/cluster.ex
+++ b/lib/trento/clusters/cluster.ex
@@ -39,19 +39,19 @@ defmodule Trento.Clusters.Cluster do
   - Distributed health (only applicable for ASCS/ERS clusters)
   - Checks health
 
-  The main cluster health is computed using the values from all of them. This means that the cluster health is the
-  worst of the two.
+  The main cluster health is computed using the values from all of them. This means that the cluster health is a
+  computation of them.
 
   ### Replication health
 
   The discovered replication health. It is based in the cluster replication values coming from cluster attributes.
-  The health is passing if the SR health is 4 and the secondary sync state "SOK". It is critical otherwise or
+  The health is passing if the SR health is 4 and the secondary sync state "SOK". It is critical or
   unknown (when the data is not available) otherwise.
 
   # Distributed health
 
-  The discovered distributed health checks if ASCS and ERS workloads are distributed among 2 nodes and not running
-  in a single one.
+  The discovered distributed health. It checks if ASCS and ERS workloads are distributed among 2 nodes and not running
+  in a single one. It is passing if all handled SAP systems are distributed and critical otherwise.
 
   ### Checks health
 

--- a/lib/trento/clusters/cluster.ex
+++ b/lib/trento/clusters/cluster.ex
@@ -136,7 +136,7 @@ defmodule Trento.Clusters.Cluster do
     field :hosts_number, :integer
     field :provider, Ecto.Enum, values: Provider.values()
     field :health, Ecto.Enum, values: Health.values(), default: Health.unknown()
-    embeds_one :health_details, HealthDetails
+    embeds_one :health_details, HealthDetails, defaults_to_struct: true
     field :state, Ecto.Enum, values: ClusterState.values()
     field :hosts, {:array, :string}, default: []
     field :offline_hosts, {:array, :string}, default: []

--- a/lib/trento/clusters/cluster.ex
+++ b/lib/trento/clusters/cluster.ex
@@ -503,22 +503,34 @@ defmodule Trento.Clusters.Cluster do
 
   # Handle old ClusterDiscoveredHealthChanged event.
   # Cannot be superseded by other events as it has different meanings for each cluster type.
-  def apply(%Cluster{type: cluster_type} = cluster, %ClusterDiscoveredHealthChanged{
-        discovered_health: discovered_health
-      })
+  def apply(
+        %Cluster{type: cluster_type, health_details: health_details} = cluster,
+        %ClusterDiscoveredHealthChanged{
+          discovered_health: discovered_health
+        }
+      )
       when cluster_type in [ClusterType.hana_scale_up(), ClusterType.hana_scale_out()] do
     %Cluster{
       cluster
-      | health_details: %HealthDetails{replication_health: discovered_health}
+      | health_details: %HealthDetails{
+          health_details
+          | replication_health: discovered_health
+        }
     }
   end
 
-  def apply(%Cluster{type: ClusterType.ascs_ers()} = cluster, %ClusterDiscoveredHealthChanged{
-        discovered_health: discovered_health
-      }) do
+  def apply(
+        %Cluster{type: ClusterType.ascs_ers(), health_details: health_details} = cluster,
+        %ClusterDiscoveredHealthChanged{
+          discovered_health: discovered_health
+        }
+      ) do
     %Cluster{
       cluster
-      | health_details: %HealthDetails{distributed_health: discovered_health}
+      | health_details: %HealthDetails{
+          health_details
+          | distributed_health: discovered_health
+        }
     }
   end
 

--- a/lib/trento/clusters/commands/register_online_cluster_host.ex
+++ b/lib/trento/clusters/commands/register_online_cluster_host.ex
@@ -11,7 +11,6 @@ defmodule Trento.Clusters.Commands.RegisterOnlineClusterHost do
     :host_id,
     :type,
     :designated_controller,
-    :discovered_health,
     :provider
   ]
 
@@ -37,7 +36,6 @@ defmodule Trento.Clusters.Commands.RegisterOnlineClusterHost do
     field :designated_controller, :boolean
     field :resources_number, :integer
     field :hosts_number, :integer
-    field :discovered_health, Ecto.Enum, values: Health.values()
     field :cib_last_written, :string
     field :state, Ecto.Enum, values: ClusterState.values()
 

--- a/lib/trento/clusters/commands/register_online_cluster_host.ex
+++ b/lib/trento/clusters/commands/register_online_cluster_host.ex
@@ -19,7 +19,6 @@ defmodule Trento.Clusters.Commands.RegisterOnlineClusterHost do
   require Trento.Enums.Provider, as: Provider
   require Trento.Clusters.Enums.ClusterType, as: ClusterType
   require Trento.Clusters.Enums.ClusterState, as: ClusterState
-  require Trento.Enums.Health, as: Health
 
   alias Trento.Clusters.ValueObjects.{
     AscsErsClusterDetails,

--- a/lib/trento/clusters/events/cluster_discovered_health_changed.ex
+++ b/lib/trento/clusters/events/cluster_discovered_health_changed.ex
@@ -4,6 +4,8 @@
 defmodule Trento.Clusters.Events.ClusterDiscoveredHealthChanged do
   @moduledoc """
   This event is emitted when the discovered health of a cluster changes.
+
+  This event is deprecated in favor of specific health change events.
   """
 
   use Trento.Support.Event

--- a/lib/trento/clusters/events/cluster_distributed_health_changed.ex
+++ b/lib/trento/clusters/events/cluster_distributed_health_changed.ex
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Clusters.Events.ClusterDistributedHealthChanged do
+  @moduledoc """
+  This event is emitted when the distribution of ASCS/ERS nodes in a cluster changes.
+  Only applicable for ASCS/ERS clusters.
+  """
+
+  use Trento.Support.Event
+
+  require Trento.Enums.Health, as: Health
+
+  defevent do
+    field :cluster_id, Ecto.UUID
+    field :distributed_health, Ecto.Enum, values: Health.values()
+  end
+end

--- a/lib/trento/clusters/events/cluster_registered.ex
+++ b/lib/trento/clusters/events/cluster_registered.ex
@@ -54,5 +54,5 @@ defmodule Trento.Clusters.Events.ClusterRegistered do
   def upcast(%{"health" => health, "type" => "ascs_ers"} = params, _, 3),
     do: Map.put(params, "health_details", %{"distributed_health" => health})
 
-  def upcast(params, _, 3), do: params
+  def upcast(params, _, 3), do: Map.put(params, "health_details", %{})
 end

--- a/lib/trento/clusters/events/cluster_registered.ex
+++ b/lib/trento/clusters/events/cluster_registered.ex
@@ -16,6 +16,7 @@ defmodule Trento.Clusters.Events.ClusterRegistered do
   alias Trento.Clusters.ValueObjects.{
     AscsErsClusterDetails,
     HanaClusterDetails,
+    HealthDetails,
     SapInstance
   }
 
@@ -29,6 +30,7 @@ defmodule Trento.Clusters.Events.ClusterRegistered do
     field :replication_health, Ecto.Enum, values: Health.values()
     field :distributed_health, Ecto.Enum, values: Health.values()
     field :health, Ecto.Enum, values: Health.values()
+    embeds_one :health_details, HealthDetails
     field :state, Ecto.Enum, values: ClusterState.values()
 
     polymorphic_embeds_one(:details,
@@ -49,10 +51,10 @@ defmodule Trento.Clusters.Events.ClusterRegistered do
 
   def upcast(%{"health" => health, "type" => type} = params, _, 3)
       when type in ["hana_scale_up", "hana_scale_out"],
-      do: Map.put(params, "replication_health", health)
+      do: Map.put(params, "health_details", %{"replication_health" => health})
 
   def upcast(%{"health" => health, "type" => "ascs_ers"} = params, _, 3),
-    do: Map.put(params, "distributed_health", health)
+    do: Map.put(params, "health_details", %{"distributed_health" => health})
 
   def upcast(params, _, 3), do: params
 end

--- a/lib/trento/clusters/events/cluster_registered.ex
+++ b/lib/trento/clusters/events/cluster_registered.ex
@@ -19,13 +19,15 @@ defmodule Trento.Clusters.Events.ClusterRegistered do
     SapInstance
   }
 
-  defevent version: 2 do
+  defevent version: 3 do
     field :cluster_id, Ecto.UUID
     field :name, :string
     field :type, Ecto.Enum, values: ClusterType.values()
     field :provider, Ecto.Enum, values: Provider.values()
     field :resources_number, :integer
     field :hosts_number, :integer
+    field :replication_health, Ecto.Enum, values: Health.values()
+    field :distributed_health, Ecto.Enum, values: Health.values()
     field :health, Ecto.Enum, values: Health.values()
     field :state, Ecto.Enum, values: ClusterState.values()
 
@@ -44,4 +46,13 @@ defmodule Trento.Clusters.Events.ClusterRegistered do
   end
 
   def upcast(params, _, 2), do: Map.put(params, "state", ClusterState.unknown())
+
+  def upcast(%{"health" => health, "type" => type} = params, _, 3)
+      when type in ["hana_scale_up", "hana_scale_out"],
+      do: Map.put(params, "replication_health", health)
+
+  def upcast(%{"health" => health, "type" => "ascs_ers"} = params, _, 3),
+    do: Map.put(params, "distributed_health", health)
+
+  def upcast(params, _, 3), do: params
 end

--- a/lib/trento/clusters/events/cluster_registered.ex
+++ b/lib/trento/clusters/events/cluster_registered.ex
@@ -15,8 +15,9 @@ defmodule Trento.Clusters.Events.ClusterRegistered do
 
   alias Trento.Clusters.ValueObjects.{
     AscsErsClusterDetails,
+    AscsErsClusterHealthDetails,
     HanaClusterDetails,
-    HealthDetails,
+    HanaClusterHealthDetails,
     SapInstance
   }
 
@@ -28,7 +29,6 @@ defmodule Trento.Clusters.Events.ClusterRegistered do
     field :resources_number, :integer
     field :hosts_number, :integer
     field :health, Ecto.Enum, values: Health.values()
-    embeds_one :health_details, HealthDetails
     field :state, Ecto.Enum, values: ClusterState.values()
 
     polymorphic_embeds_one(:details,
@@ -40,6 +40,17 @@ defmodule Trento.Clusters.Events.ClusterRegistered do
         ascs_ers: [module: AscsErsClusterDetails, identify_by_fields: [:sap_systems]]
       ],
       on_replace: :update
+    )
+
+    polymorphic_embeds_one(:health_details,
+      types: [
+        hana_scale_up: HanaClusterHealthDetails,
+        hana_scale_out: HanaClusterHealthDetails,
+        ascs_ers: AscsErsClusterHealthDetails
+      ],
+      on_replace: :update,
+      use_parent_field_for_type: :type,
+      on_type_not_found: :nilify
     )
 
     embeds_many :sap_instances, SapInstance
@@ -54,5 +65,5 @@ defmodule Trento.Clusters.Events.ClusterRegistered do
   def upcast(%{"health" => health, "type" => "ascs_ers"} = params, _, 3),
     do: Map.put(params, "health_details", %{"distributed_health" => health})
 
-  def upcast(params, _, 3), do: Map.put(params, "health_details", %{})
+  def upcast(params, _, 3), do: Map.put(params, "health_details", nil)
 end

--- a/lib/trento/clusters/events/cluster_registered.ex
+++ b/lib/trento/clusters/events/cluster_registered.ex
@@ -27,8 +27,6 @@ defmodule Trento.Clusters.Events.ClusterRegistered do
     field :provider, Ecto.Enum, values: Provider.values()
     field :resources_number, :integer
     field :hosts_number, :integer
-    field :replication_health, Ecto.Enum, values: Health.values()
-    field :distributed_health, Ecto.Enum, values: Health.values()
     field :health, Ecto.Enum, values: Health.values()
     embeds_one :health_details, HealthDetails
     field :state, Ecto.Enum, values: ClusterState.values()

--- a/lib/trento/clusters/events/cluster_replication_health_changed.ex
+++ b/lib/trento/clusters/events/cluster_replication_health_changed.ex
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Clusters.Events.ClusterReplicationHealthChanged do
+  @moduledoc """
+  This event is emitted when the replication health of a cluster changes.
+  Only applicable for HANA clusters.
+  """
+
+  use Trento.Support.Event
+
+  require Trento.Enums.Health, as: Health
+
+  defevent do
+    field :cluster_id, Ecto.UUID
+    field :replication_health, Ecto.Enum, values: Health.values()
+  end
+end

--- a/lib/trento/clusters/events/cluster_rolled_up.ex
+++ b/lib/trento/clusters/events/cluster_rolled_up.ex
@@ -34,7 +34,7 @@ defmodule Trento.Clusters.Events.ClusterRolledUp do
       when type in ["hana_scale_up", "hana_scale_out"] do
     new_snapshot =
       snapshot
-      |> Map.put("replication_health", discovered_health)
+      |> Map.put("health_details", %{"replication_health" => discovered_health})
       |> Map.drop("discovered_health")
 
     Map.put(params, "snapshot", new_snapshot)
@@ -53,7 +53,7 @@ defmodule Trento.Clusters.Events.ClusterRolledUp do
       ) do
     new_snapshot =
       snapshot
-      |> Map.put("distributed_health", discovered_health)
+      |> Map.put("health_details", %{"distributed_health" => discovered_health})
       |> Map.drop("discovered_health")
 
     Map.put(params, "snapshot", new_snapshot)

--- a/lib/trento/clusters/events/cluster_rolled_up.ex
+++ b/lib/trento/clusters/events/cluster_rolled_up.ex
@@ -62,7 +62,6 @@ defmodule Trento.Clusters.Events.ClusterRolledUp do
   def upcast(params, _, 2),
     do:
       params
-      |> Map.put("replication_health", :unknown)
-      |> Map.put("distributed_health", :unknown)
+      |> Map.put("health_details", %{})
       |> Map.drop("discovered_health")
 end

--- a/lib/trento/clusters/events/cluster_rolled_up.ex
+++ b/lib/trento/clusters/events/cluster_rolled_up.ex
@@ -11,8 +11,58 @@ defmodule Trento.Clusters.Events.ClusterRolledUp do
 
   alias Trento.Clusters.Cluster
 
-  defevent do
+  defevent resource: "cluster", version: 2 do
     field :cluster_id, Ecto.UUID
     embeds_one :snapshot, Cluster
   end
+
+  # Handle old ClusterRolledUp, inherited from the previous aggregate when
+  # discovered_health field existed.
+  # - discovered_health is moved to replication_health for HANA clusters
+  # - discovered_health is moved to distributed_health for ASCS/ERS clusters
+  def upcast(
+        %{
+          "snapshot" =>
+            %{
+              "type" => type,
+              "discovered_health" => discovered_health
+            } = snapshot
+        } = params,
+        _,
+        2
+      )
+      when type in ["hana_scale_up", "hana_scale_out"] do
+    new_snapshot =
+      snapshot
+      |> Map.put("replication_health", discovered_health)
+      |> Map.drop("discovered_health")
+
+    Map.put(params, "snapshot", new_snapshot)
+  end
+
+  def upcast(
+        %{
+          "snapshot" =>
+            %{
+              "type" => "ascs_ers",
+              "discovered_health" => discovered_health
+            } = snapshot
+        } = params,
+        _,
+        2
+      ) do
+    new_snapshot =
+      snapshot
+      |> Map.put("distributed_health", discovered_health)
+      |> Map.drop("discovered_health")
+
+    Map.put(params, "snapshot", new_snapshot)
+  end
+
+  def upcast(params, _, 2),
+    do:
+      params
+      |> Map.put("replication_health", :unknown)
+      |> Map.put("distributed_health", :unknown)
+      |> Map.drop("discovered_health")
 end

--- a/lib/trento/clusters/events/cluster_rolled_up.ex
+++ b/lib/trento/clusters/events/cluster_rolled_up.ex
@@ -25,7 +25,8 @@ defmodule Trento.Clusters.Events.ClusterRolledUp do
           "snapshot" =>
             %{
               "type" => type,
-              "discovered_health" => discovered_health
+              "discovered_health" => discovered_health,
+              "checks_health" => checks_health
             } = snapshot
         } = params,
         _,
@@ -34,8 +35,11 @@ defmodule Trento.Clusters.Events.ClusterRolledUp do
       when type in ["hana_scale_up", "hana_scale_out"] do
     new_snapshot =
       snapshot
-      |> Map.put("health_details", %{"replication_health" => discovered_health})
-      |> Map.drop("discovered_health")
+      |> Map.put("health_details", %{
+        "replication_health" => discovered_health,
+        "checks_health" => checks_health
+      })
+      |> Map.delete("discovered_health")
 
     Map.put(params, "snapshot", new_snapshot)
   end
@@ -45,7 +49,8 @@ defmodule Trento.Clusters.Events.ClusterRolledUp do
           "snapshot" =>
             %{
               "type" => "ascs_ers",
-              "discovered_health" => discovered_health
+              "discovered_health" => discovered_health,
+              "checks_health" => checks_health
             } = snapshot
         } = params,
         _,
@@ -53,8 +58,11 @@ defmodule Trento.Clusters.Events.ClusterRolledUp do
       ) do
     new_snapshot =
       snapshot
-      |> Map.put("health_details", %{"distributed_health" => discovered_health})
-      |> Map.drop("discovered_health")
+      |> Map.put("health_details", %{
+        "distributed_health" => discovered_health,
+        "checks_health" => checks_health
+      })
+      |> Map.delete("discovered_health")
 
     Map.put(params, "snapshot", new_snapshot)
   end
@@ -63,5 +71,5 @@ defmodule Trento.Clusters.Events.ClusterRolledUp do
     do:
       params
       |> Map.put("health_details", %{})
-      |> Map.drop("discovered_health")
+      |> Map.delete("discovered_health")
 end

--- a/lib/trento/clusters/value_objects/ascs_ers_cluster_health_details.ex
+++ b/lib/trento/clusters/value_objects/ascs_ers_cluster_health_details.ex
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Clusters.ValueObjects.AscsErsClusterHealthDetails do
+  @moduledoc """
+  ASCS/ERS cluster health details.
+
+  Additional information about the fields available in the cluster
+  aggregate docstring.
+  """
+
+  @required_fields []
+
+  use Trento.Support.Type
+
+  require Trento.Enums.Health, as: Health
+
+  deftype do
+    field :checks_health, Ecto.Enum, values: Health.values(), default: Health.unknown()
+    field :distributed_health, Ecto.Enum, values: Health.values(), default: Health.unknown()
+  end
+end

--- a/lib/trento/clusters/value_objects/hana_cluster_health_details.ex
+++ b/lib/trento/clusters/value_objects/hana_cluster_health_details.ex
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: SUSE LLC
 # SPDX-License-Identifier: Apache-2.0
 
-defmodule Trento.Clusters.ValueObjects.HealthDetails do
+defmodule Trento.Clusters.ValueObjects.HanaClusterHealthDetails do
   @moduledoc """
-  Cluster health details.
+  Hana cluster health details.
 
   Additional information about the fields available in the cluster
   aggregate docstring.
@@ -17,7 +17,6 @@ defmodule Trento.Clusters.ValueObjects.HealthDetails do
 
   deftype do
     field :checks_health, Ecto.Enum, values: Health.values(), default: Health.unknown()
-    field :distributed_health, Ecto.Enum, values: Health.values(), default: Health.unknown()
     field :replication_health, Ecto.Enum, values: Health.values(), default: Health.unknown()
   end
 end

--- a/lib/trento/clusters/value_objects/health_details.ex
+++ b/lib/trento/clusters/value_objects/health_details.ex
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Clusters.ValueObjects.HealthDetails do
+  @moduledoc """
+  Cluster health details.
+
+  Additional information about the fields available in the cluster
+  aggregate docstring.
+  """
+
+  @required_fields []
+
+  use Trento.Support.Type
+
+  require Trento.Enums.Health, as: Health
+
+  deftype do
+    field :checks_health, Ecto.Enum, values: Health.values(), default: Health.unknown()
+    field :distributed_health, Ecto.Enum, values: Health.values(), default: Health.unknown()
+    field :replication_health, Ecto.Enum, values: Health.values(), default: Health.unknown()
+  end
+end

--- a/lib/trento/discovery/policies/cluster_policy.ex
+++ b/lib/trento/discovery/policies/cluster_policy.ex
@@ -123,7 +123,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicy do
       resources_number: parse_resources_number(payload),
       hosts_number: parse_hosts_number(payload),
       details: cluster_details,
-      discovered_health: parse_cluster_health(cluster_details, cluster_type),
       cib_last_written: parse_cib_last_written(payload),
       provider: provider,
       state: state
@@ -1150,29 +1149,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicy do
 
   defp generate_cluster_id(nil), do: nil
   defp generate_cluster_id(id), do: UUID.uuid5(@uuid_namespace, id)
-
-  defp parse_cluster_health(details, cluster_type)
-       when cluster_type in [ClusterType.hana_scale_up(), ClusterType.hana_scale_out()],
-       do: parse_hana_cluster_health(details)
-
-  defp parse_cluster_health(%{sap_systems: sap_systems}, ClusterType.ascs_ers()) do
-    Enum.find_value(sap_systems, Health.passing(), fn %{distributed: distributed} ->
-      if not distributed, do: Health.critical()
-    end)
-  end
-
-  defp parse_cluster_health(_, _), do: Health.unknown()
-
-  # Passing state if SR Health state is 4 and Sync state is SOK, everything else is critical
-  # If data is not present for some reason the state goes to unknown
-  defp parse_hana_cluster_health(%{sr_health_state: "4", secondary_sync_state: "SOK"}),
-    do: Health.passing()
-
-  defp parse_hana_cluster_health(%{sr_health_state: "", secondary_sync_state: ""}),
-    do: Health.unknown()
-
-  defp parse_hana_cluster_health(%{sr_health_state: _, secondary_sync_state: _}),
-    do: Health.critical()
 
   defp parse_hana_scenario([]), do: HanaScenario.performance_optimized()
 

--- a/lib/trento/discovery/policies/cluster_policy.ex
+++ b/lib/trento/discovery/policies/cluster_policy.ex
@@ -10,7 +10,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicy do
   require Trento.Clusters.Enums.ClusterType, as: ClusterType
   require Trento.Clusters.Enums.ClusterHostStatus, as: ClusterHostStatus
   require Trento.Clusters.Enums.HanaArchitectureType, as: HanaArchitectureType
-  require Trento.Enums.Health, as: Health
   require Trento.Clusters.Enums.AscsErsClusterRole, as: AscsErsClusterRole
   require Trento.Clusters.Enums.HanaScenario, as: HanaScenario
   require Trento.Clusters.Enums.SapInstanceResourceType, as: SapInstanceResourceType

--- a/lib/trento/infrastructure/commanded/event_handlers/stream_roll_up_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/stream_roll_up_event_handler.ex
@@ -34,9 +34,10 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.StreamRollUpEventHandler
     Trento.Clusters.Events.ChecksSelected,
     Trento.Clusters.Events.ClusterChecksHealthChanged,
     Trento.Clusters.Events.ClusterDetailsUpdated,
-    Trento.Clusters.Events.ClusterDiscoveredHealthChanged,
+    Trento.Clusters.Events.ClusterDitributedHealthChanged,
     Trento.Clusters.Events.ClusterHealthChanged,
     Trento.Clusters.Events.ClusterRegistered,
+    Trento.Clusters.Events.ClusterReplicationHealthChanged,
     Trento.Clusters.Events.HostAddedToCluster
   ]
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -29,9 +29,9 @@ defmodule Trento.Factory do
     ClusterResource,
     ClusterResourceParent,
     HanaClusterDetails,
+    HanaClusterHealthDetails,
     HanaClusterNode,
     HanaClusterSite,
-    HealthDetails,
     SapInstance,
     SbdDevice
   }
@@ -329,7 +329,9 @@ defmodule Trento.Factory do
       hosts_number: 2,
       details: build(:hana_cluster_details),
       health: Health.passing(),
-      health_details: %HealthDetails{},
+      health_details: %HanaClusterHealthDetails{
+        replication_health: Health.passing()
+      },
       type: ClusterType.hana_scale_up(),
       state: :S_IDLE
     }

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -31,6 +31,7 @@ defmodule Trento.Factory do
     HanaClusterDetails,
     HanaClusterNode,
     HanaClusterSite,
+    HealthDetails,
     SapInstance,
     SbdDevice
   }
@@ -275,7 +276,6 @@ defmodule Trento.Factory do
       hosts_number: 2,
       details: build(:hana_cluster_details),
       type: ClusterType.hana_scale_up(),
-      discovered_health: Health.passing(),
       designated_controller: true,
       cib_last_written: Date.to_string(Faker.Date.forward(0)),
       state: :S_IDLE
@@ -329,6 +329,7 @@ defmodule Trento.Factory do
       hosts_number: 2,
       details: build(:hana_cluster_details),
       health: Health.passing(),
+      health_details: %HealthDetails{},
       type: ClusterType.hana_scale_up(),
       state: :S_IDLE
     }
@@ -714,7 +715,7 @@ defmodule Trento.Factory do
   def ascs_ers_cluster_node_factory do
     %AscsErsClusterNode{
       name: Faker.Pokemon.name(),
-      roles: [Enum.random(["ascs", "ers"])],
+      roles: [Enum.random([:ascs, :ers])],
       virtual_ips: [Faker.Internet.ip_v4_address()],
       filesystems: [Faker.File.file_name()],
       status: "Online",

--- a/test/trento/clusters/cluster_test.exs
+++ b/test/trento/clusters/cluster_test.exs
@@ -2031,15 +2031,32 @@ defmodule Trento.ClusterTest do
       scenarios = [
         %{
           type: :hana_scale_up,
-          expected_health_details: %HealthDetails{replication_health: Health.passing()}
+          expected_health_details: %HealthDetails{
+            checks_health: Health.warning(),
+            replication_health: Health.passing()
+          }
         },
         %{
           type: :hana_scale_out,
-          expected_health_details: %HealthDetails{replication_health: Health.passing()}
+          expected_health_details: %HealthDetails{
+            checks_health: Health.warning(),
+            replication_health: Health.passing()
+          }
         },
         %{
           type: :ascs_ers,
-          expected_health_details: %HealthDetails{distributed_health: Health.passing()}
+          expected_health_details: %HealthDetails{
+            checks_health: Health.warning(),
+            distributed_health: Health.passing()
+          }
+        },
+        %{
+          type: :unknown,
+          expected_health_details: %HealthDetails{
+            checks_health: Health.warning(),
+            replication_health: Health.unknown(),
+            distributed_health: Health.unknown()
+          }
         }
       ]
 
@@ -2054,6 +2071,10 @@ defmodule Trento.ClusterTest do
         assert_state(
           [
             cluster_registered_event,
+            %ClusterChecksHealthChanged{
+              cluster_id: cluster_id,
+              checks_health: Health.warning()
+            },
             %ClusterDiscoveredHealthChanged{
               cluster_id: cluster_id,
               discovered_health: Health.passing()

--- a/test/trento/clusters/cluster_test.exs
+++ b/test/trento/clusters/cluster_test.exs
@@ -6,6 +6,7 @@ defmodule Trento.ClusterTest do
 
   require Trento.Clusters.Enums.ClusterHostStatus, as: ClusterHostStatus
   require Trento.Clusters.Enums.ClusterState, as: ClusterState
+  require Trento.Enums.Health, as: Health
 
   import Trento.Factory
 
@@ -33,9 +34,11 @@ defmodule Trento.ClusterTest do
     ClusterDeregistered,
     ClusterDetailsUpdated,
     ClusterDiscoveredHealthChanged,
+    ClusterDistributedHealthChanged,
     ClusterHealthChanged,
     ClusterHostStatusChanged,
     ClusterRegistered,
+    ClusterReplicationHealthChanged,
     ClusterRestored,
     ClusterRolledUp,
     ClusterRollUpRequested,
@@ -43,6 +46,8 @@ defmodule Trento.ClusterTest do
     HostAddedToCluster,
     HostRemovedFromCluster
   }
+
+  alias Trento.Clusters.ValueObjects.HealthDetails
 
   alias Trento.Clusters.Cluster
 
@@ -67,7 +72,6 @@ defmodule Trento.ClusterTest do
           provider: :azure,
           type: type,
           details: nil,
-          discovered_health: :passing,
           designated_controller: true,
           state: state
         }),
@@ -78,7 +82,8 @@ defmodule Trento.ClusterTest do
             sap_instances: sap_instances,
             provider: :azure,
             type: type,
-            health: :passing,
+            health: Health.unknown(),
+            health_details: %HealthDetails{},
             details: nil,
             state: state
           },
@@ -95,11 +100,179 @@ defmodule Trento.ClusterTest do
           type: type,
           provider: :azure,
           hosts: [host_id],
-          discovered_health: :passing,
-          health: :passing,
+          health: Health.unknown(),
+          health_details: %HealthDetails{},
           state: state
         }
       )
+    end
+
+    test "should register a cluster with correct health for HANA type clusters" do
+      scenarios = [
+        %{
+          sr_health_state: "4",
+          secondary_sync_state: "SOK",
+          expected_health: Health.passing()
+        },
+        %{
+          sr_health_state: "1",
+          secondary_sync_state: "SFAIL",
+          expected_health: Health.critical()
+        },
+        %{
+          sr_health_state: "1",
+          secondary_sync_state: "SOK",
+          expected_health: Health.critical()
+        },
+        %{
+          sr_health_state: "4",
+          secondary_sync_state: "SFAIL",
+          expected_health: Health.critical()
+        }
+      ]
+
+      cluster_id = Faker.UUID.v4()
+      host_id = Faker.UUID.v4()
+      name = Faker.StarWars.character()
+      sap_instances = build_list(2, :clustered_sap_instance)
+
+      for %{
+            sr_health_state: sr_health_state,
+            secondary_sync_state: secondary_sync_state,
+            expected_health: expected_health
+          } <- scenarios do
+        details =
+          build(:hana_cluster_details,
+            sr_health_state: sr_health_state,
+            secondary_sync_state: secondary_sync_state
+          )
+
+        assert_events_and_state(
+          [],
+          RegisterOnlineClusterHost.new!(%{
+            cluster_id: cluster_id,
+            host_id: host_id,
+            name: name,
+            sap_instances: Enum.map(sap_instances, &Map.from_struct/1),
+            provider: :azure,
+            type: :hana_scale_up,
+            details: StructHelper.to_map(details),
+            designated_controller: true,
+            state: :S_IDLE
+          }),
+          [
+            %ClusterRegistered{
+              cluster_id: cluster_id,
+              name: name,
+              sap_instances: sap_instances,
+              provider: :azure,
+              type: :hana_scale_up,
+              details: details,
+              health: expected_health,
+              health_details: %HealthDetails{
+                replication_health: expected_health
+              },
+              state: :S_IDLE
+            },
+            %HostAddedToCluster{
+              cluster_id: cluster_id,
+              host_id: host_id,
+              cluster_host_status: ClusterHostStatus.online()
+            }
+          ],
+          %Cluster{
+            cluster_id: cluster_id,
+            name: name,
+            sap_instances: sap_instances,
+            type: :hana_scale_up,
+            provider: :azure,
+            hosts: [host_id],
+            details: details,
+            health: expected_health,
+            health_details: %HealthDetails{
+              replication_health: expected_health
+            },
+            state: :S_IDLE
+          }
+        )
+      end
+    end
+
+    test "should register a cluster with correct health for ASCS/ERS type clusters" do
+      scenarios = [
+        %{
+          distributed: true,
+          expected_health: Health.passing()
+        },
+        %{
+          distributed: false,
+          expected_health: Health.critical()
+        }
+      ]
+
+      cluster_id = Faker.UUID.v4()
+      host_id = Faker.UUID.v4()
+      name = Faker.StarWars.character()
+      sap_instances = build_list(2, :clustered_sap_instance)
+
+      for %{
+            distributed: distributed,
+            expected_health: expected_health
+          } <- scenarios do
+        details =
+          build(:ascs_ers_cluster_details,
+            sap_systems: build_list(2, :ascs_ers_cluster_sap_system, distributed: distributed)
+          )
+
+        assert_events_and_state(
+          [],
+          RegisterOnlineClusterHost.new!(%{
+            cluster_id: cluster_id,
+            host_id: host_id,
+            name: name,
+            sap_instances: Enum.map(sap_instances, &Map.from_struct/1),
+            provider: :azure,
+            type: :ascs_ers,
+            details: StructHelper.to_map(details),
+            designated_controller: true,
+            state: :S_IDLE
+          }),
+          [
+            %ClusterRegistered{
+              cluster_id: cluster_id,
+              name: name,
+              sap_instances: sap_instances,
+              provider: :azure,
+              type: :ascs_ers,
+              details: details,
+              health: expected_health,
+              health_details: %HealthDetails{
+                distributed_health: expected_health
+              },
+              state: :S_IDLE
+            },
+            %HostAddedToCluster{
+              cluster_id: cluster_id,
+              host_id: host_id,
+              cluster_host_status: ClusterHostStatus.online()
+            }
+          ],
+          %Cluster{
+            cluster_id: cluster_id,
+            name: name,
+            sap_instances: sap_instances,
+            type: :ascs_ers,
+            provider: :azure,
+            hosts: [host_id],
+            details: details,
+            health: expected_health,
+            health_details: %HealthDetails{
+              distributed_health: expected_health
+            },
+            state: :S_IDLE
+          }
+        )
+      end
     end
 
     test "should register a cluster with unknown details when the cluster was not registered yet and a message from a non-DC is received" do
@@ -114,7 +287,6 @@ defmodule Trento.ClusterTest do
           cluster_id: cluster_id,
           host_id: host_id,
           name: name,
-          discovered_health: :unknown,
           provider: :unknown,
           type: :unknown,
           designated_controller: false,
@@ -127,7 +299,8 @@ defmodule Trento.ClusterTest do
             sap_instances: [],
             provider: :unknown,
             type: :unknown,
-            health: :unknown,
+            health: Health.unknown(),
+            health_details: %HealthDetails{},
             details: nil,
             state: ClusterState.unknown()
           },
@@ -145,8 +318,8 @@ defmodule Trento.ClusterTest do
           provider: :unknown,
           hosts: [host_id],
           offline_hosts: [],
-          discovered_health: :unknown,
-          health: :unknown,
+          health: Health.unknown(),
+          health_details: %HealthDetails{},
           state: ClusterState.unknown()
         }
       )
@@ -171,7 +344,8 @@ defmodule Trento.ClusterTest do
             sap_instances: [],
             provider: :unknown,
             type: :unknown,
-            health: :unknown,
+            health: Health.unknown(),
+            health_details: %HealthDetails{},
             details: nil,
             state: ClusterState.unknown()
           },
@@ -189,8 +363,8 @@ defmodule Trento.ClusterTest do
           provider: :unknown,
           hosts: [host_id],
           offline_hosts: [host_id],
-          discovered_health: :unknown,
-          health: :unknown,
+          health: Health.unknown(),
+          health_details: %HealthDetails{},
           state: ClusterState.unknown()
         }
       )
@@ -213,7 +387,6 @@ defmodule Trento.ClusterTest do
           name: name,
           sap_instances: Enum.map(sap_instances, &Map.from_struct/1),
           type: :hana_scale_up,
-          discovered_health: :unknown,
           designated_controller: false,
           provider: :azure
         }),
@@ -240,7 +413,7 @@ defmodule Trento.ClusterTest do
 
       assert_events_and_state(
         [
-          build(:cluster_registered_event, cluster_id: cluster_id),
+          build(:cluster_registered_event, cluster_id: cluster_id, health: Health.unknown()),
           build(:host_added_to_cluster_event,
             cluster_id: cluster_id,
             host_id: host_id_1,
@@ -277,59 +450,150 @@ defmodule Trento.ClusterTest do
       cluster_id = Faker.UUID.v4()
       host_id = Faker.UUID.v4()
       name = Faker.StarWars.character()
-      registered_cluster = build(:cluster_registered_event, cluster_id: cluster_id)
 
-      assert_events_and_state(
-        [
-          registered_cluster,
-          build(:host_added_to_cluster_event,
+      scenarios = [
+        %{
+          type: :hana_scale_up,
+          health: Health.passing(),
+          health_details: %HealthDetails{
+            replication_health: Health.passing()
+          },
+          health_change_events: [
+            %ClusterReplicationHealthChanged{
+              cluster_id: cluster_id,
+              replication_health: Health.unknown()
+            },
+            %ClusterHealthChanged{
+              cluster_id: cluster_id,
+              health: :unknown
+            }
+          ]
+        },
+        %{
+          type: :hana_scale_out,
+          health: Health.passing(),
+          health_details: %HealthDetails{
+            replication_health: Health.passing()
+          },
+          health_change_events: [
+            %ClusterReplicationHealthChanged{
+              cluster_id: cluster_id,
+              replication_health: Health.unknown()
+            },
+            %ClusterHealthChanged{
+              cluster_id: cluster_id,
+              health: :unknown
+            }
+          ]
+        },
+        %{
+          type: :ascs_ers,
+          health: Health.passing(),
+          health_details: %HealthDetails{
+            distributed_health: Health.passing()
+          },
+          health_change_events: [
+            %ClusterDistributedHealthChanged{
+              cluster_id: cluster_id,
+              distributed_health: Health.unknown()
+            },
+            %ClusterHealthChanged{
+              cluster_id: cluster_id,
+              health: :unknown
+            }
+          ]
+        },
+        # Scenarios to check health is not updated if it was unknown already
+        %{
+          type: :hana_scale_up,
+          health: Health.unknown(),
+          health_details: %HealthDetails{
+            replication_health: Health.unknown()
+          },
+          health_change_events: []
+        },
+        %{
+          type: :hana_scale_out,
+          health: Health.unknown(),
+          health_details: %HealthDetails{
+            replication_health: Health.unknown()
+          },
+          health_change_events: []
+        },
+        %{
+          type: :ascs_ers,
+          health: Health.unknown(),
+          health_details: %HealthDetails{
+            distributed_health: Health.unknown()
+          },
+          health_change_events: []
+        }
+      ]
+
+      for %{
+            type: type,
+            health: health,
+            health_details: health_details,
+            health_change_events: health_change_events
+          } <-
+            scenarios do
+        registered_cluster =
+          build(:cluster_registered_event,
             cluster_id: cluster_id,
-            host_id: host_id,
-            cluster_host_status: ClusterHostStatus.online()
-          ),
-          build(:host_added_to_cluster_event,
-            cluster_id: cluster_id,
-            host_id: Faker.UUID.v4(),
-            cluster_host_status: ClusterHostStatus.offline()
+            type: type,
+            health: health,
+            health_details: health_details
           )
-        ],
-        RegisterOfflineClusterHost.new!(%{
-          cluster_id: cluster_id,
-          host_id: host_id,
-          name: name
-        }),
-        [
-          %ClusterHostStatusChanged{
+
+        assert_events_and_state(
+          [
+            registered_cluster,
+            build(:host_added_to_cluster_event,
+              cluster_id: cluster_id,
+              host_id: host_id,
+              cluster_host_status: ClusterHostStatus.online()
+            ),
+            build(:host_added_to_cluster_event,
+              cluster_id: cluster_id,
+              host_id: Faker.UUID.v4(),
+              cluster_host_status: ClusterHostStatus.offline()
+            )
+          ],
+          RegisterOfflineClusterHost.new!(%{
             cluster_id: cluster_id,
             host_id: host_id,
-            cluster_host_status: ClusterHostStatus.offline()
-          },
-          %ClusterDetailsUpdated{
-            cluster_id: cluster_id,
-            name: registered_cluster.name,
-            type: registered_cluster.type,
-            sap_instances: registered_cluster.sap_instances,
-            provider: registered_cluster.provider,
-            resources_number: registered_cluster.resources_number,
-            hosts_number: registered_cluster.hosts_number,
-            details: registered_cluster.details,
-            state: ClusterState.stopped()
-          },
-          %ClusterDiscoveredHealthChanged{
-            cluster_id: cluster_id,
-            discovered_health: :unknown
-          },
-          %ClusterHealthChanged{
-            cluster_id: cluster_id,
-            health: :unknown
-          }
-        ],
-        fn cluster ->
-          assert %Cluster{
-                   state: ClusterState.stopped()
-                 } = cluster
-        end
-      )
+            name: name
+          }),
+          [
+            %ClusterHostStatusChanged{
+              cluster_id: cluster_id,
+              host_id: host_id,
+              cluster_host_status: ClusterHostStatus.offline()
+            },
+            %ClusterDetailsUpdated{
+              cluster_id: cluster_id,
+              name: registered_cluster.name,
+              type: registered_cluster.type,
+              sap_instances: registered_cluster.sap_instances,
+              provider: registered_cluster.provider,
+              resources_number: registered_cluster.resources_number,
+              hosts_number: registered_cluster.hosts_number,
+              details: registered_cluster.details,
+              state: ClusterState.stopped()
+            }
+          ] ++ health_change_events,
+          fn cluster ->
+            assert %Cluster{
+                     state: ClusterState.stopped(),
+                     health: Health.unknown(),
+                     health_details: %HealthDetails{
+                       replication_health: Health.unknown(),
+                       distributed_health: Health.unknown()
+                     }
+                   } = cluster
+          end
+        )
+      end
     end
 
     test "should not update cluster state when all hosts are already offline" do
@@ -339,7 +603,11 @@ defmodule Trento.ClusterTest do
 
       assert_events_and_state(
         [
-          build(:cluster_registered_event, cluster_id: cluster_id, state: ClusterState.stopped()),
+          build(:cluster_registered_event,
+            cluster_id: cluster_id,
+            state: ClusterState.stopped(),
+            health: Health.unknown()
+          ),
           build(:host_added_to_cluster_event,
             cluster_id: cluster_id,
             host_id: host_id,
@@ -380,7 +648,6 @@ defmodule Trento.ClusterTest do
           name: name,
           sap_instances: [],
           type: :hana_scale_up,
-          discovered_health: :passing,
           resources_number: 8,
           hosts_number: 2,
           designated_controller: false,
@@ -411,7 +678,7 @@ defmodule Trento.ClusterTest do
 
       assert_events_and_state(
         [
-          build(:cluster_registered_event, cluster_id: cluster_id),
+          build(:cluster_registered_event, cluster_id: cluster_id, health: Health.unknown()),
           build(:host_added_to_cluster_event,
             cluster_id: cluster_id,
             host_id: host_id,
@@ -435,7 +702,6 @@ defmodule Trento.ClusterTest do
             name: another_name,
             sap_instances: [],
             type: :hana_scale_up,
-            discovered_health: :passing,
             resources_number: 8,
             hosts_number: 2,
             designated_controller: false,
@@ -468,6 +734,7 @@ defmodule Trento.ClusterTest do
             sap_instances: sap_instances,
             name: name,
             details: nil,
+            health: Health.unknown(),
             state: state
           ),
           build(:host_added_to_cluster_event, cluster_id: cluster_id)
@@ -478,7 +745,7 @@ defmodule Trento.ClusterTest do
           name: name,
           sap_instances: Enum.map(sap_instances, &Map.from_struct/1),
           type: :hana_scale_up,
-          discovered_health: :passing,
+          details: nil,
           resources_number: 8,
           hosts_number: 2,
           designated_controller: true,
@@ -510,7 +777,13 @@ defmodule Trento.ClusterTest do
       state = :S_IDLE
 
       initial_events = [
-        build(:cluster_registered_event, cluster_id: cluster_id),
+        build(:cluster_registered_event,
+          cluster_id: cluster_id,
+          health: Health.passing(),
+          health_details: %HealthDetails{
+            replication_health: Health.passing()
+          }
+        ),
         %HostAddedToCluster{
           cluster_id: cluster_id,
           host_id: host_id,
@@ -531,7 +804,6 @@ defmodule Trento.ClusterTest do
           type: :hana_scale_up,
           resources_number: 2,
           hosts_number: 1,
-          discovered_health: :passing,
           details: StructHelper.to_map(details),
           designated_controller: true,
           state: state
@@ -576,7 +848,9 @@ defmodule Trento.ClusterTest do
           sap_instances: sap_instances,
           details: nil,
           provider: :azure,
-          state: state
+          state: state,
+          health: Health.unknown(),
+          health_details: %HealthDetails{}
         ),
         build(:host_added_to_cluster_event,
           cluster_id: cluster_id,
@@ -597,7 +871,6 @@ defmodule Trento.ClusterTest do
           hosts_number: 2,
           details: nil,
           type: :hana_scale_up,
-          discovered_health: :passing,
           designated_controller: true,
           state: state
         }),
@@ -641,37 +914,20 @@ defmodule Trento.ClusterTest do
 
     test "should use discovered cluster health when no checks are selected" do
       cluster_id = Faker.UUID.v4()
-      host_id = Faker.UUID.v4()
-      name = Faker.StarWars.character()
-      sap_instances = build_list(2, :clustered_sap_instance)
 
       assert_events_and_state(
         [
           build(
             :cluster_registered_event,
             cluster_id: cluster_id,
-            name: name,
-            sap_instances: sap_instances,
-            details: nil,
-            provider: :azure
-          ),
-          build(
-            :host_added_to_cluster_event,
-            cluster_id: cluster_id,
-            host_id: host_id
+            health: Health.passing(),
+            health_details: %HealthDetails{
+              checks_health: Health.passing(),
+              replication_health: Health.passing()
+            }
           )
         ],
         [
-          build(
-            :register_online_cluster_host,
-            host_id: host_id,
-            cluster_id: cluster_id,
-            name: name,
-            sap_instances: sap_instances,
-            details: nil,
-            discovered_health: :passing,
-            provider: :azure
-          ),
           SelectChecks.new!(%{
             cluster_id: cluster_id,
             checks: []
@@ -696,72 +952,131 @@ defmodule Trento.ClusterTest do
       cluster_id = Faker.UUID.v4()
       selected_checks = Enum.map(0..4, fn _ -> Faker.Cat.name() end)
 
-      assert_events_and_state(
-        [
-          build(:cluster_registered_event, cluster_id: cluster_id, health: Health.passing()),
-          %ChecksSelected{
-            cluster_id: cluster_id,
-            checks: selected_checks
+      scenarios = [
+        %{
+          type: :hana_scale_up,
+          health_details: %HealthDetails{
+            replication_health: Health.passing()
           }
-        ],
-        CompleteChecksExecution.new!(%{
-          cluster_id: cluster_id,
-          health: Health.critical()
-        }),
-        [
-          %ClusterChecksHealthChanged{
-            cluster_id: cluster_id,
-            checks_health: Health.critical()
-          },
-          %ClusterHealthChanged{
+        },
+        %{
+          type: :hana_scale_out,
+          health_details: %HealthDetails{
+            replication_health: Health.passing()
+          }
+        },
+        %{
+          type: :ascs_ers,
+          health_details: %HealthDetails{
+            distributed_health: Health.passing()
+          }
+        }
+      ]
+
+      for %{type: type, health_details: health_details} <- scenarios do
+        assert_events_and_state(
+          [
+            build(:cluster_registered_event,
+              cluster_id: cluster_id,
+              type: type,
+              health: Health.passing(),
+              health_details: health_details
+            ),
+            %ChecksSelected{
+              cluster_id: cluster_id,
+              checks: selected_checks
+            }
+          ],
+          CompleteChecksExecution.new!(%{
             cluster_id: cluster_id,
             health: Health.critical()
-          }
-        ],
-        fn cluster ->
-          assert %Cluster{
-                   cluster_id: ^cluster_id,
-                   health: Health.critical(),
-                   checks_health: Health.critical()
-                 } = cluster
-        end
-      )
+          }),
+          [
+            %ClusterChecksHealthChanged{
+              cluster_id: cluster_id,
+              checks_health: Health.critical()
+            },
+            %ClusterHealthChanged{
+              cluster_id: cluster_id,
+              health: Health.critical()
+            }
+          ],
+          fn cluster ->
+            assert %Cluster{
+                     cluster_id: ^cluster_id,
+                     health: Health.critical(),
+                     health_details: %HealthDetails{
+                       checks_health: Health.critical()
+                     }
+                   } = cluster
+          end
+        )
+      end
     end
 
     test "should not change the the cluster aggregated health if discovery health is worse" do
       cluster_id = Faker.UUID.v4()
       selected_checks = Enum.map(0..4, fn _ -> Faker.Cat.name() end)
 
-      assert_events_and_state(
-        [
-          build(:cluster_registered_event, cluster_id: cluster_id, health: Health.critical()),
-          %ChecksSelected{
-            cluster_id: cluster_id,
-            checks: selected_checks
-          },
-          %ClusterDiscoveredHealthChanged{
-            cluster_id: cluster_id,
-            discovered_health: Health.critical()
+      scenarios = [
+        %{
+          type: :hana_scale_up,
+          health_details: %HealthDetails{
+            checks_health: Health.passing(),
+            replication_health: Health.critical()
           }
-        ],
-        CompleteChecksExecution.new!(%{
-          cluster_id: cluster_id,
-          health: Health.warning()
-        }),
-        [
-          %ClusterChecksHealthChanged{
-            cluster_id: cluster_id,
-            checks_health: Health.warning()
+        },
+        %{
+          type: :hana_scale_out,
+          health_details: %HealthDetails{
+            checks_health: Health.passing(),
+            replication_health: Health.critical()
           }
-        ],
-        fn cluster ->
-          assert %Cluster{
-                   cluster_id: ^cluster_id,
-                   health: Health.critical(),
-                   checks_health: Health.warning()
-                 } = cluster
-        end
-      )
+        },
+        %{
+          type: :ascs_ers,
+          health_details: %HealthDetails{
+            checks_health: Health.passing(),
+            distributed_health: Health.critical()
+          }
+        }
+      ]
+
+      for %{type: type, health_details: health_details} <- scenarios do
+        assert_events_and_state(
+          [
+            build(:cluster_registered_event,
+              cluster_id: cluster_id,
+              type: type,
+              health: Health.critical(),
+              health_details: health_details
+            ),
+            %ChecksSelected{
+              cluster_id: cluster_id,
+              checks: selected_checks
+            }
+          ],
+          CompleteChecksExecution.new!(%{
+            cluster_id: cluster_id,
+            health: Health.warning()
+          }),
+          [
+            %ClusterChecksHealthChanged{
+              cluster_id: cluster_id,
+              checks_health: Health.warning()
+            }
+          ],
+          fn cluster ->
+            assert %Cluster{
+                     cluster_id: ^cluster_id,
+                     health: Health.critical(),
+                     health_details: %HealthDetails{
+                       checks_health: Health.warning()
+                     }
+                   } = cluster
+          end
+        )
+      end
     end
 
     test "unknown checks health should not affect aggregated cluster's health" do
@@ -770,27 +1085,31 @@ defmodule Trento.ClusterTest do
 
       assert_events_and_state(
         [
-          build(:cluster_registered_event, cluster_id: cluster_id, health: Health.passing()),
-          %ClusterDiscoveredHealthChanged{
+          build(:cluster_registered_event,
             cluster_id: cluster_id,
-            discovered_health: Health.passing()
-          }
-        ],
-        SelectChecks.new!(%{
-          cluster_id: cluster_id,
-          checks: selected_checks
-        }),
-        [
+            health: Health.passing(),
+            health_details: %HealthDetails{
+              replication_health: Health.passing()
+            }
+          ),
           %ChecksSelected{
             cluster_id: cluster_id,
             checks: selected_checks
           }
         ],
+        CompleteChecksExecution.new!(%{
+          cluster_id: cluster_id,
+          health: Health.unknown()
+        }),
+        [],
         fn cluster ->
           assert %Cluster{
                    cluster_id: ^cluster_id,
                    health: Health.passing(),
-                   checks_health: Health.unknown()
+                   health_details: %HealthDetails{
+                     replication_health: Health.passing(),
+                     checks_health: Health.unknown()
+                   }
                  } = cluster
         end
       )
@@ -802,18 +1121,16 @@ defmodule Trento.ClusterTest do
 
       assert_events_and_state(
         [
-          build(:cluster_registered_event, cluster_id: cluster_id, health: Health.critical()),
+          build(:cluster_registered_event,
+            cluster_id: cluster_id,
+            health: Health.critical(),
+            health_details: %HealthDetails{
+              replication_health: Health.critical()
+            }
+          ),
           %ChecksSelected{
             cluster_id: cluster_id,
             checks: selected_checks
-          },
-          %ClusterChecksHealthChanged{
-            cluster_id: cluster_id,
-            checks_health: Health.warning()
-          },
-          %ClusterDiscoveredHealthChanged{
-            cluster_id: cluster_id,
-            discovered_health: Health.critical()
           }
         ],
         SelectChecks.new!(%{
@@ -829,8 +1146,7 @@ defmodule Trento.ClusterTest do
         fn cluster ->
           assert %Cluster{
                    cluster_id: ^cluster_id,
-                   health: Health.critical(),
-                   checks_health: Health.warning()
+                   health: Health.critical()
                  } = cluster
         end
       )
@@ -842,18 +1158,17 @@ defmodule Trento.ClusterTest do
 
       assert_events_and_state(
         [
-          build(:cluster_registered_event, cluster_id: cluster_id, health: Health.critical()),
+          build(:cluster_registered_event,
+            cluster_id: cluster_id,
+            health: Health.critical(),
+            health_details: %HealthDetails{
+              checks_health: Health.critical(),
+              replication_health: Health.critical()
+            }
+          ),
           %ChecksSelected{
             cluster_id: cluster_id,
             checks: selected_checks
-          },
-          %ClusterChecksHealthChanged{
-            cluster_id: cluster_id,
-            checks_health: Health.critical()
-          },
-          %ClusterDiscoveredHealthChanged{
-            cluster_id: cluster_id,
-            discovered_health: Health.critical()
           }
         ],
         CompleteChecksExecution.new!(%{
@@ -865,7 +1180,9 @@ defmodule Trento.ClusterTest do
           assert %Cluster{
                    cluster_id: ^cluster_id,
                    health: Health.critical(),
-                   checks_health: Health.critical()
+                   health_details: %HealthDetails{
+                     checks_health: Health.critical()
+                   }
                  } = cluster
         end
       )
@@ -874,100 +1191,224 @@ defmodule Trento.ClusterTest do
 
   describe "discovered health" do
     test "should change the discovered health and the cluster aggregated health" do
-      cluster_registered_event = build(:cluster_registered_event, health: :passing)
+      cluster_id = Faker.UUID.v4()
 
-      host_added_to_cluster_event =
-        build(:host_added_to_cluster_event, cluster_id: cluster_registered_event.cluster_id)
-
-      assert_events_and_state(
-        [
-          cluster_registered_event,
-          host_added_to_cluster_event,
-          %ClusterChecksHealthChanged{
-            cluster_id: cluster_registered_event.cluster_id,
-            checks_health: Health.unknown()
-          },
-          %ChecksSelected{
-            cluster_id: cluster_registered_event.cluster_id,
-            checks: []
-          }
-        ],
-        RegisterOnlineClusterHost.new!(%{
-          cluster_id: cluster_registered_event.cluster_id,
-          host_id: host_added_to_cluster_event.host_id,
-          name: cluster_registered_event.name,
-          sap_instances: Enum.map(cluster_registered_event.sap_instances, &Map.from_struct/1),
-          provider: cluster_registered_event.provider,
-          type: cluster_registered_event.type,
-          resources_number: cluster_registered_event.resources_number,
-          hosts_number: cluster_registered_event.hosts_number,
-          details: StructHelper.to_map(cluster_registered_event.details),
-          designated_controller: true,
-          discovered_health: :warning,
-          state: cluster_registered_event.state
-        }),
-        [
-          %ClusterDiscoveredHealthChanged{
-            cluster_id: cluster_registered_event.cluster_id,
-            discovered_health: :warning
-          },
-          %ClusterHealthChanged{
-            cluster_id: cluster_registered_event.cluster_id,
-            health: :warning
-          }
-        ],
-        fn cluster ->
-          %Cluster{
-            discovered_health: :warning,
+      scenarios = [
+        %{
+          type: :hana_scale_up,
+          health_details: %HealthDetails{
             checks_health: Health.unknown(),
-            health: :warning
-          } = cluster
-        end
-      )
+            replication_health: Health.passing()
+          },
+          details: build(:hana_cluster_details),
+          updated_details: build(:hana_cluster_details, sr_health_state: "1"),
+          expected_event: %ClusterReplicationHealthChanged{
+            cluster_id: cluster_id,
+            replication_health: Health.critical()
+          },
+          expected_health_details: %HealthDetails{
+            checks_health: Health.unknown(),
+            replication_health: Health.critical()
+          }
+        },
+        %{
+          type: :hana_scale_out,
+          health_details: %HealthDetails{
+            checks_health: Health.unknown(),
+            replication_health: Health.passing()
+          },
+          details: build(:hana_cluster_details),
+          updated_details: build(:hana_cluster_details, sr_health_state: "1"),
+          expected_event: %ClusterReplicationHealthChanged{
+            cluster_id: cluster_id,
+            replication_health: Health.critical()
+          },
+          expected_health_details: %HealthDetails{
+            checks_health: Health.unknown(),
+            replication_health: Health.critical()
+          }
+        },
+        %{
+          type: :ascs_ers,
+          health_details: %HealthDetails{
+            checks_health: Health.unknown(),
+            distributed_health: Health.passing()
+          },
+          details:
+            build(:ascs_ers_cluster_details,
+              sap_systems: build_list(2, :ascs_ers_cluster_sap_system, distributed: true)
+            ),
+          updated_details:
+            build(:ascs_ers_cluster_details,
+              sap_systems: build_list(2, :ascs_ers_cluster_sap_system, distributed: false)
+            ),
+          expected_event: %ClusterDistributedHealthChanged{
+            cluster_id: cluster_id,
+            distributed_health: Health.critical()
+          },
+          expected_health_details: %HealthDetails{
+            checks_health: Health.unknown(),
+            distributed_health: Health.critical()
+          }
+        }
+      ]
+
+      for %{
+            type: type,
+            health_details: health_details,
+            details: details,
+            updated_details: updated_details,
+            expected_event: expected_event,
+            expected_health_details: expected_health_details
+          } <-
+            scenarios do
+        cluster_registered_event =
+          build(:cluster_registered_event,
+            cluster_id: cluster_id,
+            health: :passing,
+            type: type,
+            health_details: health_details,
+            details: details,
+            provider: :azure
+          )
+
+        host_added_to_cluster_event =
+          build(:host_added_to_cluster_event, cluster_id: cluster_registered_event.cluster_id)
+
+        assert_events_and_state(
+          [
+            cluster_registered_event,
+            host_added_to_cluster_event
+          ],
+          RegisterOnlineClusterHost.new!(%{
+            cluster_id: cluster_registered_event.cluster_id,
+            host_id: host_added_to_cluster_event.host_id,
+            name: cluster_registered_event.name,
+            sap_instances: Enum.map(cluster_registered_event.sap_instances, &Map.from_struct/1),
+            provider: cluster_registered_event.provider,
+            type: cluster_registered_event.type,
+            resources_number: cluster_registered_event.resources_number,
+            hosts_number: cluster_registered_event.hosts_number,
+            details: StructHelper.to_map(updated_details),
+            designated_controller: true,
+            state: cluster_registered_event.state
+          }),
+          [
+            %ClusterDetailsUpdated{
+              cluster_id: cluster_registered_event.cluster_id,
+              name: cluster_registered_event.name,
+              sap_instances: cluster_registered_event.sap_instances,
+              provider: :azure,
+              type: cluster_registered_event.type,
+              resources_number: cluster_registered_event.resources_number,
+              hosts_number: cluster_registered_event.hosts_number,
+              details: updated_details,
+              state: cluster_registered_event.state
+            },
+            expected_event,
+            %ClusterHealthChanged{
+              cluster_id: cluster_registered_event.cluster_id,
+              health: Health.critical()
+            }
+          ],
+          fn cluster ->
+            %Cluster{
+              health: Health.critical(),
+              health_details: ^expected_health_details
+            } = cluster
+          end
+        )
+      end
     end
 
     test "should not change the discovered health" do
-      cluster_registered_event =
-        build(:cluster_registered_event, health: :passing, provider: :azure)
+      scenarios = [
+        %{
+          type: :hana_scale_up,
+          health_details: %HealthDetails{
+            replication_health: Health.passing()
+          },
+          details: build(:hana_cluster_details)
+        },
+        %{
+          type: :hana_scale_out,
+          health_details: %HealthDetails{
+            replication_health: Health.passing()
+          },
+          details: build(:hana_cluster_details)
+        },
+        %{
+          type: :ascs_ers,
+          health_details: %HealthDetails{
+            distributed_health: Health.passing()
+          },
+          details:
+            build(:ascs_ers_cluster_details,
+              sap_systems: build_list(2, :ascs_ers_cluster_sap_system, distributed: true)
+            )
+        }
+      ]
 
-      host_added_to_cluster_event =
-        build(:host_added_to_cluster_event, cluster_id: cluster_registered_event.cluster_id)
+      for %{type: type, health_details: health_details, details: details} <-
+            scenarios do
+        cluster_registered_event =
+          build(:cluster_registered_event,
+            health: :passing,
+            type: type,
+            health_details: health_details,
+            details: details,
+            provider: :azure
+          )
 
-      assert_events_and_state(
-        [
-          cluster_registered_event,
-          %HostAddedToCluster{
+        host_added_to_cluster_event =
+          build(:host_added_to_cluster_event, cluster_id: cluster_registered_event.cluster_id)
+
+        assert_events_and_state(
+          [
+            cluster_registered_event,
+            %HostAddedToCluster{
+              cluster_id: cluster_registered_event.cluster_id,
+              host_id: host_added_to_cluster_event.host_id,
+              cluster_host_status: host_added_to_cluster_event.cluster_host_status
+            }
+          ],
+          RegisterOnlineClusterHost.new!(%{
             cluster_id: cluster_registered_event.cluster_id,
             host_id: host_added_to_cluster_event.host_id,
-            cluster_host_status: host_added_to_cluster_event.cluster_host_status
-          }
-        ],
-        RegisterOnlineClusterHost.new!(%{
-          cluster_id: cluster_registered_event.cluster_id,
-          host_id: host_added_to_cluster_event.host_id,
-          name: cluster_registered_event.name,
-          sap_instances: Enum.map(cluster_registered_event.sap_instances, &Map.from_struct/1),
-          type: cluster_registered_event.type,
-          resources_number: cluster_registered_event.resources_number,
-          hosts_number: cluster_registered_event.hosts_number,
-          discovered_health: :passing,
-          details: StructHelper.to_map(cluster_registered_event.details),
-          designated_controller: true,
-          provider: :azure,
-          state: cluster_registered_event.state
-        }),
-        [],
-        fn cluster ->
-          %Cluster{
-            discovered_health: :passing
-          } = cluster
-        end
-      )
+            name: cluster_registered_event.name,
+            sap_instances: Enum.map(cluster_registered_event.sap_instances, &Map.from_struct/1),
+            type: cluster_registered_event.type,
+            resources_number: cluster_registered_event.resources_number,
+            hosts_number: cluster_registered_event.hosts_number,
+            details: StructHelper.to_map(details),
+            designated_controller: true,
+            provider: :azure,
+            state: cluster_registered_event.state
+          }),
+          [],
+          fn cluster ->
+            %Cluster{
+              health_details: ^health_details
+            } = cluster
+          end
+        )
+      end
     end
 
     test "should not change the the cluster aggregated health if checks health is worse" do
       cluster_registered_event =
-        build(:cluster_registered_event, health: :passing, provider: :azure)
+        build(:cluster_registered_event,
+          health: :passing,
+          provider: :azure,
+          health: Health.critical(),
+          health_details: %HealthDetails{
+            checks_health: Health.critical(),
+            replication_health: Health.passing()
+          },
+          details: build(:hana_cluster_details)
+        )
+
+      command_details = build(:hana_cluster_details, sr_health_state: "1")
 
       host_added_to_cluster_event =
         build(:host_added_to_cluster_event, cluster_id: cluster_registered_event.cluster_id)
@@ -979,14 +1420,6 @@ defmodule Trento.ClusterTest do
           %ChecksSelected{
             cluster_id: cluster_registered_event.cluster_id,
             checks: [Faker.Cat.name()]
-          },
-          %ClusterChecksHealthChanged{
-            cluster_id: cluster_registered_event.cluster_id,
-            checks_health: :critical
-          },
-          %ClusterHealthChanged{
-            cluster_id: cluster_registered_event.cluster_id,
-            health: :critical
           }
         ],
         RegisterOnlineClusterHost.new!(%{
@@ -998,23 +1431,35 @@ defmodule Trento.ClusterTest do
           type: cluster_registered_event.type,
           resources_number: cluster_registered_event.resources_number,
           hosts_number: cluster_registered_event.hosts_number,
-          details: StructHelper.to_map(cluster_registered_event.details),
+          details: StructHelper.to_map(command_details),
           designated_controller: true,
-          discovered_health: :warning,
           state: cluster_registered_event.state
         }),
         [
-          %ClusterDiscoveredHealthChanged{
+          %ClusterDetailsUpdated{
             cluster_id: cluster_registered_event.cluster_id,
-            discovered_health: :warning
+            name: cluster_registered_event.name,
+            sap_instances: cluster_registered_event.sap_instances,
+            provider: :azure,
+            type: cluster_registered_event.type,
+            resources_number: cluster_registered_event.resources_number,
+            hosts_number: cluster_registered_event.hosts_number,
+            details: command_details,
+            state: cluster_registered_event.state
+          },
+          %ClusterReplicationHealthChanged{
+            cluster_id: cluster_registered_event.cluster_id,
+            replication_health: Health.critical()
           }
         ],
         fn cluster ->
-          %Cluster{
-            discovered_health: :warning,
-            checks_health: :critical,
-            health: :critical
-          } = cluster
+          assert %Cluster{
+                   health: :critical,
+                   health_details: %HealthDetails{
+                     checks_health: Health.critical(),
+                     replication_health: Health.critical()
+                   }
+                 } = cluster
         end
       )
     end
@@ -1047,11 +1492,14 @@ defmodule Trento.ClusterTest do
             hosts_number: cluster_registered_event.hosts_number,
             details: cluster_registered_event.details,
             health: cluster_registered_event.health,
+            health_details: %HealthDetails{
+              checks_health: Health.unknown(),
+              distributed_health: Health.unknown(),
+              replication_health: Health.unknown()
+            },
             state: cluster_registered_event.state,
             hosts: [],
-            selected_checks: [],
-            discovered_health: Health.passing(),
-            checks_health: Health.unknown()
+            selected_checks: []
           }
         },
         fn %Cluster{rolling_up: rolling_up} ->
@@ -1078,10 +1526,13 @@ defmodule Trento.ClusterTest do
               hosts_number: cluster_registered_event.hosts_number,
               details: cluster_registered_event.details,
               health: cluster_registered_event.health,
+              health_details: %HealthDetails{
+                checks_health: Health.unknown(),
+                distributed_health: Health.passing(),
+                replication_health: Health.warning()
+              },
               hosts: [],
-              selected_checks: [],
-              discovered_health: Health.passing(),
-              checks_health: Health.unknown()
+              selected_checks: []
             }
           }
         ],
@@ -1096,9 +1547,14 @@ defmodule Trento.ClusterTest do
           assert cluster.hosts_number == cluster_registered_event.hosts_number
           assert cluster.details == cluster_registered_event.details
           assert cluster.health == cluster_registered_event.health
-          assert cluster.hosts == []
           assert cluster.selected_checks == []
-          assert cluster.discovered_health == Health.passing()
+          assert cluster.hosts == []
+
+          assert cluster.health_details == %HealthDetails{
+                   checks_health: Health.unknown(),
+                   distributed_health: Health.passing(),
+                   replication_health: Health.warning()
+                 }
         end
       )
     end
@@ -1121,7 +1577,6 @@ defmodule Trento.ClusterTest do
           host_id: Faker.UUID.v4(),
           name: Faker.StarWars.character(),
           sap_instances: Enum.map(sap_instances, &Map.from_struct/1),
-          discovered_health: :unknown,
           type: :hana_scale_up,
           designated_controller: false,
           provider: :azure
@@ -1265,7 +1720,7 @@ defmodule Trento.ClusterTest do
           :register_online_cluster_host,
           cluster_id: cluster_id,
           host_id: new_host_id,
-          discovered_health: :critical,
+          details: build(:hana_cluster_details, sr_health_state: "1"),
           designated_controller: true
         )
 
@@ -1292,9 +1747,9 @@ defmodule Trento.ClusterTest do
             details: restoration_command.details,
             state: restoration_command.state
           },
-          %ClusterDiscoveredHealthChanged{
+          %ClusterReplicationHealthChanged{
             cluster_id: cluster_id,
-            discovered_health: :critical
+            replication_health: Health.critical()
           },
           %ClusterHealthChanged{
             cluster_id: cluster_id,
@@ -1496,9 +1951,50 @@ defmodule Trento.ClusterTest do
           assert cluster.health == cluster_registered_event.health
           assert cluster.hosts == []
           assert cluster.selected_checks == []
-          assert cluster.discovered_health == :passing
         end
       )
+    end
+
+    test "should apply new health with legacy ClusterDiscoveredHealthChanged event" do
+      cluster_id = Faker.UUID.v4()
+
+      scenarios = [
+        %{
+          type: :hana_scale_up,
+          expected_health_details: %HealthDetails{replication_health: Health.passing()}
+        },
+        %{
+          type: :hana_scale_out,
+          expected_health_details: %HealthDetails{replication_health: Health.passing()}
+        },
+        %{
+          type: :ascs_ers,
+          expected_health_details: %HealthDetails{distributed_health: Health.passing()}
+        }
+      ]
+
+      for %{type: type, expected_health_details: expected_health_details} <- scenarios do
+        cluster_registered_event =
+          build(
+            :cluster_registered_event,
+            cluster_id: cluster_id,
+            type: type
+          )
+
+        assert_state(
+          [
+            cluster_registered_event,
+            %ClusterDiscoveredHealthChanged{
+              cluster_id: cluster_id,
+              discovered_health: Health.passing()
+            }
+          ],
+          [],
+          fn cluster ->
+            assert %Cluster{health_details: ^expected_health_details} = cluster
+          end
+        )
+      end
     end
   end
 end

--- a/test/trento/clusters/cluster_test.exs
+++ b/test/trento/clusters/cluster_test.exs
@@ -47,7 +47,10 @@ defmodule Trento.ClusterTest do
     HostRemovedFromCluster
   }
 
-  alias Trento.Clusters.ValueObjects.HealthDetails
+  alias Trento.Clusters.ValueObjects.{
+    AscsErsClusterHealthDetails,
+    HanaClusterHealthDetails
+  }
 
   alias Trento.Clusters.Cluster
 
@@ -83,7 +86,7 @@ defmodule Trento.ClusterTest do
             provider: :azure,
             type: type,
             health: Health.unknown(),
-            health_details: %HealthDetails{},
+            health_details: nil,
             details: nil,
             state: state
           },
@@ -101,7 +104,7 @@ defmodule Trento.ClusterTest do
           provider: :azure,
           hosts: [host_id],
           health: Health.unknown(),
-          health_details: %HealthDetails{},
+          health_details: nil,
           state: state
         }
       )
@@ -169,7 +172,7 @@ defmodule Trento.ClusterTest do
               type: :hana_scale_up,
               details: details,
               health: expected_health,
-              health_details: %HealthDetails{
+              health_details: %HanaClusterHealthDetails{
                 replication_health: expected_health
               },
               state: :S_IDLE
@@ -189,7 +192,7 @@ defmodule Trento.ClusterTest do
             hosts: [host_id],
             details: details,
             health: expected_health,
-            health_details: %HealthDetails{
+            health_details: %HanaClusterHealthDetails{
               replication_health: expected_health
             },
             state: :S_IDLE
@@ -246,7 +249,7 @@ defmodule Trento.ClusterTest do
               type: :ascs_ers,
               details: details,
               health: expected_health,
-              health_details: %HealthDetails{
+              health_details: %AscsErsClusterHealthDetails{
                 distributed_health: expected_health
               },
               state: :S_IDLE
@@ -266,7 +269,7 @@ defmodule Trento.ClusterTest do
             hosts: [host_id],
             details: details,
             health: expected_health,
-            health_details: %HealthDetails{
+            health_details: %AscsErsClusterHealthDetails{
               distributed_health: expected_health
             },
             state: :S_IDLE
@@ -300,7 +303,7 @@ defmodule Trento.ClusterTest do
             provider: :unknown,
             type: :unknown,
             health: Health.unknown(),
-            health_details: %HealthDetails{},
+            health_details: nil,
             details: nil,
             state: ClusterState.unknown()
           },
@@ -319,7 +322,7 @@ defmodule Trento.ClusterTest do
           hosts: [host_id],
           offline_hosts: [],
           health: Health.unknown(),
-          health_details: %HealthDetails{},
+          health_details: nil,
           state: ClusterState.unknown()
         }
       )
@@ -345,7 +348,7 @@ defmodule Trento.ClusterTest do
             provider: :unknown,
             type: :unknown,
             health: Health.unknown(),
-            health_details: %HealthDetails{},
+            health_details: nil,
             details: nil,
             state: ClusterState.unknown()
           },
@@ -364,7 +367,7 @@ defmodule Trento.ClusterTest do
           hosts: [host_id],
           offline_hosts: [host_id],
           health: Health.unknown(),
-          health_details: %HealthDetails{},
+          health_details: nil,
           state: ClusterState.unknown()
         }
       )
@@ -413,7 +416,7 @@ defmodule Trento.ClusterTest do
 
       assert_events_and_state(
         [
-          build(:cluster_registered_event, cluster_id: cluster_id, health: Health.unknown()),
+          build(:cluster_registered_event, cluster_id: cluster_id),
           build(:host_added_to_cluster_event,
             cluster_id: cluster_id,
             host_id: host_id_1,
@@ -454,8 +457,11 @@ defmodule Trento.ClusterTest do
         %{
           type: :hana_scale_up,
           health: Health.passing(),
-          health_details: %HealthDetails{
+          health_details: %HanaClusterHealthDetails{
             replication_health: Health.passing()
+          },
+          expected_health_details: %HanaClusterHealthDetails{
+            replication_health: Health.unknown()
           },
           health_change_events: [
             %ClusterReplicationHealthChanged{
@@ -471,8 +477,11 @@ defmodule Trento.ClusterTest do
         %{
           type: :hana_scale_out,
           health: Health.passing(),
-          health_details: %HealthDetails{
+          health_details: %HanaClusterHealthDetails{
             replication_health: Health.passing()
+          },
+          expected_health_details: %HanaClusterHealthDetails{
+            replication_health: Health.unknown()
           },
           health_change_events: [
             %ClusterReplicationHealthChanged{
@@ -488,8 +497,11 @@ defmodule Trento.ClusterTest do
         %{
           type: :ascs_ers,
           health: Health.passing(),
-          health_details: %HealthDetails{
+          health_details: %AscsErsClusterHealthDetails{
             distributed_health: Health.passing()
+          },
+          expected_health_details: %AscsErsClusterHealthDetails{
+            distributed_health: Health.unknown()
           },
           health_change_events: [
             %ClusterDistributedHealthChanged{
@@ -506,7 +518,10 @@ defmodule Trento.ClusterTest do
         %{
           type: :hana_scale_up,
           health: Health.unknown(),
-          health_details: %HealthDetails{
+          health_details: %HanaClusterHealthDetails{
+            replication_health: Health.unknown()
+          },
+          expected_health_details: %HanaClusterHealthDetails{
             replication_health: Health.unknown()
           },
           health_change_events: []
@@ -514,7 +529,10 @@ defmodule Trento.ClusterTest do
         %{
           type: :hana_scale_out,
           health: Health.unknown(),
-          health_details: %HealthDetails{
+          health_details: %HanaClusterHealthDetails{
+            replication_health: Health.unknown()
+          },
+          expected_health_details: %HanaClusterHealthDetails{
             replication_health: Health.unknown()
           },
           health_change_events: []
@@ -522,7 +540,10 @@ defmodule Trento.ClusterTest do
         %{
           type: :ascs_ers,
           health: Health.unknown(),
-          health_details: %HealthDetails{
+          health_details: %AscsErsClusterHealthDetails{
+            distributed_health: Health.unknown()
+          },
+          expected_health_details: %AscsErsClusterHealthDetails{
             distributed_health: Health.unknown()
           },
           health_change_events: []
@@ -533,6 +554,7 @@ defmodule Trento.ClusterTest do
             type: type,
             health: health,
             health_details: health_details,
+            expected_health_details: expected_health_details,
             health_change_events: health_change_events
           } <-
             scenarios do
@@ -586,10 +608,7 @@ defmodule Trento.ClusterTest do
             assert %Cluster{
                      state: ClusterState.stopped(),
                      health: Health.unknown(),
-                     health_details: %HealthDetails{
-                       replication_health: Health.unknown(),
-                       distributed_health: Health.unknown()
-                     }
+                     health_details: ^expected_health_details
                    } = cluster
           end
         )
@@ -603,19 +622,19 @@ defmodule Trento.ClusterTest do
       scenarios = [
         %{
           type: :hana_scale_up,
-          health_details: %HealthDetails{
+          health_details: %HanaClusterHealthDetails{
             replication_health: Health.passing()
           }
         },
         %{
           type: :hana_scale_out,
-          health_details: %HealthDetails{
+          health_details: %HanaClusterHealthDetails{
             replication_health: Health.passing()
           }
         },
         %{
           type: :ascs_ers,
-          health_details: %HealthDetails{
+          health_details: %AscsErsClusterHealthDetails{
             distributed_health: Health.passing()
           }
         }
@@ -676,7 +695,10 @@ defmodule Trento.ClusterTest do
           build(:cluster_registered_event,
             cluster_id: cluster_id,
             state: ClusterState.stopped(),
-            health: Health.unknown()
+            health: Health.unknown(),
+            health_details: %HanaClusterHealthDetails{
+              replication_health: Health.unknown()
+            }
           ),
           build(:host_added_to_cluster_event,
             cluster_id: cluster_id,
@@ -748,7 +770,11 @@ defmodule Trento.ClusterTest do
 
       assert_events_and_state(
         [
-          build(:cluster_registered_event, cluster_id: cluster_id, health: Health.unknown()),
+          build(:cluster_registered_event,
+            cluster_id: cluster_id,
+            health: Health.unknown(),
+            health_details: nil
+          ),
           build(:host_added_to_cluster_event,
             cluster_id: cluster_id,
             host_id: host_id,
@@ -805,6 +831,7 @@ defmodule Trento.ClusterTest do
             name: name,
             details: nil,
             health: Health.unknown(),
+            health_details: nil,
             state: state
           ),
           build(:host_added_to_cluster_event, cluster_id: cluster_id)
@@ -850,7 +877,7 @@ defmodule Trento.ClusterTest do
         build(:cluster_registered_event,
           cluster_id: cluster_id,
           health: Health.passing(),
-          health_details: %HealthDetails{
+          health_details: %HanaClusterHealthDetails{
             replication_health: Health.passing()
           }
         ),
@@ -920,7 +947,7 @@ defmodule Trento.ClusterTest do
           provider: :azure,
           state: state,
           health: Health.unknown(),
-          health_details: %HealthDetails{}
+          health_details: nil
         ),
         build(:host_added_to_cluster_event,
           cluster_id: cluster_id,
@@ -991,7 +1018,7 @@ defmodule Trento.ClusterTest do
             :cluster_registered_event,
             cluster_id: cluster_id,
             health: Health.passing(),
-            health_details: %HealthDetails{
+            health_details: %HanaClusterHealthDetails{
               checks_health: Health.passing(),
               replication_health: Health.passing()
             }
@@ -1025,19 +1052,19 @@ defmodule Trento.ClusterTest do
       scenarios = [
         %{
           type: :hana_scale_up,
-          health_details: %HealthDetails{
+          health_details: %HanaClusterHealthDetails{
             replication_health: Health.passing()
           }
         },
         %{
           type: :hana_scale_out,
-          health_details: %HealthDetails{
+          health_details: %HanaClusterHealthDetails{
             replication_health: Health.passing()
           }
         },
         %{
           type: :ascs_ers,
-          health_details: %HealthDetails{
+          health_details: %AscsErsClusterHealthDetails{
             distributed_health: Health.passing()
           }
         }
@@ -1075,7 +1102,7 @@ defmodule Trento.ClusterTest do
             assert %Cluster{
                      cluster_id: ^cluster_id,
                      health: Health.critical(),
-                     health_details: %HealthDetails{
+                     health_details: %{
                        checks_health: Health.critical()
                      }
                    } = cluster
@@ -1091,21 +1118,21 @@ defmodule Trento.ClusterTest do
       scenarios = [
         %{
           type: :hana_scale_up,
-          health_details: %HealthDetails{
+          health_details: %HanaClusterHealthDetails{
             checks_health: Health.passing(),
             replication_health: Health.critical()
           }
         },
         %{
           type: :hana_scale_out,
-          health_details: %HealthDetails{
+          health_details: %HanaClusterHealthDetails{
             checks_health: Health.passing(),
             replication_health: Health.critical()
           }
         },
         %{
           type: :ascs_ers,
-          health_details: %HealthDetails{
+          health_details: %AscsErsClusterHealthDetails{
             checks_health: Health.passing(),
             distributed_health: Health.critical()
           }
@@ -1140,7 +1167,7 @@ defmodule Trento.ClusterTest do
             assert %Cluster{
                      cluster_id: ^cluster_id,
                      health: Health.critical(),
-                     health_details: %HealthDetails{
+                     health_details: %{
                        checks_health: Health.warning()
                      }
                    } = cluster
@@ -1158,7 +1185,7 @@ defmodule Trento.ClusterTest do
           build(:cluster_registered_event,
             cluster_id: cluster_id,
             health: Health.passing(),
-            health_details: %HealthDetails{
+            health_details: %HanaClusterHealthDetails{
               replication_health: Health.passing()
             }
           ),
@@ -1176,7 +1203,7 @@ defmodule Trento.ClusterTest do
           assert %Cluster{
                    cluster_id: ^cluster_id,
                    health: Health.passing(),
-                   health_details: %HealthDetails{
+                   health_details: %HanaClusterHealthDetails{
                      replication_health: Health.passing(),
                      checks_health: Health.unknown()
                    }
@@ -1194,7 +1221,7 @@ defmodule Trento.ClusterTest do
           build(:cluster_registered_event,
             cluster_id: cluster_id,
             health: Health.critical(),
-            health_details: %HealthDetails{
+            health_details: %HanaClusterHealthDetails{
               replication_health: Health.critical()
             }
           ),
@@ -1231,7 +1258,7 @@ defmodule Trento.ClusterTest do
           build(:cluster_registered_event,
             cluster_id: cluster_id,
             health: Health.critical(),
-            health_details: %HealthDetails{
+            health_details: %HanaClusterHealthDetails{
               checks_health: Health.critical(),
               replication_health: Health.critical()
             }
@@ -1250,7 +1277,7 @@ defmodule Trento.ClusterTest do
           assert %Cluster{
                    cluster_id: ^cluster_id,
                    health: Health.critical(),
-                   health_details: %HealthDetails{
+                   health_details: %HanaClusterHealthDetails{
                      checks_health: Health.critical()
                    }
                  } = cluster
@@ -1266,7 +1293,7 @@ defmodule Trento.ClusterTest do
       scenarios = [
         %{
           type: :hana_scale_up,
-          health_details: %HealthDetails{
+          health_details: %HanaClusterHealthDetails{
             checks_health: Health.unknown(),
             replication_health: Health.passing()
           },
@@ -1276,14 +1303,14 @@ defmodule Trento.ClusterTest do
             cluster_id: cluster_id,
             replication_health: Health.critical()
           },
-          expected_health_details: %HealthDetails{
+          expected_health_details: %HanaClusterHealthDetails{
             checks_health: Health.unknown(),
             replication_health: Health.critical()
           }
         },
         %{
           type: :hana_scale_out,
-          health_details: %HealthDetails{
+          health_details: %HanaClusterHealthDetails{
             checks_health: Health.unknown(),
             replication_health: Health.passing()
           },
@@ -1293,14 +1320,14 @@ defmodule Trento.ClusterTest do
             cluster_id: cluster_id,
             replication_health: Health.critical()
           },
-          expected_health_details: %HealthDetails{
+          expected_health_details: %HanaClusterHealthDetails{
             checks_health: Health.unknown(),
             replication_health: Health.critical()
           }
         },
         %{
           type: :ascs_ers,
-          health_details: %HealthDetails{
+          health_details: %AscsErsClusterHealthDetails{
             checks_health: Health.unknown(),
             distributed_health: Health.passing()
           },
@@ -1316,7 +1343,7 @@ defmodule Trento.ClusterTest do
             cluster_id: cluster_id,
             distributed_health: Health.critical()
           },
-          expected_health_details: %HealthDetails{
+          expected_health_details: %AscsErsClusterHealthDetails{
             checks_health: Health.unknown(),
             distributed_health: Health.critical()
           }
@@ -1395,21 +1422,21 @@ defmodule Trento.ClusterTest do
       scenarios = [
         %{
           type: :hana_scale_up,
-          health_details: %HealthDetails{
+          health_details: %HanaClusterHealthDetails{
             replication_health: Health.passing()
           },
           details: build(:hana_cluster_details)
         },
         %{
           type: :hana_scale_out,
-          health_details: %HealthDetails{
+          health_details: %HanaClusterHealthDetails{
             replication_health: Health.passing()
           },
           details: build(:hana_cluster_details)
         },
         %{
           type: :ascs_ers,
-          health_details: %HealthDetails{
+          health_details: %AscsErsClusterHealthDetails{
             distributed_health: Health.passing()
           },
           details:
@@ -1471,7 +1498,7 @@ defmodule Trento.ClusterTest do
           health: :passing,
           provider: :azure,
           health: Health.critical(),
-          health_details: %HealthDetails{
+          health_details: %HanaClusterHealthDetails{
             checks_health: Health.critical(),
             replication_health: Health.passing()
           },
@@ -1525,7 +1552,7 @@ defmodule Trento.ClusterTest do
         fn cluster ->
           assert %Cluster{
                    health: :critical,
-                   health_details: %HealthDetails{
+                   health_details: %HanaClusterHealthDetails{
                      checks_health: Health.critical(),
                      replication_health: Health.critical()
                    }
@@ -1562,10 +1589,9 @@ defmodule Trento.ClusterTest do
             hosts_number: cluster_registered_event.hosts_number,
             details: cluster_registered_event.details,
             health: cluster_registered_event.health,
-            health_details: %HealthDetails{
+            health_details: %HanaClusterHealthDetails{
               checks_health: Health.unknown(),
-              distributed_health: Health.unknown(),
-              replication_health: Health.unknown()
+              replication_health: Health.passing()
             },
             state: cluster_registered_event.state,
             hosts: [],
@@ -1596,10 +1622,9 @@ defmodule Trento.ClusterTest do
               hosts_number: cluster_registered_event.hosts_number,
               details: cluster_registered_event.details,
               health: cluster_registered_event.health,
-              health_details: %HealthDetails{
+              health_details: %HanaClusterHealthDetails{
                 checks_health: Health.unknown(),
-                distributed_health: Health.passing(),
-                replication_health: Health.warning()
+                replication_health: Health.passing()
               },
               hosts: [],
               selected_checks: []
@@ -1620,10 +1645,9 @@ defmodule Trento.ClusterTest do
           assert cluster.selected_checks == []
           assert cluster.hosts == []
 
-          assert cluster.health_details == %HealthDetails{
+          assert cluster.health_details == %HanaClusterHealthDetails{
                    checks_health: Health.unknown(),
-                   distributed_health: Health.passing(),
-                   replication_health: Health.warning()
+                   replication_health: Health.passing()
                  }
         end
       )
@@ -2031,41 +2055,51 @@ defmodule Trento.ClusterTest do
       scenarios = [
         %{
           type: :hana_scale_up,
-          expected_health_details: %HealthDetails{
+          health_details: %HanaClusterHealthDetails{
+            replication_health: Health.unknown()
+          },
+          expected_health_details: %HanaClusterHealthDetails{
             checks_health: Health.warning(),
             replication_health: Health.passing()
           }
         },
         %{
           type: :hana_scale_out,
-          expected_health_details: %HealthDetails{
+          health_details: %HanaClusterHealthDetails{
+            replication_health: Health.unknown()
+          },
+          expected_health_details: %HanaClusterHealthDetails{
             checks_health: Health.warning(),
             replication_health: Health.passing()
           }
         },
         %{
           type: :ascs_ers,
-          expected_health_details: %HealthDetails{
+          health_details: %AscsErsClusterHealthDetails{
+            distributed_health: Health.unknown()
+          },
+          expected_health_details: %AscsErsClusterHealthDetails{
             checks_health: Health.warning(),
             distributed_health: Health.passing()
           }
         },
         %{
           type: :unknown,
-          expected_health_details: %HealthDetails{
-            checks_health: Health.warning(),
-            replication_health: Health.unknown(),
-            distributed_health: Health.unknown()
-          }
+          expected_health_details: nil
         }
       ]
 
-      for %{type: type, expected_health_details: expected_health_details} <- scenarios do
+      for %{
+            type: type,
+            health_details: health_details,
+            expected_health_details: expected_health_details
+          } <- scenarios do
         cluster_registered_event =
           build(
             :cluster_registered_event,
             cluster_id: cluster_id,
-            type: type
+            type: type,
+            health_details: health_details
           )
 
         assert_state(

--- a/test/trento/clusters/cluster_test.exs
+++ b/test/trento/clusters/cluster_test.exs
@@ -449,7 +449,6 @@ defmodule Trento.ClusterTest do
     test "should set a the cluster state to stopped and health to unknown when all nodes go offline" do
       cluster_id = Faker.UUID.v4()
       host_id = Faker.UUID.v4()
-      name = Faker.StarWars.character()
 
       scenarios = [
         %{
@@ -559,11 +558,12 @@ defmodule Trento.ClusterTest do
               cluster_host_status: ClusterHostStatus.offline()
             )
           ],
-          RegisterOfflineClusterHost.new!(%{
+          build_list(
+            2,
+            :register_offline_cluster_host,
             cluster_id: cluster_id,
-            host_id: host_id,
-            name: name
-          }),
+            host_id: host_id
+          ),
           [
             %ClusterHostStatusChanged{
               cluster_id: cluster_id,
@@ -590,6 +590,76 @@ defmodule Trento.ClusterTest do
                        replication_health: Health.unknown(),
                        distributed_health: Health.unknown()
                      }
+                   } = cluster
+          end
+        )
+      end
+    end
+
+    test "should not change cluster health when first node goes offline" do
+      cluster_id = Faker.UUID.v4()
+      host_id = Faker.UUID.v4()
+
+      scenarios = [
+        %{
+          type: :hana_scale_up,
+          health_details: %HealthDetails{
+            replication_health: Health.passing()
+          }
+        },
+        %{
+          type: :hana_scale_out,
+          health_details: %HealthDetails{
+            replication_health: Health.passing()
+          }
+        },
+        %{
+          type: :ascs_ers,
+          health_details: %HealthDetails{
+            distributed_health: Health.passing()
+          }
+        }
+      ]
+
+      for %{type: type, health_details: health_details} <- scenarios do
+        registered_cluster =
+          build(:cluster_registered_event,
+            cluster_id: cluster_id,
+            type: type,
+            health: Health.passing(),
+            health_details: health_details
+          )
+
+        assert_events_and_state(
+          [
+            registered_cluster,
+            build(:host_added_to_cluster_event,
+              cluster_id: cluster_id,
+              host_id: host_id,
+              cluster_host_status: ClusterHostStatus.online()
+            ),
+            build(:host_added_to_cluster_event,
+              cluster_id: cluster_id,
+              host_id: Faker.UUID.v4(),
+              cluster_host_status: ClusterHostStatus.online()
+            )
+          ],
+          build_list(
+            2,
+            :register_offline_cluster_host,
+            cluster_id: cluster_id,
+            host_id: host_id
+          ),
+          [
+            %ClusterHostStatusChanged{
+              cluster_id: cluster_id,
+              host_id: host_id,
+              cluster_host_status: ClusterHostStatus.offline()
+            }
+          ],
+          fn cluster ->
+            assert %Cluster{
+                     health: Health.passing()
                    } = cluster
           end
         )

--- a/test/trento/clusters/events/cluster_registered_test.exs
+++ b/test/trento/clusters/events/cluster_registered_test.exs
@@ -7,7 +7,10 @@ defmodule Trento.Cluster.Events.ClusterRegisteredTest do
   require Trento.Clusters.Enums.ClusterState, as: ClusterState
   require Trento.Enums.Health, as: Health
 
-  alias Trento.Clusters.ValueObjects.HealthDetails
+  alias Trento.Clusters.ValueObjects.{
+    AscsErsClusterHealthDetails,
+    HanaClusterHealthDetails
+  }
 
   alias Trento.Clusters.Events.ClusterRegistered
 
@@ -26,9 +29,8 @@ defmodule Trento.Cluster.Events.ClusterRegisteredTest do
       for cluster_type <- ["hana_scale_up", "hana_scale_out"] do
         assert %ClusterRegistered{
                  version: 3,
-                 health_details: %HealthDetails{
+                 health_details: %HanaClusterHealthDetails{
                    checks_health: Health.unknown(),
-                   distributed_health: Health.unknown(),
                    replication_health: Health.passing()
                  }
                } =
@@ -41,10 +43,9 @@ defmodule Trento.Cluster.Events.ClusterRegisteredTest do
     test "should upcast ClusterRegistered event with ASCS/ERS type properly from version 1" do
       assert %ClusterRegistered{
                version: 3,
-               health_details: %HealthDetails{
+               health_details: %AscsErsClusterHealthDetails{
                  checks_health: Health.unknown(),
-                 distributed_health: Health.passing(),
-                 replication_health: Health.unknown()
+                 distributed_health: Health.passing()
                }
              } =
                %{"type" => "ascs_ers", "health" => Health.passing()}
@@ -55,11 +56,7 @@ defmodule Trento.Cluster.Events.ClusterRegisteredTest do
     test "should upcast ClusterRegistered event with unknown type properly from version 1" do
       assert %ClusterRegistered{
                version: 3,
-               health_details: %HealthDetails{
-                 checks_health: Health.unknown(),
-                 distributed_health: Health.unknown(),
-                 replication_health: Health.unknown()
-               }
+               health_details: nil
              } =
                %{"type" => "unknown", "health" => Health.unknown()}
                |> ClusterRegistered.upcast(%{})

--- a/test/trento/clusters/events/cluster_registered_test.exs
+++ b/test/trento/clusters/events/cluster_registered_test.exs
@@ -5,16 +5,63 @@ defmodule Trento.Cluster.Events.ClusterRegisteredTest do
   use Trento.AggregateCase, aggregate: Trento.Hosts.Host, async: true
 
   require Trento.Clusters.Enums.ClusterState, as: ClusterState
+  require Trento.Enums.Health, as: Health
+
+  alias Trento.Clusters.ValueObjects.HealthDetails
 
   alias Trento.Clusters.Events.ClusterRegistered
 
   describe "ClusterRegistered event upcasting" do
     test "should upcast ClusterRegistered event properly from version 1" do
       assert %ClusterRegistered{
-               version: 2,
+               version: 3,
                state: ClusterState.unknown()
              } =
                %{}
+               |> ClusterRegistered.upcast(%{})
+               |> ClusterRegistered.new!()
+    end
+
+    test "should upcast ClusterRegistered event with HANA type properly from version 1" do
+      for cluster_type <- ["hana_scale_up", "hana_scale_out"] do
+        assert %ClusterRegistered{
+                 version: 3,
+                 health_details: %HealthDetails{
+                   checks_health: Health.unknown(),
+                   distributed_health: Health.unknown(),
+                   replication_health: Health.passing()
+                 }
+               } =
+                 %{"type" => cluster_type, "health" => Health.passing()}
+                 |> ClusterRegistered.upcast(%{})
+                 |> ClusterRegistered.new!()
+      end
+    end
+
+    test "should upcast ClusterRegistered event with ASCS/ERS type properly from version 1" do
+      assert %ClusterRegistered{
+               version: 3,
+               health_details: %HealthDetails{
+                 checks_health: Health.unknown(),
+                 distributed_health: Health.passing(),
+                 replication_health: Health.unknown()
+               }
+             } =
+               %{"type" => "ascs_ers", "health" => Health.passing()}
+               |> ClusterRegistered.upcast(%{})
+               |> ClusterRegistered.new!()
+    end
+
+    test "should upcast ClusterRegistered event with unknown type properly from version 1" do
+      assert %ClusterRegistered{
+               version: 3,
+               health_details: %HealthDetails{
+                 checks_health: Health.unknown(),
+                 distributed_health: Health.unknown(),
+                 replication_health: Health.unknown()
+               }
+             } =
+               %{"type" => "unknown", "health" => Health.unknown()}
                |> ClusterRegistered.upcast(%{})
                |> ClusterRegistered.new!()
     end

--- a/test/trento/clusters/events/cluster_rolled_up_test.exs
+++ b/test/trento/clusters/events/cluster_rolled_up_test.exs
@@ -8,7 +8,11 @@ defmodule Trento.Clusters.Events.ClusterRolledUpTest do
 
   alias Trento.Clusters.Cluster
   alias Trento.Clusters.Events.ClusterRolledUp
-  alias Trento.Clusters.ValueObjects.HealthDetails
+
+  alias Trento.Clusters.ValueObjects.{
+    AscsErsClusterHealthDetails,
+    HanaClusterHealthDetails
+  }
 
   describe "ClusterRolledUp event upcasting, version 2" do
     test "should upcast the legacy snapshot with HANA type" do
@@ -19,9 +23,8 @@ defmodule Trento.Clusters.Events.ClusterRolledUpTest do
                  version: 2,
                  cluster_id: ^cluster_id,
                  snapshot: %Cluster{
-                   health_details: %HealthDetails{
+                   health_details: %HanaClusterHealthDetails{
                      checks_health: Health.warning(),
-                     distributed_health: Health.unknown(),
                      replication_health: Health.passing()
                    }
                  }
@@ -47,10 +50,9 @@ defmodule Trento.Clusters.Events.ClusterRolledUpTest do
                version: 2,
                cluster_id: ^cluster_id,
                snapshot: %Cluster{
-                 health_details: %HealthDetails{
+                 health_details: %AscsErsClusterHealthDetails{
                    checks_health: Health.warning(),
-                   distributed_health: Health.passing(),
-                   replication_health: Health.unknown()
+                   distributed_health: Health.passing()
                  }
                }
              } =
@@ -74,11 +76,7 @@ defmodule Trento.Clusters.Events.ClusterRolledUpTest do
                version: 2,
                cluster_id: ^cluster_id,
                snapshot: %Cluster{
-                 health_details: %HealthDetails{
-                   checks_health: Health.unknown(),
-                   distributed_health: Health.unknown(),
-                   replication_health: Health.unknown()
-                 }
+                 health_details: nil
                }
              } =
                %{

--- a/test/trento/clusters/events/cluster_rolled_up_test.exs
+++ b/test/trento/clusters/events/cluster_rolled_up_test.exs
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Clusters.Events.ClusterRolledUpTest do
+  use Trento.AggregateCase, aggregate: Trento.Clusters.Cluster, async: true
+
+  require Trento.Enums.Health, as: Health
+
+  alias Trento.Clusters.Cluster
+  alias Trento.Clusters.Events.ClusterRolledUp
+  alias Trento.Clusters.ValueObjects.HealthDetails
+
+  describe "ClusterRolledUp event upcasting, version 2" do
+    test "should upcast the legacy snapshot with HANA type" do
+      cluster_id = Faker.UUID.v4()
+
+      for cluster_type <- ["hana_scale_up", "hana_scale_out"] do
+        assert %ClusterRolledUp{
+                 version: 2,
+                 cluster_id: ^cluster_id,
+                 snapshot: %Cluster{
+                   health_details: %HealthDetails{
+                     checks_health: Health.warning(),
+                     distributed_health: Health.unknown(),
+                     replication_health: Health.passing()
+                   }
+                 }
+               } =
+                 %{
+                   "version" => 1,
+                   "cluster_id" => cluster_id,
+                   "snapshot" => %{
+                     "type" => cluster_type,
+                     "checks_health" => Health.warning(),
+                     "discovered_health" => Health.passing()
+                   }
+                 }
+                 |> ClusterRolledUp.upcast(%{})
+                 |> ClusterRolledUp.new!()
+      end
+    end
+
+    test "should upcast the legacy snapshot with ASCS/ERS type" do
+      cluster_id = Faker.UUID.v4()
+
+      assert %ClusterRolledUp{
+               version: 2,
+               cluster_id: ^cluster_id,
+               snapshot: %Cluster{
+                 health_details: %HealthDetails{
+                   checks_health: Health.warning(),
+                   distributed_health: Health.passing(),
+                   replication_health: Health.unknown()
+                 }
+               }
+             } =
+               %{
+                 "version" => 1,
+                 "cluster_id" => cluster_id,
+                 "snapshot" => %{
+                   "type" => "ascs_ers",
+                   "checks_health" => Health.warning(),
+                   "discovered_health" => Health.passing()
+                 }
+               }
+               |> ClusterRolledUp.upcast(%{})
+               |> ClusterRolledUp.new!()
+    end
+
+    test "should upcast the legacy snapshot with unknown type" do
+      cluster_id = Faker.UUID.v4()
+
+      assert %ClusterRolledUp{
+               version: 2,
+               cluster_id: ^cluster_id,
+               snapshot: %Cluster{
+                 health_details: %HealthDetails{
+                   checks_health: Health.unknown(),
+                   distributed_health: Health.unknown(),
+                   replication_health: Health.unknown()
+                 }
+               }
+             } =
+               %{
+                 "version" => 1,
+                 "cluster_id" => cluster_id,
+                 "snapshot" => %{
+                   "type" => "unknown"
+                 }
+               }
+               |> ClusterRolledUp.upcast(%{})
+               |> ClusterRolledUp.new!()
+    end
+  end
+end

--- a/test/trento/discovery/policies/cluster_policy_test.exs
+++ b/test/trento/discovery/policies/cluster_policy_test.exs
@@ -437,7 +437,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                 type: :hana_scale_up,
                 hosts_number: 2,
                 resources_number: 8,
-                discovered_health: :passing,
                 provider: Provider.azure(),
                 state: :S_IDLE
               }
@@ -850,7 +849,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                 type: :hana_scale_up,
                 hosts_number: 2,
                 resources_number: 8,
-                discovered_health: :passing,
                 provider: Provider.azure(),
                 state: :S_IDLE
               }
@@ -1180,7 +1178,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                 type: :hana_scale_up,
                 hosts_number: 2,
                 resources_number: 8,
-                discovered_health: :passing,
                 provider: Provider.azure(),
                 state: :S_IDLE
               }
@@ -1500,7 +1497,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                 type: :ascs_ers,
                 hosts_number: 2,
                 resources_number: 9,
-                discovered_health: :passing,
                 provider: Provider.azure(),
                 state: :S_IDLE
               }
@@ -1820,7 +1816,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                 type: :ascs_ers,
                 hosts_number: 2,
                 resources_number: 9,
-                discovered_health: :passing,
                 provider: Provider.azure(),
                 state: :S_IDLE
               }
@@ -1905,7 +1900,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                 type: :unknown,
                 hosts_number: 2,
                 resources_number: 5,
-                discovered_health: :unknown,
                 provider: Provider.azure(),
                 state: :S_IDLE
               }
@@ -2494,7 +2488,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                 type: :ascs_ers,
                 hosts_number: 2,
                 resources_number: 17,
-                discovered_health: :passing,
                 provider: Provider.azure(),
                 state: :S_IDLE
               }
@@ -2769,7 +2762,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
   end
 
   describe "ascs/ers clusters health" do
-    test "should set the health to critical when one of the nodes is unclean" do
+    test "should set SAP system distributed to false when a node in unclean" do
       assert {:ok,
               [
                 %RegisterOnlineClusterHost{
@@ -2780,8 +2773,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                         distributed: false
                       }
                     ]
-                  },
-                  discovered_health: :critical
+                  }
                 }
               ]} =
                "ha_cluster_discovery_ascs_ers"
@@ -2793,7 +2785,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                |> ClusterPolicy.handle(nil)
     end
 
-    test "should set the health to critical when the SAPInstance resource is Stopped" do
+    test "should set SAP system distributed to false when the SAPInstance resource is Stopped" do
       group_1_resources =
         build_list(1, :crm_resource, %{
           "Id" => "rsc_sap_NWP_ASCS00",
@@ -2820,8 +2812,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                         distributed: false
                       }
                     ]
-                  },
-                  discovered_health: :critical
+                  }
                 }
               ]} =
                "ha_cluster_discovery_ascs_ers"
@@ -2833,7 +2824,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                |> ClusterPolicy.handle(nil)
     end
 
-    test "should set the health to critical when the SAPInstance resource is running the same node" do
+    test "should set SAP system distributed to false when the SAPInstance resource is running the same node" do
       group_1_resources =
         build_list(1, :crm_resource, %{
           "Id" => "rsc_sap_NWP_ASCS00",
@@ -2858,8 +2849,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                         distributed: false
                       }
                     ]
-                  },
-                  discovered_health: :critical
+                  }
                 }
               ]} =
                "ha_cluster_discovery_ascs_ers"
@@ -2871,7 +2861,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                |> ClusterPolicy.handle(nil)
     end
 
-    test "should set the health to critical when the SAPInstance is on failed state" do
+    test "should set SAP system distributed to false when the SAPInstance is on failed state" do
       group_1_resources =
         build_list(1, :crm_resource, %{
           "Id" => "rsc_sap_NWP_ASCS00",
@@ -2898,8 +2888,7 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                         distributed: false
                       }
                     ]
-                  },
-                  discovered_health: :critical
+                  }
                 }
               ]} =
                "ha_cluster_discovery_ascs_ers"
@@ -3159,7 +3148,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                     }
                   ]
                 },
-                discovered_health: :passing,
                 host_id: "a3279fd0-0443-1234-9354-2d7909fd6bc6",
                 hosts_number: 2,
                 name: "hana_cluster",
@@ -3491,7 +3479,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                     }
                   ]
                 },
-                discovered_health: :critical,
                 host_id: "1dc79771-0a96-1234-b5b6-cd4d0aef6acc",
                 hosts_number: 2,
                 name: "hana_cluster",
@@ -3918,7 +3905,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                 type: :hana_scale_up,
                 hosts_number: 2,
                 resources_number: 8,
-                discovered_health: :passing,
                 provider: Provider.azure(),
                 state: :S_IDLE
               }
@@ -4157,7 +4143,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                 type: :hana_scale_up,
                 hosts_number: 2,
                 resources_number: 8,
-                discovered_health: :passing,
                 provider: Provider.azure(),
                 state: :S_IDLE
               }
@@ -4213,7 +4198,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   designated_controller: true,
                   resources_number: 15,
                   hosts_number: 6,
-                  discovered_health: :passing,
                   cib_last_written: "Thu Feb 23 15:59:56 2023",
                   details: %HanaClusterDetails{
                     architecture_type: HanaArchitectureType.classic(),
@@ -4773,7 +4757,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   designated_controller: false,
                   resources_number: 13,
                   hosts_number: 5,
-                  discovered_health: :passing,
                   cib_last_written: "Tue Jan 23 12:49:07 2024",
                   details: %HanaClusterDetails{
                     architecture_type: HanaArchitectureType.classic(),
@@ -5266,7 +5249,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                   designated_controller: true,
                   resources_number: 15,
                   hosts_number: 6,
-                  discovered_health: :passing,
                   cib_last_written: "Thu Feb 23 15:59:56 2023",
                   details: %HanaClusterDetails{
                     architecture_type: HanaArchitectureType.classic(),
@@ -6389,7 +6371,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                       }
                     ]
                   },
-                  discovered_health: :passing,
                   host_id: "6eabc497-6067-4de9-b583-e4c63334ff64",
                   hosts_number: 5,
                   name: "hacluster",
@@ -6668,7 +6649,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                        }
                      ]
                    },
-                   discovered_health: :passing,
                    host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
                    hosts_number: 2,
                    name: "hana_cluster",
@@ -6911,7 +6891,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                        }
                      ]
                    },
-                   discovered_health: :critical,
                    host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
                    hosts_number: 2,
                    name: "hana_cluster",
@@ -6947,7 +6926,6 @@ defmodule Trento.Discovery.Policies.ClusterPolicyTest do
                    cluster_id: "34a94290-2236-5e4d-8def-05beb32d14d4",
                    designated_controller: true,
                    details: nil,
-                   discovered_health: :unknown,
                    host_id: "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
                    hosts_number: 2,
                    name: "hana_cluster",


### PR DESCRIPTION
# Description

Split `ClusterDiscoveredHealthChanged` event into specific events based on the real cause of the health change:
`ClusterReplicationHealthChanged` and `ClusterDistributedHealthChanged`.

I have done some relevant changes:
- Move the calculation of the health to the aggregate. I think this is a product and business logic and I find it more appropriate to be in the aggregate
- Upcasting of events
- In one of the latest commits, I have experimented with the option of putting all the health details in a value object struct. Maybe it helps reducing the number of new fields we need in the aggregate itself and have a more hierarchical structure for the healths. Before this commit, I just simply added the healths in the aggregate itself. This is the commit: https://github.com/trento-project/web/commit/85790f8e3f2abf22c30bbc2941490fede7170fc1

Potential improvements for next PRs:
- We could add additional fields to the new events. For example, for the `ClusterReplicationHealthChanged` event, we could add the `sr_health` and `replication_status` fields. They would be just informative fields showed in the activity log.

Find here the text used for the activity log:
<img width="1311" height="622" alt="image" src="https://github.com/user-attachments/assets/6bb9fbc8-fd57-4214-b45e-a64422e08351" />


## How was this tested?

UT which should cover all the updates, and I did some additional manual testing just in case

## Did you update the documentation?

No need
