### PR TITLE
Add ZAP dynamic analysis scanning

### DIFF
--- a/.github/scripts/anchor-dast-sarif.sh
+++ b/.github/scripts/anchor-dast-sarif.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+#
+# Anchor dynamic-analysis findings to a file in the repository.
+#
+# Code scanning resolves every SARIF result against the checked-out tree and
+# rejects the whole file when a location carries a URL instead of a path:
+#
+#   SARIF URI scheme "http" did not match the checkout URI scheme "file"
+#
+# Dynamic analysis has no source file to point at, so rewrite each location to
+# the file that configures the scan and move the scanned URL into the message,
+# which is where a reader needs it anyway. The original URL is also kept in the
+# location's properties so the artifact stays machine-readable.
+#
+# Anchoring collapses every location onto one line, which would otherwise let
+# code scanning treat two findings of the same rule as one alert. An explicit
+# partialFingerprints entry, built from the rule, the URL, the attack string
+# and the message, keeps them distinct.
+#
+# Digits are stripped from the message before it enters the fingerprint. ZAP
+# embeds timestamps and occurrence counts in its wording, so a fingerprint
+# carrying them would change on every run and resurrect alerts that had already
+# been dismissed. Stripping them merges the same finding across runs while
+# still separating, say, two different patterns matched on one page.
+#
+# Usage: SARIF_PATH=... ANCHOR_PATH=... anchor-dast-sarif.sh
+
+set -euo pipefail
+
+: "${SARIF_PATH:?SARIF_PATH must be set}"
+: "${ANCHOR_PATH:?ANCHOR_PATH must be set}"
+
+if [[ ! -f "$SARIF_PATH" ]]; then
+  echo "No SARIF file at ${SARIF_PATH}; nothing to anchor"
+  exit 0
+fi
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+jq --arg anchor "$ANCHOR_PATH" '
+  def is_url: test("^[a-z][a-z0-9+.-]*://");
+
+  # The region is replaced rather than kept: code scanning renders the real
+  # content of the anchor file at the reported line, so a scanner snippet left
+  # in place would be displayed as if it were text from that file. Keep it as a
+  # property instead, where it stays available without being rendered as source.
+  def anchor_location:
+    ((.physicalLocation.artifactLocation.uri // "") as $url
+     | (.physicalLocation.region.snippet.text // "") as $evidence
+     | if ($url | is_url)
+       then .physicalLocation.artifactLocation.uri = $anchor
+          | del(.physicalLocation.artifactLocation.uriBaseId)
+          | .physicalLocation.region = {"startLine": 1}
+          | .properties = ((.properties // {}) + {"scannedUrl": $url})
+          | if $evidence == "" then . else .properties.evidence = $evidence end
+       else . end);
+
+  .runs[]?.results[]? |= (
+    ([.locations[]?.physicalLocation.artifactLocation.uri // empty]
+       | map(select(is_url)) | unique) as $urls
+    | ([.locations[]? | (.properties // {}).attack // empty] | join(",")) as $attacks
+    | ((.message.text // "") | gsub("[0-9]+"; "N") | .[0:200]) as $shape
+    | if ($urls | length) == 0 then .
+      else
+        .locations = [.locations[]? | anchor_location]
+        | .message.text = (($urls | join(", ")) + "\n\n" + (.message.text // ""))
+        | .partialFingerprints = ((.partialFingerprints // {}) + {
+            "primaryLocationLineHash":
+              ((.ruleId // "") + "|" + ($urls | join(","))
+               + "|" + $attacks + "|" + $shape)
+          })
+      end
+  )
+' "$SARIF_PATH" > "$tmp"
+
+mv "$tmp" "$SARIF_PATH"
+trap - EXIT
+
+# Only location URIs are resolved against the checkout, so only those can
+# trigger the rejection. A URL anywhere else in the file is legitimate.
+remaining="$(jq '[.runs[]?.results[]?.locations[]?.physicalLocation.artifactLocation.uri // empty
+                 | select(test("^[a-z][a-z0-9+.-]*://"))] | length' "$SARIF_PATH")"
+if [[ "$remaining" != "0" ]]; then
+  echo "::error::${remaining} location URIs are still URLs; code scanning would reject this file"
+  exit 1
+fi
+
+echo "Anchored $(jq '[.runs[]?.results[]?] | length' "$SARIF_PATH") findings to ${ANCHOR_PATH}"

--- a/.github/scripts/anchor-dast-sarif.sh
+++ b/.github/scripts/anchor-dast-sarif.sh
@@ -22,8 +22,14 @@
 # Digits are stripped from the message before it enters the fingerprint. ZAP
 # embeds timestamps and occurrence counts in its wording, so a fingerprint
 # carrying them would change on every run and resurrect alerts that had already
-# been dismissed. Stripping them merges the same finding across runs while
-# still separating, say, two different patterns matched on one page.
+# been dismissed. Stripping them keeps a finding identified as the same one
+# across runs while still separating, say, two different patterns matched on
+# one page.
+#
+# Locations that are already repo-relative are left alone. Nuclei, for one,
+# reports "." and puts the target in the message, so its report passes through
+# untouched; the pass is still run over it so that a future version emitting
+# URLs does not silently break the upload.
 #
 # Usage: SARIF_PATH=... ANCHOR_PATH=... anchor-dast-sarif.sh
 
@@ -36,6 +42,15 @@ if [[ ! -f "$SARIF_PATH" ]]; then
   echo "No SARIF file at ${SARIF_PATH}; nothing to anchor"
   exit 0
 fi
+
+# Only location URIs are resolved against the checkout, so only those can
+# trigger the rejection. A URL anywhere else in the file is legitimate.
+count_urls() {
+  jq '[.runs[]?.results[]?.locations[]?.physicalLocation.artifactLocation.uri // empty
+       | select(test("^[a-z][a-z0-9+.-]*://"))] | length' "$1"
+}
+
+before="$(count_urls "$SARIF_PATH")"
 
 tmp="$(mktemp)"
 trap 'rm -f "$tmp"' EXIT
@@ -79,13 +94,15 @@ jq --arg anchor "$ANCHOR_PATH" '
 mv "$tmp" "$SARIF_PATH"
 trap - EXIT
 
-# Only location URIs are resolved against the checkout, so only those can
-# trigger the rejection. A URL anywhere else in the file is legitimate.
-remaining="$(jq '[.runs[]?.results[]?.locations[]?.physicalLocation.artifactLocation.uri // empty
-                 | select(test("^[a-z][a-z0-9+.-]*://"))] | length' "$SARIF_PATH")"
+remaining="$(count_urls "$SARIF_PATH")"
 if [[ "$remaining" != "0" ]]; then
   echo "::error::${remaining} location URIs are still URLs; code scanning would reject this file"
   exit 1
 fi
 
-echo "Anchored $(jq '[.runs[]?.results[]?] | length' "$SARIF_PATH") findings to ${ANCHOR_PATH}"
+total="$(jq '[.runs[]?.results[]?] | length' "$SARIF_PATH")"
+if [[ "$before" == "0" ]]; then
+  echo "${SARIF_PATH}: ${total} findings, none reported against a URL; left unchanged"
+else
+  echo "${SARIF_PATH}: anchored ${before} of ${total} locations to ${ANCHOR_PATH}"
+fi

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -458,9 +458,11 @@ jobs:
 
       # Code scanning resolves every result location against the checked-out
       # tree and rejects the entire file when one carries a URL instead of a
-      # path. Both scanners report URLs, so both reports are rewritten to point
-      # at the plan file that configures the scan, with the scanned URL moved
-      # into the alert message. See the script for the full rationale.
+      # path. ZAP reports URLs, so its results are rewritten to point at the
+      # plan file that configures the scan, with the scanned URL moved into the
+      # alert message. Nuclei already reports a repo-relative path and passes
+      # through untouched; it is included so that a future version emitting
+      # URLs does not silently break the upload. Rationale is in the script.
       - name: Anchor the DAST findings to a repository file
         env:
           ANCHOR_PATH: .github/zap/trento-api.yaml

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -29,6 +29,9 @@ env:
   # Only stable tags: the w2026-* weekly builds report themselves as "Dev Build",
   # which the SARIF upload validator rejects.
   ZAP_VERSION: "2.17.0" # https://github.com/zaproxy/zaproxy/releases
+  # Unlike ZAP_VERSION, this tag needs its leading "v": nuclei's own release
+  # tags are versioned that way and the bare digits are not a real tag.
+  NUCLEI_VERSION: "v3.11.1" # https://github.com/projectdiscovery/nuclei/releases
 
 jobs:
   sast-elixir:
@@ -373,6 +376,40 @@ jobs:
             "$ZAP_IMAGE" \
             zap.sh -cmd -autorun /zap/wrk/plan.yaml
 
+      # Runs after ZAP so a ZAP failure never costs the Nuclei results. Unlike
+      # ZAP, Nuclei is not given the bearer token: it runs unauthenticated
+      # against the same target, which is enough for its template-based checks
+      # and means its SARIF needs no redaction pass.
+      #
+      # -ni (no-interactsh) turns off the out-of-band templates, which rely on
+      # the target reaching back out to a public interactsh server. This
+      # target is only reachable on the runner's own network, so those
+      # templates could never produce a real match; left on, every one of them
+      # still pays the interaction poll and cooldown wait for nothing.
+      #
+      # The image has no bundled templates and runs as root (unlike ZAP's uid
+      # 1000), so it fetches nuclei-templates fresh on every run and writes
+      # into the sarif/ directory the previous step already made
+      # world-writable without needing that permission itself. -duc
+      # (disable-update-check) was considered to pin this down further, but it
+      # disables that initial template fetch too, not just the version-check
+      # log line, and the scan then fails outright with no templates loaded.
+      #
+      # Nuclei writes no file at all when it finds nothing, which the publish
+      # step below is told to treat as success rather than a missing report.
+      - name: Run Nuclei
+        continue-on-error: true
+        env:
+          NUCLEI_IMAGE: projectdiscovery/nuclei:${{ env.NUCLEI_VERSION }}
+        run: |
+          set -euo pipefail
+          docker run --rm --network host \
+            -v "$PWD/sarif:/sarif:rw" \
+            "$NUCLEI_IMAGE" \
+            -target http://localhost:4000 \
+            -ni \
+            -sarif-export /sarif/nuclei.sarif
+
       # The sarif-json template appends its own extension to reportFile, so the
       # plan's `zap.sarif` lands as `zap.sarif.json`. Rename only when the file
       # is there: if the scan produced no report at all, publish-sarif is the
@@ -426,3 +463,16 @@ jobs:
           name: zap
           path: sarif/zap.sarif
           category: zap
+
+      # optional: true because Nuclei writes no report at all on a clean scan,
+      # which is the common case, not an error. Every other publish step in
+      # this workflow keeps the strict check: a missing file from any of them
+      # means the scan died before writing anything.
+      - name: Publish Nuclei SARIF
+        if: always()
+        uses: ./.github/actions/publish-sarif
+        with:
+          name: nuclei
+          path: sarif/nuclei.sarif
+          category: nuclei
+          optional: true

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -456,6 +456,20 @@ jobs:
             exit 1
           fi
 
+      # Code scanning resolves every result location against the checked-out
+      # tree and rejects the entire file when one carries a URL instead of a
+      # path. Both scanners report URLs, so both reports are rewritten to point
+      # at the plan file that configures the scan, with the scanned URL moved
+      # into the alert message. See the script for the full rationale.
+      - name: Anchor the DAST findings to a repository file
+        env:
+          ANCHOR_PATH: .github/zap/trento-api.yaml
+        run: |
+          set -euo pipefail
+          for report in sarif/zap.sarif sarif/nuclei.sarif; do
+            SARIF_PATH="$report" .github/scripts/anchor-dast-sarif.sh
+          done
+
       - name: Publish SARIF
         if: always()
         uses: ./.github/actions/publish-sarif

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -26,6 +26,9 @@ concurrency:
 env:
   MIX_ENV: test
   OSV_SCANNER_VERSION: "v2.5.0" # https://github.com/google/osv-scanner/releases
+  # Only stable tags: the w2026-* weekly builds report themselves as "Dev Build",
+  # which the SARIF upload validator rejects.
+  ZAP_VERSION: "2.17.0" # https://github.com/zaproxy/zaproxy/releases
 
 jobs:
   sast-elixir:
@@ -212,3 +215,214 @@ jobs:
           name: ${{ matrix.category }}
           path: sarif/${{ matrix.category }}.sarif
           category: ${{ matrix.category }}
+
+  dast:
+    name: DAST (ZAP)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'dast'))
+    # Overrides the workflow default. The application is started and exercised
+    # here, matching the E2E job in ci.yaml. The active scan mutates the target,
+    # so this must only ever run against a throwaway instance.
+    env:
+      MIX_ENV: dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Gather toolchain versions
+        uses: endorama/asdf-parse-tool-versions@e60863920ff5af9bf1c794ffbaaef91384b07eed # v1.6.0
+
+      - name: Setup Elixir
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
+        with:
+          otp-version: ${{ env.ERLANG_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+
+      - name: Setup Node
+        id: setup-node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODEJS_VERSION }}
+
+      # Same key shape as ci.yaml's dev-mode jobs, so this restores their cache.
+      # Restore only, deliberately: a read-write cache action here would save
+      # under a key that ci.yaml owns.
+      - name: Retrieve Elixir cached dependencies
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            deps
+            _build/${{ env.MIX_ENV }}
+            priv/plts
+          key: erlang-${{ env.ERLANG_VERSION }}-elixir-${{ env.ELIXIR_VERSION }}-${{ hashFiles('mix.lock') }}-${{ env.MIX_ENV }}
+
+      - name: Retrieve NPM cached dependencies
+        id: npm-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            assets/node_modules
+          key: nodejs-${{ steps.setup-node.outputs.node-version }}-${{ hashFiles('assets/package-lock.json') }}
+
+      # The dev endpoint's watchers run `node build.js` and `npx tailwindcss`
+      # from assets/, so a cache miss would otherwise leave the application
+      # serving no assets and ZAP spidering a broken page.
+      - name: Install dependencies
+        if: steps.npm-cache.outputs.cache-hit != 'true'
+        run: cd assets && npm ci
+
+      - name: Docker compose dependencies
+        uses: isbang/compose-action@11beaa1c2dae4e8ed7b1665aa074723b6cecb0e4 # v3.0.0
+        with:
+          compose-file: "./docker-compose.yaml"
+          compose-flags: "--profile wanda"
+          down-flags: "--volumes"
+
+      - name: Mix setup
+        run: mix setup
+
+      - name: Generate OpenAPI spec
+        run: mix openapi.spec.json --start-app=false --spec TrentoWeb.OpenApi.All.ApiSpec
+
+      - name: Run trento detached
+        run: mix phx.server &
+
+      # A dead target makes ZAP report a clean scan. That is the worst possible
+      # outcome, so readiness is a hard failure rather than report-only.
+      - name: Wait for the application to become ready
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 60); do
+            if curl -sf http://localhost:4000/api/readyz > /dev/null; then
+              echo "Application is ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Application did not become ready within 120s"
+          exit 1
+
+      # An unauthenticated scan reaches almost nothing and still reports green,
+      # so assert the token works before handing it to ZAP.
+      #
+      # The token is signed directly rather than obtained from POST /api/session
+      # because access_token_expiration is 180 seconds and is read through
+      # compile_env, so no environment variable can extend it: a session token
+      # dies three minutes into a twenty minute scan and the rest of the run
+      # bounces off 401s. --no-start is required, otherwise mix boots a second
+      # copy of the application against the one already serving port 4000.
+      # sub 1 is the seeded admin.
+      - name: Mint and verify an API token
+        id: token
+        run: |
+          set -euo pipefail
+          mix run --no-start -e '
+            File.write!("/tmp/trento-jwt.txt",
+              TrentoWeb.Auth.AccessToken.generate_access_token!(%{
+                "sub" => 1,
+                "exp" => System.system_time(:second) + 3600
+              }))'
+          token="$(cat /tmp/trento-jwt.txt)"
+          if [[ -z "$token" ]]; then
+            echo "Failed to mint an access token"
+            exit 1
+          fi
+          echo "::add-mask::$token"
+          # -L because /api/hosts is the unversioned redirector and answers 307.
+          status="$(curl -sL -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $token" http://localhost:4000/api/hosts)"
+          if [[ "$status" != "200" ]]; then
+            echo "Token did not authenticate: GET /api/hosts returned $status"
+            exit 1
+          fi
+          echo "token=$token" >> "$GITHUB_OUTPUT"
+
+      # ZAP runs as uid 1000 inside its image while the workspace belongs to the
+      # runner user, so the report directory has to be writable by both for the
+      # report job to write through the bind mount.
+      - name: Create report directory
+        run: |
+          set -euo pipefail
+          mkdir -p sarif
+          chmod 0777 sarif
+
+      - name: Resolve the ZAP plan
+        env:
+          TRENTO_JWT: ${{ steps.token.outputs.token }}
+        run: |
+          set -euo pipefail
+          # The single quotes are deliberate: envsubst takes the list of names
+          # to substitute as a literal shell-format string.
+          # shellcheck disable=SC2016
+          envsubst '${TRENTO_JWT}' < .github/zap/trento-api.yaml > /tmp/zap-plan.yaml
+
+      - name: Run ZAP
+        continue-on-error: true
+        env:
+          ZAP_IMAGE: ghcr.io/zaproxy/zaproxy:${{ env.ZAP_VERSION }}
+        run: |
+          set -euo pipefail
+          docker run --rm --network host \
+            -v "$PWD:/zap/wrk:rw" \
+            -v /tmp/zap-plan.yaml:/zap/wrk/plan.yaml:ro \
+            "$ZAP_IMAGE" \
+            zap.sh -cmd -autorun /zap/wrk/plan.yaml
+
+      # The sarif-json template appends its own extension to reportFile, so the
+      # plan's `zap.sarif` lands as `zap.sarif.json`. Rename only when the file
+      # is there: if the scan produced no report at all, publish-sarif is the
+      # step that should say so, rather than this one failing first and pointing
+      # at the wrong component.
+      - name: Normalise the SARIF filename
+        run: |
+          set -euo pipefail
+          if [[ -f sarif/zap.sarif.json ]]; then
+            mv sarif/zap.sarif.json sarif/zap.sarif
+          fi
+
+      # ZAP embeds whole requests and responses in the report, and Phoenix debug
+      # error pages echo the Authorization header back, so the bearer token and
+      # freshly generated API keys end up in a file that is uploaded to code
+      # scanning and kept as an artifact for thirty days. ::add-mask:: only
+      # redacts log output, it does not touch file contents.
+      #
+      # An unredacted report must never reach the publish step, so any failure
+      # here deletes the report before exiting.
+      - name: Redact credentials from the SARIF
+        env:
+          TRENTO_JWT: ${{ steps.token.outputs.token }}
+        run: |
+          set -euo pipefail
+          if [[ ! -f sarif/zap.sarif ]]; then
+            echo "No report to redact"
+            exit 0
+          fi
+          if ! jq --arg token "$TRENTO_JWT" '
+                 del(.runs[]?.results[]?.webRequest, .runs[]?.results[]?.webResponse)
+                 | walk(if type == "string"
+                        then (split($token) | join("REDACTED"))
+                        else . end)
+               ' sarif/zap.sarif > /tmp/zap-redacted.json; then
+            rm -f sarif/zap.sarif
+            echo "::error::could not redact the ZAP report; the unredacted report was discarded"
+            exit 1
+          fi
+          mv /tmp/zap-redacted.json sarif/zap.sarif
+          if grep -qF -- "$TRENTO_JWT" sarif/zap.sarif; then
+            rm -f sarif/zap.sarif
+            echo "::error::the access token survived redaction; the report was discarded"
+            exit 1
+          fi
+
+      - name: Publish SARIF
+        if: always()
+        uses: ./.github/actions/publish-sarif
+        with:
+          name: zap
+          path: sarif/zap.sarif
+          category: zap

--- a/.github/zap/trento-api.yaml
+++ b/.github/zap/trento-api.yaml
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+env:
+  contexts:
+    - name: trento
+      urls:
+        - http://localhost:4000
+      includePaths:
+        - "http://localhost:4000.*"
+      excludePaths:
+        # Logging the scanner out mid-scan would silently degrade coverage.
+        - "http://localhost:4000/api/session/.*/callback.*"
+        - "http://localhost:4000/logout.*"
+  parameters:
+    failOnError: true
+    failOnWarning: false
+    progressToStdout: true
+
+jobs:
+  # Injects the bearer token on every request. TRENTO_JWT is substituted before
+  # ZAP starts; see the workflow's envsubst step.
+  - type: replacer
+    parameters:
+      deleteAllRules: true
+    rules:
+      - description: trento-bearer-token
+        matchType: req_header
+        matchString: Authorization
+        matchRegex: false
+        replacementString: "Bearer ${TRENTO_JWT}"
+        tokenProcessing: false
+
+  - type: openapi
+    parameters:
+      apiFile: /zap/wrk/openapi.json
+      targetUrl: http://localhost:4000
+      context: trento
+
+  - type: spider
+    parameters:
+      context: trento
+      url: http://localhost:4000
+      maxDuration: 5
+
+  - type: passiveScan-wait
+    parameters:
+      maxDuration: 5
+
+  - type: activeScan
+    parameters:
+      context: trento
+      maxRuleDurationInMins: 2
+      maxScanDurationInMins: 20
+
+  - type: report
+    parameters:
+      template: sarif-json
+      reportDir: /zap/wrk/sarif
+      reportFile: zap.sarif

--- a/guides/Development/security-scanning.adoc
+++ b/guides/Development/security-scanning.adoc
@@ -205,6 +205,34 @@ Every other publish step in this workflow keeps that strict check — do not
 add `optional: true` anywhere else without the same "writes nothing on a
 clean run" guarantee.
 
+=== Why DAST alerts point at the ZAP plan file
+
+Every DAST alert in the Security tab is reported against line 1 of
+`.github/zap/trento-api.yaml`, whichever URL it was actually found on. That is
+not a mistake, and the plan file is not the vulnerable code.
+
+Code scanning resolves each SARIF result location against the checked-out
+tree. A location carrying a URL is rejected, and it rejects the whole file
+rather than the single result:
+
+----
+SARIF URI scheme "http" did not match the checkout URI scheme "file"
+----
+
+Dynamic analysis has no source location to report — it knows a URL, not the
+handler behind it. `.github/scripts/anchor-dast-sarif.sh` therefore rewrites
+every location to the file that configures the scan and moves the scanned URL
+to the front of the alert message, where the triager reads it first. The full
+URL and ZAP's evidence string also stay in the result's `properties`, so the
+uploaded artifact remains machine-readable.
+
+Anchoring puts every finding on one line, which would let code scanning merge
+two findings of the same rule into a single alert. The script prevents that by
+writing an explicit `partialFingerprints` entry per result. Digits are stripped
+from the message before it enters the fingerprint: ZAP embeds timestamps and
+occurrence counts in its wording, and a fingerprint that changed on every run
+would resurrect alerts that had already been dismissed.
+
 == Known gaps
 
 * Dependencies sourced from git rather than Hex (`langchain`, `gen_rmq`,

--- a/guides/Development/security-scanning.adoc
+++ b/guides/Development/security-scanning.adoc
@@ -205,9 +205,9 @@ Every other publish step in this workflow keeps that strict check — do not
 add `optional: true` anywhere else without the same "writes nothing on a
 clean run" guarantee.
 
-=== Why DAST alerts point at the ZAP plan file
+=== Why ZAP alerts point at the ZAP plan file
 
-Every DAST alert in the Security tab is reported against line 1 of
+Every ZAP alert in the Security tab is reported against line 1 of
 `.github/zap/trento-api.yaml`, whichever URL it was actually found on. That is
 not a mistake, and the plan file is not the vulnerable code.
 
@@ -221,17 +221,23 @@ SARIF URI scheme "http" did not match the checkout URI scheme "file"
 
 Dynamic analysis has no source location to report — it knows a URL, not the
 handler behind it. `.github/scripts/anchor-dast-sarif.sh` therefore rewrites
-every location to the file that configures the scan and moves the scanned URL
-to the front of the alert message, where the triager reads it first. The full
-URL and ZAP's evidence string also stay in the result's `properties`, so the
-uploaded artifact remains machine-readable.
+every URL location to the file that configures the scan and moves the scanned
+URL to the front of the alert message, where the triager reads it first. The
+full URL and ZAP's evidence string also stay in the result's `properties`, so
+the uploaded artifact remains machine-readable.
 
-Anchoring puts every finding on one line, which would let code scanning merge
-two findings of the same rule into a single alert. The script prevents that by
-writing an explicit `partialFingerprints` entry per result. Digits are stripped
-from the message before it enters the fingerprint: ZAP embeds timestamps and
-occurrence counts in its wording, and a fingerprint that changed on every run
-would resurrect alerts that had already been dismissed.
+The script runs over Nuclei's report too, but changes nothing there: Nuclei
+already reports `.` as its location and names the target in the message. It is
+included so that a future version emitting URLs does not silently break the
+upload.
+
+Anchoring puts every ZAP finding on the same line, which leaves code scanning
+nothing to tell two findings of one rule apart by when it decides whether an
+alert it sees today is the one it saw yesterday. The script therefore writes an
+explicit `partialFingerprints` entry per result. Digits are stripped from the
+message before it enters the fingerprint: ZAP embeds timestamps and occurrence
+counts in its wording, and a fingerprint that changed on every run would
+resurrect alerts that had already been dismissed.
 
 == Known gaps
 

--- a/guides/Development/security-scanning.adoc
+++ b/guides/Development/security-scanning.adoc
@@ -1,6 +1,6 @@
 = Security scanning
 
-Trento runs static analysis and dependency scanning in the
+Trento runs static analysis, dependency scanning and dynamic analysis in the
 `Security Scanning` workflow (`.github/workflows/security.yaml`). Reports are
 published as SARIF, both as workflow artifacts and to the repository's
 Security -> Code scanning tab.
@@ -101,6 +101,109 @@ not supported for the query packs in use here.
 
 Code scanning generally:: Dismissing an alert in the Security tab records the
 reason and applies to future runs.
+
+== Dynamic analysis (DAST)
+
+DAST does not run on every pull request. It runs nightly, on manual dispatch,
+and on any pull request labelled `dast`:
+
+[source,bash]
+----
+gh pr edit --add-label dast
+gh workflow run "Security Scanning" --ref <your-branch>
+----
+
+=== Running ZAP locally
+
+Bring the stack up, seed the database and start the application:
+
+[source,bash]
+----
+docker compose --profile wanda up -d
+mix setup
+mix phx.server
+----
+
+Mint a token for the seeded admin (`sub` 1) and generate the API spec:
+
+[source,bash]
+----
+mix run --no-start -e '
+  File.write!("/tmp/trento-jwt.txt",
+    TrentoWeb.Auth.AccessToken.generate_access_token!(%{
+      "sub" => 1,
+      "exp" => System.system_time(:second) + 3600
+    }))'
+export TRENTO_JWT=$(cat /tmp/trento-jwt.txt)
+
+mix openapi.spec.json --start-app=false --spec TrentoWeb.OpenApi.All.ApiSpec
+----
+
+`POST /api/session` looks like the obvious way to mint this token, but its
+token's TTL is 180 seconds (`access_token_expiration` in
+`config/config.exs`), read through `compile_env`, so no environment variable
+can extend it. That token dies well before a twenty-minute active scan
+finishes, and the rest of the run bounces off 401s while still reporting a
+clean, green-looking scan. CI signs a token directly for that reason; this
+mirrors what CI does. `--no-start` matters too: without it, `mix run` boots a
+second copy of the application on top of the one already serving `:4000`.
+
+Resolve the plan and run the scan:
+
+[source,bash]
+----
+mkdir -p sarif
+envsubst '${TRENTO_JWT}' < .github/zap/trento-api.yaml > /tmp/zap-plan.yaml
+
+docker run --rm --network host \
+  -v "$PWD:/zap/wrk:rw" \
+  -v /tmp/zap-plan.yaml:/zap/wrk/plan.yaml:ro \
+  ghcr.io/zaproxy/zaproxy:2.17.0 \
+  zap.sh -cmd -autorun /zap/wrk/plan.yaml
+----
+
+The plan's `sarif-json` template appends its own extension to the report
+file, so the report lands at `sarif/zap.sarif.json`, not `sarif/zap.sarif`.
+CI renames it with a dedicated step; locally, use the `.json` name directly.
+
+Check that the scan was authenticated. If every reported URL is a login or
+static asset path, the token was not applied and the results are meaningless:
+
+[source,bash]
+----
+jq -r '[.runs[0].results[].locations[0].physicalLocation.artifactLocation.uri] \
+  | unique | .[]' sarif/zap.sarif.json | head -30
+----
+
+Do not commit `sarif/` or `openapi.json`.
+
+=== Nuclei
+
+Nuclei runs against the same target immediately after ZAP, unauthenticated:
+
+[source,bash]
+----
+docker run --rm --network host \
+  -v "$PWD/sarif:/sarif:rw" \
+  projectdiscovery/nuclei:v3.11.1 \
+  -target http://localhost:4000 \
+  -ni \
+  -sarif-export /sarif/nuclei.sarif
+----
+
+`-ni` (no-interactsh) disables the out-of-band templates: they rely on the
+scanned target reaching back out to a public interactsh server, which
+`localhost:4000` never can, so leaving them enabled would only spend the
+interaction poll and cooldown wait on matches that can never happen.
+
+Nuclei writes no report file at all when it finds nothing, which is the
+common case and not a failure. That is why, uniquely among the publish steps
+in this workflow, `Publish Nuclei SARIF` passes `optional: true` to
+`publish-sarif`: without it, the action's existence check treats a missing
+file as the scan having died before writing anything, and fails the job.
+Every other publish step in this workflow keeps that strict check — do not
+add `optional: true` anywhere else without the same "writes nothing on a
+clean run" guarantee.
 
 == Known gaps
 


### PR DESCRIPTION
## What this adds

The third of three stacked PRs adding security scanning. This one adds dynamic analysis: ZAP and Nuclei against a running instance of the application, published as SARIF under the `zap` and `nuclei` categories through the same `publish-sarif` composite action every other scanner uses.

- **`.github/zap/trento-api.yaml`** — a ZAP Automation Framework plan covering the OpenAPI import, spider, passive scan, active scan and SARIF report in one ZAP process.
- **`dast` job in `security.yaml`** — brings the application up, mints a token, runs both scanners, redacts, anchors and publishes.
- **`.github/scripts/anchor-dast-sarif.sh`** — makes a DAST report acceptable to code scanning.

The packaged ZAP scan scripts cannot emit SARIF at all; the `sarif-json` report template is only reachable through the Automation Framework, which is why the plan file exists rather than a one-line action invocation.

## Gating

The job does not run on ordinary pull requests. It runs on the nightly schedule, on manual dispatch, and on a pull request carrying the `dast` label. A full scan takes on the order of forty minutes, which is not worth spending on every push.

## Authentication is a hard gate

An unauthenticated scan of an API reaches almost nothing and still reports green, which is the worst possible outcome for a security check. Two things are therefore hard failures rather than report-only:

- **Readiness** — if the application never answers `/api/readyz` within 120 seconds, the job fails. A dead target makes ZAP report a clean scan.
- **Token validity** — the job asserts the minted token is non-empty and that `GET /api/hosts` with it returns 200 before handing it to ZAP.

Only the scanner invocations themselves carry `continue-on-error`.

The token is signed directly rather than fetched from `POST /api/session`. `access_token_expiration` is 180 seconds and is read through `compile_env`, so no environment variable can extend it — a session token dies three minutes into a forty-minute scan and the remainder of the run bounces off 401s. This was measured, not assumed.

## The report is redacted before it is published

ZAP embeds whole requests and responses in its report, and Phoenix debug error pages echo the `Authorization` header back, so an unredacted report contains the bearer token and freshly generated API keys — in a file that goes to code scanning *and* a 30-day artifact. `::add-mask::` only filters log output; it does not touch file contents.

A redaction step therefore removes `webRequest`, `webResponse` and the per-alert evidence snippet structurally, then replaces any surviving literal occurrence of the token and verifies it is gone. The three are not searched for secrets, because no list of known strings is a reliable gate on a verbatim fragment of a scanned response — the passive cookie rules alone quote whole `Set-Cookie` headers, which on a Phoenix application is the signed session cookie. The token walk is a backstop, not the gate. If redaction fails for any reason, nothing is published.

The report is redacted outside the workspace and only moved into the published path once every check has passed, so no cancellation or timeout can publish an unredacted report.

The cost is triage detail: rule, severity and URL survive, but the request/response pair and the evidence string do not, so reproducing a finding means re-running the scan.

## Why the ZAP alerts point at the plan file

Code scanning resolves every SARIF result location against the checked-out tree, and rejects the entire file — not the one result — when a location carries a URL:

```
SARIF URI scheme "http" did not match the checkout URI scheme "file"
```

Dynamic analysis has no source location to report; it knows a URL, not the handler behind it. `anchor-dast-sarif.sh` rewrites every URL location to `.github/zap/trento-api.yaml`, the file that configures the scan, and moves the scanned URL to the front of the alert message. The URL is also kept in the location's `properties`, so the artifact remains machine-readable. The evidence snippet is not carried over — it is the class of content the redaction step deletes, and nothing downstream may put it back.

Anchoring puts every finding on the same line, which leaves code scanning nothing to tell two findings of one rule apart by when it decides whether an alert it sees today is the one it saw yesterday. The script writes an explicit `partialFingerprints` entry per result. Digits are stripped from the message before it enters the fingerprint: ZAP embeds timestamps and occurrence counts in its wording, and a fingerprint that changed every run would resurrect alerts that had already been dismissed.

Nuclei needs none of this — it reports `.` and names the target in the message — but its report is passed through the same script so that a future version emitting URLs does not silently break the upload.

## Verified

Dispatch run [31697592600](https://github.com/trento-project/web/actions/runs/31697592600), against this branch, all six jobs green:

| | |
|---|---|
| DAST job | green end to end, 29m29s against a 45-minute timeout |
| ZAP | 38 results, uploaded, category `zap` |
| Nuclei | 13 results, uploaded, category `nuclei` |
| Redaction | published artifact holds 0 occurrences of the token, 0 `webRequest`/`webResponse` objects, 0 evidence snippets |
| Anchoring | every ZAP location rewritten to the plan file, 0 URL locations left, 33 distinct fingerprints across 38 results |
| Alert identity | 38 separate ZAP alerts, not one merged alert per rule |
| Security tab | all seven categories present — `sobelow` 12, `osv` 36, `eslint-security` 223, `codeql-javascript` 1, `codeql-actions` 52, `zap` 38, `nuclei` 13 |

The label gate was proven by comparison rather than by reading the condition: two `pull_request` runs at one head SHA, DAST skipped before the `dast` label was applied and green after.

The scan was confirmed authenticated by correlating `request_id` in the Phoenix log rather than by reading the reported URL list: the `openapi` job seeds every spec path into the report whether or not authentication succeeded. 31,212 requests to `/api/v1` and `/api/v2`, zero 401s.

## Notes for reviewers

- `actions/cache/restore` is used, never `actions/cache`. This job runs with `MIX_ENV: dev`, so its key matches the one `ci.yaml` writes — a read-write cache action here would save under a key that workflow owns.
- The active scan **mutates the target** (creates and deletes records, patches settings). It must only ever run against a throwaway instance, which is what an ephemeral runner is.
- ZAP's `sarif-json` template appends its own extension, so the plan's `zap.sarif` lands as `zap.sarif.json`; a step moves it aside, out of the workspace, before redaction. That step deliberately does not fail when no report exists — `publish-sarif` owns that error.
- The ZAP image is pinned to the `2.17.0` release build. The `w2026-*` weekly builds report a `Dev Build` version string, which the SARIF upload validator rejects.
- Nuclei runs with `-ni`. Its out-of-band templates need the target to reach a public interactsh server, which `localhost:4000` cannot, so leaving them on only spends the interaction poll and cooldown on matches that can never happen. `-duc` is *not* used: templates are not bundled in the image, and disabling the update check leaves the scan with nothing loaded.
- Nuclei writes no file at all on a clean scan. The job synthesises an empty report rather than skipping the upload: code scanning closes an alert only when a later analysis for the same category leaves it out, so publishing nothing would leave every Nuclei alert ever filed open. Synthesis is gated on the scan having actually completed — standing in an empty report for a Nuclei that crashed would close alerts on the word of a scanner that never ran.
- The raw ZAP report is set aside in `RUNNER_TEMP`, not `/tmp`. It is root-owned, `/tmp` is sticky, and the runner cannot unlink a root-owned file from a sticky directory even when it put the file there.
- `ci.yaml` is unchanged.

## Stacking

Based on the branch for #4604, which is itself based on #4603. It will be retargeted as those merge; review the commits here rather than the full diff until then.
