### PR TITLE
Fix Liz z-index

### DIFF
--- a/assets/js/common/AIAssistant/ModalFrame/ModalFrame.jsx
+++ b/assets/js/common/AIAssistant/ModalFrame/ModalFrame.jsx
@@ -76,7 +76,7 @@ function ModalFrame({
 
       <AssistantModalPrimitive.Content
         sideOffset={16}
-        className="z-[101] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+        className="z-40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
       >
         <Rnd
           bounds="window"


### PR DESCRIPTION
### Description

Tiny fix to Liz's z-index so that chatbox is above the main page content but below other full-page modals like settings.

Before

<img width="1594" height="824" alt="image" src="https://github.com/user-attachments/assets/3108277b-93fa-46f1-be9e-45529ce352f9" />

After

<img width="1594" height="824" alt="image" src="https://github.com/user-attachments/assets/6b8605af-ceeb-40c2-909a-79fa74902692" />


### How was this tested?

IRL