### PR TITLE
Handle token refresh in AI conversation

### DIFF
--- a/assets/js/common/AIAssistant/AssistantChatProvider.jsx
+++ b/assets/js/common/AIAssistant/AssistantChatProvider.jsx
@@ -20,14 +20,12 @@ function AssistantChatProvider({
 
   const agent = useMemo(() => {
     if (!socket || !userID) return null;
-    // AG-UI's AgentConfig field is `threadId` (camel) — translate.
     return new WebSocketAIAgent({
       socket,
       userID,
-      threadId: threadID,
       onConnectionChange,
     });
-  }, [socket, userID, threadID, onConnectionChange]);
+  }, [socket, userID, onConnectionChange]);
 
   useEffect(() => {
     if (!agent) return undefined;
@@ -38,13 +36,21 @@ function AssistantChatProvider({
     return () => agent.disconnect();
   }, [agent]);
 
+  useEffect(() => {
+    // The AG-UI runtime reads `agent.threadId` when building each run's
+    // payload (defaults to "main" if unset). Mutate the live agent instead
+    // of rebuilding it so the channel + websocket stay alive across thread
+    // changes.
+    if (agent) agent.threadId = threadID;
+  }, [agent, threadID]);
+
   const runtime = useAgUiRuntime({ agent });
   const aui = useAui();
 
   // useAgUiRuntime keeps its core (and the message store) in a useRef across
-  // agent swaps, so bumping threadID rebuilds the agent + websocket but
-  // leaves the prior thread's messages onscreen. Wipe them explicitly when
-  // the thread id actually changes; the first mount is a no-op.
+  // re-renders. When threadID changes we keep the same agent (above) but the
+  // UI must drop the prior thread's messages explicitly; the first mount is
+  // a no-op.
   const previousThreadIDRef = useRef(threadID);
   useEffect(() => {
     if (previousThreadIDRef.current === threadID) return;

--- a/assets/js/common/AIAssistant/AssistantChatProvider.test.jsx
+++ b/assets/js/common/AIAssistant/AssistantChatProvider.test.jsx
@@ -100,8 +100,9 @@ describe('AssistantChatProvider', () => {
     });
     const [agent] = agentModule.__getInstances();
     expect(agent.opts.userID).toBe(7);
-    // Provider translates threadID prop to AG-UI's `threadId` constructor option.
-    expect(agent.opts.threadId).toBe('thread-x');
+    // threadID is NOT passed at construction — it's a per-message field
+    // forwarded inside run({messages, threadId}) at call time.
+    expect(agent.opts.threadId).toBeUndefined();
     expect(agent.opts.socket).toBe(fakeSocket);
     expect(lastRuntimeOptions().agent).toBe(agent);
   });
@@ -139,15 +140,15 @@ describe('AssistantChatProvider', () => {
     expect(onConnectionChange).toHaveBeenCalledWith('connected');
   });
 
-  it('rebuilds the agent and disconnects the old one when threadID changes', async () => {
+  it('updates agent.threadId when threadID changes without rebuilding the agent', async () => {
     const { rerender } = render(
       <AssistantChatProvider userID={42} threadID="thread-1">
         <div />
       </AssistantChatProvider>
     );
     await waitFor(() => expect(agentModule.__getInstances()).toHaveLength(1));
-    const [first] = agentModule.__getInstances();
-    expect(first.opts.threadId).toBe('thread-1');
+    const [agent] = agentModule.__getInstances();
+    await waitFor(() => expect(agent.threadId).toBe('thread-1'));
 
     rerender(
       <AssistantChatProvider userID={42} threadID="thread-2">
@@ -155,10 +156,9 @@ describe('AssistantChatProvider', () => {
       </AssistantChatProvider>
     );
 
-    await waitFor(() => expect(agentModule.__getInstances()).toHaveLength(2));
-    const [, second] = agentModule.__getInstances();
-    expect(second.opts.threadId).toBe('thread-2');
-    expect(first.disconnect).toHaveBeenCalled();
+    await waitFor(() => expect(agent.threadId).toBe('thread-2'));
+    expect(agentModule.__getInstances()).toHaveLength(1);
+    expect(agent.disconnect).not.toHaveBeenCalled();
   });
 
   it('does not reset the runtime on the first mount', () => {

--- a/assets/js/lib/ai/WebSocketAIAgent.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.js
@@ -7,11 +7,14 @@ import { isArray, isString, last } from 'lodash';
 
 import { EventType } from '@ag-ui/core';
 
+import { getAccessTokenFromStore, refreshAndStoreAccessToken } from '@lib/auth';
+import { handleUnrecoverableAuthError } from '@lib/network';
+
 import { CONNECTION_STATUS } from './connectionStatus';
 
 // Pure helper: collapse a message's content (string or array of parts) to
 // the plain text the server expects in `send_message`.
-export function extractMessageText({ content } = {}) {
+export const extractMessageText = ({ content } = {}) => {
   if (isString(content)) return content;
   if (isArray(content)) {
     return content
@@ -20,7 +23,7 @@ export function extractMessageText({ content } = {}) {
       .join('\n');
   }
   return '';
-}
+};
 
 class AbortError extends Error {
   constructor(message) {
@@ -28,6 +31,32 @@ class AbortError extends Error {
     this.name = 'AbortError';
   }
 }
+
+const isUnauthorized = (error) => error === 'unauthorized';
+
+// Refresh the access token; on failure, kick off the global "session expired"
+// redirect and re-throw
+const refreshOrAbort = async () => {
+  try {
+    await refreshAndStoreAccessToken();
+  } catch {
+    handleUnrecoverableAuthError();
+    throw new Error('Session expired — please log in again');
+  }
+};
+
+// Run `operation` and, if it rejects with an "unauthorized" wire payload,
+// refresh the access token once and retry. Any other rejection from
+// `operation` propagates verbatim.
+const withRefreshTokenOnUnauthorized = async (operation) => {
+  try {
+    return await operation();
+  } catch (error) {
+    if (!isUnauthorized(error)) throw error;
+  }
+  await refreshOrAbort();
+  return operation();
+};
 
 // Bridges assistant-ui's AG-UI runtime with Phoenix channels: translates
 // AG-UI protocol events to/from channel events for the ai_assistant:{userID}
@@ -45,29 +74,37 @@ export class WebSocketAIAgent extends AbstractAgent {
     this._activeRunId = null;
   }
 
+  // Idempotent async initializer for the channel connection
   async initialize() {
-    if (this.channel) return undefined;
-
-    if (!this.socket) {
-      this._setConnectionStatus(CONNECTION_STATUS.DISCONNECTED);
-      throw new Error('No socket available');
-    }
-    if (!this.userID) {
-      this._setConnectionStatus(CONNECTION_STATUS.DISCONNECTED);
-      throw new Error('No userID available');
-    }
+    if (this.channel) return;
+    if (!this.socket) throw new Error('No socket available');
+    if (!this.userID) throw new Error('No userID available');
 
     this._setConnectionStatus(CONNECTION_STATUS.CONNECTING);
-    this.channel = this.socket.channel(`ai_assistant:${this.userID}`, {});
+    try {
+      await this._join();
+    } catch (error) {
+      this._teardown();
+      this._setConnectionStatus(CONNECTION_STATUS.DISCONNECTED);
+      throw error;
+    }
+  }
+
+  // Join the channel, refreshing the access token + retrying once if the
+  // server replies 'unauthorized'.
+  _join() {
+    return withRefreshTokenOnUnauthorized(() => this._doJoin());
+  }
+
+  // Build a fresh channel and await its join.
+  // On 'unauthorized' the channel reference is dropped so the helper's retry rebuilds
+  // with the just-refreshed token in the params callback.
+  _doJoin() {
+    this.channel = this.socket.channel(`ai_assistant:${this.userID}`, () => ({
+      access_token: getAccessTokenFromStore(),
+    }));
     this._setupChannelHandlers();
-
     return new Promise((resolve, reject) => {
-      const fail = (message) => {
-        this.channel = null;
-        this._setConnectionStatus(CONNECTION_STATUS.DISCONNECTED);
-        reject(new Error(message));
-      };
-
       this.channel
         .join()
         .receive('ok', () => {
@@ -75,10 +112,12 @@ export class WebSocketAIAgent extends AbstractAgent {
           resolve();
         })
         .receive('error', (resp) => {
-          fail(`Failed to join channel: ${JSON.stringify(resp)}`);
+          this._teardown();
+          reject(resp);
         })
         .receive('timeout', () => {
-          fail('Channel join timeout');
+          this._teardown();
+          reject(new Error('Channel join timeout'));
         });
     });
   }
@@ -86,7 +125,7 @@ export class WebSocketAIAgent extends AbstractAgent {
   _setupChannelHandlers() {
     // Keep `this.channel` non-null on transport drops: Phoenix's Socket
     // auto-rejoins the channel when the WS comes back, and the joinPush's
-    // existing receive('ok') handler will flip status back to CONNECTED.
+    // existing receive('ok') handler flips status back to CONNECTED.
     // Channel.push also buffers while the socket is down and flushes on
     // rejoin, so preserving the reference makes a "drop → recover → prompt"
     // sequence Just Work.
@@ -117,41 +156,38 @@ export class WebSocketAIAgent extends AbstractAgent {
 
   // Implements AbstractAgent.run — invoked by assistant-ui when the user
   // submits a message. Returns an Observable of AG-UI events.
+  //
+  // Active-run state is assigned synchronously before the async IIFE so
+  // connection-drop / disconnect handlers can surface errors on the in-flight
+  // subscriber immediately (they check _activeSubscriber, not the closure).
+  // The send itself is deferred by at most one microtask via `await initialize()`.
   run({ messages, threadId }) {
     return new Observable((subscriber) => {
       const runId = crypto.randomUUID();
+      const lastMessage = last(messages);
+
+      if (!lastMessage || lastMessage.role !== 'user') {
+        subscriber.error(
+          new Error('Cannot start a run without a new user message')
+        );
+        return undefined;
+      }
+
+      this._activeRunId = runId;
+      this._activeSubscriber = subscriber;
 
       const setupRun = async () => {
         try {
-          if (
-            !this.channel ||
-            this._connectionStatus !== CONNECTION_STATUS.CONNECTED
-          ) {
-            await this.initialize();
-          }
-
-          const lastMessage = last(messages);
-          if (!lastMessage || lastMessage.role !== 'user') {
-            subscriber.error(
-              new Error('Cannot start a run without a new user message')
-            );
-            return;
-          }
-
-          this._activeRunId = runId;
-          this._activeSubscriber = subscriber;
-
-          this.channel
-            .push('send_message', {
+          await this.initialize();
+          await withRefreshTokenOnUnauthorized(() =>
+            this._sendMessage({
               message: extractMessageText(lastMessage),
               thread_id: threadId,
               run_id: runId,
             })
-            .receive('error', (error) => {
-              if (this._activeRunId === runId) this._clearActiveRun();
-              subscriber.error(error);
-            });
+          );
         } catch (error) {
+          if (this._activeRunId === runId) this._clearActiveRun();
           subscriber.error(error);
         }
       };
@@ -163,6 +199,27 @@ export class WebSocketAIAgent extends AbstractAgent {
       return () => {
         if (this._activeRunId === runId) this._clearActiveRun();
       };
+    });
+  }
+
+  // Send the message, refreshing the access token + retrying once if the
+  // server replies 'unauthorized'.
+  _sendMessage(payload) {
+    return withRefreshTokenOnUnauthorized(() => this._doSendMessage(payload));
+  }
+
+  // Raw send: one push, resolves on 'ok', rejects on 'error'. Reads the
+  // access token fresh from storage so a retry after refresh naturally picks
+  // up the new value.
+  _doSendMessage(payload) {
+    return new Promise((resolve, reject) => {
+      this.channel
+        .push('send_message', {
+          ...payload,
+          access_token: getAccessTokenFromStore(),
+        })
+        .receive('ok', resolve)
+        .receive('error', reject);
     });
   }
 
@@ -186,13 +243,19 @@ export class WebSocketAIAgent extends AbstractAgent {
 
   disconnect() {
     if (!this.channel) return;
-    this.channel.leave();
-    this.channel = null;
+    this._teardown();
     // Tag the teardown error as an AbortError so AbstractAgent's `onError`
     // treats it as an expected unmount/cancel.
     //
     // (See AbstractAgent.onError's allowlist in @ag-ui/client.)
     this._failActiveRun(new AbortError('AI assistant disconnected'));
     this._setConnectionStatus(CONNECTION_STATUS.DISCONNECTED);
+  }
+
+  _teardown() {
+    // Releases the channel from `socket.channels` so a failed join does not
+    // accumulate as a zombie reference
+    this.channel?.leave();
+    this.channel = null;
   }
 }

--- a/assets/js/lib/ai/WebSocketAIAgent.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.js
@@ -179,13 +179,11 @@ export class WebSocketAIAgent extends AbstractAgent {
       const setupRun = async () => {
         try {
           await this.initialize();
-          await withRefreshTokenOnUnauthorized(() =>
-            this._sendMessage({
-              message: extractMessageText(lastMessage),
-              thread_id: threadId,
-              run_id: runId,
-            })
-          );
+          await this._sendMessage({
+            message: extractMessageText(lastMessage),
+            thread_id: threadId,
+            run_id: runId,
+          });
         } catch (error) {
           if (this._activeRunId === runId) this._clearActiveRun();
           subscriber.error(error);

--- a/assets/js/lib/ai/WebSocketAIAgent.test.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.test.js
@@ -2,7 +2,30 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { makeMockSocket } from '@lib/test-utils/phoenixDoubles';
+import { getAccessTokenFromStore, refreshAndStoreAccessToken } from '@lib/auth';
+import { handleUnrecoverableAuthError } from '@lib/network';
 import { extractMessageText, WebSocketAIAgent } from './WebSocketAIAgent';
+
+jest.mock('@lib/auth', () => ({
+  getAccessTokenFromStore: jest.fn(() => 'TEST_TOKEN'),
+  refreshAndStoreAccessToken: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('@lib/network', () => ({
+  handleUnrecoverableAuthError: jest.fn(),
+}));
+
+beforeEach(() => {
+  getAccessTokenFromStore.mockReset();
+  getAccessTokenFromStore.mockReturnValue('TEST_TOKEN');
+  refreshAndStoreAccessToken.mockReset();
+  // Mirror real behavior: refreshAndStoreAccessToken stores the new token
+  // in localStorage, so subsequent getAccessTokenFromStore() reads it back.
+  refreshAndStoreAccessToken.mockImplementation(async () => {
+    getAccessTokenFromStore.mockReturnValue('NEW_TOKEN');
+  });
+  handleUnrecoverableAuthError.mockClear();
+});
 
 // Wrap socket.channel + each channel.leave with jest.fn so the existing
 // `toHaveBeenCalled` / `mockClear` assertions still apply. The shared
@@ -70,7 +93,12 @@ describe('WebSocketAIAgent', () => {
 
       const initPromise = agent.initialize();
 
-      expect(socket.channel).toHaveBeenCalledWith('ai_assistant:u42', {});
+      expect(socket.channel).toHaveBeenCalledWith(
+        'ai_assistant:u42',
+        expect.any(Function)
+      );
+      const [, paramsFn] = socket.channel.mock.calls[0];
+      expect(paramsFn()).toEqual({ access_token: 'TEST_TOKEN' });
       expect(onConnectionChange).toHaveBeenNthCalledWith(1, 'connecting');
 
       getChannel().joinPush.fire('ok');
@@ -79,30 +107,23 @@ describe('WebSocketAIAgent', () => {
       expect(onConnectionChange).toHaveBeenNthCalledWith(2, 'connected');
     });
 
-    it.each([
-      {
-        scenario: 'join error',
-        receive: 'error',
-        payload: { reason: 'boom' },
-        rejectsWith: /Failed to join channel/,
-      },
-      {
-        scenario: 'join timeout',
-        receive: 'timeout',
-        payload: undefined,
-        rejectsWith: /Channel join timeout/,
-      },
-    ])(
-      'rejects on $scenario and reports disconnected',
-      async ({ receive, payload, rejectsWith }) => {
-        const { agent, onConnectionChange, getChannel } = makeAgent();
-        const initPromise = agent.initialize();
-        getChannel().joinPush.fire(receive, payload);
+    it('rejects on join error and reports disconnected', async () => {
+      const { agent, onConnectionChange, getChannel } = makeAgent();
+      const initPromise = agent.initialize();
+      getChannel().joinPush.fire('error', { reason: 'boom' });
 
-        await expect(initPromise).rejects.toThrow(rejectsWith);
-        expect(onConnectionChange).toHaveBeenLastCalledWith('disconnected');
-      }
-    );
+      await expect(initPromise).rejects.toEqual({ reason: 'boom' });
+      expect(onConnectionChange).toHaveBeenLastCalledWith('disconnected');
+    });
+
+    it('rejects on join timeout and reports disconnected', async () => {
+      const { agent, onConnectionChange, getChannel } = makeAgent();
+      const initPromise = agent.initialize();
+      getChannel().joinPush.fire('timeout');
+
+      await expect(initPromise).rejects.toThrow(/Channel join timeout/);
+      expect(onConnectionChange).toHaveBeenLastCalledWith('disconnected');
+    });
 
     it.each([
       {
@@ -131,6 +152,46 @@ describe('WebSocketAIAgent', () => {
       await agent.initialize();
 
       expect(socket.channel).not.toHaveBeenCalled();
+    });
+
+    it('refreshes and rejoins on join error with reason "unauthorized"', async () => {
+      const { agent, socket, getChannel } = makeAgent({ userID: 'u9' });
+
+      const initPromise = agent.initialize();
+      const firstChannel = getChannel();
+
+      // First join attempt fails with unauthorized.
+      firstChannel.joinPush.fire('error', 'unauthorized');
+      await flushMicrotasks();
+
+      // The agent should have requested a refresh and asked for a fresh channel.
+      expect(refreshAndStoreAccessToken).toHaveBeenCalledTimes(1);
+      // Second channel created (initialize re-entered after channel was nulled).
+      expect(socket.channel).toHaveBeenCalledTimes(2);
+
+      // Second join succeeds — initPromise resolves.
+      const secondChannel = getChannel();
+      secondChannel.joinPush.fire('ok');
+      await initPromise;
+
+      expect(agent._connectionStatus).toBe('connected');
+    });
+
+    it('fails initialize when unauthorized refresh itself errors', async () => {
+      refreshAndStoreAccessToken.mockRejectedValueOnce(
+        new Error('no refresh token available')
+      );
+
+      const { agent, getChannel } = makeAgent({ userID: 'u10' });
+      const initPromise = agent.initialize();
+
+      getChannel().joinPush.fire('error', 'unauthorized');
+
+      await expect(initPromise).rejects.toThrow(
+        'Session expired — please log in again'
+      );
+      expect(agent._connectionStatus).toBe('disconnected');
+      expect(handleUnrecoverableAuthError).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -167,6 +228,7 @@ describe('WebSocketAIAgent', () => {
         messages: [userMessage('hello there')],
       });
 
+      await flushMicrotasks();
       expect(channel.pushed).toHaveLength(1);
       expect(channel.pushed[0]).toMatchObject({
         event: 'send_message',
@@ -174,9 +236,76 @@ describe('WebSocketAIAgent', () => {
           message: 'hello there',
           thread_id: 'thread-1',
           run_id: agent._activeRunId,
+          access_token: 'TEST_TOKEN',
         },
       });
       expect(typeof agent._activeRunId).toBe('string');
+    });
+
+    it('refreshes the token and retries send_message once on unauthorized error', async () => {
+      const { agent, channel } = await connectedAgent();
+      const { error, next } = runAgent(agent);
+
+      await flushMicrotasks();
+      // First push fails with unauthorized.
+      channel.pushed[0].push.fire('error', 'unauthorized');
+      await flushMicrotasks();
+
+      // The agent refreshed and re-pushed with the new token.
+      expect(refreshAndStoreAccessToken).toHaveBeenCalledTimes(1);
+      expect(channel.pushed).toHaveLength(2);
+      expect(channel.pushed[1].payload.access_token).toBe('NEW_TOKEN');
+
+      // The retried push then succeeds (no error fired on it). Simulate an
+      // upstream event to confirm the subscriber is still alive.
+      channel.emit('ag_ui_event', {
+        type: 'TEXT_MESSAGE_CONTENT',
+        delta: 'ok',
+      });
+
+      expect(error).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith({
+        type: 'TEXT_MESSAGE_CONTENT',
+        delta: 'ok',
+      });
+    });
+
+    it('errors the subscriber when the refresh itself fails', async () => {
+      refreshAndStoreAccessToken.mockRejectedValueOnce(
+        new Error('no refresh token available')
+      );
+
+      const { agent, channel } = await connectedAgent();
+      const { error } = runAgent(agent);
+
+      await flushMicrotasks();
+      channel.pushed[0].push.fire('error', 'unauthorized');
+      await flushMicrotasks();
+      await flushMicrotasks();
+
+      expect(error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Session expired — please log in again',
+        })
+      );
+      expect(agent._activeSubscriber).toBeNull();
+      expect(handleUnrecoverableAuthError).toHaveBeenCalledTimes(1);
+    });
+
+    it('errors the subscriber when the retried push also fails', async () => {
+      const { agent, channel } = await connectedAgent();
+      const { error } = runAgent(agent);
+
+      await flushMicrotasks();
+      channel.pushed[0].push.fire('error', 'unauthorized');
+      await flushMicrotasks();
+
+      // Retried push fails for some other reason.
+      channel.pushed[1].push.fire('error', { reason: 'still broken' });
+      await flushMicrotasks();
+
+      expect(error).toHaveBeenCalledWith({ reason: 'still broken' });
+      expect(agent._activeSubscriber).toBeNull();
     });
 
     it('forwards ag_ui_event payloads to the active subscriber', async () => {
@@ -244,7 +373,10 @@ describe('WebSocketAIAgent', () => {
       const { agent, channel } = await connectedAgent();
       const { error } = runAgent(agent);
 
+      await flushMicrotasks();
       channel.pushed[0].push.fire('error', { reason: 'rejected' });
+      await flushMicrotasks();
+      await flushMicrotasks();
 
       expect(error).toHaveBeenCalledWith({ reason: 'rejected' });
       expect(agent._activeSubscriber).toBeNull();
@@ -307,6 +439,7 @@ describe('WebSocketAIAgent', () => {
       expect(agent._connectionStatus).toBe('connected');
 
       runAgent(agent);
+      await flushMicrotasks();
       expect(channel.pushed).toContainEqual(
         expect.objectContaining({ event: 'send_message' })
       );

--- a/assets/js/lib/auth/index.js
+++ b/assets/js/lib/auth/index.js
@@ -3,6 +3,7 @@
 
 import axios from 'axios';
 import { getFromConfig } from '@lib/config';
+import { logError } from '@lib/log';
 
 const STORAGE_ACCESS_TOKEN_IDENTIFIER = 'access_token';
 const STORAGE_REFRESH_TOKEN_IDENTIFIER = 'refresh_token';
@@ -70,4 +71,19 @@ export const getRefreshTokenFromStore = () =>
 export const clearCredentialsFromStore = () => {
   window.localStorage.removeItem(STORAGE_ACCESS_TOKEN_IDENTIFIER);
   window.localStorage.removeItem(STORAGE_REFRESH_TOKEN_IDENTIFIER);
+};
+
+// Look up the stored refresh token, exchange it for a new access token, persist
+// the new access token in localStorage, and return it. Throws if no refresh
+// token is stored or the refresh endpoint rejects.
+export const refreshAndStoreAccessToken = async () => {
+  const refreshToken = getRefreshTokenFromStore();
+  if (!refreshToken) {
+    logError('could not refresh access token, refresh token not found');
+    throw new Error('could not refresh access token');
+  }
+  const {
+    data: { access_token: accessToken },
+  } = await refreshAccessToken(refreshToken);
+  storeAccessToken(accessToken);
 };

--- a/assets/js/lib/auth/index.js
+++ b/assets/js/lib/auth/index.js
@@ -74,7 +74,7 @@ export const clearCredentialsFromStore = () => {
 };
 
 // Look up the stored refresh token, exchange it for a new access token, persist
-// the new access token in localStorage, and return it. Throws if no refresh
+// the new access token in localStorage. Throws if no refresh
 // token is stored or the refresh endpoint rejects.
 export const refreshAndStoreAccessToken = async () => {
   const refreshToken = getRefreshTokenFromStore();

--- a/assets/js/lib/auth/index.test.js
+++ b/assets/js/lib/auth/index.test.js
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import MockAdapter from 'axios-mock-adapter';
+import {
+  authClient,
+  clearCredentialsFromStore,
+  getAccessTokenFromStore,
+  refreshAndStoreAccessToken,
+  storeRefreshToken,
+} from './index';
+
+const mockAuth = new MockAdapter(authClient);
+
+describe('refreshAndStoreAccessToken', () => {
+  beforeEach(() => {
+    mockAuth.reset();
+    clearCredentialsFromStore();
+  });
+
+  afterEach(() => {
+    clearCredentialsFromStore();
+  });
+
+  it('exchanges the stored refresh token for a new access token, stores it, and returns it', async () => {
+    storeRefreshToken('my-refresh-token');
+    mockAuth.onPost('/api/session/refresh').reply(200, {
+      access_token: 'new-access-token',
+    });
+
+    await refreshAndStoreAccessToken();
+
+    expect(getAccessTokenFromStore()).toBe('new-access-token');
+    const [req] = mockAuth.history.post;
+    expect(JSON.parse(req.data)).toEqual({ refresh_token: 'my-refresh-token' });
+  });
+
+  it('throws without calling the endpoint when no refresh token is in storage', async () => {
+    await expect(refreshAndStoreAccessToken()).rejects.toThrow(
+      'could not refresh access token'
+    );
+    expect(mockAuth.history.post).toHaveLength(0);
+  });
+
+  it('propagates the error when the refresh endpoint rejects', async () => {
+    storeRefreshToken('my-refresh-token');
+    mockAuth.onPost('/api/session/refresh').reply(401);
+
+    await expect(refreshAndStoreAccessToken()).rejects.toThrow();
+    expect(getAccessTokenFromStore()).toBeNull();
+  });
+});

--- a/assets/js/lib/network/index.js
+++ b/assets/js/lib/network/index.js
@@ -4,12 +4,7 @@
 import axios from 'axios';
 import createAuthRefresh from 'axios-auth-refresh';
 import { logError, logWarn } from '@lib/log';
-import {
-  getAccessTokenFromStore,
-  getRefreshTokenFromStore,
-  refreshAccessToken,
-  storeAccessToken,
-} from '@lib/auth';
+import { getAccessTokenFromStore, refreshAndStoreAccessToken } from '@lib/auth';
 
 let windowReference = window;
 
@@ -33,23 +28,14 @@ networkClient.interceptors.request.use((request) => {
 });
 
 const refreshAuthLogic = async (failedRequest) => {
-  const refreshToken = getRefreshTokenFromStore();
-  if (!refreshToken) {
-    logWarn('could not refresh the access token, refresh token not found');
-    throw unrecoverableAuthError;
-  }
-
   try {
-    const { data } = await refreshAccessToken(refreshToken);
-    const accessToken = data.access_token;
-    storeAccessToken(accessToken);
-    // need the params reassign, the library works that way
-
-    failedRequest.response.config.headers.Authorization = `Bearer ${accessToken}`;
+    await refreshAndStoreAccessToken();
   } catch (e) {
     logWarn('could not refresh the token, error during the request flow', e);
     throw unrecoverableAuthError;
   }
+
+  failedRequest.response.config.headers.Authorization = `Bearer ${getAccessTokenFromStore()}`;
 };
 
 // Even though it looks counter intuitive, we need to add `deduplicateRefresh: false`
@@ -64,18 +50,18 @@ createAuthRefresh(networkClient, refreshAuthLogic, {
   deduplicateRefresh: false,
 });
 
+export const handleUnrecoverableAuthError = () => {
+  logWarn('unrecoverable auth flow, session expired');
+  const currentLocationPath = new URLSearchParams();
+  currentLocationPath.append('request_path', windowReference.location.pathname);
+  windowReference.location.assign(
+    `/session/new?${currentLocationPath.toString()}`
+  );
+};
+
 networkClient.interceptors.response.use(null, (error) => {
   if (error === unrecoverableAuthError) {
-    logWarn('unrecoverable auth flow, session expired');
-    const currentLocationPath = new URLSearchParams();
-    currentLocationPath.append(
-      'request_path',
-      windowReference.location.pathname
-    );
-
-    windowReference.location.assign(
-      `/session/new?${currentLocationPath.toString()}`
-    );
+    handleUnrecoverableAuthError();
   }
   throw error;
 });

--- a/assets/js/lib/network/network.test.js
+++ b/assets/js/lib/network/network.test.js
@@ -6,6 +6,7 @@ import {
   networkClient,
   unrecoverableAuthError,
   withWindowReference,
+  handleUnrecoverableAuthError,
 } from '@lib/network';
 import {
   clearCredentialsFromStore,
@@ -190,5 +191,27 @@ describe('networkClient', () => {
         });
       }
     });
+  });
+});
+
+describe('handleUnrecoverableAuthError', () => {
+  let mockAssign;
+
+  beforeEach(() => {
+    mockAssign = jest.fn();
+    withWindowReference({ location: { pathname: '/foo', assign: mockAssign } });
+    jest.spyOn(console, 'warn').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    withWindowReference(window);
+    /* eslint-disable-next-line */
+    console.warn.mockRestore();
+  });
+
+  it('redirects to /session/new with the current pathname as query parameter', () => {
+    handleUnrecoverableAuthError();
+
+    expect(mockAssign).toHaveBeenCalledWith('/session/new?request_path=%2Ffoo');
   });
 });

--- a/assets/js/lib/network/socket.js
+++ b/assets/js/lib/network/socket.js
@@ -5,12 +5,7 @@
 // eslint-disable-next-line
 import { Socket } from 'phoenix';
 import { logMessage, logError } from '@lib/log';
-import {
-  getAccessTokenFromStore,
-  getRefreshTokenFromStore,
-  refreshAccessToken,
-  storeAccessToken,
-} from '@lib/auth';
+import { getAccessTokenFromStore, refreshAndStoreAccessToken } from '@lib/auth';
 
 export const joinChannel = (channel) => {
   channel
@@ -18,21 +13,6 @@ export const joinChannel = (channel) => {
     .receive('ok', ({ messages }) => logMessage('catching up', messages))
     .receive('error', ({ reason }) => logError('failed join', reason))
     .receive('timeout', () => logMessage('Networking issue. Still waiting...'));
-};
-
-const refreshAuthTokenForSocket = async () => {
-  const refreshToken = getRefreshTokenFromStore();
-  if (!refreshToken) {
-    logError(
-      'could not refresh the access token for websockets, refresh token not found'
-    );
-    throw new Error('could not refresh access token for websocket connection');
-  }
-
-  const {
-    data: { access_token: accessToken },
-  } = await refreshAccessToken(refreshToken);
-  storeAccessToken(accessToken);
 };
 
 const getWebsocketParams = () => ({
@@ -55,7 +35,7 @@ export const initSocketConnection = () => {
     logMessage(
       'socket error. trying to refresh the access token before reconnecting'
     );
-    await refreshAuthTokenForSocket();
+    await refreshAndStoreAccessToken();
   });
   socket.connect();
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -388,7 +388,7 @@ if config_env() in [:prod, :demo] do
       ]
   end
 
-  wanda_base_url = Application.get_env(:trento, :checks_service)[:base_url]
+  wanda_base_url = System.get_env("CHECKS_SERVICE_BASE_URL", "")
 
   config :trento, :ai,
     base_system_prompt: Application.app_dir(:trento, "priv/ai/BASE_SYSTEM_PROMPT.md"),

--- a/lib/trento/ai/agent.ex
+++ b/lib/trento/ai/agent.ex
@@ -36,14 +36,16 @@ defmodule Trento.AI.Agent do
   """
   @spec new!(keyword()) :: Sagents.Agent.t()
   def new!(opts) do
+    tool_context = Keyword.get(opts, :tool_context, %{})
+
     Sagents.Agent.new!(
       %{
         agent_id: Keyword.fetch!(opts, :agent_id),
         model: Keyword.fetch!(opts, :model),
         scope: Keyword.fetch!(opts, :scope),
-        tool_context: Keyword.get(opts, :tool_context, %{}),
+        tool_context: tool_context,
         base_system_prompt: load_base_system_prompt(),
-        tools: ToolsRegistry.tools(),
+        tools: ToolsRegistry.tools(tool_context),
         # see https://github.com/sagents-ai/sagents#provided-middleware
         middleware: [
           # Task management with write_todos tool for tracking multi-step work

--- a/lib/trento/ai/remote_http_tool.ex
+++ b/lib/trento/ai/remote_http_tool.ex
@@ -105,7 +105,7 @@ defmodule Trento.AI.RemoteHttpTool do
     url = HttpUtils.resolve_url(base_url, resolved_path, request_origin)
     body = encode_body(verb, body_args)
     headers = build_headers(jwt, body)
-    options = [recv_timeout: @default_recv_timeout]
+    options = [recv_timeout: @default_recv_timeout, follow_redirect: true]
 
     verb
     |> http_client().request(url, body, headers, options)

--- a/lib/trento/ai/remote_open_api_tool_source.ex
+++ b/lib/trento/ai/remote_open_api_tool_source.ex
@@ -106,7 +106,7 @@ defmodule Trento.AI.RemoteOpenApiToolSource do
   defp fetch_and_decode(spec_url, request_origin) do
     url = HttpUtils.resolve_url(spec_url, "", request_origin)
     headers = [{"accept", "application/json"}]
-    options = [recv_timeout: @default_recv_timeout]
+    options = [recv_timeout: @default_recv_timeout, follow_redirect: true]
 
     with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <-
            http_client().get(url, headers, options),

--- a/lib/trento/ai/remote_open_api_tool_source.ex
+++ b/lib/trento/ai/remote_open_api_tool_source.ex
@@ -48,6 +48,8 @@ defmodule Trento.AI.RemoteOpenApiToolSource do
 
   require Logger
 
+  alias Trento.Support.HttpUtils
+
   alias Trento.AI.ApplicationConfigLoader
   alias Trento.AI.{OperationEntry, RemoteHttpTool}
 
@@ -60,7 +62,12 @@ defmodule Trento.AI.RemoteOpenApiToolSource do
     name = Keyword.fetch!(opts, :name)
     spec_url = Keyword.fetch!(opts, :spec_url)
 
-    case fetch_and_decode(spec_url) do
+    request_origin =
+      opts
+      |> Keyword.fetch!(:tool_context)
+      |> Map.get(:request_origin)
+
+    case fetch_and_decode(spec_url, request_origin) do
       {:ok, spec} ->
         build_tools(spec, name)
 
@@ -96,12 +103,13 @@ defmodule Trento.AI.RemoteOpenApiToolSource do
   defp extract_base_url(_),
     do: {:error, "spec missing servers[0].url; this source contributes no tools for this call."}
 
-  defp fetch_and_decode(spec_url) do
+  defp fetch_and_decode(spec_url, request_origin) do
+    url = HttpUtils.resolve_url(spec_url, "", request_origin)
     headers = [{"accept", "application/json"}]
     options = [recv_timeout: @default_recv_timeout]
 
     with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <-
-           http_client().get(spec_url, headers, options),
+           http_client().get(url, headers, options),
          {:ok, json} <- Jason.decode(body) do
       {:ok, OpenApiSpex.OpenApi.from_map(json)}
     else

--- a/lib/trento/ai/tools_registry.ex
+++ b/lib/trento/ai/tools_registry.ex
@@ -21,9 +21,13 @@ defmodule Trento.AI.ToolsRegistry do
 
   alias Trento.AI.ApplicationConfigLoader
 
-  @spec tools() :: [LangChain.Function.t()]
-  def tools do
-    Enum.flat_map(configured_sources(), fn {module, opts} -> module.tools(opts) end)
+  @spec tools(tool_context :: map()) :: [LangChain.Function.t()]
+  def tools(tool_context \\ %{}) do
+    Enum.flat_map(configured_sources(), fn {module, opts} ->
+      opts
+      |> Keyword.put(:tool_context, tool_context)
+      |> module.tools()
+    end)
   end
 
   defp configured_sources do

--- a/lib/trento_web/channels/ai_assistant_channel.ex
+++ b/lib/trento_web/channels/ai_assistant_channel.ex
@@ -189,10 +189,7 @@ defmodule TrentoWeb.AIAssistantChannel do
       }
     ]
     |> TrentoAIAgent.new!()
-    |> TrentoAIAgent.run(
-      prompt,
-      refresh_when: &access_token_changed/2
-    )
+    |> TrentoAIAgent.run(prompt, refresh_when: &access_token_changed/2)
     |> case do
       :ok ->
         socket

--- a/test/trento/ai/remote_open_api_tool_source_test.exs
+++ b/test/trento/ai/remote_open_api_tool_source_test.exs
@@ -82,7 +82,8 @@ defmodule Trento.AI.RemoteOpenApiToolSourceTest do
     Keyword.merge(
       [
         name: :wanda_test,
-        spec_url: "http://wanda/api/all/openapi"
+        spec_url: "http://wanda/api/all/openapi",
+        tool_context: %{request_origin: Faker.Internet.url()}
       ],
       extra
     )
@@ -220,6 +221,34 @@ defmodule Trento.AI.RemoteOpenApiToolSourceTest do
 
       ctx = %{tool_context: %{access_token: "JWT", request_origin: nil}}
       assert {:ok, _} = Function.execute(tool, %{"group_id" => "g1"}, ctx)
+    end
+  end
+
+  describe "tools/1 — spec_url resolution via tool_context.request_origin" do
+    test "relative spec_url is resolved against request_origin" do
+      expect(HttpClient.Mock, :get, fn url, _headers, _opts ->
+        assert url == "http://trento.example.com/api/all/openapi"
+        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(synthetic_spec())}}
+      end)
+
+      opts =
+        source_opts(
+          spec_url: "/api/all/openapi",
+          tool_context: %{request_origin: "http://trento.example.com"}
+        )
+
+      assert [_ | _] = RemoteOpenApiToolSource.tools(opts)
+    end
+
+    test "absolute spec_url ignores request_origin" do
+      expect(HttpClient.Mock, :get, fn url, _headers, _opts ->
+        assert url == "http://wanda/api/all/openapi"
+        {:ok, %HTTPoison.Response{status_code: 200, body: Jason.encode!(synthetic_spec())}}
+      end)
+
+      opts = source_opts(tool_context: %{request_origin: "http://something-else.example.com"})
+
+      assert [_ | _] = RemoteOpenApiToolSource.tools(opts)
     end
   end
 end

--- a/test/trento/ai/tools_registry_test.exs
+++ b/test/trento/ai/tools_registry_test.exs
@@ -47,11 +47,22 @@ defmodule Trento.AI.ToolsRegistryTest do
     end
   end
 
+  defmodule ToolContextSource do
+    @behaviour Trento.AI.ToolSource
+
+    @impl true
+    def tools(opts) do
+      ctx = Keyword.fetch!(opts, :tool_context)
+      name = ctx |> Map.fetch!(:user_id) |> to_string()
+      [Function.new!(%{name: "ctx_#{name}", function: fn _, _ -> name end})]
+    end
+  end
+
   defp stub_config(config) do
     stub(Trento.AI.ApplicationConfigLoader.Mock, :load_config, fn -> config end)
   end
 
-  describe "tools/0" do
+  describe "tools generation" do
     test "flat-concats tools from every configured source in declaration order" do
       stub_config(tool_sources: [SourceA, SourceB])
 
@@ -94,7 +105,13 @@ defmodule Trento.AI.ToolsRegistryTest do
     test "supports mixed bare-module + tuple entries" do
       stub_config(tool_sources: [SourceA, {OptsSource, name: :beta}])
 
-      assert ["a", "beta_tool"] = Enum.map(ToolsRegistry.tools(), & &1.name)
+      assert ["a", "beta_tool"] = Enum.map(ToolsRegistry.tools(%{}), & &1.name)
+    end
+
+    test "injects tool_context into source opts" do
+      stub_config(tool_sources: [ToolContextSource])
+
+      assert [%Function{name: "ctx_42"}] = ToolsRegistry.tools(%{user_id: 42})
     end
   end
 end


### PR DESCRIPTION
# Description

This PR wraps up the access token management in an AI conversation loop.

Context: we need to make requests to wanda as part of the AI tools, and to do so we need to be authenticated.

Main changes/outcome is that within an ongoing conversation the user's access token gotten at login is validated on:
- socket connection
- channel join
- on every prompt sent to the AI agent

and if needed the client refreshes the token, as it does for rest interaction.

This makes sure that the AI agent always has at hand the latest available access token in the localstorage, no matter who refreshed it.

Caveats/edge cases:
- it could happen that an almost expired token gets through to the Agent and when it is actually used for requests to wanda its usage results in a 401
- it could happen that a conversation step (prompt processing from the Agent) takes long enough so that within its execution time the token expires and we get 401s

None of these is crucial as at most the user might ask to retry and at that point a refresh would happen.
What we could actually do is to consider token expired within a certain threshold, like: is the token going to expire in less than X amount of time? if so just issue a refresh.

## How was this tested?

Automatic and IRL tests.

## Did you update the documentation?

No need.