### PR TITLE
Fixes on test suite when targeting a remote instance

### DIFF
--- a/test/e2e/cypress/e2e/checks_customization.cy.js
+++ b/test/e2e/cypress/e2e/checks_customization.cy.js
@@ -18,8 +18,10 @@ context('Checks customization', () => {
   after(() => {
     // Reset checks and run new execution to restore health
     checksSelectionPage.apiResetAllChecks();
-    checksSelectionPage.apiRequestExecution();
-    checksSelectionPage.waitUntilExecutionFinished();
+    if (Cypress.expose('wanda_mode') === 'demo') {
+      checksSelectionPage.apiRequestExecution();
+      checksSelectionPage.waitUntilExecutionFinished();
+    }
   });
 
   describe('Checks customization should be possible for a cluster target', () => {

--- a/test/e2e/cypress/pageObject/base_po.js
+++ b/test/e2e/cypress/pageObject/base_po.js
@@ -410,22 +410,6 @@ export const apiDeregisterHost = (hostId) =>
     } else return;
   });
 
-export const apiDeregisterProdHost = () =>
-  apiLogin().then(({ accessToken }) =>
-    cy
-      .request({
-        url: '/api/v1/hosts',
-        method: 'GET',
-        auth: {
-          bearer: accessToken,
-        },
-      })
-      .then(({ body }) => {
-        const hostId = body[0].id;
-        return apiDeregisterHost(hostId);
-      })
-  );
-
 export const stopAgentsHeartbeat = (agents = []) =>
   cy.task('stopAgentsHeartbeat', { agents });
 

--- a/test/e2e/cypress/support/e2e.js
+++ b/test/e2e/cypress/support/e2e.js
@@ -17,10 +17,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import {
-  apiLoginAndCreateSession,
-  apiDeregisterProdHost,
-} from '../pageObject/base_po';
+import { apiLoginAndCreateSession } from '../pageObject/base_po';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
@@ -29,15 +26,5 @@ import {
 // eslint-disable-next-line mocha/no-top-level-hooks
 before(() => {
   Cypress.session.clearAllSavedSessions();
-  if (!Cypress.expose('SSO_INTEGRATION_TESTS')) {
-    apiLoginAndCreateSession();
-  }
-
-  // This is required to not break cypress tests when running against a prod instance (which installs a real agent)
-  if (Cypress.config().baseUrl.includes('target')) apiDeregisterProdHost();
-});
-
-// This is needed because requests that depend on Prometheus in a real environment return a 500 in SLES16, this can be removed once TRNT-4344 is done.
-Cypress.on('uncaught:exception', () => {
-  if (Cypress.config().baseUrl.includes('target16sp0')) return false;
+  if (!Cypress.expose('SSO_INTEGRATION_TESTS')) apiLoginAndCreateSession();
 });


### PR DESCRIPTION
### Description

Clean up E2E test suite for remote instance runs:

- Gate `apiRequestExecution` in `checks_customization` `after` hook to demo mode only, as this was making e2e tests to fail when targetint a remote instance.
- Remove `apiDeregisterProdHost` helper and its usage in the global `before` hook.
- Remove the `uncaught:exception` 'hack' for Prometheus errors on SLES16 targets, after https://jira.suse.com/browse/TRNT-4344 was implemented.

> [!IMPORTANT]
> This PR **unblocks trento-project/trento-installation-automation#36** ("Move host deregistration logic to cleanup-trento-agent action"), whose CI cannot pass until this one is merged.

### How was this tested?
CI on https://github.com/trento-project/trento-installation-automation/pull/36

### Documentation changes

No

### Additional information

<!-- Add anything else relevant to this PR, such as screenshots or demos. -->