### PR TITLE
Fix flaky E2E test: TOTP login cases

### DIFF
--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -246,8 +246,7 @@ describe('Users', () => {
     });
   });
 
-  // eslint-disable-next-line mocha/no-exclusive-tests
-  describe.only('TOTP authentication', () => {
+  describe('TOTP authentication', () => {
     beforeEach(() => {
       basePage.logout();
       usersPage.apiDeleteAllUsers();

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -319,10 +319,10 @@ describe('Users', () => {
           usersPage.interceptDeleteTotpEnrollmentEndpoint();
           usersPage.clickDisableTotpButton();
           usersPage.removeTotpDialogTitleIsNotDisplayed();
-          usersPage.waitForTotpEnrollmentEndpoint().then(() => {
-            usersPage.clickAuthenticatorAppSwitch();
-            usersPage.newIssuedTotpSecretIsDifferent(totpSecret);
-          });
+          usersPage.waitForTotpEnrollmentEndpoint();
+          usersPage.authenticatorAppSwitchIsUnchecked();
+          usersPage.clickAuthenticatorAppSwitch();
+          usersPage.newIssuedTotpSecretIsDifferent(totpSecret);
         });
       });
     });

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -246,7 +246,8 @@ describe('Users', () => {
     });
   });
 
-  describe('TOTP authentication', () => {
+  // eslint-disable-next-line mocha/no-exclusive-tests
+  describe.only('TOTP authentication', () => {
     beforeEach(() => {
       basePage.logout();
       usersPage.apiDeleteAllUsers();

--- a/test/e2e/cypress/pageObject/users_po.js
+++ b/test/e2e/cypress/pageObject/users_po.js
@@ -327,6 +327,12 @@ export const totpEnrollmentErrorIsDisplayed = () =>
 export const authenticatorAppSwitchIsEnabled = () =>
   cy.get(authenticatorAppSwitch).should('be.enabled');
 
+export const authenticatorAppSwitchIsUnchecked = () =>
+  cy
+    .get(authenticatorAppSwitch)
+    .should('have.attr', 'aria-checked', 'false')
+    .and('be.enabled');
+
 export const totpEnabledToasterIsDisplayed = () =>
   cy.get(totpEnabledToaster).should('be.visible');
 


### PR DESCRIPTION
### Description

Fix the flaky TOTP E2E flow by waiting for the authenticator app switch to be unchecked and enabled after disabling TOTP, before enabling it again and asserting that a new secret is issued.

### How was this tested?

<!-- Describe what tests were added or updated for this change. -->

### Documentation changes

Yes / No

<!--
If yes, consider updating:
- User documentation: https://github.com/trento-project/docs/tree/main/trento/adoc
- Developer documentation: https://github.com/trento-project/docs/tree/main/content
- Component-specific documentation, e.g., https://github.com/trento-project/web/tree/main/guides for Wanda
-->

### Additional information

<!-- Add anything else relevant to this PR, such as screenshots or demos. -->
