### PR TITLE
Delete events in batch

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -13,6 +13,12 @@ import Config
 config :trento,
   ecto_repos: [Trento.Repo]
 
+# Number of rows deleted per individual statement when pruning discovery
+# events. Pruning is performed in batches so that, when a large backlog of
+# historical events has to be pruned, no single DELETE statement runs long
+# enough to exceed the default Ecto checkout timeout.
+config :trento, prune_batch_size: 1_000
+
 # Configures the endpoint
 config :trento, TrentoWeb.Endpoint,
   url: [host: "localhost"],

--- a/lib/trento/discovery.ex
+++ b/lib/trento/discovery.ex
@@ -32,6 +32,20 @@ defmodule Trento.Discovery do
 
   @type command :: struct
 
+  # Number of rows deleted per individual statement. Pruning is performed in
+  # batches so that, when a large backlog of historical events has to be pruned,
+  # no single DELETE statement runs long enough to exceed the default
+  # DBConnection/Ecto checkout timeout (15s) and get cancelled (ERROR 57014).
+  @default_prune_batch_size 1_000
+
+  # Upper bound on the number of delete batches a single prune run may perform.
+  # It caps the bounded iteration in delete_in_batches/3 so pruning never runs
+  # unbounded; in practice the iteration halts earlier, as soon as a batch
+  # deletes fewer rows than the batch size (meaning no more matching rows are
+  # left). The bound is deliberately high (10_000 batches * 1_000 rows = 10M
+  # rows per run) to stay well above any realistic backlog.
+  @default_max_prune_batches 10_000
+
   @doc """
   Transform a discovery in a list of commands event by using the appropriate policy.
   Store the event in the discovery events log for auditing purposes and dispatch the commands.
@@ -105,24 +119,71 @@ defmodule Trento.Discovery do
   defp prune_events(days) do
     end_datetime = Timex.shift(DateTime.utc_now(), days: -days)
 
-    {events_number, nil} =
-      DiscoveryEvent
-      |> where([d], d.inserted_at <= ^end_datetime)
-      |> Repo.delete_all()
-
-    events_number
+    delete_in_batches(
+      DiscoveryEvent,
+      dynamic([d], d.inserted_at <= ^end_datetime),
+      prune_batch_size()
+    )
   end
 
   @spec prune_discarded_discovery_events(number) :: non_neg_integer()
   defp prune_discarded_discovery_events(days) do
     end_datetime = Timex.shift(DateTime.utc_now(), days: -days)
 
-    {discarded_events_number, nil} =
-      DiscardedDiscoveryEvent
-      |> where([d], d.inserted_at <= ^end_datetime)
-      |> Repo.delete_all()
+    delete_in_batches(
+      DiscardedDiscoveryEvent,
+      dynamic([d], d.inserted_at <= ^end_datetime),
+      prune_batch_size()
+    )
+  end
 
-    discarded_events_number
+  @spec delete_in_batches(
+          module(),
+          Ecto.Query.dynamic_expr(),
+          non_neg_integer()
+        ) ::
+          non_neg_integer()
+  defp delete_in_batches(schema, condition, batch_size) do
+    max_batches = max_prune_batches()
+
+    Enum.reduce_while(1..max_batches, 0, fn batch, acc ->
+      ids_subquery =
+        from d in schema,
+          where: ^condition,
+          select: d.id,
+          limit: ^batch_size
+
+      delete_query =
+        from(d in schema,
+          where: d.id in subquery(ids_subquery)
+        )
+
+      {deleted, _} = Repo.delete_all(delete_query)
+
+      next = acc + deleted
+
+      Logger.info(
+        "Pruned #{deleted} #{inspect(schema)} events in this batch " <>
+          "(#{next} deleted so far)"
+      )
+
+      cond do
+        deleted < batch_size ->
+          {:halt, next}
+
+        batch >= max_batches ->
+          Logger.warning(
+            "Pruning of #{inspect(schema)} reached the max batches limit " <>
+              "(#{max_batches}); some events may still be pending and will be " <>
+              "pruned on the next run"
+          )
+
+          {:halt, next}
+
+        true ->
+          {:cont, next}
+      end
+    end)
   end
 
   @doc """
@@ -259,4 +320,10 @@ defmodule Trento.Discovery do
 
   defp commanded,
     do: Application.fetch_env!(:trento, Trento.Commanded)[:adapter]
+
+  defp prune_batch_size,
+    do: Application.get_env(:trento, :prune_batch_size, @default_prune_batch_size)
+
+  defp max_prune_batches,
+    do: Application.get_env(:trento, :max_prune_batches, @default_max_prune_batches)
 end

--- a/priv/repo/migrations/20260804084038_add_discovery_events_inserted_at_index.exs
+++ b/priv/repo/migrations/20260804084038_add_discovery_events_inserted_at_index.exs
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Repo.Migrations.AddDiscoveryEventsInsertedAtIndex do
+  use Ecto.Migration
+
+  def change do
+    create index(:discovery_events, [:inserted_at])
+    create index(:discarded_discovery_events, [:inserted_at])
+  end
+end

--- a/test/trento/discovery_test.exs
+++ b/test/trento/discovery_test.exs
@@ -115,6 +115,107 @@ defmodule Trento.DiscoveryTest do
     assert 0 == DiscardedDiscoveryEvent |> Trento.Repo.all() |> length()
   end
 
+  describe "prune discovery events in batches" do
+    setup do
+      original_batch_size = Application.get_env(:trento, :prune_batch_size)
+      Application.put_env(:trento, :prune_batch_size, 3)
+
+      on_exit(fn ->
+        if original_batch_size do
+          Application.put_env(:trento, :prune_batch_size, original_batch_size)
+        else
+          Application.delete_env(:trento, :prune_batch_size)
+        end
+      end)
+
+      :ok
+    end
+
+    test "should batch delete outdated discovery events" do
+      insert_list(
+        10,
+        :discovery_event,
+        discovery_type: "discovery_type",
+        payload: %{},
+        inserted_at: Timex.shift(DateTime.utc_now(), days: -11)
+      )
+
+      # Events newer than the cutoff must be preserved.
+      newer_events =
+        insert_list(
+          2,
+          :discovery_event,
+          discovery_type: "discovery_type",
+          payload: %{},
+          inserted_at: DateTime.utc_now()
+        )
+
+      assert :ok == Discovery.prune_discovery_events(10)
+
+      remaining = DiscoveryEvent |> Trento.Repo.all() |> length()
+      assert length(newer_events) == remaining
+    end
+
+    test "should delete all outdated discovery events when they are less than the batch size" do
+      insert_list(
+        2,
+        :discovery_event,
+        discovery_type: "discovery_type",
+        payload: %{},
+        inserted_at: Timex.shift(DateTime.utc_now(), days: -11)
+      )
+
+      # Events newer than the cutoff must be preserved.
+      newer_events =
+        insert_list(
+          2,
+          :discovery_event,
+          discovery_type: "discovery_type",
+          payload: %{},
+          inserted_at: DateTime.utc_now()
+        )
+
+      assert :ok == Discovery.prune_discovery_events(10)
+
+      remaining = DiscoveryEvent |> Trento.Repo.all() |> length()
+      assert length(newer_events) == remaining
+    end
+
+    test "should batch delete outdated discarded discovery events" do
+      insert_list(
+        10,
+        :discarded_discovery_event,
+        inserted_at: Timex.shift(DateTime.utc_now(), days: -11)
+      )
+
+      insert_list(
+        2,
+        :discarded_discovery_event,
+        inserted_at: DateTime.utc_now()
+      )
+
+      assert :ok == Discovery.prune_discovery_events(10)
+      assert 2 == DiscardedDiscoveryEvent |> Trento.Repo.all() |> length()
+    end
+
+    test "should delete all outdated discarded discovery events when they are less than the batch size" do
+      insert_list(
+        2,
+        :discarded_discovery_event,
+        inserted_at: Timex.shift(DateTime.utc_now(), days: -11)
+      )
+
+      insert_list(
+        2,
+        :discarded_discovery_event,
+        inserted_at: DateTime.utc_now()
+      )
+
+      assert :ok == Discovery.prune_discovery_events(10)
+      assert 2 == DiscardedDiscoveryEvent |> Trento.Repo.all() |> length()
+    end
+  end
+
   test "should discard discovery events with invalid payload" do
     event = %{
       "agent_id" => "invalid_uuid",


### PR DESCRIPTION
Unbounded deletes can result in timed-out operations as full table scans are required. 

This PR modifies the deletion algorithm so that the delete query is limited and the prune job is executed in batches. No user-facing changes are introduced.