### PR TITLE
Table style row with content

### DIFF
--- a/assets/js/common/Table/CollapsibleTableRow.jsx
+++ b/assets/js/common/Table/CollapsibleTableRow.jsx
@@ -28,7 +28,7 @@ function CollapsibleTableRow({
         {collapsibleDetailRenderer && (
           <td
             className={classNames(
-              'border-b border-gray-200 bg-white',
+              'border-b border-gray-200',
               { 'pl-2': !isCollapsible },
               { 'pl-4': isCollapsible }
             )}

--- a/assets/js/common/Table/Table.jsx
+++ b/assets/js/common/Table/Table.jsx
@@ -62,6 +62,9 @@ const getFilterFunction = (column, value) =>
     ? column.filter(value, column.key)
     : getDefaultFilterFunction(value, column.key);
 
+const getRowClassName = (rowClassName, item) =>
+  typeof rowClassName === 'function' ? rowClassName(item) : rowClassName;
+
 const itemsPerPageOptions = [10, 20, 50, 75, 100];
 
 function Table({
@@ -292,7 +295,7 @@ function Table({
                         renderCells={renderCells}
                         columns={columns}
                         colSpan={columns.length}
-                        className={rowClassName}
+                        className={getRowClassName(rowClassName, item)}
                         collapsedRowClassName={collapsedRowClassName}
                       />
                     );

--- a/assets/js/common/Table/Table.jsx
+++ b/assets/js/common/Table/Table.jsx
@@ -29,7 +29,7 @@ const renderCells = (columns, item) => (
           <td
             key={idx}
             className={classNames(
-              'px-5 py-5 border-b border-gray-200 bg-white',
+              'px-5 py-5 border-b border-gray-200',
               className,
               fontSize
             )}
@@ -236,7 +236,10 @@ function Table({
                     <th
                       key="collapsible"
                       scope="col"
-                      className={classNames('w-6 bg-gray-100', headerClassName)}
+                      className={classNames(
+                        'w-6 border-b bg-gray-100',
+                        headerClassName
+                      )}
                       aria-label="collapsible"
                     />
                   )}
@@ -256,7 +259,7 @@ function Table({
                             sortable
                               ? 'cursor-pointer hover:text-gray-700 '
                               : ''
-                          }px-5 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider bg-gray-100`,
+                          }px-5 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider border-b bg-gray-100`,
                           headerClassName,
                           columnClassName
                         )}
@@ -272,7 +275,7 @@ function Table({
                   )}
                 </tr>
               </thead>
-              <tbody>
+              <tbody className="bg-white">
                 {renderedData.length === 0 ? (
                   <EmptyState
                     colSpan={

--- a/assets/js/common/Table/Table.stories.jsx
+++ b/assets/js/common/Table/Table.stories.jsx
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useState } from 'react';
+import classNames from 'classnames';
+
+import Pill from '@common/Pill';
 
 import Table from '.';
 
@@ -15,6 +18,19 @@ export default {
   title: 'Components/Table',
   component: Table,
 };
+
+function StatusPill({ children }) {
+  return (
+    <Pill
+      className={classNames({
+        'bg-green-100 text-green-800': children === 'active',
+        'bg-gray-200 text-gray-800': children !== 'active',
+      })}
+    >
+      {children}
+    </Pill>
+  );
+}
 
 const config = {
   columns: [
@@ -33,15 +49,7 @@ const config = {
     {
       title: 'Status',
       key: 'status',
-      render: (content) => (
-        <span className="relative inline-block px-3 py-1 font-semibold text-green-900 leading-tight">
-          <span
-            aria-hidden="true"
-            className="absolute inset-0 bg-green-200 opacity-50 rounded-full"
-          />
-          <span className="relative">{content}</span>
-        </span>
-      ),
+      render: (status) => <StatusPill>{status}</StatusPill>,
     },
   ],
 };
@@ -66,15 +74,7 @@ const filteredConfig = {
     {
       title: 'Status',
       key: 'status',
-      render: (content) => (
-        <span className="relative inline-block px-3 py-1 font-semibold text-green-900 leading-tight">
-          <span
-            aria-hidden="true"
-            className="absolute inset-0 bg-green-200 opacity-50 rounded-full"
-          />
-          <span className="relative">{content}</span>
-        </span>
-      ),
+      render: (status) => <StatusPill>{status}</StatusPill>,
     },
   ],
 };
@@ -98,7 +98,7 @@ const data = [
   {
     user: 'Chad Carbonara',
     role: 'Employee',
-    status: 'active',
+    status: 'inactive',
     created_at: '2022-02-30',
   },
   {
@@ -162,15 +162,7 @@ export const Sorted = {
         {
           title: 'Status',
           key: 'status',
-          render: (content) => (
-            <span className="relative inline-block px-3 py-1 font-semibold text-green-900 leading-tight">
-              <span
-                aria-hidden="true"
-                className="absolute inset-0 bg-green-200 opacity-50 rounded-full"
-              />
-              <span className="relative">{content}</span>
-            </span>
-          ),
+          render: (status) => <StatusPill>{status}</StatusPill>,
         },
       ],
     };
@@ -215,6 +207,15 @@ export function WithHeader(args) {
 
 export function WithCollapsibleRow(args) {
   return <Table config={collapsibleConfig} data={data} {...args} />;
+}
+
+export function WithStyledRows() {
+  const configWithRowClass = {
+    ...config,
+    rowClassName: ({ status }) =>
+      classNames({ 'bg-gray-100': status === 'inactive' }),
+  };
+  return <Table config={configWithRowClass} data={data} />;
 }
 
 export function Empty() {

--- a/assets/js/common/Table/Table.test.jsx
+++ b/assets/js/common/Table/Table.test.jsx
@@ -65,6 +65,35 @@ describe('Table component', () => {
       .forEach((tableRow) => expect(tableRow).toHaveClass(customRowClassName));
   });
 
+  it('should allow dynamic row classes based on row content', () => {
+    const activeClass = 'bg-green-50';
+    const inactiveClass = 'bg-gray-50';
+    const data = tableDataFactory.buildList(10).map((item, index) => ({
+      ...item,
+      isActive: index % 2 === 0,
+    }));
+
+    render(
+      <Table
+        config={{
+          rowClassName: (item) => (item.isActive ? activeClass : inactiveClass),
+          ...tableConfig,
+        }}
+        data={data}
+        setSearchParams={() => {}}
+      />
+    );
+
+    const tableRows = screen.getByRole('table').querySelectorAll('tbody > tr');
+    tableRows.forEach((tableRow, index) => {
+      if (data[index].isActive) {
+        expect(tableRow).toHaveClass(activeClass);
+      } else {
+        expect(tableRow).toHaveClass(inactiveClass);
+      }
+    });
+  });
+
   it('should display the header', () => {
     const data = tableDataFactory.buildList(10);
     const headerText = faker.person.firstName();


### PR DESCRIPTION
### Description

Update `Table` component `rowClassName` configuration option to accept functions based on content.
This way, table row classes are configurable depending on the row content itself.
I have changed how the coloring `bg-` classes are applied to be white background as table level, not cell level, otherwise we cannot override the row colors.

We can do things like this, where one row styles are different:
<img width="1288" height="423" alt="image" src="https://github.com/user-attachments/assets/f10b2735-4770-47a2-8dd5-3cb268d23a74" />

In this last option the usecase implementation would be:
```
rowClassName: ({ stale_at }) =>
    classNames({
      'bg-gray-100': !!stale_at,
    }),
```


### How was this tested?

UT

### Documentation changes

No