### PR TITLE
Add database details sap system details view

### DIFF
--- a/assets/js/common/ListView/ListView.jsx
+++ b/assets/js/common/ListView/ListView.jsx
@@ -21,12 +21,13 @@ function ListView({
       {data.map(
         ({
           title,
+          key,
           content,
           className: contentClassName = '',
           render = (component) => <span>{component}</span>,
         }) => (
           <div
-            key={title}
+            key={key || title}
             className={
               orientation === 'vertical'
                 ? 'grid grid-flow-row'

--- a/assets/js/lib/model/sapSystems.js
+++ b/assets/js/lib/model/sapSystems.js
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
+import { uniq, flatMap } from 'lodash';
+
 export const DATABASE_TYPE = 'database';
 export const APPLICATION_TYPE = 'application';
 
@@ -15,3 +17,10 @@ export const isValidEnsaVersion = (ensaVersion) =>
 
 export const getEnsaVersionLabel = (ensaVersion) =>
   ensaVersion === NO_ENSA ? '-' : ensaVersion.toUpperCase();
+
+export const getSapSystemType = (applicationInstances) =>
+  uniq(flatMap(applicationInstances, ({ features }) => features.split('|')))
+    .filter((item) => item === 'J2EE' || item === 'ABAP')
+    .map((item) => (item === 'J2EE' ? 'JAVA' : item))
+    .toSorted()
+    .join('+');

--- a/assets/js/lib/model/sapSystems.test.js
+++ b/assets/js/lib/model/sapSystems.test.js
@@ -1,7 +1,13 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-import { isValidEnsaVersion, getEnsaVersionLabel } from './sapSystems';
+import { sapSystemApplicationInstanceFactory } from '@lib/test-utils/factories';
+
+import {
+  isValidEnsaVersion,
+  getEnsaVersionLabel,
+  getSapSystemType,
+} from './sapSystems';
 
 describe('sap systems', () => {
   it('should check if an ensa version is valid', () => {
@@ -20,5 +26,39 @@ describe('sap systems', () => {
     ].forEach(({ key, label }) => {
       expect(getEnsaVersionLabel(key)).toBe(label);
     });
+  });
+
+  it('should get the ABAP SAP system type', () => {
+    const instances = [
+      sapSystemApplicationInstanceFactory.build({
+        features: 'MESSAGESERVER|EMQUE',
+      }),
+      sapSystemApplicationInstanceFactory.build({ features: 'ABAP|GATEWAY' }),
+      sapSystemApplicationInstanceFactory.build({ features: 'ENQREP' }),
+    ];
+    expect(getSapSystemType(instances)).toBe('ABAP');
+  });
+
+  it('should get the JAVA SAP system type', () => {
+    const instances = [
+      sapSystemApplicationInstanceFactory.build({
+        features: 'MESSAGESERVER|EMQUE',
+      }),
+      sapSystemApplicationInstanceFactory.build({ features: 'J2EE|GATEWAY' }),
+      sapSystemApplicationInstanceFactory.build({ features: 'ENQREP' }),
+    ];
+    expect(getSapSystemType(instances)).toBe('JAVA');
+  });
+
+  it('should get the ABAP+JAVA SAP system type', () => {
+    const instances = [
+      sapSystemApplicationInstanceFactory.build({
+        features: 'MESSAGESERVER|EMQUE',
+      }),
+      sapSystemApplicationInstanceFactory.build({ features: 'J2EE|GATEWAY' }),
+      sapSystemApplicationInstanceFactory.build({ features: 'ABAP|GATEWAY' }),
+      sapSystemApplicationInstanceFactory.build({ features: 'ENQREP' }),
+    ];
+    expect(getSapSystemType(instances)).toBe('ABAP+JAVA');
   });
 });

--- a/assets/js/lib/test-utils/factories/sapSystems.js
+++ b/assets/js/lib/test-utils/factories/sapSystems.js
@@ -57,6 +57,7 @@ export const sapSystemFactory = Factory.define(({ params }) => {
     sid,
     tags: [],
     database_sid: databaseSid,
+    database_health: healthEnum(),
     tenant: databaseSid,
     database_id: databaseId,
   };

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
@@ -42,6 +42,7 @@ import {
   APPLICATION_TYPE,
   DATABASE_TYPE,
   getEnsaVersionLabel,
+  getSapSystemType,
 } from '@lib/model/sapSystems';
 import { isSomeHostHeartbeatPassing } from '@lib/model/hosts';
 
@@ -67,8 +68,8 @@ import {
 
 const SR_INACTIVE = 'INACTIVE';
 
-const renderType = (t) =>
-  t === APPLICATION_TYPE ? 'Application server' : 'HANA Database';
+const renderType = (t, system) =>
+  t === APPLICATION_TYPE ? getSapSystemType(system.instances) : 'HANA Database';
 
 const getUniqueHosts = (hosts) =>
   Array.from(
@@ -310,7 +311,8 @@ export function GenericSystemDetails({
             { title: 'Name', content: system.sid },
             {
               title: 'Type',
-              content: renderType(type),
+              content: type,
+              render: (content) => renderType(content, system),
             },
             ...(type === APPLICATION_TYPE
               ? [

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
@@ -55,6 +55,8 @@ import {
   SapStartStopOperationModal,
 } from '@common/OperationModals';
 import OperationsButton from '@common/OperationsButton';
+import HealthIcon from '@common/HealthIcon';
+import SapSystemLink from '@common/SapSystemLink';
 
 import DeregistrationModal from '@pages/DeregistrationModal';
 
@@ -67,9 +69,6 @@ import {
 } from './tableConfigs';
 
 const SR_INACTIVE = 'INACTIVE';
-
-const renderType = (t, system) =>
-  t === APPLICATION_TYPE ? getSapSystemType(system.instances) : 'HANA Database';
 
 const getUniqueHosts = (hosts) =>
   Array.from(
@@ -305,56 +304,97 @@ export function GenericSystemDetails({
         )}
       </div>
       <div className="mt-4 bg-white shadow rounded-lg py-4 px-8">
-        <ListView
-          orientation="vertical"
-          data={[
-            { title: 'Name', content: system.sid },
-            {
-              title: 'Type',
-              content: type,
-              render: (content) => renderType(content, system),
-            },
-            ...(type === APPLICATION_TYPE
-              ? [
-                  {
-                    title: 'ENSA version',
-                    content: system.ensa_version || '-',
-                    render: (content) => getEnsaVersionLabel(content),
-                  },
-                ]
-              : []),
-            ...(type === DATABASE_TYPE
-              ? [
-                  {
-                    title: 'System Replication',
-                    content: hasSystemReplication,
-                    render: (content) => capitalize(content),
-                  },
-                ]
-              : []),
-            {
-              title: '',
-              content: type,
-              render: (content) => (
-                <div className="justify-end float-right">
-                  {content === APPLICATION_TYPE ? (
+        {type === APPLICATION_TYPE ? (
+          <ListView
+            orientation="vertical"
+            className="grid-rows-2"
+            data={[
+              { title: 'Name', content: system.sid },
+              {
+                title: 'Database',
+                content: system.database_sid,
+                render: (content) => (
+                  <SapSystemLink
+                    systemType={DATABASE_TYPE}
+                    sapSystemId={system.database_id}
+                  >
+                    {content}
+                  </SapSystemLink>
+                ),
+              },
+              {
+                title: 'Type',
+                content: system.instances,
+                render: (content) => getSapSystemType(content),
+              },
+              {
+                title: 'Database health',
+                content: system.database_health,
+                render: (content) => <HealthIcon health={content} size="l" />,
+              },
+              {
+                title: 'ENSA version',
+                content: system.ensa_version || '-',
+                render: (content) => getEnsaVersionLabel(content),
+              },
+              {
+                title: 'Tenant',
+                content: system.tenant,
+                render: (content) => content,
+              },
+              {
+                key: 'application_icon',
+                render: (_) => (
+                  <div className="justify-end float-right">
                     <EOS_APPLICATION_OUTLINED
                       size={25}
                       className="fill-blue-500"
                     />
-                  ) : (
+                  </div>
+                ),
+              },
+              {
+                key: 'database_icon',
+                render: (_) => (
+                  <div className="justify-end float-right">
                     <EOS_DATABASE_OUTLINED
                       size={25}
                       className="fill-blue-500"
                     />
-                  )}
-                </div>
-              ),
-            },
-          ]}
-        />
+                  </div>
+                ),
+              },
+            ]}
+          />
+        ) : (
+          <ListView
+            orientation="vertical"
+            data={[
+              { title: 'Name', content: system.sid },
+              {
+                title: 'Type',
+                content: 'HANA Database',
+              },
+              {
+                title: 'System Replication',
+                content: hasSystemReplication,
+                render: (content) => capitalize(content),
+              },
+              {
+                key: 'database_icon',
+                render: (_) => (
+                  <div className="justify-end float-right">
+                    <EOS_DATABASE_OUTLINED
+                      size={25}
+                      className="fill-blue-500"
+                    />
+                  </div>
+                ),
+              },
+            ]}
+          />
+        )}
       </div>
-
       <div className="mt-16">
         <div className="flex flex-direction-row">
           <h2 className="text-2xl font-bold self-center">Layout</h2>

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
@@ -110,9 +110,9 @@ describe('GenericSystemDetails', () => {
     const sapSystem = sapSystemFactory.build({
       ensa_version: 'ensa1',
       instances: sapSystemApplicationInstanceFactory.buildList(5),
+      hosts: hostFactory.buildList(5),
+      database_health: 'passing',
     });
-
-    sapSystem.hosts = hostFactory.buildList(5);
 
     const { sid, application_instances: applicationInstances } = sapSystem;
     const { features } = applicationInstances[0];
@@ -139,6 +139,18 @@ describe('GenericSystemDetails', () => {
     features.split('|').forEach((role) => {
       expect(screen.queryAllByText(role)).toBeTruthy();
     });
+    const databaseLink = screen.getByText('Database').nextSibling.firstChild;
+    expect(databaseLink).toHaveTextContent(sapSystem.database_sid);
+    expect(databaseLink).toHaveAttribute(
+      'href',
+      `/databases/${sapSystem.database_id}`
+    );
+    expect(
+      screen.getByText('Database health').nextSibling.firstChild
+    ).toHaveClass('fill-jungle-green-500');
+    expect(screen.getByText('Tenant').nextSibling).toHaveTextContent(
+      sapSystem.tenant
+    );
   });
 
   it('should render a not found label if system is not there', () => {
@@ -382,8 +394,14 @@ describe('GenericSystemDetails', () => {
     );
 
     expect(screen.queryByRole('button', { name: 'Clean up' })).toBeVisible();
-    const [_mainHealth, _sapSystemIcon, health, _cleanUpIcon] =
-      screen.getAllByTestId('eos-svg-component');
+    const [
+      _mainHealth,
+      _sapSystemIcon,
+      _databaseHealth,
+      _databaseIcon,
+      health,
+      _cleanUpIcon,
+    ] = screen.getAllByTestId('eos-svg-component');
     expect(health).toHaveClass('fill-black');
   });
 

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
@@ -133,7 +133,6 @@ describe('GenericSystemDetails', () => {
     const { getByTestId } = within(header);
     expect(getByTestId('eos-svg-component')).toBeInTheDocument();
 
-    expect(screen.getByText('Application server')).toBeTruthy();
     expect(screen.getByText(sid)).toBeTruthy();
     expect(screen.getByText('ENSA1')).toBeTruthy();
     expect(screen.queryByText('System Replication')).not.toBeInTheDocument();
@@ -168,6 +167,66 @@ describe('GenericSystemDetails', () => {
     );
 
     expect(screen.getByText('ENSA version').nextSibling).toHaveTextContent('-');
+  });
+
+  it.each([
+    {
+      type: 'ABAP',
+      system: sapSystemFactory.build({
+        instances: [
+          sapSystemApplicationInstanceFactory.build({ features: 'ABAP' }),
+        ],
+        hosts: hostFactory.buildList(5),
+      }),
+    },
+    {
+      type: 'JAVA',
+      system: sapSystemFactory.build({
+        instances: [
+          sapSystemApplicationInstanceFactory.build({ features: 'J2EE' }),
+        ],
+        hosts: hostFactory.buildList(5),
+      }),
+    },
+    {
+      type: 'ABAP+JAVA',
+      system: sapSystemFactory.build({
+        instances: [
+          sapSystemApplicationInstanceFactory.build({ features: 'ABAP' }),
+          sapSystemApplicationInstanceFactory.build({ features: 'J2EE' }),
+        ],
+        hosts: hostFactory.buildList(5),
+      }),
+    },
+  ])('should render proper $type SAP system type', ({ type, system }) => {
+    renderWithRouter(
+      <GenericSystemDetails
+        title={faker.string.uuid()}
+        system={system}
+        type={APPLICATION_TYPE}
+      />
+    );
+
+    expect(screen.getByText('Type').nextSibling).toHaveTextContent(type);
+  });
+
+  it('should render proper HANA database type', () => {
+    const database = databaseFactory.build({
+      instances: databaseInstanceFactory.buildList(5),
+      hosts: hostFactory.buildList(5),
+    });
+
+    renderWithRouter(
+      <GenericSystemDetails
+        title={faker.string.uuid()}
+        system={database}
+        type={DATABASE_TYPE}
+      />
+    );
+
+    expect(screen.getByText('Type').nextSibling).toHaveTextContent(
+      'HANA Database'
+    );
   });
 
   it.each([

--- a/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.jsx
+++ b/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.jsx
@@ -3,9 +3,9 @@
 
 import React, { useState } from 'react';
 import { Link, useSearchParams } from 'react-router';
-import { filter, uniq, flatMap } from 'lodash';
+import { filter } from 'lodash';
 
-import { getEnsaVersionLabel } from '@lib/model/sapSystems';
+import { getEnsaVersionLabel, getSapSystemType } from '@lib/model/sapSystems';
 
 import HealthIcon from '@common/HealthIcon';
 import PageHeader from '@common/PageHeader';
@@ -82,14 +82,8 @@ function SapSystemsOverview({
       {
         title: 'Type',
         key: 'applicationInstances',
-        render: (content) =>
-          uniq(flatMap(content, ({ features }) => features.split('|')))
-            .filter((item) => item === 'J2EE' || item === 'ABAP')
-            .map((item) => (item === 'J2EE' ? 'JAVA' : item))
-            .toSorted()
-            .join('+'),
+        render: (content) => getSapSystemType(content),
       },
-
       {
         title: 'DB Address',
         key: 'dbAddress',

--- a/lib/trento/infrastructure/commanded/event_handlers/sap_system_database_health_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/sap_system_database_health_event_handler.ex
@@ -4,7 +4,9 @@
 defmodule Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseHealthEventHandler do
   @moduledoc """
   This event handler is responsible to forward update database health commands to the SAP systems
-  related to a database that has a new health state
+  related to a database that has a new health state.
+
+  Once the resulting event is emitted, the event handler broadcasts its results.
   """
 
   use Commanded.Event.Handler,
@@ -15,6 +17,9 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseHealthE
   alias Trento.Databases.Projections.DatabaseReadModel
   alias Trento.Repo
   alias Trento.SapSystems.Commands.UpdateDatabaseHealth
+  alias Trento.SapSystems.Events.SapSystemDatabaseHealthChanged
+
+  alias TrentoWeb.V1.SapSystemJSON
 
   import Ecto.Query, only: [from: 2]
 
@@ -43,6 +48,23 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseHealthE
     end
 
     :ok
+  end
+
+  def handle(
+        %SapSystemDatabaseHealthChanged{
+          sap_system_id: sap_system_id,
+          database_health: database_health
+        },
+        _metadata
+      ) do
+    TrentoWeb.Endpoint.broadcast(
+      "monitoring:sap_systems",
+      "sap_system_updated",
+      SapSystemJSON.sap_system_database_health_changed(%{
+        id: sap_system_id,
+        database_health: database_health
+      })
+    )
   end
 
   defp commanded,

--- a/lib/trento/sap_systems/projections/sap_system_projector.ex
+++ b/lib/trento/sap_systems/projections/sap_system_projector.ex
@@ -18,6 +18,7 @@ defmodule Trento.SapSystems.Projections.SapSystemProjector do
     ApplicationInstanceMarkedPresent,
     ApplicationInstanceMoved,
     ApplicationInstanceRegistered,
+    SapSystemDatabaseHealthChanged,
     SapSystemDeregistered,
     SapSystemHealthChanged,
     SapSystemRegistered,
@@ -266,6 +267,13 @@ defmodule Trento.SapSystems.Projections.SapSystemProjector do
     end
   )
 
+  # Do nothing in the projection.
+  # This event is only here to broadcast the new health in the after_update
+  project(
+    %SapSystemDatabaseHealthChanged{},
+    fn multi -> multi end
+  )
+
   @sap_systems_topic "monitoring:sap_systems"
 
   @impl true
@@ -488,6 +496,25 @@ defmodule Trento.SapSystems.Projections.SapSystemProjector do
       @sap_systems_topic,
       "sap_system_updated",
       SapSystemJSON.sap_system_updated(%{id: sap_system_id, ensa_version: ensa_version})
+    )
+  end
+
+  @impl true
+  def after_update(
+        %SapSystemDatabaseHealthChanged{
+          sap_system_id: sap_system_id,
+          database_health: database_health
+        },
+        _,
+        _
+      ) do
+    TrentoWeb.Endpoint.broadcast(
+      @sap_systems_topic,
+      "sap_system_updated",
+      SapSystemJSON.sap_system_database_health_changed(%{
+        id: sap_system_id,
+        database_health: database_health
+      })
     )
   end
 

--- a/lib/trento/sap_systems/projections/sap_system_projector.ex
+++ b/lib/trento/sap_systems/projections/sap_system_projector.ex
@@ -18,7 +18,6 @@ defmodule Trento.SapSystems.Projections.SapSystemProjector do
     ApplicationInstanceMarkedPresent,
     ApplicationInstanceMoved,
     ApplicationInstanceRegistered,
-    SapSystemDatabaseHealthChanged,
     SapSystemDeregistered,
     SapSystemHealthChanged,
     SapSystemRegistered,
@@ -267,13 +266,6 @@ defmodule Trento.SapSystems.Projections.SapSystemProjector do
     end
   )
 
-  # Do nothing in the projection.
-  # This event is only here to broadcast the new health in the after_update
-  project(
-    %SapSystemDatabaseHealthChanged{},
-    fn multi -> multi end
-  )
-
   @sap_systems_topic "monitoring:sap_systems"
 
   @impl true
@@ -496,25 +488,6 @@ defmodule Trento.SapSystems.Projections.SapSystemProjector do
       @sap_systems_topic,
       "sap_system_updated",
       SapSystemJSON.sap_system_updated(%{id: sap_system_id, ensa_version: ensa_version})
-    )
-  end
-
-  @impl true
-  def after_update(
-        %SapSystemDatabaseHealthChanged{
-          sap_system_id: sap_system_id,
-          database_health: database_health
-        },
-        _,
-        _
-      ) do
-    TrentoWeb.Endpoint.broadcast(
-      @sap_systems_topic,
-      "sap_system_updated",
-      SapSystemJSON.sap_system_database_health_changed(%{
-        id: sap_system_id,
-        database_health: database_health
-      })
     )
   end
 

--- a/lib/trento_web/controllers/v1/sap_system_json.ex
+++ b/lib/trento_web/controllers/v1/sap_system_json.ex
@@ -25,7 +25,7 @@ defmodule TrentoWeb.V1.SapSystemJSON do
           %{
             application_instances: application_instances,
             database_instances: database_instances,
-            database: %{sid: database_sid}
+            database: %{sid: database_sid, health: database_health}
           } = sap_system
       }) do
     rendered_application_instances =
@@ -43,10 +43,8 @@ defmodule TrentoWeb.V1.SapSystemJSON do
       :database_instances,
       rendered_database_instances
     )
-    |> Map.put(
-      :database_sid,
-      database_sid
-    )
+    |> Map.put(:database_sid, database_sid)
+    |> Map.put(:database_health, database_health)
     |> Map.put(
       :application_instances,
       rendered_application_instances

--- a/lib/trento_web/controllers/v1/sap_system_json.ex
+++ b/lib/trento_web/controllers/v1/sap_system_json.ex
@@ -52,7 +52,7 @@ defmodule TrentoWeb.V1.SapSystemJSON do
   end
 
   def sap_system_registered(%{
-        sap_system: %{database: %{sid: database_sid}} = sap_system
+        sap_system: %{database: %{sid: database_sid, health: database_health}} = sap_system
       }) do
     sap_system
     |> Map.from_struct()
@@ -62,6 +62,7 @@ defmodule TrentoWeb.V1.SapSystemJSON do
     |> Map.delete(:application_instances)
     |> Map.delete(:tags)
     |> Map.put(:database_sid, database_sid)
+    |> Map.put(:database_health, database_health)
   end
 
   def sap_system_restored(%{sap_system: sap_system}), do: sap_system(%{sap_system: sap_system})
@@ -70,6 +71,9 @@ defmodule TrentoWeb.V1.SapSystemJSON do
     do: %{id: id, ensa_version: ensa_version}
 
   def sap_system_health_changed(%{health: health}), do: health
+
+  def sap_system_database_health_changed(%{id: id, database_health: database_health}),
+    do: %{id: id, database_health: database_health}
 
   def sap_system_deregistered(%{id: id, sid: sid}), do: %{id: id, sid: sid}
 

--- a/lib/trento_web/openapi/v1/schema/sap_system.ex
+++ b/lib/trento_web/openapi/v1/schema/sap_system.ex
@@ -175,6 +175,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.SAPSystem do
             example: "6c76eb74-dd68-4c91-b4d1-4f9d91f2c2c8"
           },
           database_sid: %Schema{type: :string, description: "Database SID.", example: "HA1"},
+          database_health: ResourceHealth,
           database_instances: Database.DatabaseInstances,
           tags: Tags,
           inserted_at: %Schema{type: :string, format: :datetime, example: "2024-01-15T10:30:00Z"},

--- a/test/e2e/cypress/e2e/sap_system_details.cy.js
+++ b/test/e2e/cypress/e2e/sap_system_details.cy.js
@@ -9,6 +9,10 @@ context('SAP system details', () => {
   describe('SAP system details page is available', () => {
     beforeEach(() => sapSystemDetailsPage.visit());
 
+    after(() => {
+      sapSystemDetailsPage.restoreDatabaseInstanceHealth();
+    });
+
     it('should have expected url', () => {
       sapSystemDetailsPage.validatePageUrl();
     });
@@ -18,12 +22,24 @@ context('SAP system details', () => {
       sapSystemDetailsPage.pageTitleHealthIsCorrectlyDisplayed();
       sapSystemDetailsPage.sapSystemHasExpectedName();
       sapSystemDetailsPage.sapSystemHasExpectedType();
+      sapSystemDetailsPage.sapSystemHasExpectedEnsaVersion();
+      sapSystemDetailsPage.sapSystemHasExpectedDatabase();
+      sapSystemDetailsPage.sapSystemHasExpectedDatabaseHealth();
+      sapSystemDetailsPage.sapSystemHasExpectedDatabaseTenant();
     });
 
     it(`should display "Not found" page when SAP system doesn't exist`, () => {
       sapSystemDetailsPage.visitNonExistentSapSystem();
       sapSystemDetailsPage.validatePageUrl('other');
       sapSystemDetailsPage.notFoundLabelIsDisplayed();
+    });
+
+    it('should update system and database health icons when database health is changed', () => {
+      sapSystemDetailsPage.pageTitleHealthIsCorrectlyDisplayed();
+      sapSystemDetailsPage.sapSystemHasExpectedDatabaseHealth();
+      sapSystemDetailsPage.loadScenario('hana-database-detail-RED');
+      sapSystemDetailsPage.sapSystemHasExpectedDatabaseHealth('fill-red-500');
+      sapSystemDetailsPage.pageTitleHealthIsCorrectlyDisplayed('fill-red-500');
     });
   });
 

--- a/test/e2e/cypress/fixtures/sap-system-details/selected_system.js
+++ b/test/e2e/cypress/fixtures/sap-system-details/selected_system.js
@@ -12,7 +12,11 @@ export const selectedSystem = {
   Id: '67b247e4-ab5b-5094-993a-a4fd70d0e8d1',
   Health: 'fill-jungle-green-500',
   Sid: 'NWD',
-  Type: 'Application server',
+  Type: 'ABAP',
+  EnsaVersion: 'ENSA1',
+  Database: 'HDD',
+  DatabaseHealth: 'fill-jungle-green-500',
+  DatabaseTenant: 'HDD',
   Hosts: [
     {
       Hostname: 'sapnwdas',

--- a/test/e2e/cypress/pageObject/sap_system_details_po.js
+++ b/test/e2e/cypress/pageObject/sap_system_details_po.js
@@ -21,7 +21,14 @@ const hostToDeregister = {
 // Selectors
 
 const sapSystemName = 'div[class="font-bold"]:contains("Name") + div span';
-const sapSystemType = 'div[class="font-bold"]:contains("Type") + div span';
+const sapSystemType = 'div[class="font-bold"]:contains("Type") + div';
+const sapSystemEnsaVersion =
+  'div[class="font-bold"]:contains("ENSA version") + div';
+const sapSystemDatabase = 'div[class="font-bold"]:contains("Database") + div';
+const sapSystemDatabaseHealth =
+  'div[class="font-bold"]:contains("Database health") + div svg';
+const sapSystemDatabaseTenant =
+  'div[class="font-bold"]:contains("Tenant") + div';
 const notFoundLabel = 'div:contains("Not Found")';
 const thirdRowStatusCellSelector =
   'div[class="mt-16"]:contains("Layout") table tbody tr:eq(2) td:eq(6)';
@@ -45,14 +52,30 @@ export const visitNonExistentSapSystem = () =>
 export const validatePageUrl = (systemId = selectedSystem.Id) =>
   basePage.validateUrl(`/sap_systems/${systemId}`);
 
-export const pageTitleHealthIsCorrectlyDisplayed = () =>
-  basePage.pageTitleHealthIsCorrectlyDisplayed(selectedSystem.Health);
+export const pageTitleHealthIsCorrectlyDisplayed = (
+  health = selectedSystem.Health
+) => basePage.pageTitleHealthIsCorrectlyDisplayed(health);
 
 export const sapSystemHasExpectedName = () =>
   cy.get(sapSystemName).should('have.text', selectedSystem.Sid);
 
 export const sapSystemHasExpectedType = () =>
   cy.get(sapSystemType).should('have.text', selectedSystem.Type);
+
+export const sapSystemHasExpectedEnsaVersion = () =>
+  cy.get(sapSystemEnsaVersion).should('have.text', selectedSystem.EnsaVersion);
+
+export const sapSystemHasExpectedDatabase = () =>
+  cy.get(sapSystemDatabase).should('have.text', selectedSystem.Database);
+
+export const sapSystemHasExpectedDatabaseHealth = (
+  health = selectedSystem.DatabaseHealth
+) => cy.get(sapSystemDatabaseHealth).should('have.class', health);
+
+export const sapSystemHasExpectedDatabaseTenant = () =>
+  cy
+    .get(sapSystemDatabaseTenant)
+    .should('have.text', selectedSystem.DatabaseTenant);
 
 export const notFoundLabelIsDisplayed = () =>
   cy.get(notFoundLabel).should('be.visible');
@@ -147,6 +170,9 @@ export const newSapSystemIsDisplayed = () => {
 
 export const restoreInstanceHealth = () =>
   basePage.loadScenario('sap-system-detail-GREEN');
+
+export const restoreDatabaseInstanceHealth = () =>
+  basePage.loadScenario('hana-database-detail-GREEN');
 
 export const apiDeregisterHost = () =>
   basePage.apiDeregisterHost(hostToDeregister.id);

--- a/test/trento/infrastructure/commanded/event_handlers/sap_system_database_health_event_handler_test.exs
+++ b/test/trento/infrastructure/commanded/event_handlers/sap_system_database_health_event_handler_test.exs
@@ -2,17 +2,32 @@
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseHealthEventHandlerTest do
-  use ExUnit.Case
   use Trento.DataCase
 
   import Mox
+  import Phoenix.ChannelTest
   import Trento.Factory
+  import TrentoWeb.ChannelCase
+
+  require Trento.Enums.Health, as: Health
 
   alias Trento.Databases.Events.DatabaseHealthChanged
   alias Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseHealthEventHandler
   alias Trento.SapSystems.Commands.UpdateDatabaseHealth
+  alias Trento.SapSystems.Events.SapSystemDatabaseHealthChanged
+
+  @endpoint TrentoWeb.Endpoint
 
   setup [:set_mox_from_context, :verify_on_exit!]
+
+  setup do
+    {:ok, _, socket} =
+      TrentoWeb.UserSocket
+      |> socket("user_id", %{some: :assign})
+      |> subscribe_and_join(TrentoWeb.MonitoringChannel, "monitoring:sap_systems")
+
+    %{socket: socket}
+  end
 
   test "should dispatch UpdateDatabaseHealth commands when a database health is changed" do
     %{id: database_id} = insert(:database)
@@ -39,5 +54,25 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseHealthE
     end)
 
     assert :ok = SapSystemDatabaseHealthEventHandler.handle(event, %{})
+  end
+
+  test "should broadcast database health change when a SapSystemDatabaseHealthChanged event is received" do
+    sap_system_id = Faker.UUID.v4()
+
+    event = %SapSystemDatabaseHealthChanged{
+      sap_system_id: sap_system_id,
+      database_health: Health.critical()
+    }
+
+    assert :ok = SapSystemDatabaseHealthEventHandler.handle(event, %{})
+
+    assert_broadcast(
+      "sap_system_updated",
+      %{
+        id: ^sap_system_id,
+        database_health: Health.critical()
+      },
+      1000
+    )
   end
 end

--- a/test/trento/sap_systems/projections/sap_system_projector_test.exs
+++ b/test/trento/sap_systems/projections/sap_system_projector_test.exs
@@ -10,6 +10,7 @@ defmodule Trento.SapSystems.Projections.SapSystemProjectorTest do
 
   import Trento.Factory
 
+  require Trento.Enums.Health, as: Health
   require Trento.SapSystems.Enums.EnsaVersion, as: EnsaVersion
 
   alias Trento.SapSystems.Projections.{
@@ -24,6 +25,7 @@ defmodule Trento.SapSystems.Projections.SapSystemProjectorTest do
     ApplicationInstanceMarkedAbsent,
     ApplicationInstanceMarkedPresent,
     ApplicationInstanceMoved,
+    SapSystemDatabaseHealthChanged,
     SapSystemDeregistered,
     SapSystemHealthChanged,
     SapSystemRestored,
@@ -47,7 +49,7 @@ defmodule Trento.SapSystems.Projections.SapSystemProjectorTest do
   end
 
   test "should project a new SAP System when a SapSystemRegistered event is received" do
-    %{id: database_id, sid: database_sid} = insert(:database)
+    %{id: database_id, sid: database_sid, health: database_health} = insert(:database)
     event = build(:sap_system_registered_event, database_id: database_id)
 
     ProjectorTestHelper.project(SapSystemProjector, event, "sap_system_projector")
@@ -78,7 +80,8 @@ defmodule Trento.SapSystems.Projections.SapSystemProjectorTest do
         tenant: ^tenant,
         ensa_version: ^ensa_version,
         database_id: ^database_id,
-        database_sid: ^database_sid
+        database_sid: ^database_sid,
+        database_health: ^database_health
       },
       1000
     )
@@ -436,6 +439,26 @@ defmodule Trento.SapSystems.Projections.SapSystemProjectorTest do
       %{
         id: ^id,
         ensa_version: ^ensa_version
+      },
+      1000
+    )
+  end
+
+  test "should broadcast database health change when a SapSystemDatabaseHealthChanged event is received" do
+    sap_system_id = Faker.UUID.v4()
+
+    event = %SapSystemDatabaseHealthChanged{
+      sap_system_id: sap_system_id,
+      database_health: Health.critical()
+    }
+
+    ProjectorTestHelper.project(SapSystemProjector, event, "sap_system_projector")
+
+    assert_broadcast(
+      "sap_system_updated",
+      %{
+        id: ^sap_system_id,
+        database_health: Health.critical()
       },
       1000
     )

--- a/test/trento/sap_systems/projections/sap_system_projector_test.exs
+++ b/test/trento/sap_systems/projections/sap_system_projector_test.exs
@@ -10,7 +10,6 @@ defmodule Trento.SapSystems.Projections.SapSystemProjectorTest do
 
   import Trento.Factory
 
-  require Trento.Enums.Health, as: Health
   require Trento.SapSystems.Enums.EnsaVersion, as: EnsaVersion
 
   alias Trento.SapSystems.Projections.{
@@ -25,7 +24,6 @@ defmodule Trento.SapSystems.Projections.SapSystemProjectorTest do
     ApplicationInstanceMarkedAbsent,
     ApplicationInstanceMarkedPresent,
     ApplicationInstanceMoved,
-    SapSystemDatabaseHealthChanged,
     SapSystemDeregistered,
     SapSystemHealthChanged,
     SapSystemRestored,
@@ -439,26 +437,6 @@ defmodule Trento.SapSystems.Projections.SapSystemProjectorTest do
       %{
         id: ^id,
         ensa_version: ^ensa_version
-      },
-      1000
-    )
-  end
-
-  test "should broadcast database health change when a SapSystemDatabaseHealthChanged event is received" do
-    sap_system_id = Faker.UUID.v4()
-
-    event = %SapSystemDatabaseHealthChanged{
-      sap_system_id: sap_system_id,
-      database_health: Health.critical()
-    }
-
-    ProjectorTestHelper.project(SapSystemProjector, event, "sap_system_projector")
-
-    assert_broadcast(
-      "sap_system_updated",
-      %{
-        id: ^sap_system_id,
-        database_health: Health.critical()
       },
       1000
     )

--- a/test/trento_web/views/v1/sap_system_view_json_test.exs
+++ b/test/trento_web/views/v1/sap_system_view_json_test.exs
@@ -9,7 +9,7 @@ defmodule TrentoWeb.V1.SapSystemJSONTest do
 
   describe "SapSystemJSON" do
     test "should render sap_systems.json" do
-      %{id: database_id, sid: database_sid} = database = build(:database)
+      %{id: database_id, sid: database_sid, health: database_health} = database = build(:database)
 
       database_instances = build_list(1, :database_instance, database_id: database_id)
       application_instances = build_list(1, :application_instance)
@@ -29,6 +29,7 @@ defmodule TrentoWeb.V1.SapSystemJSONTest do
         |> Map.delete(:deregistered_at)
         |> Map.delete(:database)
         |> Map.put(:database_sid, database_sid)
+        |> Map.put(:database_health, database_health)
         |> Map.put(
           :application_instances,
           Enum.map(application_instances, fn app_instance ->


### PR DESCRIPTION
# Description

Add database information in the SAP systems view.
The health is updated automatically when it is changed in the backend.
Besides this, the `Type` value in SAP system details view is changed.
Now, instead of being a static `Application Server`, it will use the same type we have in the overview, which is `ABAP`, `JAVA` or `ABAP+JAVA`.

<img width="1338" height="314" alt="image" src="https://github.com/user-attachments/assets/eec83b0d-c8c5-477f-9870-524478eba028" />

## How was this tested?

UT and e2e

## Did you update the documentation?


