### PR TITLE
Disable AI chatbox launcher when AI is not configured

### DIFF
--- a/assets/js/common/AIAssistant/AIAssistant.jsx
+++ b/assets/js/common/AIAssistant/AIAssistant.jsx
@@ -17,12 +17,13 @@ export function AssistantUI({
   onOpenChange,
   onNewThread,
   handleClose,
+  disabled = false,
 }) {
   const isEmpty = useAuiState((s) => s.thread.isEmpty);
   const isRunning = useAuiState((s) => s.thread.isRunning);
 
   return (
-    <ModalFrame open={open} onOpenChange={onOpenChange}>
+    <ModalFrame open={open} onOpenChange={onOpenChange} disabled={disabled}>
       <AssistantThread
         connectionStatus={connectionStatus}
         onClose={handleClose}
@@ -36,6 +37,7 @@ export function AssistantUI({
 
 function AIAssistant({
   userID,
+  aiConfigured = true,
   open = false,
   initialConnectionStatus = CONNECTION_STATUS.DISCONNECTED,
 }) {
@@ -60,6 +62,7 @@ function AIAssistant({
         onOpenChange={setIsOpen}
         onNewThread={onNewThread}
         handleClose={handleClose}
+        disabled={!aiConfigured && !isOpen}
       />
     </AssistantChatProvider>
   );

--- a/assets/js/common/AIAssistant/AIAssistant.stories.jsx
+++ b/assets/js/common/AIAssistant/AIAssistant.stories.jsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useEffect, useState } from 'react';
+import { MemoryRouter } from 'react-router';
 
 import { SocketContext } from '@common/SocketProvider';
 import { makeMockSocket } from '@lib/test-utils/phoenixDoubles';
@@ -159,6 +160,19 @@ export default {
 export const Closed = {
   name: 'Closed (FAB only)',
   args: { open: false },
+};
+
+export const Disabled = {
+  name: 'Disabled — no AI configuration',
+  args: { open: false, aiConfigured: false },
+  decorators: [
+    // Router needed for the disabled launcher tooltip's Profile link.
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
 };
 
 export const OpenEmpty = {

--- a/assets/js/common/AIAssistant/AIAssistant.test.jsx
+++ b/assets/js/common/AIAssistant/AIAssistant.test.jsx
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { act, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import { renderWithRouter } from '@lib/test-utils';
+import AIAssistant from './AIAssistant';
+
+describe('AIAssistant', () => {
+  describe('when the user has no AI settings', () => {
+    it('renders a disabled launcher button', async () => {
+      await act(async () => {
+        renderWithRouter(<AIAssistant userID="1" aiConfigured={false} />);
+      });
+
+      expect(
+        screen.getByTestId('ai-assistant-trigger-disabled')
+      ).toBeDisabled();
+    });
+
+    it('shows a tooltip on hover pointing to the Profile page', async () => {
+      const user = userEvent.setup();
+      await act(async () => {
+        renderWithRouter(<AIAssistant userID="1" aiConfigured={false} />);
+      });
+
+      await user.hover(screen.getByTestId('ai-assistant-trigger-disabled'));
+
+      expect(
+        await screen.findByText(/AI Assistant is disabled/i)
+      ).toBeInTheDocument();
+
+      expect(screen.getByRole('link', { name: 'Profile' })).toHaveAttribute(
+        'href',
+        '/profile'
+      );
+    });
+  });
+});

--- a/assets/js/common/AIAssistant/ModalFrame/ModalFrame.jsx
+++ b/assets/js/common/AIAssistant/ModalFrame/ModalFrame.jsx
@@ -1,29 +1,58 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { Rnd } from 'react-rnd';
+import { Link } from 'react-router';
 import { EOS_CHAT_BUBBLE_OUTLINED } from 'eos-icons-react';
 import { AssistantModalPrimitive } from '@assistant-ui/react';
 
 import Button from '@common/Button';
+import Tooltip from '@common/Tooltip';
 
-const defaultTrigger = (
+// forwardRef + `{...props}` spread are required so the
+// enabled instance works inside `AssistantModalPrimitive.Trigger asChild`
+// (which injects onClick / data-state / aria-expanded + a ref).
+const ChatboxTrigger = forwardRef(({ disabled = false, ...props }, ref) => (
+  // `{...props}` first so injected behavior (onClick / data-state / aria-expanded)
+  // is kept, but the presentational props below win — notably `type="fab"`, which
+  // `Trigger asChild` would otherwise overwrite with the HTML `type="button"`.
   <Button
+    ref={ref}
+    {...props}
     type="fab"
     size="none"
     className="size-full"
-    data-testid="ai-assistant-trigger"
-    aria-label="Open AI Assistant"
+    disabled={disabled}
+    data-testid={
+      disabled ? 'ai-assistant-trigger-disabled' : 'ai-assistant-trigger'
+    }
+    aria-label={disabled ? 'AI Assistant is disabled' : 'Open AI Assistant'}
   >
     <EOS_CHAT_BUBBLE_OUTLINED className="fill-white" />
   </Button>
+));
+
+ChatboxTrigger.displayName = 'ChatboxTrigger';
+
+const disabledTooltipContent = (
+  <span className="text-center">
+    AI Assistant is disabled. <br />
+    Please check{' '}
+    <Link
+      to="/profile"
+      className="underline hover:opacity-75 text-jungle-green-500"
+    >
+      Profile
+    </Link>{' '}
+    for Settings.
+  </span>
 );
 
 function ModalFrame({
   open,
   onOpenChange,
-  trigger = defaultTrigger,
+  disabled = false,
   initialSize = { width: 384, height: 650 },
   initialPosition = { x: -400, y: -650 },
   minWidth = 300,
@@ -32,10 +61,22 @@ function ModalFrame({
 }) {
   return (
     <AssistantModalPrimitive.Root open={open} onOpenChange={onOpenChange}>
-      <AssistantModalPrimitive.Anchor className="fixed right-6 bottom-20 size-12 z-40">
-        <AssistantModalPrimitive.Trigger asChild>
-          {trigger}
-        </AssistantModalPrimitive.Trigger>
+      <AssistantModalPrimitive.Anchor
+        className={'fixed right-6 bottom-20 size-12 z-40'}
+      >
+        {disabled ? (
+          <Tooltip
+            content={disabledTooltipContent}
+            place="left"
+            mouseLeaveDelay={0.3}
+          >
+            <ChatboxTrigger disabled />
+          </Tooltip>
+        ) : (
+          <AssistantModalPrimitive.Trigger asChild>
+            <ChatboxTrigger />
+          </AssistantModalPrimitive.Trigger>
+        )}
       </AssistantModalPrimitive.Anchor>
 
       <AssistantModalPrimitive.Content

--- a/assets/js/common/AIAssistant/ModalFrame/ModalFrame.jsx
+++ b/assets/js/common/AIAssistant/ModalFrame/ModalFrame.jsx
@@ -61,9 +61,7 @@ function ModalFrame({
 }) {
   return (
     <AssistantModalPrimitive.Root open={open} onOpenChange={onOpenChange}>
-      <AssistantModalPrimitive.Anchor
-        className={'fixed right-6 bottom-20 size-12 z-40'}
-      >
+      <AssistantModalPrimitive.Anchor className="fixed right-6 bottom-20 size-12 z-40">
         {disabled ? (
           <Tooltip
             content={disabledTooltipContent}

--- a/assets/js/common/AIAssistant/ModalFrame/ModalFrame.stories.jsx
+++ b/assets/js/common/AIAssistant/ModalFrame/ModalFrame.stories.jsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useState } from 'react';
+import { MemoryRouter } from 'react-router';
 import ModalFrame from './ModalFrame';
 
 export default {
@@ -51,4 +52,15 @@ export const Closed = {
       </ModalFrame>
     );
   },
+};
+
+export const Disabled = {
+  name: 'Disabled (no AI configuration)',
+  render: () => (
+    <MemoryRouter>
+      <ModalFrame open={false} onOpenChange={() => {}} disabled>
+        <PlaceholderContent />
+      </ModalFrame>
+    </MemoryRouter>
+  ),
 };

--- a/assets/js/lib/test-utils/factories/users.js
+++ b/assets/js/lib/test-utils/factories/users.js
@@ -12,6 +12,11 @@ import { timezones } from '@lib/timezones';
 export const fakeAppTimezone = () =>
   faker.helpers.arrayElement(timezones).value;
 
+export const aiConfigurationFactory = Factory.define(() => ({
+  provider: 'googleai',
+  model: 'gemini-2.5-pro',
+}));
+
 export const abilityFactory = Factory.define(() => ({
   id: faker.number.int(),
   name: faker.word.noun(),
@@ -34,6 +39,7 @@ export const userFactory = Factory.define(() => ({
   last_login_at: formatISO(faker.date.past()),
   created_at: formatISO(faker.date.past()),
   updated_at: formatISO(faker.date.past()),
+  ai_configuration: aiConfigurationFactory.build(),
 }));
 
 export const profileFactory = Factory.define(() => ({
@@ -79,9 +85,4 @@ export const personalAccessTokenFactory = Factory.define(() => ({
   name: faker.internet.displayName(),
   expires_at: formatISO(faker.date.future()),
   created_at: formatISO(faker.date.past()),
-}));
-
-export const aiConfigurationFactory = Factory.define(() => ({
-  provider: 'googleai',
-  model: 'gemini-2.5-pro',
 }));

--- a/assets/js/lib/test-utils/factories/users.js
+++ b/assets/js/lib/test-utils/factories/users.js
@@ -37,9 +37,9 @@ export const userFactory = Factory.define(() => ({
   analytics_eula_enabled: faker.datatype.boolean(),
   timezone: fakeAppTimezone(),
   last_login_at: formatISO(faker.date.past()),
+  ai_configuration: aiConfigurationFactory.build(),
   created_at: formatISO(faker.date.past()),
   updated_at: formatISO(faker.date.past()),
-  ai_configuration: aiConfigurationFactory.build(),
 }));
 
 export const profileFactory = Factory.define(() => ({

--- a/assets/js/pages/Layout/Layout.jsx
+++ b/assets/js/pages/Layout/Layout.jsx
@@ -7,7 +7,7 @@ import { NavLink, Outlet } from 'react-router';
 
 import { getFromConfig } from '@lib/config';
 import { clearCredentialsFromStore } from '@lib/auth';
-import { getUserProfile } from '@state/selectors/user';
+import { getUserProfile, hasAIConfiguration } from '@state/selectors/user';
 import { optinCapturing, reset } from '@lib/analytics';
 
 import {
@@ -103,6 +103,7 @@ function Layout() {
   }, [isCollapsed]);
 
   const { id, username, email } = useSelector(getUserProfile);
+  const aiConfigured = useSelector(hasAIConfiguration);
 
   const sidebarIconColor = 'currentColor';
   const sidebarIconClassName = 'text-gray-400 hover:text-gray-300';
@@ -250,7 +251,7 @@ function Layout() {
       </div>
       {getFromConfig('aiEnabled') && (
         <SocketProvider>
-          <AIAssistant userID={id} />
+          <AIAssistant userID={id} aiConfigured={aiConfigured} />
         </SocketProvider>
       )}
     </main>

--- a/assets/js/pages/Profile/ProfilePage.jsx
+++ b/assets/js/pages/Profile/ProfilePage.jsx
@@ -180,7 +180,9 @@ function ProfilePage() {
   const handleSuccessfulAIConfigOperation =
     (successMessage) =>
     ({ data }) => {
-      setUser({ ...userState, ai_configuration: data });
+      const updatedUser = { ...userState, ai_configuration: data };
+      setUser(updatedUser);
+      dispatch(setUserInState(updatedUser));
       toast.success(successMessage);
     };
 

--- a/assets/js/state/selectors/user.js
+++ b/assets/js/state/selectors/user.js
@@ -4,6 +4,7 @@
 export const getUserProfile = (state) => state.user;
 
 // A user is considered AI-configured only when both a provider and a model are set
-export const hasAIConfiguration = ({
-  user: { ai_configuration: aiConfiguration },
-}) => Boolean(aiConfiguration?.provider && aiConfiguration?.model);
+export const hasAIConfiguration = (state) => {
+  const aiConfiguration = state?.user?.ai_configuration;
+  return Boolean(aiConfiguration?.provider && aiConfiguration?.model);
+};

--- a/assets/js/state/selectors/user.js
+++ b/assets/js/state/selectors/user.js
@@ -2,3 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export const getUserProfile = (state) => state.user;
+
+// A user is considered AI-configured only when both a provider and a model are set
+export const hasAIConfiguration = ({
+  user: { ai_configuration: aiConfiguration },
+}) => Boolean(aiConfiguration?.provider && aiConfiguration?.model);

--- a/assets/js/state/selectors/user.test.js
+++ b/assets/js/state/selectors/user.test.js
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  userFactory,
+  aiConfigurationFactory,
+} from '@lib/test-utils/factories/users';
+
+import { getUserProfile, hasAIConfiguration } from './user';
+
+describe('user selectors', () => {
+  describe('getUserProfile', () => {
+    it('should return the user slice', () => {
+      const user = userFactory.build();
+
+      expect(getUserProfile({ user })).toEqual(user);
+    });
+  });
+
+  describe('hasAIConfiguration', () => {
+    it('should return true when both provider and model are set', () => {
+      const ai_configuration = aiConfigurationFactory.build();
+
+      expect(hasAIConfiguration({ user: { ai_configuration } })).toBe(true);
+    });
+
+    it.each([
+      { name: 'provider is missing', ai_configuration: { model: 'gpt-4' } },
+      { name: 'model is missing', ai_configuration: { provider: 'openai' } },
+      {
+        name: 'provider is empty',
+        ai_configuration: { provider: '', model: 'gpt-4' },
+      },
+      {
+        name: 'model is empty',
+        ai_configuration: { provider: 'openai', model: '' },
+      },
+      { name: 'configuration is an empty object', ai_configuration: {} },
+      { name: 'configuration is null', ai_configuration: null },
+      { name: 'configuration is undefined', ai_configuration: undefined },
+    ])('should return false when $name', ({ ai_configuration }) => {
+      expect(hasAIConfiguration({ user: { ai_configuration } })).toBe(false);
+    });
+  });
+});

--- a/assets/js/state/user.js
+++ b/assets/js/state/user.js
@@ -19,6 +19,7 @@ export const initialState = {
   analytics_enabled: undefined,
   analytics_eula_accepted: undefined,
   timezone: undefined,
+  ai_configuration: undefined,
 };
 
 export const userSlice = createSlice({
@@ -53,6 +54,7 @@ export const userSlice = createSlice({
           analytics_enabled,
           analytics_eula_accepted,
           timezone,
+          ai_configuration,
         },
       }
     ) {
@@ -67,6 +69,7 @@ export const userSlice = createSlice({
       state.analytics_enabled = analytics_enabled;
       state.analytics_eula_accepted = analytics_eula_accepted;
       state.timezone = timezone;
+      state.ai_configuration = ai_configuration;
     },
   },
 });

--- a/assets/js/state/user.test.js
+++ b/assets/js/state/user.test.js
@@ -57,6 +57,7 @@ describe('user reducer', () => {
       analytics_enabled,
       analytics_eula_accepted,
       timezone,
+      ai_configuration,
     } = userFactory.build();
 
     const action = setUser({
@@ -70,6 +71,7 @@ describe('user reducer', () => {
       analytics_enabled,
       analytics_eula_accepted,
       timezone,
+      ai_configuration,
     });
 
     expect(userReducer(initialState, action)).toEqual({
@@ -84,6 +86,7 @@ describe('user reducer', () => {
       analytics_enabled,
       analytics_eula_accepted,
       timezone,
+      ai_configuration,
     });
   });
 });


### PR DESCRIPTION
### Description

This PR makes sure that the AI chatbox trigger is disabled (with a tooltip pointing to the Profile page) when the user has no provider/model configured.

https://github.com/user-attachments/assets/b42abcb4-0f92-4c71-ad65-413cac08ec61

Following up:
- broadcast of the changes to the AI settings for live update of the app's state
- stop a running AI agent when configuration is cleared + notify user in conversation
- notify user about changing model within a running conversation

### How was this tested?

Automated tests, storybooks, IRL.

### Additional information

<!-- Add anything else relevant to this PR, such as screenshots or demos. -->