### PR TITLE
Handle cancellation and thread abandonment in channel

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -301,6 +301,7 @@ config :trento, :ai,
   agent_server_adapter: Trento.Infrastructure.AI.SagentsAgentServer,
   agent_supervisor_adapter: Trento.Infrastructure.AI.SagentsDynamicSupervisor,
   ai_configuration_events_adapter: Trento.Infrastructure.AI.PubSubConfigurationEvents,
+  llm_builder_adapter: Trento.AI.LLMBuilder,
   tool_sources: [
     TrentoWeb.AI.ControllerToolSource,
     {Trento.AI.RemoteOpenApiToolSource,

--- a/lib/trento/ai/llm_builder.ex
+++ b/lib/trento/ai/llm_builder.ex
@@ -8,12 +8,22 @@ defmodule Trento.AI.LLMBuilder do
 
   alias LangChain.ChatModels.{ChatAnthropic, ChatGoogleAI, ChatOpenAI}
 
+  alias Trento.AI.ApplicationConfigLoader
   alias Trento.Users
   alias Trento.Users.User
 
-  @spec build_for_user(non_neg_integer()) ::
+  @behaviour Trento.AI.LLMBuilder
+
+  @callback build_for_user(non_neg_integer()) ::
+              {:ok, struct()}
+              | {:error, :user_not_found | :no_ai_configuration}
+
+  @spec build(non_neg_integer()) ::
           {:ok, struct()}
           | {:error, :user_not_found | :no_ai_configuration}
+  def build(user_id), do: impl().build_for_user(user_id)
+
+  @impl true
   def build_for_user(user_id) do
     case Users.get_user(user_id) do
       {:error, :not_found} ->
@@ -45,4 +55,6 @@ defmodule Trento.AI.LLMBuilder do
         stream: true,
         thinking: %{type: "enabled"}
       })
+
+  defp impl, do: Keyword.get(ApplicationConfigLoader.load(), :llm_builder_adapter)
 end

--- a/lib/trento_web/channels/ai_assistant_channel.ex
+++ b/lib/trento_web/channels/ai_assistant_channel.ex
@@ -35,7 +35,7 @@ defmodule TrentoWeb.AIAssistantChannel do
 
   - `stash_run_ids/3` — at the head of `handle_in("send_message", ...)`, before validation.
   - `activate_run/2` — once the agent is alive + subscribed + first message added; marks `:loading: true` and zeros per-run booleans.
-  - `reset_run/1` — on `:idle` (success), `:error`, and `run_agent` failure; clears per-run booleans and `:loading`. Leaves the IDs alone — next `send_message` overwrites them.
+  - `reset_run/1` — on `:idle` (success), `:error`, `run_agent` failure, the client's `cancel_run` and `abandon_thread`, and an AI-configuration clear; clears per-run booleans and `:loading`. Leaves the IDs alone — next `send_message` overwrites them.
 
   `:running` and `:llm_deltas` perform single-flag flips inline
   (`run_has_started`, `message_started`).
@@ -94,12 +94,25 @@ defmodule TrentoWeb.AIAssistantChannel do
     end
   end
 
+  @impl true
   def handle_in("send_message", payload, socket) do
     payload
     |> redact_payload()
     |> then(&Logger.warning("Received invalid send_message payload: #{inspect(&1)}"))
 
     {:reply, {:error, :invalid_payload}, socket}
+  end
+
+  @impl true
+  def handle_in(action, _payload, socket)
+      when action in ["cancel_run", "abandon_thread"] do
+    case {socket.assigns[:current_thread_id], action} do
+      {nil, _} -> :ok
+      {thread_id, "cancel_run"} -> TrentoAIAgent.cancel(thread_id)
+      {thread_id, "abandon_thread"} -> TrentoAIAgent.stop(thread_id)
+    end
+
+    {:reply, :ok, reset_run(socket)}
   end
 
   defp check_ai_enabled do
@@ -162,7 +175,7 @@ defmodule TrentoWeb.AIAssistantChannel do
          run_id,
          thread_id
        ) do
-    case LLMBuilder.build_for_user(current_user_id) do
+    case LLMBuilder.build(current_user_id) do
       {:ok, model_config} ->
         socket
         |> stash_run_ids(run_id, thread_id)

--- a/test/support/ai/ai_case.ex
+++ b/test/support/ai/ai_case.ex
@@ -6,7 +6,7 @@ defmodule Trento.AI.AICase do
 
   use ExUnit.CaseTemplate
 
-  alias Trento.AI.ApplicationConfigLoader
+  alias Trento.AI.{ApplicationConfigLoader, FakeChatModel, LLMBuilder}
   alias Trento.Infrastructure.AI.{SagentsAgentServer, SagentsDynamicSupervisor}
 
   # Booting a real sagents process tree and reaching the model call is slower
@@ -22,29 +22,22 @@ defmodule Trento.AI.AICase do
   end
 
   setup _ do
-    stub_config_loader()
-
-    :ok
-  end
-
-  def stub_config_loader do
     Mox.stub_with(
       Trento.AI.ApplicationConfigLoader.Mock,
       Trento.AI.ApplicationConfigLoader
     )
+
+    :ok
   end
 
   @doc """
-  Swaps the whole AI config over to the real implementations for the duration
-  of the test, so `Trento.AI.Agent` drives the actual sagents tree instead of
-  the Mox doubles wired in `config/test.exs`.
+  Swaps the AI config over to the real implementations for the duration of the
+  test, so `Trento.AI.Agent` drives the actual sagents tree instead of the Mox
+  doubles wired in `config/test.exs`.
 
   `:application_config_loader` goes back to the real module too, and that is
   what lets teardown call `Trento.AI.Agent.stop/1`: the Mox mock is `:private`
-  and stubbed for the *test* process, while `on_exit` runs in a process of its
-  own. Semantically it changes nothing — the mock is stubbed with
-  `Mox.stub_with(…, ApplicationConfigLoader)`, so it only ever delegated to
-  this same module.
+  and stubbed for the *test* process, while `on_exit` runs in a process of its own.
   """
   def real_sagents_adapters(_context) do
     ai = Application.get_env(:trento, :ai)
@@ -52,13 +45,43 @@ defmodule Trento.AI.AICase do
     Application.put_env(
       :trento,
       :ai,
-      ai
-      |> Keyword.put(:application_config_loader, ApplicationConfigLoader)
-      |> Keyword.put(:agent_supervisor_adapter, SagentsDynamicSupervisor)
-      |> Keyword.put(:agent_server_adapter, SagentsAgentServer)
+      Keyword.merge(ai,
+        application_config_loader: ApplicationConfigLoader,
+        agent_supervisor_adapter: SagentsDynamicSupervisor,
+        agent_server_adapter: SagentsAgentServer
+      )
     )
 
     on_exit(fn -> Application.put_env(:trento, :ai, ai) end)
+  end
+
+  @doc """
+  Makes `Trento.AI.LLMBuilder.build/1` return a `Trento.AI.FakeChatModel`.
+
+  The model answers in the agent's run task and waits.
+
+  - `{:llm_called, task_pid}` is emitted and the process that ran this setup can listen for it to know the run is genuinely in flight.
+  - When released with a `send(task_pid, :release)`, the model returns whatever is in its `:reply` field.
+
+  `@tag fake_llm: [reply: ["foo", "bar"]]` returns the stream of deltas
+  `@tag fake_llm: [reply: {:error, reason}]` fails the run
+  """
+  def fake_llm(context) do
+    model =
+      context
+      |> Map.get(:fake_llm, [])
+      |> Keyword.put(:notify, self())
+      |> then(&struct!(FakeChatModel, &1))
+
+    ai = Application.get_env(:trento, :ai)
+
+    Application.put_env(:trento, :ai, Keyword.put(ai, :llm_builder_adapter, LLMBuilder.Mock))
+
+    on_exit(fn -> Application.put_env(:trento, :ai, ai) end)
+
+    Mox.stub(LLMBuilder.Mock, :build_for_user, fn _user_id -> {:ok, model} end)
+
+    :ok
   end
 
   @doc """

--- a/test/support/ai/ai_case.ex
+++ b/test/support/ai/ai_case.ex
@@ -6,6 +6,7 @@ defmodule Trento.AI.AICase do
 
   use ExUnit.CaseTemplate
 
+  alias Trento.AI.Agent, as: TrentoAIAgent
   alias Trento.AI.{ApplicationConfigLoader, FakeChatModel, LLMBuilder}
   alias Trento.Infrastructure.AI.{SagentsAgentServer, SagentsDynamicSupervisor}
 
@@ -34,25 +35,12 @@ defmodule Trento.AI.AICase do
   Swaps the AI config over to the real implementations for the duration of the
   test, so `Trento.AI.Agent` drives the actual sagents tree instead of the Mox
   doubles wired in `config/test.exs`.
-
-  `:application_config_loader` goes back to the real module too, and that is
-  what lets teardown call `Trento.AI.Agent.stop/1`: the Mox mock is `:private`
-  and stubbed for the *test* process, while `on_exit` runs in a process of its own.
   """
-  def real_sagents_adapters(_context) do
-    ai = Application.get_env(:trento, :ai)
-
-    Application.put_env(
-      :trento,
-      :ai,
-      Keyword.merge(ai,
-        application_config_loader: ApplicationConfigLoader,
-        agent_supervisor_adapter: SagentsDynamicSupervisor,
-        agent_server_adapter: SagentsAgentServer
-      )
+  def real_sagents_adapters(context) do
+    stub_ai_config(context,
+      agent_supervisor_adapter: SagentsDynamicSupervisor,
+      agent_server_adapter: SagentsAgentServer
     )
-
-    on_exit(fn -> Application.put_env(:trento, :ai, ai) end)
   end
 
   @doc """
@@ -73,15 +61,30 @@ defmodule Trento.AI.AICase do
       |> Keyword.put(:notify, self())
       |> then(&struct!(FakeChatModel, &1))
 
-    ai = Application.get_env(:trento, :ai)
-
-    Application.put_env(:trento, :ai, Keyword.put(ai, :llm_builder_adapter, LLMBuilder.Mock))
-
-    on_exit(fn -> Application.put_env(:trento, :ai, ai) end)
-
     Mox.stub(LLMBuilder.Mock, :build_for_user, fn _user_id -> {:ok, model} end)
 
-    :ok
+    stub_ai_config(context, llm_builder_adapter: LLMBuilder.Mock)
+  end
+
+  @doc """
+  Tears the thread's agent down once the test is over, through `Trento.AI.Agent.stop/1`.
+
+  We need to re-stub the `ApplicationConfigLoader` mock in the teardown process because
+  `Trento.AI.Agent.stop/1` calls both of its adapters, which are resolved through the config loader.
+
+  Not doing so raises `Mox.UnexpectedCallError` because the teardown process is not the owner of the stub prepared in the test process.
+
+  The config is therefore read in the test process, where the stub still answers,
+  and carried into the exit closure which then owns it for the one call it makes.
+  """
+  def stop_agent_on_exit(agent_id) do
+    config = ApplicationConfigLoader.load()
+
+    on_exit(fn ->
+      Mox.stub(ApplicationConfigLoader.Mock, :load_config, fn -> config end)
+
+      TrentoAIAgent.stop(agent_id)
+    end)
   end
 
   @doc """
@@ -99,5 +102,15 @@ defmodule Trento.AI.AICase do
       {:error, reason} ->
         raise "no agent process registered for #{inspect(agent_id)}: #{inspect(reason)}"
     end
+  end
+
+  defp stub_ai_config(context, overrides) do
+    merged = Keyword.merge(Map.get(context, :ai_config_overrides, []), overrides)
+
+    Mox.stub(ApplicationConfigLoader.Mock, :load_config, fn ->
+      Keyword.merge(Application.get_env(:trento, :ai, []), merged)
+    end)
+
+    {:ok, ai_config_overrides: merged}
   end
 end

--- a/test/support/ai/fake_chat_model.ex
+++ b/test/support/ai/fake_chat_model.ex
@@ -6,17 +6,28 @@ defmodule Trento.AI.FakeChatModel do
   A `LangChain.ChatModels.ChatModel` that never talks to a provider.
 
   Exists so integration tests can hold a `Sagents.AgentServer` run genuinely
-  in flight — the only state in which `Trento.AI.Agent.cancel/1` does anything
-  — without a network call.
+  in flight - the only state in which `Trento.AI.Agent.cancel/1` does anything
+  - without a network call.
 
   `call/3` runs inside the agent's run task and parks there:
 
   - `:notify` (pid) receives `{:llm_called, task_pid}` as soon as the chain
     reaches the model, so a test can wait for a *real* in-flight run instead
     of sleeping.
-  - the park ends on a `:release` message (answers with `:reply`) or after
-    `:block_for` ms. The timeout is the CI guard: a cancel that fails to kill
-    the task makes the test fail on its own assertions rather than hang.
+  - the park ends on a `:release` message or after `:block_for` ms. The
+    timeout is the CI guard: a cancel that fails to kill the task makes the
+    test fail on its own assertions rather than hang.
+
+  `:reply` decides what the park ends with:
+
+  - a chunk of text, or a list of them - one `%MessageDelta{}` per element,
+    each fired through `:on_llm_new_delta` as a provider fires one per
+    received chunk. Every Trento model is built with `stream: true`, so this
+    is the return shape production sees.
+  - `{:error, reason}` - the failing-run path, `reason` being a message or a
+    ready-made `%LangChainError{}`.
+
+  Does not cover from drifts in the actual used models.
 
   `:callbacks` is required by `LangChain.Utils.rewrap_callbacks_for_model/3`,
   which writes the chain's wrapped callbacks onto the model struct.
@@ -24,25 +35,30 @@ defmodule Trento.AI.FakeChatModel do
 
   @behaviour LangChain.ChatModels.ChatModel
 
-  alias LangChain.Message
+  alias LangChain.LangChainError
+  alias LangChain.Message.ContentPart
+  alias LangChain.MessageDelta
+  alias LangChain.Utils
 
   defstruct callbacks: [], notify: nil, block_for: 5_000, reply: "fake reply"
+
+  @type reply :: String.t() | [String.t()] | {:error, String.t() | LangChainError.t()}
 
   @type t :: %__MODULE__{
           callbacks: [map()],
           notify: pid() | nil,
           block_for: non_neg_integer(),
-          reply: String.t()
+          reply: reply()
         }
 
   @impl LangChain.ChatModels.ChatModel
-  def call(%__MODULE__{notify: notify, block_for: block_for, reply: reply}, _messages, _tools) do
+  def call(%__MODULE__{notify: notify, block_for: block_for} = model, _messages, _tools) do
     if is_pid(notify), do: send(notify, {:llm_called, self()})
 
     receive do
-      :release -> {:ok, [Message.new_assistant!(reply)]}
+      :release -> answer(model)
     after
-      block_for -> {:ok, [Message.new_assistant!(reply)]}
+      block_for -> answer(model)
     end
   end
 
@@ -54,4 +70,32 @@ defmodule Trento.AI.FakeChatModel do
 
   @impl LangChain.ChatModels.ChatModel
   def restore_from_map(_data), do: {:ok, %__MODULE__{}}
+
+  defp answer(%__MODULE__{reply: {:error, %LangChainError{} = error}}), do: {:error, error}
+
+  defp answer(%__MODULE__{reply: {:error, message}}) when is_binary(message),
+    do: {:error, LangChainError.exception(type: "fake_error", message: message)}
+
+  defp answer(%__MODULE__{reply: reply} = model) do
+    reply
+    |> List.wrap()
+    |> deltas()
+    |> tap(fn deltas -> Enum.each(deltas, &Utils.fire_streamed_callback(model, [&1])) end)
+    |> then(fn deltas -> {:ok, deltas} end)
+  end
+
+  defp deltas(chunks) do
+    last_index = length(chunks) - 1
+
+    chunks
+    |> Enum.with_index()
+    |> Enum.map(fn {chunk, chunk_index} ->
+      MessageDelta.new!(%{
+        role: :assistant,
+        content: ContentPart.new!(%{type: :text, content: chunk}),
+        index: 0,
+        status: if(chunk_index == last_index, do: :complete, else: :incomplete)
+      })
+    end)
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -82,6 +82,11 @@ Mox.defmock(Trento.AI.Configurations.Events.Mock,
   for: Trento.AI.Configurations.Events
 )
 
+# Also deliberately NOT wired into `test_ai_config` below.
+# Integration tests opt in through `Trento.AI.AICase.fake_llm/1`
+# to get a model that answers in process instead of over the network.
+Mox.defmock(Trento.AI.LLMBuilder.Mock, for: Trento.AI.LLMBuilder)
+
 default_ai_config = Application.get_env(:trento, :ai, [])
 
 test_ai_config = [

--- a/test/trento/ai/agent_test.exs
+++ b/test/trento/ai/agent_test.exs
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Trento.AI.AgentTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
   use Trento.AI.AICase
 
   import Mox
@@ -481,7 +481,7 @@ defmodule Trento.AI.AgentTest do
     agent = TrentoAIAgent.new!(agent_id: agent_id, model: model, scope: build(:user))
 
     :ok = TrentoAIAgent.run(agent, prompt)
-    on_exit(fn -> TrentoAIAgent.stop(agent_id) end)
+    stop_agent_on_exit(agent_id)
 
     %{agent: agent, agent_id: agent_id, pid: agent_pid!(agent_id), prompt: prompt}
   end
@@ -507,7 +507,7 @@ defmodule Trento.AI.AgentTest do
         pubsub: {Phoenix.PubSub, Trento.PubSub}
       )
 
-    on_exit(fn -> TrentoAIAgent.stop(agent_id) end)
+    stop_agent_on_exit(agent_id)
 
     %{agent: agent, agent_id: agent_id, pid: agent_pid!(agent_id)}
   end

--- a/test/trento/ai/agent_test.exs
+++ b/test/trento/ai/agent_test.exs
@@ -412,27 +412,45 @@ defmodule Trento.AI.AgentTest do
 
     # Counterproof about the functioning of the FakeChatModel.
     # When the run is released, it completes successfully and the agent goes back to idle.
-    @tag running_agent: [block_for: :timer.minutes(1), reply: @fake_reply]
-    test "a released run finishes successfully", %{agent_id: agent_id} do
-      task_pid = await_in_flight_run()
+    scenarios = [
+      %{
+        name: "a released run finishes successfully",
+        reply: @fake_reply,
+        expected_content: @fake_reply
+      },
+      %{
+        name: "a run answered in several chunks lands as one assistant content part",
+        reply: ["You are ", "absolutely ", "right,", " I am a fake", " model."],
+        expected_content: @fake_reply
+      }
+    ]
 
-      send(task_pid, :release)
+    for %{name: name, reply: reply} = scenario <- scenarios do
+      @scenario scenario
+      @tag running_agent: [block_for: :timer.minutes(1), reply: reply]
+      test name, %{agent_id: agent_id} do
+        task_pid = await_in_flight_run()
 
-      assert_receive {:agent, {:status_changed, :idle, nil}}, @integration_timeout
+        send(task_pid, :release)
 
-      assert %{status: :idle, state: %{messages: messages}} =
-               TrentoAIAgentServer.get_info(agent_id)
+        assert_receive {:agent, {:status_changed, :idle, nil}}, @integration_timeout
 
-      assert Enum.any?(
-               messages,
-               &match?(
-                 %Message{
-                   role: :assistant,
-                   content: [%Message.ContentPart{content: @fake_reply}]
-                 },
-                 &1
+        assert %{status: :idle, state: %{messages: messages}} =
+                 TrentoAIAgentServer.get_info(agent_id)
+
+        expected_content = Map.fetch!(@scenario, :expected_content)
+
+        assert Enum.any?(
+                 messages,
+                 &match?(
+                   %Message{
+                     role: :assistant,
+                     content: [%Message.ContentPart{content: ^expected_content}]
+                   },
+                   &1
+                 )
                )
-             )
+      end
     end
 
     test "returns an error instead of exiting when no agent is registered for the id" do

--- a/test/trento/ai/llm_builder_test.exs
+++ b/test/trento/ai/llm_builder_test.exs
@@ -10,6 +10,20 @@ defmodule Trento.AI.LLMBuilderTest do
 
   import Trento.Factory
 
+  describe "build/1" do
+    test "builds the user's model through the default adapter" do
+      %{id: user_id} = insert(:user)
+
+      insert(:ai_user_configuration,
+        user_id: user_id,
+        provider: :google,
+        model: "gemini-2.5-flash"
+      )
+
+      assert {:ok, %ChatGoogleAI{model: "gemini-2.5-flash"}} = LLMBuilder.build(user_id)
+    end
+  end
+
   describe "build_for_user/1" do
     test "returns {:error, :user_not_found} when user does not exist" do
       assert {:error, :user_not_found} = LLMBuilder.build_for_user(999_999_999)

--- a/test/trento/ai/remote_http_tool_test.exs
+++ b/test/trento/ai/remote_http_tool_test.exs
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Trento.AI.RemoteHttpToolTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
   use Trento.AI.AICase
 
   import Mox

--- a/test/trento_web/ai/controller_tool_test.exs
+++ b/test/trento_web/ai/controller_tool_test.exs
@@ -11,6 +11,8 @@ defmodule TrentoWeb.AI.ControllerToolTest do
   alias TrentoWeb.AI.{ControllerTool, McpRouteIndex}
   alias TrentoWeb.V1
 
+  setup :verify_on_exit!
+
   defp entry_for({controller, action}) do
     Enum.find(McpRouteIndex.entries(), fn e ->
       e.controller == controller and e.action == action

--- a/test/trento_web/ai/controller_tool_test.exs
+++ b/test/trento_web/ai/controller_tool_test.exs
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule TrentoWeb.AI.ControllerToolTest do
-  use Trento.DataCase
+  use Trento.DataCase, async: true
 
   import Mox
   import Trento.Factory

--- a/test/trento_web/channels/ai_assistant_channel_test.exs
+++ b/test/trento_web/channels/ai_assistant_channel_test.exs
@@ -24,7 +24,7 @@ defmodule TrentoWeb.AIAssistantChannelTest do
   the model → AG-UI chain is pinned end to end.
   """
 
-  use TrentoWeb.ChannelCase
+  use TrentoWeb.ChannelCase, async: true
   use Trento.AI.AICase
 
   import Phoenix.ChannelTest, except: [assert_push: 2, assert_push: 3]
@@ -34,8 +34,8 @@ defmodule TrentoWeb.AIAssistantChannelTest do
   import Trento.Factory
 
   alias LangChain.ChatModels.ChatGoogleAI
-  alias Trento.AI.Agent, as: TrentoAIAgent
   alias Trento.AI.Agent.Server, as: TrentoAIAgentServer
+  alias Trento.AI.ApplicationConfigLoader
   alias Trento.AI.LLMBuilder
   alias TrentoWeb.Auth.AccessToken
 
@@ -129,7 +129,7 @@ defmodule TrentoWeb.AIAssistantChannelTest do
     end
 
     test "rejects with :ai_assistant_disabled when AI features are disabled" do
-      expect(Trento.AI.ApplicationConfigLoader.Mock, :load_config, fn -> [enabled: false] end)
+      expect(ApplicationConfigLoader.Mock, :load_config, fn -> [enabled: false] end)
 
       assert {:error, :ai_assistant_disabled} =
                UserSocket
@@ -140,7 +140,7 @@ defmodule TrentoWeb.AIAssistantChannelTest do
     end
 
     test "prefers :ai_assistant_disabled over :unauthorized when AI is disabled with mismatched user_id" do
-      expect(Trento.AI.ApplicationConfigLoader.Mock, :load_config, fn -> [enabled: false] end)
+      expect(ApplicationConfigLoader.Mock, :load_config, fn -> [enabled: false] end)
 
       assert {:error, :ai_assistant_disabled} =
                UserSocket
@@ -182,15 +182,11 @@ defmodule TrentoWeb.AIAssistantChannelTest do
     end
 
     test "rejects the join when subscribing to AI configuration events fails" do
-      ai = Application.get_env(:trento, :ai)
-
-      Application.put_env(
-        :trento,
-        :ai,
-        Keyword.put(ai, :ai_configuration_events_adapter, AIConfigurationsEvents.Mock)
-      )
-
-      on_exit(fn -> Application.put_env(:trento, :ai, ai) end)
+      stub(ApplicationConfigLoader.Mock, :load_config, fn ->
+        :trento
+        |> Application.get_env(:ai, [])
+        |> Keyword.put(:ai_configuration_events_adapter, AIConfigurationsEvents.Mock)
+      end)
 
       expect(AIConfigurationsEvents.Mock, :subscribe, fn _ -> {:error, :no_pubsub} end)
 
@@ -1305,7 +1301,7 @@ defmodule TrentoWeb.AIAssistantChannelTest do
 
       # A new chat means a new thread id, hence a brand new agent behind it.
       new_thread_id = "thread-#{Faker.UUID.v4()}"
-      on_exit(fn -> TrentoAIAgent.stop(new_thread_id) end)
+      stop_agent_on_exit(new_thread_id)
 
       push(socket, "send_message", %{
         "message" => "first prompt of the new chat",
@@ -1503,7 +1499,7 @@ defmodule TrentoWeb.AIAssistantChannelTest do
 
     assert_receive {:llm_called, task_pid}, @integration_timeout
 
-    on_exit(fn -> TrentoAIAgent.stop(thread_id) end)
+    stop_agent_on_exit(thread_id)
 
     %{thread_id: thread_id, task_pid: task_pid}
   end

--- a/test/trento_web/channels/ai_assistant_channel_test.exs
+++ b/test/trento_web/channels/ai_assistant_channel_test.exs
@@ -6,7 +6,8 @@ defmodule TrentoWeb.AIAssistantChannelTest do
   Channel tests covering:
 
   - `join/3` — happy path + auth rejections
-  - `handle_in/3` for `send_message` payload contract + `new_thread`
+  - `handle_in/3` for `send_message` payload contract, `cancel_run` and
+    `abandon_thread`
   - `handle_info/2` translation of `{:agent, ...}` PubSub events into AG-UI
     wire events (the bug-prone surface)
 
@@ -16,21 +17,25 @@ defmodule TrentoWeb.AIAssistantChannelTest do
   JS-driven assigns chain to exercise the individual handlers in
   isolation.
 
-  Happy-path `send_message` coverage uses Mox doubles for the sagents
-  adapter boundary (`Trento.AI.Agent.{Server, Supervisor}`,
-  routed via `config/test.exs`). See
-  `describe "handle_in send_message/3 — happy path"`.
+  Most `send_message` coverage stops at the Mox doubles for the sagents adapter
+  boundary (`Trento.AI.Agent.{Server, Supervisor}`, routed via
+  `config/test.exs`). The describes tagged `:integration` go past it: they run
+  the real supervisor and server with only the chat model faked, which is where
+  the model → AG-UI chain is pinned end to end.
   """
 
   use TrentoWeb.ChannelCase
   use Trento.AI.AICase
 
-  import Phoenix.ChannelTest, except: [assert_push: 2]
+  import Phoenix.ChannelTest, except: [assert_push: 2, assert_push: 3]
 
+  import ExUnit.CaptureLog
   import Mox
   import Trento.Factory
 
   alias LangChain.ChatModels.ChatGoogleAI
+  alias Trento.AI.Agent, as: TrentoAIAgent
+  alias Trento.AI.Agent.Server, as: TrentoAIAgentServer
   alias Trento.AI.LLMBuilder
   alias TrentoWeb.Auth.AccessToken
 
@@ -44,11 +49,14 @@ defmodule TrentoWeb.AIAssistantChannelTest do
   # Why it needs widening:
   # because the first `send_message` pays a one-time warm-up cost about tool generation
   # and so we mitigate possible timing out if resources are constrained.
+  #
+  # Integration tests pass `@integration_timeout` instead: booting the real
+  # sagents tree costs more than the warm-up alone.
   @push_timeout 500
 
-  defmacrop assert_push(event, payload) do
+  defmacrop assert_push(event, payload, timeout \\ @push_timeout) do
     quote do
-      Phoenix.ChannelTest.assert_push(unquote(event), unquote(payload), @push_timeout)
+      Phoenix.ChannelTest.assert_push(unquote(event), unquote(payload), unquote(timeout))
     end
   end
 
@@ -59,8 +67,8 @@ defmodule TrentoWeb.AIAssistantChannelTest do
     :ok
   end
 
-  describe "join/3 — access_token validation" do
-    test "accepts valid token, updates :access_token assign, and joins" do
+  describe "join/3" do
+    test "successfully joins and seeds the assigns when the token is valid" do
       jwt = generate_jwt(42)
 
       assert {:ok, _, socket} =
@@ -72,6 +80,7 @@ defmodule TrentoWeb.AIAssistantChannelTest do
 
       assert socket.assigns.access_token == jwt
       assert socket.assigns.current_scope == %Trento.Users.User{id: 42}
+      assert socket.assigns.loading == false
     end
 
     test "rejects with :unauthorized for an invalid token" do
@@ -92,22 +101,6 @@ defmodule TrentoWeb.AIAssistantChannelTest do
                |> subscribe_and_join(AIAssistantChannel, "ai_assistant:42", %{
                  "access_token" => jwt_for_other_user
                })
-    end
-  end
-
-  describe "join/3" do
-    test "joins ai_assistant:<user_id> when current_user_id matches" do
-      jwt = generate_jwt(42)
-
-      assert {:ok, _, socket} =
-               UserSocket
-               |> socket("user_id", %{current_user_id: 42})
-               |> subscribe_and_join(AIAssistantChannel, "ai_assistant:42", %{
-                 "access_token" => jwt
-               })
-
-      assert socket.assigns.current_scope == %Trento.Users.User{id: 42}
-      assert socket.assigns.loading == false
     end
 
     test "rejects with :unauthorized when current_user_id does not match topic" do
@@ -248,6 +241,25 @@ defmodule TrentoWeb.AIAssistantChannelTest do
         })
 
       assert_reply(ref, :error, :invalid_payload)
+    end
+
+    test "redacts the access token from the rejected payload it logs",
+         %{socket: socket, access_token: jwt} do
+      log =
+        capture_log(fn ->
+          ref =
+            push(socket, "send_message", %{
+              "run_id" => "r1",
+              "thread_id" => "t1",
+              "access_token" => jwt
+            })
+
+          assert_reply(ref, :error, :invalid_payload)
+        end)
+
+      assert log =~ "Received invalid send_message payload:"
+      assert log =~ "<REDACTED>"
+      refute log =~ jwt
     end
 
     test "rejects payload missing :run_id", %{socket: socket, access_token: jwt} do
@@ -952,21 +964,11 @@ defmodule TrentoWeb.AIAssistantChannelTest do
     end
   end
 
-  describe "handle_in send_message/3 — error paths" do
-    test "emits verbatim RUN_ERROR when user has no AI configuration" do
-      %{id: user_id} = insert(:user)
-      jwt = generate_jwt(user_id)
+  describe "handle_in send_message/3 — error paths before the agent starts" do
+    setup :join_socket_without_ai_config
 
-      {:ok, _, socket} =
-        UserSocket
-        |> socket("user_id", %{
-          current_user_id: user_id,
-          request_origin: "https://trento.test"
-        })
-        |> subscribe_and_join(AIAssistantChannel, "ai_assistant:#{user_id}", %{
-          "access_token" => jwt
-        })
-
+    test "emits verbatim RUN_ERROR when user has no AI configuration",
+         %{socket: socket, access_token: jwt} do
       push(socket, "send_message", %{
         "message" => "hi",
         "run_id" => "r1",
@@ -980,20 +982,8 @@ defmodule TrentoWeb.AIAssistantChannelTest do
       })
     end
 
-    test "does NOT stash run_id/thread_id when LLMBuilder errors out" do
-      %{id: user_id} = insert(:user)
-      jwt = generate_jwt(user_id)
-
-      {:ok, _, socket} =
-        UserSocket
-        |> socket("user_id", %{
-          current_user_id: user_id,
-          request_origin: "https://trento.test"
-        })
-        |> subscribe_and_join(AIAssistantChannel, "ai_assistant:#{user_id}", %{
-          "access_token" => jwt
-        })
-
+    test "does NOT stash run_id/thread_id when LLMBuilder errors out",
+         %{socket: socket, access_token: jwt} do
       push(socket, "send_message", %{
         "message" => "hi",
         "run_id" => "should-not-stash",
@@ -1007,30 +997,13 @@ defmodule TrentoWeb.AIAssistantChannelTest do
       refute Map.has_key?(assigns, :current_run_id)
       refute Map.has_key?(assigns, :current_thread_id)
     end
+  end
 
-    test "emits verbatim RUN_ERROR when sagents start_agent_sync fails" do
-      %{id: user_id} = insert(:user)
-      jwt = generate_jwt(user_id)
+  describe "handle_in send_message/3 — error paths while the agent starts" do
+    setup :join_socket_with_ai_config
 
-      insert(:ai_user_configuration,
-        user_id: user_id,
-        provider: :google,
-        model: "gemini-2.5-flash"
-      )
-
-      {:ok, _, socket} =
-        UserSocket
-        |> socket("user_id", %{
-          current_user_id: user_id,
-          request_origin: "https://trento.test"
-        })
-        |> subscribe_and_join(AIAssistantChannel, "ai_assistant:#{user_id}", %{
-          "access_token" => jwt
-        })
-
-      Mox.allow(Trento.AI.Agent.Supervisor.Mock, self(), socket.channel_pid)
-      Mox.allow(Trento.AI.Agent.Server.Mock, self(), socket.channel_pid)
-
+    test "emits verbatim RUN_ERROR when sagents start_agent_sync fails",
+         %{socket: socket, access_token: jwt} do
       # run_agent probes the running agent (for model-drift detection) before
       # starting it — brand-new thread here, so :not_found.
       stub(Trento.AI.Agent.Server.Mock, :get_agent, fn _ -> {:error, :not_found} end)
@@ -1053,6 +1026,101 @@ defmodule TrentoWeb.AIAssistantChannelTest do
     end
   end
 
+  describe "handle_in cancel_run/3" do
+    setup :join_socket_with_ai_config
+
+    test "cancels the in-flight run", %{socket: socket} do
+      seed_assigns(socket, %{loading: true, current_thread_id: "t-live"})
+
+      expect(Trento.AI.Agent.Server.Mock, :cancel, fn "t-live" -> :ok end)
+
+      ref = push(socket, "cancel_run", %{"run_id" => "r1", "thread_id" => "t-live"})
+      assert_reply ref, :ok
+
+      assert %{loading: false} = wait_assigns(socket)
+
+      # the client settles its own run
+      refute_push("ag_ui_event", _payload)
+    end
+
+    test "passes through cancelling a run where there's nothing running",
+         %{socket: socket} do
+      seed_assigns(socket, %{loading: false, current_thread_id: "t-idle"})
+
+      expect(Trento.AI.Agent.Server.Mock, :cancel, fn "t-idle" ->
+        {:error, "Cannot cancel, server is not running (status: idle)"}
+      end)
+
+      ref = push(socket, "cancel_run", %{})
+      assert_reply ref, :ok
+    end
+
+    test "clears :loading and reaches no agent when no thread was ever stashed to cancel",
+         %{socket: socket} do
+      seed_assigns(socket, %{loading: true})
+
+      expect(Trento.AI.Agent.Server.Mock, :cancel, 0, fn _ ->
+        :unreachable
+      end)
+
+      ref = push(socket, "cancel_run", %{})
+      assert_reply ref, :ok
+
+      assert %{loading: false} = wait_assigns(socket)
+    end
+  end
+
+  describe "handle_in abandon_thread/3" do
+    setup :join_socket_with_ai_config
+
+    test "abandons the thread of the in-flight run", %{socket: socket} do
+      seed_assigns(socket, %{loading: true, current_thread_id: "t-live"})
+
+      expect(Trento.AI.Agent.Server.Mock, :cancel, fn "t-live" -> :ok end)
+      expect(Trento.AI.Agent.Supervisor.Mock, :stop_agent, fn "t-live" -> :ok end)
+
+      ref = push(socket, "abandon_thread", %{})
+      assert_reply ref, :ok
+
+      assert %{loading: false} = wait_assigns(socket)
+
+      # the client settles its own run
+      refute_push("ag_ui_event", _payload)
+    end
+
+    test "abandons the thread where there's nothing running",
+         %{socket: socket} do
+      seed_assigns(socket, %{loading: false, current_thread_id: "t-idle"})
+
+      expect(Trento.AI.Agent.Server.Mock, :cancel, fn "t-idle" ->
+        {:error, "Cannot cancel, server is not running (status: idle)"}
+      end)
+
+      expect(Trento.AI.Agent.Supervisor.Mock, :stop_agent, fn "t-idle" -> :ok end)
+
+      ref = push(socket, "abandon_thread", %{})
+      assert_reply ref, :ok
+    end
+
+    test "clears :loading and reaches no agent when no thread was ever stashed to abandon",
+         %{socket: socket} do
+      seed_assigns(socket, %{loading: true})
+
+      expect(Trento.AI.Agent.Server.Mock, :cancel, 0, fn _ ->
+        :unreachable
+      end)
+
+      expect(Trento.AI.Agent.Supervisor.Mock, :stop_agent, 0, fn _ ->
+        :unreachable
+      end)
+
+      ref = push(socket, "abandon_thread", %{})
+      assert_reply ref, :ok
+
+      assert %{loading: false} = wait_assigns(socket)
+    end
+  end
+
   describe "handle_info — listening on ai configuration events" do
     setup :join_socket_with_ai_config
 
@@ -1068,7 +1136,7 @@ defmodule TrentoWeb.AIAssistantChannelTest do
       expect(Trento.AI.Agent.Server.Mock, :cancel, fn "t-live" -> :ok end)
       expect(Trento.AI.Agent.Supervisor.Mock, :stop_agent, fn "t-live" -> :ok end)
 
-      Trento.AI.Configurations.Events.broadcast_cleared(user_id)
+      AIConfigurationsEvents.broadcast_cleared(user_id)
 
       assert_push("ai_configuration_cleared", %{})
       assert %{loading: false} = wait_assigns(socket)
@@ -1097,7 +1165,7 @@ defmodule TrentoWeb.AIAssistantChannelTest do
     test "pushes ai_configuration_cleared without stopping any agent when no thread is active",
          %{user_id: user_id} do
       # No current_thread_id seeded → no stop_agent expectation.
-      # verify_on_exit! catches a stray stop_agent call.
+      # Mox raises on a stray stop_agent call.
       AIConfigurationsEvents.broadcast_cleared(user_id)
 
       assert_push("ai_configuration_cleared", %{})
@@ -1120,6 +1188,242 @@ defmodule TrentoWeb.AIAssistantChannelTest do
     end
   end
 
+  # Every describe above stops at the Mox adapter boundary proving the
+  # channel calls relevant downstream functions.
+  # These integration tests go all the way down the whole stack by swapping in a fake LLM implementation
+
+  describe "Agent run cancellation — integration (real supervisor + server)" do
+    @describetag :integration
+
+    setup [:join_socket_with_ai_config, :real_sagents_adapters, :fake_llm]
+
+    test "cancels the run without killing the thread's agent", %{
+      socket: socket,
+      access_token: jwt
+    } do
+      %{thread_id: thread_id} = start_run!(socket, jwt, run_id: "r1")
+
+      pid = agent_pid!(thread_id)
+      monitor = Process.monitor(pid)
+
+      ref = push(socket, "cancel_run", %{"run_id" => "r1", "thread_id" => thread_id})
+
+      assert_reply ref, :ok, %{}, 1_000
+
+      refute_push("ag_ui_event", _payload, @push_timeout)
+
+      refute_receive {:DOWN, ^monitor, :process, ^pid, _reason}, @push_timeout
+      assert Process.alive?(pid)
+    end
+
+    test "lets the same thread be prompted again after the cancel", %{
+      socket: socket,
+      access_token: jwt
+    } do
+      %{thread_id: thread_id} = start_run!(socket, jwt, run_id: "r1")
+
+      ref = push(socket, "cancel_run", %{"run_id" => "r1", "thread_id" => thread_id})
+      assert_reply ref, :ok, %{}, 1_000
+
+      push(socket, "send_message", %{
+        "message" => "a follow-up prompt",
+        "run_id" => "r2",
+        "thread_id" => thread_id,
+        "access_token" => jwt
+      })
+
+      assert_receive {:llm_called, _task_pid}, @integration_timeout
+
+      assert_push(
+        "ag_ui_event",
+        %{"type" => "RUN_STARTED", "runId" => "r2", "threadId" => ^thread_id},
+        @integration_timeout
+      )
+    end
+  end
+
+  describe "Thread abandonment/agent stopping — integration (real supervisor + server)" do
+    @describetag :integration
+
+    setup [:join_socket_with_ai_config, :real_sagents_adapters, :fake_llm]
+
+    # Nobody releases the parked model, so the run task can only end by being
+    # killed: a teardown that waited the run out would blow the timeouts below
+    # rather than pass.
+    @tag fake_llm: [block_for: :timer.minutes(1)]
+    test "tears down the thread's agent mid-run", %{socket: socket, access_token: jwt} do
+      %{thread_id: thread_id, task_pid: task_pid} = start_run!(socket, jwt, run_id: "r1")
+
+      pid = agent_pid!(thread_id)
+      monitor = Process.monitor(pid)
+      task_monitor = Process.monitor(task_pid)
+
+      ref = push(socket, "abandon_thread", %{})
+
+      assert_reply ref, :ok, %{}, 1_000
+
+      refute_push("ag_ui_event", _payload, @push_timeout)
+
+      # Run *and* conversation are gone — nothing addresses this thread again.
+      assert_receive {:DOWN, ^task_monitor, :process, ^task_pid, _reason}, @integration_timeout
+      assert_receive {:DOWN, ^monitor, :process, ^pid, _reason}, @integration_timeout
+    end
+
+    # The run is let finish first: the agent goes back to resting with its
+    # conversation still in memory — the state "New chat" leaves behind when
+    # the user reads an answer before starting over.
+    test "tears down a thread that is no longer streaming", %{socket: socket, access_token: jwt} do
+      %{thread_id: thread_id, task_pid: task_pid} = start_run!(socket, jwt, run_id: "r1")
+
+      task_monitor = Process.monitor(task_pid)
+
+      send(task_pid, :release)
+
+      pid = agent_pid!(thread_id)
+      assert Process.alive?(pid)
+      monitor = Process.monitor(pid)
+
+      assert_push("ag_ui_event", %{"type" => "RUN_FINISHED"}, @integration_timeout)
+
+      # The run task is gone by answering, not by being killed.
+      assert_receive {:DOWN, ^task_monitor, :process, ^task_pid, :normal}, @integration_timeout
+
+      ref = push(socket, "abandon_thread", %{})
+      assert_reply ref, :ok
+
+      assert_receive {:DOWN, ^monitor, :process, ^pid, _reason}, @integration_timeout
+    end
+
+    test "lets the next prompt through - a new run starts on the same socket", %{
+      socket: socket,
+      access_token: jwt
+    } do
+      start_run!(socket, jwt, run_id: "r1")
+
+      ref = push(socket, "abandon_thread", %{})
+      assert_reply ref, :ok
+
+      # A new chat means a new thread id, hence a brand new agent behind it.
+      new_thread_id = "thread-#{Faker.UUID.v4()}"
+      on_exit(fn -> TrentoAIAgent.stop(new_thread_id) end)
+
+      push(socket, "send_message", %{
+        "message" => "first prompt of the new chat",
+        "run_id" => "r2",
+        "thread_id" => new_thread_id,
+        "access_token" => jwt
+      })
+
+      assert_push(
+        "ag_ui_event",
+        %{"type" => "RUN_STARTED", "runId" => "r2", "threadId" => ^new_thread_id},
+        @integration_timeout
+      )
+
+      assert_receive {:llm_called, _task_pid}, @integration_timeout
+    end
+  end
+
+  describe "Prompt processing — integration (real supervisor + server)" do
+    @describetag :integration
+
+    setup [:join_socket_with_ai_config, :real_sagents_adapters, :fake_llm]
+
+    test "settles the run on the client and on the agent once the model answers",
+         %{socket: socket, access_token: jwt} do
+      %{thread_id: thread_id, task_pid: task_pid} = start_run!(socket, jwt, run_id: "r1")
+
+      send(task_pid, :release)
+
+      assert_push(
+        "ag_ui_event",
+        %{"type" => "RUN_FINISHED", "runId" => "r1", "threadId" => ^thread_id},
+        @integration_timeout
+      )
+
+      assert %{status: :idle} = TrentoAIAgentServer.get_info(thread_id)
+    end
+
+    @tag fake_llm: [reply: ["Hello", " world"]]
+    test "streams the model's deltas to the client as AG-UI text events", %{
+      socket: socket,
+      access_token: jwt
+    } do
+      %{task_pid: task_pid} = start_run!(socket, jwt, run_id: "r1")
+
+      send(task_pid, :release)
+
+      assert_push(
+        "ag_ui_event",
+        %{"type" => "TEXT_MESSAGE_START", "messageId" => "r1", "role" => "assistant"},
+        @integration_timeout
+      )
+
+      assert_push(
+        "ag_ui_event",
+        %{"type" => "TEXT_MESSAGE_CONTENT", "messageId" => "r1", "delta" => "Hello"},
+        @integration_timeout
+      )
+
+      assert_push(
+        "ag_ui_event",
+        %{"type" => "TEXT_MESSAGE_CONTENT", "messageId" => "r1", "delta" => " world"},
+        @integration_timeout
+      )
+
+      assert_push(
+        "ag_ui_event",
+        %{"type" => "TEXT_MESSAGE_END", "messageId" => "r1"},
+        @integration_timeout
+      )
+    end
+
+    @tag fake_llm: [reply: {:error, "the provider said no"}]
+    test "surfaces a model failure to the client as RUN_ERROR", %{
+      socket: socket,
+      access_token: jwt
+    } do
+      %{task_pid: task_pid} = start_run!(socket, jwt, run_id: "r1")
+
+      send(task_pid, :release)
+
+      assert_push(
+        "ag_ui_event",
+        %{"type" => "RUN_ERROR", "message" => message},
+        @integration_timeout
+      )
+
+      assert message =~ "the provider said no"
+    end
+  end
+
+  describe "Agent stopping on ai_configuration cleared — integration (real supervisor + server)" do
+    @describetag :integration
+
+    setup [:join_socket_with_ai_config, :real_sagents_adapters, :fake_llm]
+
+    # Nobody releases the parked model, so the run task can only end by being killed
+    @tag fake_llm: [block_for: :timer.minutes(1)]
+    test "tears down the agent of the thread that is mid-run", %{
+      socket: socket,
+      access_token: jwt,
+      user_id: user_id
+    } do
+      %{thread_id: thread_id, task_pid: task_pid} = start_run!(socket, jwt, run_id: "r1")
+
+      pid = agent_pid!(thread_id)
+      ref = Process.monitor(pid)
+      task_monitor = Process.monitor(task_pid)
+
+      AIConfigurationsEvents.broadcast_cleared(user_id)
+
+      assert_receive {:DOWN, ^task_monitor, :process, ^task_pid, _reason}, @integration_timeout
+      assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, @integration_timeout
+
+      assert_push("ai_configuration_cleared", %{}, @integration_timeout)
+    end
+  end
+
   defp join_socket(_context) do
     jwt = generate_jwt(7)
     request_origin = "https://trento.test"
@@ -1136,14 +1440,25 @@ defmodule TrentoWeb.AIAssistantChannelTest do
 
   defp join_socket_with_ai_config(_context) do
     %{id: user_id} = insert(:user)
-    jwt = generate_jwt(user_id)
-    request_origin = "https://trento.test"
 
     insert(:ai_user_configuration,
       user_id: user_id,
       provider: :google,
       model: "gemini-2.5-flash"
     )
+
+    join_as_persisted_user(user_id)
+  end
+
+  defp join_socket_without_ai_config(_context) do
+    %{id: user_id} = insert(:user)
+
+    join_as_persisted_user(user_id)
+  end
+
+  defp join_as_persisted_user(user_id) do
+    jwt = generate_jwt(user_id)
+    request_origin = "https://trento.test"
 
     {:ok, _, socket} =
       UserSocket
@@ -1154,6 +1469,7 @@ defmodule TrentoWeb.AIAssistantChannelTest do
 
     Mox.allow(Trento.AI.Agent.Supervisor.Mock, self(), socket.channel_pid)
     Mox.allow(Trento.AI.Agent.Server.Mock, self(), socket.channel_pid)
+    Mox.allow(Trento.AI.LLMBuilder.Mock, self(), socket.channel_pid)
 
     %{
       socket: socket,
@@ -1161,6 +1477,35 @@ defmodule TrentoWeb.AIAssistantChannelTest do
       access_token: jwt,
       request_origin: request_origin
     }
+  end
+
+  # Pushes a prompt and blocks until the run is really inside the model call, so
+  # a following `cancel_run` has something to cancel.
+  #
+  # `:task_pid` is the parked run task: `send(task_pid, :release)` makes the
+  # fake model answer and the run complete.
+  defp start_run!(socket, jwt, opts) do
+    run_id = Keyword.fetch!(opts, :run_id)
+    thread_id = "thread-#{Faker.UUID.v4()}"
+
+    push(socket, "send_message", %{
+      "message" => "hello",
+      "run_id" => run_id,
+      "thread_id" => thread_id,
+      "access_token" => jwt
+    })
+
+    assert_push(
+      "ag_ui_event",
+      %{"type" => "RUN_STARTED", "runId" => ^run_id, "threadId" => ^thread_id},
+      @integration_timeout
+    )
+
+    assert_receive {:llm_called, task_pid}, @integration_timeout
+
+    on_exit(fn -> TrentoAIAgent.stop(thread_id) end)
+
+    %{thread_id: thread_id, task_pid: task_pid}
   end
 
   defp generate_jwt(sub), do: AccessToken.generate_access_token!(%{"sub" => sub})

--- a/test/trento_web/views/v1/ai_configuration_view_json_test.exs
+++ b/test/trento_web/views/v1/ai_configuration_view_json_test.exs
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule TrentoWeb.V1.AIConfigurationJSONTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   import Trento.Factory
 


### PR DESCRIPTION
### Description

This PR wires the cancellation/stopping primitives from https://github.com/trento-project/web/pull/4648 in the ai assistant channel.

Now a client attached to the socket can issue:
- `cancel_run` to cancel the ongoing run processing which leaves the agent running and ready to handle other prompts
- `abandon_thread` to stop the agent process (internally it also cancels ongoing runs being processed)

These will have UI counterparts on:
- a stop button in the chatbox triggering a cancellation
- abandonment is wired to "New Chat" button in the chatbox header

Additional notes:
- improvements to `FakeChatModel` so that it can be instructed on responding behaviour
- `LLMBuilder` made a behavior so we can have it return a`FakeChatModel` in relevant tests
- some redundant ai assistant channel tests were collapsed

### How was this tested?

Automated and IRL