### PR TITLE
Extract openapi tool builder

### DIFF
--- a/lib/trento/ai/agent.ex
+++ b/lib/trento/ai/agent.ex
@@ -28,7 +28,7 @@ defmodule Trento.AI.Agent do
   Accepted `opts`:
 
   - `:agent_id`, `:model`, `:scope` — required (see Sagents docs).
-  - `:tool_context` — optional map merged verbatim into the Sagents agent's
+  - `:tool_context` — optional map set verbatim on the Sagents agent's
     `tool_context` field. Sagents propagates this into the per-call
     `context.tool_context` map that tool function closures receive.
     Used to forward request-scoped data (e.g. the websocket user's JWT)

--- a/lib/trento/ai/agent.ex
+++ b/lib/trento/ai/agent.ex
@@ -24,6 +24,15 @@ defmodule Trento.AI.Agent do
 
   @doc """
   Pure factory for a Sagents.Agent struct configured as the Trento AI Assistant.
+
+  Accepted `opts`:
+
+  - `:agent_id`, `:model`, `:scope` — required (see Sagents docs).
+  - `:tool_context` — optional map merged verbatim into the Sagents agent's
+    `tool_context` field. Sagents propagates this into the per-call
+    `context.tool_context` map that tool function closures receive.
+    Used to forward request-scoped data (e.g. the websocket user's JWT)
+    to tools that need it, without polluting `:scope`.
   """
   @spec new!(keyword()) :: Sagents.Agent.t()
   def new!(opts) do
@@ -32,6 +41,7 @@ defmodule Trento.AI.Agent do
         agent_id: Keyword.fetch!(opts, :agent_id),
         model: Keyword.fetch!(opts, :model),
         scope: Keyword.fetch!(opts, :scope),
+        tool_context: Keyword.get(opts, :tool_context, %{}),
         base_system_prompt: load_base_system_prompt(),
         tools: ToolsRegistry.tools(),
         # see https://github.com/sagents-ai/sagents#provided-middleware

--- a/lib/trento/ai/open_api_tool_builder.ex
+++ b/lib/trento/ai/open_api_tool_builder.ex
@@ -1,0 +1,211 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.AI.OpenApiToolBuilder do
+  @moduledoc """
+  Transport-agnostic helpers shared by every `Trento.AI.ToolSource` that
+  derives `LangChain.Function`s from `%OpenApiSpex.Operation{}` structs.
+
+  Two distinct concerns live here:
+
+  1. **Schema synthesis** — `description/1` and `parameters_schema/1`
+     produce the metadata `LangChain.Function.new!/1` consumes. The
+     resulting `parameters_schema` is the JSON-Schema map a provider
+     adapter (Anthropic, Google AI, OpenAI) eventually forwards to the
+     model.
+
+  2. **Arg routing** — `param_locations/1`, `split_args/2`,
+     `substitute_path/2`, `append_query/2` turn the LLM-supplied
+     argument map into a `{path, body}` pair, respecting each parameter's
+     declared `in:` location.
+
+  Both `TrentoWeb.AI.ControllerTool` (local Plug.Test dispatch) and
+  `Trento.AI.RemoteHttpTool` (remote HTTP dispatch) consume these helpers,
+  so the OpenAPI surface drives both transports identically. The only
+  thing that differs is how the resolved request is actually executed.
+  """
+
+  alias OpenApiSpex.{OpenApi, Operation, Parameter, RequestBody}
+
+  @doc """
+  Concatenates `summary` + `description` of an `%Operation{}` into the
+  human-readable tool description shown to the LLM.
+  """
+  @spec description(Operation.t() | nil) :: String.t()
+  def description(%Operation{summary: summary, description: description}) do
+    [summary, description]
+    |> Enum.reject(&(is_nil(&1) or &1 == ""))
+    |> Enum.join("\n\n")
+  end
+
+  def description(_), do: ""
+
+  @doc """
+  JSON-Schema map for `LangChain.Function.new!/1`'s `:parameters_schema`.
+
+  String-keyed throughout to match LangChain convention and the
+  `Map.put_new(schema, "additionalProperties", false)` behaviour of
+  `ChatAnthropic.get_parameters/1`. The `"required"` key is omitted when
+  empty so parameterless tools pass `ChatGoogleAI.for_api/1`'s exact-match
+  deletion check.
+  """
+  @spec parameters_schema(Operation.t() | any()) :: map()
+  def parameters_schema(%Operation{parameters: parameters} = operation)
+      when is_list(parameters) do
+    parameters
+    |> Enum.reduce({%{}, []}, &accumulate_parameter/2)
+    |> then(fn {params_schemas, params_required} ->
+      operation
+      |> request_body_props()
+      |> then(fn {body_props, body_required} ->
+        %{}
+        |> Map.put("type", "object")
+        |> Map.put("properties", Map.merge(params_schemas, body_props))
+        |> put_if("required", Enum.uniq(params_required ++ body_required))
+      end)
+    end)
+  end
+
+  def parameters_schema(_), do: %{"type" => "object", "properties" => %{}}
+
+  @doc """
+  Map of parameter name (string) → declared `:in` location
+  (`:path | :query | :body | :header`) for an `%Operation{}`.
+  """
+  @spec param_locations(Operation.t() | any()) :: %{String.t() => atom()}
+  def param_locations(%Operation{parameters: params}) when is_list(params) do
+    Map.new(params, fn %Parameter{name: name, in: location} ->
+      {to_string(name), location}
+    end)
+  end
+
+  def param_locations(_), do: %{}
+
+  @doc """
+  Splits the LLM-supplied `tool_args` map into `{path, query, body}`
+  according to each key's declared `:in` location. Unknown keys land in
+  the body bucket.
+  """
+  @spec split_args(%{String.t() => atom()}, map()) :: {map(), map(), map()}
+  def split_args(locations, tool_args) do
+    Enum.reduce(tool_args, {%{}, %{}, %{}}, fn {k, v}, {path_map, query_map, body_map} ->
+      key = to_string(k)
+
+      case Map.get(locations, key) do
+        :path -> {Map.put(path_map, key, v), query_map, body_map}
+        :query -> {path_map, Map.put(query_map, key, v), body_map}
+        _ -> {path_map, query_map, Map.put(body_map, key, v)}
+      end
+    end)
+  end
+
+  @doc """
+  Substitutes `:placeholder` (Phoenix-style) and `{placeholder}`
+  (OpenAPI-style) segments in the path template with URI-encoded values
+  from `path_args`.
+
+  Phoenix routes carry `:id`-style templates; OpenAPI specs carry
+  `{id}`-style templates. Supporting both lets the same helper drive both
+  local controller routes and remote OpenAPI-described endpoints.
+  """
+  @spec substitute_path(String.t(), map()) :: String.t()
+  def substitute_path(path_template, path_args) do
+    Enum.reduce(path_args, path_template, fn {name, value}, acc ->
+      encoded = URI.encode_www_form(to_string(value || ""))
+
+      acc
+      |> String.replace(":#{name}", encoded)
+      |> String.replace("{#{name}}", encoded)
+    end)
+  end
+
+  @doc """
+  Appends a `?k=v&...` query string to `path`. Array values explode into
+  repeated keys, matching OpenAPI 3 `style: form, explode: true`.
+  """
+  @spec append_query(String.t(), map()) :: String.t()
+  def append_query(path, query) when map_size(query) == 0, do: path
+
+  def append_query(path, query) do
+    query_string =
+      query
+      |> Enum.flat_map(&expand_query_pair/1)
+      |> URI.encode_query()
+
+    "#{path}?#{query_string}"
+  end
+
+  defp expand_query_pair({key, values}) when is_list(values),
+    do: Enum.map(values, &{to_string(key), to_string(&1)})
+
+  defp expand_query_pair({key, value}),
+    do: [{to_string(key), to_string(value)}]
+
+  defp accumulate_parameter(
+         %Parameter{
+           name: name,
+           required: required,
+           schema: schema,
+           description: description,
+           example: example
+         },
+         {accumulated_props, accumulated_required_props}
+       ) do
+    schema
+    |> resolve_schema()
+    |> OpenApi.to_map()
+    |> put_if("description", description)
+    |> put_if("example", example)
+    |> then(fn property_schema ->
+      key = to_string(name)
+
+      {
+        Map.put(accumulated_props, key, property_schema),
+        maybe_add_required_prop(accumulated_required_props, {key, required})
+      }
+    end)
+  end
+
+  defp accumulate_parameter(_, acc), do: acc
+
+  defp maybe_add_required_prop(required_so_far, {possibly_required_key, true = _required?}),
+    do: [possibly_required_key | required_so_far]
+
+  defp maybe_add_required_prop(required_so_far, _), do: required_so_far
+
+  # OpenApiSpex allows schemas to be referenced by module name; resolve
+  # those to the real `%Schema{}` so `OpenApi.to_map/1` walks something
+  # meaningful instead of stringifying the atom.
+  defp resolve_schema(%OpenApiSpex.Schema{} = schema), do: schema
+
+  defp resolve_schema(module) when is_atom(module) and not is_nil(module) do
+    if Code.ensure_loaded?(module) and function_exported?(module, :schema, 0) do
+      module.schema()
+    else
+      %OpenApiSpex.Schema{}
+    end
+  end
+
+  defp resolve_schema(_), do: %OpenApiSpex.Schema{}
+
+  defp request_body_props(%Operation{
+         requestBody: %RequestBody{content: content}
+       })
+       when is_map(content) do
+    case Map.get(content, "application/json") do
+      %{schema: schema} ->
+        schema
+        |> resolve_schema()
+        |> OpenApi.to_map()
+        |> then(&{Map.get(&1, "properties", %{}), Map.get(&1, "required", [])})
+
+      _ ->
+        {%{}, []}
+    end
+  end
+
+  defp request_body_props(_), do: {%{}, []}
+
+  defp put_if(map, _key, value) when value in [nil, "", []], do: map
+  defp put_if(map, key, value), do: Map.put(map, key, value)
+end

--- a/lib/trento/ai/open_api_tool_builder.ex
+++ b/lib/trento/ai/open_api_tool_builder.ex
@@ -69,8 +69,8 @@ defmodule Trento.AI.OpenApiToolBuilder do
   def parameters_schema(_), do: %{"type" => "object", "properties" => %{}}
 
   @doc """
-  Map of parameter name (string) → declared `:in` location
-  (`:path | :query | :body | :header`) for an `%Operation{}`.
+  Map of parameter name (string) → declared `:in` location atom
+  (`:path | :query | :header | :cookie`) for an `%Operation{}`.
   """
   @spec param_locations(Operation.t() | any()) :: %{String.t() => atom()}
   def param_locations(%Operation{parameters: params}) when is_list(params) do
@@ -83,8 +83,9 @@ defmodule Trento.AI.OpenApiToolBuilder do
 
   @doc """
   Splits the LLM-supplied `tool_args` map into `{path, query, body}`
-  according to each key's declared `:in` location. Unknown keys land in
-  the body bucket.
+  according to each key's declared `:in` location. Unknown keys (and any
+  non-`:path`/`:query` locations like `:header` or `:cookie`) land in the
+  body bucket.
   """
   @spec split_args(%{String.t() => atom()}, map()) :: {map(), map(), map()}
   def split_args(locations, tool_args) do

--- a/lib/trento/ai/tool_source.ex
+++ b/lib/trento/ai/tool_source.ex
@@ -8,11 +8,16 @@ defmodule Trento.AI.ToolSource do
 
   A source returns a list of ready-to-use `LangChain.Function` structs.
   How those functions are produced is entirely up to the implementation
-  (controller-derived, native, MCP remote, ...).
+  (controller-derived, remote-OpenAPI, MCP remote, ...).
 
   Sources are wired in via the `:tool_sources` key under
-  `config :trento, :ai, ...` and aggregated at call time.
+  `config :trento, :ai, ...`. Each entry is either a bare module
+  `MyToolSource` (normalised to `{MyToolSource, []}`) or a `{module, opts}`
+  tuple
+
+  Implementations must export `tools/1`. Sources that don't need
+  configuration match the argument with `_opts`.
   """
 
-  @callback tools() :: [LangChain.Function.t()]
+  @callback tools(opts :: keyword()) :: [LangChain.Function.t()]
 end

--- a/lib/trento/ai/tools_registry.ex
+++ b/lib/trento/ai/tools_registry.ex
@@ -6,18 +6,32 @@ defmodule Trento.AI.ToolsRegistry do
   Aggregates AI assistant tools from every configured
   `Trento.AI.ToolSource`.
 
-  The list of source modules is read at call time from
+  The list of source modules is read from
   `config :trento, :ai, tool_sources: [...]` via
-  `Trento.AI.ApplicationConfigLoader`. Each source contributes a list
-  of `LangChain.Function` structs; the aggregator flat-concats them in
-  declaration order with no dedup — name collisions are configuration
-  errors and should be surfaced loudly by LangChain.
+  `Trento.AI.ApplicationConfigLoader`. Each entry is either:
+
+  - a bare module `MyToolSource` — normalised to `{MyToolSource, []}`, or
+  - a `{module, opts}` tuple — passed through as-is.
+
+  Every source's `tools/1` callback is invoked with its opts list (empty
+  for bare-module entries). Sources are flat-concatenated in declaration
+  order; name collisions are configuration errors and should surface
+  loudly via LangChain.
   """
 
   alias Trento.AI.ApplicationConfigLoader
 
   @spec tools() :: [LangChain.Function.t()]
-  def tools, do: Enum.flat_map(sources(), & &1.tools())
+  def tools do
+    Enum.flat_map(configured_sources(), fn {module, opts} -> module.tools(opts) end)
+  end
 
-  defp sources, do: Keyword.get(ApplicationConfigLoader.load(), :tool_sources, [])
+  defp configured_sources do
+    ApplicationConfigLoader.load()
+    |> Keyword.get(:tool_sources, [])
+    |> Enum.map(&normalize_entry/1)
+  end
+
+  defp normalize_entry({module, opts}) when is_atom(module) and is_list(opts), do: {module, opts}
+  defp normalize_entry(module) when is_atom(module), do: {module, []}
 end

--- a/lib/trento_web/ai/controller_tool.ex
+++ b/lib/trento_web/ai/controller_tool.ex
@@ -27,22 +27,19 @@ defmodule TrentoWeb.AI.ControllerTool do
   against the loaded user. ControllerTool itself owns no auth logic.
 
   Args are routed by the operation's declared `:in` field
-  (`:path` / `:query` / body) via `param_locations/1` + `split_args/2`.
+  (`:path` / `:query` / body) via `Trento.AI.OpenApiToolBuilder`.
   Query-tagged args are appended to the request URL, not passed via
   `Plug.Test.conn/3`'s `params_or_body` argument — that argument is a
   single bucket routed by verb (GET → `query_string`, non-GET →
   `body_params`) and cannot carry both query and body simultaneously.
   Appending the query string to the URL is the only mechanism that
-  supports a non-GET endpoint with `:in => :query` parameters. The
-  current Trento MCP catalog is GET-only for query-tagged parameters,
-  but the routing supports any verb per the OpenAPI 3.x spec
-  (`PathItem` allows query parameters on any operation method).
+  supports a non-GET endpoint with `:in => :query` parameters.
   """
 
   require Logger
 
   alias LangChain.Function
-  alias OpenApiSpex.{OpenApi, Operation, Parameter, RequestBody}
+  alias Trento.AI.OpenApiToolBuilder
   alias Trento.Users.User
   alias TrentoWeb.AI.McpRouteIndex.Entry
 
@@ -50,115 +47,17 @@ defmodule TrentoWeb.AI.ControllerTool do
   Build a `%LangChain.Function{}` for the given catalog entry.
   """
   @spec build(Entry.t()) :: Function.t()
-  def build(%Entry{operation: operation} = entry) do
+  def build(
+        %Entry{tool_name: tool_name, display_text: display_text, operation: operation} = entry
+      ) do
     Function.new!(%{
-      name: entry.tool_name,
-      display_text: entry.display_text || entry.tool_name,
-      description: description(operation),
-      parameters_schema: parameters_schema(operation),
+      name: tool_name,
+      display_text: display_text || tool_name,
+      description: OpenApiToolBuilder.description(operation),
+      parameters_schema: OpenApiToolBuilder.parameters_schema(operation),
       function: fn args, context -> invoke(entry, args, context) end
     })
   end
-
-  defp description(%Operation{summary: summary, description: description}) do
-    [summary, description]
-    |> Enum.reject(&(is_nil(&1) or &1 == ""))
-    |> Enum.join("\n\n")
-  end
-
-  defp description(_), do: ""
-
-  # Builds a JSON-Schema map from operation parameters + requestBody.
-  # String-keyed throughout to match LangChain convention.
-  # `"required"` is omitted when empty.
-  defp parameters_schema(%Operation{parameters: parameters} = operation)
-       when is_list(parameters) do
-    parameters
-    |> Enum.reduce({%{}, []}, &accumulate_parameter/2)
-    |> then(fn {params_schemas, params_required} ->
-      operation
-      |> request_body_props()
-      |> then(fn {body_props, body_required} ->
-        %{}
-        |> Map.put("type", "object")
-        |> Map.put("properties", Map.merge(params_schemas, body_props))
-        |> put_if("required", Enum.uniq(params_required ++ body_required))
-      end)
-    end)
-  end
-
-  defp parameters_schema(_), do: %{"type" => "object", "properties" => %{}}
-
-  defp accumulate_parameter(
-         %Parameter{
-           name: name,
-           required: required,
-           schema: schema,
-           description: description,
-           example: example
-         },
-         {accumulated_props, accumulated_required_props}
-       ) do
-    schema
-    |> resolve_schema()
-    |> OpenApi.to_map()
-    |> put_if("description", description)
-    |> put_if("example", example)
-    |> then(fn property_schema ->
-      key = to_string(name)
-
-      {
-        Map.put(accumulated_props, key, property_schema),
-        maybe_add_required_prop(accumulated_required_props, {key, required})
-      }
-    end)
-  end
-
-  defp accumulate_parameter(_, acc), do: acc
-
-  defp maybe_add_required_prop(required_so_far, {possibly_required_key, true = _required?}),
-    do: [possibly_required_key | required_so_far]
-
-  defp maybe_add_required_prop(required_so_far, _), do: required_so_far
-
-  defp put_if(map, _key, value) when value in [nil, "", []], do: map
-  defp put_if(map, key, value), do: Map.put(map, key, value)
-
-  # OpenApiSpex lets controllers reference reusable schemas by module
-  # name (e.g. `request_body: {..., "application/json", UserCreationRequest}`).
-  # The raw struct then carries the module atom rather than the
-  # `%Schema{}` it generates. `OpenApi.to_map/1` on a bare atom would
-  # stringify it; resolve to the real schema first via the module's
-  # generated `schema/0` function.
-  defp resolve_schema(%OpenApiSpex.Schema{} = schema), do: schema
-
-  defp resolve_schema(module) when is_atom(module) and not is_nil(module) do
-    if Code.ensure_loaded?(module) and function_exported?(module, :schema, 0) do
-      module.schema()
-    else
-      %OpenApiSpex.Schema{}
-    end
-  end
-
-  defp resolve_schema(_), do: %OpenApiSpex.Schema{}
-
-  defp request_body_props(%Operation{
-         requestBody: %RequestBody{content: content}
-       })
-       when is_map(content) do
-    case Map.get(content, "application/json") do
-      %{schema: schema} ->
-        schema
-        |> resolve_schema()
-        |> OpenApi.to_map()
-        |> then(&{Map.get(&1, "properties", %{}), Map.get(&1, "required", [])})
-
-      _ ->
-        {%{}, []}
-    end
-  end
-
-  defp request_body_props(_), do: {%{}, []}
 
   defp invoke(
          %Entry{
@@ -171,11 +70,8 @@ defmodule TrentoWeb.AI.ControllerTool do
          tool_args,
          %{scope: %User{id: user_id}} = _context
        ) do
-    path_template
-    |> resolve_path_and_body(operation, tool_args)
-    |> then(fn {resolved_path, body_args} ->
-      dispatch_request(verb, resolved_path, body_args, user_id)
-    end)
+    {resolved_path, body_args} = resolve_path_and_body(path_template, operation, tool_args)
+    dispatch_request(verb, resolved_path, body_args, user_id)
   rescue
     exception ->
       Logger.error(
@@ -221,61 +117,18 @@ defmodule TrentoWeb.AI.ControllerTool do
   defp maybe_put_json_content_type(conn, _), do: conn
 
   defp resolve_path_and_body(path_template, operation, tool_args) do
-    operation
-    |> param_locations()
-    |> split_args(tool_args)
-    |> then(fn {path_args, query_args, body_args} ->
-      resolved_path =
-        path_template
-        |> substitute_path(path_args)
-        |> append_query(query_args)
+    {path_args, query_args, body_args} =
+      operation
+      |> OpenApiToolBuilder.param_locations()
+      |> OpenApiToolBuilder.split_args(tool_args)
 
-      {resolved_path, body_args}
-    end)
+    resolved_path =
+      path_template
+      |> OpenApiToolBuilder.substitute_path(path_args)
+      |> OpenApiToolBuilder.append_query(query_args)
+
+    {resolved_path, body_args}
   end
-
-  defp param_locations(%Operation{parameters: params}) when is_list(params) do
-    Map.new(params, fn %Parameter{name: name, in: location} ->
-      {to_string(name), location}
-    end)
-  end
-
-  defp param_locations(_), do: %{}
-
-  defp split_args(locations, tool_args) do
-    Enum.reduce(tool_args, {%{}, %{}, %{}}, fn {k, v}, {path_map, query_map, body_map} ->
-      key = to_string(k)
-
-      case Map.get(locations, key) do
-        :path -> {Map.put(path_map, key, v), query_map, body_map}
-        :query -> {path_map, Map.put(query_map, key, v), body_map}
-        _ -> {path_map, query_map, Map.put(body_map, key, v)}
-      end
-    end)
-  end
-
-  defp substitute_path(path_template, path_args) do
-    Enum.reduce(path_args, path_template, fn {name, value}, acc ->
-      String.replace(acc, ":#{name}", URI.encode_www_form(to_string(value || "")))
-    end)
-  end
-
-  defp append_query(path, query) when map_size(query) == 0, do: path
-
-  defp append_query(path, query) do
-    query_string =
-      query
-      |> Enum.flat_map(&expand_query_pair/1)
-      |> URI.encode_query()
-
-    "#{path}?#{query_string}"
-  end
-
-  defp expand_query_pair({key, values}) when is_list(values),
-    do: Enum.map(values, &{to_string(key), to_string(&1)})
-
-  defp expand_query_pair({key, value}),
-    do: [{to_string(key), to_string(value)}]
 
   defp decode_response(%Plug.Conn{status: status, resp_body: body}) when status in 200..299,
     do: {:ok, body_to_string(body)}

--- a/lib/trento_web/ai/controller_tool_source.ex
+++ b/lib/trento_web/ai/controller_tool_source.ex
@@ -13,5 +13,5 @@ defmodule TrentoWeb.AI.ControllerToolSource do
   alias TrentoWeb.AI.{ControllerTool, McpRouteIndex}
 
   @impl true
-  def tools, do: Enum.map(McpRouteIndex.entries(), &ControllerTool.build/1)
+  def tools(_opts), do: Enum.map(McpRouteIndex.entries(), &ControllerTool.build/1)
 end

--- a/test/trento/ai/open_api_tool_builder_test.exs
+++ b/test/trento/ai/open_api_tool_builder_test.exs
@@ -1,0 +1,248 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.AI.OpenApiToolBuilderTest do
+  use ExUnit.Case, async: true
+
+  alias OpenApiSpex.{MediaType, Operation, Parameter, RequestBody, Schema}
+  alias Trento.AI.OpenApiToolBuilder
+
+  describe "description/1" do
+    test "joins summary + description with a blank line" do
+      op = %Operation{summary: "Sum", description: "Long form.", responses: %{}}
+      assert OpenApiToolBuilder.description(op) == "Sum\n\nLong form."
+    end
+
+    test "drops nil / empty pieces" do
+      assert OpenApiToolBuilder.description(%Operation{
+               summary: "Sum",
+               description: nil,
+               responses: %{}
+             }) == "Sum"
+
+      assert OpenApiToolBuilder.description(%Operation{
+               summary: "",
+               description: "Body only",
+               responses: %{}
+             }) == "Body only"
+    end
+
+    test "returns '' for non-operation input" do
+      assert OpenApiToolBuilder.description(nil) == ""
+      assert OpenApiToolBuilder.description(:noop) == ""
+    end
+  end
+
+  describe "parameters_schema/1" do
+    test "returns empty object when no parameters and no request body" do
+      op = %Operation{parameters: [], responses: %{}}
+
+      assert OpenApiToolBuilder.parameters_schema(op) == %{
+               "type" => "object",
+               "properties" => %{}
+             }
+    end
+
+    test "omits 'required' when no parameter is required" do
+      op = %Operation{
+        parameters: [
+          %Parameter{
+            name: :q,
+            in: :query,
+            required: false,
+            schema: %Schema{type: :string}
+          }
+        ],
+        responses: %{}
+      }
+
+      refute Map.has_key?(OpenApiToolBuilder.parameters_schema(op), "required")
+    end
+
+    test "merges path/query parameters with request-body properties + collects required keys" do
+      op = %Operation{
+        parameters: [
+          %Parameter{
+            name: :id,
+            in: :path,
+            required: true,
+            description: "the id",
+            schema: %Schema{type: :string, format: :uuid}
+          },
+          %Parameter{
+            name: :verbose,
+            in: :query,
+            required: false,
+            schema: %Schema{type: :boolean}
+          }
+        ],
+        requestBody: %RequestBody{
+          content: %{
+            "application/json" => %MediaType{
+              schema: %Schema{
+                type: :object,
+                properties: %{name: %Schema{type: :string}},
+                required: [:name]
+              }
+            }
+          }
+        },
+        responses: %{}
+      }
+
+      schema = OpenApiToolBuilder.parameters_schema(op)
+
+      assert schema["type"] == "object"
+
+      assert %{"type" => "string", "format" => "uuid", "description" => "the id"} =
+               schema["properties"]["id"]
+
+      assert %{"type" => "boolean"} = schema["properties"]["verbose"]
+      assert %{"type" => "string"} = schema["properties"]["name"]
+      assert Enum.sort(schema["required"]) == ["id", "name"]
+    end
+
+    test "resolves a module-reference parameter schema via the module's schema/0" do
+      defmodule InlineRefSchema do
+        def schema, do: %Schema{type: :integer, example: 42}
+      end
+
+      op = %Operation{
+        parameters: [
+          %Parameter{name: :n, in: :query, required: true, schema: InlineRefSchema}
+        ],
+        responses: %{}
+      }
+
+      assert %{"properties" => %{"n" => %{"type" => "integer", "example" => 42}}} =
+               OpenApiToolBuilder.parameters_schema(op)
+    end
+
+    test "ignores requestBody.required: true flag; only collects requirements from the inner schema's required list" do
+      op = %Operation{
+        parameters: [],
+        requestBody: %RequestBody{
+          required: true,
+          content: %{
+            "application/json" => %MediaType{
+              schema: %Schema{
+                type: :object,
+                properties: %{
+                  name: %Schema{type: :string},
+                  optional_field: %Schema{type: :string}
+                },
+                required: [:name]
+              }
+            }
+          }
+        },
+        responses: %{}
+      }
+
+      schema = OpenApiToolBuilder.parameters_schema(op)
+
+      assert schema["required"] == ["name"]
+    end
+
+    test "is a no-op for non-operation input" do
+      assert OpenApiToolBuilder.parameters_schema(nil) ==
+               %{"type" => "object", "properties" => %{}}
+    end
+  end
+
+  describe "param_locations/1" do
+    test "returns a map of string parameter names to their declared location" do
+      op = %Operation{
+        parameters: [
+          %Parameter{name: :id, in: :path},
+          %Parameter{name: "verbose", in: :query}
+        ],
+        responses: %{}
+      }
+
+      assert OpenApiToolBuilder.param_locations(op) == %{
+               "id" => :path,
+               "verbose" => :query
+             }
+    end
+
+    test "returns an empty map for an empty parameter list" do
+      assert OpenApiToolBuilder.param_locations(%Operation{parameters: [], responses: %{}}) == %{}
+    end
+
+    test "returns an empty map for non-operation input" do
+      assert OpenApiToolBuilder.param_locations(nil) == %{}
+    end
+  end
+
+  describe "param_locations/1 + split_args/2" do
+    test "buckets args by declared :in field; unknown keys land in body" do
+      op = %Operation{
+        parameters: [
+          %Parameter{name: :id, in: :path, required: true, schema: %Schema{type: :string}},
+          %Parameter{name: :limit, in: :query, required: false, schema: %Schema{type: :integer}}
+        ],
+        responses: %{}
+      }
+
+      locations = OpenApiToolBuilder.param_locations(op)
+
+      assert {%{"id" => "abc"}, %{"limit" => 10}, %{"extra" => "x"}} =
+               OpenApiToolBuilder.split_args(locations, %{
+                 "id" => "abc",
+                 "limit" => 10,
+                 "extra" => "x"
+               })
+    end
+
+    test "atom keys in args are stringified" do
+      op = %Operation{
+        parameters: [
+          %Parameter{name: :id, in: :path, required: true, schema: %Schema{type: :string}}
+        ],
+        responses: %{}
+      }
+
+      locations = OpenApiToolBuilder.param_locations(op)
+
+      assert {%{"id" => "abc"}, %{}, %{}} =
+               OpenApiToolBuilder.split_args(locations, %{id: "abc"})
+    end
+  end
+
+  describe "substitute_path/2" do
+    test "fills :placeholder segments (Phoenix style)" do
+      assert OpenApiToolBuilder.substitute_path("/api/users/:id", %{"id" => "alice"}) ==
+               "/api/users/alice"
+    end
+
+    test "fills {placeholder} segments (OpenAPI style)" do
+      assert OpenApiToolBuilder.substitute_path("/api/users/{id}", %{"id" => "alice"}) ==
+               "/api/users/alice"
+    end
+
+    test "URI-encodes values" do
+      assert OpenApiToolBuilder.substitute_path("/api/users/{id}", %{"id" => "a b/c"}) ==
+               "/api/users/a+b%2Fc"
+    end
+
+    test "treats nil values as empty" do
+      assert OpenApiToolBuilder.substitute_path("/x/:id", %{"id" => nil}) == "/x/"
+    end
+  end
+
+  describe "append_query/2" do
+    test "no query → unchanged path" do
+      assert OpenApiToolBuilder.append_query("/x", %{}) == "/x"
+    end
+
+    test "scalar values → ?k=v" do
+      assert OpenApiToolBuilder.append_query("/x", %{"a" => 1}) == "/x?a=1"
+    end
+
+    test "list values explode into repeated keys" do
+      result = OpenApiToolBuilder.append_query("/x", %{"sev" => ["a", "b"]})
+      assert result == "/x?sev=a&sev=b"
+    end
+  end
+end

--- a/test/trento/ai/tools_registry_test.exs
+++ b/test/trento/ai/tools_registry_test.exs
@@ -3,6 +3,7 @@
 
 defmodule Trento.AI.ToolsRegistryTest do
   use ExUnit.Case, async: true
+  use Trento.AI.AICase
 
   import Mox
 
@@ -15,14 +16,14 @@ defmodule Trento.AI.ToolsRegistryTest do
     @behaviour Trento.AI.ToolSource
 
     @impl true
-    def tools, do: [Function.new!(%{name: "a", function: fn _, _ -> "a" end})]
+    def tools(_opts), do: [Function.new!(%{name: "a", function: fn _, _ -> "a" end})]
   end
 
   defmodule SourceB do
     @behaviour Trento.AI.ToolSource
 
     @impl true
-    def tools,
+    def tools(_opts),
       do: [
         Function.new!(%{name: "b1", function: fn _, _ -> "b1" end}),
         Function.new!(%{name: "b2", function: fn _, _ -> "b2" end})
@@ -33,43 +34,67 @@ defmodule Trento.AI.ToolsRegistryTest do
     @behaviour Trento.AI.ToolSource
 
     @impl true
-    def tools, do: []
+    def tools(_opts), do: []
   end
 
-  defp expect_config(config) do
-    expect(Trento.AI.ApplicationConfigLoader.Mock, :load_config, fn -> config end)
+  defmodule OptsSource do
+    @behaviour Trento.AI.ToolSource
+
+    @impl true
+    def tools(opts) do
+      name = Keyword.fetch!(opts, :name)
+      [Function.new!(%{name: "#{name}_tool", function: fn _, _ -> name end})]
+    end
+  end
+
+  defp stub_config(config) do
+    stub(Trento.AI.ApplicationConfigLoader.Mock, :load_config, fn -> config end)
   end
 
   describe "tools/0" do
     test "flat-concats tools from every configured source in declaration order" do
-      expect_config(tool_sources: [SourceA, SourceB])
+      stub_config(tool_sources: [SourceA, SourceB])
 
       assert [%Function{name: "a"}, %Function{name: "b1"}, %Function{name: "b2"}] =
                ToolsRegistry.tools()
     end
 
     test "preserves declaration order across sources" do
-      expect_config(tool_sources: [SourceB, SourceA])
+      stub_config(tool_sources: [SourceB, SourceA])
 
       assert ["b1", "b2", "a"] = Enum.map(ToolsRegistry.tools(), & &1.name)
     end
 
     test "returns an empty list when :tool_sources is missing" do
-      expect_config([])
+      stub_config([])
 
       assert ToolsRegistry.tools() == []
     end
 
     test "returns an empty list when :tool_sources is an empty list" do
-      expect_config(tool_sources: [])
+      stub_config(tool_sources: [])
 
       assert ToolsRegistry.tools() == []
     end
 
     test "tolerates a source that returns no tools" do
-      expect_config(tool_sources: [EmptySource, SourceA])
+      stub_config(tool_sources: [EmptySource, SourceA])
 
       assert [%Function{name: "a"}] = ToolsRegistry.tools()
+    end
+  end
+
+  describe "{module, opts} entries" do
+    test "invokes tools/1 with opts when entry is a tuple" do
+      stub_config(tool_sources: [{OptsSource, name: :alpha}])
+
+      assert [%Function{name: "alpha_tool"}] = ToolsRegistry.tools()
+    end
+
+    test "supports mixed bare-module + tuple entries" do
+      stub_config(tool_sources: [SourceA, {OptsSource, name: :beta}])
+
+      assert ["a", "beta_tool"] = Enum.map(ToolsRegistry.tools(), & &1.name)
     end
   end
 end

--- a/test/trento_web/ai/controller_tool_source_test.exs
+++ b/test/trento_web/ai/controller_tool_source_test.exs
@@ -7,9 +7,9 @@ defmodule TrentoWeb.AI.ControllerToolSourceTest do
   alias LangChain.Function
   alias TrentoWeb.AI.{ControllerToolSource, McpRouteIndex}
 
-  describe "tools/0" do
+  describe "tools/1" do
     test "returns one %LangChain.Function{} per MCP-tagged route" do
-      tools = ControllerToolSource.tools()
+      tools = ControllerToolSource.tools([])
 
       assert is_list(tools)
       assert length(tools) == length(McpRouteIndex.entries())

--- a/test/trento_web/ai/controller_tool_test.exs
+++ b/test/trento_web/ai/controller_tool_test.exs
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule TrentoWeb.AI.ControllerToolTest do
-  alias TrentoWeb.V1.ClusterController
   use Trento.DataCase
 
   import Mox
@@ -51,58 +50,12 @@ defmodule TrentoWeb.AI.ControllerToolTest do
       assert dt == entry.display_text
     end
 
-    test "translates path UUID parameters into JSON schema strings with uuid format" do
-      entry = entry_for({V1.HostController, :query_metrics})
-
-      assert %Function{
-               parameters_schema: %{"properties" => properties, "required" => required}
-             } = ControllerTool.build(entry)
-
-      assert %{"type" => "string", "format" => "uuid"} = properties["id"]
-      assert %{"type" => "string"} = properties["query"]
-      assert "id" in required
-      assert "query" in required
-      refute "time" in required
-    end
-
     test "covers every catalog entry without crashing" do
       for entry <- McpRouteIndex.entries() do
         assert %Function{name: name, display_text: dt} = ControllerTool.build(entry)
         assert is_binary(name)
         assert is_binary(dt)
       end
-    end
-
-    test "carries OpenApiSpex Parameter-level description into the property schema" do
-      entry = entry_for({V1.HostController, :query_metrics})
-
-      assert %Function{parameters_schema: %{"properties" => properties}} =
-               ControllerTool.build(entry)
-
-      assert properties["id"]["description"] =~ "Unique identifier of the host"
-      assert properties["query"]["description"] =~ "PromQL query expression"
-    end
-
-    test "request body schema's `required` list wins over RequestBody.required flag" do
-      operation =
-        ClusterController.open_api_operation(:cluster_maintenance_change)
-
-      entry = %McpRouteIndex.Entry{
-        controller: ClusterController,
-        action: :cluster_maintenance_change,
-        tool_name: "synthetic_cmc",
-        display_text: "test",
-        operation: operation,
-        verb: :post,
-        path: "/api/v1/clusters/:id/operations/cluster_maintenance_change"
-      }
-
-      assert %Function{parameters_schema: %{"required" => required}} =
-               ControllerTool.build(entry)
-
-      assert "maintenance" in required
-      refute "resource_id" in required
-      refute "node_id" in required
     end
 
     test "Function.display_text falls back to entry.tool_name when entry.display_text is nil" do
@@ -149,6 +102,17 @@ defmodule TrentoWeb.AI.ControllerToolTest do
                |> invoke(%{}, %{scope: %Trento.Users.User{id: 999_999}})
 
       assert String.starts_with?(reason, "tool invocation failed")
+    end
+
+    test "returns a 403 error when the authenticated user lacks the required ability" do
+      user = insert(:user)
+
+      assert {:error, reason} =
+               {V1.UsersController, :show}
+               |> entry_for()
+               |> invoke(%{"id" => user.id}, %{scope: user})
+
+      assert String.starts_with?(reason, "403")
     end
   end
 
@@ -273,6 +237,27 @@ defmodule TrentoWeb.AI.ControllerToolTest do
 
       assert {:ok, decoded} = Jason.decode(body)
       assert decoded == []
+    end
+
+    test "rescues exceptions during routing/execution, logging the traceback and returning error tuple",
+         %{caller: caller} do
+      entry = %McpRouteIndex.Entry{
+        controller: V1.HostController,
+        action: :list,
+        tool_name: "synthetic_crash_tool",
+        display_text: "Crash Tool",
+        operation: %OpenApiSpex.Operation{
+          parameters: [
+            %OpenApiSpex.Parameter{name: :id, in: :path, required: true}
+          ],
+          responses: %{}
+        },
+        verb: :get,
+        path: nil
+      }
+
+      assert {:error, reason} = invoke(entry, %{"id" => "123"}, %{scope: caller})
+      assert reason =~ "tool invocation failed"
     end
   end
 end


### PR DESCRIPTION
# Description

This PR:
- bumps `Trento.AI.ToolSource` callback from `tools/0` to `tools/1` so sources can accept config (name, spec_url, etc.)
- `ToolsRegistry` normalises bare modules to `{module, []}`
- Extract `Trento.AI.OpenApiToolBuilder` from `TrentoWeb.AI.ControllerTool` so that remote-OpenAPI dispatchers (wanda related) can reuse the same schema logic
- add `:tool_context` opt to `Trento.AI.Agent.new!/1`so request-scoped data can flow to tools

Extracted from https://github.com/trento-project/web/pull/4364
Further refinement of `OpenApiToolBuilder` in https://github.com/trento-project/web/pull/4374

## How was this tested?

Automated and IRL.

## Did you update the documentation?

No need