### PR TITLE
Cluster stale e2e

### DIFF
--- a/test/e2e/cypress/e2e/clusters_overview.cy.js
+++ b/test/e2e/cypress/e2e/clusters_overview.cy.js
@@ -92,6 +92,26 @@ context('Clusters Overview', () => {
     });
   });
 
+  describe('Stale data', () => {
+    before(() => {
+      clustersOverviewPage.startAllClustersAgentsHeartbeat();
+      clustersOverviewPage.visit();
+    });
+
+    after(() => clustersOverviewPage.stopAgentsHeartbeat());
+
+    it('should mark cluster data as stale when an agent composing the cluster stops reporting', () => {
+      clustersOverviewPage.stopHanaCluster1AgentHeartbeat();
+      clustersOverviewPage.hanaCluster1DataIsMarkedAsStale();
+    });
+
+    it('should mark cluster data as sync when the agent starts reporting data again', () => {
+      clustersOverviewPage.startHanaCluster1AgentHeartbeat();
+      clustersOverviewPage.apiRestoreClusterHosts();
+      clustersOverviewPage.hanaCluster1DataIsMarkedInSync();
+    });
+  });
+
   describe('Forbidden action', () => {
     describe('Tag operations', () => {
       beforeEach(() => {

--- a/test/e2e/cypress/e2e/hana_cluster_details.cy.js
+++ b/test/e2e/cypress/e2e/hana_cluster_details.cy.js
@@ -444,6 +444,28 @@ context('HANA cluster details', () => {
     });
   });
 
+  describe('Stale data', () => {
+    before(() => {
+      hanaClusterDetailsPage.startHanaClusterAgentsHeartbeat();
+      hanaClusterDetailsPage.visitAvailableHanaCluster();
+    });
+
+    after(() => hanaClusterDetailsPage.stopAgentsHeartbeat());
+
+    it('should mark cluster data as stale when an agent composing the cluster stops reporting', () => {
+      hanaClusterDetailsPage.stopHanaClusterAgentHeartbeat();
+      hanaClusterDetailsPage.hanaClusterHealthIsMarkedAsStale();
+      hanaClusterDetailsPage.hanaClusterStaleBannerIsDisplayed();
+    });
+
+    it('should mark cluster data as sync when the agent starts reporting data again', () => {
+      hanaClusterDetailsPage.startHanaClusterAgentHeartbeat();
+      hanaClusterDetailsPage.apiRestoreWdfHost();
+      hanaClusterDetailsPage.hanaClusterHealthIsMarkedInSync();
+      hanaClusterDetailsPage.hanaClusterStaleBannerIsNotDisplayed();
+    });
+  });
+
   describe('Forbidden actions', () => {
     beforeEach(() => {
       hanaClusterDetailsPage.apiDeleteAllUsers();

--- a/test/e2e/cypress/fixtures/hana-cluster-details/available_hana_cluster.js
+++ b/test/e2e/cypress/fixtures/hana-cluster-details/available_hana_cluster.js
@@ -17,6 +17,14 @@ export const availableHanaCluster = {
   sapHanaSRHealthState: 4,
   cibLastWritten: '25 Jan 2022, 15:36:59',
   hanaSystemReplicationOperationMode: 'logreplay',
+  hosts: [
+    {
+      id: '9cd46919-5f19-59aa-993e-cf3736c71053',
+    },
+    {
+      id: 'b767b3e9-e802-587e-a442-541d093b86b9',
+    },
+  ],
   sites: [
     {
       name: 'NBG',

--- a/test/e2e/cypress/pageObject/clusters_overview_po.js
+++ b/test/e2e/cypress/pageObject/clusters_overview_po.js
@@ -14,12 +14,6 @@ const url = '/clusters';
 const clustersEndpoint = '/api/v2/clusters';
 const clustersEndpointAlias = 'clustersEndpoint';
 
-//Selectors
-const clusterNames = '.tn-clustername';
-const paginationNavigationButtons = 'div[class*="bg-gray-50"] ul button';
-const tableRows = 'tbody tr';
-const rowCells = 'td';
-
 //Test data
 export const healthyClusterName = healthyClusterScenario.clusterName;
 export const unhealthyClusterName = unhealthyClusterScenario.clusterName;
@@ -43,6 +37,13 @@ const taggingRules = [
   ['hana_cluster_2', clusterTags.hana_cluster_2],
   ['hana_cluster_3', clusterTags.hana_cluster_3],
 ];
+
+//Selectors
+const clusterNames = '.tn-clustername';
+const paginationNavigationButtons = 'div[class*="bg-gray-50"] ul button';
+const tableRows = 'tbody tr';
+const rowCells = 'td';
+const hanaCluster1Row = `tr:contains("${hanaCluster1.name}")`;
 
 export const visit = () => basePage.visit(url);
 
@@ -133,6 +134,12 @@ export const clusterIsNotDisplayedWhenNodesAreDeregistered = () =>
 export const clusterNameIsDisplayed = () =>
   cy.get(`span span:contains("${hanaCluster1.name}")`).should('be.visible');
 
+export const hanaCluster1DataIsMarkedAsStale = () =>
+  basePage.elementIsMarkedStale(hanaCluster1Row);
+
+export const hanaCluster1DataIsMarkedInSync = () =>
+  basePage.elementIsMarkedInSync(hanaCluster1Row);
+
 // Helpers
 const _clusterIdByName = (clusterName) =>
   availableClusters.find(({ name }) => name === clusterName).id;
@@ -183,6 +190,23 @@ const _getClusterTags = (jsonData) => {
 
   return clusterTags;
 };
+
+const _getClustersAgentIds = () =>
+  basePage
+    .apiLogin()
+    .then(({ accessToken }) => {
+      const url = '/api/v1/hosts';
+      return cy.request({
+        method: 'GET',
+        url: url,
+        auth: {
+          bearer: accessToken,
+        },
+      });
+    })
+    .then(({ body }) =>
+      body.filter(({ cluster_id }) => cluster_id !== null).map(({ id }) => id)
+    );
 
 export const apiDeregisterAllClusterHosts = () =>
   cy
@@ -258,3 +282,14 @@ export const apiCreateUserWithClusterTagsAbilities = () =>
   basePage.apiCreateUserWithAbilities([
     { name: 'all', resource: 'cluster_tags' },
   ]);
+
+export const startHanaCluster1AgentHeartbeat = () =>
+  basePage.startAgentsHeartbeat([hanaCluster1.hosts[0]]);
+
+export const startAllClustersAgentsHeartbeat = () =>
+  _getClustersAgentIds().then((agentIds) =>
+    basePage.startAgentsHeartbeat(agentIds)
+  );
+
+export const stopHanaCluster1AgentHeartbeat = () =>
+  basePage.stopAgentsHeartbeat([hanaCluster1.hosts[0]]);

--- a/test/e2e/cypress/pageObject/hana_cluster_details_po.js
+++ b/test/e2e/cypress/pageObject/hana_cluster_details_po.js
@@ -101,6 +101,10 @@ const resourcesRowCollapsibleCell = `${resourcesTable} td:nth-child(1)`;
 const clusterStateLabel = 'span:contains("State:")';
 const clusterStateBadge = `${clusterStateLabel} svg`;
 
+const pageTitleHealthIcons = 'h1 div svg';
+const staleDataBanner =
+  'span[data-testid="banner"]:contains("An agent in one of the cluster hosts is not reporting since")';
+
 // UI Interactions
 
 export const visit = (clusterId = '') => basePage.visit(`${url}/${clusterId}`);
@@ -528,6 +532,18 @@ export const notAuthorizedTooltipIsDisplayed = () =>
 export const notAuthorizedTooltipIsNotDisplayed = () =>
   cy.get(actionNotAuthorizedTooltip).should('not.exist');
 
+export const hanaClusterHealthIsMarkedAsStale = () =>
+  basePage.healthIconIsMarkedStale(pageTitleHealthIcons);
+
+export const hanaClusterHealthIsMarkedInSync = () =>
+  basePage.healthIconIsMarkedInSync(pageTitleHealthIcons);
+
+export const hanaClusterStaleBannerIsDisplayed = () =>
+  cy.get(staleDataBanner, { timeout: 20000 }).should('be.visible');
+
+export const hanaClusterStaleBannerIsNotDisplayed = () =>
+  cy.get(staleDataBanner).should('not.exist');
+
 // API
 
 export const interceptGetChecks = () =>
@@ -590,6 +606,15 @@ export const deregisterAngiClusterCostOptHosts = () =>
   cy
     .wrap(availableAngiCluster.hosts)
     .each(({ id }) => basePage.apiDeregisterHost(id));
+
+export const startHanaClusterAgentsHeartbeat = () =>
+  basePage.startAgentsHeartbeat(availableHanaCluster.hosts.map(({ id }) => id));
+
+export const startHanaClusterAgentHeartbeat = () =>
+  basePage.startAgentsHeartbeat([availableHanaCluster.hosts[1].id]);
+
+export const stopHanaClusterAgentHeartbeat = () =>
+  basePage.stopAgentsHeartbeat([availableHanaCluster.hosts[1].id]);
 
 // Helpers
 


### PR DESCRIPTION
### Description

Add e2e tests for the cluster stale feature.
It tests:
- Cluster row is grayed out and health has stale variant in clusters overview page
- Health has stale variant and stale banner is added in cluster details view

Depends on: https://github.com/trento-project/web/pull/4553
Depends on: https://github.com/trento-project/web/pull/4554

### How was this tested?

e2e

### Documentation changes

Not yet