### PR TITLE
Mark database as stale

### DIFF
--- a/lib/trento/databases/database.ex
+++ b/lib/trento/databases/database.ex
@@ -310,19 +310,14 @@ defmodule Trento.Databases.Database do
       ) do
     case get_instance(instances, host_id, instance_number) do
       %Instance{stale_at: nil} ->
-        database
-        |> Multi.new()
-        |> Multi.execute(fn _ ->
+        [
           %DatabaseInstanceDataMarkedStale{
             database_id: database_id,
             instance_number: instance_number,
             host_id: host_id,
             stale_at: stale_at
           }
-        end)
-        |> Multi.execute(fn database ->
-          maybe_emit_database_data_marked_stale_event(database, stale_at)
-        end)
+        ] ++ maybe_emit_database_data_marked_stale_event(database, stale_at)
 
       _ ->
         nil
@@ -725,13 +720,15 @@ defmodule Trento.Databases.Database do
          },
          stale_at
        ) do
-    %DatabaseDataMarkedStale{
-      database_id: database_id,
-      stale_at: stale_at
-    }
+    [
+      %DatabaseDataMarkedStale{
+        database_id: database_id,
+        stale_at: stale_at
+      }
+    ]
   end
 
-  defp maybe_emit_database_data_marked_stale_event(_, _), do: nil
+  defp maybe_emit_database_data_marked_stale_event(_, _), do: []
 
   defp maybe_emit_database_data_marked_in_sync_event(%Database{stale_at: nil}), do: nil
 

--- a/lib/trento/databases/database.ex
+++ b/lib/trento/databases/database.ex
@@ -31,6 +31,8 @@ defmodule Trento.Databases.Database do
   }
 
   alias Trento.Databases.Events.{
+    DatabaseDataMarkedInSync,
+    DatabaseDataMarkedStale,
     DatabaseDeregistered,
     DatabaseHealthChanged,
     DatabaseInstanceDataMarkedInSync,
@@ -81,6 +83,7 @@ defmodule Trento.Databases.Database do
     field :sid, :string, default: nil
     field :health, Ecto.Enum, values: Health.values()
     field :rolling_up, :boolean, default: false
+    field :stale_at, :utc_datetime_usec
     field :deregistered_at, :utc_datetime_usec, default: nil
 
     embeds_many :instances, Instance
@@ -261,6 +264,7 @@ defmodule Trento.Databases.Database do
     |> Multi.execute(fn _ ->
       maybe_emit_database_instance_data_marked_in_sync_event(instance, command)
     end)
+    |> Multi.execute(&maybe_emit_database_data_marked_in_sync_event/1)
     |> Multi.execute(&maybe_emit_database_health_changed_event/1)
     |> Multi.execute(fn database ->
       maybe_emit_database_tenants_updated_event(database, tenants)
@@ -297,7 +301,7 @@ defmodule Trento.Databases.Database do
   end
 
   def execute(
-        %Database{database_id: database_id, instances: instances},
+        %Database{database_id: database_id, instances: instances} = database,
         %MarkDatabaseInstanceDataStale{
           instance_number: instance_number,
           host_id: host_id,
@@ -306,12 +310,19 @@ defmodule Trento.Databases.Database do
       ) do
     case get_instance(instances, host_id, instance_number) do
       %Instance{stale_at: nil} ->
-        %DatabaseInstanceDataMarkedStale{
-          database_id: database_id,
-          instance_number: instance_number,
-          host_id: host_id,
-          stale_at: stale_at
-        }
+        database
+        |> Multi.new()
+        |> Multi.execute(fn _ ->
+          %DatabaseInstanceDataMarkedStale{
+            database_id: database_id,
+            instance_number: instance_number,
+            host_id: host_id,
+            stale_at: stale_at
+          }
+        end)
+        |> Multi.execute(fn database ->
+          maybe_emit_database_data_marked_stale_event(database, stale_at)
+        end)
 
       _ ->
         nil
@@ -332,6 +343,7 @@ defmodule Trento.Databases.Database do
     |> Multi.execute(fn _ ->
       maybe_emit_database_instance_deregistered_event(database, instance)
     end)
+    |> Multi.execute(&maybe_emit_database_data_marked_in_sync_event/1)
     |> Multi.execute(fn database ->
       maybe_emit_database_deregistered_event(database, deregistered_at)
     end)
@@ -575,6 +587,17 @@ defmodule Trento.Databases.Database do
     }
   end
 
+  def apply(
+        %Database{} = database,
+        %DatabaseDataMarkedStale{stale_at: stale_at}
+      ) do
+    %Database{database | stale_at: stale_at}
+  end
+
+  def apply(%Database{} = database, %DatabaseDataMarkedInSync{}) do
+    %Database{database | stale_at: nil}
+  end
+
   # Aggregate to rolling up state
   def apply(%Database{} = database, %DatabaseRollUpRequested{}) do
     %Database{database | rolling_up: true}
@@ -694,6 +717,36 @@ defmodule Trento.Databases.Database do
   end
 
   defp maybe_emit_database_instance_data_marked_in_sync_event(_, _), do: nil
+
+  defp maybe_emit_database_data_marked_stale_event(
+         %Database{
+           database_id: database_id,
+           stale_at: nil
+         },
+         stale_at
+       ) do
+    %DatabaseDataMarkedStale{
+      database_id: database_id,
+      stale_at: stale_at
+    }
+  end
+
+  defp maybe_emit_database_data_marked_stale_event(_, _), do: nil
+
+  defp maybe_emit_database_data_marked_in_sync_event(%Database{stale_at: nil}), do: nil
+
+  defp maybe_emit_database_data_marked_in_sync_event(%Database{
+         database_id: database_id,
+         instances: instances
+       }) do
+    all_in_sync? = Enum.all?(instances, fn %{stale_at: stale_at} -> is_nil(stale_at) end)
+
+    if all_in_sync? do
+      %DatabaseDataMarkedInSync{
+        database_id: database_id
+      }
+    end
+  end
 
   defp maybe_emit_database_instance_system_replication_changed_event(nil, _), do: nil
 

--- a/lib/trento/databases/events/database_data_marked_in_sync.ex
+++ b/lib/trento/databases/events/database_data_marked_in_sync.ex
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Databases.Events.DatabaseDataMarkedInSync do
+  @moduledoc """
+  This event is emitted when a database data is marked as in sync.
+  """
+
+  use Trento.Support.Event
+
+  defevent do
+    field :database_id, Ecto.UUID
+  end
+end

--- a/lib/trento/databases/events/database_data_marked_stale.ex
+++ b/lib/trento/databases/events/database_data_marked_stale.ex
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Databases.Events.DatabaseDataMarkedStale do
+  @moduledoc """
+  This event is emitted when a database data is marked as stale.
+  """
+
+  use Trento.Support.Event
+
+  defevent do
+    field :database_id, Ecto.UUID
+    field :stale_at, :utc_datetime_usec
+  end
+end

--- a/lib/trento/databases/projections/database_projector.ex
+++ b/lib/trento/databases/projections/database_projector.ex
@@ -19,6 +19,8 @@ defmodule Trento.Databases.Projections.DatabaseProjector do
   alias TrentoWeb.V1.DatabaseJSON
 
   alias Trento.Databases.Events.{
+    DatabaseDataMarkedInSync,
+    DatabaseDataMarkedStale,
     DatabaseDeregistered,
     DatabaseHealthChanged,
     DatabaseInstanceDataMarkedInSync,
@@ -276,6 +278,35 @@ defmodule Trento.Databases.Projections.DatabaseProjector do
         })
 
       Ecto.Multi.update(multi, :database_instance, changeset)
+    end
+  )
+
+  project(
+    %DatabaseDataMarkedStale{
+      database_id: database_id,
+      stale_at: stale_at
+    },
+    fn multi ->
+      changeset =
+        DatabaseReadModel
+        |> Repo.get!(database_id)
+        |> DatabaseReadModel.changeset(%{stale_at: stale_at})
+
+      Ecto.Multi.update(multi, :database, changeset)
+    end
+  )
+
+  project(
+    %DatabaseDataMarkedInSync{
+      database_id: database_id
+    },
+    fn multi ->
+      changeset =
+        DatabaseReadModel
+        |> Repo.get!(database_id)
+        |> DatabaseReadModel.changeset(%{stale_at: nil})
+
+      Ecto.Multi.update(multi, :database, changeset)
     end
   )
 
@@ -630,6 +661,47 @@ defmodule Trento.Databases.Projections.DatabaseProjector do
       @databases_topic,
       "database_tenants_updated",
       DatabaseJSON.database_tenants_updated(%{tenants: tenants, database_id: database_id})
+    )
+  end
+
+  @impl true
+  def after_update(
+        %DatabaseDataMarkedStale{
+          database_id: database_id,
+          stale_at: stale_at
+        },
+        _,
+        _
+      ) do
+    TrentoWeb.Endpoint.broadcast(
+      @databases_topic,
+      "database_stale_changed",
+      DatabaseJSON.database_stale_changed(%{
+        database: %{
+          id: database_id,
+          stale_at: stale_at
+        }
+      })
+    )
+  end
+
+  @impl true
+  def after_update(
+        %DatabaseDataMarkedInSync{
+          database_id: database_id
+        },
+        _,
+        _
+      ) do
+    TrentoWeb.Endpoint.broadcast(
+      @databases_topic,
+      "database_stale_changed",
+      DatabaseJSON.database_stale_changed(%{
+        database: %{
+          id: database_id,
+          stale_at: nil
+        }
+      })
     )
   end
 

--- a/lib/trento/databases/projections/database_read_model.ex
+++ b/lib/trento/databases/projections/database_read_model.ex
@@ -39,6 +39,7 @@ defmodule Trento.Databases.Projections.DatabaseReadModel do
       foreign_key: :database_id,
       preload_order: [asc: :instance_number, asc: :host_id]
 
+    field :stale_at, :utc_datetime_usec
     field :deregistered_at, :utc_datetime_usec
 
     timestamps(type: :utc_datetime_usec)

--- a/lib/trento_web/controllers/v1/database_json.ex
+++ b/lib/trento_web/controllers/v1/database_json.ex
@@ -141,6 +141,17 @@ defmodule TrentoWeb.V1.DatabaseJSON do
         stale_at: stale_at
       }
 
+  def database_stale_changed(%{
+        database: %{
+          id: id,
+          stale_at: stale_at
+        }
+      }),
+      do: %{
+        id: id,
+        stale_at: stale_at
+      }
+
   def database_tenants_updated(%{tenants: tenants, database_id: database_id}) do
     rendered_tenants = Enum.map(tenants, &database_tenant(%{tenant: &1}))
 

--- a/lib/trento_web/openapi/v1/schema/database.ex
+++ b/lib/trento_web/openapi/v1/schema/database.ex
@@ -255,6 +255,14 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Database do
           health: ResourceHealth,
           database_instances: DatabaseInstances,
           tags: Tags,
+          stale_at: %Schema{
+            type: :string,
+            description:
+              "The timestamp indicating when the database data became stale, supporting monitoring and troubleshooting.",
+            format: :datetime,
+            example: "2024-01-15T08:00:00Z",
+            nullable: true
+          },
           inserted_at: %Schema{type: :string, format: :datetime, example: "2024-01-15T10:30:00Z"},
           updated_at: %Schema{
             type: :string,
@@ -269,6 +277,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Database do
           health: "passing",
           database_instances: [],
           tags: [],
+          stale_at: "2024-01-15T08:00:00Z",
           inserted_at: "2024-01-15T10:30:00Z",
           updated_at: "2024-01-15T12:30:00Z"
         }
@@ -294,6 +303,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.Database do
             health: "passing",
             database_instances: [],
             tags: [],
+            stale_at: "2024-01-15T08:00:00Z",
             inserted_at: "2024-01-15T10:30:00Z",
             updated_at: "2024-01-15T12:30:00Z"
           }

--- a/priv/repo/migrations/20260622160500_add_stale_at_database_read_model.exs
+++ b/priv/repo/migrations/20260622160500_add_stale_at_database_read_model.exs
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Repo.Migrations.AddStaleAtDatabaseReadModel do
+  use Ecto.Migration
+
+  def change do
+    alter table(:databases) do
+      add :stale_at, :utc_datetime_usec
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -66,6 +66,8 @@ defmodule Trento.Factory do
   }
 
   alias Trento.Databases.Events.{
+    DatabaseDataMarkedInSync,
+    DatabaseDataMarkedStale,
     DatabaseDeregistered,
     DatabaseHealthChanged,
     DatabaseInstanceDataMarkedInSync,
@@ -581,6 +583,19 @@ defmodule Trento.Factory do
     DatabaseDeregistered.new!(%{
       database_id: Faker.UUID.v4(),
       deregistered_at: DateTime.utc_now()
+    })
+  end
+
+  def database_data_marked_stale_event_factory do
+    DatabaseDataMarkedStale.new!(%{
+      database_id: Faker.UUID.v4(),
+      stale_at: DateTime.utc_now()
+    })
+  end
+
+  def database_data_marked_in_sync_event_factory do
+    DatabaseDataMarkedInSync.new!(%{
+      database_id: Faker.UUID.v4()
     })
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -586,17 +586,27 @@ defmodule Trento.Factory do
     })
   end
 
-  def database_data_marked_stale_event_factory do
-    DatabaseDataMarkedStale.new!(%{
+  def database_data_marked_stale_event_factory(attrs) do
+    data = %{
       database_id: Faker.UUID.v4(),
       stale_at: DateTime.utc_now()
-    })
+    }
+
+    data
+    |> merge_attributes(attrs)
+    |> evaluate_lazy_attributes
+    |> DatabaseDataMarkedStale.new!()
   end
 
-  def database_data_marked_in_sync_event_factory do
-    DatabaseDataMarkedInSync.new!(%{
+  def database_data_marked_in_sync_event_factory(attrs) do
+    data = %{
       database_id: Faker.UUID.v4()
-    })
+    }
+
+    data
+    |> merge_attributes(attrs)
+    |> evaluate_lazy_attributes
+    |> DatabaseDataMarkedInSync.new!()
   end
 
   def application_instance_registered_event_factory do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -848,7 +848,8 @@ defmodule Trento.Factory do
     %DatabaseReadModel{
       id: Faker.UUID.v4(),
       sid: Faker.StarWars.planet(),
-      health: Health.unknown()
+      health: Health.unknown(),
+      stale_at: nil
     }
   end
 

--- a/test/trento/databases/database_test.exs
+++ b/test/trento/databases/database_test.exs
@@ -17,6 +17,8 @@ defmodule Trento.Databases.DatabaseTest do
   }
 
   alias Trento.Databases.Events.{
+    DatabaseDataMarkedInSync,
+    DatabaseDataMarkedStale,
     DatabaseDeregistered,
     DatabaseHealthChanged,
     DatabaseInstanceDataMarkedInSync,
@@ -2547,7 +2549,7 @@ defmodule Trento.Databases.DatabaseTest do
     end
   end
 
-  describe "instance marked stale/in sync" do
+  describe "database marked stale/in sync" do
     test "should mark database instance data as stale" do
       database_id = Faker.UUID.v4()
       sid = fake_sid()
@@ -2583,10 +2585,15 @@ defmodule Trento.Databases.DatabaseTest do
             instance_number: instance_number,
             host_id: host_id,
             stale_at: stale_at
+          },
+          %DatabaseDataMarkedStale{
+            database_id: database_id,
+            stale_at: stale_at
           }
         ],
         fn state ->
           assert %Database{
+                   stale_at: ^stale_at,
                    instances: [
                      %Instance{
                        instance_number: ^instance_number,
@@ -2674,6 +2681,9 @@ defmodule Trento.Databases.DatabaseTest do
           database_id: database_id,
           instance_number: instance_number,
           host_id: host_id
+        ),
+        build(:database_data_marked_stale_event,
+          database_id: database_id
         )
       ]
 
@@ -2695,10 +2705,14 @@ defmodule Trento.Databases.DatabaseTest do
             database_id: database_id,
             instance_number: instance_number,
             host_id: host_id
+          },
+          %DatabaseDataMarkedInSync{
+            database_id: database_id
           }
         ],
         fn state ->
           assert %Database{
+                   stale_at: nil,
                    instances: [
                      %Instance{
                        instance_number: ^instance_number,
@@ -2754,6 +2768,384 @@ defmodule Trento.Databases.DatabaseTest do
                    instances: [
                      %Instance{
                        instance_number: ^instance_number,
+                       stale_at: nil
+                     }
+                   ]
+                 } = state
+        end
+      )
+    end
+
+    test "should not mark database data as stale again if other instance was already stale" do
+      database_id = Faker.UUID.v4()
+      sid = fake_sid()
+      host_id_1 = Faker.UUID.v4()
+      host_id_2 = Faker.UUID.v4()
+      instance_number_1 = "00"
+      instance_number_2 = "01"
+      stale_at_1 = DateTime.utc_now()
+      stale_at_2 = DateTime.utc_now()
+
+      initial_events = [
+        build(:database_registered_event,
+          database_id: database_id,
+          sid: sid
+        ),
+        build(:database_instance_registered_event,
+          database_id: database_id,
+          sid: sid,
+          host_id: host_id_1,
+          instance_number: instance_number_1,
+          features: "HDB|HDB_WORKER"
+        ),
+        build(:database_instance_registered_event,
+          database_id: database_id,
+          sid: sid,
+          host_id: host_id_2,
+          instance_number: instance_number_2,
+          features: "HDB|HDB_WORKER"
+        ),
+        build(:database_instance_data_marked_stale_event,
+          database_id: database_id,
+          instance_number: instance_number_1,
+          host_id: host_id_1,
+          stale_at: stale_at_1
+        ),
+        build(:database_data_marked_stale_event,
+          database_id: database_id,
+          stale_at: stale_at_1
+        )
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        %MarkDatabaseInstanceDataStale{
+          database_id: database_id,
+          instance_number: instance_number_2,
+          host_id: host_id_2,
+          stale_at: stale_at_2
+        },
+        [
+          %DatabaseInstanceDataMarkedStale{
+            database_id: database_id,
+            instance_number: instance_number_2,
+            host_id: host_id_2,
+            stale_at: stale_at_2
+          }
+        ],
+        fn state ->
+          assert %Database{
+                   stale_at: ^stale_at_1
+                 } = state
+        end
+      )
+    end
+
+    test "should mark database data as in sync when a stale instance is deregistered" do
+      database_id = Faker.UUID.v4()
+      sid = fake_sid()
+      host_id_1 = Faker.UUID.v4()
+      host_id_2 = Faker.UUID.v4()
+      instance_number_1 = "00"
+      instance_number_2 = "01"
+      stale_at = DateTime.utc_now()
+      deregistered_at = DateTime.utc_now()
+
+      initial_events = [
+        build(:database_registered_event,
+          database_id: database_id,
+          sid: sid
+        ),
+        build(:database_instance_registered_event,
+          database_id: database_id,
+          sid: sid,
+          host_id: host_id_1,
+          instance_number: instance_number_1,
+          features: "HDB|HDB_WORKER"
+        ),
+        build(:database_instance_registered_event,
+          database_id: database_id,
+          sid: sid,
+          host_id: host_id_2,
+          instance_number: instance_number_2,
+          features: "HDB|HDB_WORKER"
+        ),
+        build(:database_instance_data_marked_stale_event,
+          database_id: database_id,
+          instance_number: instance_number_1,
+          host_id: host_id_1,
+          stale_at: stale_at
+        ),
+        build(:database_data_marked_stale_event,
+          database_id: database_id,
+          stale_at: stale_at
+        )
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        %DeregisterDatabaseInstance{
+          database_id: database_id,
+          host_id: host_id_1,
+          instance_number: instance_number_1,
+          deregistered_at: deregistered_at
+        },
+        [
+          %DatabaseInstanceDeregistered{
+            database_id: database_id,
+            host_id: host_id_1,
+            instance_number: instance_number_1,
+            deregistered_at: deregistered_at
+          },
+          %DatabaseDataMarkedInSync{
+            database_id: database_id
+          }
+        ],
+        fn state ->
+          assert %Database{
+                   stale_at: nil,
+                   instances: [
+                     %Instance{
+                       instance_number: ^instance_number_2,
+                       host_id: ^host_id_2,
+                       stale_at: nil
+                     }
+                   ]
+                 } = state
+        end
+      )
+    end
+
+    test "should mark database data as in sync when a stale instance receives new data" do
+      database_id = Faker.UUID.v4()
+      sid = fake_sid()
+      host_id = Faker.UUID.v4()
+      instance_number = "00"
+      stale_at = DateTime.utc_now()
+      tenants = build_list(1, :tenant)
+
+      initial_events = [
+        build(:database_registered_event,
+          database_id: database_id,
+          sid: sid
+        ),
+        build(:database_instance_registered_event,
+          database_id: database_id,
+          sid: sid,
+          host_id: host_id,
+          instance_number: instance_number,
+          features: "HDB|HDB_WORKER"
+        ),
+        build(:database_tenants_updated_event,
+          database_id: database_id,
+          tenants: tenants
+        ),
+        build(:database_instance_data_marked_stale_event,
+          database_id: database_id,
+          instance_number: instance_number,
+          host_id: host_id,
+          stale_at: stale_at
+        ),
+        build(:database_data_marked_stale_event,
+          database_id: database_id,
+          stale_at: stale_at
+        )
+      ]
+
+      command =
+        build(:register_database_instance_command,
+          database_id: database_id,
+          sid: sid,
+          host_id: host_id,
+          instance_number: instance_number,
+          features: "HDB|HDB_WORKER",
+          tenants: tenants
+        )
+
+      assert_events_and_state(
+        initial_events,
+        command,
+        [
+          %DatabaseInstanceDataMarkedInSync{
+            database_id: database_id,
+            instance_number: instance_number,
+            host_id: host_id
+          },
+          %DatabaseDataMarkedInSync{
+            database_id: database_id
+          }
+        ],
+        fn state ->
+          assert %Database{
+                   stale_at: nil,
+                   instances: [
+                     %Instance{
+                       instance_number: ^instance_number,
+                       stale_at: nil
+                     }
+                   ]
+                 } = state
+        end
+      )
+    end
+
+    test "should not mark database data as in sync when an instance is deregistered but more stale instances are present" do
+      database_id = Faker.UUID.v4()
+      sid = fake_sid()
+      host_id_1 = Faker.UUID.v4()
+      host_id_2 = Faker.UUID.v4()
+      host_id_3 = Faker.UUID.v4()
+      instance_number_1 = "00"
+      instance_number_2 = "01"
+      instance_number_3 = "02"
+      stale_at = DateTime.utc_now()
+      deregistered_at = DateTime.utc_now()
+
+      initial_events = [
+        build(:database_registered_event,
+          database_id: database_id,
+          sid: sid
+        ),
+        build(:database_instance_registered_event,
+          database_id: database_id,
+          sid: sid,
+          host_id: host_id_1,
+          instance_number: instance_number_1,
+          features: "HDB|HDB_WORKER"
+        ),
+        build(:database_instance_registered_event,
+          database_id: database_id,
+          sid: sid,
+          host_id: host_id_2,
+          instance_number: instance_number_2,
+          features: "HDB|HDB_WORKER"
+        ),
+        build(:database_instance_registered_event,
+          database_id: database_id,
+          sid: sid,
+          host_id: host_id_3,
+          instance_number: instance_number_3,
+          features: "HDB|HDB_WORKER"
+        ),
+        build(:database_instance_data_marked_stale_event,
+          database_id: database_id,
+          instance_number: instance_number_1,
+          host_id: host_id_1,
+          stale_at: stale_at
+        ),
+        build(:database_instance_data_marked_stale_event,
+          database_id: database_id,
+          instance_number: instance_number_3,
+          host_id: host_id_3,
+          stale_at: stale_at
+        ),
+        build(:database_data_marked_stale_event,
+          database_id: database_id,
+          stale_at: stale_at
+        )
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        %DeregisterDatabaseInstance{
+          database_id: database_id,
+          host_id: host_id_3,
+          instance_number: instance_number_3,
+          deregistered_at: deregistered_at
+        },
+        [
+          %DatabaseInstanceDeregistered{
+            database_id: database_id,
+            host_id: host_id_3,
+            instance_number: instance_number_3,
+            deregistered_at: deregistered_at
+          }
+        ],
+        fn state ->
+          assert %Database{
+                   stale_at: ^stale_at,
+                   deregistered_at: nil,
+                   instances: [
+                     %Instance{
+                       instance_number: ^instance_number_2,
+                       stale_at: nil
+                     },
+                     %Instance{
+                       instance_number: ^instance_number_1,
+                       stale_at: ^stale_at
+                     }
+                   ]
+                 } = state
+        end
+      )
+    end
+
+    test "should not mark database data as in sync when an instance is deregistered if the database was already in sync" do
+      database_id = Faker.UUID.v4()
+      sid = fake_sid()
+      host_id_1 = Faker.UUID.v4()
+      host_id_2 = Faker.UUID.v4()
+      host_id_3 = Faker.UUID.v4()
+      instance_number_1 = "00"
+      instance_number_2 = "01"
+      instance_number_3 = "02"
+      deregistered_at = DateTime.utc_now()
+
+      initial_events = [
+        build(:database_registered_event,
+          database_id: database_id,
+          sid: sid
+        ),
+        build(:database_instance_registered_event,
+          database_id: database_id,
+          sid: sid,
+          host_id: host_id_1,
+          instance_number: instance_number_1,
+          features: "HDB|HDB_WORKER"
+        ),
+        build(:database_instance_registered_event,
+          database_id: database_id,
+          sid: sid,
+          host_id: host_id_2,
+          instance_number: instance_number_2,
+          features: "HDB|HDB_WORKER"
+        ),
+        build(:database_instance_registered_event,
+          database_id: database_id,
+          sid: sid,
+          host_id: host_id_3,
+          instance_number: instance_number_3,
+          features: "HDB|HDB_WORKER"
+        )
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        %DeregisterDatabaseInstance{
+          database_id: database_id,
+          host_id: host_id_3,
+          instance_number: instance_number_3,
+          deregistered_at: deregistered_at
+        },
+        [
+          %DatabaseInstanceDeregistered{
+            database_id: database_id,
+            host_id: host_id_3,
+            instance_number: instance_number_3,
+            deregistered_at: deregistered_at
+          }
+        ],
+        fn state ->
+          assert %Database{
+                   stale_at: nil,
+                   deregistered_at: nil,
+                   instances: [
+                     %Instance{
+                       instance_number: ^instance_number_2,
+                       stale_at: nil
+                     },
+                     %Instance{
+                       instance_number: ^instance_number_1,
                        stale_at: nil
                      }
                    ]

--- a/test/trento/databases/database_test.exs
+++ b/test/trento/databases/database_test.exs
@@ -3033,15 +3033,15 @@ defmodule Trento.Databases.DatabaseTest do
           host_id: host_id_1,
           stale_at: stale_at
         ),
+        build(:database_data_marked_stale_event,
+          database_id: database_id,
+          stale_at: stale_at
+        ),
         build(:database_instance_data_marked_stale_event,
           database_id: database_id,
           instance_number: instance_number_3,
           host_id: host_id_3,
-          stale_at: stale_at
-        ),
-        build(:database_data_marked_stale_event,
-          database_id: database_id,
-          stale_at: stale_at
+          stale_at: DateTime.add(stale_at, 1, :day)
         )
       ]
 

--- a/test/trento/databases/projections/database_projector_test.exs
+++ b/test/trento/databases/projections/database_projector_test.exs
@@ -19,6 +19,8 @@ defmodule Trento.Databases.Projections.DatabaseProjectorTest do
   }
 
   alias Trento.Databases.Events.{
+    DatabaseDataMarkedInSync,
+    DatabaseDataMarkedStale,
     DatabaseDeregistered,
     DatabaseHealthChanged,
     DatabaseInstanceDataMarkedInSync,
@@ -611,6 +613,55 @@ defmodule Trento.Databases.Projections.DatabaseProjectorTest do
         instance_number: ^instance_number,
         host_id: ^host_id,
         database_id: ^database_id,
+        stale_at: nil
+      },
+      1000
+    )
+  end
+
+  test "should mark database data as stale when DatabaseDataMarkedStale event is received" do
+    %{id: database_id} = insert(:database, stale_at: nil)
+
+    stale_at = DateTime.utc_now()
+
+    event = %DatabaseDataMarkedStale{
+      database_id: database_id,
+      stale_at: stale_at
+    }
+
+    ProjectorTestHelper.project(DatabaseProjector, event, "database_projector")
+
+    database = Repo.get!(DatabaseReadModel, database_id)
+
+    assert database.stale_at == stale_at
+
+    assert_broadcast(
+      "database_stale_changed",
+      %{
+        id: ^database_id,
+        stale_at: ^stale_at
+      },
+      1000
+    )
+  end
+
+  test "should mark database data as fresh when DatabaseDataMarkedInSync event is received" do
+    %{id: database_id} = insert(:database, stale_at: DateTime.utc_now())
+
+    event = %DatabaseDataMarkedInSync{
+      database_id: database_id
+    }
+
+    ProjectorTestHelper.project(DatabaseProjector, event, "database_projector")
+
+    database = Repo.get!(DatabaseReadModel, database_id)
+
+    assert database.stale_at == nil
+
+    assert_broadcast(
+      "database_stale_changed",
+      %{
+        id: ^database_id,
         stale_at: nil
       },
       1000


### PR DESCRIPTION
### Description

Mark database data as stale. It is marked stale when at least one instance is stale.
It handles the scenario where database instances are removed, which cause a database data going in sync (stale instance removed).

I have chosen to add this logic in the aggregate itself, instead of doing some basic computation in the views as we need the reactiveness of the events to update the frontend accordingly.

### How was this tested?

UT

### Documentation changes

No