### PR TITLE
Remove unnecessary strong consistency dispatch

### DIFF
--- a/lib/trento/infrastructure/commanded/event_handlers/database_deregistration_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/database_deregistration_event_handler.ex
@@ -42,10 +42,10 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.DatabaseDeregistrationEv
     for %{id: sap_system_id, sid: sid} <- sap_systems do
       Logger.info("Deregistering sap system #{sid} attached to database #{database_id}")
 
-      commanded().dispatch(
-        %DeregisterSapSystem{sap_system_id: sap_system_id, deregistered_at: deregistered_at},
-        consistency: :strong
-      )
+      commanded().dispatch(%DeregisterSapSystem{
+        sap_system_id: sap_system_id,
+        deregistered_at: deregistered_at
+      })
     end
 
     :ok
@@ -74,10 +74,10 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.DatabaseDeregistrationEv
           "Deregistering sap system #{sid} attached to database #{database_id} with tenant #{tenant_name}"
         )
 
-        commanded().dispatch(
-          %DeregisterSapSystem{sap_system_id: sap_system_id, deregistered_at: dereregistered_at},
-          consistency: :strong
-        )
+        commanded().dispatch(%DeregisterSapSystem{
+          sap_system_id: sap_system_id,
+          deregistered_at: dereregistered_at
+        })
       end)
     end
 

--- a/lib/trento/infrastructure/commanded/event_handlers/database_restore_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/database_restore_event_handler.ex
@@ -36,15 +36,12 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.DatabaseRestoreEventHand
     for %{id: sap_system_id, tenant: tenant, db_host: db_host, sid: sid} <- sap_systems do
       Logger.info("Restoring sap system #{sid} attached to database #{database_id}")
 
-      commanded().dispatch(
-        %RestoreSapSystem{
-          sap_system_id: sap_system_id,
-          db_host: db_host,
-          tenant: tenant,
-          database_health: database_health
-        },
-        consistency: :strong
-      )
+      commanded().dispatch(%RestoreSapSystem{
+        sap_system_id: sap_system_id,
+        db_host: db_host,
+        tenant: tenant,
+        database_health: database_health
+      })
     end
 
     :ok

--- a/lib/trento/infrastructure/commanded/event_handlers/sap_system_database_health_event_handler.ex
+++ b/lib/trento/infrastructure/commanded/event_handlers/sap_system_database_health_event_handler.ex
@@ -41,10 +41,10 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseHealthE
     for %{id: sap_system_id, sid: sid} <- sap_systems do
       Logger.info("Updating database health of #{sid} SAP system to #{health}")
 
-      commanded().dispatch(
-        %UpdateDatabaseHealth{sap_system_id: sap_system_id, database_health: health},
-        consistency: :strong
-      )
+      commanded().dispatch(%UpdateDatabaseHealth{
+        sap_system_id: sap_system_id,
+        database_health: health
+      })
     end
 
     :ok

--- a/test/trento/infrastructure/commanded/event_handlers/database_deregistration_event_handler_test.exs
+++ b/test/trento/infrastructure/commanded/event_handlers/database_deregistration_event_handler_test.exs
@@ -30,16 +30,14 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.DatabaseDeregistrationEv
     expect(Trento.Commanded.Mock, :dispatch, fn %DeregisterSapSystem{
                                                   sap_system_id: ^first_sap_system_id,
                                                   deregistered_at: ^deregistered_at
-                                                },
-                                                _ ->
+                                                } ->
       :ok
     end)
 
     expect(Trento.Commanded.Mock, :dispatch, fn %DeregisterSapSystem{
                                                   sap_system_id: ^second_sap_system_id,
                                                   deregistered_at: ^deregistered_at
-                                                },
-                                                _ ->
+                                                } ->
       :ok
     end)
 
@@ -67,8 +65,7 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.DatabaseDeregistrationEv
     expect(Trento.Commanded.Mock, :dispatch, fn %DeregisterSapSystem{
                                                   sap_system_id: ^second_sap_system_id,
                                                   deregistered_at: ^deregistered_at
-                                                },
-                                                _ ->
+                                                } ->
       :ok
     end)
 

--- a/test/trento/infrastructure/commanded/event_handlers/database_restore_event_handler_test.exs
+++ b/test/trento/infrastructure/commanded/event_handlers/database_restore_event_handler_test.exs
@@ -27,8 +27,7 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.DatabaseRestoreEventHand
                                                   tenant: ^tenant,
                                                   db_host: ^db_host,
                                                   database_health: :passing
-                                                },
-                                                _ ->
+                                                } ->
       :ok
     end)
 

--- a/test/trento/infrastructure/commanded/event_handlers/sap_system_database_health_event_handler_test.exs
+++ b/test/trento/infrastructure/commanded/event_handlers/sap_system_database_health_event_handler_test.exs
@@ -40,16 +40,14 @@ defmodule Trento.Infrastructure.Commanded.EventHandlers.SapSystemDatabaseHealthE
     expect(Trento.Commanded.Mock, :dispatch, fn %UpdateDatabaseHealth{
                                                   sap_system_id: ^first_sap_system_id,
                                                   database_health: :critical
-                                                },
-                                                _ ->
+                                                } ->
       :ok
     end)
 
     expect(Trento.Commanded.Mock, :dispatch, fn %UpdateDatabaseHealth{
                                                   sap_system_id: ^second_sap_system_id,
                                                   database_health: :critical
-                                                },
-                                                _ ->
+                                                } ->
       :ok
     end)
 


### PR DESCRIPTION
### Description

Remove unnecessary `strong` consistency dispatch in event handlers. None of them really need strong consistency.
First, because we don't have other event handler with this consistency (except the `rollup`) one. And second, because we don't really need to wait until the projection is done. They are async.

Due the first thing (no projection or event handler with `strong` consistency), this is no-op, as it was being executed as eventual consistency in any case.

It just cleans it up.

### How was this tested?

No need 

### Documentation changes

No