### PR TITLE
Home dashboard cluster not available icon

### DIFF
--- a/assets/js/common/HealthIcon/HealthIcon.jsx
+++ b/assets/js/common/HealthIcon/HealthIcon.jsx
@@ -14,6 +14,7 @@ import {
   EOS_ERROR_FILLED,
   EOS_WARNING_FILLED,
   EOS_INFO_FILLED,
+  EOS_REMOVE_FILLED,
 } from 'eos-icons-react';
 
 import Spinner from '@common/Spinner';
@@ -87,6 +88,16 @@ function HealthIcon({
       );
     case 'pending':
       return <Spinner />;
+    case 'not_available':
+      return (
+        <EOS_REMOVE_FILLED
+          size={size}
+          className={classNames(
+            hoverOpacityClass,
+            computedIconCssClass('fill-gray-500', centered)
+          )}
+        />
+      );
     default:
       return (
         <EOS_LENS_FILLED

--- a/assets/js/common/HealthIcon/HealthIcon.stories.jsx
+++ b/assets/js/common/HealthIcon/HealthIcon.stories.jsx
@@ -1,43 +1,77 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
 import HealthIcon from '.';
 
 export default {
   title: 'Components/HealthIcon',
   component: HealthIcon,
   argTypes: {
+    health: {
+      description: 'Type of health icon',
+      control: { type: 'radio' },
+      options: [
+        'passing',
+        'warning',
+        'critical',
+        'absent',
+        'pending',
+        'not_available',
+        'unknown',
+      ],
+    },
+    centered: {
+      description: 'Whether to icon is centered or not',
+      control: { type: 'boolean' },
+    },
+    hoverOpacity: {
+      description: 'Whether to change opacity on hover or not',
+      control: { type: 'boolean' },
+    },
+    size: {
+      description: 'The size of the icon',
+      control: { type: 'radio' },
+      options: ['s', 'm', 'l', 'xl', 'xxl', 16, 24, 32, 48, 64],
+      table: {
+        type: { summary: 'string|number' },
+        defaultValue: { summary: 'l' },
+      },
+    },
     isLink: {
-      control: 'boolean',
+      description: 'Whether to icon is a link or not',
+      control: { type: 'boolean' },
     },
   },
 };
 
+export const Default = {
+  args: { health: 'unknown' },
+};
+
 export const Passing = {
-  args: { health: 'passing', isLink: false },
+  args: { health: 'passing' },
 };
 
 export const Warning = {
-  args: { health: 'warning', isLink: false },
+  args: { health: 'warning' },
 };
 
 export const Critical = {
-  args: { health: 'critical', isLink: false },
+  args: { health: 'critical' },
 };
 
-export function Pending() {
-  return <HealthIcon health="pending" />;
-}
+export const Pending = {
+  args: { health: 'pending' },
+};
 
 export const Absent = {
-  args: { health: 'absent', isLink: false },
+  args: { health: 'absent' },
 };
 
-export function Default() {
-  return <HealthIcon health="unknown" />;
-}
+export const NotAvailable = {
+  args: { health: 'not_available' },
+};
 
 export const ExtraLarge = {
-  args: { health: 'passing', size: 'xl', isLink: false },
+  args: { health: 'passing', size: 'xl' },
 };

--- a/assets/js/common/HealthIcon/HealthIcon.test.jsx
+++ b/assets/js/common/HealthIcon/HealthIcon.test.jsx
@@ -31,6 +31,11 @@ describe('HealthIcon', () => {
     const svgEl = container.querySelector("[data-testid='eos-svg-component']");
     expect(svgEl.classList.toString()).toContain('fill-gray-500');
   });
+  it('should display a gray dash icon when the health is not available', () => {
+    const { container } = render(<HealthIcon health="not_available" />);
+    const svgEl = container.querySelector("[data-testid='eos-svg-component']");
+    expect(svgEl.classList.toString()).toContain('fill-gray-500');
+  });
   it('should display an svg without hovering effect', () => {
     const { container } = render(<HealthIcon health="" hoverOpacity={false} />);
     const svgEl = container.querySelector("[data-testid='eos-svg-component']");

--- a/assets/js/pages/HealthSummary/HomeHealthSummary.jsx
+++ b/assets/js/pages/HealthSummary/HomeHealthSummary.jsx
@@ -51,11 +51,7 @@ const healthSummaryTableConfig = {
             <HealthIcon health={content} centered isLink />
           </Link>
         ) : (
-          <HealthIcon
-            health={content || 'not_available'}
-            centered
-            hoverOpacity={false}
-          />
+          <HealthIcon health={'not_available'} centered hoverOpacity={false} />
         );
       },
     },
@@ -84,11 +80,7 @@ const healthSummaryTableConfig = {
             <HealthIcon health={content} centered isLink />
           </Link>
         ) : (
-          <HealthIcon
-            health={content || 'not_available'}
-            centered
-            hoverOpacity={false}
-          />
+          <HealthIcon health={'not_available'} centered hoverOpacity={false} />
         );
       },
     },

--- a/assets/js/pages/HealthSummary/HomeHealthSummary.jsx
+++ b/assets/js/pages/HealthSummary/HomeHealthSummary.jsx
@@ -51,7 +51,11 @@ const healthSummaryTableConfig = {
             <HealthIcon health={content} centered isLink />
           </Link>
         ) : (
-          <HealthIcon health={content} centered hoverOpacity={false} />
+          <HealthIcon
+            health={content || 'not_available'}
+            centered
+            hoverOpacity={false}
+          />
         );
       },
     },
@@ -80,7 +84,11 @@ const healthSummaryTableConfig = {
             <HealthIcon health={content} centered isLink />
           </Link>
         ) : (
-          <HealthIcon health={content} centered hoverOpacity={false} />
+          <HealthIcon
+            health={content || 'not_available'}
+            centered
+            hoverOpacity={false}
+          />
         );
       },
     },

--- a/assets/js/pages/HealthSummary/HomeHealthSummary.test.jsx
+++ b/assets/js/pages/HealthSummary/HomeHealthSummary.test.jsx
@@ -38,8 +38,8 @@ const homeHealthSummaryData = [
   healthSummaryFactory.build({
     application_cluster_id: null,
     database_cluster_id: null,
-    application_cluster_health: 'unknown',
-    database_cluster_health: 'unknown',
+    application_cluster_health: null,
+    database_cluster_health: null,
     application_health: 'critical',
     database_health: 'passing',
     hosts_health: 'passing',

--- a/lib/trento/sap_systems/services/health_summary_service.ex
+++ b/lib/trento/sap_systems/services/health_summary_service.ex
@@ -8,8 +8,6 @@ defmodule Trento.SapSystems.Services.HealthSummaryService do
 
   import Ecto.Query
 
-  require Trento.Enums.Health, as: HealthEnum
-
   alias Trento.Databases.Projections.DatabaseInstanceReadModel
 
   alias Trento.SapSystems.Projections.{
@@ -67,7 +65,7 @@ defmodule Trento.SapSystems.Services.HealthSummaryService do
   @spec compute_cluster_health(
           [DatabaseInstanceReadModel.t()]
           | [ApplicationInstanceReadModel.t()]
-        ) :: Health.t()
+        ) :: Health.t() | nil
   defp compute_cluster_health(instances) do
     cluster_id =
       Enum.find_value(instances, nil, fn
@@ -77,7 +75,7 @@ defmodule Trento.SapSystems.Services.HealthSummaryService do
       end)
 
     case cluster_id do
-      nil -> HealthEnum.unknown()
+      nil -> nil
       cluster_id -> ClusterReadModel |> Repo.get!(cluster_id) |> Map.get(:health)
     end
   end

--- a/test/trento/sap_systems/services/health_summary_service_test.exs
+++ b/test/trento/sap_systems/services/health_summary_service_test.exs
@@ -138,7 +138,7 @@ defmodule Trento.SapSystems.Services.HealthSummaryServiceTest do
              ] == HealthSummaryService.get_health_summary()
     end
 
-    test "should set as nil the clusters health when they are not available" do
+    test "should set as nil the database and application clusters health when those clusters do not exist" do
       %HostReadModel{id: db_host_id} =
         db_host = insert(:host, cluster_id: nil, health: Health.passing())
 

--- a/test/trento/sap_systems/services/health_summary_service_test.exs
+++ b/test/trento/sap_systems/services/health_summary_service_test.exs
@@ -138,7 +138,7 @@ defmodule Trento.SapSystems.Services.HealthSummaryServiceTest do
              ] == HealthSummaryService.get_health_summary()
     end
 
-    test "should set as unknown the clusters health when they are not available" do
+    test "should set as nil the clusters health when they are not available" do
       %HostReadModel{id: db_host_id} =
         db_host = insert(:host, cluster_id: nil, health: Health.passing())
 
@@ -185,9 +185,9 @@ defmodule Trento.SapSystems.Services.HealthSummaryServiceTest do
                  sapsystem_health: Health.critical(),
                  application_health: Health.passing(),
                  database_health: database_health,
-                 database_cluster_health: Health.unknown(),
+                 database_cluster_health: nil,
                  database_id: database_id,
-                 application_cluster_health: Health.unknown(),
+                 application_cluster_health: nil,
                  hosts_health: Health.passing(),
                  database_instances: database_instances,
                  application_instances: application_instances,


### PR DESCRIPTION
# Description

Update health summary view icons for not available clusters, using the dash icon.

<img width="1268" height="540" alt="image" src="https://github.com/user-attachments/assets/6e7884c8-78f2-44af-861f-6f805a3ff9d7" />

## How was this tested?

Update already existing tests

## Did you update the documentation?

@abravosuse do we need to update docs? In that case, let's create a ticket as reminder
