### PR TITLE
Open new tab on AI Assistant `learn more` link

### DIFF
--- a/assets/js/common/AIAssistant/PromptComposer/PromptComposer.jsx
+++ b/assets/js/common/AIAssistant/PromptComposer/PromptComposer.jsx
@@ -23,6 +23,8 @@ const footnote = (
     <a
       href="https://documentation.suse.com/sles-sap/trento/html/SLES-SAP-trento/index.html"
       className="underline hover:text-gray-500"
+      target="_blank"
+      rel="noopener noreferrer"
     >
       Learn more
     </a>

--- a/assets/js/common/AIAssistant/PromptComposer/PromptComposer.test.jsx
+++ b/assets/js/common/AIAssistant/PromptComposer/PromptComposer.test.jsx
@@ -58,9 +58,13 @@ describe('PromptComposer', () => {
   it('renders the footnote with the documentation link', () => {
     render(<PromptComposer connectionStatus="connected" />);
     expect(screen.getByText(/AI assistants can make mistakes/)).toBeVisible();
-    expect(screen.getByRole('link', { name: 'Learn more' })).toHaveAttribute(
+
+    const learnMoreLink = screen.getByRole('link', { name: 'Learn more' });
+
+    expect(learnMoreLink).toHaveAttribute(
       'href',
       expect.stringContaining('documentation.suse.com')
     );
+    expect(learnMoreLink).toHaveAttribute('target', '_blank');
   });
 });


### PR DESCRIPTION
### Description

Make sure the `Learn more` link in the AI Assistant opens in a new tab

### How was this tested?

Automatic and IRL.