### PR TITLE
Handle an unavailable sagents registry as a failed run

### DIFF
--- a/lib/trento/ai/agent.ex
+++ b/lib/trento/ai/agent.ex
@@ -70,7 +70,9 @@ defmodule Trento.AI.Agent do
   process to its event stream, and send the user prompt. Returns
   `{:ok, server_pid}` — the `Sagents.AgentServer` process now publishing to
   the caller — or the first `{:error, reason}` from the start/subscribe/send
-  chain.
+  chain. `{:error, :registry_unavailable}` among them: this node's sagents tree
+  is already down, which happens while the BEAM drains and the endpoint is
+  still serving.
 
   Callers are expected to monitor `server_pid`. Since sagents 0.8.0 the
   subscription is bound to the subscriber's pid, and the agent child is
@@ -131,23 +133,35 @@ defmodule Trento.AI.Agent do
     :exit, reason -> {:error, reason}
   end
 
+  # Refreshing the stored agent is best effort: there may be no agent process to
+  # read from yet, `refresh_when` may answer `:noop`, and a failed write leaves
+  # the previous configuration in place — none of that should stop the prompt
+  # from being sent.
+  #
+  # `{:error, :registry_unavailable}` is the one outcome that has to travel. The
+  # node's sagents tree is gone, so `subscribe/1` and `add_message/2` would fail
+  # right after; better to end the run with a reason than to send a prompt no
+  # one can answer.
   defp maybe_refresh_agent(agent_id, maybe_new_agent, refresh_when) do
     with {:ok, current_agent} <- AgentServer.get_agent(agent_id),
          {:ok, updated_agent} <- refresh_when.(current_agent, maybe_new_agent) do
       update_agent(agent_id, updated_agent)
+    else
+      {:error, :registry_unavailable} = error -> error
+      _ -> :ok
     end
-
-    :ok
   end
 
   defp default_refresh_when(_current_agent, _new_agent), do: :noop
 
   defp update_agent(agent_id, updated_agent) do
-    %{state: current_state} = AgentServer.get_info(agent_id)
-
-    AgentServer.update_agent_and_state(agent_id, updated_agent, current_state)
-
-    :ok
+    with %{state: current_state} <- AgentServer.get_info(agent_id),
+         :ok <- AgentServer.update_agent_and_state(agent_id, updated_agent, current_state) do
+      :ok
+    else
+      {:error, :registry_unavailable} = error -> error
+      _ -> :ok
+    end
   end
 
   defp start_opts(agent_id, agent) do

--- a/lib/trento/ai/agent/server.ex
+++ b/lib/trento/ai/agent/server.ex
@@ -10,6 +10,11 @@ defmodule Trento.AI.Agent.Server do
   `Trento.Infrastructure.AI.SagentsAgentServer`. Override via the
   `:trento, :ai, agent_server_adapter:` config so tests can substitute
   a Mox mock without booting the real sagents stack.
+
+  Every callback reports failure as a tagged tuple, including
+  `{:error, :registry_unavailable}` for a node whose sagents tree is already
+  down. Implementations are expected to translate — sagents itself raises for
+  some of these; see `Trento.Infrastructure.AI.SagentsAgentServer`.
   """
 
   alias LangChain.Message
@@ -20,7 +25,8 @@ defmodule Trento.AI.Agent.Server do
   @callback add_message(String.t(), Message.t()) :: :ok | {:error, term()}
   @callback cancel(String.t()) :: :ok | {:error, term()}
   @callback get_agent(String.t()) :: {:ok, Sagents.Agent.t()} | {:error, term()}
-  @callback get_info(String.t()) :: %{state: Sagents.State.t()}
+  @callback get_info(String.t()) ::
+              %{state: Sagents.State.t()} | {:error, :registry_unavailable}
   @callback update_agent_and_state(String.t(), Sagents.Agent.t(), Sagents.State.t()) ::
               :ok | {:error, term()}
 

--- a/lib/trento/infrastructure/ai/sagents_agent_server.ex
+++ b/lib/trento/infrastructure/ai/sagents_agent_server.ex
@@ -5,9 +5,24 @@ defmodule Trento.Infrastructure.AI.SagentsAgentServer do
   @moduledoc """
   Production implementation of `Trento.AI.Agent.Server` —
   delegates to `Sagents.AgentServer`.
+
+  Half of that API cannot report an unreachable registry in its return value, so
+  it raises `Sagents.RegistryUnavailableError` instead: `get_info/1` and
+  `update_agent_and_state/3` through sagents' `call!/3`, `get_agent/1` through
+  `Sagents.AgentServer.get_pid/1`. That happens while the BEAM drains — the
+  registry's ETS table goes with `Sagents.Supervisor`, and the endpoint keeps
+  serving for the rest of the platform's drain period.
+
+  Turning the raise back into `{:error, :registry_unavailable}` belongs here:
+  the behaviour's contract is a tagged tuple, and normalizing a library's
+  signalling to it is what an adapter is for. Left to propagate, the exception
+  would take the assistant channel down instead of ending the run with
+  `RUN_ERROR`.
   """
 
   @behaviour Trento.AI.Agent.Server
+
+  alias Sagents.RegistryUnavailableError
 
   @impl Trento.AI.Agent.Server
   defdelegate subscribe(agent_id), to: Sagents.AgentServer
@@ -19,11 +34,23 @@ defmodule Trento.Infrastructure.AI.SagentsAgentServer do
   defdelegate cancel(agent_id), to: Sagents.AgentServer
 
   @impl Trento.AI.Agent.Server
-  defdelegate get_agent(agent_id), to: Sagents.AgentServer
+  def get_agent(agent_id) do
+    Sagents.AgentServer.get_agent(agent_id)
+  rescue
+    RegistryUnavailableError -> {:error, :registry_unavailable}
+  end
 
   @impl Trento.AI.Agent.Server
-  defdelegate get_info(agent_id), to: Sagents.AgentServer
+  def get_info(agent_id) do
+    Sagents.AgentServer.get_info(agent_id)
+  rescue
+    RegistryUnavailableError -> {:error, :registry_unavailable}
+  end
 
   @impl Trento.AI.Agent.Server
-  defdelegate update_agent_and_state(agent_id, agent, state), to: Sagents.AgentServer
+  def update_agent_and_state(agent_id, agent, state) do
+    Sagents.AgentServer.update_agent_and_state(agent_id, agent, state)
+  rescue
+    RegistryUnavailableError -> {:error, :registry_unavailable}
+  end
 end

--- a/test/trento/ai/agent_test.exs
+++ b/test/trento/ai/agent_test.exs
@@ -250,6 +250,93 @@ defmodule Trento.AI.AgentTest do
     end
   end
 
+  # The refresh is best effort for every other failure, so these three make sure
+  # a drained sagents tree is not swallowed along with them: the caller gets a
+  # reason instead of a prompt sent into a registry that cannot route it.
+  describe "run/3 — sagents registry unavailable" do
+    setup :run_opts
+
+    test "aborts the run when get_agent reports the registry is unavailable",
+         %{agent: agent, agent_id: agent_id, prompt: prompt} do
+      expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn _ -> {:ok, self()} end)
+
+      expect(Trento.AI.Agent.Server.Mock, :get_agent, fn ^agent_id ->
+        {:error, :registry_unavailable}
+      end)
+
+      # No subscribe / add_message expectations — verify_on_exit! catches strays.
+      assert {:error, :registry_unavailable} = TrentoAIAgent.run(agent, prompt)
+    end
+
+    test "aborts the run when get_info reports the registry is unavailable",
+         %{agent: agent, agent_id: agent_id, prompt: prompt} do
+      refresh_when = fn _current, new_agent -> {:ok, new_agent} end
+
+      expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn _ -> {:ok, self()} end)
+
+      expect(Trento.AI.Agent.Server.Mock, :get_agent, fn ^agent_id ->
+        {:ok, %Sagents.Agent{agent_id: agent_id}}
+      end)
+
+      expect(Trento.AI.Agent.Server.Mock, :get_info, fn ^agent_id ->
+        {:error, :registry_unavailable}
+      end)
+
+      assert {:error, :registry_unavailable} =
+               TrentoAIAgent.run(agent, prompt, refresh_when: refresh_when)
+    end
+
+    test "aborts the run when update_agent_and_state reports the registry is unavailable",
+         %{agent: agent, agent_id: agent_id, prompt: prompt} do
+      refresh_when = fn _current, new_agent -> {:ok, new_agent} end
+
+      expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn _ -> {:ok, self()} end)
+
+      expect(Trento.AI.Agent.Server.Mock, :get_agent, fn ^agent_id ->
+        {:ok, %Sagents.Agent{agent_id: agent_id}}
+      end)
+
+      expect(Trento.AI.Agent.Server.Mock, :get_info, fn ^agent_id ->
+        %{state: %Sagents.State{agent_id: agent_id}}
+      end)
+
+      expect(Trento.AI.Agent.Server.Mock, :update_agent_and_state, fn ^agent_id, _, _ ->
+        {:error, :registry_unavailable}
+      end)
+
+      assert {:error, :registry_unavailable} =
+               TrentoAIAgent.run(agent, prompt, refresh_when: refresh_when)
+    end
+
+    test "still sends the prompt when the refresh fails for any other reason",
+         %{agent: agent, agent_id: agent_id, prompt: prompt} do
+      refresh_when = fn _current, new_agent -> {:ok, new_agent} end
+
+      expect(Trento.AI.Agent.Supervisor.Mock, :start_agent_sync, fn _ -> {:ok, self()} end)
+
+      expect(Trento.AI.Agent.Server.Mock, :get_agent, fn ^agent_id ->
+        {:ok, %Sagents.Agent{agent_id: agent_id}}
+      end)
+
+      expect(Trento.AI.Agent.Server.Mock, :get_info, fn ^agent_id ->
+        %{state: %Sagents.State{agent_id: agent_id}}
+      end)
+
+      expect(Trento.AI.Agent.Server.Mock, :update_agent_and_state, fn ^agent_id, _, _ ->
+        {:error, :agent_not_running}
+      end)
+
+      expect(Trento.AI.Agent.Server.Mock, :subscribe, fn ^agent_id ->
+        {:ok, self(), make_ref()}
+      end)
+
+      expect(Trento.AI.Agent.Server.Mock, :add_message, fn ^agent_id, _ -> :ok end)
+
+      assert {:ok, _server_pid} =
+               TrentoAIAgent.run(agent, prompt, refresh_when: refresh_when)
+    end
+  end
+
   describe "stop/1" do
     test "cancels the in-flight run, then delegates to the supervisor's stop_agent/1" do
       agent_id = "thread-#{Faker.UUID.v4()}"

--- a/test/trento/infrastructure/ai/sagents_agent_server_test.exs
+++ b/test/trento/infrastructure/ai/sagents_agent_server_test.exs
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: SUSE LLC
+# SPDX-License-Identifier: Apache-2.0
+
+defmodule Trento.Infrastructure.AI.SagentsAgentServerTest do
+  # Not async: these tests take the node's sagents tree down, which every other
+  # test touching an agent would see. ExUnit runs synchronous modules on their
+  # own, once the async ones are done.
+  use ExUnit.Case, async: false
+
+  alias Trento.Infrastructure.AI.SagentsAgentServer
+
+  setup do
+    %{
+      agent_id: "thread-#{Faker.UUID.v4()}",
+      agent: %Sagents.Agent{agent_id: "thread-1"},
+      state: %Sagents.State{agent_id: "thread-1"}
+    }
+  end
+
+  describe "when this node's sagents tree is down" do
+    setup do
+      :ok = Supervisor.terminate_child(Trento.Supervisor, Sagents.Supervisor)
+
+      on_exit(fn ->
+        {:ok, _} = Supervisor.restart_child(Trento.Supervisor, Sagents.Supervisor)
+      end)
+
+      refute Sagents.ProcessRegistry.available?()
+
+      :ok
+    end
+
+    test "get_agent/1 answers {:error, :registry_unavailable} instead of raising",
+         %{agent_id: agent_id} do
+      assert {:error, :registry_unavailable} = SagentsAgentServer.get_agent(agent_id)
+    end
+
+    test "get_info/1 answers {:error, :registry_unavailable} instead of raising",
+         %{agent_id: agent_id} do
+      assert {:error, :registry_unavailable} = SagentsAgentServer.get_info(agent_id)
+    end
+
+    test "update_agent_and_state/3 answers {:error, :registry_unavailable} instead of raising",
+         %{agent_id: agent_id, agent: agent, state: state} do
+      assert {:error, :registry_unavailable} =
+               SagentsAgentServer.update_agent_and_state(agent_id, agent, state)
+    end
+  end
+
+  describe "when this node's sagents tree is up" do
+    test "the rescue does not shadow the ordinary not-found answer",
+         %{agent_id: agent_id} do
+      assert Sagents.ProcessRegistry.available?()
+
+      assert {:error, :not_found} = SagentsAgentServer.get_agent(agent_id)
+    end
+  end
+end


### PR DESCRIPTION
sagents 0.12 introduced `{:error, :registry_unavailable}` for a node whose sagents tree is already down. That happens while the BEAM drains: the registry's ETS table goes with `Sagents.Supervisor`, and the endpoint keeps serving for the rest of the platform's drain period.

Three of the six calls `Trento.AI.Agent.Server` wraps cannot carry that in their return value and raise `Sagents.RegistryUnavailableError` instead — `get_info/1` and `update_agent_and_state/3` through sagents' `call!/3`, `get_agent/1` through `Sagents.AgentServer.get_pid/1`. All three sit on `run/3`'s refresh path, so the exception travelled out of the assistant channel and took it down rather than ending the run with RUN_ERROR.

`Trento.Infrastructure.AI.SagentsAgentServer` now rescues it into the tagged tuple the behaviour already promises; normalizing a library's signalling is what the adapter is for. `maybe_refresh_agent/3` keeps swallowing every other refresh failure — no agent process yet, a `:noop`, a write that did not land are all best effort — and propagates only this one, since `subscribe/1` and `add_message/2` would fail right after it anyway.

### Description

<!-- Describe what this PR changes. Include benefits or limitations if relevant. -->

Fixes #<issue>
<!-- Optionally use depends #<issue> for dependent PRs -->

<!--If your repository uses release drafter, ensure the appropriate release label is applied.
 To see the labels: https://github.com/trento-project/.github/blob/main/.github/release_drafter_main.yaml-->

### How was this tested?

<!-- Describe what tests were added or updated for this change. -->

### Documentation changes

Yes / No

<!--
If yes, consider updating:
- User documentation: https://github.com/trento-project/docs/tree/main/trento/adoc
- Developer documentation: https://github.com/trento-project/docs/tree/main/content
- Component-specific documentation, e.g., https://github.com/trento-project/web/tree/main/guides for Wanda
-->

### Additional information

<!-- Add anything else relevant to this PR, such as screenshots or demos. -->