### PR TITLE
Fix flaky DatabaseDeregistration tenant-removed test

### DIFF
--- a/test/trento/infrastructure/commanded/event_handlers/database_deregistration_event_handler_test.exs
+++ b/test/trento/infrastructure/commanded/event_handlers/database_deregistration_event_handler_test.exs
@@ -47,12 +47,14 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.DatabaseDeregistrationEv
   end
 
   test "should dispatch DeregisterSapSystem commands when a tenant is removed" do
-    [%{name: tenant1}, %{name: tenant2}] = tenants = build_list(2, :tenant)
+    tenant1 = "kept-tenant"
+    tenant2 = "removed-tenant"
+    tenants = [build(:tenant, name: tenant1), build(:tenant, name: tenant2)]
     %{id: database_id} = insert(:database, tenants: tenants)
 
     insert(:sap_system, database_id: database_id, tenant: tenant1)
     %{id: second_sap_system_id} = insert(:sap_system, database_id: database_id, tenant: tenant2)
-    insert(:sap_system, database_id: database_id)
+    insert(:sap_system, database_id: database_id, tenant: "unaffected-tenant")
 
     event = %DatabaseTenantsUpdated{
       database_id: database_id,


### PR DESCRIPTION
## Problem

The `DatabaseDeregistrationEventHandlerTest` test `"should dispatch DeregisterSapSystem commands when a tenant is removed"` is flaky — it failed in only one of the two Elixir CI jobs on an unrelated PR.

## Root cause

The test built its two tenants with `build_list(2, :tenant)`. The `:tenant` factory derives the name from `Faker.Beer.name()`, which draws from a small pool of names. When the two generated tenant names collided, both the "kept" and the "removed" sap systems ended up sharing the same tenant name. Removing one tenant then made the handler's `tenant == name` query match both sap systems, so it dispatched an **extra** `DeregisterSapSystem` command for the sap system that should have been left alone. The test only sets a single `Mox.expect` clause pinned to `^second_sap_system_id`, so the extra dispatch hit a non-matching argument and raised a `FunctionClauseError`.

## Fix

Use explicit, distinct tenant names instead of relying on random Faker values, and give the unaffected sap system its own explicit tenant, so no name collision is possible:

- `tenant1 = "kept-tenant"`, `tenant2 = "removed-tenant"`, built via `build(:tenant, name: ...)`
- the third (unaffected) sap system now uses `tenant: "unaffected-tenant"`

Test-only change; no production code touched.
