### PR TITLE
Mark cluster as stale - frontend part

### DIFF
--- a/assets/js/lib/model/activityLog.js
+++ b/assets/js/lib/model/activityLog.js
@@ -94,6 +94,8 @@ export const CLUSTER_TOMBSTONED = 'cluster_tombstoned';
 export const HOST_ADDED_TO_CLUSTER = 'host_added_to_cluster';
 export const HOST_REMOVED_FROM_CLUSTER = 'host_removed_from_cluster';
 export const CLUSTER_HOST_STATUS_CHANGED = 'cluster_host_status_changed';
+export const CLUSTER_DATA_MARKED_STALE = 'cluster_data_marked_stale';
+export const CLUSTER_DATA_MARKED_IN_SYNC = 'cluster_data_marked_in_sync';
 
 // SAP System events
 
@@ -567,6 +569,16 @@ export const ACTIVITY_TYPES_CONFIG = {
     label: 'Cluster Host Status Changed',
     message: ({ metadata }) =>
       `Cluster host status changed to ${metadata.cluster_host_status}`,
+    resource: clusterResourceType,
+  },
+  [CLUSTER_DATA_MARKED_STALE]: {
+    label: 'Cluster Data Marked Stale',
+    message: (_entry) => `Cluster data was marked stale`,
+    resource: clusterResourceType,
+  },
+  [CLUSTER_DATA_MARKED_IN_SYNC]: {
+    label: 'Cluster Data Marked In Sync',
+    message: (_entry) => `Cluster data was marked in sync`,
     resource: clusterResourceType,
   },
   // SAP System events

--- a/assets/js/lib/test-utils/factories/clusters.js
+++ b/assets/js/lib/test-utils/factories/clusters.js
@@ -175,6 +175,7 @@ export const clusterFactory = Factory.define(({ sequence, params }) => {
     provider: cloudProviderEnum(),
     cib_last_written: formatDateTime(faker.date.recent()),
     state: stateEnum(),
+    stale_at: null,
     details,
   };
 });

--- a/assets/js/pages/ClusterDetails/ClusterDetails.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetails.jsx
@@ -28,7 +28,10 @@ import {
   getOperationLabel,
 } from '@lib/operations';
 
+import { formatDateTime } from '@lib/timezones';
+
 import BackButton from '@common/BackButton';
+import Banner from '@common/Banners';
 import Button from '@common/Button';
 import DisabledGuard from '@common/DisabledGuard';
 import OperationsButton from '@common/OperationsButton';
@@ -58,11 +61,13 @@ function ClusterDetails({
   hosts,
   health,
   state,
+  staleAt,
   lastExecution = {},
   operationsEnabled = false,
   runningOperation,
   selectedChecks,
   userAbilities,
+  userTimezone,
   onStartExecution = noop,
   onRequestOperation = noop,
   onCleanForbiddenOperation = noop,
@@ -188,7 +193,12 @@ function ClusterDetails({
       <BackButton url="/clusters">Back to Clusters</BackButton>
       <div className="flex flex-wrap">
         <div className="flex w-1/2 h-auto overflow-hidden overflow-ellipsis break-words">
-          <DetailsViewHeader className="whitespace-normal" health={health}>
+          <DetailsViewHeader
+            className="whitespace-normal"
+            health={health}
+            staleAt={staleAt}
+            timezone={userTimezone}
+          >
             Pacemaker Cluster Details:{' '}
             <span className="font-bold">{clusterName}</span>
           </DetailsViewHeader>
@@ -258,6 +268,13 @@ function ClusterDetails({
           <ClusterStatePill state={clusterState} />
         </div>
       </div>
+      {staleAt && (
+        <Banner type="warning" truncate={false}>
+          An agent in one of the cluster hosts is not reporting since{' '}
+          {formatDateTime(staleAt, userTimezone)}. Some information in this view
+          might be stale.
+        </Banner>
+      )}
       {detailComponent}
       <Resources
         resources={details?.resources}

--- a/assets/js/pages/ClusterDetails/ClusterDetails.test.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetails.test.jsx
@@ -54,6 +54,40 @@ describe('ClusterDetails ClusterDetails component', () => {
     expect(getByTestId('eos-svg-component')).toBeInTheDocument();
   });
 
+  it('should render a stale cluster', () => {
+    const staleAt = '2026-06-15T10:30:00Z';
+    const userTimezone = 'America/New_York';
+    const { id, name, health, details } = clusterFactory.build();
+
+    renderWithRouter(
+      <ClusterDetails
+        clusterID={id}
+        clusterName={name}
+        details={details}
+        hasSelectedChecks={false}
+        hosts={[]}
+        health={health}
+        staleAt={staleAt}
+        selectedChecks={[]}
+        userAbilities={userAbilities}
+        userTimezone={userTimezone}
+        onStartExecution={noop}
+        navigate={noop}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        /An agent in one of the cluster hosts is not reporting since 15 Jun 2026, 06:30:00/
+      )
+    ).toBeInTheDocument();
+
+    const header = screen.getByRole('heading', {
+      name: `Pacemaker Cluster Details: ${name}`,
+    });
+    expect(within(header).getAllByTestId('eos-svg-component')).toHaveLength(2);
+  });
+
   it.each([
     {
       condition: 'checks are not selected',

--- a/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
+++ b/assets/js/pages/ClusterDetails/ClusterDetailsPage.jsx
@@ -126,11 +126,13 @@ export function ClusterDetailsPage() {
       hosts={clusterHosts}
       health={cluster.health}
       state={cluster.state}
+      staleAt={cluster.stale_at}
       lastExecution={lastExecution}
       operationsEnabled={operationsEnabled}
       runningOperation={runningOperation}
       selectedChecks={cluster.selected_checks}
       userAbilities={abilities}
+      userTimezone={timezone}
       onStartExecution={(_, hostList, checks) =>
         dispatch(executionRequested(clusterID, hostList, checks))
       }

--- a/assets/js/pages/ClusterDetails/ClustersList.jsx
+++ b/assets/js/pages/ClusterDetails/ClustersList.jsx
@@ -4,8 +4,10 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useSearchParams } from 'react-router';
+import classNames from 'classnames';
 
 import { post, del } from '@lib/network';
+import { STALE_ROW } from '@lib/tables';
 import {
   ASCS_ERS,
   HANA_ASCS_ERS,
@@ -62,20 +64,29 @@ function ClustersList() {
   const clusters = useSelector(getClustersWithEnrichedSapInstances);
   const dispatch = useDispatch();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { abilities } = useSelector(getUserProfile);
+  const { abilities, timezone: userTimezone } = useSelector(getUserProfile);
 
   const config = {
     pagination: true,
     usePadding: false,
+    rowClassName: ({ staleAt }) =>
+      classNames({
+        [STALE_ROW]: !!staleAt,
+      }),
     columns: [
       {
         title: 'Health',
         key: 'health',
         filter: true,
         filterFromParams: true,
-        render: (health, { checks_execution: checksExecution }) => (
+        render: (health, { checks_execution: checksExecution, staleAt }) => (
           <div className="ml-4">
-            <ExecutionIcon health={health} executionState={checksExecution} />
+            <ExecutionIcon
+              health={health}
+              executionState={checksExecution}
+              staleAt={staleAt}
+              timezone={userTimezone}
+            />
           </div>
         ),
       },
@@ -192,6 +203,7 @@ function ClustersList() {
     checks_execution: cluster.checks_execution,
     selected_checks: cluster.selected_checks,
     tags: (cluster.tags && cluster.tags.map((tag) => tag.value)) || [],
+    staleAt: cluster.stale_at,
   }));
 
   const counters = getCounters(data || []);

--- a/assets/js/pages/ClusterDetails/ClustersList.test.jsx
+++ b/assets/js/pages/ClusterDetails/ClustersList.test.jsx
@@ -360,4 +360,37 @@ describe('ClustersList component', () => {
       }
     );
   });
+
+  describe('stale clusters', () => {
+    it('should display stale clusters with gray background and stale icon', () => {
+      const staleDate = '2024-01-01T00:00:00.000Z';
+      const state = {
+        ...cleanInitialState,
+        clustersList: {
+          clusters: [
+            clusterFactory.build({ health: 'passing', stale_at: staleDate }),
+            clusterFactory.build({ health: 'passing', stale_at: null }),
+          ],
+        },
+      };
+
+      const [StatefulClustersList] = withState(<ClustersList />, state);
+
+      renderWithRouter(StatefulClustersList);
+
+      const rows = screen.getByRole('table').querySelectorAll('tbody > tr');
+      expect(rows[0]).toHaveClass('bg-gray-100');
+      expect(rows[1]).not.toHaveClass('bg-gray-100');
+
+      const staleHealthCell = rows[0].querySelector('td:nth-child(1)');
+      expect(
+        staleHealthCell.querySelectorAll('[data-testid="eos-svg-component"]')
+      ).toHaveLength(2);
+
+      const inSyncHealthCell = rows[1].querySelector('td:nth-child(1)');
+      expect(
+        inSyncHealthCell.querySelectorAll('[data-testid="eos-svg-component"]')
+      ).toHaveLength(1);
+    });
+  });
 });

--- a/assets/js/pages/ClusterDetails/ExecutionIcon.jsx
+++ b/assets/js/pages/ClusterDetails/ExecutionIcon.jsx
@@ -9,7 +9,13 @@ import { EOS_SCHEDULE } from 'eos-icons-react';
 import HealthIcon from '@common/HealthIcon';
 import Spinner from '@common/Spinner';
 
-export function ExecutionIcon({ health, executionState, centered = false }) {
+export function ExecutionIcon({
+  health,
+  executionState,
+  centered = false,
+  staleAt = null,
+  timezone = 'Etc/UTC',
+}) {
   switch (executionState) {
     case 'requested':
       return (
@@ -20,6 +26,13 @@ export function ExecutionIcon({ health, executionState, centered = false }) {
     case 'running':
       return <Spinner />;
     default:
-      return <HealthIcon health={health} centered={centered} />;
+      return (
+        <HealthIcon
+          health={health}
+          centered={centered}
+          staleAt={staleAt}
+          timezone={timezone}
+        />
+      );
   }
 }

--- a/assets/js/pages/ClusterDetails/HanaClusterDetails.stories.jsx
+++ b/assets/js/pages/ClusterDetails/HanaClusterDetails.stories.jsx
@@ -164,9 +164,11 @@ export const Hana = {
     sapSystems,
     details,
     state,
+    staleAt: null,
     lastExecution,
     catalog,
     userAbilities,
+    userTimezone: 'Etc/UTC',
     onStartExecution: () => {},
     navigate: () => {},
   },
@@ -289,5 +291,12 @@ export const AngiArchitectureCostOptScenarioWithoutEnrichedData = {
       architecture_type: 'angi',
       hana_scenario: 'cost_optimized',
     },
+  },
+};
+
+export const Stale = {
+  args: {
+    ...Hana.args,
+    staleAt: '2026-06-15T10:30:00Z',
   },
 };

--- a/assets/js/state/clusters.js
+++ b/assets/js/state/clusters.js
@@ -60,6 +60,14 @@ export const clustersListSlice = createSlice({
         return cluster;
       });
     },
+    updateClusterStaleAt: (state, { payload: { id, stale_at } }) => {
+      state.clusters = state.clusters.map((cluster) => {
+        if (cluster.id === id) {
+          cluster.stale_at = stale_at;
+        }
+        return cluster;
+      });
+    },
     startClustersLoading: (state) => {
       state.loading = true;
     },
@@ -91,6 +99,7 @@ export const CLUSTER_DEREGISTERED = 'CLUSTER_DEREGISTERED';
 export const CLUSTER_RESTORED = 'CLUSTER_RESTORED';
 export const CLUSTER_CHECKS_SELECTED = 'CLUSTER_CHECKS_SELECTED';
 export const CLUSTER_HEALTH_CHANGED = 'CLUSTER_HEALTH_CHANGED';
+export const CLUSTER_STALE_CHANGED = 'CLUSTER_STALE_CHANGED';
 
 export const clusterRegistered = createAction(CLUSTER_REGISTERED);
 export const clusterDetailsUpdated = createAction(CLUSTER_DETAILS_UPDATED);
@@ -100,6 +109,7 @@ export const clusterCibLastWrittenUpdated = createAction(
 );
 export const clusterDeregistered = createAction(CLUSTER_DEREGISTERED);
 export const clusterRestored = createAction(CLUSTER_RESTORED);
+export const clusterStaleChanged = createAction(CLUSTER_STALE_CHANGED);
 export const checksSelected = createAction(CLUSTER_CHECKS_SELECTED);
 
 export const {
@@ -111,6 +121,7 @@ export const {
   updateSelectedChecks,
   updateChecksResults,
   updateClusterHealth,
+  updateClusterStaleAt,
   updateCibLastWritten,
   startClustersLoading,
   stopClustersLoading,

--- a/assets/js/state/clusters.test.js
+++ b/assets/js/state/clusters.test.js
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-import clustersReducer, { removeCluster } from '@state/clusters';
+import clustersReducer, {
+  removeCluster,
+  updateClusterStaleAt,
+} from '@state/clusters';
 import { clusterFactory } from '@lib/test-utils/factories';
 
 describe('Clusters reducer', () => {
@@ -15,6 +18,34 @@ describe('Clusters reducer', () => {
 
     const expectedState = {
       clusters: [cluster2],
+    };
+
+    expect(clustersReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should update the stale_at field of a cluster', () => {
+    const [cluster1, cluster2] = clusterFactory.buildList(2);
+    const staleAt = Date.now();
+
+    const initialState = {
+      clusters: [cluster1, cluster2],
+    };
+
+    const clusterToUpdate = {
+      id: cluster1.id,
+      stale_at: staleAt,
+    };
+
+    const action = updateClusterStaleAt(clusterToUpdate);
+
+    const expectedState = {
+      clusters: [
+        {
+          ...cluster1,
+          stale_at: staleAt,
+        },
+        cluster2,
+      ],
     };
 
     expect(clustersReducer(initialState, action)).toEqual(expectedState);

--- a/assets/js/state/sagas/channels.js
+++ b/assets/js/state/sagas/channels.js
@@ -25,6 +25,7 @@ import {
   clusterCibLastWrittenUpdated,
   clusterDeregistered,
   clusterRestored,
+  clusterStaleChanged,
 } from '@state/clusters';
 
 import {
@@ -121,6 +122,10 @@ const clusterEvents = [
   {
     name: 'cluster_health_changed',
     action: clusterHealthChanged,
+  },
+  {
+    name: 'cluster_stale_changed',
+    action: clusterStaleChanged,
   },
   {
     name: 'cluster_cib_last_written_updated',

--- a/assets/js/state/sagas/clusters.js
+++ b/assets/js/state/sagas/clusters.js
@@ -11,10 +11,12 @@ import {
   CLUSTER_DEREGISTERED,
   CLUSTER_RESTORED,
   CLUSTER_HEALTH_CHANGED,
+  CLUSTER_STALE_CHANGED,
   appendCluster,
   removeCluster,
   updateCluster,
   updateClusterHealth,
+  updateClusterStaleAt,
   updateCibLastWritten,
 } from '@state/clusters';
 
@@ -68,11 +70,16 @@ export function* clusterHealthChanged({
   );
 }
 
+export function* clusterStaleChanged({ payload }) {
+  yield put(updateClusterStaleAt(payload));
+}
+
 export function* watchClusterEvents() {
   yield takeEvery(CLUSTER_REGISTERED, clusterRegistered);
   yield takeEvery(CLUSTER_CIB_LAST_WRITTEN_UPDATED, cibLastWrittenUpdated);
   yield takeEvery(CLUSTER_DETAILS_UPDATED, clusterDetailsUpdated);
   yield takeEvery(CLUSTER_HEALTH_CHANGED, clusterHealthChanged);
+  yield takeEvery(CLUSTER_STALE_CHANGED, clusterStaleChanged);
   yield takeEvery(CLUSTER_DEREGISTERED, clusterDeregistered);
   yield takeEvery(CLUSTER_RESTORED, clusterRestored);
 }


### PR DESCRIPTION
### Description

Use cluster `stale_at` field in frontend.
- Gray out and apply stale variant to icon in clusters overview list
- Apply stale variant and add banner in cluster details view

Depends on: https://github.com/trento-project/web/pull/4553

### How was this tested?

UT

### Documentation changes

Not yet