### PR TITLE
Use "trento-checks" img

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -95,7 +95,7 @@ services:
 
   checks:
     profiles: [wanda]
-    image: ghcr.io/trento-project/checks:rolling # https://github.com/trento-project/checks/pkgs/container/checks
+    image: ghcr.io/trento-project/trento-checks:rolling # https://github.com/trento-project/checks/pkgs/container/trento-checks
     volumes:
       - trento-checks:/usr/share/trento/checks
 


### PR DESCRIPTION
### Description

I've noticed we are using the old pkg name. In order to keep consistency, this PR aligns the value to the one used in the Helm Chart: https://github.com/trento-project/helm-charts/blob/main/charts/trento-server/values.yaml#L59

### How was this tested?

Ci

### Documentation changes

No

### Additional information

- [ ] https://github.com/trento-project/web/pull/4583
- [ ] https://github.com/trento-project/ansible/pull/133