### PR TITLE
Get mix deps in API BC check in case of cache miss, CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1105,6 +1105,9 @@ jobs:
             _build/${{ env.MIX_ENV }}
             priv/plts
           key: erlang-${{ matrix.otp }}-elixir-${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}-${{ env.MIX_ENV }}
+      - name: Install missing dependencies
+        if: step.mix-cache-target.outputs.cache-hit != 'true'
+        run: mix deps.get
       - name: Generate target openapi.json
         run: |
           mix openapi.spec.json --start-app=false --spec TrentoWeb.OpenApi.${{ matrix.version }}.ApiSpec /tmp/specs/target-spec.json


### PR DESCRIPTION
### Description

CI is failing for _target_ API BC checks when there is a cache miss. This could happen when the current PR is not rebased on the latest commit of the target branch.