### PR TITLE
Abandon the server-side thread when a new chat starts

### DIFF
--- a/assets/js/common/AIAssistant/AIAssistant.test.jsx
+++ b/assets/js/common/AIAssistant/AIAssistant.test.jsx
@@ -88,6 +88,31 @@ describe('AIAssistant', () => {
         screen.queryByText(/new AI configuration is available/i)
       ).not.toBeInTheDocument();
     });
+
+    it('starts a fresh thread so the next open is a clean conversation', async () => {
+      const { user, channel, sendUserMessage, streamAssistantTurn } =
+        await renderAIAssistant({ open: true });
+
+      const first = await sendUserMessage('hello');
+      await streamAssistantTurn(first, { messageId: 'a', deltas: ['hi'] });
+      expect(screen.getByText('hello')).toBeVisible();
+
+      await user.click(screen.getByLabelText('Close'));
+
+      await act(async () => {
+        channel.emit('ai_configuration_created');
+      });
+
+      await user.click(await findEnabledTrigger());
+
+      await waitFor(() => {
+        expect(screen.queryByText('hello')).not.toBeInTheDocument();
+      });
+
+      const second = await sendUserMessage('after');
+
+      expect(second.thread_id).not.toBe(first.thread_id);
+    });
   });
 
   describe('when the configuration changes after the launcher was opened', () => {

--- a/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
+++ b/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
@@ -229,7 +229,15 @@ describe('AG-UI event flow', () => {
     const first = await sendUserMessage('first');
     await streamAssistantTurn(first, { messageId: 'a', deltas: ['one'] });
 
+    expect(screen.getByText('first')).toBeVisible();
+    expect(await screen.findByText('one')).toBeVisible();
+
     await user.click(screen.getByRole('button', { name: 'New chat' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('first')).not.toBeInTheDocument();
+      expect(screen.queryByText('one')).not.toBeInTheDocument();
+    });
 
     const second = await sendUserMessage('second');
 

--- a/assets/js/common/AIAssistant/AssistantChatProvider.jsx
+++ b/assets/js/common/AIAssistant/AssistantChatProvider.jsx
@@ -62,8 +62,10 @@ function AssistantChatProvider({
   useEffect(() => {
     if (previousThreadIDRef.current === threadID) return;
     previousThreadIDRef.current = threadID;
+
     runtime.thread.reset();
-  }, [threadID, runtime]);
+    agent.abandonThread();
+  }, [threadID, runtime, agent]);
 
   return (
     <AssistantRuntimeProvider aui={aui} runtime={runtime}>

--- a/assets/js/common/AIAssistant/AssistantChatProvider.test.jsx
+++ b/assets/js/common/AIAssistant/AssistantChatProvider.test.jsx
@@ -24,7 +24,7 @@ jest.mock('@assistant-ui/react', () => ({
 const modelPayload = { provider: 'google', model: 'gemini-2.5-pro' };
 
 function renderProvider({ socket = makeMockSocket(), ...props } = {}) {
-  const runtime = { thread: { reset: jest.fn() } };
+  const runtime = { thread: { reset: jest.fn(), cancelRun: jest.fn() } };
   useAgUiRuntime.mockImplementation(() => runtime);
 
   const initialProps = { userID: 42, threadID: 'thread-1', ...props };
@@ -200,5 +200,17 @@ describe('AssistantChatProvider', () => {
     await waitFor(() => {
       expect(runtime.thread.reset).toHaveBeenCalledTimes(1);
     });
+    // A new chat is not a cancelled turn. `cancelRun()` not called here
+    expect(runtime.thread.cancelRun).not.toHaveBeenCalled();
+  });
+
+  it('abandons the previous thread on the transport', async () => {
+    const { rerender, channel, agent } = renderProvider();
+    await waitFor(() => expect(channel()).toBeDefined());
+    const abandonThread = jest.spyOn(agent(), 'abandonThread');
+
+    rerender({ threadID: 'thread-2' });
+
+    await waitFor(() => expect(abandonThread).toHaveBeenCalledTimes(1));
   });
 });

--- a/assets/js/lib/ai/WebSocketAIAgent.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.js
@@ -174,14 +174,23 @@ export class WebSocketAIAgent extends AbstractAgent {
     this.#callbacks.onAIConfigurationCleared();
   }
 
-  _isStaleRunFinished({ type, runId }) {
-    return type === EventType.RUN_FINISHED && runId !== this._activeRunId;
+  // The events the server stamps with a run id. RunStarted and RunFinished both enforce one.
+  // RUN_ERROR is deliberately absent: RunError has no run_id field at all, so filtering it on
+  // one would drop every error. Everything else the channel pushes
+  // (TEXT_MESSAGE_*, TOOL_CALL_*) belongs to whichever run is subscribed.
+  static RUN_SCOPED_EVENTS = [EventType.RUN_STARTED, EventType.RUN_FINISHED];
+
+  _isStaleRunEvent({ type, runId }) {
+    return (
+      WebSocketAIAgent.RUN_SCOPED_EVENTS.includes(type) &&
+      runId !== this._activeRunId
+    );
   }
 
   _handleAgUiEvent(event) {
     const subscriber = this._activeSubscriber;
     if (!subscriber) return;
-    if (this._isStaleRunFinished(event)) return;
+    if (this._isStaleRunEvent(event)) return;
 
     subscriber.next(event);
 
@@ -257,11 +266,21 @@ export class WebSocketAIAgent extends AbstractAgent {
     });
   }
 
+  // Settle the in-flight run, with an error only when the user needs to see one.
   _settleActiveRun(maybeError) {
     const subscriber = this._activeSubscriber;
     if (!subscriber) return;
     maybeError ? subscriber.error(maybeError) : subscriber.complete();
     this._clearActiveRun();
+  }
+
+  // Triggered on "New chat". Tells the server to stop the related Agent
+  // instead of waiting sagents inactivity timeout.
+  //
+  // The payload is empty because the server abandons the thread in its own assigns.
+  abandonThread() {
+    this.channel?.push('abandon_thread', {});
+    this._settleActiveRun();
   }
 
   _clearActiveRun() {

--- a/assets/js/lib/ai/WebSocketAIAgent.test.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.test.js
@@ -385,7 +385,7 @@ describe('WebSocketAIAgent', () => {
       await flushMicrotasks();
       const staleRunId = channel.pushed[0].payload.run_id;
 
-      const { complete } = runAgent(agent, {
+      const { complete, next } = runAgent(agent, {
         threadId: 't',
         messages: [userMessage('second')],
       });
@@ -398,10 +398,35 @@ describe('WebSocketAIAgent', () => {
         aguiEvents.runFinished({ threadId: 't', runId: staleRunId })
       );
 
+      expect(next).not.toHaveBeenCalled();
       expect(complete).not.toHaveBeenCalled();
       expect(agent._activeRunId).not.toBeNull();
     });
 
+    it('does not forward a RUN_STARTED from a superseded run', async () => {
+      const { agent, channel } = await connectedAgent();
+
+      runAgent(agent, { threadId: 't', messages: [userMessage('first')] });
+      await flushMicrotasks();
+      const staleRunId = channel.pushed[0].payload.run_id;
+
+      const { next } = runAgent(agent, {
+        threadId: 't',
+        messages: [userMessage('second')],
+      });
+      await flushMicrotasks();
+
+      channel.emit(
+        'ag_ui_event',
+        aguiEvents.runStarted({ threadId: 't', runId: staleRunId })
+      );
+
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    // RunError has no run_id field (deps/ag_ui_ex/lib/ag_ui/core/events.ex:138),
+    // so these events reach the client unstamped and must never be filtered as
+    // stale the way an unstamped RUN_FINISHED is.
     it.each([
       {
         scenario: 'with explicit message',
@@ -427,20 +452,6 @@ describe('WebSocketAIAgent', () => {
         expect(agent._activeSubscriber).toBeNull();
       }
     );
-
-    it('errors the observable on a RUN_ERROR that names no run', async () => {
-      const { agent, channel } = await connectedAgent();
-      const { error } = runAgent(agent);
-
-      // AgUi.Core.Events.RunError has no run_id field: the server cannot stamp
-      // one, so a RUN_ERROR must never be filtered out for lacking it.
-      channel.emit('ag_ui_event', aguiEvents.runError({ message: 'oops' }));
-
-      expect(error).toHaveBeenCalledWith(
-        expect.objectContaining({ message: 'oops' })
-      );
-      expect(agent._activeSubscriber).toBeNull();
-    });
 
     it('errors when there is no new user message to start the run with', async () => {
       const { agent } = await connectedAgent();
@@ -498,6 +509,35 @@ describe('WebSocketAIAgent', () => {
 
       expect(agent._activeSubscriber).toBeNull();
       expect(agent._activeRunId).toBeNull();
+    });
+  });
+
+  describe('abandonThread', () => {
+    it('tells the server to let the thread go', async () => {
+      const { agent, channel } = await connectedAgent();
+
+      agent.abandonThread();
+
+      expect(channel.pushed).toContainEqual(
+        expect.objectContaining({ event: 'abandon_thread', payload: {} })
+      );
+    });
+
+    it('settles an in-flight run instead of leaving it hanging', async () => {
+      const { agent } = await connectedAgent();
+      const { complete, error } = runAgent(agent, {
+        threadId: 'thread-9',
+        messages: [userMessage()],
+      });
+      await flushMicrotasks();
+
+      agent.abandonThread();
+
+      // The server terminates the agent and no RUN_FINISHED/RUN_ERROR will ever come back.
+      // The client has to settle it locally.
+      expect(complete).toHaveBeenCalledTimes(1);
+      expect(error).not.toHaveBeenCalled();
+      expect(agent._activeSubscriber).toBeNull();
     });
   });
 


### PR DESCRIPTION
### Description

This PR introduces the ability to issue an `abandon_thread` message from the client so that the server can clean up the related running Agent.

The action is wired on "New Chat" button in chat header, that means that when a user starts a new chat, not only the client will be reset to a fresh state, but contextually the server will be told to stop any previous running Agent.

### How was this tested?

Automated and IRL.