### PR TITLE
Create SIDs list properly using filtered array IDs

### DIFF
--- a/assets/js/pages/HostsList/HostsList.jsx
+++ b/assets/js/pages/HostsList/HostsList.jsx
@@ -131,19 +131,21 @@ function HostsList() {
         filterFromParams: true,
         filter: (filter, key) => (element) =>
           element[key].some((sid) => filter.includes(sid)),
-        render: (sids, { sap_systems }) => {
-          const sidsArray = uniqBy(sap_systems, getInstanceID);
-          return sidsArray.map((instance, index) => (
-            <span key={`${sids[index]}-${instance?.id}`}>
-              <SapSystemLink
-                key={`${getInstanceID(instance)}-${instance?.id}`}
-                systemType={instance?.type}
-                sapSystemId={getInstanceID(instance)}
-              >
-                {instance?.sid}
-              </SapSystemLink>{' '}
-            </span>
-          ));
+        render: (_sids, { sap_systems }) => {
+          const instances = uniqBy(sap_systems, getInstanceID);
+          return instances.map((instance) => {
+            const sapSystemId = getInstanceID(instance);
+            return (
+              <span key={sapSystemId}>
+                <SapSystemLink
+                  systemType={instance?.type}
+                  sapSystemId={sapSystemId}
+                >
+                  {instance?.sid}
+                </SapSystemLink>{' '}
+              </span>
+            );
+          });
         },
       },
       {

--- a/assets/js/pages/HostsList/HostsList.test.jsx
+++ b/assets/js/pages/HostsList/HostsList.test.jsx
@@ -349,14 +349,20 @@ describe('HostsLists component', () => {
           },
           sapSystemsList: {
             applicationInstances: [
-              { sid: 'PRD', host_id: 'host1' },
-              { sid: 'QAS', host_id: 'host3' },
+              sapSystemApplicationInstanceFactory.build({
+                sid: 'PRD',
+                host_id: 'host1',
+              }),
+              sapSystemApplicationInstanceFactory.build({
+                sid: 'QAS',
+                host_id: 'host3',
+              }),
             ],
           },
           databasesList: {
             databaseInstances: [
-              { sid: 'PRD', host_id: 'host2' },
-              { sid: 'QAS', host_id: 'host4' },
+              databaseInstanceFactory.build({ sid: 'PRD', host_id: 'host2' }),
+              databaseInstanceFactory.build({ sid: 'QAS', host_id: 'host4' }),
             ],
           },
         },
@@ -462,7 +468,10 @@ describe('HostsLists component', () => {
           hosts,
         },
         sapSystemsList: {
-          applicationInstances: [{ sid, host_id: 'host1' }],
+          applicationInstances: sapSystemApplicationInstanceFactory.buildList(
+            1,
+            { sid, host_id: 'host1' }
+          ),
           databaseInstances: [],
         },
       };


### PR DESCRIPTION
### Description

Fix a bug on how the `key` for the SIDs list was created.
The code was using the initial array with an index to get the key in `sids[index]`. This is really buggy, as the the `index` is coming from a different list.
Besides that, the `?.id` is totally wrong, as the items in the list don't have the `id` value, so it always defaults to `undefined`.
We need to use the unique ID as done in the next `key`.

Without this, in scenarios where there are duplicated SID values with different `sap_system_id`s, the list values behave totally wrong, creating duplicated lists everytime you paginate or filter. 
For example:
<img width="785" height="146" alt="image" src="https://github.com/user-attachments/assets/cf02ef21-067d-42f2-a75b-b0c8daa7054a" />


### How was this tested?

UT 

### Documentation changes

No