### PR TITLE
Fix E2E flaky test: Stabilize SAP system details link checks 

### DIFF
--- a/test/e2e/cypress/pageObject/sap_system_details_po.js
+++ b/test/e2e/cypress/pageObject/sap_system_details_po.js
@@ -116,19 +116,23 @@ export const shouldDisplayExpectedStatusChanges = () =>
 
 export const eachHostHasTheExpectedLink = () =>
   cy.wrap(attachedHosts).each((host, index) => {
+    const expectedHref = `/hosts/${host.AgentId}`;
     const tableCellSelector = `div[class="mt-8"]:contains("Hosts") table tbody tr:eq(${index}) td:eq(0) a`;
-    cy.get(tableCellSelector).click();
-    basePage.validateUrl(`/hosts/${host.AgentId}`);
-    return basePage.goBack();
+    cy.get(tableCellSelector).should('have.attr', 'href', expectedHref).click();
+    basePage.validateUrl(expectedHref);
+    basePage.goBack();
+    return validatePageUrl();
   });
 
 export const eachHostHasTheExpectedClusterLink = () =>
   cy.wrap(attachedHosts).each((host, index) => {
     if (!host.ClusterId) return;
+    const expectedHref = `/clusters/${host.ClusterId}`;
     const tableCellSelector = `div[class="mt-8"]:contains("Hosts") table tbody tr:eq(${index}) td:eq(3) a`;
-    cy.get(tableCellSelector).click();
-    basePage.validateUrl(`/clusters/${host.ClusterId}`);
-    return basePage.goBack();
+    cy.get(tableCellSelector).should('have.attr', 'href', expectedHref).click();
+    basePage.validateUrl(expectedHref);
+    basePage.goBack();
+    return validatePageUrl();
   });
 
 export const eachHostHasTheExpectedData = () =>


### PR DESCRIPTION
### Description

The SAP system details E2E test is flaky when checking host & cluster links from the hosts table. The test clicks each link and immediately moves to the next table entry after `goBack()`, without waiting for the SAP system details page to be restored. This could make the next assertion run while the browser is still on the previous host/cluster page or while navigation back is still in progress.

This change validates each link href before clicking it, checks the expected destination URL, then waits until the SAP system details URL is restored before continuing with the next entry.

Fixes #<issue>
Fix flaky test in sap system details suite.

<!--If your repository uses release drafter, ensure the appropriate release label is applied.
 To see the labels: https://github.com/trento-project/.github/blob/main/.github/release_drafter_main.yaml-->

### How was this tested?
https://github.com/trento-project/web/actions/runs/28521333929

### Documentation changes

Yes / No

<!--
If yes, consider updating:
- User documentation: https://github.com/trento-project/docs/tree/main/trento/adoc
- Developer documentation: https://github.com/trento-project/docs/tree/main/content
- Component-specific documentation, e.g., https://github.com/trento-project/web/tree/main/guides for Wanda
-->

### Additional information

<!-- Add anything else relevant to this PR, such as screenshots or demos. -->