### PR TITLE
Improve icon centering

### DIFF
--- a/assets/js/common/HealthIcon/HealthIcon.jsx
+++ b/assets/js/common/HealthIcon/HealthIcon.jsx
@@ -3,8 +3,6 @@
 
 import React from 'react';
 
-import { computedIconCssClass } from '@lib/icon';
-
 import {
   EOS_CHECK_CIRCLE_OUTLINED,
   EOS_CHECK_CIRCLE_FILLED,
@@ -17,16 +15,34 @@ import {
 } from 'eos-icons-react';
 
 import classNames from 'classnames';
+import { flow } from 'lodash';
 import Spinner from '@common/Spinner';
 import StaleIconWrapper from '@common/StaleIconWrapper';
 
-const PassingIconBlank = StaleIconWrapper(EOS_CHECK_CIRCLE_OUTLINED);
-const PassingIconLink = StaleIconWrapper(EOS_CHECK_CIRCLE_FILLED);
-const WarningIconBlank = StaleIconWrapper(EOS_WARNING_OUTLINED);
-const WarningIconLink = StaleIconWrapper(EOS_WARNING_FILLED);
-const CriticalIconBlank = StaleIconWrapper(EOS_ERROR_OUTLINED);
-const CriticalIconLink = StaleIconWrapper(EOS_ERROR_FILLED);
-const UnknownIcon = StaleIconWrapper(EOS_LENS_FILLED);
+// Makes sure an Icon, when rendered with `centered`, has its output wrapped
+// in a horizontally centering container.
+const Centerable = (Icon) =>
+  function CenteredIcon({ centered = false, ...props }) {
+    return centered ? (
+      <div className="w-fit mx-auto">
+        <Icon {...props} />
+      </div>
+    ) : (
+      <Icon {...props} />
+    );
+  };
+
+const CenteredStaleIcon = flow(StaleIconWrapper, Centerable);
+
+const PassingIconBlank = CenteredStaleIcon(EOS_CHECK_CIRCLE_OUTLINED);
+const PassingIconLink = CenteredStaleIcon(EOS_CHECK_CIRCLE_FILLED);
+const WarningIconBlank = CenteredStaleIcon(EOS_WARNING_OUTLINED);
+const WarningIconLink = CenteredStaleIcon(EOS_WARNING_FILLED);
+const CriticalIconBlank = CenteredStaleIcon(EOS_ERROR_OUTLINED);
+const CriticalIconLink = CenteredStaleIcon(EOS_ERROR_FILLED);
+const UnknownIcon = CenteredStaleIcon(EOS_LENS_FILLED);
+const PendingIcon = Centerable(Spinner);
+const NotAvailableIcon = Centerable(EOS_REMOVE_FILLED);
 
 function HealthIcon({
   health = undefined,
@@ -47,10 +63,8 @@ function HealthIcon({
       const PassingIcon = isLink ? PassingIconLink : PassingIconBlank;
       return (
         <PassingIcon
-          className={classNames(
-            hoverOpacityClass,
-            computedIconCssClass('fill-jungle-green-500', centered)
-          )}
+          centered={centered}
+          className={classNames(hoverOpacityClass, 'fill-jungle-green-500')}
           size={size}
           staleAt={staleAt}
           timezone={timezone}
@@ -63,10 +77,8 @@ function HealthIcon({
       const WarningIcon = isLink ? WarningIconLink : WarningIconBlank;
       return (
         <WarningIcon
-          className={classNames(
-            hoverOpacityClass,
-            computedIconCssClass('fill-yellow-500', centered)
-          )}
+          centered={centered}
+          className={classNames(hoverOpacityClass, 'fill-yellow-500')}
           size={size}
           staleAt={staleAt}
           timezone={timezone}
@@ -79,10 +91,8 @@ function HealthIcon({
       const CriticalIcon = isLink ? CriticalIconLink : CriticalIconBlank;
       return (
         <CriticalIcon
-          className={classNames(
-            hoverOpacityClass,
-            computedIconCssClass('fill-red-500', centered)
-          )}
+          centered={centered}
+          className={classNames(hoverOpacityClass, 'fill-red-500')}
           size={size}
           staleAt={staleAt}
           timezone={timezone}
@@ -92,17 +102,15 @@ function HealthIcon({
     }
 
     case 'pending': {
-      return <Spinner />;
+      return <PendingIcon centered={centered} />;
     }
 
     case 'not_available': {
       return (
-        <EOS_REMOVE_FILLED
+        <NotAvailableIcon
+          centered={centered}
           size={size}
-          className={classNames(
-            hoverOpacityClass,
-            computedIconCssClass('fill-gray-500', centered)
-          )}
+          className={classNames(hoverOpacityClass, 'fill-gray-500')}
         />
       );
     }
@@ -110,10 +118,8 @@ function HealthIcon({
     default: {
       return (
         <UnknownIcon
-          className={classNames(
-            hoverOpacityClass,
-            computedIconCssClass('fill-gray-500', centered)
-          )}
+          centered={centered}
+          className={classNames(hoverOpacityClass, 'fill-gray-500')}
           size={size}
           staleAt={staleAt}
           timezone={timezone}

--- a/assets/js/common/HealthIcon/HealthIcon.jsx
+++ b/assets/js/common/HealthIcon/HealthIcon.jsx
@@ -86,7 +86,7 @@ function HealthIcon({
     }
 
     case 'pending': {
-      return <Spinner className={classNames({ 'w-fit mx-auto': centered })} />;
+      return <Spinner />;
     }
 
     case 'not_available': {

--- a/assets/js/common/HealthIcon/HealthIcon.jsx
+++ b/assets/js/common/HealthIcon/HealthIcon.jsx
@@ -3,6 +3,8 @@
 
 import React from 'react';
 
+import { computedIconCssClass } from '@lib/icon';
+
 import {
   EOS_CHECK_CIRCLE_OUTLINED,
   EOS_CHECK_CIRCLE_FILLED,
@@ -15,34 +17,16 @@ import {
 } from 'eos-icons-react';
 
 import classNames from 'classnames';
-import { flow } from 'lodash';
 import Spinner from '@common/Spinner';
 import StaleIconWrapper from '@common/StaleIconWrapper';
 
-// Makes sure an Icon, when rendered with `centered`, has its output wrapped
-// in a horizontally centering container.
-const Centerable = (Icon) =>
-  function CenteredIcon({ centered = false, ...props }) {
-    return centered ? (
-      <div className="w-fit mx-auto">
-        <Icon {...props} />
-      </div>
-    ) : (
-      <Icon {...props} />
-    );
-  };
-
-const CenteredStaleIcon = flow(StaleIconWrapper, Centerable);
-
-const PassingIconBlank = CenteredStaleIcon(EOS_CHECK_CIRCLE_OUTLINED);
-const PassingIconLink = CenteredStaleIcon(EOS_CHECK_CIRCLE_FILLED);
-const WarningIconBlank = CenteredStaleIcon(EOS_WARNING_OUTLINED);
-const WarningIconLink = CenteredStaleIcon(EOS_WARNING_FILLED);
-const CriticalIconBlank = CenteredStaleIcon(EOS_ERROR_OUTLINED);
-const CriticalIconLink = CenteredStaleIcon(EOS_ERROR_FILLED);
-const UnknownIcon = CenteredStaleIcon(EOS_LENS_FILLED);
-const PendingIcon = Centerable(Spinner);
-const NotAvailableIcon = Centerable(EOS_REMOVE_FILLED);
+const PassingIconBlank = StaleIconWrapper(EOS_CHECK_CIRCLE_OUTLINED);
+const PassingIconLink = StaleIconWrapper(EOS_CHECK_CIRCLE_FILLED);
+const WarningIconBlank = StaleIconWrapper(EOS_WARNING_OUTLINED);
+const WarningIconLink = StaleIconWrapper(EOS_WARNING_FILLED);
+const CriticalIconBlank = StaleIconWrapper(EOS_ERROR_OUTLINED);
+const CriticalIconLink = StaleIconWrapper(EOS_ERROR_FILLED);
+const UnknownIcon = StaleIconWrapper(EOS_LENS_FILLED);
 
 function HealthIcon({
   health = undefined,
@@ -102,15 +86,17 @@ function HealthIcon({
     }
 
     case 'pending': {
-      return <PendingIcon centered={centered} />;
+      return <Spinner className={classNames({ 'w-fit mx-auto': centered })} />;
     }
 
     case 'not_available': {
       return (
-        <NotAvailableIcon
-          centered={centered}
+        <EOS_REMOVE_FILLED
           size={size}
-          className={classNames(hoverOpacityClass, 'fill-gray-500')}
+          className={classNames(
+            hoverOpacityClass,
+            computedIconCssClass('fill-gray-500', centered)
+          )}
         />
       );
     }

--- a/assets/js/common/StaleIconWrapper/StaleIconWrapper.jsx
+++ b/assets/js/common/StaleIconWrapper/StaleIconWrapper.jsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
+import classNames from 'classnames';
 import { EOS_SCHEDULE_OUTLINED } from 'eos-icons-react';
 
 import { getIconSize } from '@lib/icon';
@@ -27,6 +28,7 @@ function StaleIconWrapper(WrappedIcon) {
     timezone = 'Etc/UTC',
     size = 'm',
     className = '',
+    centered = false,
     ...props
   }) {
     const convertedSize = getIconSize(size);
@@ -51,7 +53,7 @@ function StaleIconWrapper(WrappedIcon) {
           isEnabled={tooltipEnabled}
           wrap={false}
         >
-          <div className="relative">
+          <div className={classNames('relative', { 'mx-auto': centered })}>
             <WrappedIcon
               size={convertedSize}
               className={className}

--- a/assets/js/pages/HealthSummary/HomeHealthSummary.test.jsx
+++ b/assets/js/pages/HealthSummary/HomeHealthSummary.test.jsx
@@ -100,7 +100,7 @@ describe('HomeHealthSummary component', () => {
 
     expect(
       container
-        .querySelector(':nth-child(4) > :nth-child(3) svg')
+        .querySelector(':nth-child(4) > :nth-child(3) > svg')
         .classList.toString()
     ).toContain('hover:opacity-100');
   });

--- a/assets/js/pages/HealthSummary/HomeHealthSummary.test.jsx
+++ b/assets/js/pages/HealthSummary/HomeHealthSummary.test.jsx
@@ -100,7 +100,7 @@ describe('HomeHealthSummary component', () => {
 
     expect(
       container
-        .querySelector(':nth-child(4) > :nth-child(3) > svg')
+        .querySelector(':nth-child(4) > :nth-child(3) svg')
         .classList.toString()
     ).toContain('hover:opacity-100');
   });


### PR DESCRIPTION
### Description

OCD Alert.

Improves centerability of icons, al least in Dashboard.

Currently on demo

<img width="1436" height="732" alt="image" src="https://github.com/user-attachments/assets/e97915e0-1a0a-491d-9787-0bca9bfebed8" />

End result
<img width="1436" height="732" alt="image" src="https://github.com/user-attachments/assets/68ab854c-64bc-49e9-ba21-a6cbd2b14dd9" />

### How was this tested?

Current tests passing + IRL/visually.

Shouldn't introduce regressions.