### PR TITLE
Generalize CommandedUtils usage

### DIFF
--- a/lib/trento/clusters.ex
+++ b/lib/trento/clusters.ex
@@ -39,6 +39,8 @@ defmodule Trento.Clusters do
 
   alias Trento.Repo
 
+  alias Trento.Support.CommandedUtils
+
   @checkable_clusters [
     ClusterType.hana_scale_up(),
     ClusterType.hana_scale_out(),
@@ -65,7 +67,7 @@ defmodule Trento.Clusters do
     Logger.debug("Selecting checks, cluster: #{cluster_id}")
 
     with {:ok, command} <- SelectChecks.new(%{cluster_id: cluster_id, checks: checks}) do
-      commanded().dispatch(command)
+      CommandedUtils.dispatch(command)
     end
   end
 
@@ -255,9 +257,6 @@ defmodule Trento.Clusters do
 
   defp managed?(%{id: resource_id, managed: managed}, resource_id), do: managed
   defp managed?(_, _), do: false
-
-  defp commanded,
-    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
 
   @spec enrich_cluster_model_query(Ecto.Query.t()) :: Ecto.Query.t()
   defp enrich_cluster_model_query(query) do

--- a/lib/trento/discovery.ex
+++ b/lib/trento/discovery.ex
@@ -30,7 +30,7 @@ defmodule Trento.Discovery do
 
   alias Trento.Discoveries.V1.DiscoveryRequested
 
-  @type command :: struct
+  alias Trento.Support.CommandedUtils
 
   @doc """
   Transform a discovery in a list of commands event by using the appropriate policy.
@@ -41,7 +41,7 @@ defmodule Trento.Discovery do
   def handle(event) do
     with {:ok, commands} <- do_handle(event),
          {:ok, _} <- store_discovery_event(event),
-         :ok <- dispatch(commands) do
+         :ok <- CommandedUtils.dispatch(commands) do
       :ok
     else
       {:error, reason} = error ->
@@ -217,27 +217,6 @@ defmodule Trento.Discovery do
   defp do_handle(_),
     do: {:error, :unknown_discovery_type}
 
-  @spec dispatch(command | [command]) :: :ok | {:error, any}
-  defp dispatch(commands) when is_list(commands) do
-    Enum.reduce(commands, :ok, fn command, acc ->
-      case {commanded().dispatch(command), acc} do
-        {:ok, :ok} ->
-          :ok
-
-        {:ok, {:error, errors}} ->
-          {:error, errors}
-
-        {{:error, error}, :ok} ->
-          {:error, [error]}
-
-        {{:error, error}, {:error, errors}} ->
-          {:error, [error | errors]}
-      end
-    end)
-  end
-
-  defp dispatch(command), do: commanded().dispatch(command)
-
   @spec request_discovery(String.t(), [String.t()]) ::
           :ok | {:error, any}
   defp request_discovery(discovery_type, targets) do
@@ -256,7 +235,4 @@ defmodule Trento.Discovery do
         error
     end
   end
-
-  defp commanded,
-    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
 end

--- a/lib/trento/infrastructure/checks/checks.ex
+++ b/lib/trento/infrastructure/checks/checks.ex
@@ -24,7 +24,10 @@ defmodule Trento.Infrastructure.Checks do
     HostExecutionEnv
   }
 
-  alias Trento.Support.Protobuf
+  alias Trento.Support.{
+    CommandedUtils,
+    Protobuf
+  }
 
   require Logger
   require Trento.Clusters.Enums.ClusterType, as: ClusterType
@@ -98,7 +101,7 @@ defmodule Trento.Infrastructure.Checks do
   def complete_execution(_, _, _, _), do: {:error, :target_not_supported}
 
   defp dispatch_completion_command(execution_id, command) do
-    commanded().dispatch(command, correlation_id: execution_id)
+    CommandedUtils.dispatch(command, correlation_id: execution_id)
   end
 
   defp build_env(%ClusterExecutionEnv{
@@ -147,7 +150,4 @@ defmodule Trento.Infrastructure.Checks do
       provider: provider
     })
   end
-
-  defp commanded,
-    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
 end

--- a/lib/trento/infrastructure/commanded/event_handlers/database_deregistration_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/database_deregistration_event_handler.ex
@@ -22,6 +22,8 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.DatabaseDeregistrationEv
   alias Trento.SapSystems.Commands.DeregisterSapSystem
   alias Trento.SapSystems.Projections.SapSystemReadModel
 
+  alias Trento.Support.CommandedUtils
+
   import Ecto.Query, only: [from: 2]
 
   require Logger
@@ -42,7 +44,7 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.DatabaseDeregistrationEv
     for %{id: sap_system_id, sid: sid} <- sap_systems do
       Logger.info("Deregistering sap system #{sid} attached to database #{database_id}")
 
-      commanded().dispatch(
+      CommandedUtils.dispatch(
         %DeregisterSapSystem{sap_system_id: sap_system_id, deregistered_at: deregistered_at},
         consistency: :strong
       )
@@ -74,7 +76,7 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.DatabaseDeregistrationEv
           "Deregistering sap system #{sid} attached to database #{database_id} with tenant #{tenant_name}"
         )
 
-        commanded().dispatch(
+        CommandedUtils.dispatch(
           %DeregisterSapSystem{sap_system_id: sap_system_id, deregistered_at: dereregistered_at},
           consistency: :strong
         )
@@ -83,7 +85,4 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.DatabaseDeregistrationEv
 
     :ok
   end
-
-  defp commanded,
-    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
 end

--- a/lib/trento/infrastructure/commanded/event_handlers/database_restore_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/database_restore_event_handler.ex
@@ -16,6 +16,8 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.DatabaseRestoreEventHand
   alias Trento.Repo
   alias Trento.SapSystems.Commands.RestoreSapSystem
 
+  alias Trento.Support.CommandedUtils
+
   import Ecto.Query, only: [from: 2]
 
   require Logger
@@ -36,7 +38,7 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.DatabaseRestoreEventHand
     for %{id: sap_system_id, tenant: tenant, db_host: db_host, sid: sid} <- sap_systems do
       Logger.info("Restoring sap system #{sid} attached to database #{database_id}")
 
-      commanded().dispatch(
+      CommandedUtils.dispatch(
         %RestoreSapSystem{
           sap_system_id: sap_system_id,
           db_host: db_host,
@@ -49,7 +51,4 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.DatabaseRestoreEventHand
 
     :ok
   end
-
-  defp commanded,
-    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
 end

--- a/lib/trento/infrastructure/commanded/event_handlers/sap_system_database_health_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/sap_system_database_health_event_handler.ex
@@ -21,6 +21,8 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseHealthE
 
   alias TrentoWeb.V1.SapSystemJSON
 
+  alias Trento.Support.CommandedUtils
+
   import Ecto.Query, only: [from: 2]
 
   require Logger
@@ -41,7 +43,7 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseHealthE
     for %{id: sap_system_id, sid: sid} <- sap_systems do
       Logger.info("Updating database health of #{sid} SAP system to #{health}")
 
-      commanded().dispatch(
+      CommandedUtils.dispatch(
         %UpdateDatabaseHealth{sap_system_id: sap_system_id, database_health: health},
         consistency: :strong
       )
@@ -66,7 +68,4 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseHealthE
       })
     )
   end
-
-  defp commanded,
-    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
 end

--- a/lib/trento/infrastructure/commanded/event_handlers/stream_roll_up_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/stream_roll_up_event_handler.ex
@@ -26,6 +26,8 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.StreamRollUpEventHandler
   alias Trento.Hosts.Events.HostTombstoned
   alias Trento.SapSystems.Events.SapSystemTombstoned
 
+  alias Trento.Support.CommandedUtils
+
   require Logger
 
   @max_stream_version Application.compile_env!(:trento, [__MODULE__, :max_stream_version])
@@ -91,7 +93,7 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.StreamRollUpEventHandler
         "Rolling up host: #{host_id} because  #{stream_version} > #{@max_stream_version}"
       )
 
-      commanded().dispatch(%RollUpHost{host_id: host_id},
+      CommandedUtils.dispatch(%RollUpHost{host_id: host_id},
         consistency: :strong
       )
     else
@@ -112,7 +114,7 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.StreamRollUpEventHandler
         "Rolling up cluster: #{cluster_id} because  #{stream_version} > #{@max_stream_version}"
       )
 
-      commanded().dispatch(%RollUpCluster{cluster_id: cluster_id},
+      CommandedUtils.dispatch(%RollUpCluster{cluster_id: cluster_id},
         consistency: :strong
       )
     else
@@ -133,7 +135,7 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.StreamRollUpEventHandler
         "Rolling up sap system: #{sap_system_id} because  #{stream_version} > #{@max_stream_version}"
       )
 
-      commanded().dispatch(%RollUpSapSystem{sap_system_id: sap_system_id},
+      CommandedUtils.dispatch(%RollUpSapSystem{sap_system_id: sap_system_id},
         consistency: :strong
       )
     else
@@ -153,7 +155,7 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.StreamRollUpEventHandler
         "Rolling up database: #{database_id} because  #{stream_version} > #{@max_stream_version}"
       )
 
-      commanded().dispatch(%RollUpDatabase{database_id: database_id},
+      CommandedUtils.dispatch(%RollUpDatabase{database_id: database_id},
         consistency: :strong
       )
     else
@@ -164,7 +166,7 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.StreamRollUpEventHandler
   def handle(%HostTombstoned{host_id: host_id}, _) do
     Logger.info("Rolling up host: #{host_id} because HostTombstoned was received")
 
-    commanded().dispatch(%RollUpHost{host_id: host_id},
+    CommandedUtils.dispatch(%RollUpHost{host_id: host_id},
       consistency: :strong
     )
   end
@@ -172,7 +174,7 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.StreamRollUpEventHandler
   def handle(%ClusterTombstoned{cluster_id: cluster_id}, _) do
     Logger.info("Rolling up cluster: #{cluster_id} because ClusterTombstoned was received")
 
-    commanded().dispatch(%RollUpCluster{cluster_id: cluster_id},
+    CommandedUtils.dispatch(%RollUpCluster{cluster_id: cluster_id},
       consistency: :strong
     )
   end
@@ -182,7 +184,7 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.StreamRollUpEventHandler
       "Rolling up sap system: #{sap_system_id} because SapSystemTombstoned was received"
     )
 
-    commanded().dispatch(%RollUpSapSystem{sap_system_id: sap_system_id},
+    CommandedUtils.dispatch(%RollUpSapSystem{sap_system_id: sap_system_id},
       consistency: :strong
     )
   end
@@ -190,11 +192,8 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.StreamRollUpEventHandler
   def handle(%DatabaseTombstoned{database_id: database_id}, _) do
     Logger.info("Rolling up database: #{database_id} because DatabaseTombstoned was received")
 
-    commanded().dispatch(%RollUpDatabase{database_id: database_id},
+    CommandedUtils.dispatch(%RollUpDatabase{database_id: database_id},
       consistency: :strong
     )
   end
-
-  defp commanded,
-    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
 end

--- a/lib/trento/support/commanded_utils.ex
+++ b/lib/trento/support/commanded_utils.ex
@@ -5,7 +5,30 @@ defmodule Trento.Support.CommandedUtils do
   @moduledoc false
   alias Trento.ActivityLog
 
-  def dispatch(command), do: commanded().dispatch(command)
+  @type command :: struct
+
+  @spec dispatch(command | [command], Keyword.t()) :: :ok | {:error, any}
+  def dispatch(commands, opts \\ [])
+
+  def dispatch(commands, opts) when is_list(commands) do
+    Enum.reduce(commands, :ok, fn command, acc ->
+      case {commanded().dispatch(command, opts), acc} do
+        {:ok, :ok} ->
+          :ok
+
+        {:ok, {:error, errors}} ->
+          {:error, errors}
+
+        {{:error, error}, :ok} ->
+          {:error, [error]}
+
+        {{:error, error}, {:error, errors}} ->
+          {:error, [error | errors]}
+      end
+    end)
+  end
+
+  def dispatch(command, opts), do: commanded().dispatch(command, opts)
 
   def correlated_dispatch(command, ctx) do
     key = ActivityLog.correlation_key(ctx)

--- a/lib/trento/support/commanded_utils.ex
+++ b/lib/trento/support/commanded_utils.ex
@@ -28,6 +28,7 @@ defmodule Trento.Support.CommandedUtils do
     end)
   end
 
+  def dispatch(command, []), do: commanded().dispatch(command)
   def dispatch(command, opts), do: commanded().dispatch(command, opts)
 
   def correlated_dispatch(command, ctx) do

--- a/test/trento/discovery_test.exs
+++ b/test/trento/discovery_test.exs
@@ -168,8 +168,8 @@ defmodule Trento.DiscoveryTest do
     }
 
     Trento.Commanded.Mock
-    |> expect(:dispatch, 1, fn _ -> {:error, error} end)
-    |> expect(:dispatch, 1, fn _ -> :ok end)
+    |> expect(:dispatch, 1, fn _, _ -> {:error, error} end)
+    |> expect(:dispatch, 1, fn _, _ -> :ok end)
 
     {:error, [^error]} = Discovery.handle(event)
 

--- a/test/trento/support/commanded_utils_test.exs
+++ b/test/trento/support/commanded_utils_test.exs
@@ -76,7 +76,7 @@ defmodule Trento.Support.CommandedUtilsTest do
         expect(
           Trento.Commanded.Mock,
           :dispatch,
-          fn ^some_command, [] ->
+          fn ^some_command ->
             :ok
           end
         )

--- a/test/trento/support/commanded_utils_test.exs
+++ b/test/trento/support/commanded_utils_test.exs
@@ -9,6 +9,64 @@ defmodule Trento.Support.CommandedUtilsTest do
 
   setup :verify_on_exit!
 
+  describe "dispatch/2" do
+    test "should dispatch a single command" do
+      some_command = %{uuid: Faker.UUID.v4()}
+
+      expect(
+        Trento.Commanded.Mock,
+        :dispatch,
+        fn ^some_command, [opt: 1] ->
+          :ok
+        end
+      )
+
+      assert :ok == CommandedUtils.dispatch(some_command, opt: 1)
+    end
+
+    test "should dispatch multiple commands successfully" do
+      some_commands = [
+        command1 = %{uuid: Faker.UUID.v4()},
+        command2 = %{uuid: Faker.UUID.v4()}
+      ]
+
+      expect(
+        Trento.Commanded.Mock,
+        :dispatch,
+        2,
+        fn
+          ^command1, [] -> :ok
+          ^command2, [] -> :ok
+        end
+      )
+
+      assert :ok == CommandedUtils.dispatch(some_commands)
+    end
+
+    test "should dispatch multiple commands with errors" do
+      some_commands = [
+        command1 = %{uuid: Faker.UUID.v4()},
+        command2 = %{uuid: Faker.UUID.v4()},
+        command3 = %{uuid: Faker.UUID.v4()},
+        command4 = %{uuid: Faker.UUID.v4()}
+      ]
+
+      expect(
+        Trento.Commanded.Mock,
+        :dispatch,
+        4,
+        fn
+          ^command1, [] -> :ok
+          ^command2, [] -> {:error, :error1}
+          ^command3, [] -> :ok
+          ^command4, [] -> {:error, :error2}
+        end
+      )
+
+      assert {:error, [:error2, :error1]} == CommandedUtils.dispatch(some_commands)
+    end
+  end
+
   describe "correlated_dispatch/2" do
     for ctx <- [:api_key, :suse_manager_settings] do
       @ctx ctx
@@ -18,7 +76,7 @@ defmodule Trento.Support.CommandedUtilsTest do
         expect(
           Trento.Commanded.Mock,
           :dispatch,
-          fn ^some_command ->
+          fn ^some_command, [] ->
             :ok
           end
         )

--- a/test/trento_web/controllers/v1/discovery_controller_test.exs
+++ b/test/trento_web/controllers/v1/discovery_controller_test.exs
@@ -49,7 +49,7 @@ defmodule TrentoWeb.V1.DiscoveryControllerTest do
       body =
         load_discovery_event_fixture("sap_system_discovery_application")
 
-      expect(Trento.Commanded.Mock, :dispatch, fn _ ->
+      expect(Trento.Commanded.Mock, :dispatch, fn _, _ ->
         {:error, :any_error}
       end)
 
@@ -71,7 +71,7 @@ defmodule TrentoWeb.V1.DiscoveryControllerTest do
       body =
         load_discovery_event_fixture("sap_system_discovery_application")
 
-      expect(Trento.Commanded.Mock, :dispatch, fn _ ->
+      expect(Trento.Commanded.Mock, :dispatch, fn _, _ ->
         {:error, :associated_database_not_found}
       end)
 
@@ -93,7 +93,7 @@ defmodule TrentoWeb.V1.DiscoveryControllerTest do
       body =
         load_discovery_event_fixture("sap_system_discovery_application")
 
-      expect(Trento.Commanded.Mock, :dispatch, fn _ ->
+      expect(Trento.Commanded.Mock, :dispatch, fn _, _ ->
         raise "Test Exception"
       end)
 


### PR DESCRIPTION
# Description

Generalize the usage of `CommandedUtils`.
I have moved the function to dispatch multiple commands to the support file. I want to use it in a future implementation.
After that, I have used the utils file everywhere.


## How was this tested?

UT

## Did you update the documentation?

No need
