### PR TITLE
Use transparent type for hosts list cleanup button

### DIFF
--- a/assets/js/pages/HostsList/HostsList.jsx
+++ b/assets/js/pages/HostsList/HostsList.jsx
@@ -227,6 +227,7 @@ function HostsList() {
             <CleanUpButton
               cleaning={item.deregistering}
               size="fit"
+              type="transparent"
               className="border-none shadow-none"
               userAbilities={abilities}
               permittedFor={['cleanup:host']}


### PR DESCRIPTION
### Description

Use transparent type for hosts list cleanup button.

Before:
<img width="1261" height="126" alt="image" src="https://github.com/user-attachments/assets/b125b1c2-aaed-4f20-8240-10a11200a582" />

After:
<img width="1251" height="107" alt="image" src="https://github.com/user-attachments/assets/bd6c3879-9de4-433d-b39f-2df7e133b048" />

### How was this tested?

Visual inspection

### Documentation changes

No