### PR TITLE
Bump prettier from 3.8.5 to 3.9.6 in /assets

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -90,7 +90,7 @@
         "jsdom-testing-mocks": "^1.16.0",
         "postcss": "^8.5.26",
         "postcss-import": "^16.1.1",
-        "prettier": "^3.8.3",
+        "prettier": "^3.9.6",
         "redux-mock-store": "^1.5.5",
         "storybook": "^10.2.10",
         "tailwindcss": "^3.4.19"
@@ -18903,9 +18903,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -39,7 +39,7 @@
     "jsdom-testing-mocks": "^1.16.0",
     "postcss": "^8.5.26",
     "postcss-import": "^16.1.1",
-    "prettier": "^3.8.3",
+    "prettier": "^3.9.6",
     "redux-mock-store": "^1.5.5",
     "storybook": "^10.2.10",
     "tailwindcss": "^3.4.19"


### PR DESCRIPTION
# Description
Backport of #4626 to `release`.