### PR TITLE
Display stale SAP system and database in frontend

### DIFF
--- a/assets/js/common/PageHeader/DetailsViewHeader.jsx
+++ b/assets/js/common/PageHeader/DetailsViewHeader.jsx
@@ -5,11 +5,16 @@ import React from 'react';
 import HealthIcon from '@common/HealthIcon';
 import PageHeader from './PageHeader';
 
-function DetailsViewHeader({ className, health, children }) {
+function DetailsViewHeader({ className, health, staleAt, timezone, children }) {
   return (
     <PageHeader className={className}>
       <div className="flex items-center justify-center space-x-2">
-        <HealthIcon health={health} size="xl" />
+        <HealthIcon
+          health={health}
+          size="xl"
+          staleAt={staleAt}
+          timezone={timezone}
+        />
         <span>{children}</span>
       </div>
     </PageHeader>

--- a/assets/js/common/PageHeader/DetailsViewHeader.stories.jsx
+++ b/assets/js/common/PageHeader/DetailsViewHeader.stories.jsx
@@ -20,6 +20,19 @@ export default {
         defaultValue: { summary: 'passing' },
       },
     },
+    staleAt: {
+      description:
+        'Timestamp when the resource became stale (null if not stale)',
+      control: {
+        type: 'text',
+      },
+    },
+    timezone: {
+      description: 'Timezone for displaying the stale timestamp',
+      control: {
+        type: 'text',
+      },
+    },
     children: {
       description: 'Content or text displayed inside the component',
       control: { type: 'text' },
@@ -32,5 +45,14 @@ export const Default = {
     className: '',
     health: 'passing',
     children: 'Default children',
+  },
+};
+
+export const Stale = {
+  args: {
+    className: '',
+    health: 'passing',
+    staleAt: '2026-06-15T10:30:00Z',
+    children: 'Stale resource',
   },
 };

--- a/assets/js/common/PageHeader/DetailsViewHeader.test.jsx
+++ b/assets/js/common/PageHeader/DetailsViewHeader.test.jsx
@@ -14,4 +14,19 @@ describe('DetailsViewHeader', () => {
       'fill-jungle-green-500'
     );
   });
+
+  it('should render a stale state', () => {
+    const staleAt = '2026-06-15T10:30:00Z';
+    const timezone = 'America/New_York';
+
+    render(
+      <DetailsViewHeader health="passing" staleAt={staleAt} timezone={timezone}>
+        Stale Resource
+      </DetailsViewHeader>
+    );
+
+    expect(screen.getByText('Stale Resource')).toBeVisible();
+    const svgs = screen.getAllByTestId('eos-svg-component');
+    expect(svgs).toHaveLength(2);
+  });
 });

--- a/assets/js/pages/DatabaseDetails/DatabaseDetails.stories.jsx
+++ b/assets/js/pages/DatabaseDetails/DatabaseDetails.stories.jsx
@@ -28,6 +28,17 @@ databaseWithAbsentInstance.instances[1].absent_at = faker.date
   .past()
   .toISOString();
 
+const databaseWithStaleData = {
+  ...databaseFactory.build({
+    stale_at: '2026-06-15T10:30:00Z',
+    instances: [
+      databaseInstanceFactory.build({ stale_at: '2026-06-15T10:30:00Z' }),
+      databaseInstanceFactory.build(),
+    ],
+  }),
+  hosts: hostFactory.buildList(2, { cluster: clusterFactory.build() }),
+};
+
 function ContainerWrapper({ children }) {
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 md:px-8">{children}</div>
@@ -45,6 +56,12 @@ export default {
     userAbilities: {
       control: 'array',
       description: 'Current user abilities',
+    },
+    userTimezone: {
+      description: 'Current user timezone',
+      control: {
+        type: 'text',
+      },
     },
     cleanUpPermittedFor: {
       control: 'array',
@@ -75,7 +92,9 @@ export const Database = {
     type: DATABASE_TYPE,
     system: database,
     userAbilities: [{ name: 'all', resource: 'all' }],
+    userTimezone: 'Etc/UTC',
     cleanUpPermittedFor: ['cleanup:database_instance'],
+    operationsEnabled: true,
   },
 };
 
@@ -90,5 +109,12 @@ export const CleanUpUnauthorized = {
   args: {
     ...DatabaseWithAbsentInstance.args,
     userAbilities: [],
+  },
+};
+
+export const DatabaseWithStaleData = {
+  args: {
+    ...Database.args,
+    system: databaseWithStaleData,
   },
 };

--- a/assets/js/pages/DatabasesOverview/DatabasesOverview.jsx
+++ b/assets/js/pages/DatabasesOverview/DatabasesOverview.jsx
@@ -4,8 +4,10 @@
 import React, { useState } from 'react';
 import { Link, useSearchParams } from 'react-router';
 import { filter } from 'lodash';
+import classNames from 'classnames';
 
 import { DATABASE_TYPE } from '@lib/model/sapSystems';
+import { STALE_ROW } from '@lib/tables';
 
 import HealthIcon from '@common/HealthIcon';
 import PageHeader from '@common/PageHeader';
@@ -36,15 +38,23 @@ function DatabasesOverview({
     pagination: true,
     usePadding: false,
     collapsedRowClassName: 'bg-gray-100',
+    rowClassName: ({ staleAt }) =>
+      classNames({
+        [STALE_ROW]: !!staleAt,
+      }),
     columns: [
       {
         title: 'Health',
         key: 'health',
         filter: true,
         filterFromParams: true,
-        render: (content) => (
+        render: (content, { staleAt }) => (
           <div className="ml-4">
-            <HealthIcon health={content} />
+            <HealthIcon
+              health={content}
+              staleAt={staleAt}
+              timezone={userTimezone}
+            />
           </div>
         ),
       },
@@ -143,6 +153,7 @@ function DatabasesOverview({
       database_id: database.id,
     }),
     tags: (database.tags && database.tags.map((tag) => tag.value)) || [],
+    staleAt: database.stale_at,
   }));
 
   const counters = getCounters(data || []);

--- a/assets/js/pages/DatabasesOverview/DatabasesOverview.stories.jsx
+++ b/assets/js/pages/DatabasesOverview/DatabasesOverview.stories.jsx
@@ -146,3 +146,24 @@ export const UnauthorizedCleanUp = {
     userAbilities: [],
   },
 };
+
+const databaseIDForStale = faker.string.uuid();
+const staleAt = faker.date.past().toISOString();
+export const WithStaleDatabase = {
+  args: {
+    userAbilities,
+    databases: databaseFactory.buildList(1, {
+      id: databaseIDForStale,
+      stale_at: staleAt,
+    }),
+    databaseInstances: [
+      databaseInstanceFactory.build({
+        database_id: databaseIDForStale,
+        stale_at: staleAt,
+      }),
+      databaseInstanceFactory.build({
+        database_id: databaseIDForStale,
+      }),
+    ],
+  },
+};

--- a/assets/js/pages/DatabasesOverview/DatabasesOverview.test.jsx
+++ b/assets/js/pages/DatabasesOverview/DatabasesOverview.test.jsx
@@ -9,25 +9,80 @@ import '@testing-library/jest-dom';
 import { faker } from '@faker-js/faker';
 import userEvent from '@testing-library/user-event';
 
-import { databaseFactory } from '@lib/test-utils/factories';
+import {
+  databaseFactory,
+  databaseInstanceFactory,
+} from '@lib/test-utils/factories';
 import { renderWithRouter } from '@lib/test-utils';
 import { filterTable, clearFilter } from '@lib/test-utils/table';
 
 import DatabasesOverview from './DatabasesOverview';
 
+const userAbilities = [{ name: 'all', resource: 'all' }];
+
 describe('DatabasesOverview component', () => {
+  describe('overview content', () => {
+    it('should display stale databases with gray background and stale icon', async () => {
+      const user = userEvent.setup();
+      const staleDate = faker.date.past().toISOString();
+      const databaseID = faker.string.uuid();
+      const database = databaseFactory.build({
+        id: databaseID,
+        health: 'passing',
+        stale_at: staleDate,
+      });
+
+      const databaseInstances = databaseInstanceFactory.buildList(2, {
+        database_id: databaseID,
+        stale_at: staleDate,
+      });
+
+      renderWithRouter(
+        <DatabasesOverview
+          databases={[database]}
+          databaseInstances={databaseInstances}
+          userAbilities={userAbilities}
+        />
+      );
+
+      const rows = screen.getByRole('table').querySelectorAll('tbody > tr');
+      expect(rows[0]).toHaveClass('bg-gray-100');
+
+      const healthCell = rows[0].querySelector('td:nth-child(2)');
+      const svgs = healthCell.querySelectorAll(
+        '[data-testid="eos-svg-component"]'
+      );
+      expect(svgs).toHaveLength(2);
+
+      const table = screen.getByRole('table');
+      await user.click(
+        table.querySelector('tbody tr:nth-child(1) td:nth-child(1)')
+      );
+
+      const detailsRow = screen
+        .getByRole('table')
+        .querySelectorAll('tbody > tr')[1];
+      expect(detailsRow).toHaveClass('bg-gray-100');
+
+      const instanceRows = detailsRow.querySelectorAll(
+        'div.table-row-group > div.table-row'
+      );
+      expect(instanceRows[0]).toHaveClass('bg-gray-100');
+    });
+  });
+
   describe('tag operations', () => {
     it('should disable tag creation and delete when user abilities are not compatible', () => {
       const database = databaseFactory.build({
         tags: [{ value: 'Tag1' }, { value: 'Tag2' }],
       });
-      const userAbilities = [{ name: 'all', resource: 'another_resource' }];
+      const abilities = [{ name: 'all', resource: 'another_resource' }];
 
       renderWithRouter(
         <DatabasesOverview
           databases={[database]}
           databaseInstances={database.database_instances}
-          userAbilities={userAbilities}
+          userAbilities={abilities}
         />
       );
 
@@ -45,7 +100,6 @@ describe('DatabasesOverview component', () => {
     it('should clean up database instance on request', async () => {
       const user = userEvent.setup();
       const mockedCleanUp = jest.fn();
-      const userAbilities = [{ name: 'all', resource: 'all' }];
 
       const database = databaseFactory.build();
 
@@ -121,8 +175,6 @@ describe('DatabasesOverview component', () => {
   });
 
   describe('filtering', () => {
-    const userAbilities = [{ name: 'all', resource: 'all' }];
-
     const scenarios = [
       {
         filter: 'Health',

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
@@ -47,6 +47,7 @@ import {
 } from '@lib/model/sapSystems';
 import { isSomeHostHeartbeatPassing } from '@lib/model/hosts';
 import { STALE_ROW } from '@lib/tables';
+import { formatDateTime } from '@lib/timezones';
 
 import ListView from '@common/ListView';
 import Table from '@common/Table';
@@ -63,6 +64,7 @@ import SapSystemLink from '@common/SapSystemLink';
 import DeregistrationModal from '@pages/DeregistrationModal';
 
 import Pill from '@common/Pill';
+import Banner from '@common/Banners';
 import { getReplicationStatusClasses } from '@pages/InstanceOverview/InstanceOverview';
 
 import {
@@ -293,7 +295,12 @@ export function GenericSystemDetails({
       />
       <div className="flex flex-wrap">
         <div className="flex w-1/2 h-auto overflow-hidden overflow-ellipsis break-words">
-          <DetailsViewHeader className="font-bold" health={system.health}>
+          <DetailsViewHeader
+            className="font-bold"
+            health={system.health}
+            staleAt={system.stale_at}
+            timezone={userTimezone}
+          >
             {title}
           </DetailsViewHeader>
         </div>
@@ -311,6 +318,13 @@ export function GenericSystemDetails({
           </div>
         )}
       </div>
+      {system.stale_at && (
+        <Banner type="warning" truncate={false}>
+          Trento agent heartbeat failed in some host composing this{' '}
+          {type === APPLICATION_TYPE ? 'SAP system' : 'Database'}... Information
+          is outdated since {formatDateTime(system.stale_at, userTimezone)}.
+        </Banner>
+      )}
       <div className="mt-4 bg-white shadow rounded-lg py-4 px-8">
         {type === APPLICATION_TYPE ? (
           <ListView
@@ -338,7 +352,14 @@ export function GenericSystemDetails({
               {
                 title: 'Database health',
                 content: system.database_health,
-                render: (content) => <HealthIcon health={content} size="l" />,
+                render: (content) => (
+                  <HealthIcon
+                    health={content}
+                    size="l"
+                    staleAt={system.database_stale_at}
+                    timezone={userTimezone}
+                  />
+                ),
               },
               {
                 title: 'ENSA version',

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.jsx
@@ -320,9 +320,10 @@ export function GenericSystemDetails({
       </div>
       {system.stale_at && (
         <Banner type="warning" truncate={false}>
-          Trento agent heartbeat failed in some host composing this{' '}
-          {type === APPLICATION_TYPE ? 'SAP system' : 'Database'}... Information
-          is outdated since {formatDateTime(system.stale_at, userTimezone)}.
+          An agent in one of the{' '}
+          {type === APPLICATION_TYPE ? 'SAP system' : 'database'} hosts is not
+          reporting since {formatDateTime(system.stale_at, userTimezone)}. Some
+          information in this view might be stale.
         </Banner>
       )}
       <div className="mt-4 bg-white shadow rounded-lg py-4 px-8">

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
@@ -511,7 +511,9 @@ describe('GenericSystemDetails', () => {
     );
 
     expect(
-      screen.getByText(/Information is outdated since 15 Jun 2026, 06:30:00/)
+      screen.getByText(
+        /An agent in one of the SAP system hosts is not reporting since 15 Jun 2026, 06:30:00/
+      )
     ).toBeInTheDocument();
 
     expect(

--- a/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
+++ b/assets/js/pages/SapSystemDetails/GenericSystemDetails.test.jsx
@@ -486,8 +486,11 @@ describe('GenericSystemDetails', () => {
     expect(health).toHaveClass('fill-black');
   });
 
-  it('should render stale instances with stale styling', () => {
+  it('should render stale system and instances', () => {
+    const staleAt = '2026-06-15T10:30:00Z';
+    const userTimezone = 'America/New_York';
     const sapSystem = sapSystemFactory.build({
+      stale_at: staleAt,
       instances: [
         sapSystemApplicationInstanceFactory.build(),
         sapSystemApplicationInstanceFactory.build({
@@ -500,11 +503,22 @@ describe('GenericSystemDetails', () => {
 
     renderWithRouter(
       <GenericSystemDetails
-        title={faker.string.uuid()}
+        title="SAP System Details"
         system={sapSystem}
         type={APPLICATION_TYPE}
+        userTimezone={userTimezone}
       />
     );
+
+    expect(
+      screen.getByText(/Information is outdated since 15 Jun 2026, 06:30:00/)
+    ).toBeInTheDocument();
+
+    expect(
+      within(
+        screen.getByText('SAP System Details').previousSibling
+      ).getAllByTestId('eos-svg-component')
+    ).toHaveLength(2);
 
     const [layoutTable, _] = screen.getAllByRole('table');
     const rows = layoutTable.querySelectorAll('tbody > tr');
@@ -512,6 +526,28 @@ describe('GenericSystemDetails', () => {
     expect(rows[0]).not.toHaveClass('bg-gray-100');
     expect(rows[1]).toHaveClass('bg-gray-100');
     expect(rows[2]).not.toHaveClass('bg-gray-100');
+  });
+
+  it('should render stale database in a SAP system details view', () => {
+    const sapSystem = sapSystemFactory.build({
+      database_stale_at: '2026-06-15T10:30:00Z',
+      instances: [],
+      hosts: [],
+    });
+
+    renderWithRouter(
+      <GenericSystemDetails
+        title={faker.string.uuid()}
+        system={sapSystem}
+        type={APPLICATION_TYPE}
+      />
+    );
+
+    expect(
+      within(screen.getByText('Database health').nextSibling).getAllByTestId(
+        'eos-svg-component'
+      ).length
+    ).toBe(2);
   });
 
   it.each([

--- a/assets/js/pages/SapSystemDetails/SapSystemDetails.stories.jsx
+++ b/assets/js/pages/SapSystemDetails/SapSystemDetails.stories.jsx
@@ -15,8 +15,6 @@ import { APPLICATION_TYPE } from '@lib/model/sapSystems';
 
 import { GenericSystemDetails } from './GenericSystemDetails';
 
-import { getSapInstanceOperations } from './sapOperations';
-
 const system = {
   ...sapSystemFactory.build({
     instances: sapSystemApplicationInstanceFactory.buildList(2),
@@ -33,6 +31,19 @@ const systemWithAbsentInstance = {
 systemWithAbsentInstance.instances[1].absent_at = faker.date
   .past()
   .toISOString();
+
+const systemWithStaleData = {
+  ...sapSystemFactory.build({
+    stale_at: '2026-06-15T10:30:00Z',
+    instances: [
+      sapSystemApplicationInstanceFactory.build({
+        stale_at: '2026-06-15T10:30:00Z',
+      }),
+      sapSystemApplicationInstanceFactory.build(),
+    ],
+  }),
+  hosts: hostFactory.buildList(2, { cluster: clusterFactory.build() }),
+};
 
 function ContainerWrapper({ children }) {
   return (
@@ -52,6 +63,12 @@ export default {
     userAbilities: {
       control: 'array',
       description: 'Current user abilities',
+    },
+    userTimezone: {
+      description: 'Current user timezone',
+      control: {
+        type: 'text',
+      },
     },
     cleanUpPermittedFor: {
       control: 'array',
@@ -86,8 +103,8 @@ export const SapSystem = {
     type: APPLICATION_TYPE,
     system,
     userAbilities: [{ name: 'all', resource: 'all' }],
+    userTimezone: 'Etc/UTC',
     cleanUpPermittedFor: ['cleanup:application_instance'],
-    getInstanceOperations: getSapInstanceOperations,
     operationsEnabled: true,
   },
 };
@@ -103,5 +120,12 @@ export const CleanUpUnauthorized = {
   args: {
     ...SapSystemWithAbsentInstance.args,
     userAbilities: [],
+  },
+};
+
+export const SapSystemWithStaleData = {
+  args: {
+    ...SapSystem.args,
+    system: systemWithStaleData,
   },
 };

--- a/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.jsx
+++ b/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.jsx
@@ -4,8 +4,10 @@
 import React, { useState } from 'react';
 import { Link, useSearchParams } from 'react-router';
 import { filter } from 'lodash';
+import classNames from 'classnames';
 
 import { getEnsaVersionLabel, getSapSystemType } from '@lib/model/sapSystems';
+import { STALE_ROW } from '@lib/tables';
 
 import HealthIcon from '@common/HealthIcon';
 import PageHeader from '@common/PageHeader';
@@ -37,15 +39,23 @@ function SapSystemsOverview({
     pagination: true,
     usePadding: false,
     collapsedRowClassName: 'bg-gray-100',
+    rowClassName: ({ staleAt }) =>
+      classNames({
+        [STALE_ROW]: !!staleAt,
+      }),
     columns: [
       {
         title: 'Health',
         key: 'health',
         filterFromParams: true,
         filter: true,
-        render: (content) => (
+        render: (content, { staleAt }) => (
           <div className="ml-4">
-            <HealthIcon health={content} />
+            <HealthIcon
+              health={content}
+              staleAt={staleAt}
+              timezone={userTimezone}
+            />
           </div>
         ),
       },
@@ -145,6 +155,7 @@ function SapSystemsOverview({
     }),
     tags: (sapSystem.tags && sapSystem.tags.map((tag) => tag.value)) || [],
     databaseId: sapSystem.database_id,
+    staleAt: sapSystem.stale_at,
   }));
 
   const counters = getCounters(data || []);

--- a/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.stories.jsx
+++ b/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.stories.jsx
@@ -114,6 +114,12 @@ export default {
       control: { type: 'array' },
       description: 'User profile abilities',
     },
+    userTimezone: {
+      description: 'Current user timezone',
+      control: {
+        type: 'text',
+      },
+    },
     onTagAdd: {
       action: 'Add tag',
       description: 'Called when a new tag is added',
@@ -144,6 +150,7 @@ export default {
 export const SapSystems = {
   args: {
     userAbilities,
+    userTimezone: 'Etc/UTC',
     sapSystems,
     applicationInstances: enrichedApplicationInstances,
     databaseInstances: enrichedDatabaseInstances,
@@ -172,6 +179,28 @@ export const SapSystemsWithDifferentTypes = {
     userAbilities,
     sapSystems: sapSystemsWithCustomTypes,
     applicationInstances: sapSystemApplicationInstances,
+    databaseInstances: {},
+  },
+};
+
+const sapSystemIDForStale = faker.string.uuid();
+const staleAt = faker.date.past().toISOString();
+export const WithStaleSystem = {
+  args: {
+    userAbilities,
+    sapSystems: sapSystemFactory.buildList(1, {
+      id: sapSystemIDForStale,
+      stale_at: staleAt,
+    }),
+    applicationInstances: [
+      sapSystemApplicationInstanceFactory.build({
+        sap_system_id: sapSystemIDForStale,
+        stale_at: staleAt,
+      }),
+      sapSystemApplicationInstanceFactory.build({
+        sap_system_id: sapSystemIDForStale,
+      }),
+    ],
     databaseInstances: {},
   },
 };

--- a/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.test.jsx
+++ b/assets/js/pages/SapSystemsOverviewPage/SapSystemsOverview.test.jsx
@@ -293,6 +293,56 @@ describe('SapSystemsOverviews component', () => {
         ).toHaveAttribute('href', `/hosts/${instance.host.id}`);
       });
     });
+
+    it('should display stale SAP systems with gray background and stale icon', async () => {
+      const user = userEvent.setup();
+      const sapSystemID = faker.string.uuid();
+      const staleDate = faker.date.past().toISOString();
+      const sapSystem = sapSystemFactory.build({
+        id: sapSystemID,
+        health: 'passing',
+        stale_at: staleDate,
+        application_instances: sapSystemApplicationInstanceFactory.buildList(
+          2,
+          { sap_system_id: sapSystemID, stale_at: staleDate }
+        ),
+      });
+
+      const { application_instances: applicationInstances } = sapSystem;
+
+      renderWithRouter(
+        <SapSystemsOverview
+          userAbilities={userAbilities}
+          sapSystems={[sapSystem]}
+          applicationInstances={applicationInstances}
+          databaseInstances={[]}
+        />
+      );
+
+      const rows = screen.getByRole('table').querySelectorAll('tbody > tr');
+      expect(rows[0]).toHaveClass('bg-gray-100');
+
+      const healthCell = rows[0].querySelector('td:nth-child(2)');
+      const svgs = healthCell.querySelectorAll(
+        '[data-testid="eos-svg-component"]'
+      );
+      expect(svgs).toHaveLength(2);
+
+      const table = screen.getByRole('table');
+      await user.click(
+        table.querySelector('tbody tr:nth-child(1) td:nth-child(1)')
+      );
+
+      const detailsRow = screen
+        .getByRole('table')
+        .querySelectorAll('tbody > tr')[1];
+      expect(detailsRow).toHaveClass('bg-gray-100');
+
+      const instanceRows = detailsRow.querySelectorAll(
+        'div.table-row-group > div.table-row'
+      );
+      expect(instanceRows[0]).toHaveClass('bg-gray-100');
+    });
   });
 
   describe('instance cleanup', () => {


### PR DESCRIPTION
### Description

Display stale SAP system and database in frontend. The stale data is displayed in the SAP system and databases overview, and in the details views as well. The changed icons show the stale at timestamp on hover.
Overviews:
<img width="1289" height="577" alt="image" src="https://github.com/user-attachments/assets/fdfa6987-4939-4f4a-bb52-9b41f79e20cd" />

Details view:
<img width="1368" height="639" alt="image" src="https://github.com/user-attachments/assets/12e4119f-d60a-46ee-bc45-51d733e8b61d" />

Depends on: https://github.com/trento-project/web/pull/4496
Depends on: https://github.com/trento-project/web/pull/4499

### How was this tested?

UT

### Documentation changes

No (we will need to handle documentation of the whole feature at some point)