### PR TITLE
Fix flaky activity log date filter pagination test

### DIFF
--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -167,15 +167,20 @@ context('Activity Log page', () => {
     it('should select correct date filter when changing page', () => {
       const fromDate = '2024-08-14T10%3A21%3A00.000Z';
       const queryString = `?from_date=custom&from_date=${fromDate}`;
+      cy.intercept('GET', '/api/v1/activity_log*', (req) => {
+        if (req.query.from_date) req.alias = 'getActivityLogFrom';
+      });
       activityLogPage.visit(queryString);
       activityLogPage.filterFromDateHasTheExpectedValue(fromDate);
-      activityLogPage.waitForActivityLogRequest().then(({ response }) => {
-        activityLogPage.clickNextPageButton();
-        activityLogPage.activityLogRequestHasExpectedStatusCode(200);
-        activityLogPage.filterFromDateHasTheExpectedValue(fromDate);
-        const expectedUrl = `/activity_log?first=20&after=${response.body.pagination.end_cursor}&from_date=custom&from_date=${fromDate}`;
-        activityLogPage.validateUrl(expectedUrl);
-      });
+      activityLogPage
+        .waitForRequest('getActivityLogFrom')
+        .then(({ response }) => {
+          activityLogPage.clickNextPageButton();
+          activityLogPage.waitForRequest('getActivityLogFrom');
+          activityLogPage.filterFromDateHasTheExpectedValue(fromDate);
+          const expectedUrl = `/activity_log?first=20&after=${response.body.pagination.end_cursor}&from_date=custom&from_date=${fromDate}`;
+          activityLogPage.validateUrl(expectedUrl);
+        });
     });
 
     it('should change items per page', () => {

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -167,20 +167,16 @@ context('Activity Log page', () => {
     it('should select correct date filter when changing page', () => {
       const fromDate = '2024-08-14T10%3A21%3A00.000Z';
       const queryString = `?from_date=custom&from_date=${fromDate}`;
-      cy.intercept('GET', '/api/v1/activity_log*', (req) => {
-        if (req.query.from_date) req.alias = 'getActivityLogFrom';
-      });
+      activityLogPage.interceptActivityLogFromDateEndpoint();
       activityLogPage.visit(queryString);
       activityLogPage.filterFromDateHasTheExpectedValue(fromDate);
-      activityLogPage
-        .waitForRequest('getActivityLogFrom')
-        .then(({ response }) => {
-          activityLogPage.clickNextPageButton();
-          activityLogPage.waitForRequest('getActivityLogFrom');
-          activityLogPage.filterFromDateHasTheExpectedValue(fromDate);
-          const expectedUrl = `/activity_log?first=20&after=${response.body.pagination.end_cursor}&from_date=custom&from_date=${fromDate}`;
-          activityLogPage.validateUrl(expectedUrl);
-        });
+      activityLogPage.waitForActivityLogFromDateRequest().then(({ response }) => {
+        activityLogPage.clickNextPageButton();
+        activityLogPage.waitForActivityLogFromDateRequest();
+        activityLogPage.filterFromDateHasTheExpectedValue(fromDate);
+        const expectedUrl = `/activity_log?first=20&after=${response.body.pagination.end_cursor}&from_date=custom&from_date=${fromDate}`;
+        activityLogPage.validateUrl(expectedUrl);
+      });
     });
 
     it('should change items per page', () => {

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -170,13 +170,15 @@ context('Activity Log page', () => {
       activityLogPage.interceptActivityLogFromDateEndpoint();
       activityLogPage.visit(queryString);
       activityLogPage.filterFromDateHasTheExpectedValue(fromDate);
-      activityLogPage.waitForActivityLogFromDateRequest().then(({ response }) => {
-        activityLogPage.clickNextPageButton();
-        activityLogPage.waitForActivityLogFromDateRequest();
-        activityLogPage.filterFromDateHasTheExpectedValue(fromDate);
-        const expectedUrl = `/activity_log?first=20&after=${response.body.pagination.end_cursor}&from_date=custom&from_date=${fromDate}`;
-        activityLogPage.validateUrl(expectedUrl);
-      });
+      activityLogPage
+        .waitForActivityLogFromDateRequest()
+        .then(({ response }) => {
+          activityLogPage.clickNextPageButton();
+          activityLogPage.waitForActivityLogFromDateRequest();
+          activityLogPage.filterFromDateHasTheExpectedValue(fromDate);
+          const expectedUrl = `/activity_log?first=20&after=${response.body.pagination.end_cursor}&from_date=custom&from_date=${fromDate}`;
+          activityLogPage.validateUrl(expectedUrl);
+        });
     });
 
     it('should change items per page', () => {

--- a/test/e2e/cypress/pageObject/activity_log_po.js
+++ b/test/e2e/cypress/pageObject/activity_log_po.js
@@ -5,6 +5,7 @@ export * from './base_po';
 import * as basePage from './base_po';
 
 const activityLogEndpointAlias = 'activityLogRequest';
+const activityLogEndpointFromAlias = 'activityLogFromRequest';
 const activityLogEndpoint = '/api/v1/activity_log*';
 
 //Selectors
@@ -50,6 +51,11 @@ export const interceptActivityLogEndpoint = () =>
     })
     .as(activityLogEndpointAlias);
 
+export const interceptActivityLogFromDateEndpoint = () =>
+  cy.intercept('GET', activityLogEndpoint, (req) => {
+    if (req.query.from_date) req.alias = activityLogEndpointFromAlias;
+  });
+
 export const spyActivityLogRequest = () => {
   cy.clock();
   return cy.intercept(
@@ -60,6 +66,9 @@ export const spyActivityLogRequest = () => {
 
 export const waitForActivityLogRequest = () =>
   basePage.waitForRequest(activityLogEndpointAlias);
+
+export const waitForActivityLogFromDateRequest = () =>
+  basePage.waitForRequest(activityLogEndpointFromAlias);
 
 // UI Interactions
 export const clickFilterTypeButton = () =>


### PR DESCRIPTION
### Description

Stabilize the Cypress pagination test for the Activity Log date filter by waiting only for activity_log requests that include from_date.

Fixes #<issue>
<!-- Optionally use depends #<issue> for dependent PRs -->

<!--If your repository uses release drafter, ensure the appropriate release label is applied.
 To see the labels: https://github.com/trento-project/.github/blob/main/.github/release_drafter_main.yaml-->

### How was this tested?
CI

### Documentation changes

Yes / No

<!--
If yes, consider updating:
- User documentation: https://github.com/trento-project/docs/tree/main/trento/adoc
- Developer documentation: https://github.com/trento-project/docs/tree/main/content
- Component-specific documentation, e.g., https://github.com/trento-project/web/tree/main/guides for Wanda
-->

### Additional information

<!-- Add anything else relevant to this PR, such as screenshots or demos. -->