### PR TITLE
Remove GCP scenario from demo

### DIFF
--- a/.photofinish.toml
+++ b/.photofinish.toml
@@ -12,7 +12,6 @@ directories = [
     "./test/fixtures/scenarios/sap-system-java",
     "./test/fixtures/scenarios/hana-scale-up-cost-opt",
     "./test/fixtures/scenarios/hana-scale-up-multi-tier",
-    "./test/fixtures/scenarios/gcp-landscape",
 ]
 
 [healthy-27-node-SAP-cluster]


### PR DESCRIPTION
### Description
Due to some bad conflict resolution `gcp` scenario was added to demo and we don't want that.
This PR removes it back again.

### How was this tested?

No need

### Documentation changes

Not