### PR TITLE
Let :public_key.cacerts_get() raise

### DIFF
--- a/lib/trento/support/http_client.ex
+++ b/lib/trento/support/http_client.ex
@@ -34,15 +34,7 @@ defmodule Trento.Support.HttpClient do
     do: HTTPoison.request(verb, url, body, headers, inject_ssl(options))
 
   defp inject_ssl(options) do
-    default_ssl = [verify: :verify_peer, cacerts: resolve_ca_certs()]
+    default_ssl = [verify: :verify_peer, cacerts: :public_key.cacerts_get()]
     Keyword.update(options, :ssl, default_ssl, &Keyword.merge(default_ssl, &1))
-  end
-
-  defp resolve_ca_certs do
-    :public_key.cacerts_get()
-  rescue
-    e ->
-      Logger.error("Failed to load system CA certificates: #{inspect(e)}")
-      []
   end
 end


### PR DESCRIPTION
### Description

Just a folllowup to https://github.com/trento-project/web/pull/4372.

We're letting `:public_key.cacerts_get()` explode if it has to explode.

@antgamdia Additionally here https://github.com/trento-project/web/pull/4372 and here https://github.com/trento-project/web/pull/4389 there were references to origin checking.
I went a bit deeper and thankfully it seems we are already covered.

Doc at https://phoenix.hexdocs.pm/1.7.23/Phoenix.Endpoint.html#socket/3-common-configuration says

> :check_origin - if the transport should check the origin of requests when the origin header is present. May be true, false, a list of hosts that are allowed, or a function provided as MFA tuple. Defaults to :check_origin setting at endpoint configuration.
>
> If true, the header is checked against :host in YourAppWeb.Endpoint.config(:url)[:host].
>

and our runtime configuration at https://github.com/trento-project/web/blob/main/config/runtime.exs#L84-L95 is the following

```elixir
config :trento, TrentoWeb.Endpoint,
    http: [
      # Enable IPv6 and bind on all interfaces.
      # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.
      # See the documentation on https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html
      # for details about using IPv6 vs IPv4 and loopback vs public addresses.
      ip: ip,
      port: String.to_integer(System.get_env("PORT") || "4000")
    ],
    check_origin: true,
    url: [host: trento_origin],
    secret_key_base: secret_key_base
```

Meaning that we already do check the origin to match what configured in `trento_origin` which is the value of `TRENTO_WEB_ORIGIN` env variable.