### PR TITLE
Adds explicit system env variable

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -89,7 +89,7 @@ if config_env() in [:prod, :demo] do
   # upon start up.
   # Exposed as a deployment environment variable.
   # If the environment variable is not set it defaults to ipv4.
-  # Accepts either ipv4 and ipv6 as possible values. (Case-insenstive)
+  # Accepts either ipv4 and ipv6 as possible values. (Case-insensitive)
   ip =
     case System.get_env("IPV4_OR_IPV6", "IPV4") |> String.downcase() do
       "ipv4" -> {0, 0, 0, 0}

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -93,8 +93,8 @@ if config_env() in [:prod, :demo] do
   ip =
     case System.get_env("IPV4_OR_IPV6", "IPV4") |> String.downcase() do
       "ipv4" -> {0, 0, 0, 0}
-       "ipv6" -> {0, 0, 0, 0, 0, 0, 0, 0}
-        _ -> raise "Invalid value set for environment variable IPV4_OR_IPV6"
+      "ipv6" -> {0, 0, 0, 0, 0, 0, 0, 0}
+      _ -> raise "Invalid value set for environment variable IPV4_OR_IPV6"
     end
 
   config :trento, TrentoWeb.Endpoint,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -84,13 +84,17 @@ if config_env() in [:prod, :demo] do
       For example: yourdomain.example.com
       """
 
-  # Returns an IP address to bind the HTTP server, based on IPv6 support.
+  # Returns an IP address to bind the HTTP server, based on explicit operator choice
   # This prevents startup failures on systems without IPv6 where the app would crash
-  # Falls back to IPv4 `{0, 0, 0, 0}` if IPv6 is not available.
+  # upon start up.
+  # Exposed as a deployment environment variable.
+  # If the environment variable is not set it defaults to ipv4
+  # if it is set, it goes
   ip =
-    case :inet.getaddr(~c"localhost", :inet6) do
-      {:ok, _addr} -> {0, 0, 0, 0, 0, 0, 0, 0}
-      {:error, _} -> {0, 0, 0, 0}
+    case System.get_env("IPV4_OR_IPV6", "IPV4") |> String.downcase() do
+      "ipv4" -> {0, 0, 0, 0}
+       "ipv6" -> {0, 0, 0, 0, 0, 0, 0, 0}
+        _ -> raise "Invalid value set for environment variable IPV4_OR_IPV6"
     end
 
   config :trento, TrentoWeb.Endpoint,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -88,8 +88,8 @@ if config_env() in [:prod, :demo] do
   # This prevents startup failures on systems without IPv6 where the app would crash
   # upon start up.
   # Exposed as a deployment environment variable.
-  # If the environment variable is not set it defaults to ipv4
-  # if it is set, it goes
+  # If the environment variable is not set it defaults to ipv4.
+  # Accepts either ipv4 and ipv6 as possible values. (Case-insenstive)
   ip =
     case System.get_env("IPV4_OR_IPV6", "IPV4") |> String.downcase() do
       "ipv4" -> {0, 0, 0, 0}

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -89,7 +89,7 @@ if config_env() in [:prod, :demo] do
   # upon start up.
   # Exposed as a deployment environment variable.
   # If the environment variable is not set it defaults to ipv4.
-  # Accepts either ipv4 and ipv6 as possible values. (Case-insensitive)
+  # Accepts either ipv4 or ipv6 as possible values. (Case-insensitive)
   ip =
     case System.get_env("IPV4_OR_IPV6", "IPV4") |> String.downcase() do
       "ipv4" -> {0, 0, 0, 0}

--- a/guides/Development/environment-variables.adoc
+++ b/guides/Development/environment-variables.adoc
@@ -27,3 +27,5 @@ Dig into link:https://github.com/trento-project/web/blob/main/config/[./config] 
 
 *AUTHENTICATION* - `+ACCESS_TOKEN_ENC_SECRET+` -
 `+REFRESH_TOKEN_ENC_SECRET+`
+
+*Runtime Networking* - `+IPV4_OR_IPV6+` - (Takes value of either "IPV4" or "IPV6" depending on what is known to the deployer to be available at application start-up.)


### PR DESCRIPTION
Explicit system env. variable for ipv4 vs ipv6 support. Exposed as operator configuration.

### Description

There are cases when the networking stack in the runtime/deployment environment is either ipv4 or ipv6. Existing detection logic based dynamic config does not correctly detect enabled/disabled status of ipv6 as evidenced in some support cases. The ultimate source of truth here is choice of the deployer of the trento-web artifact, and from their deployment (e.g. cloud) environment constraints/choices available to them.

Default networking stack chosen is ipv4, so if nothing is provided, ipv4 is chosen. ipv6 can be opted into, via explicit choice of the deploying person. In the author's understanding the default networking stack in most cloud VM environments is ipv4, but the choice of the default can be evolved/changed if there is more data from cases to support that. 

Note: In the author's understanding, there is no consideration/support envisioned for dual networking ipv4+ipv6 stack, hence the choice between networking stacks is exclusive, i.e. one or other must be chosen, and the choice made entails that the non-chosen networking stack will not be made use of by the trento-web application.

### How was this tested?

The test package/PTF will be tested by the case reporter, after this PR is reviewed by all involved.

### Documentation changes

Docs changes will be needed and will be done subsequently.