### PR TITLE
Fix E2E flaky test: should fail if required fields are missing

### DIFF
--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -20,7 +20,8 @@ describe('Users', () => {
       usersPage.pageTitleIsCorrectlyDisplayed('Create User');
     });
 
-    it('should fail if required fields are missing', () => {
+    // eslint-disable-next-line mocha/no-exclusive-tests
+    it.only('should fail if required fields are missing', () => {
       usersPage.clickSubmitUserCreationButton();
       usersPage.validateRequiredFieldsErrors();
     });

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -20,8 +20,7 @@ describe('Users', () => {
       usersPage.pageTitleIsCorrectlyDisplayed('Create User');
     });
 
-    // eslint-disable-next-line mocha/no-exclusive-tests
-    it.only('should fail if required fields are missing', () => {
+    it('should fail if required fields are missing', () => {
       usersPage.clickSubmitUserCreationButton();
       usersPage.validateRequiredFieldsErrors();
     });

--- a/test/e2e/cypress/pageObject/users_po.js
+++ b/test/e2e/cypress/pageObject/users_po.js
@@ -40,7 +40,8 @@ const passwordConfirmationInputField =
   'input[aria-label^="password"][aria-label*="confirmation"]';
 const saveNewPasswordButton = 'div[id*="panel"] button:contains("Save")';
 const generatePasswordButton = 'div[class*="grid"] button[class*="green"]';
-const submitUserCreationButton = 'button:contains("Create")';
+const submitUserCreationButton =
+  'div[class*="container"] button:contains("Create")';
 const cancelUserCreationButton = 'button:contains("Cancel")';
 const saveChangesButton = 'button:contains("Save")';
 const authenticatorAppSwitch =


### PR DESCRIPTION
### Description
The previous selector was too broad and could match the `Create User` button instead of the form submit button. As a result, the second click could trigger navigation again (it was clicking the same button again before loading the form) rather than submitting the form, so the required field errors were not displayed.

Fixes #<issue>
Flaky test on `users.cy.js` suite

<!--If your repository uses release drafter, ensure the appropriate release label is applied.
 To see the labels: https://github.com/trento-project/.github/blob/main/.github/release_drafter_main.yaml-->

### How was this tested?
https://github.com/trento-project/web/actions/runs/28502888711

### Documentation changes

N/A

<!--
If yes, consider updating:
- User documentation: https://github.com/trento-project/docs/tree/main/trento/adoc
- Developer documentation: https://github.com/trento-project/docs/tree/main/content
- Component-specific documentation, e.g., https://github.com/trento-project/web/tree/main/guides for Wanda
-->

### Additional information

<!-- Add anything else relevant to this PR, such as screenshots or demos. -->