### PR TITLE
Health Details for Host Aggregate

### DIFF
--- a/lib/trento/hosts/events/host_rolled_up.ex
+++ b/lib/trento/hosts/events/host_rolled_up.ex
@@ -11,8 +11,36 @@ defmodule Trento.Hosts.Events.HostRolledUp do
 
   alias Trento.Hosts.Host
 
-  defevent do
+  defevent version: 2 do
     field :host_id, Ecto.UUID
     embeds_one :snapshot, Host
+  end
+
+  # Handle old HostRolledUp, inherited from the previous aggregate
+  # when checks_health, saptune_health and
+  # software_updates_discovery_health were independent fields. They
+  # are now moved into combined struct located at health_details key.
+  def upcast(
+        %{
+          "snapshot" =>
+            %{
+              "checks_health" => checks_health,
+              "saptune_health" => saptune_health,
+              "software_updates_discovery_health" => software_updates_discovery_health
+            } = snapshot
+        } = params,
+        _,
+        2
+      ) do
+    new_snapshot =
+      snapshot
+      |> Map.put("health_details", %{
+        "checks_health" => checks_health,
+        "saptune_health" => saptune_health,
+        "software_updates_discovery_health" => software_updates_discovery_health
+      })
+      |> Map.drop(["checks_health", "saptune_health", "software_updates_discovery_health"])
+
+    Map.put(params, "snapshot", new_snapshot)
   end
 end

--- a/lib/trento/hosts/host.ex
+++ b/lib/trento/hosts/host.ex
@@ -910,19 +910,6 @@ defmodule Trento.Hosts.Host do
     end
   end
 
-  def maybe_emit_host_software_updates_discovery_health_changed_event(
-        %Host{
-          host_id: host_id,
-          health_details: %HealthDetails{software_updates_discovery_health: current_health}
-        },
-        health
-      )
-      when health != current_health do
-    %SoftwareUpdatesHealthChanged{host_id: host_id, health: health}
-  end
-
-  def maybe_emit_host_software_updates_discovery_health_changed_event(_host, _health), do: nil
-
   def maybe_emit_software_updates_discovery_lifecycle_events(_host_id, nil, nil), do: []
   def maybe_emit_software_updates_discovery_lifecycle_events(_host_id, fqdn, fqdn), do: []
 
@@ -940,6 +927,19 @@ defmodule Trento.Hosts.Host do
         fully_qualified_domain_name: new_fqdn
       }
     ]
+
+  def maybe_emit_host_software_updates_discovery_health_changed_event(
+        %Host{
+          host_id: host_id,
+          health_details: %HealthDetails{software_updates_discovery_health: current_health}
+        },
+        health
+      )
+      when health != current_health do
+    %SoftwareUpdatesHealthChanged{host_id: host_id, health: health}
+  end
+
+  def maybe_emit_host_software_updates_discovery_health_changed_event(_host, _health), do: nil
 
   defp compute_saptune_health(nil), do: Health.warning()
 

--- a/lib/trento/hosts/host.ex
+++ b/lib/trento/hosts/host.ex
@@ -931,15 +931,16 @@ defmodule Trento.Hosts.Host do
   def maybe_emit_host_software_updates_discovery_health_changed_event(
         %Host{
           host_id: host_id,
-          health_details: %HealthDetails{software_updates_discovery_health: current_health}
+          health_details: %HealthDetails{software_updates_discovery_health: health}
         },
         health
-      )
-      when health != current_health do
-    %SoftwareUpdatesHealthChanged{host_id: host_id, health: health}
-  end
+      ),
+      do: nil
 
-  def maybe_emit_host_software_updates_discovery_health_changed_event(_host, _health), do: nil
+  def maybe_emit_host_software_updates_discovery_health_changed_event(
+        %Host{host_id: host_id},
+        health
+      ), do: %SoftwareUpdatesHealthChanged{host_id: host_id, health: health}
 
   defp compute_saptune_health(nil), do: Health.warning()
 

--- a/lib/trento/hosts/host.ex
+++ b/lib/trento/hosts/host.ex
@@ -930,7 +930,6 @@ defmodule Trento.Hosts.Host do
 
   def maybe_emit_host_software_updates_discovery_health_changed_event(
         %Host{
-          host_id: host_id,
           health_details: %HealthDetails{software_updates_discovery_health: health}
         },
         health

--- a/lib/trento/hosts/host.ex
+++ b/lib/trento/hosts/host.ex
@@ -74,6 +74,7 @@ defmodule Trento.Hosts.Host do
     AwsProvider,
     AzureProvider,
     GcpProvider,
+    HealthDetails,
     SaptuneStatus,
     SlesSubscription,
     SystemdUnit
@@ -137,15 +138,11 @@ defmodule Trento.Hosts.Host do
     field :last_boot_timestamp, :utc_datetime
     field :installation_source, Ecto.Enum, values: [:community, :suse, :unknown]
     field :heartbeat, Ecto.Enum, values: [:passing, :critical, :unknown]
-    field :checks_health, Ecto.Enum, values: Health.values(), default: Health.unknown()
-    field :saptune_health, Ecto.Enum, values: Health.values(), default: Health.unknown()
     field :arch, Ecto.Enum, values: Architecture.values(), default: Architecture.unknown()
-
-    field :software_updates_discovery_health, Ecto.Enum,
-      values: SoftwareUpdatesHealth.values(),
-      default: SoftwareUpdatesHealth.not_set()
-
     field :health, Ecto.Enum, values: Health.values(), default: Health.unknown()
+
+    embeds_one :health_details, HealthDetails, on_replace: :update, defaults_to_struct: true
+
     field :rolling_up, :boolean, default: false
     field :selected_checks, {:array, :string}, default: []
     field :deregistered_at, :utc_datetime_usec, default: nil
@@ -208,7 +205,12 @@ defmodule Trento.Hosts.Host do
         systemd_units: systemd_units,
         last_boot_timestamp: last_boot_timestamp
       }
-    ] ++ maybe_emit_software_updates_discovery_events(host_id, nil, fully_qualified_domain_name)
+    ] ++
+      maybe_emit_software_updates_discovery_lifecycle_events(
+        host_id,
+        nil,
+        fully_qualified_domain_name
+      )
   end
 
   # Reject all the commands, except for the registration ones when the host_id does not exists
@@ -257,7 +259,12 @@ defmodule Trento.Hosts.Host do
       when not is_nil(deregistered_at) do
     [
       %HostRestored{host_id: host_id}
-    ] ++ maybe_emit_software_updates_discovery_events(host_id, nil, fully_qualified_domain_name)
+    ] ++
+      maybe_emit_software_updates_discovery_lifecycle_events(
+        host_id,
+        nil,
+        fully_qualified_domain_name
+      )
   end
 
   def execute(
@@ -303,7 +310,11 @@ defmodule Trento.Hosts.Host do
         last_boot_timestamp: last_boot_timestamp
       }
     ] ++
-      maybe_emit_software_updates_discovery_events(host_id, nil, new_fully_qualified_domain_name)
+      maybe_emit_software_updates_discovery_lifecycle_events(
+        host_id,
+        nil,
+        new_fully_qualified_domain_name
+      )
   end
 
   def execute(
@@ -403,7 +414,7 @@ defmodule Trento.Hosts.Host do
         last_boot_timestamp: last_boot_timestamp
       }
     ] ++
-      maybe_emit_software_updates_discovery_events(
+      maybe_emit_software_updates_discovery_lifecycle_events(
         host_id,
         current_fully_qualified_domain_name,
         new_fully_qualified_domain_name
@@ -610,8 +621,7 @@ defmodule Trento.Hosts.Host do
 
   def execute(
         %Host{
-          host_id: host_id,
-          software_updates_discovery_health: current_software_updates_discovery_health
+          host_id: host_id
         } = host,
         %CompleteSoftwareUpdatesDiscovery{
           host_id: host_id,
@@ -620,21 +630,16 @@ defmodule Trento.Hosts.Host do
       ) do
     host
     |> Multi.new()
-    |> Multi.execute(fn _ ->
-      if current_software_updates_discovery_health != health do
-        %SoftwareUpdatesHealthChanged{
-          host_id: host_id,
-          health: health
-        }
-      end
-    end)
+    |> Multi.execute(&maybe_emit_host_software_updates_discovery_health_changed_event(&1, health))
     |> Multi.execute(&maybe_emit_host_health_changed_event/1)
   end
 
   def execute(
         %Host{
           host_id: host_id,
-          software_updates_discovery_health: SoftwareUpdatesHealth.not_set()
+          health_details: %HealthDetails{
+            software_updates_discovery_health: SoftwareUpdatesHealth.not_set()
+          }
         },
         %ClearSoftwareUpdatesDiscovery{host_id: host_id}
       ) do
@@ -797,18 +802,12 @@ defmodule Trento.Hosts.Host do
   def apply(%Host{} = host, %HostChecksHealthChanged{
         checks_health: checks_health
       }),
-      do: %Host{
-        host
-        | checks_health: checks_health
-      }
+      do: put_in(host.health_details.checks_health, checks_health)
 
   def apply(%Host{} = host, %HostSaptuneHealthChanged{
-        saptune_health: checks_health
+        saptune_health: saptune_health
       }),
-      do: %Host{
-        host
-        | saptune_health: checks_health
-      }
+      do: put_in(host.health_details.saptune_health, saptune_health)
 
   def apply(
         %Host{} = host,
@@ -829,22 +828,18 @@ defmodule Trento.Hosts.Host do
         %SoftwareUpdatesHealthChanged{
           health: health
         }
-      ) do
-    %Host{
-      host
-      | software_updates_discovery_health: health
-    }
-  end
+      ),
+      do: put_in(host.health_details.software_updates_discovery_health, health)
 
   def apply(
         %Host{} = host,
         %SoftwareUpdatesDiscoveryCleared{}
-      ) do
-    %Host{
-      host
-      | software_updates_discovery_health: SoftwareUpdatesHealth.not_set()
-    }
-  end
+      ),
+      do:
+        put_in(
+          host.health_details.software_updates_discovery_health,
+          SoftwareUpdatesHealth.not_set()
+        )
 
   def apply(%Host{} = host, %HostHealthChanged{health: health}) do
     %Host{host | health: health}
@@ -867,7 +862,7 @@ defmodule Trento.Hosts.Host do
   end
 
   defp maybe_emit_host_checks_health_changed_event(
-         %Host{checks_health: checks_health},
+         %Host{health_details: %HealthDetails{checks_health: checks_health}},
          checks_health
        ),
        do: nil
@@ -882,7 +877,7 @@ defmodule Trento.Hosts.Host do
        }
 
   defp maybe_emit_host_saptune_health_changed_event(
-         %Host{host_id: host_id, saptune_health: saptune_health},
+         %Host{host_id: host_id, health_details: %HealthDetails{saptune_health: saptune_health}},
          false
        )
        when saptune_health != Health.passing(),
@@ -898,7 +893,11 @@ defmodule Trento.Hosts.Host do
        do: nil
 
   defp maybe_emit_host_saptune_health_changed_event(
-         %Host{host_id: host_id, saptune_status: saptune_status, saptune_health: saptune_health},
+         %Host{
+           host_id: host_id,
+           saptune_status: saptune_status,
+           health_details: %HealthDetails{saptune_health: saptune_health}
+         },
          true
        ) do
     new_saptune_health = compute_saptune_health(saptune_status)
@@ -911,17 +910,30 @@ defmodule Trento.Hosts.Host do
     end
   end
 
-  def maybe_emit_software_updates_discovery_events(_host_id, nil, nil), do: []
-  def maybe_emit_software_updates_discovery_events(_host_id, fqdn, fqdn), do: []
+  def maybe_emit_host_software_updates_discovery_health_changed_event(
+        %Host{
+          host_id: host_id,
+          health_details: %HealthDetails{software_updates_discovery_health: current_health}
+        },
+        health
+      )
+      when health != current_health do
+    %SoftwareUpdatesHealthChanged{host_id: host_id, health: health}
+  end
 
-  def maybe_emit_software_updates_discovery_events(host_id, _old_fqdn, nil),
+  def maybe_emit_host_software_updates_discovery_health_changed_event(_host, _health), do: nil
+
+  def maybe_emit_software_updates_discovery_lifecycle_events(_host_id, nil, nil), do: []
+  def maybe_emit_software_updates_discovery_lifecycle_events(_host_id, fqdn, fqdn), do: []
+
+  def maybe_emit_software_updates_discovery_lifecycle_events(host_id, _old_fqdn, nil),
     do: [
       %SoftwareUpdatesDiscoveryCleared{
         host_id: host_id
       }
     ]
 
-  def maybe_emit_software_updates_discovery_events(host_id, _old_fqdn, new_fqdn),
+  def maybe_emit_software_updates_discovery_lifecycle_events(host_id, _old_fqdn, new_fqdn),
     do: [
       %SoftwareUpdatesDiscoveryRequested{
         host_id: host_id,
@@ -947,9 +959,11 @@ defmodule Trento.Hosts.Host do
   defp maybe_emit_host_health_changed_event(%Host{
          host_id: host_id,
          heartbeat: heartbeat,
-         checks_health: checks_health,
-         saptune_health: saptune_health,
-         software_updates_discovery_health: software_updates_discovery_health,
+         health_details: %HealthDetails{
+           checks_health: checks_health,
+           saptune_health: saptune_health,
+           software_updates_discovery_health: software_updates_discovery_health
+         },
          health: current_health
        }) do
     new_health =

--- a/lib/trento/hosts/host.ex
+++ b/lib/trento/hosts/host.ex
@@ -940,7 +940,8 @@ defmodule Trento.Hosts.Host do
   def maybe_emit_host_software_updates_discovery_health_changed_event(
         %Host{host_id: host_id},
         health
-      ), do: %SoftwareUpdatesHealthChanged{host_id: host_id, health: health}
+      ),
+      do: %SoftwareUpdatesHealthChanged{host_id: host_id, health: health}
 
   defp compute_saptune_health(nil), do: Health.warning()
 

--- a/lib/trento/hosts/value_objects/health_details.ex
+++ b/lib/trento/hosts/value_objects/health_details.ex
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Hosts.ValueObjects.HealthDetails do
+  @moduledoc """
+  Host health details struct.
+
+  Additional information about the fields available in the host
+  aggregate docstring.
+  """
+
+  @required_fields nil
+
+  use Trento.Support.Type
+
+  require Trento.Enums.Health, as: Health
+  require Trento.SoftwareUpdates.Enums.SoftwareUpdatesHealth, as: SoftwareUpdatesHealth
+
+  deftype do
+    field :checks_health, Ecto.Enum, values: Health.values(), default: Health.unknown()
+    field :saptune_health, Ecto.Enum, values: Health.values(), default: Health.unknown()
+
+    field :software_updates_discovery_health, Ecto.Enum,
+      values: SoftwareUpdatesHealth.values(),
+      default: SoftwareUpdatesHealth.not_set()
+  end
+end

--- a/test/trento/hosts/events/host_rolled_up_test.exs
+++ b/test/trento/hosts/events/host_rolled_up_test.exs
@@ -6,9 +6,8 @@ defmodule Trento.Hosts.Events.HostRolledUpTest do
 
   require Trento.Enums.Health, as: Health
 
-  alias Trento.Hosts.Host
   alias Trento.Hosts.Events.HostRolledUp
-
+  alias Trento.Hosts.Host
   alias Trento.Hosts.ValueObjects.HealthDetails
 
   test "should upcast the legacy snapshot with separate health details fields" do

--- a/test/trento/hosts/events/host_rolled_up_test.exs
+++ b/test/trento/hosts/events/host_rolled_up_test.exs
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Hosts.Events.HostRolledUpTest do
+  use Trento.AggregateCase, aggregate: Trento.Hosts.Host, async: true
+
+  require Trento.Enums.Health, as: Health
+
+  alias Trento.Hosts.Host
+  alias Trento.Hosts.Events.HostRolledUp
+
+  alias Trento.Hosts.ValueObjects.HealthDetails
+
+  test "should upcast the legacy snapshot with separate health details fields" do
+    host_id = Faker.UUID.v4()
+
+    upcasted_event =
+      %{
+        "version" => 1,
+        "host_id" => host_id,
+        "snapshot" => %{
+          "checks_health" => Health.warning(),
+          "saptune_health" => Health.unknown(),
+          "software_updates_discovery_health" => Health.passing()
+        }
+      }
+      |> HostRolledUp.upcast(%{})
+      |> HostRolledUp.new!()
+
+    assert %HostRolledUp{
+             version: 2,
+             host_id: ^host_id,
+             snapshot: %Host{
+               health_details: %HealthDetails{
+                 checks_health: Health.warning(),
+                 saptune_health: Health.unknown(),
+                 software_updates_discovery_health: Health.passing()
+               }
+             }
+           } = upcasted_event
+
+    assert Map.take(
+             upcasted_event,
+             [:checks_health, :saptune_health, :software_updates_discovery_health]
+           ) == %{}
+  end
+end

--- a/test/trento/hosts/host_test.exs
+++ b/test/trento/hosts/host_test.exs
@@ -49,7 +49,8 @@ defmodule Trento.Hosts.HostTest do
   alias Trento.Hosts.ValueObjects.{
     AwsProvider,
     AzureProvider,
-    GcpProvider
+    GcpProvider,
+    HealthDetails
   }
 
   alias Trento.Hosts.Host
@@ -640,7 +641,7 @@ defmodule Trento.Hosts.HostTest do
           fn host ->
             assert %Host{
                      heartbeat: Health.unknown(),
-                     checks_health: ^health,
+                     health_details: %HealthDetails{checks_health: ^health},
                      health: Health.unknown()
                    } = host
           end
@@ -692,7 +693,7 @@ defmodule Trento.Hosts.HostTest do
           fn host ->
             assert %Host{
                      heartbeat: Health.unknown(),
-                     checks_health: ^current_checks_health,
+                     health_details: %HealthDetails{checks_health: ^current_checks_health},
                      health: Health.unknown()
                    } = host
           end
@@ -779,7 +780,7 @@ defmodule Trento.Hosts.HostTest do
           fn host ->
             assert %Host{
                      heartbeat: ^initial_heartbeat,
-                     checks_health: ^current_checks_health,
+                     health_details: %HealthDetails{checks_health: ^current_checks_health},
                      health: ^expected_health
                    } = host
           end
@@ -816,7 +817,7 @@ defmodule Trento.Hosts.HostTest do
           assert %Host{
                    heartbeat: Health.passing(),
                    selected_checks: ^selected_checks,
-                   checks_health: Health.unknown(),
+                   health_details: %HealthDetails{checks_health: Health.unknown()},
                    health: Health.warning()
                  } = host
         end
@@ -864,7 +865,7 @@ defmodule Trento.Hosts.HostTest do
           assert %Host{
                    heartbeat: Health.passing(),
                    selected_checks: [],
-                   checks_health: Health.warning(),
+                   health_details: %HealthDetails{checks_health: Health.warning()},
                    health: Health.warning()
                  } = host
         end
@@ -1453,7 +1454,7 @@ defmodule Trento.Hosts.HostTest do
         fn state ->
           assert %Host{
                    saptune_status: nil,
-                   saptune_health: Health.passing(),
+                   health_details: %HealthDetails{saptune_health: Health.passing()},
                    health: Health.passing()
                  } = state
         end
@@ -1498,7 +1499,7 @@ defmodule Trento.Hosts.HostTest do
         fn state ->
           assert %Host{
                    saptune_status: nil,
-                   saptune_health: Health.warning(),
+                   health_details: %HealthDetails{saptune_health: Health.warning()},
                    health: Health.warning()
                  } = state
         end
@@ -1544,7 +1545,7 @@ defmodule Trento.Hosts.HostTest do
                    saptune_status: %SaptuneStatus{
                      package_version: ^unsupported_version
                    },
-                   saptune_health: Health.warning(),
+                   health_details: %HealthDetails{saptune_health: Health.warning()},
                    health: Health.warning()
                  } = state
         end
@@ -1597,7 +1598,7 @@ defmodule Trento.Hosts.HostTest do
             assert %Host{
                      saptune_status: ^saptune_status,
                      health: ^health,
-                     saptune_health: ^health
+                     health_details: %HealthDetails{saptune_health: ^health}
                    } = state
           end
         )
@@ -1641,7 +1642,7 @@ defmodule Trento.Hosts.HostTest do
                      package_version: ^unsupported_version
                    },
                    health: Health.warning(),
-                   saptune_health: Health.warning()
+                   health_details: %HealthDetails{saptune_health: Health.warning()}
                  } = state
         end
       )
@@ -1683,7 +1684,7 @@ defmodule Trento.Hosts.HostTest do
                    saptune_status: %SaptuneStatus{
                      package_version: ^unsupported_version
                    },
-                   saptune_health: Health.warning(),
+                   health_details: %HealthDetails{saptune_health: Health.warning()},
                    health: Health.warning()
                  } = state
         end
@@ -1823,7 +1824,9 @@ defmodule Trento.Hosts.HostTest do
           fn host ->
             assert %Host{
                      health: ^expected_host_health,
-                     software_updates_discovery_health: ^software_updates_discovery_health
+                     health_details: %HealthDetails{
+                       software_updates_discovery_health: ^software_updates_discovery_health
+                     }
                    } = host
           end
         )
@@ -1858,8 +1861,10 @@ defmodule Trento.Hosts.HostTest do
           [],
           fn host ->
             assert %Host{
-                     software_updates_discovery_health:
-                       ^unchanged_software_updates_discovery_health
+                     health_details: %HealthDetails{
+                       software_updates_discovery_health:
+                         ^unchanged_software_updates_discovery_health
+                     }
                    } = host
           end
         )
@@ -1882,7 +1887,9 @@ defmodule Trento.Hosts.HostTest do
         fn host ->
           assert %Host{
                    health: Health.passing(),
-                   software_updates_discovery_health: SoftwareUpdatesHealth.not_set()
+                   health_details: %HealthDetails{
+                     software_updates_discovery_health: SoftwareUpdatesHealth.not_set()
+                   }
                  } = host
         end
       )
@@ -1937,7 +1944,9 @@ defmodule Trento.Hosts.HostTest do
           fn host ->
             assert %Host{
                      health: ^expected_host_health,
-                     software_updates_discovery_health: SoftwareUpdatesHealth.not_set()
+                     health_details: %HealthDetails{
+                       software_updates_discovery_health: SoftwareUpdatesHealth.not_set()
+                     }
                    } = host
           end
         )
@@ -2357,7 +2366,9 @@ defmodule Trento.Hosts.HostTest do
         },
         fn host ->
           assert %Host{
-                   software_updates_discovery_health: SoftwareUpdatesHealth.not_set(),
+                   health_details: %HealthDetails{
+                     software_updates_discovery_health: SoftwareUpdatesHealth.not_set()
+                   },
                    deregistered_at: ^deregistered_at
                  } = host
         end


### PR DESCRIPTION
### Description

Re-factoring PR that combines the individual health fields in the Host aggregate into a HealthDetails struct.
No events are changed, except the HostRolledUp event. 

Additionally, a small re-factoring was made to the software_updates_discovery_health emitting code -- it's extracted into a function now to be more consistent with the rest of the health emitting events.

### How was this tested?

UT only. Tests were adapted to fit the new shape of the Host aggregate.

### Documentation changes

No
