### PR TITLE
Relax server version validation to allow build metadata

### DIFF
--- a/test/e2e/cypress/pageObject/about_po.js
+++ b/test/e2e/cypress/pageObject/about_po.js
@@ -25,9 +25,14 @@ const amountOfSlesForSapSubscriptionsLabel =
   'div.font-bold:contains("SLES for SAP subscriptions") + div span';
 const versionFilePath = '../../VERSION';
 
-const expectedSemverVersionIsDisplayed = (versionLabel) =>
+export const visit = () => basePage.visit(url);
+
+export const pageTitleIsDisplayed = () =>
+  cy.get(pageTitle).should('have.text', 'About Trento Console');
+
+export const expectedComponentVersionIsDisplayed = (component) =>
   cy
-    .get(versionLabel)
+    .get(versionLabels[component])
     .invoke('text')
     .should((version) => {
       const isValidVersion = semver.valid(semver.coerce(version)) !== null;
@@ -35,14 +40,9 @@ const expectedSemverVersionIsDisplayed = (versionLabel) =>
         .true;
     });
 
-export const visit = () => basePage.visit(url);
-
-export const pageTitleIsDisplayed = () =>
-  cy.get(pageTitle).should('have.text', 'About Trento Console');
-
 export const expectedServerVersionIsDisplayed = () =>
   Cypress.expose('web_mode') === 'prod'
-    ? expectedSemverVersionIsDisplayed(versionLabels.server)
+    ? expectedComponentVersionIsDisplayed('server')
     : cy.readFile(versionFilePath, 'utf8').then((expectedVersion) => {
         expectedVersion = expectedVersion.trim();
 
@@ -55,9 +55,6 @@ export const expectedGithubUrlIsDisplayed = () =>
   cy
     .get(githubRepositoryLabel)
     .should('have.text', 'https://github.com/trento-project/web');
-
-export const expectedComponentVersionIsDisplayed = (component) =>
-  expectedSemverVersionIsDisplayed(versionLabels[component]);
 
 export const expectedSlesForSapSubscriptionsAreDisplayed = (subscriptions) =>
   cy

--- a/test/e2e/cypress/pageObject/about_po.js
+++ b/test/e2e/cypress/pageObject/about_po.js
@@ -25,9 +25,6 @@ const amountOfSlesForSapSubscriptionsLabel =
   'div.font-bold:contains("SLES for SAP subscriptions") + div span';
 const versionFilePath = '../../VERSION';
 
-const isValidSemver = (version) =>
-  semver.valid(semver.coerce(version)) !== null;
-
 export const visit = () => basePage.visit(url);
 
 export const pageTitleIsDisplayed = () =>
@@ -39,8 +36,11 @@ export const expectedServerVersionIsDisplayed = () =>
         .get(versionLabels.server)
         .invoke('text')
         .should((serverVersion) => {
+          const isValidVersion =
+            semver.valid(semver.coerce(serverVersion)) !== null;
+
           expect(
-            isValidSemver(serverVersion),
+            isValidVersion,
             `expected "${serverVersion}" to be a valid semver`
           ).to.be.true;
         })
@@ -62,10 +62,9 @@ export const expectedComponentVersionIsDisplayed = (component) =>
     .get(versionLabels[component])
     .invoke('text')
     .should((version) => {
-      expect(
-        isValidSemver(version),
-        `expected "${version}" to be a valid semver`
-      ).to.be.true;
+      const isValidVersion = semver.valid(semver.coerce(version)) !== null;
+      expect(isValidVersion, `expected "${version}" to be a valid semver`).to.be
+        .true;
     });
 
 export const expectedSlesForSapSubscriptionsAreDisplayed = (subscriptions) =>

--- a/test/e2e/cypress/pageObject/about_po.js
+++ b/test/e2e/cypress/pageObject/about_po.js
@@ -31,9 +31,22 @@ export const pageTitleIsDisplayed = () =>
   cy.get(pageTitle).should('have.text', 'About Trento Console');
 
 export const expectedServerVersionIsDisplayed = () =>
-  cy.readFile(versionFilePath, 'utf8').then((version) => {
-    version = version.trim();
-    return cy.get(versionLabels.server).should('have.text', version);
+  cy.readFile(versionFilePath, 'utf8').then((expectedVersion) => {
+    expectedVersion = expectedVersion.trim();
+
+    return cy
+      .get(versionLabels.server)
+      .invoke('text')
+      .should((serverVersion) => {
+        const hasExpectedVersion =
+          serverVersion === expectedVersion ||
+          serverVersion.startsWith(`${expectedVersion}+`);
+
+        expect(
+          hasExpectedVersion,
+          `expected "${serverVersion}" to be "${expectedVersion}" or start with "${expectedVersion}+"`
+        ).to.be.true;
+      });
   });
 
 export const expectedGithubUrlIsDisplayed = () =>

--- a/test/e2e/cypress/pageObject/about_po.js
+++ b/test/e2e/cypress/pageObject/about_po.js
@@ -25,6 +25,16 @@ const amountOfSlesForSapSubscriptionsLabel =
   'div.font-bold:contains("SLES for SAP subscriptions") + div span';
 const versionFilePath = '../../VERSION';
 
+const expectedSemverVersionIsDisplayed = (versionLabel) =>
+  cy
+    .get(versionLabel)
+    .invoke('text')
+    .should((version) => {
+      const isValidVersion = semver.valid(semver.coerce(version)) !== null;
+      expect(isValidVersion, `expected "${version}" to be a valid semver`).to.be
+        .true;
+    });
+
 export const visit = () => basePage.visit(url);
 
 export const pageTitleIsDisplayed = () =>
@@ -32,18 +42,7 @@ export const pageTitleIsDisplayed = () =>
 
 export const expectedServerVersionIsDisplayed = () =>
   Cypress.expose('web_mode') === 'prod'
-    ? cy
-        .get(versionLabels.server)
-        .invoke('text')
-        .should((serverVersion) => {
-          const isValidVersion =
-            semver.valid(semver.coerce(serverVersion)) !== null;
-
-          expect(
-            isValidVersion,
-            `expected "${serverVersion}" to be a valid semver`
-          ).to.be.true;
-        })
+    ? expectedSemverVersionIsDisplayed(versionLabels.server)
     : cy.readFile(versionFilePath, 'utf8').then((expectedVersion) => {
         expectedVersion = expectedVersion.trim();
 
@@ -58,14 +57,7 @@ export const expectedGithubUrlIsDisplayed = () =>
     .should('have.text', 'https://github.com/trento-project/web');
 
 export const expectedComponentVersionIsDisplayed = (component) =>
-  cy
-    .get(versionLabels[component])
-    .invoke('text')
-    .should((version) => {
-      const isValidVersion = semver.valid(semver.coerce(version)) !== null;
-      expect(isValidVersion, `expected "${version}" to be a valid semver`).to.be
-        .true;
-    });
+  expectedSemverVersionIsDisplayed(versionLabels[component]);
 
 export const expectedSlesForSapSubscriptionsAreDisplayed = (subscriptions) =>
   cy

--- a/test/e2e/cypress/pageObject/about_po.js
+++ b/test/e2e/cypress/pageObject/about_po.js
@@ -30,16 +30,6 @@ export const visit = () => basePage.visit(url);
 export const pageTitleIsDisplayed = () =>
   cy.get(pageTitle).should('have.text', 'About Trento Console');
 
-export const expectedComponentVersionIsDisplayed = (component) =>
-  cy
-    .get(versionLabels[component])
-    .invoke('text')
-    .should((version) => {
-      const isValidVersion = semver.valid(semver.coerce(version)) !== null;
-      expect(isValidVersion, `expected "${version}" to be a valid semver`).to.be
-        .true;
-    });
-
 export const expectedServerVersionIsDisplayed = () =>
   Cypress.expose('web_mode') === 'prod'
     ? expectedComponentVersionIsDisplayed('server')
@@ -55,6 +45,16 @@ export const expectedGithubUrlIsDisplayed = () =>
   cy
     .get(githubRepositoryLabel)
     .should('have.text', 'https://github.com/trento-project/web');
+
+export const expectedComponentVersionIsDisplayed = (component) =>
+  cy
+    .get(versionLabels[component])
+    .invoke('text')
+    .should((version) => {
+      const isValidVersion = semver.valid(semver.coerce(version)) !== null;
+      expect(isValidVersion, `expected "${version}" to be a valid semver`).to.be
+        .true;
+    });
 
 export const expectedSlesForSapSubscriptionsAreDisplayed = (subscriptions) =>
   cy

--- a/test/e2e/cypress/pageObject/about_po.js
+++ b/test/e2e/cypress/pageObject/about_po.js
@@ -25,29 +25,32 @@ const amountOfSlesForSapSubscriptionsLabel =
   'div.font-bold:contains("SLES for SAP subscriptions") + div span';
 const versionFilePath = '../../VERSION';
 
+const isValidSemver = (version) =>
+  semver.valid(semver.coerce(version)) !== null;
+
 export const visit = () => basePage.visit(url);
 
 export const pageTitleIsDisplayed = () =>
   cy.get(pageTitle).should('have.text', 'About Trento Console');
 
 export const expectedServerVersionIsDisplayed = () =>
-  cy.readFile(versionFilePath, 'utf8').then((expectedVersion) => {
-    expectedVersion = expectedVersion.trim();
+  Cypress.expose('web_mode') === 'prod'
+    ? cy
+        .get(versionLabels.server)
+        .invoke('text')
+        .should((serverVersion) => {
+          expect(
+            isValidSemver(serverVersion),
+            `expected "${serverVersion}" to be a valid semver`
+          ).to.be.true;
+        })
+    : cy.readFile(versionFilePath, 'utf8').then((expectedVersion) => {
+        expectedVersion = expectedVersion.trim();
 
-    return cy
-      .get(versionLabels.server)
-      .invoke('text')
-      .should((serverVersion) => {
-        const hasExpectedVersion =
-          serverVersion === expectedVersion ||
-          serverVersion.startsWith(`${expectedVersion}+`);
-
-        expect(
-          hasExpectedVersion,
-          `expected "${serverVersion}" to be "${expectedVersion}" or start with "${expectedVersion}+"`
-        ).to.be.true;
+        return cy
+          .get(versionLabels.server)
+          .should('have.text', expectedVersion);
       });
-  });
 
 export const expectedGithubUrlIsDisplayed = () =>
   cy
@@ -59,9 +62,10 @@ export const expectedComponentVersionIsDisplayed = (component) =>
     .get(versionLabels[component])
     .invoke('text')
     .should((version) => {
-      const isValidVersion = semver.valid(semver.coerce(version)) !== null;
-      expect(isValidVersion, `expected "${version}" to be a valid semver`).to.be
-        .true;
+      expect(
+        isValidSemver(version),
+        `expected "${version}" to be a valid semver`
+      ).to.be.true;
     });
 
 export const expectedSlesForSapSubscriptionsAreDisplayed = (subscriptions) =>


### PR DESCRIPTION
### Description

Validate the server version depending on the target web mode: exact `VERSION` file match in dev, semver-compatible validation in prod.

This covers both stable production versions such as `3.1.2` and rolling/RPM versions that include build metadata such as `3.1.2+git.90.1782988399.3aebaa78a`.

### How was this tested?

I triggered the tests both pointing to dev and to a prod instance.

### Documentation changes

Yes / No

<!--
If yes, consider updating:
- User documentation: https://github.com/trento-project/docs/tree/main/trento/adoc
- Developer documentation: https://github.com/trento-project/docs/tree/main/content
- Component-specific documentation, e.g., https://github.com/trento-project/web/tree/main/guides for Wanda
-->

### Additional information

<!-- Add anything else relevant to this PR, such as screenshots or demos. -->
