### PR TITLE
Make only SAPSYSTEM and SAPLOCALHOST properties mandatory

### DIFF
--- a/lib/trento/discovery/payloads/sap_system_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/sap_system_discovery_payload.ex
@@ -175,17 +175,20 @@ defmodule Trento.Discovery.Payloads.SapSystemDiscoveryPayload do
     end
 
     def changeset(sap_control, attrs) do
-      hostname = find_property("SAPLOCALHOST", attrs)
+      changeset =
+        sap_control
+        |> cast(attrs, fields())
+        |> cast_embed(:Properties, required: true)
+
+      hostname = extract_property(changeset, "SAPLOCALHOST")
 
       instance_number =
-        case find_property("SAPSYSTEM", attrs) do
-          instance_number when is_binary(instance_number) -> String.to_integer(instance_number)
+        case extract_property(changeset, "SAPSYSTEM") do
+          value when is_binary(value) -> String.to_integer(value)
           _ -> nil
         end
 
-      sap_control
-      |> cast(attrs, fields())
-      |> cast_embed(:Properties, required: true)
+      changeset
       |> cast_embed(:Instances,
         with: fn instances, attrs ->
           SapControlInstance.changeset(instances, attrs, hostname, instance_number)
@@ -196,14 +199,14 @@ defmodule Trento.Discovery.Payloads.SapSystemDiscoveryPayload do
       |> validate_required_fields(@required_fields)
     end
 
-    defp find_property(property, %{"Properties" => properties}) do
-      Enum.find_value(properties, fn
-        %{"property" => ^property, "value" => value} -> value
+    defp extract_property(changeset, property_name) do
+      changeset
+      |> get_field(:Properties)
+      |> Enum.find_value(fn
+        %{property: ^property_name, value: value} -> value
         _ -> nil
       end)
     end
-
-    defp find_property(_, _), do: nil
   end
 
   defmodule SapControlProperty do
@@ -211,7 +214,8 @@ defmodule Trento.Discovery.Payloads.SapSystemDiscoveryPayload do
     SAP control property field payload
     """
 
-    @required_fields [:value, :property]
+    @required_fields [:property]
+    @properties_requiring_value ["SAPSYSTEM", "SAPLOCALHOST"]
 
     use Trento.Support.Type
 
@@ -225,7 +229,15 @@ defmodule Trento.Discovery.Payloads.SapSystemDiscoveryPayload do
       property
       |> cast(attrs, fields())
       |> validate_required_fields(@required_fields)
+      |> validate_property_value()
     end
+
+    defp validate_property_value(%{changes: %{property: prop}} = changeset)
+         when prop in @properties_requiring_value do
+      validate_required(changeset, [:value], message: "can't be blank for property #{prop}")
+    end
+
+    defp validate_property_value(changeset), do: changeset
   end
 
   defmodule SapControlInstance do

--- a/test/trento/discovery/policies/sap_system_policy_test.exs
+++ b/test/trento/discovery/policies/sap_system_policy_test.exs
@@ -537,7 +537,51 @@ defmodule Trento.Discovery.Policies.SapSystemPolicyTest do
                    sap_system |> pop_in(["Profile", "dbs/hdb/dbname"]) |> elem(1)
                  end)
                )
-               |> SapSystemPolicy.handle([], nil)
+               |> SapSystemPolicy.handle([], [])
+    end
+
+    test "should accept payload when a non-required property has a blank value" do
+      assert {:ok, [%RegisterApplicationInstance{}]} =
+               "sap_system_discovery_application"
+               |> load_discovery_event_fixture()
+               |> update_in(
+                 ["payload", Access.at(0), "Instances", Access.at(0), "SAPControl", "Properties"],
+                 fn properties ->
+                   Enum.map(properties, fn
+                     %{"property" => "Protected Webmethods"} = prop -> %{prop | "value" => ""}
+                     prop -> prop
+                   end)
+                 end
+               )
+               |> SapSystemPolicy.handle([], [])
+    end
+
+    for {property_name, property_index} <- [{"SAPSYSTEM", 4}, {"SAPLOCALHOST", 9}] do
+      test "should fail when #{property_name} property has a blank value" do
+        property_name = unquote(property_name)
+        property_index = unquote(property_index)
+
+        assert {:error, {:validation, [%{Instances: [%{SAPControl: %{Properties: properties}}]}]}} =
+                 "sap_system_discovery_application"
+                 |> load_discovery_event_fixture()
+                 |> put_in(
+                   [
+                     "payload",
+                     Access.at(0),
+                     "Instances",
+                     Access.at(0),
+                     "SAPControl",
+                     "Properties",
+                     Access.at(property_index),
+                     "value"
+                   ],
+                   ""
+                 )
+                 |> SapSystemPolicy.handle([], [])
+
+        assert %{value: [error_message]} = Enum.at(properties, property_index)
+        assert error_message == "can't be blank for property #{property_name}"
+      end
     end
   end
 end


### PR DESCRIPTION
### Description

We have received an scenario where some SAPcontrol properties obtained from `sapcontrol -function GetInstanceProperties` have an empty value. In this case, the `Protected Webmethods` attribute.
The value of this property is optional, as it can be disabled.

For our payload, only `SAPSYSTEM` and `SAPLOCALHOST` properties need a value.
This PR makes them mandatory but leaves the rest as optional, so a blank value is accepted.

### How was this tested?

UT

### Documentation changes

No need
