### PR TITLE
Fix flaky test for checks execution & increase timeout for restored links availability in UI

### DIFF
--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -246,10 +246,22 @@ export const apiDeleteAllUsers = () =>
       )
   );
 
-export const waitForRequest = (requestAlias, timeout = 5000) =>
+const hasRefreshToken = () =>
+  cy.window().then((win) => Boolean(win.localStorage.getItem('refresh_token')));
+
+export const waitForRequest = (
+  requestAlias,
+  { timeout = 5000, retryUnauthorized = true } = {}
+) =>
   cy.wait(`@${requestAlias}`, { timeout: timeout }).then((request) => {
-    if (request.response.statusCode !== 401) return request;
-    return cy.wait(`@${requestAlias}`, { timeout: timeout });
+    if (!retryUnauthorized || request.response.statusCode !== 401) {
+      return request;
+    }
+
+    return hasRefreshToken().then((hasToken) => {
+      if (!hasToken) return request;
+      return cy.wait(`@${requestAlias}`, { timeout: timeout });
+    });
   });
 
 export const preloadTestData = ({ isDataLoadedFunc = isTestDataLoaded } = {}) =>

--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -247,7 +247,10 @@ export const apiDeleteAllUsers = () =>
   );
 
 export const waitForRequest = (requestAlias, timeout = 5000) =>
-  cy.wait(`@${requestAlias}`, { timeout: timeout });
+  cy.wait(`@${requestAlias}`, { timeout: timeout }).then((request) => {
+    if (request.response.statusCode !== 401) return request;
+    return cy.wait(`@${requestAlias}`, { timeout: timeout });
+  });
 
 export const preloadTestData = ({ isDataLoadedFunc = isTestDataLoaded } = {}) =>
   /**

--- a/test/e2e/cypress/pageObject/hana_cluster_details_po.js
+++ b/test/e2e/cypress/pageObject/hana_cluster_details_po.js
@@ -514,7 +514,8 @@ export const linkToDeregisteredHostIsNotAvailable = () =>
 export const linkToDeregisteredHostIsAvailable = () =>
   cy
     .get(
-      `div[class*="tn-site-details-${hostToDeregister.sid}"] tbody td a:contains("${hostToDeregister.name}")`
+      `div[class*="tn-site-details-${hostToDeregister.sid}"] tbody td a:contains("${hostToDeregister.name}")`,
+      { timeout: 20000 }
     )
     .should('have.attr', 'href');
 

--- a/test/e2e/cypress/pageObject/sap_systems_overview_po.js
+++ b/test/e2e/cypress/pageObject/sap_systems_overview_po.js
@@ -79,7 +79,7 @@ const pageTitle = 'h1:contains("SAP Systems")';
 export const visit = () => {
   cy.intercept('/api/v1/databases').as('databasesRequest');
   basePage.visit(url);
-  return basePage.waitForRequest('databasesRequest', 10000);
+  return basePage.waitForRequest('databasesRequest', { timeout: 10000 });
 };
 
 export const tagSapSystems = () =>

--- a/test/e2e/cypress/pageObject/settings_po.js
+++ b/test/e2e/cypress/pageObject/settings_po.js
@@ -360,20 +360,22 @@ export const waitForSettingsPageRequests = () => {
 
 export const checkSettingsEndpointsRequestsAreForbidden = (forbidden) => {
   const matcher = forbidden ? 'eq' : 'not.eq';
+  const waitOptions = { retryUnauthorized: false };
+
   basePage
-    .waitForRequest('apiKeySettingsEndpoint')
+    .waitForRequest('apiKeySettingsEndpoint', waitOptions)
     .its('response.statusCode')
     .should(matcher, 401);
   basePage
-    .waitForRequest('activityLogSettingsEndpoint')
+    .waitForRequest('activityLogSettingsEndpoint', waitOptions)
     .its('response.statusCode')
     .should(matcher, 401);
   basePage
-    .waitForRequest('sumaSettingsEndpoint')
+    .waitForRequest('sumaSettingsEndpoint', waitOptions)
     .its('response.statusCode')
     .should(matcher, 401);
   return basePage
-    .waitForRequest('alertingSettingsEndpoint')
+    .waitForRequest('alertingSettingsEndpoint', waitOptions)
     .its('response.statusCode')
     .should(matcher, 401);
 };


### PR DESCRIPTION
### Description

The checks result test can sometimes run for more than three minutes before requesting the Wanda `last execution` endpoint. In that case the access token may have expired, because the app config sets `access_token_expiration: 180` seconds in `config/config.exs`. The request can legitimately return `401`, trigger the refresh-token flow, and then be retried by the app, so the test now waits for that retried request before asserting the returned check results. I added the retry method in the `base_po.js` in case we need to apply the same behavior to some other test suite in the future.

The restored host link assertion also gets a targeted 20s timeout because the link can take longer to reappear after the restore scenario finishes. I know this is not the ideal fix but will lower a bit the flakiness on this test.

### How was this tested?
https://github.com/trento-project/web/actions/runs/29999226232

### Documentation changes

No

### Additional information

N/A