### PR TITLE
Analytics Eula Modal Cancel Event

### DIFF
--- a/assets/js/lib/analytics/index.js
+++ b/assets/js/lib/analytics/index.js
@@ -124,6 +124,13 @@ export const capture = (analyticsEnabled, event, payload) => {
   posthog.capture(event, { ...payload });
 };
 
+export const captureWithTemporaryOptIn = (eventName, userId) => {
+  identify(true, userId);
+  optinCapturing(true);
+  capture(true, eventName);
+  setTimeout(() => optinCapturing(false), 500);
+};
+
 export const reset = () => {
   if (!analyticsEnabledConfig) {
     return;

--- a/assets/js/lib/analytics/index.test.js
+++ b/assets/js/lib/analytics/index.test.js
@@ -182,4 +182,41 @@ describe('analytics', () => {
       });
     }
   );
+
+  it('should temporarily opt in to capture an event and then opt out', () => {
+    const installationID = '1775ad46-43ca-4aaa-851a-bd3688702893';
+    global.config.analyticsEnabled = true;
+    global.config.installationID = installationID;
+
+    const mockPosthog = {
+      identify: jest.fn(),
+      opt_in_capturing: jest.fn(),
+      capture: jest.fn(),
+      opt_out_capturing: jest.fn(),
+      has_opted_out_capturing: jest.fn(() => true),
+    };
+
+    jest.mock('posthog-js', () => mockPosthog);
+
+    jest.useFakeTimers();
+
+    return import('.').then(({ captureWithTemporaryOptIn }) => {
+      captureWithTemporaryOptIn('analytics_eula_rejected', 1);
+
+      expect(mockPosthog.identify).toHaveBeenCalledWith(
+        'ab156392-96c8-551b-a49b-f071c1cdcf21',
+        { installationID }
+      );
+      expect(mockPosthog.opt_in_capturing).toHaveBeenCalled();
+      expect(mockPosthog.capture).toHaveBeenCalledWith(
+        'analytics_eula_rejected',
+        {}
+      );
+      expect(mockPosthog.opt_out_capturing).not.toHaveBeenCalled();
+
+      jest.runAllTimers();
+      expect(mockPosthog.opt_out_capturing).toHaveBeenCalled();
+      jest.useRealTimers();
+    });
+  });
 });

--- a/assets/js/pages/AnalyticsEula/AnalyticsEula.jsx
+++ b/assets/js/pages/AnalyticsEula/AnalyticsEula.jsx
@@ -9,6 +9,7 @@ import { editUserProfile } from '@lib/api/users';
 import { getFromConfig } from '@lib/config/config';
 import { setUser } from '@state/user';
 import { getUserProfile } from '@state/selectors/user';
+import { captureWithTemporaryOptIn } from '@lib/analytics';
 import AnalyticsEulaModal from './AnalyticsEulaModal';
 
 const analyticsEnabledConfig = getFromConfig('analyticsEnabled');
@@ -46,6 +47,8 @@ export default function AnalyticsEula() {
         });
       }}
       onCancel={(checked) => {
+        captureWithTemporaryOptIn('analytics_eula_rejected', user.id);
+
         setAnalyticsEulaModalOpen(false);
         if (checked) {
           updateAnalyticsEula({


### PR DESCRIPTION
### Description

Adds ability for the **Continue without Analytics** button to send a single analytics event to show that analytics opt-in has been rejected by the user.

### How was this tested?

Test was written for the temporary opt-in function.

### Documentation changes

No

<img width="1424" height="873" alt="Screenshot 2026-09-02 at 15 31 23" src="https://github.com/user-attachments/assets/59dc13ea-10f5-458a-81bb-8be5255b96bb" />
