### PR TITLE
React on AI model changes

### DIFF
--- a/assets/js/common/AIAssistant/AIAssistant.jsx
+++ b/assets/js/common/AIAssistant/AIAssistant.jsx
@@ -24,6 +24,8 @@ function AssistantUI({
   onNewThread,
   handleClose,
   disabled = false,
+  modelNotice = null,
+  onDismissModelNotice,
 }) {
   const isEmpty = useAuiState((s) => s.thread.isEmpty);
   const isRunning = useAuiState((s) => s.thread.isRunning);
@@ -37,6 +39,8 @@ function AssistantUI({
         onNewThread={onNewThread}
         isEmpty={isEmpty}
         isRunning={isRunning}
+        modelNotice={modelNotice}
+        onDismissModelNotice={onDismissModelNotice}
       />
     </ModalFrame>
   );
@@ -57,6 +61,7 @@ function AIAssistant({
   const [configurationStatus, setConfigurationStatus] = useState(
     aiConfigured ? CONFIGURATION_STATUS.OK : CONFIGURATION_STATUS.CLEARED
   );
+  const [modelNotice, setModelNotice] = useState(null);
 
   // The channel stays mounted even when the launcher is disabled, so a "created" event can re-enable this tab
   const isOpenRef = useRef(isOpen);
@@ -67,7 +72,15 @@ function AIAssistant({
   const startNewThread = useCallback(() => {
     setThreadID(crypto.randomUUID());
     setConfigurationStatus(CONFIGURATION_STATUS.OK);
+    setModelNotice(null);
   }, []);
+
+  const handleModelChanged = useCallback(
+    (payload) => setModelNotice(payload),
+    []
+  );
+
+  const handleDismissModelNotice = useCallback(() => setModelNotice(null), []);
 
   const handleAIConfigurationCleared = useCallback(
     () => setConfigurationStatus(CONFIGURATION_STATUS.CLEARED),
@@ -96,6 +109,7 @@ function AIAssistant({
       onConnectionChange={setConnectionStatus}
       onAIConfigurationCleared={handleAIConfigurationCleared}
       onAIConfigurationCreated={handleAIConfigurationCreated}
+      onModelChanged={handleModelChanged}
     >
       <AssistantUI
         open={isOpen}
@@ -104,6 +118,8 @@ function AIAssistant({
         onOpenChange={setIsOpen}
         onNewThread={startNewThread}
         handleClose={handleClose}
+        modelNotice={modelNotice}
+        onDismissModelNotice={handleDismissModelNotice}
         disabled={!configurationAvailable && !isOpen}
       />
     </AssistantChatProvider>

--- a/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
+++ b/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
@@ -201,6 +201,32 @@ describe('AG-UI event flow', () => {
     );
   });
 
+  it('renders the model_changed notice as a dismissable banner', async () => {
+    const { channel } = await renderAssistant();
+
+    await act(async () => {
+      channel.emit('model_changed', {
+        provider: 'googleai',
+        model: 'gemini-2.5-pro',
+      });
+    });
+
+    const banner = await waitFor(() => {
+      const el = document.querySelector('[data-testid="model-change-banner"]');
+      if (!el) throw new Error('banner not rendered yet');
+      return el;
+    });
+    expect(banner).toHaveTextContent(/Google Gemini/i);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-testid="model-change-banner"]')
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it('prompts to start a new chat when a new config arrives after a clear', async () => {
     const { channel } = await renderAssistant();
 

--- a/assets/js/common/AIAssistant/AssistantChatProvider.jsx
+++ b/assets/js/common/AIAssistant/AssistantChatProvider.jsx
@@ -16,6 +16,7 @@ function AssistantChatProvider({
   onConnectionChange = noop,
   onAIConfigurationCleared = noop,
   onAIConfigurationCreated = noop,
+  onModelChanged = noop,
   children,
 }) {
   const socket = useSocket();
@@ -28,6 +29,7 @@ function AssistantChatProvider({
       onConnectionChange,
       onAIConfigurationCleared,
       onAIConfigurationCreated,
+      onModelChanged,
     });
   }, [
     socket,
@@ -35,6 +37,7 @@ function AssistantChatProvider({
     onConnectionChange,
     onAIConfigurationCleared,
     onAIConfigurationCreated,
+    onModelChanged,
   ]);
 
   useEffect(() => {

--- a/assets/js/common/AIAssistant/AssistantThread.jsx
+++ b/assets/js/common/AIAssistant/AssistantThread.jsx
@@ -5,10 +5,13 @@ import React from 'react';
 import { noop } from 'lodash';
 import { Link } from 'react-router';
 import { ThreadPrimitive } from '@assistant-ui/react';
+import { EOS_CLOSE } from 'eos-icons-react';
+
+import Button from '@common/Button';
+import { getProviderLabel } from '@lib/ai';
 
 import ChatHeader from './ChatHeader';
 import PromptComposer from './PromptComposer';
-
 import { AssistantMessage, UserMessage } from './MessageBubble';
 import ThreadWelcome from './ThreadWelcome';
 import {
@@ -16,6 +19,8 @@ import {
   isConfigurationCleared,
   isConfigurationRestored,
 } from './status';
+
+const stopPointerDown = (e) => e.stopPropagation();
 
 function ThreadBanner({ children }) {
   return (
@@ -52,6 +57,30 @@ function RestoredBanner() {
   );
 }
 
+function ModelChangeBanner({ provider, model, onDismiss = noop }) {
+  return (
+    <ThreadBanner>
+      <div className="flex items-start justify-between gap-2">
+        <span data-testid="model-change-banner">
+          AI model changed to{' '}
+          <span className="font-semibold">{getProviderLabel(provider)}</span> (
+          {model}) for this conversation.
+        </span>
+        <Button
+          type="icon"
+          size="none"
+          onPointerDown={stopPointerDown}
+          onClick={onDismiss}
+          aria-label="Dismiss"
+          className="!text-yellow-800 hover:opacity-75"
+        >
+          <EOS_CLOSE className="h-5 w-5 fill-current" />
+        </Button>
+      </div>
+    </ThreadBanner>
+  );
+}
+
 function AssistantThread({
   connectionStatus,
   configurationStatus,
@@ -59,6 +88,8 @@ function AssistantThread({
   isRunning = false,
   onNewThread = noop,
   onClose = noop,
+  modelNotice = null,
+  onDismissModelNotice = noop,
 }) {
   const connection = effectiveConnectionStatus(
     connectionStatus,
@@ -100,6 +131,12 @@ function AssistantThread({
         <ThreadPrimitive.ViewportFooter className="sticky bottom-0 mx-auto mt-auto flex w-full max-w-[var(--thread-max-width)] flex-col bg-white pt-4 pb-4">
           {isConfigurationCleared(configurationStatus) && <ClearedBanner />}
           {isConfigurationRestored(configurationStatus) && <RestoredBanner />}
+          {modelNotice && (
+            <ModelChangeBanner
+              {...modelNotice}
+              onDismiss={onDismissModelNotice}
+            />
+          )}
           <PromptComposer
             connectionStatus={connection}
             configurationStatus={configurationStatus}

--- a/assets/js/lib/ai/WebSocketAIAgent.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.js
@@ -68,6 +68,7 @@ export class WebSocketAIAgent extends AbstractAgent {
     onConnectionChange = noop,
     onAIConfigurationCleared = noop,
     onAIConfigurationCreated = noop,
+    onModelChanged = noop,
     ...options
   }) {
     super(options);
@@ -78,6 +79,7 @@ export class WebSocketAIAgent extends AbstractAgent {
     this.onConnectionChange = onConnectionChange;
     this.onAIConfigurationCleared = onAIConfigurationCleared;
     this.onAIConfigurationCreated = onAIConfigurationCreated;
+    this.onModelChanged = onModelChanged;
     this._connectionStatus = CONNECTION_STATUS.DISCONNECTED;
     this._activeSubscriber = null;
     this._activeRunId = null;
@@ -147,6 +149,7 @@ export class WebSocketAIAgent extends AbstractAgent {
       ['ag_ui_event', (event) => this._handleAgUiEvent(event)],
       ['ai_configuration_cleared', () => this._handleAIConfigurationCleared()],
       ['ai_configuration_created', () => this.onAIConfigurationCreated()],
+      ['model_changed', (payload) => this.onModelChanged(payload)],
     ];
 
     each(messageHandlerMap, ([eventName, handler]) =>

--- a/assets/js/lib/ai/WebSocketAIAgent.test.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.test.js
@@ -545,4 +545,21 @@ describe('WebSocketAIAgent', () => {
       expect(onAIConfigurationCreated).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('model_changed', () => {
+    it('invokes onModelChanged with the event payload', async () => {
+      const onModelChanged = jest.fn();
+      const { channel } = await connectedAgent({ onModelChanged });
+
+      channel.emit('model_changed', {
+        provider: 'googleai',
+        model: 'gemini-2.5-pro',
+      });
+
+      expect(onModelChanged).toHaveBeenCalledWith({
+        provider: 'googleai',
+        model: 'gemini-2.5-pro',
+      });
+    });
+  });
 });

--- a/config/test.exs
+++ b/config/test.exs
@@ -176,7 +176,8 @@ config :trento, :ai,
     ],
     provider2: [
       models: [
-        "model1"
+        "model1",
+        "model3"
       ]
     ]
   ]

--- a/lib/trento/ai/configurations.ex
+++ b/lib/trento/ai/configurations.ex
@@ -61,6 +61,10 @@ defmodule Trento.AI.Configurations do
         user_configuration
         |> UserConfiguration.changeset(attrs)
         |> Repo.update()
+        |> tap(fn
+          {:ok, updated} -> maybe_broadcast_update(user_configuration, updated)
+          _ -> :ok
+        end)
     end
   end
 
@@ -82,4 +86,17 @@ defmodule Trento.AI.Configurations do
   end
 
   def clear_user_configuration(%User{}), do: {:error, :forbidden}
+
+  defp maybe_broadcast_update(
+         %UserConfiguration{provider: provider, model: model},
+         %UserConfiguration{provider: provider, model: model}
+       ),
+       do: :ok
+
+  defp maybe_broadcast_update(%UserConfiguration{}, %UserConfiguration{
+         user_id: user_id,
+         provider: provider,
+         model: model
+       }),
+       do: Events.broadcast_updated(user_id, %{provider: provider, model: model})
 end

--- a/lib/trento/ai/configurations/events.ex
+++ b/lib/trento/ai/configurations/events.ex
@@ -27,11 +27,19 @@ defmodule Trento.AI.Configurations.Events do
   """
   @callback broadcast_cleared(non_neg_integer()) :: :ok
 
+  @doc """
+  Broadcasts that the given user's AI provider/model changed.
+  """
+  @callback broadcast_updated(non_neg_integer(), %{provider: atom(), model: String.t()}) ::
+              :ok
+
   def subscribe(user_id), do: impl().subscribe(user_id)
 
   def broadcast_created(user_id), do: impl().broadcast_created(user_id)
 
   def broadcast_cleared(user_id), do: impl().broadcast_cleared(user_id)
+
+  def broadcast_updated(user_id, payload), do: impl().broadcast_updated(user_id, payload)
 
   defp impl,
     do: Keyword.get(ApplicationConfigLoader.load(), :ai_configuration_events_adapter)

--- a/lib/trento/infrastructure/ai/pub_sub_configuration_events.ex
+++ b/lib/trento/infrastructure/ai/pub_sub_configuration_events.ex
@@ -18,6 +18,10 @@ defmodule Trento.Infrastructure.AI.PubSubConfigurationEvents do
   @impl true
   def broadcast_cleared(user_id), do: broadcast(user_id, {:ai_configuration, :cleared})
 
+  @impl true
+  def broadcast_updated(user_id, payload),
+    do: broadcast(user_id, {:ai_configuration, :updated, payload})
+
   defp broadcast(user_id, message),
     do: Phoenix.PubSub.broadcast(Trento.PubSub, topic(user_id), message)
 

--- a/lib/trento_web/channels/ai_assistant_channel.ex
+++ b/lib/trento_web/channels/ai_assistant_channel.ex
@@ -202,7 +202,7 @@ defmodule TrentoWeb.AIAssistantChannel do
       }
     ]
     |> TrentoAIAgent.new!()
-    |> TrentoAIAgent.run(prompt, refresh_when: &access_token_changed/2)
+    |> TrentoAIAgent.run(prompt, refresh_when: &agent_config_changed/2)
     |> case do
       :ok ->
         socket
@@ -220,18 +220,14 @@ defmodule TrentoWeb.AIAssistantChannel do
     |> then(&{:noreply, &1})
   end
 
-  defp access_token_changed(
-         %{tool_context: %{access_token: token}} = _current_agent,
-         %{tool_context: %{access_token: token}} = _new_agent
-       ) do
-    # IO.inspect("access token unchanged - no agent update needed")
-    :noop
-  end
+  # Hot-swap the running agent when either the access_token OR the effective model config changed.
+  defp agent_config_changed(
+         %{model: model, tool_context: %{access_token: token}} = _current_agent,
+         %{model: model, tool_context: %{access_token: token}} = _new_agent
+       ),
+       do: :noop
 
-  defp access_token_changed(_current_agent, new_agent) do
-    # IO.inspect("access token changed - refreshing agent with new token")
-    {:ok, new_agent}
-  end
+  defp agent_config_changed(_current_agent, new_agent), do: {:ok, new_agent}
 
   @impl true
   def handle_info({:agent, {:status_changed, :running, nil}}, socket),
@@ -307,7 +303,7 @@ defmodule TrentoWeb.AIAssistantChannel do
   @impl true
   def handle_info({:ai_configuration, :created}, socket) do
     # The user's AI configuration was (re)created.
-    # Tell the client it can re-enable the assistant.
+    # Tell the client so it can re-enable the assistant.
     push(socket, "ai_configuration_created", %{})
 
     {:noreply, socket}
@@ -325,6 +321,15 @@ defmodule TrentoWeb.AIAssistantChannel do
     push(socket, "ai_configuration_cleared", %{})
 
     {:noreply, reset_run(socket)}
+  end
+
+  @impl true
+  def handle_info({:ai_configuration, :updated, payload}, socket) do
+    # The user's AI provider/model changed.
+    # Tell the client so it can notify the user.
+    push(socket, "model_changed", payload)
+
+    {:noreply, socket}
   end
 
   @impl true

--- a/test/trento/ai/configurations_test.exs
+++ b/test/trento/ai/configurations_test.exs
@@ -630,6 +630,64 @@ defmodule Trento.Ai.ConfigurationsTest do
 
       assert ^updated_config = load_ai_config(user_id)
     end
+
+    test "should broadcast that the configuration was updated when the provider/model changed" do
+      %User{id: user_id} = user = insert(:user)
+
+      insert(:ai_user_configuration,
+        user_id: user_id,
+        provider: :provider1,
+        model: "model1"
+      )
+
+      Events.subscribe(user_id)
+
+      assert {:ok, %UserConfiguration{}} =
+               Configurations.update_user_configuration(user, %{provider: :provider2})
+
+      assert_receive {:ai_configuration, :updated, %{provider: :provider2, model: "model1"}}
+
+      assert {:ok, %UserConfiguration{}} =
+               Configurations.update_user_configuration(user, %{model: "model3"})
+
+      assert_receive {:ai_configuration, :updated, %{provider: :provider2, model: "model3"}}
+
+      assert {:ok, %UserConfiguration{}} =
+               Configurations.update_user_configuration(user, %{
+                 provider: :provider1,
+                 model: "model1"
+               })
+
+      assert_receive {:ai_configuration, :updated, %{provider: :provider1, model: "model1"}}
+    end
+
+    test "should not broadcast updated when only the api key changed" do
+      %User{id: user_id} = user = insert(:user)
+
+      insert(:ai_user_configuration, user_id: user_id)
+
+      Events.subscribe(user_id)
+
+      assert {:ok, %UserConfiguration{}} =
+               Configurations.update_user_configuration(user, %{
+                 api_key: Faker.String.base64()
+               })
+
+      refute_receive {:ai_configuration, :updated, _}
+    end
+
+    test "should not broadcast updated when the update fails" do
+      %User{id: user_id} = user = insert(:user)
+
+      insert(:ai_user_configuration, user_id: user_id)
+
+      Events.subscribe(user_id)
+
+      assert {:error, %Ecto.Changeset{}} =
+               Configurations.update_user_configuration(user, %{model: Faker.Lorem.word()})
+
+      refute_receive {:ai_configuration, :updated, _}
+    end
   end
 
   describe "clearing a user AI configuration" do

--- a/test/trento_web/channels/ai_assistant_channel_test.exs
+++ b/test/trento_web/channels/ai_assistant_channel_test.exs
@@ -28,6 +28,8 @@ defmodule TrentoWeb.AIAssistantChannelTest do
   import Mox
   import Trento.Factory
 
+  alias LangChain.ChatModels.ChatGoogleAI
+  alias Trento.AI.LLMBuilder
   alias TrentoWeb.Auth.AccessToken
 
   alias TrentoWeb.AIAssistantChannel
@@ -662,7 +664,6 @@ defmodule TrentoWeb.AIAssistantChannelTest do
     test "pushes the fresh token into the running AgentServer via update_agent_and_state when stale",
          %{socket: socket, user_id: user_id} do
       jwt = generate_jwt(user_id)
-      test_pid = self()
 
       expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn _ -> {:ok, self()} end)
 
@@ -674,10 +675,14 @@ defmodule TrentoWeb.AIAssistantChannelTest do
         %{state: %Sagents.State{agent_id: agent_id}}
       end)
 
+      # the agent handed to the AgentServer carries the token from this very message
       expect(Trento.AI.Agent.Server.Mock, :update_agent_and_state, fn _agent_id,
-                                                                      fresh_agent,
+                                                                      %Sagents.Agent{
+                                                                        tool_context: %{
+                                                                          access_token: ^jwt
+                                                                        }
+                                                                      },
                                                                       _state ->
-        send(test_pid, {:updated_with, fresh_agent})
         :ok
       end)
 
@@ -692,22 +697,32 @@ defmodule TrentoWeb.AIAssistantChannelTest do
       })
 
       assert_push("ag_ui_event", %{"type" => "RUN_STARTED"})
-
-      assert_receive {:updated_with, %Sagents.Agent{tool_context: %{access_token: ^jwt}}}, 1_000
     end
 
-    test "does not call update_agent_and_state when running AgentServer already holds the same token",
+    test "does not call update_agent_and_state when running AgentServer already holds the same token and model",
          %{socket: socket, user_id: user_id} do
       jwt = generate_jwt(user_id)
+      # Same model the channel will build for this user + same token → :noop.
+      {:ok, same_model} = LLMBuilder.build_for_user(user_id)
 
       expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn _ -> {:ok, self()} end)
 
       stub(Trento.AI.Agent.Server.Mock, :get_agent, fn _ ->
-        {:ok, %Sagents.Agent{tool_context: %{access_token: jwt}}}
+        {:ok, %Sagents.Agent{model: same_model, tool_context: %{access_token: jwt}}}
       end)
 
-      # No get_info / update_agent_and_state expectations —
-      # access_token matches so the channel's refresh_when returns :noop.
+      # Token AND model match, so the channel's agent_config_changed/2 returns
+      # :noop and Trento.AI.Agent.update_agent/2 is never reached.
+      expect(Trento.AI.Agent.Server.Mock, :get_info, 0, fn agent_id ->
+        %{state: %Sagents.State{agent_id: agent_id}}
+      end)
+
+      expect(Trento.AI.Agent.Server.Mock, :update_agent_and_state, 0, fn _agent_id,
+                                                                         _agent,
+                                                                         _state ->
+        :ok
+      end)
+
       expect(Trento.AI.Agent.Server.Mock, :subscribe, fn _ -> :ok end)
       expect(Trento.AI.Agent.Server.Mock, :add_message, fn _, _ -> :ok end)
 
@@ -789,6 +804,98 @@ defmodule TrentoWeb.AIAssistantChannelTest do
       assert %Sagents.Agent{
                tool_context: %{access_token: ^jwt, request_origin: nil}
              } = opts[:agent]
+    end
+  end
+
+  describe "handle_in send_message/3 — AI settings drift" do
+    setup :join_socket_with_ai_config
+
+    test "swaps the running agent when the model changed",
+         %{socket: socket, user_id: user_id} do
+      jwt = generate_jwt(user_id)
+
+      # The model the channel will build for this user — pins provider, model
+      # name and api key in one match.
+      {:ok, expected_model} = LLMBuilder.build_for_user(user_id)
+
+      # Running agent was started with a different model (same provider, older
+      # model) + the same token → only the model changed.
+      running_model = ChatGoogleAI.new!(%{model: "gemini-2.5-pro", api_key: "k", stream: true})
+
+      expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn _ -> {:ok, self()} end)
+
+      stub(Trento.AI.Agent.Server.Mock, :get_agent, fn _ ->
+        {:ok, %Sagents.Agent{model: running_model, tool_context: %{access_token: jwt}}}
+      end)
+
+      expect(Trento.AI.Agent.Server.Mock, :get_info, fn agent_id ->
+        %{state: %Sagents.State{agent_id: agent_id}}
+      end)
+
+      # the running agent is hot-swapped to the newly-built (gemini-2.5-flash) model
+      expect(Trento.AI.Agent.Server.Mock, :update_agent_and_state, fn _agent_id,
+                                                                      %Sagents.Agent{
+                                                                        model: ^expected_model
+                                                                      },
+                                                                      _state ->
+        :ok
+      end)
+
+      expect(Trento.AI.Agent.Server.Mock, :subscribe, fn _ -> :ok end)
+      expect(Trento.AI.Agent.Server.Mock, :add_message, fn _, _ -> :ok end)
+
+      push(socket, "send_message", %{
+        "message" => "hi",
+        "run_id" => "r-drift",
+        "thread_id" => "t-drift",
+        "access_token" => jwt
+      })
+
+      assert_push("ag_ui_event", %{"type" => "RUN_STARTED"})
+    end
+
+    test "swaps the running agent silently when only the api key changed",
+         %{socket: socket, user_id: user_id} do
+      jwt = generate_jwt(user_id)
+
+      # The model the channel will build for this user — pins provider, model
+      # name and api key in one match.
+      {:ok, expected_model} = LLMBuilder.build_for_user(user_id)
+
+      # Same provider + model as the channel will build, but a different api key.
+      running_model =
+        ChatGoogleAI.new!(%{model: "gemini-2.5-flash", api_key: "OLD-KEY", stream: true})
+
+      expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn _ -> {:ok, self()} end)
+
+      stub(Trento.AI.Agent.Server.Mock, :get_agent, fn _ ->
+        {:ok, %Sagents.Agent{model: running_model, tool_context: %{access_token: jwt}}}
+      end)
+
+      expect(Trento.AI.Agent.Server.Mock, :get_info, fn agent_id ->
+        %{state: %Sagents.State{agent_id: agent_id}}
+      end)
+
+      # the agent is still hot-swapped, so the new key takes effect
+      expect(Trento.AI.Agent.Server.Mock, :update_agent_and_state, fn _agent_id,
+                                                                      %Sagents.Agent{
+                                                                        model: ^expected_model
+                                                                      },
+                                                                      _state ->
+        :ok
+      end)
+
+      expect(Trento.AI.Agent.Server.Mock, :subscribe, fn _ -> :ok end)
+      expect(Trento.AI.Agent.Server.Mock, :add_message, fn _, _ -> :ok end)
+
+      push(socket, "send_message", %{
+        "message" => "hi",
+        "run_id" => "r-key",
+        "thread_id" => "t-key",
+        "access_token" => jwt
+      })
+
+      assert_push("ag_ui_event", %{"type" => "RUN_STARTED"})
     end
   end
 
@@ -907,6 +1014,11 @@ defmodule TrentoWeb.AIAssistantChannelTest do
         })
 
       Mox.allow(Trento.AI.Agent.Supervisor.Mock, self(), socket.channel_pid)
+      Mox.allow(Trento.AI.Agent.Server.Mock, self(), socket.channel_pid)
+
+      # run_agent probes the running agent (for model-drift detection) before
+      # starting it — brand-new thread here, so :not_found.
+      stub(Trento.AI.Agent.Server.Mock, :get_agent, fn _ -> {:error, :not_found} end)
 
       expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn _ ->
         {:error, :boom}
@@ -977,6 +1089,15 @@ defmodule TrentoWeb.AIAssistantChannelTest do
       AIConfigurationsEvents.broadcast_created(user_id)
 
       assert_push("ai_configuration_created", %{})
+    end
+
+    test "pushes model_changed when the provider/model is updated", %{user_id: user_id} do
+      AIConfigurationsEvents.broadcast_updated(user_id, %{
+        provider: :googleai,
+        model: "gemini-2.5-pro"
+      })
+
+      assert_push("model_changed", %{provider: :googleai, model: "gemini-2.5-pro"})
     end
   end
 

--- a/test/trento_web/channels/ai_assistant_channel_test.exs
+++ b/test/trento_web/channels/ai_assistant_channel_test.exs
@@ -25,6 +25,8 @@ defmodule TrentoWeb.AIAssistantChannelTest do
   use TrentoWeb.ChannelCase
   use Trento.AI.AICase
 
+  import Phoenix.ChannelTest, except: [assert_push: 2]
+
   import Mox
   import Trento.Factory
 
@@ -36,6 +38,19 @@ defmodule TrentoWeb.AIAssistantChannelTest do
   alias TrentoWeb.UserSocket
 
   alias Trento.AI.Configurations.Events, as: AIConfigurationsEvents
+
+  # Shadow `assert_push` so that we can add a timeout once for all the call sites.
+  #
+  # Why it needs widening:
+  # because the first `send_message` pays a one-time warm-up cost about tool generation
+  # and so we mitigate possible timing out if resources are constrained.
+  @push_timeout 500
+
+  defmacrop assert_push(event, payload) do
+    quote do
+      Phoenix.ChannelTest.assert_push(unquote(event), unquote(payload), @push_timeout)
+    end
+  end
 
   setup :verify_on_exit!
 


### PR DESCRIPTION
### Description

<!-- Describe what this PR changes. Include benefits or limitations if relevant. -->

This PR closes the loop about reflecting changes to the ai settings into the AI assistant chatbox.

When the provider model/pair is changed the following happens:
- the channel is notified about the change
- the running agent is updated with the new provider/model pair, if needed
- the user is notified about the change

https://github.com/user-attachments/assets/80786d72-cbc5-42ff-9e4f-ef523c273edc

### How was this tested?

Automated and IRL.