### PR TITLE
Rename remaining occurrences to Multi-Linux Manager

### DIFF
--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.stories.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.stories.jsx
@@ -86,7 +86,7 @@ export const Loading = {
 export const Error = {
   args: {
     settingsConfigured: true,
-    errorMessage: 'Connection to SUMA not working',
-    tooltip: 'Please review SUSE Manager settings',
+    errorMessage: 'Connection to SUSE Multi-Linux Manager not working',
+    tooltip: 'Please review SUSE Multi-Linux Manager settings',
   },
 };

--- a/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/AvailableSoftwareUpdates.test.jsx
@@ -69,19 +69,19 @@ describe('AvailableSoftwareUpdates component', () => {
     expect(screen.getAllByLabelText('Loading')).toHaveLength(1);
   });
 
-  it('renders "SUSE Manager is not configured"', () => {
+  it('renders "SUSE Multi-Linux Manager is not configured"', () => {
     render(<AvailableSoftwareUpdates settingsConfigured={false} />);
 
     expect(
       screen.getByText(
-        'SUSE Multi-Linux Manager is not configured. Go to Settings to add your SUSE Manager connection credentials.'
+        'SUSE Multi-Linux Manager is not configured. Go to Settings to add your SUSE Multi-Linux Manager connection credentials.'
       )
     ).toBeVisible();
 
     expect(screen.getByRole('button', { name: 'Settings' })).toBeVisible();
   });
 
-  it('should navigate to a SUSE Manager view', async () => {
+  it('should navigate to a SUSE Multi-Linux Manager view', async () => {
     const user = userEvent.setup();
     const relevantPatches = faker.number.int({ min: 1 });
     const upgradablePackages = faker.number.int();
@@ -102,7 +102,7 @@ describe('AvailableSoftwareUpdates component', () => {
     expect(navigateToPatches).toHaveBeenCalled();
   });
 
-  it('should not navigate to a SUSE Manager view when erroring', async () => {
+  it('should not navigate to a SUSE Multi-Linux Manager view when erroring', async () => {
     const user = userEvent.setup();
     const navigateToPatches = jest.fn();
     const tooltip = faker.lorem.words({ min: 3, max: 5 });

--- a/assets/js/common/AvailableSoftwareUpdates/SumaNotConfigured.jsx
+++ b/assets/js/common/AvailableSoftwareUpdates/SumaNotConfigured.jsx
@@ -6,10 +6,7 @@ import classNames from 'classnames';
 import { noop } from 'lodash';
 import { EOS_SETTINGS } from 'eos-icons-react';
 
-import {
-  SUMA_PRODUCT_LABEL,
-  SUMA_PRODUCT_LABEL_SHORT,
-} from '@lib/model/suse_manager';
+import { SUMA_PRODUCT_LABEL } from '@lib/model/suse_manager';
 
 import Button from '@common/Button';
 
@@ -28,7 +25,7 @@ function SumaNotConfigured({ className, onBackToSettings = noop }) {
 
         <p>
           {SUMA_PRODUCT_LABEL} is not configured. Go to Settings to add your{' '}
-          {SUMA_PRODUCT_LABEL_SHORT} connection credentials.
+          {SUMA_PRODUCT_LABEL} connection credentials.
         </p>
       </div>
 

--- a/assets/js/common/SuseManagerClearSettingsDialog/SuseManagerClearSettingsModal.jsx
+++ b/assets/js/common/SuseManagerClearSettingsDialog/SuseManagerClearSettingsModal.jsx
@@ -22,8 +22,8 @@ function SuseManagerClearSettingsModal({
     >
       <div className="py-4">
         <p className="text-gray-500">
-          By clearing {SUMA_PRODUCT_LABEL} Settings you will no longer be
-          able to view information relating to software packages and updates for
+          By clearing {SUMA_PRODUCT_LABEL} Settings you will no longer be able
+          to view information relating to software packages and updates for
           hosts.
         </p>
       </div>

--- a/assets/js/common/SuseManagerClearSettingsDialog/SuseManagerClearSettingsModal.jsx
+++ b/assets/js/common/SuseManagerClearSettingsDialog/SuseManagerClearSettingsModal.jsx
@@ -4,10 +4,7 @@
 import React from 'react';
 import { noop } from 'lodash';
 
-import {
-  SUMA_PRODUCT_LABEL,
-  SUMA_PRODUCT_LABEL_SHORT,
-} from '@lib/model/suse_manager';
+import { SUMA_PRODUCT_LABEL } from '@lib/model/suse_manager';
 
 import Button from '@common/Button';
 import Modal from '@common/Modal';
@@ -25,7 +22,7 @@ function SuseManagerClearSettingsModal({
     >
       <div className="py-4">
         <p className="text-gray-500">
-          By clearing {SUMA_PRODUCT_LABEL_SHORT} Settings you will no longer be
+          By clearing {SUMA_PRODUCT_LABEL} Settings you will no longer be
           able to view information relating to software packages and updates for
           hosts.
         </p>

--- a/assets/js/common/SuseManagerClearSettingsDialog/SuseManagerClearSettingsModal.test.jsx
+++ b/assets/js/common/SuseManagerClearSettingsDialog/SuseManagerClearSettingsModal.test.jsx
@@ -9,7 +9,7 @@ import '@testing-library/jest-dom';
 import SuseManagerClearSettingsModal from '.';
 
 describe('SuseManagerClearSettingsModal', () => {
-  it("Clicking 'Clear Settings' button clears the SUMA settings", async () => {
+  it("Clicking 'Clear Settings' button clears the SUSE Multi-Linux Manager settings", async () => {
     const user = userEvent.setup();
     const onClearSettings = jest.fn();
 

--- a/assets/js/common/SuseManagerConfig/SuseManagerConfig.jsx
+++ b/assets/js/common/SuseManagerConfig/SuseManagerConfig.jsx
@@ -4,10 +4,7 @@
 import React from 'react';
 import { defaultTo, noop } from 'lodash';
 
-import {
-  SUMA_PRODUCT_LABEL,
-  SUMA_PRODUCT_LABEL_SHORT,
-} from '@lib/model/suse_manager';
+import { SUMA_PRODUCT_LABEL } from '@lib/model/suse_manager';
 
 import Button from '@common/Button';
 
@@ -88,7 +85,7 @@ function SuseManagerConfig({
         </p>
 
         <div className="grid grid-cols-6 mt-5 items-center">
-          <div className="font-bold mb-3">{SUMA_PRODUCT_LABEL_SHORT} URL</div>
+          <div className="font-bold mb-3">{SUMA_PRODUCT_LABEL} URL</div>
           <div
             aria-label="suma-url"
             className="col-span-2 text-gray-500 mb-3 truncate pr-12"

--- a/assets/js/common/SuseManagerConfig/SuseManagerConfig.stories.jsx
+++ b/assets/js/common/SuseManagerConfig/SuseManagerConfig.stories.jsx
@@ -18,7 +18,8 @@ export default {
       control: { type: 'text' },
     },
     userAbilities: {
-      description: 'Users abilities that allow changing SUSE Multi-Linux Manager settings',
+      description:
+        'Users abilities that allow changing SUSE Multi-Linux Manager settings',
       control: { type: 'object' },
     },
     url: {
@@ -26,7 +27,8 @@ export default {
       control: { type: 'text' },
     },
     certUploadDate: {
-      description: 'SUSE Multi-Linux Manager self-signed certificate upload date',
+      description:
+        'SUSE Multi-Linux Manager self-signed certificate upload date',
       control: { type: 'date' },
     },
     onEditClick: {
@@ -55,7 +57,8 @@ export default {
       action: 'onCancel',
     },
     onTestConnection: {
-      description: 'Callback function to test the SUSE Multi-Linux Manager connection',
+      description:
+        'Callback function to test the SUSE Multi-Linux Manager connection',
       action: 'callback',
     },
     timezone: {

--- a/assets/js/common/SuseManagerConfig/SuseManagerConfig.stories.jsx
+++ b/assets/js/common/SuseManagerConfig/SuseManagerConfig.stories.jsx
@@ -8,23 +8,24 @@ export default {
   component: SuseManagerConfig,
   argTypes: {
     username: {
-      description: 'SUSE Manager username',
+      description: 'SUSE Multi-Linux Manager username',
       control: {
         type: 'text',
       },
     },
     userAbilities: {
-      description: 'Users abilities that allow changing SUSE Manager settings',
+      description:
+        'Users abilities that allow changing SUSE Multi-Linux Manager settings',
       control: 'array',
     },
     url: {
-      description: 'SUSE Manager URL',
+      description: 'SUSE Multi-Linux Manager URL',
       control: {
         type: 'text',
       },
     },
     certUploadDate: {
-      description: 'SUSE Manager self-signed certificate upload date',
+      description: 'SUSE Multi-Linux Manager self-signed certificate upload date',
       control: {
         type: 'date',
       },

--- a/assets/js/common/SuseManagerSettingsDialog/SuseManagerSettingsModal.jsx
+++ b/assets/js/common/SuseManagerSettingsDialog/SuseManagerSettingsModal.jsx
@@ -6,10 +6,7 @@ import { capitalize, noop } from 'lodash';
 import { EOS_LOCK_OUTLINED } from 'eos-icons-react';
 import { formatDateOnly } from '@lib/timezones';
 
-import {
-  SUMA_PRODUCT_LABEL,
-  SUMA_PRODUCT_LABEL_SHORT,
-} from '@lib/model/suse_manager';
+import { SUMA_PRODUCT_LABEL } from '@lib/model/suse_manager';
 
 import Button from '@common/Button';
 import Modal from '@common/Modal';
@@ -69,7 +66,7 @@ function SuseManagerSettingsModal({
     >
       <div className="grid grid-cols-6 my-5 gap-6">
         <Label className="col-span-2" required>
-          {SUMA_PRODUCT_LABEL_SHORT} URL
+          {SUMA_PRODUCT_LABEL} URL
         </Label>
         <div className="col-span-4">
           <Input
@@ -142,7 +139,7 @@ function SuseManagerSettingsModal({
           <Input
             value={username}
             name="suma-username-input"
-            placeholder={`Enter a ${SUMA_PRODUCT_LABEL_SHORT} username`}
+            placeholder={`Enter a ${SUMA_PRODUCT_LABEL} username`}
             error={hasError('username', errors)}
             onChange={({ target: { value } }) => {
               setUsername(value);
@@ -166,7 +163,7 @@ function SuseManagerSettingsModal({
             <Password
               initialValue={password}
               name="suma-password-input"
-              placeholder={`Enter a ${SUMA_PRODUCT_LABEL_SHORT} password`}
+              placeholder={`Enter a ${SUMA_PRODUCT_LABEL} password`}
               error={hasError('password', errors)}
               onChange={({ target: { value } }) => {
                 setPassword(value);

--- a/assets/js/common/SuseManagerSettingsDialog/SuseManagerSettingsModal.stories.jsx
+++ b/assets/js/common/SuseManagerSettingsDialog/SuseManagerSettingsModal.stories.jsx
@@ -20,13 +20,13 @@ export default {
       },
     },
     initialUsername: {
-      description: 'Initial SUSE Manager username',
+      description: 'Initial SUSE Multi-Linux Manager username',
       control: {
         type: 'string',
       },
     },
     initialUrl: {
-      description: 'Initial SUSE Manager URL',
+      description: 'Initial SUSE Multi-Linux Manager URL',
       control: {
         type: 'string',
       },

--- a/assets/js/common/SuseManagerSettingsDialog/SuseManagerSettingsModal.test.jsx
+++ b/assets/js/common/SuseManagerSettingsDialog/SuseManagerSettingsModal.test.jsx
@@ -19,13 +19,13 @@ describe('SuseManagerSettingsModal component', () => {
       )
     );
 
-    expect(screen.getByText('SUSE Manager URL')).toBeVisible();
+    expect(screen.getByText('SUSE Multi-Linux Manager URL')).toBeVisible();
     expect(screen.getByText('Username')).toBeVisible();
     expect(screen.getByText('Password')).toBeVisible();
     expect(screen.getAllByRole('textbox').length).toBe(3);
 
     expect(
-      screen.getByPlaceholderText('Enter a SUSE Manager password')
+      screen.getByPlaceholderText('Enter a SUSE Multi-Linux Manager password')
     ).toBeVisible();
   });
 
@@ -50,7 +50,7 @@ describe('SuseManagerSettingsModal component', () => {
     expect(screen.getByText('Certificate Uploaded')).toBeVisible();
     expect(screen.getByText('•••••')).toBeVisible();
     expect(
-      screen.queryByPlaceholderText('Enter a SUSE Manager password')
+      screen.queryByPlaceholderText('Enter a SUSE Multi-Linux Manager password')
     ).not.toBeInTheDocument();
   });
 
@@ -70,10 +70,10 @@ describe('SuseManagerSettingsModal component', () => {
 
     const urlInput = screen.getByPlaceholderText('Enter a URL');
     const passwordInput = screen.getByPlaceholderText(
-      'Enter a SUSE Manager password'
+      'Enter a SUSE Multi-Linux Manager password'
     );
     const userInput = screen.getByPlaceholderText(
-      'Enter a SUSE Manager username'
+      'Enter a SUSE Multi-Linux Manager username'
     );
     const certificateInput = screen.getByPlaceholderText(
       'Starts with -----BEGIN CERTIFICATE-----'
@@ -115,7 +115,7 @@ describe('SuseManagerSettingsModal component', () => {
 
     const urlInput = screen.getByPlaceholderText('Enter a URL');
     const userInput = screen.getByPlaceholderText(
-      'Enter a SUSE Manager username'
+      'Enter a SUSE Multi-Linux Manager username'
     );
 
     await user.clear(urlInput);

--- a/assets/js/lib/model/activityLog.js
+++ b/assets/js/lib/model/activityLog.js
@@ -186,7 +186,8 @@ export const availableResourceNameKeys = pipe(
   uniq
 )(resourceTypesToNameKeyMap);
 
-const sumaSettingsResourceType = (_entry) => 'SUSE Multi-Linux Manager Settings';
+const sumaSettingsResourceType = (_entry) =>
+  'SUSE Multi-Linux Manager Settings';
 const alertingSettingsResourceType = (_entry) => 'Alerting Settings';
 const userResourceType = (_entry) => 'User';
 const profileResourceType = (_entry) => 'Profile';

--- a/assets/js/lib/model/activityLog.js
+++ b/assets/js/lib/model/activityLog.js
@@ -186,7 +186,7 @@ export const availableResourceNameKeys = pipe(
   uniq
 )(resourceTypesToNameKeyMap);
 
-const sumaSettingsResourceType = (_entry) => 'SUMA Settings';
+const sumaSettingsResourceType = (_entry) => 'SUSE Multi-Linux Manager Settings';
 const alertingSettingsResourceType = (_entry) => 'Alerting Settings';
 const userResourceType = (_entry) => 'User';
 const profileResourceType = (_entry) => 'Profile';
@@ -268,18 +268,18 @@ export const ACTIVITY_TYPES_CONFIG = {
     resource: (_entry) => 'API Key',
   },
   [SAVING_SUMA_SETTINGS]: {
-    label: 'SUMA Settings Saved',
-    message: (_entry) => 'SUMA Settings was saved',
+    label: 'SUSE Multi-Linux Manager Settings Saved',
+    message: (_entry) => 'SUSE Multi-Linux Manager Settings was saved',
     resource: sumaSettingsResourceType,
   },
   [CHANGING_SUMA_SETTINGS]: {
-    label: 'SUMA Settings Changed',
-    message: (_entry) => 'SUMA Settings was changed',
+    label: 'SUSE Multi-Linux Manager Settings Changed',
+    message: (_entry) => 'SUSE Multi-Linux Manager Settings was changed',
     resource: sumaSettingsResourceType,
   },
   [CLEARING_SUMA_SETTINGS]: {
-    label: 'SUMA Settings Cleared',
-    message: (_entry) => 'SUMA Settings was cleared',
+    label: 'SUSE Multi-Linux Manager Settings Cleared',
+    message: (_entry) => 'SUSE Multi-Linux Manager Settings was cleared',
     resource: sumaSettingsResourceType,
   },
   [SAVING_ALERTING_SETTINGS]: {

--- a/assets/js/lib/model/suse_manager.js
+++ b/assets/js/lib/model/suse_manager.js
@@ -2,4 +2,3 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export const SUMA_PRODUCT_LABEL = 'SUSE Multi-Linux Manager';
-export const SUMA_PRODUCT_LABEL_SHORT = 'SUSE Manager';

--- a/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
@@ -373,7 +373,8 @@ export const WithSoftwareUpdatesFailed = {
     softwareUpdatesSettingsSaved: true,
     relevantPatches: undefined,
     upgradablePackages: undefined,
-    softwareUpdatesErrorMessage: 'Connection to SUSE Multi-Linux Manager not working',
+    softwareUpdatesErrorMessage:
+      'Connection to SUSE Multi-Linux Manager not working',
     softwareUpdatesTooltip: 'Please review SUSE Multi-Linux Manager settings',
   },
 };

--- a/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.stories.jsx
@@ -347,8 +347,8 @@ export const WithSoftwareUpdatesFailed = {
     softwareUpdatesSettingsSaved: true,
     relevantPatches: undefined,
     upgradablePackages: undefined,
-    softwareUpdatesErrorMessage: 'Connection to SUMA not working',
-    softwareUpdatesTooltip: 'Please review SUSE Manager settings',
+    softwareUpdatesErrorMessage: 'Connection to SUSE Multi-Linux Manager not working',
+    softwareUpdatesTooltip: 'Please review SUSE Multi-Linux Manager settings',
   },
 };
 

--- a/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetails.test.jsx
@@ -387,8 +387,8 @@ describe('HostDetails component', () => {
     });
   });
 
-  describe('SUSE Manager', () => {
-    it('should show the summary of SUMA software updates', () => {
+  describe('SUSE Multi-Linux Manager', () => {
+    it('should show the summary of SUSE Multi-Linux Manager software updates', () => {
       const relevantPatches = faker.number.int(100);
       const upgradablePackages = faker.number.int(100);
 
@@ -417,7 +417,7 @@ describe('HostDetails component', () => {
       );
     });
 
-    it('should display software updates showing an error message when no SUMA updates data is available', () => {
+    it('should display software updates showing an error message when no SUSE Multi-Linux Manager updates data is available', () => {
       const relevantPatches = undefined;
       const upgradablePackages = undefined;
 
@@ -443,7 +443,7 @@ describe('HostDetails component', () => {
       expect(upgradablePackagesElement).toHaveTextContent('An error message');
     });
 
-    it('should show the summary of SUMA software updates in a loading state', () => {
+    it('should show the summary of SUSE Multi-Linux Manager software updates in a loading state', () => {
       const relevantPatches = faker.number.int(100);
       const upgradablePackages = faker.number.int(100);
 

--- a/assets/js/pages/HostDetailsPage/HostDetailsPage.test.jsx
+++ b/assets/js/pages/HostDetailsPage/HostDetailsPage.test.jsx
@@ -27,7 +27,7 @@ describe('HostDetailsPage', () => {
     axiosMock.onGet(/\/api\/v1\/hosts.*/gm).reply(200, {});
   });
 
-  it('Renders SUSE Manager unknown status', async () => {
+  it('Renders SUSE Multi-Linux Manager unknown status', async () => {
     const user = userEvent.setup();
 
     const host = hostFactory.build();
@@ -79,7 +79,7 @@ describe('HostDetailsPage', () => {
     ).toBeVisible();
   });
 
-  it('Renders SUSE Manager error for host not found', async () => {
+  it('Renders SUSE Multi-Linux Manager error for host not found', async () => {
     const user = userEvent.setup();
 
     const host = hostFactory.build();
@@ -119,21 +119,21 @@ describe('HostDetailsPage', () => {
       .closest('div');
 
     expect(relevantPatchesElement).toHaveTextContent(
-      'Relevant Patches Host not found in SUSE Manager'
+      'Relevant Patches Host not found in SUSE Multi-Linux Manager'
     );
     expect(upgradablePackagesElement).toHaveTextContent(
-      'Upgradable Packages Host not found in SUSE Manager'
+      'Upgradable Packages Host not found in SUSE Multi-Linux Manager'
     );
 
     await user.hover(relevantPatchesElement);
     expect(
       screen.queryByText(
-        'Contact your SUSE Manager admin to ensure the host is managed by SUSE Manager'
+        'Contact your SUSE Multi-Linux Manager admin to ensure the host is managed by SUSE Multi-Linux Manager'
       )
     ).toBeVisible();
   });
 
-  it('Renders SUSE Manager error for connection not working', async () => {
+  it('Renders SUSE Multi-Linux Manager error for connection not working', async () => {
     const user = userEvent.setup();
 
     const host = hostFactory.build();
@@ -173,15 +173,15 @@ describe('HostDetailsPage', () => {
       .closest('div');
 
     expect(relevantPatchesElement).toHaveTextContent(
-      'Relevant Patches Connection to SUSE Manager not working'
+      'Relevant Patches Connection to SUSE Multi-Linux Manager not working'
     );
     expect(upgradablePackagesElement).toHaveTextContent(
-      'Upgradable Packages Connection to SUSE Manager not working'
+      'Upgradable Packages Connection to SUSE Multi-Linux Manager not working'
     );
 
     await user.hover(relevantPatchesElement);
     expect(
-      screen.queryByText('Please review SUSE Manager settings')
+      screen.queryByText('Please review SUSE Multi-Linux Manager settings')
     ).toBeVisible();
   });
 

--- a/assets/js/pages/HostDetailsPage/suseManagerMessaging.js
+++ b/assets/js/pages/HostDetailsPage/suseManagerMessaging.js
@@ -7,7 +7,8 @@ export const getSoftwareUpdatesErrorMessage = (errors) => {
   const hostNotFoundInSUMA = errors.some(
     ({ detail }) =>
       detail === 'The requested resource cannot be found.' ||
-      detail === `No system ID was found on ${SUMA_PRODUCT_LABEL} for this host.`
+      detail ===
+        `No system ID was found on ${SUMA_PRODUCT_LABEL} for this host.`
   );
 
   const connectionNotWorking = errors.some(
@@ -29,7 +30,8 @@ export const getSoftwareUpdatesErrorTooltip = (errors) => {
   const hostNotFoundInSUMA = errors.some(
     ({ detail }) =>
       detail === 'The requested resource cannot be found.' ||
-      detail === `No system ID was found on ${SUMA_PRODUCT_LABEL} for this host.`
+      detail ===
+        `No system ID was found on ${SUMA_PRODUCT_LABEL} for this host.`
   );
 
   const connectionNotWorking = errors.some(

--- a/assets/js/pages/HostDetailsPage/suseManagerMessaging.js
+++ b/assets/js/pages/HostDetailsPage/suseManagerMessaging.js
@@ -1,14 +1,13 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-import { SUMA_PRODUCT_LABEL_SHORT } from '@lib/model/suse_manager';
+import { SUMA_PRODUCT_LABEL } from '@lib/model/suse_manager';
 
 export const getSoftwareUpdatesErrorMessage = (errors) => {
   const hostNotFoundInSUMA = errors.some(
     ({ detail }) =>
       detail === 'The requested resource cannot be found.' ||
-      detail ===
-        `No system ID was found on ${SUMA_PRODUCT_LABEL_SHORT} for this host.`
+      detail === `No system ID was found on ${SUMA_PRODUCT_LABEL} for this host.`
   );
 
   const connectionNotWorking = errors.some(
@@ -16,11 +15,11 @@ export const getSoftwareUpdatesErrorMessage = (errors) => {
   );
 
   if (hostNotFoundInSUMA) {
-    return `Host not found in ${SUMA_PRODUCT_LABEL_SHORT}`;
+    return `Host not found in ${SUMA_PRODUCT_LABEL}`;
   }
 
   if (connectionNotWorking) {
-    return `Connection to ${SUMA_PRODUCT_LABEL_SHORT} not working`;
+    return `Connection to ${SUMA_PRODUCT_LABEL} not working`;
   }
 
   return 'Unknown';
@@ -30,8 +29,7 @@ export const getSoftwareUpdatesErrorTooltip = (errors) => {
   const hostNotFoundInSUMA = errors.some(
     ({ detail }) =>
       detail === 'The requested resource cannot be found.' ||
-      detail ===
-        `No system ID was found on ${SUMA_PRODUCT_LABEL_SHORT} for this host.`
+      detail === `No system ID was found on ${SUMA_PRODUCT_LABEL} for this host.`
   );
 
   const connectionNotWorking = errors.some(
@@ -39,11 +37,11 @@ export const getSoftwareUpdatesErrorTooltip = (errors) => {
   );
 
   if (hostNotFoundInSUMA) {
-    return `Contact your ${SUMA_PRODUCT_LABEL_SHORT} admin to ensure the host is managed by ${SUMA_PRODUCT_LABEL_SHORT}`;
+    return `Contact your ${SUMA_PRODUCT_LABEL} admin to ensure the host is managed by ${SUMA_PRODUCT_LABEL}`;
   }
 
   if (connectionNotWorking) {
-    return `Please review ${SUMA_PRODUCT_LABEL_SHORT} settings`;
+    return `Please review ${SUMA_PRODUCT_LABEL} settings`;
   }
 
   if (errors.length) {

--- a/assets/js/pages/SettingsPage/SettingsPage.jsx
+++ b/assets/js/pages/SettingsPage/SettingsPage.jsx
@@ -7,7 +7,7 @@ import { Transition } from '@headlessui/react';
 import { isBefore, parseISO } from 'date-fns';
 import { EOS_INFO_OUTLINED } from 'eos-icons-react';
 
-import { SUMA_PRODUCT_LABEL_SHORT } from '@lib/model/suse_manager';
+import { SUMA_PRODUCT_LABEL } from '@lib/model/suse_manager';
 import { formatDateOnly } from '@lib/timezones';
 
 import DisabledGuard from '@common/DisabledGuard';
@@ -272,7 +272,7 @@ function SettingsPage() {
       <section>
         <div className="py-4">
           <SettingsLoader
-            sectionName={SUMA_PRODUCT_LABEL_SHORT}
+            sectionName={SUMA_PRODUCT_LABEL}
             status={calculateSettingsLoaderStatus(
               suseManagerSettingsLoading,
               suseManagerSettingsfetchError

--- a/assets/js/pages/SettingsPage/SettingsPage.test.jsx
+++ b/assets/js/pages/SettingsPage/SettingsPage.test.jsx
@@ -116,11 +116,11 @@ describe('Settings Page', () => {
       });
 
       expect(
-        screen.getByText('Loading SUSE Manager Settings...')
+        screen.getByText('Loading SUSE Multi-Linux Manager Settings...')
       ).toBeVisible();
     });
 
-    it('should render an empty SUSE Manager Config Section', async () => {
+    it('should render an empty SUSE Multi-Linux Manager Config Section', async () => {
       const [StatefulSettings] = withState(<SettingsPage />, {
         ...defaultInitialState,
       });
@@ -131,7 +131,7 @@ describe('Settings Page', () => {
         renderWithRouter(StatefulSettings);
       });
 
-      expect(screen.getByText('SUSE Manager URL')).toBeVisible();
+      expect(screen.getByText('SUSE Multi-Linux Manager URL')).toBeVisible();
       expect(screen.getByText('https://')).toBeVisible();
 
       expect(screen.getByText('CA Certificate')).toBeVisible();
@@ -146,7 +146,7 @@ describe('Settings Page', () => {
       expect(sumaPassword).toHaveTextContent('.....');
     });
 
-    it('should render SUSE Manager Config Section with configured settings', async () => {
+    it('should render SUSE Multi-Linux Manager Config Section with configured settings', async () => {
       const settings = softwareUpdatesSettingsFactory.build();
 
       const [StatefulSettings] = withState(<SettingsPage />, {
@@ -160,7 +160,7 @@ describe('Settings Page', () => {
       await act(async () => {
         renderWithRouter(StatefulSettings);
       });
-      expect(screen.getByText('SUSE Manager URL')).toBeVisible();
+      expect(screen.getByText('SUSE Multi-Linux Manager URL')).toBeVisible();
       expect(screen.getByText(url)).toBeVisible();
 
       expect(screen.getByText('CA Certificate')).toBeVisible();

--- a/assets/js/pages/SettingsPage/hooks.test.jsx
+++ b/assets/js/pages/SettingsPage/hooks.test.jsx
@@ -36,7 +36,7 @@ describe('useSuseManagerSettings', () => {
     axiosMock.onGet('/settings/suse_manager').reply(200, baseSumaSettings);
   });
 
-  it('should fetch suse manager on mount and return the settings', async () => {
+  it('should fetch SUSE Multi-Linux Manager on mount and return the settings', async () => {
     let hookResult;
     const [hookWrapper, _] = hookWrapperWithState();
 
@@ -52,7 +52,7 @@ describe('useSuseManagerSettings', () => {
     expect(hookResult.current.suseManagerSettingsfetchError).toEqual(false);
   });
 
-  it('should perform the suse manager settings saving when the hook callback is called', async () => {
+  it('should perform the SUSE Multi-Linux Manager settings saving when the hook callback is called', async () => {
     let hookResult;
     const [hookWrapper, _] = hookWrapperWithState();
 
@@ -81,7 +81,7 @@ describe('useSuseManagerSettings', () => {
     expect(hookResult.current.suseManagerSettingsEntityErrors).toEqual([]);
   });
 
-  it('should perform the suse manager settings update when the hook callback is called and no errors are returned', async () => {
+  it('should perform the SUSE Multi-Linux Manager settings update when the hook callback is called and no errors are returned', async () => {
     let hookResult;
     const [hookWrapper, _] = hookWrapperWithState();
 
@@ -110,7 +110,7 @@ describe('useSuseManagerSettings', () => {
     expect(hookResult.current.suseManagerSettingsEntityErrors).toEqual([]);
   });
 
-  it('should not perform the suse manager settings update when the hook callback is called and errors are returned', async () => {
+  it('should not perform the SUSE Multi-Linux Manager settings update when the hook callback is called and errors are returned', async () => {
     let hookResult;
     const [hookWrapper, _] = hookWrapperWithState();
 
@@ -141,7 +141,7 @@ describe('useSuseManagerSettings', () => {
     ]);
   });
 
-  it('should perform the suse manager settings delete when the hook callback is called and no errors are returned', async () => {
+  it('should perform the SUSE Multi-Linux Manager settings delete when the hook callback is called and no errors are returned', async () => {
     let hookResult;
     const [hookWrapper, _] = hookWrapperWithState();
 
@@ -162,7 +162,7 @@ describe('useSuseManagerSettings', () => {
     expect(hookResult.current.suseManagerSettingsEntityErrors).toEqual([]);
   });
 
-  it('should not perform the suse manager settings delete when the hook callback is called and errors are returned', async () => {
+  it('should not perform the SUSE Multi-Linux Manager settings delete when the hook callback is called and errors are returned', async () => {
     let hookResult;
     const [hookWrapper, store] = hookWrapperWithState();
 
@@ -191,7 +191,7 @@ describe('useSuseManagerSettings', () => {
     ]);
   });
 
-  it('should test the suse manager settings and spawn a toast when the connection succeded', async () => {
+  it('should test the SUSE Multi-Linux Manager settings and spawn a toast when the connection succeded', async () => {
     let hookResult;
     const [hookWrapper, store] = hookWrapperWithState();
 
@@ -219,7 +219,7 @@ describe('useSuseManagerSettings', () => {
     ]);
   });
 
-  it('should test the suse manager settings and spawn a toast when the connection fails', async () => {
+  it('should test the SUSE Multi-Linux Manager settings and spawn a toast when the connection fails', async () => {
     let hookResult;
     const [hookWrapper, store] = hookWrapperWithState();
 

--- a/assets/js/state/sagas/hosts.test.js
+++ b/assets/js/state/sagas/hosts.test.js
@@ -184,7 +184,7 @@ describe('Hosts sagas', () => {
     ]);
   });
 
-  it('should fetch SUMA settings and software updates when host software updates discovery is completed', async () => {
+  it('should fetch SUSE Multi-Linux Manager settings and software updates when host software updates discovery is completed', async () => {
     const { id } = hostFactory.build();
 
     const settingsResponse = softwareUpdatesSettingsFactory.build();

--- a/assets/js/state/sagas/softwareUpdates.js
+++ b/assets/js/state/sagas/softwareUpdates.js
@@ -33,7 +33,8 @@ export function* fetchSoftwareUpdates({ payload: hostID }) {
     const errorCode = get(error, ['response', 'status']);
     const errors = get(error, ['response', 'data', 'errors'], []);
     const suma_unauthorized = errors.some(
-      ({ detail }) => detail === 'SUSE Multi-Linux Manager settings not configured.'
+      ({ detail }) =>
+        detail === 'SUSE Multi-Linux Manager settings not configured.'
     );
 
     if (errorCode === 404 && suma_unauthorized) {
@@ -64,7 +65,8 @@ export function* fetchUpgradablePackagesPatches({ payload: { hostID } }) {
     const errors = get(error, ['response', 'data', 'errors'], []);
 
     const suma_unauthorized = errors.some(
-      ({ detail }) => detail === 'SUSE Multi-Linux Manager settings not configured.'
+      ({ detail }) =>
+        detail === 'SUSE Multi-Linux Manager settings not configured.'
     );
 
     if (errorCode === 404 && suma_unauthorized) {

--- a/assets/js/state/sagas/softwareUpdates.js
+++ b/assets/js/state/sagas/softwareUpdates.js
@@ -33,7 +33,7 @@ export function* fetchSoftwareUpdates({ payload: hostID }) {
     const errorCode = get(error, ['response', 'status']);
     const errors = get(error, ['response', 'data', 'errors'], []);
     const suma_unauthorized = errors.some(
-      ({ detail }) => detail === 'SUSE Manager settings not configured.'
+      ({ detail }) => detail === 'SUSE Multi-Linux Manager settings not configured.'
     );
 
     if (errorCode === 404 && suma_unauthorized) {
@@ -64,7 +64,7 @@ export function* fetchUpgradablePackagesPatches({ payload: { hostID } }) {
     const errors = get(error, ['response', 'data', 'errors'], []);
 
     const suma_unauthorized = errors.some(
-      ({ detail }) => detail === 'SUSE Manager settings not configured.'
+      ({ detail }) => detail === 'SUSE Multi-Linux Manager settings not configured.'
     );
 
     if (errorCode === 404 && suma_unauthorized) {

--- a/assets/js/state/sagas/softwareUpdates.test.js
+++ b/assets/js/state/sagas/softwareUpdates.test.js
@@ -124,7 +124,7 @@ describe('Software Updates saga', () => {
         errors: [
           {
             title: 'Not Found',
-            detail: 'SUSE Manager settings not configured.',
+            detail: 'SUSE Multi-Linux Manager settings not configured.',
           },
         ],
       };
@@ -179,7 +179,7 @@ describe('Software Updates saga', () => {
         errors: [
           {
             title: 'Not Found',
-            detail: 'SUSE Manager settings not configured.',
+            detail: 'SUSE Multi-Linux Manager settings not configured.',
           },
         ],
       };

--- a/lib/trento/infrastructure/software_updates/suma_api.ex
+++ b/lib/trento/infrastructure/software_updates/suma_api.ex
@@ -274,7 +274,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
     do: String.trim_trailing(base_url, "/") <> "/rhn/manager/api"
 
   defp try_login(_, _, _, _, 0) do
-    Logger.error("Failed to Log into SUSE Manager. Max retries reached.")
+    Logger.error("Failed to Log into SUSE Multi-Linux Manager. Max retries reached.")
     {:error, :max_login_retries_reached}
   end
 
@@ -284,7 +284,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
         successful_login
 
       {:error, reason} ->
-        Logger.error("Failed to Log into SUSE Manager, retrying...", error: inspect(reason))
+        Logger.error("Failed to Log into SUSE Multi-Linux Manager, retrying...", error: inspect(reason))
         try_login(url, username, password, ca_cert, retry - 1)
     end
   end
@@ -292,18 +292,18 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
   defp do_login(url, username, password, ca_cert) do
     case http_executor().login(url, username, password, ca_cert) do
       {:ok, %HTTPoison.Response{headers: headers, status_code: 200} = response} ->
-        Logger.debug("Successfully logged into SUMA #{inspect(response)}")
+        Logger.debug("Successfully logged into SUSE Multi-Linux Manager #{inspect(response)}")
         {:ok, get_session_cookies(headers)}
 
       {:ok, %HTTPoison.Response{status_code: _} = response} ->
         Logger.error(
-          "Failed to login to SUSE Manager due to unsuccessful response. Response: #{inspect(response)}"
+          "Failed to login to SUSE Multi-Linux Manager due to unsuccessful response. Response: #{inspect(response)}"
         )
 
         {:error, :login_error}
 
       {:error, reason} ->
-        Logger.error("Failed to login to SUSE Manager due to an error. Error: #{inspect(reason)}")
+        Logger.error("Failed to login to SUSE Multi-Linux Manager due to an error. Error: #{inspect(reason)}")
         {:error, :login_error}
     end
   end
@@ -346,7 +346,7 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
 
   defp extract_system_id({:ok, response}) do
     Logger.error(
-      "Could not get system id for host from SUMA result. Result: #{inspect(response)}"
+      "Could not get system id for host from SUSE Multi-Linux Manager result. Result: #{inspect(response)}"
     )
 
     {:error, :system_id_not_found}

--- a/lib/trento/infrastructure/software_updates/suma_api.ex
+++ b/lib/trento/infrastructure/software_updates/suma_api.ex
@@ -284,7 +284,10 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
         successful_login
 
       {:error, reason} ->
-        Logger.error("Failed to Log into SUSE Multi-Linux Manager, retrying...", error: inspect(reason))
+        Logger.error("Failed to Log into SUSE Multi-Linux Manager, retrying...",
+          error: inspect(reason)
+        )
+
         try_login(url, username, password, ca_cert, retry - 1)
     end
   end
@@ -303,7 +306,10 @@ defmodule Trento.Infrastructure.SoftwareUpdates.SumaApi do
         {:error, :login_error}
 
       {:error, reason} ->
-        Logger.error("Failed to login to SUSE Multi-Linux Manager due to an error. Error: #{inspect(reason)}")
+        Logger.error(
+          "Failed to login to SUSE Multi-Linux Manager due to an error. Error: #{inspect(reason)}"
+        )
+
         {:error, :login_error}
     end
   end

--- a/lib/trento_web/controllers/fallback_controller.ex
+++ b/lib/trento_web/controllers/fallback_controller.ex
@@ -24,7 +24,7 @@ defmodule TrentoWeb.FallbackController do
     conn
     |> put_status(:not_found)
     |> put_view(json: ErrorJSON)
-    |> render(:"404", reason: "SUSE Manager settings not configured.")
+    |> render(:"404", reason: "SUSE Multi-Linux Manager settings not configured.")
   end
 
   def call(conn, {:error, :alerting_settings_not_configured}) do
@@ -45,7 +45,7 @@ defmodule TrentoWeb.FallbackController do
     conn
     |> put_status(:unprocessable_entity)
     |> put_view(json: ErrorJSON)
-    |> render(:"422", reason: "SUSE Manager authentication error.")
+    |> render(:"422", reason: "SUSE Multi-Linux Manager authentication error.")
   end
 
   def call(conn, {:error, :invalid_refresh_token}) do
@@ -158,7 +158,7 @@ defmodule TrentoWeb.FallbackController do
     conn
     |> put_status(:unprocessable_entity)
     |> put_view(json: ErrorJSON)
-    |> render(:"422", reason: "No system ID was found on SUSE Manager for this host.")
+    |> render(:"422", reason: "No system ID was found on SUSE Multi-Linux Manager for this host.")
   end
 
   def call(conn, {:error, :error_getting_patches}) do

--- a/priv/repo/migrations/20260730120000_rename_suma_ability_label.exs
+++ b/priv/repo/migrations/20260730120000_rename_suma_ability_label.exs
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Repo.Migrations.RenameSumaAbilityLabel do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    UPDATE abilities
+    SET label = 'Permits all operations on SUSE Multi-Linux Manager settings'
+    WHERE name = 'all' AND resource = 'suma_settings'
+    """
+  end
+
+  def down do
+    execute """
+    UPDATE abilities
+    SET label = 'Permits all operations on SUMA settings'
+    WHERE name = 'all' AND resource = 'suma_settings'
+    """
+  end
+end

--- a/test/e2e/cypress/e2e/settings.cy.js
+++ b/test/e2e/cypress/e2e/settings.cy.js
@@ -49,7 +49,7 @@ context('Settings page', () => {
     });
   });
 
-  describe('Suse Manager Settings Management', () => {
+  describe('SUSE Multi-Linux Manager Settings Management', () => {
     beforeEach(() => {
       settingsPage.clearSUMASettings();
       settingsPage.refresh();

--- a/test/e2e/cypress/e2e/suse_manager_overviews.cy.js
+++ b/test/e2e/cypress/e2e/suse_manager_overviews.cy.js
@@ -3,7 +3,7 @@
 
 import * as hostDetailsPage from '../pageObject/host_details_po.js';
 
-context('SUSE Manager overviews', () => {
+context('SUSE Multi-Linux Manager overviews', () => {
   before(() => hostDetailsPage.preloadTestData());
 
   beforeEach(() => {
@@ -11,8 +11,8 @@ context('SUSE Manager overviews', () => {
     hostDetailsPage.saveSUMASettingsForAdmin();
   });
 
-  describe('navigates and display SUSE Manager based infos', () => {
-    it('host is found on SUSE Manager and has vulnerabilities', () => {
+  describe('navigates and display SUSE Multi-Linux Manager based infos', () => {
+    it('host is found on SUSE Multi-Linux Manager and has vulnerabilities', () => {
       hostDetailsPage.interceptSumaRequestsMockedForProdInstance();
 
       hostDetailsPage.visitVmdrbddev01Host();
@@ -48,15 +48,15 @@ context('SUSE Manager overviews', () => {
       hostDetailsPage.advisoryDetailsAffectedSystemsAreTheExpected();
     });
 
-    it('host is not found on SUSE Manager', () => {
+    it('host is not found on SUSE Multi-Linux Manager', () => {
       hostDetailsPage.interceptSoftwareUpdatesRequestsMockedForProdInstance();
 
       hostDetailsPage.visitVmdrbddev02Host();
       hostDetailsPage.expectedRelevantPatchesAreDisplayed(
-        ' Host not found in SUSE Manager'
+        ' Host not found in SUSE Multi-Linux Manager'
       );
       hostDetailsPage.upgradablePackagesAmountIsTheExpected(
-        ' Host not found in SUSE Manager'
+        ' Host not found in SUSE Multi-Linux Manager'
       );
     });
   });

--- a/test/e2e/cypress/fixtures/suma-software-updates/software_updates.js
+++ b/test/e2e/cypress/fixtures/suma-software-updates/software_updates.js
@@ -103,7 +103,8 @@ const mockData = {
     host_not_found: {
       errors: [
         {
-          detail: 'No system ID was found on SUSE Manager for this host.',
+          detail:
+            'No system ID was found on SUSE Multi-Linux Manager for this host.',
           title: 'Unprocessable Entity',
         },
       ],

--- a/test/trento/infrastructure/commanded/event_handlers/software_updates_discovery_event_handler_test.exs
+++ b/test/trento/infrastructure/commanded/event_handlers/software_updates_discovery_event_handler_test.exs
@@ -92,7 +92,7 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SoftwareUpdatesDiscovery
         assert :ok = SoftwareUpdatesDiscoveryEventHandler.handle(event, %{})
       end
 
-      test "should discover data about hosts just when SUSE Manager's settings are set" do
+      test "should discover data about hosts just when SUSE Multi-Linux Manager's settings are set" do
         event = build(:software_updates_discovery_requested_event)
 
         expect(

--- a/test/trento/settings/policy_test.exs
+++ b/test/trento/settings/policy_test.exs
@@ -72,8 +72,8 @@ defmodule Trento.Settings.PolicyTest do
     end
   end
 
-  describe "suse manager settings authorization" do
-    test "should allow suma settings actions if the user has all:all ability" do
+  describe "SUSE Multi-Linux Manager settings authorization" do
+    test "should allow SUSE Multi-Linux Manager settings actions if the user has all:all ability" do
       user = %User{abilities: [%Ability{name: "all", resource: "all"}]}
 
       assert Policy.authorize(:get_suse_manager_settings, user, SuseManagerSettings)
@@ -83,7 +83,7 @@ defmodule Trento.Settings.PolicyTest do
       assert Policy.authorize(:test_suse_manager_settings, user, SuseManagerSettings)
     end
 
-    test "should allow suma settings actions if the user has all:suma_settings ability" do
+    test "should allow SUSE Multi-Linux Manager settings actions if the user has all:suma_settings ability" do
       user = %User{abilities: [%Ability{name: "all", resource: "suma_settings"}]}
 
       assert Policy.authorize(:get_suse_manager_settings, user, SuseManagerSettings)
@@ -93,14 +93,14 @@ defmodule Trento.Settings.PolicyTest do
       assert Policy.authorize(:test_suse_manager_settings, user, SuseManagerSettings)
     end
 
-    test "should allow suma settings actions if the user has no abilities" do
+    test "should allow SUSE Multi-Linux Manager settings actions if the user has no abilities" do
       user = %User{abilities: []}
 
       assert Policy.authorize(:get_suse_manager_settings, user, SuseManagerSettings)
       assert Policy.authorize(:test_suse_manager_settings, user, SuseManagerSettings)
     end
 
-    test "should disallow creating, updating or changing suma settings if the user has no abilities" do
+    test "should disallow creating, updating or changing SUSE Multi-Linux Manager settings if the user has no abilities" do
       user = %User{abilities: []}
 
       refute Policy.authorize(:save_suse_manager_settings, user, SuseManagerSettings)

--- a/test/trento/settings_test.exs
+++ b/test/trento/settings_test.exs
@@ -188,7 +188,7 @@ defmodule Trento.SettingsTest do
                 }} = Settings.get_suse_manager_settings()
       end
 
-      test "should not save invalid suse manager settings" do
+      test "should not save invalid SUSE Multi-Linux Manager settings" do
         submission = %{
           url: "https://valid.com",
           username: Faker.Internet.user_name(),
@@ -246,7 +246,7 @@ defmodule Trento.SettingsTest do
         end
       end
 
-      test "should save suse manager settings without ca cert" do
+      test "should save SUSE Multi-Linux Manager settings without ca cert" do
         settings = %{
           url: url = "https://valid.com",
           username: username = Faker.Internet.user_name(),
@@ -263,7 +263,7 @@ defmodule Trento.SettingsTest do
                 }} = Settings.save_suse_manager_settings(settings)
       end
 
-      test "should save suse manager settings with a nil ca cert" do
+      test "should save SUSE Multi-Linux Manager settings with a nil ca cert" do
         settings = %{
           url: url = "https://valid.com",
           username: username = Faker.Internet.user_name(),
@@ -281,7 +281,7 @@ defmodule Trento.SettingsTest do
                 }} = Settings.save_suse_manager_settings(settings)
       end
 
-      test "should save suse manager settings with ca cert" do
+      test "should save SUSE Multi-Linux Manager settings with ca cert" do
         now = DateTime.utc_now()
 
         expect(
@@ -308,7 +308,7 @@ defmodule Trento.SettingsTest do
                  Settings.save_suse_manager_settings(settings, Trento.Support.DateService.Mock)
       end
 
-      test "should not save suse manager settings if already saved" do
+      test "should not save SUSE Multi-Linux Manager settings if already saved" do
         settings = %{
           url: "https://valid.com",
           username: Faker.Internet.user_name(),
@@ -379,7 +379,7 @@ defmodule Trento.SettingsTest do
         end
       end
 
-      test "should not be able to change suse manager settings if none previously saved" do
+      test "should not be able to change SUSE Multi-Linux Manager settings if none previously saved" do
         submission = %{
           url: "https://valid.com",
           username: Faker.Internet.user_name(),
@@ -391,7 +391,7 @@ defmodule Trento.SettingsTest do
                  Settings.change_suse_manager_settings(submission)
       end
 
-      test "should validate partial changes to suse manager settings" do
+      test "should validate partial changes to SUSE Multi-Linux Manager settings" do
         insert_software_updates_settings()
 
         change_settings_scenarios = [
@@ -455,7 +455,7 @@ defmodule Trento.SettingsTest do
         end
       end
 
-      test "should support partial change of suse manager settings" do
+      test "should support partial change of SUSE Multi-Linux Manager settings" do
         %{
           url: initial_url,
           username: _initial_username,

--- a/test/trento/software_updates/discovery_test.exs
+++ b/test/trento/software_updates/discovery_test.exs
@@ -121,7 +121,7 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
       end
     end
 
-    test "should handle failure when SUMA settings are not configured" do
+    test "should handle failure when SUSE Multi-Linux Manager settings are not configured" do
       host_id = Faker.UUID.v4()
       fully_qualified_domain_name = Faker.Internet.domain_name()
 
@@ -342,7 +342,7 @@ defmodule Trento.SoftwareUpdates.DiscoveryTest do
                |> length()
     end
 
-    test "should handle SUMA settings not configured error" do
+    test "should handle SUSE Multi-Linux Manager settings not configured error" do
       expect(SoftwareUpdatesDiscoveryMock, :setup, fn -> {:error, :settings_not_configured} end)
 
       [%{id: host_id1}, %{id: host_id2}] = insert_list(2, :host)

--- a/test/trento_web/controllers/v1/settings_controller_test.exs
+++ b/test/trento_web/controllers/v1/settings_controller_test.exs
@@ -317,9 +317,10 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
              } == resp
     end
 
-    test "should not be able to change SUSE Multi-Linux Manager settings if none previously saved", %{
-      conn: conn
-    } do
+    test "should not be able to change SUSE Multi-Linux Manager settings if none previously saved",
+         %{
+           conn: conn
+         } do
       submission = %{
         url: "https://validurl.com",
         username: Faker.Internet.user_name(),

--- a/test/trento_web/controllers/v1/settings_controller_test.exs
+++ b/test/trento_web/controllers/v1/settings_controller_test.exs
@@ -317,7 +317,7 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
              } == resp
     end
 
-    test "should not be able to change suse manager settings if none previously saved", %{
+    test "should not be able to change SUSE Multi-Linux Manager settings if none previously saved", %{
       conn: conn
     } do
       submission = %{
@@ -335,7 +335,10 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
 
       assert %{
                "errors" => [
-                 %{"detail" => "SUSE Manager settings not configured.", "title" => "Not Found"}
+                 %{
+                   "detail" => "SUSE Multi-Linux Manager settings not configured.",
+                   "title" => "Not Found"
+                 }
                ]
              } == resp
     end
@@ -364,7 +367,7 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
              } == resp
     end
 
-    test "should validate partial changes to suse manager settings", %{conn: conn} do
+    test "should validate partial changes to SUSE Multi-Linux Manager settings", %{conn: conn} do
       insert_software_updates_settings()
 
       change_settings_scenarios = [
@@ -486,7 +489,7 @@ defmodule TrentoWeb.V1.SettingsControllerTest do
       end
     end
 
-    test "should support partial change of suse manager settings", %{conn: conn} do
+    test "should support partial change of SUSE Multi-Linux Manager settings", %{conn: conn} do
       %{
         url: initial_url,
         username: _initial_username,

--- a/test/trento_web/controllers/v1/suse_manager_controller_test.exs
+++ b/test/trento_web/controllers/v1/suse_manager_controller_test.exs
@@ -72,7 +72,10 @@ defmodule TrentoWeb.V1.SUSEManagerControllerTest do
 
       assert %{
                "errors" => [
-                 %{"detail" => "SUSE Manager settings not configured.", "title" => "Not Found"}
+                 %{
+                   "detail" => "SUSE Multi-Linux Manager settings not configured.",
+                   "title" => "Not Found"
+                 }
                ]
              } == resp
     end


### PR DESCRIPTION
### Description

This pull request standardizes the terminology across the codebase and tests by replacing all references to "SUSE Manager" and its short label with "SUSE Multi-Linux Manager". It also removes the short label constant, ensuring consistent branding and messaging throughout the UI, activity logs, and documentation.

* All user-facing strings, test descriptions, tooltips, and error messages now refer to "SUSE Multi-Linux Manager" instead of "SUSE Manager" or "SUMA". This includes updates in components, storybook stories, and test files. 
* The short label constant `SUMA_PRODUCT_LABEL_SHORT` is removed from `@lib/model/suse_manager`, and all usages are replaced with the full label `SUMA_PRODUCT_LABEL` ("SUSE Multi-Linux Manager"). 
* Activity log resource types, labels, and messages are updated to use "SUSE Multi-Linux Manager Settings" instead of "SUMA Settings". 
* Storybook stories and test descriptions are updated for clarity and consistency with the new terminology.

Fixes #https://jira.suse.com/browse/TRNT-3951

### How was this tested?

CI

### Documentation changes

No

### Additional information

There are way more instances of the old name in the backend code and API endpoints, but this is to be tackled in a separate PR.