### PR TITLE
Use uuid instead of crypto.randomUUID

### DIFF
--- a/assets/eslint.config.mjs
+++ b/assets/eslint.config.mjs
@@ -161,6 +161,21 @@ export default defineConfig([
       ...storybookPlugin.configs.recommended.rules,
 
       'no-console': 'error',
+      'no-restricted-properties': [
+        'error',
+        {
+          object: 'crypto',
+          property: 'randomUUID',
+          message:
+            "crypto.randomUUID is secure-context only and is undefined over plain http. Use `import { v4 as uuidv4 } from 'uuid'`, which falls back to crypto.getRandomValues.",
+        },
+        {
+          object: 'crypto',
+          property: 'subtle',
+          message:
+            'crypto.subtle is secure-context only and is undefined over plain http.',
+        },
+      ],
       'no-unused-vars': [
         'error',
         {

--- a/assets/js/common/AIAssistant/AIAssistant.jsx
+++ b/assets/js/common/AIAssistant/AIAssistant.jsx
@@ -4,6 +4,7 @@
 import React, { useState } from 'react';
 
 import { useAuiState } from '@assistant-ui/react';
+import { v4 as uuidv4 } from 'uuid';
 
 import { CONNECTION_STATUS } from '@lib/ai';
 
@@ -49,7 +50,7 @@ function AssistantUI({
 function AIAssistant({ userID, aiConfigured = true, open = false }) {
   const [isOpen, setIsOpen] = useState(open);
   const handleClose = () => setIsOpen(false);
-  const [threadID, setThreadID] = useState(() => crypto.randomUUID());
+  const [threadID, setThreadID] = useState(() => uuidv4());
   const [connectionStatus, setConnectionStatus] = useState(
     CONNECTION_STATUS.DISCONNECTED
   );
@@ -60,7 +61,7 @@ function AIAssistant({ userID, aiConfigured = true, open = false }) {
 
   // The channel stays mounted even when the launcher is disabled, so a "created" event can re-enable this tab
   const startNewThread = () => {
-    setThreadID(crypto.randomUUID());
+    setThreadID(uuidv4());
     setConfigurationStatus(CONFIGURATION_STATUS.OK);
     setModelNotice(null);
   };

--- a/assets/js/lib/ai/WebSocketAIAgent.js
+++ b/assets/js/lib/ai/WebSocketAIAgent.js
@@ -4,6 +4,7 @@
 import { AbstractAgent } from '@ag-ui/client';
 import { Observable } from 'rxjs';
 import { isArray, isString, last, noop, each } from 'lodash';
+import { v4 as uuidv4 } from 'uuid';
 
 import { EventType } from '@ag-ui/core';
 
@@ -202,7 +203,7 @@ export class WebSocketAIAgent extends AbstractAgent {
   // The send itself is deferred by at most one microtask via `await initialize()`.
   run({ messages, threadId }) {
     return new Observable((subscriber) => {
-      const runId = crypto.randomUUID();
+      const runId = uuidv4();
       const lastMessage = last(messages);
 
       if (!lastMessage || lastMessage.role !== 'user') {


### PR DESCRIPTION
### Description

<!-- Describe what this PR changes. Include benefits or limitations if relevant. -->

[`crypto.randomUUID`](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) is only available in https or localhost.

This breaks testing installation that do not have https.

While a production installation behind https will not have this issue it is a relief for the mentioned dev/test/evaluation cases.

Added a linter rule about not using that.

### How was this tested?

Automated tests and IRL.