### PR TITLE
Liz dynamic sizing

### DIFF
--- a/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
+++ b/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
@@ -387,7 +387,7 @@ describe('AG-UI event flow', () => {
     await user.click(screen.getByRole('button', { name: 'Open AI Assistant' }));
 
     // after opening again the chat modal, we start from a clean state
-    expect(screen.getByText("Hi, I'm Liz.")).toBeVisible();
+    expect(await screen.findByText("Hi, I'm Liz.")).toBeVisible();
     expect(await screen.findByLabelText('Send message')).toBeVisible();
     expect(screen.getByRole('button', { name: 'New chat' })).toBeEnabled();
     expect(

--- a/assets/js/common/AIAssistant/ModalFrame/ModalFrame.jsx
+++ b/assets/js/common/AIAssistant/ModalFrame/ModalFrame.jsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useEffect, useState } from 'react';
 import { Rnd } from 'react-rnd';
 import { Link } from 'react-router';
 import { EOS_CHAT_BUBBLE_OUTLINED } from 'eos-icons-react';
@@ -9,6 +9,8 @@ import { AssistantModalPrimitive } from '@assistant-ui/react';
 
 import Button from '@common/Button';
 import Tooltip from '@common/Tooltip';
+
+import { useFrameGeometry } from './hooks';
 
 // forwardRef + `{...props}` spread are required so the
 // enabled instance works inside `AssistantModalPrimitive.Trigger asChild`
@@ -46,16 +48,42 @@ const disabledTooltipContent = (
   </span>
 );
 
-function ModalFrame({
-  open,
-  onOpenChange,
-  disabled = false,
-  initialSize = { width: 384, height: 650 },
-  initialPosition = { x: -400, y: -650 },
-  minWidth = 300,
-  minHeight = 400,
-  children,
-}) {
+function ChatFrame({ geometry, onPlaced, children }) {
+  const [frameHandle, setFrameHandle] = useState(null);
+  const { size, position, minWidth, minHeight, maxWidth, maxHeight } = geometry;
+
+  useEffect(() => {
+    frameHandle?.updateSize(size);
+    frameHandle?.updatePosition(position);
+  }, [frameHandle, size, position]);
+
+  return (
+    <Rnd
+      ref={setFrameHandle}
+      bounds="window"
+      default={{ ...size, ...position }}
+      minWidth={minWidth}
+      minHeight={minHeight}
+      maxWidth={maxWidth}
+      maxHeight={maxHeight}
+      onDragStop={(_event, { x, y }) => onPlaced({ size, position: { x, y } })}
+      onResizeStop={(_event, _direction, element, _delta, movedTo) =>
+        onPlaced({
+          size: { width: element.offsetWidth, height: element.offsetHeight },
+          position: movedTo,
+        })
+      }
+      dragHandleClassName="drag-handle"
+      className="rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 shadow-2xl flex flex-col overflow-hidden"
+    >
+      {children}
+    </Rnd>
+  );
+}
+
+function ModalFrame({ open, onOpenChange, disabled = false, children }) {
+  const { geometry, rememberGeometry, popoverRef } = useFrameGeometry();
+
   return (
     <AssistantModalPrimitive.Root open={open} onOpenChange={onOpenChange}>
       <AssistantModalPrimitive.Anchor className="fixed right-6 bottom-20 size-12 z-40">
@@ -75,21 +103,15 @@ function ModalFrame({
       </AssistantModalPrimitive.Anchor>
 
       <AssistantModalPrimitive.Content
+        ref={popoverRef}
         sideOffset={16}
         className="z-40 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
       >
-        <Rnd
-          bounds="window"
-          default={{ ...initialSize, ...initialPosition }}
-          minWidth={minWidth}
-          minHeight={minHeight}
-          maxWidth={window.innerWidth - 100}
-          maxHeight={window.innerHeight - 200}
-          dragHandleClassName="drag-handle"
-          className="rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 shadow-2xl flex flex-col overflow-hidden"
-        >
-          {children}
-        </Rnd>
+        {geometry && (
+          <ChatFrame geometry={geometry} onPlaced={rememberGeometry}>
+            {children}
+          </ChatFrame>
+        )}
       </AssistantModalPrimitive.Content>
     </AssistantModalPrimitive.Root>
   );

--- a/assets/js/common/AIAssistant/ModalFrame/ModalFrame.test.jsx
+++ b/assets/js/common/AIAssistant/ModalFrame/ModalFrame.test.jsx
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
 import { renderWithRouter } from '@lib/test-utils';
+import { nextFrame } from '@lib/test-utils/modalFrame';
 
 import ModalFrame from './ModalFrame';
 
@@ -37,8 +38,9 @@ describe('ModalFrame', () => {
       expect(onOpenChange).toHaveBeenCalledWith(true);
     });
 
-    it('renders its children while open', () => {
+    it('renders its children while open', async () => {
       renderFrame({ open: true });
+      await nextFrame();
 
       expect(screen.getByText('chat panel body')).toBeVisible();
     });

--- a/assets/js/common/AIAssistant/ModalFrame/geometry.js
+++ b/assets/js/common/AIAssistant/ModalFrame/geometry.js
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+// Gap kept between the frame and the viewport edges, until the user moves it
+const VIEWPORT_MARGIN = 24;
+
+// How far the frame's right edge is from the launcher's right edge
+const LAUNCHER_GAP = 16;
+
+// Size the frame opens at, before the user resizes it
+const PREFERRED_WIDTH = 384;
+const PREFERRED_HEIGHT = 650;
+
+export const MIN_WIDTH = 300;
+export const MIN_HEIGHT = 400;
+
+// Width breakpoint below which the frame takes the whole viewport
+const MOBILE_BREAKPOINT = 640;
+
+// Keeps the frame the distance it was from whichever window edge it was nearer when the user let go.
+// Runs once per axis: start and end edges are left and right horizontally, top and bottom vertically.
+const refitAxis = (
+  fromStartEdgeWhenPlaced,
+  sizeWhenPlaced,
+  windowSizeWhenPlaced,
+  windowSize
+) => {
+  const fromEndEdgeWhenPlaced =
+    windowSizeWhenPlaced - (fromStartEdgeWhenPlaced + sizeWhenPlaced);
+  const startNearSameEdge =
+    fromStartEdgeWhenPlaced <= fromEndEdgeWhenPlaced
+      ? fromStartEdgeWhenPlaced
+      : windowSize - fromEndEdgeWhenPlaced - sizeWhenPlaced;
+  const sizeThatFits = Math.min(sizeWhenPlaced, windowSize);
+
+  return {
+    start: Math.min(Math.max(startNearSameEdge, 0), windowSize - sizeThatFits),
+    size: sizeThatFits,
+  };
+};
+
+// Always measured from where the user left the frame, never from the last
+// clamp, so shrinking the window and growing it back gives their size back.
+const refitPlacedFrame = (
+  viewport,
+  origin,
+  { size: sizeWhenPlaced, rect: rectWhenPlaced, viewport: windowWhenPlaced }
+) => {
+  const horizontal = refitAxis(
+    rectWhenPlaced.left,
+    sizeWhenPlaced.width,
+    windowWhenPlaced.width,
+    viewport.width
+  );
+  const vertical = refitAxis(
+    rectWhenPlaced.top,
+    sizeWhenPlaced.height,
+    windowWhenPlaced.height,
+    viewport.height
+  );
+
+  return {
+    size: { width: horizontal.size, height: vertical.size },
+    position: {
+      x: horizontal.start - origin.x,
+      y: vertical.start - origin.y,
+    },
+  };
+};
+
+// A window too narrow or too short for a floating chat gets the whole screen
+// instead: nothing to dodge, nowhere to drag it to.
+const fitFullViewport = ({ width, height }, origin) => ({
+  size: { width, height },
+  position: { x: -origin.x, y: -origin.y },
+  minWidth: Math.min(MIN_WIDTH, width),
+  minHeight: Math.min(MIN_HEIGHT, height),
+  maxWidth: width,
+  maxHeight: height,
+});
+
+// Where the frame belongs, relative to the measured popover origin.
+// - above the launcher by default
+// - shrinks to keep the drag handle in screen
+// - keeps the user's size and position
+// - fills the viewport on small screens
+export const computeFrameGeometry = (
+  viewport,
+  origin,
+  frameWhenPlaced = null
+) => {
+  const spaceBesideLauncher = origin.x - VIEWPORT_MARGIN;
+  const spaceAboveLauncher = origin.y - VIEWPORT_MARGIN;
+
+  if (viewport.width < MOBILE_BREAKPOINT || spaceAboveLauncher < MIN_HEIGHT) {
+    return fitFullViewport(viewport, origin);
+  }
+
+  if (frameWhenPlaced) {
+    return {
+      ...refitPlacedFrame(viewport, origin, frameWhenPlaced),
+      minWidth: MIN_WIDTH,
+      minHeight: MIN_HEIGHT,
+      maxWidth: viewport.width,
+      maxHeight: viewport.height,
+    };
+  }
+
+  const width = Math.min(PREFERRED_WIDTH, spaceBesideLauncher);
+  const height = Math.min(PREFERRED_HEIGHT, spaceAboveLauncher);
+
+  return {
+    size: { width, height },
+    position: { x: -(width + LAUNCHER_GAP), y: -height },
+    minWidth: MIN_WIDTH,
+    minHeight: MIN_HEIGHT,
+    maxWidth: spaceBesideLauncher,
+    maxHeight: spaceAboveLauncher,
+  };
+};
+
+export const readViewport = () => ({
+  width: window.innerWidth,
+  height: window.innerHeight,
+});

--- a/assets/js/common/AIAssistant/ModalFrame/geometry.test.js
+++ b/assets/js/common/AIAssistant/ModalFrame/geometry.test.js
@@ -1,0 +1,268 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import { launcherOrigin } from '@lib/test-utils/modalFrame';
+
+import { MIN_HEIGHT, computeFrameGeometry } from './geometry';
+
+const frameGeometry = (viewport, frameWhenPlaced) =>
+  computeFrameGeometry(viewport, launcherOrigin(viewport), frameWhenPlaced);
+
+// Positions are offsets from that origin; as a viewport rect they become claims
+// about what the user can see on screen.
+const frameRect = (viewport, frameWhenPlaced) => {
+  const origin = launcherOrigin(viewport);
+  const { size, position } = frameGeometry(viewport, frameWhenPlaced);
+  const left = origin.x + position.x;
+  const top = origin.y + position.y;
+
+  return {
+    left,
+    top,
+    right: left + size.width,
+    bottom: top + size.height,
+  };
+};
+
+describe('ModalFrame geometry', () => {
+  describe('above the launcher', () => {
+    it.each`
+      screen                | width   | height  | expectedWidth | expectedHeight
+      ${'4k desktop'}       | ${2560} | ${1440} | ${384}        | ${650}
+      ${'laptop'}           | ${1920} | ${1080} | ${384}        | ${650}
+      ${'14" macbook'}      | ${1512} | ${860}  | ${384}        | ${650}
+      ${'short laptop'}     | ${1366} | ${768}  | ${384}        | ${600}
+      ${'tablet landscape'} | ${1024} | ${768}  | ${384}        | ${600}
+      ${'tablet portrait'}  | ${768}  | ${1024} | ${384}        | ${650}
+    `(
+      'sizes the frame $expectedWidth x $expectedHeight on a $screen',
+      ({ width, height, expectedWidth, expectedHeight }) => {
+        expect(frameGeometry({ width, height }).size).toEqual({
+          width: expectedWidth,
+          height: expectedHeight,
+        });
+      }
+    );
+
+    it('sizes the frame from the measured popover origin, not the viewport', () => {
+      const geometry = computeFrameGeometry(
+        { width: 1920, height: 1080 },
+        { x: 300, y: 900 }
+      );
+
+      expect(geometry.size).toEqual({ width: 276, height: 650 });
+    });
+
+    it('opens right above the launcher', () => {
+      const viewport = { width: 1920, height: 1080 };
+
+      expect(frameRect(viewport)).toEqual({
+        left: 1496,
+        top: 286,
+        right: 1880,
+        bottom: 936,
+      });
+    });
+
+    it('shrinks instead of pushing the drag handle off screen', () => {
+      const viewport = { width: 1366, height: 768 };
+
+      expect(frameRect(viewport).top).toBe(24);
+    });
+
+    it('caps a manual resize at the space the frame can occupy', () => {
+      const { maxWidth, maxHeight } = frameGeometry({
+        width: 1366,
+        height: 768,
+      });
+
+      expect(maxWidth).toBe(1318);
+      expect(maxHeight).toBe(600);
+    });
+  });
+
+  describe('too small to fit above the launcher', () => {
+    it.each`
+      screen               | width   | height
+      ${'phone portrait'}  | ${390}  | ${844}
+      ${'phone landscape'} | ${844}  | ${390}
+      ${'small phone'}     | ${320}  | ${568}
+      ${'short window'}    | ${1200} | ${500}
+    `('fills the whole $screen viewport', ({ width, height }) => {
+      const viewport = { width, height };
+
+      expect(frameGeometry(viewport).size).toEqual({ width, height });
+      expect(frameRect(viewport)).toEqual({
+        left: 0,
+        top: 0,
+        right: width,
+        bottom: height,
+      });
+    });
+  });
+
+  describe('a frame the user has placed', () => {
+    // 44px from the right edge and 168px from the bottom: nearer both, so it
+    // holds on to both.
+    const frameWhenPlaced = {
+      size: { width: 800, height: 700 },
+      rect: { left: 1076, top: 212 },
+      viewport: { width: 1920, height: 1080 },
+    };
+
+    it('leaves a frame that still fits where the user put it', () => {
+      expect(frameRect({ width: 1920, height: 1080 }, frameWhenPlaced)).toEqual(
+        {
+          left: 1076,
+          top: 212,
+          right: 1876,
+          bottom: 912,
+        }
+      );
+    });
+
+    it('leaves a frame the user pushed against an edge against it', () => {
+      const flushToTheCorner = {
+        size: { width: 384, height: 650 },
+        rect: { left: 0, top: 0 },
+        viewport: { width: 1920, height: 1080 },
+      };
+
+      expect(
+        frameRect({ width: 1920, height: 1080 }, flushToTheCorner)
+      ).toEqual({ left: 0, top: 0, right: 384, bottom: 650 });
+    });
+
+    it('keeps a frame docked against the left edge docked', () => {
+      const dockedLeft = {
+        size: { width: 384, height: 650 },
+        rect: { left: 0, top: 336 },
+        viewport: { width: 1920, height: 1080 },
+      };
+
+      expect(frameRect({ width: 1900, height: 1080 }, dockedLeft).left).toBe(0);
+      expect(frameRect({ width: 1940, height: 1080 }, dockedLeft).left).toBe(0);
+    });
+
+    it('keeps a frame docked against the top edge docked', () => {
+      const dockedTop = {
+        size: { width: 384, height: 650 },
+        rect: { left: 1396, top: 0 },
+        viewport: { width: 1920, height: 1080 },
+      };
+
+      expect(frameRect({ width: 1920, height: 1060 }, dockedTop).top).toBe(0);
+      expect(frameRect({ width: 1920, height: 1100 }, dockedTop).top).toBe(0);
+    });
+
+    it('keeps a frame docked against the right edge docked', () => {
+      const dockedRight = {
+        size: { width: 384, height: 650 },
+        rect: { left: 1536, top: 336 },
+        viewport: { width: 1920, height: 1080 },
+      };
+
+      expect(frameRect({ width: 1900, height: 1080 }, dockedRight).right).toBe(
+        1900
+      );
+      expect(frameRect({ width: 1940, height: 1080 }, dockedRight).right).toBe(
+        1940
+      );
+    });
+
+    it('pulls a frame that no longer fits back inside the window', () => {
+      expect(frameRect({ width: 900, height: 600 }, frameWhenPlaced)).toEqual({
+        left: 56,
+        top: 0,
+        right: 856,
+        bottom: 600,
+      });
+    });
+
+    it('gives the user their size back when the window grows again', () => {
+      expect(
+        frameGeometry({ width: 900, height: 600 }, frameWhenPlaced).size
+      ).toEqual({ width: 800, height: 600 });
+
+      expect(
+        frameGeometry({ width: 1920, height: 1080 }, frameWhenPlaced).size
+      ).toEqual({ width: 800, height: 700 });
+    });
+
+    it('caps a manual resize at the region the frame is kept inside', () => {
+      const { maxWidth, maxHeight } = frameGeometry(
+        { width: 900, height: 600 },
+        frameWhenPlaced
+      );
+
+      expect(maxWidth).toBe(900);
+      expect(maxHeight).toBe(600);
+    });
+
+    it('still falls back to the whole viewport when the window is too small', () => {
+      const viewport = { width: 1200, height: 500 };
+
+      expect(frameGeometry(viewport, frameWhenPlaced).size).toEqual(viewport);
+    });
+  });
+
+  describe('invariants', () => {
+    const viewports = [
+      320, 390, 640, 768, 1024, 1200, 1366, 1920, 2560,
+    ].flatMap((width) =>
+      [400, 500, 568, 640, 768, 860, 1080, 1440].map((height) => ({
+        width,
+        height,
+      }))
+    );
+
+    it('stays fully inside every viewport', () => {
+      const offScreen = viewports.filter((viewport) => {
+        const { left, top, right, bottom } = frameRect(viewport);
+
+        return (
+          left < 0 ||
+          top < 0 ||
+          right > viewport.width ||
+          bottom > viewport.height
+        );
+      });
+
+      expect(offScreen).toEqual([]);
+    });
+
+    // The edges a frame holds on to decide which way it can fall off screen, so
+    // both cases have to be swept.
+    it.each`
+      held            | frame
+      ${'far edges'}  | ${{ size: { width: 1200, height: 900 }, rect: { left: 1316, top: 372 }, viewport: { width: 2560, height: 1440 } }}
+      ${'near edges'} | ${{ size: { width: 800, height: 500 }, rect: { left: 476, top: 256 }, viewport: { width: 2560, height: 1440 } }}
+    `(
+      'keeps a user-placed frame held by its $held inside every viewport',
+      ({ frame }) => {
+        const offScreen = viewports.filter((viewport) => {
+          const { left, top, right, bottom } = frameRect(viewport, frame);
+
+          return (
+            left < 0 ||
+            top < 0 ||
+            right > viewport.width ||
+            bottom > viewport.height
+          );
+        });
+
+        expect(offScreen).toEqual([]);
+      }
+    );
+
+    it('never shrinks below the usable minimum', () => {
+      const tooSmall = viewports.filter(
+        ({ width, height }) =>
+          frameGeometry({ width, height }).size.height <
+          Math.min(MIN_HEIGHT, height)
+      );
+
+      expect(tooSmall).toEqual([]);
+    });
+  });
+});

--- a/assets/js/common/AIAssistant/ModalFrame/hooks.js
+++ b/assets/js/common/AIAssistant/ModalFrame/hooks.js
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { computeFrameGeometry, readViewport } from './geometry';
+
+/**
+ * Where the chat frame should sit, kept in step with the window.
+ *
+ * Put `popoverRef` on the popover the chat opens inside. The chat is
+ * absolutely positioned, so that popover collapses to a single point, and
+ * every position here is an offset from it.
+ *
+ * `geometry` is null until that point has been measured; render nothing until
+ * it is. An untouched chat follows the window; hand `rememberGeometry` the size
+ * and position the user dropped the chat at, and it stays there instead.
+ *
+ * @returns {{ geometry: Object|null, rememberGeometry: (geometry: Object) => void, popoverRef: (node: Element|null) => void }}
+ */
+export const useFrameGeometry = () => {
+  const [popover, setPopover] = useState(null);
+  const [measurement, setMeasurement] = useState(null);
+  const [frameWhenPlaced, setFrameWhenPlaced] = useState(null);
+
+  useEffect(() => {
+    if (!popover) return undefined;
+
+    let pendingMeasurement = 0;
+
+    // The popover sits off screen until positioned, so measure a frame later.
+    const measure = () => {
+      window.cancelAnimationFrame(pendingMeasurement);
+      pendingMeasurement = window.requestAnimationFrame(() => {
+        const popoverBox = popover.getBoundingClientRect();
+
+        setMeasurement({
+          popover,
+          viewport: readViewport(),
+          origin: { x: popoverBox.left, y: popoverBox.top },
+        });
+      });
+    };
+
+    measure();
+    window.addEventListener('resize', measure);
+
+    return () => {
+      window.cancelAnimationFrame(pendingMeasurement);
+      window.removeEventListener('resize', measure);
+    };
+  }, [popover]);
+
+  // The popover goes away when the chat closes, so a stale measurement must not place the chat the user opens next
+  const currentMeasurement =
+    measurement?.popover === popover ? measurement : null;
+
+  const geometry = useMemo(
+    () =>
+      currentMeasurement
+        ? computeFrameGeometry(
+            currentMeasurement.viewport,
+            currentMeasurement.origin,
+            frameWhenPlaced
+          )
+        : null,
+    [currentMeasurement, frameWhenPlaced]
+  );
+
+  const rememberGeometry = ({ size, position }) =>
+    setFrameWhenPlaced({
+      size,
+      rect: {
+        left: currentMeasurement.origin.x + position.x,
+        top: currentMeasurement.origin.y + position.y,
+      },
+      viewport: currentMeasurement.viewport,
+    });
+
+  return { geometry, rememberGeometry, popoverRef: setPopover };
+};
+
+export default useFrameGeometry;

--- a/assets/js/common/AIAssistant/ModalFrame/hooks.test.js
+++ b/assets/js/common/AIAssistant/ModalFrame/hooks.test.js
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import { act, fireEvent, renderHook } from '@testing-library/react';
+
+import { launcherOrigin, nextFrame } from '@lib/test-utils/modalFrame';
+
+import { useFrameGeometry } from './hooks';
+
+const setViewport = ({ width, height }) => {
+  Object.defineProperty(window, 'innerWidth', {
+    writable: true,
+    configurable: true,
+    value: width,
+  });
+  Object.defineProperty(window, 'innerHeight', {
+    writable: true,
+    configurable: true,
+    value: height,
+  });
+};
+
+// The launcher is fixed to the window's edges, so it moves on resize; the spot
+// is re-read on every measurement instead of captured once.
+const currentLauncherOrigin = () =>
+  launcherOrigin({ width: window.innerWidth, height: window.innerHeight });
+
+const popoverAt = (origin) =>
+  jest
+    .spyOn(window.Element.prototype, 'getBoundingClientRect')
+    .mockImplementation(() => {
+      const { x, y } = origin();
+
+      return {
+        x,
+        y,
+        left: x,
+        top: y,
+        right: x,
+        bottom: y,
+        width: 0,
+        height: 0,
+        toJSON: () => ({}),
+      };
+    });
+
+const openPopover = () => document.createElement('div');
+
+const renderFrameGeometry = async () => {
+  const { result } = renderHook(() => useFrameGeometry());
+
+  const show = async (open) => {
+    act(() => {
+      result.current.popoverRef(open ? openPopover() : null);
+    });
+    await nextFrame();
+  };
+
+  await show(true);
+
+  return { hook: result, show };
+};
+
+const resizeTo = async (viewport) => {
+  act(() => {
+    setViewport(viewport);
+    fireEvent.resize(window);
+  });
+  await nextFrame();
+};
+
+// What react-rnd hands back after the user drags or resizes:
+// a size, and a position relative to the collapsed popover box.
+const droppedFrame = {
+  size: { width: 800, height: 700 },
+  position: { x: -820, y: -724 },
+};
+
+describe('useFrameGeometry', () => {
+  const originalViewport = {
+    width: window.innerWidth,
+    height: window.innerHeight,
+  };
+
+  beforeEach(() => popoverAt(currentLauncherOrigin));
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    setViewport(originalViewport);
+  });
+
+  it('has nowhere to put the frame until the popover has been measured', () => {
+    setViewport({ width: 1920, height: 1080 });
+    const { result } = renderHook(() => useFrameGeometry());
+
+    act(() => {
+      result.current.popoverRef(openPopover());
+    });
+
+    expect(result.current.geometry).toBeNull();
+  });
+
+  it('reads where the popover actually is, not where the launcher should be', async () => {
+    setViewport({ width: 1920, height: 1080 });
+    popoverAt(() => ({ x: 300, y: 900 }));
+
+    const { hook } = await renderFrameGeometry();
+
+    expect(hook.current.geometry.size).toEqual({ width: 276, height: 650 });
+  });
+
+  it('follows the window while the user has not touched the frame', async () => {
+    setViewport({ width: 1920, height: 1080 });
+    const { hook } = await renderFrameGeometry();
+
+    await resizeTo({ width: 1366, height: 768 });
+
+    expect(hook.current.geometry.size).toEqual({ width: 384, height: 600 });
+  });
+
+  it('measures the popover again when it is closed and reopened', async () => {
+    setViewport({ width: 1920, height: 1080 });
+    const { hook, show } = await renderFrameGeometry();
+
+    await show(false);
+    expect(hook.current.geometry).toBeNull();
+
+    setViewport({ width: 1366, height: 768 });
+    await show(true);
+
+    expect(hook.current.geometry.size).toEqual({ width: 384, height: 600 });
+  });
+
+  it('keeps the frame where the user put it when the window is resized', async () => {
+    setViewport({ width: 1920, height: 1080 });
+    const { hook } = await renderFrameGeometry();
+
+    act(() => {
+      hook.current.rememberGeometry(droppedFrame);
+    });
+    await resizeTo({ width: 1600, height: 1000 });
+
+    expect(hook.current.geometry).toMatchObject(droppedFrame);
+  });
+
+  it('stops listening for resizes once the popover is gone', async () => {
+    const listen = jest.spyOn(window, 'addEventListener');
+    const stopListening = jest.spyOn(window, 'removeEventListener');
+
+    const { show } = await renderFrameGeometry();
+    const [, measure] = listen.mock.calls.find(([event]) => event === 'resize');
+
+    await show(false);
+
+    expect(stopListening).toHaveBeenCalledWith('resize', measure);
+  });
+});

--- a/assets/js/common/AIAssistant/ThreadWelcome/ThreadWelcome.jsx
+++ b/assets/js/common/AIAssistant/ThreadWelcome/ThreadWelcome.jsx
@@ -31,7 +31,7 @@ const defaultGreeting = (
  */
 function ThreadWelcome({ greeting = defaultGreeting, children }) {
   return (
-    <div className="mx-auto flex w-full max-w-[var(--thread-max-width)] flex-col gap-6 pt-32 pb-2">
+    <div className="mx-auto flex w-full max-w-[var(--thread-max-width)] flex-1 flex-col justify-center gap-6 pb-2">
       <div className="text-[22px] leading-snug text-gray-500">{greeting}</div>
       {children && <div className="flex flex-col gap-3">{children}</div>}
     </div>

--- a/assets/js/lib/test-utils/modalFrame.js
+++ b/assets/js/lib/test-utils/modalFrame.js
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import { act } from '@testing-library/react';
+
+// Sets the launcher origin for testing: the point just above the launcher
+// where the popover lands. jsdom cannot measure it, so the spot comes from
+// `fixed right-6 bottom-20 size-12` and `sideOffset={16}` in ModalFrame.
+export const launcherOrigin = ({ width, height }) => ({
+  x: width - 24,
+  y: height - (80 + 48 + 16),
+});
+
+// Waits a render frame, because the hook measures the popover inside a
+// `requestAnimationFrame`; until it lands the chat has no geometry to render.
+export const nextFrame = () =>
+  act(() => new Promise(window.requestAnimationFrame));


### PR DESCRIPTION
### Description

This PR makes Liz positioning and sizing dynamic based on the browser/viewport size.

- always opens right above the trigger (currently if the page is small enough Liz is far too far away and the drag handle hidden, making it unusable)
- user size/position is kept within resizing, still within the boundaries of the viewport
- on small enough screens Liz takes the whole screen

Here's just an example of a basic improvement, for further testing use the PR env https://4665.prenv.trento.suse.com/ by playing with resizing the page.

Before
<img width="1519" height="783" alt="image" src="https://github.com/user-attachments/assets/006fdb6d-b6de-426d-bab0-8ee437242bf6" />

After
<img width="1519" height="783" alt="image" src="https://github.com/user-attachments/assets/463ab967-7197-4528-8b57-0c9b2bc4868f" />

### How was this tested?

Automated and IRL