### PR TITLE
Mark cluster as stale - backend part

### DIFF
--- a/lib/trento/activity_logging/activity_catalog.ex
+++ b/lib/trento/activity_logging/activity_catalog.ex
@@ -25,6 +25,8 @@ defmodule Trento.ActivityLog.ActivityCatalog do
   @excluded_events [
     Trento.Hosts.Events.HostChecksSelected,
     Trento.Clusters.Events.ChecksSelected,
+    Trento.Clusters.Events.ClusterHostDataMarkedStale,
+    Trento.Clusters.Events.ClusterHostDataMarkedInSync,
     Trento.SapSystems.Events.SapSystemDatabaseStaleAtChanged
   ]
 

--- a/lib/trento/clusters/cluster.ex
+++ b/lib/trento/clusters/cluster.ex
@@ -95,6 +95,7 @@ defmodule Trento.Clusters.Cluster do
   alias Trento.Clusters.Commands.{
     CompleteChecksExecution,
     DeregisterClusterHost,
+    MarkClusterHostStale,
     RegisterOfflineClusterHost,
     RegisterOnlineClusterHost,
     RollUpCluster,
@@ -111,11 +112,15 @@ defmodule Trento.Clusters.Cluster do
   alias Trento.Clusters.Events.{
     ChecksSelected,
     ClusterChecksHealthChanged,
+    ClusterDataMarkedInSync,
+    ClusterDataMarkedStale,
     ClusterDeregistered,
     ClusterDetailsUpdated,
     ClusterDiscoveredHealthChanged,
     ClusterDistributedHealthChanged,
     ClusterHealthChanged,
+    ClusterHostDataMarkedInSync,
+    ClusterHostDataMarkedStale,
     ClusterHostStatusChanged,
     ClusterRegistered,
     ClusterReplicationHealthChanged,
@@ -149,6 +154,7 @@ defmodule Trento.Clusters.Cluster do
     field :state, Ecto.Enum, values: ClusterState.values()
     field :hosts, {:array, :string}, default: []
     field :offline_hosts, {:array, :string}, default: []
+    field :stale_hosts, {:array, :string}, default: []
     field :selected_checks, {:array, :string}, default: []
     field :rolling_up, :boolean, default: false
     field :deregistered_at, :utc_datetime_usec, default: nil
@@ -369,7 +375,8 @@ defmodule Trento.Clusters.Cluster do
           designated_controller: false
         }
       ) do
-    maybe_emit_host_added_to_cluster_event(cluster, host_id, ClusterHostStatus.online())
+    maybe_emit_host_added_to_cluster_event(cluster, host_id, ClusterHostStatus.online()) ++
+      maybe_emit_cluster_host_data_marked_in_sync_event(cluster, host_id)
   end
 
   def execute(
@@ -385,6 +392,9 @@ defmodule Trento.Clusters.Cluster do
     end)
     |> Multi.execute(fn cluster ->
       maybe_emit_cluster_details_updated_event(cluster, command)
+    end)
+    |> Multi.execute(fn cluster ->
+      maybe_emit_cluster_host_data_marked_in_sync_event(cluster, host_id)
     end)
     |> handle_cluster_health_events(command)
   end
@@ -405,6 +415,9 @@ defmodule Trento.Clusters.Cluster do
       maybe_emit_host_added_to_cluster_event(cluster, host_id, ClusterHostStatus.online())
     end)
     |> Multi.execute(fn cluster -> maybe_emit_cluster_details_updated_event(cluster, command) end)
+    |> Multi.execute(fn cluster ->
+      maybe_emit_cluster_host_data_marked_in_sync_event(cluster, host_id)
+    end)
     |> handle_cluster_health_events(command)
   end
 
@@ -446,13 +459,47 @@ defmodule Trento.Clusters.Cluster do
       ) do
     cluster
     |> Multi.new()
-    |> Multi.execute(fn _ ->
-      %HostRemovedFromCluster{
-        cluster_id: cluster_id,
-        host_id: host_id
-      }
+    |> Multi.execute(fn cluster ->
+      [
+        %HostRemovedFromCluster{
+          cluster_id: cluster_id,
+          host_id: host_id
+        }
+      ] ++ maybe_emit_cluster_data_marked_in_sync_event(cluster, host_id)
     end)
     |> Multi.execute(&maybe_emit_cluster_deregistered_event(&1, command))
+  end
+
+  def execute(
+        %Cluster{cluster_id: cluster_id, stale_hosts: []},
+        %MarkClusterHostStale{host_id: host_id, stale_at: stale_at}
+      ) do
+    [
+      %ClusterHostDataMarkedStale{
+        cluster_id: cluster_id,
+        host_id: host_id,
+        stale_at: stale_at
+      },
+      %ClusterDataMarkedStale{
+        cluster_id: cluster_id,
+        stale_at: stale_at
+      }
+    ]
+  end
+
+  def execute(
+        %Cluster{cluster_id: cluster_id, stale_hosts: stale_hosts},
+        %MarkClusterHostStale{host_id: host_id, stale_at: stale_at}
+      ) do
+    if host_id in stale_hosts do
+      nil
+    else
+      %ClusterHostDataMarkedStale{
+        cluster_id: cluster_id,
+        host_id: host_id,
+        stale_at: stale_at
+      }
+    end
   end
 
   def apply(
@@ -722,7 +769,8 @@ defmodule Trento.Clusters.Cluster do
     %Cluster{
       cluster
       | hosts: List.delete(hosts, host_id),
-        offline_hosts: List.delete(cluster.offline_hosts, host_id)
+        offline_hosts: List.delete(cluster.offline_hosts, host_id),
+        stale_hosts: List.delete(cluster.stale_hosts, host_id)
     }
   end
 
@@ -735,6 +783,24 @@ defmodule Trento.Clusters.Cluster do
   def apply(%Cluster{} = cluster, %ClusterRestored{}) do
     %Cluster{cluster | deregistered_at: nil}
   end
+
+  def apply(
+        %Cluster{stale_hosts: stale_hosts} = cluster,
+        %ClusterHostDataMarkedStale{host_id: host_id}
+      ) do
+    %Cluster{cluster | stale_hosts: [host_id | stale_hosts]}
+  end
+
+  def apply(
+        %Cluster{stale_hosts: stale_hosts} = cluster,
+        %ClusterHostDataMarkedInSync{host_id: host_id}
+      ) do
+    %Cluster{cluster | stale_hosts: List.delete(stale_hosts, host_id)}
+  end
+
+  def apply(%Cluster{} = cluster, %ClusterDataMarkedStale{}), do: cluster
+
+  def apply(%Cluster{} = cluster, %ClusterDataMarkedInSync{}), do: cluster
 
   def apply(cluster, %legacy_event{}) when legacy_event in @legacy_events, do: cluster
 
@@ -806,30 +872,83 @@ defmodule Trento.Clusters.Cluster do
        ) do
     cond do
       host_id not in hosts ->
-        %HostAddedToCluster{
-          cluster_id: cluster_id,
-          host_id: host_id,
-          cluster_host_status: cluster_host_status
-        }
+        [
+          %HostAddedToCluster{
+            cluster_id: cluster_id,
+            host_id: host_id,
+            cluster_host_status: cluster_host_status
+          }
+        ]
 
       host_id in offline_hosts and cluster_host_status == ClusterHostStatus.online() ->
-        %ClusterHostStatusChanged{
-          cluster_id: cluster_id,
-          host_id: host_id,
-          cluster_host_status: ClusterHostStatus.online()
-        }
+        [
+          %ClusterHostStatusChanged{
+            cluster_id: cluster_id,
+            host_id: host_id,
+            cluster_host_status: ClusterHostStatus.online()
+          }
+        ]
 
       host_id not in offline_hosts and cluster_host_status == ClusterHostStatus.offline() ->
-        %ClusterHostStatusChanged{
-          cluster_id: cluster_id,
-          host_id: host_id,
-          cluster_host_status: ClusterHostStatus.offline()
-        }
+        [
+          %ClusterHostStatusChanged{
+            cluster_id: cluster_id,
+            host_id: host_id,
+            cluster_host_status: ClusterHostStatus.offline()
+          }
+        ]
 
       true ->
         []
     end
   end
+
+  defp maybe_emit_cluster_host_data_marked_in_sync_event(
+         %Cluster{cluster_id: cluster_id, stale_hosts: [host_id]},
+         host_id
+       ) do
+    [
+      %ClusterHostDataMarkedInSync{
+        cluster_id: cluster_id,
+        host_id: host_id
+      },
+      %ClusterDataMarkedInSync{
+        cluster_id: cluster_id
+      }
+    ]
+  end
+
+  defp maybe_emit_cluster_host_data_marked_in_sync_event(
+         %Cluster{cluster_id: cluster_id, stale_hosts: stale_hosts},
+         host_id
+       ) do
+    if host_id in stale_hosts do
+      [
+        %ClusterHostDataMarkedInSync{
+          cluster_id: cluster_id,
+          host_id: host_id
+        }
+      ]
+    else
+      []
+    end
+  end
+
+  # Emitted only when the removed host is the last stale one and the cluster keeps
+  # other hosts (i.e. it is not being deregistered).
+  defp maybe_emit_cluster_data_marked_in_sync_event(
+         %Cluster{cluster_id: cluster_id, stale_hosts: [host_id], hosts: hosts},
+         host_id
+       )
+       when length(hosts) > 1 do
+    [
+      %ClusterDataMarkedInSync{
+        cluster_id: cluster_id
+      }
+    ]
+  end
+
+  defp maybe_emit_cluster_data_marked_in_sync_event(_cluster, _host_id), do: []
 
   defp handle_cluster_health_events(multi, command) do
     multi

--- a/lib/trento/clusters/cluster.ex
+++ b/lib/trento/clusters/cluster.ex
@@ -388,13 +388,11 @@ defmodule Trento.Clusters.Cluster do
     cluster
     |> Multi.new()
     |> Multi.execute(fn cluster ->
-      maybe_emit_host_added_to_cluster_event(cluster, host_id, ClusterHostStatus.offline())
+      maybe_emit_host_added_to_cluster_event(cluster, host_id, ClusterHostStatus.offline()) ++
+        maybe_emit_cluster_host_data_marked_in_sync_event(cluster, host_id)
     end)
     |> Multi.execute(fn cluster ->
       maybe_emit_cluster_details_updated_event(cluster, command)
-    end)
-    |> Multi.execute(fn cluster ->
-      maybe_emit_cluster_host_data_marked_in_sync_event(cluster, host_id)
     end)
     |> handle_cluster_health_events(command)
   end
@@ -412,12 +410,10 @@ defmodule Trento.Clusters.Cluster do
     cluster
     |> Multi.new()
     |> Multi.execute(fn cluster ->
-      maybe_emit_host_added_to_cluster_event(cluster, host_id, ClusterHostStatus.online())
+      maybe_emit_host_added_to_cluster_event(cluster, host_id, ClusterHostStatus.online()) ++
+        maybe_emit_cluster_host_data_marked_in_sync_event(cluster, host_id)
     end)
     |> Multi.execute(fn cluster -> maybe_emit_cluster_details_updated_event(cluster, command) end)
-    |> Multi.execute(fn cluster ->
-      maybe_emit_cluster_host_data_marked_in_sync_event(cluster, host_id)
-    end)
     |> handle_cluster_health_events(command)
   end
 

--- a/lib/trento/clusters/commands/mark_cluster_host_stale.ex
+++ b/lib/trento/clusters/commands/mark_cluster_host_stale.ex
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Clusters.Commands.MarkClusterHostStale do
+  @moduledoc """
+  Mark a cluster host data as stale.
+  """
+  @required_fields :all
+
+  use Trento.Support.Command
+
+  defcommand do
+    field :cluster_id, Ecto.UUID
+    field :host_id, Ecto.UUID
+    field :stale_at, :utc_datetime_usec
+  end
+end

--- a/lib/trento/clusters/events/cluster_data_marked_in_sync.ex
+++ b/lib/trento/clusters/events/cluster_data_marked_in_sync.ex
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Clusters.Events.ClusterDataMarkedInSync do
+  @moduledoc """
+  This event is emitted when a cluster's data is marked as in sync after all its
+  cluster host data is marked in sync.
+  """
+
+  use Trento.Support.Event
+
+  defevent do
+    field :cluster_id, Ecto.UUID
+  end
+end

--- a/lib/trento/clusters/events/cluster_data_marked_stale.ex
+++ b/lib/trento/clusters/events/cluster_data_marked_stale.ex
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Clusters.Events.ClusterDataMarkedStale do
+  @moduledoc """
+  This event is emitted when a cluster's data is marked as stale after at least
+  one cluster host data is marked stale.
+  """
+
+  use Trento.Support.Event
+
+  defevent do
+    field :cluster_id, Ecto.UUID
+    field :stale_at, :utc_datetime_usec
+  end
+end

--- a/lib/trento/clusters/events/cluster_host_data_marked_in_sync.ex
+++ b/lib/trento/clusters/events/cluster_host_data_marked_in_sync.ex
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Clusters.Events.ClusterHostDataMarkedInSync do
+  @moduledoc """
+  This event is emitted when a cluster host data is marked as in sync
+  because the stale host sent fresh data again.
+  """
+
+  use Trento.Support.Event
+
+  defevent do
+    field :cluster_id, Ecto.UUID
+    field :host_id, Ecto.UUID
+  end
+end

--- a/lib/trento/clusters/events/cluster_host_data_marked_stale.ex
+++ b/lib/trento/clusters/events/cluster_host_data_marked_stale.ex
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Clusters.Events.ClusterHostDataMarkedStale do
+  @moduledoc """
+  This event is emitted when a cluster host data is marked as stale
+  because the host stopped sending fresh data.
+  """
+
+  use Trento.Support.Event
+
+  defevent do
+    field :cluster_id, Ecto.UUID
+    field :host_id, Ecto.UUID
+    field :stale_at, :utc_datetime_usec
+  end
+end

--- a/lib/trento/clusters/projections/cluster_projector.ex
+++ b/lib/trento/clusters/projections/cluster_projector.ex
@@ -15,6 +15,8 @@ defmodule Trento.Clusters.Projections.ClusterProjector do
 
   alias Trento.Clusters.Events.{
     ChecksSelected,
+    ClusterDataMarkedInSync,
+    ClusterDataMarkedStale,
     ClusterDeregistered,
     ClusterDetailsUpdated,
     ClusterHealthChanged,
@@ -150,6 +152,30 @@ defmodule Trento.Clusters.Projections.ClusterProjector do
     Ecto.Multi.update(multi, :cluster, changeset)
   end)
 
+  project(
+    %ClusterDataMarkedStale{cluster_id: cluster_id, stale_at: stale_at},
+    fn multi ->
+      changeset =
+        ClusterReadModel
+        |> Repo.get!(cluster_id)
+        |> ClusterReadModel.changeset(%{stale_at: stale_at})
+
+      Ecto.Multi.update(multi, :cluster, changeset)
+    end
+  )
+
+  project(
+    %ClusterDataMarkedInSync{cluster_id: cluster_id},
+    fn multi ->
+      changeset =
+        ClusterReadModel
+        |> Repo.get!(cluster_id)
+        |> ClusterReadModel.changeset(%{stale_at: nil})
+
+      Ecto.Multi.update(multi, :cluster, changeset)
+    end
+  )
+
   @impl true
   def after_update(
         %ClusterRegistered{},
@@ -217,6 +243,24 @@ defmodule Trento.Clusters.Projections.ClusterProjector do
       "monitoring:clusters",
       "cluster_restored",
       ClusterJSON.cluster_restored(%{cluster: restored_cluster})
+    )
+  end
+
+  @impl true
+  def after_update(%ClusterDataMarkedStale{}, _, %{cluster: %ClusterReadModel{} = cluster}) do
+    TrentoWeb.Endpoint.broadcast(
+      "monitoring:clusters",
+      "cluster_stale_changed",
+      ClusterJSON.cluster_stale_changed(%{cluster: cluster})
+    )
+  end
+
+  @impl true
+  def after_update(%ClusterDataMarkedInSync{}, _, %{cluster: %ClusterReadModel{} = cluster}) do
+    TrentoWeb.Endpoint.broadcast(
+      "monitoring:clusters",
+      "cluster_stale_changed",
+      ClusterJSON.cluster_stale_changed(%{cluster: cluster})
     )
   end
 

--- a/lib/trento/clusters/projections/cluster_read_model.ex
+++ b/lib/trento/clusters/projections/cluster_read_model.ex
@@ -40,6 +40,7 @@ defmodule Trento.Clusters.Projections.ClusterReadModel do
     field :hosts_number, :integer
     field :state, Ecto.Enum, values: ClusterState.values()
     field :details, Trento.Support.Ecto.Payload, keys_as_atoms: true
+    field :stale_at, :utc_datetime_usec
 
     has_many :tags, Tag, foreign_key: :resource_id
 

--- a/lib/trento/infrastructure/commanded/process_managers/deregistration_process_manager.ex
+++ b/lib/trento/infrastructure/commanded/process_managers/deregistration_process_manager.ex
@@ -86,7 +86,10 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
     MarkApplicationInstanceDataStale
   }
 
-  alias Trento.Clusters.Commands.DeregisterClusterHost
+  alias Trento.Clusters.Commands.{
+    DeregisterClusterHost,
+    MarkClusterHostStale
+  }
 
   alias Trento.SapSystems
   alias Trento.SapSystems.SapSystem
@@ -226,6 +229,7 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
 
   def handle(
         %DeregistrationProcessManager{
+          cluster_id: cluster_id,
           application_instances: application_instances,
           database_instances: database_instances
         },
@@ -260,7 +264,9 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
         }
       end)
 
-    application_commands ++ database_commands
+    application_commands ++
+      database_commands ++
+      maybe_mark_cluster_host_stale(cluster_id, host_id, created_at)
   end
 
   def apply(%DeregistrationProcessManager{} = state, %HostAddedToCluster{
@@ -469,6 +475,18 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
         host_id: host_id,
         cluster_id: cluster_id,
         deregistered_at: requested_at
+      }
+    ]
+  end
+
+  defp maybe_mark_cluster_host_stale(nil, _, _), do: []
+
+  defp maybe_mark_cluster_host_stale(cluster_id, host_id, stale_at) do
+    [
+      %MarkClusterHostStale{
+        cluster_id: cluster_id,
+        host_id: host_id,
+        stale_at: stale_at
       }
     ]
   end

--- a/lib/trento/router.ex
+++ b/lib/trento/router.ex
@@ -9,6 +9,7 @@ defmodule Trento.Router do
   alias Trento.Clusters.Commands.{
     CompleteChecksExecution,
     DeregisterClusterHost,
+    MarkClusterHostStale,
     RegisterOfflineClusterHost,
     RegisterOnlineClusterHost,
     RollUpCluster,
@@ -81,6 +82,7 @@ defmodule Trento.Router do
 
   dispatch [
              DeregisterClusterHost,
+             MarkClusterHostStale,
              RollUpCluster,
              RegisterOfflineClusterHost,
              RegisterOnlineClusterHost,

--- a/lib/trento_web/controllers/v1/cluster_json.ex
+++ b/lib/trento_web/controllers/v1/cluster_json.ex
@@ -14,6 +14,7 @@ defmodule TrentoWeb.V1.ClusterJSON do
     |> adapt_v1()
     |> Map.delete(:sap_instances)
     |> Map.delete(:state)
+    |> Map.delete(:stale_at)
   end
 
   def cluster_registered(%{cluster: cluster}) do

--- a/lib/trento_web/controllers/v2/cluster_json.ex
+++ b/lib/trento_web/controllers/v2/cluster_json.ex
@@ -31,6 +31,9 @@ defmodule TrentoWeb.V2.ClusterJSON do
   def cluster_health_changed(%{cluster: %{id: id, name: name, health: health}}),
     do: %{cluster_id: id, name: name, health: health}
 
+  def cluster_stale_changed(%{cluster: %{id: id, stale_at: stale_at}}),
+    do: %{id: id, stale_at: stale_at}
+
   defp adapt_sids(%{sap_instances: sap_instances} = cluster) do
     adapted_sap_instances =
       Enum.map(sap_instances, fn %{sid: sid, instance_number: instance_number} ->

--- a/lib/trento_web/openapi/v2/schema/cluster.ex
+++ b/lib/trento_web/openapi/v2/schema/cluster.ex
@@ -777,6 +777,14 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
           },
           details: Details,
           tags: Tags,
+          stale_at: %Schema{
+            type: :string,
+            description:
+              "The timestamp indicating when the cluster data became stale, supporting monitoring and troubleshooting.",
+            format: :datetime,
+            example: "2024-01-15T08:00:00Z",
+            nullable: true
+          },
           inserted_at: %Schema{
             type: :string,
             format: :datetime,
@@ -821,6 +829,7 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
             }
           ],
           state: "S_IDLE",
+          stale_at: "2024-01-15T08:00:00Z",
           inserted_at: "2024-01-15T09:00:00Z",
           updated_at: "2024-01-15T10:30:00Z"
         }
@@ -853,6 +862,7 @@ defmodule TrentoWeb.OpenApi.V2.Schema.Cluster do
             hosts_number: 2,
             cib_last_written: "2024-01-15T10:30:00Z",
             state: "S_IDLE",
+            stale_at: "2024-01-15T08:00:00Z",
             inserted_at: "2024-01-15T09:00:00Z",
             updated_at: "2024-01-15T10:30:00Z"
           }

--- a/priv/repo/migrations/20260722100000_add_stale_at_cluster_read_model.exs
+++ b/priv/repo/migrations/20260722100000_add_stale_at_cluster_read_model.exs
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Repo.Migrations.AddStaleAtClusterReadModel do
+  use Ecto.Migration
+
+  def change do
+    alter table(:clusters) do
+      add :stale_at, :utc_datetime_usec
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -103,10 +103,14 @@ defmodule Trento.Factory do
   alias Trento.Clusters.Events.{
     ChecksSelected,
     ClusterChecksHealthChanged,
+    ClusterDataMarkedInSync,
+    ClusterDataMarkedStale,
     ClusterDeregistered,
     ClusterDetailsUpdated,
     ClusterDiscoveredHealthChanged,
     ClusterHealthChanged,
+    ClusterHostDataMarkedInSync,
+    ClusterHostDataMarkedStale,
     ClusterHostStatusChanged,
     ClusterRegistered,
     ClusterTombstoned,
@@ -406,6 +410,54 @@ defmodule Trento.Factory do
       cluster_id: Faker.UUID.v4(),
       checks_health: Health.passing()
     }
+  end
+
+  def cluster_host_data_marked_stale_event_factory(attrs) do
+    data = %{
+      cluster_id: Faker.UUID.v4(),
+      host_id: Faker.UUID.v4(),
+      stale_at: DateTime.utc_now()
+    }
+
+    data
+    |> merge_attributes(attrs)
+    |> evaluate_lazy_attributes
+    |> ClusterHostDataMarkedStale.new!()
+  end
+
+  def cluster_host_data_marked_in_sync_event_factory(attrs) do
+    data = %{
+      cluster_id: Faker.UUID.v4(),
+      host_id: Faker.UUID.v4()
+    }
+
+    data
+    |> merge_attributes(attrs)
+    |> evaluate_lazy_attributes
+    |> ClusterHostDataMarkedInSync.new!()
+  end
+
+  def cluster_data_marked_stale_event_factory(attrs) do
+    data = %{
+      cluster_id: Faker.UUID.v4(),
+      stale_at: DateTime.utc_now()
+    }
+
+    data
+    |> merge_attributes(attrs)
+    |> evaluate_lazy_attributes
+    |> ClusterDataMarkedStale.new!()
+  end
+
+  def cluster_data_marked_in_sync_event_factory(attrs) do
+    data = %{
+      cluster_id: Faker.UUID.v4()
+    }
+
+    data
+    |> merge_attributes(attrs)
+    |> evaluate_lazy_attributes
+    |> ClusterDataMarkedInSync.new!()
   end
 
   def host_added_to_cluster_event_factory do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -519,8 +519,8 @@ defmodule Trento.Factory do
     }
   end
 
-  def cluster_factory do
-    %ClusterReadModel{
+  def cluster_factory(attrs) do
+    cluster = %ClusterReadModel{
       id: Faker.UUID.v4(),
       name: Faker.StarWars.character(),
       sap_instances: build_list(1, :clustered_sap_instance),
@@ -529,8 +529,13 @@ defmodule Trento.Factory do
       health: Health.passing(),
       selected_checks: Enum.map(0..4, fn _ -> Faker.StarWars.planet() end),
       details: %{},
-      state: :S_IDLE
+      state: :S_IDLE,
+      stale_at: nil
     }
+
+    cluster
+    |> merge_attributes(attrs)
+    |> evaluate_lazy_attributes()
   end
 
   def cluster_enrichment_data_factory do

--- a/test/trento/activity_logging/activity_catalog_test.exs
+++ b/test/trento/activity_logging/activity_catalog_test.exs
@@ -476,6 +476,8 @@ defmodule Trento.ActivityLog.ActivityCatalogTest do
       excluded_events = [
         :host_checks_selected_event,
         :cluster_checks_selected_event,
+        :cluster_host_data_marked_stale_event,
+        :cluster_host_data_marked_in_sync_event,
         :sap_system_database_stale_at_changed_event
       ]
 

--- a/test/trento/clusters/cluster_test.exs
+++ b/test/trento/clusters/cluster_test.exs
@@ -2193,7 +2193,7 @@ defmodule Trento.ClusterTest do
   end
 
   describe "cluster marked stale/in sync" do
-    test "should mark the cluster as stale only once and ignore already stale hosts" do
+    test "should mark the cluster and its hosts stale" do
       cluster_id = UUID.uuid4()
       host_1_id = UUID.uuid4()
       host_2_id = UUID.uuid4()
@@ -2218,12 +2218,6 @@ defmodule Trento.ClusterTest do
           %MarkClusterHostStale{
             cluster_id: cluster_id,
             host_id: host_2_id,
-            stale_at: stale_at
-          },
-          # an already stale host does not emit any event
-          %MarkClusterHostStale{
-            cluster_id: cluster_id,
-            host_id: host_1_id,
             stale_at: stale_at
           }
         ],

--- a/test/trento/clusters/cluster_test.exs
+++ b/test/trento/clusters/cluster_test.exs
@@ -17,6 +17,7 @@ defmodule Trento.ClusterTest do
   alias Trento.Clusters.Commands.{
     CompleteChecksExecution,
     DeregisterClusterHost,
+    MarkClusterHostStale,
     RegisterOfflineClusterHost,
     RegisterOnlineClusterHost,
     RollUpCluster,
@@ -33,11 +34,15 @@ defmodule Trento.ClusterTest do
   alias Trento.Clusters.Events.{
     ChecksSelected,
     ClusterChecksHealthChanged,
+    ClusterDataMarkedInSync,
+    ClusterDataMarkedStale,
     ClusterDeregistered,
     ClusterDetailsUpdated,
     ClusterDiscoveredHealthChanged,
     ClusterDistributedHealthChanged,
     ClusterHealthChanged,
+    ClusterHostDataMarkedInSync,
+    ClusterHostDataMarkedStale,
     ClusterHostStatusChanged,
     ClusterRegistered,
     ClusterReplicationHealthChanged,
@@ -2183,6 +2188,255 @@ defmodule Trento.ClusterTest do
           }
         ],
         fn cluster -> assert dat == cluster.deregistered_at end
+      )
+    end
+  end
+
+  describe "cluster marked stale/in sync" do
+    test "should mark the cluster as stale only once and ignore already stale hosts" do
+      cluster_id = UUID.uuid4()
+      host_1_id = UUID.uuid4()
+      host_2_id = UUID.uuid4()
+      stale_at = DateTime.utc_now()
+
+      initial_events = [
+        build(:cluster_registered_event, cluster_id: cluster_id, hosts_number: 2),
+        build(:host_added_to_cluster_event, cluster_id: cluster_id, host_id: host_1_id),
+        build(:host_added_to_cluster_event, cluster_id: cluster_id, host_id: host_2_id)
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        [
+          # first stale host marks both the host and the cluster as stale
+          %MarkClusterHostStale{
+            cluster_id: cluster_id,
+            host_id: host_1_id,
+            stale_at: stale_at
+          },
+          # a second stale host only marks the host, the cluster is already stale
+          %MarkClusterHostStale{
+            cluster_id: cluster_id,
+            host_id: host_2_id,
+            stale_at: stale_at
+          },
+          # an already stale host does not emit any event
+          %MarkClusterHostStale{
+            cluster_id: cluster_id,
+            host_id: host_1_id,
+            stale_at: stale_at
+          }
+        ],
+        [
+          %ClusterHostDataMarkedStale{
+            cluster_id: cluster_id,
+            host_id: host_1_id,
+            stale_at: stale_at
+          },
+          %ClusterDataMarkedStale{
+            cluster_id: cluster_id,
+            stale_at: stale_at
+          },
+          %ClusterHostDataMarkedStale{
+            cluster_id: cluster_id,
+            host_id: host_2_id,
+            stale_at: stale_at
+          }
+        ],
+        fn cluster ->
+          assert %Cluster{stale_hosts: [^host_2_id, ^host_1_id]} = cluster
+        end
+      )
+    end
+
+    test "should mark the cluster as in sync only when all its stale hosts send fresh data again" do
+      cluster_id = UUID.uuid4()
+      host_1_id = UUID.uuid4()
+      host_2_id = UUID.uuid4()
+      host_3_id = UUID.uuid4()
+
+      initial_events = [
+        registered_event =
+          build(:cluster_registered_event, cluster_id: cluster_id, hosts_number: 3),
+        build(:host_added_to_cluster_event, cluster_id: cluster_id, host_id: host_1_id),
+        build(:host_added_to_cluster_event, cluster_id: cluster_id, host_id: host_2_id),
+        build(:host_added_to_cluster_event, cluster_id: cluster_id, host_id: host_3_id),
+        build(:cluster_host_data_marked_stale_event, cluster_id: cluster_id, host_id: host_1_id),
+        build(:cluster_host_data_marked_stale_event, cluster_id: cluster_id, host_id: host_2_id)
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        [
+          # a host that was never stale sending data does not emit any event
+          build(:register_online_cluster_host,
+            cluster_id: cluster_id,
+            host_id: host_3_id,
+            designated_controller: false
+          ),
+          # a stale host recovering only syncs the host, the cluster is still stale
+          build(:register_online_cluster_host,
+            cluster_id: cluster_id,
+            host_id: host_2_id,
+            designated_controller: false
+          ),
+          # the last stale host recovering syncs both the host and the cluster
+          build(:register_online_cluster_host,
+            cluster_id: cluster_id,
+            host_id: host_1_id,
+            designated_controller: true,
+            name: registered_event.name,
+            type: registered_event.type,
+            sap_instances: Enum.map(registered_event.sap_instances, &Map.from_struct/1),
+            provider: registered_event.provider,
+            resources_number: registered_event.resources_number,
+            hosts_number: registered_event.hosts_number,
+            state: registered_event.state,
+            details: StructHelper.to_map(registered_event.details)
+          )
+        ],
+        [
+          %ClusterHostDataMarkedInSync{
+            cluster_id: cluster_id,
+            host_id: host_2_id
+          },
+          %ClusterHostDataMarkedInSync{
+            cluster_id: cluster_id,
+            host_id: host_1_id
+          },
+          %ClusterDataMarkedInSync{
+            cluster_id: cluster_id
+          }
+        ],
+        fn cluster ->
+          assert %Cluster{stale_hosts: []} = cluster
+        end
+      )
+    end
+
+    test "should mark the cluster host and cluster in sync when a stale host is registered as offline" do
+      cluster_id = UUID.uuid4()
+      host_1_id = UUID.uuid4()
+      host_2_id = UUID.uuid4()
+
+      initial_events = [
+        build(:cluster_registered_event, cluster_id: cluster_id, hosts_number: 2),
+        build(:host_added_to_cluster_event, cluster_id: cluster_id, host_id: host_1_id),
+        build(:host_added_to_cluster_event, cluster_id: cluster_id, host_id: host_2_id),
+        build(:cluster_host_status_changed_event,
+          cluster_id: cluster_id,
+          host_id: host_1_id,
+          cluster_host_status: ClusterHostStatus.offline()
+        ),
+        build(:cluster_host_data_marked_stale_event, cluster_id: cluster_id, host_id: host_1_id)
+      ]
+
+      register_command =
+        build(:register_offline_cluster_host, cluster_id: cluster_id, host_id: host_1_id)
+
+      assert_events_and_state(
+        initial_events,
+        register_command,
+        [
+          %ClusterHostDataMarkedInSync{
+            cluster_id: cluster_id,
+            host_id: host_1_id
+          },
+          %ClusterDataMarkedInSync{
+            cluster_id: cluster_id
+          }
+        ],
+        fn cluster ->
+          assert %Cluster{stale_hosts: []} = cluster
+        end
+      )
+    end
+
+    test "should mark the cluster in sync only when the last stale host is removed from the cluster" do
+      cluster_id = UUID.uuid4()
+      host_1_id = UUID.uuid4()
+      host_2_id = UUID.uuid4()
+      host_3_id = UUID.uuid4()
+      deregistered_at = DateTime.utc_now()
+
+      initial_events = [
+        build(:cluster_registered_event, cluster_id: cluster_id, hosts_number: 3),
+        build(:host_added_to_cluster_event, cluster_id: cluster_id, host_id: host_1_id),
+        build(:host_added_to_cluster_event, cluster_id: cluster_id, host_id: host_2_id),
+        build(:host_added_to_cluster_event, cluster_id: cluster_id, host_id: host_3_id),
+        build(:cluster_host_data_marked_stale_event, cluster_id: cluster_id, host_id: host_1_id),
+        build(:cluster_host_data_marked_stale_event, cluster_id: cluster_id, host_id: host_2_id)
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        [
+          # removing a stale host while other stale hosts remain keeps the cluster stale
+          %DeregisterClusterHost{
+            cluster_id: cluster_id,
+            host_id: host_1_id,
+            deregistered_at: deregistered_at
+          },
+          # removing the last stale host marks the cluster in sync
+          %DeregisterClusterHost{
+            cluster_id: cluster_id,
+            host_id: host_2_id,
+            deregistered_at: deregistered_at
+          }
+        ],
+        [
+          %HostRemovedFromCluster{
+            cluster_id: cluster_id,
+            host_id: host_1_id
+          },
+          %HostRemovedFromCluster{
+            cluster_id: cluster_id,
+            host_id: host_2_id
+          },
+          %ClusterDataMarkedInSync{
+            cluster_id: cluster_id
+          }
+        ],
+        fn cluster ->
+          assert %Cluster{stale_hosts: [], hosts: [^host_3_id]} = cluster
+        end
+      )
+    end
+
+    test "should not mark the cluster in sync when removing the last stale host also deregisters the cluster" do
+      cluster_id = UUID.uuid4()
+      host_id = UUID.uuid4()
+      deregistered_at = DateTime.utc_now()
+
+      initial_events = [
+        build(:cluster_registered_event, cluster_id: cluster_id, hosts_number: 1),
+        build(:host_added_to_cluster_event, cluster_id: cluster_id, host_id: host_id),
+        build(:cluster_host_data_marked_stale_event, cluster_id: cluster_id, host_id: host_id)
+      ]
+
+      assert_events_and_state(
+        initial_events,
+        %DeregisterClusterHost{
+          cluster_id: cluster_id,
+          host_id: host_id,
+          deregistered_at: deregistered_at
+        },
+        [
+          %HostRemovedFromCluster{
+            cluster_id: cluster_id,
+            host_id: host_id
+          },
+          %ClusterDeregistered{
+            cluster_id: cluster_id,
+            deregistered_at: deregistered_at
+          },
+          %ClusterTombstoned{
+            cluster_id: cluster_id
+          }
+        ],
+        fn cluster ->
+          assert %Cluster{stale_hosts: [], deregistered_at: ^deregistered_at} = cluster
+        end
       )
     end
   end

--- a/test/trento/clusters/projections/cluster_projector_test.exs
+++ b/test/trento/clusters/projections/cluster_projector_test.exs
@@ -11,6 +11,8 @@ defmodule Trento.Clusters.Projections.ClusterProjectorTest do
   import Trento.Factory
 
   alias Trento.Clusters.Events.{
+    ClusterDataMarkedInSync,
+    ClusterDataMarkedStale,
     ClusterDeregistered,
     ClusterDetailsUpdated,
     ClusterHealthChanged,
@@ -275,6 +277,55 @@ defmodule Trento.Clusters.Projections.ClusterProjectorTest do
     assert_broadcast(
       "cluster_health_changed",
       %{cluster_id: ^cluster_id, name: ^name, health: ^health},
+      1000
+    )
+  end
+
+  test "should mark cluster data as stale when ClusterDataMarkedStale event is received" do
+    %{id: cluster_id} = insert(:cluster, stale_at: nil)
+
+    stale_at = DateTime.utc_now()
+
+    event = %ClusterDataMarkedStale{
+      cluster_id: cluster_id,
+      stale_at: stale_at
+    }
+
+    ProjectorTestHelper.project(ClusterProjector, event, "cluster_projector")
+
+    cluster = Repo.get!(ClusterReadModel, cluster_id)
+
+    assert cluster.stale_at == stale_at
+
+    assert_broadcast(
+      "cluster_stale_changed",
+      %{
+        id: ^cluster_id,
+        stale_at: ^stale_at
+      },
+      1000
+    )
+  end
+
+  test "should mark cluster data as fresh when ClusterDataMarkedInSync event is received" do
+    %{id: cluster_id} = insert(:cluster, stale_at: DateTime.utc_now())
+
+    event = %ClusterDataMarkedInSync{
+      cluster_id: cluster_id
+    }
+
+    ProjectorTestHelper.project(ClusterProjector, event, "cluster_projector")
+
+    cluster = Repo.get!(ClusterReadModel, cluster_id)
+
+    assert cluster.stale_at == nil
+
+    assert_broadcast(
+      "cluster_stale_changed",
+      %{
+        id: ^cluster_id,
+        stale_at: nil
+      },
       1000
     )
   end

--- a/test/trento/infrastructure/commanded/process_managers/deregistration_process_manager_test.exs
+++ b/test/trento/infrastructure/commanded/process_managers/deregistration_process_manager_test.exs
@@ -43,7 +43,11 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
   alias Trento.SapSystems.Instance, as: SapSystemInstance
   alias Trento.SapSystems.SapSystem
 
-  alias Trento.Clusters.Commands.DeregisterClusterHost
+  alias Trento.Clusters.Commands.{
+    DeregisterClusterHost,
+    MarkClusterHostStale
+  }
+
   alias Trento.Hosts.Commands.DeregisterHost
 
   alias Trento.Databases.Commands.{
@@ -741,6 +745,31 @@ defmodule Trento.Infrastructure.Commanded.ProcessManagers.DeregistrationProcessM
                %MarkDatabaseInstanceDataStale{
                  database_id: ^database_id,
                  instance_number: ^db_instance_number_02,
+                 host_id: ^host_id,
+                 stale_at: ^created_at
+               }
+             ] = commands
+    end
+
+    test "should dispatch MarkClusterHostStale when HeartbeatFailed is emitted and the host belongs to a cluster" do
+      host_id = UUID.uuid4()
+      cluster_id = UUID.uuid4()
+      created_at = DateTime.utc_now()
+
+      initial_state = %DeregistrationProcessManager{
+        cluster_id: cluster_id,
+        database_instances: [],
+        application_instances: []
+      }
+
+      event = %HeartbeatFailed{host_id: host_id}
+      metadata = %{created_at: created_at}
+
+      commands = DeregistrationProcessManager.handle(initial_state, event, metadata)
+
+      assert [
+               %MarkClusterHostStale{
+                 cluster_id: ^cluster_id,
                  host_id: ^host_id,
                  stale_at: ^created_at
                }

--- a/test/trento_web/views/v1/cluster_view_json_test.exs
+++ b/test/trento_web/views/v1/cluster_view_json_test.exs
@@ -44,6 +44,7 @@ defmodule TrentoWeb.V1.ClusterJSONTest do
 
       refute Access.get(cluster_json, :sap_instances)
       refute Access.get(cluster_json, :state)
+      refute Access.get(cluster_json, :stale_at)
       refute Access.get(updated_details, :sites)
       refute Access.get(updated_details, :maintenance_mode)
       refute Access.get(updated_details, :architecture_type)


### PR DESCRIPTION
### Description

Implement stale feature for clusters.
In this case, if a host composing a cluster goes stale, the cluster itself goes stale. Simple as that.
We need to be careful on the deregistration side, as deregistering a stale host can put the cluster data in sync (if the remaining hosts are in sync). 

I have created host related and cluster-wide related events. They are needed to have a clean projection and broadcasting.
It is actually possible to only have 2 events, instead of 4, but this would mean adding certain logic in the projection itself (or a different read model configuration, storing each host stale at data).
This way, we follow a similar design used in the SAP system and databases.

### How was this tested?

UT (e2e tests will come at the end)

### Documentation changes

Not yet