### PR TITLE
Fix flaky tests bundled artifacts

### DIFF
--- a/.github/workflows/flaky-tests-analysis.yaml
+++ b/.github/workflows/flaky-tests-analysis.yaml
@@ -264,7 +264,7 @@ jobs:
           copy_artifacts "${{ steps.analyze.outputs.failed-reports-dir }}" "${{ inputs.junit-artifact-pattern }}" "junit"
           copy_artifacts "${{ steps.download-screenshots.outputs.download-path }}" "${{ inputs.screenshot-artifact-pattern }}" "screenshots"
 
-          if find "$BUNDLE_DIR" -mindepth 2 -type f | grep -q .; then
+          if [ -n "$(find "$BUNDLE_DIR" -mindepth 2 -type f -print -quit)" ]; then
             echo "bundle-dir=$BUNDLE_DIR" >> "$GITHUB_OUTPUT"
             echo "artifact-name=evidence-${WORKFLOW_SLUG}-${SUITE_SLUG}-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
# Description

Fixes the flaky tests evidence bundling step by avoiding a `find | grep -q` pipeline under `pipefail`.

`grep -q` could close the pipe early after finding the first file, causing `find` to fail with `SIGPIPE`. That made the workflow think no evidence files were collected, so the aggregated artifact was not uploaded and individual screenshot artifacts were left behind. The check now uses `find ... -print -quit` to safely detect bundled files.

[Run example](https://github.com/trento-project/web/actions/runs/26965909925)
Output Example:
<img width="1346" height="2006" alt="Screenshot_20260604_185502" src="https://github.com/user-attachments/assets/0726d911-c163-46e0-8875-8604bb7ca637" />



Fixes # (issue)

## Did you add the right label?

Remember to add the right labels to this PR.
- [ ] **DONE**

## How was this tested?

Describe the tests that have been added/changed for this new behavior.
- [ ] **DONE**

## Did you update the documentation?

Remember to ask yourself if your PR requires changes to the following documentation:

- [User Documentation](https://github.com/trento-project/docs/tree/main/trento/adoc)
- [Developer Documentation](https://github.com/trento-project/docs/tree/main/content)
- [Trento Web Documentation](https://github.com/trento-project/web/tree/main/guides)

- [ ] **DONE**
