### PR TITLE
Fix flaky test in home deregistration suite

### DIFF
--- a/test/e2e/cypress/e2e/home.cy.js
+++ b/test/e2e/cypress/e2e/home.cy.js
@@ -55,6 +55,7 @@ context('Homepage', () => {
 
     it('should not display SAP System NWP after it is deregistered', () => {
       homePage.nwpSystemShouldBeDisplayed();
+      homePage.nwpSystemRowIsMarkedStale();
       homePage.apiDeregisterSapSystemNwpHost();
       homePage.nwpSystemShouldNotBeDisplayed();
     });

--- a/test/e2e/cypress/pageObject/home_po.js
+++ b/test/e2e/cypress/pageObject/home_po.js
@@ -33,8 +33,10 @@ export const nwpSystemShouldBeDisplayed = () =>
 export const nwpSystemShouldNotBeDisplayed = () =>
   cy.get(nwpSystemCell, { timeout: 20000 }).should('not.exist');
 
+// Timeout is 25 seconds to cover time for heartbeat failure event
+// and home page refresh after debounce time
 export const nwpSystemRowIsMarkedStale = () =>
-  basePage.elementIsMarkedStale(nwpSystemRow);
+  basePage.elementIsMarkedStale(nwpSystemRow, 25000);
 
 export const nwpSystemRowIsMarkedInSync = () =>
   basePage.elementIsMarkedInSync(nwpSystemRow);


### PR DESCRIPTION
### Description

Fix flaky test in e2e home suite, deregistration describe.
The host must be stale before requesting a deregistration.

https://github.com/trento-project/web/actions/runs/31491282402/attempts/1
https://github.com/trento-project/web/actions/runs/31495887957/attempts/1

### How was this tested?

e2e

### Documentation changes

No