### PR TITLE
Ai access token management

### DIFF
--- a/lib/trento/ai/agent.ex
+++ b/lib/trento/ai/agent.ex
@@ -63,15 +63,37 @@ defmodule Trento.AI.Agent do
   process to its event stream, and send the user prompt. Returns `:ok`
   or the first `{:error, reason}` from the start/subscribe/send chain.
   """
-  @spec run(Sagents.Agent.t(), String.t()) :: :ok | {:error, term()}
-  def run(%Sagents.Agent{agent_id: agent_id} = agent, prompt) do
+  @spec run(Sagents.Agent.t(), String.t(), keyword()) :: :ok | {:error, term()}
+  def run(%Sagents.Agent{agent_id: agent_id} = maybe_new_agent, prompt, opts \\ []) do
+    refresh_when = Keyword.get(opts, :refresh_when, &default_refresh_when/2)
+
     with {:ok, _} <-
            agent_id
-           |> start_opts(agent)
+           |> start_opts(maybe_new_agent)
            |> AgentSupervisor.start_agent_sync(),
+         :ok <- maybe_refresh_agent(agent_id, maybe_new_agent, refresh_when),
          :ok <- AgentServer.subscribe(agent_id) do
       AgentServer.add_message(agent_id, Message.new_user!(prompt))
     end
+  end
+
+  defp maybe_refresh_agent(agent_id, maybe_new_agent, refresh_when) do
+    with {:ok, current_agent} <- AgentServer.get_agent(agent_id),
+         {:ok, updated_agent} <- refresh_when.(current_agent, maybe_new_agent) do
+      update_agent(agent_id, updated_agent)
+    end
+
+    :ok
+  end
+
+  defp default_refresh_when(_current_agent, _new_agent), do: :noop
+
+  defp update_agent(agent_id, updated_agent) do
+    %{state: current_state} = AgentServer.get_info(agent_id)
+
+    AgentServer.update_agent_and_state(agent_id, updated_agent, current_state)
+
+    :ok
   end
 
   defp start_opts(agent_id, agent) do

--- a/lib/trento/ai/agent/server.ex
+++ b/lib/trento/ai/agent/server.ex
@@ -18,9 +18,18 @@ defmodule Trento.AI.Agent.Server do
 
   @callback subscribe(String.t()) :: :ok | {:error, term()}
   @callback add_message(String.t(), Message.t()) :: :ok | {:error, term()}
+  @callback get_agent(String.t()) :: {:ok, Sagents.Agent.t()} | {:error, term()}
+  @callback get_info(String.t()) :: %{state: Sagents.State.t()}
+  @callback update_agent_and_state(String.t(), Sagents.Agent.t(), Sagents.State.t()) ::
+              :ok | {:error, term()}
 
   def subscribe(agent_id), do: impl().subscribe(agent_id)
   def add_message(agent_id, message), do: impl().add_message(agent_id, message)
+  def get_agent(agent_id), do: impl().get_agent(agent_id)
+  def get_info(agent_id), do: impl().get_info(agent_id)
+
+  def update_agent_and_state(agent_id, agent, state),
+    do: impl().update_agent_and_state(agent_id, agent, state)
 
   defp impl, do: Keyword.get(ApplicationConfigLoader.load(), :agent_server_adapter)
 end

--- a/lib/trento/infrastructure/ai/sagents_agent_server.ex
+++ b/lib/trento/infrastructure/ai/sagents_agent_server.ex
@@ -14,4 +14,13 @@ defmodule Trento.Infrastructure.AI.SagentsAgentServer do
 
   @impl Trento.AI.Agent.Server
   defdelegate add_message(agent_id, message), to: Sagents.AgentServer
+
+  @impl Trento.AI.Agent.Server
+  defdelegate get_agent(agent_id), to: Sagents.AgentServer
+
+  @impl Trento.AI.Agent.Server
+  defdelegate get_info(agent_id), to: Sagents.AgentServer
+
+  @impl Trento.AI.Agent.Server
+  defdelegate update_agent_and_state(agent_id, agent, state), to: Sagents.AgentServer
 end

--- a/lib/trento_web/channels/ai_assistant_channel.ex
+++ b/lib/trento_web/channels/ai_assistant_channel.ex
@@ -94,7 +94,10 @@ defmodule TrentoWeb.AIAssistantChannel do
   end
 
   def handle_in("send_message", payload, socket) do
-    Logger.warning("Invalid send_message payload: #{inspect(payload)}")
+    payload
+    |> redact_payload()
+    |> then(&Logger.warning("Received invalid send_message payload: #{inspect(&1)}"))
+
     {:reply, {:error, :invalid_payload}, socket}
   end
 
@@ -320,4 +323,9 @@ defmodule TrentoWeb.AIAssistantChannel do
       |> assign(:loading, false)
       |> assign(:message_started, false)
       |> assign(:run_has_started, false)
+
+  defp redact_payload(payload) when is_map(payload),
+    do: Map.replace(payload, "access_token", "<REDACTED>")
+
+  defp redact_payload(payload), do: payload
 end

--- a/lib/trento_web/channels/ai_assistant_channel.ex
+++ b/lib/trento_web/channels/ai_assistant_channel.ex
@@ -49,29 +49,68 @@ defmodule TrentoWeb.AIAssistantChannel do
   alias Trento.AI.LLMBuilder
   alias Trento.Users.User
   alias TrentoWeb.AIAssistant.AgUi
+  alias TrentoWeb.Auth.AccessToken
 
   @impl true
   def join(
         "ai_assistant:" <> user_id,
-        _session,
+        %{"access_token" => token},
         %{assigns: %{current_user_id: current_user_id}} = socket
       ) do
-    case {AI.enabled?(), allowed?(user_id, current_user_id)} do
-      {false, _} ->
-        {:error, :ai_assistant_disabled}
-
-      {_, false} ->
-        {:error, :unauthorized}
-
-      {true, true} ->
-        {:ok,
-         socket
-         |> assign(:current_scope, %User{id: current_user_id})
-         |> assign(:loading, false)}
+    with :ok <- check_ai_enabled(),
+         :ok <- check_socket_and_channel_user_match(user_id, current_user_id),
+         :ok <- validate_access_token(token, current_user_id) do
+      {:ok,
+       socket
+       |> assign(:access_token, token)
+       |> assign(:current_scope, %User{id: current_user_id})
+       |> assign(:loading, false)}
     end
   end
 
   def join("ai_assistant:" <> _user_id, _payload, _socket), do: {:error, :user_not_logged}
+
+  @impl true
+  def handle_in(
+        "send_message",
+        %{
+          "message" => prompt,
+          "run_id" => run_id,
+          "thread_id" => thread_id,
+          "access_token" => token
+        },
+        %{assigns: %{current_user_id: current_user_id}} = socket
+      )
+      when is_binary(prompt) and is_binary(run_id) and is_binary(thread_id) do
+    case validate_access_token(token, current_user_id) do
+      :ok ->
+        socket
+        |> assign(:access_token, token)
+        |> handle_incoming_prompt(String.trim(prompt), run_id, thread_id)
+
+      {:error, _} = error ->
+        {:reply, error, socket}
+    end
+  end
+
+  def handle_in("send_message", payload, socket) do
+    Logger.warning("Invalid send_message payload: #{inspect(payload)}")
+    {:reply, {:error, :invalid_payload}, socket}
+  end
+
+  defp check_ai_enabled do
+    case AI.enabled?() do
+      true -> :ok
+      false -> {:error, :ai_assistant_disabled}
+    end
+  end
+
+  defp check_socket_and_channel_user_match(user_id, current_user_id) do
+    case allowed?(user_id, current_user_id) do
+      true -> :ok
+      false -> {:error, :unauthorized}
+    end
+  end
 
   defp allowed?(user_id, current_user_id) do
     case Integer.parse(user_id) do
@@ -79,23 +118,16 @@ defmodule TrentoWeb.AIAssistantChannel do
         id == current_user_id
 
       _ ->
-        Logger.warning("Invalid user_id in topic: #{user_id}")
+        Logger.warning("Invalid user_id in AI Assistant Channel topic: #{user_id}")
         false
     end
   end
 
-  @impl true
-  def handle_in(
-        "send_message",
-        %{"message" => prompt, "run_id" => run_id, "thread_id" => thread_id},
-        socket
-      )
-      when is_binary(prompt) and is_binary(run_id) and is_binary(thread_id),
-      do: handle_incoming_prompt(socket, String.trim(prompt), run_id, thread_id)
-
-  def handle_in("send_message", payload, socket) do
-    Logger.warning("Invalid send_message payload: #{inspect(payload)}")
-    {:reply, {:error, :invalid_payload}, socket}
+  defp validate_access_token(token, current_user_id) do
+    case AccessToken.verify_and_validate(token) do
+      {:ok, %{"sub" => ^current_user_id}} -> :ok
+      _ -> {:error, :unauthorized}
+    end
   end
 
   defp handle_incoming_prompt(

--- a/lib/trento_web/channels/ai_assistant_channel.ex
+++ b/lib/trento_web/channels/ai_assistant_channel.ex
@@ -165,12 +165,13 @@ defmodule TrentoWeb.AIAssistantChannel do
 
   defp run_agent(
          %{
-           assigns:
-             %{
-               current_run_id: run_id,
-               current_thread_id: thread_id,
-               current_scope: scope
-             } = assigns
+           assigns: %{
+             current_run_id: run_id,
+             current_thread_id: thread_id,
+             current_scope: scope,
+             access_token: access_token,
+             request_origin: request_origin
+           }
          } = socket,
          model_config,
          prompt
@@ -180,12 +181,15 @@ defmodule TrentoWeb.AIAssistantChannel do
       model: model_config,
       scope: scope,
       tool_context: %{
-        access_token: Map.get(assigns, :access_token),
-        request_origin: Map.get(assigns, :request_origin)
+        access_token: access_token,
+        request_origin: request_origin
       }
     ]
     |> TrentoAIAgent.new!()
-    |> TrentoAIAgent.run(prompt)
+    |> TrentoAIAgent.run(
+      prompt,
+      refresh_when: &access_token_changed/2
+    )
     |> case do
       :ok ->
         socket
@@ -201,6 +205,19 @@ defmodule TrentoWeb.AIAssistantChannel do
         |> AgUi.run_error(error_msg)
     end
     |> then(&{:noreply, &1})
+  end
+
+  defp access_token_changed(
+         %{tool_context: %{access_token: token}} = _current_agent,
+         %{tool_context: %{access_token: token}} = _new_agent
+       ) do
+    # IO.inspect("access token unchanged - no agent update needed")
+    :noop
+  end
+
+  defp access_token_changed(_current_agent, new_agent) do
+    # IO.inspect("access token changed - refreshing agent with new token")
+    {:ok, new_agent}
   end
 
   @impl true

--- a/test/trento/ai/agent_test.exs
+++ b/test/trento/ai/agent_test.exs
@@ -95,6 +95,7 @@ defmodule Trento.AI.AgentTest do
         {:ok, self()}
       end)
 
+      stub(Trento.AI.Agent.Server.Mock, :get_agent, fn _ -> {:error, :not_found} end)
       expect(Trento.AI.Agent.Server.Mock, :subscribe, fn ^agent_id -> :ok end)
 
       expect(Trento.AI.Agent.Server.Mock, :add_message, fn ^agent_id,
@@ -124,6 +125,7 @@ defmodule Trento.AI.AgentTest do
     test "short-circuits when subscribe fails (add_message NOT called)",
          %{agent: agent, prompt: prompt} do
       expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn _ -> {:ok, self()} end)
+      stub(Trento.AI.Agent.Server.Mock, :get_agent, fn _ -> {:error, :not_found} end)
       expect(Trento.AI.Agent.Server.Mock, :subscribe, fn _ -> {:error, :no_pubsub} end)
 
       assert {:error, :no_pubsub} = TrentoAIAgent.run(agent, prompt)
@@ -131,10 +133,93 @@ defmodule Trento.AI.AgentTest do
 
     test "surfaces an add_message failure", %{agent: agent, prompt: prompt} do
       expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn _ -> {:ok, self()} end)
+      stub(Trento.AI.Agent.Server.Mock, :get_agent, fn _ -> {:error, :not_found} end)
       expect(Trento.AI.Agent.Server.Mock, :subscribe, fn _ -> :ok end)
       expect(Trento.AI.Agent.Server.Mock, :add_message, fn _, _ -> {:error, :timeout} end)
 
       assert {:error, :timeout} = TrentoAIAgent.run(agent, prompt)
+    end
+  end
+
+  describe "run/3 — refresh_when callback" do
+    setup :run_opts
+
+    test "invokes update_agent_and_state with the updated agent + current state when refresh_when returns {:ok, updated}",
+         %{agent: %Sagents.Agent{} = agent, agent_id: agent_id, prompt: prompt} do
+      current_agent = %Sagents.Agent{agent_id: agent_id, tool_context: %{flag: :current}}
+      updated_agent = %{agent | tool_context: %{flag: :updated}}
+      state = %Sagents.State{agent_id: agent_id}
+      test_pid = self()
+
+      refresh_when = fn current, new_agent ->
+        send(test_pid, {:refresh_when, current, new_agent})
+        {:ok, updated_agent}
+      end
+
+      expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn _ -> {:ok, self()} end)
+      expect(Trento.AI.Agent.Server.Mock, :get_agent, fn ^agent_id -> {:ok, current_agent} end)
+      expect(Trento.AI.Agent.Server.Mock, :get_info, fn ^agent_id -> %{state: state} end)
+
+      expect(Trento.AI.Agent.Server.Mock, :update_agent_and_state, fn ^agent_id,
+                                                                      ^updated_agent,
+                                                                      ^state ->
+        :ok
+      end)
+
+      expect(Trento.AI.Agent.Server.Mock, :subscribe, fn ^agent_id -> :ok end)
+      expect(Trento.AI.Agent.Server.Mock, :add_message, fn ^agent_id, _ -> :ok end)
+
+      assert :ok = TrentoAIAgent.run(agent, prompt, refresh_when: refresh_when)
+
+      assert_received {:refresh_when, ^current_agent, ^agent}
+    end
+
+    test "skips update_agent_and_state when refresh_when returns :noop",
+         %{agent: agent, agent_id: agent_id, prompt: prompt} do
+      refresh_when = fn _current, _new_agent -> :noop end
+
+      expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn _ -> {:ok, self()} end)
+
+      expect(Trento.AI.Agent.Server.Mock, :get_agent, fn ^agent_id ->
+        {:ok, %Sagents.Agent{agent_id: agent_id}}
+      end)
+
+      # No get_info / update_agent_and_state expectations —
+      # verify_on_exit! catches strays.
+      expect(Trento.AI.Agent.Server.Mock, :subscribe, fn ^agent_id -> :ok end)
+      expect(Trento.AI.Agent.Server.Mock, :add_message, fn ^agent_id, _ -> :ok end)
+
+      assert :ok = TrentoAIAgent.run(agent, prompt, refresh_when: refresh_when)
+    end
+
+    test "does not invoke refresh_when when AgentServer is not yet running",
+         %{agent: agent, agent_id: agent_id, prompt: prompt} do
+      refresh_when = fn _, _ ->
+        raise "refresh_when must not be called when no current agent exists"
+      end
+
+      expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn _ -> {:ok, self()} end)
+      expect(Trento.AI.Agent.Server.Mock, :get_agent, fn ^agent_id -> {:error, :not_found} end)
+      expect(Trento.AI.Agent.Server.Mock, :subscribe, fn ^agent_id -> :ok end)
+      expect(Trento.AI.Agent.Server.Mock, :add_message, fn ^agent_id, _ -> :ok end)
+
+      assert :ok = TrentoAIAgent.run(agent, prompt, refresh_when: refresh_when)
+    end
+
+    test "default refresh_when (no opt) never triggers update_agent_and_state",
+         %{agent: agent, agent_id: agent_id, prompt: prompt} do
+      expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn _ -> {:ok, self()} end)
+
+      expect(Trento.AI.Agent.Server.Mock, :get_agent, fn ^agent_id ->
+        {:ok, %Sagents.Agent{agent_id: agent_id}}
+      end)
+
+      # default_refresh_when/2 returns :noop unconditionally;
+      # no get_info / update_agent_and_state expectations.
+      expect(Trento.AI.Agent.Server.Mock, :subscribe, fn ^agent_id -> :ok end)
+      expect(Trento.AI.Agent.Server.Mock, :add_message, fn ^agent_id, _ -> :ok end)
+
+      assert :ok = TrentoAIAgent.run(agent, prompt)
     end
   end
 

--- a/test/trento_web/channels/ai_assistant_channel_test.exs
+++ b/test/trento_web/channels/ai_assistant_channel_test.exs
@@ -634,8 +634,8 @@ defmodule TrentoWeb.AIAssistantChannelTest do
         {:ok, %{tool_context: %{access_token: "stale_token"}}}
       end)
 
-      expect(Trento.AI.Agent.Server.Mock, :get_state, fn agent_id ->
-        %Sagents.State{agent_id: agent_id}
+      expect(Trento.AI.Agent.Server.Mock, :get_info, fn agent_id ->
+        %{state: %Sagents.State{agent_id: agent_id}}
       end)
 
       expect(Trento.AI.Agent.Server.Mock, :update_agent_and_state, fn _agent_id,
@@ -658,6 +658,101 @@ defmodule TrentoWeb.AIAssistantChannelTest do
       assert_push("ag_ui_event", %{"type" => "RUN_STARTED"})
 
       assert_receive {:updated_with, %Sagents.Agent{tool_context: %{access_token: ^jwt}}}, 1_000
+    end
+
+    test "does not call update_agent_and_state when running AgentServer already holds the same token",
+         %{socket: socket, user_id: user_id} do
+      jwt = generate_jwt(user_id)
+
+      expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn _ -> {:ok, self()} end)
+
+      stub(Trento.AI.Agent.Server.Mock, :get_agent, fn _ ->
+        {:ok, %Sagents.Agent{tool_context: %{access_token: jwt}}}
+      end)
+
+      # No get_info / update_agent_and_state expectations —
+      # access_token matches so the channel's refresh_when returns :noop.
+      expect(Trento.AI.Agent.Server.Mock, :subscribe, fn _ -> :ok end)
+      expect(Trento.AI.Agent.Server.Mock, :add_message, fn _, _ -> :ok end)
+
+      push(socket, "send_message", %{
+        "message" => "hi",
+        "run_id" => "r-same",
+        "thread_id" => "t-same",
+        "access_token" => jwt
+      })
+
+      assert_push("ag_ui_event", %{"type" => "RUN_STARTED"})
+    end
+
+    test "forwards :request_origin into the agent's tool_context",
+         %{socket: socket, user_id: user_id, request_origin: request_origin} do
+      jwt = generate_jwt(user_id)
+      test_pid = self()
+
+      expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn opts ->
+        send(test_pid, {:agent_opts, opts})
+        {:ok, self()}
+      end)
+
+      stub(Trento.AI.Agent.Server.Mock, :get_agent, fn _ -> {:error, :not_found} end)
+      expect(Trento.AI.Agent.Server.Mock, :subscribe, fn _ -> :ok end)
+      expect(Trento.AI.Agent.Server.Mock, :add_message, fn _, _ -> :ok end)
+
+      push(socket, "send_message", %{
+        "message" => "hi",
+        "run_id" => "r-origin",
+        "thread_id" => "t-origin",
+        "access_token" => jwt
+      })
+
+      assert_push("ag_ui_event", %{"type" => "RUN_STARTED"})
+
+      assert_receive {:agent_opts, opts}, 1_000
+
+      assert %Sagents.Agent{
+               tool_context: %{request_origin: ^request_origin}
+             } = opts[:agent]
+    end
+
+    test "tolerates :request_origin = nil and still starts the run", %{user_id: user_id} do
+      jwt = generate_jwt(user_id)
+
+      {:ok, _, socket} =
+        UserSocket
+        |> socket("user_id", %{current_user_id: user_id, request_origin: nil})
+        |> subscribe_and_join(AIAssistantChannel, "ai_assistant:#{user_id}", %{
+          "access_token" => jwt
+        })
+
+      Mox.allow(Trento.AI.Agent.Supervisor.Mock, self(), socket.channel_pid)
+      Mox.allow(Trento.AI.Agent.Server.Mock, self(), socket.channel_pid)
+
+      test_pid = self()
+
+      expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn opts ->
+        send(test_pid, {:agent_opts, opts})
+        {:ok, self()}
+      end)
+
+      stub(Trento.AI.Agent.Server.Mock, :get_agent, fn _ -> {:error, :not_found} end)
+      expect(Trento.AI.Agent.Server.Mock, :subscribe, fn _ -> :ok end)
+      expect(Trento.AI.Agent.Server.Mock, :add_message, fn _, _ -> :ok end)
+
+      push(socket, "send_message", %{
+        "message" => "hi",
+        "run_id" => "r-no-origin",
+        "thread_id" => "t-no-origin",
+        "access_token" => jwt
+      })
+
+      assert_push("ag_ui_event", %{"type" => "RUN_STARTED"})
+
+      assert_receive {:agent_opts, opts}, 1_000
+
+      assert %Sagents.Agent{
+               tool_context: %{access_token: ^jwt, request_origin: nil}
+             } = opts[:agent]
     end
   end
 
@@ -706,7 +801,10 @@ defmodule TrentoWeb.AIAssistantChannelTest do
 
       {:ok, _, socket} =
         UserSocket
-        |> socket("user_id", %{current_user_id: user_id})
+        |> socket("user_id", %{
+          current_user_id: user_id,
+          request_origin: "https://trento.test"
+        })
         |> subscribe_and_join(AIAssistantChannel, "ai_assistant:#{user_id}", %{
           "access_token" => jwt
         })
@@ -730,7 +828,10 @@ defmodule TrentoWeb.AIAssistantChannelTest do
 
       {:ok, _, socket} =
         UserSocket
-        |> socket("user_id", %{current_user_id: user_id})
+        |> socket("user_id", %{
+          current_user_id: user_id,
+          request_origin: "https://trento.test"
+        })
         |> subscribe_and_join(AIAssistantChannel, "ai_assistant:#{user_id}", %{
           "access_token" => jwt
         })
@@ -761,7 +862,10 @@ defmodule TrentoWeb.AIAssistantChannelTest do
 
       {:ok, _, socket} =
         UserSocket
-        |> socket("user_id", %{current_user_id: user_id})
+        |> socket("user_id", %{
+          current_user_id: user_id,
+          request_origin: "https://trento.test"
+        })
         |> subscribe_and_join(AIAssistantChannel, "ai_assistant:#{user_id}", %{
           "access_token" => jwt
         })
@@ -788,20 +892,22 @@ defmodule TrentoWeb.AIAssistantChannelTest do
 
   defp join_socket(_context) do
     jwt = generate_jwt(7)
+    request_origin = "https://trento.test"
 
     {:ok, _, socket} =
       UserSocket
-      |> socket("user_id", %{current_user_id: 7})
+      |> socket("user_id", %{current_user_id: 7, request_origin: request_origin})
       |> subscribe_and_join(AIAssistantChannel, "ai_assistant:7", %{
         "access_token" => jwt
       })
 
-    %{socket: socket, access_token: jwt}
+    %{socket: socket, access_token: jwt, request_origin: request_origin}
   end
 
   defp join_socket_with_ai_config(_context) do
     %{id: user_id} = insert(:user)
     jwt = generate_jwt(user_id)
+    request_origin = "https://trento.test"
 
     insert(:ai_user_configuration,
       user_id: user_id,
@@ -811,7 +917,7 @@ defmodule TrentoWeb.AIAssistantChannelTest do
 
     {:ok, _, socket} =
       UserSocket
-      |> socket("user_id", %{current_user_id: user_id})
+      |> socket("user_id", %{current_user_id: user_id, request_origin: request_origin})
       |> subscribe_and_join(AIAssistantChannel, "ai_assistant:#{user_id}", %{
         "access_token" => jwt
       })
@@ -819,7 +925,12 @@ defmodule TrentoWeb.AIAssistantChannelTest do
     Mox.allow(Trento.AI.Agent.Supervisor.Mock, self(), socket.channel_pid)
     Mox.allow(Trento.AI.Agent.Server.Mock, self(), socket.channel_pid)
 
-    %{socket: socket, user_id: user_id, access_token: jwt}
+    %{
+      socket: socket,
+      user_id: user_id,
+      access_token: jwt,
+      request_origin: request_origin
+    }
   end
 
   defp generate_jwt(sub), do: AccessToken.generate_access_token!(%{"sub" => sub})

--- a/test/trento_web/channels/ai_assistant_channel_test.exs
+++ b/test/trento_web/channels/ai_assistant_channel_test.exs
@@ -28,17 +28,64 @@ defmodule TrentoWeb.AIAssistantChannelTest do
   import Mox
   import Trento.Factory
 
+  alias TrentoWeb.Auth.AccessToken
+
   alias TrentoWeb.AIAssistantChannel
   alias TrentoWeb.UserSocket
 
   setup :verify_on_exit!
 
-  describe "join/3" do
-    test "joins ai_assistant:<user_id> when current_user_id matches" do
+  setup do
+    stub(Joken.CurrentTime.Mock, :current_time, fn -> 1_700_000_000 end)
+    :ok
+  end
+
+  describe "join/3 — access_token validation" do
+    test "accepts valid token, updates :access_token assign, and joins" do
+      jwt = generate_jwt(42)
+
       assert {:ok, _, socket} =
                UserSocket
                |> socket("user_id", %{current_user_id: 42})
-               |> subscribe_and_join(AIAssistantChannel, "ai_assistant:42")
+               |> subscribe_and_join(AIAssistantChannel, "ai_assistant:42", %{
+                 "access_token" => jwt
+               })
+
+      assert socket.assigns.access_token == jwt
+      assert socket.assigns.current_scope == %Trento.Users.User{id: 42}
+    end
+
+    test "rejects with :unauthorized for an invalid token" do
+      assert {:error, :unauthorized} =
+               UserSocket
+               |> socket("user_id", %{current_user_id: 42})
+               |> subscribe_and_join(AIAssistantChannel, "ai_assistant:42", %{
+                 "access_token" => "bad.jwt.token"
+               })
+    end
+
+    test "rejects with :unauthorized when token user does not match current_user_id" do
+      jwt_for_other_user = generate_jwt(99)
+
+      assert {:error, :unauthorized} =
+               UserSocket
+               |> socket("user_id", %{current_user_id: 42})
+               |> subscribe_and_join(AIAssistantChannel, "ai_assistant:42", %{
+                 "access_token" => jwt_for_other_user
+               })
+    end
+  end
+
+  describe "join/3" do
+    test "joins ai_assistant:<user_id> when current_user_id matches" do
+      jwt = generate_jwt(42)
+
+      assert {:ok, _, socket} =
+               UserSocket
+               |> socket("user_id", %{current_user_id: 42})
+               |> subscribe_and_join(AIAssistantChannel, "ai_assistant:42", %{
+                 "access_token" => jwt
+               })
 
       assert socket.assigns.current_scope == %Trento.Users.User{id: 42}
       assert socket.assigns.loading == false
@@ -48,13 +95,24 @@ defmodule TrentoWeb.AIAssistantChannelTest do
       assert {:error, :unauthorized} =
                UserSocket
                |> socket("user_id", %{current_user_id: 1})
-               |> subscribe_and_join(AIAssistantChannel, "ai_assistant:2")
+               |> subscribe_and_join(AIAssistantChannel, "ai_assistant:2", %{
+                 "access_token" => generate_jwt(1)
+               })
     end
 
     test "rejects with :user_not_logged when current_user_id is absent" do
       assert {:error, :user_not_logged} =
                UserSocket
                |> socket("user_id", %{})
+               |> subscribe_and_join(AIAssistantChannel, "ai_assistant:42", %{
+                 "access_token" => generate_jwt(42)
+               })
+    end
+
+    test "rejects with :user_not_logged when access_token is missing from payload" do
+      assert {:error, :user_not_logged} =
+               UserSocket
+               |> socket("user_id", %{current_user_id: 42})
                |> subscribe_and_join(AIAssistantChannel, "ai_assistant:42")
     end
 
@@ -64,7 +122,9 @@ defmodule TrentoWeb.AIAssistantChannelTest do
       assert {:error, :ai_assistant_disabled} =
                UserSocket
                |> socket("user_id", %{current_user_id: 42})
-               |> subscribe_and_join(AIAssistantChannel, "ai_assistant:42")
+               |> subscribe_and_join(AIAssistantChannel, "ai_assistant:42", %{
+                 "access_token" => generate_jwt(42)
+               })
     end
 
     test "prefers :ai_assistant_disabled over :unauthorized when AI is disabled with mismatched user_id" do
@@ -73,68 +133,105 @@ defmodule TrentoWeb.AIAssistantChannelTest do
       assert {:error, :ai_assistant_disabled} =
                UserSocket
                |> socket("user_id", %{current_user_id: 1})
-               |> subscribe_and_join(AIAssistantChannel, "ai_assistant:2")
+               |> subscribe_and_join(AIAssistantChannel, "ai_assistant:2", %{
+                 "access_token" => generate_jwt(1)
+               })
     end
 
     test "rejects with :unauthorized for non-numeric topic suffix (does not crash)" do
       assert {:error, :unauthorized} =
                UserSocket
                |> socket("user_id", %{current_user_id: 42})
-               |> subscribe_and_join(AIAssistantChannel, "ai_assistant:abc")
+               |> subscribe_and_join(AIAssistantChannel, "ai_assistant:abc", %{
+                 "access_token" => generate_jwt(42)
+               })
     end
 
     test "rejects with :unauthorized for numeric topic with trailing garbage" do
       assert {:error, :unauthorized} =
                UserSocket
                |> socket("user_id", %{current_user_id: 42})
-               |> subscribe_and_join(AIAssistantChannel, "ai_assistant:42xyz")
+               |> subscribe_and_join(AIAssistantChannel, "ai_assistant:42xyz", %{
+                 "access_token" => generate_jwt(42)
+               })
     end
   end
 
   describe "handle_in send_message/3 — payload contract" do
     setup :join_socket
 
-    test "ignores empty message text", %{socket: socket} do
+    test "ignores empty message text", %{socket: socket, access_token: jwt} do
       ref =
         push(socket, "send_message", %{
           "message" => "",
           "run_id" => "r1",
-          "thread_id" => "t1"
+          "thread_id" => "t1",
+          "access_token" => jwt
         })
 
       refute_reply(ref, _, 100)
       refute_push("agent_error", _, 100)
     end
 
-    test "ignores whitespace-only message text", %{socket: socket} do
+    test "ignores whitespace-only message text", %{socket: socket, access_token: jwt} do
       ref =
         push(socket, "send_message", %{
           "message" => "   \n\t  ",
           "run_id" => "r1",
-          "thread_id" => "t1"
+          "thread_id" => "t1",
+          "access_token" => jwt
         })
 
       refute_reply(ref, _, 100)
       refute_push("agent_error", _, 100)
     end
 
-    test "rejects payload missing :message", %{socket: socket} do
-      ref = push(socket, "send_message", %{"run_id" => "r1", "thread_id" => "t1"})
+    test "rejects payload missing :message", %{socket: socket, access_token: jwt} do
+      ref =
+        push(socket, "send_message", %{
+          "run_id" => "r1",
+          "thread_id" => "t1",
+          "access_token" => jwt
+        })
+
       assert_reply(ref, :error, :invalid_payload)
     end
 
-    test "rejects payload missing :run_id", %{socket: socket} do
-      ref = push(socket, "send_message", %{"message" => "hi", "thread_id" => "t1"})
+    test "rejects payload missing :run_id", %{socket: socket, access_token: jwt} do
+      ref =
+        push(socket, "send_message", %{
+          "message" => "hi",
+          "thread_id" => "t1",
+          "access_token" => jwt
+        })
+
       assert_reply(ref, :error, :invalid_payload)
     end
 
-    test "rejects payload missing :thread_id", %{socket: socket} do
-      ref = push(socket, "send_message", %{"message" => "hi", "run_id" => "r1"})
+    test "rejects payload missing :thread_id", %{socket: socket, access_token: jwt} do
+      ref =
+        push(socket, "send_message", %{
+          "message" => "hi",
+          "run_id" => "r1",
+          "access_token" => jwt
+        })
+
+      assert_reply(ref, :error, :invalid_payload)
+    end
+
+    test "rejects payload missing :access_token", %{socket: socket} do
+      ref =
+        push(socket, "send_message", %{
+          "message" => "hi",
+          "run_id" => "r1",
+          "thread_id" => "t1"
+        })
+
       assert_reply(ref, :error, :invalid_payload)
     end
 
     test "drops send while :loading is true and does NOT overwrite prior run_id/thread_id",
-         %{socket: socket} do
+         %{socket: socket, access_token: jwt} do
       seed_assigns(socket, %{
         loading: true,
         current_run_id: "prior-run",
@@ -145,7 +242,8 @@ defmodule TrentoWeb.AIAssistantChannelTest do
         push(socket, "send_message", %{
           "message" => "hi",
           "run_id" => "new-run",
-          "thread_id" => "new-thread"
+          "thread_id" => "new-thread",
+          "access_token" => jwt
         })
 
       refute_reply(ref, _, 100)
@@ -441,27 +539,66 @@ defmodule TrentoWeb.AIAssistantChannelTest do
     end
   end
 
-  describe "handle_in send_message/3 — tool_context" do
-    test "forwards socket :access_token to the agent as tool_context.access_token" do
-      %{id: user_id} = insert(:user)
+  describe "handle_in send_message/3 — access_token validation" do
+    setup :join_socket_with_ai_config
 
-      insert(:ai_user_configuration,
-        user_id: user_id,
-        provider: :googleai,
-        model: "gemini-2.5-flash"
-      )
+    test "updates :access_token assign and starts run when token is valid",
+         %{socket: socket, user_id: user_id} do
+      jwt = generate_jwt(user_id)
 
-      {:ok, _, socket} =
-        UserSocket
-        |> socket("user_id", %{
-          current_user_id: user_id,
-          access_token: "ws-jwt-token-xyz"
+      expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn _ -> {:ok, self()} end)
+      stub(Trento.AI.Agent.Server.Mock, :get_agent, fn _ -> {:error, :not_found} end)
+      expect(Trento.AI.Agent.Server.Mock, :subscribe, fn _ -> :ok end)
+      expect(Trento.AI.Agent.Server.Mock, :add_message, fn _, _ -> :ok end)
+
+      push(socket, "send_message", %{
+        "message" => "hello",
+        "run_id" => "r-tok",
+        "thread_id" => "t-tok",
+        "access_token" => jwt
+      })
+
+      assert_push("ag_ui_event", %{"type" => "RUN_STARTED"})
+      assert %{access_token: ^jwt} = wait_assigns(socket)
+    end
+
+    test "replies {:error, :unauthorized} and does not start run for invalid token",
+         %{socket: socket} do
+      ref =
+        push(socket, "send_message", %{
+          "message" => "hello",
+          "run_id" => "r-bad",
+          "thread_id" => "t-bad",
+          "access_token" => "bad.jwt.token"
         })
-        |> subscribe_and_join(AIAssistantChannel, "ai_assistant:#{user_id}")
 
-      Mox.allow(Trento.AI.Agent.Supervisor.Mock, self(), socket.channel_pid)
-      Mox.allow(Trento.AI.Agent.Server.Mock, self(), socket.channel_pid)
+      assert_reply ref, :error, :unauthorized
+      refute_push("ag_ui_event", _, 100)
+    end
 
+    test "replies {:error, :unauthorized} when token sub does not match the socket user",
+         %{socket: socket} do
+      jwt_for_other_user = generate_jwt(99)
+
+      ref =
+        push(socket, "send_message", %{
+          "message" => "hello",
+          "run_id" => "r-wrong-user",
+          "thread_id" => "t-wrong-user",
+          "access_token" => jwt_for_other_user
+        })
+
+      assert_reply ref, :error, :unauthorized
+      refute_push("ag_ui_event", _, 100)
+    end
+  end
+
+  describe "handle_in send_message/3 — tool_context" do
+    setup :join_socket_with_ai_config
+
+    test "forwards the per-message access_token into the agent's tool_context",
+         %{socket: socket, user_id: user_id} do
+      jwt = generate_jwt(user_id)
       test_pid = self()
 
       expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn opts ->
@@ -469,47 +606,71 @@ defmodule TrentoWeb.AIAssistantChannelTest do
         {:ok, self()}
       end)
 
+      stub(Trento.AI.Agent.Server.Mock, :get_agent, fn _ -> {:error, :not_found} end)
       expect(Trento.AI.Agent.Server.Mock, :subscribe, fn _ -> :ok end)
       expect(Trento.AI.Agent.Server.Mock, :add_message, fn _, _ -> :ok end)
 
       push(socket, "send_message", %{
         "message" => "hi",
         "run_id" => "r-jwt",
-        "thread_id" => "t-jwt"
+        "thread_id" => "t-jwt",
+        "access_token" => jwt
       })
 
-      # Wait until the channel process finishes the send_message round-trip
-      # so every Mox expectation in the chain (start_agent_sync → subscribe
-      # → add_message) actually runs before the test exits.
       assert_push("ag_ui_event", %{"type" => "RUN_STARTED"})
 
       assert_receive {:agent_opts, opts}, 1_000
-      assert %Sagents.Agent{tool_context: %{access_token: "ws-jwt-token-xyz"}} = opts[:agent]
+      assert %Sagents.Agent{tool_context: %{access_token: ^jwt}} = opts[:agent]
+    end
+
+    test "pushes the fresh token into the running AgentServer via update_agent_and_state when stale",
+         %{socket: socket, user_id: user_id} do
+      jwt = generate_jwt(user_id)
+      test_pid = self()
+
+      expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn _ -> {:ok, self()} end)
+
+      stub(Trento.AI.Agent.Server.Mock, :get_agent, fn _ ->
+        {:ok, %{tool_context: %{access_token: "stale_token"}}}
+      end)
+
+      expect(Trento.AI.Agent.Server.Mock, :get_state, fn agent_id ->
+        %Sagents.State{agent_id: agent_id}
+      end)
+
+      expect(Trento.AI.Agent.Server.Mock, :update_agent_and_state, fn _agent_id,
+                                                                      fresh_agent,
+                                                                      _state ->
+        send(test_pid, {:updated_with, fresh_agent})
+        :ok
+      end)
+
+      expect(Trento.AI.Agent.Server.Mock, :subscribe, fn _ -> :ok end)
+      expect(Trento.AI.Agent.Server.Mock, :add_message, fn _, _ -> :ok end)
+
+      push(socket, "send_message", %{
+        "message" => "hi",
+        "run_id" => "r-stale",
+        "thread_id" => "t-stale",
+        "access_token" => jwt
+      })
+
+      assert_push("ag_ui_event", %{"type" => "RUN_STARTED"})
+
+      assert_receive {:updated_with, %Sagents.Agent{tool_context: %{access_token: ^jwt}}}, 1_000
     end
   end
 
   describe "handle_in send_message/3 — happy path" do
-    test "calls Agent.run/2 and pushes RUN_STARTED on success" do
-      %{id: user_id} = insert(:user)
+    setup :join_socket_with_ai_config
 
-      insert(:ai_user_configuration,
-        user_id: user_id,
-        provider: :googleai,
-        model: "gemini-2.5-flash"
-      )
-
-      {:ok, _, socket} =
-        UserSocket
-        |> socket("user_id", %{current_user_id: user_id})
-        |> subscribe_and_join(AIAssistantChannel, "ai_assistant:#{user_id}")
-
-      Mox.allow(Trento.AI.Agent.Supervisor.Mock, self(), socket.channel_pid)
-      Mox.allow(Trento.AI.Agent.Server.Mock, self(), socket.channel_pid)
-
+    test "calls Agent.run/2 and pushes RUN_STARTED on success",
+         %{socket: socket, access_token: jwt} do
       expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn _opts ->
         {:ok, self()}
       end)
 
+      stub(Trento.AI.Agent.Server.Mock, :get_agent, fn _ -> {:error, :not_found} end)
       expect(Trento.AI.Agent.Server.Mock, :subscribe, fn _agent_id -> :ok end)
       expect(Trento.AI.Agent.Server.Mock, :add_message, fn _agent_id, _msg -> :ok end)
 
@@ -519,7 +680,8 @@ defmodule TrentoWeb.AIAssistantChannelTest do
       push(socket, "send_message", %{
         "message" => "hi",
         "run_id" => run_id,
-        "thread_id" => thread_id
+        "thread_id" => thread_id,
+        "access_token" => jwt
       })
 
       assert_push("ag_ui_event", %{
@@ -540,16 +702,20 @@ defmodule TrentoWeb.AIAssistantChannelTest do
   describe "handle_in send_message/3 — error paths" do
     test "emits verbatim RUN_ERROR when user has no AI configuration" do
       %{id: user_id} = insert(:user)
+      jwt = generate_jwt(user_id)
 
       {:ok, _, socket} =
         UserSocket
         |> socket("user_id", %{current_user_id: user_id})
-        |> subscribe_and_join(AIAssistantChannel, "ai_assistant:#{user_id}")
+        |> subscribe_and_join(AIAssistantChannel, "ai_assistant:#{user_id}", %{
+          "access_token" => jwt
+        })
 
       push(socket, "send_message", %{
         "message" => "hi",
         "run_id" => "r1",
-        "thread_id" => "t1"
+        "thread_id" => "t1",
+        "access_token" => jwt
       })
 
       assert_push("ag_ui_event", %{
@@ -560,16 +726,20 @@ defmodule TrentoWeb.AIAssistantChannelTest do
 
     test "does NOT stash run_id/thread_id when LLMBuilder errors out" do
       %{id: user_id} = insert(:user)
+      jwt = generate_jwt(user_id)
 
       {:ok, _, socket} =
         UserSocket
         |> socket("user_id", %{current_user_id: user_id})
-        |> subscribe_and_join(AIAssistantChannel, "ai_assistant:#{user_id}")
+        |> subscribe_and_join(AIAssistantChannel, "ai_assistant:#{user_id}", %{
+          "access_token" => jwt
+        })
 
       push(socket, "send_message", %{
         "message" => "hi",
         "run_id" => "should-not-stash",
-        "thread_id" => "should-not-stash"
+        "thread_id" => "should-not-stash",
+        "access_token" => jwt
       })
 
       assert_push("ag_ui_event", %{"type" => "RUN_ERROR"})
@@ -581,6 +751,7 @@ defmodule TrentoWeb.AIAssistantChannelTest do
 
     test "emits verbatim RUN_ERROR when sagents start_agent_sync fails" do
       %{id: user_id} = insert(:user)
+      jwt = generate_jwt(user_id)
 
       insert(:ai_user_configuration,
         user_id: user_id,
@@ -591,7 +762,9 @@ defmodule TrentoWeb.AIAssistantChannelTest do
       {:ok, _, socket} =
         UserSocket
         |> socket("user_id", %{current_user_id: user_id})
-        |> subscribe_and_join(AIAssistantChannel, "ai_assistant:#{user_id}")
+        |> subscribe_and_join(AIAssistantChannel, "ai_assistant:#{user_id}", %{
+          "access_token" => jwt
+        })
 
       Mox.allow(Trento.AI.Agent.Supervisor.Mock, self(), socket.channel_pid)
 
@@ -602,7 +775,8 @@ defmodule TrentoWeb.AIAssistantChannelTest do
       push(socket, "send_message", %{
         "message" => "hi",
         "run_id" => "r1",
-        "thread_id" => "t1"
+        "thread_id" => "t1",
+        "access_token" => jwt
       })
 
       assert_push("ag_ui_event", %{
@@ -613,13 +787,42 @@ defmodule TrentoWeb.AIAssistantChannelTest do
   end
 
   defp join_socket(_context) do
+    jwt = generate_jwt(7)
+
     {:ok, _, socket} =
       UserSocket
       |> socket("user_id", %{current_user_id: 7})
-      |> subscribe_and_join(AIAssistantChannel, "ai_assistant:7")
+      |> subscribe_and_join(AIAssistantChannel, "ai_assistant:7", %{
+        "access_token" => jwt
+      })
 
-    %{socket: socket}
+    %{socket: socket, access_token: jwt}
   end
+
+  defp join_socket_with_ai_config(_context) do
+    %{id: user_id} = insert(:user)
+    jwt = generate_jwt(user_id)
+
+    insert(:ai_user_configuration,
+      user_id: user_id,
+      provider: :googleai,
+      model: "gemini-2.5-flash"
+    )
+
+    {:ok, _, socket} =
+      UserSocket
+      |> socket("user_id", %{current_user_id: user_id})
+      |> subscribe_and_join(AIAssistantChannel, "ai_assistant:#{user_id}", %{
+        "access_token" => jwt
+      })
+
+    Mox.allow(Trento.AI.Agent.Supervisor.Mock, self(), socket.channel_pid)
+    Mox.allow(Trento.AI.Agent.Server.Mock, self(), socket.channel_pid)
+
+    %{socket: socket, user_id: user_id, access_token: jwt}
+  end
+
+  defp generate_jwt(sub), do: AccessToken.generate_access_token!(%{"sub" => sub})
 
   # Test escape hatch: directly seeds socket.assigns by patching the
   # channel GenServer's state. Bypasses the JS-driven assigns chain so


### PR DESCRIPTION
# Description

This PR make enhances an AI Agent so that it can be refreshed with up-to-date context.

In our usecase it means that upon a refresh of the access toke done by the client, the next interaction with the AI agent will provide the fresh token that will be available to the agent, so that requests to wanda can be successful.

token refresh in the client will follow up.

## How was this tested?

Automatic and IRL tests.

## Did you update the documentation?

No need.