### PR TITLE
Replace missing health by status in instances

### DIFF
--- a/assets/js/lib/test-utils/data/databases.js
+++ b/assets/js/lib/test-utils/data/databases.js
@@ -6,7 +6,7 @@ export default [
     database_instances: [
       {
         features: 'HDB|HDB_WORKER',
-        health: 'passing',
+        status: 'green',
         host_id: '0a055c90-4cb6-54ce-ac9c-ae3fedaf40d4',
         http_port: 51013,
         https_port: 51014,
@@ -21,7 +21,7 @@ export default [
       },
       {
         features: 'HDB|HDB_WORKER',
-        health: 'passing',
+        status: 'green',
         host_id: '13e8c25c-3180-5a9a-95c8-51ec38e50cfc',
         http_port: 51013,
         https_port: 51014,
@@ -44,7 +44,7 @@ export default [
     database_instances: [
       {
         features: 'HDB|HDB_WORKER',
-        health: 'passing',
+        status: 'green',
         host_id: '9cd46919-5f19-59aa-993e-cf3736c71053',
         http_port: 51013,
         https_port: 51014,
@@ -59,7 +59,7 @@ export default [
       },
       {
         features: 'HDB|HDB_WORKER',
-        health: 'passing',
+        status: 'green',
         host_id: 'b767b3e9-e802-587e-a442-541d093b86b9',
         http_port: 51013,
         https_port: 51014,
@@ -82,7 +82,7 @@ export default [
     database_instances: [
       {
         features: 'HDB|HDB_WORKER',
-        health: 'passing',
+        status: 'green',
         host_id: '99cf8a3a-48d6-57a4-b302-6e4482227ab6',
         http_port: 51013,
         https_port: 51014,
@@ -97,7 +97,7 @@ export default [
       },
       {
         features: 'HDB|HDB_WORKER',
-        health: 'passing',
+        status: 'green',
         host_id: 'e0c182db-32ff-55c6-a9eb-2b82dd21bc8b',
         http_port: 51013,
         https_port: 51014,

--- a/assets/js/lib/test-utils/factories/databases.js
+++ b/assets/js/lib/test-utils/factories/databases.js
@@ -5,6 +5,8 @@ import { faker } from '@faker-js/faker';
 import { Factory } from 'fishery';
 import { generateSid } from '.';
 
+const statusEnum = () =>
+  faker.helpers.arrayElement(['green', 'yellow', 'red', 'gray']);
 const healthEnum = () =>
   faker.helpers.arrayElement(['passing', 'critical', 'warning', 'unknown']);
 const features = () =>
@@ -12,7 +14,7 @@ const features = () =>
 
 export const databaseInstanceFactory = Factory.define(() => ({
   database_id: faker.string.uuid(),
-  health: healthEnum(),
+  status: statusEnum(),
   host_id: faker.string.uuid(),
   http_port: faker.internet.port(),
   https_port: faker.internet.port(),

--- a/assets/js/lib/test-utils/factories/sapSystems.js
+++ b/assets/js/lib/test-utils/factories/sapSystems.js
@@ -8,6 +8,8 @@ import { databaseInstanceFactory, generateSid } from '.';
 
 const ensaVersion = () =>
   faker.helpers.arrayElement(['no_ensa', 'ensa1', 'ensa2']);
+const statusEnum = () =>
+  faker.helpers.arrayElement(['green', 'yellow', 'red', 'gray']);
 const healthEnum = () =>
   faker.helpers.arrayElement(['passing', 'critical', 'warning', 'unknown']);
 const roles = () =>
@@ -23,7 +25,7 @@ const roles = () =>
 
 export const sapSystemApplicationInstanceFactory = Factory.define(() => ({
   features: roles().join('|'),
-  health: healthEnum(),
+  status: statusEnum(),
   host_id: faker.string.uuid(),
   http_port: faker.internet.port(),
   https_port: faker.internet.port(),

--- a/assets/js/pages/DatabaseDetails/databaseOperations.js
+++ b/assets/js/pages/DatabaseDetails/databaseOperations.js
@@ -32,7 +32,7 @@ export const getDatabaseOperations = (
       DATABASE_START,
       matchesSite(null)
     ),
-    disabled: disabled || every(database.instances, { health: 'passing' }),
+    disabled: disabled || every(database.instances, { status: 'green' }),
     permitted: ['start:database'],
     onClick: () => {
       setOperationModelOpen({ open: true, operation: DATABASE_START });
@@ -46,7 +46,7 @@ export const getDatabaseOperations = (
       DATABASE_STOP,
       matchesSite(null)
     ),
-    disabled: disabled || every(database.instances, { health: 'unknown' }),
+    disabled: disabled || every(database.instances, { status: 'gray' }),
     permitted: ['stop:database'],
     onClick: () => {
       setOperationModelOpen({ open: true, operation: DATABASE_STOP });
@@ -76,7 +76,7 @@ export const getDatabaseSiteOperations = curry(
           DATABASE_START,
           matchesSite(site)
         ),
-        disabled: disabled || every(siteInstances, { health: 'passing' }),
+        disabled: disabled || every(siteInstances, { status: 'green' }),
         permitted: ['start:database'],
         onClick: () => {
           setCurrentOperationSite(site);
@@ -91,7 +91,7 @@ export const getDatabaseSiteOperations = curry(
           DATABASE_STOP,
           matchesSite(site)
         ),
-        disabled: disabled || every(siteInstances, { health: 'unknown' }),
+        disabled: disabled || every(siteInstances, { status: 'gray' }),
         permitted: ['stop:database'],
         onClick: () => {
           setCurrentOperationSite(site);

--- a/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
@@ -388,7 +388,7 @@ export const WithRebootEnabled = {
     operationsEnabled: true,
     sapInstances: sapInstances.map((instance) => ({
       ...instance,
-      health: 'unknown',
+      status: 'gray',
     })),
     cluster: undefined,
     heartbeat: 'passing',

--- a/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
@@ -726,7 +726,7 @@ describe('HostDetails component', () => {
       const sapInstances = databaseInstanceFactory
         .buildList(1)
         .map((instance) => ({ ...instance, type: DATABASE_TYPE }))
-        .map((instance) => ({ ...instance, health: 'unknown' }));
+        .map((instance) => ({ ...instance, status: 'gray' }));
 
       renderWithRouter(
         <HostDetails

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
@@ -461,11 +461,11 @@ describe('GenericSystemDetails', () => {
       hosts,
       instances: [
         sapSystemApplicationInstanceFactory.build({
-          health: 'passing',
+          status: 'green',
           host: hosts[0],
         }),
         sapSystemApplicationInstanceFactory.build({
-          health: 'unknown',
+          status: 'gray',
           host: hosts[0],
         }),
       ],
@@ -520,33 +520,33 @@ describe('GenericSystemDetails', () => {
     {
       operation: 'Start system',
       enabled: true,
-      health: 'unknown',
+      status: 'gray',
     },
     {
       operation: 'Start system',
       enabled: false,
-      health: 'passing',
+      status: 'green',
     },
     {
       operation: 'Stop system',
       enabled: true,
-      health: 'passing',
+      status: 'green',
     },
     {
       operation: 'Stop system',
       enabled: false,
-      health: 'unknown',
+      status: 'gray',
     },
   ])(
     'should show SAP system operation $operation with enabled state as $enabled',
-    async ({ operation, enabled, health }) => {
+    async ({ operation, enabled, status }) => {
       const user = userEvent.setup();
 
       const hosts = hostFactory.buildList(5, { heartbeat: 'passing' });
       const system = sapSystemFactory.build({
         hosts,
         instances: sapSystemApplicationInstanceFactory.buildList(1, {
-          health,
+          status,
           host: hosts[0],
         }),
       });
@@ -572,33 +572,33 @@ describe('GenericSystemDetails', () => {
     {
       operation: 'Start database',
       enabled: true,
-      health: 'unknown',
+      status: 'gray',
     },
     {
       operation: 'Start database',
       enabled: false,
-      health: 'passing',
+      status: 'green',
     },
     {
       operation: 'Stop database',
       enabled: true,
-      health: 'passing',
+      status: 'green',
     },
     {
       operation: 'Stop database',
       enabled: false,
-      health: 'unknown',
+      status: 'gray',
     },
   ])(
     'should show database operation $operation with enabled state as $enabled',
-    async ({ operation, enabled, health }) => {
+    async ({ operation, enabled, status }) => {
       const user = userEvent.setup();
 
       const hosts = hostFactory.buildList(5, { heartbeat: 'passing' });
       const database = databaseFactory.build({
         hosts,
         instances: databaseInstanceFactory.buildList(1, {
-          health,
+          status,
           host: hosts[0],
         }),
       });
@@ -625,26 +625,26 @@ describe('GenericSystemDetails', () => {
     {
       operation: 'Start database',
       enabled: true,
-      health: 'unknown',
+      status: 'gray',
     },
     {
       operation: 'Start database',
       enabled: false,
-      health: 'passing',
+      status: 'green',
     },
     {
       operation: 'Stop database',
       enabled: true,
-      health: 'passing',
+      status: 'green',
     },
     {
       operation: 'Stop database',
       enabled: false,
-      health: 'unknown',
+      status: 'gray',
     },
   ])(
     'should show database site operation $operation with enabled state as $enabled',
-    async ({ operation, enabled, health }) => {
+    async ({ operation, enabled, status }) => {
       const user = userEvent.setup();
 
       const host1 = hostFactory.build({ heartbeat: 'passing' });
@@ -655,7 +655,7 @@ describe('GenericSystemDetails', () => {
         hosts: [host1, host2, host3],
         instances: [
           databaseInstanceFactory.build({
-            health,
+            status,
             system_replication: 'Primary',
             system_replication_site: 'Site1',
             system_replication_tier: 1,
@@ -718,16 +718,16 @@ describe('GenericSystemDetails', () => {
     {
       operation: SAP_INSTANCE_START,
       menuItemText: 'Start instance',
-      health: 'unknown',
+      status: 'gray',
     },
     {
       operation: SAP_INSTANCE_STOP,
       menuItemText: 'Stop instance',
-      health: 'passing',
+      status: 'green',
     },
   ])(
     'should show instance operation $operation in running state',
-    async ({ operation, menuItemText, health }) => {
+    async ({ operation, menuItemText, status }) => {
       const user = userEvent.setup();
       const hosts = hostFactory.buildList(1, { heartbeat: 'passing' });
       const hostID = hosts[0].id;
@@ -737,7 +737,7 @@ describe('GenericSystemDetails', () => {
         hosts,
         instances: [
           sapSystemApplicationInstanceFactory.build({
-            health,
+            status,
             host_id: hostID,
             host: hosts[0],
             instance_number: instanceNumber,
@@ -776,34 +776,34 @@ describe('GenericSystemDetails', () => {
     {
       operation: SAP_SYSTEM_START,
       menuItemText: 'Start system',
-      health: 'unknown',
+      status: 'gray',
       type: APPLICATION_TYPE,
       getOperations: getSapSystemOperations,
     },
     {
       operation: SAP_SYSTEM_STOP,
       menuItemText: 'Stop system',
-      health: 'passing',
+      status: 'green',
       type: APPLICATION_TYPE,
       getOperations: getSapSystemOperations,
     },
     {
       operation: DATABASE_START,
       menuItemText: 'Start database',
-      health: 'unknown',
+      status: 'gray',
       type: DATABASE_TYPE,
       getOperations: getDatabaseOperations,
     },
     {
       operation: DATABASE_STOP,
       menuItemText: 'Stop database',
-      health: 'passing',
+      status: 'green',
       type: DATABASE_TYPE,
       getOperations: getDatabaseOperations,
     },
   ])(
     'should show system/database operation $operation in running state',
-    async ({ operation, menuItemText, health, type, getOperations }) => {
+    async ({ operation, menuItemText, status, type, getOperations }) => {
       const user = userEvent.setup();
       const hosts = hostFactory.buildList(1, { heartbeat: 'passing' });
 
@@ -811,7 +811,7 @@ describe('GenericSystemDetails', () => {
         hosts,
         instances: [
           sapSystemApplicationInstanceFactory.build({
-            health,
+            status,
             host: hosts[0],
           }),
         ],
@@ -842,16 +842,16 @@ describe('GenericSystemDetails', () => {
     {
       operation: DATABASE_START,
       menuItemText: 'Start database',
-      health: 'unknown',
+      status: 'gray',
     },
     {
       operation: DATABASE_STOP,
       menuItemText: 'Stop database',
-      health: 'passing',
+      status: 'green',
     },
   ])(
     'should show database site operation $operation in running state',
-    async ({ operation, menuItemText, health }) => {
+    async ({ operation, menuItemText, status }) => {
       const user = userEvent.setup();
       const hosts = hostFactory.buildList(2, { heartbeat: 'passing' });
       const site = 'Site1';
@@ -860,13 +860,13 @@ describe('GenericSystemDetails', () => {
         hosts,
         instances: [
           databaseInstanceFactory.build({
-            health,
+            status,
             system_replication: 'Primary',
             system_replication_site: site,
             host: hosts[0],
           }),
           databaseInstanceFactory.build({
-            health,
+            status,
             system_replication: 'Secondary',
             system_replication_site: 'Site2',
             host: hosts[1],
@@ -933,7 +933,7 @@ describe('GenericSystemDetails', () => {
           sapSystemApplicationInstanceFactory.build({
             host_id: hostID,
             sap_system_id: sapSystemID,
-            health: 'passing',
+            status: 'green',
             host: hosts[0],
           }),
         ],
@@ -977,7 +977,7 @@ describe('GenericSystemDetails', () => {
       hosts,
       instances: [
         sapSystemApplicationInstanceFactory.build({
-          health: 'unknown',
+          status: 'gray',
           host_id: hostID,
           host: hosts[0],
         }),
@@ -1252,39 +1252,39 @@ describe('GenericSystemDetails', () => {
         operation: SAP_INSTANCE_START,
         label: 'Start instance',
         abilities: [],
-        health: 'unknown',
+        status: 'gray',
       },
       {
         forbidden: false,
         operation: SAP_INSTANCE_START,
         label: 'Start instance',
         abilities: [{ name: 'start', resource: 'application_instance' }],
-        health: 'unknown',
+        status: 'gray',
       },
       {
         forbidden: true,
         operation: SAP_INSTANCE_STOP,
         label: 'Stop instance',
         abilities: [],
-        health: 'passing',
+        status: 'green',
       },
       {
         forbidden: false,
         operation: SAP_INSTANCE_STOP,
         label: 'Stop instance',
         abilities: [{ name: 'stop', resource: 'application_instance' }],
-        health: 'passing',
+        status: 'green',
       },
     ])(
       'should forbid/authorize instance operation $operation',
-      async ({ forbidden, label, abilities, health }) => {
+      async ({ forbidden, label, abilities, status }) => {
         const user = userEvent.setup();
 
         const hosts = hostFactory.buildList(1, { heartbeat: 'passing' });
         const sapSystem = sapSystemFactory.build({
           hosts,
           instances: sapSystemApplicationInstanceFactory.buildList(1, {
-            health,
+            status,
             host: hosts[0],
           }),
         });
@@ -1317,7 +1317,7 @@ describe('GenericSystemDetails', () => {
         operation: SAP_SYSTEM_START,
         label: 'Start system',
         abilities: [],
-        health: 'unknown',
+        status: 'gray',
         type: APPLICATION_TYPE,
         getOperations: getSapSystemOperations,
       },
@@ -1326,7 +1326,7 @@ describe('GenericSystemDetails', () => {
         operation: SAP_SYSTEM_START,
         label: 'Start system',
         abilities: [{ name: 'start', resource: 'sap_system' }],
-        health: 'unknown',
+        status: 'gray',
         type: APPLICATION_TYPE,
         getOperations: getSapSystemOperations,
       },
@@ -1335,7 +1335,7 @@ describe('GenericSystemDetails', () => {
         operation: SAP_SYSTEM_STOP,
         label: 'Stop system',
         abilities: [],
-        health: 'passing',
+        status: 'green',
         type: APPLICATION_TYPE,
         getOperations: getSapSystemOperations,
       },
@@ -1344,7 +1344,7 @@ describe('GenericSystemDetails', () => {
         operation: SAP_SYSTEM_STOP,
         label: 'Stop system',
         abilities: [{ name: 'stop', resource: 'sap_system' }],
-        health: 'passing',
+        status: 'green',
         type: APPLICATION_TYPE,
         getOperations: getSapSystemOperations,
       },
@@ -1353,7 +1353,7 @@ describe('GenericSystemDetails', () => {
         operation: DATABASE_START,
         label: 'Start database',
         abilities: [],
-        health: 'unknown',
+        status: 'gray',
         type: DATABASE_TYPE,
         getOperations: getDatabaseOperations,
       },
@@ -1362,7 +1362,7 @@ describe('GenericSystemDetails', () => {
         operation: DATABASE_START,
         label: 'Start database',
         abilities: [{ name: 'start', resource: 'database' }],
-        health: 'unknown',
+        status: 'gray',
         type: DATABASE_TYPE,
         getOperations: getDatabaseOperations,
       },
@@ -1371,7 +1371,7 @@ describe('GenericSystemDetails', () => {
         operation: DATABASE_STOP,
         label: 'Stop database',
         abilities: [],
-        health: 'passing',
+        status: 'green',
         type: DATABASE_TYPE,
         getOperations: getDatabaseOperations,
       },
@@ -1380,13 +1380,13 @@ describe('GenericSystemDetails', () => {
         operation: DATABASE_STOP,
         label: 'Stop database',
         abilities: [{ name: 'stop', resource: 'database' }],
-        health: 'passing',
+        status: 'green',
         type: DATABASE_TYPE,
         getOperations: getDatabaseOperations,
       },
     ])(
       'should forbid/authorize system/database operation $operation',
-      async ({ forbidden, label, abilities, health, type, getOperations }) => {
+      async ({ forbidden, label, abilities, status, type, getOperations }) => {
         const user = userEvent.setup();
 
         const hosts = hostFactory.buildList(1, { heartbeat: 'passing' });
@@ -1394,7 +1394,7 @@ describe('GenericSystemDetails', () => {
         const sapSystem = sapSystemFactory.build({
           hosts,
           instances: sapSystemApplicationInstanceFactory.buildList(1, {
-            health,
+            status,
             host: hosts[0],
           }),
         });
@@ -1423,39 +1423,39 @@ describe('GenericSystemDetails', () => {
         operation: DATABASE_START,
         label: 'Start database',
         abilities: [],
-        health: 'unknown',
+        status: 'gray',
       },
       {
         forbidden: false,
         operation: DATABASE_START,
         label: 'Start database',
         abilities: [{ name: 'start', resource: 'database' }],
-        health: 'unknown',
+        status: 'gray',
       },
       {
         forbidden: true,
         operation: DATABASE_STOP,
         label: 'Stop database',
         abilities: [],
-        health: 'passing',
+        status: 'green',
       },
       {
         forbidden: false,
         operation: DATABASE_STOP,
         label: 'Stop database',
         abilities: [{ name: 'stop', resource: 'database' }],
-        health: 'passing',
+        status: 'green',
       },
     ])(
       'should forbid/authorize database site operation $operation',
-      async ({ forbidden, label, abilities, health }) => {
+      async ({ forbidden, label, abilities, status }) => {
         const user = userEvent.setup();
 
         const hosts = hostFactory.buildList(1, { heartbeat: 'passing' });
         const database = databaseFactory.build({
           hosts,
           instances: databaseInstanceFactory.buildList(1, {
-            health,
+            status,
             system_replication: 'Primary',
             system_replication_site: 'Site1',
             host: hosts[0],

--- a/assets/js/pages/SapSystemDetails/sapOperations.js
+++ b/assets/js/pages/SapSystemDetails/sapOperations.js
@@ -47,7 +47,7 @@ export const getSapInstanceOperations = curry(
           SAP_INSTANCE_START,
           matchesInstanceNumber(instance.instance_number)
         ),
-        disabled: disabled || instance.health === 'passing',
+        disabled: disabled || instance.status === 'green',
         permitted: ['start:application_instance'],
         onClick: () => {
           setCurrentOperationInstance(instance);
@@ -62,7 +62,7 @@ export const getSapInstanceOperations = curry(
           SAP_INSTANCE_STOP,
           matchesInstanceNumber(instance.instance_number)
         ),
-        disabled: disabled || instance.health === 'unknown',
+        disabled: disabled || instance.status === 'gray',
         permitted: ['stop:application_instance'],
         onClick: () => {
           setCurrentOperationInstance(instance);
@@ -86,7 +86,7 @@ export const getSapSystemOperations = (
       sapSystem.id,
       SAP_SYSTEM_START
     ),
-    disabled: disabled || every(sapSystem.instances, { health: 'passing' }),
+    disabled: disabled || every(sapSystem.instances, { status: 'green' }),
     permitted: ['start:sap_system'],
     onClick: () => {
       setOperationModelOpen({ open: true, operation: SAP_SYSTEM_START });
@@ -99,7 +99,7 @@ export const getSapSystemOperations = (
       sapSystem.id,
       SAP_SYSTEM_STOP
     ),
-    disabled: disabled || every(sapSystem.instances, { health: 'unknown' }),
+    disabled: disabled || every(sapSystem.instances, { status: 'gray' }),
     permitted: ['stop:sap_system'],
     onClick: () => {
       setOperationModelOpen({ open: true, operation: SAP_SYSTEM_STOP });


### PR DESCRIPTION
### Description

Replace missing `health` usage by `status` in frontend.
There were some leftovers from the main change.
It code actually was working, as health was still sent as backward compatibility.
I have checked, and there shouldn't be more `health` usages in application and database instances

### How was this tested?

UT

### Documentation changes

No