### PR TITLE
Update analytics docs link profile form

### DIFF
--- a/assets/js/pages/Profile/ProfileForm.jsx
+++ b/assets/js/pages/Profile/ProfileForm.jsx
@@ -23,7 +23,7 @@ const ANALYTICS_TOOLTIP_MESSAGE = (
   <span>
     Allow the collection of{' '}
     <Link
-      to="https://www.trento-project.io/docs/"
+      to="https://documentation.suse.com/sles-sap/trento/single-html/SLES-SAP-trento/SLES-SAP-trento.html#sec-trento-analytics"
       className="text-jungle-green-500 hover:opacity-75"
       target="_blank"
     >

--- a/assets/js/pages/Profile/ProfileForm.jsx
+++ b/assets/js/pages/Profile/ProfileForm.jsx
@@ -3,7 +3,6 @@
 
 import React, { useState, useEffect } from 'react';
 import { computeTimezoneOffsets, formatOffset } from '@lib/timezones';
-import { Link } from 'react-router';
 import { noop } from 'lodash';
 import { getError } from '@lib/api/validationErrors';
 import Button from '@common/Button';
@@ -22,13 +21,14 @@ import { REQUIRED_FIELD_TEXT, errorMessage } from '@lib/forms';
 const ANALYTICS_TOOLTIP_MESSAGE = (
   <span>
     Allow the collection of{' '}
-    <Link
-      to="https://documentation.suse.com/sles-sap/trento/single-html/SLES-SAP-trento/SLES-SAP-trento.html#sec-trento-analytics"
+    <a
+      href="https://documentation.suse.com/sles-sap/trento/single-html/SLES-SAP-trento/SLES-SAP-trento.html#sec-trento-analytics"
       className="text-jungle-green-500 hover:opacity-75"
       target="_blank"
+      rel="noreferrer"
     >
       anonymous metrics
-    </Link>{' '}
+    </a>{' '}
     to help improve Trento.
   </span>
 );

--- a/assets/js/pages/Profile/ProfileForm.test.jsx
+++ b/assets/js/pages/Profile/ProfileForm.test.jsx
@@ -159,6 +159,7 @@ describe('ProfileForm', () => {
   });
 
   it('should set analytics switch when analyticsEnabled is true', async () => {
+    const user = userEvent.setup();
     const { username, fullname, email, abilities } = profileFactory.build();
 
     render(
@@ -176,6 +177,16 @@ describe('ProfileForm', () => {
 
     expect(analyticsSwitch).toBeVisible();
     expect(analyticsSwitch).toBeChecked();
+
+    await user.hover(
+      screen.getByText(/Analytics Opt-in/i).querySelector('span svg')
+    );
+    const linkElement = screen.getByRole('link', { name: 'anonymous metrics' });
+    expect(linkElement).toHaveProperty('target', '_blank');
+    expect(linkElement).toHaveProperty(
+      'href',
+      'https://documentation.suse.com/sles-sap/trento/single-html/SLES-SAP-trento/SLES-SAP-trento.html#sec-trento-analytics'
+    );
   });
 
   it.each([


### PR DESCRIPTION
# Description

Update analytics link to official docs.
I have replaced the usage of `Link` by plain `a` as this is an external link and we don't need the internal react routing for this.

## How was this tested?
Test added

## Did you update the documentation?

No need
