### PR TITLE
Add stale information to instance status icon

### DIFF
--- a/assets/js/pages/SapSystemDetails/InstanceStatus.jsx
+++ b/assets/js/pages/SapSystemDetails/InstanceStatus.jsx
@@ -2,11 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { EOS_LENS_FILLED, EOS_INFO_OUTLINED } from 'eos-icons-react';
+import {
+  EOS_LENS_FILLED,
+  EOS_INFO_OUTLINED,
+  EOS_SCHEDULE_OUTLINED,
+} from 'eos-icons-react';
 import { capitalize } from 'lodash';
+import { formatDateTime } from '@lib/timezones';
 import Tooltip from '@common/Tooltip';
 
-function InstanceStatus({ status, absent = false }) {
+function InstanceStatus({ status, absent = false, staleAt = null, timezone }) {
   let cssClass;
 
   switch (status) {
@@ -24,20 +29,40 @@ function InstanceStatus({ status, absent = false }) {
       break;
   }
 
+  const IconComponent = absent ? EOS_INFO_OUTLINED : EOS_LENS_FILLED;
+  const iconClass = absent ? 'fill-black' : cssClass;
+
+  const tooltipContent = (
+    <span className="block text-center">
+      {absent ? 'Registered instance not found.' : capitalize(status)}
+      {staleAt && (
+        <>
+          <br />
+          (Stale since {formatDateTime(staleAt, timezone)})
+        </>
+      )}
+    </span>
+  );
+
   return (
-    <span className="flex items-center mx-1">
+    <div className="flex items-center mx-1">
       <Tooltip
-        content={absent ? 'Registered instance not found.' : capitalize(status)}
+        content={tooltipContent}
         place="top"
         isEnabled={true}
+        wrap={false}
       >
-        {absent ? (
-          <EOS_INFO_OUTLINED size="20" className="fill-black" />
-        ) : (
-          <EOS_LENS_FILLED size="20" className={cssClass} />
-        )}
+        <div className="relative">
+          <IconComponent size="20" className={iconClass} />
+          {staleAt && (
+            <EOS_SCHEDULE_OUTLINED
+              size="14"
+              className={`${iconClass} absolute -bottom-1 -right-1 bg-white rounded-full`}
+            />
+          )}
+        </div>
       </Tooltip>
-    </span>
+    </div>
   );
 }
 

--- a/assets/js/pages/SapSystemDetails/InstanceStatus.stories.jsx
+++ b/assets/js/pages/SapSystemDetails/InstanceStatus.stories.jsx
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import InstanceStatus from './InstanceStatus';
+
+export default {
+  title: 'Components/InstanceStatus',
+  component: InstanceStatus,
+  argTypes: {
+    status: {
+      description: 'The status color of the instance',
+      control: {
+        type: 'select',
+      },
+      options: ['green', 'yellow', 'red', 'gray'],
+    },
+    absent: {
+      description: 'Whether the instance is absent',
+      control: {
+        type: 'boolean',
+      },
+    },
+    staleAt: {
+      description:
+        'Timestamp when the instance became stale (null if not stale)',
+      control: {
+        type: 'text',
+      },
+    },
+    timezone: {
+      description: 'Timezone for displaying the stale timestamp',
+      control: {
+        type: 'text',
+      },
+    },
+  },
+  args: {
+    absent: false,
+    timezone: 'Etc/UTC',
+  },
+};
+
+export const GreenStatus = {
+  args: {
+    status: 'green',
+  },
+};
+
+export const YellowStatus = {
+  args: {
+    status: 'yellow',
+  },
+};
+
+export const RedStatus = {
+  args: {
+    status: 'red',
+  },
+};
+
+export const GrayStatus = {
+  args: {
+    status: 'gray',
+  },
+};
+
+export const AbsentInstance = {
+  args: {
+    status: 'green',
+    absent: true,
+  },
+};
+
+export const StaleGreenStatus = {
+  args: {
+    status: 'green',
+    staleAt: '2026-06-15T10:30:00Z',
+  },
+};
+
+export const StaleYellowStatus = {
+  args: {
+    status: 'yellow',
+    staleAt: '2026-06-15T10:30:00Z',
+  },
+};
+
+export const StaleRedStatus = {
+  args: {
+    status: 'red',
+    staleAt: '2026-06-15T10:30:00Z',
+  },
+};
+
+export const StaleGrayStatus = {
+  args: {
+    status: 'gray',
+    staleAt: '2026-06-15T10:30:00Z',
+  },
+};
+
+export const StaleAbsentInstance = {
+  args: {
+    status: 'green',
+    absent: true,
+    staleAt: '2026-06-15T10:30:00Z',
+  },
+};
+
+export const WithTimezone = {
+  args: {
+    status: 'green',
+    staleAt: '2026-06-15T10:30:00Z',
+    timezone: 'America/New_York',
+  },
+};

--- a/assets/js/pages/SapSystemDetails/InstanceStatus.test.jsx
+++ b/assets/js/pages/SapSystemDetails/InstanceStatus.test.jsx
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { faker } from '@faker-js/faker';
+
+import InstanceStatus from './InstanceStatus';
+
+describe('InstanceStatus Component', () => {
+  it.each([
+    { status: 'green', cssClass: 'fill-jungle-green-500' },
+    { status: 'yellow', cssClass: 'fill-yellow-500' },
+    { status: 'red', cssClass: 'fill-red-500' },
+    { status: 'gray', cssClass: 'fill-gray-500' },
+  ])(
+    'should render $status status icon with $cssClass',
+    ({ status, cssClass }) => {
+      render(<InstanceStatus status={status} />);
+
+      const icon = screen.getByTestId('eos-svg-component');
+      expect(icon).toHaveClass(cssClass);
+    }
+  );
+
+  it('should render an absent instance with black icon', () => {
+    render(<InstanceStatus status="green" absent />);
+
+    const icon = screen.getByTestId('eos-svg-component');
+    expect(icon).toHaveClass('fill-black');
+  });
+
+  it('should render stale badge when staleAt prop is provided', () => {
+    const staleDate = faker.date.past().toISOString();
+    render(
+      <InstanceStatus status="red" staleAt={staleDate} timezone="Etc/UTC" />
+    );
+
+    const icons = screen.getAllByTestId('eos-svg-component');
+    expect(icons.length).toBe(2);
+  });
+
+  it('should not render stale badge when staleAt prop is not provided', () => {
+    render(<InstanceStatus status="green" />);
+
+    const icons = screen.getAllByTestId('eos-svg-component');
+    expect(icons.length).toBe(1);
+  });
+
+  it('should display tooltip with stale information on hover', async () => {
+    const user = userEvent.setup();
+    const staleDate = '2024-06-12T13:05:10Z';
+    render(
+      <InstanceStatus status="red" staleAt={staleDate} timezone="Etc/UTC" />
+    );
+
+    const icon = screen.getAllByTestId('eos-svg-component')[0];
+    await user.hover(icon);
+
+    expect(screen.queryByText(/Red/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/\(Stale since 12 Jun 2024, 13:05:10\)/)
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Description

Add stale information to `InstanceStatus` component. It includes the new clock mini-icon and the tooltip with the date when the data was marked stale.

It is not used yet. That part will come later.

Sneak-peak:
<img width="1263" height="398" alt="image" src="https://github.com/user-attachments/assets/4c9cc635-ae6d-41e0-812f-752df6c34f8a" />

### How was this tested?

UT and storybook

### Documentation changes

No