### PR TITLE
React on AI configuration creation and clean up

### DIFF
--- a/assets/js/common/AIAssistant/AIAssistant.jsx
+++ b/assets/js/common/AIAssistant/AIAssistant.jsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useAuiState } from '@assistant-ui/react';
 
@@ -10,10 +10,16 @@ import { CONNECTION_STATUS } from '@lib/ai';
 import AssistantChatProvider from './AssistantChatProvider';
 import AssistantThread from './AssistantThread';
 import ModalFrame from './ModalFrame';
+import {
+  CONFIGURATION_STATUS,
+  isConfigurationCleared,
+  isConfigurationAvailable,
+} from './status';
 
-export function AssistantUI({
+function AssistantUI({
   open,
   connectionStatus,
+  configurationStatus,
   onOpenChange,
   onNewThread,
   handleClose,
@@ -26,6 +32,7 @@ export function AssistantUI({
     <ModalFrame open={open} onOpenChange={onOpenChange} disabled={disabled}>
       <AssistantThread
         connectionStatus={connectionStatus}
+        configurationStatus={configurationStatus}
         onClose={handleClose}
         onNewThread={onNewThread}
         isEmpty={isEmpty}
@@ -47,22 +54,57 @@ function AIAssistant({
   const [connectionStatus, setConnectionStatus] = useState(
     initialConnectionStatus
   );
+  const [configurationStatus, setConfigurationStatus] = useState(
+    aiConfigured ? CONFIGURATION_STATUS.OK : CONFIGURATION_STATUS.CLEARED
+  );
 
-  const onNewThread = () => setThreadID(crypto.randomUUID());
+  // The channel stays mounted even when the launcher is disabled, so a "created" event can re-enable this tab
+  const isOpenRef = useRef(isOpen);
+  useEffect(() => {
+    isOpenRef.current = isOpen;
+  }, [isOpen]);
+
+  const startNewThread = useCallback(() => {
+    setThreadID(crypto.randomUUID());
+    setConfigurationStatus(CONFIGURATION_STATUS.OK);
+  }, []);
+
+  const handleAIConfigurationCleared = useCallback(
+    () => setConfigurationStatus(CONFIGURATION_STATUS.CLEARED),
+    []
+  );
+
+  const handleAIConfigurationCreated = useCallback(() => {
+    // A still-open cleared chat must be explicitly restarted by the user;
+    // otherwise (closed launcher) just re-enable and reset the thread so the
+    // next open starts fresh.
+    if (isOpenRef.current) {
+      setConfigurationStatus((prev) =>
+        isConfigurationCleared(prev) ? CONFIGURATION_STATUS.RESTORED : prev
+      );
+    } else {
+      startNewThread();
+    }
+  }, [startNewThread]);
+
+  const configurationAvailable = isConfigurationAvailable(configurationStatus);
 
   return (
     <AssistantChatProvider
       userID={userID}
       threadID={threadID}
       onConnectionChange={setConnectionStatus}
+      onAIConfigurationCleared={handleAIConfigurationCleared}
+      onAIConfigurationCreated={handleAIConfigurationCreated}
     >
       <AssistantUI
         open={isOpen}
         connectionStatus={connectionStatus}
+        configurationStatus={configurationStatus}
         onOpenChange={setIsOpen}
-        onNewThread={onNewThread}
+        onNewThread={startNewThread}
         handleClose={handleClose}
-        disabled={!aiConfigured && !isOpen}
+        disabled={!configurationAvailable && !isOpen}
       />
     </AssistantChatProvider>
   );

--- a/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
+++ b/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
+import { BrowserRouter } from 'react-router';
 import { config as rxjsConfig } from 'rxjs';
 import { makeMockSocket } from '@lib/test-utils/phoenixDoubles';
 import { buildAssistantTurn } from '@lib/test-utils/aguiEvents';
@@ -40,7 +41,11 @@ async function renderAssistant({ userId = 'user-1' } = {}) {
   const socket = makeMockSocket();
   useSocket.mockReturnValue(socket);
 
-  const utils = render(<AIAssistant userID={userId} open />);
+  const utils = render(
+    <BrowserRouter>
+      <AIAssistant userID={userId} open />
+    </BrowserRouter>
+  );
 
   const channel = await waitFor(() => {
     const c = socket.channels.get(`ai_assistant:${userId}`);
@@ -154,10 +159,11 @@ describe('AG-UI event flow', () => {
     });
   });
 
-  it('disables the composer input when the channel drops', async () => {
+  it('disables the composer input and "New chat" when the channel drops', async () => {
     const { channel } = await renderAssistant();
 
     expect(screen.getByLabelText('Message input')).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'New chat' })).not.toBeDisabled();
 
     await act(async () => {
       channel.errorHandlers.forEach((cb) => cb());
@@ -166,6 +172,72 @@ describe('AG-UI event flow', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('Message input')).toBeDisabled();
     });
+    expect(screen.getByRole('button', { name: 'New chat' })).toBeDisabled();
+  });
+
+  it('goes read-only with a banner when the AI configuration is cleared', async () => {
+    const { channel } = await renderAssistant();
+
+    expect(screen.getByLabelText('Message input')).not.toBeDisabled();
+    expect(screen.getByText('Online')).toBeInTheDocument();
+
+    await act(async () => {
+      channel.emit('ai_configuration_cleared');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Message input')).toBeDisabled();
+    });
+
+    // Liz goes offline in the header alongside the read-only banner, and a new
+    // chat is off too: the channel is still live, but there is no configuration
+    // left to back it.
+    expect(screen.getByText('Offline')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'New chat' })).toBeDisabled();
+    expect(screen.getByText(/settings were cleared/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Profile' })).toHaveAttribute(
+      'href',
+      '/profile'
+    );
+  });
+
+  it('prompts to start a new chat when a new config arrives after a clear', async () => {
+    const { channel } = await renderAssistant();
+
+    await act(async () => {
+      channel.emit('ai_configuration_cleared');
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText('Message input')).toBeDisabled();
+    });
+
+    await act(async () => {
+      channel.emit('ai_configuration_created');
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/new AI configuration is available/i)
+      ).toBeInTheDocument();
+    });
+    // Still read-only until the user explicitly restarts
+    expect(screen.getByLabelText('Message input')).toBeDisabled();
+    expect(
+      screen.getByPlaceholderText('Start a new chat to continue')
+    ).toBeVisible();
+
+    const newChat = screen.getByRole('button', { name: 'New chat' });
+    expect(newChat).not.toBeDisabled();
+
+    const user = userEvent.setup();
+    await user.click(newChat);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Message input')).not.toBeDisabled();
+    });
+    expect(
+      screen.queryByText(/new AI configuration is available/i)
+    ).not.toBeInTheDocument();
   });
 
   it('handles a follow-up turn after the previous one finishes', async () => {

--- a/assets/js/common/AIAssistant/AssistantChatProvider.jsx
+++ b/assets/js/common/AIAssistant/AssistantChatProvider.jsx
@@ -14,6 +14,8 @@ function AssistantChatProvider({
   userID,
   threadID,
   onConnectionChange = noop,
+  onAIConfigurationCleared = noop,
+  onAIConfigurationCreated = noop,
   children,
 }) {
   const socket = useSocket();
@@ -24,8 +26,16 @@ function AssistantChatProvider({
       socket,
       userID,
       onConnectionChange,
+      onAIConfigurationCleared,
+      onAIConfigurationCreated,
     });
-  }, [socket, userID, onConnectionChange]);
+  }, [
+    socket,
+    userID,
+    onConnectionChange,
+    onAIConfigurationCleared,
+    onAIConfigurationCreated,
+  ]);
 
   useEffect(() => {
     if (!agent) return undefined;

--- a/assets/js/common/AIAssistant/AssistantThread.jsx
+++ b/assets/js/common/AIAssistant/AssistantThread.jsx
@@ -3,20 +3,68 @@
 
 import React from 'react';
 import { noop } from 'lodash';
+import { Link } from 'react-router';
 import { ThreadPrimitive } from '@assistant-ui/react';
 
 import ChatHeader from './ChatHeader';
 import PromptComposer from './PromptComposer';
+
 import { AssistantMessage, UserMessage } from './MessageBubble';
 import ThreadWelcome from './ThreadWelcome';
+import {
+  effectiveConnectionStatus,
+  isConfigurationCleared,
+  isConfigurationRestored,
+} from './status';
+
+function ThreadBanner({ children }) {
+  return (
+    <div
+      className="mb-3 rounded-md border border-yellow-300 bg-yellow-50 px-4 py-3 text-sm text-yellow-800"
+      role="alert"
+    >
+      {children}
+    </div>
+  );
+}
+
+function ClearedBanner() {
+  return (
+    <ThreadBanner>
+      Your AI settings were cleared. This conversation is now read-only.
+      Configure AI in your{' '}
+      <Link
+        to="/profile"
+        className="underline hover:opacity-75 text-jungle-green-500"
+      >
+        Profile
+      </Link>{' '}
+      to continue.
+    </ThreadBanner>
+  );
+}
+
+function RestoredBanner() {
+  return (
+    <ThreadBanner>
+      A new AI configuration is available. Start a new chat to continue.
+    </ThreadBanner>
+  );
+}
 
 function AssistantThread({
   connectionStatus,
+  configurationStatus,
   isEmpty = false,
   isRunning = false,
   onNewThread = noop,
   onClose = noop,
 }) {
+  const connection = effectiveConnectionStatus(
+    connectionStatus,
+    configurationStatus
+  );
+
   return (
     <ThreadPrimitive.Root
       className="relative flex h-full flex-col bg-white text-sm"
@@ -27,7 +75,7 @@ function AssistantThread({
       }}
     >
       <ChatHeader
-        connectionStatus={connectionStatus}
+        connectionStatus={connection}
         onNewChat={onNewThread}
         onClose={onClose}
       />
@@ -50,8 +98,11 @@ function AssistantThread({
           }}
         </ThreadPrimitive.Messages>
         <ThreadPrimitive.ViewportFooter className="sticky bottom-0 mx-auto mt-auto flex w-full max-w-[var(--thread-max-width)] flex-col bg-white pt-4 pb-4">
+          {isConfigurationCleared(configurationStatus) && <ClearedBanner />}
+          {isConfigurationRestored(configurationStatus) && <RestoredBanner />}
           <PromptComposer
-            connectionStatus={connectionStatus}
+            connectionStatus={connection}
+            configurationStatus={configurationStatus}
             isRunning={isRunning}
           />
         </ThreadPrimitive.ViewportFooter>

--- a/assets/js/common/AIAssistant/ChatHeader/ChatHeader.jsx
+++ b/assets/js/common/AIAssistant/ChatHeader/ChatHeader.jsx
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
+import { get } from 'lodash';
 import { EOS_CLOSE } from 'eos-icons-react';
 
 import Button from '@common/Button';
-import { CONNECTION_STATUS } from '@lib/ai';
+import { CONNECTION_STATUS, isOnline } from '@lib/ai';
 
-const STATUS_VIEW = {
+const CONNECTION_VIEW = {
   [CONNECTION_STATUS.CONNECTED]: { text: 'Online', dot: 'bg-white' },
   [CONNECTION_STATUS.CONNECTING]: {
     text: 'Connecting...',
@@ -19,9 +20,12 @@ const STATUS_VIEW = {
 const stopPointerDown = (e) => e.stopPropagation();
 
 function ChatHeader({ connectionStatus, onNewChat, onClose }) {
-  const { text, dot } =
-    STATUS_VIEW[connectionStatus] ??
-    STATUS_VIEW[CONNECTION_STATUS.DISCONNECTED];
+  const { text, dot } = get(
+    CONNECTION_VIEW,
+    connectionStatus,
+    CONNECTION_VIEW[CONNECTION_STATUS.DISCONNECTED]
+  );
+  const canStartNewChat = isOnline(connectionStatus);
 
   return (
     <div className="drag-handle flex items-center justify-between bg-[#2fb371] px-5 py-4 text-white cursor-move">
@@ -38,6 +42,7 @@ function ChatHeader({ connectionStatus, onNewChat, onClose }) {
         <Button
           type="link"
           size="none"
+          disabled={!canStartNewChat}
           onPointerDown={stopPointerDown}
           onClick={onNewChat}
           className="text-sm !text-white hover:!text-white hover:underline"

--- a/assets/js/common/AIAssistant/ChatHeader/ChatHeader.test.jsx
+++ b/assets/js/common/AIAssistant/ChatHeader/ChatHeader.test.jsx
@@ -30,6 +30,19 @@ describe('ChatHeader', () => {
     expect(screen.getByText('Offline')).toBeVisible();
   });
 
+  it.each(['connecting', 'disconnected', 'unknown'])(
+    'disables the "New chat" button when %s',
+    (connectionStatus) => {
+      render(<ChatHeader {...defaults} connectionStatus={connectionStatus} />);
+      expect(screen.getByRole('button', { name: 'New chat' })).toBeDisabled();
+    }
+  );
+
+  it('enables the "New chat" button when connected', () => {
+    render(<ChatHeader {...defaults} connectionStatus="connected" />);
+    expect(screen.getByRole('button', { name: 'New chat' })).not.toBeDisabled();
+  });
+
   it('invokes onNewChat when the "New chat" button is clicked', async () => {
     const user = userEvent.setup();
     const onNewChat = jest.fn();

--- a/assets/js/common/AIAssistant/MessageBubble/MessageBubble.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/MessageBubble.jsx
@@ -44,7 +44,7 @@ function MarkdownText(props) {
 function MessageError() {
   return (
     <MessagePrimitive.Error>
-      <ErrorPrimitive.Root className="mt-2 rounded-md border border-destructive bg-destructive/10 p-3 text-destructive text-sm dark:bg-destructive/5 dark:text-red-200">
+      <ErrorPrimitive.Root className="mt-2 rounded-md bg-red-50 p-3 text-red-500 text-sm">
         <ErrorPrimitive.Message className="line-clamp-2" />
       </ErrorPrimitive.Root>
     </MessagePrimitive.Error>
@@ -66,9 +66,9 @@ export function AssistantMessage({ isRunning }) {
     <MessagePrimitive.Root className={ROOT_CLASS_NAME} data-role="assistant">
       <MessageBubbleView variant="assistant">
         <MessagePrimitive.Parts components={{ Text: MarkdownText }} />
-        <MessageError />
         <AgentProgressIndicator isRunning={isRunning} />
       </MessageBubbleView>
+      <MessageError />
     </MessagePrimitive.Root>
   );
 }

--- a/assets/js/common/AIAssistant/PromptComposer/PromptComposer.jsx
+++ b/assets/js/common/AIAssistant/PromptComposer/PromptComposer.jsx
@@ -2,10 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
+import { get } from 'lodash';
 import { ComposerPrimitive } from '@assistant-ui/react';
 
 import Button from '@common/Button';
 import { CONNECTION_STATUS } from '@lib/ai';
+
+import {
+  CONFIGURATION_STATUS,
+  canSendMessage,
+  isChatReadOnly,
+} from '../status';
 
 const COMPOSER_INPUT_CLASS_NAME =
   'w-full border border-gray-300 rounded-lg p-4 text-gray-700 resize-none h-[130px] focus:outline-none focus:border-[#2fb371] focus:ring-1 focus:ring-[#2fb371] placeholder-gray-400 text-lg font-medium bg-white shadow-sm disabled:bg-gray-50 disabled:cursor-not-allowed';
@@ -14,6 +21,14 @@ const PLACEHOLDERS = {
   [CONNECTION_STATUS.CONNECTED]: 'How can I help you?',
   [CONNECTION_STATUS.CONNECTING]: 'Connecting...',
   [CONNECTION_STATUS.DISCONNECTED]: 'Offline - waiting to reconnect...',
+};
+
+// Read-only has two causes that need different wording:
+// - CLEARED means there is nothing left to answer with
+// - RESTORED means a configuration is back but a new chat needs to be started
+const READ_ONLY_PLACEHOLDERS = {
+  [CONFIGURATION_STATUS.CLEARED]: 'AI Assistant is disabled',
+  [CONFIGURATION_STATUS.RESTORED]: 'Start a new chat to continue',
 };
 
 const footnote = (
@@ -31,7 +46,7 @@ const footnote = (
   </>
 );
 
-function SendButton({ disabled, isRunning }) {
+function SendButton({ disabled, isRunning, reason }) {
   if (isRunning) return null;
   return (
     <ComposerPrimitive.Send asChild>
@@ -40,7 +55,7 @@ function SendButton({ disabled, isRunning }) {
         type="default-fit"
         disabled={disabled}
         aria-label="Send message"
-        title={disabled ? 'Waiting for connection...' : 'Send message'}
+        title={disabled ? reason : 'Send message'}
       >
         Send
       </Button>
@@ -48,11 +63,23 @@ function SendButton({ disabled, isRunning }) {
   );
 }
 
-function PromptComposer({ connectionStatus, isRunning = false }) {
-  const isConnected = connectionStatus === CONNECTION_STATUS.CONNECTED;
-  const placeholder =
-    PLACEHOLDERS[connectionStatus] ??
-    PLACEHOLDERS[CONNECTION_STATUS.DISCONNECTED];
+function PromptComposer({
+  connectionStatus,
+  configurationStatus = CONFIGURATION_STATUS.OK,
+  isRunning = false,
+}) {
+  const inputDisabled = !canSendMessage(connectionStatus, configurationStatus);
+  const placeholder = isChatReadOnly(configurationStatus)
+    ? get(
+        READ_ONLY_PLACEHOLDERS,
+        configurationStatus,
+        READ_ONLY_PLACEHOLDERS[CONFIGURATION_STATUS.CLEARED]
+      )
+    : get(
+        PLACEHOLDERS,
+        connectionStatus,
+        PLACEHOLDERS[CONNECTION_STATUS.DISCONNECTED]
+      );
 
   return (
     <ComposerPrimitive.Root className="relative flex w-full flex-col">
@@ -61,14 +88,18 @@ function PromptComposer({ connectionStatus, isRunning = false }) {
           <ComposerPrimitive.Input
             className={COMPOSER_INPUT_CLASS_NAME}
             placeholder={placeholder}
-            disabled={!isConnected}
+            disabled={inputDisabled}
             aria-label="Message input"
           />
         </ComposerPrimitive.AttachmentDropzone>
       </div>
       <div className="flex justify-between items-center w-full mt-4">
         <div className="text-sm text-gray-400 leading-tight">{footnote}</div>
-        <SendButton disabled={!isConnected} isRunning={isRunning} />
+        <SendButton
+          disabled={inputDisabled}
+          isRunning={isRunning}
+          reason={placeholder}
+        />
       </div>
     </ComposerPrimitive.Root>
   );

--- a/assets/js/common/AIAssistant/PromptComposer/PromptComposer.test.jsx
+++ b/assets/js/common/AIAssistant/PromptComposer/PromptComposer.test.jsx
@@ -36,19 +36,86 @@ describe('PromptComposer', () => {
     }
   );
 
-  it('disables the input and the send button when not connected', () => {
-    render(<PromptComposer connectionStatus="disconnected" />);
-    expect(screen.getByLabelText('Message input')).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled();
-  });
+  it.each([
+    { configurationStatus: 'cleared', placeholder: 'AI Assistant is disabled' },
+    {
+      configurationStatus: 'restored',
+      placeholder: 'Start a new chat to continue',
+    },
+  ])(
+    'uses the $placeholder placeholder when the configuration is $configurationStatus',
+    ({ configurationStatus, placeholder }) => {
+      render(
+        <PromptComposer
+          connectionStatus="connected"
+          configurationStatus={configurationStatus}
+        />
+      );
+      expect(screen.getByPlaceholderText(placeholder)).toBeVisible();
+    }
+  );
 
-  it('enables the input and the send button when connected', () => {
+  it.each([
+    { connectionStatus: 'connecting', configurationStatus: 'ok' },
+    { connectionStatus: 'disconnected', configurationStatus: 'ok' },
+    // Online, but there is nothing configured to answer with.
+    { connectionStatus: 'connected', configurationStatus: 'cleared' },
+    // Online and configured, but this thread belongs to the old configuration.
+    { connectionStatus: 'connected', configurationStatus: 'restored' },
+  ])(
+    'disables the input and the send button when $connectionStatus and the configuration is $configurationStatus',
+    ({ connectionStatus, configurationStatus }) => {
+      render(
+        <PromptComposer
+          connectionStatus={connectionStatus}
+          configurationStatus={configurationStatus}
+        />
+      );
+      expect(screen.getByLabelText('Message input')).toBeDisabled();
+      expect(
+        screen.getByRole('button', { name: 'Send message' })
+      ).toBeDisabled();
+    }
+  );
+
+  it('enables the input and the send button when connected with an ok configuration', () => {
     render(<PromptComposer connectionStatus="connected" />);
     expect(screen.getByLabelText('Message input')).not.toBeDisabled();
     expect(
       screen.getByRole('button', { name: 'Send message' })
     ).not.toBeDisabled();
   });
+
+  it.each([
+    {
+      connectionStatus: 'disconnected',
+      configurationStatus: 'ok',
+      title: 'Offline - waiting to reconnect...',
+    },
+    {
+      connectionStatus: 'connected',
+      configurationStatus: 'cleared',
+      title: 'AI Assistant is disabled',
+    },
+    {
+      connectionStatus: 'connected',
+      configurationStatus: 'restored',
+      title: 'Start a new chat to continue',
+    },
+  ])(
+    'explains why sending is off with "$title"',
+    ({ connectionStatus, configurationStatus, title }) => {
+      render(
+        <PromptComposer
+          connectionStatus={connectionStatus}
+          configurationStatus={configurationStatus}
+        />
+      );
+      expect(
+        screen.getByRole('button', { name: 'Send message' })
+      ).toHaveAttribute('title', title);
+    }
+  );
 
   it('hides the send button while the thread is running', () => {
     render(<PromptComposer connectionStatus="connected" isRunning />);

--- a/assets/js/common/AIAssistant/status.js
+++ b/assets/js/common/AIAssistant/status.js
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import { CONNECTION_STATUS, isOnline } from '@lib/ai';
+
+// Lifecycle of the assistant relative to the user's AI configuration:
+//   ok       - configured and usable
+//   cleared  - configuration was removed; chat is read-only, launcher disabled
+//   restored - configuration came back while a cleared chat was still open;
+//              the user must start a new chat to resume
+export const CONFIGURATION_STATUS = {
+  OK: 'ok',
+  CLEARED: 'cleared',
+  RESTORED: 'restored',
+};
+
+export const isConfigurationCleared = (configurationStatus) =>
+  configurationStatus === CONFIGURATION_STATUS.CLEARED;
+
+export const isConfigurationRestored = (configurationStatus) =>
+  configurationStatus === CONFIGURATION_STATUS.RESTORED;
+
+export const isConfigurationAvailable = (configurationStatus) =>
+  !isConfigurationCleared(configurationStatus);
+
+// The conversation can only be written to while the configuration is intact.
+// - a cleared configuration has nothing to answer with
+// - a restored one belongs to a fresh chat, so the current thread stays read-only
+export const isChatReadOnly = (configurationStatus) =>
+  configurationStatus !== CONFIGURATION_STATUS.OK;
+
+// --- Folding the two axes into one ------------------------------------------
+// Connection and configuration are orthogonal, but a cleared configuration
+// makes the live socket irrelevant: there is nothing to talk to.
+export const effectiveConnectionStatus = (
+  connectionStatus,
+  configurationStatus
+) =>
+  isConfigurationCleared(configurationStatus)
+    ? CONNECTION_STATUS.DISCONNECTED
+    : connectionStatus;
+
+// Sending is the one capability the fold cannot express: a restored
+// configuration passes through it as online (a new chat *is* startable) while
+// this thread stays read-only, so the configuration axis is still needed here.
+// A cleared configuration is already read-only, so folding the connection first
+// would change nothing - which also makes this safe to call with either the raw
+// or the effective connection status.
+export const canSendMessage = (connectionStatus, configurationStatus) =>
+  isOnline(connectionStatus) && !isChatReadOnly(configurationStatus);

--- a/assets/js/common/AIAssistant/status.test.js
+++ b/assets/js/common/AIAssistant/status.test.js
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import { CONNECTION_STATUS, isOnline } from '@lib/ai';
+
+import {
+  CONFIGURATION_STATUS,
+  canSendMessage,
+  effectiveConnectionStatus,
+  isChatReadOnly,
+  isConfigurationAvailable,
+  isConfigurationCleared,
+  isConfigurationRestored,
+} from './status';
+
+const { CONNECTED, CONNECTING, DISCONNECTED } = CONNECTION_STATUS;
+const { OK, CLEARED, RESTORED } = CONFIGURATION_STATUS;
+
+describe('AIAssistant configuration status', () => {
+  describe('isChatReadOnly', () => {
+    it.each([
+      { configurationStatus: CONFIGURATION_STATUS.OK, readOnly: false },
+      { configurationStatus: CONFIGURATION_STATUS.CLEARED, readOnly: true },
+      { configurationStatus: CONFIGURATION_STATUS.RESTORED, readOnly: true },
+    ])(
+      'is $readOnly when the configuration is $configurationStatus',
+      ({ configurationStatus, readOnly }) => {
+        expect(isChatReadOnly(configurationStatus)).toBe(readOnly);
+      }
+    );
+  });
+
+  describe('canSendMessage', () => {
+    it.each([
+      { connectionStatus: CONNECTED, configurationStatus: OK, allowed: true },
+      {
+        connectionStatus: CONNECTED,
+        configurationStatus: RESTORED,
+        allowed: false,
+      },
+      {
+        connectionStatus: CONNECTED,
+        configurationStatus: CLEARED,
+        allowed: false,
+      },
+      {
+        connectionStatus: CONNECTING,
+        configurationStatus: OK,
+        allowed: false,
+      },
+      {
+        connectionStatus: DISCONNECTED,
+        configurationStatus: OK,
+        allowed: false,
+      },
+    ])(
+      'is $allowed when $connectionStatus and the configuration is $configurationStatus',
+      ({ connectionStatus, configurationStatus, allowed }) => {
+        expect(canSendMessage(connectionStatus, configurationStatus)).toBe(
+          allowed
+        );
+      }
+    );
+  });
+
+  describe('isConfigurationCleared', () => {
+    it.each([
+      { configurationStatus: CONFIGURATION_STATUS.OK, cleared: false },
+      { configurationStatus: CONFIGURATION_STATUS.RESTORED, cleared: false },
+      { configurationStatus: CONFIGURATION_STATUS.CLEARED, cleared: true },
+    ])(
+      'is $cleared when the configuration is $configurationStatus',
+      ({ configurationStatus, cleared }) => {
+        expect(isConfigurationCleared(configurationStatus)).toBe(cleared);
+      }
+    );
+  });
+
+  describe('isConfigurationRestored', () => {
+    it.each([
+      { configurationStatus: CONFIGURATION_STATUS.OK, restored: false },
+      { configurationStatus: CONFIGURATION_STATUS.CLEARED, restored: false },
+      { configurationStatus: CONFIGURATION_STATUS.RESTORED, restored: true },
+    ])(
+      'is $restored when the configuration is $configurationStatus',
+      ({ configurationStatus, restored }) => {
+        expect(isConfigurationRestored(configurationStatus)).toBe(restored);
+      }
+    );
+  });
+
+  describe('isConfigurationAvailable', () => {
+    it.each([
+      { configurationStatus: CONFIGURATION_STATUS.OK, available: true },
+      { configurationStatus: CONFIGURATION_STATUS.RESTORED, available: true },
+      { configurationStatus: CONFIGURATION_STATUS.CLEARED, available: false },
+    ])(
+      'is $available when the configuration is $configurationStatus',
+      ({ configurationStatus, available }) => {
+        expect(isConfigurationAvailable(configurationStatus)).toBe(available);
+      }
+    );
+  });
+
+  describe('effectiveConnectionStatus', () => {
+    it.each([CONNECTED, CONNECTING, DISCONNECTED])(
+      'passes the %s connection status through when the configuration is ok or restored',
+      (connectionStatus) => {
+        expect(effectiveConnectionStatus(connectionStatus, OK)).toBe(
+          connectionStatus
+        );
+        expect(effectiveConnectionStatus(connectionStatus, RESTORED)).toBe(
+          connectionStatus
+        );
+      }
+    );
+
+    it('forces disconnected when the configuration was cleared, even while connected', () => {
+      expect(effectiveConnectionStatus(CONNECTED, CLEARED)).toBe(DISCONNECTED);
+    });
+
+    it.each([
+      {
+        connectionStatus: CONNECTED,
+        configurationStatus: OK,
+        allowed: true,
+      },
+      {
+        connectionStatus: CONNECTED,
+        configurationStatus: RESTORED,
+        allowed: true,
+      },
+      {
+        connectionStatus: CONNECTED,
+        configurationStatus: CLEARED,
+        allowed: false,
+      },
+      {
+        connectionStatus: CONNECTING,
+        configurationStatus: OK,
+        allowed: false,
+      },
+      {
+        connectionStatus: DISCONNECTED,
+        configurationStatus: OK,
+        allowed: false,
+      },
+    ])(
+      'is online $allowed when $connectionStatus and the configuration is $configurationStatus',
+      ({ connectionStatus, configurationStatus, allowed }) => {
+        const effectiveStatus = effectiveConnectionStatus(
+          connectionStatus,
+          configurationStatus
+        );
+        expect(isOnline(effectiveStatus)).toBe(allowed);
+      }
+    );
+  });
+});

--- a/assets/js/lib/ai/WebSocketAIAgent.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.js
@@ -3,7 +3,7 @@
 
 import { AbstractAgent } from '@ag-ui/client';
 import { Observable } from 'rxjs';
-import { isArray, isString, last } from 'lodash';
+import { isArray, isString, last, noop, each } from 'lodash';
 
 import { EventType } from '@ag-ui/core';
 
@@ -62,13 +62,22 @@ const withRefreshTokenOnUnauthorized = async (operation) => {
 // AG-UI protocol events to/from channel events for the ai_assistant:{userID}
 // topic.
 export class WebSocketAIAgent extends AbstractAgent {
-  constructor({ socket, userID, onConnectionChange, ...options }) {
+  constructor({
+    socket,
+    userID,
+    onConnectionChange = noop,
+    onAIConfigurationCleared = noop,
+    onAIConfigurationCreated = noop,
+    ...options
+  }) {
     super(options);
 
     this.socket = socket;
     this.userID = userID;
     this.channel = null;
     this.onConnectionChange = onConnectionChange;
+    this.onAIConfigurationCleared = onAIConfigurationCleared;
+    this.onAIConfigurationCreated = onAIConfigurationCreated;
     this._connectionStatus = CONNECTION_STATUS.DISCONNECTED;
     this._activeSubscriber = null;
     this._activeRunId = null;
@@ -134,9 +143,25 @@ export class WebSocketAIAgent extends AbstractAgent {
       this._failActiveRun(new Error('AI assistant connection lost'));
     };
 
-    this.channel.on('ag_ui_event', (event) => this._handleAgUiEvent(event));
+    const messageHandlerMap = [
+      ['ag_ui_event', (event) => this._handleAgUiEvent(event)],
+      ['ai_configuration_cleared', () => this._handleAIConfigurationCleared()],
+      ['ai_configuration_created', () => this.onAIConfigurationCreated()],
+    ];
+
+    each(messageHandlerMap, ([eventName, handler]) =>
+      this.channel.on(eventName, handler)
+    );
     this.channel.onError(dropConnection);
     this.channel.onClose(dropConnection);
+  }
+
+  // User's AI configuration was cleared server-side.
+  // Settle any in-flight run without surfacing an error
+  // and let the UI switch to its read-only / disabled state via the callback.
+  _handleAIConfigurationCleared() {
+    this._failActiveRun(new AbortError('AI configuration cleared'));
+    this.onAIConfigurationCleared();
   }
 
   _handleAgUiEvent(event) {
@@ -236,7 +261,7 @@ export class WebSocketAIAgent extends AbstractAgent {
   _setConnectionStatus(status) {
     if (this._connectionStatus === status) return;
     this._connectionStatus = status;
-    this.onConnectionChange?.(status);
+    this.onConnectionChange(status);
   }
 
   disconnect() {

--- a/assets/js/lib/ai/WebSocketAIAgent.test.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.test.js
@@ -508,4 +508,41 @@ describe('WebSocketAIAgent', () => {
       expect(extractMessageText(message)).toBe('');
     });
   });
+
+  describe('ai_configuration_cleared', () => {
+    it('settles the active run (AbortError) and invokes the callback', async () => {
+      const onAIConfigurationCleared = jest.fn();
+      const { channel, agent } = await connectedAgent({
+        onAIConfigurationCleared,
+      });
+      const { error } = runAgent(agent);
+      await flushMicrotasks();
+
+      channel.emit('ai_configuration_cleared');
+
+      expect(onAIConfigurationCleared).toHaveBeenCalledTimes(1);
+      expect(error).toHaveBeenCalledTimes(1);
+      expect(error.mock.calls[0][0].name).toBe('AbortError');
+    });
+
+    it('invokes the callback even when no run is active', async () => {
+      const onAIConfigurationCleared = jest.fn();
+      const { channel } = await connectedAgent({ onAIConfigurationCleared });
+
+      channel.emit('ai_configuration_cleared');
+
+      expect(onAIConfigurationCleared).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('ai_configuration_created', () => {
+    it('invokes onAIConfigurationCreated', async () => {
+      const onAIConfigurationCreated = jest.fn();
+      const { channel } = await connectedAgent({ onAIConfigurationCreated });
+
+      channel.emit('ai_configuration_created');
+
+      expect(onAIConfigurationCreated).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/assets/js/lib/ai/connectionStatus.js
+++ b/assets/js/lib/ai/connectionStatus.js
@@ -10,3 +10,6 @@ export const CONNECTION_STATUS = Object.freeze({
   CONNECTING: 'connecting',
   DISCONNECTED: 'disconnected',
 });
+
+export const isOnline = (connectionStatus) =>
+  connectionStatus === CONNECTION_STATUS.CONNECTED;

--- a/assets/js/lib/ai/connectionStatus.test.js
+++ b/assets/js/lib/ai/connectionStatus.test.js
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import { CONNECTION_STATUS, isOnline } from './connectionStatus';
+
+const { CONNECTED, CONNECTING, DISCONNECTED } = CONNECTION_STATUS;
+
+describe('isOnline', () => {
+  it.each([
+    { connectionStatus: CONNECTED, online: true },
+    { connectionStatus: CONNECTING, online: false },
+    { connectionStatus: DISCONNECTED, online: false },
+    { connectionStatus: 'unknown', online: false },
+    { connectionStatus: undefined, online: false },
+  ])('is $online when $connectionStatus', ({ connectionStatus, online }) => {
+    expect(isOnline(connectionStatus)).toBe(online);
+  });
+});

--- a/assets/js/lib/ai/index.js
+++ b/assets/js/lib/ai/index.js
@@ -3,4 +3,4 @@
 
 export { getProviderLabel, getProviderIcon } from './providers';
 export { WebSocketAIAgent, extractMessageText } from './WebSocketAIAgent';
-export { CONNECTION_STATUS } from './connectionStatus';
+export { CONNECTION_STATUS, isOnline } from './connectionStatus';

--- a/assets/js/lib/test-utils/factories/users.js
+++ b/assets/js/lib/test-utils/factories/users.js
@@ -40,6 +40,7 @@ export const userFactory = Factory.define(() => ({
   ai_configuration: aiConfigurationFactory.build(),
   created_at: formatISO(faker.date.past()),
   updated_at: formatISO(faker.date.past()),
+  ai_configuration: aiConfigurationFactory.build(),
 }));
 
 export const profileFactory = Factory.define(() => ({

--- a/assets/js/lib/test-utils/factories/users.js
+++ b/assets/js/lib/test-utils/factories/users.js
@@ -40,7 +40,6 @@ export const userFactory = Factory.define(() => ({
   ai_configuration: aiConfigurationFactory.build(),
   created_at: formatISO(faker.date.past()),
   updated_at: formatISO(faker.date.past()),
-  ai_configuration: aiConfigurationFactory.build(),
 }));
 
 export const profileFactory = Factory.define(() => ({


### PR DESCRIPTION
### Description

This PR wires up the backend part in https://github.com/trento-project/web/pull/4535 allowing the UI to reflect real-time the changes to the AI configuration (creation/clean up in this PR. Changes to the model are in the follow up https://github.com/trento-project/web/pull/4536)

Outline:
- when AI config is cleared the chatbox trigger is disabled in all open tabs
- in an open conversation the user is notified about the configuration being cleared and the conversation becomes read only
- upon creation of AI configuration the chatbox trigger is enabled in all open tabs
- in an open conversation the user is notified about the configuration being created and prompted to start a new conversation

https://github.com/user-attachments/assets/0dc4393b-7400-4a00-ae14-4c73af006190

### How was this tested?

Automated and IRL