### PR TITLE
Disable `New Chat` during a run

### DIFF
--- a/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
+++ b/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
@@ -196,6 +196,32 @@ describe('AG-UI event flow', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('locks "New chat" for the length of the run', async () => {
+    const { emitAgUi, sendUserMessage } = await renderAIAssistant({
+      open: true,
+    });
+    const newChat = () => screen.getByRole('button', { name: 'New chat' });
+
+    expect(newChat()).toBeEnabled();
+
+    const { thread_id: threadId, run_id: runId } =
+      await sendUserMessage('hello');
+
+    expect(newChat()).toBeDisabled();
+
+    const messageId = 'asst-1';
+    await emitAgUi(aguiEvents.runStarted({ threadId, runId }));
+    await emitAgUi(aguiEvents.textStart({ messageId }));
+    await emitAgUi(aguiEvents.textContent({ messageId, delta: 'half' }));
+
+    expect(newChat()).toBeDisabled();
+
+    await emitAgUi(aguiEvents.textEnd({ messageId }));
+    await emitAgUi(aguiEvents.runFinished({ threadId, runId }));
+
+    await waitFor(() => expect(newChat()).toBeEnabled());
+  });
+
   it('"New chat" starts a new conversation with a new thread ID', async () => {
     const { user, sendUserMessage, streamAssistantTurn } =
       await renderAIAssistant({ open: true });

--- a/assets/js/common/AIAssistant/AssistantThread.jsx
+++ b/assets/js/common/AIAssistant/AssistantThread.jsx
@@ -104,6 +104,7 @@ function AssistantThread({
     >
       <ChatHeader
         connectionStatus={connection}
+        isRunning={isRunning}
         onNewChat={onNewThread}
         onClose={onClose}
       />

--- a/assets/js/common/AIAssistant/AssistantThread.test.jsx
+++ b/assets/js/common/AIAssistant/AssistantThread.test.jsx
@@ -130,6 +130,12 @@ describe('AssistantThread', () => {
     expect(newChat()).toBeEnabled();
   });
 
+  it('locks "New chat" while the assistant is answering', () => {
+    renderThread({ isRunning: true });
+
+    expect(newChat()).toBeDisabled();
+  });
+
   it('passes the raw connection status through when the configuration is fine', () => {
     renderThread({ connectionStatus: DISCONNECTED, configurationStatus: OK });
 

--- a/assets/js/common/AIAssistant/ChatHeader/ChatHeader.jsx
+++ b/assets/js/common/AIAssistant/ChatHeader/ChatHeader.jsx
@@ -19,13 +19,18 @@ const CONNECTION_VIEW = {
 
 const stopPointerDown = (e) => e.stopPropagation();
 
-function ChatHeader({ connectionStatus, onNewChat, onClose }) {
+function ChatHeader({
+  connectionStatus,
+  isRunning = false,
+  onNewChat,
+  onClose,
+}) {
   const { text, dot } = get(
     CONNECTION_VIEW,
     connectionStatus,
     CONNECTION_VIEW[CONNECTION_STATUS.DISCONNECTED]
   );
-  const canStartNewChat = isOnline(connectionStatus);
+  const canStartNewChat = isOnline(connectionStatus) && !isRunning;
 
   return (
     <div className="drag-handle flex items-center justify-between bg-[#2fb371] px-5 py-4 text-white cursor-move">

--- a/assets/js/common/AIAssistant/ChatHeader/ChatHeader.stories.jsx
+++ b/assets/js/common/AIAssistant/ChatHeader/ChatHeader.stories.jsx
@@ -13,6 +13,11 @@ export default {
       options: ['connected', 'connecting', 'disconnected'],
       control: { type: 'radio' },
     },
+    isRunning: {
+      description:
+        'Whether a run is in flight — "New chat" is locked until it settles',
+      control: { type: 'boolean' },
+    },
     onNewChat: {
       description: 'Fired when the "New chat" button is clicked',
       type: 'function',
@@ -38,4 +43,8 @@ export const Connecting = {
 
 export const Disconnected = {
   args: { connectionStatus: 'disconnected' },
+};
+
+export const Running = {
+  args: { connectionStatus: 'connected', isRunning: true },
 };

--- a/assets/js/common/AIAssistant/ChatHeader/ChatHeader.test.jsx
+++ b/assets/js/common/AIAssistant/ChatHeader/ChatHeader.test.jsx
@@ -45,6 +45,11 @@ describe('ChatHeader', () => {
     expect(screen.getByRole('button', { name: 'New chat' })).not.toBeDisabled();
   });
 
+  it('disables the "New chat" button while a run is in flight', () => {
+    render(<ChatHeader {...defaults} connectionStatus={CONNECTED} isRunning />);
+    expect(screen.getByRole('button', { name: 'New chat' })).toBeDisabled();
+  });
+
   it('invokes onNewChat when the "New chat" button is clicked', async () => {
     const user = userEvent.setup();
     const onNewChat = jest.fn();


### PR DESCRIPTION
### Description

This PR makes sure that during a run the "New Chat" button is disabled in chat header.

This prevents seeing a "Thinking" spinner on a new chat until the previous run actually finishes.

I am opening this because the more complete cancellation feature at https://github.com/trento-project/web/pull/4563 requires some more love and it is currently lower prio.

Current solution prevents weird situations at least.

### How was this tested?

Automated and IRL