### PR TITLE
Enforce using erlang26 on SLES15 with bumped erlang

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 elixir 1.18.4-otp-27
-erlang 27.1.3
+erlang 27.3.4.13
 nodejs 24.13.1

--- a/packaging/suse/rpm/trento-web.spec
+++ b/packaging/suse/rpm/trento-web.spec
@@ -29,7 +29,6 @@ Source2:        package-lock.json
 Source3:        node_modules.spec.inc
 %include        %{_sourcedir}/node_modules.spec.inc
 Group:          System/Monitoring
-BuildRequires:  elixir >= 1.15
 BuildRequires:  elixir-hex
 BuildRequires:  erlang-rebar3
 BuildRequires:  gcc
@@ -37,6 +36,15 @@ BuildRequires:  git-core
 BuildRequires:  local-npm-registry
 BuildRequires:  make
 BuildRequires:  npm >= 20
+
+%if !0%{?is_opensuse} && 0%{?suse_version} < 1600
+BuildRequires:  erlang26
+BuildConflicts: erlang27
+BuildRequires:  elixir115
+BuildConflicts: elixir119
+%else
+BuildRequires:  elixir >= 1.15
+%endif
 
 %description
 Trento is an open cloud-native web application for SAP Applications administrators.


### PR DESCRIPTION
### Description

<!-- Describe what this PR changes. Include benefits or limitations if relevant. -->

Fixes #<issue>
<!-- Optionally use depends #<issue> for dependent PRs -->

<!--If your repository uses release drafter, ensure the appropriate release label is applied.
 To see the labels: https://github.com/trento-project/.github/blob/main/.github/release_drafter_main.yaml-->

### How was this tested?

<!-- Describe what tests were added or updated for this change. -->

### Documentation changes

Yes / No

<!--
If yes, consider updating:
- User documentation: https://github.com/trento-project/docs/tree/main/trento/adoc
- Developer documentation: https://github.com/trento-project/docs/tree/main/content
- Component-specific documentation, e.g., https://github.com/trento-project/web/tree/main/guides for Wanda
-->

### Additional information

<!-- Add anything else relevant to this PR, such as screenshots or demos. -->