### PR TITLE
Copy Liz reply

### DIFF
--- a/assets/eslint.config.mjs
+++ b/assets/eslint.config.mjs
@@ -139,6 +139,7 @@ export default defineConfig([
             '^@pages',
             '^@state',
             '^@static',
+            '^@assistant-ui/core/react$',
           ],
         },
       ],

--- a/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
+++ b/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
@@ -5,8 +5,11 @@ import React from 'react';
 import { act, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
+import copy from 'copy-to-clipboard';
 import { renderAIAssistant } from '@lib/test-utils/aiAssistant';
 import { aguiEvents } from '@lib/test-utils/aguiEvents';
+
+jest.mock('copy-to-clipboard', () => jest.fn(() => true));
 
 const assistantBubbles = () =>
   Array.from(document.querySelectorAll('[data-role="assistant"]'));
@@ -396,32 +399,100 @@ describe('AG-UI event flow', () => {
     expect(screen.queryByText('hello')).not.toBeInTheDocument();
   });
 
-  it('allows copying the reply only once the run has finished', async () => {
-    const { emitAgUi, sendUserMessage } = await renderAIAssistant({
-      open: true,
+  describe('Copying replies', () => {
+    it('allows copying the last reply only once the run has finished', async () => {
+      const { emitAgUi, sendUserMessage } = await renderAIAssistant({
+        open: true,
+      });
+      const { thread_id: threadId, run_id: runId } = await sendUserMessage(
+        'how many hosts are healthy?'
+      );
+
+      const messageId = 'asst-1';
+      await emitAgUi(aguiEvents.runStarted({ threadId, runId }));
+      await emitAgUi(aguiEvents.textStart({ messageId }));
+      await emitAgUi(
+        aguiEvents.textContent({ messageId, delta: 'All **3** ' })
+      );
+
+      const copyReplyButton = () =>
+        screen.queryByRole('button', { name: 'copy to clipboard' });
+
+      await waitFor(() => expect(assistantBubble()).toHaveTextContent('All'));
+      expect(copyReplyButton()).not.toBeInTheDocument();
+
+      await emitAgUi(
+        aguiEvents.textContent({ messageId, delta: 'are healthy.' })
+      );
+      await emitAgUi(aguiEvents.textEnd({ messageId }));
+      await emitAgUi(aguiEvents.runFinished({ threadId, runId }));
+
+      await waitFor(() => expect(copyReplyButton()).toBeVisible());
     });
-    const { thread_id: threadId, run_id: runId } = await sendUserMessage(
-      'how many hosts are healthy?'
-    );
 
-    const messageId = 'asst-1';
-    await emitAgUi(aguiEvents.runStarted({ threadId, runId }));
-    await emitAgUi(aguiEvents.textStart({ messageId }));
-    await emitAgUi(aguiEvents.textContent({ messageId, delta: 'All **3** ' }));
+    it('allows copying the answer the user stopped', async () => {
+      const context = await renderAIAssistant({ open: true });
+      const { user } = context;
+      await streamThenStop(context);
 
-    const copyReplyButton = () =>
-      screen.queryByRole('button', { name: 'copy to clipboard' });
+      const stoppedBubble = assistantBubble();
+      const copyReplyButton = await within(stoppedBubble).findByRole('button', {
+        name: 'copy to clipboard',
+      });
 
-    await waitFor(() => expect(assistantBubble()).toHaveTextContent('All'));
-    expect(copyReplyButton()).not.toBeInTheDocument();
+      await user.click(copyReplyButton);
 
-    await emitAgUi(
-      aguiEvents.textContent({ messageId, delta: 'are healthy.' })
-    );
-    await emitAgUi(aguiEvents.textEnd({ messageId }));
-    await emitAgUi(aguiEvents.runFinished({ threadId, runId }));
+      expect(copy).toHaveBeenCalledWith('half an answer', expect.anything());
+    });
 
-    await waitFor(() => expect(copyReplyButton()).toBeVisible());
+    it('allows copying an earlier reply while a new run is streaming', async () => {
+      const { user, emitAgUi, sendUserMessage, streamAssistantTurn } =
+        await renderAIAssistant({ open: true });
+
+      const first = await sendUserMessage('first');
+      await streamAssistantTurn(first, { messageId: 'a', deltas: ['one'] });
+
+      const earlierReplyCopyButton = () =>
+        within(assistantBubbles()[0]).queryByRole('button', {
+          name: 'copy to clipboard',
+        });
+
+      await waitFor(() => expect(earlierReplyCopyButton()).toBeVisible());
+
+      const second = await sendUserMessage('second');
+      await emitAgUi(
+        aguiEvents.runStarted({
+          threadId: second.thread_id,
+          runId: second.run_id,
+        })
+      );
+
+      expect(await screen.findByText('Thinking...')).toBeVisible();
+      expect(earlierReplyCopyButton()).toBeVisible();
+
+      await user.click(earlierReplyCopyButton());
+
+      expect(copy).toHaveBeenCalledWith('one', expect.anything());
+    });
+
+    it('copies a specific reply in the conversation', async () => {
+      const { user, sendUserMessage, streamAssistantTurn } =
+        await renderAIAssistant({ open: true });
+
+      const first = await sendUserMessage('first');
+      await streamAssistantTurn(first, { messageId: 'a', deltas: ['one'] });
+      const second = await sendUserMessage('second');
+      await streamAssistantTurn(second, { messageId: 'b', deltas: ['two'] });
+
+      await waitFor(() => expect(assistantBubbles()).toHaveLength(2));
+
+      const earlierReply = assistantBubbles()[0];
+      await user.click(
+        within(earlierReply).getByRole('button', { name: 'copy to clipboard' })
+      );
+
+      expect(copy).toHaveBeenCalledWith('one', expect.anything());
+    });
   });
 
   it('"New chat" starts a new conversation with a new thread ID', async () => {

--- a/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
+++ b/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
@@ -396,6 +396,34 @@ describe('AG-UI event flow', () => {
     expect(screen.queryByText('hello')).not.toBeInTheDocument();
   });
 
+  it('allows copying the reply only once the run has finished', async () => {
+    const { emitAgUi, sendUserMessage } = await renderAIAssistant({
+      open: true,
+    });
+    const { thread_id: threadId, run_id: runId } = await sendUserMessage(
+      'how many hosts are healthy?'
+    );
+
+    const messageId = 'asst-1';
+    await emitAgUi(aguiEvents.runStarted({ threadId, runId }));
+    await emitAgUi(aguiEvents.textStart({ messageId }));
+    await emitAgUi(aguiEvents.textContent({ messageId, delta: 'All **3** ' }));
+
+    const copyReplyButton = () =>
+      screen.queryByRole('button', { name: 'copy to clipboard' });
+
+    await waitFor(() => expect(assistantBubble()).toHaveTextContent('All'));
+    expect(copyReplyButton()).not.toBeInTheDocument();
+
+    await emitAgUi(
+      aguiEvents.textContent({ messageId, delta: 'are healthy.' })
+    );
+    await emitAgUi(aguiEvents.textEnd({ messageId }));
+    await emitAgUi(aguiEvents.runFinished({ threadId, runId }));
+
+    await waitFor(() => expect(copyReplyButton()).toBeVisible());
+  });
+
   it('"New chat" starts a new conversation with a new thread ID', async () => {
     const { user, sendUserMessage, streamAssistantTurn } =
       await renderAIAssistant({ open: true });

--- a/assets/js/common/AIAssistant/AssistantThread.test.jsx
+++ b/assets/js/common/AIAssistant/AssistantThread.test.jsx
@@ -84,6 +84,27 @@ describe('AssistantThread', () => {
     expect(assistantBubble.queryByText('You')).not.toBeInTheDocument();
   });
 
+  it('allows copying the assistant turn only', () => {
+    renderThread({
+      messages: [
+        { id: 'm1', role: 'user', content: 'ping' },
+        { id: 'm2', role: 'assistant', content: 'pong' },
+      ],
+    });
+
+    const userBubble = within(document.querySelector('[data-role="user"]'));
+    const assistantBubble = within(
+      document.querySelector('[data-role="assistant"]')
+    );
+
+    expect(
+      assistantBubble.getByRole('button', { name: 'copy to clipboard' })
+    ).toBeVisible();
+    expect(
+      userBubble.queryByRole('button', { name: 'copy to clipboard' })
+    ).not.toBeInTheDocument();
+  });
+
   it('shows no banner while the configuration is intact', () => {
     renderThread({ configurationStatus: OK });
 

--- a/assets/js/common/AIAssistant/MessageBubble/CopyReplyButton.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/CopyReplyButton.jsx
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { useActionBarCopy } from '@assistant-ui/core/react';
+
+import CopyButton, {
+  COPIED_FEEDBACK_MS,
+  writeToClipboard,
+} from '@common/CopyButton';
+
+// Copies the reply in both flavours:
+// - the markdown source as plain text
+// - `contentRef`'s markup as HTML
+//
+// This allows pasting both the plain markdown and the HTML into a rich target, keeping the
+// formatting intact.
+function CopyReplyButton({
+  contentRef,
+  onWriteToClipboard = writeToClipboard,
+}) {
+  const { copy, disabled, isCopied } = useActionBarCopy({
+    copiedDuration: COPIED_FEEDBACK_MS,
+    copyToClipboard: async (markdown) => {
+      if (!onWriteToClipboard(markdown, contentRef?.current?.innerHTML)) {
+        throw new Error('clipboard write failed');
+      }
+    },
+  });
+
+  if (disabled) return null;
+
+  return <CopyButton onCopy={copy} isCopied={isCopied} />;
+}
+
+export default CopyReplyButton;

--- a/assets/js/common/AIAssistant/MessageBubble/CopyReplyButton.test.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/CopyReplyButton.test.jsx
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { useActionBarCopy } from '@assistant-ui/core/react';
+
+import CopyReplyButton from './CopyReplyButton';
+
+jest.mock('@assistant-ui/core/react', () => ({
+  useActionBarCopy: jest.fn(),
+}));
+
+const REPLY_MARKDOWN = 'All **3** hosts are healthy.';
+const REPLY_HTML = '<p>All <strong>3</strong> hosts are healthy.</p>';
+
+const copyButton = () =>
+  screen.queryByRole('button', { name: 'copy to clipboard' });
+
+const renderButton = (contentRef = { current: null }, state = {}) => {
+  useActionBarCopy.mockReturnValue({
+    copy: jest.fn(),
+    disabled: false,
+    isCopied: false,
+    ...state,
+  });
+
+  const onWriteToClipboard = jest.fn(() => true);
+
+  render(
+    <CopyReplyButton
+      contentRef={contentRef}
+      onWriteToClipboard={onWriteToClipboard}
+    />
+  );
+
+  return { onWriteToClipboard };
+};
+
+const writeReply = (text = REPLY_MARKDOWN) => {
+  const [options] = useActionBarCopy.mock.lastCall;
+
+  return options.copyToClipboard(text);
+};
+
+describe('CopyReplyButton', () => {
+  it('allows copying a copyable reply', () => {
+    renderButton();
+
+    expect(copyButton()).toBeVisible();
+  });
+
+  it('does not allow copying while there is no reply to copy', () => {
+    renderButton(undefined, { disabled: true });
+
+    expect(copyButton()).not.toBeInTheDocument();
+  });
+
+  it('calls assistant ui copy function', async () => {
+    const user = userEvent.setup();
+    const copyReply = jest.fn();
+
+    renderButton(undefined, { copy: copyReply });
+    await user.click(copyButton());
+
+    expect(copyReply).toHaveBeenCalled();
+  });
+
+  it('copies the markdown and html', async () => {
+    const contentRef = { current: { innerHTML: '<p>partial</p>' } };
+    const { onWriteToClipboard } = renderButton(contentRef);
+
+    contentRef.current.innerHTML = REPLY_HTML;
+
+    await writeReply();
+
+    expect(onWriteToClipboard).toHaveBeenCalledWith(REPLY_MARKDOWN, REPLY_HTML);
+  });
+
+  it('copies the markdown alone when the reply has no rendered markup', async () => {
+    const { onWriteToClipboard } = renderButton();
+
+    await writeReply();
+
+    expect(onWriteToClipboard).toHaveBeenCalledWith(REPLY_MARKDOWN, undefined);
+  });
+
+  it('leaves the copy unconfirmed when the clipboard write fails', async () => {
+    const { onWriteToClipboard } = renderButton({
+      current: { innerHTML: REPLY_HTML },
+    });
+
+    onWriteToClipboard.mockReturnValue(false);
+
+    await expect(writeReply()).rejects.toThrow();
+  });
+
+  it('confirms the copy for as long as the library holds the reply as copied', () => {
+    renderButton(undefined, { isCopied: true });
+
+    expect(screen.getByText('Copied to clipboard')).toBeInTheDocument();
+  });
+});

--- a/assets/js/common/AIAssistant/MessageBubble/MessageBubble.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/MessageBubble.jsx
@@ -1,13 +1,18 @@
 // SPDX-FileCopyrightText: SUSE LLC
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
-import { ErrorPrimitive, MessagePrimitive } from '@assistant-ui/react';
+import React, { useRef } from 'react';
+import {
+  ActionBarPrimitive,
+  ErrorPrimitive,
+  MessagePrimitive,
+} from '@assistant-ui/react';
 import { MarkdownTextPrimitive } from '@assistant-ui/react-markdown';
 import remarkGfm from 'remark-gfm';
 
 import AgentProgressIndicator from '../AgentProgressIndicator';
 import CodeBlock from './CodeBlock';
+import CopyReplyButton from './CopyReplyButton';
 
 const ROOT_CLASS_NAME =
   'mx-auto w-full max-w-[var(--thread-max-width)] py-2 fade-in slide-in-from-bottom-1 animate-in duration-150';
@@ -44,6 +49,7 @@ function MarkdownText(props) {
           </div>
         ),
       }}
+      smooth={false}
       {...props}
     />
   );
@@ -70,11 +76,19 @@ export function UserMessage() {
 }
 
 export function AssistantMessage({ isRunning }) {
+  // `CopyReplyButton` copies this subtree's HTML
+  const replyRef = useRef(null);
+
   return (
     <MessagePrimitive.Root className={ROOT_CLASS_NAME} data-role="assistant">
       <MessageBubbleView variant="assistant">
-        <MessagePrimitive.Parts components={{ Text: MarkdownText }} />
+        <div ref={replyRef} data-testid="assistant-reply">
+          <MessagePrimitive.Parts components={{ Text: MarkdownText }} />
+        </div>
         <AgentProgressIndicator isRunning={isRunning} />
+        <ActionBarPrimitive.Root className="mt-1 flex">
+          <CopyReplyButton contentRef={replyRef} />
+        </ActionBarPrimitive.Root>
       </MessageBubbleView>
       <MessageError />
     </MessagePrimitive.Root>

--- a/assets/js/common/AIAssistant/MessageBubble/MessageBubble.test.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/MessageBubble.test.jsx
@@ -6,7 +6,10 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { useAuiState } from '@assistant-ui/react';
+import { useActionBarCopy } from '@assistant-ui/core/react';
 import { UserMessage, AssistantMessage } from './MessageBubble';
+
+jest.mock('copy-to-clipboard', () => jest.fn());
 
 jest.mock('@assistant-ui/react', () => ({
   ErrorPrimitive: {
@@ -20,7 +23,14 @@ jest.mock('@assistant-ui/react', () => ({
     // error. This stub is unconditional, so the tests below can prove the slot is mounted
     Error: ({ children }) => <div>{children}</div>,
   },
+  ActionBarPrimitive: {
+    Root: ({ children, ...props }) => <div {...props}>{children}</div>,
+  },
   useAuiState: jest.fn(),
+}));
+
+jest.mock('@assistant-ui/core/react', () => ({
+  useActionBarCopy: jest.fn(),
 }));
 
 jest.mock('@assistant-ui/react-markdown', () => ({
@@ -38,6 +48,19 @@ const mockAssistantMessage = (overrides = {}) => {
   useAuiState.mockImplementation((selector) => selector({ message }));
 };
 
+const mockCopyableReply = (copyable) => {
+  useActionBarCopy.mockReturnValue({
+    copy: jest.fn(),
+    disabled: !copyable,
+    isCopied: false,
+  });
+};
+
+const copyButton = () =>
+  screen.queryByRole('button', { name: 'copy to clipboard' });
+
+beforeEach(() => mockCopyableReply(false));
+
 describe('UserMessage', () => {
   it('renders the user message bubble with the "You" label and parts slot', () => {
     const { container } = render(<UserMessage />);
@@ -50,6 +73,14 @@ describe('UserMessage', () => {
   it('does not render the assistant-only error slot', () => {
     render(<UserMessage />);
     expect(screen.queryByText('Error message')).not.toBeInTheDocument();
+  });
+
+  it('does not allow copying user messages', () => {
+    mockCopyableReply(true);
+
+    render(<UserMessage />);
+
+    expect(copyButton()).not.toBeInTheDocument();
   });
 });
 
@@ -97,5 +128,19 @@ describe('AssistantMessage', () => {
     render(<AssistantMessage />);
 
     expect(screen.getByRole('status')).toHaveTextContent('Response stopped.');
+  });
+
+  it('allows copying an assistant reply', () => {
+    mockCopyableReply(true);
+
+    render(<AssistantMessage />);
+
+    expect(copyButton()).toBeVisible();
+  });
+
+  it('keeps the copy action out of the way while the reply is still coming', () => {
+    render(<AssistantMessage isRunning />);
+
+    expect(copyButton()).not.toBeInTheDocument();
   });
 });

--- a/assets/js/common/CopyButton/CopyButton.jsx
+++ b/assets/js/common/CopyButton/CopyButton.jsx
@@ -47,7 +47,7 @@ function CopyButton({
   };
 
   return (
-    <Tooltip content="Copied to clipboard" visible={contentCopied}>
+    <Tooltip content="Copied to clipboard" visible={contentCopied} wrap={false}>
       <button
         type="button"
         onClick={() => copyText()}

--- a/assets/js/common/CopyButton/CopyButton.jsx
+++ b/assets/js/common/CopyButton/CopyButton.jsx
@@ -3,31 +3,51 @@
 
 import React, { useEffect, useState } from 'react';
 import { EOS_CONTENT_COPY } from 'eos-icons-react';
+import { noop } from 'lodash';
 import copy from 'copy-to-clipboard';
 import Tooltip from '@common/Tooltip';
 
-function CopyButton({ content }) {
+export const COPIED_FEEDBACK_MS = 2000;
+
+// Make sure both flavours go out in a single clipboard event:
+// - `text/html` so rich targets (docs, mail, ticket trackers) keep the formatting
+// - `text/plain` so everything else gets `content` as it would have without the HTML
+export const writeToClipboard = (content, html) => {
+  if (!html) return copy(content);
+
+  return copy(content, {
+    onCopy: (clipboardData) => {
+      clipboardData.setData('text/plain', content);
+      clipboardData.setData('text/html', html);
+    },
+  });
+};
+
+function CopyButton({
+  content,
+  getHtml = noop,
+  onCopy = undefined,
+  isCopied = false,
+}) {
   const [copied, setCopied] = useState(false);
+  const contentCopied = isCopied || copied;
 
   useEffect(() => {
-    if (copied) {
-      setTimeout(() => {
-        setCopied(false);
-      }, 2000);
-    }
+    if (!copied) return undefined;
+
+    const timeout = setTimeout(() => setCopied(false), COPIED_FEEDBACK_MS);
+    return () => clearTimeout(timeout);
   }, [copied]);
 
   const copyText = () => {
-    copy(content);
+    if (onCopy) return onCopy();
+
+    writeToClipboard(content, getHtml());
     setCopied(true);
   };
 
   return (
-    <Tooltip
-      content="Copied to clipboard"
-      isEnabled={copied}
-      mouseLeaveDelay={2}
-    >
+    <Tooltip content="Copied to clipboard" visible={contentCopied}>
       <button
         type="button"
         onClick={() => copyText()}

--- a/assets/js/common/CopyButton/CopyButton.test.jsx
+++ b/assets/js/common/CopyButton/CopyButton.test.jsx
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import copy from 'copy-to-clipboard';
+
+import CopyButton from './CopyButton';
+
+jest.mock('copy-to-clipboard', () => jest.fn());
+
+const getCopyButton = () =>
+  screen.getByRole('button', { name: 'copy to clipboard' });
+
+const writtenContentTypes = () => {
+  const [, options] = copy.mock.calls[0];
+  const setData = jest.fn();
+
+  options.onCopy({ setData });
+
+  return Object.fromEntries(setData.mock.calls);
+};
+
+describe('CopyButton', () => {
+  it('copies plain content as it is', async () => {
+    const user = userEvent.setup();
+    render(<CopyButton content="an-api-key" />);
+
+    await user.click(getCopyButton());
+
+    expect(copy).toHaveBeenCalledWith('an-api-key');
+  });
+
+  it('copies the HTML alongside the plain content when one is available', async () => {
+    const user = userEvent.setup();
+    render(
+      <CopyButton
+        content="**bold**"
+        getHtml={() => '<p><strong>bold</strong></p>'}
+      />
+    );
+
+    await user.click(getCopyButton());
+
+    expect(writtenContentTypes()).toEqual({
+      'text/plain': '**bold**',
+      'text/html': '<p><strong>bold</strong></p>',
+    });
+  });
+
+  it('reads the HTML on click, not on render', async () => {
+    const user = userEvent.setup();
+    const getHtml = jest.fn(() => '<p>done</p>');
+
+    render(<CopyButton content="done" getHtml={getHtml} />);
+
+    expect(getHtml).not.toHaveBeenCalled();
+
+    await user.click(getCopyButton());
+
+    expect(getHtml).toHaveBeenCalled();
+  });
+
+  it('falls back to plain content when there is no HTML to copy', async () => {
+    const user = userEvent.setup();
+    render(<CopyButton content="plain" />);
+
+    await user.click(getCopyButton());
+
+    expect(copy).toHaveBeenCalledWith('plain');
+  });
+
+  it('delegates the copy to the caller', async () => {
+    const user = userEvent.setup();
+    const onCopy = jest.fn();
+
+    render(<CopyButton content="an-api-key" onCopy={onCopy} />);
+
+    await user.click(getCopyButton());
+
+    expect(onCopy).toHaveBeenCalled();
+    expect(copy).not.toHaveBeenCalled();
+  });
+
+  it('shows a copy confirmation', async () => {
+    render(<CopyButton content="an-api-key" isCopied onCopy={jest.fn()} />);
+
+    expect(screen.getByText('Copied to clipboard')).toBeVisible();
+  });
+
+  it('internal copy confirmation is ignored when copy is controlled by the caller', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <CopyButton content="an-api-key" isCopied={false} onCopy={jest.fn()} />
+    );
+
+    await user.click(getCopyButton());
+
+    expect(screen.queryByText('Copied to clipboard')).not.toBeInTheDocument();
+  });
+
+  it('shows the copy confirmation when the caller sets it', async () => {
+    const onCopy = jest.fn();
+    const withCopied = (isCopied) => (
+      <CopyButton content="an-api-key" isCopied={isCopied} onCopy={onCopy} />
+    );
+
+    const { rerender } = render(withCopied(false));
+
+    rerender(withCopied(true));
+
+    expect(screen.getByText('Copied to clipboard')).toBeVisible();
+  });
+
+  it('confirms the copy, then tooltip disappears again', async () => {
+    const user = userEvent.setup();
+    render(<CopyButton content="an-api-key" />);
+
+    expect(screen.queryByText('Copied to clipboard')).not.toBeInTheDocument();
+
+    await user.click(getCopyButton());
+
+    const confirmation = () =>
+      screen.getByText('Copied to clipboard').closest('.rc-tooltip');
+
+    expect(confirmation()).not.toHaveClass('rc-tooltip-visible');
+
+    await waitFor(
+      () => expect(confirmation()).toHaveClass('rc-tooltip-hidden'),
+      { timeout: 4000 }
+    );
+  }, 10000);
+});

--- a/assets/js/common/CopyButton/index.js
+++ b/assets/js/common/CopyButton/index.js
@@ -3,4 +3,6 @@
 
 import CopyButton from './CopyButton';
 
+export { COPIED_FEEDBACK_MS, writeToClipboard } from './CopyButton';
+
 export default CopyButton;

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -7,6 +7,7 @@
       "dependencies": {
         "@ag-ui/client": "^0.0.57",
         "@ag-ui/core": "^0.0.57",
+        "@assistant-ui/core": "^0.3.12",
         "@assistant-ui/react": "^0.15.13",
         "@assistant-ui/react-ag-ui": "^0.0.53",
         "@assistant-ui/react-markdown": "^0.14.10",

--- a/assets/package.json
+++ b/assets/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@ag-ui/client": "^0.0.57",
     "@ag-ui/core": "^0.0.57",
+    "@assistant-ui/core": "^0.3.12",
     "@assistant-ui/react": "^0.15.13",
     "@assistant-ui/react-ag-ui": "^0.0.53",
     "@assistant-ui/react-markdown": "^0.14.10",


### PR DESCRIPTION
### Description

This PR introduces the ability to copy any AI assistant's response, not only the last one.
- existing `CopyButton` enhanced to support plain text and rich content copy and tests added
- Copy of assistant's reply is available only when the run is finished
- a stopped response is still copyable even though truncated
- copied content can be pasted into markdown file or rich application as a google doc and would retain formatting at its best capabilities

### How was this tested?

Automated and IRL.