### PR TITLE
Fix Activity Log date filter pagination flake

### DIFF
--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -156,6 +156,7 @@ context('Activity Log page', () => {
       activityLogPage.searchForDesiredFilterType('Login');
       activityLogPage.selectFilterTypeOption('Login Attempt');
       activityLogPage.clickApplyFiltersButton();
+      activityLogPage.activityLogRequestHasExpectedStatusCode(200);
       cy.get('button[data-testid="filter-Type"]').should(
         'have.text',
         'Login Attempt'
@@ -174,7 +175,7 @@ context('Activity Log page', () => {
         activityLogPage.activityLogRequestHasExpectedStatusCode(200);
         activityLogPage.filterFromDateHasTheExpectedValue(fromDate);
         const expectedUrl = `/activity_log?first=20&after=${response.body.pagination.end_cursor}&from_date=custom&from_date=${fromDate}`;
-        activityLogPage.validateUrlWithActivityLogRequestsDebug(expectedUrl);
+        activityLogPage.validateUrl(expectedUrl);
       });
     });
 

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -174,7 +174,7 @@ context('Activity Log page', () => {
         activityLogPage.activityLogRequestHasExpectedStatusCode(200);
         activityLogPage.filterFromDateHasTheExpectedValue(fromDate);
         const expectedUrl = `/activity_log?first=20&after=${response.body.pagination.end_cursor}&from_date=custom&from_date=${fromDate}`;
-        activityLogPage.validateUrl(expectedUrl);
+        activityLogPage.validateUrlWithActivityLogRequestsDebug(expectedUrl);
       });
     });
 

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -84,6 +84,7 @@ context('Activity Log page', () => {
 
       activityLogPage.typeMetadataFilter('foo bar');
       activityLogPage.clickApplyFiltersButton();
+      activityLogPage.activityLogRequestHasExpectedStatusCode(200);
 
       const fromDateQueryString =
         activityLogPage.formatEncodedDateForQueryString(fromDate);
@@ -149,6 +150,7 @@ context('Activity Log page', () => {
         activityLogPage.paginationPropertiesAreTheExpected(response);
         let expectedUrl = `/activity_log?first=20&after=${response.body.pagination.end_cursor}&${defaultSeverity}`;
         activityLogPage.clickNextPageButton();
+        activityLogPage.activityLogRequestHasExpectedStatusCode(200);
         activityLogPage.validateUrl(expectedUrl);
       });
       activityLogPage.clickFilterTypeButton();
@@ -333,6 +335,7 @@ context('Activity Log page', () => {
       activityLogPage.selectFilterTypeOption('Tag Added');
       activityLogPage.typeMetadataFilter('foo bar');
       activityLogPage.clickApplyFiltersButton();
+      activityLogPage.activityLogRequestHasExpectedStatusCode(200);
       const expectedUrl = `/activity_log?${defaultSeverity}&refreshRate=5000&type=login_attempt&type=resource_tagging&search=foo+bar&first=20`;
       activityLogPage.validateUrl(expectedUrl);
     });

--- a/test/e2e/cypress/e2e/activity_log.cy.js
+++ b/test/e2e/cypress/e2e/activity_log.cy.js
@@ -71,6 +71,7 @@ context('Activity Log page', () => {
       const toDate = '2024-08-14T10:21';
 
       activityLogPage.visit(`?${defaultSeverity}`);
+      activityLogPage.waitForActivityLogRequest();
 
       activityLogPage.clickFilterFromDateButton();
       activityLogPage.typeFilterFromDateInputField(fromDate);
@@ -84,7 +85,7 @@ context('Activity Log page', () => {
 
       activityLogPage.typeMetadataFilter('foo bar');
       activityLogPage.clickApplyFiltersButton();
-      activityLogPage.activityLogRequestHasExpectedStatusCode(200);
+      activityLogPage.waitForActivityLogRequest();
 
       const fromDateQueryString =
         activityLogPage.formatEncodedDateForQueryString(fromDate);
@@ -98,6 +99,7 @@ context('Activity Log page', () => {
     it('should reset filters', () => {
       const queryString = `?${defaultSeverity}&from_date=custom&from_date=2024-08-14T10%3A21%3A00.000Z&type=login_attempt&type=resource_tagging&search=foo+bar`;
       activityLogPage.visit(queryString);
+      activityLogPage.waitForActivityLogRequest();
       activityLogPage.clickResetFiltersButton();
       activityLogPage.filterTypeHasNothingSelected();
       activityLogPage.filterFromDateHasNothingSelected();
@@ -150,7 +152,7 @@ context('Activity Log page', () => {
         activityLogPage.paginationPropertiesAreTheExpected(response);
         let expectedUrl = `/activity_log?first=20&after=${response.body.pagination.end_cursor}&${defaultSeverity}`;
         activityLogPage.clickNextPageButton();
-        activityLogPage.activityLogRequestHasExpectedStatusCode(200);
+        activityLogPage.waitForActivityLogRequest();
         activityLogPage.validateUrl(expectedUrl);
       });
       activityLogPage.clickFilterTypeButton();
@@ -158,7 +160,7 @@ context('Activity Log page', () => {
       activityLogPage.searchForDesiredFilterType('Login');
       activityLogPage.selectFilterTypeOption('Login Attempt');
       activityLogPage.clickApplyFiltersButton();
-      activityLogPage.activityLogRequestHasExpectedStatusCode(200);
+      activityLogPage.waitForActivityLogRequest();
       cy.get('button[data-testid="filter-Type"]').should(
         'have.text',
         'Login Attempt'
@@ -285,8 +287,10 @@ context('Activity Log page', () => {
       const queryString =
         '?from_date=custom&from_date=2024-08-14T10%3A21%3A00.000Z&type=login_attempt&type=resource_tagging&search=foo+bar&refreshRate=10000';
       activityLogPage.visit(queryString);
+      activityLogPage.waitForActivityLogRequest();
       activityLogPage.autoRefreshIntervalButtonHasTheExpectedValue('10s');
       activityLogPage.clickResetFiltersButton();
+      activityLogPage.waitForActivityLogRequest();
       activityLogPage.autoRefreshIntervalButtonHasTheExpectedValue('10s');
       const expectedUrl = `/activity_log?${defaultSeverity}&first=20&refreshRate=10000`;
       activityLogPage.validateUrl(expectedUrl);
@@ -327,15 +331,15 @@ context('Activity Log page', () => {
         activityLogPage.expectedAggregateAmountOfRequests(4);
       });
     });
-
-    it(`should update querystring when filters are selected`, () => {
+    it('should update querystring when filters are selected', () => {
       activityLogPage.visit(`?${defaultSeverity}&refreshRate=5000`);
+      activityLogPage.waitForActivityLogRequest();
       activityLogPage.clickFilterTypeButton();
       activityLogPage.selectFilterTypeOption('Login Attempt');
       activityLogPage.selectFilterTypeOption('Tag Added');
       activityLogPage.typeMetadataFilter('foo bar');
       activityLogPage.clickApplyFiltersButton();
-      activityLogPage.activityLogRequestHasExpectedStatusCode(200);
+      activityLogPage.waitForActivityLogRequest();
       const expectedUrl = `/activity_log?${defaultSeverity}&refreshRate=5000&type=login_attempt&type=resource_tagging&search=foo+bar&first=20`;
       activityLogPage.validateUrl(expectedUrl);
     });

--- a/test/e2e/cypress/pageObject/activity_log_po.js
+++ b/test/e2e/cypress/pageObject/activity_log_po.js
@@ -120,27 +120,6 @@ export const selectRefreshRate = (refreshRate) => {
 export const searchForDesiredFilterType = (text) =>
   cy.get(`${filterTypeButton} + div input`).type(text);
 
-export const validateUrlWithActivityLogRequestsDebug = (expectedUrl) =>
-  cy.get(`@${activityLogEndpointAlias}.all`).then((requests) => {
-    const requestSummary = requests.map(({ request, response }, index) => ({
-      index,
-      requestUrl: request.url,
-      responseUrl: response?.url,
-      statusCode: response?.statusCode,
-      endCursor: response?.body?.pagination?.end_cursor,
-      hasNextPage: response?.body?.pagination?.has_next_page,
-    }));
-
-    cy.url().should((url) => {
-      expect(
-        url,
-        `Activity log requests (${requestSummary.length}): ${JSON.stringify(
-          requestSummary
-        )}`
-      ).to.eq(`${Cypress.config().baseUrl}${expectedUrl}`);
-    });
-  });
-
 export const filterTypeOptionsAreDisplayed = () =>
   cy.get(`${filterTypeButton} + div`).should('be.visible');
 

--- a/test/e2e/cypress/pageObject/activity_log_po.js
+++ b/test/e2e/cypress/pageObject/activity_log_po.js
@@ -120,6 +120,27 @@ export const selectRefreshRate = (refreshRate) => {
 export const searchForDesiredFilterType = (text) =>
   cy.get(`${filterTypeButton} + div input`).type(text);
 
+export const validateUrlWithActivityLogRequestsDebug = (expectedUrl) =>
+  cy.get(`@${activityLogEndpointAlias}.all`).then((requests) => {
+    const requestSummary = requests.map(({ request, response }, index) => ({
+      index,
+      requestUrl: request.url,
+      responseUrl: response?.url,
+      statusCode: response?.statusCode,
+      endCursor: response?.body?.pagination?.end_cursor,
+      hasNextPage: response?.body?.pagination?.has_next_page,
+    }));
+
+    cy.url().should((url) => {
+      expect(
+        url,
+        `Activity log requests (${requestSummary.length}): ${JSON.stringify(
+          requestSummary
+        )}`
+      ).to.eq(`${Cypress.config().baseUrl}${expectedUrl}`);
+    });
+  });
+
 export const filterTypeOptionsAreDisplayed = () =>
   cy.get(`${filterTypeButton} + div`).should('be.visible');
 


### PR DESCRIPTION
### Description

Fix a flaky Activity Log Cypress test `'should select correct date filter when changing page'` by waiting for Activity Log API requests after filter and pagination actions. When tests finish by asserting on the UI without ensuring that the request has completed, Cypress can consume that response in the following test because we use `testIsolation: false`. This can lead to using the wrong `end_cursor` when asserting pagination changes.

The same wait was also added to similar filter and pagination flows as a harmless safeguard against pending Activity Log requests leaking into subsequent tests.

### How was this tested?
Running a couple of times this: https://github.com/trento-project/web/actions/runs/29900272792
using this branch and only the affected test suite.

### Documentation changes

No

### Additional information

No