### PR TITLE
Rename s/googleai/google

### DIFF
--- a/assets/.storybook/preview-head.html
+++ b/assets/.storybook/preview-head.html
@@ -11,7 +11,7 @@
 <script>
   const config = {
     aiProviders: {
-      googleai: [
+      google: [
         'gemini-2.5-pro',
         'gemini-2.5-flash',
         'gemini-2.5-flash-lite',

--- a/assets/jest.config.js
+++ b/assets/jest.config.js
@@ -74,7 +74,7 @@ module.exports = {
       aTestVariable: 123,
       aiEnabled: true,
       aiProviders: {
-        googleai: [
+        google: [
           'gemini-2.5-pro',
           'gemini-2.5-flash',
           'gemini-2.5-flash-lite',

--- a/assets/js/common/AIAssistant/AIAssistant.stories.jsx
+++ b/assets/js/common/AIAssistant/AIAssistant.stories.jsx
@@ -264,7 +264,7 @@ export const OpenModelChanged = {
       events: [
         {
           event: 'model_changed',
-          payload: { provider: 'googleai', model: 'gemini-2.5-pro' },
+          payload: { provider: 'google', model: 'gemini-2.5-pro' },
         },
       ],
     },

--- a/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
+++ b/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
@@ -122,7 +122,7 @@ describe('AG-UI event flow', () => {
   const emitModelChange = (channel) =>
     act(async () => {
       channel.emit('model_changed', {
-        provider: 'googleai',
+        provider: 'google',
         model: 'gemini-2.5-pro',
       });
     });

--- a/assets/js/common/AIAssistant/AssistantChatProvider.test.jsx
+++ b/assets/js/common/AIAssistant/AssistantChatProvider.test.jsx
@@ -21,7 +21,7 @@ jest.mock('@assistant-ui/react', () => ({
   useAui: () => ({}),
 }));
 
-const modelPayload = { provider: 'googleai', model: 'gemini-2.5-pro' };
+const modelPayload = { provider: 'google', model: 'gemini-2.5-pro' };
 
 function renderProvider({ socket = makeMockSocket(), ...props } = {}) {
   const runtime = { thread: { reset: jest.fn() } };

--- a/assets/js/common/AIAssistant/AssistantThread.test.jsx
+++ b/assets/js/common/AIAssistant/AssistantThread.test.jsx
@@ -147,7 +147,7 @@ describe('AssistantThread', () => {
     const user = userEvent.setup();
     const onDismissModelNotice = jest.fn();
     renderThread({
-      modelNotice: { provider: 'googleai', model: 'gemini-2.5-pro' },
+      modelNotice: { provider: 'google', model: 'gemini-2.5-pro' },
       onDismissModelNotice,
     });
 

--- a/assets/js/common/AIConfiguration/AIConfiguration.test.jsx
+++ b/assets/js/common/AIConfiguration/AIConfiguration.test.jsx
@@ -26,7 +26,7 @@ describe('AIConfiguration', () => {
 
   it('should show saved AI configuration', () => {
     const aiConfiguration = aiConfigurationFactory.build({
-      provider: 'googleai',
+      provider: 'google',
       model: 'gemini-2.5-pro',
     });
     render(<AIConfiguration aiConfiguration={aiConfiguration} />);

--- a/assets/js/common/AIConfiguration/EditModal/AIConfigurationModal.test.jsx
+++ b/assets/js/common/AIConfiguration/EditModal/AIConfigurationModal.test.jsx
@@ -12,7 +12,7 @@ import AIConfigurationModal from './AIConfigurationModal';
 
 describe('AIConfigurationModal', () => {
   const aiProviders = {
-    googleai: ['gemini-2.5-pro', 'gemini-1.5-pro'],
+    google: ['gemini-2.5-pro', 'gemini-1.5-pro'],
     openai: ['gpt-4o', 'gpt-4-turbo'],
   };
 
@@ -38,7 +38,7 @@ describe('AIConfigurationModal', () => {
 
   it('should render with saved configuration', async () => {
     const aiConfiguration = aiConfigurationFactory.build({
-      provider: 'googleai',
+      provider: 'google',
       model: 'gemini-2.5-pro',
     });
 
@@ -109,7 +109,7 @@ describe('AIConfigurationModal', () => {
     );
 
     expect(onSave).toHaveBeenCalledWith(
-      'googleai',
+      'google',
       'gemini-2.5-pro',
       'my-api-key'
     );
@@ -119,7 +119,7 @@ describe('AIConfigurationModal', () => {
     const user = userEvent.setup();
     const onUpdate = jest.fn();
     const aiConfiguration = aiConfigurationFactory.build({
-      provider: 'googleai',
+      provider: 'google',
       model: 'gemini-2.5-pro',
     });
 

--- a/assets/js/common/AIProviderLabel/AIProviderLabel.stories.jsx
+++ b/assets/js/common/AIProviderLabel/AIProviderLabel.stories.jsx
@@ -10,7 +10,7 @@ export default {
     provider: {
       description: 'AI provider name',
       control: { type: 'select' },
-      options: ['googleai', 'openai', 'anthropic', 'unmapped_provider'],
+      options: ['google', 'openai', 'anthropic', 'unmapped_provider'],
     },
   },
 };
@@ -24,7 +24,7 @@ export const Default = {
 export const GoogleAI = {
   args: {
     ...Default.args,
-    provider: 'googleai',
+    provider: 'google',
   },
 };
 

--- a/assets/js/common/AIProviderLabel/AIProviderLabel.test.jsx
+++ b/assets/js/common/AIProviderLabel/AIProviderLabel.test.jsx
@@ -8,10 +8,10 @@ import AIProviderLabel from './AIProviderLabel';
 
 describe('AI Provider Label', () => {
   it('should display an icon and label with Google AI as the provider', () => {
-    const { container } = render(<AIProviderLabel provider="googleai" />);
+    const { container } = render(<AIProviderLabel provider="google" />);
     expect(screen.getAllByText(/Google Gemini/)).toBeTruthy();
     expect(container.querySelector('img').getAttribute('alt')).toContain(
-      'googleai'
+      'google'
     );
   });
 

--- a/assets/js/lib/ai/WebSocketAIAgent.test.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.test.js
@@ -598,7 +598,7 @@ describe('WebSocketAIAgent', () => {
   });
 
   describe('configuration changes callbacks', () => {
-    const modelPayload = { provider: 'googleai', model: 'gemini-2.5-pro' };
+    const modelPayload = { provider: 'google', model: 'gemini-2.5-pro' };
 
     const forwardedEvents = [
       {

--- a/assets/js/lib/ai/providers.js
+++ b/assets/js/lib/ai/providers.js
@@ -8,7 +8,7 @@ import OpenAIIcon from '@static/openai-logo.svg';
 import AnthropicIcon from '@static/anthropic-logo.svg';
 
 const providerRenderingConfig = {
-  googleai: {
+  google: {
     icon: GeminiIcon,
     label: 'Google Gemini',
   },

--- a/assets/js/lib/ai/providers.test.js
+++ b/assets/js/lib/ai/providers.test.js
@@ -6,7 +6,7 @@ import { getProviderLabel, getProviderIcon } from './providers';
 describe('providers', () => {
   describe('getProviderLabel', () => {
     it('should return the provider label', () => {
-      expect(getProviderLabel('googleai')).toBe('Google Gemini');
+      expect(getProviderLabel('google')).toBe('Google Gemini');
       expect(getProviderLabel('openai')).toBe('OpenAI GPT');
       expect(getProviderLabel('anthropic')).toBe('Anthropic Claude');
     });
@@ -18,7 +18,7 @@ describe('providers', () => {
 
   describe('getProviderIcon', () => {
     it('should return the provider icon', () => {
-      expect(getProviderIcon('googleai')).toBeDefined();
+      expect(getProviderIcon('google')).toBeDefined();
       expect(getProviderIcon('openai')).toBeDefined();
       expect(getProviderIcon('anthropic')).toBeDefined();
     });

--- a/assets/js/lib/test-utils/factories/users.js
+++ b/assets/js/lib/test-utils/factories/users.js
@@ -13,7 +13,7 @@ export const fakeAppTimezone = () =>
   faker.helpers.arrayElement(timezones).value;
 
 export const aiConfigurationFactory = Factory.define(() => ({
-  provider: 'googleai',
+  provider: 'google',
   model: 'gemini-2.5-pro',
 }));
 

--- a/lib/trento/ai/llm_builder.ex
+++ b/lib/trento/ai/llm_builder.ex
@@ -31,7 +31,7 @@ defmodule Trento.AI.LLMBuilder do
     end
   end
 
-  defp do_build(:googleai, model, api_key),
+  defp do_build(:google, model, api_key),
     do: ChatGoogleAI.new!(%{model: model, api_key: api_key, stream: true})
 
   defp do_build(:openai, model, api_key),

--- a/lib/trento/ai/llm_registry.ex
+++ b/lib/trento/ai/llm_registry.ex
@@ -6,7 +6,7 @@ defmodule Trento.AI.LLMRegistry do
   This module is responsible for managing the registry of available LLM providers and their models.
   """
 
-  @providers [:openai, :googleai, :anthropic]
+  @providers [:openai, :google, :anthropic]
 
   @required_capabilities [
     chat: true,
@@ -25,15 +25,6 @@ defmodule Trento.AI.LLMRegistry do
   Returns the list of models for a given provider.
   """
   def get_provider_models(provider) when provider in @providers do
-    provider =
-      case provider == :googleai do
-        true ->
-          :google
-
-        _ ->
-          provider
-      end
-
     [scope: provider, require: @required_capabilities]
     |> LLMDB.candidates()
     |> Enum.map(fn {_provider, model_id} -> model_id end)

--- a/lib/trento_web/openapi/v1/schema/ai.ex
+++ b/lib/trento_web/openapi/v1/schema/ai.ex
@@ -21,7 +21,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.AI do
           provider: %Schema{
             type: :string,
             description: "Chosen AI provider.",
-            example: "googleai",
+            example: "google",
             nullable: false
           },
           model: %Schema{
@@ -32,7 +32,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.AI do
           }
         },
         example: %{
-          provider: "googleai",
+          provider: "google",
           model: "gemini-2.0-flash"
         },
         required: [:provider, :model]
@@ -55,7 +55,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.AI do
             type: :string,
             description: "AI provider.",
             nullable: false,
-            example: "googleai"
+            example: "google"
           },
           model: %Schema{
             type: :string,
@@ -71,7 +71,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.AI do
           }
         },
         example: %{
-          provider: "googleai",
+          provider: "google",
           model: "gemini-2.0-flash",
           api_key: "AIza..."
         },
@@ -96,7 +96,7 @@ defmodule TrentoWeb.OpenApi.V1.Schema.AI do
             type: :string,
             description: "AI provider.",
             nullable: false,
-            example: "googleai"
+            example: "google"
           },
           model: %Schema{
             type: :string,

--- a/test/e2e/cypress/e2e/users.cy.js
+++ b/test/e2e/cypress/e2e/users.cy.js
@@ -536,7 +536,7 @@ describe('Users', () => {
   });
 
   describe('AI Configuration', () => {
-    const GOOGLE_AI = 'googleai';
+    const GOOGLE_AI = 'google';
     const OPEN_AI = 'openai';
 
     beforeEach(() => {

--- a/test/trento/ai/configurations_test.exs
+++ b/test/trento/ai/configurations_test.exs
@@ -141,7 +141,7 @@ defmodule Trento.Ai.ConfigurationsTest do
       %{
         name: "model unsupported by the specified provider",
         attrs: %{
-          provider: :googleai,
+          provider: :google,
           model: "gpt-5.4",
           api_key: Faker.String.base64()
         },
@@ -154,8 +154,8 @@ defmodule Trento.Ai.ConfigurationsTest do
       %{
         name: "missing api key",
         attrs: %{
-          provider: :googleai,
-          model: build(:random_ai_model, provider: :googleai)
+          provider: :google,
+          model: build(:random_ai_model, provider: :google)
         },
         expected_errors: [
           api_key: {"can't be blank", [validation: :required]}
@@ -227,7 +227,7 @@ defmodule Trento.Ai.ConfigurationsTest do
                        [
                          type: _,
                          validation: :inclusion,
-                         enum: ["anthropic", "googleai", "openai" | _]
+                         enum: ["anthropic", "google", "openai" | _]
                        ]}
                   ]
                 }} =
@@ -389,7 +389,7 @@ defmodule Trento.Ai.ConfigurationsTest do
       %{
         name: "model unsupported by the specified provider",
         attrs: %{
-          provider: :googleai,
+          provider: :google,
           model: "gpt-5.4"
         },
         expected_errors: [
@@ -488,8 +488,8 @@ defmodule Trento.Ai.ConfigurationsTest do
       } =
         insert(:ai_user_configuration,
           user_id: user_id,
-          provider: :googleai,
-          model: build(:random_ai_model, provider: :googleai)
+          provider: :google,
+          model: build(:random_ai_model, provider: :google)
         )
 
       new_provider = :openai

--- a/test/trento/ai/llm_builder_test.exs
+++ b/test/trento/ai/llm_builder_test.exs
@@ -21,13 +21,13 @@ defmodule Trento.AI.LLMBuilderTest do
       assert {:error, :no_ai_configuration} = LLMBuilder.build_for_user(user_id)
     end
 
-    test "builds a streaming ChatGoogleAI for the :googleai provider" do
+    test "builds a streaming ChatGoogleAI for the :google provider" do
       %{id: user_id} = insert(:user)
 
       %{api_key: api_key} =
         insert(:ai_user_configuration,
           user_id: user_id,
-          provider: :googleai,
+          provider: :google,
           model: "gemini-2.5-flash"
         )
 

--- a/test/trento_web/channels/ai_assistant_channel_test.exs
+++ b/test/trento_web/channels/ai_assistant_channel_test.exs
@@ -1014,7 +1014,7 @@ defmodule TrentoWeb.AIAssistantChannelTest do
 
       insert(:ai_user_configuration,
         user_id: user_id,
-        provider: :googleai,
+        provider: :google,
         model: "gemini-2.5-flash"
       )
 
@@ -1108,11 +1108,11 @@ defmodule TrentoWeb.AIAssistantChannelTest do
 
     test "pushes model_changed when the provider/model is updated", %{user_id: user_id} do
       AIConfigurationsEvents.broadcast_updated(user_id, %{
-        provider: :googleai,
+        provider: :google,
         model: "gemini-2.5-pro"
       })
 
-      assert_push("model_changed", %{provider: :googleai, model: "gemini-2.5-pro"})
+      assert_push("model_changed", %{provider: :google, model: "gemini-2.5-pro"})
     end
   end
 
@@ -1137,7 +1137,7 @@ defmodule TrentoWeb.AIAssistantChannelTest do
 
     insert(:ai_user_configuration,
       user_id: user_id,
-      provider: :googleai,
+      provider: :google,
       model: "gemini-2.5-flash"
     )
 

--- a/test/trento_web/controllers/v1/ai_configuration_controller_test.exs
+++ b/test/trento_web/controllers/v1/ai_configuration_controller_test.exs
@@ -220,7 +220,7 @@ defmodule TrentoWeb.V1.AIConfigurationControllerTest do
       %{
         name: "model unsupported by the specified provider",
         request_body: %{
-          model: build(:random_ai_model, provider: :googleai),
+          model: build(:random_ai_model, provider: :google),
           provider: :openai,
           api_key: Faker.String.base64()
         },
@@ -573,7 +573,7 @@ defmodule TrentoWeb.V1.AIConfigurationControllerTest do
       %{
         name: "model unsupported by the specified provider",
         request_body: %{
-          provider: :googleai,
+          provider: :google,
           model: "gpt-5.4",
           api_key: Faker.String.base64()
         },


### PR DESCRIPTION
### Description

s/googleai/google since the latter is a more canonical name in the model/provider scheme of things.

### How was this tested?

Automated tests.

