### PR TITLE
Fix IPv6 fallback detection to prevent startup crashes when disabled at boot

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -84,14 +84,21 @@ if config_env() in [:prod, :demo] do
       For example: yourdomain.example.com
       """
 
-  # Returns an IP address to bind the HTTP server, based on IPv6 support.
-  # This prevents startup failures on systems without IPv6 where the app would crash
-  # Falls back to IPv4 `{0, 0, 0, 0}` if IPv6 is not available.
+  # We test IPv6 support by actually attempting to open a listener socket.
+  # This prevents startup crashes with `:eafnosupport` on systems where IPv6
+  # is disabled at the OS level (e.g., via GRUB), but `localhost` still
+  # resolves to an IPv6 address in `/etc/hosts`.
   ip =
-    case :inet.getaddr(~c"localhost", :inet6) do
-      {:ok, _addr} -> {0, 0, 0, 0, 0, 0, 0, 0}
-      {:error, _} -> {0, 0, 0, 0}
-    end
+    case :gen_tcp.listen(0, [:inet6]) do
+      {:ok, socket} ->
+      # IPv6 is supported by the kernel, close the test socket and return the IPv6 "any" address.
+      :gen_tcp.close(socket)
+      {0, 0, 0, 0, 0, 0, 0, 0}
+
+    {:error, _reason} ->
+          # IPv6 is not supported (e.g., :eafnosupport), fall back to IPv4
+          {0, 0, 0, 0}
+      end
 
   config :trento, TrentoWeb.Endpoint,
     http: [


### PR DESCRIPTION
We test IPv6 support by actually attempting to open a listener socket. This prevents startup crashes with `:eafnosupport` on systems where IPv6 is disabled at the OS level (e.g., via GRUB), but `localhost` still resolves to an IPv6 address in `/etc/hosts`.

### Description

**The Issue:**

Previously, the application checked for IPv6 support using :inet.getaddr(~c"localhost", :inet6). However, on systems where IPv6 is explicitly disabled at the OS/kernel level (e.g., via ipv6.disable=1 in GRUB), /etc/hosts often still contains a ::1 localhost entry.

Because inet.getaddr checks the resolver (which reads the hosts file) rather than checking actual socket capability, it falsely returns {:ok, {0,0,0,0,0,0,0,1}}. The application then attempts to bind Ranch to {0, 0, 0, 0, 0, 0, 0, 0}, which immediately crashes the service with :eafnosupport (address family not supported by protocol family) because the kernel cannot actually create an IPv6 socket.

**The Fix:**

This PR changes the detection mechanism to actually attempt to open an ephemeral TCP socket bound to inet6 via :gen_tcp.listen(0, [:inet6]).

If it succeeds, we know the kernel truly supports IPv6 sockets. We safely close the test socket and proceed with the IPv6 "any" address.

If it fails (e.g., throwing :eafnosupport), it correctly falls back to the IPv4 {0, 0, 0, 0} address, allowing the application to boot normally.

**Considerations:**

Performance: Opening and closing a socket on port 0 (which assigns an ephemeral, available port) is a very fast system call. Since this only happens once at application startup, there is virtually zero performance penalty.

Reliability: This is an established pattern in the Erlang ecosystem when strict guarantees about system socket capabilities are needed over simple DNS/host file resolution.

### How was this tested?

On a SLES 15 SP7 system, I deployed Trento 3.1.4 (systemd deployment). Then I did the following to disable IPv6

- Modify "/etc/default/grub" to `GRUB_CMDLINE_LINUX_DEFAULT="ipv6.disable=1"`
- Regenerate the Grub Configuration: `grub2-mkconfig -o /boot/grub2/grub.cfg`
- reboot

Upon startup, the trento-web and trento-wanda services are failing. I adjusted the following files with commit fix: 
- /usr/lib/trento/releases/3.1.2/runtime.exs
- /usr/lib/wanda/releases/2.1.0/runtime.exs

After stopping and starting the services back up, all is running as expected. 

I also undid the ipv6.disable, rebooted, and tested with the fix in place, and services continue working normally. 

### Documentation changes

No

### Additional Information

If this PR is accepted, we'd also need to make the same change on the trento-wanda runtime.exs file. 
