### PR TITLE
Remove PR `labeled` trigger from main CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
       - "VERSION"
       - "CHANGELOG.md"
   pull_request:
-    types: [opened, synchronize, labeled]
+    types: [opened, synchronize]
     paths-ignore:
       - "VERSION"
   workflow_dispatch:


### PR DESCRIPTION
### Description

Remove `labeled` trigger from main CI `pull_request` event. It starts a 20 min CI run on every individual label in a PR. Wrecks havoc when backporting without need. I double-checked the jobs, not a single one needs the labels for anything.

### How was this tested?

Not tested.
