### PR TITLE
Improve websocket ai agent

### DIFF
--- a/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
+++ b/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
@@ -2,33 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import { BrowserRouter } from 'react-router';
-import { config as rxjsConfig } from 'rxjs';
-import { makeMockSocket } from '@lib/test-utils/phoenixDoubles';
-import { buildAssistantTurn } from '@lib/test-utils/aguiEvents';
-
-import { useSocket } from '@common/SocketProvider';
-import AIAssistant from './AIAssistant';
-
-// RxJS reports unhandled subscriber errors via setTimeout(() => throw err) by
-// default — terminal AG-UI events (ie RUN_ERROR) hit
-// this path and would crash the test runner. Capture them instead so tests
-// can assert on observable outcomes.
-let unhandledRxErrors = [];
-beforeEach(() => {
-  unhandledRxErrors = [];
-  rxjsConfig.onUnhandledError = (err) => unhandledRxErrors.push(err);
-});
-afterEach(() => {
-  rxjsConfig.onUnhandledError = null;
-});
-
-jest.mock('@common/SocketProvider', () => ({
-  useSocket: jest.fn(),
-}));
+import { renderAIAssistant } from '@lib/test-utils/aiAssistant';
+import { aguiEvents } from '@lib/test-utils/aguiEvents';
 
 // Markdown rendering is its own concern — replace with a plain span so the
 // scenarios can assert text directly without dragging react-markdown into
@@ -37,136 +15,91 @@ jest.mock('@assistant-ui/react-markdown', () => ({
   MarkdownTextPrimitive: ({ text }) => <span data-aui-md>{text}</span>,
 }));
 
-async function renderAssistant({ userId = 'user-1' } = {}) {
-  const socket = makeMockSocket();
-  useSocket.mockReturnValue(socket);
-
-  const utils = render(
-    <BrowserRouter>
-      <AIAssistant userID={userId} open />
-    </BrowserRouter>
-  );
-
-  const channel = await waitFor(() => {
-    const c = socket.channels.get(`ai_assistant:${userId}`);
-    if (!c) throw new Error('channel not opened yet');
-    return c;
-  });
-
-  // Complete the channel join handshake — agent transitions to 'connected'.
-  await act(async () => {
-    channel.joinPush.fire('ok');
-  });
-
-  await screen.findByLabelText('Message input');
-  const user = userEvent.setup();
-
-  // Synchronously fire an AG-UI event on the channel. Terminal events
-  // (ie RUN_ERROR) call subscriber.error which RxJS
-  // reports as an unhandled error after a microtask tick — act() surfaces
-  // that as a throw, so we swallow it; tests assert on observable outcomes.
-  const emitAgUi = async (event) => {
-    try {
-      await act(async () => {
-        try {
-          channel.emit('ag_ui_event', event);
-        } catch {
-          // assistant-ui's subscription error handlers re-throw synchronously
-          // for terminal events (RUN_ERROR); swallow here so the test can
-          // assert on observable outcomes rather than the throw.
-        }
-      });
-    } catch {
-      // ditto, in case act() surfaces it on the outer await
-    }
-  };
-
-  // Drives a user turn through the real composer and waits for the agent to
-  // push a NEW send_message back to the channel. Re-queries DOM each time
-  // because assistant-ui swaps composer/send subtrees as thread state changes.
-  const sendUserMessage = async (text) => {
-    const sentBefore = channel.pushed.filter(
-      (p) => p.event === 'send_message'
-    ).length;
-    const composer = await screen.findByLabelText('Message input');
-    const send = await screen.findByLabelText('Send message');
-    await user.click(composer);
-    await user.keyboard(text);
-    await user.click(send);
-    await waitFor(() => {
-      const sent = channel.pushed.filter((p) => p.event === 'send_message');
-      if (sent.length <= sentBefore) {
-        throw new Error('send_message not pushed yet');
-      }
-    });
-    const sent = channel.pushed.filter((p) => p.event === 'send_message');
-    return sent[sent.length - 1].payload;
-  };
-
-  // Streams a complete assistant turn (RUN_STARTED → text → RUN_FINISHED)
-  // through the channel one event at a time so each is wrapped in act().
-  const streamAssistantTurn = async (params) => {
-    for (const event of buildAssistantTurn(params)) {
-      await emitAgUi(event);
-    }
-    return params.messageId;
-  };
-
-  return {
-    ...utils,
-    channel,
-    socket,
-    emitAgUi,
-    sendUserMessage,
-    streamAssistantTurn,
-  };
-}
-
 const assistantBubble = () => {
   const nodes = document.querySelectorAll('[data-role="assistant"]');
   return nodes[nodes.length - 1] || null;
 };
 
 describe('AG-UI event flow', () => {
+  it('clears the empty-thread greeting once the runtime reports a message', async () => {
+    const { sendUserMessage } = await renderAIAssistant({ open: true });
+
+    expect(screen.getByText("Hi, I'm Liz.")).toBeVisible();
+
+    await sendUserMessage('hello');
+
+    await waitFor(() => {
+      expect(screen.queryByText("Hi, I'm Liz.")).not.toBeInTheDocument();
+    });
+  });
+
   it('streams an assistant response delta-by-delta into a message bubble', async () => {
-    const { emitAgUi, sendUserMessage } = await renderAssistant();
+    const { emitAgUi, sendUserMessage } = await renderAIAssistant({
+      open: true,
+    });
     const { thread_id: threadId, run_id: runId } =
       await sendUserMessage('hello');
 
     const messageId = 'asst-1';
-    await emitAgUi({ type: 'RUN_STARTED', threadId, runId });
-    await emitAgUi({
-      type: 'TEXT_MESSAGE_START',
-      messageId,
-      role: 'assistant',
-    });
-    await emitAgUi({ type: 'TEXT_MESSAGE_CONTENT', messageId, delta: 'Hi ' });
+    await emitAgUi(aguiEvents.runStarted({ threadId, runId }));
+    await emitAgUi(aguiEvents.textStart({ messageId }));
+    await emitAgUi(aguiEvents.textContent({ messageId, delta: 'Hi ' }));
 
     await waitFor(() => {
       expect(assistantBubble()).toHaveTextContent(/Hi/);
     });
 
-    await emitAgUi({
-      type: 'TEXT_MESSAGE_CONTENT',
-      messageId,
-      delta: 'there',
-    });
-    await emitAgUi({ type: 'TEXT_MESSAGE_END', messageId });
-    await emitAgUi({ type: 'RUN_FINISHED', threadId, runId });
+    await emitAgUi(aguiEvents.textContent({ messageId, delta: 'there' }));
+    await emitAgUi(aguiEvents.textEnd({ messageId }));
+    await emitAgUi(aguiEvents.runFinished({ threadId, runId }));
 
     await waitFor(() => {
       expect(assistantBubble()).toHaveTextContent('Hi there');
     });
   });
 
-  it('disables the composer input and "New chat" when the channel drops', async () => {
-    const { channel } = await renderAssistant();
+  it('shows the progress indicator while a run is in flight', async () => {
+    const { emitAgUi, sendUserMessage } = await renderAIAssistant({
+      open: true,
+    });
+    const { thread_id: threadId, run_id: runId } =
+      await sendUserMessage('hello');
 
-    expect(screen.getByLabelText('Message input')).not.toBeDisabled();
-    expect(screen.getByRole('button', { name: 'New chat' })).not.toBeDisabled();
+    await emitAgUi(aguiEvents.runStarted({ threadId, runId }));
+
+    expect(await screen.findByText('Thinking...')).toBeVisible();
+
+    const messageId = 'assistant-progress';
+    await emitAgUi(aguiEvents.textStart({ messageId }));
+    await emitAgUi(aguiEvents.textContent({ messageId, delta: 'Working' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Thinking...')).not.toBeInTheDocument();
+    });
+  });
+
+  it('settles the thread silently when unmounted mid-run', async () => {
+    const { channel, emitAgUi, sendUserMessage, unmount } =
+      await renderAIAssistant({ open: true });
+    const leave = jest.spyOn(channel, 'leave');
+    const { thread_id: threadId, run_id: runId } =
+      await sendUserMessage('hello');
+
+    await emitAgUi(aguiEvents.runStarted({ threadId, runId }));
+
+    unmount();
+
+    expect(leave).toHaveBeenCalled();
+  });
+
+  it('disables the composer input and "New chat" when the channel drops', async () => {
+    const { channel } = await renderAIAssistant({ open: true });
+
+    expect(screen.getByLabelText('Message input')).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'New chat' })).toBeEnabled();
 
     await act(async () => {
-      channel.errorHandlers.forEach((cb) => cb());
+      channel.triggerError();
     });
 
     await waitFor(() => {
@@ -175,34 +108,27 @@ describe('AG-UI event flow', () => {
     expect(screen.getByRole('button', { name: 'New chat' })).toBeDisabled();
   });
 
-  it('goes read-only with a banner when the AI configuration is cleared', async () => {
-    const { channel } = await renderAssistant();
+  it('goes read-only when the AI configuration is cleared', async () => {
+    const { channel } = await renderAIAssistant({ open: true });
 
-    expect(screen.getByLabelText('Message input')).not.toBeDisabled();
-    expect(screen.getByText('Online')).toBeInTheDocument();
+    expect(screen.getByLabelText('Message input')).toBeEnabled();
 
     await act(async () => {
       channel.emit('ai_configuration_cleared');
     });
 
+    // The placeholder, not just the disabled flag, is what distinguishes a
+    // cleared configuration from a dropped channel
     await waitFor(() => {
-      expect(screen.getByLabelText('Message input')).toBeDisabled();
+      expect(
+        screen.getByPlaceholderText('AI Assistant is disabled')
+      ).toBeDisabled();
     });
-
-    // Liz goes offline in the header alongside the read-only banner, and a new
-    // chat is off too: the channel is still live, but there is no configuration
-    // left to back it.
-    expect(screen.getByText('Offline')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'New chat' })).toBeDisabled();
-    expect(screen.getByText(/settings were cleared/i)).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Profile' })).toHaveAttribute(
-      'href',
-      '/profile'
-    );
   });
 
   it('renders the model_changed notice as a dismissable banner', async () => {
-    const { channel } = await renderAssistant();
+    const user = userEvent.setup();
+    const { channel } = await renderAIAssistant({ open: true });
 
     await act(async () => {
       channel.emit('model_changed', {
@@ -211,24 +137,19 @@ describe('AG-UI event flow', () => {
       });
     });
 
-    const banner = await waitFor(() => {
-      const el = document.querySelector('[data-testid="model-change-banner"]');
-      if (!el) throw new Error('banner not rendered yet');
-      return el;
-    });
-    expect(banner).toHaveTextContent(/Google Gemini/i);
+    expect(await screen.findByText(/AI model changed to/i)).toBeVisible();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    await user.click(screen.getByRole('button', { name: 'Dismiss' }));
 
     await waitFor(() => {
       expect(
-        document.querySelector('[data-testid="model-change-banner"]')
+        screen.queryByText(/AI model changed to/i)
       ).not.toBeInTheDocument();
     });
   });
 
   it('prompts to start a new chat when a new config arrives after a clear', async () => {
-    const { channel } = await renderAssistant();
+    const { channel, user } = await renderAIAssistant({ open: true });
 
     await act(async () => {
       channel.emit('ai_configuration_cleared');
@@ -247,48 +168,51 @@ describe('AG-UI event flow', () => {
       ).toBeInTheDocument();
     });
     // Still read-only until the user explicitly restarts
-    expect(screen.getByLabelText('Message input')).toBeDisabled();
     expect(
       screen.getByPlaceholderText('Start a new chat to continue')
-    ).toBeVisible();
+    ).toBeDisabled();
 
     const newChat = screen.getByRole('button', { name: 'New chat' });
-    expect(newChat).not.toBeDisabled();
+    expect(newChat).toBeEnabled();
 
-    const user = userEvent.setup();
     await user.click(newChat);
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Message input')).not.toBeDisabled();
+      expect(screen.getByLabelText('Message input')).toBeEnabled();
     });
     expect(
       screen.queryByText(/new AI configuration is available/i)
     ).not.toBeInTheDocument();
   });
 
-  it('handles a follow-up turn after the previous one finishes', async () => {
-    const { sendUserMessage, streamAssistantTurn } = await renderAssistant();
+  it('"New chat" starts a new conversation with a new thread ID', async () => {
+    const { user, sendUserMessage, streamAssistantTurn } =
+      await renderAIAssistant({ open: true });
 
-    {
-      const { thread_id: threadId, run_id: runId } =
-        await sendUserMessage('first');
-      await streamAssistantTurn({
-        threadId,
-        runId,
-        messageId: 'a',
-        deltas: ['one'],
-      });
-    }
-    {
-      const { thread_id: threadId, run_id: runId } =
-        await sendUserMessage('second');
-      await streamAssistantTurn({
-        threadId,
-        runId,
-        messageId: 'b',
-        deltas: ['two'],
-      });
-    }
+    const first = await sendUserMessage('first');
+    await streamAssistantTurn(first, { messageId: 'a', deltas: ['one'] });
+
+    await user.click(screen.getByRole('button', { name: 'New chat' }));
+
+    const second = await sendUserMessage('second');
+
+    expect(second.thread_id).not.toBe(first.thread_id);
+  });
+
+  it('handles a follow-up turn after the previous one finishes', async () => {
+    const { sendUserMessage, streamAssistantTurn } = await renderAIAssistant({
+      open: true,
+    });
+
+    const first = await sendUserMessage('first');
+    await streamAssistantTurn(first, { messageId: 'a', deltas: ['one'] });
+
+    const second = await sendUserMessage('second');
+    await streamAssistantTurn(second, { messageId: 'b', deltas: ['two'] });
+
+    // Same conversation, distinct runs
+    expect(second.thread_id).toBe(first.thread_id);
+    expect(second.run_id).not.toBe(first.run_id);
 
     await waitFor(() => {
       expect(screen.getByText('first')).toBeInTheDocument();

--- a/assets/js/common/AIAssistant/AssistantChatProvider.jsx
+++ b/assets/js/common/AIAssistant/AssistantChatProvider.jsx
@@ -23,22 +23,18 @@ function AssistantChatProvider({
 
   const agent = useMemo(() => {
     if (!socket || !userID) return null;
-    return new WebSocketAIAgent({
-      socket,
-      userID,
+    return new WebSocketAIAgent({ socket, userID });
+  }, [socket, userID]);
+
+  useEffect(() => {
+    if (!agent) return;
+    agent.withCallbacks({
       onConnectionChange,
       onAIConfigurationCleared,
       onAIConfigurationCreated,
       onModelChanged,
     });
-  }, [
-    socket,
-    userID,
-    onConnectionChange,
-    onAIConfigurationCleared,
-    onAIConfigurationCreated,
-    onModelChanged,
-  ]);
+  });
 
   useEffect(() => {
     if (!agent) return undefined;

--- a/assets/js/common/AIAssistant/AssistantChatProvider.test.jsx
+++ b/assets/js/common/AIAssistant/AssistantChatProvider.test.jsx
@@ -4,15 +4,13 @@
 import React from 'react';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { CONNECTING, CONNECTED } from '@lib/ai/connectionStatus';
 
 import { useAgUiRuntime } from '@assistant-ui/react-ag-ui';
-import * as agentModule from '@lib/ai';
-import { useSocket } from '@common/SocketProvider';
+import { WebSocketAIAgent } from '@lib/ai';
+import { makeMockSocket } from '@lib/test-utils/phoenixDoubles';
+import { SocketContext } from '@common/SocketProvider';
 import AssistantChatProvider from './AssistantChatProvider';
-
-jest.mock('@common/SocketProvider', () => ({
-  useSocket: jest.fn(),
-}));
 
 jest.mock('@assistant-ui/react-ag-ui', () => ({
   useAgUiRuntime: jest.fn(),
@@ -23,165 +21,182 @@ jest.mock('@assistant-ui/react', () => ({
   useAui: () => ({}),
 }));
 
-jest.mock('@lib/ai', () => {
-  const instances = [];
-  class WebSocketAIAgent {
-    constructor(opts) {
-      this.opts = opts;
-      this.initialize = jest.fn(() => Promise.resolve());
-      this.disconnect = jest.fn();
-      instances.push(this);
-    }
-  }
-  return {
-    WebSocketAIAgent,
-    __getInstances: () => instances,
-    __resetInstances: () => {
-      instances.length = 0;
-    },
-  };
-});
+const modelPayload = { provider: 'googleai', model: 'gemini-2.5-pro' };
 
-const lastRuntimeOptions = () =>
-  useAgUiRuntime.mock.calls[useAgUiRuntime.mock.calls.length - 1][0];
+function renderProvider({ socket = makeMockSocket(), ...props } = {}) {
+  const runtime = { thread: { reset: jest.fn() } };
+  useAgUiRuntime.mockImplementation(() => runtime);
 
-let fakeSocket;
-let runtimeStub;
+  const initialProps = { userID: 42, threadID: 'thread-1', ...props };
 
-beforeEach(() => {
-  agentModule.__resetInstances();
-  jest.clearAllMocks();
-
-  runtimeStub = { thread: { reset: jest.fn() } };
-  useAgUiRuntime.mockImplementation(() => runtimeStub);
-
-  fakeSocket = {
-    channel: jest.fn(),
-    connect: jest.fn(),
-    disconnect: jest.fn(),
-  };
-  useSocket.mockReturnValue(fakeSocket);
-});
-
-const renderProvider = (
-  props = {},
-  children = <div data-testid="child">hi</div>
-) =>
-  render(
-    <AssistantChatProvider userID={42} threadID="thread-1" {...props}>
-      {children}
-    </AssistantChatProvider>
+  const tree = (nextProps) => (
+    <SocketContext.Provider value={socket}>
+      <AssistantChatProvider {...nextProps}>
+        <div>hi</div>
+      </AssistantChatProvider>
+    </SocketContext.Provider>
   );
+
+  const view = render(tree(initialProps));
+
+  // runtimeOptions, agent, channel are lazy on purpose:
+  // Snapshotting any of them to a value would invalidate the post-rerender identity assertions.
+  const runtimeOptions = () => useAgUiRuntime.mock.calls.at(-1)[0];
+
+  return {
+    ...view,
+    socket,
+    runtime,
+    runtimeOptions,
+    agent: () => runtimeOptions().agent,
+    channel: (userID = initialProps.userID) =>
+      socket.channels.get(`ai_assistant:${userID}`),
+    rerender: (nextProps) =>
+      view.rerender(tree({ ...initialProps, ...nextProps })),
+  };
+}
 
 describe('AssistantChatProvider', () => {
   it('renders children inside the runtime provider', () => {
     renderProvider();
-    expect(screen.getByTestId('child')).toBeVisible();
+    expect(screen.getByText('hi')).toBeVisible();
   });
 
   it('does not create the agent when no socket is available', () => {
-    useSocket.mockReturnValue(null);
-    renderProvider();
-    expect(lastRuntimeOptions().agent).toBeNull();
-    expect(agentModule.__getInstances()).toHaveLength(0);
+    const { agent } = renderProvider({ socket: null });
+    expect(agent()).toBeNull();
   });
 
   it('does not create the agent when no userID is provided', () => {
-    renderProvider({ userID: undefined });
-    expect(lastRuntimeOptions().agent).toBeNull();
-    expect(agentModule.__getInstances()).toHaveLength(0);
+    const { socket, agent } = renderProvider({ userID: undefined });
+    expect(agent()).toBeNull();
+    expect(socket.channels.size).toBe(0);
   });
 
-  it('creates the agent and forwards it to useAgUiRuntime when userID and socket are present', async () => {
-    renderProvider({ userID: 7, threadID: 'thread-x' });
+  it('creates the agent, initializes it, and forwards it to useAgUiRuntime', async () => {
+    const { socket, agent } = renderProvider({
+      userID: 7,
+      threadID: 'thread-x',
+    });
 
     await waitFor(() => {
-      expect(agentModule.__getInstances()).toHaveLength(1);
+      expect(socket.channels.has('ai_assistant:7')).toBe(true);
     });
-    const [agent] = agentModule.__getInstances();
-    expect(agent.opts.userID).toBe(7);
-    // threadID is NOT passed at construction — it's a per-message field
-    // forwarded inside run({messages, threadId}) at call time.
-    expect(agent.opts.threadId).toBeUndefined();
-    expect(agent.opts.socket).toBe(fakeSocket);
-    expect(lastRuntimeOptions().agent).toBe(agent);
-  });
-
-  it('does not pass a threadList adapter to the runtime', () => {
-    renderProvider();
-    expect(lastRuntimeOptions().adapters).toBeUndefined();
-  });
-
-  it('initializes the agent after construction', async () => {
-    renderProvider();
-    await waitFor(() => {
-      expect(agentModule.__getInstances()[0].initialize).toHaveBeenCalled();
-    });
+    expect(agent()).toBeInstanceOf(WebSocketAIAgent);
+    expect(agent().socket).toBe(socket);
   });
 
   it('disconnects the agent when the provider unmounts', async () => {
-    const { unmount } = renderProvider();
-    await waitFor(() => expect(agentModule.__getInstances()).toHaveLength(1));
-    const [agent] = agentModule.__getInstances();
+    const { unmount, channel, agent } = renderProvider();
+    await waitFor(() => expect(channel()).toBeDefined());
+    const disconnect = jest.spyOn(agent(), 'disconnect');
 
     unmount();
-    expect(agent.disconnect).toHaveBeenCalled();
+
+    expect(disconnect).toHaveBeenCalled();
   });
 
   it('forwards onConnectionChange to the agent so the parent can observe transitions', async () => {
     const onConnectionChange = jest.fn();
-    renderProvider({ onConnectionChange });
-    await waitFor(() => expect(agentModule.__getInstances()).toHaveLength(1));
-    const [agent] = agentModule.__getInstances();
+    const { channel } = renderProvider({ onConnectionChange });
+    await waitFor(() => expect(channel()).toBeDefined());
 
-    expect(agent.opts.onConnectionChange).toBe(onConnectionChange);
+    await act(async () => {
+      channel().joinPush.fire('ok');
+    });
 
-    act(() => agent.opts.onConnectionChange('connected'));
-    expect(onConnectionChange).toHaveBeenCalledWith('connected');
+    expect(onConnectionChange).toHaveBeenCalledWith(CONNECTED);
+  });
+
+  it('attaches the callbacks before initializing, so the first transition is not lost', async () => {
+    const onConnectionChange = jest.fn();
+    const { channel } = renderProvider({ onConnectionChange });
+
+    await waitFor(() => expect(channel()).toBeDefined());
+
+    expect(onConnectionChange).toHaveBeenCalledWith(CONNECTING);
+  });
+
+  it('forwards the AI configuration lifecycle callbacks to the agent', async () => {
+    const onAIConfigurationCleared = jest.fn();
+    const onAIConfigurationCreated = jest.fn();
+    const onModelChanged = jest.fn();
+
+    const { channel } = renderProvider({
+      onAIConfigurationCleared,
+      onAIConfigurationCreated,
+      onModelChanged,
+    });
+    await waitFor(() => expect(channel()).toBeDefined());
+
+    await act(async () => {
+      channel().emit('ai_configuration_cleared');
+      channel().emit('ai_configuration_created');
+      channel().emit('model_changed', modelPayload);
+    });
+
+    expect(onAIConfigurationCleared).toHaveBeenCalled();
+    expect(onAIConfigurationCreated).toHaveBeenCalled();
+    expect(onModelChanged).toHaveBeenCalledWith(modelPayload);
+  });
+
+  it('keeps the same agent when the callback identities change', async () => {
+    const firstOnModelChanged = jest.fn();
+    const secondOnModelChanged = jest.fn();
+
+    const { rerender, channel, agent } = renderProvider({
+      onModelChanged: firstOnModelChanged,
+    });
+    await waitFor(() => expect(channel()).toBeDefined());
+    const initialAgent = agent();
+    const disconnect = jest.spyOn(initialAgent, 'disconnect');
+
+    rerender({ onModelChanged: secondOnModelChanged });
+
+    expect(agent()).toBe(initialAgent);
+    expect(disconnect).not.toHaveBeenCalled();
+
+    // Same agent, but it now routes to the latest closure rather than a stale
+    // one.
+    await act(async () => {
+      channel().emit('model_changed', modelPayload);
+    });
+    expect(secondOnModelChanged).toHaveBeenCalledWith(modelPayload);
+    expect(firstOnModelChanged).not.toHaveBeenCalled();
+  });
+
+  it('rebuilds the agent when the socket or userID changes', async () => {
+    const { rerender, socket, channel, agent } = renderProvider();
+    await waitFor(() => expect(channel()).toBeDefined());
+    const firstAgent = agent();
+    const disconnect = jest.spyOn(firstAgent, 'disconnect');
+
+    rerender({ userID: 43 });
+
+    await waitFor(() => expect(agent()).not.toBe(firstAgent));
+    expect(disconnect).toHaveBeenCalled();
+    expect(socket.channels.has('ai_assistant:43')).toBe(true);
   });
 
   it('updates agent.threadId when threadID changes without rebuilding the agent', async () => {
-    const { rerender } = render(
-      <AssistantChatProvider userID={42} threadID="thread-1">
-        <div />
-      </AssistantChatProvider>
-    );
-    await waitFor(() => expect(agentModule.__getInstances()).toHaveLength(1));
-    const [agent] = agentModule.__getInstances();
-    await waitFor(() => expect(agent.threadId).toBe('thread-1'));
+    const { rerender, agent } = renderProvider();
+    await waitFor(() => expect(agent()?.threadId).toBe('thread-1'));
+    const initialAgent = agent();
 
-    rerender(
-      <AssistantChatProvider userID={42} threadID="thread-2">
-        <div />
-      </AssistantChatProvider>
-    );
+    rerender({ threadID: 'thread-2' });
 
-    await waitFor(() => expect(agent.threadId).toBe('thread-2'));
-    expect(agentModule.__getInstances()).toHaveLength(1);
-    expect(agent.disconnect).not.toHaveBeenCalled();
-  });
-
-  it('does not reset the runtime on the first mount', () => {
-    renderProvider();
-    expect(runtimeStub.thread.reset).not.toHaveBeenCalled();
+    await waitFor(() => expect(agent().threadId).toBe('thread-2'));
+    expect(agent()).toBe(initialAgent);
   });
 
   it('resets the runtime when threadID changes so prior messages are wiped', async () => {
-    const { rerender } = render(
-      <AssistantChatProvider userID={42} threadID="thread-1">
-        <div />
-      </AssistantChatProvider>
-    );
-    expect(runtimeStub.thread.reset).not.toHaveBeenCalled();
+    const { rerender, runtime } = renderProvider();
+    expect(runtime.thread.reset).not.toHaveBeenCalled();
 
-    rerender(
-      <AssistantChatProvider userID={42} threadID="thread-2">
-        <div />
-      </AssistantChatProvider>
-    );
+    rerender({ threadID: 'thread-2' });
 
     await waitFor(() => {
-      expect(runtimeStub.thread.reset).toHaveBeenCalledTimes(1);
+      expect(runtime.thread.reset).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/assets/js/lib/ai/WebSocketAIAgent.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.js
@@ -25,50 +25,20 @@ export const extractMessageText = ({ content } = {}) => {
   return '';
 };
 
-class AbortError extends Error {
-  constructor(message) {
-    super(message);
-    this.name = 'AbortError';
-  }
-}
-
 const isUnauthorized = (error) => error === 'unauthorized';
-
-// Refresh the access token; on failure, kick off the global "session expired"
-// redirect and re-throw
-const refreshOrAbort = async () => {
-  try {
-    await refreshAndStoreAccessToken();
-  } catch {
-    handleUnrecoverableAuthError();
-    throw new Error('Session expired — please log in again');
-  }
-};
-
-// Run `operation` and, if it rejects with an "unauthorized" wire payload,
-// refresh the access token once and retry. Any other rejection from
-// `operation` propagates verbatim.
-const withRefreshTokenOnUnauthorized = async (operation) => {
-  try {
-    return await operation();
-  } catch (error) {
-    if (!isUnauthorized(error)) throw error;
-  }
-  await refreshOrAbort();
-  return operation();
-};
 
 // Bridges assistant-ui's AG-UI runtime with Phoenix channels: translates
 // AG-UI protocol events to/from channel events for the ai_assistant:{userID}
 // topic.
 export class WebSocketAIAgent extends AbstractAgent {
+  #callbacks = {};
+
   constructor({
     socket,
     userID,
-    onConnectionChange = noop,
-    onAIConfigurationCleared = noop,
-    onAIConfigurationCreated = noop,
-    onModelChanged = noop,
+    getAccessToken = getAccessTokenFromStore,
+    refreshToken = refreshAndStoreAccessToken,
+    onUnrecoverableAuthError = handleUnrecoverableAuthError,
     ...options
   }) {
     super(options);
@@ -76,13 +46,28 @@ export class WebSocketAIAgent extends AbstractAgent {
     this.socket = socket;
     this.userID = userID;
     this.channel = null;
-    this.onConnectionChange = onConnectionChange;
-    this.onAIConfigurationCleared = onAIConfigurationCleared;
-    this.onAIConfigurationCreated = onAIConfigurationCreated;
-    this.onModelChanged = onModelChanged;
     this._connectionStatus = CONNECTION_STATUS.DISCONNECTED;
     this._activeSubscriber = null;
     this._activeRunId = null;
+    this._getAccessToken = getAccessToken;
+    this._refreshToken = refreshToken;
+    this._onUnrecoverableAuthError = onUnrecoverableAuthError;
+    this.withCallbacks();
+  }
+
+  withCallbacks({
+    onConnectionChange = noop,
+    onAIConfigurationCleared = noop,
+    onAIConfigurationCreated = noop,
+    onModelChanged = noop,
+  } = {}) {
+    this.#callbacks = {
+      onConnectionChange,
+      onAIConfigurationCleared,
+      onAIConfigurationCreated,
+      onModelChanged,
+    };
+    return this;
   }
 
   // Idempotent async initializer for the channel connection
@@ -93,7 +78,7 @@ export class WebSocketAIAgent extends AbstractAgent {
 
     this._setConnectionStatus(CONNECTION_STATUS.CONNECTING);
     try {
-      await this._join();
+      await this._withRefreshTokenOnUnauthorized(() => this._join());
     } catch (error) {
       this._teardown();
       this._setConnectionStatus(CONNECTION_STATUS.DISCONNECTED);
@@ -101,18 +86,36 @@ export class WebSocketAIAgent extends AbstractAgent {
     }
   }
 
-  // Join the channel, refreshing the access token + retrying once if the
-  // server replies 'unauthorized'.
-  _join() {
-    return withRefreshTokenOnUnauthorized(() => this._doJoin());
+  // Run `operation` and, if it rejects with an "unauthorized" wire payload,
+  // refresh the access token once and retry. Any other rejection from
+  // `operation` propagates verbatim.
+  async _withRefreshTokenOnUnauthorized(operation) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (!isUnauthorized(error)) throw error;
+    }
+    await this._refreshOrAbort();
+    return operation();
+  }
+
+  // Refresh the access token; on failure, kick off the global "session expired"
+  // redirect and re-throw
+  async _refreshOrAbort() {
+    try {
+      await this._refreshToken();
+    } catch {
+      this._onUnrecoverableAuthError();
+      throw new Error('Session expired — please log in again');
+    }
   }
 
   // Build a fresh channel and await its join.
   // On 'unauthorized' the channel reference is dropped so the helper's retry rebuilds
   // with the just-refreshed token in the params callback.
-  _doJoin() {
+  _join() {
     this.channel = this.socket.channel(`ai_assistant:${this.userID}`, () => ({
-      access_token: getAccessTokenFromStore(),
+      access_token: this._getAccessToken(),
     }));
     this._setupChannelHandlers();
     return new Promise((resolve, reject) => {
@@ -142,14 +145,17 @@ export class WebSocketAIAgent extends AbstractAgent {
     // sequence Just Work.
     const dropConnection = () => {
       this._setConnectionStatus(CONNECTION_STATUS.DISCONNECTED);
-      this._failActiveRun(new Error('AI assistant connection lost'));
+      this._settleActiveRun(new Error('AI assistant connection lost'));
     };
 
     const messageHandlerMap = [
       ['ag_ui_event', (event) => this._handleAgUiEvent(event)],
       ['ai_configuration_cleared', () => this._handleAIConfigurationCleared()],
-      ['ai_configuration_created', () => this.onAIConfigurationCreated()],
-      ['model_changed', (payload) => this.onModelChanged(payload)],
+      [
+        'ai_configuration_created',
+        () => this.#callbacks.onAIConfigurationCreated(),
+      ],
+      ['model_changed', (payload) => this.#callbacks.onModelChanged(payload)],
     ];
 
     each(messageHandlerMap, ([eventName, handler]) =>
@@ -163,13 +169,18 @@ export class WebSocketAIAgent extends AbstractAgent {
   // Settle any in-flight run without surfacing an error
   // and let the UI switch to its read-only / disabled state via the callback.
   _handleAIConfigurationCleared() {
-    this._failActiveRun(new AbortError('AI configuration cleared'));
-    this.onAIConfigurationCleared();
+    this._settleActiveRun();
+    this.#callbacks.onAIConfigurationCleared();
+  }
+
+  _isStaleRunFinished({ type, runId }) {
+    return type === EventType.RUN_FINISHED && runId !== this._activeRunId;
   }
 
   _handleAgUiEvent(event) {
     const subscriber = this._activeSubscriber;
     if (!subscriber) return;
+    if (this._isStaleRunFinished(event)) return;
 
     subscriber.next(event);
 
@@ -207,11 +218,13 @@ export class WebSocketAIAgent extends AbstractAgent {
       const setupRun = async () => {
         try {
           await this.initialize();
-          await this._sendMessage({
-            message: extractMessageText(lastMessage),
-            thread_id: threadId,
-            run_id: runId,
-          });
+          await this._withRefreshTokenOnUnauthorized(() =>
+            this._sendMessage({
+              message: extractMessageText(lastMessage),
+              thread_id: threadId,
+              run_id: runId,
+            })
+          );
         } catch (error) {
           if (this._activeRunId === runId) this._clearActiveRun();
           subscriber.error(error);
@@ -228,31 +241,25 @@ export class WebSocketAIAgent extends AbstractAgent {
     });
   }
 
-  // Send the message, refreshing the access token + retrying once if the
-  // server replies 'unauthorized'.
-  _sendMessage(payload) {
-    return withRefreshTokenOnUnauthorized(() => this._doSendMessage(payload));
-  }
-
   // Raw send: one push, resolves on 'ok', rejects on 'error'. Reads the
   // access token fresh from storage so a retry after refresh naturally picks
   // up the new value.
-  _doSendMessage(payload) {
+  _sendMessage(payload) {
     return new Promise((resolve, reject) => {
       this.channel
         .push('send_message', {
           ...payload,
-          access_token: getAccessTokenFromStore(),
+          access_token: this._getAccessToken(),
         })
         .receive('ok', resolve)
         .receive('error', reject);
     });
   }
 
-  _failActiveRun(error) {
+  _settleActiveRun(maybeError) {
     const subscriber = this._activeSubscriber;
     if (!subscriber) return;
-    subscriber.error(error);
+    maybeError ? subscriber.error(maybeError) : subscriber.complete();
     this._clearActiveRun();
   }
 
@@ -264,17 +271,13 @@ export class WebSocketAIAgent extends AbstractAgent {
   _setConnectionStatus(status) {
     if (this._connectionStatus === status) return;
     this._connectionStatus = status;
-    this.onConnectionChange(status);
+    this.#callbacks.onConnectionChange(status);
   }
 
   disconnect() {
     if (!this.channel) return;
     this._teardown();
-    // Tag the teardown error as an AbortError so AbstractAgent's `onError`
-    // treats it as an expected unmount/cancel.
-    //
-    // (See AbstractAgent.onError's allowlist in @ag-ui/client.)
-    this._failActiveRun(new AbortError('AI assistant disconnected'));
+    this._settleActiveRun();
     this._setConnectionStatus(CONNECTION_STATUS.DISCONNECTED);
   }
 

--- a/assets/js/lib/ai/WebSocketAIAgent.test.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.test.js
@@ -2,30 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { makeMockSocket } from '@lib/test-utils/phoenixDoubles';
-import { getAccessTokenFromStore, refreshAndStoreAccessToken } from '@lib/auth';
-import { handleUnrecoverableAuthError } from '@lib/network';
+import { aguiEvents } from '@lib/test-utils/aguiEvents';
+
 import { extractMessageText, WebSocketAIAgent } from './WebSocketAIAgent';
-
-jest.mock('@lib/auth', () => ({
-  getAccessTokenFromStore: jest.fn(() => 'TEST_TOKEN'),
-  refreshAndStoreAccessToken: jest.fn(() => Promise.resolve()),
-}));
-
-jest.mock('@lib/network', () => ({
-  handleUnrecoverableAuthError: jest.fn(),
-}));
-
-beforeEach(() => {
-  getAccessTokenFromStore.mockReset();
-  getAccessTokenFromStore.mockReturnValue('TEST_TOKEN');
-  refreshAndStoreAccessToken.mockReset();
-  // Mirror real behavior: refreshAndStoreAccessToken stores the new token
-  // in localStorage, so subsequent getAccessTokenFromStore() reads it back.
-  refreshAndStoreAccessToken.mockImplementation(async () => {
-    getAccessTokenFromStore.mockReturnValue('NEW_TOKEN');
-  });
-  handleUnrecoverableAuthError.mockClear();
-});
+import { CONNECTING, CONNECTED, DISCONNECTED } from './connectionStatus';
 
 // Wrap socket.channel + each channel.leave with jest.fn so the existing
 // `toHaveBeenCalled` / `mockClear` assertions still apply. The shared
@@ -49,21 +29,35 @@ const flushMicrotasks = async () => {
 
 const userMessage = (content = 'hi') => ({ role: 'user', content });
 
+function makeAuthDoubles() {
+  let storedToken = 'TEST_TOKEN';
+  return {
+    getAccessToken: jest.fn(() => storedToken),
+    refreshToken: jest.fn(async () => {
+      storedToken = 'NEW_TOKEN';
+    }),
+    onUnrecoverableAuthError: jest.fn(),
+  };
+}
+
 // Standard test setup: a fresh agent + socket + channel + onConnectionChange spy.
 // `overrides` is spread after the defaults so callers can pass `userId: undefined`
-// or `socket: undefined` to exercise the missing-prerequisite branches.
+// or `socket: undefined` to exercise the missing-prerequisite branches. The auth
+// doubles come last and are returned as handles: a test that needs a failing
+// refresh does `refreshToken.mockRejectedValueOnce(...)` on the returned spy.
 function makeAgent(overrides = {}) {
   const socket = makeJestSocket();
-  const onConnectionChange = jest.fn();
+  const auth = makeAuthDoubles();
   const agent = new WebSocketAIAgent({
     socket,
     userID: 'u',
-    onConnectionChange,
     ...overrides,
-  });
+    ...auth,
+  }).withCallbacks({ ...overrides });
+
   const getChannel = () =>
     agent.socket?.channels.get(`ai_assistant:${agent.userID}`);
-  return { agent, socket: agent.socket, onConnectionChange, getChannel };
+  return { agent, socket: agent.socket, getChannel, ...auth };
 }
 
 // Setup that resolves agent.initialize() by firing 'ok' on the join push.
@@ -87,8 +81,10 @@ function runAgent(agent, input = { threadId: 't', messages: [userMessage()] }) {
 describe('WebSocketAIAgent', () => {
   describe('initialize', () => {
     it('joins ai_assistant:{userID} and reports connecting → connected', async () => {
-      const { agent, socket, onConnectionChange, getChannel } = makeAgent({
+      const onConnectionChange = jest.fn();
+      const { agent, socket, getChannel } = makeAgent({
         userID: 'u42',
+        onConnectionChange,
       });
 
       const initPromise = agent.initialize();
@@ -99,30 +95,32 @@ describe('WebSocketAIAgent', () => {
       );
       const [, paramsFn] = socket.channel.mock.calls[0];
       expect(paramsFn()).toEqual({ access_token: 'TEST_TOKEN' });
-      expect(onConnectionChange).toHaveBeenNthCalledWith(1, 'connecting');
+      expect(onConnectionChange).toHaveBeenNthCalledWith(1, CONNECTING);
 
       getChannel().joinPush.fire('ok');
       await initPromise;
 
-      expect(onConnectionChange).toHaveBeenNthCalledWith(2, 'connected');
+      expect(onConnectionChange).toHaveBeenNthCalledWith(2, CONNECTED);
     });
 
     it('rejects on join error and reports disconnected', async () => {
-      const { agent, onConnectionChange, getChannel } = makeAgent();
+      const onConnectionChange = jest.fn();
+      const { agent, getChannel } = makeAgent({ onConnectionChange });
       const initPromise = agent.initialize();
       getChannel().joinPush.fire('error', { reason: 'boom' });
 
       await expect(initPromise).rejects.toEqual({ reason: 'boom' });
-      expect(onConnectionChange).toHaveBeenLastCalledWith('disconnected');
+      expect(onConnectionChange).toHaveBeenLastCalledWith(DISCONNECTED);
     });
 
     it('rejects on join timeout and reports disconnected', async () => {
-      const { agent, onConnectionChange, getChannel } = makeAgent();
+      const onConnectionChange = jest.fn();
+      const { agent, getChannel } = makeAgent({ onConnectionChange });
       const initPromise = agent.initialize();
       getChannel().joinPush.fire('timeout');
 
       await expect(initPromise).rejects.toThrow(/Channel join timeout/);
-      expect(onConnectionChange).toHaveBeenLastCalledWith('disconnected');
+      expect(onConnectionChange).toHaveBeenLastCalledWith(DISCONNECTED);
     });
 
     it.each([
@@ -139,7 +137,8 @@ describe('WebSocketAIAgent', () => {
     ])(
       'throws when no $missing is provided and never reports a status change',
       async ({ overrides, error }) => {
-        const { agent, onConnectionChange } = makeAgent(overrides);
+        const onConnectionChange = jest.fn();
+        const { agent } = makeAgent({ ...overrides, onConnectionChange });
         await expect(agent.initialize()).rejects.toThrow(error);
         expect(onConnectionChange).not.toHaveBeenCalled();
       }
@@ -155,7 +154,11 @@ describe('WebSocketAIAgent', () => {
     });
 
     it('refreshes and rejoins on join error with reason "unauthorized"', async () => {
-      const { agent, socket, getChannel } = makeAgent({ userID: 'u9' });
+      const onConnectionChange = jest.fn();
+      const { agent, socket, getChannel, refreshToken } = makeAgent({
+        userID: 'u9',
+        onConnectionChange,
+      });
 
       const initPromise = agent.initialize();
       const firstChannel = getChannel();
@@ -165,24 +168,31 @@ describe('WebSocketAIAgent', () => {
       await flushMicrotasks();
 
       // The agent should have requested a refresh and asked for a fresh channel.
-      expect(refreshAndStoreAccessToken).toHaveBeenCalledTimes(1);
-      // Second channel created (initialize re-entered after channel was nulled).
+      expect(refreshToken).toHaveBeenCalledTimes(1);
+      // Second channel created (initialize re-entered after channel was nulled),
+      // and its params callback reads the token refreshed in between.
       expect(socket.channel).toHaveBeenCalledTimes(2);
+      const [, retryParamsFn] = socket.channel.mock.calls[1];
+      expect(retryParamsFn()).toEqual({ access_token: 'NEW_TOKEN' });
 
       // Second join succeeds — initPromise resolves.
       const secondChannel = getChannel();
       secondChannel.joinPush.fire('ok');
       await initPromise;
 
-      expect(agent._connectionStatus).toBe('connected');
+      expect(onConnectionChange).toHaveBeenLastCalledWith(CONNECTED);
     });
 
     it('fails initialize when unauthorized refresh itself errors', async () => {
-      refreshAndStoreAccessToken.mockRejectedValueOnce(
+      const onConnectionChange = jest.fn();
+      const { agent, getChannel, refreshToken, onUnrecoverableAuthError } =
+        makeAgent({
+          userID: 'u10',
+          onConnectionChange,
+        });
+      refreshToken.mockRejectedValueOnce(
         new Error('no refresh token available')
       );
-
-      const { agent, getChannel } = makeAgent({ userID: 'u10' });
       const initPromise = agent.initialize();
 
       getChannel().joinPush.fire('error', 'unauthorized');
@@ -190,8 +200,8 @@ describe('WebSocketAIAgent', () => {
       await expect(initPromise).rejects.toThrow(
         'Session expired — please log in again'
       );
-      expect(agent._connectionStatus).toBe('disconnected');
-      expect(handleUnrecoverableAuthError).toHaveBeenCalledTimes(1);
+      expect(onConnectionChange).toHaveBeenLastCalledWith(DISCONNECTED);
+      expect(onUnrecoverableAuthError).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -200,22 +210,25 @@ describe('WebSocketAIAgent', () => {
       { trigger: 'channel error', method: 'triggerError' },
       { trigger: 'channel close', method: 'triggerClose' },
     ])('reports disconnected on $trigger', async ({ method }) => {
-      const { channel, onConnectionChange } = await connectedAgent();
+      const onConnectionChange = jest.fn();
+      const { channel } = await connectedAgent({ onConnectionChange });
+
       onConnectionChange.mockClear();
 
       channel[method]();
 
-      expect(onConnectionChange).toHaveBeenCalledWith('disconnected');
+      expect(onConnectionChange).toHaveBeenCalledWith(DISCONNECTED);
     });
 
     it('only invokes onConnectionChange when the status actually changes', () => {
-      const { agent, onConnectionChange } = makeAgent();
+      const onConnectionChange = jest.fn();
+      const { agent } = makeAgent({ onConnectionChange });
 
-      agent._setConnectionStatus('disconnected'); // already disconnected
-      agent._setConnectionStatus('connecting');
-      agent._setConnectionStatus('connecting'); // no change
+      agent._setConnectionStatus(DISCONNECTED); // already disconnected
+      agent._setConnectionStatus(CONNECTING);
+      agent._setConnectionStatus(CONNECTING); // no change
 
-      expect(onConnectionChange.mock.calls).toEqual([['connecting']]);
+      expect(onConnectionChange.mock.calls).toEqual([[CONNECTING]]);
     });
   });
 
@@ -242,8 +255,29 @@ describe('WebSocketAIAgent', () => {
       expect(typeof agent._activeRunId).toBe('string');
     });
 
-    it('refreshes the token and retries send_message once on unauthorized error', async () => {
+    it('mints a fresh run_id per run while forwarding the same thread_id', async () => {
       const { agent, channel } = await connectedAgent();
+
+      runAgent(agent, {
+        threadId: 'thread-1',
+        messages: [userMessage('first')],
+      });
+      await flushMicrotasks();
+      runAgent(agent, {
+        threadId: 'thread-1',
+        messages: [userMessage('second')],
+      });
+      await flushMicrotasks();
+
+      const [first, second] = channel.pushed;
+      // run_id becomes the server's `message_id`, so a repeat would make the
+      // second turn's TEXT_MESSAGE_* deltas land on the first turn's message.
+      expect(second.payload.run_id).not.toBe(first.payload.run_id);
+      expect(second.payload.thread_id).toBe(first.payload.thread_id);
+    });
+
+    it('refreshes the token and retries send_message once on unauthorized error', async () => {
+      const { agent, channel, refreshToken } = await connectedAgent();
       const { error, next } = runAgent(agent);
 
       await flushMicrotasks();
@@ -252,7 +286,7 @@ describe('WebSocketAIAgent', () => {
       await flushMicrotasks();
 
       // The agent refreshed and re-pushed with the new token.
-      expect(refreshAndStoreAccessToken).toHaveBeenCalledTimes(1);
+      expect(refreshToken).toHaveBeenCalledTimes(1);
       expect(channel.pushed).toHaveLength(2);
       expect(channel.pushed[1].payload.access_token).toBe('NEW_TOKEN');
 
@@ -271,11 +305,11 @@ describe('WebSocketAIAgent', () => {
     });
 
     it('errors the subscriber when the refresh itself fails', async () => {
-      refreshAndStoreAccessToken.mockRejectedValueOnce(
+      const { agent, channel, refreshToken, onUnrecoverableAuthError } =
+        await connectedAgent();
+      refreshToken.mockRejectedValueOnce(
         new Error('no refresh token available')
       );
-
-      const { agent, channel } = await connectedAgent();
       const { error } = runAgent(agent);
 
       await flushMicrotasks();
@@ -289,7 +323,7 @@ describe('WebSocketAIAgent', () => {
         })
       );
       expect(agent._activeSubscriber).toBeNull();
-      expect(handleUnrecoverableAuthError).toHaveBeenCalledTimes(1);
+      expect(onUnrecoverableAuthError).toHaveBeenCalledTimes(1);
     });
 
     it('errors the subscriber when the retried push also fails', async () => {
@@ -322,31 +356,70 @@ describe('WebSocketAIAgent', () => {
       const { agent, channel } = await connectedAgent();
       const { complete } = runAgent(agent);
 
-      channel.emit('ag_ui_event', { type: 'RUN_FINISHED' });
+      channel.emit(
+        'ag_ui_event',
+        aguiEvents.runFinished({ threadId: 't', runId: agent._activeRunId })
+      );
 
       expect(complete).toHaveBeenCalledTimes(1);
       expect(agent._activeSubscriber).toBeNull();
       expect(agent._activeRunId).toBeNull();
     });
 
+    it('does not settle the active run on a RUN_FINISHED that names no run', async () => {
+      const { agent, channel } = await connectedAgent();
+      const { complete } = runAgent(agent);
+
+      // The server stamps run_id on every RUN_FINISHED, so an unstamped one
+      // cannot be attributed to the run in flight.
+      channel.emit('ag_ui_event', { type: 'RUN_FINISHED' });
+
+      expect(complete).not.toHaveBeenCalled();
+      expect(agent._activeRunId).not.toBeNull();
+    });
+
+    it('does not settle the active run on a terminal event from a superseded run', async () => {
+      const { agent, channel } = await connectedAgent();
+
+      runAgent(agent, { threadId: 't', messages: [userMessage('first')] });
+      await flushMicrotasks();
+      const staleRunId = channel.pushed[0].payload.run_id;
+
+      const { complete } = runAgent(agent, {
+        threadId: 't',
+        messages: [userMessage('second')],
+      });
+      await flushMicrotasks();
+
+      // The first run was abandoned when the second replaced it; its late
+      // RUN_FINISHED must not close the run now in flight.
+      channel.emit(
+        'ag_ui_event',
+        aguiEvents.runFinished({ threadId: 't', runId: staleRunId })
+      );
+
+      expect(complete).not.toHaveBeenCalled();
+      expect(agent._activeRunId).not.toBeNull();
+    });
+
     it.each([
       {
         scenario: 'with explicit message',
-        event: { type: 'RUN_ERROR', message: 'oops' },
+        sent: 'oops',
         message: 'oops',
       },
       {
         scenario: 'with default message when none is given',
-        event: { type: 'RUN_ERROR' },
+        sent: undefined,
         message: 'Agent execution failed',
       },
     ])(
       'errors the observable on RUN_ERROR $scenario',
-      async ({ event, message }) => {
+      async ({ sent, message }) => {
         const { agent, channel } = await connectedAgent();
         const { error } = runAgent(agent);
 
-        channel.emit('ag_ui_event', event);
+        channel.emit('ag_ui_event', aguiEvents.runError({ message: sent }));
 
         expect(error).toHaveBeenCalledWith(
           expect.objectContaining({ message })
@@ -354,6 +427,20 @@ describe('WebSocketAIAgent', () => {
         expect(agent._activeSubscriber).toBeNull();
       }
     );
+
+    it('errors the observable on a RUN_ERROR that names no run', async () => {
+      const { agent, channel } = await connectedAgent();
+      const { error } = runAgent(agent);
+
+      // AgUi.Core.Events.RunError has no run_id field: the server cannot stamp
+      // one, so a RUN_ERROR must never be filtered out for lacking it.
+      channel.emit('ag_ui_event', aguiEvents.runError({ message: 'oops' }));
+
+      expect(error).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'oops' })
+      );
+      expect(agent._activeSubscriber).toBeNull();
+    });
 
     it('errors when there is no new user message to start the run with', async () => {
       const { agent } = await connectedAgent();
@@ -383,14 +470,16 @@ describe('WebSocketAIAgent', () => {
     });
 
     it('initializes the channel lazily when run() is called before initialize()', async () => {
-      const { agent, getChannel, onConnectionChange } = makeAgent({
+      const onConnectionChange = jest.fn();
+      const { agent, getChannel } = makeAgent({
         userID: 'u2',
+        onConnectionChange,
       });
 
       runAgent(agent);
 
       expect(getChannel()).toBeDefined();
-      expect(onConnectionChange).toHaveBeenCalledWith('connecting');
+      expect(onConnectionChange).toHaveBeenCalledWith(CONNECTING);
 
       getChannel().joinPush.fire('ok');
       await flushMicrotasks();
@@ -430,13 +519,14 @@ describe('WebSocketAIAgent', () => {
     });
 
     it('keeps the channel reference after a drop so a later push does not throw', async () => {
-      const { agent, channel } = await connectedAgent();
+      const onConnectionChange = jest.fn();
+      const { agent, channel } = await connectedAgent({ onConnectionChange });
       channel.triggerClose();
       expect(agent.channel).toBe(channel);
 
       // Simulate Phoenix's auto-rejoin: same channel, same joinPush, fires 'ok' again.
       channel.joinPush.fire('ok');
-      expect(agent._connectionStatus).toBe('connected');
+      expect(onConnectionChange).toHaveBeenLastCalledWith(CONNECTED);
 
       runAgent(agent);
       await flushMicrotasks();
@@ -448,34 +538,32 @@ describe('WebSocketAIAgent', () => {
 
   describe('disconnect', () => {
     it('leaves the channel and reports disconnected', async () => {
-      const { agent, channel, onConnectionChange } = await connectedAgent();
+      const onConnectionChange = jest.fn();
+      const { agent, channel } = await connectedAgent({ onConnectionChange });
       onConnectionChange.mockClear();
 
       agent.disconnect();
 
       expect(channel.leave).toHaveBeenCalled();
       expect(agent.channel).toBeNull();
-      expect(onConnectionChange).toHaveBeenCalledWith('disconnected');
+      expect(onConnectionChange).toHaveBeenCalledWith(DISCONNECTED);
     });
 
-    it('errors the active subscriber when disconnected mid-run', async () => {
+    it('completes the active subscriber when disconnected mid-run', async () => {
       const { agent } = await connectedAgent();
-      const { error } = runAgent(agent);
+      const { error, complete } = runAgent(agent);
 
       agent.disconnect();
 
-      expect(error).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'AbortError',
-          message: 'AI assistant disconnected',
-        })
-      );
+      expect(complete).toHaveBeenCalledTimes(1);
+      expect(error).not.toHaveBeenCalled();
       expect(agent._activeSubscriber).toBeNull();
       expect(agent._activeRunId).toBeNull();
     });
 
     it('is a no-op when never connected', () => {
-      const { agent, onConnectionChange } = makeAgent();
+      const onConnectionChange = jest.fn();
+      const { agent } = makeAgent({ onConnectionChange });
 
       expect(() => agent.disconnect()).not.toThrow();
       expect(onConnectionChange).not.toHaveBeenCalled();
@@ -509,57 +597,91 @@ describe('WebSocketAIAgent', () => {
     });
   });
 
-  describe('ai_configuration_cleared', () => {
-    it('settles the active run (AbortError) and invokes the callback', async () => {
-      const onAIConfigurationCleared = jest.fn();
-      const { channel, agent } = await connectedAgent({
-        onAIConfigurationCleared,
-      });
-      const { error } = runAgent(agent);
+  describe('configuration changes callbacks', () => {
+    const modelPayload = { provider: 'googleai', model: 'gemini-2.5-pro' };
+
+    const forwardedEvents = [
+      {
+        event: 'ai_configuration_cleared',
+        callback: 'onAIConfigurationCleared',
+        args: [],
+      },
+      {
+        event: 'ai_configuration_created',
+        callback: 'onAIConfigurationCreated',
+        args: [],
+      },
+      {
+        event: 'model_changed',
+        callback: 'onModelChanged',
+        args: [modelPayload],
+      },
+    ];
+
+    it.each(forwardedEvents)(
+      'forwards $event to the attached $callback',
+      async ({ event, callback, args }) => {
+        const spy = jest.fn();
+        const { channel } = await connectedAgent({ [callback]: spy });
+
+        channel.emit(event, ...args);
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(...args);
+      }
+    );
+
+    it('settles the active run on ai_configuration_cleared', async () => {
+      const { channel, agent } = await connectedAgent();
+      const { error, complete } = runAgent(agent);
       await flushMicrotasks();
 
       channel.emit('ai_configuration_cleared');
 
-      expect(onAIConfigurationCleared).toHaveBeenCalledTimes(1);
-      expect(error).toHaveBeenCalledTimes(1);
-      expect(error.mock.calls[0][0].name).toBe('AbortError');
+      expect(complete).toHaveBeenCalledTimes(1);
+      expect(error).not.toHaveBeenCalled();
+      expect(agent._activeSubscriber).toBeNull();
+      expect(agent._activeRunId).toBeNull();
     });
 
-    it('invokes the callback even when no run is active', async () => {
-      const onAIConfigurationCleared = jest.fn();
-      const { channel } = await connectedAgent({ onAIConfigurationCleared });
+    it('resets omitted callback to a noop', async () => {
+      const spies = {
+        onConnectionChange: jest.fn(),
+        onAIConfigurationCleared: jest.fn(),
+        onModelChanged: jest.fn(),
+      };
+      const { agent, channel } = await connectedAgent(spies);
 
-      channel.emit('ai_configuration_cleared');
+      const calledOnAIConfigurationCreated = jest.fn();
 
-      expect(onAIConfigurationCleared).toHaveBeenCalledTimes(1);
-    });
-  });
+      Object.values(spies).forEach((spy) => spy.mockClear());
 
-  describe('ai_configuration_created', () => {
-    it('invokes onAIConfigurationCreated', async () => {
-      const onAIConfigurationCreated = jest.fn();
-      const { channel } = await connectedAgent({ onAIConfigurationCreated });
-
-      channel.emit('ai_configuration_created');
-
-      expect(onAIConfigurationCreated).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('model_changed', () => {
-    it('invokes onModelChanged with the event payload', async () => {
-      const onModelChanged = jest.fn();
-      const { channel } = await connectedAgent({ onModelChanged });
-
-      channel.emit('model_changed', {
-        provider: 'googleai',
-        model: 'gemini-2.5-pro',
+      agent.withCallbacks({
+        onAIConfigurationCreated: calledOnAIConfigurationCreated,
       });
 
-      expect(onModelChanged).toHaveBeenCalledWith({
-        provider: 'googleai',
-        model: 'gemini-2.5-pro',
-      });
+      expect(() => {
+        forwardedEvents.forEach(({ event, args }) =>
+          channel.emit(event, ...args)
+        );
+        channel.triggerClose();
+      }).not.toThrow();
+
+      Object.values(spies).forEach((spy) => expect(spy).not.toHaveBeenCalled());
+      expect(calledOnAIConfigurationCreated).toHaveBeenCalled();
+    });
+
+    it('correctly overrides a callback', async () => {
+      const initialCallback = jest.fn();
+      const overridingCallback = jest.fn();
+      const { agent, channel } = await connectedAgent();
+
+      agent.withCallbacks({ onModelChanged: initialCallback });
+      agent.withCallbacks({ onModelChanged: overridingCallback });
+      channel.emit('model_changed', modelPayload);
+
+      expect(initialCallback).not.toHaveBeenCalled();
+      expect(overridingCallback).toHaveBeenCalledWith(modelPayload);
     });
   });
 });

--- a/assets/js/lib/ai/connectionStatus.js
+++ b/assets/js/lib/ai/connectionStatus.js
@@ -1,14 +1,18 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
+export const CONNECTING = 'connecting';
+export const CONNECTED = 'connected';
+export const DISCONNECTED = 'disconnected';
+
 // Connection lifecycle states reported by the WebSocketAIAgent and consumed
 // by the AssistantChatProvider context. Single source of truth so UI code
 // (status indicators, composer placeholders, header dot) doesn't drift from
 // what the agent actually emits.
 export const CONNECTION_STATUS = Object.freeze({
-  CONNECTED: 'connected',
-  CONNECTING: 'connecting',
-  DISCONNECTED: 'disconnected',
+  CONNECTED,
+  CONNECTING,
+  DISCONNECTED,
 });
 
 export const isOnline = (connectionStatus) =>

--- a/assets/js/lib/ai/connectionStatus.test.js
+++ b/assets/js/lib/ai/connectionStatus.test.js
@@ -1,9 +1,12 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-import { CONNECTION_STATUS, isOnline } from './connectionStatus';
-
-const { CONNECTED, CONNECTING, DISCONNECTED } = CONNECTION_STATUS;
+import {
+  CONNECTING,
+  CONNECTED,
+  DISCONNECTED,
+  isOnline,
+} from './connectionStatus';
 
 describe('isOnline', () => {
   it.each([

--- a/assets/js/lib/ai/index.js
+++ b/assets/js/lib/ai/index.js
@@ -3,4 +3,10 @@
 
 export { getProviderLabel, getProviderIcon } from './providers';
 export { WebSocketAIAgent, extractMessageText } from './WebSocketAIAgent';
-export { CONNECTION_STATUS, isOnline } from './connectionStatus';
+export {
+  CONNECTING,
+  CONNECTED,
+  DISCONNECTED,
+  CONNECTION_STATUS,
+  isOnline,
+} from './connectionStatus';

--- a/assets/js/lib/test-utils/aiAssistant.jsx
+++ b/assets/js/lib/test-utils/aiAssistant.jsx
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { act, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { SocketContext } from '@common/SocketProvider';
+import AIAssistant from '@common/AIAssistant';
+
+import { renderWithRouter } from '@lib/test-utils';
+import { buildAssistantTurn } from '@lib/test-utils/aguiEvents';
+import { makeMockSocket } from '@lib/test-utils/phoenixDoubles';
+
+export async function renderAIAssistant({
+  open = false,
+  userID = '1',
+  ...props
+} = {}) {
+  const socket = makeMockSocket();
+
+  const utils = renderWithRouter(
+    <SocketContext.Provider value={socket}>
+      <AIAssistant userID={userID} open={open} {...props} />
+    </SocketContext.Provider>
+  );
+
+  const channel = await waitFor(() => {
+    const openedChannel = socket.channels.get(`ai_assistant:${userID}`);
+    if (!openedChannel) throw new Error('channel not opened yet');
+    return openedChannel;
+  });
+
+  // Complete the channel join handshake — the agent transitions to 'connected'.
+  await act(async () => {
+    channel.joinPush.fire('ok');
+  });
+
+  if (open) await screen.findByLabelText('Message input');
+
+  const user = userEvent.setup();
+
+  // Fire one AG-UI event on the channel and let the runtime settle.
+  const emitAgUi = async (event) => {
+    await act(async () => {
+      channel.emit('ag_ui_event', event);
+    });
+  };
+
+  const sendUserMessage = async (text) => {
+    const sentBefore = channel.pushed.filter(
+      (p) => p.event === 'send_message'
+    ).length;
+    const composer = await screen.findByLabelText('Message input');
+    const send = await screen.findByLabelText('Send message');
+    await user.click(composer);
+    await user.keyboard(text);
+    await user.click(send);
+    await waitFor(() => {
+      const sent = channel.pushed.filter((p) => p.event === 'send_message');
+      if (sent.length <= sentBefore) {
+        throw new Error('send_message not pushed yet');
+      }
+    });
+    const sent = channel.pushed.filter((p) => p.event === 'send_message');
+    return sent[sent.length - 1].payload;
+  };
+
+  // first argument is the payload sendUserMessage returned, so the streamed run is
+  // always correlated with the send that started it
+  const streamAssistantTurn = async (
+    { thread_id: threadId, run_id: runId },
+    params
+  ) => {
+    for (const event of buildAssistantTurn({ threadId, runId, ...params })) {
+      await emitAgUi(event);
+    }
+    return params.messageId;
+  };
+
+  return {
+    ...utils,
+    user,
+    socket,
+    channel,
+    emitAgUi,
+    sendUserMessage,
+    streamAssistantTurn,
+  };
+}
+
+export default renderAIAssistant;


### PR DESCRIPTION
### Description

This PR mainly improves `WebSocketAIAgent` by injecting dependencies:
- auth is injected
- state change callbacks are passed via `withCallbacks` to decouple components lifecycle from those callbacks and reduce the usage of `useCallback` in https://github.com/trento-project/web/pull/4560

This generally speaking simplifies and improves testability.

### How was this tested?

Automated and IRL.