### PR TITLE
AI cancel run core

### DIFF
--- a/lib/trento/ai/agent.ex
+++ b/lib/trento/ai/agent.ex
@@ -82,11 +82,39 @@ defmodule Trento.AI.Agent do
   @doc """
   Stops the running agent for `agent_id`, terminating any in-flight run.
 
-  Best-effort — returns the supervisor's result verbatim (`{:error, term()}`
-  when no agent is running for the id).
+  It cancels in-flight runs first, then stops the agent process.
+
+  This is faster than only stopping the agent, because `Sagents.AgentServer.terminate/2`
+  waits for the running task to finish (up to 25s) before the process exits.
+
+  Best-effort — the cancel result is discarded and the supervisor's result is
+  returned verbatim (`{:error, term()}` when no agent is running for the id).
   """
   @spec stop(String.t()) :: :ok | {:error, term()}
-  def stop(agent_id), do: AgentSupervisor.stop_agent(agent_id)
+  def stop(agent_id) do
+    cancel(agent_id)
+    AgentSupervisor.stop_agent(agent_id)
+  end
+
+  @doc """
+  Cancels the in-flight run for `agent_id`, keeping the agent process and its
+  conversation state alive.
+
+  Best-effort — returns `{:error, reason}` when nothing is running for the id.
+  """
+  @spec cancel(String.t()) :: :ok | {:error, term()}
+  def cancel(agent_id) do
+    AgentServer.cancel(agent_id)
+  catch
+    # `AgentServer.cancel/1` is a `GenServer.call` on a via-registry name, so it
+    # exits rather than returning an error when:
+    #   - nothing is registered for `agent_id` (`:noproc`) — never started, or already stopped
+    #   - the reply outlives the 5s default (`:timeout`) — the server answers only after a 2s task grace
+    #   - the server dies mid-call — a concurrent `stop/1` parks in `terminate/2` for up to 25s
+    # None of these leaves a run worth reporting on, and the exit signal must not
+    # take the caller down with it.
+    :exit, reason -> {:error, reason}
+  end
 
   defp maybe_refresh_agent(agent_id, maybe_new_agent, refresh_when) do
     with {:ok, current_agent} <- AgentServer.get_agent(agent_id),

--- a/lib/trento/ai/agent/server.ex
+++ b/lib/trento/ai/agent/server.ex
@@ -18,6 +18,7 @@ defmodule Trento.AI.Agent.Server do
 
   @callback subscribe(String.t()) :: :ok | {:error, term()}
   @callback add_message(String.t(), Message.t()) :: :ok | {:error, term()}
+  @callback cancel(String.t()) :: :ok | {:error, term()}
   @callback get_agent(String.t()) :: {:ok, Sagents.Agent.t()} | {:error, term()}
   @callback get_info(String.t()) :: %{state: Sagents.State.t()}
   @callback update_agent_and_state(String.t(), Sagents.Agent.t(), Sagents.State.t()) ::
@@ -25,6 +26,7 @@ defmodule Trento.AI.Agent.Server do
 
   def subscribe(agent_id), do: impl().subscribe(agent_id)
   def add_message(agent_id, message), do: impl().add_message(agent_id, message)
+  def cancel(agent_id), do: impl().cancel(agent_id)
   def get_agent(agent_id), do: impl().get_agent(agent_id)
   def get_info(agent_id), do: impl().get_info(agent_id)
 

--- a/lib/trento/infrastructure/ai/sagents_agent_server.ex
+++ b/lib/trento/infrastructure/ai/sagents_agent_server.ex
@@ -16,6 +16,9 @@ defmodule Trento.Infrastructure.AI.SagentsAgentServer do
   defdelegate add_message(agent_id, message), to: Sagents.AgentServer
 
   @impl Trento.AI.Agent.Server
+  defdelegate cancel(agent_id), to: Sagents.AgentServer
+
+  @impl Trento.AI.Agent.Server
   defdelegate get_agent(agent_id), to: Sagents.AgentServer
 
   @impl Trento.AI.Agent.Server

--- a/test/support/ai/ai_case.ex
+++ b/test/support/ai/ai_case.ex
@@ -62,15 +62,19 @@ defmodule Trento.AI.AICase do
   end
 
   @doc """
-  Returns the pid of the running agent process for `agent_id`, failing the test
-  when nothing is registered.
+  Returns the pid of the running agent process for `agent_id`, raising when
+  nothing is registered.
 
   The registry is the one piece of sagents with no `Trento.AI` port in front of
-  it, so it is reached here once instead of at every assertion site.
+  it, so it is reached here once instead of at every call site.
   """
   def agent_pid!(agent_id) do
-    assert {:ok, pid} = Sagents.AgentSupervisor.get_pid(agent_id)
+    case Sagents.AgentSupervisor.get_pid(agent_id) do
+      {:ok, pid} ->
+        pid
 
-    pid
+      {:error, reason} ->
+        raise "no agent process registered for #{inspect(agent_id)}: #{inspect(reason)}"
+    end
   end
 end

--- a/test/support/ai/ai_case.ex
+++ b/test/support/ai/ai_case.ex
@@ -6,6 +6,21 @@ defmodule Trento.AI.AICase do
 
   use ExUnit.CaseTemplate
 
+  alias Trento.AI.ApplicationConfigLoader
+  alias Trento.Infrastructure.AI.{SagentsAgentServer, SagentsDynamicSupervisor}
+
+  # Booting a real sagents process tree and reaching the model call is slower
+  # than any mocked round-trip, so integration tests wait longer.
+  @integration_timeout 5_000
+
+  using do
+    quote do
+      import Trento.AI.AICase
+
+      @integration_timeout unquote(@integration_timeout)
+    end
+  end
+
   setup _ do
     stub_config_loader()
 
@@ -17,5 +32,45 @@ defmodule Trento.AI.AICase do
       Trento.AI.ApplicationConfigLoader.Mock,
       Trento.AI.ApplicationConfigLoader
     )
+  end
+
+  @doc """
+  Swaps the whole AI config over to the real implementations for the duration
+  of the test, so `Trento.AI.Agent` drives the actual sagents tree instead of
+  the Mox doubles wired in `config/test.exs`.
+
+  `:application_config_loader` goes back to the real module too, and that is
+  what lets teardown call `Trento.AI.Agent.stop/1`: the Mox mock is `:private`
+  and stubbed for the *test* process, while `on_exit` runs in a process of its
+  own. Semantically it changes nothing — the mock is stubbed with
+  `Mox.stub_with(…, ApplicationConfigLoader)`, so it only ever delegated to
+  this same module.
+  """
+  def real_sagents_adapters(_context) do
+    ai = Application.get_env(:trento, :ai)
+
+    Application.put_env(
+      :trento,
+      :ai,
+      ai
+      |> Keyword.put(:application_config_loader, ApplicationConfigLoader)
+      |> Keyword.put(:agent_supervisor_adapter, SagentsDynamicSupervisor)
+      |> Keyword.put(:agent_server_adapter, SagentsAgentServer)
+    )
+
+    on_exit(fn -> Application.put_env(:trento, :ai, ai) end)
+  end
+
+  @doc """
+  Returns the pid of the running agent process for `agent_id`, failing the test
+  when nothing is registered.
+
+  The registry is the one piece of sagents with no `Trento.AI` port in front of
+  it, so it is reached here once instead of at every assertion site.
+  """
+  def agent_pid!(agent_id) do
+    assert {:ok, pid} = Sagents.AgentSupervisor.get_pid(agent_id)
+
+    pid
   end
 end

--- a/test/support/ai/fake_chat_model.ex
+++ b/test/support/ai/fake_chat_model.ex
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.AI.FakeChatModel do
+  @moduledoc """
+  A `LangChain.ChatModels.ChatModel` that never talks to a provider.
+
+  Exists so integration tests can hold a `Sagents.AgentServer` run genuinely
+  in flight — the only state in which `Trento.AI.Agent.cancel/1` does anything
+  — without a network call.
+
+  `call/3` runs inside the agent's run task and parks there:
+
+  - `:notify` (pid) receives `{:llm_called, task_pid}` as soon as the chain
+    reaches the model, so a test can wait for a *real* in-flight run instead
+    of sleeping.
+  - the park ends on a `:release` message (answers with `:reply`) or after
+    `:block_for` ms. The timeout is the CI guard: a cancel that fails to kill
+    the task makes the test fail on its own assertions rather than hang.
+
+  `:callbacks` is required by `LangChain.Utils.rewrap_callbacks_for_model/3`,
+  which writes the chain's wrapped callbacks onto the model struct.
+  """
+
+  @behaviour LangChain.ChatModels.ChatModel
+
+  alias LangChain.Message
+
+  defstruct callbacks: [], notify: nil, block_for: 5_000, reply: "fake reply"
+
+  @type t :: %__MODULE__{
+          callbacks: [map()],
+          notify: pid() | nil,
+          block_for: non_neg_integer(),
+          reply: String.t()
+        }
+
+  @impl LangChain.ChatModels.ChatModel
+  def call(%__MODULE__{notify: notify, block_for: block_for, reply: reply}, _messages, _tools) do
+    if is_pid(notify), do: send(notify, {:llm_called, self()})
+
+    receive do
+      :release -> {:ok, [Message.new_assistant!(reply)]}
+    after
+      block_for -> {:ok, [Message.new_assistant!(reply)]}
+    end
+  end
+
+  @impl LangChain.ChatModels.ChatModel
+  def retry_on_fallback?(_error), do: false
+
+  @impl LangChain.ChatModels.ChatModel
+  def serialize_config(%__MODULE__{}), do: %{"module" => Atom.to_string(__MODULE__)}
+
+  @impl LangChain.ChatModels.ChatModel
+  def restore_from_map(_data), do: {:ok, %__MODULE__{}}
+end

--- a/test/trento/ai/agent_test.exs
+++ b/test/trento/ai/agent_test.exs
@@ -337,15 +337,15 @@ defmodule Trento.AI.AgentTest do
     end
 
     test "kills the in-flight run instead of waiting it out" do
-      %{agent_id: agent_id, pid: pid, task_pid: task_pid} =
-        start_running_agent(block_for: :timer.minutes(1))
+      %{agent_id: agent_id, pid: pid} = start_running_agent(block_for: :timer.minutes(1))
+      task_pid = await_in_flight_run()
 
       server_ref = Process.monitor(pid)
       task_ref = Process.monitor(task_pid)
 
       stopping = Task.async(fn -> TrentoAIAgent.stop(agent_id) end)
 
-      # Nobody releases the pending model, so the run can only end by being killed.
+      # Nothing releases the pending model, so the run can only end by being killed.
       # `Sagents.AgentServer.terminate/2` waits up to 25s for a running task,
       # so a `stop` that did not cancel first would wait for 25s.
       assert :ok = Task.await(stopping, 3_000)
@@ -365,6 +365,8 @@ defmodule Trento.AI.AgentTest do
 
       %{agent_id: agent_id, pid: pid} =
         start_running_agent(initial_user_prompt: initial_user_prompt)
+
+      await_in_flight_run()
 
       assert :ok = TrentoAIAgent.cancel(agent_id)
 
@@ -388,6 +390,7 @@ defmodule Trento.AI.AgentTest do
 
     test "leaves the thread usable — the next prompt starts a new run" do
       %{agent: agent, agent_id: agent_id} = start_running_agent()
+      await_in_flight_run()
 
       assert :ok = TrentoAIAgent.cancel(agent_id)
       assert_receive {:agent, {:status_changed, :cancelled, nil}}, @integration_timeout
@@ -400,6 +403,7 @@ defmodule Trento.AI.AgentTest do
 
     test "the cancelled agent can still be stopped afterwards" do
       %{agent_id: agent_id, pid: pid} = start_running_agent()
+      await_in_flight_run()
 
       assert :ok = TrentoAIAgent.cancel(agent_id)
       assert_receive {:agent, {:status_changed, :cancelled, nil}}, @integration_timeout
@@ -442,11 +446,13 @@ defmodule Trento.AI.AgentTest do
     # Counterproof about the functioning of the FakeChatModel.
     # When the run is released, it completes successfully and the agent goes back to idle.
     test "a released run finishes successfully" do
-      %{agent_id: agent_id, task_pid: task_pid} =
+      %{agent_id: agent_id} =
         start_running_agent(
           block_for: :timer.minutes(1),
           reply: "You are absolutely right, I am a fake model."
         )
+
+      task_pid = await_in_flight_run()
 
       send(task_pid, :release)
 
@@ -482,36 +488,35 @@ defmodule Trento.AI.AgentTest do
   # a live run to act on. Subscribes the *test* process to the agent's event
   # stream (`run/3` does that for its caller).
   #
-  # `:task_pid` is the parked run task: `send(task_pid, :release)` makes the
-  # fake model answer and the run complete.
-  #
-  # `:block_for` overrides how long the fake model parks, for the one test that
-  # has to rule the park's own timeout out as the thing that ended the run. It
+  # `:block_for` overrides how long the fake model parks, for the tests that
+  # have to rule the park's own timeout out as the thing that ended the run. It
   # defaults to the fake model's own default rather than restating it.
   defp start_running_agent(opts \\ []) do
     agent_id = "thread-#{Faker.UUID.v4()}"
-    model = %FakeChatModel{notify: self()}
+    defaults = %FakeChatModel{notify: self()}
 
-    block_for = Keyword.get(opts, :block_for, model.block_for)
-    reply = Keyword.get(opts, :reply, model.reply)
-    initial_user_prompt = Keyword.get(opts, :initial_user_prompt, "hello")
+    model = %FakeChatModel{
+      defaults
+      | block_for: Keyword.get(opts, :block_for, defaults.block_for),
+        reply: Keyword.get(opts, :reply, defaults.reply)
+    }
 
-    agent =
-      TrentoAIAgent.new!(
-        agent_id: agent_id,
-        model: %FakeChatModel{model | block_for: block_for, reply: reply},
-        scope: build(:user)
-      )
+    agent = TrentoAIAgent.new!(agent_id: agent_id, model: model, scope: build(:user))
 
-    assert :ok = TrentoAIAgent.run(agent, initial_user_prompt)
-    pid = agent_pid!(agent_id)
+    :ok = TrentoAIAgent.run(agent, Keyword.get(opts, :initial_user_prompt, "hello"))
+    on_exit(fn -> TrentoAIAgent.stop(agent_id) end)
 
+    %{agent: agent, agent_id: agent_id, pid: agent_pid!(agent_id)}
+  end
+
+  # Blocks until the run started by `start_agent/1` is actually inside the model call.
+  #
+  # Returns the parked run task: `send(task_pid, :release)` makes the fake model answer and the run complete.
+  defp await_in_flight_run do
     assert_receive {:agent, {:status_changed, :running, nil}}, @integration_timeout
     assert_receive {:llm_called, task_pid}, @integration_timeout
 
-    on_exit(fn -> TrentoAIAgent.stop(agent_id) end)
-
-    %{agent: agent, agent_id: agent_id, pid: pid, task_pid: task_pid}
+    task_pid
   end
 
   defp run_opts(_ctx) do

--- a/test/trento/ai/agent_test.exs
+++ b/test/trento/ai/agent_test.exs
@@ -17,6 +17,8 @@ defmodule Trento.AI.AgentTest do
   alias Trento.AI.{ApplicationConfigLoader, FakeChatModel}
   alias Trento.Users.User
 
+  @fake_reply "You are absolutely right, I am a fake model."
+
   setup :verify_on_exit!
 
   describe "new!/1" do
@@ -299,26 +301,10 @@ defmodule Trento.AI.AgentTest do
   describe "stop/1 — integration (real supervisor + server)" do
     @describetag :integration
 
-    setup :real_sagents_adapters
+    setup [:real_sagents_adapters, :idle_agent, :running_agent]
 
-    test "terminates the running agent's process tree" do
-      agent_id = "thread-#{Faker.UUID.v4()}"
-
-      agent =
-        TrentoAIAgent.new!(
-          agent_id: agent_id,
-          model: build(:random_langchain_model),
-          scope: build(:user)
-        )
-
-      assert {:ok, _sup} =
-               TrentoAIAgentSupervisor.start_agent_sync(
-                 agent_id: agent_id,
-                 agent: agent,
-                 pubsub: {Phoenix.PubSub, Trento.PubSub}
-               )
-
-      pid = agent_pid!(agent_id)
+    @tag :idle_agent
+    test "terminates the running agent's process tree", %{agent_id: agent_id, pid: pid} do
       assert Process.alive?(pid)
       ref = Process.monitor(pid)
 
@@ -336,8 +322,8 @@ defmodule Trento.AI.AgentTest do
       assert {:error, :not_found} = TrentoAIAgent.stop("thread-#{Faker.UUID.v4()}")
     end
 
-    test "kills the in-flight run instead of waiting it out" do
-      %{agent_id: agent_id, pid: pid} = start_running_agent(block_for: :timer.minutes(1))
+    @tag running_agent: [block_for: :timer.minutes(1)]
+    test "kills the in-flight run instead of waiting it out", %{agent_id: agent_id, pid: pid} do
       task_pid = await_in_flight_run()
 
       server_ref = Process.monitor(pid)
@@ -358,14 +344,11 @@ defmodule Trento.AI.AgentTest do
   describe "cancel/1 — integration (real supervisor + server)" do
     @describetag :integration
 
-    setup :real_sagents_adapters
+    setup [:real_sagents_adapters, :idle_agent, :running_agent]
 
-    test "kills the in-flight run, keeping the agent process and its conversation" do
-      initial_user_prompt = Faker.Lorem.sentence()
-
-      %{agent_id: agent_id, pid: pid} =
-        start_running_agent(initial_user_prompt: initial_user_prompt)
-
+    @tag :running_agent
+    test "kills the in-flight run, keeping the agent process and its conversation",
+         %{agent_id: agent_id, pid: pid, prompt: prompt} do
       await_in_flight_run()
 
       assert :ok = TrentoAIAgent.cancel(agent_id)
@@ -381,15 +364,16 @@ defmodule Trento.AI.AgentTest do
                &match?(
                  %Message{
                    role: :user,
-                   content: [%Message.ContentPart{content: ^initial_user_prompt}]
+                   content: [%Message.ContentPart{content: ^prompt}]
                  },
                  &1
                )
              )
     end
 
-    test "leaves the thread usable — the next prompt starts a new run" do
-      %{agent: agent, agent_id: agent_id} = start_running_agent()
+    @tag :running_agent
+    test "leaves the thread usable — the next prompt starts a new run",
+         %{agent: agent, agent_id: agent_id} do
       await_in_flight_run()
 
       assert :ok = TrentoAIAgent.cancel(agent_id)
@@ -401,8 +385,8 @@ defmodule Trento.AI.AgentTest do
       assert_receive {:agent, {:status_changed, :running, nil}}, @integration_timeout
     end
 
-    test "the cancelled agent can still be stopped afterwards" do
-      %{agent_id: agent_id, pid: pid} = start_running_agent()
+    @tag :running_agent
+    test "the cancelled agent can still be stopped afterwards", %{agent_id: agent_id, pid: pid} do
       await_in_flight_run()
 
       assert :ok = TrentoAIAgent.cancel(agent_id)
@@ -416,26 +400,9 @@ defmodule Trento.AI.AgentTest do
       assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, @integration_timeout
     end
 
-    test "does not cancel — nor kill — an agent that is sitting idle" do
-      agent_id = "thread-#{Faker.UUID.v4()}"
-
-      agent =
-        TrentoAIAgent.new!(
-          agent_id: agent_id,
-          model: %FakeChatModel{notify: self()},
-          scope: build(:user)
-        )
-
-      assert {:ok, _sup} =
-               TrentoAIAgentSupervisor.start_agent_sync(
-                 agent_id: agent_id,
-                 agent: agent,
-                 pubsub: {Phoenix.PubSub, Trento.PubSub}
-               )
-
-      pid = agent_pid!(agent_id)
-      on_exit(fn -> TrentoAIAgent.stop(agent_id) end)
-
+    @tag :idle_agent
+    test "does not cancel — nor kill — an agent that is sitting idle",
+         %{agent_id: agent_id, pid: pid} do
       # the error sagents returns
       assert {:error, "Cannot cancel, server is not running (status: idle)"} =
                TrentoAIAgent.cancel(agent_id)
@@ -445,13 +412,8 @@ defmodule Trento.AI.AgentTest do
 
     # Counterproof about the functioning of the FakeChatModel.
     # When the run is released, it completes successfully and the agent goes back to idle.
-    test "a released run finishes successfully" do
-      %{agent_id: agent_id} =
-        start_running_agent(
-          block_for: :timer.minutes(1),
-          reply: "You are absolutely right, I am a fake model."
-        )
-
+    @tag running_agent: [block_for: :timer.minutes(1), reply: @fake_reply]
+    test "a released run finishes successfully", %{agent_id: agent_id} do
       task_pid = await_in_flight_run()
 
       send(task_pid, :release)
@@ -466,9 +428,7 @@ defmodule Trento.AI.AgentTest do
                &match?(
                  %Message{
                    role: :assistant,
-                   content: [
-                     %Message.ContentPart{content: "You are absolutely right, I am a fake model."}
-                   ]
+                   content: [%Message.ContentPart{content: @fake_reply}]
                  },
                  &1
                )
@@ -483,33 +443,60 @@ defmodule Trento.AI.AgentTest do
     end
   end
 
-  # Boots a real agent through the public API and blocks until its run is
-  # actually inside the model call, so that a following cancel/1 or stop/1 has
-  # a live run to act on. Subscribes the *test* process to the agent's event
-  # stream (`run/3` does that for its caller).
+  # Boots a real agent through the public API and starts a run on it, so that a
+  # following cancel/1 or stop/1 has a live run to act on. Subscribes the *test*
+  # process to the agent's event stream (`run/3` does that for its caller):
+  # setup runs in the test process, so `await_in_flight_run/0` sees the events.
   #
-  # `:block_for` overrides how long the fake model parks, for the tests that
-  # have to rule the park's own timeout out as the thing that ended the run. It
-  # defaults to the fake model's own default rather than restating it.
-  defp start_running_agent(opts \\ []) do
+  # `@tag running_agent: opts` takes `Trento.AI.FakeChatModel`'s own fields verbatim.
+  # The tests that must rule the park's own timeout out as the thing that ended the run pass
+  # `[block_for: :timer.minutes(1)]`.
+  #
+  # Untagged tests get no agent: the ones asserting on an *absent* or idle agent
+  # must not have one booted behind.
+  defp running_agent(%{running_agent: true}), do: running_agent(%{running_agent: []})
+
+  defp running_agent(%{running_agent: model_opts}) when is_list(model_opts) do
     agent_id = "thread-#{Faker.UUID.v4()}"
-    defaults = %FakeChatModel{notify: self()}
-
-    model = %FakeChatModel{
-      defaults
-      | block_for: Keyword.get(opts, :block_for, defaults.block_for),
-        reply: Keyword.get(opts, :reply, defaults.reply)
-    }
-
+    prompt = Faker.Lorem.sentence()
+    model = struct!(FakeChatModel, Keyword.put(model_opts, :notify, self()))
     agent = TrentoAIAgent.new!(agent_id: agent_id, model: model, scope: build(:user))
 
-    :ok = TrentoAIAgent.run(agent, Keyword.get(opts, :initial_user_prompt, "hello"))
+    :ok = TrentoAIAgent.run(agent, prompt)
+    on_exit(fn -> TrentoAIAgent.stop(agent_id) end)
+
+    %{agent: agent, agent_id: agent_id, pid: agent_pid!(agent_id), prompt: prompt}
+  end
+
+  defp running_agent(_context), do: :ok
+
+  # Boots a real agent straight through the supervisor and leaves it idle: no
+  # run, so nothing for cancel/1 to kill and nothing for stop/1 to wait out.
+  defp idle_agent(%{idle_agent: true}) do
+    agent_id = "thread-#{Faker.UUID.v4()}"
+
+    agent =
+      TrentoAIAgent.new!(
+        agent_id: agent_id,
+        model: %FakeChatModel{notify: self()},
+        scope: build(:user)
+      )
+
+    {:ok, _sup} =
+      TrentoAIAgentSupervisor.start_agent_sync(
+        agent_id: agent_id,
+        agent: agent,
+        pubsub: {Phoenix.PubSub, Trento.PubSub}
+      )
+
     on_exit(fn -> TrentoAIAgent.stop(agent_id) end)
 
     %{agent: agent, agent_id: agent_id, pid: agent_pid!(agent_id)}
   end
 
-  # Blocks until the run started by `start_agent/1` is actually inside the model call.
+  defp idle_agent(_context), do: :ok
+
+  # Blocks until the run started by `running_agent/1` is actually inside the model call.
   #
   # Returns the parked run task: `send(task_pid, :release)` makes the fake model answer and the run complete.
   defp await_in_flight_run do

--- a/test/trento/ai/agent_test.exs
+++ b/test/trento/ai/agent_test.exs
@@ -10,11 +10,11 @@ defmodule Trento.AI.AgentTest do
   import Trento.Factory
 
   alias LangChain.Message
-  alias Sagents.AgentSupervisor
   alias Sagents.Middleware.{PatchToolCalls, Summarization, TodoList}
   alias Trento.AI.Agent, as: TrentoAIAgent
+  alias Trento.AI.Agent.Server, as: TrentoAIAgentServer
   alias Trento.AI.Agent.Supervisor, as: TrentoAIAgentSupervisor
-  alias Trento.Infrastructure.AI.SagentsDynamicSupervisor
+  alias Trento.AI.{ApplicationConfigLoader, FakeChatModel}
   alias Trento.Users.User
 
   setup :verify_on_exit!
@@ -65,7 +65,7 @@ defmodule Trento.AI.AgentTest do
       model = build(:random_langchain_model)
       scope = build(:user)
 
-      expect(Trento.AI.ApplicationConfigLoader.Mock, :load_config, fn ->
+      expect(ApplicationConfigLoader.Mock, :load_config, fn ->
         [base_system_prompt: "priv/ai/does_not_exist.md"]
       end)
 
@@ -78,7 +78,7 @@ defmodule Trento.AI.AgentTest do
       model = build(:random_langchain_model)
       scope = build(:user)
 
-      expect(Trento.AI.ApplicationConfigLoader.Mock, :load_config, fn -> [] end)
+      expect(ApplicationConfigLoader.Mock, :load_config, fn -> [] end)
 
       assert_raise KeyError, fn ->
         TrentoAIAgent.new!(agent_id: "thread-1", model: model, scope: scope)
@@ -227,8 +227,21 @@ defmodule Trento.AI.AgentTest do
   end
 
   describe "stop/1" do
-    test "delegates to the supervisor's stop_agent/1" do
+    test "cancels the in-flight run, then delegates to the supervisor's stop_agent/1" do
       agent_id = "thread-#{Faker.UUID.v4()}"
+
+      expect(Trento.AI.Agent.Server.Mock, :cancel, fn ^agent_id -> :ok end)
+      expect(Trento.AI.Agent.Supervisor.Mock, :stop_agent, fn ^agent_id -> :ok end)
+
+      assert :ok = TrentoAIAgent.stop(agent_id)
+    end
+
+    test "terminates anyway when there was no run to cancel" do
+      agent_id = "thread-#{Faker.UUID.v4()}"
+
+      expect(Trento.AI.Agent.Server.Mock, :cancel, fn ^agent_id ->
+        {:error, "Cannot cancel, server is not running (status: idle)"}
+      end)
 
       expect(Trento.AI.Agent.Supervisor.Mock, :stop_agent, fn ^agent_id -> :ok end)
 
@@ -237,6 +250,9 @@ defmodule Trento.AI.AgentTest do
 
     test "propagates the supervisor's error verbatim (nothing running)" do
       agent_id = "thread-#{Faker.UUID.v4()}"
+      reason = {:noproc, {GenServer, :call, [agent_id, :cancel, 5000]}}
+
+      expect(Trento.AI.Agent.Server.Mock, :cancel, fn ^agent_id -> exit(reason) end)
 
       expect(Trento.AI.Agent.Supervisor.Mock, :stop_agent, fn ^agent_id ->
         {:error, :not_found}
@@ -246,26 +262,44 @@ defmodule Trento.AI.AgentTest do
     end
   end
 
+  describe "cancel/1" do
+    test "delegates to the agent server's cancel/1" do
+      agent_id = "thread-#{Faker.UUID.v4()}"
+
+      expect(Trento.AI.Agent.Server.Mock, :cancel, fn ^agent_id -> :ok end)
+
+      assert :ok = TrentoAIAgent.cancel(agent_id)
+    end
+
+    test "propagates the server's error verbatim (nothing running)" do
+      agent_id = "thread-#{Faker.UUID.v4()}"
+
+      expect(Trento.AI.Agent.Server.Mock, :cancel, fn ^agent_id ->
+        {:error, :not_found}
+      end)
+
+      assert {:error, :not_found} = TrentoAIAgent.cancel(agent_id)
+    end
+
+    test "returns an error instead of exiting when the agent process is gone" do
+      agent_id = "thread-#{Faker.UUID.v4()}"
+      reason = {:noproc, {GenServer, :call, [agent_id, :cancel, 5000]}}
+
+      expect(Trento.AI.Agent.Server.Mock, :cancel, fn ^agent_id -> exit(reason) end)
+
+      assert {:error, ^reason} = TrentoAIAgent.cancel(agent_id)
+    end
+  end
+
   # Exercises the real Sagents supervisor tree through the public API,
   # proving that a genuinely running agent process is actually terminated
   # the mock tests above only prove the call is wired.
   #
-  # The test adapters are mocks (see test_helper.exs), so this describe swaps the
-  # supervisor adapter for the real SagentsDynamicSupervisor for its duration.
-  describe "stop/1 — integration (real supervisor)" do
+  # A fake model (see Trento.AI.FakeChatModel) holds a run in flight.
+  describe "stop/1 — integration (real supervisor + server)" do
     @describetag :integration
 
-    setup do
-      ai = Application.get_env(:trento, :ai)
-
-      Application.put_env(
-        :trento,
-        :ai,
-        Keyword.put(ai, :agent_supervisor_adapter, SagentsDynamicSupervisor)
-      )
-
-      on_exit(fn -> Application.put_env(:trento, :ai, ai) end)
-    end
+    setup :real_sagents_adapters
 
     test "terminates the running agent's process tree" do
       agent_id = "thread-#{Faker.UUID.v4()}"
@@ -284,23 +318,200 @@ defmodule Trento.AI.AgentTest do
                  pubsub: {Phoenix.PubSub, Trento.PubSub}
                )
 
-      assert {:ok, pid} = AgentSupervisor.get_pid(agent_id)
+      pid = agent_pid!(agent_id)
       assert Process.alive?(pid)
       ref = Process.monitor(pid)
 
       assert :ok = TrentoAIAgent.stop(agent_id)
 
       # DOWN + not-alive prove the process tree is gone.
-      # Deliberately not asserting on AgentSupervisor.get_pid/1
-      # the registry unregisters via its own monitor, asynchronously,
+      # Deliberately not asserting on the registry afterwards:
+      # it unregisters via its own monitor, asynchronously,
       # so it can still return the stale entry right after DOWN.
-      assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 5_000
+      assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, @integration_timeout
       refute Process.alive?(pid)
     end
 
     test "returns {:error, :not_found} when no agent is running for the id" do
       assert {:error, :not_found} = TrentoAIAgent.stop("thread-#{Faker.UUID.v4()}")
     end
+
+    test "kills the in-flight run instead of waiting it out" do
+      %{agent_id: agent_id, pid: pid, task_pid: task_pid} =
+        start_running_agent(block_for: :timer.minutes(1))
+
+      server_ref = Process.monitor(pid)
+      task_ref = Process.monitor(task_pid)
+
+      stopping = Task.async(fn -> TrentoAIAgent.stop(agent_id) end)
+
+      # Nobody releases the pending model, so the run can only end by being killed.
+      # `Sagents.AgentServer.terminate/2` waits up to 25s for a running task,
+      # so a `stop` that did not cancel first would wait for 25s.
+      assert :ok = Task.await(stopping, 3_000)
+
+      assert_receive {:DOWN, ^task_ref, :process, ^task_pid, _reason}, 1_000
+      assert_receive {:DOWN, ^server_ref, :process, ^pid, _reason}, 1_000
+    end
+  end
+
+  describe "cancel/1 — integration (real supervisor + server)" do
+    @describetag :integration
+
+    setup :real_sagents_adapters
+
+    test "kills the in-flight run, keeping the agent process and its conversation" do
+      initial_user_prompt = Faker.Lorem.sentence()
+
+      %{agent_id: agent_id, pid: pid} =
+        start_running_agent(initial_user_prompt: initial_user_prompt)
+
+      assert :ok = TrentoAIAgent.cancel(agent_id)
+
+      assert_receive {:agent, {:status_changed, :cancelled, nil}}, @integration_timeout
+      assert Process.alive?(pid)
+
+      assert %{status: :cancelled, state: %{messages: messages}} =
+               TrentoAIAgentServer.get_info(agent_id)
+
+      assert Enum.any?(
+               messages,
+               &match?(
+                 %Message{
+                   role: :user,
+                   content: [%Message.ContentPart{content: ^initial_user_prompt}]
+                 },
+                 &1
+               )
+             )
+    end
+
+    test "leaves the thread usable — the next prompt starts a new run" do
+      %{agent: agent, agent_id: agent_id} = start_running_agent()
+
+      assert :ok = TrentoAIAgent.cancel(agent_id)
+      assert_receive {:agent, {:status_changed, :cancelled, nil}}, @integration_timeout
+
+      assert :ok = TrentoAIAgent.run(agent, "second prompt")
+
+      assert_receive {:llm_called, _task_pid}, @integration_timeout
+      assert_receive {:agent, {:status_changed, :running, nil}}, @integration_timeout
+    end
+
+    test "the cancelled agent can still be stopped afterwards" do
+      %{agent_id: agent_id, pid: pid} = start_running_agent()
+
+      assert :ok = TrentoAIAgent.cancel(agent_id)
+      assert_receive {:agent, {:status_changed, :cancelled, nil}}, @integration_timeout
+
+      ref = Process.monitor(pid)
+
+      # stop/1 cancels again an already cancelled agent
+      # error is discarded, and termination succeeds
+      assert :ok = TrentoAIAgent.stop(agent_id)
+      assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, @integration_timeout
+    end
+
+    test "does not cancel — nor kill — an agent that is sitting idle" do
+      agent_id = "thread-#{Faker.UUID.v4()}"
+
+      agent =
+        TrentoAIAgent.new!(
+          agent_id: agent_id,
+          model: %FakeChatModel{notify: self()},
+          scope: build(:user)
+        )
+
+      assert {:ok, _sup} =
+               TrentoAIAgentSupervisor.start_agent_sync(
+                 agent_id: agent_id,
+                 agent: agent,
+                 pubsub: {Phoenix.PubSub, Trento.PubSub}
+               )
+
+      pid = agent_pid!(agent_id)
+      on_exit(fn -> TrentoAIAgent.stop(agent_id) end)
+
+      # the error sagents returns
+      assert {:error, "Cannot cancel, server is not running (status: idle)"} =
+               TrentoAIAgent.cancel(agent_id)
+
+      assert Process.alive?(pid)
+    end
+
+    # Counterproof about the functioning of the FakeChatModel.
+    # When the run is released, it completes successfully and the agent goes back to idle.
+    test "a released run finishes successfully" do
+      %{agent_id: agent_id, task_pid: task_pid} =
+        start_running_agent(
+          block_for: :timer.minutes(1),
+          reply: "You are absolutely right, I am a fake model."
+        )
+
+      send(task_pid, :release)
+
+      assert_receive {:agent, {:status_changed, :idle, nil}}, @integration_timeout
+
+      assert %{status: :idle, state: %{messages: messages}} =
+               TrentoAIAgentServer.get_info(agent_id)
+
+      assert Enum.any?(
+               messages,
+               &match?(
+                 %Message{
+                   role: :assistant,
+                   content: [
+                     %Message.ContentPart{content: "You are absolutely right, I am a fake model."}
+                   ]
+                 },
+                 &1
+               )
+             )
+    end
+
+    test "returns an error instead of exiting when no agent is registered for the id" do
+      agent_id = "thread-#{Faker.UUID.v4()}"
+
+      assert {:error, {:noproc, {GenServer, :call, [_name, :cancel, _timeout]}}} =
+               TrentoAIAgent.cancel(agent_id)
+    end
+  end
+
+  # Boots a real agent through the public API and blocks until its run is
+  # actually inside the model call, so that a following cancel/1 or stop/1 has
+  # a live run to act on. Subscribes the *test* process to the agent's event
+  # stream (`run/3` does that for its caller).
+  #
+  # `:task_pid` is the parked run task: `send(task_pid, :release)` makes the
+  # fake model answer and the run complete.
+  #
+  # `:block_for` overrides how long the fake model parks, for the one test that
+  # has to rule the park's own timeout out as the thing that ended the run. It
+  # defaults to the fake model's own default rather than restating it.
+  defp start_running_agent(opts \\ []) do
+    agent_id = "thread-#{Faker.UUID.v4()}"
+    model = %FakeChatModel{notify: self()}
+
+    block_for = Keyword.get(opts, :block_for, model.block_for)
+    reply = Keyword.get(opts, :reply, model.reply)
+    initial_user_prompt = Keyword.get(opts, :initial_user_prompt, "hello")
+
+    agent =
+      TrentoAIAgent.new!(
+        agent_id: agent_id,
+        model: %FakeChatModel{model | block_for: block_for, reply: reply},
+        scope: build(:user)
+      )
+
+    assert :ok = TrentoAIAgent.run(agent, initial_user_prompt)
+    pid = agent_pid!(agent_id)
+
+    assert_receive {:agent, {:status_changed, :running, nil}}, @integration_timeout
+    assert_receive {:llm_called, task_pid}, @integration_timeout
+
+    on_exit(fn -> TrentoAIAgent.stop(agent_id) end)
+
+    %{agent: agent, agent_id: agent_id, pid: pid, task_pid: task_pid}
   end
 
   defp run_opts(_ctx) do

--- a/test/trento_web/channels/ai_assistant_channel_test.exs
+++ b/test/trento_web/channels/ai_assistant_channel_test.exs
@@ -1064,6 +1064,8 @@ defmodule TrentoWeb.AIAssistantChannelTest do
         run_has_started: true
       })
 
+      # stop/1 cancels the in-flight run before terminating the agent.
+      expect(Trento.AI.Agent.Server.Mock, :cancel, fn "t-live" -> :ok end)
       expect(Trento.AI.Agent.Supervisor.Mock, :stop_agent, fn "t-live" -> :ok end)
 
       Trento.AI.Configurations.Events.broadcast_cleared(user_id)
@@ -1079,6 +1081,8 @@ defmodule TrentoWeb.AIAssistantChannelTest do
         loading: true,
         run_has_started: true
       })
+
+      expect(Trento.AI.Agent.Server.Mock, :cancel, fn "t-live" -> {:error, :not_found} end)
 
       expect(Trento.AI.Agent.Supervisor.Mock, :stop_agent, fn "t-live" ->
         {:error, :not_found}


### PR DESCRIPTION
### Description

This PR wires up the ability to cancel an ongoing LLM request processing.

Cancelling stops current running LLM task and keeps the agent running, ready for another prompt, whereas stopping means actually bringing down the agent process.

Notes:
- previously implemented stop feature now attempts a best effort cancellation first. This means that for instance when clearing ai settings the teardown of the agent is quicker.
- added a `FakeChatModel` test support utility
- the above allows for more integration oriented testing of the processes stack adding up to what unit tests cannot cover by mocking

Fixes #<issue>
<!-- Optionally use depends #<issue> for dependent PRs -->

<!--If your repository uses release drafter, ensure the appropriate release label is applied.
 To see the labels: https://github.com/trento-project/.github/blob/main/.github/release_drafter_main.yaml-->

### How was this tested?

Automated and IRL with following PRs in the stack of this feature.