### PR TITLE
Add debug severity filter to related events link

### DIFF
--- a/assets/js/common/ActivityLogDetailsModal/ActivityLogDetailModal.jsx
+++ b/assets/js/common/ActivityLogDetailsModal/ActivityLogDetailModal.jsx
@@ -52,7 +52,7 @@ const renderResource = (entry) => (
 function RenderCorrelatedEventsLink({ onClose, entry }) {
   return (
     <NavLink
-      to={`/activity_log?severity=info&severity=warning&severity=critical&search=${entry.metadata.correlation_id}&first=20`}
+      to={`/activity_log?severity=debug&severity=info&severity=warning&severity=critical&search=${entry.metadata.correlation_id}&first=20`}
       onClick={onClose}
       className="text-jungle-green-500"
     >


### PR DESCRIPTION
### Description

Add `debug` severity to the filter used when `Related events` link is clicked in the activity log entry modal.
Without this, if you click the link in a `debug` event, it will show the related events, but not the clicked one, which is really confusing.
As this feature is a "debugging" tool, it makes sense to add all different severities.
The other option would be to only add `debug` if the event itself is debug, but this would make the usage inconsistent.

### How was this tested?

No need

### Documentation changes

No