### PR TITLE
Remove absent value usage from HealthIcon

### DIFF
--- a/assets/js/common/HealthIcon/HealthIcon.jsx
+++ b/assets/js/common/HealthIcon/HealthIcon.jsx
@@ -10,10 +10,8 @@ import {
   EOS_ERROR_OUTLINED,
   EOS_WARNING_OUTLINED,
   EOS_LENS_FILLED,
-  EOS_INFO_OUTLINED,
   EOS_ERROR_FILLED,
   EOS_WARNING_FILLED,
-  EOS_INFO_FILLED,
   EOS_REMOVE_FILLED,
 } from 'eos-icons-react';
 
@@ -37,9 +35,6 @@ function HealthIcon({
 
   const criticalIcon = () => (isLink ? EOS_ERROR_FILLED : EOS_ERROR_OUTLINED);
   const CriticalIcon = criticalIcon();
-
-  const absentIcon = () => (isLink ? EOS_INFO_FILLED : EOS_INFO_OUTLINED);
-  const AbsentIcon = absentIcon();
 
   const hoverOpacityClass = {
     'hover:opacity-75': hoverOpacity,
@@ -73,16 +68,6 @@ function HealthIcon({
           className={classNames(
             hoverOpacityClass,
             computedIconCssClass('fill-red-500', centered)
-          )}
-        />
-      );
-    case 'absent':
-      return (
-        <AbsentIcon
-          size={size}
-          className={classNames(
-            hoverOpacityClass,
-            computedIconCssClass('fill-black', centered)
           )}
         />
       );

--- a/assets/js/common/HealthIcon/HealthIcon.stories.jsx
+++ b/assets/js/common/HealthIcon/HealthIcon.stories.jsx
@@ -14,7 +14,6 @@ export default {
         'passing',
         'warning',
         'critical',
-        'absent',
         'pending',
         'not_available',
         'unknown',
@@ -62,10 +61,6 @@ export const Critical = {
 
 export const Pending = {
   args: { health: 'pending' },
-};
-
-export const Absent = {
-  args: { health: 'absent' },
 };
 
 export const NotAvailable = {

--- a/assets/js/pages/HostDetailsPage/HostSummary.jsx
+++ b/assets/js/pages/HostDetailsPage/HostSummary.jsx
@@ -3,8 +3,8 @@
 
 import React from 'react';
 import { chunk } from 'lodash';
+import { EOS_INFO_OUTLINED } from 'eos-icons-react';
 
-import HealthIcon from '@common/HealthIcon';
 import { formatDateTime } from '@lib/timezones';
 import ListView from '@common/ListView';
 import Tooltip from '@common/Tooltip';
@@ -28,7 +28,7 @@ const renderIpAddresses = (ipAddresses) => {
   return (
     <div className="flex flex-row">
       <Tooltip content={prepareTooltipContent(ipAddresses)}>
-        <HealthIcon health="absent" />
+        <EOS_INFO_OUTLINED size="l" className="hover:opacity-75 fill-black" />
       </Tooltip>
       <span className="truncate ml-1">{joinedIpAddresses}</span>
     </div>


### PR DESCRIPTION
### Description

Remove absent value usage from HealthIcon.
It is not used as a health since we remove its usage from the SAP/Database instances.

### Documentation changes

No