### PR TITLE
Add retry last prompt capability

### DIFF
--- a/assets/js/common/AIAssistant/AIAssistant.stories.jsx
+++ b/assets/js/common/AIAssistant/AIAssistant.stories.jsx
@@ -65,6 +65,19 @@ function useConfigurationEvents(socket, events) {
   }, [socket]);
 }
 
+// Polls until `probe` returns something truthy.
+// The chat frame measures itself before the composer mounts, so we wait.
+const waitUntil = async (probe, timeoutMs = 2000) => {
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    const found = probe();
+    if (found) return found;
+    if (Date.now() >= deadline) return null;
+    await new Promise((resolve) => window.requestAnimationFrame(resolve));
+  }
+};
+
 // Types the user's prompt into the composer, hits send, then plays an
 // assistant turn back through the channel. Assumes useChannelScript has
 // already brought the channel up. `turn.stepDelayMs > 0` reveals deltas
@@ -90,25 +103,20 @@ function useSimulatedTurn(socket, turn) {
     };
 
     const run = async () => {
-      // Wait one paint so composer + send have mounted.
-      await new Promise((resolve) => window.requestAnimationFrame(resolve));
-      if (cancelled) return;
-
-      const composer = document.querySelector('[aria-label="Message input"]');
+      const composer = await waitUntil(() =>
+        document.querySelector('[aria-label="Message input"]')
+      );
       const send = document.querySelector('[aria-label="Send message"]');
-      if (!composer || !send) return;
+      if (cancelled || !composer || !send) return;
 
       setNativeValue(composer, turn.userText);
       send.click();
 
       // Wait for WebSocketAIAgent to push send_message back to the channel.
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      if (cancelled) return;
-
-      const sent = channel.pushed
-        .filter((p) => p.event === 'send_message')
-        .at(-1);
-      if (!sent) return;
+      const sent = await waitUntil(() =>
+        channel.pushed.filter((p) => p.event === 'send_message').at(-1)
+      );
+      if (cancelled || !sent) return;
 
       const { thread_id: threadId, run_id: runId } = sent.payload;
       const events = buildAssistantTurn({

--- a/assets/js/common/AIAssistant/AIAssistant.test.jsx
+++ b/assets/js/common/AIAssistant/AIAssistant.test.jsx
@@ -110,8 +110,10 @@ describe('AIAssistant', () => {
       });
 
       const second = await sendUserMessage('after');
+      await streamAssistantTurn(second, { messageId: 'b', deltas: ['sure'] });
 
       expect(second.thread_id).not.toBe(first.thread_id);
+      expect(await screen.findByText('sure')).toBeVisible();
     });
   });
 

--- a/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
+++ b/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
@@ -495,26 +495,129 @@ describe('AG-UI event flow', () => {
     });
   });
 
-  it('allows retrying the last reply only', async () => {
-    const { sendUserMessage, streamAssistantTurn } = await renderAIAssistant({
-      open: true,
+  describe('Retrying behavior', () => {
+    it('allows retrying the last reply only', async () => {
+      const { sendUserMessage, streamAssistantTurn } = await renderAIAssistant({
+        open: true,
+      });
+
+      const first = await sendUserMessage('first');
+      await streamAssistantTurn(first, { messageId: 'a', deltas: ['one'] });
+
+      const second = await sendUserMessage('second');
+      await streamAssistantTurn(second, { messageId: 'b', deltas: ['two'] });
+
+      await waitFor(() =>
+        expect(screen.getAllByRole('button', { name: 'retry' })).toHaveLength(1)
+      );
+
+      const [earlier, latest] = assistantBubbles();
+      expect(
+        within(earlier).queryByRole('button', { name: 'retry' })
+      ).not.toBeInTheDocument();
+      expect(
+        within(latest).getByRole('button', { name: 'retry' })
+      ).toBeVisible();
     });
 
-    const first = await sendUserMessage('first');
-    await streamAssistantTurn(first, { messageId: 'a', deltas: ['one'] });
+    it('retrying a reply re-sends its prompt on the same thread under a new run', async () => {
+      const { user, channel, sendUserMessage, streamAssistantTurn } =
+        await renderAIAssistant({ open: true });
 
-    const second = await sendUserMessage('second');
-    await streamAssistantTurn(second, { messageId: 'b', deltas: ['two'] });
+      const first = await sendUserMessage('first');
+      await streamAssistantTurn(first, { messageId: 'a', deltas: ['one'] });
 
-    await waitFor(() =>
-      expect(screen.getAllByRole('button', { name: 'retry' })).toHaveLength(1)
-    );
+      expect(await screen.findByText('one')).toBeVisible();
 
-    const [earlier, latest] = assistantBubbles();
-    expect(
-      within(earlier).queryByRole('button', { name: 'retry' })
-    ).not.toBeInTheDocument();
-    expect(within(latest).getByRole('button', { name: 'retry' })).toBeVisible();
+      await user.click(await screen.findByRole('button', { name: 'retry' }));
+
+      const sends = () =>
+        channel.pushed
+          .filter(({ event }) => event === 'send_message')
+          .map(({ payload }) => payload);
+
+      await waitFor(() => expect(sends()).toHaveLength(2));
+
+      const [original, retried] = sends();
+      expect(retried.message).toBe('first');
+      expect(retried.thread_id).toBe(original.thread_id);
+      expect(retried.run_id).not.toBe(original.run_id);
+
+      await streamAssistantTurn(retried, { messageId: 'b', deltas: ['two'] });
+
+      expect(await screen.findByText('two')).toBeVisible();
+      expect(screen.queryByText('one')).not.toBeInTheDocument();
+    });
+
+    it('cannot retry when the AI configuration is cleared', async () => {
+      const { channel, sendUserMessage, streamAssistantTurn } =
+        await renderAIAssistant({ open: true });
+
+      const first = await sendUserMessage('first');
+      await streamAssistantTurn(first, { messageId: 'a', deltas: ['one'] });
+
+      expect(
+        await screen.findByRole('button', { name: 'retry' })
+      ).toBeVisible();
+
+      await act(async () => {
+        channel.emit('ai_configuration_cleared');
+      });
+
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('button', { name: 'retry' })
+        ).not.toBeInTheDocument()
+      );
+    });
+
+    it('cannot retry after the configuration has been restored. a new chat must be started', async () => {
+      const { channel, sendUserMessage, streamAssistantTurn } =
+        await renderAIAssistant({ open: true });
+
+      const first = await sendUserMessage('first');
+      await streamAssistantTurn(first, { messageId: 'a', deltas: ['one'] });
+
+      expect(
+        await screen.findByRole('button', { name: 'retry' })
+      ).toBeVisible();
+
+      await act(async () => {
+        channel.emit('ai_configuration_cleared');
+      });
+      await act(async () => {
+        channel.emit('ai_configuration_created');
+      });
+
+      expect(
+        await screen.findByText(/Start a new chat to continue/)
+      ).toBeVisible();
+      expect(
+        screen.queryByRole('button', { name: 'retry' })
+      ).not.toBeInTheDocument();
+    });
+
+    it('cannot retry while the channel is down', async () => {
+      const { channel, sendUserMessage, streamAssistantTurn } =
+        await renderAIAssistant({ open: true });
+
+      const first = await sendUserMessage('first');
+      await streamAssistantTurn(first, { messageId: 'a', deltas: ['one'] });
+
+      expect(
+        await screen.findByRole('button', { name: 'retry' })
+      ).toBeVisible();
+
+      await act(async () => {
+        channel.triggerError();
+      });
+
+      await waitFor(() =>
+        expect(
+          screen.queryByRole('button', { name: 'retry' })
+        ).not.toBeInTheDocument()
+      );
+    });
   });
 
   it('"New chat" starts a new conversation with a new thread ID', async () => {
@@ -535,8 +638,10 @@ describe('AG-UI event flow', () => {
     });
 
     const second = await sendUserMessage('second');
+    await streamAssistantTurn(second, { messageId: 'b', deltas: ['two'] });
 
     expect(second.thread_id).not.toBe(first.thread_id);
+    expect(await screen.findByText('two')).toBeVisible();
   });
 
   it('handles a follow-up turn after the previous one finishes', async () => {

--- a/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
+++ b/assets/js/common/AIAssistant/AgUiEventFlow.test.jsx
@@ -495,6 +495,28 @@ describe('AG-UI event flow', () => {
     });
   });
 
+  it('allows retrying the last reply only', async () => {
+    const { sendUserMessage, streamAssistantTurn } = await renderAIAssistant({
+      open: true,
+    });
+
+    const first = await sendUserMessage('first');
+    await streamAssistantTurn(first, { messageId: 'a', deltas: ['one'] });
+
+    const second = await sendUserMessage('second');
+    await streamAssistantTurn(second, { messageId: 'b', deltas: ['two'] });
+
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: 'retry' })).toHaveLength(1)
+    );
+
+    const [earlier, latest] = assistantBubbles();
+    expect(
+      within(earlier).queryByRole('button', { name: 'retry' })
+    ).not.toBeInTheDocument();
+    expect(within(latest).getByRole('button', { name: 'retry' })).toBeVisible();
+  });
+
   it('"New chat" starts a new conversation with a new thread ID', async () => {
     const { user, sendUserMessage, streamAssistantTurn } =
       await renderAIAssistant({ open: true });

--- a/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.jsx
+++ b/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.jsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { useAuiState } from '@assistant-ui/react';
 import { filter, isUndefined, last } from 'lodash';
 
 import Spinner from '@common/Spinner';
@@ -40,12 +39,7 @@ const deriveNotice = ({ isRunning, message }) => {
   return null;
 };
 
-// Reads `s.message` from the per-message scope set up by assistant-ui's
-// MessageByIndexProvider (one per <MessagePrimitive.Root>). Subscribing
-// directly here keeps the indicator reactive to streaming tool-call
-// updates
-function AgentProgressIndicator({ isRunning }) {
-  const message = useAuiState((s) => s.message);
+function AgentProgressIndicator({ isRunning, message }) {
   const notice = deriveNotice({ isRunning, message });
 
   if (!notice) return null;

--- a/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.test.jsx
+++ b/assets/js/common/AIAssistant/AgentProgressIndicator/AgentProgressIndicator.test.jsx
@@ -5,17 +5,10 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import { useAuiState } from '@assistant-ui/react';
 import AgentProgressIndicator, {
   AgentProgressIndicatorView,
   deriveProgressLabel,
 } from './AgentProgressIndicator';
-
-jest.mock('@assistant-ui/react', () => ({
-  useAuiState: jest.fn(),
-}));
-
-const mockMessage = (message) => useAuiState.mockReturnValue(message);
 
 describe('AgentProgressIndicatorView', () => {
   it.each(['Thinking...', 'Calling get_hosts...'])(
@@ -94,38 +87,44 @@ describe('deriveProgressLabel', () => {
 
 describe('AgentProgressIndicator', () => {
   it('renders nothing when the thread is not running', () => {
-    mockMessage({ content: [], isLast: true });
-    const { container } = render(<AgentProgressIndicator isRunning={false} />);
+    const message = { content: [], isLast: true };
+    const { container } = render(
+      <AgentProgressIndicator isRunning={false} message={message} />
+    );
     expect(container).toBeEmptyDOMElement();
   });
 
   it('renders nothing when the assistant has already produced text', () => {
-    mockMessage({
+    const message = {
       content: [{ type: 'text', text: 'partial answer' }],
       isLast: true,
-    });
-    const { container } = render(<AgentProgressIndicator isRunning />);
+    };
+    const { container } = render(
+      <AgentProgressIndicator isRunning={true} message={message} />
+    );
     expect(container).toBeEmptyDOMElement();
   });
 
   it('renders nothing on an earlier answer', () => {
-    mockMessage({ content: [], isLast: false });
-    const { container } = render(<AgentProgressIndicator isRunning />);
+    const message = { content: [], isLast: false };
+    const { container } = render(
+      <AgentProgressIndicator isRunning={true} message={message} />
+    );
     expect(container).toBeEmptyDOMElement();
   });
 
   it('renders "Thinking..." while the thread is running and no content has streamed', () => {
-    mockMessage({ content: [], isLast: true });
-    render(<AgentProgressIndicator isRunning />);
+    const message = { content: [], isLast: true };
+    render(<AgentProgressIndicator isRunning={true} message={message} />);
     expect(screen.getByText('Thinking...')).toBeVisible();
   });
 
   it('renders the tool name while a tool call is in flight', () => {
-    mockMessage({
+    const message = {
       content: [{ type: 'tool-call', toolName: 'get_hosts' }],
       isLast: true,
-    });
-    render(<AgentProgressIndicator isRunning />);
+    };
+    render(<AgentProgressIndicator isRunning={true} message={message} />);
     expect(screen.getByText('Calling get_hosts...')).toBeVisible();
   });
 
@@ -138,9 +137,8 @@ describe('AgentProgressIndicator', () => {
     });
 
     it('says the response was stopped, without a spinner', () => {
-      mockMessage(cancelled());
-
-      render(<AgentProgressIndicator isRunning={false} />);
+      const message = cancelled();
+      render(<AgentProgressIndicator isRunning={false} message={message} />);
 
       expect(screen.getByText('Response stopped.')).toBeVisible();
       expect(screen.queryByLabelText('Loading')).toBeNull();
@@ -153,17 +151,15 @@ describe('AgentProgressIndicator', () => {
         overrides: { content: [{ type: 'text', text: 'half an answer' }] },
       },
     ])('keeps the mark when $label', ({ overrides }) => {
-      mockMessage(cancelled(overrides));
-
-      render(<AgentProgressIndicator isRunning={false} />);
+      const message = cancelled(overrides);
+      render(<AgentProgressIndicator isRunning={false} message={message} />);
 
       expect(screen.getByText('Response stopped.')).toBeVisible();
     });
 
     it('stopped mark takes precedence over thinking', () => {
-      mockMessage(cancelled());
-
-      render(<AgentProgressIndicator isRunning />);
+      const message = cancelled();
+      render(<AgentProgressIndicator isRunning={true} message={message} />);
 
       expect(screen.getByText('Response stopped.')).toBeVisible();
       expect(screen.queryByText('Thinking...')).toBeNull();
@@ -177,9 +173,14 @@ describe('AgentProgressIndicator', () => {
       status: { type: 'incomplete', reason: 'error', error: 'boom' },
     },
   ])('renders nothing when $label', ({ status }) => {
-    mockMessage({ content: [], isLast: true, status });
-
-    const { container } = render(<AgentProgressIndicator isRunning={false} />);
+    const message = {
+      content: [],
+      isLast: true,
+      status,
+    };
+    const { container } = render(
+      <AgentProgressIndicator isRunning={false} message={message} />
+    );
 
     expect(container).toBeEmptyDOMElement();
   });

--- a/assets/js/common/AIAssistant/AssistantThread.jsx
+++ b/assets/js/common/AIAssistant/AssistantThread.jsx
@@ -78,6 +78,38 @@ function ModelChangeBanner({ provider, model, onDismiss = noop }) {
   );
 }
 
+export function ThreadContainer({ children }) {
+  return (
+    <ThreadPrimitive.Root
+      className="relative flex h-full flex-col bg-white text-sm"
+      style={{
+        '--thread-max-width': '44rem',
+        '--accent-color': '#2fb371',
+        '--accent-foreground': '#ffffff',
+      }}
+    >
+      {children}
+    </ThreadPrimitive.Root>
+  );
+}
+
+export function ThreadMessages({ isRunning = false }) {
+  return (
+    <ThreadPrimitive.Messages>
+      {({ message }) => {
+        switch (message.role) {
+          case 'user':
+            return <UserMessage />;
+          case 'assistant':
+            return <AssistantMessage isRunning={isRunning} message={message} />;
+          default:
+            return null;
+        }
+      }}
+    </ThreadPrimitive.Messages>
+  );
+}
+
 function AssistantThread({
   connectionStatus,
   configurationStatus,
@@ -94,14 +126,7 @@ function AssistantThread({
   );
 
   return (
-    <ThreadPrimitive.Root
-      className="relative flex h-full flex-col bg-white text-sm"
-      style={{
-        '--thread-max-width': '44rem',
-        '--accent-color': '#2fb371',
-        '--accent-foreground': '#ffffff',
-      }}
-    >
+    <ThreadContainer>
       <ChatHeader
         connectionStatus={connection}
         isRunning={isRunning}
@@ -114,20 +139,7 @@ function AssistantThread({
       >
         {isEmpty && <ThreadWelcome />}
 
-        <ThreadPrimitive.Messages>
-          {({ message }) => {
-            switch (message.role) {
-              case 'user':
-                return <UserMessage />;
-              case 'assistant':
-                return (
-                  <AssistantMessage isRunning={isRunning} message={message} />
-                );
-              default:
-                return null;
-            }
-          }}
-        </ThreadPrimitive.Messages>
+        <ThreadMessages isRunning={isRunning} />
         <ThreadPrimitive.ViewportFooter className="sticky bottom-0 mx-auto mt-auto flex w-full max-w-[var(--thread-max-width)] flex-col bg-white pt-4 pb-4">
           {isConfigurationCleared(configurationStatus) && <ClearedBanner />}
           {isConfigurationRestored(configurationStatus) && <RestoredBanner />}
@@ -144,7 +156,7 @@ function AssistantThread({
           />
         </ThreadPrimitive.ViewportFooter>
       </ThreadPrimitive.Viewport>
-    </ThreadPrimitive.Root>
+    </ThreadContainer>
   );
 }
 

--- a/assets/js/common/AIAssistant/AssistantThread.jsx
+++ b/assets/js/common/AIAssistant/AssistantThread.jsx
@@ -15,6 +15,7 @@ import PromptComposer from './PromptComposer';
 import { AssistantMessage, UserMessage } from './MessageBubble';
 import ThreadWelcome from './ThreadWelcome';
 import {
+  canSendMessage,
   effectiveConnectionStatus,
   isConfigurationCleared,
   isConfigurationRestored,
@@ -93,7 +94,7 @@ export function ThreadContainer({ children }) {
   );
 }
 
-export function ThreadMessages({ isRunning = false }) {
+export function ThreadMessages({ isRunning = false, isChatActive = false }) {
   return (
     <ThreadPrimitive.Messages>
       {({ message }) => {
@@ -101,7 +102,13 @@ export function ThreadMessages({ isRunning = false }) {
           case 'user':
             return <UserMessage />;
           case 'assistant':
-            return <AssistantMessage isRunning={isRunning} message={message} />;
+            return (
+              <AssistantMessage
+                isChatActive={isChatActive}
+                isRunning={isRunning}
+                message={message}
+              />
+            );
           default:
             return null;
         }
@@ -125,6 +132,8 @@ function AssistantThread({
     configurationStatus
   );
 
+  const isChatActive = canSendMessage(connection, configurationStatus);
+
   return (
     <ThreadContainer>
       <ChatHeader
@@ -139,7 +148,7 @@ function AssistantThread({
       >
         {isEmpty && <ThreadWelcome />}
 
-        <ThreadMessages isRunning={isRunning} />
+        <ThreadMessages isChatActive={isChatActive} isRunning={isRunning} />
         <ThreadPrimitive.ViewportFooter className="sticky bottom-0 mx-auto mt-auto flex w-full max-w-[var(--thread-max-width)] flex-col bg-white pt-4 pb-4">
           {isConfigurationCleared(configurationStatus) && <ClearedBanner />}
           {isConfigurationRestored(configurationStatus) && <RestoredBanner />}

--- a/assets/js/common/AIAssistant/AssistantThread.jsx
+++ b/assets/js/common/AIAssistant/AssistantThread.jsx
@@ -120,7 +120,9 @@ function AssistantThread({
               case 'user':
                 return <UserMessage />;
               case 'assistant':
-                return <AssistantMessage isRunning={isRunning} />;
+                return (
+                  <AssistantMessage isRunning={isRunning} message={message} />
+                );
               default:
                 return null;
             }

--- a/assets/js/common/AIAssistant/MessageBubble/MessageBubble.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/MessageBubble.jsx
@@ -13,6 +13,7 @@ import remarkGfm from 'remark-gfm';
 import AgentProgressIndicator from '../AgentProgressIndicator';
 import CodeBlock from './CodeBlock';
 import CopyReplyButton from './CopyReplyButton';
+import RetryReplyButton from './RetryReplyButton';
 
 const ROOT_CLASS_NAME =
   'mx-auto w-full max-w-[var(--thread-max-width)] py-2 fade-in slide-in-from-bottom-1 animate-in duration-150';
@@ -88,6 +89,7 @@ export function AssistantMessage({ isRunning }) {
         <AgentProgressIndicator isRunning={isRunning} />
         <ActionBarPrimitive.Root className="mt-1 flex">
           <CopyReplyButton contentRef={replyRef} />
+          <RetryReplyButton />
         </ActionBarPrimitive.Root>
       </MessageBubbleView>
       <MessageError />

--- a/assets/js/common/AIAssistant/MessageBubble/MessageBubble.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/MessageBubble.jsx
@@ -76,7 +76,7 @@ export function UserMessage() {
   );
 }
 
-export function AssistantMessage({ isRunning, message }) {
+export function AssistantMessage({ isRunning, message, isChatActive = false }) {
   // `CopyReplyButton` copies this subtree's HTML
   const replyRef = useRef(null);
 
@@ -89,7 +89,10 @@ export function AssistantMessage({ isRunning, message }) {
         <AgentProgressIndicator isRunning={isRunning} message={message} />
         <ActionBarPrimitive.Root className="mt-1 flex">
           <CopyReplyButton contentRef={replyRef} />
-          <RetryReplyButton isLast={message.isLast} />
+          <RetryReplyButton
+            isLast={message.isLast}
+            isChatActive={isChatActive}
+          />
         </ActionBarPrimitive.Root>
       </MessageBubbleView>
       <MessageError />

--- a/assets/js/common/AIAssistant/MessageBubble/MessageBubble.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/MessageBubble.jsx
@@ -76,7 +76,7 @@ export function UserMessage() {
   );
 }
 
-export function AssistantMessage({ isRunning }) {
+export function AssistantMessage({ isRunning, message }) {
   // `CopyReplyButton` copies this subtree's HTML
   const replyRef = useRef(null);
 
@@ -86,10 +86,10 @@ export function AssistantMessage({ isRunning }) {
         <div ref={replyRef} data-testid="assistant-reply">
           <MessagePrimitive.Parts components={{ Text: MarkdownText }} />
         </div>
-        <AgentProgressIndicator isRunning={isRunning} />
+        <AgentProgressIndicator isRunning={isRunning} message={message} />
         <ActionBarPrimitive.Root className="mt-1 flex">
           <CopyReplyButton contentRef={replyRef} />
-          <RetryReplyButton />
+          <RetryReplyButton isLast={message.isLast} />
         </ActionBarPrimitive.Root>
       </MessageBubbleView>
       <MessageError />

--- a/assets/js/common/AIAssistant/MessageBubble/MessageBubble.stories.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/MessageBubble.stories.jsx
@@ -36,9 +36,15 @@ function StubRuntime({ messages, children }) {
 function SeededThread({ messages }) {
   return (
     <StubRuntime messages={messages}>
-      <ThreadPrimitive.Messages
-        components={{ UserMessage, AssistantMessage }}
-      />
+      <ThreadPrimitive.Messages>
+        {({ message }) =>
+          message.role === 'user' ? (
+            <UserMessage />
+          ) : (
+            <AssistantMessage message={message} />
+          )
+        }
+      </ThreadPrimitive.Messages>
     </StubRuntime>
   );
 }

--- a/assets/js/common/AIAssistant/MessageBubble/MessageBubble.stories.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/MessageBubble.stories.jsx
@@ -4,20 +4,15 @@
 import React from 'react';
 import {
   AssistantRuntimeProvider,
-  ThreadPrimitive,
-  useAui,
   useExternalStoreRuntime,
 } from '@assistant-ui/react';
 
-import { AssistantMessage, UserMessage } from './MessageBubble';
 import { identity } from 'lodash';
 
-// UserMessage / AssistantMessage rely on MessagePrimitive scoping established
-// by <ThreadPrimitive.Messages>. Mount a minimal external-store runtime
-// seeded with the messages we want to render — no backend, no agent, just
-// static state. onNew is required by the adapter contract but never fires
-// here since the stories don't render a composer.
-function StubRuntime({ messages, children }) {
+import { ThreadContainer, ThreadMessages } from '../AssistantThread';
+
+// A thread seeded via a custom external-store runtime with static messages.
+function SeededThread({ messages }) {
   const runtime = useExternalStoreRuntime({
     messages,
     isRunning: false,
@@ -25,27 +20,13 @@ function StubRuntime({ messages, children }) {
     convertMessage: identity,
     onNew: () => Promise.resolve(),
   });
-  const aui = useAui();
-  return (
-    <AssistantRuntimeProvider aui={aui} runtime={runtime}>
-      <ThreadPrimitive.Root>{children}</ThreadPrimitive.Root>
-    </AssistantRuntimeProvider>
-  );
-}
 
-function SeededThread({ messages }) {
   return (
-    <StubRuntime messages={messages}>
-      <ThreadPrimitive.Messages>
-        {({ message }) =>
-          message.role === 'user' ? (
-            <UserMessage />
-          ) : (
-            <AssistantMessage message={message} />
-          )
-        }
-      </ThreadPrimitive.Messages>
-    </StubRuntime>
+    <AssistantRuntimeProvider runtime={runtime}>
+      <ThreadContainer>
+        <ThreadMessages />
+      </ThreadContainer>
+    </AssistantRuntimeProvider>
   );
 }
 

--- a/assets/js/common/AIAssistant/MessageBubble/MessageBubble.test.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/MessageBubble.test.jsx
@@ -5,7 +5,6 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import { useAuiState } from '@assistant-ui/react';
 import { useActionBarCopy, useActionBarReload } from '@assistant-ui/core/react';
 import { UserMessage, AssistantMessage } from './MessageBubble';
 
@@ -27,7 +26,6 @@ jest.mock('@assistant-ui/react', () => ({
     Root: ({ children, ...props }) => <div {...props}>{children}</div>,
     Reload: ({ children }) => children,
   },
-  useAuiState: jest.fn(),
 }));
 
 jest.mock('@assistant-ui/core/react', () => ({
@@ -39,16 +37,21 @@ jest.mock('@assistant-ui/react-markdown', () => ({
   MarkdownTextPrimitive: () => null,
 }));
 
-const mockAssistantMessage = (overrides = {}) => {
-  const message = {
-    content: [],
-    id: 'message-1',
-    isLast: true,
-    status: { type: 'complete', reason: 'unknown' },
-    ...overrides,
-  };
-  useAuiState.mockImplementation((selector) => selector({ message }));
-};
+const assistantMessage = (overrides = {}) => ({
+  content: [],
+  id: 'message-1',
+  isLast: true,
+  status: { type: 'complete', reason: 'unknown' },
+  ...overrides,
+});
+
+const renderAssistant = ({ isRunning = false, ...overrides } = {}) =>
+  render(
+    <AssistantMessage
+      isRunning={isRunning}
+      message={assistantMessage(overrides)}
+    />
+  );
 
 const mockCopyableReply = (copyable) => {
   useActionBarCopy.mockReturnValue({
@@ -99,10 +102,8 @@ describe('UserMessage', () => {
 });
 
 describe('AssistantMessage', () => {
-  beforeEach(() => mockAssistantMessage());
-
   it('renders the assistant message bubble with the parts and error slots', () => {
-    const { container } = render(<AssistantMessage />);
+    const { container } = renderAssistant();
 
     expect(
       container.querySelector('[data-role="assistant"]')
@@ -113,21 +114,20 @@ describe('AssistantMessage', () => {
   });
 
   it('omits the user-only "You" label', () => {
-    render(<AssistantMessage />);
+    renderAssistant();
     expect(screen.queryByText('You')).toBeNull();
   });
 
   it('shows the agent progress indicator while a run is in flight', () => {
-    render(<AssistantMessage isRunning />);
+    renderAssistant({ isRunning: true });
     expect(screen.getByRole('status')).toHaveTextContent('Thinking...');
   });
 
   it('names the tool the agent is calling', () => {
-    mockAssistantMessage({
+    renderAssistant({
+      isRunning: true,
       content: [{ type: 'tool-call', toolName: 'get_hosts' }],
     });
-
-    render(<AssistantMessage isRunning />);
 
     expect(screen.getByRole('status')).toHaveTextContent(
       'Calling get_hosts...'
@@ -135,11 +135,7 @@ describe('AssistantMessage', () => {
   });
 
   it('marks an answer the user stopped', () => {
-    mockAssistantMessage({
-      status: { type: 'incomplete', reason: 'cancelled' },
-    });
-
-    render(<AssistantMessage />);
+    renderAssistant({ status: { type: 'incomplete', reason: 'cancelled' } });
 
     expect(screen.getByRole('status')).toHaveTextContent('Response stopped.');
   });
@@ -147,27 +143,25 @@ describe('AssistantMessage', () => {
   it('allows copying an assistant reply', () => {
     mockCopyableReply(true);
 
-    render(<AssistantMessage />);
+    renderAssistant();
 
     expect(copyButton()).toBeVisible();
   });
 
   it('keeps the copy action out of the way while the reply is still coming', () => {
-    render(<AssistantMessage isRunning />);
+    renderAssistant({ isRunning: true });
 
     expect(copyButton()).not.toBeInTheDocument();
   });
 
   it('allows retrying the latest assistant reply', () => {
-    render(<AssistantMessage />);
+    renderAssistant();
 
     expect(retryButton()).toBeVisible();
   });
 
   it('does not allow retrying an earlier reply', () => {
-    mockAssistantMessage({ isLast: false });
-
-    render(<AssistantMessage />);
+    renderAssistant({ isLast: false });
 
     expect(retryButton()).not.toBeInTheDocument();
   });

--- a/assets/js/common/AIAssistant/MessageBubble/MessageBubble.test.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/MessageBubble.test.jsx
@@ -45,10 +45,15 @@ const assistantMessage = (overrides = {}) => ({
   ...overrides,
 });
 
-const renderAssistant = ({ isRunning = false, ...overrides } = {}) =>
+const renderAssistant = ({
+  isRunning = false,
+  isChatActive = true,
+  ...overrides
+} = {}) =>
   render(
     <AssistantMessage
       isRunning={isRunning}
+      isChatActive={isChatActive}
       message={assistantMessage(overrides)}
     />
   );

--- a/assets/js/common/AIAssistant/MessageBubble/MessageBubble.test.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/MessageBubble.test.jsx
@@ -6,7 +6,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 import { useAuiState } from '@assistant-ui/react';
-import { useActionBarCopy } from '@assistant-ui/core/react';
+import { useActionBarCopy, useActionBarReload } from '@assistant-ui/core/react';
 import { UserMessage, AssistantMessage } from './MessageBubble';
 
 jest.mock('copy-to-clipboard', () => jest.fn());
@@ -25,12 +25,14 @@ jest.mock('@assistant-ui/react', () => ({
   },
   ActionBarPrimitive: {
     Root: ({ children, ...props }) => <div {...props}>{children}</div>,
+    Reload: ({ children }) => children,
   },
   useAuiState: jest.fn(),
 }));
 
 jest.mock('@assistant-ui/core/react', () => ({
   useActionBarCopy: jest.fn(),
+  useActionBarReload: jest.fn(),
 }));
 
 jest.mock('@assistant-ui/react-markdown', () => ({
@@ -59,7 +61,19 @@ const mockCopyableReply = (copyable) => {
 const copyButton = () =>
   screen.queryByRole('button', { name: 'copy to clipboard' });
 
-beforeEach(() => mockCopyableReply(false));
+const retryButton = () => screen.queryByRole('button', { name: 'retry' });
+
+const mockReloadableReply = (reloadable) => {
+  useActionBarReload.mockReturnValue({
+    reload: jest.fn(),
+    disabled: !reloadable,
+  });
+};
+
+beforeEach(() => {
+  mockCopyableReply(false);
+  mockReloadableReply(true);
+});
 
 describe('UserMessage', () => {
   it('renders the user message bubble with the "You" label and parts slot', () => {
@@ -142,5 +156,19 @@ describe('AssistantMessage', () => {
     render(<AssistantMessage isRunning />);
 
     expect(copyButton()).not.toBeInTheDocument();
+  });
+
+  it('allows retrying the latest assistant reply', () => {
+    render(<AssistantMessage />);
+
+    expect(retryButton()).toBeVisible();
+  });
+
+  it('does not allow retrying an earlier reply', () => {
+    mockAssistantMessage({ isLast: false });
+
+    render(<AssistantMessage />);
+
+    expect(retryButton()).not.toBeInTheDocument();
   });
 });

--- a/assets/js/common/AIAssistant/MessageBubble/RetryReplyButton.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/RetryReplyButton.jsx
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { ActionBarPrimitive, useAuiState } from '@assistant-ui/react';
+import { useActionBarReload } from '@assistant-ui/core/react';
+import { EOS_REFRESH_FILLED } from 'eos-icons-react';
+
+// Re-runs the prompt this reply answered.
+//
+// Offered on the newest reply only: the server keeps the conversation of its
+// own, keyed by thread, so re-asking an older question would append it after
+// everything that has been said since.
+//
+// `ActionBarPrimitive.Reload` would render itself disabled while the thread is
+// busy. We drop it from the bar instead, the way `CopyReplyButton` does, so
+// each action owns when it is offered and the bar never holds a dead button.
+function RetryReplyButton() {
+  const isLast = useAuiState((s) => s.message.isLast);
+  const { disabled } = useActionBarReload();
+
+  if (!isLast || disabled) return null;
+
+  return (
+    <ActionBarPrimitive.Reload asChild>
+      <button
+        aria-label="retry"
+        className="hover:bg-gray-100 rounded-full p-2 hover:opacity-60"
+      >
+        <EOS_REFRESH_FILLED className="p-1 mx-auto" size="25" />
+      </button>
+    </ActionBarPrimitive.Reload>
+  );
+}
+
+export default RetryReplyButton;

--- a/assets/js/common/AIAssistant/MessageBubble/RetryReplyButton.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/RetryReplyButton.jsx
@@ -6,13 +6,14 @@ import { ActionBarPrimitive } from '@assistant-ui/react';
 import { useActionBarReload } from '@assistant-ui/core/react';
 import { EOS_REFRESH_FILLED } from 'eos-icons-react';
 
-// Re-runs the last prompt. Only the last can be retried.
-//
-// Current response for the last prompts goes away from screen
-function RetryReplyButton({ isLast = false }) {
+// Re-runs the last prompt.
+// - Only the last reply can be retried
+// - current response to the last prompt goes away from the screen
+// - retrial is available only on active chats
+function RetryReplyButton({ isLast = false, isChatActive = false }) {
   const { disabled } = useActionBarReload();
 
-  if (disabled || !isLast) return null;
+  if (disabled || !isLast || !isChatActive) return null;
 
   return (
     <ActionBarPrimitive.Reload asChild>

--- a/assets/js/common/AIAssistant/MessageBubble/RetryReplyButton.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/RetryReplyButton.jsx
@@ -2,24 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react';
-import { ActionBarPrimitive, useAuiState } from '@assistant-ui/react';
+import { ActionBarPrimitive } from '@assistant-ui/react';
 import { useActionBarReload } from '@assistant-ui/core/react';
 import { EOS_REFRESH_FILLED } from 'eos-icons-react';
 
-// Re-runs the prompt this reply answered.
+// Re-runs the last prompt. Only the last can be retried.
 //
-// Offered on the newest reply only: the server keeps the conversation of its
-// own, keyed by thread, so re-asking an older question would append it after
-// everything that has been said since.
-//
-// `ActionBarPrimitive.Reload` would render itself disabled while the thread is
-// busy. We drop it from the bar instead, the way `CopyReplyButton` does, so
-// each action owns when it is offered and the bar never holds a dead button.
-function RetryReplyButton() {
-  const isLast = useAuiState((s) => s.message.isLast);
+// Current response for the last prompts goes away from screen
+function RetryReplyButton({ isLast = false }) {
   const { disabled } = useActionBarReload();
 
-  if (!isLast || disabled) return null;
+  if (disabled || !isLast) return null;
 
   return (
     <ActionBarPrimitive.Reload asChild>

--- a/assets/js/common/AIAssistant/MessageBubble/RetryReplyButton.test.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/RetryReplyButton.test.jsx
@@ -15,7 +15,11 @@ jest.mock('@assistant-ui/core/react', () => ({
 
 const retryButton = () => screen.queryByRole('button', { name: 'retry' });
 
-const renderRetryButton = ({ isLast = true, ...reloadState } = {}) => {
+const renderRetryButton = ({
+  isLast = true,
+  isChatActive = true,
+  ...reloadState
+} = {}) => {
   const reload = jest.fn();
   useActionBarReload.mockReturnValue({
     reload,
@@ -23,7 +27,7 @@ const renderRetryButton = ({ isLast = true, ...reloadState } = {}) => {
     ...reloadState,
   });
 
-  render(<RetryReplyButton isLast={isLast} />);
+  render(<RetryReplyButton isChatActive={isChatActive} isLast={isLast} />);
 
   return { reload };
 };
@@ -37,6 +41,12 @@ describe('RetryReplyButton', () => {
 
   it('does not allow retrying previous replies', () => {
     renderRetryButton({ isLast: false });
+
+    expect(retryButton()).not.toBeInTheDocument();
+  });
+
+  it('cannot retry while the chat is read-only', () => {
+    renderRetryButton({ isChatActive: false });
 
     expect(retryButton()).not.toBeInTheDocument();
   });

--- a/assets/js/common/AIAssistant/MessageBubble/RetryReplyButton.test.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/RetryReplyButton.test.jsx
@@ -5,63 +5,51 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import { useAuiState } from '@assistant-ui/react';
 import { useActionBarReload } from '@assistant-ui/core/react';
 
 import RetryReplyButton from './RetryReplyButton';
 
-// Only the two hooks are stubbed. The real `ActionBarPrimitive.Reload` stays in
-// the tree, so what is under test is our wiring through it: the disabled state
-// it derives from the hook and the callback it composes onto our button.
-jest.mock('@assistant-ui/react', () => ({
-  __esModule: true,
-  ...jest.requireActual('@assistant-ui/react'),
-  useAuiState: jest.fn(),
-}));
-
 jest.mock('@assistant-ui/core/react', () => ({
-  __esModule: true,
-  ...jest.requireActual('@assistant-ui/core/react'),
   useActionBarReload: jest.fn(),
 }));
 
 const retryButton = () => screen.queryByRole('button', { name: 'retry' });
 
-const renderButton = ({ isLast = true, ...state } = {}) => {
-  useAuiState.mockImplementation((selector) =>
-    selector({ message: { isLast } })
-  );
-
+const renderRetryButton = ({ isLast = true, ...reloadState } = {}) => {
   const reload = jest.fn();
-  useActionBarReload.mockReturnValue({ reload, disabled: false, ...state });
+  useActionBarReload.mockReturnValue({
+    reload,
+    disabled: false,
+    ...reloadState,
+  });
 
-  render(<RetryReplyButton />);
+  render(<RetryReplyButton isLast={isLast} />);
 
   return { reload };
 };
 
 describe('RetryReplyButton', () => {
-  it('offers to retry the newest reply', () => {
-    renderButton();
+  it('allows to retry latest reply', () => {
+    renderRetryButton({ isLast: true });
 
     expect(retryButton()).toBeEnabled();
   });
 
-  it('does not offer to retry an earlier reply', () => {
-    renderButton({ isLast: false });
+  it('does not allow retrying previous replies', () => {
+    renderRetryButton({ isLast: false });
 
     expect(retryButton()).not.toBeInTheDocument();
   });
 
-  it('stays out of the way while the library reports the thread busy', () => {
-    renderButton({ disabled: true });
+  it('cannot retry while the thread is busy', () => {
+    renderRetryButton({ disabled: true });
 
     expect(retryButton()).not.toBeInTheDocument();
   });
 
-  it('leaves the re-run itself to the library', async () => {
+  it('retries the latest reply', async () => {
     const user = userEvent.setup();
-    const { reload } = renderButton();
+    const { reload } = renderRetryButton({ isLast: true });
 
     await user.click(retryButton());
 

--- a/assets/js/common/AIAssistant/MessageBubble/RetryReplyButton.test.jsx
+++ b/assets/js/common/AIAssistant/MessageBubble/RetryReplyButton.test.jsx
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: SUSE LLC
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { useAuiState } from '@assistant-ui/react';
+import { useActionBarReload } from '@assistant-ui/core/react';
+
+import RetryReplyButton from './RetryReplyButton';
+
+// Only the two hooks are stubbed. The real `ActionBarPrimitive.Reload` stays in
+// the tree, so what is under test is our wiring through it: the disabled state
+// it derives from the hook and the callback it composes onto our button.
+jest.mock('@assistant-ui/react', () => ({
+  __esModule: true,
+  ...jest.requireActual('@assistant-ui/react'),
+  useAuiState: jest.fn(),
+}));
+
+jest.mock('@assistant-ui/core/react', () => ({
+  __esModule: true,
+  ...jest.requireActual('@assistant-ui/core/react'),
+  useActionBarReload: jest.fn(),
+}));
+
+const retryButton = () => screen.queryByRole('button', { name: 'retry' });
+
+const renderButton = ({ isLast = true, ...state } = {}) => {
+  useAuiState.mockImplementation((selector) =>
+    selector({ message: { isLast } })
+  );
+
+  const reload = jest.fn();
+  useActionBarReload.mockReturnValue({ reload, disabled: false, ...state });
+
+  render(<RetryReplyButton />);
+
+  return { reload };
+};
+
+describe('RetryReplyButton', () => {
+  it('offers to retry the newest reply', () => {
+    renderButton();
+
+    expect(retryButton()).toBeEnabled();
+  });
+
+  it('does not offer to retry an earlier reply', () => {
+    renderButton({ isLast: false });
+
+    expect(retryButton()).not.toBeInTheDocument();
+  });
+
+  it('stays out of the way while the library reports the thread busy', () => {
+    renderButton({ disabled: true });
+
+    expect(retryButton()).not.toBeInTheDocument();
+  });
+
+  it('leaves the re-run itself to the library', async () => {
+    const user = userEvent.setup();
+    const { reload } = renderButton();
+
+    await user.click(retryButton());
+
+    expect(reload).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Description

This PR adds the ability to retry the last prompt.

Notes:
- only the last prompt can be retried
- retrial is available when the run is finished
- the response for the last prompt goes away from the screen, but it remains in Agent's memory

### How was this tested?

Automated and IRL

### Additional information

A few extra enhancments are coming along:
- improved component breakdown allowing to simplify stories
- improved aui state usage for simpler testing
- fixed broken story due to Liz dynamic sizing