### PR TITLE
Stale database instances when host hearbeat fails

### DIFF
--- a/lib/trento/databases/commands/mark_database_instance_data_stale.ex
+++ b/lib/trento/databases/commands/mark_database_instance_data_stale.ex
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Databases.Commands.MarkDatabaseInstanceDataStale do
+  @moduledoc """
+  Mark a database instance data as stale.
+  """
+  @required_fields :all
+
+  use Trento.Support.Command
+
+  defcommand do
+    field :database_id, Ecto.UUID
+    field :instance_number, :string
+    field :host_id, Ecto.UUID
+    field :stale_at, :utc_datetime_usec
+  end
+end

--- a/lib/trento/databases/database.ex
+++ b/lib/trento/databases/database.ex
@@ -25,6 +25,7 @@ defmodule Trento.Databases.Database do
   alias Trento.Databases.Commands.{
     DeregisterDatabaseInstance,
     MarkDatabaseInstanceAbsent,
+    MarkDatabaseInstanceDataStale,
     RegisterDatabaseInstance,
     RollUpDatabase
   }
@@ -32,6 +33,8 @@ defmodule Trento.Databases.Database do
   alias Trento.Databases.Events.{
     DatabaseDeregistered,
     DatabaseHealthChanged,
+    DatabaseInstanceDataMarkedInSync,
+    DatabaseInstanceDataMarkedStale,
     DatabaseInstanceDeregistered,
     DatabaseInstanceMarkedAbsent,
     DatabaseInstanceMarkedPresent,
@@ -255,6 +258,9 @@ defmodule Trento.Databases.Database do
     |> Multi.execute(fn _ ->
       maybe_emit_database_instance_marked_present_event(instance, command)
     end)
+    |> Multi.execute(fn _ ->
+      maybe_emit_database_instance_data_marked_in_sync_event(instance, command)
+    end)
     |> Multi.execute(&maybe_emit_database_health_changed_event/1)
     |> Multi.execute(fn database ->
       maybe_emit_database_tenants_updated_event(database, tenants)
@@ -283,6 +289,28 @@ defmodule Trento.Databases.Database do
           host_id: host_id,
           database_id: database_id,
           absent_at: absent_at
+        }
+
+      _ ->
+        nil
+    end
+  end
+
+  def execute(
+        %Database{database_id: database_id, instances: instances},
+        %MarkDatabaseInstanceDataStale{
+          instance_number: instance_number,
+          host_id: host_id,
+          stale_at: stale_at
+        }
+      ) do
+    case get_instance(instances, host_id, instance_number) do
+      %Instance{stale_at: nil} ->
+        %DatabaseInstanceDataMarkedStale{
+          database_id: database_id,
+          instance_number: instance_number,
+          host_id: host_id,
+          stale_at: stale_at
         }
 
       _ ->
@@ -376,7 +404,8 @@ defmodule Trento.Databases.Database do
         features: features,
         host_id: host_id,
         status: status,
-        absent_at: nil
+        absent_at: nil,
+        stale_at: nil
       }
       | instances
     ]
@@ -478,6 +507,31 @@ defmodule Trento.Databases.Database do
         }
       ) do
     instances = update_instance(instances, instance_number, host_id, %{absent_at: absent_at})
+
+    %Database{database | instances: instances}
+  end
+
+  def apply(
+        %Database{instances: instances} = database,
+        %DatabaseInstanceDataMarkedInSync{
+          instance_number: instance_number,
+          host_id: host_id
+        }
+      ) do
+    instances = update_instance(instances, instance_number, host_id, %{stale_at: nil})
+
+    %Database{database | instances: instances}
+  end
+
+  def apply(
+        %Database{instances: instances} = database,
+        %DatabaseInstanceDataMarkedStale{
+          instance_number: instance_number,
+          host_id: host_id,
+          stale_at: stale_at
+        }
+      ) do
+    instances = update_instance(instances, instance_number, host_id, %{stale_at: stale_at})
 
     %Database{database | instances: instances}
   end
@@ -622,6 +676,24 @@ defmodule Trento.Databases.Database do
   end
 
   defp maybe_emit_database_instance_marked_present_event(_, _), do: nil
+
+  defp maybe_emit_database_instance_data_marked_in_sync_event(
+         %Instance{stale_at: stale_at},
+         %RegisterDatabaseInstance{
+           database_id: database_id,
+           instance_number: instance_number,
+           host_id: host_id
+         }
+       )
+       when not is_nil(stale_at) do
+    %DatabaseInstanceDataMarkedInSync{
+      database_id: database_id,
+      instance_number: instance_number,
+      host_id: host_id
+    }
+  end
+
+  defp maybe_emit_database_instance_data_marked_in_sync_event(_, _), do: nil
 
   defp maybe_emit_database_instance_system_replication_changed_event(nil, _), do: nil
 

--- a/lib/trento/databases/events/database_instance_data_marked_in_sync.ex
+++ b/lib/trento/databases/events/database_instance_data_marked_in_sync.ex
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Databases.Events.DatabaseInstanceDataMarkedInSync do
+  @moduledoc """
+  This event is emitted when a database instance data is marked as
+  synchronized and valid.
+  """
+
+  use Trento.Support.Event
+
+  defevent do
+    field :database_id, Ecto.UUID
+    field :instance_number, :string
+    field :host_id, Ecto.UUID
+  end
+end

--- a/lib/trento/databases/events/database_instance_data_marked_stale.ex
+++ b/lib/trento/databases/events/database_instance_data_marked_stale.ex
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Databases.Events.DatabaseInstanceDataMarkedStale do
+  @moduledoc """
+  This event is emitted when a database instance data is marked as stale.
+  """
+
+  use Trento.Support.Event
+
+  defevent do
+    field :database_id, Ecto.UUID
+    field :instance_number, :string
+    field :host_id, Ecto.UUID
+    field :stale_at, :utc_datetime_usec
+  end
+end

--- a/lib/trento/databases/projections/database_instance_read_model.ex
+++ b/lib/trento/databases/projections/database_instance_read_model.ex
@@ -40,6 +40,7 @@ defmodule Trento.Databases.Projections.DatabaseInstanceReadModel do
     field :system_replication_tier, :integer
     field :status, Ecto.Enum, values: Status.values()
     field :absent_at, :utc_datetime_usec
+    field :stale_at, :utc_datetime_usec
 
     belongs_to :host, HostReadModel,
       references: :id,

--- a/lib/trento/databases/projections/database_projector.ex
+++ b/lib/trento/databases/projections/database_projector.ex
@@ -21,6 +21,8 @@ defmodule Trento.Databases.Projections.DatabaseProjector do
   alias Trento.Databases.Events.{
     DatabaseDeregistered,
     DatabaseHealthChanged,
+    DatabaseInstanceDataMarkedInSync,
+    DatabaseInstanceDataMarkedStale,
     DatabaseInstanceDeregistered,
     DatabaseInstanceMarkedAbsent,
     DatabaseInstanceMarkedPresent,
@@ -121,7 +123,8 @@ defmodule Trento.Databases.Projections.DatabaseProjector do
           system_replication_operation_mode: system_replication_operation_mode,
           system_replication_source_site: system_replication_source_site,
           system_replication_tier: system_replication_tier,
-          status: status
+          status: status,
+          stale_at: nil
         })
 
       Ecto.Multi.insert(multi, :database_instance, database_instance_changeset)
@@ -225,6 +228,51 @@ defmodule Trento.Databases.Projections.DatabaseProjector do
         )
         |> DatabaseInstanceReadModel.changeset(%{
           absent_at: nil
+        })
+
+      Ecto.Multi.update(multi, :database_instance, changeset)
+    end
+  )
+
+  project(
+    %DatabaseInstanceDataMarkedStale{
+      database_id: database_id,
+      instance_number: instance_number,
+      host_id: host_id,
+      stale_at: stale_at
+    },
+    fn multi ->
+      changeset =
+        DatabaseInstanceReadModel
+        |> Repo.get_by(
+          database_id: database_id,
+          instance_number: instance_number,
+          host_id: host_id
+        )
+        |> DatabaseInstanceReadModel.changeset(%{
+          stale_at: stale_at
+        })
+
+      Ecto.Multi.update(multi, :database_instance, changeset)
+    end
+  )
+
+  project(
+    %DatabaseInstanceDataMarkedInSync{
+      database_id: database_id,
+      instance_number: instance_number,
+      host_id: host_id
+    },
+    fn multi ->
+      changeset =
+        DatabaseInstanceReadModel
+        |> Repo.get_by(
+          database_id: database_id,
+          instance_number: instance_number,
+          host_id: host_id
+        )
+        |> DatabaseInstanceReadModel.changeset(%{
+          stale_at: nil
         })
 
       Ecto.Multi.update(multi, :database_instance, changeset)
@@ -446,6 +494,55 @@ defmodule Trento.Databases.Projections.DatabaseProjector do
           database_id: database_id,
           sid: sid,
           absent_at: nil
+        }
+      })
+    )
+  end
+
+  @impl true
+  def after_update(
+        %DatabaseInstanceDataMarkedStale{
+          instance_number: instance_number,
+          host_id: host_id,
+          database_id: database_id,
+          stale_at: stale_at
+        },
+        _,
+        _
+      ) do
+    TrentoWeb.Endpoint.broadcast(
+      @databases_topic,
+      "database_instance_stale_changed",
+      DatabaseJSON.database_instance_stale_changed(%{
+        instance: %{
+          instance_number: instance_number,
+          host_id: host_id,
+          database_id: database_id,
+          stale_at: stale_at
+        }
+      })
+    )
+  end
+
+  @impl true
+  def after_update(
+        %DatabaseInstanceDataMarkedInSync{
+          instance_number: instance_number,
+          host_id: host_id,
+          database_id: database_id
+        },
+        _,
+        _
+      ) do
+    TrentoWeb.Endpoint.broadcast(
+      @databases_topic,
+      "database_instance_stale_changed",
+      DatabaseJSON.database_instance_stale_changed(%{
+        instance: %{
+          instance_number: instance_number,
+          host_id: host_id,
+          database_id: database_id,
+          stale_at: nil
         }
       })
     )

--- a/lib/trento/infrastructure/commanded/process_managers/deregistration_process_manager.ex
+++ b/lib/trento/infrastructure/commanded/process_managers/deregistration_process_manager.ex
@@ -72,7 +72,10 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
 
   alias Trento.Hosts.Commands.DeregisterHost
 
-  alias Trento.Databases.Commands.DeregisterDatabaseInstance
+  alias Trento.Databases.Commands.{
+    DeregisterDatabaseInstance,
+    MarkDatabaseInstanceDataStale
+  }
 
   alias Trento.SapSystems.Commands.{
     DeregisterApplicationInstance,
@@ -219,24 +222,41 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
 
   def handle(
         %DeregistrationProcessManager{
-          application_instances: application_instances
+          application_instances: application_instances,
+          database_instances: database_instances
         },
         %HeartbeatFailed{
           host_id: host_id
         },
         %{created_at: created_at}
       ) do
-    Enum.map(application_instances, fn %Instance{
-                                         sap_system_id: sap_system_id,
-                                         instance_number: instance_number
-                                       } ->
-      %MarkApplicationInstanceDataStale{
-        sap_system_id: sap_system_id,
-        instance_number: instance_number,
-        host_id: host_id,
-        stale_at: created_at
-      }
-    end)
+    application_commands =
+      Enum.map(application_instances, fn %Instance{
+                                           sap_system_id: sap_system_id,
+                                           instance_number: instance_number
+                                         } ->
+        %MarkApplicationInstanceDataStale{
+          sap_system_id: sap_system_id,
+          instance_number: instance_number,
+          host_id: host_id,
+          stale_at: created_at
+        }
+      end)
+
+    database_commands =
+      Enum.map(database_instances, fn %Instance{
+                                        sap_system_id: database_id,
+                                        instance_number: instance_number
+                                      } ->
+        %MarkDatabaseInstanceDataStale{
+          database_id: database_id,
+          instance_number: instance_number,
+          host_id: host_id,
+          stale_at: created_at
+        }
+      end)
+
+    application_commands ++ database_commands
   end
 
   def apply(%DeregistrationProcessManager{} = state, %HostAddedToCluster{

--- a/lib/trento/router.ex
+++ b/lib/trento/router.ex
@@ -33,6 +33,7 @@ defmodule Trento.Router do
   alias Trento.Databases.Commands.{
     DeregisterDatabaseInstance,
     MarkDatabaseInstanceAbsent,
+    MarkDatabaseInstanceDataStale,
     RegisterDatabaseInstance,
     RollUpDatabase
   }
@@ -108,6 +109,7 @@ defmodule Trento.Router do
   dispatch [
              DeregisterDatabaseInstance,
              MarkDatabaseInstanceAbsent,
+             MarkDatabaseInstanceDataStale,
              RegisterDatabaseInstance,
              RollUpDatabase
            ],

--- a/lib/trento_web/controllers/v1/database_json.ex
+++ b/lib/trento_web/controllers/v1/database_json.ex
@@ -126,6 +126,21 @@ defmodule TrentoWeb.V1.DatabaseJSON do
         absent_at: absent_at
       }
 
+  def database_instance_stale_changed(%{
+        instance: %{
+          instance_number: instance_number,
+          host_id: host_id,
+          database_id: database_id,
+          stale_at: stale_at
+        }
+      }),
+      do: %{
+        instance_number: instance_number,
+        host_id: host_id,
+        database_id: database_id,
+        stale_at: stale_at
+      }
+
   def database_tenants_updated(%{tenants: tenants, database_id: database_id}) do
     rendered_tenants = Enum.map(tenants, &database_tenant(%{tenant: &1}))
 

--- a/lib/trento_web/openapi/v1/schema/database.ex
+++ b/lib/trento_web/openapi/v1/schema/database.ex
@@ -151,6 +151,14 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Database do
             format: :datetime,
             nullable: true
           },
+          stale_at: %Schema{
+            type: :string,
+            description:
+              "The timestamp indicating when the database instance data became stale, supporting monitoring and troubleshooting.",
+            format: :datetime,
+            example: "2024-01-15T08:00:00Z",
+            nullable: true
+          },
           inserted_at: %Schema{type: :string, format: :datetime},
           updated_at: %Schema{type: :string, format: :datetime, nullable: true}
         },
@@ -177,6 +185,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Database do
           health: "passing",
           status: "green",
           absent_at: "2024-01-15T08:00:00Z",
+          stale_at: "2024-01-15T09:00:00Z",
           inserted_at: "2024-01-15T10:30:00Z",
           updated_at: "2024-01-15T12:45:00Z"
         }

--- a/priv/repo/migrations/20260617093859_add_stale_at_database_instance_read_model.exs
+++ b/priv/repo/migrations/20260617093859_add_stale_at_database_instance_read_model.exs
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Repo.Migrations.AddStaleAtDatabaseInstanceReadModel do
+  use Ecto.Migration
+
+  def change do
+    alter table(:database_instances) do
+      add :stale_at, :utc_datetime_usec
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -68,6 +68,8 @@ defmodule Trento.Factory do
   alias Trento.Databases.Events.{
     DatabaseDeregistered,
     DatabaseHealthChanged,
+    DatabaseInstanceDataMarkedInSync,
+    DatabaseInstanceDataMarkedStale,
     DatabaseInstanceDeregistered,
     DatabaseInstanceMarkedAbsent,
     DatabaseInstanceRegistered,
@@ -538,6 +540,23 @@ defmodule Trento.Factory do
     })
   end
 
+  def database_instance_data_marked_stale_event_factory do
+    DatabaseInstanceDataMarkedStale.new!(%{
+      database_id: Faker.UUID.v4(),
+      instance_number: "00",
+      host_id: Faker.UUID.v4(),
+      stale_at: DateTime.utc_now()
+    })
+  end
+
+  def database_instance_data_marked_in_sync_event_factory do
+    DatabaseInstanceDataMarkedInSync.new!(%{
+      database_id: Faker.UUID.v4(),
+      instance_number: "00",
+      host_id: Faker.UUID.v4()
+    })
+  end
+
   def database_restored_event_factory do
     DatabaseRestored.new!(%{
       database_id: Faker.UUID.v4(),
@@ -841,7 +860,8 @@ defmodule Trento.Factory do
       system_replication: "",
       system_replication_status: "",
       status: Status.gray(),
-      absent_at: nil
+      absent_at: nil,
+      stale_at: nil
     }
   end
 

--- a/test/trento/databases/database_test.exs
+++ b/test/trento/databases/database_test.exs
@@ -11,6 +11,7 @@ defmodule Trento.Databases.DatabaseTest do
   alias Trento.Databases.Commands.{
     DeregisterDatabaseInstance,
     MarkDatabaseInstanceAbsent,
+    MarkDatabaseInstanceDataStale,
     RegisterDatabaseInstance,
     RollUpDatabase
   }
@@ -18,6 +19,8 @@ defmodule Trento.Databases.DatabaseTest do
   alias Trento.Databases.Events.{
     DatabaseDeregistered,
     DatabaseHealthChanged,
+    DatabaseInstanceDataMarkedInSync,
+    DatabaseInstanceDataMarkedStale,
     DatabaseInstanceDeregistered,
     DatabaseInstanceMarkedAbsent,
     DatabaseInstanceMarkedPresent,
@@ -130,7 +133,8 @@ defmodule Trento.Databases.DatabaseTest do
               features: features,
               host_id: host_id,
               status: Status.green(),
-              absent_at: nil
+              absent_at: nil,
+              stale_at: nil
             }
           ]
         }
@@ -223,7 +227,8 @@ defmodule Trento.Databases.DatabaseTest do
               instance_number: instance_number,
               features: features,
               host_id: host_id,
-              status: Status.green()
+              status: Status.green(),
+              stale_at: nil
             }
           ]
         }
@@ -918,7 +923,8 @@ defmodule Trento.Databases.DatabaseTest do
               features: features,
               host_id: host_id,
               status: Status.green(),
-              absent_at: nil
+              absent_at: nil,
+              stale_at: nil
             }
           ]
         }
@@ -2533,6 +2539,222 @@ defmodule Trento.Databases.DatabaseTest do
                      },
                      %Instance{
                        absent_at: nil
+                     }
+                   ]
+                 } = state
+        end
+      )
+    end
+  end
+
+  describe "instance marked stale/in sync" do
+    test "should mark database instance data as stale" do
+      database_id = Faker.UUID.v4()
+      sid = fake_sid()
+      host_id = Faker.UUID.v4()
+      instance_number = "00"
+      stale_at = DateTime.utc_now()
+
+      initial_events = [
+        build(:database_registered_event,
+          database_id: database_id,
+          sid: sid
+        ),
+        build(:database_instance_registered_event,
+          database_id: database_id,
+          sid: sid,
+          host_id: host_id,
+          instance_number: instance_number,
+          features: "HDB|HDB_WORKER"
+        )
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        %MarkDatabaseInstanceDataStale{
+          database_id: database_id,
+          instance_number: instance_number,
+          host_id: host_id,
+          stale_at: stale_at
+        },
+        [
+          %DatabaseInstanceDataMarkedStale{
+            database_id: database_id,
+            instance_number: instance_number,
+            host_id: host_id,
+            stale_at: stale_at
+          }
+        ],
+        fn state ->
+          assert %Database{
+                   instances: [
+                     %Instance{
+                       instance_number: ^instance_number,
+                       stale_at: ^stale_at
+                     }
+                   ]
+                 } = state
+        end
+      )
+    end
+
+    test "should not mark database instance data as stale if already stale" do
+      database_id = Faker.UUID.v4()
+      sid = fake_sid()
+      host_id = Faker.UUID.v4()
+      instance_number = "00"
+      stale_at = DateTime.utc_now()
+
+      initial_events = [
+        build(:database_registered_event,
+          database_id: database_id,
+          sid: sid
+        ),
+        build(:database_instance_registered_event,
+          database_id: database_id,
+          sid: sid,
+          host_id: host_id,
+          instance_number: instance_number,
+          features: "HDB|HDB_WORKER"
+        ),
+        build(:database_instance_data_marked_stale_event,
+          database_id: database_id,
+          instance_number: instance_number,
+          host_id: host_id,
+          stale_at: stale_at
+        )
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        %MarkDatabaseInstanceDataStale{
+          database_id: database_id,
+          instance_number: instance_number,
+          host_id: host_id,
+          stale_at: stale_at
+        },
+        [],
+        fn state ->
+          assert %Database{
+                   instances: [
+                     %Instance{
+                       instance_number: ^instance_number,
+                       stale_at: ^stale_at
+                     }
+                   ]
+                 } = state
+        end
+      )
+    end
+
+    test "should mark database instance data as in sync when registering a stale instance" do
+      database_id = Faker.UUID.v4()
+      sid = fake_sid()
+      host_id = Faker.UUID.v4()
+      instance_number = "00"
+      tenants = build_list(1, :tenant)
+
+      initial_events = [
+        build(:database_registered_event,
+          database_id: database_id,
+          sid: sid
+        ),
+        build(:database_instance_registered_event,
+          database_id: database_id,
+          sid: sid,
+          host_id: host_id,
+          instance_number: instance_number,
+          features: "HDB|HDB_WORKER"
+        ),
+        build(:database_tenants_updated_event,
+          database_id: database_id,
+          tenants: tenants
+        ),
+        build(:database_instance_data_marked_stale_event,
+          database_id: database_id,
+          instance_number: instance_number,
+          host_id: host_id
+        )
+      ]
+
+      command =
+        build(:register_database_instance_command,
+          database_id: database_id,
+          sid: sid,
+          host_id: host_id,
+          instance_number: instance_number,
+          features: "HDB|HDB_WORKER",
+          tenants: tenants
+        )
+
+      assert_events_and_state(
+        initial_events,
+        command,
+        [
+          %DatabaseInstanceDataMarkedInSync{
+            database_id: database_id,
+            instance_number: instance_number,
+            host_id: host_id
+          }
+        ],
+        fn state ->
+          assert %Database{
+                   instances: [
+                     %Instance{
+                       instance_number: ^instance_number,
+                       stale_at: nil
+                     }
+                   ]
+                 } = state
+        end
+      )
+    end
+
+    test "should not mark database instance data as in sync if already in sync" do
+      database_id = Faker.UUID.v4()
+      sid = fake_sid()
+      host_id = Faker.UUID.v4()
+      instance_number = "00"
+      tenants = build_list(1, :tenant)
+
+      initial_events = [
+        build(:database_registered_event,
+          database_id: database_id,
+          sid: sid
+        ),
+        build(:database_instance_registered_event,
+          database_id: database_id,
+          sid: sid,
+          host_id: host_id,
+          instance_number: instance_number,
+          features: "HDB|HDB_WORKER"
+        ),
+        build(:database_tenants_updated_event,
+          database_id: database_id,
+          tenants: tenants
+        )
+      ]
+
+      command =
+        build(:register_database_instance_command,
+          database_id: database_id,
+          sid: sid,
+          host_id: host_id,
+          instance_number: instance_number,
+          features: "HDB|HDB_WORKER",
+          tenants: tenants
+        )
+
+      assert_events_and_state(
+        initial_events,
+        command,
+        [],
+        fn state ->
+          assert %Database{
+                   instances: [
+                     %Instance{
+                       instance_number: ^instance_number,
+                       stale_at: nil
                      }
                    ]
                  } = state

--- a/test/trento/databases/database_test.exs
+++ b/test/trento/databases/database_test.exs
@@ -2647,7 +2647,7 @@ defmodule Trento.Databases.DatabaseTest do
       )
     end
 
-    test "should mark database instance data as in sync when registering a stale instance" do
+    test "should mark database instance data as in sync when a stale instance receives data again" do
       database_id = Faker.UUID.v4()
       sid = fake_sid()
       host_id = Faker.UUID.v4()

--- a/test/trento/databases/events/database_rolled_up_test.exs
+++ b/test/trento/databases/events/database_rolled_up_test.exs
@@ -61,6 +61,7 @@ defmodule Trento.Databases.Events.DatabaseRolledUpTest do
           instance
           |> StructHelper.to_map()
           |> Map.put("health", "passing")
+          |> Map.delete("stale_at")
         end)
 
       assert %DatabaseRolledUp{

--- a/test/trento/databases/projections/database_projector_test.exs
+++ b/test/trento/databases/projections/database_projector_test.exs
@@ -21,6 +21,8 @@ defmodule Trento.Databases.Projections.DatabaseProjectorTest do
   alias Trento.Databases.Events.{
     DatabaseDeregistered,
     DatabaseHealthChanged,
+    DatabaseInstanceDataMarkedInSync,
+    DatabaseInstanceDataMarkedStale,
     DatabaseInstanceDeregistered,
     DatabaseInstanceMarkedAbsent,
     DatabaseInstanceMarkedPresent,
@@ -538,5 +540,80 @@ defmodule Trento.Databases.Projections.DatabaseProjectorTest do
     assert_broadcast "database_tenants_updated",
                      %{database_id: ^database_id, tenants: ^broadcasted_tenants},
                      1000
+  end
+
+  test "should mark database instance data as stale when DatabaseInstanceDataMarkedStale event is received" do
+    %{
+      database_id: database_id,
+      instance_number: instance_number,
+      host_id: host_id
+    } = insert(:database_instance)
+
+    stale_at = DateTime.utc_now()
+
+    event = %DatabaseInstanceDataMarkedStale{
+      database_id: database_id,
+      instance_number: instance_number,
+      host_id: host_id,
+      stale_at: stale_at
+    }
+
+    ProjectorTestHelper.project(DatabaseProjector, event, "database_projector")
+
+    database_instance =
+      Repo.get_by(DatabaseInstanceReadModel,
+        database_id: database_id,
+        instance_number: instance_number,
+        host_id: host_id
+      )
+
+    assert database_instance.stale_at == stale_at
+
+    assert_broadcast(
+      "database_instance_stale_changed",
+      %{
+        instance_number: ^instance_number,
+        host_id: ^host_id,
+        database_id: ^database_id,
+        stale_at: ^stale_at
+      },
+      1000
+    )
+  end
+
+  test "should mark database instance data as fresh when DatabaseInstanceDataMarkedInSync event is received" do
+    %{
+      database_id: database_id,
+      instance_number: instance_number,
+      host_id: host_id
+    } = insert(:database_instance, stale_at: DateTime.utc_now())
+
+    event = %DatabaseInstanceDataMarkedInSync{
+      database_id: database_id,
+      instance_number: instance_number,
+      host_id: host_id
+    }
+
+    ProjectorTestHelper.project(DatabaseProjector, event, "database_projector")
+
+    database_instance =
+      Repo.get_by(DatabaseInstanceReadModel,
+        database_id: database_id,
+        instance_number: instance_number,
+        host_id: host_id
+      )
+
+    assert database_instance.stale_at == nil
+
+    assert_broadcast(
+      "database_instance_stale_changed",
+      %{
+        instance_number: ^instance_number,
+        host_id: ^host_id,
+        database_id: ^database_id,
+        stale_at: nil
+      },
+      1000
+    )
   end
 end

--- a/test/trento/infrastructure/commanded/process_managers/deregistration_process_manager_test.exs
+++ b/test/trento/infrastructure/commanded/process_managers/deregistration_process_manager_test.exs
@@ -46,7 +46,10 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
   alias Trento.Clusters.Commands.DeregisterClusterHost
   alias Trento.Hosts.Commands.DeregisterHost
 
-  alias Trento.Databases.Commands.DeregisterDatabaseInstance
+  alias Trento.Databases.Commands.{
+    DeregisterDatabaseInstance,
+    MarkDatabaseInstanceDataStale
+  }
 
   alias Trento.SapSystems.Commands.{
     DeregisterApplicationInstance,
@@ -692,13 +695,19 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
     test "should dispatch commands when HeartbeatFailed is emitted and the host has instances associated" do
       host_id = UUID.uuid4()
       sap_system_id = UUID.uuid4()
+      database_id = UUID.uuid4()
       app_instance_number_01 = "01"
       app_instance_number_02 = "02"
+      db_instance_number_01 = "00"
+      db_instance_number_02 = "10"
       created_at = DateTime.utc_now()
 
       initial_state = %DeregistrationProcessManager{
         cluster_id: nil,
-        database_instances: [],
+        database_instances: [
+          %Instance{sap_system_id: database_id, instance_number: db_instance_number_01},
+          %Instance{sap_system_id: database_id, instance_number: db_instance_number_02}
+        ],
         application_instances: [
           %Instance{sap_system_id: sap_system_id, instance_number: app_instance_number_01},
           %Instance{sap_system_id: sap_system_id, instance_number: app_instance_number_02}
@@ -720,6 +729,18 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
                %MarkApplicationInstanceDataStale{
                  sap_system_id: ^sap_system_id,
                  instance_number: ^app_instance_number_02,
+                 host_id: ^host_id,
+                 stale_at: ^created_at
+               },
+               %MarkDatabaseInstanceDataStale{
+                 database_id: ^database_id,
+                 instance_number: ^db_instance_number_01,
+                 host_id: ^host_id,
+                 stale_at: ^created_at
+               },
+               %MarkDatabaseInstanceDataStale{
+                 database_id: ^database_id,
+                 instance_number: ^db_instance_number_02,
                  host_id: ^host_id,
                  stale_at: ^created_at
                }


### PR DESCRIPTION
### Description

Stale database instances when the host heartbeat fails.
It includes new events to change the aggregate of the database and the corresponding changes in the read model.
It replicates the same logic done in SAP systems: https://github.com/trento-project/web/pull/4399

### How was this tested?

UT

### Documentation changes

No (not yet, at least)