### PR TITLE
[TRNT-4419] Fix cert manager install command in demo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1187,7 +1187,7 @@ jobs:
           metrics-enabled: false
       - name: Install cert-manager
         run: |
-          helm install cert-manager oci://quay.io/jetstack/charts/cert-manager \
+          helm upgrade -i cert-manager oci://quay.io/jetstack/charts/cert-manager \
             --version ${{ env.CERT_MANAGER_VERSION }} \
             --namespace cert-manager \
             --create-namespace \


### PR DESCRIPTION
# Description

This is a follow-up to #4328. Since we are upgrading the cert-manager version, the `helm install` command is failing in the demo environment,

See

```
  helm install cert-manager oci://quay.io/jetstack/charts/cert-manager \
    --version v1.20.2 \
    --namespace cert-manager \
    --create-namespace \
    --set crds.enabled=true

  kubectl wait --for=condition=available --timeout=300s \
    deployment/cert-manager -n cert-manager
...
Pulled: quay.io/jetstack/charts/cert-manager:v1.20.2
Digest: sha256:294a761ca972ea11ae79b9219960ca13a5337a1cbb550604c151586d266159eb
level=ERROR msg="release name check failed" error="cannot reuse a name that is still in use"
Error: INSTALLATION FAILED: release name check failed: cannot reuse a name that is still in use
```

Related # TRNT-4419

## How was this tested?

CI
