### PR TITLE
Stop a running answer from the composer

### DIFF
--- a/assets/eslint.config.mjs
+++ b/assets/eslint.config.mjs
@@ -54,6 +54,7 @@ export default defineConfig([
         setInterval: true,
         clearTimeout: true,
         clearInterval: true,
+        queueMicrotask: true,
         $: false,
         jQuery: false,
         CustomEvent: true,

--- a/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
+++ b/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
@@ -2,15 +2,36 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { act, screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { renderAIAssistant } from '@lib/test-utils/aiAssistant';
 import { aguiEvents } from '@lib/test-utils/aguiEvents';
 
+const assistantBubbles = () =>
+  Array.from(document.querySelectorAll('[data-role="assistant"]'));
+
 const assistantBubble = () => {
-  const nodes = document.querySelectorAll('[data-role="assistant"]');
+  const nodes = assistantBubbles();
   return nodes[nodes.length - 1] || null;
+};
+
+const streamThenStop = async (
+  { user, emitAgUi, sendUserMessage },
+  delta = 'half an answer'
+) => {
+  const { thread_id: threadId, run_id: runId } = await sendUserMessage('hello');
+  const messageId = 'asst-1';
+
+  await emitAgUi(aguiEvents.runStarted({ threadId, runId }));
+  await emitAgUi(aguiEvents.textStart({ messageId }));
+  await emitAgUi(aguiEvents.textContent({ messageId, delta }));
+  await screen.findByText(delta);
+
+  await user.click(screen.getByRole('button', { name: 'Stop generating' }));
+  await screen.findByLabelText('Send message');
+
+  return { threadId, runId };
 };
 
 describe('AG-UI event flow', () => {
@@ -119,6 +140,39 @@ describe('AG-UI event flow', () => {
     });
   });
 
+  it('marks a streaming answer as stopped when the AI configuration is cleared', async () => {
+    const { channel, emitAgUi, sendUserMessage } = await renderAIAssistant({
+      open: true,
+    });
+    const { thread_id: threadId, run_id: runId } =
+      await sendUserMessage('hello');
+    const messageId = 'asst-1';
+
+    await emitAgUi(aguiEvents.runStarted({ threadId, runId }));
+    await emitAgUi(aguiEvents.textStart({ messageId }));
+    await emitAgUi(
+      aguiEvents.textContent({ messageId, delta: 'half an answer' })
+    );
+    await waitFor(() => {
+      expect(assistantBubble()).toHaveTextContent('half an answer');
+    });
+
+    await act(async () => {
+      channel.emit('ai_configuration_cleared');
+    });
+
+    expect(assistantBubble()).toHaveTextContent('half an answer');
+    expect(
+      await within(assistantBubble()).findByText('Response stopped.')
+    ).toBeVisible();
+    expect(
+      screen.queryByRole('button', { name: 'Stop generating' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('AI Assistant is disabled')
+    ).toBeDisabled();
+  });
+
   const emitModelChange = (channel) =>
     act(async () => {
       channel.emit('model_changed', {
@@ -222,6 +276,126 @@ describe('AG-UI event flow', () => {
     await waitFor(() => expect(newChat()).toBeEnabled());
   });
 
+  it('stops a streaming run without discarding what is on screen', async () => {
+    const context = await renderAIAssistant({ open: true });
+    await streamThenStop(context);
+
+    expect(
+      context.channel.pushed.filter((p) => p.event === 'cancel_run')
+    ).toEqual([expect.objectContaining({ payload: {} })]);
+
+    expect(screen.getByText('hello')).toBeVisible();
+    expect(assistantBubble()).toHaveTextContent('half an answer');
+    expect(
+      within(assistantBubble()).getByText('Response stopped.')
+    ).toBeVisible();
+
+    // The composer is promptable again, empty, with nothing left spinning.
+    expect(screen.getByLabelText('Message input')).toHaveValue('');
+    expect(screen.queryByText('Thinking...')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Send message')).toBeVisible();
+    expect(
+      screen.queryByRole('button', { name: 'Stop generating' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('prompt is sent back to the composer when the run is stopped before its first token', async () => {
+    const { user, channel, sendUserMessage } = await renderAIAssistant({
+      open: true,
+    });
+    await sendUserMessage('hello');
+
+    // No server event. The run is stopped between the push and the first RUN_STARTED.
+    expect(await screen.findByText('Thinking...')).toBeVisible();
+
+    await user.click(screen.getByRole('button', { name: 'Stop generating' }));
+
+    expect(channel.pushed.filter((p) => p.event === 'cancel_run')).toEqual([
+      expect.objectContaining({ payload: {} }),
+    ]);
+
+    await waitFor(() => {
+      expect(assistantBubbles()).toHaveLength(0);
+    });
+    expect(screen.getByLabelText('Message input')).toHaveValue('hello');
+    expect(await screen.findByLabelText('Send message')).toBeVisible();
+  });
+
+  it('keeps the marker on the stopped answer once a follow-up prompt starts a new run', async () => {
+    const context = await renderAIAssistant({ open: true });
+    const { emitAgUi, sendUserMessage } = context;
+    const { threadId, runId } = await streamThenStop(context);
+
+    const stoppedBubble = assistantBubble();
+    expect(within(stoppedBubble).getByText('Response stopped.')).toBeVisible();
+
+    const next = await sendUserMessage('try again');
+    await emitAgUi(aguiEvents.runStarted({ threadId, runId: next.run_id }));
+
+    // same thread, different run
+    expect(next.thread_id).toBe(threadId);
+    expect(next.run_id).not.toBe(runId);
+
+    // stopped marker remains on the old bubble, and new bubble is clean
+    expect(within(stoppedBubble).getByText('Response stopped.')).toBeVisible();
+    const newBubble = assistantBubble();
+    expect(newBubble).not.toBe(stoppedBubble);
+    expect(
+      within(newBubble).queryByText('Response stopped.')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the progress indicator only on the answer in flight, never on an earlier stopped one', async () => {
+    const context = await renderAIAssistant({ open: true });
+    const { emitAgUi, sendUserMessage } = context;
+    const { threadId } = await streamThenStop(context);
+
+    const stoppedBubble = assistantBubble();
+
+    const next = await sendUserMessage('try again');
+    await emitAgUi(aguiEvents.runStarted({ threadId, runId: next.run_id }));
+
+    expect(await screen.findByText('Thinking...')).toBeVisible();
+    expect(screen.getAllByText('Thinking...')).toHaveLength(1);
+    expect(
+      within(stoppedBubble).queryByText('Thinking...')
+    ).not.toBeInTheDocument();
+  });
+
+  it('starts over when a cross-tab config swap lands on a run streaming behind a closed launcher', async () => {
+    const { user, channel, sendUserMessage } = await renderAIAssistant({
+      open: true,
+    });
+
+    await sendUserMessage('hello');
+    expect(
+      screen.getByRole('button', { name: 'Stop generating' })
+    ).toBeVisible();
+
+    // Closing the launcher does not tear the run down
+    await user.click(screen.getByLabelText('Close'));
+
+    await act(async () => {
+      // this settles the run, but the user has no way to see that yet
+      channel.emit('ai_configuration_cleared');
+    });
+    await act(async () => {
+      // this re-enables the launcher
+      channel.emit('ai_configuration_created');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Open AI Assistant' }));
+
+    // after opening again the chat modal, we start from a clean state
+    expect(screen.getByText("Hi, I'm Liz.")).toBeVisible();
+    expect(await screen.findByLabelText('Send message')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'New chat' })).toBeEnabled();
+    expect(
+      screen.queryByRole('button', { name: 'Stop generating' })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('hello')).not.toBeInTheDocument();
+  });
+
   it('"New chat" starts a new conversation with a new thread ID', async () => {
     const { user, sendUserMessage, streamAssistantTurn } =
       await renderAIAssistant({ open: true });
@@ -229,8 +403,8 @@ describe('AG-UI event flow', () => {
     const first = await sendUserMessage('first');
     await streamAssistantTurn(first, { messageId: 'a', deltas: ['one'] });
 
-    expect(screen.getByText('first')).toBeVisible();
     expect(await screen.findByText('one')).toBeVisible();
+    expect(screen.getByText('first')).toBeVisible();
 
     await user.click(screen.getByRole('button', { name: 'New chat' }));
 

--- a/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.jsx
+++ b/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.jsx
@@ -17,7 +17,7 @@ export function deriveProgressLabel(content) {
 export function AgentProgressIndicatorView({ spinner = true, children }) {
   return (
     <div role="status" className="flex items-center gap-2 text-gray-600 mt-2">
-      {spinner && <Spinner />}
+      {spinner && <Spinner aria-hidden="true" />}
       <span className="text-sm">{children}</span>
     </div>
   );

--- a/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.jsx
+++ b/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.jsx
@@ -14,14 +14,31 @@ export function deriveProgressLabel(content) {
   return 'Thinking...';
 }
 
-export function AgentProgressIndicatorView({ children }) {
+export function AgentProgressIndicatorView({ spinner = true, children }) {
   return (
-    <div className="flex items-center gap-2 text-muted-foreground mt-2">
-      <Spinner />
+    <div role="status" className="flex items-center gap-2 text-gray-600 mt-2">
+      {spinner && <Spinner />}
       <span className="text-sm">{children}</span>
     </div>
   );
 }
+
+const wasStopped = (status) =>
+  status?.type === 'incomplete' && status.reason === 'cancelled';
+
+const hasStreamedText = (content) =>
+  content.some((part) => part.type === 'text' && part.text?.trim().length > 0);
+
+const deriveNotice = ({ isRunning, message }) => {
+  const { status, content, isLast } = message;
+
+  if (wasStopped(status)) return { label: 'Response stopped.', spinner: false };
+
+  if (isRunning && isLast && !hasStreamedText(content))
+    return { label: deriveProgressLabel(content), spinner: true };
+
+  return null;
+};
 
 // Reads `s.message` from the per-message scope set up by assistant-ui's
 // MessageByIndexProvider (one per <MessagePrimitive.Root>). Subscribing
@@ -29,20 +46,13 @@ export function AgentProgressIndicatorView({ children }) {
 // updates
 function AgentProgressIndicator({ isRunning }) {
   const message = useAuiState((s) => s.message);
-  const canShowIndicator = isRunning && message.isLast;
+  const notice = deriveNotice({ isRunning, message });
 
-  if (!canShowIndicator) return null;
-  if (
-    message.content.some(
-      (part) => part.type === 'text' && part.text?.trim().length > 0
-    )
-  ) {
-    return null;
-  }
+  if (!notice) return null;
 
   return (
-    <AgentProgressIndicatorView>
-      {deriveProgressLabel(message.content)}
+    <AgentProgressIndicatorView spinner={notice.spinner}>
+      {notice.label}
     </AgentProgressIndicatorView>
   );
 }

--- a/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.jsx
+++ b/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.jsx
@@ -29,8 +29,9 @@ export function AgentProgressIndicatorView({ children }) {
 // updates
 function AgentProgressIndicator({ isRunning }) {
   const message = useAuiState((s) => s.message);
+  const canShowIndicator = isRunning && message.isLast;
 
-  if (!isRunning) return null;
+  if (!canShowIndicator) return null;
   if (
     message.content.some(
       (part) => part.type === 'text' && part.text?.trim().length > 0

--- a/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.stories.jsx
+++ b/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.stories.jsx
@@ -12,16 +12,26 @@ export default {
       description: 'Label rendered next to the spinner',
       control: { type: 'text' },
     },
+    spinner: {
+      description: 'Whether the agent is still working on the answer',
+      control: { type: 'boolean' },
+    },
   },
   render: (args) => (
-    <AgentProgressIndicatorView>{args.children}</AgentProgressIndicatorView>
+    <AgentProgressIndicatorView spinner={args.spinner}>
+      {args.children}
+    </AgentProgressIndicatorView>
   ),
 };
 
 export const Thinking = {
-  args: { children: 'Thinking...' },
+  args: { children: 'Thinking...', spinner: true },
 };
 
 export const CallingTool = {
-  args: { children: 'Calling get_hosts...' },
+  args: { children: 'Calling get_hosts...', spinner: true },
+};
+
+export const Stopped = {
+  args: { children: 'Response stopped.', spinner: false },
 };

--- a/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.test.jsx
+++ b/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.test.jsx
@@ -23,6 +23,7 @@ describe('AgentProgressIndicatorView', () => {
     (label) => {
       render(<AgentProgressIndicatorView>{label}</AgentProgressIndicatorView>);
       expect(screen.getByText(label)).toBeVisible();
+      expect(screen.getByRole('status')).toHaveTextContent(label);
     }
   );
 
@@ -30,7 +31,12 @@ describe('AgentProgressIndicatorView', () => {
     render(
       <AgentProgressIndicatorView>Thinking...</AgentProgressIndicatorView>
     );
-    expect(screen.getByRole('alert', { name: 'Loading' })).toBeVisible();
+
+    const spinner = screen.getByLabelText('Loading');
+
+    expect(spinner).toBeVisible();
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(spinner).toHaveAttribute('aria-hidden', 'true');
   });
 
   it('renders no spinner when the answer is not in progress', () => {
@@ -39,7 +45,7 @@ describe('AgentProgressIndicatorView', () => {
         Response stopped.
       </AgentProgressIndicatorView>
     );
-    expect(screen.queryByRole('alert', { name: 'Loading' })).toBeNull();
+    expect(screen.queryByLabelText('Loading')).toBeNull();
   });
 });
 
@@ -137,7 +143,7 @@ describe('AgentProgressIndicator', () => {
       render(<AgentProgressIndicator isRunning={false} />);
 
       expect(screen.getByText('Response stopped.')).toBeVisible();
-      expect(screen.queryByRole('alert', { name: 'Loading' })).toBeNull();
+      expect(screen.queryByLabelText('Loading')).toBeNull();
     });
 
     it.each([

--- a/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.test.jsx
+++ b/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.test.jsx
@@ -32,6 +32,15 @@ describe('AgentProgressIndicatorView', () => {
     );
     expect(screen.getByRole('alert', { name: 'Loading' })).toBeVisible();
   });
+
+  it('renders no spinner when the answer is not in progress', () => {
+    render(
+      <AgentProgressIndicatorView spinner={false}>
+        Response stopped.
+      </AgentProgressIndicatorView>
+    );
+    expect(screen.queryByRole('alert', { name: 'Loading' })).toBeNull();
+  });
 });
 
 describe('deriveProgressLabel', () => {
@@ -93,7 +102,7 @@ describe('AgentProgressIndicator', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('renders nothing on an earlier answer once a later one exists', () => {
+  it('renders nothing on an earlier answer', () => {
     mockMessage({ content: [], isLast: false });
     const { container } = render(<AgentProgressIndicator isRunning />);
     expect(container).toBeEmptyDOMElement();
@@ -112,5 +121,60 @@ describe('AgentProgressIndicator', () => {
     });
     render(<AgentProgressIndicator isRunning />);
     expect(screen.getByText('Calling get_hosts...')).toBeVisible();
+  });
+
+  describe('once the user has stopped the answer', () => {
+    const cancelled = (overrides = {}) => ({
+      content: [],
+      isLast: true,
+      status: { type: 'incomplete', reason: 'cancelled' },
+      ...overrides,
+    });
+
+    it('says the response was stopped, without a spinner', () => {
+      mockMessage(cancelled());
+
+      render(<AgentProgressIndicator isRunning={false} />);
+
+      expect(screen.getByText('Response stopped.')).toBeVisible();
+      expect(screen.queryByRole('alert', { name: 'Loading' })).toBeNull();
+    });
+
+    it.each([
+      { label: 'a later answer exists', overrides: { isLast: false } },
+      {
+        label: 'the answer got some text out',
+        overrides: { content: [{ type: 'text', text: 'half an answer' }] },
+      },
+    ])('keeps the mark when $label', ({ overrides }) => {
+      mockMessage(cancelled(overrides));
+
+      render(<AgentProgressIndicator isRunning={false} />);
+
+      expect(screen.getByText('Response stopped.')).toBeVisible();
+    });
+
+    it('stopped mark takes precedence over thinking', () => {
+      mockMessage(cancelled());
+
+      render(<AgentProgressIndicator isRunning />);
+
+      expect(screen.getByText('Response stopped.')).toBeVisible();
+      expect(screen.queryByText('Thinking...')).toBeNull();
+    });
+  });
+
+  it.each([
+    { label: 'the answer completed', status: { type: 'complete' } },
+    {
+      label: 'the answer failed',
+      status: { type: 'incomplete', reason: 'error', error: 'boom' },
+    },
+  ])('renders nothing when $label', ({ status }) => {
+    mockMessage({ content: [], isLast: true, status });
+
+    const { container } = render(<AgentProgressIndicator isRunning={false} />);
+
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.test.jsx
+++ b/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.test.jsx
@@ -79,7 +79,7 @@ describe('deriveProgressLabel', () => {
 
 describe('AgentProgressIndicator', () => {
   it('renders nothing when the thread is not running', () => {
-    mockMessage({ content: [] });
+    mockMessage({ content: [], isLast: true });
     const { container } = render(<AgentProgressIndicator isRunning={false} />);
     expect(container).toBeEmptyDOMElement();
   });
@@ -87,13 +87,20 @@ describe('AgentProgressIndicator', () => {
   it('renders nothing when the assistant has already produced text', () => {
     mockMessage({
       content: [{ type: 'text', text: 'partial answer' }],
+      isLast: true,
     });
     const { container } = render(<AgentProgressIndicator isRunning />);
     expect(container).toBeEmptyDOMElement();
   });
 
+  it('renders nothing on an earlier answer once a later one exists', () => {
+    mockMessage({ content: [], isLast: false });
+    const { container } = render(<AgentProgressIndicator isRunning />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
   it('renders "Thinking..." while the thread is running and no content has streamed', () => {
-    mockMessage({ content: [] });
+    mockMessage({ content: [], isLast: true });
     render(<AgentProgressIndicator isRunning />);
     expect(screen.getByText('Thinking...')).toBeVisible();
   });
@@ -101,6 +108,7 @@ describe('AgentProgressIndicator', () => {
   it('renders the tool name while a tool call is in flight', () => {
     mockMessage({
       content: [{ type: 'tool-call', toolName: 'get_hosts' }],
+      isLast: true,
     });
     render(<AgentProgressIndicator isRunning />);
     expect(screen.getByText('Calling get_hosts...')).toBeVisible();

--- a/assets/js/common/AIAssistant/AssistantChatProvider.test.jsx
+++ b/assets/js/common/AIAssistant/AssistantChatProvider.test.jsx
@@ -208,9 +208,11 @@ describe('AssistantChatProvider', () => {
     const { rerender, channel, agent } = renderProvider();
     await waitFor(() => expect(channel()).toBeDefined());
     const abandonThread = jest.spyOn(agent(), 'abandonThread');
+    const abortRun = jest.spyOn(agent(), 'abortRun');
 
     rerender({ threadID: 'thread-2' });
 
     await waitFor(() => expect(abandonThread).toHaveBeenCalledTimes(1));
+    expect(abortRun).not.toHaveBeenCalled();
   });
 });

--- a/assets/js/common/AIAssistant/MessageBubble/MessageBubble.test.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/MessageBubble.test.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
+import { useAuiState } from '@assistant-ui/react';
 import { UserMessage, AssistantMessage } from './MessageBubble';
 
 jest.mock('@assistant-ui/react', () => ({
@@ -19,14 +20,23 @@ jest.mock('@assistant-ui/react', () => ({
     // error. This stub is unconditional, so the tests below can prove the slot is mounted
     Error: ({ children }) => <div>{children}</div>,
   },
-  // AssistantMessage renders <AgentProgressIndicator> which subscribes via
-  // useAuiState((s) => s.message). Default: empty content + no run in flight.
-  useAuiState: () => ({ content: [] }),
+  useAuiState: jest.fn(),
 }));
 
 jest.mock('@assistant-ui/react-markdown', () => ({
   MarkdownTextPrimitive: () => null,
 }));
+
+const mockAssistantMessage = (overrides = {}) => {
+  const message = {
+    content: [],
+    id: 'message-1',
+    isLast: true,
+    status: { type: 'complete', reason: 'unknown' },
+    ...overrides,
+  };
+  useAuiState.mockImplementation((selector) => selector({ message }));
+};
 
 describe('UserMessage', () => {
   it('renders the user message bubble with the "You" label and parts slot', () => {
@@ -44,6 +54,8 @@ describe('UserMessage', () => {
 });
 
 describe('AssistantMessage', () => {
+  beforeEach(() => mockAssistantMessage());
+
   it('renders the assistant message bubble with the parts and error slots', () => {
     const { container } = render(<AssistantMessage />);
 
@@ -52,6 +64,7 @@ describe('AssistantMessage', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('message parts')).toBeVisible();
     expect(screen.getByText('Error message')).toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });
 
   it('omits the user-only "You" label', () => {
@@ -61,6 +74,28 @@ describe('AssistantMessage', () => {
 
   it('shows the agent progress indicator while a run is in flight', () => {
     render(<AssistantMessage isRunning />);
-    expect(screen.getByText('Thinking...')).toBeVisible();
+    expect(screen.getByRole('status')).toHaveTextContent('Thinking...');
+  });
+
+  it('names the tool the agent is calling', () => {
+    mockAssistantMessage({
+      content: [{ type: 'tool-call', toolName: 'get_hosts' }],
+    });
+
+    render(<AssistantMessage isRunning />);
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Calling get_hosts...'
+    );
+  });
+
+  it('marks an answer the user stopped', () => {
+    mockAssistantMessage({
+      status: { type: 'incomplete', reason: 'cancelled' },
+    });
+
+    render(<AssistantMessage />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('Response stopped.');
   });
 });

--- a/assets/js/common/AIAssistant/PromptComposer/PromptComposer.jsx
+++ b/assets/js/common/AIAssistant/PromptComposer/PromptComposer.jsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import { get } from 'lodash';
+import { EOS_STOP_FILLED } from 'eos-icons-react';
 import { ComposerPrimitive } from '@assistant-ui/react';
 
 import Button from '@common/Button';
@@ -16,6 +17,9 @@ import {
 
 const COMPOSER_INPUT_CLASS_NAME =
   'w-full border border-gray-300 rounded-lg p-4 text-gray-700 resize-none h-[130px] focus:outline-none focus:border-[#2fb371] focus:ring-1 focus:ring-[#2fb371] placeholder-gray-400 text-lg font-medium bg-white shadow-sm disabled:bg-gray-50 disabled:cursor-not-allowed';
+
+const ACTION_BUTTON_CLASS_NAME =
+  'min-w-20 inline-flex items-center justify-center';
 
 const PLACEHOLDERS = {
   [CONNECTION_STATUS.CONNECTED]: 'How can I help you?',
@@ -46,13 +50,13 @@ const footnote = (
   </>
 );
 
-function SendButton({ disabled, isRunning, reason }) {
-  if (isRunning) return null;
+function SendButton({ disabled, reason }) {
   return (
     <ComposerPrimitive.Send asChild>
       <Button
         asSubmit
         type="default-fit"
+        className={ACTION_BUTTON_CLASS_NAME}
         disabled={disabled}
         aria-label="Send message"
         title={disabled ? reason : 'Send message'}
@@ -60,6 +64,21 @@ function SendButton({ disabled, isRunning, reason }) {
         Send
       </Button>
     </ComposerPrimitive.Send>
+  );
+}
+
+function StopButton() {
+  return (
+    <ComposerPrimitive.Cancel asChild>
+      <Button
+        type="danger-bold"
+        className={ACTION_BUTTON_CLASS_NAME}
+        aria-label="Stop generating"
+        title="Stop generating"
+      >
+        <EOS_STOP_FILLED className="h-6 w-6 fill-current" />
+      </Button>
+    </ComposerPrimitive.Cancel>
   );
 }
 
@@ -95,11 +114,11 @@ function PromptComposer({
       </div>
       <div className="flex justify-between items-center w-full mt-4">
         <div className="text-sm text-gray-400 leading-tight">{footnote}</div>
-        <SendButton
-          disabled={inputDisabled}
-          isRunning={isRunning}
-          reason={placeholder}
-        />
+        {isRunning ? (
+          <StopButton />
+        ) : (
+          <SendButton disabled={inputDisabled} reason={placeholder} />
+        )}
       </div>
     </ComposerPrimitive.Root>
   );

--- a/assets/js/common/AIAssistant/PromptComposer/PromptComposer.stories.jsx
+++ b/assets/js/common/AIAssistant/PromptComposer/PromptComposer.stories.jsx
@@ -47,7 +47,8 @@ export default {
       control: { type: 'radio' },
     },
     isRunning: {
-      description: 'Whether a run is in flight (hides the send button)',
+      description:
+        'Whether a run is in flight — Stop replaces Send until it settles',
       control: { type: 'boolean' },
     },
   },
@@ -69,7 +70,7 @@ export const Disabled = {
   args: { connectionStatus: CONNECTION_STATUS.DISCONNECTED, isRunning: false },
 };
 
-export const Sending = {
+export const Running = {
   args: { connectionStatus: CONNECTION_STATUS.CONNECTED, isRunning: true },
 };
 

--- a/assets/js/common/AIAssistant/PromptComposer/PromptComposer.test.jsx
+++ b/assets/js/common/AIAssistant/PromptComposer/PromptComposer.test.jsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
 import { CONNECTED, CONNECTING, DISCONNECTED } from '@lib/ai';
@@ -10,18 +11,25 @@ import { CONNECTED, CONNECTING, DISCONNECTED } from '@lib/ai';
 import { OK, CLEARED, RESTORED } from '../status';
 import PromptComposer from './PromptComposer';
 
-jest.mock('@assistant-ui/react', () => ({
-  ComposerPrimitive: {
-    Root: ({ children, ...props }) => <form {...props}>{children}</form>,
-    AttachmentDropzone: ({ children, ...props }) => (
-      <div {...props}>{children}</div>
-    ),
-    Input: ({ disabled, placeholder, ...props }) => (
-      <textarea disabled={disabled} placeholder={placeholder} {...props} />
-    ),
-    Send: ({ children }) => children,
-  },
-}));
+const mockCancel = jest.fn();
+
+jest.mock('@assistant-ui/react', () => {
+  const { cloneElement } = jest.requireActual('react');
+
+  return {
+    ComposerPrimitive: {
+      Root: ({ children, ...props }) => <form {...props}>{children}</form>,
+      AttachmentDropzone: ({ children, ...props }) => (
+        <div {...props}>{children}</div>
+      ),
+      Input: ({ disabled, placeholder, ...props }) => (
+        <textarea disabled={disabled} placeholder={placeholder} {...props} />
+      ),
+      Send: ({ children }) => children,
+      Cancel: ({ children }) => cloneElement(children, { onClick: mockCancel }),
+    },
+  };
+});
 
 describe('PromptComposer', () => {
   it.each([
@@ -125,9 +133,22 @@ describe('PromptComposer', () => {
     }
   );
 
-  it('hides the send button while the thread is running', () => {
+  it('replaces the send button with a stop button while the thread is running', () => {
     render(<PromptComposer connectionStatus={CONNECTED} isRunning />);
+
     expect(screen.queryByRole('button', { name: 'Send message' })).toBeNull();
+    expect(
+      screen.getByRole('button', { name: 'Stop generating' })
+    ).toBeVisible();
+  });
+
+  it('routes the stop button through the composer cancel primitive', async () => {
+    const user = userEvent.setup();
+    render(<PromptComposer connectionStatus={CONNECTED} isRunning />);
+
+    await user.click(screen.getByRole('button', { name: 'Stop generating' }));
+
+    expect(mockCancel).toHaveBeenCalledTimes(1);
   });
 
   it('renders the footnote with the documentation link', () => {

--- a/assets/js/common/Spinner/Spinner.jsx
+++ b/assets/js/common/Spinner/Spinner.jsx
@@ -4,9 +4,9 @@
 import React from 'react';
 import { EOS_LOADING_ANIMATED } from 'eos-icons-react';
 
-function Spinner({ className = '', size = 'm' }) {
+function Spinner({ className = '', size = 'm', ...props }) {
   return (
-    <div role="alert" aria-label="Loading" className={className}>
+    <div role="alert" aria-label="Loading" className={className} {...props}>
       <EOS_LOADING_ANIMATED size={size} className="fill-jungle-green-500" />
     </div>
   );

--- a/assets/js/common/Spinner/Spinner.test.jsx
+++ b/assets/js/common/Spinner/Spinner.test.jsx
@@ -23,4 +23,14 @@ describe('Spinner', () => {
     expect(spinnerElement).toHaveClass('pt-12');
     expect(spinnerElement.firstChild).toHaveAttribute('width', '32');
   });
+
+  it('lets the caller hide the spinner from assistive technology', () => {
+    render(<Spinner aria-hidden="true" />);
+
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(screen.getByRole('alert', { hidden: true })).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    );
+  });
 });

--- a/assets/js/lib/ai/WebSocketAIAgent.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.js
@@ -28,6 +28,15 @@ export const extractMessageText = ({ content } = {}) => {
 
 const isUnauthorized = (error) => error === 'unauthorized';
 
+// The error shape @assistant-ui/react-ag-ui reads as "this run was stopped".
+// RUN_CANCELLED is dispatched instead of RUN_ERROR, so the message ends up marked as
+// stopped rather than failed.
+const abortedRunError = () => {
+  const error = new Error('AI assistant run stopped');
+  error.name = 'AbortError';
+  return error;
+};
+
 // Bridges assistant-ui's AG-UI runtime with Phoenix channels: translates
 // AG-UI protocol events to/from channel events for the ai_assistant:{userID}
 // topic.
@@ -166,11 +175,8 @@ export class WebSocketAIAgent extends AbstractAgent {
     this.channel.onClose(dropConnection);
   }
 
-  // User's AI configuration was cleared server-side.
-  // Settle any in-flight run without surfacing an error
-  // and let the UI switch to its read-only / disabled state via the callback.
   _handleAIConfigurationCleared() {
-    this._settleActiveRun();
+    this._settleActiveRun(abortedRunError());
     this.#callbacks.onAIConfigurationCleared();
   }
 
@@ -274,10 +280,40 @@ export class WebSocketAIAgent extends AbstractAgent {
     this._clearActiveRun();
   }
 
-  // Triggered on "New chat". Tells the server to stop the related Agent
-  // instead of waiting sagents inactivity timeout.
+  // Our AbortError has to land last after library's cancellation steps.
   //
-  // The payload is empty because the server abandons the thread in its own assigns.
+  // Cancelling has ag ui runtime write to the message twice:
+  // - `cancel()` aborts its controller, which marks the run cancelled and turns any later error into a stop rather than a failure
+  // - `cancelRun()` then schedules a timer re-applying a snapshot it took while the answer still looked alive.
+  //
+  // The microtask waits out that whole synchronous turn, making sure the state of the message is properly marked as stopped
+  _settleAsAborted(subscriber) {
+    queueMicrotask(() =>
+      setTimeout(() => subscriber.error(abortedRunError()), 0)
+    );
+  }
+
+  // Stop, from the composer.
+  // `AgUiThreadRuntimeCore.cancel()` calls it before aborting its own AbortController.
+  //
+  // The payload is empty because the server cancels the thread named in its
+  // own socket assigns.
+  abortRun() {
+    const subscriber = this._activeSubscriber;
+
+    if (subscriber) {
+      this.channel?.push('cancel_run', {});
+
+      this._clearActiveRun();
+      this._settleAsAborted(subscriber);
+    }
+
+    super.abortRun();
+  }
+
+  // "New chat". Tells the server the thread is gone so the running agent process can be killed.
+  //
+  // The payload is empty for the same reason as `abortRun`'s.
   abandonThread() {
     this.channel?.push('abandon_thread', {});
     this._settleActiveRun();

--- a/assets/js/lib/ai/WebSocketAIAgent.test.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.test.js
@@ -27,6 +27,11 @@ const flushMicrotasks = async () => {
   for (let i = 0; i < 5; i += 1) await Promise.resolve();
 };
 
+const flushDeferredWork = async () => {
+  await flushMicrotasks();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
 const userMessage = (content = 'hi') => ({ role: 'user', content });
 
 function makeAuthDoubles() {
@@ -512,6 +517,39 @@ describe('WebSocketAIAgent', () => {
     });
   });
 
+  describe('abortRun', () => {
+    it('tells the server to stop and settles the run as aborted', async () => {
+      const { agent, channel } = await connectedAgent();
+      const { complete, error } = runAgent(agent, {
+        threadId: 'thread-9',
+        messages: [userMessage()],
+      });
+      await flushMicrotasks();
+
+      agent.abortRun();
+      await flushDeferredWork();
+
+      expect(channel.pushed).toContainEqual(
+        expect.objectContaining({ event: 'cancel_run', payload: {} })
+      );
+      expect(error).toHaveBeenCalledTimes(1);
+      expect(error.mock.calls[0][0]).toMatchObject({ name: 'AbortError' });
+      expect(complete).not.toHaveBeenCalled();
+      expect(agent._activeSubscriber).toBeNull();
+      expect(agent._activeRunId).toBeNull();
+    });
+
+    it('does nothing when no run is in flight', async () => {
+      const { agent, channel } = await connectedAgent();
+
+      agent.abortRun();
+
+      expect(channel.pushed).not.toContainEqual(
+        expect.objectContaining({ event: 'cancel_run' })
+      );
+    });
+  });
+
   describe('abandonThread', () => {
     it('tells the server to let the thread go', async () => {
       const { agent, channel } = await connectedAgent();
@@ -671,15 +709,16 @@ describe('WebSocketAIAgent', () => {
       }
     );
 
-    it('settles the active run on ai_configuration_cleared', async () => {
+    it('settles the active run as stopped on ai_configuration_cleared', async () => {
       const { channel, agent } = await connectedAgent();
       const { error, complete } = runAgent(agent);
       await flushMicrotasks();
 
       channel.emit('ai_configuration_cleared');
 
-      expect(complete).toHaveBeenCalledTimes(1);
-      expect(error).not.toHaveBeenCalled();
+      expect(error).toHaveBeenCalledTimes(1);
+      expect(error.mock.calls[0][0]).toMatchObject({ name: 'AbortError' });
+      expect(complete).not.toHaveBeenCalled();
       expect(agent._activeSubscriber).toBeNull();
       expect(agent._activeRunId).toBeNull();
     });


### PR DESCRIPTION
### Description

Last PR of the cancellation stack.

- swaps the send button with a stop one that cancels in-flight processing
- cancelled response is marked as `Response stopped.`
- cross-tab config clearing also marks in-flight processing as stopped

### How was this tested?

Automated and IRL.