### PR TITLE
Remove 'env: :prod' from top level eventstore dep

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -81,6 +81,7 @@ defmodule Trento.MixProject do
       {:dialyxir, "~> 1.4.7", only: [:dev, :test], runtime: false},
       {:ecto_sql, "~> 3.14"},
       {:esbuild, "~> 0.2", runtime: Mix.env() == :dev},
+      {:eventstore, "~> 1.4"},
       # {:eventstore_dashboard, github: "commanded/eventstore-dashboard"},
       {:ex_doc, "~> 0.29", only: [:dev, :test], runtime: false},
       {:ex_machina, "~> 2.8.0", only: :test},

--- a/mix.exs
+++ b/mix.exs
@@ -81,7 +81,6 @@ defmodule Trento.MixProject do
       {:dialyxir, "~> 1.4.7", only: [:dev, :test], runtime: false},
       {:ecto_sql, "~> 3.14"},
       {:esbuild, "~> 0.2", runtime: Mix.env() == :dev},
-      {:eventstore, "~> 1.4", [env: :prod]},
       # {:eventstore_dashboard, github: "commanded/eventstore-dashboard"},
       {:ex_doc, "~> 0.29", only: [:dev, :test], runtime: false},
       {:ex_machina, "~> 2.8.0", only: :test},


### PR DESCRIPTION
### Description

Removed `env: :prod` specifier for  `eventstore`. It used to be specified when this dep was sourced from git but since it's installed from hex now, it's a noop.