### PR TITLE
Augmented HealthIcon with stale indications

### DIFF
--- a/assets/js/common/HealthIcon/HealthIcon.jsx
+++ b/assets/js/common/HealthIcon/HealthIcon.jsx
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
+import { capitalize } from 'lodash';
+
 import { computedIconCssClass } from '@lib/icon';
 
 import {
@@ -15,8 +17,17 @@ import {
   EOS_REMOVE_FILLED,
 } from 'eos-icons-react';
 
-import Spinner from '@common/Spinner';
 import classNames from 'classnames';
+import Spinner from '@common/Spinner';
+import StaleIconWrapper from '@common/StaleIconWrapper'
+
+const PassingIconBlank = StaleIconWrapper(EOS_CHECK_CIRCLE_OUTLINED);
+const PassingIconLink = StaleIconWrapper(EOS_CHECK_CIRCLE_FILLED);
+const WarningIconBlank = StaleIconWrapper(EOS_WARNING_OUTLINED);
+const WarningIconLink = StaleIconWrapper(EOS_WARNING_FILLED);
+const CriticalIconBlank = StaleIconWrapper(EOS_ERROR_OUTLINED);
+const CriticalIconLink = StaleIconWrapper(EOS_ERROR_FILLED);
+const UnknownIcon = StaleIconWrapper(EOS_LENS_FILLED);
 
 function HealthIcon({
   health = undefined,
@@ -24,55 +35,61 @@ function HealthIcon({
   hoverOpacity = true,
   size = 'l',
   isLink = false,
+  staleAt = null
 }) {
-  const passingIcon = () =>
-    isLink ? EOS_CHECK_CIRCLE_FILLED : EOS_CHECK_CIRCLE_OUTLINED;
-  const PassingIcon = passingIcon();
-
-  const warningIcon = () =>
-    isLink ? EOS_WARNING_FILLED : EOS_WARNING_OUTLINED;
-  const WarningIcon = warningIcon();
-
-  const criticalIcon = () => (isLink ? EOS_ERROR_FILLED : EOS_ERROR_OUTLINED);
-  const CriticalIcon = criticalIcon();
-
   const hoverOpacityClass = {
     'hover:opacity-75': hoverOpacity,
     'hover:opacity-100': !hoverOpacity,
   };
+
   switch (health) {
     case 'passing':
+      const PassingIcon = isLink ? PassingIconLink : PassingIconBlank;
       return (
         <PassingIcon
-          size={size}
           className={classNames(
             hoverOpacityClass,
             computedIconCssClass('fill-jungle-green-500', centered)
           )}
+          size={size}
+          staleAt={staleAt}
+          timezone={"Etc/UTC"}
+          tooltipText={capitalize(health)}
         />
       );
+
     case 'warning':
+      const WarningIcon = isLink ? WarningIconLink : WarningIconBlank;
       return (
         <WarningIcon
-          size={size}
           className={classNames(
             hoverOpacityClass,
             computedIconCssClass('fill-yellow-500', centered)
           )}
+          size={size}
+          staleAt={staleAt}
+          timezone={"Etc/UTC"}
+          tooltipText={capitalize(health)}
         />
       );
+
     case 'critical':
+      const CriticalIcon = isLink ? CriticalIconLink : CriticalIconBlank
       return (
         <CriticalIcon
-          size={size}
           className={classNames(
             hoverOpacityClass,
             computedIconCssClass('fill-red-500', centered)
           )}
+          size={size}
+          staleAt={staleAt}
+          timezone={"Etc/UTC"}
+          tooltipText={capitalize(health)}
         />
       );
     case 'pending':
       return <Spinner />;
+
     case 'not_available':
       return (
         <EOS_REMOVE_FILLED
@@ -83,17 +100,21 @@ function HealthIcon({
           )}
         />
       );
+
     default:
       return (
-        <EOS_LENS_FILLED
-          size={size}
+        <UnknownIcon
           className={classNames(
             hoverOpacityClass,
             computedIconCssClass('fill-gray-500', centered)
           )}
+          size={size}
+          staleAt={staleAt}
+          timezone={"Etc/UTC"}
+          tooltipText={capitalize(health)}
         />
       );
-  }
+  };
 }
 
 export default HealthIcon;

--- a/assets/js/common/HealthIcon/HealthIcon.jsx
+++ b/assets/js/common/HealthIcon/HealthIcon.jsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { capitalize } from 'lodash';
 
 import { computedIconCssClass } from '@lib/icon';
 
@@ -36,7 +35,7 @@ function HealthIcon({
   size = 'l',
   isLink = false,
   staleAt = null,
-  timezone = 'Etc/UTC'
+  timezone = 'Etc/UTC',
 }) {
   const hoverOpacityClass = {
     'hover:opacity-75': hoverOpacity,

--- a/assets/js/common/HealthIcon/HealthIcon.jsx
+++ b/assets/js/common/HealthIcon/HealthIcon.jsx
@@ -19,7 +19,7 @@ import {
 
 import classNames from 'classnames';
 import Spinner from '@common/Spinner';
-import StaleIconWrapper from '@common/StaleIconWrapper'
+import StaleIconWrapper from '@common/StaleIconWrapper';
 
 const PassingIconBlank = StaleIconWrapper(EOS_CHECK_CIRCLE_OUTLINED);
 const PassingIconLink = StaleIconWrapper(EOS_CHECK_CIRCLE_FILLED);
@@ -35,7 +35,7 @@ function HealthIcon({
   hoverOpacity = true,
   size = 'l',
   isLink = false,
-  staleAt = null
+  staleAt = null,
 }) {
   const hoverOpacityClass = {
     'hover:opacity-75': hoverOpacity,
@@ -53,7 +53,7 @@ function HealthIcon({
           )}
           size={size}
           staleAt={staleAt}
-          timezone={"Etc/UTC"}
+          timezone={'Etc/UTC'}
           tooltipText={capitalize(health)}
         />
       );
@@ -68,13 +68,13 @@ function HealthIcon({
           )}
           size={size}
           staleAt={staleAt}
-          timezone={"Etc/UTC"}
+          timezone={'Etc/UTC'}
           tooltipText={capitalize(health)}
         />
       );
 
     case 'critical':
-      const CriticalIcon = isLink ? CriticalIconLink : CriticalIconBlank
+      const CriticalIcon = isLink ? CriticalIconLink : CriticalIconBlank;
       return (
         <CriticalIcon
           className={classNames(
@@ -83,7 +83,7 @@ function HealthIcon({
           )}
           size={size}
           staleAt={staleAt}
-          timezone={"Etc/UTC"}
+          timezone={'Etc/UTC'}
           tooltipText={capitalize(health)}
         />
       );
@@ -110,11 +110,11 @@ function HealthIcon({
           )}
           size={size}
           staleAt={staleAt}
-          timezone={"Etc/UTC"}
+          timezone={'Etc/UTC'}
           tooltipText={capitalize(health)}
         />
       );
-  };
+  }
 }
 
 export default HealthIcon;

--- a/assets/js/common/HealthIcon/HealthIcon.jsx
+++ b/assets/js/common/HealthIcon/HealthIcon.jsx
@@ -36,6 +36,7 @@ function HealthIcon({
   size = 'l',
   isLink = false,
   staleAt = null,
+  timezone = 'Etc/UTC'
 }) {
   const hoverOpacityClass = {
     'hover:opacity-75': hoverOpacity,
@@ -53,7 +54,7 @@ function HealthIcon({
           )}
           size={size}
           staleAt={staleAt}
-          timezone={'Etc/UTC'}
+          timezone={timezone}
           tooltipEnabled={!!staleAt}
         />
       );
@@ -69,7 +70,7 @@ function HealthIcon({
           )}
           size={size}
           staleAt={staleAt}
-          timezone={'Etc/UTC'}
+          timezone={timezone}
           tooltipEnabled={!!staleAt}
         />
       );
@@ -85,7 +86,7 @@ function HealthIcon({
           )}
           size={size}
           staleAt={staleAt}
-          timezone={'Etc/UTC'}
+          timezone={timezone}
           tooltipEnabled={!!staleAt}
         />
       );
@@ -116,7 +117,7 @@ function HealthIcon({
           )}
           size={size}
           staleAt={staleAt}
-          timezone={'Etc/UTC'}
+          timezone={timezone}
           tooltipEnabled={!!staleAt}
         />
       );

--- a/assets/js/common/HealthIcon/HealthIcon.jsx
+++ b/assets/js/common/HealthIcon/HealthIcon.jsx
@@ -43,7 +43,7 @@ function HealthIcon({
   };
 
   switch (health) {
-    case 'passing':
+    case 'passing': {
       const PassingIcon = isLink ? PassingIconLink : PassingIconBlank;
       return (
         <PassingIcon
@@ -57,8 +57,9 @@ function HealthIcon({
           tooltipText={capitalize(health)}
         />
       );
+    }
 
-    case 'warning':
+    case 'warning': {
       const WarningIcon = isLink ? WarningIconLink : WarningIconBlank;
       return (
         <WarningIcon
@@ -72,8 +73,9 @@ function HealthIcon({
           tooltipText={capitalize(health)}
         />
       );
+    }
 
-    case 'critical':
+    case 'critical': {
       const CriticalIcon = isLink ? CriticalIconLink : CriticalIconBlank;
       return (
         <CriticalIcon
@@ -87,10 +89,13 @@ function HealthIcon({
           tooltipText={capitalize(health)}
         />
       );
-    case 'pending':
-      return <Spinner />;
+    }
 
-    case 'not_available':
+    case 'pending': {
+      return <Spinner />;
+    }
+
+    case 'not_available': {
       return (
         <EOS_REMOVE_FILLED
           size={size}
@@ -100,8 +105,9 @@ function HealthIcon({
           )}
         />
       );
+    }
 
-    default:
+    default: {
       return (
         <UnknownIcon
           className={classNames(
@@ -114,6 +120,7 @@ function HealthIcon({
           tooltipText={capitalize(health)}
         />
       );
+    }
   }
 }
 

--- a/assets/js/common/HealthIcon/HealthIcon.jsx
+++ b/assets/js/common/HealthIcon/HealthIcon.jsx
@@ -54,7 +54,7 @@ function HealthIcon({
           size={size}
           staleAt={staleAt}
           timezone={'Etc/UTC'}
-          tooltipText={capitalize(health)}
+          tooltipEnabled={!!staleAt}
         />
       );
     }
@@ -70,7 +70,7 @@ function HealthIcon({
           size={size}
           staleAt={staleAt}
           timezone={'Etc/UTC'}
-          tooltipText={capitalize(health)}
+          tooltipEnabled={!!staleAt}
         />
       );
     }
@@ -86,7 +86,7 @@ function HealthIcon({
           size={size}
           staleAt={staleAt}
           timezone={'Etc/UTC'}
-          tooltipText={capitalize(health)}
+          tooltipEnabled={!!staleAt}
         />
       );
     }
@@ -117,7 +117,7 @@ function HealthIcon({
           size={size}
           staleAt={staleAt}
           timezone={'Etc/UTC'}
-          tooltipText={capitalize(health)}
+          tooltipEnabled={!!staleAt}
         />
       );
     }

--- a/assets/js/common/HealthIcon/HealthIcon.stories.jsx
+++ b/assets/js/common/HealthIcon/HealthIcon.stories.jsx
@@ -46,6 +46,12 @@ export default {
       description: 'Whether to icon is a link or not',
       control: { type: 'boolean' },
     },
+    timezone: {
+      description: 'Timezone for displaying the stale timestamp',
+      control: {
+        type: 'text',
+      },
+    },
   },
 };
 

--- a/assets/js/common/HealthIcon/HealthIcon.stories.jsx
+++ b/assets/js/common/HealthIcon/HealthIcon.stories.jsx
@@ -37,8 +37,7 @@ export default {
       },
     },
     staleAt: {
-      description:
-        'Timestamp when the host became stale (null if not stale)',
+      description: 'Timestamp when the host became stale (null if not stale)',
       control: {
         type: 'text',
       },
@@ -65,7 +64,7 @@ export const LargeStaleUnknown = {
   args: {
     health: 'unknown',
     staleAt: '2026-06-15T10:30:00Z',
-    size: 'xl'
+    size: 'xl',
   },
 };
 

--- a/assets/js/common/HealthIcon/HealthIcon.stories.jsx
+++ b/assets/js/common/HealthIcon/HealthIcon.stories.jsx
@@ -36,6 +36,13 @@ export default {
         defaultValue: { summary: 'l' },
       },
     },
+    staleAt: {
+      description:
+        'Timestamp when the host became stale (null if not stale)',
+      control: {
+        type: 'text',
+      },
+    },
     isLink: {
       description: 'Whether to icon is a link or not',
       control: { type: 'boolean' },
@@ -47,16 +54,52 @@ export const Default = {
   args: { health: 'unknown' },
 };
 
+export const StaleUnknown = {
+  args: {
+    health: 'unknown',
+    staleAt: '2026-06-15T10:30:00Z',
+  },
+};
+
+export const LargeStaleUnknown = {
+  args: {
+    health: 'unknown',
+    staleAt: '2026-06-15T10:30:00Z',
+    size: 'xl'
+  },
+};
+
 export const Passing = {
   args: { health: 'passing' },
+};
+
+export const StalePassing = {
+  args: {
+    health: 'passing',
+    staleAt: '2026-06-15T10:30:00Z',
+  },
 };
 
 export const Warning = {
   args: { health: 'warning' },
 };
 
+export const StaleWarning = {
+  args: {
+    health: 'warning',
+    staleAt: '2026-06-15T10:30:00Z',
+  },
+};
+
 export const Critical = {
   args: { health: 'critical' },
+};
+
+export const StaleCritical = {
+  args: {
+    health: 'critical',
+    staleAt: '2026-06-15T10:30:00Z',
+  },
 };
 
 export const Pending = {

--- a/assets/js/common/HealthIcon/HealthIcon.stories.jsx
+++ b/assets/js/common/HealthIcon/HealthIcon.stories.jsx
@@ -78,6 +78,13 @@ export const Passing = {
   args: { health: 'passing' },
 };
 
+export const LinkPassing = {
+  args: {
+    health: 'passing',
+    isLink: true,
+  },
+};
+
 export const StalePassing = {
   args: {
     health: 'passing',
@@ -89,6 +96,13 @@ export const Warning = {
   args: { health: 'warning' },
 };
 
+export const LinkWarning = {
+  args: {
+    health: 'warning',
+    isLink: true,
+  },
+};
+
 export const StaleWarning = {
   args: {
     health: 'warning',
@@ -98,6 +112,13 @@ export const StaleWarning = {
 
 export const Critical = {
   args: { health: 'critical' },
+};
+
+export const LinkCritical = {
+  args: {
+    health: 'critical',
+    isLink: true,
+  },
 };
 
 export const StaleCritical = {

--- a/assets/js/common/HealthIcon/HealthIcon.test.jsx
+++ b/assets/js/common/HealthIcon/HealthIcon.test.jsx
@@ -131,7 +131,7 @@ describe('HealthIcon', () => {
       const healthSvg = svgs[0];
       await user.hover(healthSvg);
 
-      const tooltip = document.querySelector(".rc-tooltip");
+      const tooltip = document.querySelector('.rc-tooltip');
       expect(tooltip).toBeInTheDocument();
       expect(tooltip).toHaveTextContent('Stale since 15 Jun 2026, 10:30:00');
     }
@@ -153,7 +153,7 @@ describe('HealthIcon', () => {
       const healthSvg = screen.getByTestId('eos-svg-component');
       await user.hover(healthSvg);
 
-      const tooltip = document.querySelector(".rc-tooltip");
+      const tooltip = document.querySelector('.rc-tooltip');
       expect(tooltip).not.toBeInTheDocument();
     }
   );

--- a/assets/js/common/HealthIcon/HealthIcon.test.jsx
+++ b/assets/js/common/HealthIcon/HealthIcon.test.jsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
 import HealthIcon from '.';
@@ -112,6 +113,48 @@ describe('HealthIcon', () => {
         SCHEDULE_OUTLINED
       );
       expect(svgs[1]).toHaveClass(cssColor);
+    }
+  );
+
+  it.each([
+    { health: 'passing' },
+    { health: 'warning' },
+    { health: 'critical' },
+    { health: 'unknown' },
+  ])(
+    'shows a tooltip with staleAt timestamp for $health health',
+    async ({ health }) => {
+      const user = userEvent.setup();
+      render(<HealthIcon health={health} staleAt="2026-06-15T10:30:00Z" />);
+
+      const svgs = screen.getAllByTestId('eos-svg-component');
+      const healthSvg = svgs[0];
+      await user.hover(healthSvg);
+
+      const tooltip = document.querySelector(".rc-tooltip");
+      expect(tooltip).toBeInTheDocument();
+      expect(tooltip).toHaveTextContent('Stale since 15 Jun 2026, 10:30:00');
+    }
+  );
+
+  it.each([
+    { health: 'passing' },
+    { health: 'warning' },
+    { health: 'critical' },
+    { health: 'unknown' },
+    { health: 'not_available' },
+    { health: 'pending' },
+  ])(
+    "does not show a tooltip for $health health when it's not stale",
+    async ({ health }) => {
+      const user = userEvent.setup();
+      render(<HealthIcon health={health} />);
+
+      const healthSvg = screen.getByTestId('eos-svg-component');
+      await user.hover(healthSvg);
+
+      const tooltip = document.querySelector(".rc-tooltip");
+      expect(tooltip).not.toBeInTheDocument();
     }
   );
 

--- a/assets/js/common/HealthIcon/HealthIcon.test.jsx
+++ b/assets/js/common/HealthIcon/HealthIcon.test.jsx
@@ -2,48 +2,136 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import HealthIcon from '.';
 
+const PASSING_OUTLINED =
+  'M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm4.59-12.42L10 14.17l-2.59-2.58L6 13l4 4 8-8z';
+const PASSING_FILLED =
+  'M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z';
+const WARNING_OUTLINED =
+  'M12 5.99L19.53 19H4.47L12 5.99M12 2L1 21h22L12 2zm1 14h-2v2h2v-2zm0-6h-2v4h2v-4z';
+const WARNING_FILLED = 'M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z';
+const CRITICAL_OUTLINED =
+  'M11 15h2v2h-2v-2zm0-8h2v6h-2V7zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z';
+const CRITICAL_FILLED =
+  'M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z';
+const PENDING =
+  'M12,2A10,10,0,1,0,22,12,10,10,0,0,0,12,2Zm0,18a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z';
+const UNKNOWN =
+  'M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z';
+const NOT_AVAILABLE = 'M19 13H5v-2h14v2z';
+const SCHEDULE_OUTLINED =
+  'M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm.5-13H11v6l5.25 3.15.75-1.23-4.5-2.67z';
+
 describe('HealthIcon', () => {
-  it('should display a green svg when the health is passing', () => {
-    const { container } = render(<HealthIcon health="passing" />);
-    const svgEl = container.querySelector("[data-testid='eos-svg-component']");
-    expect(svgEl.classList.toString()).toContain(
-      'hover:opacity-75 fill-jungle-green-500'
-    );
-    expect(svgEl).toHaveAttribute('width', '24');
-  });
-  it('should display a yellow svg when the health is warning', () => {
-    const { container } = render(<HealthIcon health="warning" />);
-    const svgEl = container.querySelector("[data-testid='eos-svg-component']");
-    expect(svgEl.classList.toString()).toContain('fill-yellow-500');
-  });
-  it('should display a red svg when the health is critical', () => {
-    const { container } = render(<HealthIcon health="critical" />);
-    const svgEl = container.querySelector("[data-testid='eos-svg-component']");
-    expect(svgEl.classList.toString()).toContain('fill-red-500');
-  });
-  it('should display a grey circle when the health is unknown', () => {
-    const { container } = render(<HealthIcon health="" />);
-    const svgEl = container.querySelector("[data-testid='eos-svg-component']");
-    expect(svgEl.classList.toString()).toContain('fill-gray-500');
-  });
-  it('should display a gray dash icon when the health is not available', () => {
-    const { container } = render(<HealthIcon health="not_available" />);
-    const svgEl = container.querySelector("[data-testid='eos-svg-component']");
-    expect(svgEl.classList.toString()).toContain('fill-gray-500');
-  });
-  it('should display an svg without hovering effect', () => {
-    const { container } = render(<HealthIcon health="" hoverOpacity={false} />);
-    const svgEl = container.querySelector("[data-testid='eos-svg-component']");
-    expect(svgEl.classList.toString()).toContain('hover:opacity-100');
-  });
+  it.each([
+    {
+      health: 'passing',
+      isLink: false,
+      icon: PASSING_OUTLINED,
+      cssColor: 'fill-jungle-green-500',
+    },
+    {
+      health: 'passing',
+      isLink: true,
+      icon: PASSING_FILLED,
+      cssColor: 'fill-jungle-green-500',
+    },
+    {
+      health: 'warning',
+      isLink: false,
+      icon: WARNING_OUTLINED,
+      cssColor: 'fill-yellow-500',
+    },
+    {
+      health: 'warning',
+      isLink: true,
+      icon: WARNING_FILLED,
+      cssColor: 'fill-yellow-500',
+    },
+    {
+      health: 'critical',
+      isLink: false,
+      icon: CRITICAL_OUTLINED,
+      cssColor: 'fill-red-500',
+    },
+    {
+      health: 'critical',
+      isLink: true,
+      icon: CRITICAL_FILLED,
+      cssColor: 'fill-red-500',
+    },
+    // For the following the value of `isLink` doesn't matter.
+    {
+      health: 'unknown',
+      isLink: false,
+      icon: UNKNOWN,
+      cssColor: 'fill-gray-500',
+    },
+    {
+      health: 'not_available',
+      isLink: false,
+      icon: NOT_AVAILABLE,
+      cssColor: 'fill-gray-500',
+    },
+    {
+      health: 'pending',
+      isLink: false,
+      icon: PENDING,
+      cssColor: 'fill-jungle-green-500',
+    },
+  ])(
+    'renders $health with correct icon and color (isLink: $isLink)',
+    ({ health, icon, cssColor, isLink }) => {
+      render(<HealthIcon health={health} isLink={isLink} />);
+
+      const svg = screen.getByTestId('eos-svg-component');
+      expect(svg).toBeInTheDocument();
+      expect(svg).toHaveClass(cssColor);
+      expect(svg.querySelector('path')).toHaveAttribute('d', icon);
+    }
+  );
+
+  it.each([
+    { health: 'passing', cssColor: 'fill-jungle-green-500' },
+    { health: 'warning', cssColor: 'fill-yellow-500' },
+    { health: 'critical', cssColor: 'fill-red-500' },
+    { health: 'unknown', cssColor: 'fill-gray-500' },
+  ])(
+    'renders stale $health health with correct icon and color',
+    ({ health, cssColor }) => {
+      render(<HealthIcon health={health} staleAt="2026-06-15T10:30:00Z" />);
+
+      const svgs = screen.getAllByTestId('eos-svg-component');
+      expect(svgs).toHaveLength(2);
+      expect(svgs[1].querySelector('path')).toHaveAttribute(
+        'd',
+        SCHEDULE_OUTLINED
+      );
+      expect(svgs[1]).toHaveClass(cssColor);
+    }
+  );
+
+  it.each([
+    { hoverOpacity: true, cssClass: 'hover:opacity-75' },
+    { hoverOpacity: false, cssClass: 'hover:opacity-100' },
+  ])(
+    'has the right opacity on hover when the corresponding property is $hoverOpacity',
+    ({ hoverOpacity, cssClass }) => {
+      render(<HealthIcon health="passing" hoverOpacity={hoverOpacity} />);
+
+      const svg = screen.getByTestId('eos-svg-component');
+      expect(svg).toHaveClass(cssClass);
+    }
+  );
+
   it('should display the icon with the applied size', () => {
-    const { container } = render(<HealthIcon health="passing" size="m" />);
-    const svgEl = container.querySelector("[data-testid='eos-svg-component']");
-    expect(svgEl).toHaveAttribute('width', '18');
+    render(<HealthIcon health="passing" size="m" />);
+
+    const svg = screen.getByTestId('eos-svg-component');
+    expect(svg).toHaveAttribute('width', '18');
   });
 });

--- a/assets/js/common/StaleIconWrapper/StaleIconWrapper.jsx
+++ b/assets/js/common/StaleIconWrapper/StaleIconWrapper.jsx
@@ -22,6 +22,7 @@ import Tooltip from '@common/Tooltip';
 function StaleIconWrapper(WrappedIcon) {
   function StaleAugmentedHealthIcon({
     staleAt,
+    tooltipEnabled = true,
     tooltipText = "",
     timezone = 'Etc/UTC',
     size = "m",
@@ -35,18 +36,14 @@ function StaleIconWrapper(WrappedIcon) {
     const tooltipContent = (
       <span className="block text-center">
         {tooltipText}
-        {staleAt && (
-          <>
-            <br />
-            (Stale since {formatDateTime(staleAt, timezone)})
-          </>
-        )}
+        {staleAt && tooltipText && <br />}
+        {staleAt && <>Stale since {formatDateTime(staleAt, timezone)}</>}
       </span>
     );
 
     return (
       <div className="flex items-center mx-1">
-        <Tooltip content={tooltipContent} place="top" isEanbled wrap={false}>
+        <Tooltip content={tooltipContent} place="top" isEnabled={tooltipEnabled} wrap={false}>
           <div className="relative">
             <WrappedIcon
               size={convertedSize}

--- a/assets/js/common/StaleIconWrapper/StaleIconWrapper.jsx
+++ b/assets/js/common/StaleIconWrapper/StaleIconWrapper.jsx
@@ -37,9 +37,9 @@ function StaleIconWrapper(WrappedIcon) {
       <span className="block text-center">
         {tooltipText}
         {staleAt && tooltipText && <br />}
-        {staleAt && tooltipText && "("}
+        {staleAt && tooltipText && '('}
         {staleAt && `Stale since ${formatDateTime(staleAt, timezone)}`}
-        {staleAt && tooltipText && ")"}
+        {staleAt && tooltipText && ')'}
       </span>
     );
 

--- a/assets/js/common/StaleIconWrapper/StaleIconWrapper.jsx
+++ b/assets/js/common/StaleIconWrapper/StaleIconWrapper.jsx
@@ -22,10 +22,10 @@ import Tooltip from '@common/Tooltip';
 function StaleIconWrapper(WrappedIcon) {
   function StaleAugmentedHealthIcon({
     staleAt,
-    timezone,
-    tooltipText,
-    className,
-    size,
+    tooltipText = "",
+    timezone = 'Etc/UTC',
+    size = "m",
+    className = "",
     ...props
   }) {
     const convertedSize = getIconSize(size);

--- a/assets/js/common/StaleIconWrapper/StaleIconWrapper.jsx
+++ b/assets/js/common/StaleIconWrapper/StaleIconWrapper.jsx
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { EOS_SCHEDULE_OUTLINED } from 'eos-icons-react';
+
+import { getIconSize } from '@lib/icon';
+import { formatDateTime } from '@lib/timezones';
+import Tooltip from '@common/Tooltip';
+
+/**
+ * Augments an Icon component with stale data capabilities.
+ *
+ * If `staleAt` parameter is not falsey, then an additional icon is
+ * added signifying that the state indicated by the original icon is
+ * stale.  In addition to that, this component adds a Tooltip showing
+ * since when the state is stale. The timezone for the staleness
+ * message needs to be provided with the `timezone` property. The text
+ * before the staleness info can be configured by `tooltipText`
+ * property.
+ */
+function StaleIconWrapper(WrappedIcon) {
+  function StaleAugmentedHealthIcon({ staleAt, timezone, tooltipText, className, size, ...props }) {
+    const convertedSize = getIconSize(size)
+    const fillColor = className.split(' ').find(cls => cls.startsWith('fill-')) ?? 'fill-gray-500'
+    const tooltipContent = (
+      <span className="block text-center">
+        {tooltipText}
+        {staleAt && (
+          <>
+            <br />
+            (Stale since {formatDateTime(staleAt, timezone)})
+          </>
+        )}
+      </span>
+    );
+
+    return (
+      <div className="flex items-center mx-1">
+        <Tooltip content={tooltipContent} place='top' isEanbled wrap={false}>
+          <div className="relative">
+            <WrappedIcon size={convertedSize} className={className} {...props} />
+            {staleAt && <EOS_SCHEDULE_OUTLINED size={convertedSize * 0.7} className={`${fillColor} absolute overflow-visible bottom-0 right-0 translate-x-1/4 translate-y-1/4 bg-white rounded-full`} />}
+          </div>
+        </Tooltip>
+      </div>
+    )
+  }
+
+  return StaleAugmentedHealthIcon
+}
+
+export default StaleIconWrapper

--- a/assets/js/common/StaleIconWrapper/StaleIconWrapper.jsx
+++ b/assets/js/common/StaleIconWrapper/StaleIconWrapper.jsx
@@ -23,10 +23,10 @@ function StaleIconWrapper(WrappedIcon) {
   function StaleAugmentedHealthIcon({
     staleAt,
     tooltipEnabled = true,
-    tooltipText = "",
+    tooltipText = '',
     timezone = 'Etc/UTC',
-    size = "m",
-    className = "",
+    size = 'm',
+    className = '',
     ...props
   }) {
     const convertedSize = getIconSize(size);
@@ -43,7 +43,12 @@ function StaleIconWrapper(WrappedIcon) {
 
     return (
       <div className="flex items-center mx-1">
-        <Tooltip content={tooltipContent} place="top" isEnabled={tooltipEnabled} wrap={false}>
+        <Tooltip
+          content={tooltipContent}
+          place="top"
+          isEnabled={tooltipEnabled}
+          wrap={false}
+        >
           <div className="relative">
             <WrappedIcon
               size={convertedSize}

--- a/assets/js/common/StaleIconWrapper/StaleIconWrapper.jsx
+++ b/assets/js/common/StaleIconWrapper/StaleIconWrapper.jsx
@@ -20,9 +20,18 @@ import Tooltip from '@common/Tooltip';
  * property.
  */
 function StaleIconWrapper(WrappedIcon) {
-  function StaleAugmentedHealthIcon({ staleAt, timezone, tooltipText, className, size, ...props }) {
-    const convertedSize = getIconSize(size)
-    const fillColor = className.split(' ').find(cls => cls.startsWith('fill-')) ?? 'fill-gray-500'
+  function StaleAugmentedHealthIcon({
+    staleAt,
+    timezone,
+    tooltipText,
+    className,
+    size,
+    ...props
+  }) {
+    const convertedSize = getIconSize(size);
+    const fillColor =
+      className.split(' ').find((cls) => cls.startsWith('fill-')) ??
+      'fill-gray-500';
     const tooltipContent = (
       <span className="block text-center">
         {tooltipText}
@@ -37,17 +46,26 @@ function StaleIconWrapper(WrappedIcon) {
 
     return (
       <div className="flex items-center mx-1">
-        <Tooltip content={tooltipContent} place='top' isEanbled wrap={false}>
+        <Tooltip content={tooltipContent} place="top" isEanbled wrap={false}>
           <div className="relative">
-            <WrappedIcon size={convertedSize} className={className} {...props} />
-            {staleAt && <EOS_SCHEDULE_OUTLINED size={convertedSize * 0.7} className={`${fillColor} absolute overflow-visible bottom-0 right-0 translate-x-1/4 translate-y-1/4 bg-white rounded-full`} />}
+            <WrappedIcon
+              size={convertedSize}
+              className={className}
+              {...props}
+            />
+            {staleAt && (
+              <EOS_SCHEDULE_OUTLINED
+                size={convertedSize * 0.7}
+                className={`${fillColor} absolute overflow-visible bottom-0 right-0 translate-x-1/4 translate-y-1/4 bg-white rounded-full`}
+              />
+            )}
           </div>
         </Tooltip>
       </div>
-    )
+    );
   }
 
-  return StaleAugmentedHealthIcon
+  return StaleAugmentedHealthIcon;
 }
 
-export default StaleIconWrapper
+export default StaleIconWrapper;

--- a/assets/js/common/StaleIconWrapper/StaleIconWrapper.jsx
+++ b/assets/js/common/StaleIconWrapper/StaleIconWrapper.jsx
@@ -37,7 +37,9 @@ function StaleIconWrapper(WrappedIcon) {
       <span className="block text-center">
         {tooltipText}
         {staleAt && tooltipText && <br />}
-        {staleAt && <>Stale since {formatDateTime(staleAt, timezone)}</>}
+        {staleAt && tooltipText && "("}
+        {staleAt && `Stale since ${formatDateTime(staleAt, timezone)}`}
+        {staleAt && tooltipText && ")"}
       </span>
     );
 

--- a/assets/js/common/StaleIconWrapper/index.js
+++ b/assets/js/common/StaleIconWrapper/index.js
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-import StaleIconWrapper from './StaleIconWrapper'
+import StaleIconWrapper from './StaleIconWrapper';
 
-export default StaleIconWrapper
+export default StaleIconWrapper;

--- a/assets/js/common/StaleIconWrapper/index.js
+++ b/assets/js/common/StaleIconWrapper/index.js
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import StaleIconWrapper from './StaleIconWrapper'
+
+export default StaleIconWrapper

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
@@ -146,7 +146,9 @@ describe('GenericSystemDetails', () => {
       `/databases/${sapSystem.database_id}`
     );
     expect(
-      screen.getByText('Database health').nextSibling.firstChild
+      within(screen.getByText('Database health').nextSibling).getByTestId(
+        'eos-svg-component'
+      )
     ).toHaveClass('fill-jungle-green-500');
     expect(screen.getByText('Tenant').nextSibling).toHaveTextContent(
       sapSystem.tenant

--- a/test/e2e/cypress/pageObject/saptune_details_po.js
+++ b/test/e2e/cypress/pageObject/saptune_details_po.js
@@ -28,13 +28,13 @@ const notFoundContainer = 'div[class="py-4"]';
 const saptunePackageVersion = 'div:contains("Package") + div span span';
 const saptuneConfiguredVersion =
   'div div[class*="bold"]:contains("Configured Version") + div span';
-const saptuneTuningStatus = 'div:contains("Tuning") + div svg + span';
+const saptuneTuningStatus = 'div:contains("Tuning") + div span';
 const saptuneService =
-  'div[class*="bold"]:contains("saptune.service") + div svg + span';
+  'div[class*="bold"]:contains("saptune.service") + div span';
 const sapConf =
-  'div[class*="bold"]:contains("sapconf.service") + div svg + span';
+  'div[class*="bold"]:contains("sapconf.service") + div span';
 const tunedService =
-  'div[class*="bold"]:contains("tuned.service") + div svg + span';
+  'div[class*="bold"]:contains("tuned.service") + div span';
 const enabledSolutionSelector =
   'div div[class*="bold"]:contains("Enabled Solution") + div span span';
 const saptuneAppliedSolution =

--- a/test/e2e/cypress/pageObject/saptune_details_po.js
+++ b/test/e2e/cypress/pageObject/saptune_details_po.js
@@ -31,10 +31,8 @@ const saptuneConfiguredVersion =
 const saptuneTuningStatus = 'div:contains("Tuning") + div span';
 const saptuneService =
   'div[class*="bold"]:contains("saptune.service") + div span';
-const sapConf =
-  'div[class*="bold"]:contains("sapconf.service") + div span';
-const tunedService =
-  'div[class*="bold"]:contains("tuned.service") + div span';
+const sapConf = 'div[class*="bold"]:contains("sapconf.service") + div span';
+const tunedService = 'div[class*="bold"]:contains("tuned.service") + div span';
 const enabledSolutionSelector =
   'div div[class*="bold"]:contains("Enabled Solution") + div span span';
 const saptuneAppliedSolution =

--- a/test/e2e/cypress/pageObject/saptune_details_po.js
+++ b/test/e2e/cypress/pageObject/saptune_details_po.js
@@ -62,19 +62,19 @@ export const hasExpectedConfiguredVersion = () =>
   cy.get(saptuneConfiguredVersion).should('have.text', configuredVersion);
 
 export const hasExpectedTuning = () =>
-  cy.get(saptuneTuningStatus).should('have.text', 'No tuning');
+  cy.get(saptuneTuningStatus).first().should('have.text', 'No tuning');
 
 export const hasExpectedServiceStatus = () =>
-  cy.get(saptuneService).should('have.text', saptuneServiceStatus);
+  cy.get(saptuneService).first().should('have.text', saptuneServiceStatus);
 
 export const hasExpectedSapConf = () =>
-  cy.get(sapConf).should('have.text', sapconfServiceStatus);
+  cy.get(sapConf).first().should('have.text', sapconfServiceStatus);
 
 export const hasExpectedTunedService = () =>
-  cy.get(tunedService).should('have.text', tunedServiceStatus);
+  cy.get(tunedService).first().should('have.text', tunedServiceStatus);
 
 export const hasExpectedEnabledSolution = () =>
-  cy.get(enabledSolutionSelector).should('have.text', enabledSolutions);
+  cy.get(enabledSolutionSelector).first().should('have.text', enabledSolutions);
 
 export const hasExpectedAppliedSolution = () =>
   cy.get(saptuneAppliedSolution).should('have.text', appliedSolutions);


### PR DESCRIPTION
### Description

HealthIconi is now augmented with stale indication capabilities:

1. When staleAt prop is provided then a small "clock" icon is added to the original health icon, indicating that the status shown is stale. This icon is with the same color as the original icon.
2. Added is a tooltip that shows since when the status is stale. Additionally, the tooltip shows the capitalized health.

Implementation details: The stale functionality (adding the clock icon with the logic when to show it and the tooltip) are extracted into a higher order React component. It takes a reference to a component rendering function and returns another rendering function that adds the stale functionality. This could potentially be used in InstanceStatus component and in future stale indicators.

### How was this tested?

UT