### PR TITLE
AI socket: thread access_token + request_origin into tool_context

### DIFF
--- a/lib/trento_web/channels/ai_assistant_channel.ex
+++ b/lib/trento_web/channels/ai_assistant_channel.ex
@@ -19,6 +19,8 @@ defmodule TrentoWeb.AIAssistantChannel do
   | Assign | Type | Lifetime | Why |
   |---|---|---|---|
   | `:current_user_id` | integer | from `UserSocket.connect` | auth + identifies the authenticated user |
+  | `:access_token` | string | from `UserSocket.connect` | raw JWT, forwarded to remote AI tools via `tool_context.access_token` so wanda etc. can authenticate the user on outbound calls |
+  | `:request_origin` | string \| nil | from `UserSocket.connect` | scheme + host + port of the websocket request, forwarded via `tool_context.request_origin` so `Trento.AI.RemoteHttpTool` can resolve partial `:checks_service` base URLs (e.g. `/wanda`) against the same origin the browser used |
   | `:current_scope` | `%Trento.Users.User{id: id}` | from `join/3` | passed to `Sagents.Agent.new!` as `:scope` so tool callbacks see `context.scope.id` |
   | `:loading` | boolean | toggled per run | double-send guard — prevents race conditions |
   | `:current_run_id` | UUID string | set at each `send_message` | echoed in `RUN_STARTED` + `RUN_FINISHED` AG-UI events for client-side correlation |
@@ -131,16 +133,25 @@ defmodule TrentoWeb.AIAssistantChannel do
 
   defp run_agent(
          %{
-           assigns: %{
-             current_run_id: run_id,
-             current_thread_id: thread_id,
-             current_scope: scope
-           }
+           assigns:
+             %{
+               current_run_id: run_id,
+               current_thread_id: thread_id,
+               current_scope: scope
+             } = assigns
          } = socket,
          model_config,
          prompt
        ) do
-    [agent_id: thread_id, model: model_config, scope: scope]
+    [
+      agent_id: thread_id,
+      model: model_config,
+      scope: scope,
+      tool_context: %{
+        access_token: Map.get(assigns, :access_token),
+        request_origin: Map.get(assigns, :request_origin)
+      }
+    ]
     |> TrentoAIAgent.new!()
     |> TrentoAIAgent.run(prompt)
     |> case do

--- a/lib/trento_web/channels/user_socket.ex
+++ b/lib/trento_web/channels/user_socket.ex
@@ -7,6 +7,8 @@ defmodule TrentoWeb.UserSocket do
   require Logger
   alias TrentoWeb.Auth.AccessToken
 
+  alias Trento.Support.HttpUtils
+
   # A Socket handler
   #
   # It's possible to control the websocket connection and
@@ -31,10 +33,19 @@ defmodule TrentoWeb.UserSocket do
   # See `Phoenix.Token` documentation for examples in
   # performing token verification on connect.
   @impl true
-  def connect(%{"access_token" => access_token}, socket, _connect_info) do
+  def connect(%{"access_token" => access_token}, socket, %{uri: %URI{} = uri}) do
     case AccessToken.verify_and_validate(access_token) do
       {:ok, %{"sub" => user_id}} ->
-        {:ok, assign(socket, :current_user_id, user_id)}
+        # Keep the raw JWT alongside the resolved user id so downstream
+        # tools (e.g. Trento.AI.RemoteHttpTool) can forward it as the
+        # Authorization header on outbound calls. The token is the
+        # caller's own credential — never persisted, only attached to
+        # in-flight requests originating from this socket.
+        {:ok,
+         socket
+         |> assign(:current_user_id, user_id)
+         |> assign(:access_token, access_token)
+         |> assign(:request_origin, HttpUtils.request_origin(uri))}
 
       {:error, reason} ->
         Logger.error("Could not authenticate user socket: #{inspect(reason)}")

--- a/lib/trento_web/channels/user_socket.ex
+++ b/lib/trento_web/channels/user_socket.ex
@@ -36,11 +36,6 @@ defmodule TrentoWeb.UserSocket do
   def connect(%{"access_token" => access_token}, socket, connect_info) do
     case AccessToken.verify_and_validate(access_token) do
       {:ok, %{"sub" => user_id}} ->
-        # Keep the raw JWT alongside the resolved user id so downstream
-        # tools (e.g. Trento.AI.RemoteHttpTool) can forward it as the
-        # Authorization header on outbound calls. The token is the
-        # caller's own credential — never persisted, only attached to
-        # in-flight requests originating from this socket.
         {:ok,
          socket
          |> assign(:current_user_id, user_id)

--- a/lib/trento_web/channels/user_socket.ex
+++ b/lib/trento_web/channels/user_socket.ex
@@ -33,7 +33,7 @@ defmodule TrentoWeb.UserSocket do
   # See `Phoenix.Token` documentation for examples in
   # performing token verification on connect.
   @impl true
-  def connect(%{"access_token" => access_token}, socket, %{uri: %URI{} = uri}) do
+  def connect(%{"access_token" => access_token}, socket, connect_info) do
     case AccessToken.verify_and_validate(access_token) do
       {:ok, %{"sub" => user_id}} ->
         # Keep the raw JWT alongside the resolved user id so downstream
@@ -45,7 +45,7 @@ defmodule TrentoWeb.UserSocket do
          socket
          |> assign(:current_user_id, user_id)
          |> assign(:access_token, access_token)
-         |> assign(:request_origin, HttpUtils.request_origin(uri))}
+         |> assign(:request_origin, detect_request_origin(connect_info))}
 
       {:error, reason} ->
         Logger.error("Could not authenticate user socket: #{inspect(reason)}")
@@ -70,4 +70,7 @@ defmodule TrentoWeb.UserSocket do
   # Returning `nil` makes this socket anonymous.
   @impl true
   def id(socket), do: "user_socket:#{socket.assigns.current_user_id}"
+
+  defp detect_request_origin(%{uri: uri}), do: HttpUtils.request_origin(uri)
+  defp detect_request_origin(_), do: nil
 end

--- a/lib/trento_web/endpoint.ex
+++ b/lib/trento_web/endpoint.ex
@@ -14,7 +14,7 @@ defmodule TrentoWeb.Endpoint do
   ]
 
   socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
-  socket "/socket", TrentoWeb.UserSocket, websocket: true, longpoll: false
+  socket "/socket", TrentoWeb.UserSocket, websocket: [connect_info: [:uri]]
 
   # Serve at "/" the static files from "priv/static" directory.
   #

--- a/test/trento_web/channels/ai_assistant_channel_test.exs
+++ b/test/trento_web/channels/ai_assistant_channel_test.exs
@@ -441,6 +441,53 @@ defmodule TrentoWeb.AIAssistantChannelTest do
     end
   end
 
+  describe "handle_in send_message/3 — tool_context" do
+    test "forwards socket :access_token to the agent as tool_context.access_token" do
+      %{id: user_id} = insert(:user)
+
+      insert(:ai_user_configuration,
+        user_id: user_id,
+        provider: :googleai,
+        model: "gemini-2.5-flash"
+      )
+
+      {:ok, _, socket} =
+        UserSocket
+        |> socket("user_id", %{
+          current_user_id: user_id,
+          access_token: "ws-jwt-token-xyz"
+        })
+        |> subscribe_and_join(AIAssistantChannel, "ai_assistant:#{user_id}")
+
+      Mox.allow(Trento.AI.Agent.Supervisor.Mock, self(), socket.channel_pid)
+      Mox.allow(Trento.AI.Agent.Server.Mock, self(), socket.channel_pid)
+
+      test_pid = self()
+
+      expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn opts ->
+        send(test_pid, {:agent_opts, opts})
+        {:ok, self()}
+      end)
+
+      expect(Trento.AI.Agent.Server.Mock, :subscribe, fn _ -> :ok end)
+      expect(Trento.AI.Agent.Server.Mock, :add_message, fn _, _ -> :ok end)
+
+      push(socket, "send_message", %{
+        "message" => "hi",
+        "run_id" => "r-jwt",
+        "thread_id" => "t-jwt"
+      })
+
+      # Wait until the channel process finishes the send_message round-trip
+      # so every Mox expectation in the chain (start_agent_sync → subscribe
+      # → add_message) actually runs before the test exits.
+      assert_push("ag_ui_event", %{"type" => "RUN_STARTED"})
+
+      assert_receive {:agent_opts, opts}, 1_000
+      assert %Sagents.Agent{tool_context: %{access_token: "ws-jwt-token-xyz"}} = opts[:agent]
+    end
+  end
+
   describe "handle_in send_message/3 — happy path" do
     test "calls Agent.run/2 and pushes RUN_STARTED on success" do
       %{id: user_id} = insert(:user)

--- a/test/trento_web/channels/user_socket_test.exs
+++ b/test/trento_web/channels/user_socket_test.exs
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule TrentoWeb.UserSocketTest do
+  use TrentoWeb.ChannelCase
+
+  import Mox
+
+  alias TrentoWeb.Auth.AccessToken
+  alias TrentoWeb.UserSocket
+
+  setup :verify_on_exit!
+
+  describe "connect/3" do
+    setup do
+      url = Faker.Internet.url()
+      %{connect_info: %{uri: URI.parse(url)}, expected_origin: url}
+    end
+
+    test "stores :current_user_id, :access_token and :request_origin when JWT validates", %{
+      connect_info: connect_info,
+      expected_origin: expected_origin
+    } do
+      # AccessToken.generate_access_token!/1 + verify_and_validate/1 each
+      # call Joken.CurrentTime once. Stub both.
+      stub(Joken.CurrentTime.Mock, :current_time, fn -> 1_700_000_000 end)
+
+      jwt = AccessToken.generate_access_token!(%{"sub" => 42})
+
+      assert {:ok, %{assigns: assigns}} =
+               UserSocket.connect(%{"access_token" => jwt}, socket(UserSocket), connect_info)
+
+      assert %{
+               current_user_id: 42,
+               access_token: ^jwt,
+               request_origin: ^expected_origin
+             } = assigns
+    end
+
+    test "rejects invalid JWT and assigns nothing", %{connect_info: connect_info} do
+      assert {:error, _reason} =
+               UserSocket.connect(
+                 %{"access_token" => "not-a-jwt"},
+                 socket(UserSocket),
+                 connect_info
+               )
+    end
+
+    test "rejects missing access_token param", %{connect_info: connect_info} do
+      assert {:error, :missing_auth_token} =
+               UserSocket.connect(%{}, socket(UserSocket), connect_info)
+    end
+  end
+end

--- a/test/trento_web/channels/user_socket_test.exs
+++ b/test/trento_web/channels/user_socket_test.exs
@@ -50,5 +50,20 @@ defmodule TrentoWeb.UserSocketTest do
       assert {:error, :missing_auth_token} =
                UserSocket.connect(%{}, socket(UserSocket), connect_info)
     end
+
+    test "authenticates and sets request_origin to nil when connect_info has no :uri" do
+      stub(Joken.CurrentTime.Mock, :current_time, fn -> 1_700_000_000 end)
+
+      jwt = AccessToken.generate_access_token!(%{"sub" => 42})
+
+      assert {:ok, %{assigns: assigns}} =
+               UserSocket.connect(%{"access_token" => jwt}, socket(UserSocket), %{})
+
+      assert %{
+               current_user_id: 42,
+               access_token: ^jwt,
+               request_origin: nil
+             } = assigns
+    end
   end
 end


### PR DESCRIPTION
# Description

This PR makes sure that the user socket assigns, next to current_user_id, also
- `access_token`: the jwt gotten at login
- `request_origin`: basically browser's url connecting to websocket

AI Assistant channel forwards both via the agent's tool_context map so outbound tools (e.g. remote OpenAPI tool source for wanda) can authenticate as the caller and resolve relative base URLs against the same origin the browser used (unless the configuration is an absolute url or the server url in OAS is absolute).

Extracted from https://github.com/trento-project/web/pull/4364

The main caveat here is about token expiration.

The JWT created at login is short lived (3 minutes by default) and upon expiration it must go through the refresh mechanism.

It is not enough passing the token at `connect` because it never gets checked against expiration and never gets refreshed.

The idea, to be addressed in a followup PR, would be:
- validate token on each `join/send_message`
- if expired tell the client
- the client refreshes (as it currently does on REST endpoints)
- the possibly pending prompt is retried with the new token

## How was this tested?

Automated and IRL.

## Did you update the documentation?

No need.