### PR TITLE
Mark SAP system as stale

### DIFF
--- a/lib/trento/activity_logging/activity_catalog.ex
+++ b/lib/trento/activity_logging/activity_catalog.ex
@@ -24,7 +24,8 @@ defmodule Trento.ActivityLog.ActivityCatalog do
 
   @excluded_events [
     Trento.Hosts.Events.HostChecksSelected,
-    Trento.Clusters.Events.ChecksSelected
+    Trento.Clusters.Events.ChecksSelected,
+    Trento.SapSystems.Events.SapSystemDatabaseStaleAtChanged
   ]
 
   @operation_activities [

--- a/lib/trento/event_handlers_supervisor.ex
+++ b/lib/trento/event_handlers_supervisor.ex
@@ -13,6 +13,7 @@ defmodule Trento.EventHandlersSupervisor do
     DatabaseRestoreEventHandler,
     RollUpEventHandler,
     SapSystemDatabaseHealthEventHandler,
+    SapSystemDatabaseStaleAtEventHandler,
     SaptuneStatusUpdateEventHandler,
     SoftwareUpdatesDiscoveryEventHandler,
     StreamRollUpEventHandler
@@ -33,6 +34,7 @@ defmodule Trento.EventHandlersSupervisor do
       DatabaseDeregistrationEventHandler,
       DatabaseRestoreEventHandler,
       SapSystemDatabaseHealthEventHandler,
+      SapSystemDatabaseStaleAtEventHandler,
       SaptuneStatusUpdateEventHandler
     ]
 

--- a/lib/trento/infrastructure/commanded/event_handlers/sap_system_database_stale_at_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/sap_system_database_stale_at_event_handler.ex
@@ -14,10 +14,10 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseStaleAt
     name: "sap_system_database_stale_at_event_handler"
 
   alias Trento.Databases.Events.{DatabaseDataMarkedInSync, DatabaseDataMarkedStale}
-  alias Trento.Databases.Projections.DatabaseReadModel
   alias Trento.Repo
   alias Trento.SapSystems.Commands.UpdateDatabaseStaleAt
   alias Trento.SapSystems.Events.SapSystemDatabaseStaleAtChanged
+  alias Trento.SapSystems.Projections.SapSystemReadModel
 
   alias TrentoWeb.V1.SapSystemJSON
 
@@ -57,12 +57,11 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseStaleAt
          database_stale_at,
          %{correlation_id: correlation_id, causation_id: causation_id}
        ) do
-    %{sap_systems: sap_systems} =
-      Repo.one!(
-        from(d in DatabaseReadModel,
-          where: d.id == ^database_id,
-          preload: [:sap_systems],
-          select: [:id]
+    sap_systems =
+      Repo.all(
+        from(s in SapSystemReadModel,
+          where: s.database_id == ^database_id,
+          select: [:id, :sid]
         )
       )
 

--- a/lib/trento/infrastructure/commanded/event_handlers/sap_system_database_stale_at_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/sap_system_database_stale_at_event_handler.ex
@@ -76,8 +76,7 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseStaleAt
           database_stale_at: database_stale_at
         },
         correlation_id: correlation_id,
-        causation_id: causation_id,
-        consistency: :strong
+        causation_id: causation_id
       )
     end
 

--- a/lib/trento/infrastructure/commanded/event_handlers/sap_system_database_stale_at_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/sap_system_database_stale_at_event_handler.ex
@@ -44,8 +44,10 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseStaleAt
       "monitoring:sap_systems",
       "sap_system_updated",
       SapSystemJSON.sap_system_database_stale_at_changed(%{
-        id: sap_system_id,
-        database_stale_at: database_stale_at
+        sap_system: %{
+          id: sap_system_id,
+          database_stale_at: database_stale_at
+        }
       })
     )
   end

--- a/lib/trento/infrastructure/commanded/event_handlers/sap_system_database_stale_at_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/sap_system_database_stale_at_event_handler.ex
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseStaleAtEventHandler do
+  @moduledoc """
+  This event handler is responsible to forward update database stale_at commands to the SAP systems
+  related to a database that has a new stale_at state.
+
+  Once the resulting event is emitted, the event handler broadcasts its results.
+  """
+
+  use Commanded.Event.Handler,
+    application: Trento.Commanded,
+    name: "sap_system_database_stale_at_event_handler"
+
+  alias Trento.Databases.Events.{DatabaseDataMarkedInSync, DatabaseDataMarkedStale}
+  alias Trento.Databases.Projections.DatabaseReadModel
+  alias Trento.Repo
+  alias Trento.SapSystems.Commands.UpdateDatabaseStaleAt
+  alias Trento.SapSystems.Events.SapSystemDatabaseStaleAtChanged
+
+  alias TrentoWeb.V1.SapSystemJSON
+
+  import Ecto.Query, only: [from: 2]
+
+  require Logger
+
+  def handle(%DatabaseDataMarkedStale{database_id: database_id, stale_at: stale_at}, metadata) do
+    update_sap_systems_database_stale_at(database_id, stale_at, metadata)
+  end
+
+  def handle(%DatabaseDataMarkedInSync{database_id: database_id}, metadata) do
+    update_sap_systems_database_stale_at(database_id, nil, metadata)
+  end
+
+  def handle(
+        %SapSystemDatabaseStaleAtChanged{
+          sap_system_id: sap_system_id,
+          database_stale_at: database_stale_at
+        },
+        _metadata
+      ) do
+    TrentoWeb.Endpoint.broadcast(
+      "monitoring:sap_systems",
+      "sap_system_updated",
+      SapSystemJSON.sap_system_database_stale_at_changed(%{
+        id: sap_system_id,
+        database_stale_at: database_stale_at
+      })
+    )
+  end
+
+  defp update_sap_systems_database_stale_at(
+         database_id,
+         database_stale_at,
+         %{correlation_id: correlation_id, causation_id: causation_id}
+       ) do
+    %{sap_systems: sap_systems} =
+      Repo.one!(
+        from(d in DatabaseReadModel,
+          where: d.id == ^database_id,
+          preload: [:sap_systems],
+          select: [:id]
+        )
+      )
+
+    for %{id: sap_system_id, sid: sid} <- sap_systems do
+      stale_at_message = if database_stale_at, do: database_stale_at, else: "nil (in-sync)"
+      Logger.info("Updating database stale_at of #{sid} SAP system to #{stale_at_message}")
+
+      commanded().dispatch(
+        %UpdateDatabaseStaleAt{
+          sap_system_id: sap_system_id,
+          database_stale_at: database_stale_at
+        },
+        correlation_id: correlation_id,
+        causation_id: causation_id,
+        consistency: :strong
+      )
+    end
+
+    :ok
+  end
+
+  defp commanded,
+    do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
+end

--- a/lib/trento/infrastructure/commanded/middleware/enrich_register_application_instance.ex
+++ b/lib/trento/infrastructure/commanded/middleware/enrich_register_application_instance.ex
@@ -34,13 +34,14 @@ defimpl Trento.Infrastructure.Commanded.Middleware.Enrichable,
             is_nil(h.deregistered_at) and is_nil(d.deregistered_at)
 
     case Repo.one(query) do
-      %DatabaseReadModel{id: database_id, health: database_health} ->
+      %DatabaseReadModel{id: database_id, health: database_health, stale_at: database_stale_at} ->
         {:ok,
          %RegisterApplicationInstance{
            command
            | sap_system_id: UUID.uuid5(database_id, tenant),
              database_id: database_id,
-             database_health: database_health
+             database_health: database_health,
+             database_stale_at: database_stale_at
          }}
 
       nil ->

--- a/lib/trento/router.ex
+++ b/lib/trento/router.ex
@@ -46,7 +46,8 @@ defmodule Trento.Router do
     RegisterApplicationInstance,
     RestoreSapSystem,
     RollUpSapSystem,
-    UpdateDatabaseHealth
+    UpdateDatabaseHealth,
+    UpdateDatabaseStaleAt
   }
 
   alias Trento.Clusters
@@ -99,7 +100,8 @@ defmodule Trento.Router do
              MarkApplicationInstanceDataStale,
              RegisterApplicationInstance,
              RollUpSapSystem,
-             UpdateDatabaseHealth
+             UpdateDatabaseHealth,
+             UpdateDatabaseStaleAt
            ],
            to: SapSystems.SapSystem,
            lifespan: SapSystems.Lifespan

--- a/lib/trento/sap_systems/commands/register_application_instance.ex
+++ b/lib/trento/sap_systems/commands/register_application_instance.ex
@@ -55,6 +55,7 @@ defmodule Trento.SapSystems.Commands.RegisterApplicationInstance do
     field :start_priority, :string
     field :status, Ecto.Enum, values: Status.values()
     field :database_health, Ecto.Enum, values: Health.values()
+    field :database_stale_at, :utc_datetime_usec
     field :ensa_version, Ecto.Enum, values: EnsaVersion.values()
   end
 end

--- a/lib/trento/sap_systems/commands/update_database_stale_at.ex
+++ b/lib/trento/sap_systems/commands/update_database_stale_at.ex
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.SapSystems.Commands.UpdateDatabaseStaleAt do
+  @moduledoc """
+  Update the stale_at timestamp of the database associated to the SAP system.
+  """
+
+  @required_fields [:sap_system_id]
+
+  use Trento.Support.Command
+
+  defcommand do
+    field :sap_system_id, Ecto.UUID
+    field :database_stale_at, :utc_datetime_usec
+  end
+end

--- a/lib/trento/sap_systems/events/sap_system_data_marked_in_sync.ex
+++ b/lib/trento/sap_systems/events/sap_system_data_marked_in_sync.ex
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.SapSystems.Events.SapSystemDataMarkedInSync do
+  @moduledoc """
+  This event is emitted when a SAP system data is marked as in sync.
+  """
+
+  use Trento.Support.Event
+
+  defevent do
+    field :sap_system_id, Ecto.UUID
+  end
+end

--- a/lib/trento/sap_systems/events/sap_system_data_marked_stale.ex
+++ b/lib/trento/sap_systems/events/sap_system_data_marked_stale.ex
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.SapSystems.Events.SapSystemDataMarkedStale do
+  @moduledoc """
+  This event is emitted when a SAP system data is marked as stale.
+  """
+
+  use Trento.Support.Event
+
+  defevent do
+    field :sap_system_id, Ecto.UUID
+    field :stale_at, :utc_datetime_usec
+  end
+end

--- a/lib/trento/sap_systems/events/sap_system_database_stale_at_changed.ex
+++ b/lib/trento/sap_systems/events/sap_system_database_stale_at_changed.ex
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.SapSystems.Events.SapSystemDatabaseStaleAtChanged do
+  @moduledoc """
+  This event is emitted when the database stale state associated to a SAP System changes.
+  """
+
+  use Trento.Support.Event
+
+  defevent do
+    field :sap_system_id, Ecto.UUID
+    field :database_stale_at, :utc_datetime_usec
+  end
+end

--- a/lib/trento/sap_systems/events/sap_system_registered.ex
+++ b/lib/trento/sap_systems/events/sap_system_registered.ex
@@ -19,6 +19,7 @@ defmodule Trento.SapSystems.Events.SapSystemRegistered do
     field :database_id, Ecto.UUID
     field :health, Ecto.Enum, values: Health.values()
     field :database_health, Ecto.Enum, values: Health.values()
+    field :database_stale_at, :utc_datetime_usec
     field :ensa_version, Ecto.Enum, values: EnsaVersion.values(), default: EnsaVersion.no_ensa()
   end
 end

--- a/lib/trento/sap_systems/events/sap_system_restored.ex
+++ b/lib/trento/sap_systems/events/sap_system_restored.ex
@@ -16,5 +16,6 @@ defmodule Trento.SapSystems.Events.SapSystemRestored do
     field :db_host, :string
     field :health, Ecto.Enum, values: Health.values()
     field :database_health, Ecto.Enum, values: Health.values()
+    field :database_stale_at, :utc_datetime_usec
   end
 end

--- a/lib/trento/sap_systems/projections/sap_system_projector.ex
+++ b/lib/trento/sap_systems/projections/sap_system_projector.ex
@@ -621,41 +621,30 @@ defmodule Trento.SapSystems.Projections.SapSystemProjector do
 
   @impl true
   def after_update(
-        %SapSystemDataMarkedStale{
-          sap_system_id: sap_system_id,
-          stale_at: stale_at
-        },
+        %SapSystemDataMarkedStale{},
         _,
-        _
+        %{sap_system: %SapSystemReadModel{} = sap_system}
       ) do
     TrentoWeb.Endpoint.broadcast(
       @sap_systems_topic,
       "sap_system_stale_changed",
       SapSystemJSON.sap_system_stale_changed(%{
-        sap_system: %{
-          id: sap_system_id,
-          stale_at: stale_at
-        }
+        sap_system: sap_system
       })
     )
   end
 
   @impl true
   def after_update(
-        %SapSystemDataMarkedInSync{
-          sap_system_id: sap_system_id
-        },
+        %SapSystemDataMarkedInSync{},
         _,
-        _
+        %{sap_system: %SapSystemReadModel{} = sap_system}
       ) do
     TrentoWeb.Endpoint.broadcast(
       @sap_systems_topic,
       "sap_system_stale_changed",
       SapSystemJSON.sap_system_stale_changed(%{
-        sap_system: %{
-          id: sap_system_id,
-          stale_at: nil
-        }
+        sap_system: sap_system
       })
     )
   end

--- a/lib/trento/sap_systems/projections/sap_system_projector.ex
+++ b/lib/trento/sap_systems/projections/sap_system_projector.ex
@@ -20,6 +20,8 @@ defmodule Trento.SapSystems.Projections.SapSystemProjector do
     ApplicationInstanceMoved,
     ApplicationInstanceRegistered,
     ApplicationInstanceStatusChanged,
+    SapSystemDataMarkedInSync,
+    SapSystemDataMarkedStale,
     SapSystemDeregistered,
     SapSystemHealthChanged,
     SapSystemRegistered,
@@ -239,6 +241,35 @@ defmodule Trento.SapSystems.Projections.SapSystemProjector do
         })
 
       Ecto.Multi.update(multi, :application_instance, changeset)
+    end
+  )
+
+  project(
+    %SapSystemDataMarkedStale{
+      sap_system_id: sap_system_id,
+      stale_at: stale_at
+    },
+    fn multi ->
+      changeset =
+        SapSystemReadModel
+        |> Repo.get!(sap_system_id)
+        |> SapSystemReadModel.changeset(%{stale_at: stale_at})
+
+      Ecto.Multi.update(multi, :sap_system, changeset)
+    end
+  )
+
+  project(
+    %SapSystemDataMarkedInSync{
+      sap_system_id: sap_system_id
+    },
+    fn multi ->
+      changeset =
+        SapSystemReadModel
+        |> Repo.get!(sap_system_id)
+        |> SapSystemReadModel.changeset(%{stale_at: nil})
+
+      Ecto.Multi.update(multi, :sap_system, changeset)
     end
   )
 
@@ -585,6 +616,47 @@ defmodule Trento.SapSystems.Projections.SapSystemProjector do
       @sap_systems_topic,
       "sap_system_updated",
       SapSystemJSON.sap_system_updated(%{id: sap_system_id, ensa_version: ensa_version})
+    )
+  end
+
+  @impl true
+  def after_update(
+        %SapSystemDataMarkedStale{
+          sap_system_id: sap_system_id,
+          stale_at: stale_at
+        },
+        _,
+        _
+      ) do
+    TrentoWeb.Endpoint.broadcast(
+      @sap_systems_topic,
+      "sap_system_stale_changed",
+      SapSystemJSON.sap_system_stale_changed(%{
+        sap_system: %{
+          id: sap_system_id,
+          stale_at: stale_at
+        }
+      })
+    )
+  end
+
+  @impl true
+  def after_update(
+        %SapSystemDataMarkedInSync{
+          sap_system_id: sap_system_id
+        },
+        _,
+        _
+      ) do
+    TrentoWeb.Endpoint.broadcast(
+      @sap_systems_topic,
+      "sap_system_stale_changed",
+      SapSystemJSON.sap_system_stale_changed(%{
+        sap_system: %{
+          id: sap_system_id,
+          stale_at: nil
+        }
+      })
     )
   end
 

--- a/lib/trento/sap_systems/projections/sap_system_read_model.ex
+++ b/lib/trento/sap_systems/projections/sap_system_read_model.ex
@@ -49,6 +49,7 @@ defmodule Trento.SapSystems.Projections.SapSystemReadModel do
 
     has_many :tags, Tag, foreign_key: :resource_id
 
+    field :stale_at, :utc_datetime_usec
     field :deregistered_at, :utc_datetime_usec
 
     timestamps(type: :utc_datetime_usec)

--- a/lib/trento/sap_systems/sap_system.ex
+++ b/lib/trento/sap_systems/sap_system.ex
@@ -57,7 +57,8 @@ defmodule Trento.SapSystems.SapSystem do
     RegisterApplicationInstance,
     RestoreSapSystem,
     RollUpSapSystem,
-    UpdateDatabaseHealth
+    UpdateDatabaseHealth,
+    UpdateDatabaseStaleAt
   }
 
   alias Trento.SapSystems.Events.{
@@ -70,6 +71,9 @@ defmodule Trento.SapSystems.SapSystem do
     ApplicationInstanceRegistered,
     ApplicationInstanceStatusChanged,
     SapSystemDatabaseHealthChanged,
+    SapSystemDatabaseStaleAtChanged,
+    SapSystemDataMarkedInSync,
+    SapSystemDataMarkedStale,
     SapSystemDeregistered,
     SapSystemHealthChanged,
     SapSystemRegistered,
@@ -95,6 +99,8 @@ defmodule Trento.SapSystems.SapSystem do
     # field :tenant, :string
     field :ensa_version, Ecto.Enum, values: EnsaVersion.values(), default: EnsaVersion.no_ensa()
     field :rolling_up, :boolean, default: false
+    field :stale_at, :utc_datetime_usec
+    field :database_stale_at, :utc_datetime_usec
     field :deregistered_at, :utc_datetime_usec, default: nil
 
     embeds_many :instances, Instance
@@ -127,6 +133,7 @@ defmodule Trento.SapSystems.SapSystem do
     |> Multi.execute(fn sap_system ->
       maybe_emit_sap_system_restored_event(sap_system, instance)
     end)
+    |> Multi.execute(&maybe_emit_sap_system_data_marked_in_sync_event/1)
     |> Multi.execute(&maybe_emit_sap_system_health_changed_event/1)
   end
 
@@ -165,6 +172,7 @@ defmodule Trento.SapSystems.SapSystem do
     |> Multi.execute(fn sap_system ->
       maybe_emit_sap_system_registered_or_updated_event(sap_system, instance)
     end)
+    |> Multi.execute(&maybe_emit_sap_system_data_marked_in_sync_event/1)
     |> Multi.execute(&maybe_emit_sap_system_health_changed_event/1)
   end
 
@@ -198,7 +206,7 @@ defmodule Trento.SapSystems.SapSystem do
   end
 
   def execute(
-        %SapSystem{sap_system_id: sap_system_id, instances: instances},
+        %SapSystem{sap_system_id: sap_system_id, instances: instances} = sap_system,
         %MarkApplicationInstanceDataStale{
           instance_number: instance_number,
           host_id: host_id,
@@ -207,12 +215,14 @@ defmodule Trento.SapSystems.SapSystem do
       ) do
     case get_instance(instances, host_id, instance_number) do
       %Instance{stale_at: nil} ->
-        %ApplicationInstanceDataMarkedStale{
-          sap_system_id: sap_system_id,
-          instance_number: instance_number,
-          host_id: host_id,
-          stale_at: stale_at
-        }
+        [
+          %ApplicationInstanceDataMarkedStale{
+            sap_system_id: sap_system_id,
+            instance_number: instance_number,
+            host_id: host_id,
+            stale_at: stale_at
+          }
+        ] ++ maybe_emit_sap_system_data_marked_stale_event(sap_system, stale_at)
 
       _ ->
         nil
@@ -235,6 +245,7 @@ defmodule Trento.SapSystems.SapSystem do
     |> Multi.execute(fn _ ->
       maybe_emit_application_instance_deregistered_event(sap_system, instance)
     end)
+    |> Multi.execute(&maybe_emit_sap_system_data_marked_in_sync_event/1)
     |> Multi.execute(fn sap_system ->
       maybe_emit_sap_system_deregistered_event(
         sap_system,
@@ -299,6 +310,41 @@ defmodule Trento.SapSystems.SapSystem do
       }
     end)
     |> Multi.execute(&maybe_emit_sap_system_health_changed_event/1)
+  end
+
+  def execute(
+        %SapSystem{database_stale_at: database_stale_at},
+        %UpdateDatabaseStaleAt{database_stale_at: database_stale_at}
+      ) do
+    nil
+  end
+
+  def execute(
+        %SapSystem{sap_system_id: sap_system_id} = sap_system,
+        %UpdateDatabaseStaleAt{database_stale_at: nil}
+      ) do
+    sap_system
+    |> Multi.new()
+    |> Multi.execute(fn _ ->
+      %SapSystemDatabaseStaleAtChanged{
+        sap_system_id: sap_system_id,
+        database_stale_at: nil
+      }
+    end)
+    |> Multi.execute(&maybe_emit_sap_system_data_marked_in_sync_event/1)
+  end
+
+  def execute(
+        %SapSystem{sap_system_id: sap_system_id} = sap_system,
+        %UpdateDatabaseStaleAt{database_stale_at: database_stale_at}
+      ) do
+    [
+      %SapSystemDatabaseStaleAtChanged{
+        sap_system_id: sap_system_id,
+        database_stale_at: database_stale_at
+      }
+    ] ++
+      maybe_emit_sap_system_data_marked_stale_event(sap_system, database_stale_at)
   end
 
   def execute(
@@ -442,6 +488,15 @@ defmodule Trento.SapSystems.SapSystem do
     }
   end
 
+  def apply(%SapSystem{} = sap_system, %SapSystemDatabaseStaleAtChanged{
+        database_stale_at: database_stale_at
+      }) do
+    %SapSystem{
+      sap_system
+      | database_stale_at: database_stale_at
+    }
+  end
+
   def apply(%SapSystem{} = sap_system, %SapSystemUpdated{
         ensa_version: ensa_version
       }) do
@@ -554,6 +609,17 @@ defmodule Trento.SapSystems.SapSystem do
   end
 
   def apply(%SapSystem{} = sap_system, %SapSystemTombstoned{}), do: sap_system
+
+  def apply(
+        %SapSystem{} = sap_system,
+        %SapSystemDataMarkedStale{stale_at: stale_at}
+      ) do
+    %SapSystem{sap_system | stale_at: stale_at}
+  end
+
+  def apply(%SapSystem{} = sap_system, %SapSystemDataMarkedInSync{}) do
+    %SapSystem{sap_system | stale_at: nil}
+  end
 
   defp maybe_emit_application_instance_registered_or_moved_event(
          %SapSystem{instances: []},
@@ -692,6 +758,43 @@ defmodule Trento.SapSystems.SapSystem do
   end
 
   defp maybe_emit_application_instance_data_marked_in_sync_event(_, _), do: nil
+
+  defp maybe_emit_sap_system_data_marked_stale_event(
+         %SapSystem{
+           sap_system_id: sap_system_id,
+           stale_at: nil
+         },
+         stale_at
+       ) do
+    [
+      %SapSystemDataMarkedStale{
+        sap_system_id: sap_system_id,
+        stale_at: stale_at
+      }
+    ]
+  end
+
+  defp maybe_emit_sap_system_data_marked_stale_event(_, _), do: []
+
+  defp maybe_emit_sap_system_data_marked_in_sync_event(%SapSystem{stale_at: nil}), do: nil
+
+  defp maybe_emit_sap_system_data_marked_in_sync_event(%SapSystem{
+         sap_system_id: sap_system_id,
+         instances: instances,
+         database_stale_at: database_stale_at
+       }) do
+    all_in_sync? =
+      instances
+      |> Enum.map(fn %{stale_at: stale_at} -> stale_at end)
+      |> Enum.concat([database_stale_at])
+      |> Enum.all?(&is_nil/1)
+
+    if all_in_sync? do
+      %SapSystemDataMarkedInSync{
+        sap_system_id: sap_system_id
+      }
+    end
+  end
 
   defp maybe_emit_application_instance_status_changed_event(
          %SapSystem{instances: instances},

--- a/lib/trento/sap_systems/sap_system.ex
+++ b/lib/trento/sap_systems/sap_system.ex
@@ -291,6 +291,14 @@ defmodule Trento.SapSystems.SapSystem do
   end
 
   def execute(
+        %SapSystem{deregistered_at: deregistered_at},
+        _
+      )
+      when not is_nil(deregistered_at) do
+    {:error, :sap_system_not_registered}
+  end
+
+  def execute(
         %SapSystem{database_health: database_health},
         %UpdateDatabaseHealth{database_health: database_health}
       ) do
@@ -335,14 +343,6 @@ defmodule Trento.SapSystems.SapSystem do
       maybe_emit_sap_system_data_marked_stale_event(sap_system, database_stale_at)
     end)
     |> Multi.execute(&maybe_emit_sap_system_data_marked_in_sync_event/1)
-  end
-
-  def execute(
-        %SapSystem{deregistered_at: deregistered_at},
-        _
-      )
-      when not is_nil(deregistered_at) do
-    {:error, :sap_system_not_registered}
   end
 
   def apply(
@@ -450,6 +450,7 @@ defmodule Trento.SapSystems.SapSystem do
         sid: sid,
         health: health,
         database_health: database_health,
+        database_stale_at: database_stale_at,
         ensa_version: ensa_version
       }) do
     %SapSystem{
@@ -458,6 +459,7 @@ defmodule Trento.SapSystems.SapSystem do
         sid: sid,
         health: health,
         database_health: database_health,
+        database_stale_at: database_stale_at,
         ensa_version: ensa_version
     }
   end
@@ -588,12 +590,14 @@ defmodule Trento.SapSystems.SapSystem do
 
   def apply(%SapSystem{} = sap_system, %SapSystemRestored{
         health: health,
-        database_health: database_health
+        database_health: database_health,
+        database_stale_at: database_stale_at
       }) do
     %SapSystem{
       sap_system
       | health: health,
         database_health: database_health,
+        database_stale_at: database_stale_at,
         deregistered_at: nil
     }
   end
@@ -815,7 +819,8 @@ defmodule Trento.SapSystems.SapSystem do
            tenant: tenant,
            db_host: db_host,
            status: status,
-           database_health: database_health
+           database_health: database_health,
+           database_stale_at: database_stale_at
          }
        ) do
     if instances_have_abap_or_java?(instances) and instances_have_messageserver?(instances) do
@@ -824,12 +829,15 @@ defmodule Trento.SapSystems.SapSystem do
         health: SapSystemsHealthService.derive_health_from_status(status),
         sap_system_id: sap_system_id,
         tenant: tenant,
-        database_health: database_health
+        database_health: database_health,
+        database_stale_at: database_stale_at
       }
     end
   end
 
-  # Restore a SAP system when the restore command is received, check for the required instances
+  # Restore a SAP system when the restore command is received, check for the required instances.
+  # stale_at is set to nil as the SAP is restored because the associated database was restored,
+  # which cannot happen being stale
   defp maybe_emit_sap_system_restored_event(
          %SapSystem{instances: instances, health: health},
          %RestoreSapSystem{
@@ -845,7 +853,8 @@ defmodule Trento.SapSystems.SapSystem do
         db_host: db_host,
         tenant: tenant,
         sap_system_id: sap_system_id,
-        database_health: database_health
+        database_health: database_health,
+        database_stale_at: nil
       }
     end
   end
@@ -860,7 +869,8 @@ defmodule Trento.SapSystems.SapSystem do
            status: status,
            ensa_version: ensa_version,
            database_id: database_id,
-           database_health: database_health
+           database_health: database_health,
+           database_stale_at: database_stale_at
          }
        ) do
     if instances_have_abap_or_java?(instances) and instances_have_messageserver?(instances) do
@@ -872,7 +882,8 @@ defmodule Trento.SapSystems.SapSystem do
         health: SapSystemsHealthService.derive_health_from_status(status),
         ensa_version: ensa_version,
         database_id: database_id,
-        database_health: database_health
+        database_health: database_health,
+        database_stale_at: database_stale_at
       }
     end
   end

--- a/lib/trento/sap_systems/sap_system.ex
+++ b/lib/trento/sap_systems/sap_system.ex
@@ -321,30 +321,20 @@ defmodule Trento.SapSystems.SapSystem do
 
   def execute(
         %SapSystem{sap_system_id: sap_system_id} = sap_system,
-        %UpdateDatabaseStaleAt{database_stale_at: nil}
+        %UpdateDatabaseStaleAt{database_stale_at: database_stale_at}
       ) do
     sap_system
     |> Multi.new()
     |> Multi.execute(fn _ ->
       %SapSystemDatabaseStaleAtChanged{
         sap_system_id: sap_system_id,
-        database_stale_at: nil
-      }
-    end)
-    |> Multi.execute(&maybe_emit_sap_system_data_marked_in_sync_event/1)
-  end
-
-  def execute(
-        %SapSystem{sap_system_id: sap_system_id} = sap_system,
-        %UpdateDatabaseStaleAt{database_stale_at: database_stale_at}
-      ) do
-    [
-      %SapSystemDatabaseStaleAtChanged{
-        sap_system_id: sap_system_id,
         database_stale_at: database_stale_at
       }
-    ] ++
+    end)
+    |> Multi.execute(fn sap_system ->
       maybe_emit_sap_system_data_marked_stale_event(sap_system, database_stale_at)
+    end)
+    |> Multi.execute(&maybe_emit_sap_system_data_marked_in_sync_event/1)
   end
 
   def execute(

--- a/lib/trento/sap_systems/sap_system.ex
+++ b/lib/trento/sap_systems/sap_system.ex
@@ -836,9 +836,10 @@ defmodule Trento.SapSystems.SapSystem do
     end
   end
 
-  # Restore a SAP system when the restore command is received, check for the required instances.
-  # stale_at is set to nil as the SAP is restored because the associated database was restored,
-  # which cannot happen being stale
+  # Restore a SAP system when the RestoreSapSystem command is received, checking that the required instances are
+  # present. This command is sent when the database associated to this SAP system was restored.
+  #
+  # A database can only be restored while it is not stale, so database_stale_at is set to nil to reflect that.
   defp maybe_emit_sap_system_restored_event(
          %SapSystem{instances: instances, health: health},
          %RestoreSapSystem{

--- a/lib/trento/sap_systems/sap_system.ex
+++ b/lib/trento/sap_systems/sap_system.ex
@@ -759,7 +759,8 @@ defmodule Trento.SapSystems.SapSystem do
            stale_at: nil
          },
          stale_at
-       ) do
+       )
+       when not is_nil(stale_at) do
     [
       %SapSystemDataMarkedStale{
         sap_system_id: sap_system_id,

--- a/lib/trento_web/controllers/v1/sap_system_json.ex
+++ b/lib/trento_web/controllers/v1/sap_system_json.ex
@@ -82,8 +82,10 @@ defmodule TrentoWeb.V1.SapSystemJSON do
   def sap_system_database_health_changed(%{id: id, database_health: database_health}),
     do: %{id: id, database_health: database_health}
 
-  def sap_system_database_stale_at_changed(%{id: id, database_stale_at: database_stale_at}),
-    do: %{id: id, database_stale_at: database_stale_at}
+  def sap_system_database_stale_at_changed(%{
+        sap_system: %{id: id, database_stale_at: database_stale_at}
+      }),
+      do: %{id: id, database_stale_at: database_stale_at}
 
   def sap_system_deregistered(%{id: id, sid: sid}), do: %{id: id, sid: sid}
 

--- a/lib/trento_web/controllers/v1/sap_system_json.ex
+++ b/lib/trento_web/controllers/v1/sap_system_json.ex
@@ -28,7 +28,7 @@ defmodule TrentoWeb.V1.SapSystemJSON do
           %{
             application_instances: application_instances,
             database_instances: database_instances,
-            database: %{sid: database_sid, health: database_health}
+            database: %{sid: database_sid, health: database_health, stale_at: database_stale_at}
           } = sap_system
       }) do
     rendered_application_instances =
@@ -48,6 +48,7 @@ defmodule TrentoWeb.V1.SapSystemJSON do
     )
     |> Map.put(:database_sid, database_sid)
     |> Map.put(:database_health, database_health)
+    |> Map.put(:database_stale_at, database_stale_at)
     |> Map.put(
       :application_instances,
       rendered_application_instances
@@ -55,7 +56,9 @@ defmodule TrentoWeb.V1.SapSystemJSON do
   end
 
   def sap_system_registered(%{
-        sap_system: %{database: %{sid: database_sid, health: database_health}} = sap_system
+        sap_system:
+          %{database: %{sid: database_sid, health: database_health, stale_at: database_stale_at}} =
+            sap_system
       }) do
     sap_system
     |> Map.from_struct()
@@ -66,6 +69,7 @@ defmodule TrentoWeb.V1.SapSystemJSON do
     |> Map.delete(:tags)
     |> Map.put(:database_sid, database_sid)
     |> Map.put(:database_health, database_health)
+    |> Map.put(:database_stale_at, database_stale_at)
   end
 
   def sap_system_restored(%{sap_system: sap_system}), do: sap_system(%{sap_system: sap_system})
@@ -77,6 +81,9 @@ defmodule TrentoWeb.V1.SapSystemJSON do
 
   def sap_system_database_health_changed(%{id: id, database_health: database_health}),
     do: %{id: id, database_health: database_health}
+
+  def sap_system_database_stale_at_changed(%{id: id, database_stale_at: database_stale_at}),
+    do: %{id: id, database_stale_at: database_stale_at}
 
   def sap_system_deregistered(%{id: id, sid: sid}), do: %{id: id, sid: sid}
 
@@ -117,6 +124,17 @@ defmodule TrentoWeb.V1.SapSystemJSON do
         instance_number: instance_number,
         host_id: host_id,
         sap_system_id: sap_system_id,
+        stale_at: stale_at
+      }
+
+  def sap_system_stale_changed(%{
+        sap_system: %{
+          id: id,
+          stale_at: stale_at
+        }
+      }),
+      do: %{
+        id: id,
         stale_at: stale_at
       }
 end

--- a/lib/trento_web/openapi/v1/schema/sap_system.ex
+++ b/lib/trento_web/openapi/v1/schema/sap_system.ex
@@ -199,8 +199,24 @@ defmodule TrentoWeb.OpenApi.V1.Schema.SAPSystem do
           },
           database_sid: %Schema{type: :string, description: "Database SID.", example: "HA1"},
           database_health: ResourceHealth,
+          database_stale_at: %Schema{
+            type: :string,
+            description:
+              "The timestamp indicating when the database associated to this SAP system data became stale, supporting monitoring and troubleshooting.",
+            format: :datetime,
+            example: "2024-01-15T08:00:00Z",
+            nullable: true
+          },
           database_instances: Database.DatabaseInstances,
           tags: Tags,
+          stale_at: %Schema{
+            type: :string,
+            description:
+              "The timestamp indicating when the SAP system data became stale, supporting monitoring and troubleshooting.",
+            format: :datetime,
+            example: "2024-01-15T08:00:00Z",
+            nullable: true
+          },
           inserted_at: %Schema{type: :string, format: :datetime, example: "2024-01-15T10:30:00Z"},
           updated_at: %Schema{
             type: :string,
@@ -221,6 +237,8 @@ defmodule TrentoWeb.OpenApi.V1.Schema.SAPSystem do
           database_sid: "HA1",
           database_instances: [],
           tags: [],
+          stale_at: "2024-01-15T08:00:00Z",
+          database_stale_at: "2024-01-15T08:00:00Z",
           inserted_at: "2024-01-15T10:30:00Z",
           updated_at: "2024-01-15T12:30:00Z"
         }
@@ -252,6 +270,8 @@ defmodule TrentoWeb.OpenApi.V1.Schema.SAPSystem do
             database_sid: "HA1",
             database_instances: [],
             tags: [],
+            stale_at: "2024-01-15T08:00:00Z",
+            database_stale_at: "2024-01-15T08:00:00Z",
             inserted_at: "2024-01-15T10:30:00Z",
             updated_at: "2024-01-15T12:30:00Z"
           }

--- a/priv/repo/migrations/20260622152417_add_stale_at_sap_system_read_model.exs
+++ b/priv/repo/migrations/20260622152417_add_stale_at_sap_system_read_model.exs
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Repo.Migrations.AddStaleAtSapSystemReadModel do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sap_systems) do
+      add :stale_at, :utc_datetime_usec
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -90,6 +90,9 @@ defmodule Trento.Factory do
     ApplicationInstanceMarkedAbsent,
     ApplicationInstanceMoved,
     ApplicationInstanceRegistered,
+    SapSystemDatabaseStaleAtChanged,
+    SapSystemDataMarkedInSync,
+    SapSystemDataMarkedStale,
     SapSystemDeregistered,
     SapSystemHealthChanged,
     SapSystemRegistered,
@@ -659,6 +662,29 @@ defmodule Trento.Factory do
     })
   end
 
+  def sap_system_data_marked_stale_event_factory(attrs) do
+    data = %{
+      sap_system_id: Faker.UUID.v4(),
+      stale_at: DateTime.utc_now()
+    }
+
+    data
+    |> merge_attributes(attrs)
+    |> evaluate_lazy_attributes
+    |> SapSystemDataMarkedStale.new!()
+  end
+
+  def sap_system_data_marked_in_sync_event_factory(attrs) do
+    data = %{
+      sap_system_id: Faker.UUID.v4()
+    }
+
+    data
+    |> merge_attributes(attrs)
+    |> evaluate_lazy_attributes
+    |> SapSystemDataMarkedInSync.new!()
+  end
+
   def deregister_application_instance_command_factory do
     DeregisterApplicationInstance.new!(%{
       sap_system_id: Faker.UUID.v4(),
@@ -701,6 +727,18 @@ defmodule Trento.Factory do
       sap_system_id: Faker.UUID.v4(),
       health: Health.passing()
     }
+  end
+
+  def sap_system_database_stale_at_changed_event_factory(attrs) do
+    data = %{
+      sap_system_id: Faker.UUID.v4(),
+      database_stale_at: DateTime.utc_now()
+    }
+
+    data
+    |> merge_attributes(attrs)
+    |> evaluate_lazy_attributes
+    |> SapSystemDatabaseStaleAtChanged.new!()
   end
 
   def application_instance_moved_event_factory do
@@ -871,6 +909,7 @@ defmodule Trento.Factory do
       db_host: Faker.Internet.ip_v4_address(),
       health: Health.unknown(),
       ensa_version: EnsaVersion.ensa1(),
+      stale_at: nil,
       deregistered_at: nil,
       database_id: Faker.UUID.v4()
     }

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -709,8 +709,8 @@ defmodule Trento.Factory do
     }
   end
 
-  def sap_system_registered_event_factory do
-    %SapSystemRegistered{
+  def sap_system_registered_event_factory(attrs) do
+    data = %{
       sap_system_id: Faker.UUID.v4(),
       sid: Faker.UUID.v4(),
       db_host: Faker.Internet.ip_v4_address(),
@@ -718,8 +718,14 @@ defmodule Trento.Factory do
       health: Health.passing(),
       database_id: Faker.UUID.v4(),
       database_health: Health.passing(),
+      database_stale_at: nil,
       ensa_version: EnsaVersion.ensa1()
     }
+
+    data
+    |> merge_attributes(attrs)
+    |> evaluate_lazy_attributes
+    |> SapSystemRegistered.new!()
   end
 
   def sap_system_health_changed_event_factory do
@@ -757,14 +763,20 @@ defmodule Trento.Factory do
     })
   end
 
-  def sap_system_restored_event_factory do
-    %SapSystemRestored{
+  def sap_system_restored_event_factory(attrs) do
+    data = %{
       sap_system_id: Faker.UUID.v4(),
       tenant: Faker.Beer.hop(),
       db_host: Faker.Internet.ip_v4_address(),
       health: Health.passing(),
-      database_health: Health.passing()
+      database_health: Health.passing(),
+      database_stale_at: nil
     }
+
+    data
+    |> merge_attributes(attrs)
+    |> evaluate_lazy_attributes
+    |> SapSystemRestored.new!()
   end
 
   def rollup_sap_system_command_factory do
@@ -979,8 +991,8 @@ defmodule Trento.Factory do
     }
   end
 
-  def register_application_instance_command_factory do
-    RegisterApplicationInstance.new!(%{
+  def register_application_instance_command_factory(attrs) do
+    command = %{
       sap_system_id: Faker.UUID.v4(),
       sid: Faker.StarWars.planet(),
       db_host: Faker.Internet.ip_v4_address(),
@@ -996,8 +1008,14 @@ defmodule Trento.Factory do
       ensa_version: EnsaVersion.ensa1(),
       database_id: Faker.UUID.v4(),
       database_health: Health.passing(),
+      database_stale_at: nil,
       clustered: false
-    })
+    }
+
+    command
+    |> merge_attributes(attrs)
+    |> evaluate_lazy_attributes()
+    |> RegisterApplicationInstance.new!()
   end
 
   def register_database_instance_command_factory do

--- a/test/trento/activity_logging/activity_catalog_test.exs
+++ b/test/trento/activity_logging/activity_catalog_test.exs
@@ -475,7 +475,8 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
     test "should ignore specific domain events" do
       excluded_events = [
         :host_checks_selected_event,
-        :cluster_checks_selected_event
+        :cluster_checks_selected_event,
+        :sap_system_database_stale_at_changed_event
       ]
 
       for excluded_event <- excluded_events do

--- a/test/trento/infrastructure/commanded/event_handlers/sap_system_database_stale_at_event_handler_test.exs
+++ b/test/trento/infrastructure/commanded/event_handlers/sap_system_database_stale_at_event_handler_test.exs
@@ -131,24 +131,4 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseStaleAt
       1000
     )
   end
-
-  test "should broadcast database stale_at change with nil when a SapSystemDatabaseStaleAtChanged event is received with nil" do
-    sap_system_id = Faker.UUID.v4()
-
-    event = %SapSystemDatabaseStaleAtChanged{
-      sap_system_id: sap_system_id,
-      database_stale_at: nil
-    }
-
-    assert :ok = SapSystemDatabaseStaleAtEventHandler.handle(event, %{})
-
-    assert_broadcast(
-      "sap_system_updated",
-      %{
-        id: ^sap_system_id,
-        database_stale_at: nil
-      },
-      1000
-    )
-  end
 end

--- a/test/trento/infrastructure/commanded/event_handlers/sap_system_database_stale_at_event_handler_test.exs
+++ b/test/trento/infrastructure/commanded/event_handlers/sap_system_database_stale_at_event_handler_test.exs
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseStaleAtEventHandlerTest do
+  use Trento.DataCase
+
+  import Mox
+  import Phoenix.ChannelTest
+  import Trento.Factory
+  import TrentoWeb.ChannelCase
+
+  alias Trento.Databases.Events.{DatabaseDataMarkedInSync, DatabaseDataMarkedStale}
+
+  alias Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseStaleAtEventHandler
+
+  alias Trento.SapSystems.Commands.UpdateDatabaseStaleAt
+  alias Trento.SapSystems.Events.SapSystemDatabaseStaleAtChanged
+
+  @endpoint TrentoWeb.Endpoint
+
+  setup [:set_mox_from_context, :verify_on_exit!]
+
+  setup do
+    {:ok, _, socket} =
+      TrentoWeb.UserSocket
+      |> socket("user_id", %{some: :assign})
+      |> subscribe_and_join(TrentoWeb.MonitoringChannel, "monitoring:sap_systems")
+
+    %{socket: socket}
+  end
+
+  test "should dispatch UpdateDatabaseStaleAt commands when a database is marked stale" do
+    %{id: database_id} = insert(:database)
+
+    [%{id: first_sap_system_id}, %{id: second_sap_system_id}] =
+      insert_list(2, :sap_system, database_id: database_id)
+
+    stale_at = DateTime.utc_now()
+
+    event = %DatabaseDataMarkedStale{database_id: database_id, stale_at: stale_at}
+
+    metadata = %{
+      correlation_id: Faker.UUID.v4(),
+      causation_id: Faker.UUID.v4()
+    }
+
+    expect(Trento.Commanded.Mock, :dispatch, fn %UpdateDatabaseStaleAt{
+                                                  sap_system_id: ^first_sap_system_id,
+                                                  database_stale_at: ^stale_at
+                                                },
+                                                _ ->
+      :ok
+    end)
+
+    expect(Trento.Commanded.Mock, :dispatch, fn %UpdateDatabaseStaleAt{
+                                                  sap_system_id: ^second_sap_system_id,
+                                                  database_stale_at: ^stale_at
+                                                },
+                                                _ ->
+      :ok
+    end)
+
+    assert :ok = SapSystemDatabaseStaleAtEventHandler.handle(event, metadata)
+  end
+
+  test "should dispatch UpdateDatabaseStaleAt commands with nil when a database is marked in-sync" do
+    %{id: database_id} = insert(:database)
+
+    [%{id: first_sap_system_id}, %{id: second_sap_system_id}] =
+      insert_list(2, :sap_system, database_id: database_id)
+
+    event = %DatabaseDataMarkedInSync{database_id: database_id}
+
+    metadata = %{
+      correlation_id: Faker.UUID.v4(),
+      causation_id: Faker.UUID.v4()
+    }
+
+    expect(Trento.Commanded.Mock, :dispatch, fn %UpdateDatabaseStaleAt{
+                                                  sap_system_id: ^first_sap_system_id,
+                                                  database_stale_at: nil
+                                                },
+                                                _ ->
+      :ok
+    end)
+
+    expect(Trento.Commanded.Mock, :dispatch, fn %UpdateDatabaseStaleAt{
+                                                  sap_system_id: ^second_sap_system_id,
+                                                  database_stale_at: nil
+                                                },
+                                                _ ->
+      :ok
+    end)
+
+    assert :ok = SapSystemDatabaseStaleAtEventHandler.handle(event, metadata)
+  end
+
+  test "should broadcast database stale_at change when a SapSystemDatabaseStaleAtChanged event is received" do
+    sap_system_id = Faker.UUID.v4()
+    stale_at = DateTime.utc_now()
+
+    event = %SapSystemDatabaseStaleAtChanged{
+      sap_system_id: sap_system_id,
+      database_stale_at: stale_at
+    }
+
+    assert :ok = SapSystemDatabaseStaleAtEventHandler.handle(event, %{})
+
+    assert_broadcast(
+      "sap_system_updated",
+      %{
+        id: ^sap_system_id,
+        database_stale_at: ^stale_at
+      },
+      1000
+    )
+  end
+
+  test "should broadcast database stale_at change with nil when a SapSystemDatabaseStaleAtChanged event is received with nil" do
+    sap_system_id = Faker.UUID.v4()
+
+    event = %SapSystemDatabaseStaleAtChanged{
+      sap_system_id: sap_system_id,
+      database_stale_at: nil
+    }
+
+    assert :ok = SapSystemDatabaseStaleAtEventHandler.handle(event, %{})
+
+    assert_broadcast(
+      "sap_system_updated",
+      %{
+        id: ^sap_system_id,
+        database_stale_at: nil
+      },
+      1000
+    )
+  end
+end

--- a/test/trento/infrastructure/commanded/event_handlers/sap_system_database_stale_at_event_handler_test.exs
+++ b/test/trento/infrastructure/commanded/event_handlers/sap_system_database_stale_at_event_handler_test.exs
@@ -95,6 +95,22 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseStaleAt
     assert :ok = SapSystemDatabaseStaleAtEventHandler.handle(event, metadata)
   end
 
+  test "should not dispatch any command when the database does not have associated SAP systems" do
+    event = %DatabaseDataMarkedStale{
+      database_id: Faker.UUID.v4(),
+      stale_at: DateTime.utc_now()
+    }
+
+    metadata = %{
+      correlation_id: Faker.UUID.v4(),
+      causation_id: Faker.UUID.v4()
+    }
+
+    expect(Trento.Commanded.Mock, :dispatch, 0, fn _ -> :ok end)
+
+    assert :ok = SapSystemDatabaseStaleAtEventHandler.handle(event, metadata)
+  end
+
   test "should broadcast database stale_at change when a SapSystemDatabaseStaleAtChanged event is received" do
     sap_system_id = Faker.UUID.v4()
     stale_at = DateTime.utc_now()

--- a/test/trento/infrastructure/commanded/middleware/enrich_register_application_instance_test.exs
+++ b/test/trento/infrastructure/commanded/middleware/enrich_register_application_instance_test.exs
@@ -16,7 +16,7 @@ defmodule Trento.Infrastructure.Commanded.Middleware.EnrichRegisterApplicationIn
     [%{name: tenant_name}, _] = tenants = build_list(2, :tenant)
 
     %{id: host_id, ip_addresses: [ip]} = insert(:host)
-    %{id: database_id, health: health} = insert(:database, tenants: tenants)
+    %{id: database_id, health: health, stale_at: stale_at} = insert(:database, tenants: tenants)
     insert(:database_instance, database_id: database_id, host_id: host_id)
 
     command =
@@ -37,7 +37,8 @@ defmodule Trento.Infrastructure.Commanded.Middleware.EnrichRegisterApplicationIn
             %RegisterApplicationInstance{
               sap_system_id: ^expected_sap_system_id,
               database_id: ^database_id,
-              database_health: ^health
+              database_health: ^health,
+              database_stale_at: ^stale_at
             }} =
              Enrichable.enrich(command, %{})
   end

--- a/test/trento/sap_systems/projections/sap_system_projector_test.exs
+++ b/test/trento/sap_systems/projections/sap_system_projector_test.exs
@@ -27,6 +27,8 @@ defmodule Trento.SapSystems.Projections.SapSystemProjectorTest do
     ApplicationInstanceMarkedPresent,
     ApplicationInstanceMoved,
     ApplicationInstanceStatusChanged,
+    SapSystemDataMarkedInSync,
+    SapSystemDataMarkedStale,
     SapSystemDeregistered,
     SapSystemHealthChanged,
     SapSystemRestored,
@@ -518,6 +520,55 @@ defmodule Trento.SapSystems.Projections.SapSystemProjectorTest do
         instance_number: ^instance_number,
         host_id: ^host_id,
         sap_system_id: ^sap_system_id,
+        stale_at: nil
+      },
+      1000
+    )
+  end
+
+  test "should mark SAP system data as stale when SapSystemDataMarkedStale event is received" do
+    %{id: sap_system_id} = insert(:sap_system, stale_at: nil)
+
+    stale_at = DateTime.utc_now()
+
+    event = %SapSystemDataMarkedStale{
+      sap_system_id: sap_system_id,
+      stale_at: stale_at
+    }
+
+    ProjectorTestHelper.project(SapSystemProjector, event, "sap_system_projector")
+
+    sap_system = Repo.get!(SapSystemReadModel, sap_system_id)
+
+    assert sap_system.stale_at == stale_at
+
+    assert_broadcast(
+      "sap_system_stale_changed",
+      %{
+        id: ^sap_system_id,
+        stale_at: ^stale_at
+      },
+      1000
+    )
+  end
+
+  test "should mark SAP system data as fresh when SapSystemDataMarkedInSync event is received" do
+    %{id: sap_system_id} = insert(:sap_system, stale_at: DateTime.utc_now())
+
+    event = %SapSystemDataMarkedInSync{
+      sap_system_id: sap_system_id
+    }
+
+    ProjectorTestHelper.project(SapSystemProjector, event, "sap_system_projector")
+
+    sap_system = Repo.get!(SapSystemReadModel, sap_system_id)
+
+    assert sap_system.stale_at == nil
+
+    assert_broadcast(
+      "sap_system_stale_changed",
+      %{
+        id: ^sap_system_id,
         stale_at: nil
       },
       1000

--- a/test/trento/sap_systems/sap_system_test.exs
+++ b/test/trento/sap_systems/sap_system_test.exs
@@ -17,7 +17,8 @@ defmodule Trento.SapSystems.SapSystemTest do
     RegisterApplicationInstance,
     RestoreSapSystem,
     RollUpSapSystem,
-    UpdateDatabaseHealth
+    UpdateDatabaseHealth,
+    UpdateDatabaseStaleAt
   }
 
   alias Trento.SapSystems.Events.{
@@ -30,6 +31,9 @@ defmodule Trento.SapSystems.SapSystemTest do
     ApplicationInstanceRegistered,
     ApplicationInstanceStatusChanged,
     SapSystemDatabaseHealthChanged,
+    SapSystemDatabaseStaleAtChanged,
+    SapSystemDataMarkedInSync,
+    SapSystemDataMarkedStale,
     SapSystemDeregistered,
     SapSystemHealthChanged,
     SapSystemRegistered,
@@ -2582,7 +2586,7 @@ defmodule Trento.SapSystems.SapSystemTest do
     end
   end
 
-  describe "instance marked stale/in sync" do
+  describe "sap system marked stale/in sync" do
     test "should mark application instance data as stale" do
       sap_system_id = Faker.UUID.v4()
       sid = fake_sid()
@@ -2618,10 +2622,15 @@ defmodule Trento.SapSystems.SapSystemTest do
             instance_number: instance_number,
             host_id: host_id,
             stale_at: stale_at
+          },
+          %SapSystemDataMarkedStale{
+            sap_system_id: sap_system_id,
+            stale_at: stale_at
           }
         ],
         fn state ->
           assert %SapSystem{
+                   stale_at: ^stale_at,
                    instances: [
                      %Instance{
                        instance_number: ^instance_number,
@@ -2682,7 +2691,7 @@ defmodule Trento.SapSystems.SapSystemTest do
       )
     end
 
-    test "should mark application instance data as in sync when registering a stale instance" do
+    test "should mark application instance data as in sync when data from a stale instance is received" do
       sap_system_id = Faker.UUID.v4()
       sid = fake_sid()
       host_id = Faker.UUID.v4()
@@ -2704,6 +2713,9 @@ defmodule Trento.SapSystems.SapSystemTest do
           sap_system_id: sap_system_id,
           instance_number: instance_number,
           host_id: host_id
+        ),
+        build(:sap_system_data_marked_stale_event,
+          sap_system_id: sap_system_id
         )
       ]
 
@@ -2724,10 +2736,14 @@ defmodule Trento.SapSystems.SapSystemTest do
             sap_system_id: sap_system_id,
             instance_number: instance_number,
             host_id: host_id
+          },
+          %SapSystemDataMarkedInSync{
+            sap_system_id: sap_system_id
           }
         ],
         fn state ->
           assert %SapSystem{
+                   stale_at: nil,
                    instances: [
                      %Instance{
                        instance_number: ^instance_number,
@@ -2780,6 +2796,680 @@ defmodule Trento.SapSystems.SapSystemTest do
                        stale_at: nil
                      }
                    ]
+                 } = state
+        end
+      )
+    end
+
+    test "should not mark sap system data as stale again if other instance was already stale" do
+      sap_system_id = Faker.UUID.v4()
+      sid = fake_sid()
+      host_id_1 = Faker.UUID.v4()
+      host_id_2 = Faker.UUID.v4()
+      instance_number_1 = "00"
+      instance_number_2 = "01"
+      stale_at_1 = DateTime.utc_now()
+      stale_at_2 = DateTime.utc_now()
+
+      initial_events = [
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          host_id: host_id_1,
+          instance_number: instance_number_1,
+          features: "MESSAGESERVER"
+        ),
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          host_id: host_id_2,
+          instance_number: instance_number_2,
+          features: "ABAP"
+        ),
+        build(:sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid
+        ),
+        build(:application_instance_data_marked_stale_event,
+          sap_system_id: sap_system_id,
+          instance_number: instance_number_1,
+          host_id: host_id_1,
+          stale_at: stale_at_1
+        ),
+        build(:sap_system_data_marked_stale_event,
+          sap_system_id: sap_system_id,
+          stale_at: stale_at_1
+        )
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        %MarkApplicationInstanceDataStale{
+          sap_system_id: sap_system_id,
+          instance_number: instance_number_2,
+          host_id: host_id_2,
+          stale_at: stale_at_2
+        },
+        [
+          %ApplicationInstanceDataMarkedStale{
+            sap_system_id: sap_system_id,
+            instance_number: instance_number_2,
+            host_id: host_id_2,
+            stale_at: stale_at_2
+          }
+        ],
+        fn state ->
+          assert %SapSystem{
+                   stale_at: ^stale_at_1
+                 } = state
+        end
+      )
+    end
+
+    test "should mark sap system data as in sync when a stale instance receives new data" do
+      sap_system_id = Faker.UUID.v4()
+      sid = fake_sid()
+      host_id = Faker.UUID.v4()
+      instance_number = "00"
+      stale_at = DateTime.utc_now()
+
+      initial_events = [
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          host_id: host_id,
+          instance_number: instance_number,
+          features: "MESSAGESERVER"
+        ),
+        build(:sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid
+        ),
+        build(:application_instance_data_marked_stale_event,
+          sap_system_id: sap_system_id,
+          instance_number: instance_number,
+          host_id: host_id,
+          stale_at: stale_at
+        ),
+        build(:sap_system_data_marked_stale_event,
+          sap_system_id: sap_system_id,
+          stale_at: stale_at
+        )
+      ]
+
+      command =
+        build(:register_application_instance_command,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          host_id: host_id,
+          instance_number: instance_number,
+          features: "MESSAGESERVER"
+        )
+
+      assert_events_and_state(
+        initial_events,
+        command,
+        [
+          %ApplicationInstanceDataMarkedInSync{
+            sap_system_id: sap_system_id,
+            instance_number: instance_number,
+            host_id: host_id
+          },
+          %SapSystemDataMarkedInSync{
+            sap_system_id: sap_system_id
+          }
+        ],
+        fn state ->
+          assert %SapSystem{
+                   stale_at: nil,
+                   instances: [
+                     %Instance{
+                       instance_number: ^instance_number,
+                       stale_at: nil
+                     }
+                   ]
+                 } = state
+        end
+      )
+    end
+
+    test "should mark sap system data as in sync when a stale instance is deregistered" do
+      sap_system_id = Faker.UUID.v4()
+      sid = fake_sid()
+      host_id_1 = Faker.UUID.v4()
+      host_id_2 = Faker.UUID.v4()
+      instance_number_1 = "00"
+      instance_number_2 = "01"
+      stale_at = DateTime.utc_now()
+      deregistered_at = DateTime.utc_now()
+
+      initial_events = [
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          host_id: host_id_1,
+          instance_number: instance_number_1,
+          features: "ENQREP"
+        ),
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          host_id: host_id_2,
+          instance_number: instance_number_2,
+          features: "MESSAGESERVER"
+        ),
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          host_id: host_id_2,
+          instance_number: "02",
+          features: "ABAP"
+        ),
+        build(:sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid
+        ),
+        build(:application_instance_data_marked_stale_event,
+          sap_system_id: sap_system_id,
+          instance_number: instance_number_1,
+          host_id: host_id_1,
+          stale_at: stale_at
+        ),
+        build(:sap_system_data_marked_stale_event,
+          sap_system_id: sap_system_id,
+          stale_at: stale_at
+        )
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        %DeregisterApplicationInstance{
+          sap_system_id: sap_system_id,
+          host_id: host_id_1,
+          instance_number: instance_number_1,
+          deregistered_at: deregistered_at
+        },
+        [
+          %ApplicationInstanceDeregistered{
+            sap_system_id: sap_system_id,
+            host_id: host_id_1,
+            instance_number: instance_number_1,
+            deregistered_at: deregistered_at
+          },
+          %SapSystemDataMarkedInSync{
+            sap_system_id: sap_system_id
+          }
+        ],
+        fn state ->
+          assert %SapSystem{
+                   stale_at: nil,
+                   deregistered_at: nil
+                 } = state
+        end
+      )
+    end
+
+    test "should not mark sap system data as in sync when an instance is deregistered but more stale instances are present" do
+      sap_system_id = Faker.UUID.v4()
+      sid = fake_sid()
+      host_id_1 = Faker.UUID.v4()
+      host_id_2 = Faker.UUID.v4()
+      host_id_3 = Faker.UUID.v4()
+      instance_number_1 = "00"
+      instance_number_2 = "01"
+      instance_number_3 = "02"
+      stale_at = DateTime.utc_now()
+      deregistered_at = DateTime.utc_now()
+
+      initial_events = [
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          host_id: host_id_1,
+          instance_number: instance_number_1,
+          features: "MESSAGESERVER"
+        ),
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          host_id: host_id_2,
+          instance_number: instance_number_2,
+          features: "ABAP"
+        ),
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          host_id: host_id_3,
+          instance_number: instance_number_3,
+          features: "ENQREP"
+        ),
+        build(:sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid
+        ),
+        build(:application_instance_data_marked_stale_event,
+          sap_system_id: sap_system_id,
+          instance_number: instance_number_1,
+          host_id: host_id_1,
+          stale_at: stale_at
+        ),
+        build(:application_instance_data_marked_stale_event,
+          sap_system_id: sap_system_id,
+          instance_number: instance_number_3,
+          host_id: host_id_3,
+          stale_at: stale_at
+        ),
+        build(:sap_system_data_marked_stale_event,
+          sap_system_id: sap_system_id,
+          stale_at: stale_at
+        )
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        %DeregisterApplicationInstance{
+          sap_system_id: sap_system_id,
+          host_id: host_id_3,
+          instance_number: instance_number_3,
+          deregistered_at: deregistered_at
+        },
+        [
+          %ApplicationInstanceDeregistered{
+            sap_system_id: sap_system_id,
+            host_id: host_id_3,
+            instance_number: instance_number_3,
+            deregistered_at: deregistered_at
+          }
+        ],
+        fn state ->
+          assert %SapSystem{
+                   stale_at: ^stale_at,
+                   deregistered_at: nil,
+                   instances: [
+                     %Instance{
+                       instance_number: ^instance_number_2,
+                       stale_at: nil
+                     },
+                     %Instance{
+                       instance_number: ^instance_number_1,
+                       stale_at: ^stale_at
+                     }
+                   ]
+                 } = state
+        end
+      )
+    end
+
+    test "should not mark sap system data as in sync when an instance is deregistered if the system was already in sync" do
+      sap_system_id = Faker.UUID.v4()
+      sid = fake_sid()
+      host_id_1 = Faker.UUID.v4()
+      host_id_2 = Faker.UUID.v4()
+      host_id_3 = Faker.UUID.v4()
+      instance_number_1 = "00"
+      instance_number_2 = "01"
+      instance_number_3 = "02"
+      deregistered_at = DateTime.utc_now()
+
+      initial_events = [
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          host_id: host_id_1,
+          instance_number: instance_number_1,
+          features: "MESSAGESERVER"
+        ),
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          host_id: host_id_2,
+          instance_number: instance_number_2,
+          features: "ABAP"
+        ),
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          host_id: host_id_3,
+          instance_number: instance_number_3,
+          features: "ENQREP"
+        ),
+        build(:sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid
+        )
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        %DeregisterApplicationInstance{
+          sap_system_id: sap_system_id,
+          host_id: host_id_3,
+          instance_number: instance_number_3,
+          deregistered_at: deregistered_at
+        },
+        [
+          %ApplicationInstanceDeregistered{
+            sap_system_id: sap_system_id,
+            host_id: host_id_3,
+            instance_number: instance_number_3,
+            deregistered_at: deregistered_at
+          }
+        ],
+        fn state ->
+          assert %SapSystem{
+                   stale_at: nil,
+                   deregistered_at: nil,
+                   instances: [
+                     %Instance{
+                       instance_number: ^instance_number_2,
+                       stale_at: nil
+                     },
+                     %Instance{
+                       instance_number: ^instance_number_1,
+                       stale_at: nil
+                     }
+                   ]
+                 } = state
+        end
+      )
+    end
+
+    test "should mark SAP system as stale when database goes stale and system was in sync" do
+      sap_system_id = Faker.UUID.v4()
+      sid = fake_sid()
+      database_stale_at = DateTime.utc_now()
+
+      initial_events = [
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          features: "MESSAGESERVER"
+        ),
+        build(:sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid
+        )
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        UpdateDatabaseStaleAt.new!(%{
+          sap_system_id: sap_system_id,
+          database_stale_at: database_stale_at
+        }),
+        [
+          %SapSystemDatabaseStaleAtChanged{
+            sap_system_id: sap_system_id,
+            database_stale_at: database_stale_at
+          },
+          %SapSystemDataMarkedStale{
+            sap_system_id: sap_system_id,
+            stale_at: database_stale_at
+          }
+        ],
+        fn state ->
+          assert %SapSystem{
+                   stale_at: ^database_stale_at,
+                   database_stale_at: ^database_stale_at
+                 } = state
+        end
+      )
+    end
+
+    test "should not mark SAP system as stale again when database goes stale and system was already stale" do
+      sap_system_id = Faker.UUID.v4()
+      sid = fake_sid()
+      host_id = Faker.UUID.v4()
+      instance_number = "00"
+      instance_stale_at = DateTime.utc_now()
+      database_stale_at = DateTime.add(instance_stale_at, 60, :second)
+
+      initial_events = [
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          host_id: host_id,
+          instance_number: instance_number,
+          features: "MESSAGESERVER"
+        ),
+        build(:sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid
+        ),
+        build(:application_instance_data_marked_stale_event,
+          sap_system_id: sap_system_id,
+          instance_number: instance_number,
+          host_id: host_id,
+          stale_at: instance_stale_at
+        ),
+        build(:sap_system_data_marked_stale_event,
+          sap_system_id: sap_system_id,
+          stale_at: instance_stale_at
+        )
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        UpdateDatabaseStaleAt.new!(%{
+          sap_system_id: sap_system_id,
+          database_stale_at: database_stale_at
+        }),
+        [
+          %SapSystemDatabaseStaleAtChanged{
+            sap_system_id: sap_system_id,
+            database_stale_at: database_stale_at
+          }
+        ],
+        fn state ->
+          assert %SapSystem{
+                   stale_at: ^instance_stale_at,
+                   database_stale_at: ^database_stale_at
+                 } = state
+        end
+      )
+    end
+
+    test "should mark SAP system as in sync when database goes in sync and all instances are in sync" do
+      sap_system_id = Faker.UUID.v4()
+      sid = fake_sid()
+      database_stale_at = DateTime.utc_now()
+
+      initial_events = [
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          features: "MESSAGESERVER"
+        ),
+        build(:sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid
+        ),
+        build(:sap_system_database_stale_at_changed_event,
+          sap_system_id: sap_system_id,
+          database_stale_at: database_stale_at
+        ),
+        build(:sap_system_data_marked_stale_event,
+          sap_system_id: sap_system_id,
+          stale_at: database_stale_at
+        )
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        UpdateDatabaseStaleAt.new!(%{
+          sap_system_id: sap_system_id,
+          database_stale_at: nil
+        }),
+        [
+          %SapSystemDatabaseStaleAtChanged{
+            sap_system_id: sap_system_id,
+            database_stale_at: nil
+          },
+          %SapSystemDataMarkedInSync{
+            sap_system_id: sap_system_id
+          }
+        ],
+        fn state ->
+          assert %SapSystem{
+                   stale_at: nil,
+                   database_stale_at: nil
+                 } = state
+        end
+      )
+    end
+
+    test "should not mark SAP system as in sync when database goes in sync but instances are still stale" do
+      sap_system_id = Faker.UUID.v4()
+      sid = fake_sid()
+      host_id = Faker.UUID.v4()
+      instance_number = "00"
+      instance_stale_at = DateTime.utc_now()
+      database_stale_at = DateTime.add(instance_stale_at, 60, :second)
+
+      initial_events = [
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          host_id: host_id,
+          instance_number: instance_number,
+          features: "MESSAGESERVER"
+        ),
+        build(:sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid
+        ),
+        build(:application_instance_data_marked_stale_event,
+          sap_system_id: sap_system_id,
+          instance_number: instance_number,
+          host_id: host_id,
+          stale_at: instance_stale_at
+        ),
+        build(:sap_system_data_marked_stale_event,
+          sap_system_id: sap_system_id,
+          stale_at: instance_stale_at
+        ),
+        build(:sap_system_database_stale_at_changed_event,
+          sap_system_id: sap_system_id,
+          database_stale_at: database_stale_at
+        )
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        UpdateDatabaseStaleAt.new!(%{
+          sap_system_id: sap_system_id,
+          database_stale_at: nil
+        }),
+        [
+          %SapSystemDatabaseStaleAtChanged{
+            sap_system_id: sap_system_id,
+            database_stale_at: nil
+          }
+        ],
+        fn state ->
+          assert %SapSystem{
+                   stale_at: ^instance_stale_at,
+                   database_stale_at: nil,
+                   instances: [
+                     %Instance{
+                       instance_number: ^instance_number,
+                       stale_at: ^instance_stale_at
+                     }
+                   ]
+                 } = state
+        end
+      )
+    end
+
+    test "should not emit any events when database stale_at is the same" do
+      sap_system_id = Faker.UUID.v4()
+      sid = fake_sid()
+      database_stale_at = DateTime.utc_now()
+
+      initial_events = [
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          features: "MESSAGESERVER"
+        ),
+        build(:sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid
+        ),
+        build(:sap_system_database_stale_at_changed_event,
+          sap_system_id: sap_system_id,
+          database_stale_at: database_stale_at
+        ),
+        build(:sap_system_data_marked_stale_event,
+          sap_system_id: sap_system_id,
+          stale_at: database_stale_at
+        )
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        UpdateDatabaseStaleAt.new!(%{
+          sap_system_id: sap_system_id,
+          database_stale_at: database_stale_at
+        }),
+        [],
+        fn state ->
+          assert %SapSystem{
+                   stale_at: ^database_stale_at,
+                   database_stale_at: ^database_stale_at
+                 } = state
+        end
+      )
+    end
+
+    test "should not override sap system stale_at when database goes stale after an instance" do
+      sap_system_id = Faker.UUID.v4()
+      sid = fake_sid()
+      host_id = Faker.UUID.v4()
+      instance_number = "00"
+      instance_stale_at = DateTime.utc_now()
+      database_stale_at = DateTime.add(instance_stale_at, 60, :second)
+
+      initial_events = [
+        build(:application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid,
+          host_id: host_id,
+          instance_number: instance_number,
+          features: "MESSAGESERVER"
+        ),
+        build(:sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid
+        ),
+        build(:application_instance_data_marked_stale_event,
+          sap_system_id: sap_system_id,
+          instance_number: instance_number,
+          host_id: host_id,
+          stale_at: instance_stale_at
+        ),
+        build(:sap_system_data_marked_stale_event,
+          sap_system_id: sap_system_id,
+          stale_at: instance_stale_at
+        )
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        UpdateDatabaseStaleAt.new!(%{
+          sap_system_id: sap_system_id,
+          database_stale_at: database_stale_at
+        }),
+        [
+          %SapSystemDatabaseStaleAtChanged{
+            sap_system_id: sap_system_id,
+            database_stale_at: database_stale_at
+          }
+        ],
+        fn state ->
+          assert %SapSystem{
+                   stale_at: ^instance_stale_at,
+                   database_stale_at: ^database_stale_at
                  } = state
         end
       )

--- a/test/trento/sap_systems/sap_system_test.exs
+++ b/test/trento/sap_systems/sap_system_test.exs
@@ -2586,7 +2586,7 @@ defmodule Trento.SapSystems.SapSystemTest do
     end
   end
 
-  describe "sap system marked stale/in sync" do
+  describe "SAP system marked stale/in sync" do
     test "should mark application instance data as stale" do
       sap_system_id = Faker.UUID.v4()
       sid = fake_sid()
@@ -2801,7 +2801,7 @@ defmodule Trento.SapSystems.SapSystemTest do
       )
     end
 
-    test "should not mark sap system data as stale again if other instance was already stale" do
+    test "should not mark SAP system data as stale again if other instance was already stale" do
       sap_system_id = Faker.UUID.v4()
       sid = fake_sid()
       host_id_1 = Faker.UUID.v4()
@@ -2809,7 +2809,7 @@ defmodule Trento.SapSystems.SapSystemTest do
       instance_number_1 = "00"
       instance_number_2 = "01"
       stale_at_1 = DateTime.utc_now()
-      stale_at_2 = DateTime.utc_now()
+      stale_at_2 = DateTime.add(stale_at_1, 1, :day)
 
       initial_events = [
         build(:application_instance_registered_event,
@@ -2866,7 +2866,7 @@ defmodule Trento.SapSystems.SapSystemTest do
       )
     end
 
-    test "should mark sap system data as in sync when a stale instance receives new data" do
+    test "should mark SAP system data as in sync when a stale instance receives new data" do
       sap_system_id = Faker.UUID.v4()
       sid = fake_sid()
       host_id = Faker.UUID.v4()
@@ -2933,7 +2933,7 @@ defmodule Trento.SapSystems.SapSystemTest do
       )
     end
 
-    test "should mark sap system data as in sync when a stale instance is deregistered" do
+    test "should mark SAP system data as in sync when a stale instance is deregistered" do
       sap_system_id = Faker.UUID.v4()
       sid = fake_sid()
       host_id_1 = Faker.UUID.v4()
@@ -3009,7 +3009,7 @@ defmodule Trento.SapSystems.SapSystemTest do
       )
     end
 
-    test "should not mark sap system data as in sync when an instance is deregistered but more stale instances are present" do
+    test "should not mark SAP system data as in sync when an instance is deregistered but more stale instances are present" do
       sap_system_id = Faker.UUID.v4()
       sid = fake_sid()
       host_id_1 = Faker.UUID.v4()
@@ -3036,6 +3036,10 @@ defmodule Trento.SapSystems.SapSystemTest do
           instance_number: instance_number_2,
           features: "ABAP"
         ),
+        build(:sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid
+        ),
         build(:application_instance_registered_event,
           sap_system_id: sap_system_id,
           sid: sid,
@@ -3043,25 +3047,21 @@ defmodule Trento.SapSystems.SapSystemTest do
           instance_number: instance_number_3,
           features: "ENQREP"
         ),
-        build(:sap_system_registered_event,
-          sap_system_id: sap_system_id,
-          sid: sid
-        ),
         build(:application_instance_data_marked_stale_event,
           sap_system_id: sap_system_id,
           instance_number: instance_number_1,
           host_id: host_id_1,
           stale_at: stale_at
         ),
+        build(:sap_system_data_marked_stale_event,
+          sap_system_id: sap_system_id,
+          stale_at: stale_at
+        ),
         build(:application_instance_data_marked_stale_event,
           sap_system_id: sap_system_id,
           instance_number: instance_number_3,
           host_id: host_id_3,
-          stale_at: stale_at
-        ),
-        build(:sap_system_data_marked_stale_event,
-          sap_system_id: sap_system_id,
-          stale_at: stale_at
+          stale_at: DateTime.add(stale_at, 1, :day)
         )
       ]
 
@@ -3126,16 +3126,16 @@ defmodule Trento.SapSystems.SapSystemTest do
           instance_number: instance_number_2,
           features: "ABAP"
         ),
+        build(:sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: sid
+        ),
         build(:application_instance_registered_event,
           sap_system_id: sap_system_id,
           sid: sid,
           host_id: host_id_3,
           instance_number: instance_number_3,
           features: "ENQREP"
-        ),
-        build(:sap_system_registered_event,
-          sap_system_id: sap_system_id,
-          sid: sid
         )
       ]
 
@@ -3422,7 +3422,7 @@ defmodule Trento.SapSystems.SapSystemTest do
       )
     end
 
-    test "should not override sap system stale_at when database goes stale after an instance" do
+    test "should not override SAP system stale_at when database goes stale after an instance" do
       sap_system_id = Faker.UUID.v4()
       sid = fake_sid()
       host_id = Faker.UUID.v4()

--- a/test/trento/sap_systems/sap_system_test.exs
+++ b/test/trento/sap_systems/sap_system_test.exs
@@ -3483,7 +3483,7 @@ defmodule Trento.SapSystems.SapSystemTest do
       )
     end
 
-    test "should mark SAP system data as in sync when the SAP is restored and database sync state has changed" do
+    test "should mark SAP system data as in sync when the SAP is restored and database stale state had changed in the meantime" do
       sap_system_id = UUID.uuid4()
 
       database_host_id = UUID.uuid4()

--- a/test/trento/sap_systems/sap_system_test.exs
+++ b/test/trento/sap_systems/sap_system_test.exs
@@ -61,6 +61,7 @@ defmodule Trento.SapSystems.SapSystemTest do
       start_priority = "0.9"
       host_id = Faker.UUID.v4()
       ensa_version = EnsaVersion.ensa1()
+      database_stale_at = DateTime.utc_now()
 
       initial_events = [
         build(:application_instance_registered_event,
@@ -88,6 +89,7 @@ defmodule Trento.SapSystems.SapSystemTest do
           status: Status.green(),
           ensa_version: ensa_version,
           database_health: :passing,
+          database_stale_at: database_stale_at,
           clustered: false
         }),
         [
@@ -110,6 +112,7 @@ defmodule Trento.SapSystems.SapSystemTest do
             tenant: tenant,
             health: :passing,
             database_health: :passing,
+            database_stale_at: database_stale_at,
             ensa_version: ensa_version
           }
         ],
@@ -118,6 +121,7 @@ defmodule Trento.SapSystems.SapSystemTest do
                    sid: ^sid,
                    ensa_version: ^ensa_version,
                    database_health: :passing,
+                   database_stale_at: ^database_stale_at,
                    instances: [
                      %Instance{
                        sid: ^sid,
@@ -1538,6 +1542,7 @@ defmodule Trento.SapSystems.SapSystemTest do
       sap_system_id = UUID.uuid4()
 
       database_host_id = UUID.uuid4()
+      database_stale_at = DateTime.utc_now()
 
       deregistered_at = DateTime.utc_now()
 
@@ -1589,7 +1594,8 @@ defmodule Trento.SapSystems.SapSystemTest do
           sid: application_sid,
           db_host: database_host_id,
           features: "MESSAGESERVER",
-          database_health: :critical
+          database_health: :critical,
+          database_stale_at: database_stale_at
         )
 
       assert_events_and_state(
@@ -1613,7 +1619,8 @@ defmodule Trento.SapSystems.SapSystemTest do
             tenant: command.tenant,
             db_host: command.db_host,
             health: :passing,
-            database_health: command.database_health
+            database_health: command.database_health,
+            database_stale_at: command.database_stale_at
           },
           %SapSystemHealthChanged{
             sap_system_id: sap_system_id,
@@ -1624,6 +1631,7 @@ defmodule Trento.SapSystems.SapSystemTest do
           assert %SapSystem{
                    health: :critical,
                    database_health: :critical,
+                   database_stale_at: ^database_stale_at,
                    deregistered_at: nil
                  } = sap_system
         end
@@ -3471,6 +3479,113 @@ defmodule Trento.SapSystems.SapSystemTest do
                    stale_at: ^instance_stale_at,
                    database_stale_at: ^database_stale_at
                  } = state
+        end
+      )
+    end
+
+    test "should mark SAP system data as in sync when the SAP is restored and database sync state has changed" do
+      sap_system_id = UUID.uuid4()
+
+      database_host_id = UUID.uuid4()
+      database_stale_at = DateTime.utc_now()
+
+      deregistered_at = DateTime.utc_now()
+
+      application_sid = fake_sid()
+
+      message_server_host_id = UUID.uuid4()
+      message_server_instance_number = "00"
+      abap_host_id = UUID.uuid4()
+      abap_instance_number = "01"
+
+      initial_events = [
+        build(
+          :application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          features: "MESSAGESERVER|ENQUE",
+          host_id: message_server_host_id,
+          instance_number: message_server_instance_number,
+          sid: application_sid
+        ),
+        build(
+          :application_instance_registered_event,
+          sap_system_id: sap_system_id,
+          features: "ABAP|GATEWAY|ICMAN|IGS",
+          host_id: abap_host_id,
+          instance_number: abap_instance_number,
+          sid: application_sid
+        ),
+        build(
+          :sap_system_registered_event,
+          sap_system_id: sap_system_id,
+          sid: application_sid
+        ),
+        build(
+          :sap_system_database_stale_at_changed_event,
+          sap_system_id: sap_system_id,
+          database_stale_at: database_stale_at
+        ),
+        build(:sap_system_data_marked_stale_event,
+          sap_system_id: sap_system_id,
+          stale_at: database_stale_at
+        ),
+        build(:sap_system_deregistered_event,
+          sap_system_id: sap_system_id,
+          deregistered_at: deregistered_at
+        ),
+        build(:application_instance_deregistered_event,
+          sap_system_id: sap_system_id,
+          deregistered_at: deregistered_at,
+          instance_number: message_server_instance_number,
+          host_id: message_server_host_id
+        )
+      ]
+
+      command =
+        build(
+          :register_application_instance_command,
+          sap_system_id: sap_system_id,
+          sid: application_sid,
+          db_host: database_host_id,
+          features: "MESSAGESERVER",
+          database_stale_at: nil
+        )
+
+      assert_events_and_state(
+        initial_events,
+        command,
+        [
+          %ApplicationInstanceRegistered{
+            sap_system_id: sap_system_id,
+            sid: application_sid,
+            host_id: command.host_id,
+            instance_number: command.instance_number,
+            instance_hostname: command.instance_hostname,
+            features: command.features,
+            http_port: command.http_port,
+            https_port: command.https_port,
+            start_priority: command.start_priority,
+            status: command.status
+          },
+          %SapSystemRestored{
+            sap_system_id: sap_system_id,
+            tenant: command.tenant,
+            db_host: command.db_host,
+            health: :passing,
+            database_health: command.database_health,
+            database_stale_at: command.database_stale_at
+          },
+          %SapSystemDataMarkedInSync{
+            sap_system_id: sap_system_id
+          }
+        ],
+        fn sap_system ->
+          assert %SapSystem{
+                   health: :passing,
+                   database_health: :passing,
+                   database_stale_at: nil,
+                   deregistered_at: nil
+                 } = sap_system
         end
       )
     end

--- a/test/trento_web/views/v1/sap_system_view_json_test.exs
+++ b/test/trento_web/views/v1/sap_system_view_json_test.exs
@@ -9,7 +9,8 @@ defmodule TrentoWeb.V1.SapSystemJSONTest do
 
   describe "SapSystemJSON" do
     test "should render sap_systems.json" do
-      %{id: database_id, sid: database_sid, health: database_health} = database = build(:database)
+      %{id: database_id, sid: database_sid, health: database_health, stale_at: database_stale_at} =
+        database = build(:database)
 
       database_instances = build_list(1, :database_instance, database_id: database_id)
       application_instances = build_list(1, :application_instance)
@@ -30,6 +31,7 @@ defmodule TrentoWeb.V1.SapSystemJSONTest do
         |> Map.delete(:database)
         |> Map.put(:database_sid, database_sid)
         |> Map.put(:database_health, database_health)
+        |> Map.put(:database_stale_at, database_stale_at)
         |> Map.put(
           :application_instances,
           Enum.map(application_instances, fn app_instance ->


### PR DESCRIPTION
### Description

Add `stale_at` field and transition events to the sap system aggregate.
It follow a similar logic than the database sibling with an exception.
The sap system is stale if the associated database is stale, that's where the `UpdateDatabaseStaleAt` and the event handler come in place.

### How was this tested?

UT

### Documentation changes

No