### PR TITLE
Gray out SR data header in database details view

### DIFF
--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
@@ -408,7 +408,7 @@ export function GenericSystemDetails({
           <h2 className="text-2xl font-bold self-center">Layout</h2>
         </div>
         {map(sitedInstances, (instances, site) => {
-          const instance = getActiveInstance(instances);
+          const activeInstance = getActiveInstance(instances);
           const isSiteStale = every(
             instances,
             ({ stale_at: staleAt }) => staleAt !== null
@@ -441,41 +441,45 @@ export function GenericSystemDetails({
                         <div className="flex space-x-2 mr-3">
                           <h3 className="text-l font-bold">{site}</h3>
                           <Pill className="bg-green-100 text-green-800 !py-0 items-center">
-                            {upperCase(instance.system_replication)}
+                            {upperCase(activeInstance.system_replication)}
                           </Pill>
                         </div>
                         <SystemReplicationDataPill
                           label="Tier"
-                          data={instance.system_replication_tier || '-'}
+                          data={activeInstance.system_replication_tier || '-'}
                         />
 
-                        {instance.system_replication === 'Primary' && (
+                        {activeInstance.system_replication === 'Primary' && (
                           <SystemReplicationDataPill
                             label="Status"
                             data={
-                              instance.system_replication_status || SR_INACTIVE
+                              activeInstance.system_replication_status ||
+                              SR_INACTIVE
                             }
                             className={getReplicationStatusClasses(
-                              instance.system_replication_status
+                              activeInstance.system_replication_status
                             )}
                           />
                         )}
-                        {instance.system_replication === 'Secondary' && (
+                        {activeInstance.system_replication === 'Secondary' && (
                           <>
                             <SystemReplicationDataPill
                               label="Replicating"
                               data={
-                                instance.system_replication_source_site || '-'
+                                activeInstance.system_replication_source_site ||
+                                '-'
                               }
                               className="bg-gray-200 text-gray-500 max-w-32 truncate !inline self-center !py-0.5"
                             />
                             <SystemReplicationDataPill
                               label="Replication Mode"
-                              data={instance.system_replication_mode}
+                              data={activeInstance.system_replication_mode}
                             />
                             <SystemReplicationDataPill
                               label="Operation Mode"
-                              data={instance.system_replication_operation_mode}
+                              data={
+                                activeInstance.system_replication_operation_mode
+                              }
                             />
                           </>
                         )}

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
@@ -17,6 +17,7 @@ import {
   overSome,
   isEmpty,
   every,
+  maxBy,
 } from 'lodash';
 
 import classNames from 'classnames';
@@ -45,6 +46,7 @@ import {
   getSapSystemType,
 } from '@lib/model/sapSystems';
 import { isSomeHostHeartbeatPassing } from '@lib/model/hosts';
+import { STALE_ROW } from '@lib/tables';
 
 import ListView from '@common/ListView';
 import Table from '@common/Table';
@@ -81,6 +83,11 @@ const getUniqueHosts = (hosts) =>
   );
 
 const mapInstancesHosts = (instances) => map(instances, ({ host }) => host);
+
+// Returns an active instance (stale_at === null) if available,
+// otherwise returns the most recently stale instance (highest stale_at)
+const getActiveInstance = (instances) =>
+  find(instances, ['stale_at', null]) || maxBy(instances, 'stale_at');
 
 // it includes SAP and HANA operations
 const instanceStartStopOperations = [SAP_INSTANCE_START, SAP_INSTANCE_STOP];
@@ -401,9 +408,13 @@ export function GenericSystemDetails({
           <h2 className="text-2xl font-bold self-center">Layout</h2>
         </div>
         {map(sitedInstances, (instances, site) => {
-          const instance = instances[0];
+          const instance = getActiveInstance(instances);
+          const isSiteStale = every(
+            instances,
+            ({ stale_at: staleAt }) => staleAt !== null
+          );
           return (
-            <div key={site} className="mt-4 bg-white rounded-lg">
+            <div key={site} className="mt-4 rounded-lg">
               <Table
                 config={getSystemInstancesTableConfiguration({
                   type,
@@ -417,7 +428,15 @@ export function GenericSystemDetails({
                 data={instances}
                 header={
                   hasSystemReplication && (
-                    <div className="flex py-4 px-5">
+                    <div
+                      className={classNames(
+                        'flex py-4 px-5 border-b border-gray-200 ',
+                        {
+                          [STALE_ROW]: isSiteStale,
+                          'bg-white': !isSiteStale,
+                        }
+                      )}
+                    >
                       <div className="flex w-11/12 space-x-3">
                         <div className="flex space-x-2 mr-3">
                           <h3 className="text-l font-bold">{site}</h3>

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
@@ -379,6 +379,7 @@ describe('GenericSystemDetails', () => {
     const siteTables = screen.getAllByRole('table');
     const { getByText } = within(siteTables[0].previousSibling);
 
+    expect(siteTables[0].previousSibling).toHaveClass('bg-white');
     expect(getByText('Tier').nextSibling).toHaveTextContent('1');
     expect(getByText('Status').nextSibling).toHaveTextContent('ACTIVE');
   });
@@ -419,6 +420,7 @@ describe('GenericSystemDetails', () => {
     const siteTables = screen.getAllByRole('table');
     const { getByText } = within(siteTables[0].previousSibling);
 
+    expect(siteTables[0].previousSibling).toHaveClass('bg-gray-100');
     expect(getByText('Tier').nextSibling).toHaveTextContent('2');
     expect(getByText('Status').nextSibling).toHaveTextContent('RECENT_STATUS');
   });

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
@@ -346,6 +346,83 @@ describe('GenericSystemDetails', () => {
     );
   });
 
+  it('should render System Replication data with active instance data', () => {
+    const database = databaseFactory.build({
+      hosts: hostFactory.buildList(2),
+      instances: [
+        databaseInstanceFactory.build({
+          system_replication: 'Primary',
+          system_replication_site: 'Site1',
+          system_replication_tier: 999,
+          system_replication_status: 'STALE_STATUS',
+          stale_at: faker.date.past().toISOString(),
+        }),
+        databaseInstanceFactory.build({
+          system_replication: 'Primary',
+          system_replication_site: 'Site1',
+          system_replication_tier: 1,
+          system_replication_status: 'ACTIVE',
+          stale_at: null,
+        }),
+      ],
+    });
+
+    renderWithRouter(
+      <GenericSystemDetails
+        title={faker.string.uuid()}
+        system={database}
+        type={DATABASE_TYPE}
+        getSiteOperations={getDatabaseSiteOperations}
+      />
+    );
+
+    const siteTables = screen.getAllByRole('table');
+    const { getByText } = within(siteTables[0].previousSibling);
+
+    expect(getByText('Tier').nextSibling).toHaveTextContent('1');
+    expect(getByText('Status').nextSibling).toHaveTextContent('ACTIVE');
+  });
+
+  it('should render System Replication data with newest stale instance data if all instances are stale', () => {
+    const olderDate = new Date('2024-01-01T10:00:00Z');
+    const newerDate = new Date('2024-01-02T10:00:00Z');
+
+    const database = databaseFactory.build({
+      hosts: hostFactory.buildList(2),
+      instances: [
+        databaseInstanceFactory.build({
+          system_replication: 'Primary',
+          system_replication_site: 'Site1',
+          system_replication_tier: 1,
+          system_replication_status: 'OLD_STATUS',
+          stale_at: olderDate.toISOString(),
+        }),
+        databaseInstanceFactory.build({
+          system_replication: 'Primary',
+          system_replication_site: 'Site1',
+          system_replication_tier: 2,
+          system_replication_status: 'RECENT_STATUS',
+          stale_at: newerDate.toISOString(),
+        }),
+      ],
+    });
+
+    renderWithRouter(
+      <GenericSystemDetails
+        title={faker.string.uuid()}
+        system={database}
+        type={DATABASE_TYPE}
+        getSiteOperations={getDatabaseSiteOperations}
+      />
+    );
+
+    const siteTables = screen.getAllByRole('table');
+    const { getByText } = within(siteTables[0].previousSibling);
+
+    expect(getByText('Tier').nextSibling).toHaveTextContent('2');
+    expect(getByText('Status').nextSibling).toHaveTextContent('RECENT_STATUS');
+  });
+
   it('should render hosts table', () => {
     const cluster = clusterFactory.build({ type: 'hana_scale_up' });
     const host = hostFactory.build({ cluster });


### PR DESCRIPTION
### Description

Gray out (stale) System replication header in Database details view.
Besides this, now, the data there is taken from the first not stale instance, and if all the instances are stale from the instance that got stale latest.

<img width="1252" height="433" alt="image" src="https://github.com/user-attachments/assets/7a6827c1-3136-4343-aa65-864d73ef8136" />

### How was this tested?

UT

### Documentation changes

No