### PR TITLE
Refine agent status pill

### DIFF
--- a/assets/js/pages/HostDetailsPage/HostDetails.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.jsx
@@ -141,7 +141,7 @@ function HostDetails({
       <StatusPill
         key={exporterName}
         className="self-center ml-4 shadow"
-        heartbeat={exporterStatus}
+        status={exporterStatus}
       >
         {startCase(exporterName)}
       </StatusPill>
@@ -333,7 +333,7 @@ function HostDetails({
             </div>
           </div>
           <div className="pb-3">
-            <StatusPill className="self-center shadow" heartbeat={heartbeat}>
+            <StatusPill className="self-center shadow" status={heartbeat}>
               Agent
             </StatusPill>
             {renderedExporters}

--- a/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
@@ -756,11 +756,11 @@ describe('HostDetails component', () => {
     it.each([
       {
         state: 'passing',
-        label: 'running',
+        label: 'Reporting',
       },
       {
         state: 'critical',
-        label: 'not running',
+        label: 'Not reporting',
       },
     ])('should show exporters state as $state', ({ state, label }) => {
       renderWithRouter(

--- a/assets/js/pages/HostDetailsPage/StatusPill.jsx
+++ b/assets/js/pages/HostDetailsPage/StatusPill.jsx
@@ -8,43 +8,30 @@ import { EOS_LENS_FILLED } from 'eos-icons-react';
 
 import Pill from '@common/Pill';
 
-function StatusPill({ className, children, heartbeat }) {
-  switch (heartbeat) {
+const pillBgClass = 'bg-gray-200 text-gray-500 items-center';
+
+function StatusPill({ className, children, status }) {
+  switch (status) {
     case 'passing':
       return (
-        <Pill
-          className={classNames(
-            className,
-            'bg-gray-200 text-gray-500 items-center'
-          )}
-        >
+        <Pill className={classNames(className, pillBgClass)}>
           {children}:
           <EOS_LENS_FILLED size="base" className="fill-jungle-green-500 mx-1" />
-          running
+          Reporting
         </Pill>
       );
     case 'critical':
       return (
-        <Pill
-          className={classNames(
-            'bg-gray-200 text-gray-500 items-center',
-            className
-          )}
-        >
+        <Pill className={classNames(className, pillBgClass)}>
           {children}:
-          <EOS_LENS_FILLED size="base" className="fill-red-500 px-2" />
-          not running
+          <EOS_LENS_FILLED size="base" className="fill-red-500 mx-1" />
+          Not reporting
         </Pill>
       );
     default:
       return (
-        <Pill
-          className={classNames(
-            'bg-gray-200 text-gray-500 items-center',
-            className
-          )}
-        >
-          {children}: unknown
+        <Pill className={classNames(className, pillBgClass)}>
+          {children}: Unknown
         </Pill>
       );
   }

--- a/assets/js/pages/HostDetailsPage/StatusPill.test.jsx
+++ b/assets/js/pages/HostDetailsPage/StatusPill.test.jsx
@@ -9,32 +9,32 @@ import StatusPill from './StatusPill';
 
 describe('StatusPill', () => {
   it('should render passing status correctly', () => {
-    render(<StatusPill heartbeat="passing">Test Service</StatusPill>);
+    render(<StatusPill status="passing">Test Service</StatusPill>);
 
     const statusPill = screen.getByText('Test Service', { exact: false });
     const svgElement = screen.getByTestId('eos-svg-component');
 
-    expect(statusPill).toHaveTextContent('running');
+    expect(statusPill).toHaveTextContent('Reporting');
     expect(statusPill).toContainElement(svgElement);
     expect(svgElement).toHaveClass('fill-jungle-green-500');
   });
 
   it('should render critical status correctly', () => {
-    render(<StatusPill heartbeat="critical">Test Service</StatusPill>);
+    render(<StatusPill status="critical">Test Service</StatusPill>);
 
     const statusPill = screen.getByText('Test Service', { exact: false });
     const svgElement = screen.getByTestId('eos-svg-component');
 
-    expect(statusPill).toHaveTextContent('not running');
+    expect(statusPill).toHaveTextContent('Not reporting');
     expect(statusPill).toContainElement(svgElement);
     expect(svgElement).toHaveClass('fill-red-500');
   });
 
   it('should render unknown status correctly', () => {
-    render(<StatusPill heartbeat="unknown">Test Service</StatusPill>);
+    render(<StatusPill status="unknown">Test Service</StatusPill>);
 
     expect(
       screen.getByText('Test Service', { exact: false })
-    ).toHaveTextContent('unknown');
+    ).toHaveTextContent('Unknown');
   });
 });

--- a/test/e2e/cypress/e2e/host_details.cy.js
+++ b/test/e2e/cypress/e2e/host_details.cy.js
@@ -157,21 +157,21 @@ context('Host Details', () => {
     });
   });
 
-  describe("Trento agent status should be 'running'", () => {
+  describe("Trento agent status should be 'Reporting'", () => {
     beforeEach(() => hostDetailsPage.visitSelectedHost());
 
-    it("should show the status as 'running'", () => {
+    it("should show the status as 'Reporting'", () => {
       hostDetailsPage.agentStatusIsCorrectlyDisplayed();
     });
   });
 
-  describe("Node exporter status should be 'running'", () => {
+  describe("Node exporter status should be 'Reporting'", () => {
     beforeEach(() => {
       hostDetailsPage.interceptNodeExporterStatusMockedForProdInstance();
       hostDetailsPage.visitSelectedHost();
     });
 
-    it("should show the status as 'running'", () => {
+    it("should show the status as 'Reporting'", () => {
       hostDetailsPage.nodeExporterStatusIsCorrectlyDisplayed();
     });
   });

--- a/test/e2e/cypress/pageObject/host_details_po.js
+++ b/test/e2e/cypress/pageObject/host_details_po.js
@@ -29,9 +29,9 @@ const architectureLabel =
   'div[class="font-bold"]:contains("Architecture") + div';
 const ipAddressesLabel =
   'div[class="font-bold"]:contains("IP Addresses") + div';
-const agentRunningLabel = 'span:contains("Agent:running")';
-const agentRunningBadge = `${agentRunningLabel} svg`;
-const nodeExporterLabel = 'span:contains("Node Exporter:running")';
+const agentReportingLabel = 'span:contains("Agent:Reporting")';
+const agentReportingBadge = `${agentReportingLabel} svg`;
+const nodeExporterLabel = 'span:contains("Node Exporter:Reporting")';
 const nodeExporterBadge = `${nodeExporterLabel} svg`;
 const providerDetailsBox = 'div[class="mt-16"]:contains("Provider details")';
 const notRecognizedProviderLabel = 'div:contains("Provider not recognized")';
@@ -396,9 +396,9 @@ const _getTableHeaders = (tableName) =>
   });
 
 export const agentStatusIsCorrectlyDisplayed = () => {
-  cy.get(agentRunningLabel).should('be.visible');
+  cy.get(agentReportingLabel).should('be.visible');
   return cy
-    .get(agentRunningBadge)
+    .get(agentReportingBadge)
     .invoke('attr', 'class')
     .then((classAttr) => {
       expect(classAttr).to.contain('jungle-green');


### PR DESCRIPTION
### Description

Re-touch agent running status pill in host details view:

<img width="618" height="238" alt="image" src="https://github.com/user-attachments/assets/162654a2-b953-4baa-90a5-e24a682c74c6" />

<img width="537" height="250" alt="image" src="https://github.com/user-attachments/assets/d8f321a0-717a-4fcc-bcfb-38d87d1b34f2" />


### How was this tested?

UT

### Documentation changes

No