### PR TITLE
Add default version for dependabot

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -241,13 +241,13 @@ defmodule Trento.MixProject do
     end
   end
 
-# Dependabot's hex file fetcher only pulls mix.exs, mix.lock, subapp mixfiles and paths
-# referenced by Code.eval_file/Code.require_file.
-# get_version_from_file/0 reads VERSION,so the reference below is what makes Dependabot fetch it.
-# Do not delete.
-#
-# Code.eval_file("VERSION")
-defp get_version_from_file do
-  __DIR__ |> Path.join("VERSION") |> File.read!() |> String.trim()
-end
+  # Dependabot's hex file fetcher only pulls mix.exs, mix.lock, subapp mixfiles and paths
+  # referenced by Code.eval_file/Code.require_file.
+  # get_version_from_file/0 reads VERSION,so the reference below is what makes Dependabot fetch it.
+  # Do not delete.
+  #
+  # Code.eval_file("VERSION")
+  defp get_version_from_file do
+    __DIR__ |> Path.join("VERSION") |> File.read!() |> String.trim()
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -241,10 +241,13 @@ defmodule Trento.MixProject do
     end
   end
 
-  defp get_version_from_file do
-    case __DIR__ |> Path.join("VERSION") |> File.read() do
-      {:ok, version} -> String.trim(version)
-      {:error, _} -> "0.0.0"
-    end
-  end
+# Dependabot's hex file fetcher only pulls mix.exs, mix.lock, subapp mixfiles and paths
+# referenced by Code.eval_file/Code.require_file.
+# get_version_from_file/0 reads VERSION,so the reference below is what makes Dependabot fetch it.
+# Do not delete.
+#
+# Code.eval_file("VERSION")
+defp get_version_from_file do
+  __DIR__ |> Path.join("VERSION") |> File.read!() |> String.trim()
+end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -243,7 +243,7 @@ defmodule Trento.MixProject do
 
   # Dependabot's hex file fetcher only pulls mix.exs, mix.lock, subapp mixfiles and paths
   # referenced by Code.eval_file/Code.require_file.
-  # get_version_from_file/0 reads VERSION,so the reference below is what makes Dependabot fetch it.
+  # get_version_from_file/0 reads VERSION, so the reference below is what makes Dependabot fetch it.
   # Do not delete.
   #
   # Code.eval_file("VERSION")

--- a/mix.exs
+++ b/mix.exs
@@ -242,6 +242,9 @@ defmodule Trento.MixProject do
   end
 
   defp get_version_from_file do
-    __DIR__ |> Path.join("VERSION") |> File.read!() |> String.trim()
+    case __DIR__ |> Path.join("VERSION") |> File.read() do
+      {:ok, version} -> String.trim(version)
+      {:error, _} -> "0.0.0"
+    end
   end
 end


### PR DESCRIPTION
### Description

Dependabot's Elixir file-fetcher only downloads the manifest files it recognizes into its sandboxed dependabot_tmp_dir. It doesn't know to also fetch a VERSION file just because mix.exs happens to read it at config-evaluation time via File.read!. 
So even though VERSION is committed and present in your normal checkout, it's simply never copied into Dependabot's temp working dir.

```console
"message": "** (File.Error) could not read file \"dependabot_tmp_dir/VERSION\": no such file or directory\n    (elixir 1.19.5) lib/file.ex:435: File.read!/1\n    mix.exs:236: Trento.MixProject.get_version_from_file/0\n    mix.exs:14: Trento.MixProject.project/0\n    (mix 1.19.5) lib/mix/project.ex:1093: Mix.Project.get_project_config/1\n    (mix 1.19.5) lib/mix/project.ex:299: Mix.Project.push_config/2\n    (mix 1.19.5) lib/mix/project.ex:262: Mix.Project.push/3\n\n{\"error\":\"\"}" |                                                                                                                                                                                                                                                                                                                                                                                                                                                     
```

This PR is to fall back to a placeholder version instead of raising an error when VERSION isn't present.

Fixes #TRNT-4622

### How was this tested?

N/A

### Documentation changes

No

### Additional information

- [ ] https://github.com/trento-project/web/pull/4574
- [ ] https://github.com/trento-project/wanda/pull/738