### PR TITLE
Relax gcp image metadata requirement

### DIFF
--- a/.photofinish.toml
+++ b/.photofinish.toml
@@ -12,6 +12,7 @@ directories = [
     "./test/fixtures/scenarios/sap-system-java",
     "./test/fixtures/scenarios/hana-scale-up-cost-opt",
     "./test/fixtures/scenarios/hana-scale-up-multi-tier",
+    "./test/fixtures/scenarios/gcp-landscape",
 ]
 
 [healthy-27-node-SAP-cluster]

--- a/lib/trento/discovery/payloads/cloud_discovery_payload.ex
+++ b/lib/trento/discovery/payloads/cloud_discovery_payload.ex
@@ -113,7 +113,14 @@ defmodule Trento.Discovery.Payloads.CloudDiscoveryPayload do
   defmodule GcpMetadata do
     @moduledoc nil
 
-    @required_fields :all
+    @required_fields [
+      :disk_number,
+      :instance_name,
+      :machine_type,
+      :network,
+      :project_id,
+      :zone
+    ]
     use Trento.Support.Type
 
     deftype do

--- a/lib/trento_web/openapi/v1/schema/provider.ex
+++ b/lib/trento_web/openapi/v1/schema/provider.ex
@@ -105,7 +105,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Provider do
         additionalProperties: false,
         properties: %{
           disk_number: %Schema{type: :integer},
-          image: %Schema{type: :string},
+          image: %Schema{type: :string, nullable: true},
           instance_name: %Schema{type: :string},
           machine_type: %Schema{type: :string},
           network: %Schema{type: :string},

--- a/test/fixtures/scenarios/gcp-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_cloud_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_cloud_discovery.json
@@ -1,8 +1,0 @@
-{
-  "discovery_type": "cloud_discovery",
-  "agent_id": "13e8c25c-3180-5a9a-95c8-51ec38e50cfc",
-  "payload": {
-    "Provider": "gcp",
-    "Metadata": null
-  }
-}

--- a/test/fixtures/scenarios/gcp-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_cloud_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/1b0e9297-97dd-55d6-9874-8efde4d84c90_cloud_discovery.json
@@ -1,8 +1,0 @@
-{
-  "discovery_type": "cloud_discovery",
-  "agent_id": "1b0e9297-97dd-55d6-9874-8efde4d84c90",
-  "payload": {
-    "Provider": "gcp",
-    "Metadata": null
-  }
-}

--- a/test/fixtures/scenarios/gcp-landscape/1b4c7585-66d6-47a5-bb6b-f7965f4885e4_cloud_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/1b4c7585-66d6-47a5-bb6b-f7965f4885e4_cloud_discovery.json
@@ -1,0 +1,16 @@
+{
+  "discovery_type": "cloud_discovery",
+  "agent_id": "1b4c7585-66d6-47a5-bb6b-f7965f4885e4",
+  "payload": {
+    "Provider": "gcp",
+    "Metadata": {
+      "disk_number": 4,
+      "image": "sles-15-sp1-sap-byos-v20220126",
+      "instance_name": "vmhana01",
+      "machine_type": "n1-highmem-8",
+      "network": "network",
+      "project_id": "123456",
+      "zone": "europe-west1-b"
+    }
+  }
+}

--- a/test/fixtures/scenarios/gcp-landscape/1b4c7585-66d6-47a5-bb6b-f7965f4885e4_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/1b4c7585-66d6-47a5-bb6b-f7965f4885e4_ha_cluster_discovery.json
@@ -1,8 +1,8 @@
 {
-  "agent_id": "7269ee51-5007-5849-aaa7-7c4a98b0c9ce",
+  "agent_id": "1b4c7585-66d6-47a5-bb6b-f7965f4885e4",
   "discovery_type": "ha_cluster_discovery",
   "payload": {
-    "DC": true,
+    "DC": false,
     "Provider": "gcp",
     "Id": "057f083c3be591f4398eed816d4c8cd7",
     "State": "S_IDLE",
@@ -84,7 +84,7 @@
                     {
                       "Id": "rsc_ip_NWD_ASCS00-instance_attributes-ip",
                       "Name": "ip",
-                      "Value": "10.100.1.25"
+                      "Value": "10.100.2.25"
                     }
                   ]
                 },
@@ -121,7 +121,7 @@
                     {
                       "Id": "rsc_fs_NWD_ASCS00-instance_attributes-device",
                       "Name": "device",
-                      "Value": "10.100.1.33:/NWD/ASCS"
+                      "Value": "10.100.2.33:/NWD/ASCS"
                     },
                     {
                       "Id": "rsc_fs_NWD_ASCS00-instance_attributes-directory",
@@ -236,7 +236,7 @@
                     {
                       "Id": "rsc_ip_NWD_ERS10-instance_attributes-ip",
                       "Name": "ip",
-                      "Value": "10.100.1.26"
+                      "Value": "10.100.2.26"
                     }
                   ]
                 },
@@ -273,7 +273,7 @@
                     {
                       "Id": "rsc_fs_NWD_ERS10-instance_attributes-device",
                       "Name": "device",
-                      "Value": "10.100.1.33:/NWD/ERS"
+                      "Value": "10.100.2.33:/NWD/ERS"
                     },
                     {
                       "Id": "rsc_fs_NWD_ERS10-instance_attributes-directory",

--- a/test/fixtures/scenarios/gcp-landscape/1b4c7585-66d6-47a5-bb6b-f7965f4885e4_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/1b4c7585-66d6-47a5-bb6b-f7965f4885e4_host_discovery.json
@@ -1,26 +1,28 @@
 {
-  "agent_id": "0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4",
+  "agent_id": "1b4c7585-66d6-47a5-bb6b-f7965f4885e4",
   "discovery_type": "host_discovery",
   "payload": {
-    "hostname": "vmhdbdev02",
-    "cpu_count": 4,
+    "hostname": "vmnwdev02",
+    "cpu_count": 2,
     "os_version": "15-SP3",
     "ip_addresses": [
       "127.0.0.1",
       "::1",
-      "10.100.1.12",
-      "fe80::6245:bdff:fe8a:5f6b"
+      "10.100.2.22",
+      "10.100.2.26",
+      "fe80::6245:bdff:fe8d:9c7d"
     ],
     "netmasks": [
       "8",
       "128",
       "24",
+      "24",
       "64"
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 32107,
-    "fully_qualified_domain_name": "vmhdbdev02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwdev02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
     "arch": "x86_64",
     "systemd_units": [
       {

--- a/test/fixtures/scenarios/gcp-landscape/1b4c7585-66d6-47a5-bb6b-f7965f4885e4_sap_system_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/1b4c7585-66d6-47a5-bb6b-f7965f4885e4_sap_system_discovery.json
@@ -1,14 +1,14 @@
 {
-  "agent_id": "9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f",
+  "agent_id": "1b4c7585-66d6-47a5-bb6b-f7965f4885e4",
   "discovery_type": "sap_system_discovery",
   "payload": [
     {
       "Id": "a1e80e3e152a903662f7882fb3f8a851",
       "SID": "NWD",
       "Type": 2,
-      "DBAddress": "10.100.1.13",
+      "DBAddress": "10.100.2.13",
       "Profile": {
-        "SAPDBHOST": "10.100.1.13",
+        "SAPDBHOST": "10.100.2.13",
         "dbms/name": "HDD",
         "dbms/type": "hdb",
         "gw/acl_mode": "1",
@@ -43,8 +43,8 @@
       "Databases": null,
       "Instances": [
         {
-          "Host": "vmnwdev03",
-          "Name": "D01",
+          "Host": "vmnwdev02",
+          "Name": "ERS10",
           "Type": 2,
           "SAPControl": {
             "Instances": [
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "currentInstance": false
+                "currentInstance": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "currentInstance": true
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -91,65 +91,18 @@
             ],
             "Processes": [
               {
-                "pid": 27224,
-                "name": "gwrd",
-                "starttime": "2022 01 11 13:03:58",
+                "pid": 6720,
+                "name": "enrepserver",
+                "starttime": "2022 01 11 12:55:17",
                 "dispstatus": "SAPControl-GREEN",
                 "textstatus": "Running",
-                "description": "Gateway",
-                "elapsedtime": "151:48:10"
-              },
-              {
-                "pid": 27225,
-                "name": "icman",
-                "starttime": "2022 01 11 13:03:58",
-                "dispstatus": "SAPControl-GREEN",
-                "textstatus": "Running",
-                "description": "ICM",
-                "elapsedtime": "151:48:10"
-              },
-              {
-                "pid": 26907,
-                "name": "igswd_mt",
-                "starttime": "2022 01 11 13:03:55",
-                "dispstatus": "SAPControl-GREEN",
-                "textstatus": "Running",
-                "description": "IGS Watchdog",
-                "elapsedtime": "151:48:13"
-              },
-              {
-                "pid": 26906,
-                "name": "disp+work",
-                "starttime": "2022 01 11 13:03:55",
-                "dispstatus": "SAPControl-GREEN",
-                "textstatus": "Running",
-                "description": "Dispatcher",
-                "elapsedtime": "151:48:13"
+                "description": "EnqueueReplicator",
+                "elapsedtime": "151:56:49"
               }
             ],
             "Properties": [
               {
-                "value": "HTTP://sapnwdpas:0/sap/admin/public/index.html",
-                "property": "ICM",
-                "propertytype": "NodeURL"
-              },
-              {
-                "value": "http://sapnwdpas:40180",
-                "property": "IGS",
-                "propertytype": "NodeURL"
-              },
-              {
-                "value": "ABAPReadSyslog",
-                "property": "Syslog",
-                "propertytype": "NodeWebmethod"
-              },
-              {
-                "value": "ICMGetCacheEntries",
-                "property": "ICM Cache",
-                "propertytype": "NodeWebmethod"
-              },
-              {
-                "value": "01",
+                "value": "10",
                 "property": "SAPSYSTEM",
                 "propertytype": "Attribute"
               },
@@ -159,29 +112,14 @@
                 "propertytype": "Attribute"
               },
               {
-                "value": "ICMGetThreadList",
-                "property": "ICM Threads",
-                "propertytype": "NodeWebmethod"
-              },
-              {
-                "value": "GetAlertTree",
-                "property": "Open Alerts",
-                "propertytype": "NodeWebmethod"
-              },
-              {
                 "value": "GetProcessList",
                 "property": "Process List",
                 "propertytype": "NodeWebmethod"
               },
               {
-                "value": "sapnwdpas",
+                "value": "sapnwder",
                 "property": "SAPLOCALHOST",
                 "propertytype": "Attribute"
-              },
-              {
-                "value": "ABAPGetWPTable",
-                "property": "ABAP WP Table",
-                "propertytype": "NodeWebmethod"
               },
               {
                 "value": "GetAccessPointList",
@@ -189,7 +127,7 @@
                 "propertytype": "NodeWebmethod"
               },
               {
-                "value": "D01",
+                "value": "ERS10",
                 "property": "INSTANCE_NAME",
                 "propertytype": "Attribute"
               },
@@ -204,34 +142,9 @@
                 "propertytype": "Attribute"
               },
               {
-                "value": "3",
+                "value": "0.5",
                 "property": "StartPriority",
                 "propertytype": "Attribute"
-              },
-              {
-                "value": "GetAlertTree",
-                "property": "Current Status",
-                "propertytype": "NodeWebmethod"
-              },
-              {
-                "value": "GWGetClientList",
-                "property": "Gateway Clients",
-                "propertytype": "NodeWebmethod"
-              },
-              {
-                "value": "ICMGetConnectionList",
-                "property": "ICM Connections",
-                "propertytype": "NodeWebmethod"
-              },
-              {
-                "value": "GetQueueStatistic",
-                "property": "Queue Statistic",
-                "propertytype": "NodeWebmethod"
-              },
-              {
-                "value": "GWGetConnectionList",
-                "property": "Gateway Connections",
-                "propertytype": "NodeWebmethod"
               },
               {
                 "value": "ABAPAcknowledgeAlerts,ABAPCheckRFCDestinations,ABAPGetComponentList,ABAPGetSystemWPTable,ABAPGetWPTable,ABAPReadRawSyslog,ABAPReadSyslog,ABAPSetServerInactive,AnalyseLogFiles,Bootstrap,CheckParameter,CheckPSE,CheckUpdateSystem,ConfigureLogFileList,CreatePSECredential,CreateSnapshot,DeletePSE,DeleteSnapshots,EnqGetLockTable,EnqGetStatistic,EnqRemoveLocks,EnqRemoveUserLocks,GetAccessPointList,GetAlerts,GetAlertTree,GetCallstack,GetEnvironment,GetLogFileList,GetProcessParameter,GetQueueStatistic,GetStartProfile,GetSystemUpdateList,GetTraceFile,GetVersionInfo,GWCancelConnections,GWDeleteClients,GWDeleteConnections,GWGetConnectionList,GWGetClientList,HACheckConfig,HACheckFailoverConfig,HACheckMaintenanceMode,HAFailoverToNode,HAGetFailoverConfig,HASetMaintenanceMode,ICMGetCacheEntries,ICMGetConnectionList,ICMGetProxyConnectionList,ICMGetThreadList,InstanceStart,InstanceStop,J2EEControlCluster,J2EEControlComponents,J2EEControlProcess,J2EEDisableDbgSession,J2EEEnableDbgSession,J2EEGetApplicationAliasList,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetClusterMsgList,J2EEGetComponentList,J2EEGetEJBSessionList,J2EEGetProcessList,J2EEGetProcessList2,J2EEGetRemoteObjectList,J2EEGetSessionList,J2EEGetSharedTableInfo,J2EEGetThreadCallStack,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadTaskStack,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetWebSessionList,J2EEGetWebSessionList2,ListConfigFiles,ListDeveloperTraces,ListLogFiles,ListSnapshots,OSExecute,ParameterValue,ReadConfigFile,ReadDeveloperTrace,ReadLogFile,ReadSnapshot,RestartInstance,RestartService,RestartSystem,SendSignal,SetProcessParameter,SetProcessParameter2,ShmDetach,Shutdown,Start,StartBypassHA,StartSystem,Stop,StopBypassHA,StopService,StopSystem,StorePSE,UpdateInstancePSE,UpdateSCSInstance,UpdateSystem,UpdateSystemPKI,WebDispGetServerList,WebDispGetGroupList,WebDispGetVirtHostList,WebDispGetUrlPrefixList,GetAgentConfig,GetListOfMaByCusGrp,GetMcInLocalMs,GetMtesByRequestTable,GetMtListByMtclass,InfoGetTree,MscCustomizeWrite,MscDeleteLines,MscReadCache,MsGetLocalMsInfo,MsGetMteclsInLocalMs,MtChangeStatus,MtCustomizeWrite,MtDbsetToWpsetByTid,MtDestroyMarkNTry,MteGetByToolRunstatus,MtGetAllToCust,MtGetAllToolsToSet,MtGetMteinfo,MtGetTidByName,MtRead,MtReset,PerfCustomizeWrite,PerfRead,PerfReadSmoothData,ReadDirectory,ReadFile,ReadProfileParameters,ReferenceRead,Register,RequestLogonFile,SnglmgsCustomizeWrite,SystemObjectSetValue,TextAttrRead,ToolGetEffective,ToolSet,ToolSetRuntimeStatus,TriggerDataCollection,Unregister,UtilAlChangeStatus,UtilMtGetAidByTid,UtilMtGetTreeLocal,UtilMtReadAll,UtilReadRawalertByAid,UtilSnglmsgReadRawdata",
@@ -239,12 +152,7 @@
                 "propertytype": "Attribute"
               },
               {
-                "value": "ICMGetProxyConnectionList",
-                "property": "ICM Proxy Connections",
-                "propertytype": "NodeWebmethod"
-              },
-              {
-                "value": "http://sapnwdpas:50113/sapparamEN.html",
+                "value": "http://sapnwder:51013/sapparamEN.html",
                 "property": "Parameter Documentation",
                 "propertytype": "NodeURL"
               }

--- a/test/fixtures/scenarios/gcp-landscape/1b4c7585-66d6-47a5-bb6b-f7965f4885e4_subscription_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/1b4c7585-66d6-47a5-bb6b-f7965f4885e4_subscription_discovery.json
@@ -1,5 +1,5 @@
 {
-  "agent_id": "13e8c25c-3180-5a9a-95c8-51ec38e50cfc",
+  "agent_id": "1b4c7585-66d6-47a5-bb6b-f7965f4885e4",
   "discovery_type": "subscription_discovery",
   "payload": [
     {

--- a/test/fixtures/scenarios/gcp-landscape/653fa371-b322-4029-bfa0-a82b81c08c34_cloud_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/653fa371-b322-4029-bfa0-a82b81c08c34_cloud_discovery.json
@@ -1,0 +1,16 @@
+{
+  "discovery_type": "cloud_discovery",
+  "agent_id": "653fa371-b322-4029-bfa0-a82b81c08c34",
+  "payload": {
+    "Provider": "gcp",
+    "Metadata": {
+      "disk_number": 4,
+      "image": "",
+      "instance_name": "vmhana01",
+      "machine_type": "n1-highmem-8",
+      "network": "network",
+      "project_id": "123456",
+      "zone": "europe-west1-b"
+    }
+  }
+}

--- a/test/fixtures/scenarios/gcp-landscape/653fa371-b322-4029-bfa0-a82b81c08c34_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/653fa371-b322-4029-bfa0-a82b81c08c34_ha_cluster_discovery.json
@@ -1,8 +1,8 @@
 {
-  "agent_id": "fb2c6b8a-9915-5969-a6b7-8b5a42de1971",
+  "agent_id": "653fa371-b322-4029-bfa0-a82b81c08c34",
   "discovery_type": "ha_cluster_discovery",
   "payload": {
-    "DC": false,
+    "DC": true,
     "Provider": "gcp",
     "Id": "057f083c3be591f4398eed816d4c8cd7",
     "State": "S_IDLE",
@@ -84,7 +84,7 @@
                     {
                       "Id": "rsc_ip_NWD_ASCS00-instance_attributes-ip",
                       "Name": "ip",
-                      "Value": "10.100.1.25"
+                      "Value": "10.100.2.25"
                     }
                   ]
                 },
@@ -121,7 +121,7 @@
                     {
                       "Id": "rsc_fs_NWD_ASCS00-instance_attributes-device",
                       "Name": "device",
-                      "Value": "10.100.1.33:/NWD/ASCS"
+                      "Value": "10.100.2.33:/NWD/ASCS"
                     },
                     {
                       "Id": "rsc_fs_NWD_ASCS00-instance_attributes-directory",
@@ -236,7 +236,7 @@
                     {
                       "Id": "rsc_ip_NWD_ERS10-instance_attributes-ip",
                       "Name": "ip",
-                      "Value": "10.100.1.26"
+                      "Value": "10.100.2.26"
                     }
                   ]
                 },
@@ -273,7 +273,7 @@
                     {
                       "Id": "rsc_fs_NWD_ERS10-instance_attributes-device",
                       "Name": "device",
-                      "Value": "10.100.1.33:/NWD/ERS"
+                      "Value": "10.100.2.33:/NWD/ERS"
                     },
                     {
                       "Id": "rsc_fs_NWD_ERS10-instance_attributes-directory",

--- a/test/fixtures/scenarios/gcp-landscape/653fa371-b322-4029-bfa0-a82b81c08c34_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/653fa371-b322-4029-bfa0-a82b81c08c34_host_discovery.json
@@ -1,16 +1,16 @@
 {
-  "agent_id": "fb2c6b8a-9915-5969-a6b7-8b5a42de1971",
+  "agent_id": "653fa371-b322-4029-bfa0-a82b81c08c34",
   "discovery_type": "host_discovery",
   "payload": {
-    "hostname": "vmnwdev02",
+    "hostname": "vmnwdev01",
     "cpu_count": 2,
     "os_version": "15-SP3",
     "ip_addresses": [
       "127.0.0.1",
       "::1",
-      "10.100.1.22",
-      "10.100.1.26",
-      "fe80::6245:bdff:fe8d:9c7d"
+      "10.100.2.21",
+      "10.100.2.25",
+      "fe80::6245:bdff:fe8a:5ce7"
     ],
     "netmasks": [
       "8",
@@ -22,7 +22,7 @@
     "socket_count": 1,
     "agent_version": "2.1.0",
     "total_memory_mb": 7951,
-    "fully_qualified_domain_name": "vmnwdev02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "fully_qualified_domain_name": "vmnwdev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
     "arch": "x86_64",
     "systemd_units": [
       {

--- a/test/fixtures/scenarios/gcp-landscape/653fa371-b322-4029-bfa0-a82b81c08c34_sap_system_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/653fa371-b322-4029-bfa0-a82b81c08c34_sap_system_discovery.json
@@ -1,14 +1,14 @@
 {
-  "agent_id": "7269ee51-5007-5849-aaa7-7c4a98b0c9ce",
+  "agent_id": "653fa371-b322-4029-bfa0-a82b81c08c34",
   "discovery_type": "sap_system_discovery",
   "payload": [
     {
       "Id": "a1e80e3e152a903662f7882fb3f8a851",
       "SID": "NWD",
       "Type": 2,
-      "DBAddress": "10.100.1.13",
+      "DBAddress": "10.100.2.13",
       "Profile": {
-        "SAPDBHOST": "10.100.1.13",
+        "SAPDBHOST": "10.100.2.13",
         "dbms/name": "HDD",
         "dbms/type": "hdb",
         "gw/acl_mode": "1",

--- a/test/fixtures/scenarios/gcp-landscape/653fa371-b322-4029-bfa0-a82b81c08c34_subscription_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/653fa371-b322-4029-bfa0-a82b81c08c34_subscription_discovery.json
@@ -1,5 +1,5 @@
 {
-  "agent_id": "9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f",
+  "agent_id": "653fa371-b322-4029-bfa0-a82b81c08c34",
   "discovery_type": "subscription_discovery",
   "payload": [
     {

--- a/test/fixtures/scenarios/gcp-landscape/73d438ee-03bf-453d-a863-8767ef2840b5_cloud_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/73d438ee-03bf-453d-a863-8767ef2840b5_cloud_discovery.json
@@ -1,0 +1,16 @@
+{
+  "discovery_type": "cloud_discovery",
+  "agent_id": "73d438ee-03bf-453d-a863-8767ef2840b5",
+  "payload": {
+    "Provider": "gcp",
+    "Metadata": {
+      "disk_number": 4,
+      "image": null,
+      "instance_name": "vmhana01",
+      "machine_type": "n1-highmem-8",
+      "network": "network",
+      "project_id": "123456",
+      "zone": "europe-west1-b"
+    }
+  }
+}

--- a/test/fixtures/scenarios/gcp-landscape/73d438ee-03bf-453d-a863-8767ef2840b5_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/73d438ee-03bf-453d-a863-8767ef2840b5_ha_cluster_discovery.json
@@ -1,5 +1,5 @@
 {
-  "agent_id": "13e8c25c-3180-5a9a-95c8-51ec38e50cfc",
+  "agent_id": "73d438ee-03bf-453d-a863-8767ef2840b5",
   "discovery_type": "ha_cluster_discovery",
   "payload": {
     "DC": true,
@@ -223,7 +223,7 @@
                     {
                       "Id": "rsc_ip_HDD_HDB10-instance_attributes-ip",
                       "Name": "ip",
-                      "Value": "10.100.1.13"
+                      "Value": "10.100.2.13"
                     },
                     {
                       "Id": "rsc_ip_HDD_HDB10-instance_attributes-cidr_netmask",

--- a/test/fixtures/scenarios/gcp-landscape/73d438ee-03bf-453d-a863-8767ef2840b5_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/73d438ee-03bf-453d-a863-8767ef2840b5_host_discovery.json
@@ -1,16 +1,16 @@
 {
-  "agent_id": "9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f",
+  "agent_id": "73d438ee-03bf-453d-a863-8767ef2840b5",
   "discovery_type": "host_discovery",
   "payload": {
-    "hostname": "vmnwdev03",
-    "cpu_count": 2,
+    "hostname": "vmhdbdev01",
+    "cpu_count": 4,
     "os_version": "15-SP3",
     "ip_addresses": [
       "127.0.0.1",
       "::1",
-      "10.100.1.23",
-      "10.100.1.27",
-      "fe80::6245:bdff:fe8d:9ef4"
+      "10.100.2.11",
+      "10.100.2.13",
+      "fe80::6245:bdff:fe8d:9b69"
     ],
     "netmasks": [
       "8",
@@ -21,8 +21,8 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951,
-    "fully_qualified_domain_name": "vmnwdev03.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "total_memory_mb": 32107,
+    "fully_qualified_domain_name": "vmhdbdev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
     "arch": "x86_64",
     "systemd_units": [
       {

--- a/test/fixtures/scenarios/gcp-landscape/73d438ee-03bf-453d-a863-8767ef2840b5_sap_system_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/73d438ee-03bf-453d-a863-8767ef2840b5_sap_system_discovery.json
@@ -1,5 +1,5 @@
 {
-  "agent_id": "13e8c25c-3180-5a9a-95c8-51ec38e50cfc",
+  "agent_id": "73d438ee-03bf-453d-a863-8767ef2840b5",
   "discovery_type": "sap_system_discovery",
   "payload": [
     {

--- a/test/fixtures/scenarios/gcp-landscape/73d438ee-03bf-453d-a863-8767ef2840b5_subscription_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/73d438ee-03bf-453d-a863-8767ef2840b5_subscription_discovery.json
@@ -1,5 +1,5 @@
 {
-  "agent_id": "fb2c6b8a-9915-5969-a6b7-8b5a42de1971",
+  "agent_id": "73d438ee-03bf-453d-a863-8767ef2840b5",
   "discovery_type": "subscription_discovery",
   "payload": [
     {

--- a/test/fixtures/scenarios/gcp-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_cloud_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_cloud_discovery.json
@@ -1,8 +1,0 @@
-{
-  "discovery_type": "cloud_discovery",
-  "agent_id": "9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f",
-  "payload": {
-    "Provider": "gcp",
-    "Metadata": null
-  }
-}

--- a/test/fixtures/scenarios/gcp-landscape/a1af7f7b-03bd-47ad-be1c-7995991e8c55_cloud_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/a1af7f7b-03bd-47ad-be1c-7995991e8c55_cloud_discovery.json
@@ -1,0 +1,16 @@
+{
+  "discovery_type": "cloud_discovery",
+  "agent_id": "a1af7f7b-03bd-47ad-be1c-7995991e8c55",
+  "payload": {
+    "Provider": "gcp",
+    "Metadata": {
+      "disk_number": 4,
+      "image": "    ",
+      "instance_name": "vmhana01",
+      "machine_type": "n1-highmem-8",
+      "network": "network",
+      "project_id": "123456",
+      "zone": "europe-west1-b"
+    }
+  }
+}

--- a/test/fixtures/scenarios/gcp-landscape/a1af7f7b-03bd-47ad-be1c-7995991e8c55_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/a1af7f7b-03bd-47ad-be1c-7995991e8c55_host_discovery.json
@@ -1,5 +1,5 @@
 {
-  "agent_id": "1b0e9297-97dd-55d6-9874-8efde4d84c90",
+  "agent_id": "a1af7f7b-03bd-47ad-be1c-7995991e8c55",
   "discovery_type": "host_discovery",
   "payload": {
     "hostname": "vmnwdev04",
@@ -8,8 +8,8 @@
     "ip_addresses": [
       "127.0.0.1",
       "::1",
-      "10.100.1.24",
-      "10.100.1.28",
+      "10.100.2.24",
+      "10.100.2.28",
       "fe80::6245:bdff:fe8d:9a74"
     ],
     "netmasks": [

--- a/test/fixtures/scenarios/gcp-landscape/a1af7f7b-03bd-47ad-be1c-7995991e8c55_sap_system_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/a1af7f7b-03bd-47ad-be1c-7995991e8c55_sap_system_discovery.json
@@ -1,14 +1,14 @@
 {
-  "agent_id": "1b0e9297-97dd-55d6-9874-8efde4d84c90",
+  "agent_id": "a1af7f7b-03bd-47ad-be1c-7995991e8c55",
   "discovery_type": "sap_system_discovery",
   "payload": [
     {
       "Id": "a1e80e3e152a903662f7882fb3f8a851",
       "SID": "NWD",
       "Type": 2,
-      "DBAddress": "10.100.1.13",
+      "DBAddress": "10.100.2.13",
       "Profile": {
-        "SAPDBHOST": "10.100.1.13",
+        "SAPDBHOST": "10.100.2.13",
         "dbms/name": "HDD",
         "dbms/type": "hdb",
         "gw/acl_mode": "1",

--- a/test/fixtures/scenarios/gcp-landscape/a1af7f7b-03bd-47ad-be1c-7995991e8c55_subscription_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/a1af7f7b-03bd-47ad-be1c-7995991e8c55_subscription_discovery.json
@@ -1,5 +1,5 @@
 {
-  "agent_id": "1b0e9297-97dd-55d6-9874-8efde4d84c90",
+  "agent_id": "a1af7f7b-03bd-47ad-be1c-7995991e8c55",
   "discovery_type": "subscription_discovery",
   "payload": [
     {

--- a/test/fixtures/scenarios/gcp-landscape/f7012ac4-6f6b-45e6-b6c1-e154d43d0e42_cloud_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/f7012ac4-6f6b-45e6-b6c1-e154d43d0e42_cloud_discovery.json
@@ -1,6 +1,6 @@
 {
   "discovery_type": "cloud_discovery",
-  "agent_id": "0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4",
+  "agent_id": "f7012ac4-6f6b-45e6-b6c1-e154d43d0e42",
   "payload": {
     "Provider": "gcp",
     "Metadata": null

--- a/test/fixtures/scenarios/gcp-landscape/f7012ac4-6f6b-45e6-b6c1-e154d43d0e42_ha_cluster_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/f7012ac4-6f6b-45e6-b6c1-e154d43d0e42_ha_cluster_discovery.json
@@ -1,5 +1,5 @@
 {
-  "agent_id": "0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4",
+  "agent_id": "f7012ac4-6f6b-45e6-b6c1-e154d43d0e42",
   "discovery_type": "ha_cluster_discovery",
   "payload": {
     "DC": false,
@@ -223,7 +223,7 @@
                     {
                       "Id": "rsc_ip_HDD_HDB10-instance_attributes-ip",
                       "Name": "ip",
-                      "Value": "10.100.1.13"
+                      "Value": "10.100.2.13"
                     },
                     {
                       "Id": "rsc_ip_HDD_HDB10-instance_attributes-cidr_netmask",

--- a/test/fixtures/scenarios/gcp-landscape/f7012ac4-6f6b-45e6-b6c1-e154d43d0e42_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/f7012ac4-6f6b-45e6-b6c1-e154d43d0e42_host_discovery.json
@@ -1,28 +1,26 @@
 {
-  "agent_id": "7269ee51-5007-5849-aaa7-7c4a98b0c9ce",
+  "agent_id": "f7012ac4-6f6b-45e6-b6c1-e154d43d0e42",
   "discovery_type": "host_discovery",
   "payload": {
-    "hostname": "vmnwdev01",
-    "cpu_count": 2,
+    "hostname": "vmhdbdev02",
+    "cpu_count": 4,
     "os_version": "15-SP3",
     "ip_addresses": [
       "127.0.0.1",
       "::1",
-      "10.100.1.21",
-      "10.100.1.25",
-      "fe80::6245:bdff:fe8a:5ce7"
+      "10.100.2.12",
+      "fe80::6245:bdff:fe8a:5f6b"
     ],
     "netmasks": [
       "8",
       "128",
       "24",
-      "24",
       "64"
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 7951,
-    "fully_qualified_domain_name": "vmnwdev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "total_memory_mb": 32107,
+    "fully_qualified_domain_name": "vmhdbdev02.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
     "arch": "x86_64",
     "systemd_units": [
       {

--- a/test/fixtures/scenarios/gcp-landscape/f7012ac4-6f6b-45e6-b6c1-e154d43d0e42_sap_system_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/f7012ac4-6f6b-45e6-b6c1-e154d43d0e42_sap_system_discovery.json
@@ -1,5 +1,5 @@
 {
-  "agent_id": "0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4",
+  "agent_id": "f7012ac4-6f6b-45e6-b6c1-e154d43d0e42",
   "discovery_type": "sap_system_discovery",
   "payload": [
     {

--- a/test/fixtures/scenarios/gcp-landscape/f7012ac4-6f6b-45e6-b6c1-e154d43d0e42_subscription_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/f7012ac4-6f6b-45e6-b6c1-e154d43d0e42_subscription_discovery.json
@@ -1,5 +1,5 @@
 {
-  "agent_id": "0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4",
+  "agent_id": "f7012ac4-6f6b-45e6-b6c1-e154d43d0e42",
   "discovery_type": "subscription_discovery",
   "payload": [
     {

--- a/test/fixtures/scenarios/gcp-landscape/f7b89bd5-45bc-4372-bec5-dd41eb1cc217_cloud_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/f7b89bd5-45bc-4372-bec5-dd41eb1cc217_cloud_discovery.json
@@ -1,6 +1,6 @@
 {
   "discovery_type": "cloud_discovery",
-  "agent_id": "7269ee51-5007-5849-aaa7-7c4a98b0c9ce",
+  "agent_id": "f7b89bd5-45bc-4372-bec5-dd41eb1cc217",
   "payload": {
     "Provider": "gcp",
     "Metadata": null

--- a/test/fixtures/scenarios/gcp-landscape/f7b89bd5-45bc-4372-bec5-dd41eb1cc217_host_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/f7b89bd5-45bc-4372-bec5-dd41eb1cc217_host_discovery.json
@@ -1,16 +1,16 @@
 {
-  "agent_id": "13e8c25c-3180-5a9a-95c8-51ec38e50cfc",
+  "agent_id": "f7b89bd5-45bc-4372-bec5-dd41eb1cc217",
   "discovery_type": "host_discovery",
   "payload": {
-    "hostname": "vmhdbdev01",
-    "cpu_count": 4,
+    "hostname": "vmnwdev03",
+    "cpu_count": 2,
     "os_version": "15-SP3",
     "ip_addresses": [
       "127.0.0.1",
       "::1",
-      "10.100.1.11",
-      "10.100.1.13",
-      "fe80::6245:bdff:fe8d:9b69"
+      "10.100.2.23",
+      "10.100.2.27",
+      "fe80::6245:bdff:fe8d:9ef4"
     ],
     "netmasks": [
       "8",
@@ -21,8 +21,8 @@
     ],
     "socket_count": 1,
     "agent_version": "2.1.0",
-    "total_memory_mb": 32107,
-    "fully_qualified_domain_name": "vmhdbdev01.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
+    "total_memory_mb": 7951,
+    "fully_qualified_domain_name": "vmnwdev03.l15cqsinwnpu5gfyrf1r5l51fe.ax.internal.cloudapp.net",
     "arch": "x86_64",
     "systemd_units": [
       {

--- a/test/fixtures/scenarios/gcp-landscape/f7b89bd5-45bc-4372-bec5-dd41eb1cc217_sap_system_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/f7b89bd5-45bc-4372-bec5-dd41eb1cc217_sap_system_discovery.json
@@ -1,14 +1,14 @@
 {
-  "agent_id": "fb2c6b8a-9915-5969-a6b7-8b5a42de1971",
+  "agent_id": "f7b89bd5-45bc-4372-bec5-dd41eb1cc217",
   "discovery_type": "sap_system_discovery",
   "payload": [
     {
       "Id": "a1e80e3e152a903662f7882fb3f8a851",
       "SID": "NWD",
       "Type": 2,
-      "DBAddress": "10.100.1.13",
+      "DBAddress": "10.100.2.13",
       "Profile": {
-        "SAPDBHOST": "10.100.1.13",
+        "SAPDBHOST": "10.100.2.13",
         "dbms/name": "HDD",
         "dbms/type": "hdb",
         "gw/acl_mode": "1",
@@ -43,8 +43,8 @@
       "Databases": null,
       "Instances": [
         {
-          "Host": "vmnwdev02",
-          "Name": "ERS10",
+          "Host": "vmnwdev03",
+          "Name": "D01",
           "Type": 2,
           "SAPControl": {
             "Instances": [
@@ -66,7 +66,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 10,
                 "startPriority": "0.5",
-                "currentInstance": true
+                "currentInstance": false
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -76,7 +76,7 @@
                 "dispstatus": "SAPControl-GREEN",
                 "instanceNr": 1,
                 "startPriority": "3",
-                "currentInstance": false
+                "currentInstance": true
               },
               {
                 "features": "ABAP|GATEWAY|ICMAN|IGS",
@@ -91,18 +91,65 @@
             ],
             "Processes": [
               {
-                "pid": 6720,
-                "name": "enrepserver",
-                "starttime": "2022 01 11 12:55:17",
+                "pid": 27224,
+                "name": "gwrd",
+                "starttime": "2022 01 11 13:03:58",
                 "dispstatus": "SAPControl-GREEN",
                 "textstatus": "Running",
-                "description": "EnqueueReplicator",
-                "elapsedtime": "151:56:49"
+                "description": "Gateway",
+                "elapsedtime": "151:48:10"
+              },
+              {
+                "pid": 27225,
+                "name": "icman",
+                "starttime": "2022 01 11 13:03:58",
+                "dispstatus": "SAPControl-GREEN",
+                "textstatus": "Running",
+                "description": "ICM",
+                "elapsedtime": "151:48:10"
+              },
+              {
+                "pid": 26907,
+                "name": "igswd_mt",
+                "starttime": "2022 01 11 13:03:55",
+                "dispstatus": "SAPControl-GREEN",
+                "textstatus": "Running",
+                "description": "IGS Watchdog",
+                "elapsedtime": "151:48:13"
+              },
+              {
+                "pid": 26906,
+                "name": "disp+work",
+                "starttime": "2022 01 11 13:03:55",
+                "dispstatus": "SAPControl-GREEN",
+                "textstatus": "Running",
+                "description": "Dispatcher",
+                "elapsedtime": "151:48:13"
               }
             ],
             "Properties": [
               {
-                "value": "10",
+                "value": "HTTP://sapnwdpas:0/sap/admin/public/index.html",
+                "property": "ICM",
+                "propertytype": "NodeURL"
+              },
+              {
+                "value": "http://sapnwdpas:40180",
+                "property": "IGS",
+                "propertytype": "NodeURL"
+              },
+              {
+                "value": "ABAPReadSyslog",
+                "property": "Syslog",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "ICMGetCacheEntries",
+                "property": "ICM Cache",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "01",
                 "property": "SAPSYSTEM",
                 "propertytype": "Attribute"
               },
@@ -112,14 +159,29 @@
                 "propertytype": "Attribute"
               },
               {
+                "value": "ICMGetThreadList",
+                "property": "ICM Threads",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "GetAlertTree",
+                "property": "Open Alerts",
+                "propertytype": "NodeWebmethod"
+              },
+              {
                 "value": "GetProcessList",
                 "property": "Process List",
                 "propertytype": "NodeWebmethod"
               },
               {
-                "value": "sapnwder",
+                "value": "sapnwdpas",
                 "property": "SAPLOCALHOST",
                 "propertytype": "Attribute"
+              },
+              {
+                "value": "ABAPGetWPTable",
+                "property": "ABAP WP Table",
+                "propertytype": "NodeWebmethod"
               },
               {
                 "value": "GetAccessPointList",
@@ -127,7 +189,7 @@
                 "propertytype": "NodeWebmethod"
               },
               {
-                "value": "ERS10",
+                "value": "D01",
                 "property": "INSTANCE_NAME",
                 "propertytype": "Attribute"
               },
@@ -142,9 +204,34 @@
                 "propertytype": "Attribute"
               },
               {
-                "value": "0.5",
+                "value": "3",
                 "property": "StartPriority",
                 "propertytype": "Attribute"
+              },
+              {
+                "value": "GetAlertTree",
+                "property": "Current Status",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "GWGetClientList",
+                "property": "Gateway Clients",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "ICMGetConnectionList",
+                "property": "ICM Connections",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "GetQueueStatistic",
+                "property": "Queue Statistic",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "GWGetConnectionList",
+                "property": "Gateway Connections",
+                "propertytype": "NodeWebmethod"
               },
               {
                 "value": "ABAPAcknowledgeAlerts,ABAPCheckRFCDestinations,ABAPGetComponentList,ABAPGetSystemWPTable,ABAPGetWPTable,ABAPReadRawSyslog,ABAPReadSyslog,ABAPSetServerInactive,AnalyseLogFiles,Bootstrap,CheckParameter,CheckPSE,CheckUpdateSystem,ConfigureLogFileList,CreatePSECredential,CreateSnapshot,DeletePSE,DeleteSnapshots,EnqGetLockTable,EnqGetStatistic,EnqRemoveLocks,EnqRemoveUserLocks,GetAccessPointList,GetAlerts,GetAlertTree,GetCallstack,GetEnvironment,GetLogFileList,GetProcessParameter,GetQueueStatistic,GetStartProfile,GetSystemUpdateList,GetTraceFile,GetVersionInfo,GWCancelConnections,GWDeleteClients,GWDeleteConnections,GWGetConnectionList,GWGetClientList,HACheckConfig,HACheckFailoverConfig,HACheckMaintenanceMode,HAFailoverToNode,HAGetFailoverConfig,HASetMaintenanceMode,ICMGetCacheEntries,ICMGetConnectionList,ICMGetProxyConnectionList,ICMGetThreadList,InstanceStart,InstanceStop,J2EEControlCluster,J2EEControlComponents,J2EEControlProcess,J2EEDisableDbgSession,J2EEEnableDbgSession,J2EEGetApplicationAliasList,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetClusterMsgList,J2EEGetComponentList,J2EEGetEJBSessionList,J2EEGetProcessList,J2EEGetProcessList2,J2EEGetRemoteObjectList,J2EEGetSessionList,J2EEGetSharedTableInfo,J2EEGetThreadCallStack,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadTaskStack,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetWebSessionList,J2EEGetWebSessionList2,ListConfigFiles,ListDeveloperTraces,ListLogFiles,ListSnapshots,OSExecute,ParameterValue,ReadConfigFile,ReadDeveloperTrace,ReadLogFile,ReadSnapshot,RestartInstance,RestartService,RestartSystem,SendSignal,SetProcessParameter,SetProcessParameter2,ShmDetach,Shutdown,Start,StartBypassHA,StartSystem,Stop,StopBypassHA,StopService,StopSystem,StorePSE,UpdateInstancePSE,UpdateSCSInstance,UpdateSystem,UpdateSystemPKI,WebDispGetServerList,WebDispGetGroupList,WebDispGetVirtHostList,WebDispGetUrlPrefixList,GetAgentConfig,GetListOfMaByCusGrp,GetMcInLocalMs,GetMtesByRequestTable,GetMtListByMtclass,InfoGetTree,MscCustomizeWrite,MscDeleteLines,MscReadCache,MsGetLocalMsInfo,MsGetMteclsInLocalMs,MtChangeStatus,MtCustomizeWrite,MtDbsetToWpsetByTid,MtDestroyMarkNTry,MteGetByToolRunstatus,MtGetAllToCust,MtGetAllToolsToSet,MtGetMteinfo,MtGetTidByName,MtRead,MtReset,PerfCustomizeWrite,PerfRead,PerfReadSmoothData,ReadDirectory,ReadFile,ReadProfileParameters,ReferenceRead,Register,RequestLogonFile,SnglmgsCustomizeWrite,SystemObjectSetValue,TextAttrRead,ToolGetEffective,ToolSet,ToolSetRuntimeStatus,TriggerDataCollection,Unregister,UtilAlChangeStatus,UtilMtGetAidByTid,UtilMtGetTreeLocal,UtilMtReadAll,UtilReadRawalertByAid,UtilSnglmsgReadRawdata",
@@ -152,7 +239,12 @@
                 "propertytype": "Attribute"
               },
               {
-                "value": "http://sapnwder:51013/sapparamEN.html",
+                "value": "ICMGetProxyConnectionList",
+                "property": "ICM Proxy Connections",
+                "propertytype": "NodeWebmethod"
+              },
+              {
+                "value": "http://sapnwdpas:50113/sapparamEN.html",
                 "property": "Parameter Documentation",
                 "propertytype": "NodeURL"
               }

--- a/test/fixtures/scenarios/gcp-landscape/f7b89bd5-45bc-4372-bec5-dd41eb1cc217_subscription_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/f7b89bd5-45bc-4372-bec5-dd41eb1cc217_subscription_discovery.json
@@ -1,5 +1,5 @@
 {
-  "agent_id": "7269ee51-5007-5849-aaa7-7c4a98b0c9ce",
+  "agent_id": "f7b89bd5-45bc-4372-bec5-dd41eb1cc217",
   "discovery_type": "subscription_discovery",
   "payload": [
     {

--- a/test/fixtures/scenarios/gcp-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_cloud_discovery.json
+++ b/test/fixtures/scenarios/gcp-landscape/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_cloud_discovery.json
@@ -1,8 +1,0 @@
-{
-  "discovery_type": "cloud_discovery",
-  "agent_id": "fb2c6b8a-9915-5969-a6b7-8b5a42de1971",
-  "payload": {
-    "Provider": "gcp",
-    "Metadata": null
-  }
-}

--- a/test/trento/discovery/policies/host_policy_test.exs
+++ b/test/trento/discovery/policies/host_policy_test.exs
@@ -281,7 +281,7 @@ defmodule Trento.Discovery.Policies.HostPolicyTest do
              |> HostPolicy.handle()
   end
 
-  test "should return the expected commands when a cloud_discovery payload with an gcp provider is handled with missing metadata" do
+  test "should return the expected commands when a gcp cloud_discovery is handled with missing metadata" do
     assert {
              :ok,
              %UpdateProvider{
@@ -296,7 +296,7 @@ defmodule Trento.Discovery.Policies.HostPolicyTest do
              |> HostPolicy.handle()
   end
 
-  test "should return the expected commands when a cloud_discovery payload with an gcp provider is handled with partially missing metadata" do
+  test "should return the expected commands when a gcp cloud_discovery is handled with partially missing metadata" do
     base_fixture = load_discovery_event_fixture("cloud_discovery_gcp")
 
     scenarios = [

--- a/test/trento/discovery/policies/host_policy_test.exs
+++ b/test/trento/discovery/policies/host_policy_test.exs
@@ -281,6 +281,53 @@ defmodule Trento.Discovery.Policies.HostPolicyTest do
              |> HostPolicy.handle()
   end
 
+  test "should return the expected commands when a cloud_discovery payload with an gcp provider is handled with missing metadata" do
+    assert {
+             :ok,
+             %UpdateProvider{
+               host_id: "0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4",
+               provider: Provider.gcp(),
+               provider_data: nil
+             }
+           } ==
+             "cloud_discovery_gcp"
+             |> load_discovery_event_fixture()
+             |> put_in(["payload", "Metadata"], nil)
+             |> HostPolicy.handle()
+  end
+
+  test "should return the expected commands when a cloud_discovery payload with an gcp provider is handled with partially missing metadata" do
+    base_fixture = load_discovery_event_fixture("cloud_discovery_gcp")
+
+    scenarios = [
+      put_in(base_fixture, ["payload", "Metadata", "image"], nil),
+      put_in(base_fixture, ["payload", "Metadata", "image"], ""),
+      put_in(base_fixture, ["payload", "Metadata", "image"], "   "),
+      base_fixture
+      |> pop_in(["payload", "Metadata", "image"])
+      |> elem(1)
+    ]
+
+    for scenario_fixture <- scenarios do
+      assert {
+               :ok,
+               %UpdateProvider{
+                 host_id: "0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4",
+                 provider: Provider.gcp(),
+                 provider_data: %GcpProvider{
+                   disk_number: 4,
+                   image: nil,
+                   instance_name: "vmhana01",
+                   machine_type: "n1-highmem-8",
+                   network: "network",
+                   project_id: "123456",
+                   zone: "europe-west1-b"
+                 }
+               }
+             } == HostPolicy.handle(scenario_fixture)
+    end
+  end
+
   test "should return the expected commands when a cloud_discovery payload with an kvm provider is handled" do
     assert {
              :ok,

--- a/test/trento_web/controllers/v1/host_controller_test.exs
+++ b/test/trento_web/controllers/v1/host_controller_test.exs
@@ -14,6 +14,7 @@ defmodule TrentoWeb.V1.HostControllerTest do
 
   alias Trento.ActivityLog
   alias Trento.Hosts.Commands.RequestHostDeregistration
+  alias Trento.Hosts.ValueObjects.GcpProvider
 
   alias Trento.Infrastructure.Checks.AMQP.Publisher
   alias Trento.Infrastructure.Operations.AMQP.Publisher, as: OperationsPublisher
@@ -34,6 +35,40 @@ defmodule TrentoWeb.V1.HostControllerTest do
       get(conn, "/api/v1/hosts")
       |> json_response(200)
       |> assert_schema("HostsCollectionV1", api_spec)
+    end
+
+    test "should list gcp hosts with relevant metadata", %{conn: conn, api_spec: api_spec} do
+      gcp_metadata = %GcpProvider{
+        disk_number: 4,
+        image: "sles-15-sp1-sap-byos-v20220126",
+        instance_name: "vmhana01",
+        machine_type: "n1-highmem-8",
+        network: "network",
+        project_id: "123456",
+        zone: "europe-west1-b"
+      }
+
+      insert(:host,
+        provider: :gcp,
+        provider_data: gcp_metadata
+      )
+
+      insert(:host,
+        provider: :gcp,
+        provider_data: nil
+      )
+
+      insert(:host,
+        provider: :gcp,
+        provider_data: Map.put(gcp_metadata, :image, nil)
+      )
+
+      hosts =
+        get(conn, "/api/v1/hosts")
+        |> json_response(200)
+        |> assert_schema("HostsCollectionV1", api_spec)
+
+      assert length(hosts) == 3
     end
 
     test "should handle null cluster_id", %{conn: conn, api_spec: api_spec} do

--- a/test/trento_web/views/v1/host_view_json_test.exs
+++ b/test/trento_web/views/v1/host_view_json_test.exs
@@ -45,4 +45,50 @@ defmodule TrentoWeb.V1.HostJSONTest do
 
     assert Enum.all?(ignored_properties, &(!Map.has_key?(rendered_map, &1)))
   end
+
+  test "should handle gcp host metadata" do
+    gcp_metadata = %{
+      "disk_number" => 4,
+      "image" => "sles-15-sp1-sap-byos-v20220126",
+      "instance_name" => "vmhana01",
+      "machine_type" => "n1-highmem-8",
+      "network" => "network",
+      "project_id" => "123456",
+      "zone" => "europe-west1-b"
+    }
+
+    hosts = [
+      build(:host,
+        sles_subscriptions: build_list(1, :sles_subscription),
+        provider: :gcp,
+        provider_data: gcp_metadata
+      ),
+      build(:host,
+        sles_subscriptions: build_list(1, :sles_subscription),
+        provider: :gcp,
+        provider_data: nil
+      ),
+      build(:host,
+        sles_subscriptions: build_list(1, :sles_subscription),
+        provider: :gcp,
+        provider_data: Map.put(gcp_metadata, "image", nil)
+      )
+    ]
+
+    assert [
+             %{
+               provider_data: %{
+                 "image" => "sles-15-sp1-sap-byos-v20220126"
+               }
+             },
+             %{
+               provider_data: nil
+             },
+             %{
+               provider_data: %{
+                 "image" => nil
+               }
+             }
+           ] = HostJSON.hosts(%{hosts: hosts})
+  end
 end


### PR DESCRIPTION
### Description

It could happen that gcp cloud discovery does not send the `image` metadata. and the whole metadata are rejected.

This PR relaxes the strict requirement on that entry and gracefully handles it by accepting null/empty values.

Note that other metadata entries are intentionally left required as they currently are. If needed we can relax on them, too.

Additionally I took the liberty to adjust the scenario fixtures in `test/fixtures/scenarios/gcp-landscape` and add them to the compound `demo` scenario.

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1268363

### How was this tested?

Automated and IRL.