### PR TITLE
Broadcast AI configuration creation and clean up

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -323,6 +323,7 @@ config :trento, :ai,
   ],
   agent_server_adapter: Trento.Infrastructure.AI.SagentsAgentServer,
   agent_supervisor_adapter: Trento.Infrastructure.AI.SagentsDynamicSupervisor,
+  ai_configuration_events_adapter: Trento.Infrastructure.AI.PubSubConfigurationEvents,
   tool_sources: [
     TrentoWeb.AI.ControllerToolSource,
     {Trento.AI.RemoteOpenApiToolSource,

--- a/lib/trento/ai.ex
+++ b/lib/trento/ai.ex
@@ -41,6 +41,20 @@ defmodule Trento.AI do
   def clear_user_configuration(user),
     do: configurations().clear_user_configuration(user)
 
+  @doc """
+  Subscribes the calling process to the given user's AI configuration lifecycle
+  events.
+
+  Every AI Assistant channel (one per browser tab) subscribes on join so it can
+  react in real time to configuration changes made elsewhere (another tab, or a
+  raw API call). See `Trento.AI.Configurations.Events` for the message contract.
+  """
+  @spec subscribe_to_configuration_events(non_neg_integer() | String.t()) ::
+          :ok | {:error, term()}
+  defdelegate subscribe_to_configuration_events(user_id),
+    to: Configurations.Events,
+    as: :subscribe
+
   defp configurations,
     do: Keyword.get(ApplicationConfigLoader.load(), :configurations, Configurations)
 end

--- a/lib/trento/ai/agent.ex
+++ b/lib/trento/ai/agent.ex
@@ -79,6 +79,15 @@ defmodule Trento.AI.Agent do
     end
   end
 
+  @doc """
+  Stops the running agent for `agent_id`, terminating any in-flight run.
+
+  Best-effort — returns the supervisor's result verbatim (`{:error, term()}`
+  when no agent is running for the id).
+  """
+  @spec stop(String.t()) :: :ok | {:error, term()}
+  def stop(agent_id), do: AgentSupervisor.stop_agent(agent_id)
+
   defp maybe_refresh_agent(agent_id, maybe_new_agent, refresh_when) do
     with {:ok, current_agent} <- AgentServer.get_agent(agent_id),
          {:ok, updated_agent} <- refresh_when.(current_agent, maybe_new_agent) do

--- a/lib/trento/ai/agent/supervisor.ex
+++ b/lib/trento/ai/agent/supervisor.ex
@@ -25,7 +25,16 @@ defmodule Trento.AI.Agent.Supervisor do
   """
   @callback start_agent_sync(keyword()) :: {:ok, pid()} | {:error, term()}
 
+  @doc """
+  Stop the running agent for `agent_id`.
+
+  Best-effort: returns `{:error, term()}` when no agent is running for the id.
+  """
+  @callback stop_agent(String.t()) :: :ok | {:error, term()}
+
   def start_agent_sync(opts), do: impl().start_agent_sync(opts)
+
+  def stop_agent(agent_id), do: impl().stop_agent(agent_id)
 
   defp impl, do: Keyword.get(ApplicationConfigLoader.load(), :agent_supervisor_adapter)
 end

--- a/lib/trento/ai/configurations.ex
+++ b/lib/trento/ai/configurations.ex
@@ -10,6 +10,7 @@ defmodule Trento.AI.Configurations do
 
   alias Trento.Users.User
 
+  alias Trento.AI.Configurations.Events
   alias Trento.AI.UserConfiguration
 
   alias Trento.Repo
@@ -28,6 +29,10 @@ defmodule Trento.AI.Configurations do
     %UserConfiguration{}
     |> UserConfiguration.changeset(Map.put(attrs, :user_id, user_id))
     |> Repo.insert()
+    |> tap(fn
+      {:ok, _} -> Events.broadcast_created(user_id)
+      _ -> :ok
+    end)
   end
 
   def create_user_configuration(%User{}, _), do: {:error, :forbidden}
@@ -70,6 +75,8 @@ defmodule Trento.AI.Configurations do
   def clear_user_configuration(%User{id: user_id, deleted_at: nil, locked_at: nil})
       when not is_nil(user_id) do
     Repo.delete_all(from u in UserConfiguration, where: u.user_id == ^user_id)
+
+    Events.broadcast_cleared(user_id)
 
     :ok
   end

--- a/lib/trento/ai/configurations/events.ex
+++ b/lib/trento/ai/configurations/events.ex
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.AI.Configurations.Events do
+  @moduledoc """
+  Behaviour + dispatcher for per-user AI configuration lifecycle events.
+
+  The default production implementation is
+  `Trento.Infrastructure.AI.PubSubConfigurationEvents`.
+  """
+
+  alias Trento.AI.ApplicationConfigLoader
+
+  @doc """
+  Subscribes the **calling process** to the given user's AI configuration
+  lifecycle events.
+  """
+  @callback subscribe(non_neg_integer() | String.t()) :: :ok | {:error, term()}
+
+  @doc """
+  Broadcasts that the given user's AI configuration was created.
+  """
+  @callback broadcast_created(non_neg_integer()) :: :ok
+
+  @doc """
+  Broadcasts that the given user's AI configuration was cleared.
+  """
+  @callback broadcast_cleared(non_neg_integer()) :: :ok
+
+  def subscribe(user_id), do: impl().subscribe(user_id)
+
+  def broadcast_created(user_id), do: impl().broadcast_created(user_id)
+
+  def broadcast_cleared(user_id), do: impl().broadcast_cleared(user_id)
+
+  defp impl,
+    do: Keyword.get(ApplicationConfigLoader.load(), :ai_configuration_events_adapter)
+end

--- a/lib/trento/infrastructure/ai/pub_sub_configuration_events.ex
+++ b/lib/trento/infrastructure/ai/pub_sub_configuration_events.ex
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Infrastructure.AI.PubSubConfigurationEvents do
+  @moduledoc """
+  Default `Trento.AI.Configurations.Events` implementation: per-user AI
+  configuration lifecycle events carried over `Phoenix.PubSub`.
+  """
+
+  @behaviour Trento.AI.Configurations.Events
+
+  @impl true
+  def subscribe(user_id), do: Phoenix.PubSub.subscribe(Trento.PubSub, topic(user_id))
+
+  @impl true
+  def broadcast_created(user_id), do: broadcast(user_id, {:ai_configuration, :created})
+
+  @impl true
+  def broadcast_cleared(user_id), do: broadcast(user_id, {:ai_configuration, :cleared})
+
+  defp broadcast(user_id, message),
+    do: Phoenix.PubSub.broadcast(Trento.PubSub, topic(user_id), message)
+
+  defp topic(user_id), do: "ai_user_config:#{user_id}"
+end

--- a/lib/trento/infrastructure/ai/pub_sub_configuration_events.ex
+++ b/lib/trento/infrastructure/ai/pub_sub_configuration_events.ex
@@ -21,5 +21,5 @@ defmodule Trento.Infrastructure.AI.PubSubConfigurationEvents do
   defp broadcast(user_id, message),
     do: Phoenix.PubSub.broadcast(Trento.PubSub, topic(user_id), message)
 
-  defp topic(user_id), do: "ai_user_config:#{user_id}"
+  defp topic(user_id), do: "ai_user_configuration:#{user_id}"
 end

--- a/lib/trento/infrastructure/ai/sagents_dynamic_supervisor.ex
+++ b/lib/trento/infrastructure/ai/sagents_dynamic_supervisor.ex
@@ -11,4 +11,7 @@ defmodule Trento.Infrastructure.AI.SagentsDynamicSupervisor do
 
   @impl Trento.AI.Agent.Supervisor
   defdelegate start_agent_sync(opts), to: Sagents.AgentsDynamicSupervisor
+
+  @impl Trento.AI.Agent.Supervisor
+  defdelegate stop_agent(agent_id), to: Sagents.AgentsDynamicSupervisor
 end

--- a/lib/trento_web/channels/ai_assistant_channel.ex
+++ b/lib/trento_web/channels/ai_assistant_channel.ex
@@ -59,7 +59,8 @@ defmodule TrentoWeb.AIAssistantChannel do
       ) do
     with :ok <- check_ai_enabled(),
          :ok <- check_socket_and_channel_user_match(user_id, current_user_id),
-         :ok <- validate_access_token(token, current_user_id) do
+         :ok <- validate_access_token(token, current_user_id),
+         :ok <- subscribe_to_configuration_events(current_user_id) do
       {:ok,
        socket
        |> assign(:access_token, token)
@@ -130,6 +131,18 @@ defmodule TrentoWeb.AIAssistantChannel do
     case AccessToken.verify_and_validate(token) do
       {:ok, %{"sub" => ^current_user_id}} -> :ok
       _ -> {:error, :unauthorized}
+    end
+  end
+
+  defp subscribe_to_configuration_events(user_id) do
+    case AI.subscribe_to_configuration_events(user_id) do
+      :ok ->
+        :ok
+
+      error ->
+        Logger.warning("Cannot subscribe to AI configuration events: #{inspect(error)}")
+
+        {:error, :unable_to_subscribe_to_ai_configuration_events}
     end
   end
 
@@ -290,6 +303,29 @@ defmodule TrentoWeb.AIAssistantChannel do
         socket
       ),
       do: {:noreply, AgUi.tool_call_result(socket, call_id, tool_info[:result] || %{})}
+
+  @impl true
+  def handle_info({:ai_configuration, :created}, socket) do
+    # The user's AI configuration was (re)created.
+    # Tell the client it can re-enable the assistant.
+    push(socket, "ai_configuration_created", %{})
+
+    {:noreply, socket}
+  end
+
+  @impl true
+  def handle_info({:ai_configuration, :cleared}, socket) do
+    # The user's AI configuration was cleared.
+    # Stop any in-flight agent for this thread and notify the client
+    case socket.assigns[:current_thread_id] do
+      nil -> :ok
+      thread_id -> TrentoAIAgent.stop(thread_id)
+    end
+
+    push(socket, "ai_configuration_cleared", %{})
+
+    {:noreply, reset_run(socket)}
+  end
 
   @impl true
   def handle_info(_msg, socket), do: {:noreply, socket}

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -74,6 +74,14 @@ Mox.defmock(Trento.AI.Agent.Supervisor.Mock,
   for: Trento.AI.Agent.Supervisor
 )
 
+# Deliberately NOT wired into `test_ai_config` below — the real
+# `PubSubConfigurationEvents` stays the default so the config-events tests keep
+# their real PubSub round-trips.
+# Override in tests that need failure
+Mox.defmock(Trento.AI.Configurations.Events.Mock,
+  for: Trento.AI.Configurations.Events
+)
+
 default_ai_config = Application.get_env(:trento, :ai, [])
 
 test_ai_config = [

--- a/test/trento/ai/agent_test.exs
+++ b/test/trento/ai/agent_test.exs
@@ -10,8 +10,11 @@ defmodule Trento.AI.AgentTest do
   import Trento.Factory
 
   alias LangChain.Message
+  alias Sagents.AgentSupervisor
   alias Sagents.Middleware.{PatchToolCalls, Summarization, TodoList}
   alias Trento.AI.Agent, as: TrentoAIAgent
+  alias Trento.AI.Agent.Supervisor, as: TrentoAIAgentSupervisor
+  alias Trento.Infrastructure.AI.SagentsDynamicSupervisor
   alias Trento.Users.User
 
   setup :verify_on_exit!
@@ -220,6 +223,83 @@ defmodule Trento.AI.AgentTest do
       expect(Trento.AI.Agent.Server.Mock, :add_message, fn ^agent_id, _ -> :ok end)
 
       assert :ok = TrentoAIAgent.run(agent, prompt)
+    end
+  end
+
+  describe "stop/1" do
+    test "delegates to the supervisor's stop_agent/1" do
+      agent_id = "thread-#{Faker.UUID.v4()}"
+
+      expect(Trento.AI.Agent.Supervisor.Mock, :stop_agent, fn ^agent_id -> :ok end)
+
+      assert :ok = TrentoAIAgent.stop(agent_id)
+    end
+
+    test "propagates the supervisor's error verbatim (nothing running)" do
+      agent_id = "thread-#{Faker.UUID.v4()}"
+
+      expect(Trento.AI.Agent.Supervisor.Mock, :stop_agent, fn ^agent_id ->
+        {:error, :not_found}
+      end)
+
+      assert {:error, :not_found} = TrentoAIAgent.stop(agent_id)
+    end
+  end
+
+  # Exercises the real Sagents supervisor tree through the public API,
+  # proving that a genuinely running agent process is actually terminated
+  # the mock tests above only prove the call is wired.
+  #
+  # The test adapters are mocks (see test_helper.exs), so this describe swaps the
+  # supervisor adapter for the real SagentsDynamicSupervisor for its duration.
+  describe "stop/1 — integration (real supervisor)" do
+    @describetag :integration
+
+    setup do
+      ai = Application.get_env(:trento, :ai)
+
+      Application.put_env(
+        :trento,
+        :ai,
+        Keyword.put(ai, :agent_supervisor_adapter, SagentsDynamicSupervisor)
+      )
+
+      on_exit(fn -> Application.put_env(:trento, :ai, ai) end)
+    end
+
+    test "terminates the running agent's process tree" do
+      agent_id = "thread-#{Faker.UUID.v4()}"
+
+      agent =
+        TrentoAIAgent.new!(
+          agent_id: agent_id,
+          model: build(:random_langchain_model),
+          scope: build(:user)
+        )
+
+      assert {:ok, _sup} =
+               TrentoAIAgentSupervisor.start_agent_sync(
+                 agent_id: agent_id,
+                 agent: agent,
+                 pubsub: {Phoenix.PubSub, Trento.PubSub}
+               )
+
+      assert {:ok, pid} = AgentSupervisor.get_pid(agent_id)
+      assert Process.alive?(pid)
+      ref = Process.monitor(pid)
+
+      assert :ok = TrentoAIAgent.stop(agent_id)
+
+      # DOWN + not-alive prove the process tree is gone.
+      # Deliberately not assertin on AgentSupervisor.get_pid/1
+      # the registry unregisters via its own monitor, asynchronously,
+      # so it can still return the stale entry right after DOWN.
+      assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 5_000
+      refute Process.alive?(pid)
+    end
+
+    test "returns {:error, :not_found} when no agent is running for the id" do
+      assert {:error, :not_found} = TrentoAIAgent.stop("thread-#{Faker.UUID.v4()}")
     end
   end
 

--- a/test/trento/ai/agent_test.exs
+++ b/test/trento/ai/agent_test.exs
@@ -291,7 +291,7 @@ defmodule Trento.AI.AgentTest do
       assert :ok = TrentoAIAgent.stop(agent_id)
 
       # DOWN + not-alive prove the process tree is gone.
-      # Deliberately not assertin on AgentSupervisor.get_pid/1
+      # Deliberately not asserting on AgentSupervisor.get_pid/1
       # the registry unregisters via its own monitor, asynchronously,
       # so it can still return the stale entry right after DOWN.
       assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 5_000

--- a/test/trento/ai/configurations_test.exs
+++ b/test/trento/ai/configurations_test.exs
@@ -9,6 +9,8 @@ defmodule Trento.Ai.ConfigurationsTest do
 
   alias Trento.AI.{Configurations, UserConfiguration}
 
+  alias Trento.AI.Configurations.Events
+
   import Trento.Factory
 
   import Mox
@@ -280,6 +282,31 @@ defmodule Trento.Ai.ConfigurationsTest do
                )
 
       assert ^created_config = load_ai_config(user_id)
+    end
+
+    test "should broadcast that the configuration was created" do
+      %User{id: user_id} = user = insert(:user)
+
+      Events.subscribe(user_id)
+
+      assert {:ok, %UserConfiguration{}} =
+               Configurations.create_user_configuration(
+                 user,
+                 build(:ai_configuration_creation_params)
+               )
+
+      assert_receive {:ai_configuration, :created}
+    end
+
+    test "should not broadcast created when creation fails" do
+      %User{id: user_id} = user = insert(:user)
+
+      Events.subscribe(user_id)
+
+      assert {:error, %Ecto.Changeset{}} =
+               Configurations.create_user_configuration(user, %{})
+
+      refute_receive {:ai_configuration, :created}
     end
 
     test "should support creating AI configuration with a model that is supported by multiple providers" do
@@ -655,6 +682,15 @@ defmodule Trento.Ai.ConfigurationsTest do
 
       assert :ok == Configurations.clear_user_configuration(user)
       assert nil == load_ai_config(user_id)
+    end
+
+    test "should broadcast that the configuration was cleared" do
+      %User{id: user_id} = user = insert(:user, ai_configuration: build(:ai_user_configuration))
+
+      Events.subscribe(user_id)
+
+      assert :ok == Configurations.clear_user_configuration(user)
+      assert_receive {:ai_configuration, :cleared}
     end
   end
 

--- a/test/trento/ai_test.exs
+++ b/test/trento/ai_test.exs
@@ -32,7 +32,7 @@ defmodule Trento.AITest do
 
   describe "delegating creation and update to configurations module" do
     test "should delegate to configurations module" do
-      expect(Trento.AI.ApplicationConfigLoader.Mock, :load_config, 2, fn ->
+      expect(Trento.AI.ApplicationConfigLoader.Mock, :load_config, 3, fn ->
         [
           enabled: true,
           configurations: DummyConfigurations
@@ -48,6 +48,7 @@ defmodule Trento.AITest do
 
       assert AI.create_user_configuration(user, attrs) == {:ok, :created}
       assert AI.update_user_configuration(user, attrs) == {:ok, :updated}
+      assert AI.clear_user_configuration(user) == {:ok, :cleared}
     end
   end
 end
@@ -59,5 +60,9 @@ defmodule DummyConfigurations do
 
   def update_user_configuration(_user, _attrs) do
     {:ok, :updated}
+  end
+
+  def clear_user_configuration(_user) do
+    {:ok, :cleared}
   end
 end

--- a/test/trento_web/channels/ai_assistant_channel_test.exs
+++ b/test/trento_web/channels/ai_assistant_channel_test.exs
@@ -33,6 +33,8 @@ defmodule TrentoWeb.AIAssistantChannelTest do
   alias TrentoWeb.AIAssistantChannel
   alias TrentoWeb.UserSocket
 
+  alias Trento.AI.Configurations.Events, as: AIConfigurationsEvents
+
   setup :verify_on_exit!
 
   setup do
@@ -152,6 +154,40 @@ defmodule TrentoWeb.AIAssistantChannelTest do
                UserSocket
                |> socket("user_id", %{current_user_id: 42})
                |> subscribe_and_join(AIAssistantChannel, "ai_assistant:42xyz", %{
+                 "access_token" => generate_jwt(42)
+               })
+    end
+
+    test "subscribes the joined channel to AI configuration lifecycle events" do
+      {:ok, _, _socket} =
+        UserSocket
+        |> socket("user_id", %{current_user_id: 42})
+        |> subscribe_and_join(AIAssistantChannel, "ai_assistant:42", %{
+          "access_token" => generate_jwt(42)
+        })
+
+      AIConfigurationsEvents.broadcast_created(42)
+
+      assert_push("ai_configuration_created", %{})
+    end
+
+    test "rejects the join when subscribing to AI configuration events fails" do
+      ai = Application.get_env(:trento, :ai)
+
+      Application.put_env(
+        :trento,
+        :ai,
+        Keyword.put(ai, :ai_configuration_events_adapter, AIConfigurationsEvents.Mock)
+      )
+
+      on_exit(fn -> Application.put_env(:trento, :ai, ai) end)
+
+      expect(AIConfigurationsEvents.Mock, :subscribe, fn _ -> {:error, :no_pubsub} end)
+
+      assert {:error, :unable_to_subscribe_to_ai_configuration_events} =
+               UserSocket
+               |> socket("user_id", %{current_user_id: 42})
+               |> subscribe_and_join(AIAssistantChannel, "ai_assistant:42", %{
                  "access_token" => generate_jwt(42)
                })
     end
@@ -887,6 +923,60 @@ defmodule TrentoWeb.AIAssistantChannelTest do
         "type" => "RUN_ERROR",
         "message" => "Failed to start agent: :boom"
       })
+    end
+  end
+
+  describe "handle_info — listening on ai configuration events" do
+    setup :join_socket_with_ai_config
+
+    test "stops the active agent, pushes ai_configuration_cleared, and resets loading",
+         %{socket: socket, user_id: user_id} do
+      seed_assigns(socket, %{
+        current_thread_id: "t-live",
+        loading: true,
+        run_has_started: true
+      })
+
+      expect(Trento.AI.Agent.Supervisor.Mock, :stop_agent, fn "t-live" -> :ok end)
+
+      Trento.AI.Configurations.Events.broadcast_cleared(user_id)
+
+      assert_push("ai_configuration_cleared", %{})
+      assert %{loading: false} = wait_assigns(socket)
+    end
+
+    test "still goes read-only when stopping the agent fails (best-effort stop)",
+         %{socket: socket, user_id: user_id} do
+      seed_assigns(socket, %{
+        current_thread_id: "t-live",
+        loading: true,
+        run_has_started: true
+      })
+
+      expect(Trento.AI.Agent.Supervisor.Mock, :stop_agent, fn "t-live" ->
+        {:error, :not_found}
+      end)
+
+      AIConfigurationsEvents.broadcast_cleared(user_id)
+
+      assert_push("ai_configuration_cleared", %{})
+      assert %{loading: false} = wait_assigns(socket)
+    end
+
+    test "pushes ai_configuration_cleared without stopping any agent when no thread is active",
+         %{user_id: user_id} do
+      # No current_thread_id seeded → no stop_agent expectation.
+      # verify_on_exit! catches a stray stop_agent call.
+      AIConfigurationsEvents.broadcast_cleared(user_id)
+
+      assert_push("ai_configuration_cleared", %{})
+    end
+
+    test "pushes ai_configuration_created when the configuration is (re)created",
+         %{user_id: user_id} do
+      AIConfigurationsEvents.broadcast_created(user_id)
+
+      assert_push("ai_configuration_created", %{})
     end
   end
 


### PR DESCRIPTION
### Description

This PR adds the ability to broadcast creation and clear up of AI configuration so that the UI can react to it.

UI PR at https://github.com/trento-project/web/pull/4556

### How was this tested?

Automated and IRL.