### PR TITLE
Switch to pull_request_target for backport action

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -5,7 +5,7 @@
 name: Backport PR
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [closed, labeled]
 


### PR DESCRIPTION
### Description

Switch the backport workflow to `pull_request_target` triggers.

This might be a temporary fix, let's discuss it. The problem we're facing is the following:
If using `pull_request` trigger, the PRs run workflows in the context of their base branches, eg. with with the temporary merge commit towards `main`  at the time of their opening. Since the backport action is introduced later than these PRs, the backport workflow is non-existent at that time, thus no workflow is triggered.

Switching to `pull_request_target` would run the backport action in the context of the `main` branch. This has some security implications, but I think we're safe since the backport workflow don't execute code from the PR itself. There is a checkout step, but it doesn't checkout the PR code per se. It only needs access to the repository to execute a `git cherry-pick -x` command. 