### PR TITLE
Fix conflicting erlang27 packages

### DIFF
--- a/packaging/suse/rpm/trento-web.spec
+++ b/packaging/suse/rpm/trento-web.spec
@@ -40,6 +40,7 @@ BuildRequires:  npm >= 20
 %if !0%{?is_opensuse} && 0%{?suse_version} < 1600
 BuildRequires:  erlang26
 BuildConflicts: erlang27
+BuildConflicts: erlang27-providers
 BuildRequires:  elixir115
 BuildConflicts: elixir119
 %else


### PR DESCRIPTION
### Description

With the release of the erlang27 family of packages now we have this conflict.

> have choice for erlang-providers needed by erlang-rebar3: erlang-providers erlang27-providers
>

This change fixes it so we build against the erlang26 family. 

This has to stay like this until we release 3.2.0 targeting erlang27/elixir119.

To be backported into 3.1.6

### How was this tested?

OBS