### PR TITLE
Checks execution for ASCS/ERS clusters when SAP system is not registered

### DIFF
--- a/assets/js/state/selectors/cluster.js
+++ b/assets/js/state/selectors/cluster.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-import { get, find, uniq, has } from 'lodash';
+import { get, find, map, uniq, has } from 'lodash';
 import { createSelector } from '@reduxjs/toolkit';
 
 import {
@@ -88,20 +88,18 @@ export const getClusterSapApplicationInstances = createSelector(
 );
 
 export const MIXED_VERSIONS = 'mixed_versions';
+export const UNKNOWN_ENSA_VERSION = 'unknown';
 
 export const getEnsaVersion = createSelector(
   [getClusterSapApplicationInstances],
   (sapSystems) => {
-    const ensaVersions = new Set();
-    sapSystems.forEach(({ ensa_version }) => {
-      ensaVersions.add(ensa_version);
-    });
+    const ensaVersions = uniq(map(sapSystems, 'ensa_version'));
 
-    const firstEnsaVersion = [...ensaVersions.values()][0];
+    if (ensaVersions.length > 1) {
+      return MIXED_VERSIONS;
+    }
 
-    return firstEnsaVersion && ensaVersions.size === 1
-      ? firstEnsaVersion
-      : MIXED_VERSIONS;
+    return ensaVersions[0] || UNKNOWN_ENSA_VERSION;
   }
 );
 

--- a/assets/js/state/selectors/cluster.test.js
+++ b/assets/js/state/selectors/cluster.test.js
@@ -29,6 +29,7 @@ import {
   getFilesystemType,
   getEnsaVersion,
   MIXED_VERSIONS,
+  UNKNOWN_ENSA_VERSION,
 } from './cluster';
 
 describe('Cluster selector', () => {
@@ -276,6 +277,31 @@ describe('Cluster selector', () => {
     };
 
     expect(getEnsaVersion(state, clusterID)).toEqual('ensa1');
+  });
+
+  it('should return an unknown ENSA version if the SAP system is not registered', () => {
+    const clusterID = faker.string.uuid();
+    const cluster = clusterFactory.build({ id: clusterID });
+
+    const state = {
+      hostsList: {
+        hosts: hostFactory.buildList(2, { cluster_id: clusterID }),
+      },
+      databasesList: {
+        databases: [],
+        databaseInstances: [],
+      },
+      sapSystemsList: {
+        sapSystems: [],
+        applicationInstances: [],
+        databaseInstances: [],
+      },
+      clustersList: {
+        clusters: [cluster],
+      },
+    };
+
+    expect(getEnsaVersion(state, clusterID)).toEqual(UNKNOWN_ENSA_VERSION);
   });
 
   it('should return mixed ENSA versions', () => {

--- a/lib/trento/clusters.ex
+++ b/lib/trento/clusters.ex
@@ -274,38 +274,22 @@ defmodule Trento.Clusters do
            id: cluster_id,
            provider: provider,
            type: ClusterType.ascs_ers(),
-           sap_instances: sap_instances,
            selected_checks: selected_checks
          } = cluster
        ) do
-    sap_instance_sids = SapInstance.get_sap_instance_sids(sap_instances)
-
-    clustered_sap_instances =
-      sap_instances
-      |> Enum.map(& &1.instance_number)
-      |> Enum.uniq()
-
     hosts_data =
       Repo.all(
         from h in HostReadModel,
-          join: a in ApplicationInstanceReadModel,
-          on: h.id == a.host_id,
-          where:
-            h.cluster_id == ^cluster_id and is_nil(h.deregistered_at) and
-              a.sid in ^sap_instance_sids and a.instance_number in ^clustered_sap_instances,
-          select: %{host_id: h.id, sap_system_id: a.sap_system_id}
+          where: h.cluster_id == ^cluster_id and is_nil(h.deregistered_at),
+          select: %{host_id: h.id}
       )
 
-    aggregated_ensa_version =
-      hosts_data
-      |> Enum.map(fn %{sap_system_id: sap_system_id} -> sap_system_id end)
-      |> Enum.uniq()
-      |> get_cluster_ensa_version()
+    host_ids = Enum.map(hosts_data, & &1.host_id)
 
     env = %Checks.ClusterExecutionEnv{
       provider: provider,
       cluster_type: ClusterType.ascs_ers(),
-      ensa_version: aggregated_ensa_version,
+      ensa_version: get_cluster_ensa_version(cluster, host_ids),
       filesystem_type: get_filesystem_type(cluster)
     }
 
@@ -393,18 +377,30 @@ defmodule Trento.Clusters do
     end
   end
 
-  @spec get_cluster_ensa_version([String.t()]) :: ClusterEnsaVersion.t()
-  defp get_cluster_ensa_version(sap_system_ids) do
+  @spec get_cluster_ensa_version(ClusterReadModel.t(), [String.t()]) :: ClusterEnsaVersion.t()
+  defp get_cluster_ensa_version(%ClusterReadModel{sap_instances: sap_instances}, host_ids) do
+    sap_instance_sids = SapInstance.get_sap_instance_sids(sap_instances)
+
+    clustered_sap_instances =
+      sap_instances
+      |> Enum.map(& &1.instance_number)
+      |> Enum.uniq()
+
     ensa_versions =
       Repo.all(
         from(s in SapSystemReadModel,
+          join: a in ApplicationInstanceReadModel,
+          on: a.sap_system_id == s.id,
           select: s.ensa_version,
-          where: s.id in ^sap_system_ids and is_nil(s.deregistered_at),
+          where:
+            a.host_id in ^host_ids and a.sid in ^sap_instance_sids and
+              a.instance_number in ^clustered_sap_instances and is_nil(s.deregistered_at),
           distinct: true
         )
       )
 
     case ensa_versions do
+      [] -> ClusterEnsaVersion.unknown()
       [ensa_version] -> ensa_version
       _ -> ClusterEnsaVersion.mixed_versions()
     end

--- a/lib/trento/clusters/enums/cluster_ensa_version.ex
+++ b/lib/trento/clusters/enums/cluster_ensa_version.ex
@@ -6,5 +6,5 @@ defmodule Trento.Clusters.Enums.ClusterEnsaVersion do
   Type that represents the ENSA version info for a cluster.
   """
 
-  use Trento.Support.Enum, values: [:mixed_versions, :ensa1, :ensa2]
+  use Trento.Support.Enum, values: [:mixed_versions, :ensa1, :ensa2, :unknown]
 end

--- a/test/trento/clusters_test.exs
+++ b/test/trento/clusters_test.exs
@@ -813,7 +813,7 @@ defmodule Trento.ClustersTest do
                                                                         "executions",
                                                                         message ->
         assert message.group_id == cluster_id
-        assert length(message.targets) == 2
+        assert length(message.targets) == 3
 
         assert message.env == %{
                  "provider" => %ProtobufValue{kind: {:string_value, Atom.to_string(provider)}},
@@ -911,7 +911,7 @@ defmodule Trento.ClustersTest do
                                                                         "executions",
                                                                         message ->
         assert message.group_id == cluster_id
-        assert length(message.targets) == 2
+        assert length(message.targets) == 3
 
         assert message.env == %{
                  "provider" => %ProtobufValue{kind: {:string_value, Atom.to_string(provider)}},
@@ -1009,7 +1009,7 @@ defmodule Trento.ClustersTest do
                                                                         "executions",
                                                                         message ->
         assert message.group_id == cluster_id
-        assert length(message.targets) == 2
+        assert length(message.targets) == 3
 
         assert message.env == %{
                  "provider" => %ProtobufValue{kind: {:string_value, Atom.to_string(provider)}},
@@ -1090,6 +1090,60 @@ defmodule Trento.ClustersTest do
                                                                         "executions",
                                                                         message ->
         assert length(message.targets) == 2
+
+        :ok
+      end)
+
+      assert :ok = Clusters.request_checks_execution(cluster_id)
+    end
+
+    test "should start a checks execution on demand for ascs_ers clusters with an unknown ENSA version when the SAP system is not registered" do
+      sid = "ASD"
+
+      %{id: cluster_id, provider: provider, type: cluster_type} =
+        insert(:cluster,
+          type: ClusterType.ascs_ers(),
+          sap_instances:
+            build_list(1, :clustered_sap_instance,
+              sid: sid,
+              resource_type: SapInstanceResourceType.sap_instance()
+            ),
+          details:
+            build(:ascs_ers_cluster_details,
+              sap_systems:
+                build_list(1, :ascs_ers_cluster_sap_system,
+                  sid: sid,
+                  filesystem_resource_based: true
+                )
+            )
+        )
+
+      insert(:host, deregistered_at: DateTime.utc_now(), cluster_id: cluster_id)
+      hosts = insert_list(2, :host, cluster_id: cluster_id)
+      expected_agent_ids = hosts |> Enum.map(& &1.id) |> Enum.sort()
+
+      expect(Trento.Infrastructure.Messaging.Adapter.Mock, :publish, fn Publisher,
+                                                                        "executions",
+                                                                        message ->
+        assert message.group_id == cluster_id
+
+        assert expected_agent_ids ==
+                 message.targets |> Enum.map(& &1.agent_id) |> Enum.sort()
+
+        assert message.env == %{
+                 "provider" => %ProtobufValue{kind: {:string_value, Atom.to_string(provider)}},
+                 "cluster_type" => %ProtobufValue{
+                   kind: {:string_value, Atom.to_string(cluster_type)}
+                 },
+                 "filesystem_type" => %ProtobufValue{
+                   kind: {:string_value, Atom.to_string(:resource_managed)}
+                 },
+                 "ensa_version" => %ProtobufValue{
+                   kind: {:string_value, Atom.to_string(ClusterEnsaVersion.unknown())}
+                 }
+               }
+
+        assert message.target_type == "cluster"
 
         :ok
       end)


### PR DESCRIPTION
### Description

Fix for ASCS/ERS clusters checks exectution when SAP system is not registered.
I know users should have fully database and SAP systems registered, but trento show this clusters, and the checks execution is available. I think it is good to give the chance to run the correct checks for these cases.

When a SAP system handled by the pacemaker cluster is not registered in Trento, the targets information we create is invalid, as it doesn't create any target.
This resolves not sending any valid check and wanda failing with the next error:

```
[error] Unable to handle message: #GenRMQ.Message<[attributes: %{priority: :undefined, timestamp: 1786372500208, type: :undefined, exchange: "trento.checks", persistent: false, user_id: :undefined, routing_key: "executions", headers: [], consumer_tag: "wanda_checks", content_type: "application/x-protobuf", delivery_tag: 9, redelivered: false, app_id: "gen_rmq", content_encoding: :undefined, correlation_id: :undefined, reply_to: :undefined, expiration: :undefined, message_id: :undefined, cluster_id: :undefined}, payload: <<10, 36, 102, 54, 50, 48, 54, 99, 54, 48, 45, 54, 52, 57, 99, 45, 52, 102, 49, 97, 45, 57, 55, 56, 99, 45, 101, 53, 57, 55, 50, 50, 101, 101, 102, 102, 53, 99, 18, 29, 103, 105, 116, 104, 117, 98, 46, 99, 111, 109, 47, 116, 114, 101, 110, 116, 111, 45, 112, 114, 111, 106, 101, 99, 116, 47, 119, 101, 98, 26, 3, 49, 46, 48, 34, 35, 84, 114, 101, ...>>]>. Reason: :no_checks_selected

```

This causes `web` staying with a spinner saying the checks are being executed forever.

As an additional improvement, the catalog won't show for this cluster checks which need `ensa_version` metadata information, so they cannot select the check itself.

### How was this tested?

UT and some manual testing

### Documentation changes

No