### PR TITLE
Bump prettier from 3.8.3 to 3.8.5 in /assets

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -91,7 +91,7 @@
         "jsdom-testing-mocks": "^1.16.0",
         "postcss": "^8.5.12",
         "postcss-import": "^16.1.1",
-        "prettier": "^3.8.3",
+        "prettier": "^3.8.5",
         "redux-mock-store": "^1.5.5",
         "storybook": "^10.2.10",
         "tailwindcss": "^3.4.19"
@@ -18974,9 +18974,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.5.tgz",
+      "integrity": "sha512-zxcTTCedNGJM4R8sj/Cq/F0W/c4iE0afWBcBwMTRtw4WHYP9TWkYjdiH3npPRUYsXQCPR0hTU9yjovOu+E6EQA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -40,7 +40,7 @@
     "postcss": "^8.5.12",
     "jsdom-testing-mocks": "^1.16.0",
     "postcss-import": "^16.1.1",
-    "prettier": "^3.8.3",
+    "prettier": "^3.8.5",
     "redux-mock-store": "^1.5.5",
     "storybook": "^10.2.10",
     "tailwindcss": "^3.4.19"


### PR DESCRIPTION
Backport of #4482 for the 3.1.4 patch release.