### PR TITLE
Add remote OpenAPI tool source (wanda)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -323,7 +323,12 @@ config :trento, :ai,
   ],
   agent_server_adapter: Trento.Infrastructure.AI.SagentsAgentServer,
   agent_supervisor_adapter: Trento.Infrastructure.AI.SagentsDynamicSupervisor,
-  tool_sources: [TrentoWeb.AI.ControllerToolSource]
+  tool_sources: [
+    TrentoWeb.AI.ControllerToolSource,
+    {Trento.AI.RemoteOpenApiToolSource,
+     name: :wanda, spec_url: "http://localhost:4001/api/all/openapi"}
+  ],
+  http_client: Trento.Support.HttpClient
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -388,6 +388,13 @@ if config_env() in [:prod, :demo] do
       ]
   end
 
+  wanda_base_url = Application.get_env(:trento, :checks_service)[:base_url]
+
   config :trento, :ai,
-    base_system_prompt: Application.app_dir(:trento, "priv/ai/BASE_SYSTEM_PROMPT.md")
+    base_system_prompt: Application.app_dir(:trento, "priv/ai/BASE_SYSTEM_PROMPT.md"),
+    tool_sources: [
+      TrentoWeb.AI.ControllerToolSource,
+      {Trento.AI.RemoteOpenApiToolSource,
+       name: :wanda, spec_url: "#{wanda_base_url}/api/all/openapi"}
+    ]
 end

--- a/config/test.exs
+++ b/config/test.exs
@@ -165,6 +165,9 @@ config :trento,
        enabled?: System.get_env("WRITE_JUNIT") == "1"
 
 config :trento, :ai,
+  # Avoid the live Wanda fetch during tests. Individual tests opt in by
+  # overriding :tool_sources via ApplicationConfigLoader.Mock.
+  tool_sources: [TrentoWeb.AI.ControllerToolSource],
   providers: [
     provider1: [
       models: [

--- a/lib/trento/ai/open_api_tool_builder.ex
+++ b/lib/trento/ai/open_api_tool_builder.ex
@@ -14,10 +14,9 @@ defmodule Trento.AI.OpenApiToolBuilder do
      adapter (Anthropic, Google AI, OpenAI) eventually forwards to the
      model.
 
-  2. **Arg routing** — `param_locations/1`, `split_args/2`,
-     `substitute_path/2`, `append_query/2` turn the LLM-supplied
-     argument map into a `{path, body}` pair, respecting each parameter's
-     declared `in:` location.
+  2. **Arg routing** — `resolve_path_and_body/3` turns the LLM-supplied
+     argument map into a `{resolved_path, body_args}` pair, respecting
+     each parameter's declared `in:` location.
 
   Both `TrentoWeb.AI.ControllerTool` (local Plug.Test dispatch) and
   `Trento.AI.RemoteHttpTool` (remote HTTP dispatch) consume these helpers,
@@ -69,26 +68,43 @@ defmodule Trento.AI.OpenApiToolBuilder do
   def parameters_schema(_), do: %{"type" => "object", "properties" => %{}}
 
   @doc """
-  Map of parameter name (string) → declared `:in` location atom
-  (`:path | :query | :header | :cookie`) for an `%Operation{}`.
+  Resolves a path template and splits `tool_args` into `{resolved_path, body_args}`.
+  Combines `param_locations/1`, `split_args/2`, `substitute_path/2`, and `append_query/2`.
   """
-  @spec param_locations(Operation.t() | any()) :: %{String.t() => atom()}
-  def param_locations(%Operation{parameters: params}) when is_list(params) do
+  @spec resolve_path_and_body(String.t() | nil, Operation.t() | nil, map()) ::
+          {String.t() | nil, map()}
+  def resolve_path_and_body(path_template, operation, tool_args) do
+    {path_args, query_args, body_args} =
+      operation
+      |> param_locations()
+      |> split_args(tool_args)
+
+    resolved_path =
+      path_template
+      |> substitute_path(path_args)
+      |> append_query(query_args)
+
+    {resolved_path, body_args}
+  end
+
+  @doc """
+  Coerces a response body to `String.t()`. `nil` → `""`, binaries pass through,
+  anything else is `inspect`-ed.
+  """
+  @spec body_to_string(String.t() | nil | any()) :: String.t()
+  def body_to_string(nil), do: ""
+  def body_to_string(body) when is_binary(body), do: body
+  def body_to_string(other), do: inspect(other)
+
+  defp param_locations(%Operation{parameters: params}) when is_list(params) do
     Map.new(params, fn %Parameter{name: name, in: location} ->
       {to_string(name), location}
     end)
   end
 
-  def param_locations(_), do: %{}
+  defp param_locations(_), do: %{}
 
-  @doc """
-  Splits the LLM-supplied `tool_args` map into `{path, query, body}`
-  according to each key's declared `:in` location. Unknown keys (and any
-  non-`:path`/`:query` locations like `:header` or `:cookie`) land in the
-  body bucket.
-  """
-  @spec split_args(%{String.t() => atom()}, map()) :: {map(), map(), map()}
-  def split_args(locations, tool_args) do
+  defp split_args(locations, tool_args) do
     Enum.reduce(tool_args, {%{}, %{}, %{}}, fn {k, v}, {path_map, query_map, body_map} ->
       key = to_string(k)
 
@@ -100,17 +116,7 @@ defmodule Trento.AI.OpenApiToolBuilder do
     end)
   end
 
-  @doc """
-  Substitutes `:placeholder` (Phoenix-style) and `{placeholder}`
-  (OpenAPI-style) segments in the path template with URI-encoded values
-  from `path_args`.
-
-  Phoenix routes carry `:id`-style templates; OpenAPI specs carry
-  `{id}`-style templates. Supporting both lets the same helper drive both
-  local controller routes and remote OpenAPI-described endpoints.
-  """
-  @spec substitute_path(String.t(), map()) :: String.t()
-  def substitute_path(path_template, path_args) do
+  defp substitute_path(path_template, path_args) do
     Enum.reduce(path_args, path_template, fn {name, value}, acc ->
       encoded = URI.encode_www_form(to_string(value || ""))
 
@@ -120,14 +126,9 @@ defmodule Trento.AI.OpenApiToolBuilder do
     end)
   end
 
-  @doc """
-  Appends a `?k=v&...` query string to `path`. Array values explode into
-  repeated keys, matching OpenAPI 3 `style: form, explode: true`.
-  """
-  @spec append_query(String.t(), map()) :: String.t()
-  def append_query(path, query) when map_size(query) == 0, do: path
+  defp append_query(path, query) when map_size(query) == 0, do: path
 
-  def append_query(path, query) do
+  defp append_query(path, query) do
     query_string =
       query
       |> Enum.flat_map(&expand_query_pair/1)

--- a/lib/trento/ai/open_api_tool_builder.ex
+++ b/lib/trento/ai/open_api_tool_builder.ex
@@ -71,8 +71,7 @@ defmodule Trento.AI.OpenApiToolBuilder do
   Resolves a path template and splits `tool_args` into `{resolved_path, body_args}`.
   Combines `param_locations/1`, `split_args/2`, `substitute_path/2`, and `append_query/2`.
   """
-  @spec resolve_path_and_body(String.t() | nil, Operation.t() | nil, map()) ::
-          {String.t() | nil, map()}
+  @spec resolve_path_and_body(String.t(), Operation.t() | nil, map()) :: {String.t(), map()}
   def resolve_path_and_body(path_template, operation, tool_args) do
     {path_args, query_args, body_args} =
       operation

--- a/lib/trento/ai/operation_entry.ex
+++ b/lib/trento/ai/operation_entry.ex
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.AI.OperationEntry do
+  @moduledoc """
+  Transport-agnostic catalog entry shared by every `Trento.AI.ToolSource`
+  that derives AI tools from `%OpenApiSpex.Operation{}` structs.
+
+  Self-describing — the HTTP verb + path template are baked in at
+  construction time so dispatchers don't need to re-walk the source
+  document per tool call.
+
+  `TrentoWeb.AI.McpRouteIndex.Entry` is the local-controller counterpart
+  with two extra fields (`:controller`, `:action`). Remote sources use
+  this struct directly.
+  """
+
+  @enforce_keys [:tool_name, :operation, :verb, :path]
+  defstruct [:tool_name, :display_text, :operation, :verb, :path]
+
+  @type t :: %__MODULE__{
+          tool_name: String.t(),
+          display_text: String.t() | nil,
+          operation: OpenApiSpex.Operation.t(),
+          verb: atom(),
+          path: String.t()
+        }
+end

--- a/lib/trento/ai/remote_http_tool.ex
+++ b/lib/trento/ai/remote_http_tool.ex
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.AI.RemoteHttpTool do
+  @moduledoc """
+  Translates a `Trento.AI.OperationEntry` into a `%LangChain.Function{}`
+  whose execution dispatches an authenticated HTTP request against a
+  remote service described by its OpenAPI document.
+
+  This is the remote counterpart of `TrentoWeb.AI.ControllerTool`. Both
+  share `Trento.AI.OpenApiToolBuilder` for the transport-independent
+  pieces (description, parameters_schema, arg routing, path templating,
+  query encoding). Only the actual dispatch differs — `ControllerTool`
+  re-enters `TrentoWeb.Endpoint.call/2` via `Plug.Test`; this module
+  performs an outbound HTTP request via `HTTPoison`.
+
+  The JWT used to authenticate the websocket conversation is forwarded
+  to the remote service as an `Authorization: Bearer <token>` header.
+  Remote services that share an introspection endpoint with trento web
+  (e.g. wanda's `WandaWeb.Auth.AuthPlug`) authenticate the request as
+  the same user.
+
+  Arguments are routed by the operation's declared `:in` field
+  (`:path` / `:query` / body). Body args for non-GET verbs are
+  JSON-encoded and sent with `Content-Type: application/json`. GET
+  bodies are dropped — query args end up in the URL via
+  `OpenApiToolBuilder.append_query/2`.
+
+  Return convention mirrors `ControllerTool` so LangChain marks
+  `ToolResult.is_error` correctly:
+
+  - `{:ok, body_string}` for 2xx responses
+  - `{:error, "<status> <body>"}` for non-2xx responses
+  - `{:error, "tool invocation failed (<reason>)"}` for transport-level
+    failures or unexpected closure crashes
+  """
+
+  require Logger
+
+  alias LangChain.Function
+
+  alias Trento.AI.ApplicationConfigLoader
+  alias Trento.AI.{OpenApiToolBuilder, OperationEntry}
+  alias Trento.Support.HttpUtils
+
+  @default_recv_timeout 30_000
+
+  @doc """
+  Build a `%LangChain.Function{}` for the given entry. `base_url` is
+  the dispatch base supplied by the source (typically
+  `spec.servers[0].url`). When `base_url` carries an http/https scheme
+  it's used verbatim; otherwise the websocket request origin forwarded
+  through `tool_context.request_origin` is prepended at request time.
+  """
+  @spec build(OperationEntry.t(), String.t()) :: Function.t()
+  def build(
+        %OperationEntry{tool_name: tool_name, display_text: display_text, operation: operation} =
+          entry,
+        base_url
+      )
+      when is_binary(base_url) do
+    Function.new!(%{
+      name: tool_name,
+      display_text: display_text || tool_name,
+      description: OpenApiToolBuilder.description(operation),
+      parameters_schema: OpenApiToolBuilder.parameters_schema(operation),
+      function: fn args, context -> invoke(entry, base_url, args, context) end
+    })
+  end
+
+  defp invoke(
+         %OperationEntry{operation: operation, verb: verb, path: path_template} = entry,
+         base_url,
+         tool_args,
+         context
+       ) do
+    with {:ok, jwt} <- fetch_access_token(context) do
+      {resolved_path, body_args} =
+        OpenApiToolBuilder.resolve_path_and_body(path_template, operation, tool_args)
+
+      origin = fetch_request_origin(context)
+      dispatch_request(verb, base_url, resolved_path, body_args, jwt, origin)
+    end
+  rescue
+    exception ->
+      Logger.error(
+        "Remote AI tool #{entry.tool_name} crashed: " <>
+          Exception.format(:error, exception, __STACKTRACE__)
+      )
+
+      {:error, "tool invocation failed (#{Exception.message(exception)})"}
+  end
+
+  defp fetch_access_token(%{tool_context: %{access_token: token}})
+       when is_binary(token) and token != "",
+       do: {:ok, token}
+
+  defp fetch_access_token(_context),
+    do: {:error, "tool invocation failed (missing access_token in tool context)"}
+
+  defp fetch_request_origin(%{tool_context: %{request_origin: origin}}), do: origin
+  defp fetch_request_origin(_), do: nil
+
+  defp dispatch_request(verb, base_url, resolved_path, body_args, jwt, request_origin) do
+    url = HttpUtils.resolve_url(base_url, resolved_path, request_origin)
+    body = encode_body(verb, body_args)
+    headers = build_headers(jwt, body)
+    options = [recv_timeout: @default_recv_timeout]
+
+    verb
+    |> http_client().request(url, body, headers, options)
+    |> decode_response()
+  end
+
+  defp encode_body(verb, body_args)
+       when verb in [:get, :head] or map_size(body_args) == 0,
+       do: ""
+
+  defp encode_body(_verb, body_args), do: Jason.encode!(body_args)
+
+  defp build_headers(jwt, body) do
+    base = [
+      {"authorization", "Bearer #{jwt}"},
+      {"accept", "application/json"}
+    ]
+
+    if body != "" do
+      [{"content-type", "application/json"} | base]
+    else
+      base
+    end
+  end
+
+  defp decode_response({:ok, %HTTPoison.Response{status_code: status, body: body}})
+       when status in 200..299,
+       do: {:ok, OpenApiToolBuilder.body_to_string(body)}
+
+  defp decode_response({:ok, %HTTPoison.Response{status_code: status, body: body}}),
+    do: {:error, "#{status} #{OpenApiToolBuilder.body_to_string(body)}"}
+
+  defp decode_response({:error, %HTTPoison.Error{reason: reason}}),
+    do: {:error, "tool invocation failed (#{inspect(reason)})"}
+
+  defp decode_response(other),
+    do: {:error, "tool invocation failed (unexpected response #{inspect(other)})"}
+
+  defp http_client,
+    do: Keyword.fetch!(ApplicationConfigLoader.load(), :http_client)
+end

--- a/lib/trento/ai/remote_http_tool.ex
+++ b/lib/trento/ai/remote_http_tool.ex
@@ -24,7 +24,7 @@ defmodule Trento.AI.RemoteHttpTool do
   (`:path` / `:query` / body). Body args for non-GET verbs are
   JSON-encoded and sent with `Content-Type: application/json`. GET
   bodies are dropped — query args end up in the URL via
-  `OpenApiToolBuilder.append_query/2`.
+  `OpenApiToolBuilder.resolve_path_and_body/3`.
 
   Return convention mirrors `ControllerTool` so LangChain marks
   `ToolResult.is_error` correctly:

--- a/lib/trento/ai/remote_open_api_tool_source.ex
+++ b/lib/trento/ai/remote_open_api_tool_source.ex
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.AI.RemoteOpenApiToolSource do
+  @moduledoc """
+  `Trento.AI.ToolSource` implementation that derives AI assistant tools
+  from a remote service's OpenAPI document.
+
+  At `tools/1` time:
+
+  1. Fetch the spec from `:spec_url` (HTTP GET, JSON response).
+  2. Decode via `OpenApiSpex.OpenApi.Decode.decode/1` into the struct
+     hierarchy.
+  3. Walk every `(path, verb)` pair, keep operations whose `tags`
+     include `"MCP"`.
+  4. Build a `Trento.AI.OperationEntry` per operation. `tool_name` and
+     `display_text` follow the same fallback chain used locally:
+     `operation.extensions["x-ai-tool"]["name" | "display_text"]` →
+     `operation.operation_id` / `operation.summary` → derived
+     `\#{verb}_<slugified path>` / `tool_name`.
+  5. Extract the dispatch base URL from `spec.servers |> List.first()`'s
+     `:url` field.
+  6. Map each entry through `Trento.AI.RemoteHttpTool.build/2`, threading
+     that base URL into the dispatcher's closure.
+
+  ## Configuration
+
+      config :trento, :ai,
+        tool_sources: [
+          ...,
+          {Trento.AI.RemoteOpenApiToolSource,
+           name: :wanda,
+           spec_url: "http://localhost:4001/api/all/openapi"}
+        ]
+
+  The base URL used for tool invocations comes from `spec.servers[0].url`
+  in the fetched OpenAPI document — the spec itself is the source of
+  truth. Relative server URLs (no http/https scheme) are resolved against
+  `tool_context.request_origin` at request time — see
+  `Trento.AI.RemoteHttpTool`.
+
+  Spec-fetch failures, and specs missing a usable `servers[0].url`, are
+  logged and the source contributes `[]` for the current call; other
+  configured sources still surface their tools.
+  """
+
+  @behaviour Trento.AI.ToolSource
+
+  require Logger
+
+  alias Trento.AI.ApplicationConfigLoader
+  alias Trento.AI.{OperationEntry, RemoteHttpTool}
+
+  @verbs [:get, :put, :post, :delete, :options, :head, :patch, :trace]
+  @mcp_tag "MCP"
+  @x_ai_tool_extension "x-ai-tool"
+  @default_recv_timeout 15_000
+
+  @impl true
+  def tools(opts) do
+    name = Keyword.fetch!(opts, :name)
+    spec_url = Keyword.fetch!(opts, :spec_url)
+
+    case fetch_and_decode(spec_url) do
+      {:ok, spec} ->
+        build_tools(spec, name)
+
+      {:error, reason} ->
+        Logger.warning(
+          "Trento.AI.RemoteOpenApiToolSource[#{inspect(name)}]: spec fetch failed " <>
+            "(#{inspect(reason)}); this source contributes no tools for this call."
+        )
+
+        []
+    end
+  end
+
+  defp build_tools(spec, name) do
+    case extract_base_url(spec) do
+      {:ok, base_url} ->
+        spec
+        |> build_entries()
+        |> Enum.map(&RemoteHttpTool.build(&1, base_url))
+
+      {:error, reason} ->
+        Logger.warning("Trento.AI.RemoteOpenApiToolSource[#{inspect(name)}]: #{reason}")
+        []
+    end
+  end
+
+  defp extract_base_url(%OpenApiSpex.OpenApi{
+         servers: [%OpenApiSpex.Server{url: url} | _]
+       })
+       when is_binary(url) and url != "",
+       do: {:ok, url}
+
+  defp extract_base_url(_),
+    do: {:error, "spec missing servers[0].url; this source contributes no tools for this call."}
+
+  defp fetch_and_decode(spec_url) do
+    headers = [{"accept", "application/json"}]
+    options = [recv_timeout: @default_recv_timeout]
+
+    with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <-
+           http_client().get(spec_url, headers, options),
+         {:ok, json} <- Jason.decode(body) do
+      {:ok, OpenApiSpex.OpenApi.Decode.decode(json)}
+    else
+      {:ok, %HTTPoison.Response{status_code: status}} -> {:error, {:http_status, status}}
+      {:error, %HTTPoison.Error{reason: reason}} -> {:error, {:transport, reason}}
+      {:error, %Jason.DecodeError{} = err} -> {:error, {:invalid_json, err}}
+      other -> {:error, {:unexpected, other}}
+    end
+  end
+
+  defp build_entries(%OpenApiSpex.OpenApi{paths: paths}) when is_map(paths) do
+    for {path, %OpenApiSpex.PathItem{} = path_item} <- paths,
+        verb <- @verbs,
+        operation = Map.get(path_item, verb),
+        is_struct(operation, OpenApiSpex.Operation),
+        @mcp_tag in (operation.tags || []) do
+      build_entry(path, verb, operation)
+    end
+  end
+
+  defp build_entries(_), do: []
+
+  defp build_entry(path, verb, %OpenApiSpex.Operation{} = operation) do
+    overrides = ai_tool_overrides(operation)
+
+    %OperationEntry{
+      tool_name: tool_name(overrides, operation, verb, path),
+      display_text: display_text(overrides, operation),
+      operation: normalize_operation(operation),
+      verb: verb,
+      path: path
+    }
+  end
+
+  defp ai_tool_overrides(%OpenApiSpex.Operation{extensions: %{} = exts}) do
+    case Map.get(exts, @x_ai_tool_extension) do
+      %{} = m -> m
+      _ -> %{}
+    end
+  end
+
+  defp ai_tool_overrides(_), do: %{}
+
+  defp tool_name(%{"name" => name}, _operation, _verb, _path)
+       when is_binary(name) and name != "",
+       do: name
+
+  defp tool_name(_, %OpenApiSpex.Operation{operationId: op_id}, _verb, _path)
+       when is_binary(op_id) and op_id != "",
+       do: op_id
+
+  defp tool_name(_, _operation, verb, path), do: "#{verb}_#{slugify(path)}"
+
+  defp display_text(%{"display_text" => display}, _operation)
+       when is_binary(display) and display != "",
+       do: display
+
+  defp display_text(_, %OpenApiSpex.Operation{summary: summary})
+       when is_binary(summary) and summary != "",
+       do: summary
+
+  defp display_text(_, _), do: nil
+
+  # Mirror McpRouteIndex.build_entry/1 — Operation.deprecated is typed
+  # boolean but defaults to nil; dialyzer complains downstream.
+  defp normalize_operation(%OpenApiSpex.Operation{deprecated: nil} = op),
+    do: %{op | deprecated: false}
+
+  defp normalize_operation(op), do: op
+
+  defp slugify(path) do
+    path
+    |> String.replace(~r/[\/{}]+/, "_")
+    |> String.trim("_")
+    |> String.downcase()
+  end
+
+  defp http_client,
+    do: Keyword.fetch!(ApplicationConfigLoader.load(), :http_client)
+end

--- a/lib/trento/ai/remote_open_api_tool_source.ex
+++ b/lib/trento/ai/remote_open_api_tool_source.ex
@@ -51,7 +51,6 @@ defmodule Trento.AI.RemoteOpenApiToolSource do
   alias Trento.AI.ApplicationConfigLoader
   alias Trento.AI.{OperationEntry, RemoteHttpTool}
 
-  @verbs [:get, :put, :post, :delete, :options, :head, :patch, :trace]
   @mcp_tag "MCP"
   @x_ai_tool_extension "x-ai-tool"
   @default_recv_timeout 15_000
@@ -115,8 +114,7 @@ defmodule Trento.AI.RemoteOpenApiToolSource do
 
   defp build_entries(%OpenApiSpex.OpenApi{paths: paths}) when is_map(paths) do
     for {path, %OpenApiSpex.PathItem{} = path_item} <- paths,
-        verb <- @verbs,
-        operation = Map.get(path_item, verb),
+        {verb, operation} <- Map.from_struct(path_item),
         is_struct(operation, OpenApiSpex.Operation),
         @mcp_tag in (operation.tags || []) do
       build_entry(path, verb, operation)

--- a/lib/trento/ai/remote_open_api_tool_source.ex
+++ b/lib/trento/ai/remote_open_api_tool_source.ex
@@ -9,7 +9,7 @@ defmodule Trento.AI.RemoteOpenApiToolSource do
   At `tools/1` time:
 
   1. Fetch the spec from `:spec_url` (HTTP GET, JSON response).
-  2. Decode via `OpenApiSpex.OpenApi.Decode.decode/1` into the struct
+  2. Decode via `OpenApiSpex.OpenApi.from_map/1` into the struct
      hierarchy.
   3. Walk every `(path, verb)` pair, keep operations whose `tags`
      include `"MCP"`.
@@ -104,7 +104,7 @@ defmodule Trento.AI.RemoteOpenApiToolSource do
     with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <-
            http_client().get(spec_url, headers, options),
          {:ok, json} <- Jason.decode(body) do
-      {:ok, OpenApiSpex.OpenApi.Decode.decode(json)}
+      {:ok, OpenApiSpex.OpenApi.from_map(json)}
     else
       {:ok, %HTTPoison.Response{status_code: status}} -> {:error, {:http_status, status}}
       {:error, %HTTPoison.Error{reason: reason}} -> {:error, {:transport, reason}}

--- a/lib/trento/ai/remote_open_api_tool_source.ex
+++ b/lib/trento/ai/remote_open_api_tool_source.ex
@@ -16,8 +16,8 @@ defmodule Trento.AI.RemoteOpenApiToolSource do
   4. Build a `Trento.AI.OperationEntry` per operation. `tool_name` and
      `display_text` follow the same fallback chain used locally:
      `operation.extensions["x-ai-tool"]["name" | "display_text"]` →
-     `operation.operation_id` / `operation.summary` → derived
-     `\#{verb}_<slugified path>` / `tool_name`.
+     `operation.operationId` / `operation.summary` → derived
+     `#{verb}_<slugified path>` / `tool_name`.
   5. Extract the dispatch base URL from `spec.servers |> List.first()`'s
      `:url` field.
   6. Map each entry through `Trento.AI.RemoteHttpTool.build/2`, threading

--- a/lib/trento/ai/remote_open_api_tool_source.ex
+++ b/lib/trento/ai/remote_open_api_tool_source.ex
@@ -17,7 +17,7 @@ defmodule Trento.AI.RemoteOpenApiToolSource do
      `display_text` follow the same fallback chain used locally:
      `operation.extensions["x-ai-tool"]["name" | "display_text"]` →
      `operation.operationId` / `operation.summary` → derived
-     `#{verb}_<slugified path>` / `tool_name`.
+     `<verb>_<slugified path>` / `tool_name`.
   5. Extract the dispatch base URL from `spec.servers |> List.first()`'s
      `:url` field.
   6. Map each entry through `Trento.AI.RemoteHttpTool.build/2`, threading

--- a/lib/trento_web/ai/controller_tool.ex
+++ b/lib/trento_web/ai/controller_tool.ex
@@ -70,7 +70,9 @@ defmodule TrentoWeb.AI.ControllerTool do
          tool_args,
          %{scope: %User{id: user_id}} = _context
        ) do
-    {resolved_path, body_args} = resolve_path_and_body(path_template, operation, tool_args)
+    {resolved_path, body_args} =
+      OpenApiToolBuilder.resolve_path_and_body(path_template, operation, tool_args)
+
     dispatch_request(verb, resolved_path, body_args, user_id)
   rescue
     exception ->
@@ -116,29 +118,11 @@ defmodule TrentoWeb.AI.ControllerTool do
 
   defp maybe_put_json_content_type(conn, _), do: conn
 
-  defp resolve_path_and_body(path_template, operation, tool_args) do
-    {path_args, query_args, body_args} =
-      operation
-      |> OpenApiToolBuilder.param_locations()
-      |> OpenApiToolBuilder.split_args(tool_args)
-
-    resolved_path =
-      path_template
-      |> OpenApiToolBuilder.substitute_path(path_args)
-      |> OpenApiToolBuilder.append_query(query_args)
-
-    {resolved_path, body_args}
-  end
-
   defp decode_response(%Plug.Conn{status: status, resp_body: body}) when status in 200..299,
-    do: {:ok, body_to_string(body)}
+    do: {:ok, OpenApiToolBuilder.body_to_string(body)}
 
   defp decode_response(%Plug.Conn{status: status, resp_body: body}),
-    do: {:error, "#{status} #{body_to_string(body)}"}
+    do: {:error, "#{status} #{OpenApiToolBuilder.body_to_string(body)}"}
 
   defp decode_response(other), do: {:error, "unexpected response #{inspect(other)}"}
-
-  defp body_to_string(nil), do: ""
-  defp body_to_string(body) when is_binary(body), do: body
-  defp body_to_string(other), do: inspect(other)
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -188,7 +188,8 @@ defmodule Trento.Factory do
 
   alias TrentoWeb.Auth.PersonalAccessToken, as: PAT
 
-  alias Trento.AI.{LLMRegistry, UserConfiguration}
+  alias OpenApiSpex.Operation
+  alias Trento.AI.{LLMRegistry, OperationEntry, UserConfiguration}
 
   alias Trento.AI.AICase
 
@@ -1482,6 +1483,21 @@ defmodule Trento.Factory do
       check_id: Faker.UUID.v4(),
       group_id: Faker.UUID.v4(),
       target_type: Enum.random(["host", "cluster"])
+    }
+  end
+
+  def operation_entry_factory do
+    %OperationEntry{
+      tool_name: Faker.Internet.slug(),
+      display_text: Faker.Lorem.sentence(),
+      operation: %Operation{
+        summary: Faker.Lorem.sentence(),
+        description: Faker.Lorem.paragraph(),
+        parameters: [],
+        responses: %{}
+      },
+      verb: :get,
+      path: "/#{Faker.Internet.slug()}"
     }
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -79,7 +79,8 @@ default_ai_config = Application.get_env(:trento, :ai, [])
 test_ai_config = [
   application_config_loader: Trento.AI.ApplicationConfigLoader.Mock,
   agent_server_adapter: Trento.AI.Agent.Server.Mock,
-  agent_supervisor_adapter: Trento.AI.Agent.Supervisor.Mock
+  agent_supervisor_adapter: Trento.AI.Agent.Supervisor.Mock,
+  http_client: Trento.Support.HttpClient.Mock
 ]
 
 Application.put_env(:trento, :ai, Keyword.merge(default_ai_config, test_ai_config))

--- a/test/trento/ai/open_api_tool_builder_test.exs
+++ b/test/trento/ai/open_api_tool_builder_test.exs
@@ -150,33 +150,8 @@ defmodule Trento.AI.OpenApiToolBuilderTest do
     end
   end
 
-  describe "param_locations/1" do
-    test "returns a map of string parameter names to their declared location" do
-      op = %Operation{
-        parameters: [
-          %Parameter{name: :id, in: :path},
-          %Parameter{name: "verbose", in: :query}
-        ],
-        responses: %{}
-      }
-
-      assert OpenApiToolBuilder.param_locations(op) == %{
-               "id" => :path,
-               "verbose" => :query
-             }
-    end
-
-    test "returns an empty map for an empty parameter list" do
-      assert OpenApiToolBuilder.param_locations(%Operation{parameters: [], responses: %{}}) == %{}
-    end
-
-    test "returns an empty map for non-operation input" do
-      assert OpenApiToolBuilder.param_locations(nil) == %{}
-    end
-  end
-
-  describe "param_locations/1 + split_args/2" do
-    test "buckets args by declared :in field; unknown keys land in body" do
+  describe "resolve_path_and_body/3" do
+    test "routes path param into URL, query param into URL, body param into body map" do
       op = %Operation{
         parameters: [
           %Parameter{name: :id, in: :path, required: true, schema: %Schema{type: :string}},
@@ -185,14 +160,12 @@ defmodule Trento.AI.OpenApiToolBuilderTest do
         responses: %{}
       }
 
-      locations = OpenApiToolBuilder.param_locations(op)
-
-      assert {%{"id" => "abc"}, %{"limit" => 10}, %{"extra" => "x"}} =
-               OpenApiToolBuilder.split_args(locations, %{
-                 "id" => "abc",
-                 "limit" => 10,
-                 "extra" => "x"
-               })
+      assert {"/api/users/abc?limit=10", %{"extra" => "x"}} =
+               OpenApiToolBuilder.resolve_path_and_body(
+                 "/api/users/:id",
+                 op,
+                 %{"id" => "abc", "limit" => 10, "extra" => "x"}
+               )
     end
 
     test "atom keys in args are stringified" do
@@ -203,46 +176,91 @@ defmodule Trento.AI.OpenApiToolBuilderTest do
         responses: %{}
       }
 
-      locations = OpenApiToolBuilder.param_locations(op)
-
-      assert {%{"id" => "abc"}, %{}, %{}} =
-               OpenApiToolBuilder.split_args(locations, %{id: "abc"})
+      assert {"/api/users/abc", %{}} =
+               OpenApiToolBuilder.resolve_path_and_body("/api/users/:id", op, %{id: "abc"})
     end
-  end
 
-  describe "substitute_path/2" do
+    test "no declared params — all args land in body, path unchanged" do
+      op = %Operation{parameters: [], responses: %{}}
+
+      assert {"/api/things", %{"foo" => "bar"}} =
+               OpenApiToolBuilder.resolve_path_and_body("/api/things", op, %{"foo" => "bar"})
+    end
+
+    test "nil operation — all args land in body, path unchanged" do
+      assert {"/api/things", %{"foo" => "bar"}} =
+               OpenApiToolBuilder.resolve_path_and_body("/api/things", nil, %{"foo" => "bar"})
+    end
+
     test "fills :placeholder segments (Phoenix style)" do
-      assert OpenApiToolBuilder.substitute_path("/api/users/:id", %{"id" => "alice"}) ==
-               "/api/users/alice"
+      op = %Operation{
+        parameters: [%Parameter{name: :id, in: :path, schema: %Schema{type: :string}}],
+        responses: %{}
+      }
+
+      assert {"/api/users/alice", %{}} =
+               OpenApiToolBuilder.resolve_path_and_body("/api/users/:id", op, %{"id" => "alice"})
     end
 
     test "fills {placeholder} segments (OpenAPI style)" do
-      assert OpenApiToolBuilder.substitute_path("/api/users/{id}", %{"id" => "alice"}) ==
-               "/api/users/alice"
+      op = %Operation{
+        parameters: [%Parameter{name: :id, in: :path, schema: %Schema{type: :string}}],
+        responses: %{}
+      }
+
+      assert {"/api/users/alice", %{}} =
+               OpenApiToolBuilder.resolve_path_and_body("/api/users/{id}", op, %{"id" => "alice"})
     end
 
-    test "URI-encodes values" do
-      assert OpenApiToolBuilder.substitute_path("/api/users/{id}", %{"id" => "a b/c"}) ==
-               "/api/users/a+b%2Fc"
+    test "URI-encodes path values" do
+      op = %Operation{
+        parameters: [%Parameter{name: :id, in: :path, schema: %Schema{type: :string}}],
+        responses: %{}
+      }
+
+      assert {"/api/users/a+b%2Fc", %{}} =
+               OpenApiToolBuilder.resolve_path_and_body(
+                 "/api/users/{id}",
+                 op,
+                 %{"id" => "a b/c"}
+               )
     end
 
-    test "treats nil values as empty" do
-      assert OpenApiToolBuilder.substitute_path("/x/:id", %{"id" => nil}) == "/x/"
-    end
-  end
+    test "nil path param value substitutes to empty string" do
+      op = %Operation{
+        parameters: [%Parameter{name: :id, in: :path, schema: %Schema{type: :string}}],
+        responses: %{}
+      }
 
-  describe "append_query/2" do
-    test "no query → unchanged path" do
-      assert OpenApiToolBuilder.append_query("/x", %{}) == "/x"
-    end
-
-    test "scalar values → ?k=v" do
-      assert OpenApiToolBuilder.append_query("/x", %{"a" => 1}) == "/x?a=1"
+      assert {"/x/", %{}} =
+               OpenApiToolBuilder.resolve_path_and_body("/x/:id", op, %{"id" => nil})
     end
 
-    test "list values explode into repeated keys" do
-      result = OpenApiToolBuilder.append_query("/x", %{"sev" => ["a", "b"]})
-      assert result == "/x?sev=a&sev=b"
+    test "no query params — path has no query string" do
+      op = %Operation{parameters: [], responses: %{}}
+
+      assert {"/x", %{}} =
+               OpenApiToolBuilder.resolve_path_and_body("/x", op, %{})
+    end
+
+    test "scalar query param appended as ?k=v" do
+      op = %Operation{
+        parameters: [%Parameter{name: :a, in: :query, schema: %Schema{type: :integer}}],
+        responses: %{}
+      }
+
+      assert {"/x?a=1", %{}} =
+               OpenApiToolBuilder.resolve_path_and_body("/x", op, %{"a" => 1})
+    end
+
+    test "list query param explodes into repeated keys" do
+      op = %Operation{
+        parameters: [%Parameter{name: :sev, in: :query, schema: %Schema{type: :string}}],
+        responses: %{}
+      }
+
+      assert {"/x?sev=a&sev=b", %{}} =
+               OpenApiToolBuilder.resolve_path_and_body("/x", op, %{"sev" => ["a", "b"]})
     end
   end
 end

--- a/test/trento/ai/remote_http_tool_test.exs
+++ b/test/trento/ai/remote_http_tool_test.exs
@@ -6,50 +6,40 @@ defmodule Trento.AI.RemoteHttpToolTest do
   use Trento.AI.AICase
 
   import Mox
+  import Trento.Factory
 
   alias LangChain.Function
-  alias OpenApiSpex.{Operation, Parameter, Schema}
-  alias Trento.AI.{OperationEntry, RemoteHttpTool}
+  alias OpenApiSpex.{Parameter, Schema}
+  alias Trento.AI.RemoteHttpTool
   alias Trento.Support.HttpClient
 
   setup :verify_on_exit!
 
   @base_url "http://wanda"
 
-  defp entry(verb, path, parameters \\ []) do
-    %OperationEntry{
-      tool_name: "test_tool",
-      display_text: "Test Tool",
-      operation: %Operation{
-        summary: "test",
-        description: "desc",
-        parameters: parameters,
-        responses: %{}
-      },
-      verb: verb,
-      path: path
-    }
-  end
-
   defp context(jwt, request_origin \\ nil),
     do: %{tool_context: %{access_token: jwt, request_origin: request_origin}}
 
   describe "build/2 — function metadata" do
     test "wires tool_name, display_text, description, parameters_schema, function" do
+      e = build(:operation_entry, verb: :get, path: "/x")
+      tool_name = e.tool_name
+      display_text = e.display_text
+
       assert %Function{
-               name: "test_tool",
-               display_text: "Test Tool",
-               description: "test\n\ndesc",
+               name: ^tool_name,
+               display_text: ^display_text,
                parameters_schema: %{"type" => "object"},
                function: function
-             } = RemoteHttpTool.build(entry(:get, "/x"), @base_url)
+             } = RemoteHttpTool.build(e, @base_url)
 
       assert is_function(function, 2)
     end
 
     test "falls back to tool_name when display_text is nil" do
-      e = %{entry(:get, "/x") | display_text: nil}
-      assert %Function{display_text: "test_tool"} = RemoteHttpTool.build(e, @base_url)
+      e = %{build(:operation_entry, verb: :get, path: "/x") | display_text: nil}
+      tool_name = e.tool_name
+      assert %Function{display_text: ^tool_name} = RemoteHttpTool.build(e, @base_url)
     end
   end
 
@@ -66,10 +56,22 @@ defmodule Trento.AI.RemoteHttpToolTest do
       end)
 
       e =
-        entry(:get, "/api/v1/users/{id}", [
-          %Parameter{name: :id, in: :path, required: true, schema: %Schema{type: :string}},
-          %Parameter{name: :limit, in: :query, required: false, schema: %Schema{type: :integer}}
-        ])
+        build(:operation_entry,
+          verb: :get,
+          path: "/api/v1/users/{id}",
+          operation: %OpenApiSpex.Operation{
+            parameters: [
+              %Parameter{name: :id, in: :path, required: true, schema: %Schema{type: :string}},
+              %Parameter{
+                name: :limit,
+                in: :query,
+                required: false,
+                schema: %Schema{type: :integer}
+              }
+            ],
+            responses: %{}
+          }
+        )
 
       assert {:ok, ~s({"ok":true})} =
                e
@@ -87,9 +89,21 @@ defmodule Trento.AI.RemoteHttpToolTest do
       end)
 
       e =
-        entry(:post, "/api/v1/groups/{group_id}/start", [
-          %Parameter{name: :group_id, in: :path, required: true, schema: %Schema{type: :string}}
-        ])
+        build(:operation_entry,
+          verb: :post,
+          path: "/api/v1/groups/{group_id}/start",
+          operation: %OpenApiSpex.Operation{
+            parameters: [
+              %Parameter{
+                name: :group_id,
+                in: :path,
+                required: true,
+                schema: %Schema{type: :string}
+              }
+            ],
+            responses: %{}
+          }
+        )
 
       assert {:ok, _} =
                e
@@ -108,7 +122,7 @@ defmodule Trento.AI.RemoteHttpToolTest do
       end)
 
       assert {:error, msg} =
-               entry(:get, "/x")
+               build(:operation_entry, verb: :get, path: "/x")
                |> RemoteHttpTool.build(@base_url)
                |> Function.execute(%{}, context("JWT"))
 
@@ -122,7 +136,7 @@ defmodule Trento.AI.RemoteHttpToolTest do
       end)
 
       assert {:error, "500 boom"} =
-               entry(:get, "/x")
+               build(:operation_entry, verb: :get, path: "/x")
                |> RemoteHttpTool.build(@base_url)
                |> Function.execute(%{}, context("JWT"))
     end
@@ -133,7 +147,7 @@ defmodule Trento.AI.RemoteHttpToolTest do
       end)
 
       assert {:error, msg} =
-               entry(:get, "/x")
+               build(:operation_entry, verb: :get, path: "/x")
                |> RemoteHttpTool.build(@base_url)
                |> Function.execute(%{}, context("JWT"))
 
@@ -143,7 +157,7 @@ defmodule Trento.AI.RemoteHttpToolTest do
 
     test "refuses to dispatch when access_token missing from tool_context" do
       assert {:error, msg} =
-               entry(:get, "/x")
+               build(:operation_entry, verb: :get, path: "/x")
                |> RemoteHttpTool.build(@base_url)
                |> Function.execute(%{}, %{tool_context: %{}})
 
@@ -152,7 +166,7 @@ defmodule Trento.AI.RemoteHttpToolTest do
 
     test "refuses to dispatch when context has no tool_context at all" do
       assert {:error, msg} =
-               entry(:get, "/x")
+               build(:operation_entry, verb: :get, path: "/x")
                |> RemoteHttpTool.build(@base_url)
                |> Function.execute(%{}, %{scope: nil})
 
@@ -168,7 +182,7 @@ defmodule Trento.AI.RemoteHttpToolTest do
       end)
 
       assert {:ok, _} =
-               entry(:get, "/x")
+               build(:operation_entry, verb: :get, path: "/x")
                |> RemoteHttpTool.build("/wanda")
                |> Function.execute(%{}, context("JWT", "https://trento.example.com"))
     end

--- a/test/trento/ai/remote_http_tool_test.exs
+++ b/test/trento/ai/remote_http_tool_test.exs
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.AI.RemoteHttpToolTest do
+  use ExUnit.Case, async: false
+  use Trento.AI.AICase
+
+  import Mox
+
+  alias LangChain.Function
+  alias OpenApiSpex.{Operation, Parameter, Schema}
+  alias Trento.AI.{OperationEntry, RemoteHttpTool}
+  alias Trento.Support.HttpClient
+
+  setup :verify_on_exit!
+
+  @base_url "http://wanda"
+
+  defp entry(verb, path, parameters \\ []) do
+    %OperationEntry{
+      tool_name: "test_tool",
+      display_text: "Test Tool",
+      operation: %Operation{
+        summary: "test",
+        description: "desc",
+        parameters: parameters,
+        responses: %{}
+      },
+      verb: verb,
+      path: path
+    }
+  end
+
+  defp context(jwt, request_origin \\ nil),
+    do: %{tool_context: %{access_token: jwt, request_origin: request_origin}}
+
+  describe "build/2 — function metadata" do
+    test "wires tool_name, display_text, description, parameters_schema, function" do
+      assert %Function{
+               name: "test_tool",
+               display_text: "Test Tool",
+               description: "test\n\ndesc",
+               parameters_schema: %{"type" => "object"},
+               function: function
+             } = RemoteHttpTool.build(entry(:get, "/x"), @base_url)
+
+      assert is_function(function, 2)
+    end
+
+    test "falls back to tool_name when display_text is nil" do
+      e = %{entry(:get, "/x") | display_text: nil}
+      assert %Function{display_text: "test_tool"} = RemoteHttpTool.build(e, @base_url)
+    end
+  end
+
+  describe "dispatch — happy path" do
+    test "GET with path placeholder + query param + Bearer header" do
+      expect(HttpClient.Mock, :request, fn :get, url, body, headers, _opts ->
+        assert url == "http://wanda/api/v1/users/42?limit=10"
+        assert body == ""
+        assert {"authorization", "Bearer JWT123"} in headers
+        assert {"accept", "application/json"} in headers
+        refute Enum.any?(headers, fn {k, _} -> k == "content-type" end)
+
+        {:ok, %HTTPoison.Response{status_code: 200, body: ~s({"ok":true})}}
+      end)
+
+      e =
+        entry(:get, "/api/v1/users/{id}", [
+          %Parameter{name: :id, in: :path, required: true, schema: %Schema{type: :string}},
+          %Parameter{name: :limit, in: :query, required: false, schema: %Schema{type: :integer}}
+        ])
+
+      assert {:ok, ~s({"ok":true})} =
+               e
+               |> RemoteHttpTool.build(@base_url)
+               |> Function.execute(%{"id" => "42", "limit" => 10}, context("JWT123"))
+    end
+
+    test "POST body args JSON-encoded with content-type header" do
+      expect(HttpClient.Mock, :request, fn :post, url, body, headers, _opts ->
+        assert url == "http://wanda/api/v1/groups/g1/start"
+        assert {:ok, %{"checks" => ["c1", "c2"]}} = Jason.decode(body)
+        assert {"content-type", "application/json"} in headers
+
+        {:ok, %HTTPoison.Response{status_code: 202, body: ~s({"accepted":true})}}
+      end)
+
+      e =
+        entry(:post, "/api/v1/groups/{group_id}/start", [
+          %Parameter{name: :group_id, in: :path, required: true, schema: %Schema{type: :string}}
+        ])
+
+      assert {:ok, _} =
+               e
+               |> RemoteHttpTool.build(@base_url)
+               |> Function.execute(
+                 %{"group_id" => "g1", "checks" => ["c1", "c2"]},
+                 context("JWT")
+               )
+    end
+  end
+
+  describe "dispatch — error paths" do
+    test "returns tagged error for 4xx" do
+      expect(HttpClient.Mock, :request, fn _, _, _, _, _ ->
+        {:ok, %HTTPoison.Response{status_code: 404, body: ~s({"error":"not found"})}}
+      end)
+
+      assert {:error, msg} =
+               entry(:get, "/x")
+               |> RemoteHttpTool.build(@base_url)
+               |> Function.execute(%{}, context("JWT"))
+
+      assert msg =~ "404"
+      assert msg =~ "not found"
+    end
+
+    test "returns tagged error for 5xx" do
+      expect(HttpClient.Mock, :request, fn _, _, _, _, _ ->
+        {:ok, %HTTPoison.Response{status_code: 500, body: "boom"}}
+      end)
+
+      assert {:error, "500 boom"} =
+               entry(:get, "/x")
+               |> RemoteHttpTool.build(@base_url)
+               |> Function.execute(%{}, context("JWT"))
+    end
+
+    test "returns tool-invocation-failed on transport error" do
+      expect(HttpClient.Mock, :request, fn _, _, _, _, _ ->
+        {:error, %HTTPoison.Error{reason: :nxdomain}}
+      end)
+
+      assert {:error, msg} =
+               entry(:get, "/x")
+               |> RemoteHttpTool.build(@base_url)
+               |> Function.execute(%{}, context("JWT"))
+
+      assert msg =~ "tool invocation failed"
+      assert msg =~ "nxdomain"
+    end
+
+    test "refuses to dispatch when access_token missing from tool_context" do
+      assert {:error, msg} =
+               entry(:get, "/x")
+               |> RemoteHttpTool.build(@base_url)
+               |> Function.execute(%{}, %{tool_context: %{}})
+
+      assert msg =~ "missing access_token"
+    end
+
+    test "refuses to dispatch when context has no tool_context at all" do
+      assert {:error, msg} =
+               entry(:get, "/x")
+               |> RemoteHttpTool.build(@base_url)
+               |> Function.execute(%{}, %{scope: nil})
+
+      assert msg =~ "missing access_token"
+    end
+  end
+
+  describe "dispatch — URL resolution from base_url + request_origin" do
+    test "prepends request_origin when base_url is relative" do
+      expect(HttpClient.Mock, :request, fn :get, url, _body, _headers, _opts ->
+        assert url == "https://trento.example.com/wanda/x"
+        {:ok, %HTTPoison.Response{status_code: 200, body: ""}}
+      end)
+
+      assert {:ok, _} =
+               entry(:get, "/x")
+               |> RemoteHttpTool.build("/wanda")
+               |> Function.execute(%{}, context("JWT", "https://trento.example.com"))
+    end
+  end
+end

--- a/test/trento/ai/remote_open_api_tool_source_test.exs
+++ b/test/trento/ai/remote_open_api_tool_source_test.exs
@@ -1,0 +1,225 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.AI.RemoteOpenApiToolSourceTest do
+  use ExUnit.Case, async: true
+  use Trento.AI.AICase
+
+  import Mox
+
+  import ExUnit.CaptureLog
+
+  alias LangChain.Function
+  alias Trento.AI.RemoteOpenApiToolSource
+  alias Trento.Support.HttpClient
+
+  setup :verify_on_exit!
+
+  defp synthetic_spec do
+    %{
+      "openapi" => "3.0.0",
+      "info" => %{"title" => "Wanda", "version" => "1"},
+      "servers" => [%{"url" => "http://wanda"}],
+      "paths" => %{
+        "/api/v1/groups/{group_id}/checks" => %{
+          "get" => %{
+            "operationId" => "selectable_checks_default",
+            "summary" => "Selectable checks",
+            "description" => "List checks for a group.",
+            "tags" => ["Catalog", "MCP"],
+            "x-ai-tool" => %{
+              "name" => "selectable_checks",
+              "display_text" => "Selectable Checks"
+            },
+            "parameters" => [
+              %{
+                "name" => "group_id",
+                "in" => "path",
+                "required" => true,
+                "schema" => %{"type" => "string", "format" => "uuid"}
+              }
+            ],
+            "responses" => %{"200" => %{"description" => "ok"}}
+          }
+        },
+        "/api/v2/checks/executions" => %{
+          "get" => %{
+            "operationId" => "list_executions",
+            "summary" => "List executions",
+            "tags" => ["Checks", "MCP"],
+            "parameters" => [],
+            "responses" => %{"200" => %{"description" => "ok"}}
+          }
+        },
+        "/api/v2/internal" => %{
+          "get" => %{
+            "operationId" => "internal_only",
+            "summary" => "Internal",
+            "tags" => ["Internal"],
+            "parameters" => [],
+            "responses" => %{"200" => %{"description" => "ok"}}
+          }
+        },
+        "/api/v2/no-op-id" => %{
+          "post" => %{
+            "summary" => "No op id",
+            "tags" => ["MCP"],
+            "parameters" => [],
+            "responses" => %{"202" => %{"description" => "ok"}}
+          }
+        }
+      }
+    }
+  end
+
+  defp expect_spec_fetch_ok(spec \\ synthetic_spec()) do
+    expect(HttpClient.Mock, :get, fn _url, _headers, _opts ->
+      {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(spec)}}
+    end)
+  end
+
+  defp source_opts(extra \\ []) do
+    Keyword.merge(
+      [
+        name: :wanda_test,
+        spec_url: "http://wanda/api/all/openapi"
+      ],
+      extra
+    )
+  end
+
+  describe "tools/1 — fallback chain" do
+    test "uses x-ai-tool.name and display_text when present" do
+      expect_spec_fetch_ok()
+
+      tools = RemoteOpenApiToolSource.tools(source_opts())
+
+      assert tool = Enum.find(tools, &(&1.name == "selectable_checks"))
+      assert %Function{display_text: "Selectable Checks"} = tool
+      assert tool.description =~ "Selectable checks"
+      assert tool.description =~ "List checks for a group."
+    end
+
+    test "falls back to operationId + summary when x-ai-tool missing" do
+      expect_spec_fetch_ok()
+
+      tools = RemoteOpenApiToolSource.tools(source_opts())
+
+      assert tool = Enum.find(tools, &(&1.name == "list_executions"))
+      assert %Function{display_text: "List executions"} = tool
+    end
+
+    test "falls back to verb_path when operationId also missing" do
+      expect_spec_fetch_ok()
+
+      tools = RemoteOpenApiToolSource.tools(source_opts())
+
+      assert tool = Enum.find(tools, &(&1.name == "post_api_v2_no-op-id"))
+      assert %Function{display_text: "No op id"} = tool
+    end
+
+    test "filters out operations without the MCP tag" do
+      expect_spec_fetch_ok()
+
+      tools = RemoteOpenApiToolSource.tools(source_opts())
+
+      refute Enum.any?(tools, &(&1.name == "internal_only"))
+    end
+  end
+
+  describe "tools/1 — parameters_schema propagation" do
+    test "remote operation parameters surface in the tool's parameters_schema" do
+      expect_spec_fetch_ok()
+
+      tools = RemoteOpenApiToolSource.tools(source_opts())
+
+      tool = Enum.find(tools, &(&1.name == "selectable_checks"))
+
+      assert %{
+               "type" => "object",
+               "properties" => %{"group_id" => %{"type" => "string", "format" => "uuid"}},
+               "required" => ["group_id"]
+             } = tool.parameters_schema
+    end
+  end
+
+  describe "tools/1 — failure modes" do
+    test "returns [] when spec endpoint returns non-200" do
+      expect(HttpClient.Mock, :get, fn _, _, _ ->
+        {:ok, %HTTPoison.Response{status_code: 503, body: ""}}
+      end)
+
+      assert [] = RemoteOpenApiToolSource.tools(source_opts())
+    end
+
+    test "returns [] on transport error" do
+      expect(HttpClient.Mock, :get, fn _, _, _ ->
+        {:error, %HTTPoison.Error{reason: :timeout}}
+      end)
+
+      assert [] = RemoteOpenApiToolSource.tools(source_opts())
+    end
+
+    test "returns [] on invalid JSON body" do
+      expect(HttpClient.Mock, :get, fn _, _, _ ->
+        {:ok, %HTTPoison.Response{status_code: 200, body: "not json"}}
+      end)
+
+      assert [] = RemoteOpenApiToolSource.tools(source_opts())
+    end
+  end
+
+  describe "tools/1 — base_url extraction from servers[0].url" do
+    test "returns [] and logs when spec has no servers key" do
+      spec = Map.delete(synthetic_spec(), "servers")
+      expect_spec_fetch_ok(spec)
+
+      log =
+        capture_log(fn ->
+          assert [] = RemoteOpenApiToolSource.tools(source_opts())
+        end)
+
+      assert log =~ "missing servers[0].url"
+    end
+
+    test "returns [] and logs when servers list is empty" do
+      spec = Map.put(synthetic_spec(), "servers", [])
+      expect_spec_fetch_ok(spec)
+
+      log =
+        capture_log(fn ->
+          assert [] = RemoteOpenApiToolSource.tools(source_opts())
+        end)
+
+      assert log =~ "missing servers[0].url"
+    end
+
+    test "returns [] and logs when servers[0].url is nil" do
+      spec = Map.put(synthetic_spec(), "servers", [%{"url" => nil}])
+      expect_spec_fetch_ok(spec)
+
+      log =
+        capture_log(fn ->
+          assert [] = RemoteOpenApiToolSource.tools(source_opts())
+        end)
+
+      assert log =~ "missing servers[0].url"
+    end
+
+    test "extracted base_url is used as dispatch prefix" do
+      spec = Map.put(synthetic_spec(), "servers", [%{"url" => "http://elsewhere.example"}])
+      expect_spec_fetch_ok(spec)
+
+      expect(HttpClient.Mock, :request, fn :get, url, _body, _headers, _opts ->
+        assert String.starts_with?(url, "http://elsewhere.example/")
+        {:ok, %HTTPoison.Response{status_code: 200, body: ~s({"ok":true})}}
+      end)
+
+      tools = RemoteOpenApiToolSource.tools(source_opts())
+      tool = Enum.find(tools, &(&1.name == "selectable_checks"))
+
+      ctx = %{tool_context: %{access_token: "JWT", request_origin: nil}}
+      assert {:ok, _} = Function.execute(tool, %{"group_id" => "g1"}, ctx)
+    end
+  end
+end


### PR DESCRIPTION
# Description

This PR introduces:
- `Trento.AI.RemoteOpenApiToolSource` responsible to fetch an OpenAPI spec from a remote service and build one AI tool per operation having the `x-ai-tool` extension
- `Trento.AI.RemoteHttpTool` builds a `%LangChain.Function{}` that dispatches HTTP requests. 
  - Uses `access_token` forwarded via `tool_context`
  - resolves relative base URLs against the websocket request origin (base_url extracted from remote OAS)
- extracts path resolution to `OpenApiToolBuilder` common to internal and remote openapi tools

Note: `Trento.AI.OperationEntry` differs from `TrentoWeb.AI.McpRouteIndex.Entry` by only two fields.
Further unification refactor is left out of scope from here.

Extracted from https://github.com/trento-project/web/pull/4364

## How was this tested?

Automatic and IRL.

## Did you update the documentation?

Not needed.